### PR TITLE
fixes for out of tree builds

### DIFF
--- a/etc/Makefile.inc.in
+++ b/etc/Makefile.inc.in
@@ -1,6 +1,6 @@
 FLUX_LIBS = \
-	-Wl,-rpath,@abs_top_builddir@/src/lib/libcore/.libs \
-	-L@abs_top_builddir@/src/lib/libcore/.libs -lflux-core \
+	-Wl,-rpath,@abs_top_builddir@/src/common/.libs \
+	-L@abs_top_builddir@/src/common/.libs -lflux-internal -lflux-core \
 	@LIBZMQ@ @LIBCZMQ@ @JSON_LIBS@ @LUA_LIB@
 
 FLUX_CFLAGS = \

--- a/flux-core.spec.in
+++ b/flux-core.spec.in
@@ -51,6 +51,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/flux/*.so.*
 %dir %{_libdir}/flux/modules
 %{_libdir}/flux/modules/*.so
+%{_libdir}/flux/connectors/*.so
 %{_libdir}/lua/*/*.so
 %{_prefix}/share/lua/*/*.lua
 %{_prefix}/share/lua/*/flux-lua/*.lua
@@ -73,6 +74,9 @@ if [ -x /sbin/ldconfig ]; then /sbin/ldconfig %{_libdir}/flux; fi
 if [ -x /sbin/ldconfig ]; then /sbin/ldconfig %{_libdir}/flux; fi
 
 %changelog
+* Wed May 20 2015 Jim Garlick <garlick@llnl.gov> 0.1.0-1
+- Include connector dso's in package
+
 * Wed Sep 24 2014 Mark A. Grondona <mgrondona@llnl.gov> 0.1.0-1
 - Package wreck lua extensions
 

--- a/src/common/libutil/test/coproc.c
+++ b/src/common/libutil/test/coproc.c
@@ -180,11 +180,12 @@ int main (int argc, char *argv[])
         "coproc_get_stacksize returned %d", ssize);
 
     /* We can't use all of the stack and get away with it.
-     * FIXME: it is unclaer why this number must be so large.
+     * FIXME: it is unclear why this number must be so large.
      * I found it experimentally; maybe it is non-portable and that
      * will make this test fragile?
      */
-    const size_t stack_reserve = 2560; // XXX 2540 is too small
+    //const size_t stack_reserve = 2560; // XXX 2540 is too small
+    const size_t stack_reserve = 3000;
 
     /* should be OK */
     ssize -= stack_reserve;


### PR DESCRIPTION
This PR includes the fix to `Makefile.inc` proposed by @lipari in PR #193, plus fixes to two problems encountered when building a flux-core RPM on rhel6:
* Tweak a fragile coproc unit test
* Update spec file to include "connectors"

Still todo for RPM is to resolve unsatisfied liblive, libmodctl.  Waiting for @trws to settle PR #192 before tackling that one.
