### PR TITLE
testing: lua: allow tests to run inside flux session

### DIFF
--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -80,8 +80,9 @@ end
 --  Reinvoke "current" test script under a flux session using flux-start
 --
 function fluxTest:start_session (t)
-    -- Avoid flux-in-flux for now:
-    if os.getenv ("FLUX_TMPDIR") then return end
+    -- If fluxometer session is already active just return:
+    if os.getenv ("FLUXOMETER_ACTIVE") then return end
+    posix.setenv ("FLUXOMETER_ACTIVE", "t")
 
     local size = t.size or 1
     local extra_args = t.args or {}


### PR DESCRIPTION
Fix fluxometer lua test library to allow a fluxometer session to
be nested within an existing flux session.

Fixes #155.