### PR TITLE
libflux-core.so is now stand-alone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ install:
   - (cd czmq-2.2.0 && ./configure && make -j2 && sudo make install)
   - sudo ldconfig
 
-script: ./autogen.sh && ./configure  && make -j2 distcheck
+script: ./autogen.sh && ./configure  && make -j2 V=1 distcheck
 
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -12,11 +12,9 @@ AM_CPPFLAGS = \
 	-DMANDIR=\"$(mandir)\"
 
 fluxcmd_ldadd = \
-	$(top_builddir)/src/common/libflux/libflux.la \
-	$(top_builddir)/src/common/libutil/libutil.la \
-	$(top_builddir)/src/common/liblsd/liblsd.la \
-	$(top_builddir)/src/common/libev/libev.la \
-	-L$(top_builddir)/src/modules/live -llive \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/modules/live/liblive.la \
 	$(top_builddir)/src/modules/kvs/libkvs.la \
 	$(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBMUNGE) $(LIBPTHREAD) $(LIBDL)
 
@@ -53,12 +51,12 @@ fluxcmd_PROGRAMS = \
 
 flux_zio_LDADD = \
 	$(top_builddir)/src/common/libzio/libzio.la \
-	$(top_builddir)/src/common/liblsd/liblsd.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(fluxcmd_ldadd) \
 	$(LIBUTIL)
 flux_mping_LDADD = \
 	$(top_builddir)/src/modules/libmrpc/libmrpc.la \
-	$(top_builddir)/src/common/liblsd/liblsd.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(fluxcmd_ldadd) \
 	$(LIBUTIL)
 flux_module_LDADD = \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -13,11 +13,15 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libev/libev.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt
+libflux_internal_la_LDFLAGS = -static -export-dynamic --disable-shared \
+			      -Wl,--no-undefined
 
 libflux_core_la_SOURCES =
 libflux_core_la_LIBADD = \
 	$(builddir)/libflux/libflux.la \
-	libflux-internal.la
+	libflux-internal.la \
+	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
+	$(LIBDL) -lrt
 #-lrt is for clock_gettime, this should be abstracted
 
 libflux_core_la_LDFLAGS = -Wl,--version-script=$(srcdir)/version.map \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -11,21 +11,22 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/libutil.la \
 	$(builddir)/libev/libev.la \
+libflux_internal_la_LDFLAGS = \
+	-static -export-dynamic --disable-shared -Wl,--no-undefined \
 	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt
-libflux_internal_la_LDFLAGS = -static -export-dynamic --disable-shared \
-			      -Wl,--no-undefined
 
 libflux_core_la_SOURCES =
 libflux_core_la_LIBADD = \
 	$(builddir)/libflux/libflux.la \
-	libflux-internal.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt
 #-lrt is for clock_gettime, this should be abstracted
 
-libflux_core_la_LDFLAGS = -Wl,--version-script=$(srcdir)/version.map \
-			  -shared -export-dynamic --disable-static \
-			  -Wl,--no-undefined
+libflux_core_la_LDFLAGS = \
+	-Wl,--version-script=$(srcdir)/version.map \
+	-shared -export-dynamic --disable-static \
+	-Wl,--no-undefined \
+	libflux-internal.la
 
 EXTRA_DIST = version.map

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -5,18 +5,18 @@ AM_CFLAGS = @GCCWARN@
 AM_CPPFLAGS =
 
 fluxinclude_HEADERS = core.h
-noinst_LTLIBRARIES = libflux-internal.la
-fluxlib_LTLIBRARIES = libflux-core.la
+fluxlib_LTLIBRARIES = libflux-core.la libflux-internal.la
 libflux_internal_la_SOURCES =
 libflux_internal_la_LIBADD = \
-	$(builddir)/libflux/libflux.la \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/libutil.la \
 	$(builddir)/libev/libev.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt
+
 libflux_core_la_SOURCES =
 libflux_core_la_LIBADD = \
+	$(builddir)/libflux/libflux.la \
 	libflux-internal.la
 #-lrt is for clock_gettime, this should be abstracted
 

--- a/src/common/version.map
+++ b/src/common/version.map
@@ -1,8 +1,5 @@
 { global:
     flux_*;
-    kvs_*;
-    kvsitr_*;
-    kvsdir_*;
     local: *;
 };
 

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -47,6 +47,8 @@ TESTS = \
 test_ldadd = \
         $(top_builddir)/src/modules/kvs/waitqueue.o \
         $(top_builddir)/src/modules/kvs/libkvs.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
         $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
 


### PR DESCRIPTION
Since the KVS symbols are in the module library now, the only symbols left to
be exported by the core were the flux_* symbols.  Since all of those are in
libflux, libflux is now linked into libflux-core but *not* into
libflux-internal.  This way there will only be one copy of the flux_* symbols
in a final application, and they will be exported by the so.