### PR TITLE
flux-module: fix segfault loading out of tree mod

### DIFF
--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -115,9 +115,11 @@ static char *modfind (const char *dirpath, const char *modname)
     if (glob (globstr, 0, NULL, &gl) == 0) {
         for (i = 0; i < gl.gl_pathc && !modpath; i++) {
             char *name = flux_modname (gl.gl_pathv[i]);
-            if (!strcmp (name, modname))
-                modpath = xstrdup (gl.gl_pathv[i]);
-            free (name);
+            if (name) {
+                if (!strcmp (name, modname))
+                    modpath = xstrdup (gl.gl_pathv[i]);
+                free (name);
+            }
         }
         globfree (&gl);
     }


### PR DESCRIPTION
flux-module would segfault in some cases when searching the module
path, if the glob matched a file that could not be dlopened or which
was not a module.
