### PR TITLE
Add Jadd_int64

### DIFF
--- a/src/common/libutil/shortjson.h
+++ b/src/common/libutil/shortjson.h
@@ -68,6 +68,17 @@ Jadd_double (JSON o, const char *name, double d)
     json_object_object_add (o, (char *)name, n);
 }
 
+/* Add 64bit integer to JSON.
+ */
+static __inline__ void
+Jadd_int64 (JSON o, const char *name, int64_t i)
+{
+    JSON n = json_object_new_int64 (i);
+    if (!n)
+        oom ();
+    json_object_object_add (o, (char *)name, n);
+}
+
 /* Add string to JSON (caller retains ownership of original).
  */
 static __inline__ void


### PR DESCRIPTION
This is just a simple patch to add Jadd_int64 to shortjason.h. Since Jget_int64 is already defined in this file, it seems to make sense to add Jadd_int64 here as well. And I also need this for the job status and control API I am working on. Thanks!

Dong