### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/flux-framework/flux-core.png?label=ready&title=Ready)](https://waffle.io/flux-framework/flux-core)
 _NOTE: This project is currently EXPERIMENTAL (as indicated by its
 0.x.x version) and is being actively developed.  We offer no guarantee
 of API stablility from release to release at this time._


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/flux-framework/flux-core

This was requested by a real person (user garlick) on waffle.io, we're not trying to spam you.
