### PR TITLE
lua: more updates to Lua API to adapt to recent flux message protocol changes

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -291,6 +291,7 @@ static int l_flux_send (lua_State *L)
     const char *tag = luaL_checkstring (L, 2);
     json_object *o;
     uint32_t nodeid = FLUX_NODEID_ANY;
+    uint32_t matchtag;
 
     if (lua_value_to_json (L, 3, &o) < 0)
         return lua_pusherror (L, "JSON conversion error");
@@ -301,11 +302,14 @@ static int l_flux_send (lua_State *L)
     if (nargs >= 3)
         nodeid = lua_tointeger (L, 4);
 
-    rc = flux_json_request (f, nodeid, 0, tag, o);
+    matchtag = flux_matchtag_alloc (f, 1);
+
+    rc = flux_json_request (f, nodeid, matchtag, tag, o);
     json_object_put (o);
     if (rc < 0)
         return lua_pusherror (L, strerror (errno));
-    return l_pushresult (L, 1);
+
+    return l_pushresult (L, matchtag);
 }
 
 static int l_flux_recv (lua_State *L)

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -157,6 +157,13 @@ static int l_zmsg_info_index (lua_State *L)
         lua_pushnumber (L, errnum);
         return (1);
     }
+    if (strcmp (key, "matchtag") == 0) {
+        uint32_t matchtag;
+        if (flux_msg_get_matchtag (zi->zmsg, &matchtag) < 0)
+            return lua_pusherror (L, "zmsg: matchtag: %s", strerror (errno));
+        lua_pushnumber (L, matchtag);
+        return (1);
+    }
 
     /* Push metatable value onto stack */
     lua_getmetatable (L, 1);

--- a/t/lua/t0001-send-recv.t
+++ b/t/lua/t0001-send-recv.t
@@ -6,7 +6,7 @@ local t = require 'fluxometer'.init (...)
 t:start_session { size = 2}
 t:say ("starting send/recv tests")
 
-plan (13)
+plan (22)
 
 local flux = require_ok ('flux')
 local f, err = flux.new()
@@ -41,6 +41,23 @@ local msg, tag = f:recv ()
 is (msg.seq, "1", "recv: got expected ping sequence")
 is (msg.pad, "xxxxxx", "recv: got expected ping pad")
 is (tag, "live.ping", "recv: got expected tag on ping response")
+
+
+---
+---  Test send with recvmsg()
+---
+local matchtag, err = f:send ("live.ping", packet, 1)
+isnt (rc, 0, "send to rank 1: rc is not nil or zero")
+isnt (rc, nil, "send to rank 1: rc is not nil or zero")
+is (err, nil, "send to rank 1: err is nil")
+
+local msg = f:recvmsg ()
+ok (msg, "msg is non-nil")
+is (msg.matchtag, matchtag, "recvmsg: matchtag matches (".. matchtag..")")
+is (msg.errnum, 0, "recvmsg: message errnum is 0")
+is (msg.data.seq, "1", "recv: got expected ping sequence")
+is (msg.data.pad, "xxxxxx", "recv: got expected ping pad")
+is (msg.tag, "live.ping", "recv: got expected tag on ping response")
 
 done_testing ()
 

--- a/t/lua/t0001-send-recv.t
+++ b/t/lua/t0001-send-recv.t
@@ -18,8 +18,8 @@ is (err, nil, "error is nil")
 --
 
 local packet = { seq = "1", pad = "xxxxxx" }
-local rc, err = f:send ("live.ping", packet)
-is (rc, 1, "send: rc is 1")
+local matchtag, err = f:send ("live.ping", packet)
+isnt (rc, 0, "send: rc is not 0")
 is (err, nil, "send: err is nil")
 
 
@@ -34,7 +34,7 @@ for k,v in pairs(msg) do note ("msg."..k.."="..v) end
 --  Test f:send() with rank argument
 --
 local rc, err = f:send ("live.ping", packet, 0)
-is (rc, 1, "send to rank 0: rc is 1")
+isnt (rc, 0, "send to rank 0: rc is not nil or zero")
 is (err, nil, "send to rank 0: err is nil")
 
 local msg, tag = f:recv ()


### PR DESCRIPTION
Further stopgap measures to adapt to recent Flux protocol changes:

 - Just enough "matchtag" support to get some other things working (Warning: no facility for freeing a matchtag at this time, not sure how that should work...)
 - `recv` will now promote and non-zero `errnum` into the returned Lua table... this is just a temporary measure until `recv` can be replaced.
 - `recvmsg` will eventually replace the simpler `recv`. Data such as `errnum` and `matchtag` are part of flux msg, not the JSON payload, so it no longer makes sense to pretend the message is json. For now we can use recvmsg where the matchtag is required. 