### PR TITLE
API: add core.h header file for main public API

### DIFF
--- a/src/lib/libcore/core.h
+++ b/src/lib/libcore/core.h
@@ -50,11 +50,12 @@ enum {
 };
 
 /* Create/destroy a broker handle.
- * If 'path' is NULL, derive socket path from FLUX_TMPDIR
- * environment variable;  otherwise it can be a zeromq URI or a socket path.
- * On error, NULL is returned with ernno set.
+ * The 'uri' scheme name selects a handle implementation to dynamically load.
+ * The rest of the URI is parsed in an implementation-specific manner.
+ * A NULL uri selects the "local" implementation with socket path derived
+ * from the FLUX_TMPDIR environment variable.
  */
-flux_t flux_open (const char *path, int flags);
+flux_t flux_open (const char *uri, int flags);
 void flux_close (flux_t h);
 
 /* Send/recv Flux messages.

--- a/src/lib/libcore/core.h
+++ b/src/lib/libcore/core.h
@@ -1,5 +1,5 @@
 /*****************************************************************************\
- *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
  *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
  *  LLNL-CODE-658032 All rights reserved.
  *
@@ -22,19 +22,84 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
+/* The Flux public, versioned API.
+ */
+
 #ifndef _FLUX_CORE_H
 #define _FLUX_CORE_H
 
-/* NOTE: these programming interfaces should be considered EXPERIMENTAL
- * and are subject to change in flux-core releases prefixed with "0."
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct flux_struct *flux_t;
+typedef struct flux_msg_struct *flux_msg_t;
+
+/* Open flags
  */
+enum {
+    FLUX_O_TRACE        = 1,    /* send message trace to stderr */
+    FLUX_O_COPROC       = 2,    /* start reactor callbacks as coprocesses */
+};
 
-#include "core/flux.h"
+/* sendmsg/recvmsg/putmsg flags.
+ */
+enum {
+    FLUX_IO_NONBLOCK    = 1,
+    FLUX_IO_PUT_BEGIN   = 2,    /* putmsg adds to front of receive queue */
+    FLUX_IO_PUT_END     = 4,    /* putmsg adds to end of receive queue */
+};
 
-#include "core/api.h"
-#include "core/kvs.h"
-#include "core/live.h"
-#include "core/barrier.h"
+/* Create/destroy a broker handle.
+ * If 'path' is NULL, derive socket path from FLUX_TMPDIR
+ * environment variable;  otherwise it can be a zeromq URI or a socket path.
+ * On error, NULL is returned with ernno set.
+ */
+flux_t flux_open (const char *path, int flags);
+void flux_close (flux_t h);
+
+/* Send/recv Flux messages.
+ * Putmsg adds 'msg' to the handle's recveive queue.
+ * On success return 0; on failure return -1 with errno set.
+ */
+int flux_sendmsg (flux_t h, flux_msg_t msg, int flags);
+flux_msg_t flux_recvmsg (flux_t h, int flags);
+int flux_putmsg (flux_t h, flux_msg_t msg, int flags);
+
+/* Subscribe/unsubscribe to events.  A NULL topic_glob matches all events.
+ * On success return 0; on failure return -1 with errno set.
+ */
+int flux_subscribe (flux_t h, const char *topic_glob);
+int flux_unsubscribe (flux_t h, const char *topic_glob);
+
+/* Publish one event message.
+ * If non-NULL, 'json_in' is the payload.
+ * On success return 0; on failure return -1 with errno set.
+ */
+int flux_publish (flux_t h, const char *topic, const char *json_in);
+
+/* Send one request message.
+ * The value of nodeid can be a broker rank, FLUX_NODEID_ANY,
+ * or FLUX_NODEID_UPSTREAM and affects request routing per RFC 3.
+ * If non-NULL, 'json_in' is the payload.
+ * On success return 0; on failure return -1 with errno set.
+ */
+int flux_request (flux_t h, uint32_t nodeid, const char *topic,
+                  const char *json_in);
+
+/* Send one request message and receive one response message.
+ * The value of 'nodeid' can be a broker rank, FLUX_NODEID_ANY,
+ * or FLUX_NODEID_UPSTREAM and affects request routing per RFC 3.
+ * If non-NULL, 'json_in' is the request payload.
+ * If a response payload is expected, 'json_out' must be non-NULL
+ * (caller frees the returned string).
+ * If timeout is nonzero, the RPC should return with ETIMEDOUT if
+ * more than the specified number of milliseconds elapses before a
+ * response is received.
+ * On success return 0; on failure return -1 with errno set.
+ */
+int flux_rpc (flux_t h, uint32_t nodeid, const char *topic,
+              const char *json_in, char **json_out, int timeout);
+
 
 #endif /* !_FLUX_CORE_H */
 

--- a/src/lib/libcore/message.h
+++ b/src/lib/libcore/message.h
@@ -43,6 +43,10 @@ int flux_msg_get_type (flux_msg_t msg, int *type);
 int flux_msg_set_topic (flux_msg_t msg, const char *topic);
 int flux_msg_get_topic (flux_msg_t msg, const char **topic);
 
