### PR TITLE
fix assorted memory leaks

### DIFF
--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -194,6 +194,9 @@ done:
 
 void flux_conf_itr_destroy (flux_conf_itr_t itr)
 {
+    char *item;
+    while ((item = zlist_pop (itr->zl)))
+        free (item);
     zlist_destroy (&itr->zl);
     free (itr);
 }
@@ -222,7 +225,6 @@ flux_conf_itr_t flux_conf_itr_create (flux_conf_t cf)
     itr->cf = cf;
     if (!(itr->zl = zlist_new ()))
         oom ();
-    zlist_autofree (itr->zl); 
     zconfig_to_zlist (cf->z, NULL, itr->zl);
     itr->item = zlist_first (itr->zl);
     return itr;

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -201,6 +201,7 @@ int flux_json_rpc (flux_t h, uint32_t nodeid, const char *topic,
 done:
     if (match.matchtag != FLUX_MATCHTAG_NONE)
         flux_matchtag_free (h, match.matchtag, match.bsize);
+    zmsg_destroy (&zmsg);
     return rc;
 }
 

--- a/src/modules/api/libapi.c
+++ b/src/modules/api/libapi.c
@@ -479,8 +479,7 @@ flux_t flux_api_openpath (const char *path, int flags)
 {
     cmb_t *c = NULL;
     struct sockaddr_un addr;
-    char *cpy = xstrdup (path);
-    char *pidfile = NULL;
+    char pidfile[PATH_MAX + 1];
 
     c = xzmalloc (sizeof (*c));
     c->magic = CMB_CTX_MAGIC;
@@ -500,7 +499,9 @@ flux_t flux_api_openpath (const char *path, int flags)
         oom ();
     ev_zlist_init (&c->putmsg_w, putmsg_cb, c->putmsg, EV_READ);
 
-    pidfile = xasprintf ("%s/cmbd.pid", dirname (cpy));
+    char *cpy = xstrdup (path);
+    snprintf (pidfile, sizeof (pidfile), "%s/cmbd.pid", dirname (cpy));
+    free (cpy);
     for (;;) {
         if (!pidcheck (pidfile))
             goto error;
@@ -517,10 +518,6 @@ flux_t flux_api_openpath (const char *path, int flags)
 error:
     if (c)
         cmb_fini (c);
-    if (cpy)
-        free (cpy);
-    if (pidfile)
-        free (pidfile);
     return NULL;
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1154,7 +1154,7 @@ static int watch_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         JSON out = NULL;
         if (!(zcpy = zmsg_dup (*zmsg)))
             oom ();
-        out = kp_rwatch_enc (key, val);
+        out = kp_rwatch_enc (key, Jget (val));
         if (flux_json_respond (ctx->h, out, &zcpy) < 0)
             flux_log (ctx->h, LOG_ERR, "%s: flux_respond: %s",
                      __FUNCTION__, strerror (errno));
@@ -1167,7 +1167,7 @@ static int watch_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
      */
     if (!reply_sent || !once) {
         first = false;
-        if (!(in2 = kp_twatch_enc (key, val, once, first, dir, link))) {
+        if (!(in2 = kp_twatch_enc (key, Jget (val), once, first, dir, link))) {
             errnum = errno;
             goto done;
         }
@@ -1183,6 +1183,7 @@ done:
         flux_log (ctx->h, LOG_ERR, "%s: flux_err_respond: %s",
                   __FUNCTION__, strerror (errno));
     }
+    Jput (val);
     Jput (in);
     Jput (in2);
     Jput (out);


### PR DESCRIPTION
Some low hanging fruit from running valgrind on flux commands, inspired by issue #152.

There is a biggie in here where the response zmsg was leaked in every call to flux_json_rpc().