### PR TITLE
add kvs_unwatch() and improve matchtag allocator

### DIFF
--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -32,6 +32,7 @@ void flux_flags_unset (flux_t h, int flags);
  */
 uint32_t flux_matchtag_alloc (flux_t h, int size);
 void flux_matchtag_free (flux_t h, uint32_t t, int size);
+uint32_t flux_matchtag_avail (flux_t h);
 
 /* Low level message send/recv functions.
  */

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -39,8 +39,8 @@ int kvs_get_symlink (flux_t h, const char *key, char **valp);
 
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial
- * value and again each time the value changes.  There is currently no
- * "unwatch" function.  Any storage associated with the value given the
+ * value and again each time the value changes.
+ * Any storage associated with the value given the
  * callback is freed when the callback returns.  If a value is unset, the
  * callback gets errnum = ENOENT.
  */
@@ -51,6 +51,11 @@ int kvs_watch_int (flux_t h, const char *key, KVSSetIntF *set, void *arg);
 int kvs_watch_int64 (flux_t h, const char *key, KVSSetInt64F *set, void *arg);
 int kvs_watch_double (flux_t h, const char *key, KVSSetDoubleF *set, void *arg);
 int kvs_watch_boolean (flux_t h, const char *key, KVSSetBooleanF *set,void *arg);
+
+/* Cancel a kvs_watch, freeing server-side state, and unregistering any
+ * callback.  Returns 0 on success, or -1 with errno set on error.
+ */
+int kvs_unwatch (flux_t h, const char *key);
 
 /* While the above callback interface makes sense in plugin context,
  * the following is better for API context.  'valp' is an IN/OUT parameter.

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -42,6 +42,7 @@
 #include <stdarg.h>
 #include <flux/core.h>
 
+#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
@@ -490,6 +491,23 @@ done:
 /**
  ** WATCH
  **/
+
+int kvs_unwatch (flux_t h, const char *key)
+{
+    kvsctx_t *ctx = getctx (h);
+    JSON o = Jnew ();
+    int rc = -1;
+
+    Jadd_str (o, "key", key);
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "kvs.unwatch", o, NULL) < 0)
+        goto done;
+    if (ctx)
+        zhash_delete (ctx->watchers, key);
+    rc = 0;
+done:
+    Jput (o);
+    return rc;
+}
 
 static int dispatch_watch (flux_t h, kvs_watcher_t *wp, const char *key,
                             json_object *val)

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -230,13 +230,18 @@ test_expect_success 'kvs: tcommit: start 100 API threads each doing 50 put,fence
 		$(basename ${SHARNESS_TEST_FILE})
 '
 test_expect_success 'kvs: tkvswatch-mt: multi-threaded kvs watch program' '
-	${FLUX_BUILD_DIR}/src/test/tkvswatch mt 100 100 TEST.a &&
-	flux kvs unlink TEST.a
+	${FLUX_BUILD_DIR}/src/test/tkvswatch mt 100 100 $TEST.a &&
+	flux kvs unlink $TEST.a
 '
 
 test_expect_success 'kvs: tkvswatch-selfmod: watch callback modifies watched key' '
-	${FLUX_BUILD_DIR}/src/test/tkvswatch selfmod TEST.a &&
-	flux kvs unlink TEST.a
+	${FLUX_BUILD_DIR}/src/test/tkvswatch selfmod $TEST.a &&
+	flux kvs unlink $TEST.a
+'
+
+test_expect_success 'kvs: tkvswatch-unwatch unwatch works' '
+	${FLUX_BUILD_DIR}/src/test/tkvswatch unwatch $TEST.a &&
+	flux kvs unlink $TEST.a
 '
 
 test_done

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -244,4 +244,10 @@ test_expect_success 'kvs: tkvswatch-unwatch unwatch works' '
 	flux kvs unlink $TEST.a
 '
 
+test_expect_success 'kvs: tkvswatch-unwatchloop 1000 watch/unwatch ok' '
+	${FLUX_BUILD_DIR}/src/test/tkvswatch unwatchloop $TEST.a &&
+	flux kvs unlink $TEST.a
+'
+
+
 test_done


### PR DESCRIPTION
This PR adds a `kvs_unwatch ()` call which was conspicuously absent from the original KVS API.  When a key is unwatched, server side (KVS comms module) resources are freed up and notifications will no longer be received by the handle when the key changes.  In addition, the matchtag used in the original watch request, and reused on watch notifications (responses), is freed back to the matchtag pool.

RFC 3 defines a 32-bit matchtag space, but the allocator in the generic handle code was just a toy and limited the available matchtags to 255.  (actually blocks of up to 2^24 tags could be allocated at once for `flux_json_multrpc()`, but internally even a single tag consumed a full block).  This was changed so that the formerly unused block 0 space is covered with a veb tree allocator.  The size of the veb tree is fixed so that up to 64K matchtags can be allocated with O(log m) performance, where m is 64K.  This hardwired size could be made dynamic up to 2^24.

Finally, tests were added for `kvs_unwatch()` including a matchtag leak test.




