### PR TITLE
initial commit, does nothing so far

### DIFF
--- a/src/lib/libcore/flux.h
+++ b/src/lib/libcore/flux.h
@@ -1,0 +1,37 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef _FLUX_API_H
+#define _FLUX_API_H
+
+/* External Flux API */
+
+// ...
+
+#endif /* !_FLUX_API_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
As Jim suggested, this is a PR for a new header file in the libcore directory.  Normally my preference for this kind of thing would be to have 'core.h' serve as the implementation include, since everything already uses it, and have it reference this one.  Given how much existing code there is, I'm not sure what the best way is, but at least we have a spot to discuss it.