### PR TITLE
Misc lua binding fixes and updates

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -315,8 +315,8 @@ static int l_flux_send (lua_State *L)
 static int l_flux_recv (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
-    char *tag;
-    json_object *o;
+    char *tag = NULL;
+    json_object *o = NULL;
     uint32_t matchtag;
     int errnum;
     zmsg_t *zmsg;

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -361,20 +361,26 @@ static int l_flux_rpc (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
     const char *tag = luaL_checkstring (L, 2);
-    json_object *o;
-    json_object *resp;
+    json_object *o = NULL;
+    json_object *resp = NULL;
+    int nodeid;
 
     if (lua_value_to_json (L, 3, &o) < 0)
         return lua_pusherror (L, "JSON conversion error");
 
+    if (lua_gettop (L) > 3)
+        nodeid = lua_tonumber (L, 4);
+    else
+        nodeid = FLUX_NODEID_ANY;
+
     if (tag == NULL || o == NULL)
         return lua_pusherror (L, "Invalid args");
 
-    resp = flux_rpc (f, o, tag);
-    json_object_put (o);
-    if (resp == NULL)
+    if (flux_json_rpc (f, nodeid, tag, o, &resp) < 0) {
+        json_object_put (o);
         return lua_pusherror (L, strerror (errno));
-
+    }
+    json_object_put (o);
     json_object_to_lua (L, resp);
     json_object_put (resp);
     return (1);

--- a/src/bindings/lua/json-lua.c
+++ b/src/bindings/lua/json-lua.c
@@ -160,8 +160,10 @@ static int lua_is_integer (lua_State *L, int index)
 
 static int lua_table_is_array (lua_State *L, int index)
 {
+    int haskeys = 0;
     lua_pushnil (L);
     while (lua_next (L, index)) {
+        haskeys = 1;
         /* If key is not a number abort */
         if (!lua_is_integer (L, -2)) {
             lua_pop (L, 2); /* pop key and value */
@@ -169,7 +171,7 @@ static int lua_table_is_array (lua_State *L, int index)
         }
         lua_pop (L, 1);
     }
-    return (1);
+    return (haskeys);
 }
 
 static json_object * lua_table_to_json_array (lua_State *L, int index)


### PR DESCRIPTION
Updates `flux_rpc` lua binding for better compatibility with new protocol, fixes encoding of an empty Lua table in JSON (empty Lua table becomes JSON object, not JSON array), and fixes compile error for `l_flux_recv`