### PR TITLE
improve coproc tests

### DIFF
--- a/src/common/libutil/coproc.c
+++ b/src/common/libutil/coproc.c
@@ -179,6 +179,11 @@ bool coproc_returned (coproc_t c, int *rc)
     return (c->state == CS_RETURNED);
 }
 
+size_t coproc_get_stacksize (coproc_t c)
+{
+    return c->ssize - 2*c->pagesize;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libutil/coproc.h
+++ b/src/common/libutil/coproc.h
@@ -39,6 +39,10 @@ bool coproc_returned (coproc_t c, int *rc);
  */
 bool coproc_started (coproc_t c);
 
+/* Get the size of the coproc stack in bytes.
+ */
+size_t coproc_get_stacksize (coproc_t c);
+
 #endif /* !_UTIL_COPROC_H */
 
 /*


### PR DESCRIPTION
Here's a test that exceeding the coproc stack generates a `SIGSEGV` as discussed in PR #159 