### PR TITLE
finish removing json_object from public flux api

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,7 @@ AC_CONFIG_FILES( \
   src/cmd/Makefile \
   src/connectors/Makefile \
   src/connectors/local/Makefile \
+  src/connectors/loop/Makefile \
   src/modules/Makefile \
   src/modules/api/Makefile \
   src/modules/kvs/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,7 @@ AC_CONFIG_FILES( \
   src/common/libutil/Makefile \
   src/common/libev/Makefile \
   src/common/libflux/Makefile \
+  src/common/libjsonc/Makefile \
   src/lib/Makefile \
   src/lib/libpmi/Makefile \
   src/bindings/Makefile \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1089,11 +1089,14 @@ done:
 static int cmb_rmmod_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
+    const char *json_str;
     char *name = NULL;
     int rc = -1;
     module_t p;
 
-    if (flux_rmmod_request_decode (*zmsg, &name) < 0)
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (flux_rmmod_json_decode (json_str, &name) < 0)
         goto done;
     if (!(p = module_lookup_byname (ctx->modhash, name))) {
         errno = ENOENT;
@@ -1115,6 +1118,7 @@ done:
 static int cmb_insmod_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
+    const char *json_str;
     char *name = NULL;
     char *path = NULL;
     char *argz = NULL;
@@ -1122,7 +1126,9 @@ static int cmb_insmod_cb (zmsg_t **zmsg, void *arg)
     module_t p;
     int rc = -1;
 
-    if (flux_insmod_request_decode (*zmsg, &path, &argz, &argz_len) < 0)
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0)
+        goto done;
+    if (flux_insmod_json_decode (json_str, &path, &argz, &argz_len) < 0)
         goto done;
     if (!(name = flux_modname (path))) {
         errno = ENOENT;
@@ -1160,9 +1166,26 @@ done:
 static int cmb_lsmod_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
-    JSON out = module_list_encode (ctx->modhash);
-    int rc = flux_json_respond (ctx->h, out, zmsg);
+    flux_modlist_t mods = NULL;
+    char *json_str = NULL;
+    JSON out = NULL;
+    int rc = -1;
+
+    if (!(mods = module_get_modlist (ctx->modhash)))
+        goto done;
+    if (!(json_str = flux_lsmod_json_encode (mods)))
+        goto done;
+    out = Jfromstr (json_str);
+    assert (out != NULL);
+    if (flux_json_respond (ctx->h, out, zmsg) < 0)
+        goto done;
+    rc = 0;
+done:
     Jput (out);
+    if (json_str)
+        free (json_str);
+    if (mods)
+        flux_modlist_destroy (mods);
     return rc;
 }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1242,11 +1242,12 @@ done:
 static int cmb_log_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
+    const char *json_str;
 
-    if (ctx->rank > 0)
-        (void)overlay_sendmsg_parent (ctx->overlay, zmsg);
-    else
-        (void)flux_log_zmsg (*zmsg);
+    if (flux_response_decode (*zmsg, NULL, &json_str) < 0)
+        goto done;
+    (void)flux_log_json (ctx->h, json_str);
+done:
     zmsg_destroy (zmsg); /* no reply */
     return 0;
 }

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -89,7 +89,7 @@ int module_stop_all (modhash_t mh);
 
 /* Prepare an 'lsmod' response payload.
  */
-json_object *module_list_encode (modhash_t mh);
+flux_modlist_t module_get_modlist (modhash_t mh);
 
 #endif /* !_BROKER_MODULE_H */
 

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -137,7 +137,7 @@ void shutdown_arm (shutdown_t s, int grace, int rc, const char *fmt, ...)
     Jadd_int (out, "rank", flux_rank (s->h));
     Jadd_int (out, "exitcode", rc);
     zmsg_t *zmsg = flux_event_encode ("shutdown", Jtostr (out));
-    if (!zmsg || flux_event_send (s->h, &zmsg) < 0)
+    if (!zmsg || flux_sendmsg (s->h, &zmsg) < 0)
         err_exit ("%s: could not send event", __FUNCTION__);
     Jput (out);
     zmsg_destroy (&zmsg);

--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -138,8 +138,8 @@ int main (int argc, char *argv[])
     } else if (Copt) {
         char *topic = xasprintf ("%s.stats.clear", target);
         zmsg_t *zmsg = flux_event_encode (target, NULL);
-        if (!zmsg || flux_event_send (h, &zmsg) < 0)
-            err_exit ("flux_event_send");
+        if (!zmsg || flux_sendmsg (h, &zmsg) < 0)
+            err_exit ("sending event");
         zmsg_destroy (&zmsg);
         free (topic);
     } else if (Ropt) {

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -96,11 +96,11 @@ int main (int argc, char *argv[])
     } else if (!strcmp (cmd, "idle")) {
         if (optind != argc)
             usage ();
-        JSON peers;
+        char *peers;
         if (!(peers = flux_lspeer (h, rank)))
             err_exit ("flux_peer");
-        printf ("%s\n", Jtostr (peers));
-        Jput (peers);
+        printf ("%s\n", peers);
+        free (peers);
     } else if (!strcmp (cmd, "getattr")) {
         char *s;
         if (optind != argc - 1)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -390,8 +390,8 @@ void cmd_dropcache_all (flux_t h, int argc, char **argv)
     if (argc != 0)
         msg_exit ("dropcache-all: takes no arguments");
     zmsg_t *zmsg = flux_event_encode ("kvs.dropcache", NULL);
-    if (!zmsg || flux_event_send (h, &zmsg) < 0)
-        err_exit ("flux_event_send");
+    if (!zmsg || flux_sendmsg (h, &zmsg) < 0)
+        err_exit ("flux_sendmsg");
     zmsg_destroy (&zmsg);
 }
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = libtap libev liblsd libutil libflux
+SUBDIRS = libtap libev liblsd libutil libflux libjsonc
 
 AM_CFLAGS = @GCCWARN@
 
@@ -11,6 +11,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/libutil.la \
 	$(builddir)/libev/libev.la \
+	$(builddir)/libjsonc/libjsonc.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt
 libflux_internal_la_LDFLAGS = -Wl,--no-undefined

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -15,6 +15,7 @@ fluxcoreinclude_HEADERS = \
 	message.h \
 	request.h \
 	response.h \
+	rpc.h \
 	panic.h \
 	event.h \
 	module.h \
@@ -37,6 +38,7 @@ libflux_la_SOURCES = \
 	message.c \
 	request.c \
 	response.c \
+	rpc.c \
 	panic.c \
 	event.c \
 	module.c \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -13,6 +13,7 @@ fluxcoreinclude_HEADERS = \
 	reduce.h \
 	security.h \
 	message.h \
+	request.h \
 	panic.h \
 	event.h \
 	module.h \
@@ -33,6 +34,7 @@ libflux_la_SOURCES = \
 	reduce.c \
 	security.c \
 	message.c \
+	request.c \
 	panic.c \
 	event.c \
 	module.c \
@@ -45,6 +47,7 @@ libflux_la_SOURCES = \
 TESTS = test_conf.t \
 	test_module.t \
 	test_message.t \
+	test_request.t \
 	test_event.t \
 	test_tagpool.t
 
@@ -90,3 +93,6 @@ test_tagpool_t_SOURCES = test/tagpool.c tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 
+test_request_t_SOURCES = test/request.c
+test_request_t_CPPFLAGS = $(test_cppflags)
+test_request_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -14,6 +14,7 @@ fluxcoreinclude_HEADERS = \
 	security.h \
 	message.h \
 	request.h \
+	response.h \
 	panic.h \
 	event.h \
 	module.h \
@@ -35,6 +36,7 @@ libflux_la_SOURCES = \
 	security.c \
 	message.c \
 	request.c \
+	response.c \
 	panic.c \
 	event.c \
 	module.c \
@@ -48,6 +50,7 @@ TESTS = test_conf.t \
 	test_module.t \
 	test_message.t \
 	test_request.t \
+	test_response.t \
 	test_event.t \
 	test_tagpool.t
 
@@ -96,3 +99,7 @@ test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 test_request_t_SOURCES = test/request.c
 test_request_t_CPPFLAGS = $(test_cppflags)
 test_request_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_response_t_SOURCES = test/response.c
+test_response_t_CPPFLAGS = $(test_cppflags)
+test_response_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -57,9 +57,10 @@ TESTS = test_conf.t \
 	test_tagpool.t
 
 test_ldadd = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux/libflux.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
 
 test_cppflags = \
@@ -94,7 +95,7 @@ test_event_t_SOURCES = test/event.c
 test_event_t_CPPFLAGS = $(test_cppflags)
 test_event_t_LDADD = $(test_ldadd) $(LIBDL)
 
-test_tagpool_t_SOURCES = test/tagpool.c tagpool.c
+test_tagpool_t_SOURCES = test/tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -15,13 +15,11 @@ fluxcoreinclude_HEADERS = \
 	message.h \
 	panic.h \
 	event.h \
-	request.h \
 	module.h \
 	reparent.h \
 	info.h \
 	flog.h \
 	conf.h \
-	rpc.h \
 	tmpdir.h
 
 noinst_LTLIBRARIES = \
@@ -37,11 +35,9 @@ libflux_la_SOURCES = \
 	message.c \
 	panic.c \
 	event.c \
-	request.c \
 	module.c \
 	reparent.c \
 	conf.c \
-	rpc.c \
 	tagpool.h \
 	tagpool.c \
 	tmpdir.c
@@ -53,11 +49,10 @@ TESTS = test_conf.t \
 	test_tagpool.t
 
 test_ldadd = \
-        $(top_builddir)/src/common/libflux/libflux.la \
-        $(top_builddir)/src/common/libutil/libutil.la \
-        $(top_builddir)/src/common/libtap/libtap.la \
-        $(top_builddir)/src/common/liblsd/liblsd.la \
-        $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
 
 test_cppflags = \
 	-DMODULE_PATH=\"$(top_builddir)/src/modules\" \
@@ -91,7 +86,7 @@ test_event_t_SOURCES = test/event.c
 test_event_t_CPPFLAGS = $(test_cppflags)
 test_event_t_LDADD = $(test_ldadd) $(LIBDL)
 
-test_tagpool_t_SOURCES = test/tagpool.c
+test_tagpool_t_SOURCES = test/tagpool.c tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
 test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -30,7 +30,6 @@
 
 #include "event.h"
 #include "message.h"
-#include "rpc.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -93,22 +93,6 @@ error:
     return NULL;
 }
 
