### PR TITLE
workaround for subprocess unit test failures under test driver

### DIFF
--- a/src/common/libutil/subprocess.c
+++ b/src/common/libutil/subprocess.c
@@ -360,6 +360,13 @@ static void subprocess_child (struct subprocess *p)
     environ = subprocess_env_expand (p);
     argv = subprocess_argv_expand (p);
     execvp (argv[0], argv);
+    /*
+     * XXX: close stdout and stderr here to avoid flushing buffers at exit.
+     *  This can cause duplicate output if parent was running in fully
+     *  bufferred mode, and there was buffered output.
+     */
+    close (STDOUT_FILENO);
+    close (STDERR_FILENO);
     sp_barrier_write_error (p->childfd, errno);
     exit (127);
 }


### PR DESCRIPTION
When a process using the subprocess_manager code is running
with fully buffered output, a child which fails during exec(2)
may flush the parent's buffers on the subsequent call to exit(127).

This is only a problem when child shares parent stdio streams,
and will be fixed when the subprocess code properly redirects
child fds to pipes or other destinations. For now, we close
stdout and stdin before exit() to avoid this issue.

This issue was causing failures in subprocess unit tests when run
under test drivers like `tap-driver.sh` or `prove(1)` (because lack of
a terminal caused unbuffered output to be used)