+/* Get message flags.
+ */
+int flux_msg_get_flags (flux_msg_t msg, int *flags);
+
 /* Get/set payload.
  * Set function adds/deletes/replaces payload frame as needed.
  * The new payload will be copied (caller retains ownership).
@@ -84,55 +88,9 @@ int flux_msg_get_seq (flux_msg_t msg, uint32_t *seq);
 int flux_msg_set_matchtag (flux_msg_t msg, uint32_t matchtag);
 int flux_msg_get_matchtag (flux_msg_t msg, uint32_t *matchtag);
 
-/* NOTE: routing frames are pushed on a message traveling dealer
- * to router, and popped off a message traveling router to dealer.
- * A message intended for dealer-router sockets must first be enabled for
- * routing.
+/* Get sender uuid (request only)
  */
-
-/* Prepare a message for routing, which consists of pushing a nil delimiter
- * frame and setting FLUX_MSGFLAG_ROUTE.  This function is a no-op if the
- * flag is already set.
- * Returns 0 on success, -1 with errno set on failure.
- */
-int flux_msg_enable_route (flux_msg_t msg);
-
-/* Strip route frames, nil delimiter, and clear FLUX_MSGFLAG_ROUTE flag.
- * This function is a no-op if the flag is already clear.
- * Returns 0 on success, -1 with errno set on failure.
- */
-int flux_msg_clear_route (flux_msg_t msg);
-
-/* Push a route frame onto the message (mimic what dealer socket does).
- * 'id' is copied internally.
- * Returns 0 on success, -1 with errno set (e.g. EINVAL) on failure.
- */
-int flux_msg_push_route (flux_msg_t msg, const char *id);
-
-/* Pop a route frame off the message and return identity (or NULL) in 'id'.
- * Caller must free 'id'.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
- */
-int flux_msg_pop_route (flux_msg_t msg, char **id);
-
-/* Copy the first routing frame (closest to delimiter) contents (or NULL)
- * to 'id'.  Caller must free 'id'.
- * For requests, this is the sender; for responses, this is the recipient.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
- */
-int flux_msg_get_route_first (flux_msg_t msg, char **id); /* closest to delim */
-
-/* Copy the last routing frame (farthest from delimiter) contents (or NULL)
- * to 'id'.  Caller must free 'id'.
- * For requests, this is the last hop; for responses: this is the next hop.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
- */
-int flux_msg_get_route_last (flux_msg_t msg, char **id); /* farthest from delim */
-
-/* Return the number of route frames in the message.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
- */
-int flux_msg_get_route_count (flux_msg_t msg);
+int flux_msg_get_sender (flux_msg_t msg, const char **id);
 
 /* Return string representation of message type.  Do not free.
  */

