### PR TITLE
flux-lua reactor signal handler support

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -30,6 +30,8 @@
 #include <errno.h>
 #include <string.h>
 
+#include <sys/signalfd.h>
+
 #include <lua.h>
 #include <lauxlib.h>
 
@@ -1386,6 +1388,185 @@ static int l_timeout_handler_newindex (lua_State *L)
     return (0);
 }
 
+static int sigmask_from_lua_table (lua_State *L, int index, sigset_t *maskp)
+{
+    sigemptyset (maskp);
+    lua_pushvalue (L, index);
+    lua_pushnil (L);
+    while (lua_next(L, -2))
+    {
+        int sig = lua_tointeger (L, -1);
+        if (sig <= 0) {
+            lua_pop (L, 3);
+            return (-1);
+        }
+        sigaddset (maskp, sig);
+        lua_pop(L, 1);
+    }
+    lua_pop(L, 1);
+    return (0);
+}
+
+static int get_signal_from_signalfd (int fd)
+{
+    int n;
+    struct signalfd_siginfo si;
+    n = read (fd, &si, sizeof (si));
+    if (n != sizeof (si))
+        return (-1);
+
+    return (si.ssi_signo);
+}
+
+static int signal_handler (flux_t f, int fd, short revents, void *arg)
+{
+    int t, rc;
+    int sig;
+    struct l_flux_ref *sigh = arg;
+    lua_State *L = sigh->L;
+
+    assert (L != NULL);
+
+    if ((sig = get_signal_from_signalfd (fd)) < 0)
+        return (luaL_error (L, "failed to read signal from signalfd"));
+
+    l_flux_ref_gettable (sigh, "signal_handler");
+    t = lua_gettop (L);
+
+    lua_getfield (L, t, "handler");
+    assert (lua_isfunction (L, -1));
+
+    lua_push_flux_handle (L, f);
+    assert (lua_isuserdata (L, -1));
+
+    lua_getfield (L, t, "userdata");
+    assert (lua_isuserdata (L, -1));
+
+    lua_pushinteger (L, sig);
+
+    if ((rc = lua_pcall (L, 3, 1, 0))) {
+        return luaL_error (L, "pcall: %s", lua_tostring (L, -1));
+    }
+
+    rc = lua_tonumber (L, -1);
+
+    /* Reset Lua stack */
+    lua_settop (L, 0);
+
+    return (rc);
+}
+
+static int l_signal_handler_add (lua_State *L)
+{
+    int fd;
+    sigset_t mask;
+    struct l_flux_ref *sigh = NULL;
+    flux_t f = lua_get_flux (L, 1);
+
+    if (!lua_istable (L, 2))
+        return lua_pusherror (L, "Expected table as 2nd argument");
+
+    /*
+     *  Check table for mandatory arguments
+     */
+    lua_getfield (L, 2, "sigmask");
+    if (lua_isnil (L, -1))
+        return lua_pusherror (L, "Mandatory table argument 'sigmask' missing");
+    if (sigmask_from_lua_table (L, -1, &mask) < 0)
+        return lua_pusherror (L, "Mandatory table argument 'sigmask' invalid");
+    lua_pop (L, 1);
+
+    if ((fd = signalfd (-1, &mask, SFD_NONBLOCK | SFD_CLOEXEC)) < 0)
+        return lua_pusherror (L, "signalfd: %s", strerror (errno));
+
+    lua_getfield (L, 2, "handler");
+    if (lua_isnil (L, -1))
+        return lua_pusherror (L, "Mandatory table argument 'handler' missing");
+    lua_pop (L, 1);
+
+    sigprocmask (SIG_BLOCK, &mask, NULL);
+
+    sigh = l_flux_ref_create (L, f, 2, "signal_handler");
+    if (flux_fdhandler_add (f, fd, ZMQ_POLLIN | ZMQ_POLLERR,
+        (FluxFdHandler) signal_handler,
+        (void *) sigh) < 0)
+        return lua_pusherror (L, "flux_fdhandler_add: %s", strerror (errno));
+
+    /*
+     *  Get a copy of the underlying sighandler reftable on the stack
+     *   and set table.fd to signalfd.
+     */
+    l_flux_ref_gettable (sigh, "signal_handler");
+    lua_pushstring (L, "fd");
+    lua_pushnumber (L, fd);
+    lua_rawset (L, -3);
+
+    /*
+     *  Pop reftable table and leave ref userdata on stack as return value:
+     */
+    lua_pop (L, 1);
+
+    return (1);
+}
+
+static int l_signal_handler_remove (lua_State *L)
+{
+    int t;
+    int fd;
+    struct l_flux_ref *s = luaL_checkudata (L, 1, "FLUX.signal_handler");
+
+    l_flux_ref_gettable (s, "signal_handler");
+    t = lua_gettop (L);
+
+    lua_getfield (L, t, "fd");
+    fd = lua_tointeger (L, -1);
+    /*
+     *  Drop reference to the table and allow garbage collection
+     */
+    flux_fdhandler_remove (s->flux, fd, ZMQ_POLLIN | ZMQ_POLLERR);
+    close (fd);
+    l_flux_ref_destroy (s, "signal_handler");
+    return (0);
+}
+
+static int l_signal_handler_index (lua_State *L)
+{
+    struct l_flux_ref *s = luaL_checkudata (L, 1, "FLUX.signal_handler");
+    const char *key = lua_tostring (L, 2);
+
+    /*
+     *  Check for method names
+     */
+    if (strcmp (key, "remove") == 0) {
+        lua_getmetatable (L, 1);
+        lua_getfield (L, -1, "remove");
+        return (1);
+    }
+
+    /*  Get a copy of the underlying timeout handler Lua table and pass-through
+     *   the index:
+     */
+    l_flux_ref_gettable (s, "signal_handler");
+    lua_getfield (L, -1, key);
+    return (1);
+}
+
+
+static int l_signal_handler_newindex (lua_State *L)
+{
+    struct l_flux_ref *s = luaL_checkudata (L, 1, "FLUX.signal_handler");
+
+    /*  Set value in the underlying msghandler table:
+     */
+    l_flux_ref_gettable (s, "signal_handler");
+    lua_pushvalue (L, 2); /* Key   */
+    lua_pushvalue (L, 3); /* Value */
+    lua_rawset (L, -3);
+    return (0);
+}
+
+
+
 static int l_flux_reactor_start (lua_State *L)
 {
     return l_pushresult (L, flux_reactor_start (lua_get_flux (L, 1)));
@@ -1491,6 +1672,7 @@ static const struct luaL_Reg flux_methods [] = {
     { "kvswatcher",      l_kvswatcher_add    },
     { "iowatcher",       l_iowatcher_add     },
     { "timer",           l_timeout_handler_add },
+    { "sighandler",      l_signal_handler_add },
     { "reactor",         l_flux_reactor_start },
     { "reactor_stop",    l_flux_reactor_stop },
     { NULL,              NULL               }
@@ -1547,6 +1729,14 @@ static const struct luaL_Reg timeout_handler_methods [] = {
     { NULL,              NULL                  }
 };
 
+static const struct luaL_Reg signal_handler_methods [] = {
+    { "__index",         l_signal_handler_index    },
+    { "__newindex",      l_signal_handler_newindex },
+    { "remove",          l_signal_handler_remove   },
+    { NULL,              NULL                  }
+};
+
+
 #define MSGTYPE_SET(L, name) do { \
   lua_pushlstring(L, #name, sizeof(#name)-1); \
   lua_pushnumber(L, FLUX_ ## name); \
@@ -1570,6 +1760,8 @@ int luaopen_flux (lua_State *L)
     luaL_setfuncs (L, kz_methods, 0);
     luaL_newmetatable (L, "FLUX.timeout_handler");
     luaL_setfuncs (L, timeout_handler_methods, 0);
+    luaL_newmetatable (L, "FLUX.signal_handler");
+    luaL_setfuncs (L, signal_handler_methods, 0);
 
     luaL_newmetatable (L, "FLUX.handle");
     luaL_setfuncs (L, flux_methods, 0);

--- a/src/cmd/flux-exec
+++ b/src/cmd/flux-exec
@@ -24,24 +24,6 @@ terminate = false
 -------------------------------------------------------------------------------
 --
 --
-local function setup_signal_handlers()
-    local signal = posix.signal
-    local fn = function() terminate = true end
-    --
-    --  Support both old-style lua-posix signal-as-a-table interface,
-    --   and newer signal-as-a-function api:
-    --
-    if type (signal) == "table" then
-        signal[posix.SIGINT] = fn
-        signal[posix.SIGTERM] = signal[posix.SIGINT]
-        return true
-    end
-
-    signal (posix.SIGINT, fn)
-    signal (posix.SIGTERM, fn)
-    return true
-end
-
 local function say (fmt, ...)
     if not verbose then return end
     io.stderr:write (string.format ("%s: "..fmt, shortprog, ...))
@@ -140,9 +122,6 @@ end
 
 local sigtimer
 
--- Set signal handlers
-setup_signal_handlers()
-
 -- Start in-program timer:
 local tt = timer.new()
 local t = timer.new()
@@ -184,6 +163,14 @@ local mh, err = f:msghandler {
         end
     end
 
+}
+
+local s, err = f:sighandler {
+    sigmask = { posix.SIGINT, posix.SIGTERM },
+    handler = function (f, s, sig)
+        terminate = true
+        f:reactor_stop()
+    end
 }
 
 

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -134,24 +134,6 @@ local function alloc_tasks_hack (f, wreck, lwj)
     wreck:say ("tasks per node: %s\n", summarize_tasks_per_node (r))
 end
 
-local function setup_signal_handlers()
-    local signal = posix.signal
-    local fn = function() terminate = true end
-    --
-    --  Support both old-style lua-posix signal-as-a-table interface,
-    --   and newer signal-as-a-function api:
-    --
-    if type (signal) == "table" then
-        signal[posix.SIGINT] = fn
-        signal[posix.SIGTERM] = signal[posix.SIGINT]
-        return true
-    end
-
-    signal (posix.SIGINT, fn)
-    signal (posix.SIGTERM, fn)
-    return true
-end
-
 -------------------------------------------------------------------------------
 -- Main program:
 -------------------------------------------------------------------------------
@@ -176,9 +158,6 @@ wreck:add_options ({
 if not wreck:parse_cmdline (arg) then
     wreck:die ("Failed to process cmdline args\n")
 end
-
--- Set signal handlers
-setup_signal_handlers()
 
 -- Start in-program timer:
 local tt = timer.new()
@@ -309,6 +288,14 @@ local kw, err = f:kvswatcher  {
             wreck:say ("%-4.03fs: State = %s\n", tt:get0(), result)
             check_job_completed ()
         end
+    end
+}
+
+local s, err = f:sighandler {
+    sigmask = { posix.SIGINT, posix.SIGTERM },
+    handler = function (f, s, sig)
+        terminate = true
+        f:reactor_stop ()
     end
 }
 

--- a/t/lua/t1004-sighandler.t
+++ b/t/lua/t1004-sighandler.t
@@ -1,0 +1,52 @@
+#!/usr/bin/lua
+--
+--  Basic flux/lua signal handler interface testing
+--
+local test = require 'fluxometer'.init (...)
+test:start_session {}
+
+require 'Test.More'
+
+local flux = require_ok ('flux')
+local posix = require_ok ('posix')
+local f, err = flux.new()
+type_ok (f, 'userdata', "create new flux handle")
+is (err, nil, "error is nil")
+
+success = false
+local sigh, err = f:sighandler {
+    sigmask = {posix.SIGINT},
+    handler = function (f, s, sig)
+        is (s.test, "foo", "Able to retrieve private key in signal handler table")
+        is (sig, posix.SIGINT, "Got SIGINT")
+        f:reactor_stop()
+    end
+}
+type_ok (sigh, 'userdata', "created signal handler")
+is (err, nil, "error from signal handler creation is nil")
+
+sigh.test = "foo"
+is (sigh.test, "foo", "Successfully set key in signal handler table")
+
+local to, err = f:timer {
+    timeout = 500,
+    handler = function (f, to)
+        fail ("Failed to get signal withn 500ms")
+        return -1
+    end
+}
+type_ok (to, 'userdata', "created timeout handler")
+is (err, nil, "error from timer creation is nil")
+
+local pid = posix.getpid ()
+os.execute ('sleep .2 && kill -INT '..pid.pid)
+
+local r, err = f:reactor()
+isnt (r, -1, "Return from reactor, rc >= 0")
+is (err, nil, "error is nil")
+
+is (sigh:remove(), nil, "Removing signal handler works")
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Use `signalfd(2)` in flux-lua to add signal handler support to the flux Lua bindings.

Other interfaces to the API can use `signalfd(2)` along with `flux_fdhandler_add()` to handle signals within the current flux reactor, but I didn't find a simple, available signalfd library for Lua, so took the easy way out and simulated reactor signal handlers internally in lua bindings.

This fixes Ctrl-C on `flux-wreckrun` and `flux-exec` utilities.
