### PR TITLE
Small build/test fixes and lua binding support for kvs_unwatch

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1029,6 +1029,12 @@ static int l_kvswatcher_add (lua_State *L)
     kw = l_flux_ref_create (L, f, 2, "kvswatcher");
     kvs_watch (f, key, l_kvswatcher, (void *) kw);
 
+    /*
+     *  Return kvswatcher object to caller
+     */
+    l_flux_ref_gettable (kw, "kvswatcher");
+    lua_getfield (L, -1, "userdata");
+    assert (lua_isuserdata (L, -1));
     return (1);
 }
 

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -998,10 +998,16 @@ static int l_kvswatcher (const char *key, json_object *val, void *arg, int errnu
 
 static int l_kvswatcher_remove (lua_State *L)
 {
-    /* No support for removing kvs watchers */
-    lua_pushnil (L);
-    lua_pushliteral (L, "Not implemented");
-    return (2);
+    struct l_flux_ref *kw = luaL_checkudata (L, 1, "FLUX.kvswatcher");
+    l_flux_ref_gettable (kw, "kvswatcher");
+    lua_getfield (L, -1, "key");
+    if (kvs_unwatch (kw->flux, lua_tostring (L, -1)) < 0)
+        return (lua_pusherror (L, "kvs_unwatch: %s", strerror (errno)));
+    /*
+     *  Destroy reftable and allow garbage collection
+     */
+    l_flux_ref_destroy (kw, "kvswatcher");
+    return (1);
 }
 
 static int l_kvswatcher_add (lua_State *L)

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = libtap liblsd libutil libflux libzio libmrpc libev
+SUBDIRS = libtap libev liblsd libutil libflux libzio libmrpc

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -73,6 +73,11 @@ test_conf_t_LDADD = $(test_ldadd)
 test_module_t_SOURCES = test/module.c
 test_module_t_CPPFLAGS = $(test_cppflags)
 test_module_t_LDADD = $(test_ldadd) $(LIBDL)
+test_module_t_DEPENDENCIES = $(top_builddir)/src/modules/kvs/kvs.la
+
+$(test_module_t_DEPENDENCIES):
+	@cd `dirname $@` && $(MAKE)
+
 
 test_message_t_SOURCES = test/message.c
 test_message_t_CPPFLAGS = $(test_cppflags)
@@ -81,3 +86,4 @@ test_message_t_LDADD = $(test_ldadd) $(LIBDL)
 test_tagpool_t_SOURCES = test/tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
+

--- a/src/common/libzio/Makefile.am
+++ b/src/common/libzio/Makefile.am
@@ -19,12 +19,18 @@ check_PROGRAMS = \
 	zio-test \
 	flux-zio-test
 
-LDADD = $(top_builddir)/src/common/libzio/libzio.la \
+libzio_deps = \
+	$(top_builddir)/src/common/libzio/libzio.la \
 	$(top_builddir)/src/modules/kvs/libkvs.la \
 	$(top_builddir)/src/modules/api/libapi.la \
 	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
-	$(top_builddir)/src/common/libev/libev.la \
+	$(top_builddir)/src/common/libev/libev.la
+
+LDADD = $(libzio_deps) \
 	$(JSON_LIBS) $(LIBCZMQ) $(LIBZMQ) $(LIBMUNGE) \
 	$(LIBPTHREAD)
+
+$(libzio_deps):
+	@(cd `dirname $@` && $(MAKE) `basename $@`)

--- a/src/lib/libpmi/Makefile.am
+++ b/src/lib/libpmi/Makefile.am
@@ -14,7 +14,8 @@ libpmi_la_SOURCES = \
 libpmi_la_LIBADD = \
 	$(top_builddir)/src/lib/libcore/libflux-core.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
-	$(top_builddir)/src/common/liblsd/liblsd.la
+	$(top_builddir)/src/common/liblsd/liblsd.la \
+	$(top_builddir)/src/common/libev/libev.la
 
 libpmi_la_LDFLAGS = -Wl,--version-script=$(srcdir)/version.map
 

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -85,10 +85,15 @@ local kw,err = f:kvswatcher {
     end
 }
 
+type_ok (kw, 'userdata', "f:kvswatcher returns kvswatcher object")
+kw.testkey = "foo"
+is (kw.testkey, 'foo', "Can set arbitrary members of kvswatcher object")
+
 os.execute (string.format ("flux kvs put %s=%s", data.key, data.value))
 local r = f:reactor()
 
 is (r, 0, "reactor exited normally")
+
 
 --
 -- Again, but this time ensure callback is not called more than the


### PR DESCRIPTION
This set of small fixes are mainly minor build/test enhancements.

The first part of this PR fixes a couple dependency issues so that `make check` will work without
first running `make all` or `make`. This isn't a critical issue, but it seemed wrong that `make clean && make check` was failing, especially since some tests were failing in the middle due to missing *runtime* dependencies.

I also wanted to enhance the lua/kvs tests, and while doing that, ran across some bugs and missing functionality in the lua bindings. These minor issues are fixed here, and tests added.