### PR TITLE
fix issue #151 extraneous kvs_watch callbacks

### DIFF
--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -102,6 +102,10 @@ static int msg_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
     assert (zmsg != NULL);
     assert (*zmsg != NULL);
 
+    if (flux_flags_get (h) & FLUX_FLAGS_TRACE) {
+        zdump_fprint (stderr, *zmsg, flux_msgtype_shortstr (type));
+    }
+
     d = zlist_first (r->dsp);
     while (d) {
         if (flux_msg_cmp (*zmsg, d->match)) {


### PR DESCRIPTION
Fix bug in `kvs_watch` handler logic introduced recently by commit 0232626.
This was causing watch callbacks to be called on each commit, when the value had not necessarily changed.

Add test coverage for this to `tkvswatch`.

Also address a missing trace call that came up while debugging.  Tracing would go silent when the reactor was entered.