### PR TITLE
Fix for cmbd crash with invalid ping packet

### DIFF
--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -348,10 +348,12 @@ static int ping_req_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     char *s = NULL;
     int rc = 0;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL) {
-        err ("%s: protocol error", __FUNCTION__);
+    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL ||
+        !json_object_is_type (o, json_type_object)) {
+        flux_err_respond (h, EPROTO, zmsg);
         goto done; /* reactor continues */
     }
+
     /* Route string will not include the endpoints.
      * On arrival here, uuid of dst plugin has been stripped.
      * The '1' arg to zdump_routestr strips the uuid of the sender.

--- a/t/lua/t0002-rpc.t
+++ b/t/lua/t0002-rpc.t
@@ -5,7 +5,7 @@
 local test = require 'fluxometer'.init (...)
 test:start_session { size=1 }
 
-plan (7)
+plan (9)
 
 local flux = require_ok ('flux')
 local f, err = flux.new()
@@ -21,5 +21,13 @@ type_ok (msg, 'table', "rpc: return type is table")
 is (err, nil, "rpc: err is nil")
 is (msg.seq, "1", "recv: got expected ping sequence")
 is (msg.pad, "xxxxxx", "recv: got expected ping pad")
+
+--
+--  Send invalid 'ping' packet to test response
+--
+local packet = { 1, 2, 3 }  -- Force encoding to be 'array'
+local msg, err = f:rpc ("live.ping", packet)
+is (msg, nil, "rpc: invalid packet: nil response indicates error")
+is (err, "Protocol error", "rpc: invalid packet: err is 'Protocol error'")
 
 done_testing ()


### PR DESCRIPTION
As I was developing tests I inadvertently created a ping packet that was invalid (a json array instead of a json object), and this caused cmbd to segfault when trying to add the `route` entry to the json object
```
util_json_object_add_string (o, "route", s);
```

Yeah, this is more likely a json-c bug, but to be a bit defensive in the `ping` service, this patch checks to make sure the received object is specifically a `json_object`, and returns `EPROTO` if not.
(The patch also returns EPROTO on other `flux_msg_decode` errors as well to avoid ping hangs)

Probably other services should be audited at some point to verify data sent in the payload too, though this is probably more important when flux instances handle multiple users...

