### PR TITLE
run reactor message handlers as coprocesses if FLUX_FLAGS_COPROC is set

### DIFF
--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -227,6 +227,15 @@ int flux_putmsg (flux_t h, zmsg_t **zmsg)
     return h->ops->putmsg (h->impl, zmsg);
 }
 
+int flux_pushmsg (flux_t h, zmsg_t **zmsg)
+{
+    if (!h->ops->pushmsg) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return h->ops->pushmsg (h->impl, zmsg);
+}
+
 int flux_event_subscribe (flux_t h, const char *topic)
 {
     if (!h->ops->event_subscribe) {

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -165,6 +165,11 @@ zmsg_t *flux_recvmsg_match (flux_t h, flux_match_t match, zlist_t *nomatch,
     zmsg_t *zmsg = NULL;
     zlist_t *putmsg = nomatch;
 
+    if (flux_sleep_on (h, match) < 0) {
+        if (errno != EINVAL)
+            goto done;
+        errno = 0; /* EINVAL: not running in a coprocess */
+    }
     while (!zmsg) {
         if (!(zmsg = flux_recvmsg (h, nonblock)))
             goto done;

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -40,6 +40,7 @@ uint32_t flux_matchtag_avail (flux_t h);
 int flux_sendmsg (flux_t h, zmsg_t **zmsg);
 zmsg_t *flux_recvmsg (flux_t h, bool nonblock);
 int flux_putmsg (flux_t h, zmsg_t **zmsg);
+int flux_pushmsg (flux_t h, zmsg_t **zmsg);
 
 /* Receive a message matching 'match' (see message.h).
  * Any unmatched messages are returned to the handle with flux_putmsg(),

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -13,6 +13,7 @@ typedef struct flux_handle_struct *flux_t;
 enum {
     FLUX_FLAGS_TRACE = 1,   /* print 0MQ messages sent over the flux_t */
                             /*   handle on stdout. */
+    FLUX_FLAGS_COPROC = 2,  /* start reactor callbacks as coprocesses */
 };
 
 /* A mechanism is provide for users to attach auxiliary state to the flux_t

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -19,6 +19,7 @@ struct flux_handle_ops {
     int         (*sendmsg)(void *impl, zmsg_t **zmsg);
     zmsg_t *    (*recvmsg)(void *impl, bool nonblock);
     int         (*putmsg)(void *impl, zmsg_t **zmsg);
+    int         (*pushmsg)(void *impl, zmsg_t **zmsg);
     void        (*purge)(void *impl, flux_match_t match);
 
     int         (*event_subscribe)(void *impl, const char *topic);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -11,6 +11,8 @@
  ** Flux_t handle users should not use these interfaces.
  */
 
+typedef int (*flux_msg_f)(flux_t h, void *arg);
+
 typedef struct reactor_struct *reactor_t;
 
 struct flux_handle_ops {
@@ -38,7 +40,7 @@ struct flux_handle_ops {
     int         (*reactor_tmout_add)(void *impl, unsigned long ms, bool oneshot,
                                      FluxTmoutHandler cb, void *arg);
     void        (*reactor_tmout_remove)(void *impl, int timer_id);
-    int         (*reactor_msg_add)(void *impl, FluxMsgHandler cb, void *arg);
+    int         (*reactor_msg_add)(void *impl, flux_msg_f cb, void *arg);
     void        (*reactor_msg_remove)(void *impl);
 
     void        (*impl_destroy)(void *impl);

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -91,6 +91,14 @@ int flux_reactor_start (flux_t h);
  */
 void flux_reactor_stop (flux_t h);
 
+/* Give control back to the reactor until a message matching 'match'
+ * is queued in the handle.  This will return -1 with errno = EINVAL
+ * if called from a reactor handler that is not running in as a coprocess.
+ * Currently only message handlers are started as coprocesses, if the
+ * handle has FLUX_FLAGS_COPROC set.
+ */
+int flux_sleep_on (flux_t h, flux_match_t match);
+
 #endif /* !_FLUX_CORE_REACTOR_H */
 
 /*

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -46,14 +46,17 @@ libutil_la_SOURCES = \
 	ev_zmq.c \
 	ev_zmq.h \
 	ev_zlist.c \
-	ev_zlist.h
+	ev_zlist.h \
+	coproc.c \
+	coproc.h
 
 EXTRA_DIST = veb_mach.c
 
 TESTS = test_nodeset.t \
 	test_optparse.t \
 	test_subprocess.t \
-	test_ev.t
+	test_ev.t \
+	test_coproc.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -87,3 +90,7 @@ test_subprocess_t_LDADD = $(test_ldadd)
 test_ev_t_SOURCES = test/ev.c
 test_ev_t_CPPFLAGS = $(test_cppflags)
 test_ev_t_LDADD = $(test_ldadd)
+
+test_coproc_t_SOURCES = test/coproc.c
+test_coproc_t_CPPFLAGS = $(test_cppflags)
+test_coproc_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/coproc.c
+++ b/src/common/libutil/coproc.c
@@ -1,0 +1,193 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* See issue #126 for portability and performance drawbacks of
+ * {get,put,make,swap}context and two alternative approaches.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <ucontext.h>
+#include <stdint.h>
+#include <string.h>
+#include <signal.h>
+
+#include "coproc.h"
+#include "xzmalloc.h"
+#include "log.h"
+
+typedef enum {
+    CS_INIT,
+    CS_RUNNING,
+    CS_YIELDED,
+    CS_RETURNED,
+} coproc_state_t;
+
+#define COPROC_MAGIC 0x0103ea02
+struct coproc_struct {
+    int magic;
+    ucontext_t parent;
+    ucontext_t uc;
+    coproc_cb_t cb;
+    size_t ssize;
+    uint8_t *stack;
+    coproc_state_t state;
+    int rc;
+    void *arg;
+};
+
+static const size_t default_stack_size = SIGSTKSZ*2;
+static const size_t redzone = 16;
+static const uint8_t redzone_pattern = 0x66;
+
+void coproc_destroy (coproc_t c)
+{
+    if (c) {
+        assert (c->magic == COPROC_MAGIC);
+        if (c->stack)
+            free (c->stack);
+        c->magic = ~COPROC_MAGIC;
+        free (c);
+    }
+}
+
+static void trampoline (const unsigned int high, const unsigned int low)
+{
+    coproc_t c = (coproc_t)((((uintptr_t)high) << 32) | low);
+    assert (c->magic == COPROC_MAGIC);
+
+    c->rc = c->cb (c, c->arg);
+    c->state = CS_RETURNED;
+
+    swapcontext (&c->uc, &c->parent);
+}
+
+coproc_t coproc_create (coproc_cb_t cb)
+{
+    coproc_t c = xzmalloc (sizeof (*c));
+
+    c->magic = COPROC_MAGIC;
+    if (getcontext (&c->uc) < 0) {
+        coproc_destroy (c);
+        return NULL;
+    }
+    c->state = CS_INIT;
+    c->ssize = default_stack_size;
+    assert (c->ssize > 2*redzone);
+    if (!(c->stack = malloc (c->ssize)))
+        oom ();
+    memset (c->stack, redzone_pattern, c->ssize);
+    c->uc.uc_stack.ss_sp = c->stack + redzone;
+    c->uc.uc_stack.ss_size = c->ssize - 2*redzone;
+
+    c->cb = cb;
+
+    return c;
+}
+
+int coproc_yield (coproc_t c)
+{
+    assert (c->magic == COPROC_MAGIC);
+    if (c->state != CS_RUNNING) {
+        errno = EINVAL;
+        return -1;
+    }
+    c->state = CS_YIELDED;
+    swapcontext (&c->uc, &c->parent);
+    return 0;
+}
+
+static int verify_redzone (coproc_t c)
+{
+    int i;
+    for (i = 0; i < redzone; i++) {
+        if (c->stack[i] != redzone_pattern
+         || c->stack[c->ssize - 1 - i] != redzone_pattern) {
+            errno = EINVAL; /* FIXME need appropriate errno value */
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int coproc_resume (coproc_t c)
+{
+    assert (c->magic == COPROC_MAGIC);
+    if (c->state != CS_YIELDED) {
+        errno = EINVAL;
+        return -1;
+    }
+    c->state = CS_RUNNING;
+    if (swapcontext (&c->parent, &c->uc) < 0)
+        return -1;
+    if (verify_redzone (c) < 0)
+        return -1;
+    return 0;
+}
+
+int coproc_start (coproc_t c, void *arg)
+{
+    assert (c->magic == COPROC_MAGIC);
+
+    if (c->state != CS_INIT && c->state != CS_RETURNED) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    const unsigned int high = ((uintptr_t)c) >> 32;
+    const unsigned int low = ((uintptr_t)c) & 0xffffffff;
+    makecontext (&c->uc, (void (*)(void))trampoline, 2, high, low);
+
+    c->arg = arg;
+    c->state = CS_RUNNING;
+    if (swapcontext (&c->parent, &c->uc) < 0)
+        return -1;
+    if (verify_redzone (c) < 0)
+        return -1;
+    return 0;
+}
+
+bool coproc_started (coproc_t c)
+{
+    assert (c->magic == COPROC_MAGIC);
+    if (c->state == CS_RUNNING || c->state == CS_YIELDED)
+        return true;
+    return false;
+}
+
+bool coproc_returned (coproc_t c, int *rc)
+{
+    assert (c->magic == COPROC_MAGIC);
+    if (rc && c->state == CS_RETURNED)
+        *rc = c->rc;
+    return (c->state == CS_RETURNED);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/coproc.h
+++ b/src/common/libutil/coproc.h
@@ -1,0 +1,46 @@
+#ifndef _UTIL_COPROC_H
+#define _UTIL_COPROC_H
+
+#include <stdbool.h>
+
+typedef struct coproc_struct *coproc_t;
+typedef int (*coproc_cb_t)(coproc_t c, void *arg);
+
+/* Destroy a coproc, freeing its stack.
+ */
+void coproc_destroy (coproc_t c);
+
+/* Create a new coproc, allocating its stack.
+ */
+coproc_t coproc_create (coproc_cb_t cb);
+
+/* Coproc calls this to yield back to coproc_start/resume caller.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int coproc_yield (coproc_t c);
+
+/* Start a coproc.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int coproc_start (coproc_t c, void *arg);
+
+/* Resume a coproc.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int coproc_resume (coproc_t c);
+
+/* Return true if coproc has returned (as opposed to yielded or not started).
+ * If it has returned and 'rc' is non-NULL, set 'rc' to return value.
+ */
+bool coproc_returned (coproc_t c, int *rc);
+
+/* Return true if coproc has been started with coproc_start(), but
+ * has not yet returned.
+ */
+bool coproc_started (coproc_t c);
+
+#endif /* !_UTIL_COPROC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/coproc.c
+++ b/src/common/libutil/test/coproc.c
@@ -1,0 +1,133 @@
+#include <pthread.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/coproc.h"
+
+static bool death = false;
+
+int bar_cb (coproc_t c, void *arg)
+{
+    while (!death) {
+        if (coproc_yield (c) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+int foo_cb (coproc_t c, void *arg)
+{
+    int n; /* number of times to yield */
+
+    ok (arg && *(int *)arg >= 0 && *(int *)arg <= 16,
+        "coproc args are valid");
+    n = *(int *)arg;
+
+    while (n > 0) {
+        if (coproc_yield (c) < 0)
+            return -1;
+        n--;
+    }
+    return n;
+}
+
+void *threadmain (void *arg)
+{
+    coproc_t c;
+
+    ok ((c = coproc_create (bar_cb)) != NULL,
+        "coproc_create works in a pthread");
+    ok (coproc_start (c, NULL) == 0,
+        "coproc_start works in a pthread");
+    ok (!coproc_returned (c, NULL),
+        "coproc_start did not return (yielded)");
+    coproc_destroy (c);
+    return NULL;
+}
+
+int main (int argc, char *argv[])
+{
+    coproc_t c;
+    int i;
+    int rc;
+
+    plan (22);
+
+    ok ((c = coproc_create (foo_cb)) != NULL,
+        "coproc_create works");
+
+    i = 0;
+    rc = -1;
+    ok (coproc_start (c, &i) == 0,
+        "coproc_start works");
+    ok (coproc_returned (c, &rc),
+        "coproc returned");
+    cmp_ok (rc, "==", 0,
+        "rc is set to coproc return value");
+
+    i = 2;
+    rc = -1;
+    ok (coproc_start (c, &i) == 0,
+        "coproc_start works");
+    ok (!coproc_returned (c, NULL),
+        "coproc did not return (yielded)");
+
+    ok (coproc_resume (c) == 0,
+        "coproc_resume works");
+    ok (!coproc_returned (c, NULL),
+        "coproc did not return (yielded)");
+
+    ok (coproc_resume (c) == 0,
+        "coproc_resume works");
+    ok (coproc_returned (c, &rc),
+        "coproc returned");
+    cmp_ok (rc, "==", 0,
+        "rc is set to coproc return value");
+
+    errno = 0;
+    ok (coproc_resume (c) < 0 && errno == EINVAL,
+        "coproc_resume on returned coproc fails with EINVAL");
+
+    coproc_destroy (c);
+
+    pthread_t t;
+    ok (pthread_create (&t, NULL, threadmain, NULL) == 0,
+        "pthread_create OK");
+    ok (pthread_join (t, NULL) == 0,
+        "pthread_join OK");
+
+    coproc_t cps[10000];
+    for (i = 0; i < 10000; i++) {
+        if (!(cps[i] = coproc_create (bar_cb)))
+            break;
+        if (coproc_start (cps[i], NULL) < 0 || coproc_returned (cps[i], NULL))
+            break;
+    }
+    ok (i == 10000,
+        "started 10000 coprocs that yielded");
+    for (i = 0; i < 10000; i++) {
+        if (coproc_resume (cps[i]) < 0 || coproc_returned (cps[i], NULL))
+            break;
+    }
+    ok (i == 10000,
+        "resumed 10000 coprocs that yielded");
+    death = true;
+    for (i = 0; i < 10000; i++) {
+        if (coproc_resume (cps[i]) < 0 || !coproc_returned (cps[i], &rc)
+                                       || rc != 0)
+            break;
+    }
+    ok (i == 10000,
+        "resumed 10000 coprocs that exited with rc=0");
+
+    for (i = 0; i < 10000; i++)
+        coproc_destroy (cps[i]);
+
+
+    done_testing ();
+
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/api/libapi.c
+++ b/src/modules/api/libapi.c
@@ -66,7 +66,7 @@ typedef struct {
     ev_zlist putmsg_w;
     int loop_rc;
 
-    FluxMsgHandler msg_cb;
+    flux_msg_f msg_cb;
     void *msg_cb_arg;
 
     zhash_t *watchers;
@@ -207,53 +207,31 @@ static void putmsg_cb (struct ev_loop *loop, ev_zlist *w, int revents)
 {
     cmb_t *c = (cmb_t *)((char *)w - offsetof (cmb_t, putmsg_w));
     assert (c->magic == CMB_CTX_MAGIC);
-    zmsg_t *zmsg = NULL;
-    int type;
 
     assert (zlist_size (c->putmsg) > 0);
     if (c->msg_cb) {
-        if (!(zmsg = cmb_recvmsg_putmsg (c)))
-            goto done;
-        if (flux_msg_get_type (zmsg, &type) < 0)
-            goto done;
-        if (c->msg_cb (c->h, type, &zmsg, c->msg_cb_arg) < 0) {
+        if (c->msg_cb (c->h, c->msg_cb_arg) < 0)
             cmb_reactor_stop (c, -1);
-            goto done;
-        }
     }
-done:
-    zmsg_destroy (&zmsg);
 }
 
 static void unix_cb (struct ev_loop *loop, ev_io *w, int revents)
 {
     cmb_t *c = (cmb_t *)((char *)w - offsetof (cmb_t, unix_w));
     assert (c->magic == CMB_CTX_MAGIC);
-    zmsg_t *zmsg = NULL;
-    int type;
 
-    assert (zlist_size (c->putmsg) == 0);
-    if (c->msg_cb) {
-        if (revents & EV_READ) {
-            if ((zmsg = zfd_recv (w->fd, true))) {
-                if (flux_msg_get_type (zmsg, &type) < 0)
-                    goto done;
-                if (c->msg_cb (c->h, type, &zmsg, c->msg_cb_arg) < 0) {
-                    cmb_reactor_stop (c, -1);
-                    goto done;
-                }
-            }
-        }
-        if (revents & EV_ERROR) {
-            cmb_reactor_stop (c, -1);
-            goto done;
+    if (revents & EV_ERROR) {
+        cmb_reactor_stop (c, -1);
+    } else if (revents & EV_READ) {
+        assert (zlist_size (c->putmsg) == 0);
+        if (c->msg_cb) {
+            if (c->msg_cb (c->h, c->msg_cb_arg) < 0)
+                cmb_reactor_stop (c, -1);
         }
     }
-done:
-    zmsg_destroy (&zmsg);
 }
 
-static int cmb_reactor_msg_add (void *impl, FluxMsgHandler cb, void *arg)
+static int cmb_reactor_msg_add (void *impl, flux_msg_f cb, void *arg)
 {
     cmb_t *c = impl;
     assert (c->magic == CMB_CTX_MAGIC);

--- a/src/test/request/Makefile.am
+++ b/src/test/request/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = \
 #
 # Comms module
 #
-check_LTLIBRARIES = req.la
+check_LTLIBRARIES = req.la coproc.la
 
 fluxmod_libadd = \
 	$(top_builddir)/src/modules/kvs/libkvs.la \
@@ -24,6 +24,10 @@ req_la_SOURCES = req.c
 # N.B. "-rpath /nowhere" forces .so build, despite noinst/check
 req_la_LDFLAGS = $(fluxmod_ldflags) -rpath /nowhere
 req_la_LIBADD = $(fluxmod_libadd)
+
+coproc_la_SOURCES = coproc.c
+coproc_la_LDFLAGS = $(fluxmod_ldflags) -rpath /nowhere
+coproc_la_LIBADD = $(fluxmod_libadd)
 
 #
 # Test proggie

--- a/src/test/request/coproc.c
+++ b/src/test/request/coproc.c
@@ -1,0 +1,63 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/shortjson.h"
+
+/* The req.clog request will not be answered until req.flush is called.
+ */
+static int stuck_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
+{
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "req.clog", NULL, NULL) < 0) {
+        flux_log (h, LOG_ERR, "%s: req.clog RPC: %s", __FUNCTION__,
+                  strerror (errno));
+        return -1;
+    }
+    if (flux_err_respond (h, 0, zmsg) < 0) {
+        flux_log (h, LOG_ERR, "%s: responding: %s", __FUNCTION__,
+                  strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int hi_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
+{
+    if (flux_err_respond (h, 0, zmsg) < 0) {
+        flux_log (h, LOG_ERR, "%s: responding: %s", __FUNCTION__,
+                  strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+
+static msghandler_t htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "coproc.stuck",           stuck_request_cb },
+    { FLUX_MSGTYPE_REQUEST, "coproc.hi",              hi_request_cb },
+};
+const int htablen = sizeof (htab) / sizeof (htab[0]);
+
+int mod_main (flux_t h, zhash_t *args)
+{
+    flux_flags_set (h, FLUX_FLAGS_COPROC);
+
+    if (flux_msghandler_addvec (h, htab, htablen, NULL) < 0) {
+        flux_log (h, LOG_ERR, "flux_msghandler_addvec: %s", strerror (errno));
+        return -1;
+    }
+    if (flux_reactor_start (h) < 0) {
+        flux_log (h, LOG_ERR, "flux_reactor_start: %s", strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+MOD_NAME ("coproc");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0002-request.t
+++ b/t/t0002-request.t
@@ -73,6 +73,19 @@ test_expect_success 'request: proxy ping any from 1 is one hop' '
 	${FLUX_BUILD_DIR}/src/test/request/treq --rank 1 pingany | grep hops=1
 '
 
+# Coprroc test
+
+test_expect_success 'request: load coproc module on rank 0' '
+	flux module load -d --rank=0 \
+		${FLUX_BUILD_DIR}/src/test/request/.libs/coproc.so
+'
+test_expect_success 'request: FLUX_FLAGS_COPROC works' '
+	${FLUX_BUILD_DIR}/src/test/request/treq --rank 0 coproc
+'
+test_expect_success 'request: unloaded coproc module on rank 0' '
+	flux module remove -d --rank=0 coproc
+'
+
 # FIXME: test doesn't handle this and leaves RPC unanswered
 #test_expect_success 'request: proxy ping any from 0 is ENOSYS' '
 #	${FLUX_BUILD_DIR}/src/test/request/treq --rank 0 pingany


### PR DESCRIPTION
This PR implements getcontext(2) based coprocesses for Flux reactor message handlers.

A per-handle "opt-in" flag `FLUX_FLAGS_COPROC` enables the new capability.

When enabled, reactor message handlers are started in a coprocess context.  They can yield control back to the reactor by calling `flux_sleep_on()`, which takes a flux_match_t argument.  Once the handle produces a message matching the argument, it resumes the handler coprocess where it left off, with the matching message queued up to be read next by `flux_recvmsg()`.

Only one coprocess is allowed to be active per message handler.  If request messages arrive for a handler that is blocked waiting for an RPC response, it is queued and put back to the handle (where it can make the reactor ready once again) after the handler coprocess returns.

The coprocess integration is fully contained in the (generic) reactor implementation in `src/common/libflux/reactor.c`, with with the exception of a single `flux_sleep_on()` call added to `flux_recvmsg_match()`, the function that is called by `flux_json_rpc()` to wait and receive the RPC response.  No Flux API interfaces have changed.

The coprocess implementation is abstracted in a `coproc_t` class in `src/libutil/coproc.[ch]`, with unit tests.  Coprocesses are currenly created with fixed 16K stacks, and signal masks inherited from the reactor.

This PR brings together ideas that were discussed in issue #126 

Some open issues  (though unsure whether they should block this PR):
* should stack size be configurable per message handler?
* could stack size be dynamic?
* should coproc mode be selectable per message handler?
* is tiny redzone protection sufficient for coproc stacks?
* currently only message handlers can be coprocs.  This should be extended to include fd handlers, timers, zmq socket handlers, and all future reactor callbacks that may make RPC calls.

