### PR TITLE
remove deprecated functions

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -335,9 +335,10 @@ static int l_flux_recv (lua_State *L)
         return lua_pusherror (L, strerror (errno));
 
     if (flux_msg_get_errnum (zmsg, &errnum) < 0)
-        return lua_pusherror (L, "flux_msg_get_errnum: %s", strerror (errno));
+        return lua_pusherror (L, strerror (errno));
 
-    if (errnum == 0 && flux_msg_decode (zmsg, &tag, &o) < 0)
+    if (errnum == 0 && (flux_msg_get_topic (zmsg, &tag) < 0
+                     || flux_msg_get_payload_json (zmsg, &o) < 0))
         return lua_pusherror (L, strerror (errno));
 
     if (o != NULL) {

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -787,7 +787,7 @@ static int l_f_zi_resp_cb (lua_State *L,
     struct zmsg_info *zi, json_object *resp, void *arg)
 {
     flux_t f = arg;
-    return l_pushresult (L, flux_respond (f, zmsg_info_zmsg (zi), resp));
+    return l_pushresult (L, flux_json_respond (f, resp, zmsg_info_zmsg (zi)));
 }
 
 static int create_and_push_zmsg_info (lua_State *L,

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -58,7 +58,12 @@ struct zmsg_info * zmsg_info_create (zmsg_t **zmsg, int typemask)
     if (zi == NULL)
         return (NULL);
 
-    if (flux_msg_decode (*zmsg, &zi->tag, &zi->o) < 0) {
+    if (flux_msg_get_topic (*zmsg, &zi->tag) < 0) {
+        free (zi);
+        return (NULL);
+    }
+    if (flux_msg_get_payload_json (*zmsg, &zi->o) < 0) {
+        free (zi->tag);
         free (zi);
         return (NULL);
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1400,7 +1400,7 @@ static void child_cb (overlay_t ov, void *sock, void *arg)
         case FLUX_MSGTYPE_REQUEST:
             rc = flux_sendmsg (ctx->h, &zmsg);
             if (zmsg)
-                flux_respond_errnum (ctx->h, &zmsg, rc < 0 ? errno : 0);
+                flux_err_respond (ctx->h, rc < 0 ? errno : 0, &zmsg);
             break;
         case FLUX_MSGTYPE_EVENT:
             rc = flux_sendmsg (ctx->h, &zmsg);
@@ -1521,7 +1521,7 @@ static void module_cb (module_t p, void *arg)
         case FLUX_MSGTYPE_REQUEST:
             rc = flux_sendmsg (ctx->h, &zmsg);
             if (zmsg)
-                flux_respond_errnum (ctx->h, &zmsg, rc < 0 ? errno : 0);
+                flux_err_respond (ctx->h, rc < 0 ? errno : 0, &zmsg);
             break;
         case FLUX_MSGTYPE_EVENT:
             if (flux_sendmsg (ctx->h, &zmsg) < 0) {
@@ -1546,8 +1546,8 @@ static void rmmod_cb (module_t p, void *arg)
     zmsg_t *zmsg;
 
     while ((zmsg = module_pop_rmmod (p))) {
-        if (flux_respond_errnum (ctx->h, &zmsg, 0) < 0)
-            err ("%s: flux_respond_errnum", __FUNCTION__);
+        if (flux_err_respond (ctx->h, 0, &zmsg) < 0)
+            err ("%s: flux_err_respond", __FUNCTION__);
         zmsg_destroy (&zmsg);
     }
 }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -952,10 +952,8 @@ static int cmb_exec_cb (zmsg_t **zmsg, void *arg)
     int i, argc;
     int rc = -1;
 
-    if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL) {
-        errno = EPROTO;
-        return -1;
-    }
+    if (flux_json_request_decode (*zmsg, &request) < 0)
+        goto out_free;
 
     if (!json_object_object_get_ex (request, "cmdline", &o)
         || o == NULL

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1071,7 +1071,7 @@ done:
     return rc;
 }
 
-static int cmb_getrusage_cb (zmsg_t **zmsg, void *arg)
+static int cmb_rusage_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
     JSON out = NULL;
@@ -1348,7 +1348,7 @@ static void broker_add_services (ctx_t *ctx)
 {
     if (!svc_add (ctx->services, "cmb.info", cmb_info_cb, ctx)
           || !svc_add (ctx->services, "cmb.getattr", cmb_getattr_cb, ctx)
-          || !svc_add (ctx->services, "cmb.getrusage", cmb_getrusage_cb, ctx)
+          || !svc_add (ctx->services, "cmb.rusage", cmb_rusage_cb, ctx)
           || !svc_add (ctx->services, "cmb.rmmod", cmb_rmmod_cb, ctx)
           || !svc_add (ctx->services, "cmb.insmod", cmb_insmod_cb, ctx)
           || !svc_add (ctx->services, "cmb.lsmod", cmb_lsmod_cb, ctx)

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -69,8 +69,8 @@ static int ping_req_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
      */
     s = zdump_routestr (*zmsg, 1);
     util_json_object_add_string (o, "route", s);
-    if (flux_respond (h, zmsg, o) < 0) {
-        err ("%s: flux_respond", __FUNCTION__);
+    if (flux_json_respond (h, o, zmsg) < 0) {
+        err ("%s: flux_json_respond", __FUNCTION__);
         rc = -1; /* reactor terminates */
         goto done;
     }
@@ -150,8 +150,8 @@ static int rusage_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         goto done;
     }
     response = rusage_to_json (&usage);
-    if (flux_respond (h, zmsg, response) < 0) {
-        err ("%s: flux_respond", __FUNCTION__);
+    if (flux_json_respond (h, response, zmsg) < 0) {
+        err ("%s: flux_json_respond", __FUNCTION__);
         rc = -1;
         goto done;
     }

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -51,44 +51,40 @@
 
 #include "modservice.h"
 
+/* Route string will not include the endpoints.
+ * On arrival here, uuid of dst module has been stripped.
+ * The '1' arg to zdump_routestr strips the uuid of the sender.
+ * FIXME: t/lua/t0002-rpc.t tries to ping with an array object.
+ * This should be caught at a lower level - see issue #181
+ */
 static int ping_req_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
-    json_object *o = NULL;
+    JSON in = NULL;
     char *s = NULL;
-    int rc = 0;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL ||
-        !json_object_is_type (o, json_type_object)) {
+    if (flux_json_request_decode (*zmsg, &in) < 0
+         || !json_object_is_type (in, json_type_object)) { // see FIXME above
         flux_err_respond (h, EPROTO, zmsg);
-        goto done; /* reactor continues */
+        goto done;
     }
-
-    /* Route string will not include the endpoints.
-     * On arrival here, uuid of dst module has been stripped.
-     * The '1' arg to zdump_routestr strips the uuid of the sender.
-     */
     s = zdump_routestr (*zmsg, 1);
-    util_json_object_add_string (o, "route", s);
-    if (flux_json_respond (h, o, zmsg) < 0) {
+    Jadd_str (in, "route", s);
+    if (flux_json_respond (h, in, zmsg) < 0) {
         err ("%s: flux_json_respond", __FUNCTION__);
-        rc = -1; /* reactor terminates */
         goto done;
     }
 done:
-    if (o)
-        json_object_put (o);
+    Jput (in);
+    zmsg_destroy (zmsg);
     if (s)
         free (s);
-    if (*zmsg)
-        zmsg_destroy (zmsg);
-    return rc;
+    return 0;
 }
 
 static int stats_get_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     flux_msgcounters_t mcs;
     JSON out = Jnew ();
-    int rc = -1;
 
     flux_get_msgcounters (h, &mcs);
     Jadd_int (out, "#request (tx)", mcs.request_tx);
@@ -100,67 +96,50 @@ static int stats_get_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     Jadd_int (out, "#keepalive (tx)", mcs.keepalive_tx);
     Jadd_int (out, "#keepalive (rx)", mcs.keepalive_rx);
 
-    if (flux_json_respond (h, out, zmsg) < 0) {
+    if (flux_json_respond (h, out, zmsg) < 0)
         flux_log (h, LOG_ERR, "%s: flux_json_respond: %s", __FUNCTION__,
                   strerror (errno));
-        goto done;
-    }
-    rc = 0;
-done:
     Jput (out);
     zmsg_destroy (zmsg);
-    return rc;
+    return 0;
 }
 
-static int stats_clear_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
+static int stats_clear_event_cb (flux_t h, int typemask, zmsg_t **zmsg,
+                                 void *arg)
 {
-    int rc = -1;
-
     flux_clr_msgcounters (h);
-
-    if (typemask & FLUX_MSGTYPE_REQUEST) {
-        if (flux_err_respond (h, 0, zmsg) < 0) {
-            flux_log (h, LOG_ERR, "%s: flux_err_respond: %s", __FUNCTION__,
-                      strerror (errno));
-            goto done;
-        }
-    }
-    rc = 0;
-done:
     zmsg_destroy (zmsg);
-    return rc;
+    return 0;
+}
+
+static int stats_clear_request_cb (flux_t h, int typemask, zmsg_t **zmsg,
+                                   void *arg)
+{
+    flux_clr_msgcounters (h);
+    if (flux_err_respond (h, 0, zmsg) < 0)
+        flux_log (h, LOG_ERR, "%s: flux_err_respond: %s", __FUNCTION__,
+                  strerror (errno));
+    zmsg_destroy (zmsg);
+    return 0;
 }
 
 static int rusage_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
-    json_object *response = NULL;
-    int rc = 0;
+    JSON out = NULL;
     struct rusage usage;
 
-    if (flux_msg_decode (*zmsg, NULL, NULL) < 0) {
-        flux_log (h, LOG_ERR, "%s: error decoding message", __FUNCTION__);
-        goto done;
-    }
     if (getrusage (RUSAGE_THREAD, &usage) < 0) {
-        if (flux_err_respond (h, errno, zmsg) < 0) {
+        if (flux_err_respond (h, errno, zmsg) < 0)
             err ("%s: flux_err_respond", __FUNCTION__);
-            rc = -1;
-            goto done;
-        }
         goto done;
     }
-    response = rusage_to_json (&usage);
-    if (flux_json_respond (h, response, zmsg) < 0) {
+    out = rusage_to_json (&usage);
+    if (flux_json_respond (h, out, zmsg) < 0)
         err ("%s: flux_json_respond", __FUNCTION__);
-        rc = -1;
-        goto done;
-    }
 done:
-    if (response)
-        json_object_put (response);
-    if (*zmsg)
-        zmsg_destroy (zmsg);
-    return rc;
+    Jput (out);
+    zmsg_destroy (zmsg);
+    return 0;
 }
 
 static int shutdown_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
@@ -195,10 +174,10 @@ void modservice_register (flux_t h, const char *name)
     register_request (h, name, "shutdown", shutdown_cb);
     register_request (h, name, "ping", ping_req_cb);
     register_request (h, name, "stats.get", stats_get_cb);
-    register_request (h, name, "stats.clear", stats_clear_cb);
+    register_request (h, name, "stats.clear", stats_clear_request_cb);
     register_request (h, name, "rusage", rusage_cb);
 
-    register_event   (h, name, "stats.clear", stats_clear_cb);
+    register_event   (h, name, "stats.clear", stats_clear_event_cb);
 }
 
 /*

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -142,8 +142,8 @@ static int rusage_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         goto done;
     }
     if (getrusage (RUSAGE_THREAD, &usage) < 0) {
-        if (flux_respond_errnum (h, zmsg, errno) < 0) {
-            err ("%s: flux_respond_errnum", __FUNCTION__);
+        if (flux_err_respond (h, errno, zmsg) < 0) {
+            err ("%s: flux_err_respond", __FUNCTION__);
             rc = -1;
             goto done;
         }

--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -58,6 +58,7 @@ void usage (void)
 "Usage: flux-comms-stats [--scale N] [--type int|double] --parse a[.b]... name\n"
 "       flux-comms-stats --clear-all name\n"
 "       flux-comms-stats --clear name\n"
+"       flux-comms-stats --rusage name\n"
 );
     exit (1);
 }

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -76,7 +76,9 @@ int flux_event_recv (flux_t h, json_object **in, char **topic, bool nb)
 
     if (!(zmsg = flux_recvmsg_match (h, match, NULL, nb)))
         goto done;
-    if (flux_msg_decode (zmsg, topic, in) < 0)
+    if (flux_msg_get_topic (zmsg, topic) < 0)
+        goto done;
+    if (flux_msg_get_payload_json (zmsg, in) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -183,7 +183,7 @@ int flux_log_zmsg (zmsg_t *zmsg)
     flog_t f;
     int rc = -1;
 
-    if (flux_msg_decode (zmsg, NULL, &o) < 0 || !o || flog_decode (o, &f) < 0){
+    if (flux_json_request_decode (zmsg, &o) < 0 || flog_decode (o, &f) < 0) {
         errno = EPROTO;
         goto done;
     }

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -156,7 +156,8 @@ int flux_vlog (flux_t h, int lev, const char *fmt, va_list ap)
     } else {
         if (!(o = flog_encode (&flog)))
             goto done;
-        rc = flux_request_send (h, o, "cmb.log");
+        rc = flux_json_request (h, FLUX_NODEID_ANY,
+                                   FLUX_MATCHTAG_NONE, "cmb.log", o);
     }
 done:
     if (s)

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -63,7 +63,7 @@ int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp)
     bool treeroot;
     int ret = -1;
 
-    if (!(response = flux_rpc (h, NULL, "cmb.info")))
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "cmb.info", NULL, &response) < 0)
         goto done;
     if (!Jget_bool (response, "treeroot", &treeroot)
             || !Jget_int (response, "rank", &rank)

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -930,38 +930,6 @@ done:
     return 0;
 }
 
-int flux_msg_replace_json (zmsg_t *zmsg, json_object *o)
-{
-    const char *s = NULL;
-    int flags = 0;
-
-    if (o) {
-        if (!(s = json_object_to_json_string (o))) {
-            errno = EINVAL; /* not really sure if this can happen */
-            return -1;
-        }
-        flags |= FLUX_MSGFLAG_JSON;
-    }
-    return flux_msg_set_payload (zmsg, flags, (char *)s, strlen (s));
-}
-
-zmsg_t *flux_msg_encode (const char *topic, json_object *o)
-{
-    zmsg_t *zmsg;
-
-    if (!topic) {
-        errno = EINVAL;
-        return NULL;
-    }
-    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_REQUEST))
-            || (flux_msg_set_topic (zmsg, topic) < 0)
-            || (o && flux_msg_replace_json (zmsg, o) < 0)) {
-        zmsg_destroy (&zmsg);
-        return NULL;
-    }
-    return zmsg;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -897,16 +897,6 @@ const char *flux_msgtype_shortstr (int typemask)
  ** Deprecated functions
  **/
 
