### PR TITLE
Add subprocess management and simple remote execution to flux-core 

### DIFF
--- a/doc/cmd/Makefile.am
+++ b/doc/cmd/Makefile.am
@@ -11,7 +11,8 @@ MAN1_FILES = \
 	flux-wreckrun.1 \
 	flux-start.1 \
 	flux-config.1 \
-	flux-module.1
+	flux-module.1 \
+	flux-exec.1
 
 ADOC_FILES  = $(MAN1_FILES:%.1=%.adoc)
 XML_FILES   = $(MAN1_FILES:%.1=%.xml)

--- a/doc/cmd/flux-exec.adoc
+++ b/doc/cmd/flux-exec.adoc
@@ -1,0 +1,60 @@
+FLUX-EXEC(1)
+============
+:doctype: manpage
+
+
+NAME
+----
+flux-exec - Execute processes across flux ranks
+
+
+SYNOPSIS
+--------
+*flux* *exec* ['--dir=DIR'] ['--rank=RANKS'] ['--verbose'] COMMANDS...
+
+
+DESCRIPTION
+-----------
+flux-exec(1) runs commands across one or more cmb ranks using the 'cmb.exec'
+service. The commands are direct children of cmbd, and stdio is thus folded
+into the stdout and stderr of cmbd.
+
+flux-exec(1) is meant as an administrative and test utility, and should not
+be used for executing lightweight jobs (LWJs) or user commands.
+
+EXIT STATUS
+-----------
+In the case that all processes are successfully launched, the exit status
+of flux-exec(1) is the largest of the remote process exit codes.
+
+If a non-existent rank is targeted, flux-exec(1) will return with
+code 68 (EX_NOHOST from sysexits.h).
+
+OPTIONS
+-------
+
+*-d, --dir*'=DIR'::
+Set the working directory of remote 'COMMANDS' to 'DIR'. The default is to
+propagate the current working directory of flux-exec(1).
+
+*-r, --rank*'=RANKS'::
+Target specific ranks in 'RANKS'. Default is to target all ranks.
+
+*-v, --verbose*::
+Run with more verbosity.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+

--- a/doc/cmd/spell.en.pws
+++ b/doc/cmd/spell.en.pws
@@ -141,3 +141,5 @@ modctl
 MODPATH
 SHA
 fanout
+NOHOST
+sysexits

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -31,6 +31,7 @@ bin_PROGRAMS = flux
 dist_fluxcmd_SCRIPTS = \
 	flux-screen \
 	flux-wreckrun \
+	flux-exec \
 	flux-topo
 
 fluxcmd_PROGRAMS = \

