### PR TITLE
finish removing json_object from libflux API functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,7 @@ AC_CONFIG_FILES( \
   src/cmd/Makefile \
   src/connectors/Makefile \
   src/connectors/local/Makefile \
+  src/connectors/loop/Makefile \
   src/modules/Makefile \
   src/modules/api/Makefile \
   src/modules/kvs/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,7 @@ AC_CONFIG_FILES( \
   src/common/libutil/Makefile \
   src/common/libev/Makefile \
   src/common/libflux/Makefile \
+  src/common/libjsonc/Makefile \
   src/lib/Makefile \
   src/lib/libpmi/Makefile \
   src/bindings/Makefile \

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -89,7 +89,7 @@ int module_stop_all (modhash_t mh);
 
 /* Prepare an 'lsmod' response payload.
  */
-json_object *module_list_encode (modhash_t mh);
+flux_modlist_t module_get_modlist (modhash_t mh);
 
 #endif /* !_BROKER_MODULE_H */
 

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -96,11 +96,11 @@ int main (int argc, char *argv[])
     } else if (!strcmp (cmd, "idle")) {
         if (optind != argc)
             usage ();
-        JSON peers;
+        char *peers;
         if (!(peers = flux_lspeer (h, rank)))
             err_exit ("flux_peer");
-        printf ("%s\n", Jtostr (peers));
-        Jput (peers);
+        printf ("%s\n", peers);
+        free (peers);
     } else if (!strcmp (cmd, "getattr")) {
         char *s;
         if (optind != argc - 1)

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = libtap libev liblsd libutil libflux
+SUBDIRS = libtap libev liblsd libutil libflux libjsonc
 
 AM_CFLAGS = @GCCWARN@
 
@@ -11,6 +11,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/libutil.la \
 	$(builddir)/libev/libev.la \
+	$(builddir)/libjsonc/libjsonc.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt
 libflux_internal_la_LDFLAGS = -Wl,--no-undefined

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -15,6 +15,7 @@ fluxcoreinclude_HEADERS = \
 	message.h \
 	request.h \
 	response.h \
+	rpc.h \
 	panic.h \
 	event.h \
 	module.h \
@@ -37,6 +38,7 @@ libflux_la_SOURCES = \
 	message.c \
 	request.c \
 	response.c \
+	rpc.c \
 	panic.c \
 	event.c \
 	module.c \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -13,6 +13,7 @@ fluxcoreinclude_HEADERS = \
 	reduce.h \
 	security.h \
 	message.h \
+	request.h \
 	panic.h \
 	event.h \
 	module.h \
@@ -33,6 +34,7 @@ libflux_la_SOURCES = \
 	reduce.c \
 	security.c \
 	message.c \
+	request.c \
 	panic.c \
 	event.c \
 	module.c \
@@ -45,6 +47,7 @@ libflux_la_SOURCES = \
 TESTS = test_conf.t \
 	test_module.t \
 	test_message.t \
+	test_request.t \
 	test_event.t \
 	test_tagpool.t
 
@@ -90,3 +93,6 @@ test_tagpool_t_SOURCES = test/tagpool.c tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 
+test_request_t_SOURCES = test/request.c
+test_request_t_CPPFLAGS = $(test_cppflags)
+test_request_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -14,6 +14,7 @@ fluxcoreinclude_HEADERS = \
 	security.h \
 	message.h \
 	request.h \
+	response.h \
 	panic.h \
 	event.h \
 	module.h \
@@ -35,6 +36,7 @@ libflux_la_SOURCES = \
 	security.c \
 	message.c \
 	request.c \
+	response.c \
 	panic.c \
 	event.c \
 	module.c \
@@ -48,6 +50,7 @@ TESTS = test_conf.t \
 	test_module.t \
 	test_message.t \
 	test_request.t \
+	test_response.t \
 	test_event.t \
 	test_tagpool.t
 
@@ -96,3 +99,7 @@ test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 test_request_t_SOURCES = test/request.c
 test_request_t_CPPFLAGS = $(test_cppflags)
 test_request_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_response_t_SOURCES = test/response.c
+test_response_t_CPPFLAGS = $(test_cppflags)
+test_response_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -57,9 +57,10 @@ TESTS = test_conf.t \
 	test_tagpool.t
 
 test_ldadd = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux/libflux.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
 
 test_cppflags = \
@@ -94,7 +95,7 @@ test_event_t_SOURCES = test/event.c
 test_event_t_CPPFLAGS = $(test_cppflags)
 test_event_t_LDADD = $(test_ldadd) $(LIBDL)
 
-test_tagpool_t_SOURCES = test/tagpool.c tagpool.c
+test_tagpool_t_SOURCES = test/tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -15,13 +15,11 @@ fluxcoreinclude_HEADERS = \
 	message.h \
 	panic.h \
 	event.h \
-	request.h \
 	module.h \
 	reparent.h \
 	info.h \
 	flog.h \
 	conf.h \
-	rpc.h \
 	tmpdir.h
 
 noinst_LTLIBRARIES = \
@@ -37,11 +35,9 @@ libflux_la_SOURCES = \
 	message.c \
 	panic.c \
 	event.c \
-	request.c \
 	module.c \
 	reparent.c \
 	conf.c \
-	rpc.c \
 	tagpool.h \
 	tagpool.c \
 	tmpdir.c
@@ -53,11 +49,10 @@ TESTS = test_conf.t \
 	test_tagpool.t
 
 test_ldadd = \
-        $(top_builddir)/src/common/libflux/libflux.la \
-        $(top_builddir)/src/common/libutil/libutil.la \
-        $(top_builddir)/src/common/libtap/libtap.la \
-        $(top_builddir)/src/common/liblsd/liblsd.la \
-        $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
 
 test_cppflags = \
 	-DMODULE_PATH=\"$(top_builddir)/src/modules\" \
@@ -91,7 +86,7 @@ test_event_t_SOURCES = test/event.c
 test_event_t_CPPFLAGS = $(test_cppflags)
 test_event_t_LDADD = $(test_ldadd) $(LIBDL)
 
-test_tagpool_t_SOURCES = test/tagpool.c
+test_tagpool_t_SOURCES = test/tagpool.c tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -30,7 +30,6 @@
 
 #include "event.h"
 #include "message.h"
-#include "rpc.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -31,9 +31,9 @@
 
 #include "flog.h"
 #include "info.h"
-#include "request.h"
 #include "message.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -32,8 +32,8 @@
 #include "flog.h"
 #include "info.h"
 #include "message.h"
+#include "request.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
@@ -46,9 +46,9 @@ typedef struct {
 
 typedef struct {
     int level;
-    const char *facility;
+    char facility[64];
     int rank;
-    const char *msg;
+    char msg[1024];
     struct timeval tv;
 } flog_t;
 
@@ -72,9 +72,10 @@ static logctx_t *getctx (flux_t h)
     return ctx;
 }
 
-static JSON flog_encode (flog_t *f)
+static zmsg_t *flog_encode (flog_t *f)
 {
     JSON o = Jnew ();
+    zmsg_t *zmsg;
 
     Jadd_str (o, "facility", f->facility);
     Jadd_int (o, "level", f->level);
@@ -82,29 +83,39 @@ static JSON flog_encode (flog_t *f)
     Jadd_int (o, "timestamp_usec", (int)f->tv.tv_usec);
     Jadd_int (o, "timestamp_sec", (int)f->tv.tv_sec);
     Jadd_str (o, "message", f->msg);
-    return o;
+    zmsg = flux_request_encode ("cmb.log", Jtostr (o));
+    Jput (o);
+    return zmsg;
 }
 
-static int flog_decode (JSON o, flog_t *f)
+static int flog_decode (zmsg_t *zmsg, flog_t *f)
 {
-    int rc = -1;
+    const char *json_str;
+    JSON o = NULL;
     int sec, usec;
-    if (!Jget_str (o, "facility", &f->facility))
+    const char *s;
+    const char *facility;
+    int rc = -1;
+
+    if (flux_request_decode (zmsg, NULL, &json_str) < 0)
         goto done;
-    if (!Jget_int (o, "level", &f->level))
+    if (!(o = Jfromstr (json_str))
+            || !Jget_str (o, "facility", &facility)
+            || !Jget_int (o, "level", &f->level)
+            || !Jget_int (o, "rank", &f->rank)
+            || !Jget_int (o, "timestamp_usec", &usec)
+            || !Jget_int (o, "timestamp_sec", &sec)
+            || !Jget_str (o, "message", &s)) {
+        errno = EPROTO;
         goto done;
-    if (!Jget_int (o, "rank", &f->rank))
-        goto done;
-    if (!Jget_int (o, "timestamp_usec", &usec))
-        goto done;
-    if (!Jget_int (o, "timestamp_sec", &sec))
-        goto done;
+    }
+    snprintf (f->facility, sizeof (f->facility), "%s", facility);
+    snprintf (f->msg, sizeof (f->msg), "%s", s);
     f->tv.tv_sec = sec;
     f->tv.tv_usec = usec;
-    if (!Jget_str (o, "message", &f->msg))
-        goto done;
     rc = 0;
 done:
+    Jput (o);
     return rc;
 }
 
@@ -136,33 +147,26 @@ void flux_log_set_redirect (flux_t h, bool flag)
 int flux_vlog (flux_t h, int lev, const char *fmt, va_list ap)
 {
     logctx_t *ctx = getctx (h);
-    JSON o = NULL;
-    char *s = NULL;
     flog_t flog;
+    zmsg_t *zmsg = NULL;
     int rc = -1;
 
-    flog.facility = ctx->facility;
+    snprintf (flog.facility, sizeof (flog.facility), "%s", ctx->facility);
     flog.level = lev;
     flog.rank = flux_rank (h);
     if (gettimeofday (&flog.tv, NULL) < 0)
         err_exit ("gettimeofday");
-    if (vasprintf (&s, fmt, ap) < 0)
-        oom ();
-    flog.msg = s;
+    (void)vsnprintf (flog.msg, sizeof (flog.msg), fmt, ap);
 
     if (ctx->redirect) {
         flog_msg (&flog);
-        rc = 0;
-    } else {
-        if (!(o = flog_encode (&flog)))
-            goto done;
-        rc = flux_json_request (h, FLUX_NODEID_ANY,
-                                   FLUX_MATCHTAG_NONE, "cmb.log", o);
+    } else if (!(zmsg = flog_encode (&flog))
+                     || flux_request_send (h, FLUX_MATCHTAG_NONE, &zmsg) < 0) {
+        goto done;
     }
+    rc = 0;
 done:
-    if (s)
-        free (s);
-    Jput (o);
+    zmsg_destroy (&zmsg);
     return rc;
 }
 
@@ -179,18 +183,14 @@ int flux_log (flux_t h, int lev, const char *fmt, ...)
 
 int flux_log_zmsg (zmsg_t *zmsg)
 {
-    JSON o = NULL;
     flog_t f;
     int rc = -1;
 
-    if (flux_json_request_decode (zmsg, &o) < 0 || flog_decode (o, &f) < 0) {
-        errno = EPROTO;
+    if (flog_decode (zmsg, &f) < 0)
         goto done;
-    }
     flog_msg (&f);
     rc = 0;
 done:
-    Jput (o);
     return rc;
 }
 

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -7,6 +7,7 @@
 #include "security.h"
 #include "reduce.h"
 #include "message.h"
+#include "request.h"
 #include "panic.h"
 #include "event.h"
 #include "module.h"

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -8,6 +8,7 @@
 #include "reduce.h"
 #include "message.h"
 #include "request.h"
+#include "response.h"
 #include "panic.h"
 #include "event.h"
 #include "module.h"

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -9,8 +9,6 @@
 #include "message.h"
 #include "panic.h"
 #include "event.h"
-#include "request.h"
-#include "rpc.h"
 #include "module.h"
 #include "reparent.h"
 #include "info.h"

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -9,6 +9,7 @@
 #include "message.h"
 #include "request.h"
 #include "response.h"
+#include "rpc.h"
 #include "panic.h"
 #include "event.h"
 #include "module.h"

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -29,8 +29,8 @@
 #include <stdbool.h>
 
 #include "info.h"
-#include "rpc.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -29,8 +29,9 @@
 #include <stdbool.h>
 
 #include "info.h"
+#include "rpc.h"
+#include "response.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
@@ -38,14 +39,18 @@ char *flux_getattr (flux_t h, int rank, const char *name)
 {
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
     JSON in = Jnew ();
+    zmsg_t *zmsg = NULL;
+    const char *json_str;
     JSON out = NULL;
     char *ret = NULL;
     const char *val = NULL;
 
     Jadd_str (in, "name", name);
-    if (flux_json_rpc (h, nodeid, "cmb.getattr", in, &out) < 0)
+    if (flux_rpcto (h, "cmb.getattr", Jtostr (in), &zmsg, nodeid) < 0)
         goto done;
-    if (!out || !Jget_str (out, (char *)name, &val)) {
+    if (flux_response_decode (zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (!(out = Jfromstr (json_str)) || !Jget_str (out, (char *)name, &val)) {
         errno = EPROTO;
         goto done;
     }
@@ -53,21 +58,27 @@ char *flux_getattr (flux_t h, int rank, const char *name)
 done:
     Jput (in);
     Jput (out);
+    zmsg_destroy (&zmsg);
     return ret;
 }
 
 int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp)
 {
-    JSON response = NULL;
+    zmsg_t *zmsg = NULL;
+    JSON out = NULL;
+    const char *json_str;
     int rank, size;
     bool treeroot;
     int ret = -1;
 
-    if (flux_json_rpc (h, FLUX_NODEID_ANY, "cmb.info", NULL, &response) < 0)
+    if (flux_rpc (h, "cmb.info", NULL, &zmsg) < 0)
         goto done;
-    if (!Jget_bool (response, "treeroot", &treeroot)
-            || !Jget_int (response, "rank", &rank)
-            || !Jget_int (response, "size", &size)) {
+    if (flux_response_decode (zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (!(out = Jfromstr (json_str))
+            || !Jget_bool (out, "treeroot", &treeroot)
+            || !Jget_int (out, "rank", &rank)
+            || !Jget_int (out, "size", &size)) {
         errno = EPROTO;
         goto done;
     }
@@ -79,7 +90,8 @@ int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp)
         *treerootp = treeroot;
     ret = 0;
 done:
-    Jput (response);
+    Jput (out);
+    zmsg_destroy (&zmsg);
     return ret;
 }
 

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -29,10 +29,9 @@
 #include <argz.h>
 
 #include "module.h"
-#include "request.h"
-#include "rpc.h"
 #include "message.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -30,10 +30,16 @@
 
 #include "module.h"
 #include "message.h"
+#include "response.h"
+#include "rpc.h"
 
 #include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
+
+struct flux_modlist_struct {
+    JSON a;
+};
 
 /* Get service name from module name string.
  */
@@ -53,15 +59,19 @@ static char *mod_service (const char *modname)
  ** JSON encode/decode functions
  **/
 
-int flux_insmod_json_decode (JSON o, char **path, char **argz, size_t *argz_len)
+int flux_insmod_json_decode (const char *json_str,
+                             char **path, char **argz, size_t *argz_len)
 {
+    JSON o = NULL;
     JSON args = NULL;
     const char *s;
     int i, ac;
     int rc = -1;
 
-    if (!Jget_str (o, "path", &s) || !Jget_obj (o, "args", &args)
-                                  || !Jget_ar_len (args, &ac)) {
+    if (!(o = Jfromstr (json_str))
+                || !Jget_str (o, "path", &s)
+                || !Jget_obj (o, "args", &args)
+                || !Jget_ar_len (args, &ac)) {
         errno = EPROTO;
         goto done;
     }
@@ -73,53 +83,62 @@ int flux_insmod_json_decode (JSON o, char **path, char **argz, size_t *argz_len)
     rc = 0;
 done:
     Jput (args);
+    Jput (o);
     return rc;
 }
 
-JSON flux_insmod_json_encode (const char *path, int argc, char **argv)
+char *flux_insmod_json_encode (const char *path, int argc, char **argv)
 {
     JSON o = Jnew ();
     JSON args = Jnew_ar ();
+    char *json_str;
     int i;
 
     Jadd_str (o, "path", path);
     for (i = 0; i < argc; i++)
         Jadd_ar_str (args, argv[i]);
     Jadd_obj (o, "args", args);
-    return o;
+    json_str = xstrdup (Jtostr (o));
+    Jput (o);
+    return json_str;
 }
 
-int flux_rmmod_json_decode (JSON o, char **name)
+int flux_rmmod_json_decode (const char *json_str, char **name)
 {
+    JSON o = NULL;
     const char *s;
     int rc = -1;
-    if (!Jget_str (o, "name", &s)) {
+    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "name", &s)) {
         errno = EPROTO;
         goto done;
     }
     *name = xstrdup (s);
     rc = 0;
 done:
+    Jput (o);
     return rc;
 }
 
-JSON flux_rmmod_json_encode (const char *name)
+char *flux_rmmod_json_encode (const char *name)
 {
     JSON o = Jnew ();
+    char *json_str;
     Jadd_str (o, "name", name);
-    return o;
+    json_str = xstrdup (Jtostr (o)); 
+    Jput (o);
+    return json_str;
 }
 
-int flux_lsmod_json_decode_nth (JSON a, int n, const char **name, int *size,
+int flux_modlist_get (flux_modlist_t mods, int n, const char **name, int *size,
                                 const char **digest, int *idle)
 {
     JSON o;
     int rc = -1;
 
-    if (!Jget_ar_obj (a, n, &o) || !Jget_str (o, "name", name)
-                                || !Jget_int (o, "size", size)
-                                || !Jget_str (o, "digest", digest)
-                                || !Jget_int (o, "idle", idle)) {
+    if (!Jget_ar_obj (mods->a, n, &o) || !Jget_str (o, "name", name)
+                                      || !Jget_int (o, "size", size)
+                                      || !Jget_str (o, "digest", digest)
+                                      || !Jget_int (o, "idle", idle)) {
         errno = EPROTO;
         goto done;
     }
@@ -128,20 +147,18 @@ done:
     return rc;
 }
 
-int flux_lsmod_json_decode (JSON a, int *len)
+int flux_modlist_count (flux_modlist_t mods)
 {
-    int rc = -1;
+    int len;
 
-    if (!Jget_ar_len (a, len)) {
+    if (!Jget_ar_len (mods->a, &len)) {
         errno = EPROTO;
-        goto done;
+        return -1;
     }
-    rc = 0;
-done:
-    return rc;
+    return len;
 }
 
-int flux_lsmod_json_append (JSON a, const char *name, int size,
+int flux_modlist_append (flux_modlist_t mods, const char *name, int size,
                             const char *digest, int idle)
 {
     JSON o = Jnew ();
@@ -149,14 +166,40 @@ int flux_lsmod_json_append (JSON a, const char *name, int size,
     Jadd_int (o, "size", size);
     Jadd_str (o, "digest", digest);
     Jadd_int (o, "idle", idle);
-    Jadd_ar_obj (a, o); /* takes a ref on o */
+    Jadd_ar_obj (mods->a, o); /* takes a ref on o */
     Jput (o);
     return 0;
 }
 
-JSON flux_lsmod_json_create (void)
+void flux_modlist_destroy (flux_modlist_t mods)
 {
-    return Jnew_ar ();
+    if (mods) {
+        Jput (mods->a);
+        free (mods);
+    }
+}
+
+flux_modlist_t flux_modlist_create (void)
+{
+    flux_modlist_t mods = xzmalloc (sizeof (*mods));
+    mods->a = Jnew_ar ();
+    return mods;
+}
+
+char *flux_lsmod_json_encode (flux_modlist_t mods)
+{
+    return xstrdup (Jtostr (mods->a));
+}
+
+flux_modlist_t flux_lsmod_json_decode (const char *json_str)
+{
+    flux_modlist_t mods = xzmalloc (sizeof (*mods));
+    if (!(mods->a = Jfromstr (json_str))) {
+        free (mods);
+        errno = EPROTO;
+        return NULL;
+    }
+    return mods;
 }
 
 char *flux_modname(const char *path)
@@ -258,31 +301,29 @@ char *flux_modfind (const char *searchpath, const char *modname)
 int flux_insmod_request_decode (zmsg_t *zmsg, char **path,
                                 char **argz, size_t *argz_len)
 {
-    JSON in = NULL;
+    const char *json_str;
     int rc = -1;
 
-    if (flux_json_request_decode (zmsg, &in) < 0)
+    if (flux_request_decode (zmsg, NULL, &json_str) < 0)
         goto done;
-    if (flux_insmod_json_decode (in, path, argz, argz_len) < 0)
+    if (flux_insmod_json_decode (json_str, path, argz, argz_len) < 0)
         goto done;
     rc = 0;
 done:
-    Jput (in);
     return rc;
 }
 
 int flux_rmmod_request_decode (zmsg_t *zmsg, char **name)
 {
-    JSON in = NULL;
+    const char *json_str;
     int rc = -1;
 
-    if (flux_json_request_decode (zmsg, &in) < 0)
+    if (flux_request_decode (zmsg, NULL, &json_str) < 0)
         goto done;
-    if (flux_rmmod_json_decode (in, name) < 0)
+    if (flux_rmmod_json_decode (json_str, name) < 0)
         goto done;
     rc = 0;
 done:
-    Jput (in);
     return rc;
 }
 
@@ -304,39 +345,46 @@ done:
 
 int flux_rmmod (flux_t h, uint32_t nodeid, const char *name)
 {
-    JSON in = NULL;
     char *service = mod_service (name);
     char *topic = xasprintf ("%s.rmmod", service);
+    char *json_str = NULL;
     int rc = -1;
 
-    in = flux_rmmod_json_encode (name);
-    Jadd_str (in, "name", name);
-    if (flux_json_rpc (h, nodeid, topic, in, NULL) < 0)
+    if (!(json_str = flux_rmmod_json_encode (name)))
+        goto done;
+    if (flux_rpcto (h, topic, json_str, NULL, nodeid) < 0)
         goto done;
     rc = 0;
 done:
     free (service);
     free (topic);
-    Jput (in);
+    if (json_str)
+        free (json_str);
     return rc;
 }
 
 int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
                 flux_lsmod_f cb, void *arg)
 {
-    JSON out = NULL;
+    zmsg_t *zmsg = NULL;
     char *topic = xasprintf ("%s.lsmod", service ? service : "cmb");
+    flux_modlist_t mods = NULL;
+    const char *json_str;
     int rc = -1;
     int i, len;
 
-    if (flux_json_rpc (h, nodeid, topic, NULL, &out) < 0)
+    if (flux_rpcto (h, topic, NULL, &zmsg, nodeid) < 0)
         goto done;
-    if (flux_lsmod_json_decode (out, &len) < 0)
+    if (flux_response_decode (zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (!(mods = flux_lsmod_json_decode (json_str)) < 0)
+        goto done;
+    if ((len = flux_modlist_count (mods)) == -1)
         goto done;
     for (i = 0; i < len; i++) {
         const char *name, *digest;
         int size, idle;
-        if (flux_lsmod_json_decode_nth (out, i, &name, &size, &digest, &idle) < 0)
+        if (flux_modlist_get (mods, i, &name, &size, &digest, &idle) < 0)
             goto done;
         if (cb (name, size, digest, idle, NULL, arg) < 0)
             goto done;
@@ -344,6 +392,9 @@ int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
     rc = 0;
 done:
     free (topic);
+    zmsg_destroy (&zmsg);
+    if (mods)
+        flux_modlist_destroy (mods);
     return rc;
 }
 
@@ -354,6 +405,7 @@ int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
     char *name = NULL;
     char *service = NULL;
     char *topic = NULL;
+    char *json_str = NULL;
     int rc = -1;
 
     if (!(name = flux_modname (path))) {
@@ -363,8 +415,8 @@ int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
     service = mod_service (name);
     topic = xasprintf ("%s.insmod", service);
 
-    in = flux_insmod_json_encode (path, argc, argv);
-    if (flux_json_rpc (h, nodeid, topic, in, NULL) < 0)
+    json_str = flux_insmod_json_encode (path, argc, argv);
+    if (flux_rpcto (h, topic, json_str, NULL, nodeid) < 0)
         goto done;
     rc = 0;
 done:
@@ -372,6 +424,8 @@ done:
         free (service);
     if (topic)
         free (topic);
+    if (json_str)
+        free (json_str);
     Jput (in);
     return rc;
 }

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -6,7 +6,6 @@
  */
 
 #include <stdint.h>
-#include <json.h>
 #include <czmq.h>
 
 #include "handle.h"
@@ -68,21 +67,35 @@ char *flux_modname (const char *filename);
  */
 char *flux_modfind (const char *searchpath, const char *modname);
 
-/* Codecs for module control payloads
+/* Encode/decode lsmod payload
+ * 'flux_modlist_t' is an intermediate object that can encode/decode
+ * to/from a JSON string, and provides accessors for module list entries.
  */
-json_object *flux_lsmod_json_create (void);
-int flux_lsmod_json_append (json_object *a, const char *name, int size,
+typedef struct flux_modlist_struct *flux_modlist_t;
+
+flux_modlist_t flux_modlist_create (void);
+void flux_modlist_destroy (flux_modlist_t mods);
+int flux_modlist_append (flux_modlist_t mods, const char *name, int size,
                             const char *digest, int idle);
-int flux_lsmod_json_decode (json_object *a, int *len);
-int flux_lsmod_json_decode_nth (json_object *a, int n, const char **name,
+int flux_modlist_count (flux_modlist_t mods);
+int flux_modlist_get (flux_modlist_t mods, int idx, const char **name,
                                 int *size, const char **digest, int *idle);
 
-json_object *flux_rmmod_json_encode (const char *name);
-int flux_rmmod_json_decode (json_object *o, char **name);
+char *flux_lsmod_json_encode (flux_modlist_t mods);
+flux_modlist_t flux_lsmod_json_decode (const char *json_str);
 
-json_object *flux_insmod_json_encode (const char *path,
-                                      int argc, char **argv);
-int flux_insmod_json_decode (json_object *o, char **path,
+
+/* Encode/decode rmmod payload.
+ * Caller must free the string returned by encode.
+ */
+char *flux_rmmod_json_encode (const char *name);
+int flux_rmmod_json_decode (const char *json_str, char **name);
+
+/* Encode/decode insmod payload.
+ * Caller must free the string returned by encode.
+ */
+char *flux_insmod_json_encode (const char *path, int argc, char **argv);
+int flux_insmod_json_decode (const char *json_str, char **path,
                              char **argz, size_t *argz_len);
 
 /* Decode an insmod request message.

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -26,9 +26,9 @@
 #include "config.h"
 #endif
 #include "panic.h"
-#include "request.h"
 #include "flog.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -34,9 +34,9 @@
 #include "reactor.h"
 #include "handle_impl.h"
 #include "message.h"
+#include "response.h"
 #include "tagpool.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/coproc.h"
@@ -237,6 +237,7 @@ static int msg_cb (flux_t h, void *arg)
     dispatch_t *d;
     int rc = -1;
     zmsg_t *zmsg = NULL;
+    zmsg_t *response = NULL;
     int type;
 
     if (!(zmsg = flux_recvmsg (h, true))) {
@@ -277,7 +278,8 @@ static int msg_cb (flux_t h, void *arg)
      */
     } else {
         if (type == FLUX_MSGTYPE_REQUEST) {
-            if (flux_err_respond (h, ENOSYS, &zmsg) < 0)
+            if (!(response = flux_response_encode_err (zmsg, ENOSYS))
+                          || flux_response_send (h, &response) < 0)
                 goto done;
         } else if (flux_flags_get (h) & FLUX_O_TRACE) {
             const char *topic = NULL;
@@ -289,6 +291,7 @@ static int msg_cb (flux_t h, void *arg)
     }
 done:
     zmsg_destroy (&zmsg);
+    zmsg_destroy (&response);
     return rc;
 }
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -32,11 +32,11 @@
 
 #include "handle.h"
 #include "reactor.h"
-#include "request.h"
 #include "handle_impl.h"
 #include "message.h"
 #include "tagpool.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/coproc.h"

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -26,8 +26,8 @@
 #include "config.h"
 #endif
 #include "reparent.h"
-#include "rpc.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 
 

--- a/src/common/libflux/reparent.h
+++ b/src/common/libflux/reparent.h
@@ -4,7 +4,7 @@
 #include <json.h>
 #include "handle.h"
 
-json_object *flux_lspeer (flux_t h, int rank);
+char *flux_lspeer (flux_t h, int rank);
 
 int flux_reparent (flux_t h, int rank, const char *uri);
 

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -1,0 +1,151 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "request.h"
+#include "message.h"
+#include "info.h"
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/nodeset.h"
+
+int flux_request_decode (zmsg_t *zmsg, const char **topic,
+                         const char **json_str)
+{
+    int type;
+    const char *ts, *js;
+    int rc = -1;
+
+    if (zmsg == NULL) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (flux_msg_get_type (zmsg, &type) < 0)
+        goto done;
+    if (type != FLUX_MSGTYPE_REQUEST) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (flux_msg_get_topic (zmsg, &ts) < 0)
+        goto done;
+    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+        goto done;
+    if ((json_str && !js) || (!json_str && js)) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (topic)
+        *topic = ts;
+    if (json_str)
+        *json_str = js;
+    rc = 0;
+done:
+    return rc;
+}
+
+zmsg_t *flux_request_encode (const char *topic, const char *json_str)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!topic) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        goto error;
+    if (flux_msg_set_topic (zmsg, topic) < 0)
+        goto error;
+    if (flux_msg_enable_route (zmsg) < 0)
+        goto error;
+    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+        goto error;
+    return zmsg;
+error:
+    if (zmsg) {
+        int saved_errno = errno;
+        zmsg_destroy (&zmsg);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+int flux_request_send (flux_t h, uint32_t *matchtag, zmsg_t **zmsg)
+{
+    uint32_t mtag = FLUX_MATCHTAG_NONE;
+
+    if (matchtag) {
+        mtag = flux_matchtag_alloc (h, 1);
+        if (mtag == FLUX_MATCHTAG_NONE) {
+            errno = EAGAIN; /* XXX better errno? */
+            goto error;
+        }
+        if (flux_msg_set_matchtag (*zmsg, mtag) < 0)
+            goto error;
+    }
+    if (flux_sendmsg (h, zmsg) < 0)
+        goto error;
+    if (matchtag)
+        *matchtag = mtag;
+    return 0;
+error:
+    if (mtag != FLUX_MATCHTAG_NONE) {
+        int saved_errno = errno;
+        flux_matchtag_free (h, mtag, 1);
+        errno = saved_errno;
+    }
+    return -1;
+}
+
+int flux_request_sendto (flux_t h, uint32_t *matchtag, zmsg_t **zmsg,
+                         uint32_t nodeid)
+{
+    int flags = 0;
+
+    if (nodeid == FLUX_NODEID_UPSTREAM) {
+        flags |= FLUX_MSGFLAG_UPSTREAM;
+        nodeid = flux_rank (h);
+    }
+    if (flux_msg_set_nodeid (*zmsg, nodeid, flags) < 0)
+        return -1;
+    return flux_request_send (h, matchtag, zmsg);
+}
+
+zmsg_t *flux_request_recv (flux_t h, bool nonblock)
+{
+    flux_match_t match = {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .matchtag = FLUX_MATCHTAG_NONE,
+        .bsize = 0,
+        .topic_glob = NULL,
+    };
+    return flux_recvmsg_match (h, match, NULL, nonblock);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -1,0 +1,43 @@
+#ifndef _FLUX_CORE_REQUEST_H
+#define _FLUX_CORE_REQUEST_H
+
+#include <json.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <czmq.h>
+
+#include "handle.h"
+
+/* Decode a request message.
+ * If topic is non-NULL, assign the request topic string.
+ * If json_str is non-NULL, assign the payload.  json_str indicates whether
+ * payload is expected and it is an EPROTO error if expectations are not met.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_request_decode (zmsg_t *zmsg, const char **topic,
+                         const char **json_str);
+
+/* Encode a response message.
+ * If json_str is non-NULL, assign the payload.
+ */
+zmsg_t *flux_request_encode (const char *topic, const char *json_str);
+
+/* Send a request.
+ * If matchtag is non-NULL, allocate a unique matchtag from the handle
+ * and set it in the message bvefore sending, then assign it to *matchtag.
+ * The _sendto variant may be used to send a request to a specific node
+ * or to FLUX_NODEID_UPSTREAM.  Otherwise FLUX_NODEID_ANY is assumed.
+ */
+int flux_request_send (flux_t h, uint32_t *matchtag, zmsg_t **zmsg);
+int flux_request_sendto (flux_t h, uint32_t *matchtag, zmsg_t **zmsg,
+                         uint32_t nodeid);
+
+/* Receive a request.
+ */
+zmsg_t *flux_request_recv (flux_t h, bool nonblock);
+
+#endif /* !_FLUX_CORE_REQUEST_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -1,0 +1,181 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "response.h"
+#include "message.h"
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/nodeset.h"
+
+
+int flux_response_decode (zmsg_t *zmsg, const char **topic,
+                          const char **json_str)
+{
+    int type;
+    const char *ts, *js;
+    int errnum = 0;
+    int rc = -1;
+
+    if (zmsg == NULL) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (flux_msg_get_type (zmsg, &type) < 0)
+        goto done;
+    if (type != FLUX_MSGTYPE_RESPONSE) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (flux_msg_get_errnum (zmsg, &errnum) < 0)
+        goto done;
+    if (errnum != 0) {
+        errno = errnum;
+        goto done;
+    }
+    if (flux_msg_get_topic (zmsg, &ts) < 0)
+        goto done;
+    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+        goto done;
+    if ((json_str && !js) || (!json_str && js)) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (topic)
+        *topic = ts;
+    if (json_str)
+        *json_str = js;
+    rc = 0;
+done:
+    return rc;
+}
+
+zmsg_t *flux_response_encode (const char *topic, int errnum,
+                              const char *json_str)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!topic || (errnum != 0 && json_str != NULL)) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)))
+        goto error;
+    if (flux_msg_set_topic (zmsg, topic) < 0)
+        goto error;
+    if (flux_msg_enable_route (zmsg) < 0)
+        goto error;
+    if (flux_msg_set_errnum (zmsg, errnum) < 0)
+        goto error;
+    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+        goto error;
+    return zmsg;
+error:
+    if (zmsg) {
+        int saved_errno = errno;
+        zmsg_destroy (&zmsg);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+zmsg_t *flux_response_encode_ok (zmsg_t *request, const char *json_str)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!request) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(zmsg = zmsg_dup (request))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_msg_set_type (zmsg, FLUX_MSGTYPE_RESPONSE) < 0)
+        goto error;
+    if (flux_msg_set_errnum (zmsg, 0) < 0)
+        goto error;
+    if (flux_msg_set_payload_json (zmsg, json_str) < 0)
+        goto error;
+    return zmsg;
+error:
+    if (zmsg) {
+        int saved_errno = errno;
+        zmsg_destroy (&zmsg);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+zmsg_t *flux_response_encode_err (zmsg_t *request, int errnum)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!request) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(zmsg = zmsg_dup (request))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_msg_set_type (zmsg, FLUX_MSGTYPE_RESPONSE) < 0)
+        goto error;
+    if (flux_msg_set_errnum (zmsg, errnum) < 0)
+        goto error;
+    if (flux_msg_set_payload_json (zmsg, NULL) < 0)
+        goto error;
+    return zmsg;
+error:
+    if (zmsg) {
+        int saved_errno = errno;
+        zmsg_destroy (&zmsg);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+int flux_response_send (flux_t h, zmsg_t **zmsg)
+{
+    return flux_sendmsg (h, zmsg);
+}
+
+zmsg_t *flux_response_recv (flux_t h, uint32_t matchtag, bool nonblock)
+{
+    flux_match_t match = {
+        .typemask = FLUX_MSGTYPE_RESPONSE,
+        .matchtag = matchtag,
+        .bsize = 0,
+        .topic_glob = NULL,
+    };
+    return flux_recvmsg_match (h, match, NULL, nonblock);
+
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -1,0 +1,44 @@
+#ifndef _FLUX_CORE_RESPONSE_H
+#define _FLUX_CORE_RESPONSE_H
+
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include "message.h"
+#include "handle.h"
+
+/* Decode a response message.
+ * If topic is non-NULL, assign the response topic string.
+ * If json_str is non-NULL, assign the payload.  json_str indicates whether
+ * payload is expected and it is an EPROTO error if expectations are not met.
+ * If response includes a nonzero errnum, errno is set to the errnum value
+ * and -1 is returned with no assignments to topic or json_str.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_response_decode (zmsg_t *zmsg, const char **topic,
+                          const char **json_str);
+
+
+/* Encode a response message, copying the matchtag, topic string, and
+ * route stack from the supplied request message.
+ * If json_str is non-NULL, it is copied to the response message payload.
+ * Use the _err variant to return a UNIX errno value to the caller.
+ * (_ok with payload of NULL == _err with errnum of 0)
+ * Returns message on success, or NULL on failure with errno set.
+ */
+zmsg_t *flux_response_encode_ok (zmsg_t *request, const char *json_str);
+zmsg_t *flux_response_encode_err (zmsg_t *request, int errnum);
+
+zmsg_t *flux_response_encode (const char *topic, int errnum,
+                              const char *json_str);
+
+/* Send/receive response
+ */
+int flux_response_send (flux_t h, zmsg_t **zmsg);
+zmsg_t *flux_response_recv (flux_t h, uint32_t matchtag, bool nonblock);
+
+#endif /* !_FLUX_CORE_RESPONSE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -1,0 +1,315 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+
+#include "request.h"
+#include "response.h"
+#include "message.h"
+#include "info.h"
+#include "rpc.h"
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/nodeset.h"
+
+struct response_struct {
+    zmsg_t *zmsg;
+    int errnum;
+};
+
+struct flux_mresponse_struct {
+    uint32_t count;
+    uint32_t matchbase;
+    struct response_struct *r;
+    zhash_t *bynodeid;
+};
+
+int flux_rpcto (flux_t h, const char *topic,
+                const char *json_str, zmsg_t **response, uint32_t nodeid)
+{
+    zmsg_t *tx_zmsg = NULL;
+    zmsg_t *rx_zmsg = NULL;
+    uint32_t matchtag = FLUX_MATCHTAG_NONE;
+    int errnum;
+    int rc = -1;
+
+    if (!(tx_zmsg = flux_request_encode (topic, json_str)))
+        goto done;
+    if (flux_request_sendto (h, &matchtag, &tx_zmsg, nodeid) < 0)
+        goto done;
+    if (!(rx_zmsg = flux_response_recv (h, matchtag, false)))
+        goto done;
+    if (flux_msg_get_errnum (rx_zmsg, &errnum) < 0)
+        goto done;
+    if (errnum != 0) {
+        errno = errnum;
+        goto done;
+    }
+    if (response) {
+        *response = rx_zmsg;
+        rx_zmsg = NULL;
+    }
+    rc = 0;
+done:
+    if (matchtag != FLUX_MATCHTAG_NONE)
+        flux_matchtag_free (h, matchtag, 1);
+    zmsg_destroy (&tx_zmsg);
+    zmsg_destroy (&rx_zmsg);
+    return rc;
+}
+
+int flux_rpc (flux_t h, const char *topic,
+              const char *json_str, zmsg_t **response)
+{
+    return flux_rpcto (h, topic, json_str, response, FLUX_NODEID_ANY);
+}
+
+void flux_mresponse_destroy (flux_mresponse_t r)
+{
+    if (r) {
+        if (r->r) {
+            int i;
+            for (i = 0; i < r->count; i++)
+                zmsg_destroy (&r->r[i].zmsg);
+            free (r->r);
+        }
+        zhash_destroy (&r->bynodeid);
+        free (r);
+    }
+}
+
+static void mresponse_create_hash (flux_mresponse_t r, nodeset_t ns)
+{
+    nodeset_itr_t itr;
+    uint32_t nodeid;
+    char tmp[16];
+    int i = 0;
+
+    if (!r->bynodeid) {
+        if (!(r->bynodeid = zhash_new()))
+            oom ();
+        if (!(itr = nodeset_itr_new (ns)))
+            oom ();
+        for (i = 0; i < r->count; i++) {
+            nodeid = nodeset_next (itr);
+            assert (nodeid != NODESET_EOF);
+            snprintf (tmp, sizeof (tmp), "%u", nodeid);
+            zhash_update (r->bynodeid, tmp, &r->r[i]);
+        }
+        nodeset_itr_destroy (itr);
+    }
+}
+
+static flux_mresponse_t mresponse_create (nodeset_t ns, uint32_t matchbase)
+{
+    flux_mresponse_t r = xzmalloc (sizeof (*r));
+
+    r->count = nodeset_count (ns);
+    r->matchbase = matchbase;
+    if (!(r->r = xzmalloc (sizeof (r->r[0]) * r->count)))
+        oom ();
+    mresponse_create_hash (r, ns);
+    return r;
+}
+
+static void mresponse_set_zmsg (flux_mresponse_t r, uint32_t matchtag,
+                                zmsg_t **zmsg)
+{
+    int i = matchtag - r->matchbase;
+    assert (i >= 0 && i < r->count);
+    r->r[i].zmsg = *zmsg;
+    *zmsg = NULL;
+}
+
+static void mresponse_set_errnum (flux_mresponse_t r, uint32_t matchtag,
+                                  int errnum)
+{
+    int i = matchtag - r->matchbase;
+    assert (i >= 0 && i < r->count);
+    r->r[i].errnum = errnum;
+}
+
+static int mresponse_decode_all (flux_mresponse_t r) {
+    int i, errnum = 0;
+
+    for (i = 0; i < r->count; i++) {
+        int e = r->r[i].errnum;
+        if (e == 0 && r->r[i].zmsg)
+            if (flux_msg_get_errnum (r->r[i].zmsg, &e) < 0)
+                e = errno;
+        if (errnum == 0 || errnum < e)
+            errnum = e;
+    }
+    if (errnum) {
+        errno = errnum;
+        return -1;
+    }
+    return 0;
+}
+
+int flux_mresponse_decode (flux_mresponse_t r, uint32_t nodeid,
+                           const char **topic, const char **json_str)
+{
+    char tmp[16];
+    struct response_struct *res;
+    int rc = -1;
+
+    snprintf (tmp, sizeof (tmp), "%u", nodeid);
+    if (!(res = zhash_lookup (r->bynodeid, tmp))) {
+        errno = ENOENT;
+        goto done;
+    }
+    if (res->errnum != 0) {
+        errno = res->errnum;
+        goto done;
+    }
+    if (res->zmsg && flux_response_decode (res->zmsg, topic, json_str) < 0)
+        goto done;
+    rc = 0;
+done:
+    return rc;
+}
+
+int flux_multrpcto (flux_t h, int fanout,
+                   const char *topic, const char *json_str,
+                   flux_mresponse_t *mresponse, const char *nodeset)
+{
+    flux_match_t match = {
+        .typemask = FLUX_MSGTYPE_RESPONSE,
+        .topic_glob = NULL,
+    };
+    int saved_errno;
+    flux_mresponse_t r = NULL;
+    nodeset_t ns = NULL;
+    nodeset_itr_t itr = NULL;
+    zlist_t *nomatch = NULL;
+    int ntx, nrx;
+    int rc = -1;
+
+    if (!topic) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (fanout == 0)
+        fanout = INT_MAX;
+    if (nodeset)
+        ns = nodeset_new_str (nodeset);
+    else
+        ns = nodeset_new_range (0, flux_size (h) - 1);
+    if (!ns)
+        goto done;
+    /* Allocate a block of matchtags
+     */
+    match.bsize = nodeset_count (ns);
+    match.matchtag = flux_matchtag_alloc (h, match.bsize);
+    if (match.matchtag == FLUX_MATCHTAG_NONE) {
+        errno = EAGAIN;
+        goto done;
+    }
+    /* Allocate result object
+     */
+    if (!(r = mresponse_create (ns, match.matchtag)))
+        goto done;
+
+    /* Send requests and receive responses, keeping a maximum of
+     * 'fanout' requests outstanding.
+     */
+    if (!(nomatch = zlist_new ()))
+        oom ();
+    ntx = nrx = 0;
+    if (!(itr = nodeset_itr_new (ns)))
+        oom ();
+    while (ntx < match.bsize || nrx < match.bsize) {
+        while (ntx < match.bsize && ntx - nrx < fanout) {
+            uint32_t matchtag = match.matchtag + ntx;
+            uint32_t nodeid = nodeset_next (itr);
+            assert (nodeid != NODESET_EOF);
+            zmsg_t *zmsg;
+
+            if (!(zmsg = flux_request_encode (topic, json_str))
+                     || flux_msg_set_matchtag (zmsg, matchtag) < 0
+                     || flux_request_sendto (h, NULL, &zmsg, nodeid) < 0) {
+                mresponse_set_errnum (r, matchtag, errno);
+                nrx++;
+            }
+            zmsg_destroy (&zmsg);
+            ntx++;
+        }
+        while (nrx < match.bsize
+                    && (ntx - nrx == fanout || ntx == match.bsize)) {
+            uint32_t matchtag;
+            zmsg_t *zmsg;
+
+            if (!(zmsg = flux_recvmsg_match (h, match, nomatch, false)))
+                continue;
+            if (flux_msg_get_matchtag (zmsg, &matchtag) < 0) {
+                zmsg_destroy (&zmsg);
+                continue;
+            }
+            mresponse_set_zmsg (r, matchtag, &zmsg);
+            zmsg_destroy (&zmsg);
+            nrx++;
+        }
+    }
+    if (flux_putmsg_list (h, nomatch) < 0)
+        goto done;
+    if (mresponse) {
+        *mresponse = r;
+        r = NULL;
+    } else {
+        if (mresponse_decode_all (r) < 0)
+            goto done;
+    }
+    rc = 0;
+done:
+    saved_errno = errno;
+    if (r)
+        flux_mresponse_destroy (r);
+    if (itr)
+        nodeset_itr_destroy (itr);
+    if (ns)
+        nodeset_destroy (ns);
+    if (match.matchtag != FLUX_MATCHTAG_NONE)
+        flux_matchtag_free (h, match.matchtag, match.bsize);
+    if (nomatch)
+        zlist_destroy (&nomatch);
+    errno = saved_errno;
+    return rc;
+}
+
+int flux_multrpc (flux_t h, int fanout,
+                  const char *topic, const char *json_str,
+                  flux_mresponse_t *mresponse)
+{
+    return flux_multrpcto (h, fanout, topic, json_str, mresponse, NULL);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -1,0 +1,58 @@
+#ifndef _FLUX_CORE_RPC_H
+#define _FLUX_CORE_RPC_H
+
+#include <json.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <czmq.h>
+
+#include "handle.h"
+#include "request.h"
+
+typedef struct flux_mresponse_struct *flux_mresponse_t;
+
+
+/* Synchronous request/response.
+ * If FLUX_O_COPROC is set, this call can sleep and let other reactor
+ * callbacks be serviced, otherwise it blocks until the response is received.
+ * If the response contains a nonzero errnum, this becomes the errno of
+ * the flux_rpc call.  If 'response' is non-NULL, the response message
+ * is assigned to it for further decoding (caller must destroy).
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+
+int flux_rpc (flux_t h, const char *topic,
+              const char *json_str, zmsg_t **response);
+int flux_rpcto (flux_t h, const char *topic,
+                const char *json_str, zmsg_t **response, uint32_t nodeid);
+
+/* Bulk synchronous request/response.
+ * If FLUX_O_COPROC is set, this call can sleep and let other reactor
+ * callbacks be serviced, otherwise it blocks until all responses are received.
+ * 'fanout' limits the number of concurrent requests (0 == unlimited).
+ * If 'r' is non-NULL, it is assigned to a flux_mresponse_t that can be
+ * used to decode individual responses (caller must destroy).  If 'r' is
+ * NULL, the responses are decoded internally to detect any failure responses,
+ * but response payloads, if any, are discarded.  If any failures are detected,
+ * flux_multrpc fails with errno = the largest response errnum.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+
+int flux_multrpcto (flux_t h, int fanout,
+                   const char *topic, const char *json_str,
+                   flux_mresponse_t *r, const char *nodeset);
+
+int flux_multrpc (flux_t h, int fanout,
+                  const char *topic, const char *json_str,
+                  flux_mresponse_t *r);
+
+int flux_mresponse_decode (flux_mresponse_t r, uint32_t nodeid,
+                           const char **topic, const char **json_str);
+
+void flux_mresponse_destroy (flux_mresponse_t r);
+
+#endif /* !_FLUX_CORE_RPC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/tagpool.c
+++ b/src/common/libflux/tagpool.c
@@ -25,10 +25,10 @@
 /* tagpool.c - allocator for 32-bit matchtags */
 
 /* Matchtags are used to match requests and responses in RPC's.
- * There are two main use cases: flux_json_rpc() and flux_json_multrpc().
- * The former allocates and retires one matchtag, the latter a block of
- * matchtags.  A variant of flux_json_rpc() is kvs_watch() which sends one
- * request and reecives multiple replies with the same matchtag.
+ * There are two main use cases in rpc.c.  The plain rpc call allocates
+ * and retires one matchtag, the multiple call allocates a block of
+ * matchtags.  kvs_watch() is another use case.  It sends one request
+ * and reecives multiple replies with the same matchtag.
  *
  * This implementation could be improved:
  * - allocations of len = 1 are allocated from a fixed 2^16 tag pool,

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -56,44 +56,63 @@ void test_helpers (void)
 
 void test_lsmod_codec (void)
 {
-    JSON o;
-    int len;
+    flux_modlist_t mods;
     int idle, size;
     const char *name, *digest;
+    char *json_str;
 
-    o = flux_lsmod_json_create ();
-    ok (o != NULL,
-        "flux_lsmod_json_create works");
-    ok (flux_lsmod_json_append (o, "foo", 42, "aa", 3) == 0,
-        "first flux_lsmod_json_append works");
-    ok (flux_lsmod_json_append (o, "bar", 43, "bb", 2) == 0,
-        "second flux_lsmod_json_append works");
-    ok (flux_lsmod_json_decode (o, &len) == 0 && len == 2,
-        "flux_lsmod_json_decode works");
-    ok (flux_lsmod_json_decode_nth (o, 0, &name, &size, &digest, &idle) == 0
+    mods = flux_modlist_create ();
+    ok (mods != NULL,
+        "flux_modlist_create works");
+    ok (flux_modlist_append (mods, "foo", 42, "aa", 3) == 0,
+        "first flux_modlist_append works");
+    ok (flux_modlist_append (mods, "bar", 43, "bb", 2) == 0,
+        "second flux_modlist_append works");
+    ok (flux_modlist_count (mods) == 2,
+        "flux_modlist_count works");
+    ok (flux_modlist_get (mods, 0, &name, &size, &digest, &idle) == 0
         && name && size == 42 && digest && idle == 3
         && !strcmp (name, "foo") && !strcmp (digest, "aa"),
-        "flux_lsmod_json_decode_nth(0) works");
-    ok (flux_lsmod_json_decode_nth (o, 1, &name, &size, &digest, &idle) == 0
+        "flux_modlist_get(0) works");
+    ok (flux_modlist_get (mods, 1, &name, &size, &digest, &idle) == 0
         && name && size == 43 && digest && idle == 2
         && !strcmp (name, "bar") && !strcmp (digest, "bb"),
-        "flux_lsmod_json_decode_nth(1) works");
+        "flux_modlist_get(1) works");
 
-    Jput (o);
+    /* again after encode/decode */
+    ok ((json_str = flux_lsmod_json_encode (mods)) != NULL,
+        "flux_lsmod_json_encode works");
+    flux_modlist_destroy (mods);
+    ok ((mods = flux_lsmod_json_decode (json_str)) != NULL,
+        "flux_lsmod_json_decode works");
+    ok (flux_modlist_count (mods) == 2,
+        "flux_modlist_count still works");
+    ok (flux_modlist_get (mods, 0, &name, &size, &digest, &idle) == 0
+        && name && size == 42 && digest && idle == 3
+        && !strcmp (name, "foo") && !strcmp (digest, "aa"),
+        "flux_modlist_get(0) still works");
+    ok (flux_modlist_get (mods, 1, &name, &size, &digest, &idle) == 0
+        && name && size == 43 && digest && idle == 2
+        && !strcmp (name, "bar") && !strcmp (digest, "bb"),
+        "flux_modlist_get(1) still works");
+
+    flux_modlist_destroy (mods);
+    free (json_str);
 }
 
 void test_rmmod_codec (void)
 {
-    JSON o;
+    char *json_str;
     char *s = NULL;
 
-    o = flux_rmmod_json_encode ("xyz");
-    ok (o != NULL,
+    json_str = flux_rmmod_json_encode ("xyz");
+    ok (json_str != NULL,
         "flux_rmmod_json_encode works");
-    ok (flux_rmmod_json_decode (o, &s) == 0 && s != NULL && !strcmp (s, "xyz"),
+    ok (flux_rmmod_json_decode (json_str, &s) == 0
+        && s != NULL && !strcmp (s, "xyz"),
         "flux_rmmod_json_decode works");
     free (s);
-    Jput (o);
+    free (json_str);
 }
 
 void test_insmod_codec (void)
@@ -103,15 +122,15 @@ void test_insmod_codec (void)
     char *argz = NULL;
     size_t argz_len = 0;
     char *av[16];
-    JSON o;
+    char *json_str;
     char *s;
     int rc;
 
-    o = flux_insmod_json_encode ("/foo/bar", argc, argv);
-    ok (o != NULL,
+    json_str = flux_insmod_json_encode ("/foo/bar", argc, argv);
+    ok (json_str != NULL,
         "flux_insmod_json_encode works");
 
-    rc = flux_insmod_json_decode (o, &s, &argz, &argz_len);
+    rc = flux_insmod_json_decode (json_str, &s, &argz, &argz_len);
     argz_extract (argz, argz_len, av);
     ok (rc == 0 && s != NULL && !strcmp (s, "/foo/bar")
         && !strcmp (av[0], "foo") && !strcmp (av[1], "bar") && av[2] == NULL,
@@ -120,15 +139,15 @@ void test_insmod_codec (void)
     if (argz)
         free (argz);
     free (s);
-    Jput (o);
+    free (json_str);
 }
 
 int main (int argc, char *argv[])
 {
-    plan (19);
+    plan (24);
 
     test_helpers (); // 9
-    test_lsmod_codec (); // 6
+    test_lsmod_codec (); // 11
     test_rmmod_codec (); // 2
     test_insmod_codec (); // 2
 

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -1,0 +1,52 @@
+#include "src/common/libflux/request.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    const char *topic, *s;
+    const char *json_str = "{\"a\":42}";
+
+    plan (8);
+
+    /* no topic is an error */
+    errno = 0;
+    ok ((zmsg = flux_request_encode (NULL, json_str)) == NULL
+        && errno == EINVAL,
+        "flux_request_encode returns EINVAL with no topic string");
+
+    /* without payload */
+    ok ((zmsg = flux_request_encode ("foo.bar", NULL)) != NULL,
+        "flux_request_encode works with NULL payload");
+    topic = NULL;
+    ok (flux_request_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "foo.bar"),
+        "flux_request_decode returns encoded topic");
+    ok (flux_request_decode (zmsg, NULL, NULL) == 0,
+        "flux_request_decode topic is optional");
+    errno = 0;
+    ok (flux_request_decode (zmsg, NULL, &s) < 0 && errno == EPROTO,
+        "flux_request_decode returns EPROTO when expected payload is missing");
+    zmsg_destroy(&zmsg);
+
+    /* with payload */
+    ok ((zmsg = flux_request_encode ("foo.bar", json_str)) != NULL,
+        "flux_request_encode works with payload");
+
+    s = NULL;
+    ok (flux_request_decode (zmsg, NULL, &s) == 0
+        && s != NULL && !strcmp (s, json_str),
+        "flux_request_decode returns encoded payload");
+    errno = 0;
+    ok (flux_request_decode (zmsg, NULL, NULL) < 0 && errno == EPROTO,
+        "flux_request_decode returns EPROTO when payload is unexpected");
+    zmsg_destroy (&zmsg);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -1,0 +1,86 @@
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg, *request;
+    const char *topic, *s;
+    const char *json_str = "{\"a\":42}";
+
+    plan (16);
+
+    /* no topic is an error */
+    errno = 0;
+    ok ((zmsg = flux_response_encode (NULL, 0, json_str)) == NULL
+        && errno == EINVAL,
+        "flux_response_encode returns EINVAL with no topic string");
+
+    /* both errnum and json_str is an error */
+    errno = 0;
+    ok ((zmsg = flux_response_encode ("foo.bar", 1, json_str)) == NULL
+        && errno == EINVAL,
+        "flux_response_encode returns EINVAL with both json and errnum");
+
+    /* without payload */
+    ok ((zmsg = flux_response_encode ("foo.bar", 0, NULL)) != NULL,
+        "flux_response_encode works with NULL payload");
+
+    topic = NULL;
+    ok (flux_response_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "foo.bar"),
+        "flux_response_decode returns encoded topic");
+    ok (flux_response_decode (zmsg, NULL, NULL) == 0,
+        "flux_response_decode topic is optional");
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, &s) < 0 && errno == EPROTO,
+        "flux_response_decode returns EPROTO when expected payload is missing");
+    zmsg_destroy(&zmsg);
+
+    /* with payload */
+    ok ((zmsg = flux_response_encode ("foo.bar", 0, json_str)) != NULL,
+        "flux_response_encode works with payload");
+
+    s = NULL;
+    ok (flux_response_decode (zmsg, NULL, &s) == 0
+        && s != NULL && !strcmp (s, json_str),
+        "flux_response_decode returns encoded payload");
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, NULL) < 0 && errno == EPROTO,
+        "flux_response_decode returns EPROTO when payload is unexpected");
+    zmsg_destroy (&zmsg);
+
+    /* with error */
+    ok ((zmsg = flux_response_encode ("foo.bar", 42, NULL)) != NULL,
+        "flux_response_encode works with errnum");
+    s = NULL;
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, NULL) < 0
+        && errno == 42,
+        "flux_response_decode fails with encoded errnum");
+    zmsg_destroy (&zmsg);
+
+    /* from request */
+    ok ((request = flux_request_encode ("foo.zzz", NULL)) != NULL,
+        "flux_request_encode works");
+    ok ((zmsg = flux_response_encode_ok (request, NULL)) != NULL,
+        "flux_response_encode_ok works");
+    ok (flux_response_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "foo.zzz"),
+        "flux_response_decode returns topic from request");
+    zmsg_destroy (&zmsg);
+    ok ((zmsg = flux_response_encode_err (request, 44)) != NULL,
+        "flux_response_encode_err works");
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, NULL) < 0 && errno == 44,
+        "flux_response_decode returns encoded errno");
+    zmsg_destroy (&request);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libjsonc/Makefile.am
+++ b/src/common/libjsonc/Makefile.am
@@ -1,0 +1,14 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+	$(JSON_CFLAGS) \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include
+
+noinst_LTLIBRARIES = libjsonc.la
+
+libjsonc_la_SOURCES = \
+	request.c \
+	request.h \
+	rpc.c \
+	rpc.h \
+	jsonc.h

--- a/src/common/libjsonc/jsonc.h
+++ b/src/common/libjsonc/jsonc.h
@@ -1,0 +1,20 @@
+#ifndef _FLUX_CORE_JSONC_H
+#define _FLUX_CORE_JSONC_H
+
+#define flux_json_request           jsonc_request
+#define flux_json_respond           jsonc_respond
+#define flux_err_respond            jsonc_respond_err
+#define flux_json_request_decode    jsonc_request_decode
+#define flux_json_response_decode   jsonc_response_decode
+
+#define flux_json_rpc               jsonc_rpc
+#define flux_json_multrpc           jsonc_multrpc
+
+#include "request.h"
+#include "rpc.h"
+
+#endif /* !_FLUX_CORE_JSONC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjsonc/request.c
+++ b/src/common/libjsonc/request.c
@@ -25,14 +25,16 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "request.h"
-#include "message.h"
-#include "info.h"
+
+#include "src/common/libflux/message.h"
+#include "src/common/libflux/info.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
+
+#include "jsonc.h"
 
 int flux_json_request_decode (zmsg_t *zmsg, json_object **in)
 {
@@ -87,30 +89,6 @@ int flux_json_response_decode (zmsg_t *zmsg, json_object **out)
         goto done;
     }
     *out = o;
-    rc = 0;
-done:
-    return rc;
-}
-
-int flux_response_decode (zmsg_t *zmsg)
-{
-    int rc = -1;
-    int errnum;
-
-    if (zmsg == NULL) {
-        errno = EINVAL;
-        goto done;
-    }
-    if (flux_msg_get_errnum (zmsg, &errnum) < 0)
-        goto done;
-    if (errnum != 0) {
-        errno = errnum;
-        goto done;
-    }
-    if (flux_msg_has_payload (zmsg)) {
-        errno = EPROTO;
-        goto done;
-    }
     rc = 0;
 done:
     return rc;

--- a/src/common/libjsonc/request.h
+++ b/src/common/libjsonc/request.h
@@ -1,12 +1,9 @@
-#ifndef _FLUX_CORE_REQUEST_H
-#define _FLUX_CORE_REQUEST_H
+#ifndef _FLUX_JSONC_REQUEST_H
+#define _FLUX_JSONC_REQUEST_H
 
 #include <json.h>
-#include <stdbool.h>
-#include <stdarg.h>
 #include <czmq.h>
-
-#include "handle.h"
+#include <stdint.h>
 
 /* Request and response messages are constructed according to Flux RFC 3.
  * https://github.com/flux-framework/rfc/blob/master/spec_3.adoc
@@ -50,14 +47,7 @@ int flux_json_request_decode (zmsg_t *zmsg, json_object **in);
  */
 int flux_json_response_decode (zmsg_t *zmsg, json_object **out);
 
-/* Decode response message with no payload.
- * If there is a payload, fail with errno == EPROTO.
- * If errnum is nonzero in response, fail with errno == errnum.
- * Returns 0 on success, or -1 on failure with errno set.
- */
-int flux_response_decode (zmsg_t *zmsg);
-
-#endif /* !_FLUX_CORE_REQUEST_H */
+#endif /* !_FLUX_JSONC_REQUEST_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libjsonc/rpc.c
+++ b/src/common/libjsonc/rpc.c
@@ -27,15 +27,15 @@
 #endif
 #include <czmq.h>
 
-#include "request.h"
-#include "message.h"
-#include "info.h"
-#include "rpc.h"
+#include "src/common/libflux/message.h"
+#include "src/common/libflux/info.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
+
+#include "jsonc.h"
 
 /* helper for flux_json_multrpc */
 static int multrpc_cb (zmsg_t *zmsg, uint32_t nodeid,

--- a/src/common/libjsonc/rpc.h
+++ b/src/common/libjsonc/rpc.h
@@ -1,13 +1,9 @@
-#ifndef _FLUX_CORE_RPC_H
-#define _FLUX_CORE_RPC_H
+#ifndef _FLUX_JSONC_RPC_H
+#define _FLUX_JSONC_RPC_H
 
 #include <json.h>
-#include <stdbool.h>
-#include <stdarg.h>
 #include <czmq.h>
-
-#include "handle.h"
-#include "request.h"
+#include <stdint.h>
 
 /* Send a request to 'nodeid' addressed to 'topic'.
  * If 'in' is non-NULL, attach JSON payload, caller retains ownership.
@@ -31,7 +27,7 @@ int flux_json_multrpc (flux_t h, const char *nodeset, int fanout,
                        const char *topic, json_object *in,
                        flux_multrpc_f cb, void *arg);
 
-#endif /* !_FLUX_CORE_REQUEST_H */
+#endif /* !_FLUX_JSONC_RPC_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = local
+SUBDIRS = local loop

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -1,0 +1,17 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+	$(JSON_CFLAGS) \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include
+
+fluxconnector_LTLIBRARIES = loop.la
+
+loop_la_SOURCES = loop.c
+
+loop_la_LDFLAGS = -module -Wl,--no-undefined \
+	-export-symbols-regex '^connector_init$$' \
+	--disable-static -avoid-version -shared -export-dynamic \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+loop_la_LIBADD = $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ)

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -1,0 +1,442 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* loop connector - mainly for testing */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/param.h>
+#include <stdbool.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <ctype.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+#include "src/common/libev/ev.h"
+#include "src/common/libutil/ev_zlist.h"
+#include "src/common/libutil/ev_zmq.h"
+
+#define CTX_MAGIC   0xf434aaa0
+typedef struct {
+    int magic;
+    int rank;
+    flux_t h;
+
+    zlist_t *queue;
+    ev_zlist queue_w;
+    struct ev_loop *loop;
+    int loop_rc;
+
+    flux_msg_f msg_cb;
+    void *msg_cb_arg;
+
+    zhash_t *watchers;
+    int timer_seq;
+} ctx_t;
+
+#define HASHKEY_LEN 80
+
+typedef struct {
+    ev_timer w;
+    FluxTmoutHandler cb;
+    void *arg;
+    int id;
+} atimer_t;
+
+typedef struct {
+    ev_zmq w;
+    FluxZsHandler cb;
+    void *arg;
+} azs_t;
+
+typedef struct {
+    ev_io w;
+    FluxFdHandler cb;
+    void *arg;
+} afd_t;
+
+static void op_reactor_stop (void *impl, int rc);
+
+
+static const struct flux_handle_ops handle_ops;
+
+const char *fake_uuid = "12345678123456781234567812345678";
+
+static int op_sendmsg (void *impl, zmsg_t **zmsg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    int type;
+    int rc = -1;
+
+    if (flux_msg_get_type (*zmsg, &type) < 0)
+        goto done;
+    switch (type) {
+        case FLUX_MSGTYPE_REQUEST:
+        case FLUX_MSGTYPE_EVENT:
+            if (flux_msg_enable_route (*zmsg) < 0)
+                goto done;
+            if (flux_msg_push_route (*zmsg, fake_uuid) < 0)
+                goto done;
+            break;
+    }
+    if (zlist_append (c->queue, *zmsg) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    *zmsg = NULL;
+    rc = 0;
+done:
+    return rc;
+}
+
+static zmsg_t *op_recvmsg (void *impl, bool nonblock)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    zmsg_t *zmsg = zlist_pop (c->queue);
+    if (!zmsg)
+        errno = EWOULDBLOCK;
+    return zmsg;
+}
+
+static int op_putmsg (void *impl, zmsg_t **zmsg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    if (zlist_append (c->queue, *zmsg) < 0)
+        oom ();
+    *zmsg = NULL;
+    return 0;
+}
+
+static int op_pushmsg (void *impl, zmsg_t **zmsg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    if (zlist_push (c->queue, *zmsg) < 0)
+        oom ();
+    *zmsg = NULL;
+    return 0;
+}
+
+static void op_purge (void *impl, flux_match_t match)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    zmsg_t *zmsg = zlist_first (c->queue);
+
+    while (zmsg) {
+        if (flux_msg_cmp (zmsg, match)) {
+            zlist_remove (c->queue, zmsg);
+            zmsg_destroy (&zmsg);
+        }
+        zmsg = zlist_next (c->queue);
+    }
+}
+
+static int op_rank (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    return c->rank;
+}
+
+static int op_reactor_start (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    c->loop_rc = 0;
+    ev_run (c->loop, 0);
+    return c->loop_rc;
+}
+
+static void op_reactor_stop (void *impl, int rc)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    c->loop_rc = rc;
+    ev_break (c->loop, EVBREAK_ALL);
+}
+
+static void queue_cb (struct ev_loop *loop, ev_zlist *w, int revents)
+{
+    ctx_t *c = (ctx_t *)((char *)w - offsetof (ctx_t, queue_w));
+    assert (c->magic == CTX_MAGIC);
+
+    assert (zlist_size (c->queue) > 0);
+    if (c->msg_cb) {
+        if (c->msg_cb (c->h, c->msg_cb_arg) < 0)
+            op_reactor_stop (c, -1);
+    }
+}
+
+static int op_reactor_msg_add (void *impl, flux_msg_f cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    int rc = -1;
+
+    if (c->msg_cb != NULL) {
+        errno = EBUSY;
+        goto done;
+    }
+    c->msg_cb = cb;
+    c->msg_cb_arg = arg;
+    rc = 0;
+done:
+    return rc;
+}
+
+static void op_reactor_msg_remove (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    c->msg_cb = NULL;
+    c->msg_cb_arg = NULL;
+}
+
+static void fd_cb (struct ev_loop *loop, ev_io *w, int revents)
+{
+    afd_t *f = (afd_t *)((char *)w - offsetof (afd_t, w));
+    ctx_t *c = w->data;
+    assert (c->magic == CTX_MAGIC);
+
+    if (f->cb (c->h, w->fd, etoz (revents), f->arg) < 0)
+        op_reactor_stop (c, -1);
+}
+
+static int op_reactor_fd_add (void *impl, int fd, int events,
+                               FluxFdHandler cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    afd_t *f = xzmalloc (sizeof (*f));
+    ev_io_init (&f->w, fd_cb, fd, ztoe (events));
+    f->w.data = c;
+    f->cb = cb;
+    f->arg = arg;
+
+    snprintf (hashkey, sizeof (hashkey), "fd:%d:%d", fd, events);
+    zhash_update (c->watchers, hashkey, f);
+    zhash_freefn (c->watchers, hashkey, free);
+
+    ev_io_start (c->loop, &f->w);
+
+    return 0;
+}
+
+static void op_reactor_fd_remove (void *impl, int fd, int events)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    snprintf (hashkey, sizeof (hashkey), "fd:%d:%d", fd, events);
+    afd_t *f = zhash_lookup (c->watchers, hashkey);
+    if (f) {
+        ev_io_stop (c->loop, &f->w);
+        zhash_delete (c->watchers, hashkey);
+    }
+}
+
+static void zs_cb (struct ev_loop *loop, ev_zmq *w, int revents)
+{
+    azs_t *z = (azs_t *)((char *)w - offsetof (azs_t, w));
+    ctx_t *c = w->data;
+    assert (c->magic == CTX_MAGIC);
+
+    int rc = z->cb (c->h, w->zsock, etoz (revents), z->arg);
+    if (rc < 0)
+        op_reactor_stop (c, -1);
+}
+
+static int op_reactor_zs_add (void *impl, void *zs, int events,
+                               FluxZsHandler cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    azs_t *z = xzmalloc (sizeof (*z));
+    ev_zmq_init (&z->w, zs_cb, zs, ztoe (events));
+    z->w.data = c;
+    z->cb = cb;
+    z->arg = arg;
+
+    snprintf (hashkey, sizeof (hashkey), "zsock:%p:%d", zs, events);
+    zhash_update (c->watchers, hashkey, z);
+    zhash_freefn (c->watchers, hashkey, free);
+
+    ev_zmq_start (c->loop, &z->w);
+    return 0;
+}
+
+static void op_reactor_zs_remove (void *impl, void *zs, int events)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    snprintf (hashkey, sizeof (hashkey), "zsock:%p:%d", zs, events);
+    azs_t *z = zhash_lookup (c->watchers, hashkey);
+    if (z) {
+        ev_zmq_stop (c->loop, &z->w);
+        zhash_delete (c->watchers, hashkey);
+    }
+}
+
+static void timer_cb (struct ev_loop *loop, ev_timer *w, int revents)
+{
+    atimer_t *t = (atimer_t *)((char *)w - offsetof (atimer_t, w));
+    ctx_t *c = w->data;
+    assert (c->magic == CTX_MAGIC);
+
+    if (t->cb (c->h, t->arg) < 0)
+         op_reactor_stop (c, -1);
+}
+
+static int op_reactor_tmout_add (void *impl, unsigned long msec, bool oneshot,
+                                  FluxTmoutHandler cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    double after = (double)msec / 1000.0;
+    double repeat = oneshot ? 0 : after;
+    char hashkey[HASHKEY_LEN];
+
+    atimer_t *t = xzmalloc (sizeof (*t));
+    t->id = c->timer_seq++;
+    t->w.data = c;
+    ev_timer_init (&t->w, timer_cb, after, repeat);
+    t->cb = cb;
+    t->arg = arg;
+
+    snprintf (hashkey, sizeof (hashkey), "timer:%d", t->id);
+    zhash_update (c->watchers, hashkey, t);
+    zhash_freefn (c->watchers, hashkey, free);
+
+    ev_timer_start (c->loop, &t->w);
+
+    return t->id;
+}
+
+static void op_reactor_tmout_remove (void *impl, int timer_id)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    snprintf (hashkey, sizeof (hashkey), "timer:%d", timer_id);
+    atimer_t *t = zhash_lookup (c->watchers, hashkey);
+    if (t) {
+        ev_timer_stop (c->loop, &t->w);
+        zhash_delete (c->watchers, hashkey);
+    }
+}
+
+static void op_fini (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    if (c->loop)
+        ev_loop_destroy (c->loop);
+    if (c->queue) {
+        zmsg_t *zmsg;
+        while ((zmsg = zlist_pop (c->queue)))
+            zmsg_destroy (&zmsg);
+        zlist_destroy (&c->queue);
+    }
+    zhash_destroy (&c->watchers);
+    c->magic = ~CTX_MAGIC;
+    free (c);
+}
+
+flux_t connector_init (const char *path, int flags)
+{
+    ctx_t *c = xzmalloc (sizeof (*c));
+    c->magic = CTX_MAGIC;
+    c->rank = 0;
+    if (!(c->loop = ev_loop_new (EVFLAG_AUTO))
+                            || !(c->watchers = zhash_new ())
+                            || !(c->queue = zlist_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    ev_zlist_init (&c->queue_w, queue_cb, c->queue, EV_READ);
+    ev_zlist_start (c->loop, &c->queue_w);
+    c->h = flux_handle_create (c, &handle_ops, flags);
+    return c->h;
+error:
+    if (c) {
+        int saved_errno = errno;
+        op_fini (c);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+static const struct flux_handle_ops handle_ops = {
+    .sendmsg = op_sendmsg,
+    .recvmsg = op_recvmsg,
+    .putmsg = op_putmsg,
+    .pushmsg = op_pushmsg,
+    .purge = op_purge,
+    .event_subscribe = NULL,
+    .event_unsubscribe = NULL,
+    .rank = op_rank,
+    .reactor_stop = op_reactor_stop,
+    .reactor_start = op_reactor_start,
+    .reactor_fd_add = op_reactor_fd_add,
+    .reactor_fd_remove = op_reactor_fd_remove,
+    .reactor_zs_add = op_reactor_zs_add,
+    .reactor_zs_remove = op_reactor_zs_remove,
+    .reactor_tmout_add = op_reactor_tmout_add,
+    .reactor_tmout_remove = op_reactor_tmout_remove,
+    .reactor_msg_add = op_reactor_msg_add,
+    .reactor_msg_remove = op_reactor_msg_remove,
+    .impl_destroy = op_fini,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/include/flux/core.h
+++ b/src/include/flux/core.h
@@ -5,6 +5,7 @@
 #define FLUX_CORE_H
 
 #include "src/common/libflux/flux.h"
+#include "src/common/libjsonc/jsonc.h" // temporary
 
 #include "src/modules/kvs/kvs.h"
 #include "src/modules/live/live.h"

--- a/src/test/module/parent.c
+++ b/src/test/module/parent.c
@@ -86,26 +86,27 @@ static module_t *module_create (const char *path, char *argz, size_t argz_len)
     return m;
 }
 
-static JSON module_list (void)
+static flux_modlist_t module_list (void)
 {
-    JSON o = flux_lsmod_json_create ();
+    flux_modlist_t mods = flux_modlist_create ();
     zlist_t *keys = zhash_keys (modules);
     module_t *m;
     char *name;
     int rc;
 
+    assert (mods != NULL);
     if (!keys)
         oom ();
     name = zlist_first (keys);
     while (name) {
         m = zhash_lookup (modules, name);
         assert (m != NULL);
-        rc = flux_lsmod_json_append (o, m->name, m->size, m->digest, m->idle);
+        rc = flux_modlist_append (mods, m->name, m->size, m->digest, m->idle);
         assert (rc == 0);
         name = zlist_next (keys);
     }
     zlist_destroy (&keys);
-    return o;
+    return mods;
 }
 
 static int insmod_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
@@ -163,11 +164,12 @@ static int rmmod_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 static int lsmod_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     JSON out = NULL;
+    flux_modlist_t mods = NULL;
     int errnum;
 
     if (flux_lsmod_request_decode (*zmsg) < 0)
         errnum = errno;
-    else if (!(out = module_list ()))
+    else if (!(mods = module_list ()))
         errnum = errno;
     else
         errnum = 0;
@@ -176,12 +178,18 @@ static int lsmod_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
             flux_log (h, LOG_ERR, "%s: flux_err_respond: %s", __FUNCTION__,
                       strerror (errno));
     } else {
+        char *json_str = flux_lsmod_json_encode (mods);
+        assert (json_str != NULL);
+        out = Jfromstr (json_str);
+        assert (out != NULL);
         if (flux_json_respond (h, out, zmsg) < 0)
             flux_log (h, LOG_ERR, "%s: flux_json_respond: %s", __FUNCTION__,
                       strerror (errno));
     }
     Jput (out);
     zmsg_destroy (zmsg);
+    if (mods)
+        flux_modlist_destroy (mods);
     return 0;
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -12,6 +12,8 @@ TESTS = \
 	loop/request.t \
 	loop/response.t \
 	loop/event.t \
+	loop/rpc.t \
+	loop/multrpc.t \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -68,7 +70,9 @@ check_SCRIPTS = \
 check_PROGRAMS = \
         loop/request.t \
         loop/response.t \
-        loop/event.t
+        loop/event.t \
+	loop/rpc.t \
+	loop/multrpc.t
 
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \
@@ -93,3 +97,11 @@ loop_response_t_LDADD = $(test_ldadd) $(LIBDL)
 loop_event_t_SOURCES = loop/event.c
 loop_event_t_CPPFLAGS = $(test_cppflags)
 loop_event_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_rpc_t_SOURCES = loop/rpc.c
+loop_rpc_t_CPPFLAGS = $(test_cppflags)
+loop_rpc_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_multrpc_t_SOURCES = loop/multrpc.c
+loop_multrpc_t_CPPFLAGS = $(test_cppflags)
+loop_multrpc_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,8 +1,17 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+        $(JSON_CFLAGS) \
+        -I$(top_srcdir) -I$(top_srcdir)/src/include
+
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
 
 TESTS = \
+	loop/request.t \
+	loop/response.t \
+	loop/event.t \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -25,7 +34,7 @@ TESTS = \
 	lua/t1003-iowatcher.t
 
 EXTRA_DIST= \
-	$(TESTS) \
+	$(check_SCRIPTS) \
 	aggregate-results.sh \
 	sharness.sh \
 	sharness.d \
@@ -33,3 +42,54 @@ EXTRA_DIST= \
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove
+
+check_SCRIPTS = \
+	t0000-sharness.t \
+	t0001-basic.t \
+	t0002-request.t \
+	t0003-module.t \
+	t0005-exec.t \
+	t1000-kvs-basic.t \
+	t1001-barrier-basic.t \
+	t1002-modctl.t \
+	t1003-mecho.t \
+	t1004-log.t \
+	t1005-cmddriver.t \
+	t2000-wreck.t \
+	lua/t0001-send-recv.t \
+	lua/t0002-rpc.t \
+	lua/t0003-events.t \
+	lua/t0007-alarm.t \
+	lua/t1000-reactor.t \
+	lua/t1001-timeouts.t \
+	lua/t1002-kvs.t \
+	lua/t1003-iowatcher.t
+
+check_PROGRAMS = \
+        loop/request.t \
+        loop/response.t \
+        loop/event.t
+
+test_ldadd = \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libtap/libtap.la \
+        $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
+
+test_cppflags = \
+        -DMODULE_PATH=\"$(top_builddir)/src/modules\" \
+        -DCONNECTOR_PATH=\"$(top_builddir)/src/connectors\" \
+        -I$(top_srcdir)/src/common/libtap \
+        $(AM_CPPFLAGS)
+
+loop_request_t_SOURCES = loop/request.c
+loop_request_t_CPPFLAGS = $(test_cppflags)
+loop_request_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_response_t_SOURCES = loop/response.c
+loop_response_t_CPPFLAGS = $(test_cppflags)
+loop_response_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_event_t_SOURCES = loop/event.c
+loop_event_t_CPPFLAGS = $(test_cppflags)
+loop_event_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/t/loop/event.c
+++ b/t/loop/event.c
@@ -1,0 +1,41 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/event.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    const char *topic;
+    flux_t h;
+
+    plan (5);
+
+    /* send/recv */
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "flux_open successfully opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    ok ((zmsg = flux_event_encode ("foo.bar", NULL)) != NULL,
+        "flux_event_encode works");
+    ok (flux_event_send (h, &zmsg) == 0 && zmsg == NULL,
+        "flux_event_send works");
+    ok ((zmsg = flux_event_recv (h, false)) != NULL,
+        "flux_event_recv works");
+    topic = NULL;
+    ok (flux_event_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "foo.bar"),
+        "flux_event_decode works");
+
+    zmsg_destroy (&zmsg);
+    flux_close (h);
+
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -1,0 +1,272 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/rpc.h"
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libflux/reactor.h"
+#include "src/common/libflux/info.h"
+
+#include "src/common/libutil/shortjson.h"
+
+#include "src/common/libtap/tap.h"
+
+/* request nodeid and flags returned in response */
+static int nodeid_fake_error = -1;
+int rpctest_nodeid_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+    uint32_t nodeid;
+    JSON o = NULL;
+    int flags;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0)
+        goto done;
+    if (flux_msg_get_nodeid (*zmsg, &nodeid, &flags) < 0)
+        goto done;
+    if (nodeid == nodeid_fake_error) {
+        nodeid_fake_error = -1;
+        errno = EPERM; /* an error not likely to be seen */
+        goto done;
+    }
+    o = Jnew ();
+    Jadd_int (o, "nodeid", nodeid);
+    Jadd_int (o, "flags", flags);
+    if (!(response = flux_response_encode_ok (*zmsg, Jtostr (o))))
+        goto done;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    return 0;
+}
+
+/* request payload echoed in response */
+int rpctest_echo_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+    const char *json_str;
+
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (!(response = flux_response_encode_ok (*zmsg, json_str)))
+        goto done;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    return 0;
+}
+
+/* no-payload response */
+static int hello_count = 0;
+int rpctest_hello_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0)
+        goto done;
+    if (!(response = flux_response_encode_ok (*zmsg, NULL)))
+        goto done;
+    hello_count++;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    return 0;
+}
+
+/* flux_multrpc() makes a flux_size() call, faked here for loop connector.
+ */
+static volatile int fake_size = 1;
+int cmb_info_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+    JSON o = Jnew ();
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0)
+        goto done;
+    Jadd_bool (o, "treeroot", true);
+    Jadd_int (o, "rank", 0);
+    Jadd_int (o, "size", fake_size);
+    if (!(response = flux_response_encode_ok (*zmsg, Jtostr (o))))
+        goto done;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    Jput (o);
+    return 0;
+}
+
+int rpctest_begin_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int i, errors, old_count;
+    flux_mresponse_t r;
+    const char *json_str;
+
+    errno = 0;
+    ok (flux_multrpc (h, 0, NULL, NULL, NULL) == -1 && errno == EINVAL,
+        "flux_multrpc [0] with NULL topic fails with EINVAL");
+
+    ok (flux_multrpc (h, 0, "rpctest.hello", "foo", NULL) == -1
+        && errno == EPROTO,
+        "flux_multrpc [0] with unexpected payload fails with EPROTO");
+
+    old_count = hello_count;
+    ok (flux_multrpc (h, 0, "rpctest.hello", NULL, NULL) == 0
+        && hello_count == old_count + 1,
+        "flux_multrpc [0] with expected payload works");
+
+    /* fake that we have a larger session */
+    fake_size = 128;
+    cmp_ok (flux_size (h), "==", fake_size,
+        "successfully faked flux_size() of %d", fake_size);
+
+    old_count = hello_count;
+    ok (flux_multrpc (h, 0, "rpctest.hello", NULL, NULL) == 0,
+        "flux_multrpc [0-%d] works", fake_size - 1);
+    cmp_ok (hello_count - old_count, "==", fake_size,
+        "service was called %d times", fake_size);
+
+    old_count = hello_count;
+    ok (flux_multrpcto (h, 0, "rpctest.hello", NULL, NULL, "[0-63]") == 0,
+        "flux_multrpcto [0-63] works");
+    cmp_ok (hello_count - old_count, "==", 64,
+        "service was called 64 times");
+
+    /* no payload */
+    r = NULL;
+    ok (flux_multrpcto (h, 0, "rpctest.hello", NULL, &r, "[0-63]") == 0
+        && r != NULL,
+        "flux_multrpcto [0-63] works, no payload");
+    errors = 0;
+    for (i = 0; i < 64; i++)
+        if (flux_mresponse_decode (r, i, NULL, NULL) < 0)
+            errors++;
+    ok (errors == 0,
+        "flux_mresponse_decode works, no return payload");
+    flux_mresponse_destroy (r);
+
+    /* with payload */
+    r = NULL;
+    ok (flux_multrpcto (h, 0, "rpctest.echo", "foo", &r, "[0-63]") == 0
+        && r != NULL,
+        "flux_multrpcto [0-63] works, with payload");
+    errors = 0;
+    for (i = 0; i < 64; i++)
+        if (flux_mresponse_decode (r, i, NULL, &json_str) < 0
+                || strcmp (json_str, "foo") != 0)
+            errors++;
+    ok (errors == 0,
+        "flux_mresponse_decode works, return payload verified");
+    flux_mresponse_destroy (r);
+
+    /* response ranks properly mapped */
+    r = NULL;
+    ok (flux_multrpcto (h, 0, "rpctest.nodeid", NULL, &r, "[0-63]") == 0
+        && r != NULL,
+        "flux_multrpcto [0-63] works, return payload only");
+    errors = 0;
+    for (i = 0; i < 64; i++) {
+        JSON o = NULL;
+        int nodeid = -1, flags = -1;
+        if (flux_mresponse_decode (r, i, NULL, &json_str) < 0
+                || !(o = Jfromstr (json_str))
+                || !Jget_int (o, "nodeid", &nodeid)
+                || !Jget_int (o, "flags", &flags)
+                || nodeid != i
+                || flags != 0) {
+            errors++;
+            fprintf (stderr, "%d: nodeid:%d, flags:%d\n", i, nodeid, flags);
+        }
+        Jput (o);
+    }
+    ok (errors == 0,
+        "flux_mresponse_decode works, nodes properly mapped");
+    flux_mresponse_destroy (r);
+
+    /* detect partial failure without mresponse */
+    nodeid_fake_error = 20;
+    ok (flux_multrpcto (h, 0, "rpctest.nodeid", NULL, NULL, "[0-63]") < 0
+        && errno == EPERM,
+        "flux_multrpcto [0-63] correctly reports single error response");
+
+    /* detect partial failure with mresponse */
+    nodeid_fake_error = 20;
+    r = NULL;
+    ok (flux_multrpcto (h, 0, "rpctest.nodeid", NULL, &r, "[0-63]") == 0
+        && r != NULL,
+        "flux_multrpcto [0-63] returns success with error in mresponse");
+    for (i = 0; i < 64; i++)
+        if (flux_mresponse_decode (r, i, NULL, &json_str) < 0)
+            break;
+    ok (i == 20 && errno == EPERM,
+        "flux_mresponse_decode correctly reports single error");
+    flux_mresponse_destroy (r);
+
+    flux_reactor_stop (h);
+    return 0;
+}
+
+
+static msghandler_t htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.begin",          rpctest_begin_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb},
+    { FLUX_MSGTYPE_REQUEST,   "cmb.info",               cmb_info_cb},
+};
+const int htablen = sizeof (htab) / sizeof (htab[0]);
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    flux_t h;
+
+    plan (21);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", FLUX_O_COPROC)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+
+    ok (flux_msghandler_addvec (h, htab, htablen, NULL) == 0,
+        "registered message handlers");
+    /* test continues in rpctest_begin_cb() so that rpc calls
+     * can sleep while we answer them
+     */
+    ok ((zmsg = flux_request_encode ("rpctest.begin", NULL)) != NULL
+        && flux_request_send (h, NULL, &zmsg) == 0,
+        "sent message to initiate test");
+    ok (flux_reactor_start (h) == 0,
+        "reactor completed normally");
+    flux_close (h);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/loop/request.c
+++ b/t/loop/request.c
@@ -1,0 +1,87 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libflux/event.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    const char *topic;
+    uint32_t matchtag, matchtag2;
+    uint32_t nodeid;
+    int flags;
+    flux_t h;
+
+    plan (18);
+
+    /* send/recv without payload */
+    /* N.B. normally FLUX_CONNECTOR_PATH is set by flux command driver */
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "flux_open successfully opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    ok ((zmsg = flux_request_encode ("a.b.c", NULL)) != NULL,
+        "message encoded with no payload");
+    ok (flux_request_send (h, NULL, &zmsg) == 0 && zmsg == NULL,
+        "message sent to loop with matchtag==NULL");
+    ok ((zmsg = flux_request_recv (h, false)) != NULL,
+        "message received from loop");
+    topic = NULL;
+    ok (flux_request_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "a.b.c"),
+        "flux_request_decode OK");
+    matchtag = 123456UL;
+    ok (flux_msg_get_matchtag (zmsg, &matchtag) == 0
+        && matchtag == FLUX_MATCHTAG_NONE,
+        "matchtag is FLUX_MATCHTAG_NONE");
+    ok (flux_request_send (h, &matchtag, &zmsg) == 0 && zmsg == NULL
+        && matchtag != FLUX_MATCHTAG_NONE,
+        "message resent to loop with matchtag set");
+    ok ((zmsg = flux_request_recv (h, false)) != NULL,
+        "message received from loop");
+    matchtag2 = 123456UL;
+    ok (flux_msg_get_matchtag (zmsg, &matchtag2) == 0
+        && matchtag2 == matchtag,
+        "matchtag correctly decoded");
+    ok (flux_request_send (h, NULL, &zmsg) == 0 && zmsg == NULL,
+        "message resent to loop with matchtag==NULL");
+    ok ((zmsg = flux_request_recv (h, false)) != NULL,
+        "message received from loop");
+    matchtag2 = 123456UL;
+    ok (flux_msg_get_matchtag (zmsg, &matchtag2) == 0
+        && matchtag2 == matchtag,
+        "matchtag from last time was undisturbed");
+    ok (flux_request_sendto (h, NULL, &zmsg, 42) == 0 && zmsg == NULL,
+        "message resent to loop with nodeid==42");
+    ok ((zmsg = flux_request_recv (h, false)) != NULL,
+        "message received from loop");
+    nodeid = 0xfffff;
+    flags  = 0xfffff;
+    ok (flux_msg_get_nodeid (zmsg, &nodeid, &flags) == 0
+        && nodeid == 42 && flags == 0,
+        "nodeid correctly decoded");
+    ok (flux_request_sendto (h, NULL, &zmsg, FLUX_NODEID_UPSTREAM) == 0
+        && zmsg == NULL,
+        "message resent to loop with nodeid==FLUX_NODEID_UPSTREAM");
+    ok ((zmsg = flux_request_recv (h, false)) != NULL,
+        "message received from loop");
+    nodeid = 0xfffff;
+    flags  = 0xfffff;
+    /* N.B. loop connector hardwires the nodeid to 0 */
+    ok (flux_msg_get_nodeid (zmsg, &nodeid, &flags) == 0
+        && nodeid == 0 && flags == FLUX_MSGFLAG_UPSTREAM,
+        "upstream nodeid and flags correctly decoded");
+
+    zmsg_destroy (&zmsg);
+    flux_close (h);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/loop/response.c
+++ b/t/loop/response.c
@@ -1,0 +1,55 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    const char *topic;
+    uint32_t matchtag;
+    flux_t h;
+
+    plan (10);
+
+    /* send/recv */
+    /* N.B. normally FLUX_CONNECTOR_PATH is set by flux command driver */
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "flux_open successfully opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    ok ((zmsg = flux_response_encode ("a.b.c", 0, NULL)) != NULL,
+        "flux_response_encode works");
+    ok (flux_response_send (h, &zmsg) == 0 && zmsg == NULL,
+        "flux_response_send works");
+    ok ((zmsg = flux_response_recv (h, 42, true)) == NULL
+        && errno == EWOULDBLOCK,
+        "flux_response_recv nonblock on wrong matchtag returns EWOULDBLOCK");
+    ok ((zmsg = flux_response_recv (h, FLUX_MATCHTAG_NONE, false)) != NULL,
+        "flux_response_recv FLUX_MATCHTAG_NONE works");
+    topic = NULL;
+    ok (flux_response_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "a.b.c"),
+        "flux_response_decode works");
+    ok ((matchtag = flux_matchtag_alloc (h, 1)) != FLUX_MATCHTAG_NONE
+        && flux_msg_set_matchtag (zmsg, matchtag) == 0,
+        "allocated and set a matchtag in message");
+    ok (flux_response_send (h, &zmsg) == 0 && zmsg == NULL,
+        "flux_response_send works");
+    ok ((zmsg = flux_response_recv (h, matchtag +  1, true)) == NULL,
+        "flux_response_recv nonblock with non-matching matchtag fails");
+    ok ((zmsg = flux_response_recv (h, matchtag, false)) != NULL,
+        "flux_response_recv with matching matchtag works");
+
+    zmsg_destroy (&zmsg);
+    flux_close (h);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -1,0 +1,193 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/rpc.h"
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libflux/reactor.h"
+
+#include "src/common/libutil/shortjson.h"
+
+#include "src/common/libtap/tap.h"
+
+/* request nodeid and flags returned in response */
+int rpctest_nodeid_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+    uint32_t nodeid;
+    JSON o = NULL;
+    int flags;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0)
+        goto done;
+    if (flux_msg_get_nodeid (*zmsg, &nodeid, &flags) < 0)
+        goto done;
+    o = Jnew ();
+    Jadd_int (o, "nodeid", nodeid);
+    Jadd_int (o, "flags", flags);
+    if (!(response = flux_response_encode_ok (*zmsg, Jtostr (o))))
+        goto done;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    return 0;
+}
+
+/* request payload echoed in response */
+int rpctest_echo_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+    const char *json_str;
+
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (!(response = flux_response_encode_ok (*zmsg, json_str)))
+        goto done;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    return 0;
+}
+
+/* no-payload response */
+int rpctest_hello_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int rc;
+    zmsg_t *response = NULL;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0)
+        goto done;
+    if (!(response = flux_response_encode_ok (*zmsg, NULL)))
+        goto done;
+done:
+    if (!response)
+        response = flux_response_encode_err (*zmsg, errno);
+    assert (response != NULL);
+    rc = flux_response_send (h, &response);
+    assert (rc == 0);
+    zmsg_destroy (zmsg);
+    zmsg_destroy (&response);
+    return 0;
+}
+
+int rpctest_begin_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    const char *topic;
+    const char *json_str;
+    int nodeid, flags;
+    JSON o = NULL;
+    zmsg_t *response;
+
+    errno = 0;
+    ok (flux_rpc (h, NULL, NULL, NULL) == -1 && errno == EINVAL,
+        "flux_rpc with NULL topic fails with EINVAL");
+
+    ok (flux_rpc (h, "rpctest.hello", NULL, NULL) == 0,
+        "flux_rpc with no payload when none is expected works");
+
+    errno = 0;
+    ok (flux_rpc (h, "rpctest.hello", "foo", NULL) == -1 && errno == EPROTO,
+        "flux_rpc with payload when none is expected fails with EPROTO");
+
+    errno = 0;
+    ok (flux_rpc (h, "rpctest.echo", NULL, NULL) == -1 && errno == EPROTO,
+        "flux_rpc with no payload when payload is expected fails with EPROTO");
+
+    ok (flux_rpc (h, "rpctest.echo", "foo", NULL) == 0,
+        "flux_rpc with payload when payload expected works");
+
+    ok (flux_rpc (h, "rpctest.echo", "foo", &response) == 0 && response != NULL,
+        "flux_rpc returns response message");
+    ok (flux_response_decode (response, &topic, &json_str) == 0
+        && topic && !strcmp (topic, "rpctest.echo")
+        && json_str && !strcmp (json_str, "foo"),
+        "and response contains expected topic and payload");
+    zmsg_destroy (&response);
+
+    ok (flux_rpc (h, "rpctest.nodeid", NULL, &response) == 0
+        && response != NULL
+        && flux_response_decode (response, NULL, &json_str) == 0
+        && (o = Jfromstr (json_str)) != NULL
+        && Jget_int (o, "nodeid", &nodeid) && Jget_int (o, "flags", &flags)
+        && nodeid == FLUX_NODEID_ANY && flags == 0,
+        "flux_rpc sent request with FLUX_NODEID_ANY");
+    zmsg_destroy (&response);
+    Jput (o);
+
+    ok (flux_rpcto (h, "rpctest.nodeid", NULL, &response, 64) == 0
+        && response != NULL
+        && flux_response_decode (response, NULL, &json_str) == 0
+        && (o = Jfromstr (json_str)) != NULL
+        && Jget_int (o, "nodeid", &nodeid) && Jget_int (o, "flags", &flags)
+        && nodeid == 64 && flags == 0,
+        "flux_rpcto sent request with nodeid set properly");
+    zmsg_destroy (&response);
+    Jput (o);
+
+    ok (flux_rpcto (h, "rpctest.nodeid", NULL, &response, FLUX_NODEID_UPSTREAM) == 0
+        && response != NULL
+        && flux_response_decode (response, NULL, &json_str) == 0
+        && (o = Jfromstr (json_str)) != NULL
+        && Jget_int (o, "nodeid", &nodeid) && Jget_int (o, "flags", &flags)
+        && nodeid == 0 && flags == FLUX_MSGFLAG_UPSTREAM,
+        "flux_rpcto FLUX_NODEID_UPSTREAM correctly constructed request");
+    zmsg_destroy (&response);
+    Jput (o);
+
+    zmsg_destroy (zmsg);
+    flux_reactor_stop (h);
+    return 0;
+}
+
+static msghandler_t htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.begin",          rpctest_begin_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb},
+};
+const int htablen = sizeof (htab) / sizeof (htab[0]);
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    flux_t h;
+
+    plan (15);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", FLUX_O_COPROC)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+
+    ok (flux_msghandler_addvec (h, htab, htablen, NULL) == 0,
+        "registered message handlers");
+    /* test continues in rpctest_begin_cb() so that rpc calls
+     * can sleep while we answer them
+     */
+    ok ((zmsg = flux_request_encode ("rpctest.begin", NULL)) != NULL,
+        "encoded rpctest.begin request OK");
+    ok (flux_request_send (h, NULL, &zmsg) == 0,
+        "sent rpctest.begin request");
+    ok (flux_reactor_start (h) == 0,
+        "reactor completed normally");
+    flux_close (h);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This PR reworks the request, response, rpc, and a small assortment of other functions in the public API that had `json_object` parameters.  Like the recently added event functions, these request and response functions are divided into clean encode/decode and send/recv groups.