-char *flux_msg_nexthop (zmsg_t *zmsg)
-{
-    char *id = NULL;
-    if (flux_msg_get_route_last (zmsg, &id) < 0) {
-        errno = 0;
-        return NULL;
-    }
-    return id;
-}
-
 char *flux_msg_sender (zmsg_t *zmsg)
 {
     char *id = NULL;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -897,16 +897,6 @@ const char *flux_msgtype_shortstr (int typemask)
  ** Deprecated functions
  **/
 
-char *flux_msg_sender (zmsg_t *zmsg)
-{
-    char *id = NULL;
-    if (flux_msg_get_route_first (zmsg, &id) < 0) {
-        errno = 0;
-        return NULL;
-    }
-    return id;
-}
-
 int flux_msg_hopcount (zmsg_t *zmsg)
 {
     int n = flux_msg_get_route_count (zmsg);

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -930,16 +930,6 @@ done:
     return 0;
 }
 
-char *flux_msg_tag (zmsg_t *zmsg)
-{
-    char *s;
-    if (flux_msg_get_topic (zmsg, &s) < 0) {
-        errno = 0;
-        return NULL;
-    }
-    return s;
-}
-
 char *flux_msg_tag_short (zmsg_t *zmsg)
 {
     char *s, *p;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -893,43 +893,6 @@ const char *flux_msgtype_shortstr (int typemask)
     return "?";
 }
 
-/**
- ** Deprecated functions
- **/
-
-int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o)
-{
-    struct json_tokener *tok = NULL;
-;
-    if (topic && flux_msg_get_topic (zmsg, topic) < 0) {
-        errno = 0;
-        *topic = NULL;
-    }
-    if (o) {
-        int size = 0;
-        char *buf = NULL;
-        int flags;
-        if (flux_msg_get_payload (zmsg, &flags, (void **)&buf, &size) < 0
-                || buf == NULL || size == 0 || !(flags & FLUX_MSGFLAG_JSON)) {
-            errno = 0;
-            *o = NULL;
-        } else {
-            if (!(tok = json_tokener_new ())) {
-                errno = ENOMEM;
-                goto done;
-            }
-            if (!(*o = json_tokener_parse_ex (tok, buf, size))) {
-                errno = EPROTO;
-                goto done;
-            }
-        }
-    }
-done:
-    if (tok)
-        json_tokener_free (tok);
-    return 0;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -930,18 +930,6 @@ done:
     return 0;
 }
 