--- a/src/cmd/flux-exec
+++ b/src/cmd/flux-exec
@@ -1,0 +1,234 @@
+#!/usr/bin/lua
+
+-------------------------------------------------------------------------------
+-- Modules:
+-------------------------------------------------------------------------------
+local flux = require 'flux'
+local posix = require 'flux-lua.posix'
+local timer = require 'flux-lua.timer'
+local hostlist = require 'hostlist'
+
+local prog = string.match (arg[0], "([^/]+)$")
+local shortprog = prog:match ("flux%-(.+)$")
+local verbose = false
+
+
+--
+-- Termination state needs to remain a global for access from
+--  signal handler functions. See setup_signal_handlers() below.
+--
+terminate = false
+
+-------------------------------------------------------------------------------
+-- Local functions:
+-------------------------------------------------------------------------------
+--
+--
+local function setup_signal_handlers()
+    local signal = posix.signal
+    local fn = function() terminate = true end
+    --
+    --  Support both old-style lua-posix signal-as-a-table interface,
+    --   and newer signal-as-a-function api:
+    --
+    if type (signal) == "table" then
+        signal[posix.SIGINT] = fn
+        signal[posix.SIGTERM] = signal[posix.SIGINT]
+        return true
+    end
+
+    signal (posix.SIGINT, fn)
+    signal (posix.SIGTERM, fn)
+    return true
+end
+
+local function say (fmt, ...)
+    if not verbose then return end
+    io.stderr:write (string.format ("%s: "..fmt, shortprog, ...))
+end
+
+local function warn (fmt, ...)
+    io.stderr:write (string.format ("%s: "..fmt, shortprog, ...))
+end
+
+local function die (fmt, ...)
+    io.stderr:write (string.format ("%s: "..fmt, shortprog, ...))
+    os.exit (1)
+end
+
+local function program_state_create (n)
+    local s = {
+        size = n or 1,
+        nexited = 0,
+        nstarted = 0,
+        running = {},
+        status = {},
+        code = {},
+        matchtag = {},
+    }
+    local T = {}
+    function T.size (n)
+        if n then s.size = n end
+        return s.size
+    end
+    function T.matchtag (mt, rank)
+        if rank then
+            s.matchtag [mt] = rank
+            return rank
+        else
+            return s.matchtag [mt]
+        end
+    end
+    function T.exited (resp)
+        s.nexited = s.nexited + 1
+        s.code [resp.rank] = resp.code
+        s.status [resp.rank] = resp.status
+    end
+    function T.started (rank, pid)
+        s.nstarted = s.nstarted + 1
+        s.running [rank] = pid
+    end
+    function T.failed (rank, errnum)
+        s.nstarted = s.nstarted + 1
+        s.nexited = s.nexited + 1
+        s.code [rank] = 68 -- EX_NOHOST
+        s.status [rank] = 68
+    end
+    function T.complete ()
+        if s.nexited == s.size then return true end
+        return false
+    end
+    function T.status (rank)
+        if rank then return s.status [rank] end
+        local rv = 0
+        for k,v in pairs (s.status) do
+            if v > rv then rv = v end
+        end
+        return rv
+    end
+    function T.exit_code (rank)
+        if rank then return s.code [rank] end
+        local rv = 0
+        for k,v in pairs (s.code) do
+            if v > rv then rv = v end
+        end
+        return rv
+    end
+    return T
+end
+
+local function get_ranklist (f, r)
+    if not r then r = '0-'..f.size-1 end
+    return hostlist.new ('['..r..']')
+end
+
+-------------------------------------------------------------------------------
+-- Main program:
+-------------------------------------------------------------------------------
+--  Parse cmdline args:
+--
+local getopt = require 'flux-lua.alt_getopt' .get_opts
+local opts, optind = getopt (arg, "d:r:v",
+                        { rank = "r", verbose = "v", dir = "d" })
+
+if opts.v then verbose = true end
+if not arg[optind] then die ("Command to run required\n") end
+local cmdline = {}
+for i = optind, #arg do
+    table.insert (cmdline, arg[i])
+end
+
+local sigtimer
+
+-- Set signal handlers
+setup_signal_handlers()
+
+-- Start in-program timer:
+local tt = timer.new()
+local t = timer.new()
+
+--  Create new connection to local cmbd:
+--
+local f, err = flux.new()
+if not f then die ("Connecting to flux failed: %s\n", err) end
+
+local ranks = get_ranklist (f, opts.r)
+local state = program_state_create (#ranks)
+
+--  Set up msghandler for exec responses
+--
+local mh, err = f:msghandler {
+    pattern = "*.exec",
+    msgtypes = { flux.MSGTYPE_RESPONSE },
+
+    handler = function (f, zmsg, mh)
+        if zmsg.errnum ~= 0 then
+            local rank = state.matchtag (zmsg.matchtag)
+            warn ("Error: rank %d: %s\n", rank, posix.errno (zmsg.errnum))
+            state.failed (rank, zmsg.errnum)
+            if state.complete() then
+                f:reactor_stop ()
+            end
+            return
+        end
+
+        local resp = zmsg.data
+        --say ("%03fms: rank %d %s\n", t:get0() * 1000, resp.rank or -1, resp.state or "error")
+        if resp.state == "Running" then
+            state.started (resp.rank, resp.pid)
+        elseif resp.state == "Exited" then
+            state.exited (resp)
+            if state.complete() then
+                f:reactor_stop ()
+            end
+        end
+    end
+
+}
+
+
+--  Begin reactor loop:
+--
+local sigtimer = nil
+
+t:set()
+say ("%03fms: Starting %s on %s\n", t:get0() * 1000, cmdline[1], tostring(ranks))
+
+local env = posix.getenv()
+
+local cwd = opts.d or posix.getcwd()
+
+local msg = {
+    cmdline = cmdline,
+    env = env,
+    cwd = cwd
+}
+
+for i in ranks:next() do
+    local matchtag, err = f:send ("cmb.exec", msg, i )
+    if not matchtag then error (err) end
+    state.matchtag (matchtag, i)
+end
+say ("%03fms: Sent all requests\n", t:get0() * 1000)
+
+repeat
+    local r = f:reactor()
+    if not terminate then break end
+    --
+    --  If we catch a signal then lwj:watch() will be interrupted.
+    --   Check to see if we should terminate the job now:
+    --
+    if not sigtimer then
+        sigtimer = timer.new()
+        sigtimer:get()
+    elseif sigtimer:get() < 1.0 then
+        say ("Detaching from job. Processes may still be running\n");
+        os.exit (0);
+    end
+    terminate = false
+until false
+
+say ("%03fms: %d tasks complete with code %d\n", t:get0() * 1000, state.size(), state.exit_code())
+os.exit (state.exit_code())
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -46,7 +46,8 @@ libutil_la_SOURCES = \
 EXTRA_DIST = veb_mach.c
 
 TESTS = test_nodeset.t \
-	test_optparse.t
+	test_optparse.t \
+	test_subprocess.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -61,7 +62,8 @@ test_cppflags = \
 
 check_PROGRAMS = \
 	test_nodeset.t \
-	test_optparse.t
+	test_optparse.t \
+	test_subprocess.t
 
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
@@ -74,3 +76,7 @@ test_nodeset_t_LDADD = $(test_ldadd)
 test_optparse_t_SOURCES = optparse.c
 test_optparse_t_CPPFLAGS = $(test_cppflags)
 test_optparse_t_LDADD = $(test_ldadd)
+
+test_subprocess_t_SOURCES = test/subprocess.c
+test_subprocess_t_CPPFLAGS = $(test_cppflags)
+test_subprocess_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -39,7 +39,9 @@ libutil_la_SOURCES = \
 	nodeset.h \
 	shortjson.h \
 	readall.c \
-	readall.h
+	readall.h \
+	subprocess.c \
+	subprocess.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/subprocess.c
+++ b/src/common/libutil/subprocess.c
@@ -1,0 +1,597 @@
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <sys/types.h>
+#include <sys/socket.h> /* socketpair(2) */
+#include <sys/wait.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <czmq.h>
+#include <argz.h>
+#include <envz.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/subprocess.h"
+
+struct subprocess_manager {
+    zlist_t *processes;
+    int wait_flags;
+};
+
+struct subprocess {
+    struct subprocess_manager *sm;
+    void *ctx;
+
+    pid_t pid;
+
+    /* socketpair for synchronization */
+    int parentfd;
+    int childfd;
+
+    char *cwd;
+
+    size_t argz_len;
+    char *argz;
+
+    size_t envz_len;
+    char *envz;
+
+    int status;
+    int exec_error;
+
+    unsigned short started:1;
+    unsigned short execed:1;
+    unsigned short running:1;
+    unsigned short exited:1;
+
+    subprocess_cb_f *exit_cb;
+    void *arg;
+};
+
+static int sigmask_unblock_all (void)
+{
+    sigset_t mask;
+    sigemptyset (&mask);
+    return sigprocmask (SIG_SETMASK, &mask, NULL);
+}
+
+
+struct subprocess * subprocess_create (struct subprocess_manager *sm)
+{
+    int fds[2];
+    struct subprocess *p = xzmalloc (sizeof (*p));
+
+    p->sm = sm;
+
+    p->pid = (pid_t) -1;
+
+    if (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, fds) < 0) {
+        msg ("socketpair: %m");
+        free (p);
+        return (NULL);
+    }
+    p->childfd = fds[0];
+    p->parentfd = fds[1];
+
+    p->started = 0;
+    p->running = 0;
+    p->exited = 0;
+
+    zlist_append (sm->processes, (void *)p);
+
+    return (p);
+}
+
+void subprocess_destroy (struct subprocess *p)
+{
+    if (p->sm)
+        zlist_remove (p->sm->processes, (void *) p);
+
+    p->sm = NULL;
+    free (p->argz);
+    p->argz = NULL;
+    p->argz_len = 0;
+    free (p->envz);
+    p->envz = NULL;
+    p->envz_len = 0;
+
+    free (p);
+}
+
+int
+subprocess_set_callback (struct subprocess *p, subprocess_cb_f fn, void *arg)
+{
+    p->exit_cb = fn;
+    p->arg = arg;
+    return (0);
+}
+
+void
+subprocess_set_context (struct subprocess *p, void *ctx)
+{
+    p->ctx = ctx;
+}
+
+void *
+subprocess_get_context (struct subprocess *p)
+{
+    return (p->ctx);
+}
+
+static int init_argz (char **argzp, size_t *argz_lenp, char * const av[])
+{
+    if (*argzp != NULL) {
+        free (*argzp);
+        *argz_lenp = 0;
+    }
+
+    if (av && argz_create (av, argzp, argz_lenp) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return (0);
+}
+
+int subprocess_set_args (struct subprocess *p, int argc, char **argv)
+{
+    if (p->started || (argv [argc] != NULL)) {
+        errno = EINVAL;
+        return (-1);
+    }
+    return (init_argz (&p->argz, &p->argz_len, argv));
+}
+
+const char * subprocess_get_arg (struct subprocess *p, int n)
+{
+    int i;
+    char *entry = NULL;
+
+    if (n > subprocess_get_argc (p))
+        return (NULL);
+
+    for (i = 0; i <= n; i++)
+        entry = argz_next (p->argz, p->argz_len, entry);
+
+    return (entry);
+}
+
+int subprocess_get_argc (struct subprocess *p)
+{
+    return (argz_count (p->argz, p->argz_len));
+}
+
+int subprocess_set_cwd (struct subprocess *p, const char *cwd)
+{
+    if (p->started) {
+        errno = EINVAL;
+        return (-1);
+    }
+    if (p->cwd)
+        free (p->cwd);
+    p->cwd = strdup (cwd);
+    return (0);
+}
+
+const char *subprocess_get_cwd (struct subprocess *p)
+{
+    return (p->cwd);
+}
+
+int subprocess_set_environ (struct subprocess *p, char **env)
+{
+    return (init_argz (&p->envz, &p->envz_len, env));
+}
+
+int subprocess_argv_append (struct subprocess *p, const char *s)
+{
+    if (p->started) {
+        errno = EINVAL;
+        return (-1);
+    }
+
+    if (argz_add (&p->argz, &p->argz_len, s) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return (0);
+}
+
+int subprocess_set_command (struct subprocess *p, const char *cmd)
+{
+    if (p->started) {
+        errno = EINVAL;
+        return (-1);
+    }
+    init_argz (&p->argz, &p->argz_len, NULL);
+
+    if (argz_add (&p->argz, &p->argz_len, "sh") < 0
+        || argz_add (&p->argz, &p->argz_len, "-c") < 0
+        || argz_add (&p->argz, &p->argz_len, cmd) < 0) {
+        errno = ENOMEM;
+        return (-1);
+    }
+    return (0);
+}
+
+int subprocess_setenv (struct subprocess *p,
+    const char *k, const char *v, int overwrite)
+{
+    if (p->started) {
+        errno = EINVAL;
+        return (-1);
+    }
+    if (!overwrite && envz_entry (p->envz, p->envz_len, k)) {
+        errno = EEXIST;
+        return -1;
+    }
+    if (envz_add (&p->envz, &p->envz_len, k, v) < 0) {
+        errno = ENOMEM;
+        return (-1);
+    }
+    return (0);
+}
+
+int subprocess_setenvf (struct subprocess *p,
+    const char *k, int overwrite, const char *fmt, ...)
+{
+    va_list ap;
+    char *val;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = vasprintf (&val, fmt, ap);
+    va_end (ap);
+    if (rc < 0)
+        return (rc);
+
+    rc = subprocess_setenv (p, k, val, overwrite);
+    free (val);
+    return (rc);
+}
+
+int subprocess_unsetenv (struct subprocess *p, const char *name)
+{
+    if (p->started) {
+        errno = EINVAL;
+        return (-1);
+    }
+    envz_remove (&p->envz, &p->envz_len, name);
+    return (0);
+}
+
+char * subprocess_getenv (struct subprocess *p, const char *name)
+{
+    return (envz_get (p->envz, p->envz_len, name));
+}
+
+static char **expand_argz (char *argz, size_t argz_len)
+{
+    size_t len;
+    char **argv;
+
+    len = argz_count (argz, argz_len) + 1;
+    argv = xzmalloc (len * sizeof (char *));
+
+    argz_extract (argz, argz_len, argv);
+
+    return (argv);
+}
+
+char **subprocess_argv_expand (struct subprocess *p)
+{
+    return (expand_argz (p->argz, p->argz_len));
+}
+
+char **subprocess_env_expand (struct subprocess *p)
+{
+    envz_strip (&p->envz, &p->envz_len);
+    return (expand_argz (p->envz, p->envz_len));
+}
+
+static int sp_barrier_read_error (int fd)
+{
+    int e;
+    ssize_t n = read (fd, &e, sizeof (int));
+    if (n < 0) {
+        err ("sp_read_error: read: %m");
+        return (-1);
+    }
+    else if (n == sizeof (int)) {
+        /* exec failure */
+        return (e);
+    }
+    return (0);
+}
+
+static int sp_barrier_signal (int fd)
+{
+    char c = 0;
+    if (write (fd, &c, sizeof (c)) != 1) {
+        err ("sp_barrier_signal: write: %m");
+        return (-1);
+    }
+    return (0);
+}
+
+static int sp_barrier_wait (int fd)
+{
+    char c;
+    if (read (fd, &c, sizeof (c)) != 1) {
+        err ("sp_barrier_wait: read: %m");
+        return (-1);
+    }
+    return (0);
+}
+
+static void sp_barrier_write_error (int fd, int e)
+{
+    if (write (fd, &e, sizeof (int)) != sizeof (int)) {
+        err ("sp_barrier_error: write: %m");
+    }
+}
+
+static void subprocess_child (struct subprocess *p)
+{
+    char **argv;
+
+    sigmask_unblock_all ();
+
+    close (p->parentfd);
+    p->parentfd = -1;
+
+    if (p->cwd && chdir (p->cwd) < 0) {
+        err ("Couldn't change dir to %s: going to /tmp instead", p->cwd);
+        if (chdir ("/tmp") < 0)
+            exit (1);
+    }
+
+    /*
+     *  Send ready signal to parent
+     */
+    sp_barrier_signal (p->childfd);
+
+    /*
+     *  Wait for ready signal from parent
+     */
+    sp_barrier_wait (p->childfd);
+
+    environ = subprocess_env_expand (p);
+    argv = subprocess_argv_expand (p);
+    execvp (argv[0], argv);
+    sp_barrier_write_error (p->childfd, errno);
+    exit (127);
+}
+
+int subprocess_exec (struct subprocess *p)
+{
+    if (sp_barrier_signal (p->parentfd) < 0)
+        return (-1);
+
+    if ((p->exec_error = sp_barrier_read_error (p->parentfd)) != 0) {
+        /*  reap child */
+        subprocess_reap (p);
+        errno = p->exec_error;
+        return (-1);
+    }
+
+    p->running = 1;
+
+    /* No longer need parentfd socket */
+    close (p->parentfd);
+    p->parentfd = -1;
+    return (0);
+}
+
+int subprocess_fork (struct subprocess *p)
+{
+    if (p->argz_len <= 0 || p->argz == NULL || p->started) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if ((p->pid = fork ()) < 0)
+        return (-1);
+
+    if (p->pid == 0)
+        subprocess_child (p); /* No return */
+
+    close (p->childfd);
+    p->childfd = -1;
+
+    sp_barrier_wait (p->parentfd);
+    p->started = 1;
+    return (0);
+}
+
+int subprocess_run (struct subprocess *p)
+{
+    if (subprocess_fork (p) < 0)
+        return (-1);
+    return subprocess_exec (p);
+}
+
+int subprocess_kill (struct subprocess *p, int sig)
+{
+    if (p->pid < (pid_t) 0)
+        return (-1);
+    return (kill (p->pid, sig));
+}
+
+pid_t subprocess_pid (struct subprocess *p)
+{
+    return (p->pid);
+}
+
+int subprocess_exit_status (struct subprocess *p)
+{
+    return (p->status);
+}
+
+int subprocess_exited (struct subprocess *p)
+{
+    return (p->exited);
+}
+
+int subprocess_exit_code (struct subprocess *p)
+{
+    if (WIFEXITED (p->status))
+        return (WEXITSTATUS (p->status));
+    return (-1);
+}
+
+int subprocess_signaled (struct subprocess *p)
+{
+    if (WIFSIGNALED (p->status))
+        return (WTERMSIG (p->status));
+    return (0);
+}
+
+const char * subprocess_state_string (struct subprocess *p)
+{
+    if (!p->started)
+        return ("Pending");
+    if (p->exec_error)
+        return ("Exec Failure");
+    if (!p->running)
+        return ("Waiting");
+    if (!p->exited)
+        return ("Running");
+    return ("Exited");
+}
+
+const char * subprocess_exit_string (struct subprocess *p)
+{
+    if (p->exec_error)
+        return ("Exec Failure");
+
+    if (!p->exited)
+        return ("Process is still running or has not been started");
+
+    if (WIFSIGNALED (p->status)) {
+        int sig = WTERMSIG (p->status);
+        return (strsignal (sig));
+    }
+
+    if (WEXITSTATUS (p->status) != 0)
+        return ("Exited with non-zero status");
+
+    return ("Exited");
+}
+
+struct subprocess_manager * subprocess_manager_create (void)
+{
+    struct subprocess_manager *sm = xzmalloc (sizeof (*sm));
+
+    sm->processes = zlist_new ();
+
+    return (sm);
+}
+
+void subprocess_manager_destroy (struct subprocess_manager *sm)
+{
+    size_t n = zlist_size (sm->processes);
+    assert (n == 0);
+
+    zlist_destroy (&sm->processes);
+    free (sm);
+}
+
+struct subprocess *
+subprocess_manager_find (struct subprocess_manager *sm, pid_t pid)
+{
+    struct subprocess *p = zlist_first (sm->processes);
+    while (p) {
+        if (p->pid == pid)
+            return (p);
+        p = zlist_next (sm->processes);
+    }
+    return (NULL);
+}
+
+struct subprocess *
+subprocess_manager_run (struct subprocess_manager *sm, int ac, char **av,
+    char **env)
+{
+    struct subprocess *p = subprocess_create (sm);
+    if (p == NULL)
+        return (NULL);
+
+    if ((subprocess_set_args (p, ac, av) < 0) ||
+        (env && subprocess_set_environ (p, env) < 0)) {
+        subprocess_destroy (p);
+        return (NULL);
+    }
+
+    if (subprocess_run (p) < 0) {
+        subprocess_destroy (p);
+        return (NULL);
+    }
+
+    return (p);
+}
+
+int subprocess_reap (struct subprocess *p)
+{
+    if (waitpid (p->pid, &p->status, p->sm->wait_flags) == (pid_t) -1)
+        return (-1);
+    p->exited = 1;
+    return (0);
+}
+
+struct subprocess *
+subprocess_manager_wait (struct subprocess_manager *sm)
+{
+    int status;
+    pid_t pid;
+    struct subprocess *p;
+
+    pid = waitpid (-1, &status, sm->wait_flags);
+    if ((pid < 0) || !(p = subprocess_manager_find (sm, pid))) {
+        return (NULL);
+    }
+    p->status = status;
+    p->exited = 1;
+    return (p);
+}
+
+int
+subprocess_manager_reap_all (struct subprocess_manager *sm)
+{
+    struct subprocess *p;
+    while ((p = subprocess_manager_wait (sm))) {
+        if (p->exit_cb) {
+            if ((*p->exit_cb) (p, p->arg) < 0)
+                return (-1);
+            subprocess_destroy (p);
+        }
+    }
+    return (0);
+}
+
+int
+subprocess_manager_set (struct subprocess_manager *sm, sm_item_t item, ...)
+{
+    va_list ap;
+
+    if (!sm)
+        return (-1);
+
+    va_start (ap, item);
+    switch (item) {
+        case SM_WAIT_FLAGS:
+            sm->wait_flags = va_arg (ap, int);
+            break;
+        default:
+            errno = EINVAL;
+            return -1;
+    }
+    va_end (ap);
+    return (0);
+}
+
+
+/*
+ *  vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/subprocess.h
+++ b/src/common/libutil/subprocess.h
@@ -1,0 +1,221 @@
+
+struct subprocess_manager;
+struct subprocess;
+
+typedef enum sm_item {
+    SM_WAIT_FLAGS
+} sm_item_t;
+
+typedef int (subprocess_cb_f) (struct subprocess *p, void *arg);
+
+/*
+ *  Create a subprocess manager to manage creation, destruction, and
+ *   management of subprocess.
+ */
+struct subprocess_manager * subprocess_manager_create (void);
+
+/*
+ *  Set value for item [item] in subprocess manager [sm]
+ */
+int subprocess_manager_set (struct subprocess_manager *sm,
+	sm_item_t item, ...);
+
+/*
+ *  Free memory associated with a subprocess manager object:
+ */
+void subprocess_manager_destroy (struct subprocess_manager *sm);
+
+/*
+ *  Execute a new subprocess with arguments argc,argv, and environment
+ *   env. The child process will have forked, but not necessarily
+ *   executed by the time this function returns.
+ */
+struct subprocess * subprocess_manager_run (struct subprocess_manager *sm,
+	int argc, char *argv[], char **env);
+
+/*
+ *  Wait for any child to exit and return the handle of the exited
+ *   subprocess to caller.
+ */
+struct subprocess * subprocess_manager_wait (struct subprocess_manager *sm);
+
+int subprocess_manager_reap_all (struct subprocess_manager *sm);
+
+/*
+ *  Create a new, empty handle for a subprocess object.
+ */
+struct subprocess * subprocess_create (struct subprocess_manager *sm);
+
+/*
+ *  Set a callback function for subprocess exit
+ */
+int subprocess_set_callback (struct subprocess *p, subprocess_cb_f fn, void *arg);
+
+/*
+ *  Destroy a subprocess. Free memory and remove from subprocess
+ *   manager list.
+ */
+void subprocess_destroy (struct subprocess *p);
+
+/*
+ *  Set an arbitrary context in the subprocess [p].
+ */
+void subprocess_set_context (struct subprocess *p, void *ctx);
+
+/*
+ *  Return the saved context for subprocess [p].
+ */
+void *subprocess_get_context (struct subprocess *p);
+
+/*
+ *  Set argument vector for subprocess [p]. This function is only valid
+ *   before subprocess_run() is called. Any existing args associated with
+ *   subprocess are discarded.
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_set_args (struct subprocess *p, int argc, char *argv[]);
+
+/*
+ *  Identical subprocess_set_args(), subprocess_set_command() is a
+ *   convenience function similar to system(3). That is, it will set
+ *   arguments for subprocess [p] to
+ *
+ *     /bin/sh -c "command"
+ *
+ */
+int subprocess_set_command (struct subprocess *p, const char *command);
+
+
+
+/*
+ *  Append a single argument to the subprocess [p] argument vector.
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_argv_append (struct subprocess *p, const char *arg);
+
+/*
+ *  Get argument at index [n] from current argv array for process [p]
+ *  Returns NULL if n > argc - 1.
+ */
+const char *subprocess_get_arg (struct subprocess *p, int n);
+
+/*
+ *  Return current argument count for subprocess [p].
+ */
+int subprocess_get_argc (struct subprocess *p);
+
+/*
+ *  Set working directory for subprocess [p].
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_set_cwd (struct subprocess *p, const char *cwd);
+
+/*
+ *  Get working directory (if any) for subprocess [p].
+ *   Returns (NULL) if no working directory is set.
+ */
+const char *subprocess_get_cwd (struct subprocess *p);
+
+/*
+ *  Set initial subprocess environment. This function is only valid
+ *   before subprocess_run() is called. Any existing environment array
+ *   associated with this subprocess is discarded.
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_set_environ (struct subprocess *p, char **env);
+
+/*
+ *  Setenv() equivalent with optional overwrite for subprocess [p].
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_setenv (struct subprocess *p,
+	const char *name, const char *val, int overwrite);
+
+/*
+ *   As above but allows formatted args.
+ */
+int subprocess_setenvf (struct subprocess *p,
+	const char *name, int overwrite, const char *fmt, ...);
+
+/*
+ *  Unset [name] in the environment array of subprocess [p].
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_unsetenv (struct subprocess *p, const char *name);
+
+/*
+ *  getenv(3) equivalent for subprocess [p].
+ */
+char *subprocess_getenv (struct subprocess *p, const char *name);
+
+/*
+ *  Send signal [signo] to subprocess [p]
+ */
+int subprocess_kill (struct subprocess *p, int signo);
+
+/*
+ *  Return PID of process [p] if it is started.
+ *   Returns (pid_t) -1 otherwise.
+ */
+pid_t subprocess_pid (struct subprocess *p);
+
+/*
+ *  Wait for and reap the subprocess [p]. After a successful return,
+ *   subprocess_exited (p) will be true, and subprocess_exit* will
+ *   be valid, etc.
+ *  Returns -1 on failure.
+ */
+int subprocess_reap (struct subprocess *p);
+
+/*
+ *  Return 1 if subprocess [p] has exited.
+ */
+int subprocess_exited (struct subprocess *p);
+
+/*
+ *  Return exit status as returned by wait(2) for subprocess [p].
+ */
+int subprocess_exit_status (struct subprocess *p);
+
+/*
+ *  Return exit code for subprocess [p] if !subprocess_signaled()
+ */
+int subprocess_exit_code (struct subprocess *p);
+
+/*
+ *  Return number of the signal that caused process to exit,
+ *   or 0 if process was not killed by a signal.
+ */
+int subprocess_signaled (struct subprocess *p);
+
+/*
+ *  Return string representation of process [p] current state,
+ *   "Pending", "Exec Failure", "Waiting", "Running", "Exited"
+ */
+const char * subprocess_state_string (struct subprocess *p);
+
+/*
+ *  Convenience function returning a state string corresponding to
+ *   process [p] exit status.
+ */
+const char * subprocess_exit_string (struct subprocess *p);
+
+/*
+ *  Fork, but wait to exec(), subprocess [p].
+ *   Returns -1 and EINVAL if subprocess argv is not initialized.
+ *           -1 and errno on fork() failure.
+ */
+int subprocess_fork (struct subprocess *p);
+
+/*
+ *   Unblock subprocess [p] and allow it to call exec.
+ *    Returns -1 and EINVAL if subprocess is not in state 'started'.
+ *            -1 and error if exec failed.
+ */
+int subprocess_exec (struct subprocess *p);
+
+/*
+ *  Same as calling subprocess_fork() + subprocess_exec()
+ */
+int subprocess_run (struct subprocess *p);
+

--- a/src/common/libutil/test/subprocess.c
+++ b/src/common/libutil/test/subprocess.c
@@ -1,0 +1,223 @@
+
+#include <errno.h>
+#include <string.h>
+#include "src/common/libtap/tap.h"
+
+#include "src/common/libutil/subprocess.h"
+
+extern char **environ;
+
+static void *myfatal_h = NULL;
+void myfatal (void *h, int exit_code, const char *fmt, ...)
+{
+    myfatal_h = h;
+}
+
+int main (int ac, char **av)
+{
+    int rc;
+    struct subprocess_manager *sm;
+    struct subprocess *p, *q;
+    const char *s;
+    char *args[] = { "hello", NULL };
+    char *args2[] = { "goodbye", NULL };
+    char *args3[] = { "/bin/true", NULL };
+    char *args4[] = { "/bin/sleep", "10", NULL };
+
+    plan (NO_PLAN);
+
+    if (!(sm = subprocess_manager_create ()))
+        BAIL_OUT ("Failed to create subprocess manager");
+    ok (sm != NULL, "create subprocess manager");
+
+    if (!(p = subprocess_create (sm)))
+        BAIL_OUT ("Failed to create subprocess handle");
+    ok (p != NULL, "create subprocess handle");
+
+    rc = subprocess_set_args (p, 1, args);
+    ok (rc >= 0, "subprocess_set_args: %s", strerror (errno));
+
+    ok (subprocess_get_argc (p) == 1, "subprocess argc is 1");
+
+    s = subprocess_get_arg (p, 0);
+    is (s, "hello", "subprocess argv[0] is 'hello'");
+
+    rc = subprocess_argv_append (p, "foo");
+    ok (rc >= 0, "subprocess_arg_append");
+    ok (subprocess_get_argc (p) == 2, "subprocess argc is now 2");
+
+    s = subprocess_get_arg (p, 2);
+    ok (s == NULL, "subprocess_get_arg() out of bounds returns NULL");
+
+    rc = subprocess_set_args (p, 1, args2);
+    ok (rc >= 0, "set_args replaces existing");
+
+    s = subprocess_get_arg (p, 0);
+    is (s, "goodbye", "subprocess argv[0] is 'goodbye'");
+
+    rc = subprocess_setenv (p, "FOO", "bar", 1);
+    ok (rc >= 0, "subprocess_setenv");
+
+    s = subprocess_getenv (p, "FOO");
+    is (s, "bar", "subprocess_getenv works");
+
+    rc = subprocess_setenv (p, "FOO", "bar2", 0);
+    ok (rc == -1, "subprocess_setenv without overwrite fails for existing var");
+    ok (errno == EEXIST, "and with appropriate errno");
+
+    s = subprocess_getenv (p, "FOO");
+    is (s, "bar", "subproces_getenv still shows correct variable");
+
+    subprocess_unsetenv (p, "FOO");
+    s = subprocess_getenv (p, "FOO");
+    ok (s == NULL, "subproces_getenv fails for unset variable");
+
+    rc = subprocess_setenvf (p, "FOO", 1, "%d", 42);
+    ok (rc >= 0, "subprocess_setenvf");
+
+    s = subprocess_getenv (p, "FOO");
+    is (s, "42", "subprocess_getenv works after setenvf");
+
+    is (subprocess_state_string (p), "Pending",
+        "Unstarted process has state 'Pending'");
+
+    subprocess_destroy (p);
+
+    /* Test running an executable */
+    p = subprocess_manager_run (sm, 1, args3, NULL);
+    ok (p != NULL, "subprocess_manager_run");
+    ok (subprocess_pid (p) != (pid_t) -1, "process has valid pid");
+
+    q = subprocess_manager_wait (sm);
+    ok (p == q, "subprocess_manager_wait returns correct process");
+
+    ok (subprocess_exited (p), "subprocess has exited after wait returns");
+    is (subprocess_state_string (p), "Exited", "State is now 'Exited'");
+    ok (subprocess_exit_code (p) == 0, "With expected exit code");
+    subprocess_destroy (p);
+    q = NULL;
+
+    /*  Test failing program */
+    args3[0] = "/bin/false";
+    p = subprocess_manager_run (sm, 1, args3, NULL);
+    if (p) {
+        ok (p != NULL, "subprocess_manager_run");
+        ok (subprocess_pid (p) != (pid_t) -1, "process has valid pid");
+        q = subprocess_manager_wait (sm);
+        ok (p == q, "subprocess_manager_wait returns correct process");
+        is (subprocess_state_string (p), "Exited", "State is now 'Exited'");
+        is (subprocess_exit_string (p), "Exited with non-zero status",
+                "State is now 'Exited with non-zero status'");
+        ok (subprocess_exit_code (p) == 1, "Exit code is 1.");
+        subprocess_destroy (p);
+        q = NULL;
+    }
+
+
+    /* Test signaled program */
+    p = subprocess_manager_run (sm, 2, args4, NULL);
+    ok (p != NULL, "subprocess_manager_run: %s", strerror (errno));
+    if (p) {
+        ok (subprocess_pid (p) != (pid_t) -1, "process has valid pid");
+
+        ok (subprocess_kill (p, SIGKILL) >= 0, "subprocess_kill");
+
+        q = subprocess_manager_wait (sm);
+        ok (p == q, "subprocess_manager_wait returns correct process");
+        is (subprocess_state_string (p), "Exited", "State is now 'Exited'");
+        is (subprocess_exit_string (p), "Killed", "Exit string is 'Killed'");
+        ok (subprocess_signaled (p) == 9, "Killed by signal 9.");
+        subprocess_destroy (p);
+    }
+
+    q = NULL;
+
+    /* Test separate fork/exec interface */
+    p = subprocess_create (sm);
+    ok (p != NULL, "subprocess_create works");
+    ok (subprocess_pid (p) == (pid_t) -1, "Initial pid value is -1");
+    ok (subprocess_fork (p) == -1, "fork on unitialized subprocess should fail");
+    ok (subprocess_kill (p, 1) == -1, "kill on unitialized subprocess should fail");
+    is (subprocess_state_string (p), "Pending",
+        "initial subprocess state is 'Pending'");
+
+    ok (subprocess_argv_append (p, "true") >= 0, "set argv");
+    ok (subprocess_setenv (p, "PATH", getenv ("PATH"), 1) >= 0, "set dnv");
+
+    ok (subprocess_fork (p) == 0, "subprocess_fork");
+    is (subprocess_state_string (p), "Waiting", "subprocess is Waiting");
+    ok (subprocess_pid (p) > 0, "subprocess_pid() is valid");
+
+    ok (subprocess_exec (p) == 0, "subprocess_run");
+    is (subprocess_state_string (p), "Running", "subprocess is Running");
+    q = subprocess_manager_wait (sm);
+    ok (q != NULL, "subprocess_manager_wait");
+    ok (q == p, "got correct child after wait");
+
+    ok (subprocess_exit_code (p) == 0, "Child exited normally");
+
+    subprocess_destroy (p);
+    q = NULL;
+
+    /* Test exec failure */
+    p = subprocess_create (sm);
+    ok (p != NULL, "subprocess create");
+    ok (subprocess_argv_append (p, "/unlikely/program") >= 0, "set argv");
+    ok (subprocess_setenv (p, "PATH", getenv ("PATH"), 1) >= 0, "setnv");
+
+    ok (subprocess_fork (p) == 0, "subprocess_fork");
+    rc = subprocess_exec (p);
+    ok (rc < 0, "subprocess_exec should fail");
+    ok (errno == ENOENT, "errno should be ENOENT");
+    is (subprocess_state_string (p), "Exec Failure", "State is Exec Failed");
+    is (subprocess_exit_string (p), "Exec Failure", "Exit state is Exec Failed");
+    subprocess_destroy (p);
+
+    /* Test set working directory */
+    p = subprocess_create (sm);
+    ok (p != NULL, "subprocess create");
+    ok (subprocess_get_cwd (p) == NULL, "CWD is not set");
+    ok (subprocess_set_cwd (p, "/tmp") >= 0, "Set CWD to /tmp");
+    is (subprocess_get_cwd (p), "/tmp", "CWD is now /tmp");
+    ok (subprocess_setenv (p, "PATH", getenv ("PATH"), 1) >= 0, "set PATH");
+    ok (subprocess_set_command (p, "test `pwd` = '/tmp'" ) >= 0, "Set args");
+    ok (subprocess_run (p) >= 0, "subprocess_run");
+    is (subprocess_state_string (p), "Running", "subprocess now running");
+    q = subprocess_manager_wait (sm);
+    ok (q != NULL, "subprocess_manager_wait: %s", strerror (errno));
+    ok (q == p, "subprocess_manager_wait() got expected subprocess");
+    ok (subprocess_exited (p), "subprocess exited");
+    ok (!subprocess_signaled (p), "subprocess didn't die from signal");
+    ok (subprocess_exit_code (p) == 0, "subprocess successfully run in /tmp");
+    subprocess_destroy (p);
+
+    /* Test subprocess_reap */
+    p = subprocess_create (sm);
+    q = subprocess_create (sm);
+
+    ok (subprocess_argv_append (p, "/bin/true") >= 0,
+        "set argv for first subprocess");
+    ok (subprocess_argv_append (q, "/bin/true") >= 0,
+        "set argv for second subprocess");
+    ok (subprocess_run (p) >= 0, "run process 1");
+    ok (subprocess_run (q) >= 0, "run process 2");
+
+    ok (subprocess_reap (q) >= 0, "reap process 2");
+    ok (subprocess_exited (q), "process 2 is now exited");
+    ok (subprocess_exit_code (q) == 0, "process 2 exited with code 0");
+
+    ok (subprocess_reap (p) >= 0, "reap process 1");
+    ok (subprocess_exited (p), "process 1 is now exited");
+    ok (subprocess_exit_code (p) == 0, "process 1 exited with code 0");
+
+    subprocess_destroy (p);
+    subprocess_destroy (q);
+
+    subprocess_manager_destroy (sm);
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -7,6 +7,7 @@ TESTS = \
 	t0001-basic.t \
 	t0002-request.t \
 	t0003-module.t \
+	t0005-exec.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1002-modctl.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -66,6 +66,20 @@ test_under_flux() {
       exec flux start --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
+#
+#  Execute arguments $2-N on rank or ranks specified in arg $1
+#   using the flux-exec utility
+#
+test_on_rank() {
+    test "$#" -ge 2 ||
+        error "test_on_rank expects at least two parameters"
+    test -n "$TEST_UNDER_FLUX_ACTIVE"  ||
+        error "test_on_rank: test_under_flux not active ($TEST_UNDER_FLUX_ACTIVE)"
+
+    ranks=$1; shift;
+    flux exec --rank=${ranks} "$@"
+}
+
 
 #
 #  Export some extra variables to test scripts specific to Flux

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -47,7 +47,6 @@ run_timeout() {
 test_under_flux() {
     size=${1:-1}
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
-        unset TEST_UNDER_FLUX_ACTIVE
         return
     fi
     quiet="-o -q"

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -38,8 +38,10 @@ test_expect_success 'test_on_rank works with test_must_fail' '
 
 test_expect_success 'flux exec passes environment variables' '
 	test_must_fail flux exec -r 0 sh -c "test \"\$FOOTEST\" = \"t\"" &&
-	FOOTEST=t flux exec -r 0 sh -c "test \"\$FOOTEST\" = \"t\"" &&
-	FOOTEST=t test_on_rank 0 sh -c "test \"\$FOOTEST\" = \"t\""
+	FOOTEST=t &&
+	export FOOTEST &&
+	flux exec -r 0 sh -c "test \"\$FOOTEST\" = \"t\"" &&
+	test_on_rank 0 sh -c "test \"\$FOOTEST\" = \"t\""
 '
 
 test_expect_success 'flux exec does not pass FLUX_TMPDIR' '

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+
+test_description='Test CMB exec functionality, used by later tests
+
+
+Test exec functionality
+'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+test_under_flux ${SIZE}
+
+test_expect_success 'basic exec functionality' '
+	flux exec /bin/true
+'
+
+test_expect_success 'exec to specific rank' '
+	flux exec -r 0 /bin/true
+'
+
+test_expect_success 'exec to non-existent rank is an error' '
+	test_must_fail flux exec -r 9999 /bin/true
+'
+
+test_expect_success 'test_on_rank works' '
+	test_on_rank 1 /bin/true
+'
+
+test_expect_success 'test_on_rank sends to correct rank' '
+	flux comms info | grep rank=0 && 
+	test_on_rank 1 sh -c "flux comms info | grep -q rank=1"
+'
+
+test_expect_success 'test_on_rank works with test_must_fail' '
+	test_must_fail test_on_rank 1 sh -c "flux comms info | grep -q rank=0"
+'
+
+test_expect_success 'flux exec passes environment variables' '
+	test_must_fail flux exec -r 0 sh -c "test \"\$FOOTEST\" = \"t\"" &&
+	FOOTEST=t flux exec -r 0 sh -c "test \"\$FOOTEST\" = \"t\"" &&
+	FOOTEST=t test_on_rank 0 sh -c "test \"\$FOOTEST\" = \"t\""
+'
+
+test_expect_success 'flux exec does not pass FLUX_TMPDIR' '
+        # Ensure FLUX_TMPDIR for rank 1 doesn not equal FLUX_TMPDIR for 0
+	flux exec -r 1 sh -c "test \"\$FLUX_TMPDIR\" != \"$FLUX_TMPDIR\""
+'
+
+test_expect_success 'flux exec passes cwd' '
+	(cd /tmp &&
+	flux exec sh -c "test \`pwd\` = \"/tmp\"")
+'
+
+test_expect_success 'flux exec -d option works' '
+	flux exec -d /tmp sh -c "test \`pwd\` = \"/tmp\""
+'
+
+# Run a script on ranks 0-3 simultaneously with each rank writing the
+#  rank id to a file. After successful completion, the contents of the files
+#  are verfied to ensure each rank connected to the right cmbd.
+test_expect_success 'test_on_rank works on multiple ranks' '
+	ouput_dir=$(pwd) &&
+	rm -f rank_output.* &&
+	cat >multiple_rank_test <<EOF &&
+rank=\`flux comms info | grep rank | sed s/rank=//\`
+echo \$rank > $(pwd)/rank_output.\${rank}
+exit 0
+EOF
+	test_on_rank 0-3 sh $(pwd)/multiple_rank_test &&
+	test `cat rank_output.0`  = "0" &&
+	test `cat rank_output.1`  = "1" &&
+	test `cat rank_output.2`  = "2" &&
+	test `cat rank_output.3`  = "3"
+'
+
+
+
+test_done

--- a/t/t1001-barrier-basic.t
+++ b/t/t1001-barrier-basic.t
@@ -9,10 +9,15 @@ before other tests that depend on barriers.
 '
 
 . `dirname $0`/sharness.sh
-test_under_flux 4
+SIZE=4
+test_under_flux ${SIZE}
 
 test_expect_success 'barrier: returns when complete' '
 	${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs 1 abc
+'
+
+test_expect_success 'barrier: returns when complete (all ranks)' '
+	flux exec ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs ${SIZE} abc
 '
 
 test_expect_success 'barrier: blocks while incomplete' '
@@ -30,13 +35,13 @@ test_expect_success 'barrier: fails with name=NULL outside of LWJ' '
 test_expect_success 'barrier: succeeds with name=NULL inside LWJ' '
 	unset SLURM_STEPID
         FLUX_LWJ_ID=1; export FLUX_LWJ_ID
-	${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs 1
+	flux exec ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs ${SIZE}
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside SLURM step' '
 	unset FLUX_LWJ_ID
         SLURM_STEPID=1; export SLURM_STEPID
-	${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs 1
+	flux exec ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs ${SIZE}
 '
 
 test_done


### PR DESCRIPTION
Ok, trying again:

This PR adds a very simple remote execution service directly to `cmbd` as a `cmb.exec` service.
Subprocess management function are encapsulated into a new `subprocess_manager` API under `common/libutil` in the hopes this code can be reused by other remote and local execution services.

A `subprocess manager` instance is added to `cmbd` and is used to replaced the hand-coded fork/exec for the cmbd interactive shell, and subsequently the `cmb.exec` service is built using this same `subprocess manager` instance.

A new `flux-exec` utility is added to "execute" processes across a session as direct children of `cmbd` or individual ranks may be targeted. By default, `flux-exec` copies the current environment minus `FLUX_TMPDIR` and uses the current working directory, but these are adjustable via command line arguments.

The purpose of the simple `flux-exec` service is to expand testing to multiple ranks, and in this PR this is enabled via a `run_on_rank` function added to the `sharness` testsuite, as well as by the use of `flux-exec` directly. As a demonstration, multi-rank barrier tests are added.
