### PR TITLE
Support build against json-c-0.11

### DIFF
--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -165,7 +165,7 @@ static void parse_json (const char *n, json_object *o, double scale,
         char *name, *saveptr = NULL, *a1 = cpy;
 
         while ((name = strtok_r (a1, ".", &saveptr))) {
-            if (!(o = json_object_object_get (o, name)))
+            if (!json_object_object_get_ex (o, name, &o) || o == NULL)
                 err_exit ("`%s' not found in response", n);
             a1 = NULL;
         }

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -40,7 +40,7 @@ char *flux_getattr (flux_t h, int rank, const char *name)
     JSON in = Jnew ();
     JSON out = NULL;
     char *ret = NULL;
-    const char *val;
+    const char *val = NULL;
 
     Jadd_str (in, "name", name);
     if (flux_json_rpc (h, nodeid, "cmb.getattr", in, &out) < 0)

--- a/src/common/libutil/jsonutil.c
+++ b/src/common/libutil/jsonutil.c
@@ -138,9 +138,16 @@ void util_json_object_add_timeval (json_object *o, char *name,
     json_object_object_add (o, name, no);
 }
 
+static json_object *util_json_object_object_get (json_object *o, char *name)
+{
+    json_object *ret = NULL;
+    json_object_object_get_ex (o, name, &ret);
+    return (ret);
+}
+
 int util_json_object_get_boolean (json_object *o, char *name, bool *vp)
 {
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     if (!no)
         return -1;
     *vp = json_object_get_boolean (no);
@@ -149,7 +156,7 @@ int util_json_object_get_boolean (json_object *o, char *name, bool *vp)
 
 int util_json_object_get_double (json_object *o, char *name, double *dp)
 {
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     if (!no)
         return -1;
     *dp = json_object_get_double (no);
@@ -158,7 +165,7 @@ int util_json_object_get_double (json_object *o, char *name, double *dp)
 
 int util_json_object_get_int (json_object *o, char *name, int *ip)
 {
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     if (!no)
         return -1;
     *ip = json_object_get_int (no);
@@ -167,7 +174,7 @@ int util_json_object_get_int (json_object *o, char *name, int *ip)
 
 int util_json_object_get_int64 (json_object *o, char *name, int64_t *ip)
 {
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     if (!no)
         return -1;
     *ip = json_object_get_int64 (no);
@@ -176,7 +183,7 @@ int util_json_object_get_int64 (json_object *o, char *name, int64_t *ip)
 
 int util_json_object_get_string (json_object *o, char *name, const char **sp)
 {
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     if (!no)
         return -1;
     *sp = json_object_get_string (no);
@@ -210,7 +217,7 @@ int util_json_object_get_timeval (json_object *o, char *name,
 {
     struct timeval tv;
     char *endptr;
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     if (!no)
         return -1;
     tv.tv_sec = strtoul (json_object_get_string (no), &endptr, 10);
@@ -222,7 +229,7 @@ int util_json_object_get_timeval (json_object *o, char *name,
 int util_json_object_get_int_array (json_object *o, char *name,
                                     int **ap, int *lp)
 {
-    json_object *no = json_object_object_get (o, name);
+    json_object *no = util_json_object_object_get (o, name);
     json_object *vo;
     int i, len, *arr = NULL;
 

--- a/src/common/libutil/shortjson.h
+++ b/src/common/libutil/shortjson.h
@@ -87,12 +87,22 @@ Jadd_obj (JSON o, const char *name, JSON obj)
     json_object_object_add (o, (char *)name, Jget (obj));
 }
 
+/* Wrapper for json_object_object_get_ex()
+ */
+static __inline__ JSON
+Jobj_get (JSON o, const char *name)
+{
+    JSON n = NULL;
+    json_object_object_get_ex (o, (char *)name, &n);
+    return (n);
+}
+
 /* Get integer from JSON.
  */
 static __inline__ bool
 Jget_int (JSON o, const char *name, int *ip)
 {
-    JSON n = json_object_object_get (o, (char *)name);
+    JSON n = Jobj_get (o, name);
     if (n)
         *ip = json_object_get_int (n);
     return (n != NULL);
@@ -103,7 +113,7 @@ Jget_int (JSON o, const char *name, int *ip)
 static __inline__ bool
 Jget_double (JSON o, const char *name, double *dp)
 {
-    JSON n = json_object_object_get (o, (char *)name);
+    JSON n = Jobj_get (o, name);
     if (n)
         *dp = json_object_get_double (n);
     return (n != NULL);
@@ -114,7 +124,7 @@ Jget_double (JSON o, const char *name, double *dp)
 static __inline__ bool
 Jget_int64 (JSON o, const char *name, int64_t *ip)
 {
-    JSON n = json_object_object_get (o, (char *)name);
+    JSON n = Jobj_get (o, name);
     if (n)
         *ip = json_object_get_int64 (n);
     return (n != NULL);
@@ -125,7 +135,7 @@ Jget_int64 (JSON o, const char *name, int64_t *ip)
 static __inline__ bool
 Jget_str (JSON o, const char *name, const char **sp)
 {
-    JSON n = json_object_object_get (o, (char *)name);
+    JSON n = Jobj_get (o, name);
     if (n)
         *sp = json_object_get_string (n);
     return (n != NULL);
@@ -136,7 +146,7 @@ Jget_str (JSON o, const char *name, const char **sp)
 static __inline__ bool
 Jget_obj (JSON o, const char *name, JSON *op)
 {
-    JSON n = json_object_object_get (o, (char *)name);
+    JSON n = Jobj_get (o, name);
     if (n)
         *op = n;
     return (n != NULL);
@@ -147,7 +157,7 @@ Jget_obj (JSON o, const char *name, JSON *op)
 static __inline__ bool
 Jget_bool (JSON o, const char *name, bool *bp)
 {
-    JSON n = json_object_object_get (o, (char *)name);
+    JSON n = Jobj_get (o, name);
     if (n)
         *bp = json_object_get_boolean (n);
     return (n != NULL);


### PR DESCRIPTION
In json-c-0.11 the function json_object_object_get() was deprecated in
favor of json_object_object_get_ex(). The prototypes differ like such:

 struct json_object* json_object_object_get(struct json_object* obj,
                                                  const char *key);

vs

 json_bool json_object_object_get_ex(struct json_object* obj,
                                                  const char *key,
                                                  struct json_object **value);

This commit updates all code using json_object_object_get() to use
the non-deprecated function. One note is that json_object_object_get_ex()
returns `true' if the key exists in the JSON object, but *value may
still end up NULL if the key points to a NULL JSON object. Presumably,
this is the reason the old function is being deprecated.

Fixes Issue #133.