-char *flux_msg_tag_short (zmsg_t *zmsg)
-{
-    char *s, *p;
-    if (flux_msg_get_topic (zmsg, &s) < 0) {
-        errno = 0;
-        return NULL;
-    }
-    if ((p = strchr (s, '.')))
-        *p = '\0';
-    return s;
-}
-
 int flux_msg_replace_json (zmsg_t *zmsg, json_object *o)
 {
     const char *s = NULL;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -962,11 +962,6 @@ zmsg_t *flux_msg_encode (const char *topic, json_object *o)
     return zmsg;
 }
 
-bool flux_msg_match (zmsg_t *msg, const char *topic)
-{
-    return flux_msg_streq_topic (msg, topic);
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -897,16 +897,6 @@ const char *flux_msgtype_shortstr (int typemask)
  ** Deprecated functions
  **/
 
-int flux_msg_hopcount (zmsg_t *zmsg)
-{
-    int n = flux_msg_get_route_count (zmsg);
-    if (n < 0) {
-        errno = 0;
-        return 0;
-    }
-    return n;
-}
-
 int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o)
 {
     struct json_tokener *tok = NULL;

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -162,8 +162,6 @@ const char *flux_msgtype_shortstr (int typemask);
  **/
 
 int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o);
-int flux_msg_replace_json (zmsg_t *zmsg, json_object *o);
-zmsg_t *flux_msg_encode (const char *topic, json_object *o);
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -161,7 +161,6 @@ const char *flux_msgtype_shortstr (int typemask);
  ** Deprecated interfaces.
  **/
 
-char *flux_msg_sender (zmsg_t *zmsg);
 int flux_msg_hopcount (zmsg_t *zmsg);
 char *flux_msg_tag (zmsg_t *zmsg);
 char *flux_msg_tag_short (zmsg_t *zmsg);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -161,7 +161,6 @@ const char *flux_msgtype_shortstr (int typemask);
  ** Deprecated interfaces.
  **/
 
-char *flux_msg_tag (zmsg_t *zmsg);
 char *flux_msg_tag_short (zmsg_t *zmsg);
 int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o);
 int flux_msg_replace_json (zmsg_t *zmsg, json_object *o);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -161,7 +161,6 @@ const char *flux_msgtype_shortstr (int typemask);
  ** Deprecated interfaces.
  **/
 
-char *flux_msg_nexthop (zmsg_t *zmsg);
 char *flux_msg_sender (zmsg_t *zmsg);
 int flux_msg_hopcount (zmsg_t *zmsg);
 char *flux_msg_tag (zmsg_t *zmsg);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -157,12 +157,6 @@ int flux_msg_get_type (zmsg_t *zmsg, int *type);
 const char *flux_msgtype_string (int typemask);
 const char *flux_msgtype_shortstr (int typemask);
 
-/**
- ** Deprecated interfaces.
- **/
-
-int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o);
-
 #endif /* !_FLUX_CORE_MESSAGE_H */
 
 /*

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -161,7 +161,6 @@ const char *flux_msgtype_shortstr (int typemask);
  ** Deprecated interfaces.
  **/
 