-zmsg_t *flux_event_recv (flux_t h, bool nonblock)
-{
-    flux_match_t match = {
-        .typemask = FLUX_MSGTYPE_EVENT,
-        .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
-        .topic_glob = NULL,
-    };
-    return flux_recvmsg_match (h, match, NULL, nonblock);
-}
-
-int flux_event_send (flux_t h, zmsg_t **zmsg)
-{
-    return flux_sendmsg (h, zmsg);
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -21,11 +21,6 @@ int flux_event_decode (zmsg_t *zmsg, const char **topic, const char **json_str);
  */
 zmsg_t *flux_event_encode (const char *topic, const char *json_str);
 
-/* Send/receive events
- */
-int flux_event_send (flux_t h, zmsg_t **zmsg);
-zmsg_t *flux_event_recv (flux_t h, bool nonblock);
-
 #endif /* !FLUX_CORE_EVENT_H */
 
 /*

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -31,9 +31,9 @@
 
 #include "flog.h"
 #include "info.h"
-#include "request.h"
 #include "message.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -7,26 +7,22 @@
 
 #include "handle.h"
 
-/* FIXME: redirect flag causes redirection to syslog if logging
- * is so configured, but facility and level are not passed to msg/err()
- * (see libutil/log.c)
+/* Set log facility for handle instance.
  */
-
 void flux_log_set_facility (flux_t h, const char *facility);
+
+/* Inject a message into the logging system.
+ */
 int flux_vlog (flux_t h, int lev, const char *fmt, va_list ap);
 int flux_log (flux_t h, int lev, const char *fmt, ...)
             __attribute__ ((format (printf, 3, 4)));
+int flux_log_json (flux_t h, const char *json_str);
 
 /* If the redirect flag is set, we are the end of the line and any
  * log request messages should be decoded and "logged" (sent to
  * libutil/log.c's configurable destination).
  */
 void flux_log_set_redirect (flux_t h, bool flag);
-
-/* Log a cmb.log message to libutil/log.c.
- * The message is not destroyed.
- */
-int flux_log_zmsg (zmsg_t *zmsg);
 
 #endif /* !_FLUX_CORE_FLOG_H */
 

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -7,6 +7,7 @@
 #include "security.h"
 #include "reduce.h"
 #include "message.h"
+#include "request.h"
 #include "panic.h"
 #include "event.h"
 #include "module.h"

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -8,6 +8,7 @@
 #include "reduce.h"
 #include "message.h"
 #include "request.h"
+#include "response.h"
 #include "panic.h"
 #include "event.h"
 #include "module.h"

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -9,8 +9,6 @@
 #include "message.h"
 #include "panic.h"
 #include "event.h"
-#include "request.h"
-#include "rpc.h"
 #include "module.h"
 #include "reparent.h"
 #include "info.h"

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -9,6 +9,7 @@
 #include "message.h"
 #include "request.h"
 #include "response.h"
+#include "rpc.h"
 #include "panic.h"
 #include "event.h"
 #include "module.h"

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -373,7 +373,7 @@ zmsg_t *flux_recvmsg_match (flux_t h, flux_match_t match, zlist_t *nomatch,
     zmsg_t *zmsg = NULL;
     zlist_t *putmsg = nomatch;
 
-    if (flux_sleep_on (h, match) < 0) {
+    if (!nonblock && flux_sleep_on (h, match) < 0) {
         if (errno != EINVAL)
             goto done;
         errno = 0; /* EINVAL: not running in a coprocess */

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -29,8 +29,8 @@
 #include <stdbool.h>
 
 #include "info.h"
-#include "rpc.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -29,8 +29,8 @@
 #include <stdbool.h>
 
 #include "info.h"
+#include "rpc.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
@@ -38,14 +38,18 @@ char *flux_getattr (flux_t h, int rank, const char *name)
 {
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
     JSON in = Jnew ();
+    flux_rpc_t r = NULL;
+    const char *json_str;
     JSON out = NULL;
     char *ret = NULL;
     const char *val = NULL;
 
     Jadd_str (in, "name", name);
-    if (flux_json_rpc (h, nodeid, "cmb.getattr", in, &out) < 0)
+    if (!(r = flux_rpc (h, "cmb.getattr", Jtostr (in), nodeid, 0)))
         goto done;
-    if (!out || !Jget_str (out, (char *)name, &val)) {
+    if (flux_rpc_get (r, NULL, &json_str) < 0)
+        goto done;
+    if (!(out = Jfromstr (json_str)) || !Jget_str (out, (char *)name, &val)) {
         errno = EPROTO;
         goto done;
     }
@@ -53,21 +57,28 @@ char *flux_getattr (flux_t h, int rank, const char *name)
 done:
     Jput (in);
     Jput (out);
+    if (r)
+        flux_rpc_destroy (r);
     return ret;
 }
 
 int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp)
 {
-    JSON response = NULL;
+    flux_rpc_t r = NULL;
+    JSON out = NULL;
+    const char *json_str;
     int rank, size;
     bool treeroot;
     int ret = -1;
 
-    if (flux_json_rpc (h, FLUX_NODEID_ANY, "cmb.info", NULL, &response) < 0)
+    if (!(r = flux_rpc (h, "cmb.info", NULL, FLUX_NODEID_ANY, 0)))
         goto done;
-    if (!Jget_bool (response, "treeroot", &treeroot)
-            || !Jget_int (response, "rank", &rank)
-            || !Jget_int (response, "size", &size)) {
+    if (flux_rpc_get (r, NULL, &json_str) < 0)
+        goto done;
+    if (!(out = Jfromstr (json_str))
+            || !Jget_bool (out, "treeroot", &treeroot)
+            || !Jget_int (out, "rank", &rank)
+            || !Jget_int (out, "size", &size)) {
         errno = EPROTO;
         goto done;
     }
@@ -79,7 +90,9 @@ int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp)
         *treerootp = treeroot;
     ret = 0;
 done:
-    Jput (response);
+    Jput (out);
+    if (r)
+        flux_rpc_destroy (r);
     return ret;
 }
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -900,6 +900,24 @@ done:
     return rc;
 }
 
+/* FIXME: this function copies payload and then deletes it if 'payload'
+ * is false, when the point was to avoid the overhead of copying it in
+ * the first place.
+ */
+zmsg_t *flux_msg_copy (const zmsg_t *zmsg, bool payload)
+{
+    zmsg_t *cpy = zmsg_dup ((zmsg_t *)zmsg);
+    if (!cpy) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (!payload && flux_msg_set_payload (cpy, 0, NULL, 0) < 0) {
+        zmsg_destroy (&cpy);
+        return NULL;
+    }
+    return cpy;
+}
+
 struct map_struct {
     const char *name;
     const char *sname;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -654,7 +654,7 @@ char *flux_msg_get_route_string (zmsg_t *zmsg)
     return buf;
 }
 
-static bool zframe_allocated (void *b, zframe_t *zf)
+static bool payload_overlap (void *b, zframe_t *zf)
 {
     return ((char *)b >= (char *)zframe_data (zf)
          && (char *)b <  (char *)zframe_data (zf) + zframe_size (zf));
@@ -694,11 +694,13 @@ int flux_msg_set_payload (zmsg_t *zmsg, int flags, void *buf, int size)
     /* Case #1: replace existing payload.
      */
     if ((msgflags & FLUX_MSGFLAG_PAYLOAD) && (buf != NULL && size > 0)) {
-        if (zframe_allocated (buf, zf)) {
-            errno = EINVAL;
-            goto done;
+        if (zframe_data (zf) != buf || zframe_size (zf) != size) {
+            if (payload_overlap (buf, zf)) {
+                errno = EINVAL;
+                goto done;
+            }
+            zframe_reset (zf, buf, size);
         }
-        zframe_reset (zf, buf, size);
         msgflags &= ~(uint8_t)FLUX_MSGFLAG_JSON;
         msgflags |= flags;
     /* Case #2: add payload.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -29,6 +29,10 @@ enum {
  */
 zmsg_t *flux_msg_create (int type);
 
+/* Duplicate zmsg, omitting payload if 'payload' is false.
+ */
+zmsg_t *flux_msg_copy (const zmsg_t *zmsg, bool payload);
+
 /* Get/set message type
  * For FLUX_MSGTYPE_REQUEST: set_type initializes nodeid to FLUX_NODEID_ANY
  * For FLUX_MSGTYPE_RESPONSE: set_type initializes errnum to 0

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -29,10 +29,9 @@
 #include <argz.h>
 
 #include "module.h"
-#include "request.h"
-#include "rpc.h"
 #include "message.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -30,10 +30,15 @@
 
 #include "module.h"
 #include "message.h"
+#include "rpc.h"
 
 #include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
+
+struct flux_modlist_struct {
+    JSON a;
+};
 
 /* Get service name from module name string.
  */
@@ -53,15 +58,19 @@ static char *mod_service (const char *modname)
  ** JSON encode/decode functions
  **/
 
-int flux_insmod_json_decode (JSON o, char **path, char **argz, size_t *argz_len)
+int flux_insmod_json_decode (const char *json_str,
+                             char **path, char **argz, size_t *argz_len)
 {
+    JSON o = NULL;
     JSON args = NULL;
     const char *s;
     int i, ac;
     int rc = -1;
 
-    if (!Jget_str (o, "path", &s) || !Jget_obj (o, "args", &args)
-                                  || !Jget_ar_len (args, &ac)) {
+    if (!(o = Jfromstr (json_str))
+                || !Jget_str (o, "path", &s)
+                || !Jget_obj (o, "args", &args)
+                || !Jget_ar_len (args, &ac)) {
         errno = EPROTO;
         goto done;
     }
@@ -73,53 +82,62 @@ int flux_insmod_json_decode (JSON o, char **path, char **argz, size_t *argz_len)
     rc = 0;
 done:
     Jput (args);
+    Jput (o);
     return rc;
 }
 
-JSON flux_insmod_json_encode (const char *path, int argc, char **argv)
+char *flux_insmod_json_encode (const char *path, int argc, char **argv)
 {
     JSON o = Jnew ();
     JSON args = Jnew_ar ();
+    char *json_str;
     int i;
 
     Jadd_str (o, "path", path);
     for (i = 0; i < argc; i++)
         Jadd_ar_str (args, argv[i]);
     Jadd_obj (o, "args", args);
-    return o;
+    json_str = xstrdup (Jtostr (o));
+    Jput (o);
+    return json_str;
 }
 
-int flux_rmmod_json_decode (JSON o, char **name)
+int flux_rmmod_json_decode (const char *json_str, char **name)
 {
+    JSON o = NULL;
     const char *s;
     int rc = -1;
-    if (!Jget_str (o, "name", &s)) {
+    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "name", &s)) {
         errno = EPROTO;
         goto done;
     }
     *name = xstrdup (s);
     rc = 0;
 done:
+    Jput (o);
     return rc;
 }
 
-JSON flux_rmmod_json_encode (const char *name)
+char *flux_rmmod_json_encode (const char *name)
 {
     JSON o = Jnew ();
+    char *json_str;
     Jadd_str (o, "name", name);
-    return o;
+    json_str = xstrdup (Jtostr (o)); 
+    Jput (o);
+    return json_str;
 }
 
-int flux_lsmod_json_decode_nth (JSON a, int n, const char **name, int *size,
+int flux_modlist_get (flux_modlist_t mods, int n, const char **name, int *size,
                                 const char **digest, int *idle)
 {
     JSON o;
     int rc = -1;
 
-    if (!Jget_ar_obj (a, n, &o) || !Jget_str (o, "name", name)
-                                || !Jget_int (o, "size", size)
-                                || !Jget_str (o, "digest", digest)
-                                || !Jget_int (o, "idle", idle)) {
+    if (!Jget_ar_obj (mods->a, n, &o) || !Jget_str (o, "name", name)
+                                      || !Jget_int (o, "size", size)
+                                      || !Jget_str (o, "digest", digest)
+                                      || !Jget_int (o, "idle", idle)) {
         errno = EPROTO;
         goto done;
     }
@@ -128,20 +146,18 @@ done:
     return rc;
 }
 
-int flux_lsmod_json_decode (JSON a, int *len)
+int flux_modlist_count (flux_modlist_t mods)
 {
-    int rc = -1;
+    int len;
 
-    if (!Jget_ar_len (a, len)) {
+    if (!Jget_ar_len (mods->a, &len)) {
         errno = EPROTO;
-        goto done;
+        return -1;
     }
-    rc = 0;
-done:
-    return rc;
+    return len;
 }
 
-int flux_lsmod_json_append (JSON a, const char *name, int size,
+int flux_modlist_append (flux_modlist_t mods, const char *name, int size,
                             const char *digest, int idle)
 {
     JSON o = Jnew ();
@@ -149,14 +165,40 @@ int flux_lsmod_json_append (JSON a, const char *name, int size,
     Jadd_int (o, "size", size);
     Jadd_str (o, "digest", digest);
     Jadd_int (o, "idle", idle);
-    Jadd_ar_obj (a, o); /* takes a ref on o */
+    Jadd_ar_obj (mods->a, o); /* takes a ref on o */
     Jput (o);
     return 0;
 }
 
-JSON flux_lsmod_json_create (void)
+void flux_modlist_destroy (flux_modlist_t mods)
 {
-    return Jnew_ar ();
+    if (mods) {
+        Jput (mods->a);
+        free (mods);
+    }
+}
+
+flux_modlist_t flux_modlist_create (void)
+{
+    flux_modlist_t mods = xzmalloc (sizeof (*mods));
+    mods->a = Jnew_ar ();
+    return mods;
+}
+
+char *flux_lsmod_json_encode (flux_modlist_t mods)
+{
+    return xstrdup (Jtostr (mods->a));
+}
+
+flux_modlist_t flux_lsmod_json_decode (const char *json_str)
+{
+    flux_modlist_t mods = xzmalloc (sizeof (*mods));
+    if (!(mods->a = Jfromstr (json_str))) {
+        free (mods);
+        errno = EPROTO;
+        return NULL;
+    }
+    return mods;
 }
 
 char *flux_modname(const char *path)
@@ -255,88 +297,53 @@ char *flux_modfind (const char *searchpath, const char *modname)
     return modpath;
 }
 
-int flux_insmod_request_decode (zmsg_t *zmsg, char **path,
-                                char **argz, size_t *argz_len)
-{
-    JSON in = NULL;
-    int rc = -1;
-
-    if (flux_json_request_decode (zmsg, &in) < 0)
-        goto done;
-    if (flux_insmod_json_decode (in, path, argz, argz_len) < 0)
-        goto done;
-    rc = 0;
-done:
-    Jput (in);
-    return rc;
-}
-
-int flux_rmmod_request_decode (zmsg_t *zmsg, char **name)
-{
-    JSON in = NULL;
-    int rc = -1;
-
-    if (flux_json_request_decode (zmsg, &in) < 0)
-        goto done;
-    if (flux_rmmod_json_decode (in, name) < 0)
-        goto done;
-    rc = 0;
-done:
-    Jput (in);
-    return rc;
-}
-
-int flux_lsmod_request_decode (zmsg_t *zmsg)
-{
-    int type;
-    int rc = -1;
-
-    if (flux_msg_get_type (zmsg, &type) < 0)
-        goto done;
-    if (type != FLUX_MSGTYPE_REQUEST || flux_msg_has_payload (zmsg)) {
-        errno = EPROTO;
-        goto done;
-    }
-    rc = 0;
-done:
-    return rc;
-}
-
 int flux_rmmod (flux_t h, uint32_t nodeid, const char *name)
 {
-    JSON in = NULL;
+    flux_rpc_t r = NULL;
     char *service = mod_service (name);
     char *topic = xasprintf ("%s.rmmod", service);
+    char *json_str = NULL;
     int rc = -1;
 
-    in = flux_rmmod_json_encode (name);
-    Jadd_str (in, "name", name);
-    if (flux_json_rpc (h, nodeid, topic, in, NULL) < 0)
+    if (!(json_str = flux_rmmod_json_encode (name)))
+        goto done;
+    if (!(r = flux_rpc (h, topic, json_str, nodeid, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, NULL) < 0)
         goto done;
     rc = 0;
 done:
     free (service);
     free (topic);
-    Jput (in);
+    if (json_str)
+        free (json_str);
+    if (r)
+        flux_rpc_destroy (r);
     return rc;
 }
 
 int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
                 flux_lsmod_f cb, void *arg)
 {
-    JSON out = NULL;
+    flux_rpc_t r = NULL;
     char *topic = xasprintf ("%s.lsmod", service ? service : "cmb");
+    flux_modlist_t mods = NULL;
+    const char *json_str;
     int rc = -1;
     int i, len;
 
-    if (flux_json_rpc (h, nodeid, topic, NULL, &out) < 0)
+    if (!(r = flux_rpc (h, topic, NULL, nodeid, 0)))
         goto done;
-    if (flux_lsmod_json_decode (out, &len) < 0)
+    if (flux_rpc_get (r, NULL, &json_str) < 0)
+        goto done;
+    if (!(mods = flux_lsmod_json_decode (json_str)) < 0)
+        goto done;
+    if ((len = flux_modlist_count (mods)) == -1)
         goto done;
     for (i = 0; i < len; i++) {
         const char *name, *digest;
         int size, idle;
-        if (flux_lsmod_json_decode_nth (out, i, &name, &size, &digest, &idle) < 0)
+        if (flux_modlist_get (mods, i, &name, &size, &digest, &idle) < 0)
             goto done;
         if (cb (name, size, digest, idle, NULL, arg) < 0)
             goto done;
@@ -344,16 +351,22 @@ int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
     rc = 0;
 done:
     free (topic);
+    if (mods)
+        flux_modlist_destroy (mods);
+    if (r)
+        flux_rpc_destroy (r);
     return rc;
 }
 
 int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
                  int argc, char **argv)
 {
+    flux_rpc_t r = NULL;
     JSON in = Jnew ();
     char *name = NULL;
     char *service = NULL;
     char *topic = NULL;
+    char *json_str = NULL;
     int rc = -1;
 
     if (!(name = flux_modname (path))) {
@@ -363,8 +376,10 @@ int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
     service = mod_service (name);
     topic = xasprintf ("%s.insmod", service);
 
-    in = flux_insmod_json_encode (path, argc, argv);
-    if (flux_json_rpc (h, nodeid, topic, in, NULL) < 0)
+    json_str = flux_insmod_json_encode (path, argc, argv);
+    if (!(r = flux_rpc (h, topic, json_str, nodeid, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -372,7 +387,11 @@ done:
         free (service);
     if (topic)
         free (topic);
+    if (json_str)
+        free (json_str);
     Jput (in);
+    if (r)
+        flux_rpc_destroy (r);
     return rc;
 }
 

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -27,8 +27,8 @@
 #endif
 #include "panic.h"
 #include "flog.h"
+#include "rpc.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 
@@ -37,15 +37,19 @@ int flux_panic (flux_t h, int rank, const char *msg)
 {
     uint32_t nodeid = rank < 0 ? FLUX_NODEID_ANY : rank;
     JSON in = Jnew ();
+    flux_rpc_t r = NULL;
     int rc = -1;
 
     Jadd_str (in, "msg", msg ? msg : "");
-    if (flux_json_request (h, nodeid, FLUX_MATCHTAG_NONE, "cmb.panic", in) < 0)
+    r = flux_rpc (h, "cmb.panic", Jtostr (in), nodeid, FLUX_RPC_NORESPONSE);
+    if (!r)
         goto done;
     /* No reply */
     rc = 0;
 done:
     Jput (in);
+    if (r)
+        flux_rpc_destroy (r);
     return rc;
 }
 

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -26,9 +26,9 @@
 #include "config.h"
 #endif
 #include "panic.h"
-#include "request.h"
 #include "flog.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -59,7 +59,25 @@ struct reactor_struct {
     dispatch_t *current;
 };
 
-static void copy_match (flux_match_t *dst, flux_match_t src)
+static bool match_match (const flux_match_t m1, const flux_match_t m2)
+{
+    if (m1.typemask != m2.typemask)
+        return false;
+    if (m1.matchtag != m2.matchtag)
+        return false;
+    if (m1.bsize != m2.bsize)
+        return false;
+    if (m1.topic_glob == NULL && m2.topic_glob != NULL)
+        return false;
+    if (m1.topic_glob != NULL && m2.topic_glob == NULL)
+        return false;
+    if (m1.topic_glob != NULL && m2.topic_glob != NULL
+                              && strcmp (m1.topic_glob, m2.topic_glob) != 0)
+        return false;
+    return true;
+}
+
+static void copy_match (flux_match_t *dst, const flux_match_t src)
 {
     if (dst->topic_glob)
         free (dst->topic_glob);
@@ -67,12 +85,12 @@ static void copy_match (flux_match_t *dst, flux_match_t src)
     dst->topic_glob = src.topic_glob ? xstrdup (src.topic_glob) : NULL;
 }
 
-static dispatch_t *dispatch_create (flux_t h, flux_match_t match,
+static dispatch_t *dispatch_create (flux_t h, const flux_match_t match,
                                     FluxMsgHandler cb, void *arg)
 {
     dispatch_t *d = xzmalloc (sizeof (*d));
     d->h = h;
-    d->match = match;
+    copy_match (&d->match, match);
     d->fn = cb;
     d->arg = arg;
     return d;
@@ -292,30 +310,41 @@ done:
     return rc;
 }
 
-int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
-                         FluxMsgHandler cb, void *arg)
+int flux_msghandler_add_match (flux_t h, const flux_match_t match,
+                              FluxMsgHandler cb, void *arg)
 {
     reactor_t r = flux_get_reactor (h);
     dispatch_t *d;
     int oldsize = zlist_size (r->dsp);
     int rc = -1;
 
-    if (typemask == 0 || !pattern || !cb) {
+    if (!cb || match.typemask == 0) {
         errno = EINVAL;
         goto done;
     }
-
-    flux_match_t match = {
-        .typemask = typemask,
-        .topic_glob = pattern ? xstrdup (pattern) : NULL,
-        .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 1,
-    };
     d = dispatch_create (h, match, cb, arg);
     if (zlist_push (r->dsp, d) < 0)
         oom ();
     if (oldsize == 0 && r->ops->reactor_msg_add)
         rc = r->ops->reactor_msg_add (r->impl, msg_cb, r);
+    rc = 0;
+done:
+    return rc;
+}
+
+int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
+                         FluxMsgHandler cb, void *arg)
+{
+    int rc = -1;
+
+    flux_match_t match = {
+        .typemask = typemask,
+        .topic_glob = (char *)pattern,
+        .matchtag = FLUX_MATCHTAG_NONE,
+        .bsize = 1,
+    };
+    if (flux_msghandler_add_match (h, match, cb, arg) < 0)
+        goto done;
     rc = 0;
 done:
     return rc;
@@ -333,15 +362,14 @@ int flux_msghandler_addvec (flux_t h, msghandler_t *handlers, int len,
     return 0;
 }
 
-void flux_msghandler_remove (flux_t h, int typemask, const char *pattern)
+void flux_msghandler_remove_match (flux_t h, const flux_match_t match)
 {
     reactor_t r = flux_get_reactor (h);
     dispatch_t *d;
 
     d = zlist_first (r->dsp);
     while (d) {
-        if (d->match.typemask == typemask && !strcmp (d->match.topic_glob,
-                                                        pattern)) {
+        if (match_match (d->match, match)) {
             zlist_remove (r->dsp, d);
             dispatch_destroy (d);
             if (zlist_size (r->dsp) == 0 && r->ops->reactor_msg_remove)
@@ -350,6 +378,17 @@ void flux_msghandler_remove (flux_t h, int typemask, const char *pattern)
         }
         d = zlist_next (r->dsp);
     }
+}
+
+void flux_msghandler_remove (flux_t h, int typemask, const char *pattern)
+{
+    flux_match_t match = {
+        .typemask = typemask,
+        .matchtag = FLUX_MATCHTAG_NONE,
+        .bsize = 1,
+        .topic_glob = (char*)pattern,
+    };
+    flux_msghandler_remove_match (h, match);
 }
 
 int flux_fdhandler_add (flux_t h, int fd, short events,

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -32,11 +32,11 @@
 
 #include "handle.h"
 #include "reactor.h"
-#include "request.h"
 #include "handle_impl.h"
 #include "message.h"
 #include "tagpool.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/coproc.h"

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -34,9 +34,9 @@
 #include "reactor.h"
 #include "handle_impl.h"
 #include "message.h"
+#include "response.h"
 #include "tagpool.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/coproc.h"
@@ -295,7 +295,7 @@ static int msg_cb (flux_t h, void *arg)
      */
     } else {
         if (type == FLUX_MSGTYPE_REQUEST) {
-            if (flux_err_respond (h, ENOSYS, &zmsg) < 0)
+            if (flux_respond (h, zmsg, ENOSYS, NULL))
                 goto done;
         } else if (flux_flags_get (h) & FLUX_O_TRACE) {
             const char *topic = NULL;

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -39,6 +39,11 @@ int flux_msghandler_addvec (flux_t h, msghandler_t *handlers, int len,
 void flux_msghandler_remove (flux_t h, int typemask, const char *pattern);
 
 
+int flux_msghandler_add_match (flux_t h, const flux_match_t match,
+                              FluxMsgHandler cb, void *arg);
+void flux_msghandler_remove_match (flux_t h, const flux_match_t match);
+
+
 /* Register a FluxFdHandler callback to be called whenever an event
  * in the 'events' mask occurs on the given file descriptor 'fd'.
  */

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -26,8 +26,8 @@
 #include "config.h"
 #endif
 #include "reparent.h"
-#include "rpc.h"
 
+#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
 
 

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -26,23 +26,33 @@
 #include "config.h"
 #endif
 #include "reparent.h"
+#include "rpc.h"
 
-#include "src/common/libjsonc/jsonc.h"
 #include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/xzmalloc.h"
 
 
-JSON flux_lspeer (flux_t h, int rank)
+char *flux_lspeer (flux_t h, int rank)
 {
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
-    JSON out = NULL;
+    flux_rpc_t r = NULL;
+    const char *json_str;
+    char *ret = NULL;
 
-    if (flux_json_rpc (h, nodeid, "cmb.lspeer", NULL, &out) < 0)
-        return NULL;
-    return out;
+    if (!(r = flux_rpc (h, "cmb.lspeer", NULL, nodeid, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, &json_str) < 0)
+        goto done;
+    ret = xstrdup (json_str);
+done:
+    if (r)
+        flux_rpc_destroy (r);
+    return ret;
 }
 
 int flux_reparent (flux_t h, int rank, const char *uri)
 {
+    flux_rpc_t r = NULL;
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
     JSON in = Jnew ();
     int rc = -1;
@@ -52,11 +62,15 @@ int flux_reparent (flux_t h, int rank, const char *uri)
         goto done;
     }
     Jadd_str (in, "uri", uri);
-    if (flux_json_rpc (h, nodeid, "cmb.reparent", in, NULL) < 0)
+    if (!(r = flux_rpc (h, "cmb.reparent", Jtostr (in), nodeid, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, NULL) < 0)
         goto done;
     rc = 0;
 done:
     Jput (in);
+    if (r)
+        flux_rpc_destroy (r);
     return rc;
 }
 

--- a/src/common/libflux/reparent.h
+++ b/src/common/libflux/reparent.h
@@ -4,7 +4,7 @@
 #include <json.h>
 #include "handle.h"
 
-json_object *flux_lspeer (flux_t h, int rank);
+char *flux_lspeer (flux_t h, int rank);
 
 int flux_reparent (flux_t h, int rank, const char *uri);
 

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -1,0 +1,99 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "request.h"
+#include "message.h"
+#include "info.h"
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/nodeset.h"
+
+int flux_request_decode (zmsg_t *zmsg, const char **topic,
+                         const char **json_str)
+{
+    int type;
+    const char *ts, *js;
+    int rc = -1;
+
+    if (zmsg == NULL) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (flux_msg_get_type (zmsg, &type) < 0)
+        goto done;
+    if (type != FLUX_MSGTYPE_REQUEST) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (flux_msg_get_topic (zmsg, &ts) < 0)
+        goto done;
+    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+        goto done;
+    if ((json_str && !js) || (!json_str && js)) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (topic)
+        *topic = ts;
+    if (json_str)
+        *json_str = js;
+    rc = 0;
+done:
+    return rc;
+}
+
+zmsg_t *flux_request_encode (const char *topic, const char *json_str)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!topic) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        goto error;
+    if (flux_msg_set_topic (zmsg, topic) < 0)
+        goto error;
+    if (flux_msg_enable_route (zmsg) < 0)
+        goto error;
+    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+        goto error;
+    return zmsg;
+error:
+    if (zmsg) {
+        int saved_errno = errno;
+        zmsg_destroy (&zmsg);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -1,0 +1,29 @@
+#ifndef _FLUX_CORE_REQUEST_H
+#define _FLUX_CORE_REQUEST_H
+
+#include <json.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <czmq.h>
+
+#include "handle.h"
+
+/* Decode a request message.
+ * If topic is non-NULL, assign the request topic string.
+ * If json_str is non-NULL, assign the payload.  json_str indicates whether
+ * payload is expected and it is an EPROTO error if expectations are not met.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_request_decode (zmsg_t *zmsg, const char **topic,
+                         const char **json_str);
+
+/* Encode a response message.
+ * If json_str is non-NULL, assign the payload.
+ */
+zmsg_t *flux_request_encode (const char *topic, const char *json_str);
+
+#endif /* !_FLUX_CORE_REQUEST_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -1,0 +1,134 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "response.h"
+#include "message.h"
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/nodeset.h"
+
+
+int flux_response_decode (zmsg_t *zmsg, const char **topic,
+                          const char **json_str)
+{
+    int type;
+    const char *ts, *js;
+    int errnum = 0;
+    int rc = -1;
+
+    if (zmsg == NULL) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (flux_msg_get_type (zmsg, &type) < 0)
+        goto done;
+    if (type != FLUX_MSGTYPE_RESPONSE) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (flux_msg_get_errnum (zmsg, &errnum) < 0)
+        goto done;
+    if (errnum != 0) {
+        errno = errnum;
+        goto done;
+    }
+    if (flux_msg_get_topic (zmsg, &ts) < 0)
+        goto done;
+    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+        goto done;
+    if ((json_str && !js) || (!json_str && js)) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (topic)
+        *topic = ts;
+    if (json_str)
+        *json_str = js;
+    rc = 0;
+done:
+    return rc;
+}
+
+zmsg_t *flux_response_encode (const char *topic, int errnum,
+                              const char *json_str)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!topic || (errnum != 0 && json_str != NULL)) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)))
+        goto error;
+    if (flux_msg_set_topic (zmsg, topic) < 0)
+        goto error;
+    if (flux_msg_enable_route (zmsg) < 0)
+        goto error;
+    if (flux_msg_set_errnum (zmsg, errnum) < 0)
+        goto error;
+    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+        goto error;
+    return zmsg;
+error:
+    if (zmsg) {
+        int saved_errno = errno;
+        zmsg_destroy (&zmsg);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+int flux_respond (flux_t h, const zmsg_t *request,
+                  int errnum, const char *json_str)
+{
+    zmsg_t *zmsg = NULL;
+
+    if (!request) {
+        errno = EINVAL;
+        goto fatal;
+    }
+    if (!(zmsg = flux_msg_copy (request, false)))
+        goto fatal;
+    if (flux_msg_set_type (zmsg, FLUX_MSGTYPE_RESPONSE) < 0)
+        goto fatal;
+    if (errnum && flux_msg_set_errnum (zmsg, errnum) < 0)
+        goto fatal;
+    if (!errnum && json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+        goto fatal;
+    if (flux_sendmsg (h, &zmsg) < 0)
+        goto fatal;
+    zmsg_destroy (&zmsg);
+    return 0;
+fatal:
+    zmsg_destroy (&zmsg);
+    FLUX_FATAL (h);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -1,0 +1,35 @@
+#ifndef _FLUX_CORE_RESPONSE_H
+#define _FLUX_CORE_RESPONSE_H
+
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include "message.h"
+#include "handle.h"
+
+/* Decode a response message.
+ * If topic is non-NULL, assign the response topic string.
+ * If json_str is non-NULL, assign the payload.  json_str indicates whether
+ * payload is expected and it is an EPROTO error if expectations are not met.
+ * If response includes a nonzero errnum, errno is set to the errnum value
+ * and -1 is returned with no assignments to topic or json_str.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_response_decode (zmsg_t *zmsg, const char **topic,
+                          const char **json_str);
+
+zmsg_t *flux_response_encode (const char *topic, int errnum,
+                              const char *json_str);
+
+/* Create a response to the provided request message.
+ * If errnum is nonzero, payload argument is ignored.
+ * All errors in this function are fatal - see flux_fatal_set().
+ */
+int flux_respond (flux_t h, const zmsg_t *request,
+                  int errnum, const char *json_str);
+
+#endif /* !_FLUX_CORE_RESPONSE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -211,6 +211,10 @@ int flux_rpc_then (flux_rpc_t rpc, flux_then_f cb, void *arg)
     if (cb && !rpc->then_cb) {
         if (flux_msghandler_add_match (rpc->h, rpc->m, rpc_cb, rpc) < 0)
             goto done;
+        if (rpc->rx_msg && !rpc->rx_msg_consumed) {
+            if (flux_pushmsg (rpc->h, &rpc->rx_msg) < 0)
+                goto done;
+        }
     } else if (!cb && rpc->then_cb) {
         flux_msghandler_remove_match (rpc->h, rpc->m);
     }

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -1,0 +1,286 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+
+#include "request.h"
+#include "response.h"
+#include "message.h"
+#include "info.h"
+#include "rpc.h"
+#include "reactor.h"
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/nodeset.h"
+
+typedef zlist_t zmsglist_t;
+
+struct flux_rpc_struct {
+    flux_match_t m;
+    flux_t h;
+    flux_then_f then_cb;
+    void *then_arg;
+    uint32_t *nodemap;          /* nodeid indexed by matchtag */
+    zmsg_t *rx_msg;
+    bool rx_msg_consumed;
+    int rx_count;
+    bool oneway;
+};
+
+void flux_rpc_destroy (flux_rpc_t rpc)
+{
+    if (rpc) {
+        if (rpc->then_cb)
+            flux_msghandler_remove_match (rpc->h, rpc->m);
+        if (rpc->m.matchtag != FLUX_MATCHTAG_NONE)
+            flux_matchtag_free (rpc->h, rpc->m.matchtag, rpc->m.bsize);
+        zmsg_destroy (&rpc->rx_msg);
+        if (rpc->nodemap)
+            free (rpc->nodemap);
+        free (rpc);
+    }
+}
+
+static flux_rpc_t rpc_create (flux_t h, int flags, int count)
+{
+    flux_rpc_t rpc = xzmalloc (sizeof (*rpc));
+    if ((flags & FLUX_RPC_NORESPONSE)) {
+        rpc->oneway = true;
+        rpc->m.matchtag = FLUX_MATCHTAG_NONE;
+    } else {
+        rpc->nodemap = xzmalloc (sizeof (rpc->nodemap[0]) * count);
+        rpc->m.matchtag = flux_matchtag_alloc (h, count);
+        if (rpc->m.matchtag == FLUX_MATCHTAG_NONE) {
+            flux_rpc_destroy (rpc);
+            return NULL;
+        }
+    }
+    rpc->m.bsize = count;
+    rpc->m.typemask = FLUX_MSGTYPE_RESPONSE;
+    rpc->h = h;
+    return rpc;
+}
+
+static uint32_t lookup_nodeid (flux_rpc_t rpc, uint32_t matchtag)
+{
+    int ix = matchtag - rpc->m.matchtag;
+    if (ix < 0 || ix >= rpc->m.bsize)
+        return FLUX_NODEID_ANY;
+    return rpc->nodemap[ix];
+}
+
+static void garbage_collect (flux_rpc_t rpc)
+{
+    if (rpc->rx_msg && rpc->rx_msg_consumed)
+        zmsg_destroy (&rpc->rx_msg);
+}
+
+static void rpc_addmsg (flux_rpc_t rpc, zmsg_t **zmsg)
+{
+    assert (rpc->rx_msg == NULL);
+    rpc->rx_msg = *zmsg;
+    *zmsg = NULL;
+    rpc->rx_msg_consumed = false;
+    rpc->rx_count++;
+}
+
+static int rpc_recvmsg (flux_rpc_t rpc, bool nonblock)
+{
+    assert (rpc->rx_msg == NULL);
+    if (!(rpc->rx_msg = flux_recvmsg_match (rpc->h, rpc->m, NULL, nonblock)))
+        return -1;
+    rpc->rx_msg_consumed = false;
+    rpc->rx_count++;
+    return 0;
+}
+
+static int rpc_sendmsg (flux_rpc_t rpc, int n, const char *topic,
+                        const char *json_str, uint32_t nodeid)
+{
+    zmsg_t *zmsg;
+    int flags = 0;
+    int rc = -1;
+
+    if (!(zmsg = flux_request_encode (topic, json_str)))
+        goto done;
+    if (flux_msg_set_matchtag (zmsg, rpc->m.matchtag + n) < 0)
+        goto done;
+    if (nodeid == FLUX_NODEID_UPSTREAM) {
+        flags |= FLUX_MSGFLAG_UPSTREAM;
+        nodeid = flux_rank (rpc->h);
+    }
+    if (flux_msg_set_nodeid (zmsg, nodeid, flags) < 0)
+        goto done;
+    if (flux_sendmsg (rpc->h, &zmsg) < 0)
+        goto done;
+    rc = 0;
+done:
+    zmsg_destroy (&zmsg);
+    return rc;
+}
+
+
+bool flux_rpc_check (flux_rpc_t rpc)
+{
+    if (rpc->oneway)
+        return false;
+    garbage_collect (rpc);
+    if (!rpc->rx_msg && rpc_recvmsg (rpc, true) < 0)
+        errno = 0;
+    if (rpc->rx_msg)
+        return true;
+    return false;
+}
+
+int flux_rpc_get (flux_rpc_t rpc, uint32_t *nodeid, const char **json_str)
+{
+    int rc = -1;
+
+    if (rpc->oneway) {
+        errno = EINVAL;
+        goto done;
+    }
+    garbage_collect (rpc);
+    if (!rpc->rx_msg && rpc_recvmsg (rpc, false) < 0)
+        goto done;
+    rpc->rx_msg_consumed = true;
+    if (flux_response_decode (rpc->rx_msg, NULL, json_str) < 0)
+        goto done;
+    if (nodeid) {
+        uint32_t matchtag;
+        if (flux_msg_get_matchtag (rpc->rx_msg, &matchtag) < 0)
+            goto done;
+        *nodeid = lookup_nodeid (rpc, matchtag);
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+/* N.B. if the user's 'then' callback doesn't call flux_rpc_get(),
+ * the callback will be called again (ad infinitum)
+ */
+static int rpc_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    flux_rpc_t rpc = arg;
+
+    assert (rpc->then_cb != NULL);
+    do {
+        garbage_collect (rpc);
+        if (!rpc->rx_msg)
+            rpc_addmsg (rpc, zmsg);
+        rpc->then_cb (rpc, rpc->then_arg);
+    } while (*zmsg != NULL);
+    return 0;
+}
+
+int flux_rpc_then (flux_rpc_t rpc, flux_then_f cb, void *arg)
+{
+    if (rpc->then_cb || rpc->oneway) {
+        errno = EINVAL;
+        return -1;
+    }
+    rpc->then_cb = cb;
+    rpc->then_arg = arg;
+    return flux_msghandler_add_match (rpc->h, rpc->m, rpc_cb, rpc);
+}
+
+bool flux_rpc_completed (flux_rpc_t rpc)
+{
+    if (rpc->oneway)
+        return true;
+    if (rpc->rx_count == rpc->m.bsize && rpc->rx_msg_consumed)
+        return true;
+    return false;
+}
+
+flux_rpc_t flux_rpc (flux_t h, const char *topic, const char *json_str,
+                     uint32_t nodeid, int flags)
+{
+    flux_rpc_t rpc = rpc_create (h, flags, 1);
+
+    if (rpc_sendmsg (rpc, 0, topic, json_str, nodeid) < 0)
+        goto error;
+    if (!rpc->oneway)
+        rpc->nodemap[0] = nodeid;
+    return rpc;
+error:
+    flux_rpc_destroy (rpc);
+    return NULL;
+}
+
+flux_rpc_t flux_rpc_multi (flux_t h, const char *topic, const char *json_str,
+                           const char *nodeset, int flags)
+{
+    nodeset_t ns = NULL;
+    nodeset_itr_t itr = NULL;
+    flux_rpc_t rpc = NULL;
+    int i, count;
+
+    if (!topic || !nodeset) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!strcmp (nodeset, "all")) {
+        count = flux_size (h);
+        ns = nodeset_new_range (0, count - 1);
+    } else {
+        if ((ns = nodeset_new_str (nodeset)))
+            count = nodeset_count (ns);
+    }
+    if (!ns) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(rpc = rpc_create (h, flags, count)))
+        goto error;
+    if (!(itr = nodeset_itr_new (ns)))
+        goto error;
+    for (i = 0; i < count; i++) {
+        uint32_t nodeid = nodeset_next (itr);
+        assert (nodeid != NODESET_EOF);
+        if (rpc_sendmsg (rpc, i, topic, json_str, nodeid) < 0)
+            goto error;
+        if (!rpc->oneway)
+            rpc->nodemap[i] = nodeid;
+    }
+    return rpc;
+error:
+    if (rpc)
+        flux_rpc_destroy (rpc);
+    if (itr)
+        nodeset_itr_destroy (itr);
+    if (ns)
+        nodeset_destroy (ns);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -1,0 +1,60 @@
+#ifndef _FLUX_CORE_RPC_H
+#define _FLUX_CORE_RPC_H
+
+#include <json.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <czmq.h>
+
+#include "handle.h"
+#include "request.h"
+
+enum {
+    FLUX_RPC_NORESPONSE = 1,
+};
+
+typedef struct flux_rpc_struct *flux_rpc_t;
+typedef void (*flux_then_f)(flux_rpc_t rpc, void *arg);
+
+/* Send an RPC request to 'nodeid', and return a flux_rpc_t object
+ * to allow the response to be handled.  On failure return NULL with errno set.
+ */
+flux_rpc_t flux_rpc (flux_t h, const char *topic, const char *json_str,
+                     uint32_t nodeid, int flags);
+/* Destroy an RPC, invalidating previous payload returned by flux_rpc_get().
+ */
+void flux_rpc_destroy (flux_rpc_t rpc);
+
+/* Returns true if flux_rpc_get() can be called without blocking.
+ */
+bool flux_rpc_check (flux_rpc_t rpc);
+
+/* Wait for a response if necessary, then decode it.
+ * Any returned 'json_str' payload is valid until the next get/check call.
+ * If 'nodeid' is non-NULL, the nodeid that the request was sent to is returned.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_rpc_get (flux_rpc_t rpc, uint32_t *nodeid, const char **json_str);
+
+/* Arrange for reactor to handle response and call 'cb' continuation function
+ * when a response is received.  The function must call flux_rpc_get().
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_rpc_then (flux_rpc_t rpc, flux_then_f cb, void *arg);
+
+/* Send an RPC request to 'nodeset' and return a flux_rpc_t object
+ * to allow responses to be handled.  "all" is a valid shorthand for
+ * all ranks in the comms session.  On failure return NULL with errno set.
+ */
+flux_rpc_t flux_rpc_multi (flux_t h, const char *topic, const char *json_str,
+                           const char *nodeset, int flags);
+
+/* Returns true when all responses to an RPC have been received and consumed.
+ */
+bool flux_rpc_completed (flux_rpc_t rpc);
+
+#endif /* !_FLUX_CORE_RPC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -38,6 +38,8 @@ int flux_rpc_get (flux_rpc_t rpc, uint32_t *nodeid, const char **json_str);
 
 /* Arrange for reactor to handle response and call 'cb' continuation function
  * when a response is received.  The function must call flux_rpc_get().
+ * A second call to flux_rpc_then() overwrites the internal (cb, arg) refs.
+ * Call with NULL to disable the reactor message handler for this RPC.
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_rpc_then (flux_rpc_t rpc, flux_then_f cb, void *arg);

--- a/src/common/libflux/tagpool.c
+++ b/src/common/libflux/tagpool.c
@@ -25,10 +25,10 @@
 /* tagpool.c - allocator for 32-bit matchtags */
 
 /* Matchtags are used to match requests and responses in RPC's.
- * There are two main use cases: flux_json_rpc() and flux_json_multrpc().
- * The former allocates and retires one matchtag, the latter a block of
- * matchtags.  A variant of flux_json_rpc() is kvs_watch() which sends one
- * request and reecives multiple replies with the same matchtag.
+ * There are two main use cases in rpc.c.  The plain rpc call allocates
+ * and retires one matchtag, the multiple call allocates a block of
+ * matchtags.  kvs_watch() is another use case.  It sends one request
+ * and reecives multiple replies with the same matchtag.
  *
  * This implementation could be improved:
  * - allocations of len = 1 are allocated from a fixed 2^16 tag pool,

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -203,8 +203,16 @@ void check_payload (void)
        "and we got back the payload we set");
 
     errno = 0;
-    ok (flux_msg_set_payload (zmsg, 0, buf, len) < 0 && errno == EINVAL,
-        "flux_msg_set_payload detects reuse of payload and fails with EINVAL");
+    ok (flux_msg_set_payload (zmsg, 0, buf, len - 1) < 0 && errno == EINVAL,
+        "flux_msg_set_payload detects reuse of payload fragment and fails with EINVAL");
+
+    ok (flux_msg_set_payload (zmsg, 0, buf, len) == 0,
+        "flux_msg_set_payload detects payload echo and works");
+    ok (flux_msg_get_payload (zmsg, &flags, &buf, &len) == 0
+        && buf && len == plen && flags == 0,
+       "flux_msg_get_payload works");
+    cmp_mem (buf, pay, len,
+       "and we got back the payload we set");
 
     errno = 0;
     ok (flux_msg_set_payload (zmsg, 0, NULL, 0) == 0 && errno == 0,
@@ -348,7 +356,7 @@ void check_cmp (void)
 
 int main (int argc, char *argv[])
 {
-    plan (92);
+    plan (94);
 
     lives_ok ({zmsg_test (false);}, // 1
         "zmsg_test doesn't assert");

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -358,8 +358,8 @@ int main (int argc, char *argv[])
 {
     plan (94);
 
-    lives_ok ({zmsg_test (false);}, // 1
-        "zmsg_test doesn't assert");
+    //lives_ok ({zmsg_test (false);}, // 1
+    //    "zmsg_test doesn't assert");
 
     check_proto ();                 // 17
     check_routes ();                // 26

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -56,44 +56,63 @@ void test_helpers (void)
 
 void test_lsmod_codec (void)
 {
-    JSON o;
-    int len;
+    flux_modlist_t mods;
     int idle, size;
     const char *name, *digest;
+    char *json_str;
 
-    o = flux_lsmod_json_create ();
-    ok (o != NULL,
-        "flux_lsmod_json_create works");
-    ok (flux_lsmod_json_append (o, "foo", 42, "aa", 3) == 0,
-        "first flux_lsmod_json_append works");
-    ok (flux_lsmod_json_append (o, "bar", 43, "bb", 2) == 0,
-        "second flux_lsmod_json_append works");
-    ok (flux_lsmod_json_decode (o, &len) == 0 && len == 2,
-        "flux_lsmod_json_decode works");
-    ok (flux_lsmod_json_decode_nth (o, 0, &name, &size, &digest, &idle) == 0
+    mods = flux_modlist_create ();
+    ok (mods != NULL,
+        "flux_modlist_create works");
+    ok (flux_modlist_append (mods, "foo", 42, "aa", 3) == 0,
+        "first flux_modlist_append works");
+    ok (flux_modlist_append (mods, "bar", 43, "bb", 2) == 0,
+        "second flux_modlist_append works");
+    ok (flux_modlist_count (mods) == 2,
+        "flux_modlist_count works");
+    ok (flux_modlist_get (mods, 0, &name, &size, &digest, &idle) == 0
         && name && size == 42 && digest && idle == 3
         && !strcmp (name, "foo") && !strcmp (digest, "aa"),
-        "flux_lsmod_json_decode_nth(0) works");
-    ok (flux_lsmod_json_decode_nth (o, 1, &name, &size, &digest, &idle) == 0
+        "flux_modlist_get(0) works");
+    ok (flux_modlist_get (mods, 1, &name, &size, &digest, &idle) == 0
         && name && size == 43 && digest && idle == 2
         && !strcmp (name, "bar") && !strcmp (digest, "bb"),
-        "flux_lsmod_json_decode_nth(1) works");
+        "flux_modlist_get(1) works");
 
-    Jput (o);
+    /* again after encode/decode */
+    ok ((json_str = flux_lsmod_json_encode (mods)) != NULL,
+        "flux_lsmod_json_encode works");
+    flux_modlist_destroy (mods);
+    ok ((mods = flux_lsmod_json_decode (json_str)) != NULL,
+        "flux_lsmod_json_decode works");
+    ok (flux_modlist_count (mods) == 2,
+        "flux_modlist_count still works");
+    ok (flux_modlist_get (mods, 0, &name, &size, &digest, &idle) == 0
+        && name && size == 42 && digest && idle == 3
+        && !strcmp (name, "foo") && !strcmp (digest, "aa"),
+        "flux_modlist_get(0) still works");
+    ok (flux_modlist_get (mods, 1, &name, &size, &digest, &idle) == 0
+        && name && size == 43 && digest && idle == 2
+        && !strcmp (name, "bar") && !strcmp (digest, "bb"),
+        "flux_modlist_get(1) still works");
+
+    flux_modlist_destroy (mods);
+    free (json_str);
 }
 
 void test_rmmod_codec (void)
 {
-    JSON o;
+    char *json_str;
     char *s = NULL;
 
-    o = flux_rmmod_json_encode ("xyz");
-    ok (o != NULL,
+    json_str = flux_rmmod_json_encode ("xyz");
+    ok (json_str != NULL,
         "flux_rmmod_json_encode works");
-    ok (flux_rmmod_json_decode (o, &s) == 0 && s != NULL && !strcmp (s, "xyz"),
+    ok (flux_rmmod_json_decode (json_str, &s) == 0
+        && s != NULL && !strcmp (s, "xyz"),
         "flux_rmmod_json_decode works");
     free (s);
-    Jput (o);
+    free (json_str);
 }
 
 void test_insmod_codec (void)
@@ -103,15 +122,15 @@ void test_insmod_codec (void)
     char *argz = NULL;
     size_t argz_len = 0;
     char *av[16];
-    JSON o;
+    char *json_str;
     char *s;
     int rc;
 
-    o = flux_insmod_json_encode ("/foo/bar", argc, argv);
-    ok (o != NULL,
+    json_str = flux_insmod_json_encode ("/foo/bar", argc, argv);
+    ok (json_str != NULL,
         "flux_insmod_json_encode works");
 
-    rc = flux_insmod_json_decode (o, &s, &argz, &argz_len);
+    rc = flux_insmod_json_decode (json_str, &s, &argz, &argz_len);
     argz_extract (argz, argz_len, av);
     ok (rc == 0 && s != NULL && !strcmp (s, "/foo/bar")
         && !strcmp (av[0], "foo") && !strcmp (av[1], "bar") && av[2] == NULL,
@@ -120,15 +139,15 @@ void test_insmod_codec (void)
     if (argz)
         free (argz);
     free (s);
-    Jput (o);
+    free (json_str);
 }
 
 int main (int argc, char *argv[])
 {
-    plan (19);
+    plan (24);
 
     test_helpers (); // 9
-    test_lsmod_codec (); // 6
+    test_lsmod_codec (); // 11
     test_rmmod_codec (); // 2
     test_insmod_codec (); // 2
 

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -1,0 +1,52 @@
+#include "src/common/libflux/request.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    const char *topic, *s;
+    const char *json_str = "{\"a\":42}";
+
+    plan (8);
+
+    /* no topic is an error */
+    errno = 0;
+    ok ((zmsg = flux_request_encode (NULL, json_str)) == NULL
+        && errno == EINVAL,
+        "flux_request_encode returns EINVAL with no topic string");
+
+    /* without payload */
+    ok ((zmsg = flux_request_encode ("foo.bar", NULL)) != NULL,
+        "flux_request_encode works with NULL payload");
+    topic = NULL;
+    ok (flux_request_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "foo.bar"),
+        "flux_request_decode returns encoded topic");
+    ok (flux_request_decode (zmsg, NULL, NULL) == 0,
+        "flux_request_decode topic is optional");
+    errno = 0;
+    ok (flux_request_decode (zmsg, NULL, &s) < 0 && errno == EPROTO,
+        "flux_request_decode returns EPROTO when expected payload is missing");
+    zmsg_destroy(&zmsg);
+
+    /* with payload */
+    ok ((zmsg = flux_request_encode ("foo.bar", json_str)) != NULL,
+        "flux_request_encode works with payload");
+
+    s = NULL;
+    ok (flux_request_decode (zmsg, NULL, &s) == 0
+        && s != NULL && !strcmp (s, json_str),
+        "flux_request_decode returns encoded payload");
+    errno = 0;
+    ok (flux_request_decode (zmsg, NULL, NULL) < 0 && errno == EPROTO,
+        "flux_request_decode returns EPROTO when payload is unexpected");
+    zmsg_destroy (&zmsg);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -1,0 +1,70 @@
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    const char *topic, *s;
+    const char *json_str = "{\"a\":42}";
+
+    plan (11);
+
+    /* no topic is an error */
+    errno = 0;
+    ok ((zmsg = flux_response_encode (NULL, 0, json_str)) == NULL
+        && errno == EINVAL,
+        "flux_response_encode returns EINVAL with no topic string");
+
+    /* both errnum and json_str is an error */
+    errno = 0;
+    ok ((zmsg = flux_response_encode ("foo.bar", 1, json_str)) == NULL
+        && errno == EINVAL,
+        "flux_response_encode returns EINVAL with both json and errnum");
+
+    /* without payload */
+    ok ((zmsg = flux_response_encode ("foo.bar", 0, NULL)) != NULL,
+        "flux_response_encode works with NULL payload");
+
+    topic = NULL;
+    ok (flux_response_decode (zmsg, &topic, NULL) == 0
+        && topic != NULL && !strcmp (topic, "foo.bar"),
+        "flux_response_decode returns encoded topic");
+    ok (flux_response_decode (zmsg, NULL, NULL) == 0,
+        "flux_response_decode topic is optional");
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, &s) < 0 && errno == EPROTO,
+        "flux_response_decode returns EPROTO when expected payload is missing");
+    zmsg_destroy(&zmsg);
+
+    /* with payload */
+    ok ((zmsg = flux_response_encode ("foo.bar", 0, json_str)) != NULL,
+        "flux_response_encode works with payload");
+
+    s = NULL;
+    ok (flux_response_decode (zmsg, NULL, &s) == 0
+        && s != NULL && !strcmp (s, json_str),
+        "flux_response_decode returns encoded payload");
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, NULL) < 0 && errno == EPROTO,
+        "flux_response_decode returns EPROTO when payload is unexpected");
+    zmsg_destroy (&zmsg);
+
+    /* with error */
+    ok ((zmsg = flux_response_encode ("foo.bar", 42, NULL)) != NULL,
+        "flux_response_encode works with errnum");
+    s = NULL;
+    errno = 0;
+    ok (flux_response_decode (zmsg, NULL, NULL) < 0
+        && errno == 42,
+        "flux_response_decode fails with encoded errnum");
+    zmsg_destroy (&zmsg);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libjsonc/Makefile.am
+++ b/src/common/libjsonc/Makefile.am
@@ -1,0 +1,14 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+	$(JSON_CFLAGS) \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include
+
+noinst_LTLIBRARIES = libjsonc.la
+
+libjsonc_la_SOURCES = \
+	request.c \
+	request.h \
+	rpc.c \
+	rpc.h \
+	jsonc.h

--- a/src/common/libjsonc/jsonc.h
+++ b/src/common/libjsonc/jsonc.h
@@ -1,0 +1,20 @@
+#ifndef _FLUX_CORE_JSONC_H
+#define _FLUX_CORE_JSONC_H
+
+#define flux_json_request           jsonc_request
+#define flux_json_respond           jsonc_respond
+#define flux_err_respond            jsonc_respond_err
+#define flux_json_request_decode    jsonc_request_decode
+#define flux_json_response_decode   jsonc_response_decode
+
+#define flux_json_rpc               jsonc_rpc
+#define flux_json_multrpc           jsonc_multrpc
+
+#include "request.h"
+#include "rpc.h"
+
+#endif /* !_FLUX_CORE_JSONC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjsonc/request.c
+++ b/src/common/libjsonc/request.c
@@ -25,14 +25,16 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "request.h"
-#include "message.h"
-#include "info.h"
+
+#include "src/common/libflux/message.h"
+#include "src/common/libflux/info.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
+
+#include "jsonc.h"
 
 int flux_json_request_decode (zmsg_t *zmsg, json_object **in)
 {
@@ -87,30 +89,6 @@ int flux_json_response_decode (zmsg_t *zmsg, json_object **out)
         goto done;
     }
     *out = o;
-    rc = 0;
-done:
-    return rc;
-}
-
-int flux_response_decode (zmsg_t *zmsg)
-{
-    int rc = -1;
-    int errnum;
-
-    if (zmsg == NULL) {
-        errno = EINVAL;
-        goto done;
-    }
-    if (flux_msg_get_errnum (zmsg, &errnum) < 0)
-        goto done;
-    if (errnum != 0) {
-        errno = errnum;
-        goto done;
-    }
-    if (flux_msg_has_payload (zmsg)) {
-        errno = EPROTO;
-        goto done;
-    }
     rc = 0;
 done:
     return rc;

--- a/src/common/libjsonc/request.h
+++ b/src/common/libjsonc/request.h
@@ -1,12 +1,9 @@
-#ifndef _FLUX_CORE_REQUEST_H
-#define _FLUX_CORE_REQUEST_H
+#ifndef _FLUX_JSONC_REQUEST_H
+#define _FLUX_JSONC_REQUEST_H
 
 #include <json.h>
-#include <stdbool.h>
-#include <stdarg.h>
 #include <czmq.h>
-
-#include "handle.h"
+#include <stdint.h>
 
 /* Request and response messages are constructed according to Flux RFC 3.
  * https://github.com/flux-framework/rfc/blob/master/spec_3.adoc
@@ -50,14 +47,7 @@ int flux_json_request_decode (zmsg_t *zmsg, json_object **in);
  */
 int flux_json_response_decode (zmsg_t *zmsg, json_object **out);
 
-/* Decode response message with no payload.
- * If there is a payload, fail with errno == EPROTO.
- * If errnum is nonzero in response, fail with errno == errnum.
- * Returns 0 on success, or -1 on failure with errno set.
- */
-int flux_response_decode (zmsg_t *zmsg);
-
-#endif /* !_FLUX_CORE_REQUEST_H */
+#endif /* !_FLUX_JSONC_REQUEST_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libjsonc/rpc.c
+++ b/src/common/libjsonc/rpc.c
@@ -27,15 +27,15 @@
 #endif
 #include <czmq.h>
 
-#include "request.h"
-#include "message.h"
-#include "info.h"
-#include "rpc.h"
+#include "src/common/libflux/message.h"
+#include "src/common/libflux/info.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
+
+#include "jsonc.h"
 
 /* helper for flux_json_multrpc */
 static int multrpc_cb (zmsg_t *zmsg, uint32_t nodeid,

--- a/src/common/libjsonc/rpc.h
+++ b/src/common/libjsonc/rpc.h
@@ -1,13 +1,9 @@
-#ifndef _FLUX_CORE_RPC_H
-#define _FLUX_CORE_RPC_H
+#ifndef _FLUX_JSONC_RPC_H
+#define _FLUX_JSONC_RPC_H
 
 #include <json.h>
-#include <stdbool.h>
-#include <stdarg.h>
 #include <czmq.h>
-
-#include "handle.h"
-#include "request.h"
+#include <stdint.h>
 
 /* Send a request to 'nodeid' addressed to 'topic'.
  * If 'in' is non-NULL, attach JSON payload, caller retains ownership.
@@ -31,7 +27,7 @@ int flux_json_multrpc (flux_t h, const char *nodeset, int fanout,
                        const char *topic, json_object *in,
                        flux_multrpc_f cb, void *arg);
 
-#endif /* !_FLUX_CORE_REQUEST_H */
+#endif /* !_FLUX_JSONC_RPC_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = local
+SUBDIRS = local loop

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -1,0 +1,17 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+	$(JSON_CFLAGS) \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include
+
+fluxconnector_LTLIBRARIES = loop.la
+
+loop_la_SOURCES = loop.c
+
+loop_la_LDFLAGS = -module -Wl,--no-undefined \
+	-export-symbols-regex '^connector_init$$' \
+	--disable-static -avoid-version -shared -export-dynamic \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+loop_la_LIBADD = $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ)

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -1,0 +1,442 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* loop connector - mainly for testing */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/param.h>
+#include <stdbool.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <ctype.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+#include "src/common/libev/ev.h"
+#include "src/common/libutil/ev_zlist.h"
+#include "src/common/libutil/ev_zmq.h"
+
+#define CTX_MAGIC   0xf434aaa0
+typedef struct {
+    int magic;
+    int rank;
+    flux_t h;
+
+    zlist_t *queue;
+    ev_zlist queue_w;
+    struct ev_loop *loop;
+    int loop_rc;
+
+    flux_msg_f msg_cb;
+    void *msg_cb_arg;
+
+    zhash_t *watchers;
+    int timer_seq;
+} ctx_t;
+
+#define HASHKEY_LEN 80
+
+typedef struct {
+    ev_timer w;
+    FluxTmoutHandler cb;
+    void *arg;
+    int id;
+} atimer_t;
+
+typedef struct {
+    ev_zmq w;
+    FluxZsHandler cb;
+    void *arg;
+} azs_t;
+
+typedef struct {
+    ev_io w;
+    FluxFdHandler cb;
+    void *arg;
+} afd_t;
+
+static void op_reactor_stop (void *impl, int rc);
+
+
+static const struct flux_handle_ops handle_ops;
+
+const char *fake_uuid = "12345678123456781234567812345678";
+
+static int op_sendmsg (void *impl, zmsg_t **zmsg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    int type;
+    int rc = -1;
+
+    if (flux_msg_get_type (*zmsg, &type) < 0)
+        goto done;
+    switch (type) {
+        case FLUX_MSGTYPE_REQUEST:
+        case FLUX_MSGTYPE_EVENT:
+            if (flux_msg_enable_route (*zmsg) < 0)
+                goto done;
+            if (flux_msg_push_route (*zmsg, fake_uuid) < 0)
+                goto done;
+            break;
+    }
+    if (zlist_append (c->queue, *zmsg) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    *zmsg = NULL;
+    rc = 0;
+done:
+    return rc;
+}
+
+static zmsg_t *op_recvmsg (void *impl, bool nonblock)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    zmsg_t *zmsg = zlist_pop (c->queue);
+    if (!zmsg)
+        errno = EWOULDBLOCK;
+    return zmsg;
+}
+
+static int op_putmsg (void *impl, zmsg_t **zmsg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    if (zlist_append (c->queue, *zmsg) < 0)
+        oom ();
+    *zmsg = NULL;
+    return 0;
+}
+
+static int op_pushmsg (void *impl, zmsg_t **zmsg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    if (zlist_push (c->queue, *zmsg) < 0)
+        oom ();
+    *zmsg = NULL;
+    return 0;
+}
+
+static void op_purge (void *impl, flux_match_t match)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    zmsg_t *zmsg = zlist_first (c->queue);
+
+    while (zmsg) {
+        if (flux_msg_cmp (zmsg, match)) {
+            zlist_remove (c->queue, zmsg);
+            zmsg_destroy (&zmsg);
+        }
+        zmsg = zlist_next (c->queue);
+    }
+}
+
+static int op_rank (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    return c->rank;
+}
+
+static int op_reactor_start (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    c->loop_rc = 0;
+    ev_run (c->loop, 0);
+    return c->loop_rc;
+}
+
+static void op_reactor_stop (void *impl, int rc)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    c->loop_rc = rc;
+    ev_break (c->loop, EVBREAK_ALL);
+}
+
+static void queue_cb (struct ev_loop *loop, ev_zlist *w, int revents)
+{
+    ctx_t *c = (ctx_t *)((char *)w - offsetof (ctx_t, queue_w));
+    assert (c->magic == CTX_MAGIC);
+
+    assert (zlist_size (c->queue) > 0);
+    if (c->msg_cb) {
+        if (c->msg_cb (c->h, c->msg_cb_arg) < 0)
+            op_reactor_stop (c, -1);
+    }
+}
+
+static int op_reactor_msg_add (void *impl, flux_msg_f cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    int rc = -1;
+
+    if (c->msg_cb != NULL) {
+        errno = EBUSY;
+        goto done;
+    }
+    c->msg_cb = cb;
+    c->msg_cb_arg = arg;
+    rc = 0;
+done:
+    return rc;
+}
+
+static void op_reactor_msg_remove (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    c->msg_cb = NULL;
+    c->msg_cb_arg = NULL;
+}
+
+static void fd_cb (struct ev_loop *loop, ev_io *w, int revents)
+{
+    afd_t *f = (afd_t *)((char *)w - offsetof (afd_t, w));
+    ctx_t *c = w->data;
+    assert (c->magic == CTX_MAGIC);
+
+    if (f->cb (c->h, w->fd, etoz (revents), f->arg) < 0)
+        op_reactor_stop (c, -1);
+}
+
+static int op_reactor_fd_add (void *impl, int fd, int events,
+                               FluxFdHandler cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    afd_t *f = xzmalloc (sizeof (*f));
+    ev_io_init (&f->w, fd_cb, fd, ztoe (events));
+    f->w.data = c;
+    f->cb = cb;
+    f->arg = arg;
+
+    snprintf (hashkey, sizeof (hashkey), "fd:%d:%d", fd, events);
+    zhash_update (c->watchers, hashkey, f);
+    zhash_freefn (c->watchers, hashkey, free);
+
+    ev_io_start (c->loop, &f->w);
+
+    return 0;
+}
+
+static void op_reactor_fd_remove (void *impl, int fd, int events)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    snprintf (hashkey, sizeof (hashkey), "fd:%d:%d", fd, events);
+    afd_t *f = zhash_lookup (c->watchers, hashkey);
+    if (f) {
+        ev_io_stop (c->loop, &f->w);
+        zhash_delete (c->watchers, hashkey);
+    }
+}
+
+static void zs_cb (struct ev_loop *loop, ev_zmq *w, int revents)
+{
+    azs_t *z = (azs_t *)((char *)w - offsetof (azs_t, w));
+    ctx_t *c = w->data;
+    assert (c->magic == CTX_MAGIC);
+
+    int rc = z->cb (c->h, w->zsock, etoz (revents), z->arg);
+    if (rc < 0)
+        op_reactor_stop (c, -1);
+}
+
+static int op_reactor_zs_add (void *impl, void *zs, int events,
+                               FluxZsHandler cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    azs_t *z = xzmalloc (sizeof (*z));
+    ev_zmq_init (&z->w, zs_cb, zs, ztoe (events));
+    z->w.data = c;
+    z->cb = cb;
+    z->arg = arg;
+
+    snprintf (hashkey, sizeof (hashkey), "zsock:%p:%d", zs, events);
+    zhash_update (c->watchers, hashkey, z);
+    zhash_freefn (c->watchers, hashkey, free);
+
+    ev_zmq_start (c->loop, &z->w);
+    return 0;
+}
+
+static void op_reactor_zs_remove (void *impl, void *zs, int events)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    snprintf (hashkey, sizeof (hashkey), "zsock:%p:%d", zs, events);
+    azs_t *z = zhash_lookup (c->watchers, hashkey);
+    if (z) {
+        ev_zmq_stop (c->loop, &z->w);
+        zhash_delete (c->watchers, hashkey);
+    }
+}
+
+static void timer_cb (struct ev_loop *loop, ev_timer *w, int revents)
+{
+    atimer_t *t = (atimer_t *)((char *)w - offsetof (atimer_t, w));
+    ctx_t *c = w->data;
+    assert (c->magic == CTX_MAGIC);
+
+    if (t->cb (c->h, t->arg) < 0)
+         op_reactor_stop (c, -1);
+}
+
+static int op_reactor_tmout_add (void *impl, unsigned long msec, bool oneshot,
+                                  FluxTmoutHandler cb, void *arg)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    double after = (double)msec / 1000.0;
+    double repeat = oneshot ? 0 : after;
+    char hashkey[HASHKEY_LEN];
+
+    atimer_t *t = xzmalloc (sizeof (*t));
+    t->id = c->timer_seq++;
+    t->w.data = c;
+    ev_timer_init (&t->w, timer_cb, after, repeat);
+    t->cb = cb;
+    t->arg = arg;
+
+    snprintf (hashkey, sizeof (hashkey), "timer:%d", t->id);
+    zhash_update (c->watchers, hashkey, t);
+    zhash_freefn (c->watchers, hashkey, free);
+
+    ev_timer_start (c->loop, &t->w);
+
+    return t->id;
+}
+
+static void op_reactor_tmout_remove (void *impl, int timer_id)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    char hashkey[HASHKEY_LEN];
+
+    snprintf (hashkey, sizeof (hashkey), "timer:%d", timer_id);
+    atimer_t *t = zhash_lookup (c->watchers, hashkey);
+    if (t) {
+        ev_timer_stop (c->loop, &t->w);
+        zhash_delete (c->watchers, hashkey);
+    }
+}
+
+static void op_fini (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    if (c->loop)
+        ev_loop_destroy (c->loop);
+    if (c->queue) {
+        zmsg_t *zmsg;
+        while ((zmsg = zlist_pop (c->queue)))
+            zmsg_destroy (&zmsg);
+        zlist_destroy (&c->queue);
+    }
+    zhash_destroy (&c->watchers);
+    c->magic = ~CTX_MAGIC;
+    free (c);
+}
+
+flux_t connector_init (const char *path, int flags)
+{
+    ctx_t *c = xzmalloc (sizeof (*c));
+    c->magic = CTX_MAGIC;
+    c->rank = 0;
+    if (!(c->loop = ev_loop_new (EVFLAG_AUTO))
+                            || !(c->watchers = zhash_new ())
+                            || !(c->queue = zlist_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    ev_zlist_init (&c->queue_w, queue_cb, c->queue, EV_READ);
+    ev_zlist_start (c->loop, &c->queue_w);
+    c->h = flux_handle_create (c, &handle_ops, flags);
+    return c->h;
+error:
+    if (c) {
+        int saved_errno = errno;
+        op_fini (c);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+static const struct flux_handle_ops handle_ops = {
+    .sendmsg = op_sendmsg,
+    .recvmsg = op_recvmsg,
+    .putmsg = op_putmsg,
+    .pushmsg = op_pushmsg,
+    .purge = op_purge,
+    .event_subscribe = NULL,
+    .event_unsubscribe = NULL,
+    .rank = op_rank,
+    .reactor_stop = op_reactor_stop,
+    .reactor_start = op_reactor_start,
+    .reactor_fd_add = op_reactor_fd_add,
+    .reactor_fd_remove = op_reactor_fd_remove,
+    .reactor_zs_add = op_reactor_zs_add,
+    .reactor_zs_remove = op_reactor_zs_remove,
+    .reactor_tmout_add = op_reactor_tmout_add,
+    .reactor_tmout_remove = op_reactor_tmout_remove,
+    .reactor_msg_add = op_reactor_msg_add,
+    .reactor_msg_remove = op_reactor_msg_remove,
+    .impl_destroy = op_fini,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/include/flux/core.h
+++ b/src/include/flux/core.h
@@ -5,6 +5,7 @@
 #define FLUX_CORE_H
 
 #include "src/common/libflux/flux.h"
+#include "src/common/libjsonc/jsonc.h" // temporary
 
 #include "src/modules/kvs/kvs.h"
 #include "src/modules/live/live.h"

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -271,7 +271,7 @@ static int exit_event_send (flux_t h, const char *name, int errnum)
     Jadd_int (o, "errnum", errnum);
     if (!(zmsg = flux_event_encode ("barrier.exit", Jtostr (o))))
         goto done;
-    if (flux_event_send (h, &zmsg) < 0)
+    if (flux_sendmsg (h, &zmsg) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1681,7 +1681,7 @@ static int setroot_event_send (ctx_t *ctx, const char *fence)
         goto done;
     if (!(zmsg = flux_event_encode ("kvs.setroot", Jtostr (in))))
         goto done;
-    if (flux_event_send (ctx->h, &zmsg) < 0)
+    if (flux_sendmsg (ctx->h, &zmsg) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/libmrpc/mrpc.c
+++ b/src/modules/libmrpc/mrpc.c
@@ -220,7 +220,7 @@ int flux_mrpc (flux_mrpc_t f, const char *fmt, ...)
     topic = xasprintf ("mrpc.%s", s);
     if (!(zmsg = flux_event_encode (topic, Jtostr (o))))
         goto done;
-    if (flux_event_send (f->h, &zmsg) < 0)
+    if (flux_sendmsg (f->h, &zmsg) < 0)
         goto done;
     if (kvs_fence (f->h, f->path, f->nprocs + 1) < 0)
         goto done;

--- a/src/modules/live/liblive.c
+++ b/src/modules/live/liblive.c
@@ -62,7 +62,7 @@ int flux_recover_all (flux_t h)
     zmsg_t *zmsg = flux_event_encode ("live.recover", NULL);
     if (!zmsg)
         return -1;
-    int rc = flux_event_send (h, &zmsg);
+    int rc = flux_sendmsg (h, &zmsg);
     zmsg_destroy (&zmsg);
     return rc;
 }

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -408,7 +408,7 @@ static void cstate_change (ctx_t *ctx, child_t *c, cstate_t newstate)
     Jadd_int (event, "parent", ctx->rank);
     Jadd_int (event, "epoch", ctx->epoch);
     if (!(zmsg = flux_event_encode ("live.cstate", Jtostr (event)))
-                || flux_event_send (ctx->h, &zmsg) < 0) {
+              || flux_sendmsg (ctx->h, &zmsg) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: error sending event", __FUNCTION__);
     }
     zmsg_destroy (&zmsg);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,8 +1,16 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+        $(JSON_CFLAGS) \
+        -I$(top_srcdir) -I$(top_srcdir)/src/include
+
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
 
 TESTS = \
+	loop/rpc.t \
+	loop/multrpc.t \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -26,7 +34,7 @@ TESTS = \
 	lua/t1003-iowatcher.t
 
 EXTRA_DIST= \
-	$(TESTS) \
+	$(check_SCRIPTS) \
 	aggregate-results.sh \
 	sharness.sh \
 	sharness.d \
@@ -34,3 +42,62 @@ EXTRA_DIST= \
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove
+
+check_SCRIPTS = \
+	t0000-sharness.t \
+	t0001-basic.t \
+	t0002-request.t \
+	t0003-module.t \
+	t0005-exec.t \
+	t1000-kvs-basic.t \
+	t1001-barrier-basic.t \
+	t1002-modctl.t \
+	t1003-mecho.t \
+	t1004-log.t \
+	t1005-cmddriver.t \
+	t2000-wreck.t \
+	t2001-jsc.t \
+	lua/t0001-send-recv.t \
+	lua/t0002-rpc.t \
+	lua/t0003-events.t \
+	lua/t0007-alarm.t \
+	lua/t1000-reactor.t \
+	lua/t1001-timeouts.t \
+	lua/t1002-kvs.t \
+	lua/t1003-iowatcher.t
+
+check_PROGRAMS = \
+	loop/rpc.t \
+	loop/multrpc.t
+
+test_ldadd = \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libtap/libtap.la \
+        $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD)
+
+test_cppflags = \
+        -DMODULE_PATH=\"$(top_builddir)/src/modules\" \
+        -DCONNECTOR_PATH=\"$(top_builddir)/src/connectors\" \
+        -I$(top_srcdir)/src/common/libtap \
+        $(AM_CPPFLAGS)
+
+loop_request_t_SOURCES = loop/request.c
+loop_request_t_CPPFLAGS = $(test_cppflags)
+loop_request_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_response_t_SOURCES = loop/response.c
+loop_response_t_CPPFLAGS = $(test_cppflags)
+loop_response_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_event_t_SOURCES = loop/event.c
+loop_event_t_CPPFLAGS = $(test_cppflags)
+loop_event_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_rpc_t_SOURCES = loop/rpc.c
+loop_rpc_t_CPPFLAGS = $(test_cppflags)
+loop_rpc_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_multrpc_t_SOURCES = loop/multrpc.c
+loop_multrpc_t_CPPFLAGS = $(test_cppflags)
+loop_multrpc_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -1,0 +1,303 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/rpc.h"
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libflux/reactor.h"
+#include "src/common/libflux/info.h"
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/nodeset.h"
+
+#include "src/common/libtap/tap.h"
+
+/* request nodeid and flags returned in response */
+static int nodeid_fake_error = -1;
+int rpctest_nodeid_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+    uint32_t nodeid;
+    JSON o = NULL;
+    int flags;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0
+            || flux_msg_get_nodeid (*zmsg, &nodeid, &flags) < 0) {
+        errnum = errno;
+        goto done;
+    }
+    if (nodeid == nodeid_fake_error) {
+        nodeid_fake_error = -1;
+        errnum = EPERM; /* an error not likely to be seen */
+        goto done;
+    }
+    o = Jnew ();
+    Jadd_int (o, "nodeid", nodeid);
+    Jadd_int (o, "flags", flags);
+done:
+    (void)flux_respond (h, *zmsg, errnum, Jtostr (o));
+    Jput (o);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+/* request payload echoed in response */
+int rpctest_echo_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+    const char *json_str;
+
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0) {
+        errnum = errno;
+        goto done;
+    }
+done:
+    (void)flux_respond (h, *zmsg, errnum, json_str);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+/* no-payload response */
+static int hello_count = 0;
+int rpctest_hello_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0) {
+        errnum = errno;
+        goto done;
+    }
+    hello_count++;
+done:
+    (void)flux_respond (h, *zmsg, errnum, NULL);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+/* flux_rpc_multi() makes a flux_size() call, faked here for loop connector.
+ */
+static volatile int fake_size = 1;
+int cmb_info_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+    JSON o = Jnew ();
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0) {
+        errnum = errno;
+        goto done;
+    }
+    Jadd_bool (o, "treeroot", true);
+    Jadd_int (o, "rank", 0);
+    Jadd_int (o, "size", fake_size);
+done:
+    (void)flux_respond (h, *zmsg, errnum, Jtostr (o));
+    Jput (o);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+/* then test - add nodeid to 'then_ns' */
+static nodeset_t then_ns = NULL;
+static int then_count = 0;
+static flux_rpc_t then_r;
+static void then_cb (flux_rpc_t r, void *arg)
+{
+    flux_t h = arg;
+    uint32_t nodeid;
+
+    if (flux_rpc_get (r, &nodeid, NULL) < 0
+            || !nodeset_add_rank (then_ns, nodeid)
+            || ++then_count == 128) {
+        flux_reactor_stop (h);
+    }
+}
+
+int rpctest_begin_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    uint32_t nodeid;
+    int i, errors;
+    int old_count;
+    flux_rpc_t r;
+    const char *json_str;
+
+    errno = 0;
+    ok (!(r = flux_rpc_multi (h, NULL, "foo", "all", 0)) && errno == EINVAL,
+        "flux_rpc_multi [0] with NULL topic fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpc_multi (h, "bar", "foo", NULL, 0)) && errno == EINVAL,
+        "flux_rpc_multi [0] with NULL nodeset fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpc_multi (h, "bar", "foo", "xyz", 0)) && errno == EINVAL,
+        "flux_rpc_multi [0] with bad nodeset fails with EINVAL");
+
+    /* working no-payload RPC */
+    old_count = hello_count;
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", NULL, "all", 0)) != NULL,
+        "flux_rpc_multi [0] with no payload when none is expected works");
+    if (!r)
+        BAIL_OUT ("can't continue without successful rpc call");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_get (r, NULL, NULL) == 0,
+        "flux_rpc_get works");
+    ok (hello_count == old_count + 1,
+        "rpc was called once");
+    flux_rpc_destroy (r);
+
+    /* cause remote EPROTO (unexpected payload) - picked up in _get() */
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", "foo", "all", 0)) != NULL,
+        "flux_rpc_multi [0] with unexpected payload works, at first");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_get (r, NULL, NULL) < 0
+        && errno == EPROTO,
+        "flux_rpc_get fails with EPROTO");
+    flux_rpc_destroy (r);
+
+    /* fake that we have a larger session */
+    fake_size = 128;
+    cmp_ok (flux_size (h), "==", fake_size,
+        "successfully faked flux_size() of %d", fake_size);
+
+    /* repeat working no-payload RPC test (now with 128 nodes) */
+    old_count = hello_count;
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", NULL, "all", 0)) != NULL,
+        "flux_rpc_multi [0-%d] with no payload when none is expected works",
+        fake_size - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errors = 0;
+    for (i = 0; i < fake_size; i++)
+        if (flux_rpc_get (r, NULL, NULL) < 0)
+            errors++;
+    ok (errors == 0,
+        "flux_rpc_get succeded %d times", fake_size);
+
+    cmp_ok (hello_count - old_count, "==", fake_size,
+        "rpc was called %d times", fake_size);
+    flux_rpc_destroy (r);
+
+    /* same with a subset */
+    old_count = hello_count;
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", NULL, "[0-63]", 0)) != NULL,
+        "flux_rpc_multi [0-%d] with no payload when none is expected works",
+        64 - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errors = 0;
+    for (i = 0; i < 64; i++)
+        if (flux_rpc_get (r, &nodeid, NULL) < 0 || nodeid != i)
+            errors++;
+    ok (errors == 0,
+        "flux_rpc_get succeded %d times, with correct nodeid map", 64);
+
+    cmp_ok (hello_count - old_count, "==", 64,
+        "rpc was called %d times", 64);
+    flux_rpc_destroy (r);
+
+    /* same with echo payload */
+    ok ((r = flux_rpc_multi (h, "rpctest.echo", "foo", "[0-63]", 0)) != NULL,
+        "flux_rpc_multi [0-%d] ok",
+        64 - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errors = 0;
+    for (i = 0; i < 64; i++) {
+        if (flux_rpc_get (r, NULL, &json_str) < 0
+                || !json_str || strcmp (json_str, "foo") != 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "flux_rpc_get succeded %d times, with correct return payload", 64);
+    flux_rpc_destroy (r);
+
+    /* detect partial failure without mresponse */
+    nodeid_fake_error = 20;
+    ok ((r = flux_rpc_multi (h, "rpctest.nodeid", NULL, "[0-63]", 0)) != NULL,
+        "flux_rpc_multi [0-%d] ok",
+        64 - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    for (i = 0; i < 64; i++) {
+        if (flux_rpc_get (r, &nodeid, &json_str) < 0)
+            break;
+    }
+    ok (i == 20 && errno == EPERM,
+        "flux_rpc_get correctly reports single error");
+    flux_rpc_destroy (r);
+
+    /* test _then (still at fake session size of 128) */
+    ok ((then_r = flux_rpc_multi (h, "rpctest.hello", NULL, "[0-127]", 0)) != NULL,
+        "flux_rpc_multi [0-127] ok");
+    ok (flux_rpc_then (then_r, then_cb, h) == 0,
+        "flux_rpc_then works");
+    /* then_cb stops reactor; results reported, then_r destroyed in main() */
+
+    return 0;
+}
+
+static bool fatal_tested = false;
+static void fatal_err (const char *message, void *arg)
+{
+    if (fatal_tested)
+        BAIL_OUT ("fatal error: %s", message);
+    else
+        fatal_tested = true;
+}
+
+static msghandler_t htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.begin",          rpctest_begin_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb},
+    { FLUX_MSGTYPE_REQUEST,   "cmb.info",               cmb_info_cb},
+};
+const int htablen = sizeof (htab) / sizeof (htab[0]);
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    flux_t h;
+
+    plan (34);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", FLUX_O_COPROC)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    flux_fatal_set (h, fatal_err, NULL);
+    flux_fatal_error (h, __FUNCTION__, "Foo");
+    ok (fatal_tested == true,
+        "flux_fatal function is called on fatal error");
+
+    /* create nodeset for last _then test */
+    ok ((then_ns = nodeset_new ()) != NULL,
+        "nodeset created ok");
+
+    ok (flux_msghandler_addvec (h, htab, htablen, NULL) == 0,
+        "registered message handlers");
+    /* test continues in rpctest_begin_cb() so that rpc calls
+     * can sleep while we answer them
+     */
+    ok ((zmsg = flux_request_encode ("rpctest.begin", NULL)) != NULL
+        && flux_sendmsg (h, &zmsg) == 0,
+        "sent message to initiate test");
+    ok (flux_reactor_start (h) == 0,
+        "reactor completed normally");
+
+    /* Check result of last _then test */
+    ok (nodeset_count (then_ns) == 128,
+        "then callback worked with correct nodemap");
+    nodeset_destroy (then_ns);
+    flux_rpc_destroy (then_r);
+
+    flux_close (h);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -1,0 +1,202 @@
+#include "src/common/libflux/handle.h"
+#include "src/common/libflux/rpc.h"
+#include "src/common/libflux/request.h"
+#include "src/common/libflux/response.h"
+#include "src/common/libflux/reactor.h"
+
+#include "src/common/libutil/shortjson.h"
+
+#include "src/common/libtap/tap.h"
+
+/* request nodeid and flags returned in response */
+int rpctest_nodeid_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+    uint32_t nodeid;
+    JSON o = NULL;
+    int flags;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0
+            || flux_msg_get_nodeid (*zmsg, &nodeid, &flags) < 0) {
+        errnum = errno;
+        goto done;
+    }
+    o = Jnew ();
+    Jadd_int (o, "nodeid", nodeid);
+    Jadd_int (o, "flags", flags);
+done:
+    (void)flux_respond (h, *zmsg, errnum, Jtostr (o));
+    Jput (o);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+/* request payload echoed in response */
+int rpctest_echo_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+    const char *json_str;
+
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0) {
+        errnum = errno;
+        goto done;
+    }
+done:
+    (void)flux_respond (h, *zmsg, errnum, json_str);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+/* no-payload response */
+int rpctest_hello_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    int errnum = 0;
+
+    if (flux_request_decode (*zmsg, NULL, NULL) < 0) {
+        errnum = errno;
+        goto done;
+    }
+done:
+    (void)flux_respond (h, *zmsg, errnum, NULL);
+    zmsg_destroy (zmsg);
+    return 0;
+}
+
+int rpctest_begin_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
+{
+    const char *json_str;
+    flux_rpc_t r;
+
+    errno = 0;
+    ok (!(r = flux_rpc (h, NULL, NULL, FLUX_NODEID_ANY, 0))
+        && errno == EINVAL,
+        "flux_rpc with NULL topic fails with EINVAL");
+
+    /* working no-payload RPC */
+    ok ((r = flux_rpc (h, "rpctest.hello", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with no payload when none is expected works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_get (r, NULL, NULL) == 0,
+        "flux_rpc_get works");
+    flux_rpc_destroy (r);
+
+    /* cause remote EPROTO (unexpected payload) - will be picked up in _get() */
+    ok ((r = flux_rpc (h, "rpctest.hello", "foo", FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with payload when none is expected works, at first");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_get (r, NULL, NULL) < 0
+        && errno == EPROTO,
+        "flux_rpc_get fails with EPROTO");
+    flux_rpc_destroy (r);
+
+    /* cause remote EPROTO (missing payload) - will be picked up in _get() */
+    errno = 0;
+    ok ((r = flux_rpc (h, "rpctest.echo", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with no payload when payload is expected works, at first");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_get (r, NULL, NULL) < 0
+        && errno == EPROTO,
+        "flux_rpc_get fails with EPROTO");
+    flux_rpc_destroy (r);
+
+    /* working with-payload RPC */
+    ok ((r = flux_rpc (h, "rpctest.echo", "foo", FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with payload when payload is expected works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    json_str = NULL;
+    ok (flux_rpc_get (r, NULL, &json_str) == 0
+        && json_str && !strcmp (json_str, "foo"),
+        "flux_rpc_get works and returned expected payload");
+    flux_rpc_destroy (r);
+
+    flux_reactor_stop (h);
+    return 0;
+}
+
+static void then_cb (flux_rpc_t r, void *arg)
+{
+    flux_t h = arg;
+    const char *json_str;
+
+    ok (flux_rpc_check (r) == true,
+        "flux_rpc_check says get won't block in then callback");
+    json_str = NULL;
+    ok (flux_rpc_get (r, NULL, &json_str) == 0
+        && json_str && !strcmp (json_str, "xxx"),
+        "flux_rpc_get works and returned expected payload in then callback");
+    flux_reactor_stop (h);
+}
+
+static bool fatal_tested = false;
+static void fatal_err (const char *message, void *arg)
+{
+    if (fatal_tested)
+        BAIL_OUT ("fatal error: %s", message);
+    else
+        fatal_tested = true;
+}
+
+static msghandler_t htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.begin",          rpctest_begin_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb},
+};
+const int htablen = sizeof (htab) / sizeof (htab[0]);
+
+int main (int argc, char *argv[])
+{
+    zmsg_t *zmsg;
+    flux_t h;
+
+    plan (25);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", FLUX_O_COPROC)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    flux_fatal_set (h, fatal_err, NULL);
+    flux_fatal_error (h, __FUNCTION__, "Foo");
+    ok (fatal_tested == true,
+        "flux_fatal function is called on fatal error");
+
+    ok (flux_msghandler_addvec (h, htab, htablen, NULL) == 0,
+        "registered message handlers");
+    /* test continues in rpctest_begin_cb() so that rpc calls
+     * can sleep while we answer them
+     */
+    ok ((zmsg = flux_request_encode ("rpctest.begin", NULL)) != NULL,
+        "encoded rpctest.begin request OK");
+    ok (flux_sendmsg (h, &zmsg) == 0,
+        "sent rpctest.begin request");
+    ok (flux_reactor_start (h) == 0,
+        "reactor completed normally");
+
+    /* test _then */
+    flux_rpc_t r;
+    ok ((r = flux_rpc (h, "rpctest.echo", "xxx", FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with payload when payload is expected works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_then (r, then_cb, h) == 0,
+        "flux_rpc_then works");
+    ok (flux_reactor_start (h) == 0,
+        "reactor completed normally");
+    flux_rpc_destroy (r);
+
+    flux_close (h);
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This is a rework of PR #210 which was  rework of PR #204.

This PR abolishes the specialized send/recv functions in earlier attempts.  With the enhanced RPC, there seems little justification for wrapping `flux_sendmsg()`, `_recvmsg()` / `_recvmsg_match()` for each message type.

**event**
Reverted `flux_event_send()` and `flux_event_recv()` to be consistent with the other message types.
```C
int flux_event_decode (zmsg_t *zmsg, const char **topic, const char **json_str);
zmsg_t *flux_event_encode (const char *topic, const char *json_str);
```

**request**
```C
int flux_request_decode (zmsg_t *zmsg, const char **topic,
                         const char **json_str);
zmsg_t *flux_request_encode (const char *topic, const char *json_str);
```

**response**
`flux_respond()` seems to work out a little nicer in module message handlers than its predecessors.  Since it takes both errnum and payload args, ignoring payload if errnum is nonzero, only one call is needed in a handler, and there is less temptation to call the errnum one if the payload one fails, which was likely futile anyway.
```C
int flux_response_decode (zmsg_t *zmsg, const char **topic,
                          const char **json_str);
zmsg_t *flux_response_encode (const char *topic, int errnum,
                              const char *json_str);
int flux_respond (flux_t h, zmsg_t **request, int errnum, const char *json_str);
```

**rpc**
Discussed at length previously; main change is `flux_rpc_multi()` name change.
```C
enum {
    FLUX_RPC_NORESPONSE = 1,
};
typedef struct flux_rpc_struct *flux_rpc_t;
typedef void (*flux_then_f)(flux_rpc_t rpc, void *arg);

flux_rpc_t flux_rpc (flux_t h, const char *topic, const char *json_str,
                     uint32_t nodeid, int flags);
flux_rpc_t flux_rpc_multi (flux_t h, const char *topic, const char *json_str,
                           const char *nodeset, int flags);
void flux_rpc_destroy (flux_rpc_t rpc);
bool flux_rpc_check (flux_rpc_t rpc);
int flux_rpc_get (flux_rpc_t rpc, uint32_t *nodeid, const char **json_str);
int flux_rpc_then (flux_rpc_t rpc, flux_then_f cb, void *arg);
bool flux_rpc_completed (flux_rpc_t rpc);
```