### PR TITLE
link connectors in a manner similar to comms modules

### DIFF
--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -955,7 +955,7 @@ void flux_msg_fprint (FILE *f, zmsg_t *zmsg)
     /* Route stack
      */
     hops = flux_msg_get_route_count (zmsg); /* -1 if no route stack */
-    if (hops > 0) {
+    if (hops >= 0) {
         int len = flux_msg_get_route_size (zmsg);
         char *rte = flux_msg_get_route_string (zmsg);
         assert (rte != NULL);

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -6,16 +6,12 @@ AM_CPPFLAGS = \
 
 fluxconnector_LTLIBRARIES = local.la
 
-fluxconnector_libadd = \
-	$(top_builddir)/src/common/libflux/libflux.la \
-	$(top_builddir)/src/common/libutil/libutil.la \
-	$(top_builddir)/src/common/liblsd/liblsd.la \
-	$(top_builddir)/src/common/libev/libev.la \
-	$(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ)
-
-fluxconnector_ldflags = -avoid-version -module -shared -export-dynamic \
-	-export-symbols-regex '^connector_init$$'
-
 local_la_SOURCES = local.c
-local_la_LDFLAGS = $(fluxconnector_ldflags)
-local_la_LIBADD = $(fluxconnector_libadd)
+
+local_la_LDFLAGS = -module -Wl,--no-undefined \
+	-export-symbols-regex '^connector_init$$' \
+	--disable-static -avoid-version -shared -export-dynamic \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+local_la_LIBADD = $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ)


### PR DESCRIPTION
Update the `Makefile.am` used to build the `local.so` connector so that it links against `libflux-core` and `libflux-internal`, and uses ldflags similar to that used to build comms modules.

This fixes a spurious segfault in the lua event test in anther PR I was working.  Full disclosure: I could not debug that segfault, except to get a general idea that something was failing in the main libflux code that was working perfectly well for many other tests.  I got a hunch that this had to do with missing symbols lazily resolved at runtime, discovered that the connector Makefile.am was probably not right, made this change, and it went away.

This PR also contains a tiny fix to `flux_msg_fprint()`.