### PR TITLE
zio: export zio_read

### DIFF
--- a/src/modules/libzio/zio.c
+++ b/src/modules/libzio/zio.c
@@ -361,7 +361,7 @@ int zio_set_close_cb (zio_t zio, zio_close_f closef)
     return (0);
 }
 
-static int zio_read (zio_t zio, void *dst, int len)
+static int zio_fd_read (zio_t zio, void *dst, int len)
 {
     assert (zio != NULL);
     assert (zio->magic == ZIO_MAGIC);
@@ -473,7 +473,7 @@ int zio_flush (zio_t zio)
         zio_debug (zio, "zio_flush: len = %d, eof = %d\n", len, zio_eof (zio));
         if (len > 0) {
             buf = xzmalloc (len + 1);
-            if ((n = zio_read (zio, buf, len + 1)) <= 0) {
+            if ((n = zio_fd_read (zio, buf, len + 1)) <= 0) {
                 if (n < 0) {
                     zio_debug (zio, "zio_read: %s", strerror (errno));
                     rc = -1;

--- a/src/modules/libzio/zio.c
+++ b/src/modules/libzio/zio.c
@@ -499,17 +499,14 @@ int zio_flush (zio_t zio)
     return (rc);
 }
 
-static int zio_read_cb_common (zio_t zio)
+
+int zio_read (zio_t zio)
 {
     int n;
-    if ((n = cbuf_write_from_fd (zio->buf, zio->srcfd, -1, NULL)) < 0) {
-        if (errno == EAGAIN);
-            return (0);
-        zio_debug (zio, "read: %s\n", strerror (errno));
+    if ((n = cbuf_write_from_fd (zio->buf, zio->srcfd, -1, NULL)) < 0)
         return (-1);
-    }
 
-    zio_debug (zio, "zio_read_cb: read = %d\n", n);
+    zio_debug (zio, "zio_read: read = %d\n", n);
 
     if (n == 0) {
         zio_set_eof (zio);
@@ -518,7 +515,15 @@ static int zio_read_cb_common (zio_t zio)
 
     zio_flush (zio);
 
-    return (0);
+    return (n);
+}
+
+static int zio_read_cb_common (zio_t zio)
+{
+    int rc = zio_read (zio);
+    if ((rc < 0) && (errno == EAGAIN))
+        rc = 0;
+    return (rc);
 }
 
 static int zio_zloop_read_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t zio)

--- a/src/modules/libzio/zio.h
+++ b/src/modules/libzio/zio.h
@@ -65,11 +65,19 @@ int zio_dst_fd (zio_t zio);
 int zio_closed (zio_t zio);
 
 /*
+ *  Non-blocking read from zio object. Will read from zio object's src fd
+ *   and buffer I/O according to buffering policy of object. Callbacks
+ *   will be called synchronously if required by buffering policy.
+ */
+int zio_read (zio_t zio);
+
+/*
  *  Write data from json object [o] to zio object [z], data is buffered
  *   if necessary. Only data destined for specific object [z] is read,
  *   and the data is consumed after reading.
  */
 int zio_write_json (zio_t z, json_object *o);
+
 
 /*
  *   Attach zio object [x] to zloop poll loop [zloop].


### PR DESCRIPTION
Somehow during the shuffle in #200 a couple commits got dropped from the zio code

6fbe4fa50dc9e92775f288413b68af50b89e3e78
6053a339ba2280a780eaf117f3ab6df980ee9d6c

This PR pulls them back. I suppose this could wait until we have a PR with users of the new code, but since this code was already in there for a bit I figure I might as well throw them back up here. No problem if you guys want to wait.