### PR TITLE
Minor updates to Lua API for recent flux protocol changes

### DIFF
--- a/src/bindings/lua/Test/Builder.lua
+++ b/src/bindings/lua/Test/Builder.lua
@@ -219,6 +219,7 @@ function m:done_testing (num_tests)
     if self.curr_test == 0 then
         self.is_passing = false
     end
+    if not self.is_passing then os.exit (1) end
 end
 
 function m:has_plan ()

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -286,9 +286,11 @@ static int l_flux_index (lua_State *L)
 static int l_flux_send (lua_State *L)
 {
     int rc;
+    int nargs = lua_gettop (L) - 1;
     flux_t f = lua_get_flux (L, 1);
     const char *tag = luaL_checkstring (L, 2);
     json_object *o;
+    uint32_t nodeid = FLUX_NODEID_ANY;
 
     if (lua_value_to_json (L, 3, &o) < 0)
         return lua_pusherror (L, "JSON conversion error");
@@ -296,7 +298,10 @@ static int l_flux_send (lua_State *L)
     if (tag == NULL)
         return lua_pusherror (L, "Invalid args");
 
-    rc = flux_request_send (f, o, tag);
+    if (nargs >= 3)
+        nodeid = lua_tointeger (L, 4);
+
+    rc = flux_json_request (f, nodeid, 0, tag, o);
     json_object_put (o);
     if (rc < 0)
         return lua_pusherror (L, strerror (errno));

--- a/src/bindings/lua/json-lua.c
+++ b/src/bindings/lua/json-lua.c
@@ -47,6 +47,8 @@ int lua_is_json_null (lua_State *L, int index)
 
 int json_object_to_lua (lua_State *L, json_object *o)
 {
+        if (o == NULL)
+            lua_pushnil (L);
         switch (json_object_get_type (o)) {
         case json_type_object:
             json_object_to_lua_table (L, o);

--- a/src/bindings/lua/tests/t0001-zmsg.t
+++ b/src/bindings/lua/tests/t0001-zmsg.t
@@ -80,4 +80,14 @@ subtest ('Test zmsg response', function ()
 
 end)
 
+subtest ('Test zmsg errnum', function ()
+	local resp = z.resp_err ("test.resp_err", 255)
+
+	type_ok (resp,    'userdata',             'type is userdata')
+	is (resp.tag,     "test.resp_err",        'msg.tag is correct')
+	is (resp.type,    "response",             'msg.type is response')
+	is (resp.data,    nil,                    'msg.data is nil')
+	is (resp.errnum,  255,                    'msg.errnum is non-nil')
+end)
+
 done_testing()

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -148,6 +148,15 @@ static int l_zmsg_info_index (lua_State *L)
     if (strcmp (key, "data") == 0) {
         return json_object_to_lua (L, zi->o);
     }
+    if (strcmp (key, "errnum") == 0) {
+        int errnum;
+        if (!(zi->typemask & FLUX_MSGTYPE_RESPONSE))
+            return lua_pusherror (L,
+                "zmsg: errnum requested for non-respose msg");
+        flux_msg_get_errnum (zi->zmsg, &errnum);
+        lua_pushnumber (L, errnum);
+        return (1);
+    }
 
     /* Push metatable value onto stack */
     lua_getmetatable (L, 1);

--- a/t/lua/t0001-send-recv.t
+++ b/t/lua/t0001-send-recv.t
@@ -3,10 +3,10 @@
 --  Basic flux reactor testing using ping interface to kvs
 --
 local t = require 'fluxometer'.init (...)
-t:start_session { size = 1}
+t:start_session { size = 2}
 t:say ("starting send/recv tests")
 
-plan (8)
+plan (13)
 
 local flux = require_ok ('flux')
 local f, err = flux.new()
@@ -29,6 +29,18 @@ is (msg.pad, "xxxxxx", "recv: got expected ping pad")
 is (tag, "live.ping", "recv: got expected tag on ping response")
 
 for k,v in pairs(msg) do note ("msg."..k.."="..v) end
+
+--
+--  Test f:send() with rank argument
+--
+local rc, err = f:send ("live.ping", packet, 0)
+is (rc, 1, "send to rank 0: rc is 1")
+is (err, nil, "send to rank 0: err is nil")
+
+local msg, tag = f:recv ()
+is (msg.seq, "1", "recv: got expected ping sequence")
+is (msg.pad, "xxxxxx", "recv: got expected ping pad")
+is (tag, "live.ping", "recv: got expected tag on ping response")
 
 done_testing ()
 

--- a/t/lua/t1000-reactor.t
+++ b/t/lua/t1000-reactor.t
@@ -24,7 +24,7 @@ local mh, err = f:msghandler {
 
     handler = function (f, zmsg, mh)
         local resp = zmsg.data
-        is (resp.errnum, nil, "ping: no error in response msg")
+        is (zmsg.errnum, 0, "ping: no error in response msg")
         is (zmsg.tag, "kvs.ping", "ping: got correct tag")
         is (resp.seq, "1", "ping: got first sequence number")
         is (resp.pad, "TestPAD", "ping: got correct pad")


### PR DESCRIPTION
Quick Lua bindings update for recent flux protocol/API changes:
 - Add optional extra `nodeid` argument to `send` call, allowing lua api to target ranks as in flux api
 - Error number is no longer transported in json payload, it is part of flux message, so add new index field to `zmsg_info` object to access error number. (There is no facility for setting an error number yet)

Also includes a couple minor fixes
 - Lua-TestMore scripts should exit non-zero if any test fails
 - NULL json_object is represented as `nil` in Lua