### PR TITLE
build: check for a2x program

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,10 @@ if test "$GCC" = yes; then
 fi
 AC_PROG_RANLIB
 AC_PROG_LIBTOOL
+AC_CHECK_PROG(A2X,[a2x],[a2x])
+if test "$A2X" != "a2x"; then
+  AC_MSG_ERROR([Please install asciidoc to get a2x utility.])
+fi
 
 ##
 # Checks for header files.

--- a/doc/cmd/Makefile.am
+++ b/doc/cmd/Makefile.am
@@ -25,7 +25,7 @@ stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
 .adoc.1:
-	$(AM_V_GEN)a2x --attribute mansource=$(META_NAME) \
+	$(AM_V_GEN)$(A2X) --attribute mansource=$(META_NAME) \
 	    --attribute manversion=$(META_VERSION) \
 	    --attribute manmanual="Flux Manual" \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)


### PR DESCRIPTION
Abort configure if a2x is not found.
Fixes issue #4