-int flux_msg_hopcount (zmsg_t *zmsg);
 char *flux_msg_tag (zmsg_t *zmsg);
 char *flux_msg_tag_short (zmsg_t *zmsg);
 int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -164,7 +164,6 @@ const char *flux_msgtype_shortstr (int typemask);
 int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o);
 int flux_msg_replace_json (zmsg_t *zmsg, json_object *o);
 zmsg_t *flux_msg_encode (const char *topic, json_object *o);
-bool flux_msg_match (zmsg_t *msg, const char *topic);
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -161,7 +161,6 @@ const char *flux_msgtype_shortstr (int typemask);
  ** Deprecated interfaces.
  **/
 
-char *flux_msg_tag_short (zmsg_t *zmsg);
 int flux_msg_decode (zmsg_t *zmsg, char **topic, json_object **o);
 int flux_msg_replace_json (zmsg_t *zmsg, json_object *o);
 zmsg_t *flux_msg_encode (const char *topic, json_object *o);

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -174,15 +174,6 @@ done:
     return rc;
 }
 
-/**
- ** Deprecated functions.
- */
-
-int flux_respond_errnum (flux_t h, zmsg_t **zmsg, int errnum)
-{
-    return flux_err_respond (h, errnum, zmsg);
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -188,21 +188,6 @@ int flux_respond_errnum (flux_t h, zmsg_t **zmsg, int errnum)
     return flux_err_respond (h, errnum, zmsg);
 }
 