To avoid updating all users, the original functions were moved, unmodified, to a new internal library called `libjsonc`.  This allows us to iterate on the API design without a huge churn among all the users.  After we've settled, perhaps this library can morph into a convenience library that facilitates using the I/O functions with json-c.

Unit tests were added for the new functions, and a new `loop` connector was added that allows the send/recv functions to be exercised in unit tests.  Combined with the `FLUX_O_COPROC` mode we are able to even test the new `flux_rpc()` and `flux_multrpc()` functions without starting a broker.  A new directory `t/loop` was added for these sort of tests.

The API redesign needs some feedback.  It does clash somewhat with the current structure of reactor message callbacks, but I hope we can rework _that_ interface along with `flux_msg_t` changes so that it all comes together.  Here's a summary of the important ones with some notes:

**request**
```
int flux_request_decode (zmsg_t *zmsg, const char **topic,
                         const char **json_str);
zmsg_t *flux_request_encode (const char *topic, const char *json_str);

int flux_request_send (flux_t h, uint32_t *matchtag, zmsg_t **zmsg);
int flux_request_sendto (flux_t h, uint32_t *matchtag, zmsg_t **zmsg,
                         uint32_t nodeid);
zmsg_t *flux_request_recv (flux_t h, bool nonblock);
```
`flux_request_send()` optionally allows a matchtag to be returned which can be passed to `flux_response_recv()`.  By default, messages are sent to `FLUX_NODEID_ANY`.  The sendto variant allows a nodeid to be specified, or `FLUX_NODEID_UPSTREAM`.  A side effect of this style of API is that the messages, at least currently, can't be a `const` as suggested earlier by @trws since the nodeid has to be set in the message before it is sent.  Perhaps this can be dealt with when we introduce `flux_msg_t`.