--- a/src/lib/libcore/message.h
+++ b/src/lib/libcore/message.h
@@ -1,0 +1,147 @@
+#ifndef _FLUX_CORE_MESSAGE_H
+#define _FLUX_CORE_MESSAGE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct flux_msg_struct *flux_msg_t;
+
+enum {
+    FLUX_MSGTYPE_REQUEST    = 0x01,
+    FLUX_MSGTYPE_RESPONSE   = 0x02,
+    FLUX_MSGTYPE_EVENT      = 0x04,
+    FLUX_MSGTYPE_KEEPALIVE  = 0x08,
+    FLUX_MSGTYPE_ANY        = 0x0f,
+    FLUX_MSGTYPE_MASK       = 0x0f,
+};
+
+enum {
+    FLUX_MSGFLAG_TOPIC      = 0x01,	/* message has topic string */
+    FLUX_MSGFLAG_PAYLOAD    = 0x02,	/* message has payload */
+    FLUX_MSGFLAG_JSON       = 0x04,	/* message payload is JSON */
+    FLUX_MSGFLAG_ROUTE      = 0x08,	/* message is routable */
+    FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
+};
+
+/* Create/destroy a new Flux message.
+ * Create returns new message or NULL on failure, with errno set.
+ */
+flux_msg_t flux_msg_create (int type);
+void flux_msg_destroy (flux_msg_t msg);
+
+/* Get/set message type
+ * For FLUX_MSGTYPE_REQUEST: set_type initializes nodeid to FLUX_NODEID_ANY
+ * For FLUX_MSGTYPE_RESPONSE: set_type initializes errnum to 0
+ */
+int flux_msg_set_type (flux_msg_t msg, int type);
+int flux_msg_get_type (flux_msg_t msg, int *type);
+
+/* Get/set message topic string.
+ * set adds/deletes/replaces topic frame as needed.
+ * get returns pointer to msg-owned string.
+ */
+int flux_msg_set_topic (flux_msg_t msg, const char *topic);
+int flux_msg_get_topic (flux_msg_t msg, const char **topic);
+
+/* Get/set payload.
+ * Set function adds/deletes/replaces payload frame as needed.
+ * The new payload will be copied (caller retains ownership).
+ * Any old payload is deleted.
+ * Get_payload returns pointer to msg-owned buf.
+ * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
+ */
+int flux_msg_set_payload (flux_msg_t msg, int flags, void *buf, int size);
+int flux_msg_get_payload (flux_msg_t msg, int *flags, void **buf, int *size);
+
+/* Get/set json payload (payload may be NULL).
+ */
+int flux_msg_set_payload_json (flux_msg_t msg, const char *json);
+int flux_msg_get_payload_json (flux_msg_t msg, const char **json);
+
+/* Get/set nodeid (request only)
+ * If flags includes FLUX_NODEID_UPSTREAM, nodeid is the sending rank.
+ * FLUX_NODEID_UPSTREAM is a stand in for this flag + sending rank in
+ * higher level functions (not to be used here).
+ */
+#define FLUX_NODEID_ANY         (~(uint32_t)0)
+#define FLUX_NODEID_UPSTREAM	(~(uint32_t)1)
+int flux_msg_set_nodeid (flux_msg_t msg, uint32_t nodeid, int flags);
+int flux_msg_get_nodeid (flux_msg_t msg, uint32_t *nodeid, int *flags);
+
+/* Get/set errnum (response only)
+ */
+int flux_msg_set_errnum (flux_msg_t msg, int errnum);
+int flux_msg_get_errnum (flux_msg_t msg, int *errnum);
+
+/* Get/set sequence number (event only)
+ */
+int flux_msg_set_seq (flux_msg_t msg, uint32_t seq);
+int flux_msg_get_seq (flux_msg_t msg, uint32_t *seq);
+
+/* Get/set match tag (request/response only)
+ */
+#define FLUX_MATCHTAG_NONE (0)
+int flux_msg_set_matchtag (flux_msg_t msg, uint32_t matchtag);
+int flux_msg_get_matchtag (flux_msg_t msg, uint32_t *matchtag);
+
+/* NOTE: routing frames are pushed on a message traveling dealer
+ * to router, and popped off a message traveling router to dealer.
+ * A message intended for dealer-router sockets must first be enabled for
+ * routing.
+ */
+
+/* Prepare a message for routing, which consists of pushing a nil delimiter
+ * frame and setting FLUX_MSGFLAG_ROUTE.  This function is a no-op if the
+ * flag is already set.
+ * Returns 0 on success, -1 with errno set on failure.
+ */
+int flux_msg_enable_route (flux_msg_t msg);
+
+/* Strip route frames, nil delimiter, and clear FLUX_MSGFLAG_ROUTE flag.
+ * This function is a no-op if the flag is already clear.
+ * Returns 0 on success, -1 with errno set on failure.
+ */
+int flux_msg_clear_route (flux_msg_t msg);
+
+/* Push a route frame onto the message (mimic what dealer socket does).
+ * 'id' is copied internally.
+ * Returns 0 on success, -1 with errno set (e.g. EINVAL) on failure.
+ */
+int flux_msg_push_route (flux_msg_t msg, const char *id);
+
+/* Pop a route frame off the message and return identity (or NULL) in 'id'.
+ * Caller must free 'id'.
+ * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ */
+int flux_msg_pop_route (flux_msg_t msg, char **id);
+
+/* Copy the first routing frame (closest to delimiter) contents (or NULL)
+ * to 'id'.  Caller must free 'id'.
+ * For requests, this is the sender; for responses, this is the recipient.
+ * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ */
+int flux_msg_get_route_first (flux_msg_t msg, char **id); /* closest to delim */
+
+/* Copy the last routing frame (farthest from delimiter) contents (or NULL)
+ * to 'id'.  Caller must free 'id'.
+ * For requests, this is the last hop; for responses: this is the next hop.
+ * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ */
+int flux_msg_get_route_last (flux_msg_t msg, char **id); /* farthest from delim */
+
+/* Return the number of route frames in the message.
+ * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ */
+int flux_msg_get_route_count (flux_msg_t msg);
+
+/* Return string representation of message type.  Do not free.
+ */
+const char *flux_msgtype_string (int typemask);
+const char *flux_msgtype_shortstr (int typemask);
+
+#endif /* !_FLUX_CORE_MESSAGE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This PR is a continuation of #173, in which we can discuss a revamp of the Flux public API.
I will add commits as we go and squash them down at the end.  Since in-tree code is built against `src/include/flux/core.h` and `src/lib/libcore/core.h` is only for external users, I modified the latter in this PR.

* I think we agreed in #173 that there should be one `flux_open()`/`flux_close()` which can internally select the appropriate back end handle implementation.  I renamed the open flags to `FLUX_O_*` (from `FLUX_FLAGS_*`) to make it clear they are open flags.

* Pulled in the low-level `flux_sendmsg()`, `flux_recvmsg()`, `flux_putmsg()` functions.  I changed the prototypes slightly so they all look similar, with `FLUX_IO_*` flags expressing the optional behavior.  Converted to flux-specific opaque message type `flux_msg_t` as we had discussed.

* Pulled in the high level `flux_publish()`, `flux_request()`, and `flux_rpc()` functions.  JSON arguments are now valid json strings as we had discussed.  I added a timeout to `flux_rpc()`.