-int flux_request_send (flux_t h, JSON o, const char *fmt, ...)
-{
-    va_list ap;
-    char *topic;
-    int rc;
-
-    va_start (ap, fmt);
-    topic = xvasprintf (fmt, ap);
-    va_end (ap);
-
-    rc = flux_json_request (h, FLUX_NODEID_ANY, FLUX_MATCHTAG_NONE, topic, o);
-    free (topic);
-    return rc;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -178,11 +178,6 @@ done:
  ** Deprecated functions.
  */
 
-int flux_respond (flux_t h, zmsg_t **zmsg, JSON o)
-{
-    return flux_json_respond (h, o, zmsg);
-}
-
 int flux_respond_errnum (flux_t h, zmsg_t **zmsg, int errnum)
 {
     return flux_err_respond (h, errnum, zmsg);

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -62,7 +62,6 @@ int flux_response_decode (zmsg_t *zmsg);
  ** Deprecated interfaces.
  **/
 
-int flux_respond (flux_t h, zmsg_t **request, json_object *response);
 int flux_respond_errnum (flux_t h, zmsg_t **request, int errnum);
 
 #endif /* !_FLUX_CORE_REQUEST_H */

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -65,8 +65,6 @@ int flux_response_decode (zmsg_t *zmsg);
 int flux_respond (flux_t h, zmsg_t **request, json_object *response);
 int flux_respond_errnum (flux_t h, zmsg_t **request, int errnum);
 
-int flux_request_send (flux_t h, json_object *request, const char *fmt, ...);
-
 #endif /* !_FLUX_CORE_REQUEST_H */
 
 /*

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -57,13 +57,6 @@ int flux_json_response_decode (zmsg_t *zmsg, json_object **out);
  */
 int flux_response_decode (zmsg_t *zmsg);
 
-
-/**
- ** Deprecated interfaces.
- **/
-
-int flux_respond_errnum (flux_t h, zmsg_t **request, int errnum);
-
 #endif /* !_FLUX_CORE_REQUEST_H */
 
 /*

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -205,26 +205,6 @@ done:
     return rc;
 }
 
-/**
- ** Deprecated functions.
- */
-
-JSON flux_rpc (flux_t h, JSON o, const char *fmt, ...)
-{
-    va_list ap;
-    JSON out;
-    char *topic;
-    int rc;
-
-    va_start (ap, fmt);
-    topic = xvasprintf (fmt, ap);
-    va_end (ap);
-
-    rc = flux_json_rpc (h, FLUX_NODEID_ANY, topic, o, &out);
-    free (topic);
-    return rc < 0 ? NULL : out;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -182,13 +182,9 @@ int flux_json_rpc (flux_t h, uint32_t nodeid, const char *topic,
     }
     if (flux_msg_get_payload_json (zmsg, &o) < 0)
         goto done;
-    /* In order to support flux_rpc(), which in turn must support no-payload
-     * responses, this cannot be an error yet.
-     */
     if ((!o && out)) {
-        *out = NULL;
-        //errno = EPROTO;
-        //goto done;
+        errno = EPROTO;
+        goto done;
     }
     if ((o && !out)) {
         Jput (o);

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -31,12 +31,6 @@ int flux_json_multrpc (flux_t h, const char *nodeset, int fanout,
                        const char *topic, json_object *in,
                        flux_multrpc_f cb, void *arg);
 
-/**
- ** Deprecated interfaces.
- **/
-
-json_object *flux_rpc (flux_t h, json_object *in, const char *fmt, ...);
-
 #endif /* !_FLUX_CORE_REQUEST_H */
 
 /*

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -210,41 +210,6 @@ void check_payload (void)
     zmsg_destroy (&zmsg);
 }
 
-/* flux_msg_replace_json
- *   on message with and without JSON frame
- */
-void check_legacy_replace_json (void)
-{
-    zmsg_t *zmsg;
-    JSON o;
-    int i;
-
-    ok ((zmsg = flux_msg_encode ("baz", NULL)) != NULL && zmsg_size (zmsg) == 2,
-        "flux_msg_encode with topic string works");
-    o = Jnew ();
-    Jadd_int (o, "x", 2);
-    ok (flux_msg_replace_json (zmsg, o) == 0 && zmsg_size (zmsg) == 3,
-        "flux_msg_replace_json works on json-less message");
-    zmsg_destroy (&zmsg);
-
-    ok ((zmsg = flux_msg_encode ("baz", o)) != NULL && zmsg_size (zmsg) == 3,
-        "flux_msg_encode works with topic string and JSON");
-    Jput (o);
-
-    o = Jnew ();
-    Jadd_int (o, "y", 3);
-    ok (flux_msg_replace_json (zmsg, o) == 0 && zmsg_size (zmsg) == 3,
-        "flux_msg_replace_json works json-ful message");
-    Jput (o);
-    ok (flux_msg_decode (zmsg, NULL, &o) == 0 && o != NULL,
-        "flux_msg_decode works");
-    ok (Jget_int (o, "y", &i) && i == 3,
-        "flux_msg_decode returned replaced json");
-    Jput (o);
-
-    zmsg_destroy (&zmsg);
-}
-
 /* flux_msg_set_type, flux_msg_get_type
  * flux_msg_set_nodeid, flux_msg_get_nodeid
  * flux_msg_set_errnum, flux_msg_get_errnum
@@ -377,7 +342,7 @@ void check_cmp (void)
 
 int main (int argc, char *argv[])
 {
-    plan (96);
+    plan (90);
 
     lives_ok ({zmsg_test (false);}, // 1
         "zmsg_test doesn't assert");
@@ -387,8 +352,6 @@ int main (int argc, char *argv[])
     check_topic ();                 // 11
     check_payload ();               // 21
     check_matchtag ();              // 6
-
-    check_legacy_replace_json ();   // 6
 
     check_cmp ();                   // 8
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -2,42 +2,6 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/shortjson.h"
 
-/* flux_msg_encode, flux_msg_decode, flux_msg_match
- *   on message with no JSON frame
- */
-void check_legacy_encode (void)
-{
-    zmsg_t *zmsg;
-    JSON o = NULL;
-    char *s = NULL;
-
-    errno = 0;
-    ok (!(zmsg = flux_msg_encode (NULL, NULL)) && errno == EINVAL,
-        "flux_msg_encode with NULL topic fails with errno == EINVAL");
-    zmsg_destroy (&zmsg);
-
-    errno = 0;
-    ok ((zmsg = flux_msg_encode ("foo", NULL)) && errno == 0
-                                               && zmsg_size (zmsg) == 2,
-        "flux_msg_encode with NULL json works");
-
-    errno = 0;
-    ok ((   !flux_msg_match (zmsg, "f") && errno == 0
-            && flux_msg_match (zmsg, "foo") && errno == 0
-            && !flux_msg_match (zmsg, "foobar") && errno == 0),
-        "flux_msg_match works");
-
-    o = (JSON)&o; // make it non-NULL
-    errno = 0;
-    ok ((flux_msg_decode (zmsg, &s, &o) == 0 && errno == 0
-                                             && s != NULL && o == NULL),
-        "flux_msg_decode works");
-    like (s, "foo",
-        "and returned topic we encoded");
-    free (s);
-    zmsg_destroy (&zmsg);
-}
-
 /* flux_msg_get_route_first, flux_msg_get_route_last, _get_route_count
  *   on message with variable number of routing frames
  */
@@ -413,7 +377,7 @@ void check_cmp (void)
 
 int main (int argc, char *argv[])
 {
-    plan (101);
+    plan (96);
 
     lives_ok ({zmsg_test (false);}, // 1
         "zmsg_test doesn't assert");
@@ -424,7 +388,6 @@ int main (int argc, char *argv[])
     check_payload ();               // 21
     check_matchtag ();              // 6
 
-    check_legacy_encode ();         // 5
     check_legacy_replace_json ();   // 6
 
     check_cmp ();                   // 8

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -38,52 +38,6 @@ void check_legacy_encode (void)
     zmsg_destroy (&zmsg);
 }
 
-/* flux_msg_encode, flux_msg_decode, flux_msg_tag, flux_msg_tag_short
- *   on message with JSON
- */
-void check_legacy_encode_json (void)
-{
-    JSON o;
-    zmsg_t *zmsg;
-    char *s;
-    int i;
-
-    o = Jnew ();
-    Jadd_int (o, "x", 42);
-    errno = 0;
-    ok ((zmsg = flux_msg_encode ("a.b.c.d", o)) && errno == 0
-                                                && zmsg_size (zmsg) == 3,
-        "flux_msg_encode with JSON works");
-    Jput (o);
-
-    s = NULL;
-    o = NULL;
-    errno = 0;
-    ok (flux_msg_decode (zmsg, &s, &o) == 0 && errno == 0 && o && s,
-        "flux_msg_decode works");
-    ok (Jget_int (o, "x", &i) && i == 42,
-        "flux_msg_decode returned JSON we encoded");
-    Jput (o);
-    like (s, "a.b.c.d",
-        "flux_msg_decode returned topic string we encoded");
-    free (s);
-
-    errno = 0;
-    ok ((s = flux_msg_tag (zmsg)) != NULL && errno == 0,
-        "flux_msg_tag works");
-    like (s, "a.b.c.d",
-        "flux_msg_tag returned topic string we encoded");
-    free (s);
-
-    errno = 0;
-    ok ((s = flux_msg_tag_short (zmsg)) != NULL && errno == 0,
-        "flux_msg_tag_short works");
-    like (s, "a",
-        "flux_msg_tag_short returned first word of topic string");
-    free (s);
-    zmsg_destroy (&zmsg);
-}
-
 /* flux_msg_get_route_first, flux_msg_get_route_last, _get_route_count
  *   on message with variable number of routing frames
  */
@@ -459,7 +413,7 @@ void check_cmp (void)
 
 int main (int argc, char *argv[])
 {
-    plan (109);
+    plan (101);
 
     lives_ok ({zmsg_test (false);}, // 1
         "zmsg_test doesn't assert");
@@ -471,7 +425,6 @@ int main (int argc, char *argv[])
     check_matchtag ();              // 6
 
     check_legacy_encode ();         // 5
-    check_legacy_encode_json ();    // 8
     check_legacy_replace_json ();   // 6
 
     check_cmp ();                   // 8

--- a/src/modules/api/libapi.c
+++ b/src/modules/api/libapi.c
@@ -174,16 +174,22 @@ static int api_event_subscribe (void *impl, const char *s)
 {
     ctx_t *c = impl;
     assert (c->magic == API_CTX_MAGIC);
-    flux_t h = c->h;
-    return flux_request_send (h, NULL, "api.event.subscribe.%s", s ? s : "");
+    char *topic = xasprintf ("api.event.subscribe.%s", s ? s : "");
+    int rc = flux_json_request (c->h, FLUX_NODEID_ANY,
+                                      FLUX_MATCHTAG_NONE, topic, NULL);
+    free (topic);
+    return rc;
 }
 
 static int api_event_unsubscribe (void *impl, const char *s)
 {
     ctx_t *c = impl;
     assert (c->magic == API_CTX_MAGIC);
-    flux_t h = c->h;
-    return flux_request_send (h, NULL, "api.event.unsubscribe.%s", s ? s : "");
+    char *topic = xasprintf ("api.event.unsubscribe.%s", s ? s : "");
+    int rc = flux_json_request (c->h, FLUX_NODEID_ANY,
+                                      FLUX_MATCHTAG_NONE, topic, NULL);
+    free (topic);
+    return rc;
 }
 
 static int api_rank (void *impl)

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -164,7 +164,7 @@ static int enter_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     const char *name;
     int count, nprocs, hopcount;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL
+    if (flux_json_request_decode (*zmsg, &o) < 0
      || flux_msg_get_route_first (*zmsg, &sender) < 0
      || util_json_object_get_string (o, "name", &name) < 0
      || util_json_object_get_int (o, "count", &count) < 0
@@ -280,7 +280,7 @@ static int exit_event_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     const char *name;
     int errnum;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL
+    if (flux_json_event_decode (*zmsg, &o) < 0
             || util_json_object_get_string (o, "name", &name) < 0
             || util_json_object_get_int (o, "errnum", &errnum) < 0) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -181,7 +181,7 @@ static int enter_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
      */
     if (util_json_object_get_int (o, "hopcount", &hopcount) < 0) {
         if (barrier_add_client (b, sender, zmsg) < 0) {
-            flux_respond_errnum (ctx->h, zmsg, EEXIST);
+            flux_err_respond (ctx->h, EEXIST, zmsg);
             flux_log (ctx->h, LOG_ERR,
                         "abort %s due to double entry by client %s",
                         name, sender);
@@ -255,7 +255,7 @@ static int send_enter_response (const char *key, void *item, void *arg)
 
     if (!(cpy = zmsg_dup (zmsg)))
         oom ();
-    flux_respond_errnum (b->ctx->h, &cpy, b->errnum);
+    flux_err_respond (b->ctx->h, b->errnum, &cpy);
     return 0;
 }
 

--- a/src/modules/barrier/libbarrier.c
+++ b/src/modules/barrier/libbarrier.c
@@ -57,9 +57,8 @@ static ctx_t *getctx (flux_t h)
 int flux_barrier (flux_t h, const char *name, int nprocs)
 {
     JSON request = Jnew ();
-    JSON response = NULL;
-    int ret = -1;
     char *s = NULL;
+    int ret = -1;
 
     if (!name) {
         ctx_t *ctx = getctx (h);
@@ -73,19 +72,13 @@ int flux_barrier (flux_t h, const char *name, int nprocs)
     Jadd_int (request, "count", 1);
     Jadd_int (request, "nprocs", nprocs);
 
-    response = flux_rpc (h, request, "barrier.enter");
-    if (!response && errno > 0)
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "barrier.enter", request, NULL) < 0)
         goto done;
-    if (response) {
-        errno = EPROTO;
-        goto done;
-    }
     ret = 0;
 done:
     if (s)
         free (s);
     Jput (request);
-    Jput (response);
     return ret;
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -749,7 +749,7 @@ static int load_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     }
     if (!stall) {
         wait_destroy (w, zmsg, NULL);
-        flux_respond (ctx->h, zmsg, cpy);
+        flux_json_respond (ctx->h, cpy, zmsg);
     }
 done:
     if (o)
@@ -802,7 +802,7 @@ static int store_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
             flux_log (ctx->h, LOG_ERR, "%s: bad href %s", __FUNCTION__, iter.key);
         json_object_object_add (cpy, iter.key, NULL);
     }
-    flux_respond (ctx->h, zmsg, cpy);
+    flux_json_respond (ctx->h, cpy, zmsg);
 done:
     if (o)
         json_object_put (o);
@@ -1578,7 +1578,7 @@ static int sync_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     response = util_json_object_new_object ();
     util_json_object_add_int (response, "rootseq", ctx->rootseq);
     util_json_object_add_string (response, "rootdir", ctx->rootdir);
-    flux_respond (h, zmsg, response);
+    flux_json_respond (h, response, zmsg);
 done:
     if (request)
         json_object_put (request);
@@ -1784,8 +1784,8 @@ static int stats_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 
         util_json_object_add_int (o, "store revision", ctx->rootseq);
 
-        if (flux_respond (h, zmsg, o) < 0) {
-            err ("%s: flux_respond", __FUNCTION__);
+        if (flux_json_respond (h, o, zmsg) < 0) {
+            err ("%s: flux_json_respond", __FUNCTION__);
             goto done_stop;
         }
     } else if (fnmatch ("*.stats.clear", tag, 0) == 0) {

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -879,7 +879,7 @@ static int dropcache_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     }
     flux_log (h, LOG_ALERT, "dropped %d of %d cache entries", expcount, sz);
     if ((typemask & FLUX_MSGTYPE_REQUEST))
-        flux_respond_errnum (h, zmsg, rc);
+        flux_err_respond (h, rc, zmsg);
     return 0;
 }
 
@@ -1791,8 +1791,8 @@ static int stats_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     } else if (fnmatch ("*.stats.clear", tag, 0) == 0) {
         memset (&ctx->stats, 0, sizeof (ctx->stats));
         if ((typemask & FLUX_MSGTYPE_REQUEST)) {
-            if (flux_respond_errnum (h, zmsg, 0) < 0) {
-                err ("%s: flux_respond_errnum", __FUNCTION__);
+            if (flux_err_respond (h, 0, zmsg) < 0) {
+                err ("%s: flux_err_respond", __FUNCTION__);
                 goto done_stop;
             }
         } else

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -733,7 +733,7 @@ static int load_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     wait_t w = NULL;
     bool stall = false;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL) {
+    if (flux_json_request_decode (*zmsg, &o) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -767,7 +767,7 @@ static int load_response_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     json_object *o = NULL;
     json_object_iter iter;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL) {
+    if (flux_json_response_decode (*zmsg, &o) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -790,7 +790,7 @@ static int store_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     json_object_iter iter;
     href_t href;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL) {
+    if (flux_json_request_decode (*zmsg, &o) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -819,7 +819,7 @@ static int store_response_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     json_object *o = NULL;
     json_object_iter iter;
 
-    if (flux_msg_decode (*zmsg, NULL, &o) < 0 || o == NULL) {
+    if (flux_json_response_decode (*zmsg, &o) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -888,7 +888,7 @@ static int hb_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     ctx_t *ctx = arg;
     json_object *event = NULL;
 
-    if (flux_msg_decode (*zmsg, NULL, &event) < 0 || event == NULL
+    if (flux_json_event_decode (*zmsg, &event) < 0
                 || util_json_object_get_int (event, "epoch", &ctx->epoch) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
@@ -1565,7 +1565,7 @@ static int sync_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     json_object *response = NULL;
     int rootseq;
 
-    if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL
+    if (flux_json_request_decode (*zmsg, &request) < 0
                 || util_json_object_get_int (request, "rootseq", &rootseq) < 0){
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
@@ -1738,14 +1738,14 @@ static int stats_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
     json_object *o = NULL;
-    char *tag = NULL;
+    char *topic = NULL;
     int rc = -1;
 
-    if (flux_msg_decode (*zmsg, &tag, NULL) < 0) {
+    if (flux_msg_get_topic (*zmsg, &topic) < 0) {
         flux_log (h, LOG_ERR, "%s: error decoding message", __FUNCTION__);
         goto done;
     }
-    if (fnmatch ("*.stats.get", tag, 0) == 0) {
+    if (fnmatch ("*.stats.get", topic, 0) == 0) {
         tstat_t ts;
         int size, incomplete, dirty;
 
@@ -1788,7 +1788,7 @@ static int stats_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
             err ("%s: flux_json_respond", __FUNCTION__);
             goto done_stop;
         }
-    } else if (fnmatch ("*.stats.clear", tag, 0) == 0) {
+    } else if (fnmatch ("*.stats.clear", topic, 0) == 0) {
         memset (&ctx->stats, 0, sizeof (ctx->stats));
         if ((typemask & FLUX_MSGTYPE_REQUEST)) {
             if (flux_err_respond (h, 0, zmsg) < 0) {
@@ -1804,8 +1804,8 @@ done:       /* reactor continues */
 done_stop:  /* reactor terminates */
     if (o)
         json_object_put (o);
-    if (tag)
-        free (tag);
+    if (topic)
+        free (topic);
     return rc;
 }
 

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -1089,66 +1089,51 @@ done:
 
 int kvs_get_version (flux_t h, int *versionp)
 {
-    json_object *request = util_json_object_new_object ();
-    json_object *reply = NULL;
+    JSON in = Jnew ();
+    JSON out = NULL;
     int ret = -1;
     int version;
- 
-    reply = flux_rpc (h, request, "kvs.getroot");
-    if (!reply)
+
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "kvs.getroot", in, &out) < 0)
         goto done;
-    if (util_json_object_get_int (reply, "rootseq", &version) < 0) {
+    if (!Jget_int (out, "rootseq", &version)) {
         errno = EPROTO;
         goto done;
     }
     *versionp = version;
     ret = 0;
 done:
-    if (request)
-        json_object_put (request);
-    if (reply)
-        json_object_put (reply); 
+    Jput (in);
+    Jput (out);
     return ret;
 }
 
 int kvs_wait_version (flux_t h, int version)
 {
-    json_object *request = util_json_object_new_object ();
-    json_object *reply = NULL;
+    JSON in = Jnew ();
+    JSON out = NULL;
     int ret = -1;
- 
-    util_json_object_add_int (request, "rootseq", version);
-    reply = flux_rpc (h, request, "kvs.sync");
-    if (!reply)
+
+    Jadd_int (in, "rootseq", version);
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "kvs.sync", in, &out) < 0)
         goto done;
     ret = 0;
 done:
-    if (request)
-        json_object_put (request);
-    if (reply)
-        json_object_put (reply); 
+    Jput (in);
+    Jput (out);
     return ret;
 }
 
 int kvs_dropcache (flux_t h)
 {
-    json_object *request = util_json_object_new_object ();
-    json_object *reply = NULL;
+    JSON in = Jnew ();
     int ret = -1;
- 
-    reply = flux_rpc (h, request, "kvs.dropcache");
-    if (!reply && errno > 0)
+
+    if (flux_json_rpc (h, FLUX_NODEID_ANY, "kvs.dropcache", in, NULL) < 0)
         goto done;
-    if (reply) { 
-        errno = EPROTO;
-        goto done;
-    }
     ret = 0;
 done:
-    if (request)
-        json_object_put (request);
-    if (reply)
-        json_object_put (reply); 
+    Jput (in);
     return ret;
 }
 

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -529,14 +529,14 @@ static int goodbye_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         goto done;
     }
     if (prank != ctx->rank) { /* in case misdirected to new parent */
-        flux_respond_errnum (h, zmsg, EINVAL);
+        flux_err_respond (h, EINVAL, zmsg);
         goto done;
     }
     if (asprintf (&rankstr, "%d", rank) < 0)
         oom ();
     zhash_delete (ctx->children, rankstr);
     manage_subscriptions (ctx);
-    flux_respond_errnum (h, zmsg, 0);
+    flux_err_respond (h, 0, zmsg);
 done:
     if (rankstr)
         free (rankstr);
@@ -968,9 +968,9 @@ static int failover_request_cb (flux_t h, int typemask, zmsg_t **zmsg,void *arg)
     ctx_t *ctx = arg;
 
     if (failover (ctx) < 0)
-        flux_respond_errnum (h, zmsg, errno);
+        flux_err_respond (h, errno, zmsg);
     else
-        flux_respond_errnum (h, zmsg, 0);
+        flux_err_respond (h, 0, zmsg);
 
     return 0;
 }
@@ -980,9 +980,9 @@ static int recover_request_cb (flux_t h, int typemask, zmsg_t **zmsg,void *arg)
     ctx_t *ctx = arg;
 
     if (recover (ctx) < 0)
-        flux_respond_errnum (h, zmsg, errno);
+        flux_err_respond (h, errno, zmsg);
     else
-        flux_respond_errnum (h, zmsg, 0);
+        flux_err_respond (h, 0, zmsg);
 
     return 0;
 }

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -354,7 +354,7 @@ static int cstate_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     cstate_t ostate, nstate;
     int rc = 0;
 
-    if (flux_msg_decode (*zmsg, NULL, &event) < 0 || event == NULL
+    if (flux_json_event_decode (*zmsg, &event) < 0
             || !Jget_int (event, "epoch", &epoch)
             || !Jget_int (event, "parent", &parent)
             || !Jget_int (event, "rank", &rank)
@@ -420,7 +420,7 @@ static int hb_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     zlist_t *keys = NULL;
     char *key;
 
-    if (flux_msg_decode (*zmsg, NULL, &event) < 0 || event == NULL
+    if (flux_json_event_decode (*zmsg, &event) < 0
             || !Jget_int (event, "epoch", &ctx->epoch)) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
@@ -522,7 +522,7 @@ static int goodbye_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     int rank, prank;
     char *rankstr = NULL;
 
-    if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL
+    if (flux_json_request_decode (*zmsg, &request) < 0
                             || !Jget_int (request, "parent-rank", &prank)
                             || !Jget_int (request, "rank", &rank)) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
@@ -890,7 +890,7 @@ static int push_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     ctx_t *ctx = arg;
     JSON request = NULL;
 
-    if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL) {
+    if (flux_json_request_decode (*zmsg, &request) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -912,7 +912,7 @@ static int hello_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     int rank;
     child_t *c;
 
-    if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL
+    if (flux_json_request_decode (*zmsg, &request) < 0
                             || !Jget_int (request, "rank", &rank)) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -935,7 +935,7 @@ static int hello_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     response = parents_tojson (ctx);
     parent_destroy (zlist_pop (ctx->parents));
 
-    flux_respond (h, zmsg, response);
+    flux_json_respond (h, response, zmsg);
 done:
     Jput (request);
     Jput (response);

--- a/src/modules/mecho/mecho.c
+++ b/src/modules/mecho/mecho.c
@@ -38,8 +38,8 @@ static int mecho_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     json_object *inarg = NULL;
     flux_mrpc_t f = NULL;
 
-    if (flux_msg_decode (*zmsg, NULL, &request) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_decode: %s", strerror (errno));
+    if (flux_json_event_decode (*zmsg, &request) < 0) {
+        flux_log (h, LOG_ERR, "flux_json_event_decode: %s", strerror (errno));
         goto done;
     }
     if (!request) {

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -143,8 +143,9 @@ static unsigned long lwj_next_id (flux_t h)
         ret = increment_jobid (h);
     else {
         json_object *na = json_object_new_object ();
-        json_object *o = flux_rpc (h, na, "job.next-id");
-        if (util_json_object_get_int64 (o, "id", (int64_t *) &ret) < 0) {
+        json_object *o = NULL;
+        if (flux_json_rpc (h, FLUX_NODEID_ANY, "job.next-id", na, &o) < 0
+                || util_json_object_get_int64 (o, "id", (int64_t *) &ret) < 0) {
             err ("lwj_next_id: Bad object!");
             ret = 0;
         }
@@ -208,8 +209,9 @@ static int wait_for_lwj_watch_init (flux_t h, int64_t id)
     rpc_o = util_json_object_new_object ();
     util_json_object_add_string (rpc_o, "key", "lwj.next-id");
     util_json_object_add_int64 (rpc_o, "val", id);
-    rpc_resp = flux_rpc (h, rpc_o, "sim_sched.lwj-watch");
+    flux_json_rpc (h, FLUX_NODEID_ANY, "sim_sched.lwj-watch", rpc_o, &rpc_resp);
     util_json_object_get_int (rpc_resp, "rc", &rc);
+done:
     json_object_put (rpc_resp);
     json_object_put (rpc_o);
     return rc;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -234,7 +234,8 @@ static int job_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
             }
             else {
                 fprintf (stderr, "%s: forwarding request\n", tag);
-                flux_request_send (h, o, tag);
+                flux_json_request (h, FLUX_NODEID_ANY,
+                                      FLUX_MATCHTAG_NONE, tag, o);
             }
         }
         if (strcmp (tag, "job.create") == 0) {

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -229,7 +229,7 @@ static int job_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
             if (flux_treeroot (h)) {
                 unsigned long id = lwj_next_id (h);
                 json_object *ox = json_id (id);
-                flux_respond (h, zmsg, ox);
+                flux_json_respond (h, ox, zmsg);
                 json_object_put (o);
             }
             else {
@@ -260,7 +260,7 @@ static int job_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
             /* Generate reply with new jobid */
             jobinfo = util_json_object_new_object ();
             util_json_object_add_int64 (jobinfo, "jobid", id);
-            flux_respond (h, zmsg, jobinfo);
+            flux_json_respond (h, jobinfo, zmsg);
             json_object_put (jobinfo);
         }
     }

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -244,13 +244,13 @@ static int job_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 #if SIMULATOR_RACE_WORKAROUND
             //"Fix" for Race Condition
             if (wait_for_lwj_watch_init (h, id) < 0) {
-                flux_respond_errnum (h, zmsg, errno);
+                flux_err_respond (h, errno, zmsg);
                 goto out;
             }
 #endif
             int rc = kvs_job_new (h, id);
             if (rc < 0) {
-                flux_respond_errnum (h, zmsg, errno);
+                flux_err_respond (h, errno, zmsg);
                 goto out;
             }
             add_jobinfo (h, id, o);

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -486,7 +486,9 @@ int lwj_targets_this_node (struct rexec_ctx *ctx, int64_t id)
 static int event_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     struct rexec_ctx *ctx = arg;
-    char *tag = flux_msg_tag (*zmsg);
+    char *tag = NULL;
+    if (flux_msg_get_topic (*zmsg, &tag) < 0)
+        goto done;
     if (strncmp (tag, "wrexec.run", 10) == 0) {
         int64_t id = id_from_tag (tag + 11, NULL);
         if (id < 0)
@@ -506,6 +508,7 @@ static int event_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         mrpc_handler (ctx, *zmsg);
     }
     free (tag);
+done:
     if (zmsg && *zmsg)
         zmsg_destroy (zmsg);
     return 0;

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1445,19 +1445,23 @@ int signal_cb (flux_t f, int fd, short revents, struct prog_ctx *ctx)
 
 int cmb_cb (flux_t f, void *zs, short revents, struct prog_ctx *ctx)
 {
-    char *tag;
-    json_object *o;
+    char *tag = NULL;
+    json_object *o = NULL;
 
     zmsg_t *zmsg = zmsg_recv (zs);
     if (!zmsg) {
         log_msg (ctx, "rexec_cb: no msg to recv!");
-        return (0);
+        goto done;
     }
     free (zmsg_popstr (zmsg)); /* Destroy dealer id */
 
-    if (flux_msg_decode (zmsg, &tag, &o) < 0) {
-        log_err (ctx, "cmb_msg_decode");
-        return (0);
+    if (flux_msg_get_topic (zmsg, &tag) < 0) {
+        log_err (ctx, "flux_msg_get_topic");
+        goto done;
+    }
+    if (flux_msg_get_payload_json (zmsg, &o) < 0) {
+        log_err (ctx, "flux_msg_get_payload_json");
+        goto done;
     }
 
     /* Got an incoming message from cmbd */
@@ -1468,8 +1472,12 @@ int cmb_cb (flux_t f, void *zs, short revents, struct prog_ctx *ctx)
         log_msg (ctx, "Killing jobid %lu with signal %d", ctx->id, sig);
         prog_ctx_signal (ctx, sig);
     }
+done:
     zmsg_destroy (&zmsg);
-    json_object_put (o);
+    if (o)
+        json_object_put (o);
+    if (tag)
+        free (tag);
     return (0);
 }
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -391,14 +391,6 @@ static char * ctime_iso8601_now (char *buf, size_t sz)
 /*
  *  Send a message to rexec plugin
  */
-int rexec_send_msg (struct prog_ctx *ctx, char *tag, json_object *o)
-{
-    zmsg_t *zmsg = flux_msg_encode (tag, o);
-    if (!zmsg)
-        return (-1);
-    zmsg_dump (zmsg);
-    return zmsg_send (&zmsg, ctx->zs_req);
-}
 
 static int get_executable_path (char *buf, size_t len)
 {

--- a/t/t1003-mecho.t
+++ b/t/t1003-mecho.t
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+
+test_description='Test mecho service
+
+Verify mecho in a running flux comms session.
+'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+test_under_flux ${SIZE}
+
+test_expect_success 'mecho: mping 0-3 works' '
+	flux mping --count 1 \[0-3\]
+'
+test_expect_success 'mecho: mping 1-2 works' '
+	flux mping --count 1 \[1-2\]
+'
+
+test_expect_success 'mecho: mping 0 works' '
+	flux mping --count 1 0
+'
+
+test_expect_success 'mecho: mping bad rank fails' '
+	test_must_fail flux mping --count 1 42
+'
+
+test_done

--- a/t/t1004-log.t
+++ b/t/t1004-log.t
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# FIXME: this test will always succeed as long as the logger
+# command thinks everything is OK, a dubious proposition since
+# Flux log messages are fire and forget.  Logging needs a makeover,
+# and so does this test.
+
+test_description='Test logging service
+
+Verify flux logger in a running flux comms session.
+'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+test_under_flux ${SIZE}
+
+test_expect_success 'logger: log from all ranks works' '
+	flux exec flux logger test message
+'
+test_done


### PR DESCRIPTION
Convert all uses of deprecated functions to newer equivalents, then remove them and their tests.

Add a few tests to cover areas that were touched and had no tests.

I will submit a PR to update `flux-sched`

resolves #180