**response**
```
int flux_response_decode (zmsg_t *zmsg, const char **topic,
                          const char **json_str);
zmsg_t *flux_response_encode_ok (zmsg_t *request, const char *json_str);
zmsg_t *flux_response_encode_err (zmsg_t *request, int errnum);
zmsg_t *flux_response_encode (const char *topic, int errnum,
                              const char *json_str);

int flux_response_send (flux_t h, zmsg_t **zmsg);
zmsg_t *flux_response_recv (flux_t h, uint32_t matchtag, bool nonblock);
```
The `flux_response_encode_ok()` and `encode_err()` build a response from a request message, but unlike the functions they replace, do not modify/destroy the request.  As noted above,  `flux_response_recv()` can accept a matchtag or `FLUX_MATCHTAG_NONE` to receive any response message.

**rpc**
```
int flux_rpc (flux_t h, const char *topic,
              const char *json_str, zmsg_t **response);
int flux_rpcto (flux_t h, const char *topic,
                const char *json_str, zmsg_t **response, uint32_t nodeid);
```
I question whether these rpc functions are quite right.  Returning the response zmsg seems unbalanced, but to return a JSON string would require the message payload to be duplicated before the response message could be destroyed internally.  With this RPC prototype, one has to call `flux_response_decode()` on the result if there is a payload.  If the payload is empty, `response` can be set NULL.
