### PR TITLE
eliminate czmq dependency in public api

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -322,7 +322,7 @@ static int l_flux_recv (lua_State *L)
     json_object *o = NULL;
     int errnum;
     zmsg_t *zmsg;
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .matchtag = FLUX_MATCHTAG_NONE,
         .bsize = 0,
@@ -462,7 +462,7 @@ static int l_flux_recv_event (lua_State *L)
     json_object *o = NULL;
     const char *json_str = NULL;
     const char *topic;
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = FLUX_MSGTYPE_EVENT,
         .matchtag = FLUX_MATCHTAG_NONE,
         .bsize = 0,
@@ -843,7 +843,7 @@ static int l_flux_recvmsg (lua_State *L)
     flux_t f = lua_get_flux (L, 1);
     zmsg_t *zmsg;
     int type;
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .matchtag = FLUX_MATCHTAG_NONE,
         .bsize = 0,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -121,6 +121,10 @@ typedef struct {
     struct subprocess *shell;
 } ctx_t;
 
+static int broker_event_sendmsg (ctx_t *ctx, zmsg_t **zmsg);
+static int broker_response_sendmsg (ctx_t *ctx, zmsg_t **zmsg);
+static int broker_request_sendmsg (ctx_t *ctx, zmsg_t **zmsg);
+
 static void event_cb (overlay_t ov, void *sock, void *arg);
 static void parent_cb (overlay_t ov, void *sock, void *arg);
 static void child_cb (overlay_t ov, void *sock, void *arg);
@@ -894,12 +898,12 @@ static int broker_init_signalfd (ctx_t *ctx)
  ** Built-in services
  **
  ** Requests received from modules/peers via their respective reactor
- ** callbacks are sent on via flux_sendmsg().  The broker handle
+ ** callbacks are sent on via broker_request_sendmsg().  The broker handle
  ** then dispatches locally matched ones to their svc handlers.
  **
- ** If the request zmsg is not destroyed by the service handler, the
- ** handle code will generate an 'errnum' response containing 0 if
- ** the handler returns 0, or errno if it returns -1.
+ ** If the request zmsg is not destroyed by the service handler, an
+ ** a no-payload response is generated.  If the handler returned -1,
+ ** the response errnum is set to errno, else 0.
  **/
 
 static json_object *
@@ -1401,9 +1405,6 @@ static void broker_add_services (ctx_t *ctx)
 
 
 /* Handle requests from overlay peers.
- * We pass requests to our own handle 'sendmsg' which dispatches
- * it elsewhere.  If the message was not destroyed by the handler
- * (e.g. by responding to it) generate a response here.
  */
 static void child_cb (overlay_t ov, void *sock, void *arg)
 {
@@ -1425,12 +1426,12 @@ static void child_cb (overlay_t ov, void *sock, void *arg)
             (void)snoop_sendmsg (ctx->snoop, zmsg);
             break;
         case FLUX_MSGTYPE_REQUEST:
-            rc = flux_sendmsg (ctx->h, &zmsg);
+            rc = broker_request_sendmsg (ctx, &zmsg);
             if (zmsg)
                 flux_err_respond (ctx->h, rc < 0 ? errno : 0, &zmsg);
             break;
         case FLUX_MSGTYPE_EVENT:
-            rc = flux_sendmsg (ctx->h, &zmsg);
+            rc = broker_event_sendmsg (ctx, &zmsg);
             break;
     }
 done:
@@ -1500,7 +1501,7 @@ static void parent_cb (overlay_t ov, void *sock, void *arg)
         goto done;
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
-            if (flux_sendmsg (ctx->h, &zmsg) < 0)
+            if (broker_response_sendmsg (ctx, &zmsg) < 0)
                 goto done;
             break;
         case FLUX_MSGTYPE_EVENT:
@@ -1543,16 +1544,16 @@ static void module_cb (module_t p, void *arg)
         goto done;
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
-            (void)flux_sendmsg (ctx->h, &zmsg);
+            (void)broker_response_sendmsg (ctx, &zmsg);
             break;
         case FLUX_MSGTYPE_REQUEST:
-            rc = flux_sendmsg (ctx->h, &zmsg);
+            rc = broker_request_sendmsg (ctx, &zmsg);
             if (zmsg)
                 flux_err_respond (ctx->h, rc < 0 ? errno : 0, &zmsg);
             break;
         case FLUX_MSGTYPE_EVENT:
-            if (flux_sendmsg (ctx->h, &zmsg) < 0) {
-                flux_log (ctx->h, LOG_ERR, "%s(%s): flux_sendmsg %s: %s",
+            if (broker_event_sendmsg (ctx, &zmsg) < 0) {
+                flux_log (ctx->h, LOG_ERR, "%s(%s): broker_event_sendmsg %s: %s",
                           __FUNCTION__, module_get_name (p),
                           flux_msg_typestr (type), strerror (errno));
             }
@@ -1619,8 +1620,8 @@ static void heartbeat_cb (heartbeat_t h, void *arg)
         err ("%s: heartbeat_event_encode failed", __FUNCTION__);
         goto done;
     }
-    if (flux_sendmsg (ctx->h, &zmsg) < 0) {
-        err ("%s: flux_sendmsg", __FUNCTION__);
+    if (broker_event_sendmsg (ctx, &zmsg) < 0) {
+        err ("%s: broker_event_sendmsg", __FUNCTION__);
         goto done;
     }
 done:
@@ -1645,11 +1646,6 @@ static int signal_cb (zloop_t *zl, zmq_pollitem_t *item, ctx_t *ctx)
     }
     return 0;
 }
-
-/**
- ** Broker's internal, minimal flux_t implementation.
- **   to use flux_log() here, we need sendmsg() and rank().
- **/
 
 static int broker_request_sendmsg (ctx_t *ctx, zmsg_t **zmsg)
 {
@@ -1717,25 +1713,33 @@ done:
     return rc;
 }
 
-static int broker_sendmsg (void *impl, zmsg_t **zmsg)
+/**
+ ** Broker's internal, minimal flux_t implementation.
+ **   to use flux_log() here, we need sendmsg() and rank().
+ **/
+
+static int broker_send (void *impl, const flux_msg_t msg, int flags)
 {
     ctx_t *ctx = impl;
     int type;
+    flux_msg_t cpy = NULL;
     int rc = -1;
 
-    (void)snoop_sendmsg (ctx->snoop, *zmsg);
+    (void)snoop_sendmsg (ctx->snoop, msg);
 
-    if (flux_msg_get_type (*zmsg, &type) < 0)
+    if (flux_msg_get_type (msg, &type) < 0)
+        goto done;
+    if (!(cpy = flux_msg_copy (msg, true)))
         goto done;
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
-            rc = broker_request_sendmsg (ctx, zmsg);
+            rc = broker_request_sendmsg (ctx, &cpy);
             break;
         case FLUX_MSGTYPE_RESPONSE:
-            rc = broker_response_sendmsg (ctx, zmsg);
+            rc = broker_response_sendmsg (ctx, &cpy);
             break;
         case FLUX_MSGTYPE_EVENT:
-            rc = broker_event_sendmsg (ctx, zmsg);
+            rc = broker_event_sendmsg (ctx, &cpy);
             break;
         default:
             errno = EINVAL;
@@ -1752,7 +1756,7 @@ static int broker_rank (void *impl)
 }
 
 static const struct flux_handle_ops broker_handle_ops = {
-    .sendmsg = broker_sendmsg,
+    .send = broker_send,
     .rank = broker_rank,
 };
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1718,14 +1718,14 @@ done:
  **   to use flux_log() here, we need sendmsg() and rank().
  **/
 
-static int broker_send (void *impl, const flux_msg_t msg, int flags)
+static int broker_send (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *ctx = impl;
     int type;
-    flux_msg_t cpy = NULL;
+    flux_msg_t *cpy = NULL;
     int rc = -1;
 
-    (void)snoop_sendmsg (ctx->snoop, msg);
+    (void)snoop_sendmsg (ctx->snoop, (zmsg_t *)msg);
 
     if (flux_msg_get_type (msg, &type) < 0)
         goto done;

--- a/src/broker/modhandle.c
+++ b/src/broker/modhandle.c
@@ -281,7 +281,7 @@ done:
     return rc;
 }
 
-static void mod_purge (void *impl, flux_match_t match)
+static void mod_purge (void *impl, struct flux_match match)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);

--- a/src/broker/modhandle.c
+++ b/src/broker/modhandle.c
@@ -244,15 +244,15 @@ static zmsg_t *mod_recvmsg_putmsg (ctx_t *ctx)
     return zmsg;
 }
 
-static zmsg_t *mod_recvmsg (void *impl, bool nonblock)
+static flux_msg_t mod_recv (void *impl, int flags)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    zmsg_t *zmsg = NULL;
+    flux_msg_t msg = NULL;
 
-    if (!(zmsg = mod_recvmsg_putmsg (ctx)))
-        zmsg = mod_recvmsg_main (ctx, nonblock);
-    return zmsg;
+    if (!(msg = mod_recvmsg_putmsg (ctx)))
+        msg = mod_recvmsg_main (ctx, (flags & FLUX_O_NONBLOCK) ? true : false);
+    return msg;
 }
 
 static int mod_requeue (void *impl, const flux_msg_t msg, int flags)
@@ -560,7 +560,7 @@ static void putmsg_cb (struct ev_loop *loop, ev_zlist *w, int revents)
 
 static const struct flux_handle_ops mod_handle_ops = {
     .send = mod_send,
-    .recvmsg = mod_recvmsg,
+    .recv = mod_recv,
     .requeue = mod_requeue,
     .purge = mod_purge,
     .event_subscribe = mod_event_subscribe,

--- a/src/broker/modhandle.c
+++ b/src/broker/modhandle.c
@@ -173,11 +173,11 @@ static void sync_msg_watchers (ctx_t *ctx)
     }
 }
 
-static int mod_send (void *impl, const flux_msg_t msg, int flags)
+static int mod_send (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    flux_msg_t cpy = NULL;
+    flux_msg_t *cpy = NULL;
     int type;
     int rc = -1;
 
@@ -244,24 +244,24 @@ static zmsg_t *mod_recvmsg_putmsg (ctx_t *ctx)
     return zmsg;
 }
 
-static flux_msg_t mod_recv (void *impl, int flags)
+static flux_msg_t *mod_recv (void *impl, int flags)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    flux_msg_t msg = NULL;
+    flux_msg_t *msg = NULL;
 
     if (!(msg = mod_recvmsg_putmsg (ctx)))
         msg = mod_recvmsg_main (ctx, (flags & FLUX_O_NONBLOCK) ? true : false);
     return msg;
 }
 
-static int mod_requeue (void *impl, const flux_msg_t msg, int flags)
+static int mod_requeue (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
     int oldcount = zlist_size (ctx->putmsg);
     int rc = -1;
-    flux_msg_t cpy = NULL;
+    flux_msg_t *cpy = NULL;
 
     if (!(cpy = flux_msg_copy (msg, true)))
         goto done;

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -130,12 +130,7 @@ static void unsubscribe_all (flux_t h, int tc, char **tv)
 static void event_sub (flux_t h, int argc, char **argv)
 {
     zmsg_t *zmsg;
-    flux_match_t match = {
-        .typemask = FLUX_MSGTYPE_EVENT,
-        .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
-        .topic_glob = NULL,
-    };
+    struct flux_match match = FLUX_MATCH_EVENT;
 
     if (argc > 0)
         subscribe_all (h, argc, argv);

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -77,8 +77,9 @@ static void usage (void)
     exit (1);
 }
 
-static void freectx (jstatctx_t *ctx)
+static void freectx (void *arg)
 {
+    jstatctx_t *ctx = arg;
     if (ctx->op)
         fclose (ctx->op);
 }
@@ -90,7 +91,7 @@ static jstatctx_t *getctx (flux_t h)
         ctx = xzmalloc (sizeof (*ctx));
         ctx->h = h;
         ctx->op = NULL;
-        flux_aux_set (h, "jstat", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "jstat", ctx, freectx);
     }
     return ctx;
 }

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -33,6 +33,7 @@ libflux_la_SOURCES = \
 	info.c \
 	handle.c \
 	reactor.c \
+	reactor_impl.h \
 	reduce.c \
 	security.c \
 	message.c \

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -29,6 +29,7 @@
 #include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <czmq.h>
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -1,7 +1,6 @@
 #ifndef _FLUX_CORE_CONF_H
 #define _FLUX_CORE_CONF_H
 
-#include <czmq.h>
 #include <stdbool.h>
 #include <stdarg.h>
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -27,6 +27,7 @@
 #endif
 #include <errno.h>
 #include <stdbool.h>
+#include <czmq.h>
 
 #include "event.h"
 #include "message.h"

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -35,25 +35,25 @@
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
-int flux_event_decode (zmsg_t *zmsg, const char **topic, const char **json_str)
+int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **json_str)
 {
     int type;
     const char *ts, *js;
     int rc = -1;
 
-    if (zmsg == NULL) {
+    if (msg == NULL) {
         errno = EINVAL;
         goto done;
     }
-    if (flux_msg_get_type (zmsg, &type) < 0)
+    if (flux_msg_get_type (msg, &type) < 0)
         goto done;
     if (type != FLUX_MSGTYPE_EVENT) {
         errno = EPROTO;
         goto done;
     }
-    if (flux_msg_get_topic (zmsg, &ts) < 0)
+    if (flux_msg_get_topic (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+    if (flux_msg_get_payload_json (msg, &js) < 0)
         goto done;
     if ((json_str && !js) || (!json_str && js)) {
         errno = EPROTO;

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -3,9 +3,8 @@
 
 #include <stdbool.h>
 #include <stdarg.h>
-#include <czmq.h>
 
-#include "handle.h"
+#include "message.h"
 
 /* Decode an event message.
  * If topic is non-NULL, assign the event topic string.
@@ -13,13 +12,14 @@
  * payload is expected and it is an EPROTO error if they don't match.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_event_decode (zmsg_t *zmsg, const char **topic, const char **json_str);
+int flux_event_decode (flux_msg_t msg, const char **topic,
+                       const char **json_str);
 
 /* Encode an event message.
  * If json_str is non-NULL, it is copied to the message payload.
  * Returns message or NULL on failure with errno set.
  */
-zmsg_t *flux_event_encode (const char *topic, const char *json_str);
+flux_msg_t flux_event_encode (const char *topic, const char *json_str);
 
 #endif /* !FLUX_CORE_EVENT_H */
 

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -12,14 +12,14 @@
  * payload is expected and it is an EPROTO error if they don't match.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_event_decode (flux_msg_t msg, const char **topic,
+int flux_event_decode (const flux_msg_t *msg, const char **topic,
                        const char **json_str);
 
 /* Encode an event message.
  * If json_str is non-NULL, it is copied to the message payload.
  * Returns message or NULL on failure with errno set.
  */
-flux_msg_t flux_event_encode (const char *topic, const char *json_str);
+flux_msg_t *flux_event_encode (const char *topic, const char *json_str);
 
 #endif /* !FLUX_CORE_EVENT_H */
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#include <sys/time.h>
 
 #include "flog.h"
 #include "info.h"

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -43,8 +43,9 @@ typedef struct {
     bool redirect;
 } logctx_t;
 
-static void freectx (logctx_t *ctx)
+static void freectx (void *arg)
 {
+    logctx_t *ctx = arg;
     if (ctx->facility)
         free (ctx->facility);
     free (ctx);
@@ -57,7 +58,7 @@ static logctx_t *getctx (flux_t h)
     if (!ctx) {
         ctx = xzmalloc (sizeof (*ctx));
         ctx->facility = xstrdup ("unknown");
-        flux_aux_set (h, "log", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "log", ctx, freectx);
     }
     return ctx;
 }

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -3,7 +3,6 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
-#include <czmq.h>
 
 #include "handle.h"
 

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -341,8 +341,9 @@ int flux_send (flux_t h, const flux_msg_t msg, int flags)
         errno = ENOSYS;
         goto fatal;
     }
+    flags |= h->flags;
     update_tx_stats (h, msg);
-    if (h->flags & FLUX_O_TRACE)
+    if (flags & FLUX_O_TRACE)
         flux_msg_fprint (stderr, msg);
     if (h->ops->send (h->impl, msg, flags) < 0)
         goto fatal;
@@ -406,6 +407,7 @@ flux_msg_t flux_recv (flux_t h, flux_match_t match, int flags)
         errno = ENOSYS;
         goto fatal;
     }
+    flags |= h->flags;
     if (!(flags & FLUX_O_NONBLOCK) && flux_sleep_on (h, match) < 0) {
         if (errno != EINVAL)
             goto fatal;
@@ -428,7 +430,7 @@ flux_msg_t flux_recv (flux_t h, flux_match_t match, int flags)
         }
     } while (!msg);
     update_rx_stats (h, msg);
-    if ((h->flags & FLUX_O_TRACE))
+    if ((flags & FLUX_O_TRACE))
         flux_msg_fprint (stderr, msg);
     if (defer_requeue (&l, h) < 0)
         goto fatal;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <dlfcn.h>
+#include <czmq.h>
 
 #include "handle.h"
 #include "reactor.h"

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -275,7 +275,7 @@ uint32_t flux_matchtag_alloc (flux_t h, int len)
 
 void flux_matchtag_free (flux_t h, uint32_t matchtag, int len)
 {
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .topic_glob = NULL,
         .matchtag = matchtag,
@@ -397,7 +397,7 @@ static void defer_destroy (zlist_t **l)
  * non-matching messages have to be requeued in the handle, hence the
  * defer_*() helper calls.
  */
-flux_msg_t *flux_recv (flux_t h, flux_match_t match, int flags)
+flux_msg_t *flux_recv (flux_t h, struct flux_match match, int flags)
 {
     zlist_t *l = NULL;
     flux_msg_t *msg = NULL;
@@ -456,11 +456,12 @@ int flux_sendmsg (flux_t h, zmsg_t **zmsg)
 
 flux_msg_t *flux_recvmsg (flux_t h, bool nonblock)
 {
-    flux_match_t match = FLUX_MATCH_ANY;
+    struct flux_match match = FLUX_MATCH_ANY;
     return flux_recv (h, match, nonblock ? FLUX_O_NONBLOCK : 0);
 }
 
-flux_msg_t *flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock)
+flux_msg_t *flux_recvmsg_match (flux_t h, struct flux_match match,
+                                bool nonblock)
 {
     return flux_recv (h, match, nonblock ? FLUX_O_NONBLOCK : 0);
 }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -35,6 +35,7 @@
 #include "handle.h"
 #include "reactor.h"
 #include "handle_impl.h"
+#include "reactor_impl.h"
 #include "message.h"
 #include "tagpool.h"
 
@@ -49,7 +50,7 @@ struct flux_handle_struct {
     void            *dso;
     zhash_t         *aux;
     tagpool_t       tagpool;
-    reactor_t       reactor;
+    struct reactor  *reactor;
     flux_msgcounters_t msgcounters;
     flux_fatal_f    fatal;
     void            *fatal_arg;
@@ -194,7 +195,7 @@ flux_t flux_handle_create (void *impl, const struct flux_handle_ops *ops, int fl
     h->ops = ops;
     h->impl = impl;
     h->tagpool = tagpool_create ();
-    h->reactor = flux_reactor_create (impl, ops);
+    h->reactor = reactor_create (impl, ops);
     return h;
 }
 
@@ -207,7 +208,7 @@ void flux_handle_destroy (flux_t *hp)
         if (h->ops->impl_destroy)
             h->ops->impl_destroy (h->impl);
         tagpool_destroy (h->tagpool);
-        flux_reactor_destroy (h->reactor);
+        reactor_destroy (h->reactor);
         if (h->dso)
             dlclose (h->dso);
         free (h);
@@ -530,7 +531,7 @@ zctx_t *flux_get_zctx (flux_t h)
     return h->ops->get_zctx (h->impl);
 }
 
-reactor_t flux_get_reactor (flux_t h)
+struct reactor *reactor_get (flux_t h)
 {
     return h->reactor;
 }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -291,7 +291,7 @@ uint32_t flux_matchtag_avail (flux_t h)
     return tagpool_avail (h->tagpool);
 }
 
-static void update_tx_stats (flux_t h, const flux_msg_t msg)
+static void update_tx_stats (flux_t h, const flux_msg_t *msg)
 {
     int type;
     if (flux_msg_get_type (msg, &type) == 0) {
@@ -313,7 +313,7 @@ static void update_tx_stats (flux_t h, const flux_msg_t msg)
         errno = 0;
 }
 
-static void update_rx_stats (flux_t h, const flux_msg_t msg)
+static void update_rx_stats (flux_t h, const flux_msg_t *msg)
 {
     int type;
     if (flux_msg_get_type (msg, &type) == 0) {
@@ -335,7 +335,7 @@ static void update_rx_stats (flux_t h, const flux_msg_t msg)
         errno = 0;
 }
 
-int flux_send (flux_t h, const flux_msg_t msg, int flags)
+int flux_send (flux_t h, const flux_msg_t *msg, int flags)
 {
     if (!h->ops->send) {
         errno = ENOSYS;
@@ -353,7 +353,7 @@ fatal:
     return -1;
 }
 
-static int defer_enqueue (zlist_t **l, flux_msg_t msg)
+static int defer_enqueue (zlist_t **l, flux_msg_t *msg)
 {
     if ((!*l && !(*l = zlist_new ())) || zlist_append (*l, msg) < 0) {
         errno = ENOMEM;
@@ -364,7 +364,7 @@ static int defer_enqueue (zlist_t **l, flux_msg_t msg)
 
 static int defer_requeue (zlist_t **l, flux_t h)
 {
-    flux_msg_t msg;
+    flux_msg_t *msg;
     if (*l) {
         while ((msg = zlist_pop (*l))) {
             if (flux_requeue (h, msg, FLUX_RQ_TAIL) < 0) {
@@ -378,7 +378,7 @@ static int defer_requeue (zlist_t **l, flux_t h)
 
 static void defer_destroy (zlist_t **l)
 {
-    flux_msg_t msg;
+    flux_msg_t *msg;
     if (*l) {
         while ((msg = zlist_pop (*l)))
             flux_msg_destroy (msg);
@@ -397,10 +397,10 @@ static void defer_destroy (zlist_t **l)
  * non-matching messages have to be requeued in the handle, hence the
  * defer_*() helper calls.
  */
-flux_msg_t flux_recv (flux_t h, flux_match_t match, int flags)
+flux_msg_t *flux_recv (flux_t h, flux_match_t match, int flags)
 {
     zlist_t *l = NULL;
-    flux_msg_t msg = NULL;
+    flux_msg_t *msg = NULL;
     int saved_errno;
 
     if (!h->ops->recv || !h->ops->requeue) {
@@ -454,20 +454,20 @@ int flux_sendmsg (flux_t h, zmsg_t **zmsg)
     return 0;
 }
 
-flux_msg_t flux_recvmsg (flux_t h, bool nonblock)
+flux_msg_t *flux_recvmsg (flux_t h, bool nonblock)
 {
     flux_match_t match = FLUX_MATCH_ANY;
     return flux_recv (h, match, nonblock ? FLUX_O_NONBLOCK : 0);
 }
 
-flux_msg_t flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock)
+flux_msg_t *flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock)
 {
     return flux_recv (h, match, nonblock ? FLUX_O_NONBLOCK : 0);
 }
 
 /* FIXME: FLUX_O_TRACE will show these messages being received again
  */
-int flux_requeue (flux_t h, const flux_msg_t msg, int flags)
+int flux_requeue (flux_t h, const flux_msg_t *msg, int flags)
 {
     if (!h->ops->requeue) {
         errno = ENOSYS;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -234,7 +234,7 @@ void *flux_aux_get (flux_t h, const char *name)
     return zhash_lookup (h->aux, name);
 }
 
-void flux_aux_set (flux_t h, const char *name, void *aux, FluxFreeFn destroy)
+void flux_aux_set (flux_t h, const char *name, void *aux, flux_free_f destroy)
 {
     zhash_update (h->aux, name, aux);
     zhash_freefn (h->aux, name, destroy);

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -7,6 +7,8 @@
 #include <czmq.h>
 #include "message.h"
 
+struct _zctx_t;
+
 typedef struct flux_handle_struct *flux_t;
 
 typedef struct {
@@ -91,7 +93,7 @@ int flux_event_unsubscribe (flux_t h, const char *topic);
 
 /* Get handle's zctx (if any).
  */
-zctx_t *flux_get_zctx (flux_t h);
+struct _zctx_t *flux_get_zctx (flux_t h);
 
 /* Get/clear handle message counters.
  */

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -55,12 +55,12 @@ void flux_fatal_error (flux_t h, const char *fun, const char *msg);
 } while (0)
 
 /* A mechanism is provide for users to attach auxiliary state to the flux_t
- * handle by name.  The FluxFreeFn, if non-NULL, will be called
+ * handle by name.  The flux_free_f, if non-NULL, will be called
  * to destroy this state when the handle is destroyed.
  */
-typedef void (*FluxFreeFn)(void *arg);
+typedef void (*flux_free_f)(void *arg);
 void *flux_aux_get (flux_t h, const char *name);
-void flux_aux_set (flux_t h, const char *name, void *aux, FluxFreeFn destroy);
+void flux_aux_set (flux_t h, const char *name, void *aux, flux_free_f destroy);
 
 /* Set/clear FLUX_O_* on a flux_t handle.
  */

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
-#include <czmq.h>
+
 #include "message.h"
 
 struct _zctx_t;
@@ -76,15 +76,15 @@ uint32_t flux_matchtag_avail (flux_t h);
 
 /* Low level message send/recv functions.
  */
-int flux_sendmsg (flux_t h, zmsg_t **zmsg);
-zmsg_t *flux_recvmsg (flux_t h, bool nonblock);
-int flux_putmsg (flux_t h, zmsg_t **zmsg);
-int flux_pushmsg (flux_t h, zmsg_t **zmsg);
+int flux_sendmsg (flux_t h, flux_msg_t *msg);
+flux_msg_t flux_recvmsg (flux_t h, bool nonblock);
+int flux_putmsg (flux_t h, flux_msg_t *msg);
+int flux_pushmsg (flux_t h, flux_msg_t *msg);
 
 /* Receive a message matching 'match' (see message.h).
  * Any unmatched messages are returned to the handle with flux_putmsg(),
  */
-zmsg_t *flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
+flux_msg_t flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
 
 /* Event subscribe/unsubscribe.
  */

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -85,12 +85,13 @@ uint32_t flux_matchtag_avail (flux_t h);
 /* Low level message send/recv functions.
  */
 int flux_send (flux_t h, const flux_msg_t *msg, int flags);
-flux_msg_t *flux_recv (flux_t h, flux_match_t match, int flags);
+flux_msg_t *flux_recv (flux_t h, struct flux_match match, int flags);
 
 /* deprecated */
 int flux_sendmsg (flux_t h, flux_msg_t **msg);
 flux_msg_t *flux_recvmsg (flux_t h, bool nonblock);
-flux_msg_t *flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
+flux_msg_t *flux_recvmsg_match (flux_t h, struct flux_match match,
+                                bool nonblock);
 
 /* Requeue message in the handle (head or tail according to flags)
  */

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -31,6 +31,13 @@ enum {
     FLUX_O_COPROC = 2,  /* start reactor callbacks as coprocesses */
 };
 
+/* Flags for flux_requeue().
+ */
+enum {
+    FLUX_RQ_HEAD = 1,   /* requeue message at head of queue */
+    FLUX_RQ_TAIL = 2,   /* requeue message at tail of queue */
+};
+
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a handle implementation to dynamically load.
  * The rest of the URI is parsed in an implementation-specific manner.
@@ -78,8 +85,10 @@ uint32_t flux_matchtag_avail (flux_t h);
  */
 int flux_sendmsg (flux_t h, flux_msg_t *msg);
 flux_msg_t flux_recvmsg (flux_t h, bool nonblock);
-int flux_putmsg (flux_t h, flux_msg_t *msg);
-int flux_pushmsg (flux_t h, flux_msg_t *msg);
+
+/* Requeue message in the handle (head or tail according to flags)
+ */
+int flux_requeue (flux_t h, const flux_msg_t msg, int flags);
 
 /* Receive a message matching 'match' (see message.h).
  * Any unmatched messages are returned to the handle with flux_putmsg(),

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -84,17 +84,17 @@ uint32_t flux_matchtag_avail (flux_t h);
 
 /* Low level message send/recv functions.
  */
-int flux_send (flux_t h, const flux_msg_t msg, int flags);
-flux_msg_t flux_recv (flux_t h, flux_match_t match, int flags);
+int flux_send (flux_t h, const flux_msg_t *msg, int flags);
+flux_msg_t *flux_recv (flux_t h, flux_match_t match, int flags);
 
 /* deprecated */
-int flux_sendmsg (flux_t h, flux_msg_t *msg);
-flux_msg_t flux_recvmsg (flux_t h, bool nonblock);
-flux_msg_t flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
+int flux_sendmsg (flux_t h, flux_msg_t **msg);
+flux_msg_t *flux_recvmsg (flux_t h, bool nonblock);
+flux_msg_t *flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
 
 /* Requeue message in the handle (head or tail according to flags)
  */
-int flux_requeue (flux_t h, const flux_msg_t msg, int flags);
+int flux_requeue (flux_t h, const flux_msg_t *msg, int flags);
 
 /* Event subscribe/unsubscribe.
  */

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -83,6 +83,7 @@ uint32_t flux_matchtag_avail (flux_t h);
 
 /* Low level message send/recv functions.
  */
+int flux_send (flux_t h, const flux_msg_t msg, int flags);
 int flux_sendmsg (flux_t h, flux_msg_t *msg);
 flux_msg_t flux_recvmsg (flux_t h, bool nonblock);
 

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -29,6 +29,7 @@ typedef void (*flux_fatal_f)(const char *msg, void *arg);
 enum {
     FLUX_O_TRACE = 1,   /* send message trace to stderr */
     FLUX_O_COPROC = 2,  /* start reactor callbacks as coprocesses */
+    FLUX_O_NONBLOCK = 4,/* handle should not block on send/recv */
 };
 
 /* Flags for flux_requeue().
@@ -84,17 +85,16 @@ uint32_t flux_matchtag_avail (flux_t h);
 /* Low level message send/recv functions.
  */
 int flux_send (flux_t h, const flux_msg_t msg, int flags);
+flux_msg_t flux_recv (flux_t h, flux_match_t match, int flags);
+
+/* deprecated */
 int flux_sendmsg (flux_t h, flux_msg_t *msg);
 flux_msg_t flux_recvmsg (flux_t h, bool nonblock);
+flux_msg_t flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
 
 /* Requeue message in the handle (head or tail according to flags)
  */
 int flux_requeue (flux_t h, const flux_msg_t msg, int flags);
-
-/* Receive a message matching 'match' (see message.h).
- * Any unmatched messages are returned to the handle with flux_putmsg(),
- */
-flux_msg_t flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
 
 /* Event subscribe/unsubscribe.
  */

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -17,9 +17,9 @@ typedef int (*flux_msg_f)(flux_t h, void *arg);
 typedef struct reactor_struct *reactor_t;
 
 struct flux_handle_ops {
-    int         (*send)(void *impl, const flux_msg_t msg, int flags);
-    flux_msg_t  (*recv)(void *impl, int flags);
-    int         (*requeue)(void *impl, const flux_msg_t msg, int flags);
+    int         (*send)(void *impl, const flux_msg_t *msg, int flags);
+    flux_msg_t* (*recv)(void *impl, int flags);
+    int         (*requeue)(void *impl, const flux_msg_t *msg, int flags);
     void        (*purge)(void *impl, flux_match_t match);
 
     int         (*event_subscribe)(void *impl, const char *topic);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -14,8 +14,6 @@ typedef flux_t (connector_init_f)(const char *uri, int flags);
 
 typedef int (*flux_msg_f)(flux_t h, void *arg);
 
-typedef struct reactor_struct *reactor_t;
-
 struct flux_handle_ops {
     int         (*send)(void *impl, const flux_msg_t *msg, int flags);
     flux_msg_t* (*recv)(void *impl, int flags);
@@ -51,11 +49,8 @@ flux_t flux_handle_create (void *impl, const struct flux_handle_ops *ops, int fl
 void flux_handle_destroy (flux_t *hp);
 
 struct _zctx_t *flux_get_zctx (flux_t h);
-reactor_t flux_get_reactor (flux_t h);
-reactor_t flux_reactor_create (void *impl, const struct flux_handle_ops *ops);
-void flux_reactor_destroy (reactor_t r);
 
-#endif /* !_FLUX_CORE_HANDLE_H */
+#endif /* !_FLUX_CORE_HANDLE_IMPL_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -17,7 +17,7 @@ typedef int (*flux_msg_f)(flux_t h, void *arg);
 typedef struct reactor_struct *reactor_t;
 
 struct flux_handle_ops {
-    int         (*sendmsg)(void *impl, flux_msg_t *msg);
+    int         (*send)(void *impl, const flux_msg_t msg, int flags);
     flux_msg_t  (*recvmsg)(void *impl, bool nonblock);
     int         (*requeue)(void *impl, const flux_msg_t msg, int flags);
     void        (*purge)(void *impl, flux_match_t match);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -19,8 +19,7 @@ typedef struct reactor_struct *reactor_t;
 struct flux_handle_ops {
     int         (*sendmsg)(void *impl, flux_msg_t *msg);
     flux_msg_t  (*recvmsg)(void *impl, bool nonblock);
-    int         (*putmsg)(void *impl, flux_msg_t *msg);
-    int         (*pushmsg)(void *impl, flux_msg_t *msg);
+    int         (*requeue)(void *impl, const flux_msg_t msg, int flags);
     void        (*purge)(void *impl, flux_match_t match);
 
     int         (*event_subscribe)(void *impl, const char *topic);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -20,7 +20,7 @@ struct flux_handle_ops {
     int         (*send)(void *impl, const flux_msg_t *msg, int flags);
     flux_msg_t* (*recv)(void *impl, int flags);
     int         (*requeue)(void *impl, const flux_msg_t *msg, int flags);
-    void        (*purge)(void *impl, flux_match_t match);
+    void        (*purge)(void *impl, struct flux_match match);
 
     int         (*event_subscribe)(void *impl, const char *topic);
     int         (*event_unsubscribe)(void *impl, const char *topic);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -28,7 +28,7 @@ struct flux_handle_ops {
 
     int         (*rank)(void *impl);
 
-    zctx_t *    (*get_zctx)(void *impl);
+    struct _zctx_t * (*get_zctx)(void *impl);
 
     int         (*reactor_start)(void *impl);
     void        (*reactor_stop)(void *impl, int rc);
@@ -51,7 +51,7 @@ struct flux_handle_ops {
 flux_t flux_handle_create (void *impl, const struct flux_handle_ops *ops, int flags);
 void flux_handle_destroy (flux_t *hp);
 
-zctx_t *flux_get_zctx (flux_t h);
+struct _zctx_t *flux_get_zctx (flux_t h);
 reactor_t flux_get_reactor (flux_t h);
 reactor_t flux_reactor_create (void *impl, const struct flux_handle_ops *ops);
 void flux_reactor_destroy (reactor_t r);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -2,8 +2,8 @@
 #define _FLUX_CORE_HANDLE_IMPL_H
 
 #include <stdbool.h>
-#include <czmq.h>
 
+#include "message.h"
 #include "handle.h"
 
 /**
@@ -17,10 +17,10 @@ typedef int (*flux_msg_f)(flux_t h, void *arg);
 typedef struct reactor_struct *reactor_t;
 
 struct flux_handle_ops {
-    int         (*sendmsg)(void *impl, zmsg_t **zmsg);
-    zmsg_t *    (*recvmsg)(void *impl, bool nonblock);
-    int         (*putmsg)(void *impl, zmsg_t **zmsg);
-    int         (*pushmsg)(void *impl, zmsg_t **zmsg);
+    int         (*sendmsg)(void *impl, flux_msg_t *msg);
+    flux_msg_t  (*recvmsg)(void *impl, bool nonblock);
+    int         (*putmsg)(void *impl, flux_msg_t *msg);
+    int         (*pushmsg)(void *impl, flux_msg_t *msg);
     void        (*purge)(void *impl, flux_match_t match);
 
     int         (*event_subscribe)(void *impl, const char *topic);

--- a/src/common/libflux/handle_impl.h
+++ b/src/common/libflux/handle_impl.h
@@ -18,7 +18,7 @@ typedef struct reactor_struct *reactor_t;
 
 struct flux_handle_ops {
     int         (*send)(void *impl, const flux_msg_t msg, int flags);
-    flux_msg_t  (*recvmsg)(void *impl, bool nonblock);
+    flux_msg_t  (*recv)(void *impl, int flags);
     int         (*requeue)(void *impl, const flux_msg_t msg, int flags);
     void        (*purge)(void *impl, flux_match_t match);
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -396,7 +396,7 @@ static bool isa_glob (const char *s)
     return false;
 }
 
-bool flux_msg_cmp (const flux_msg_t *msg, flux_match_t match)
+bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
 {
     if (match.typemask != 0) {
         int type;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -31,6 +31,7 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <fnmatch.h>
+#include <czmq.h>
 
 #include "message.h"
 
@@ -193,6 +194,11 @@ zmsg_t *flux_msg_create (int type)
     }
 done:
     return zmsg;
+}
+
+void flux_msg_destroy (flux_msg_t msg)
+{
+    zmsg_destroy (&msg);
 }
 
 int flux_msg_set_type (zmsg_t *zmsg, int type)
@@ -904,9 +910,9 @@ done:
  * is false, when the point was to avoid the overhead of copying it in
  * the first place.
  */
-zmsg_t *flux_msg_copy (const zmsg_t *zmsg, bool payload)
+flux_msg_t flux_msg_copy (const flux_msg_t msg, bool payload)
 {
-    zmsg_t *cpy = zmsg_dup ((zmsg_t *)zmsg);
+    zmsg_t *cpy = zmsg_dup ((zmsg_t *)msg);
     if (!cpy) {
         errno = ENOMEM;
         return NULL;

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -24,6 +24,26 @@ enum {
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
 };
 
+typedef struct {
+    int typemask;           /* bitmask of matching message types (or 0) */
+    uint32_t matchtag;      /* matchtag block begin (or FLUX_MATCHTAG_NONE) */
+    int bsize;              /* size of matchtag block (or 0) */
+    char *topic_glob;       /* glob matching topic string (or NULL) */
+} flux_match_t;
+
+#define FLUX_MATCH_ANY { \
+    .typemask = FLUX_MSGTYPE_ANY, \
+    .matchtag = FLUX_MATCHTAG_NONE, \
+    .bsize = 0, \
+    .topic_glob = NULL, \
+}
+#define FLUX_MATCH_EVENT { \
+    .typemask = FLUX_MSGTYPE_EVENT, \
+    .matchtag = FLUX_MATCHTAG_NONE, \
+    .bsize = 0, \
+    .topic_glob = NULL, \
+}
+
 /* Create a new Flux message.
  * Returns new message or null on failure, with errno set (e.g. ENOMEM, EINVAL)
  * Caller must destroy message with flux_msg_destroy() or equivalent.
@@ -95,13 +115,6 @@ bool flux_msg_cmp_matchtag (flux_msg_t msg, uint32_t matchtag);
 
 /* Match a message.
  */
-typedef struct {
-    int typemask;           /* bitmask of matching message types (or 0) */
-    uint32_t matchtag;      /* matchtag block begin (or FLUX_MATCHTAG_NONE) */
-    int bsize;              /* size of matchtag block (or 0) */
-    char *topic_glob;       /* glob matching topic string (or NULL) */
-} flux_match_t;
-
 bool flux_msg_cmp (flux_msg_t msg, flux_match_t match);
 
 /* Print a Flux message on specified output stream.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-typedef struct _zmsg_t *flux_msg_t;
+typedef struct _zmsg_t flux_msg_t;
 
 enum {
     FLUX_MSGTYPE_REQUEST    = 0x01,
@@ -48,25 +48,25 @@ typedef struct {
  * Returns new message or null on failure, with errno set (e.g. ENOMEM, EINVAL)
  * Caller must destroy message with flux_msg_destroy() or equivalent.
  */
-flux_msg_t flux_msg_create (int type);
-void flux_msg_destroy (flux_msg_t msg);
+flux_msg_t *flux_msg_create (int type);
+void flux_msg_destroy (flux_msg_t *msg);
 
 /* Duplicate msg, omitting payload if 'payload' is false.
  */
-flux_msg_t flux_msg_copy (const flux_msg_t msg, bool payload);
+flux_msg_t *flux_msg_copy (const flux_msg_t *msg, bool payload);
 
 /* Get/set message type
  * For FLUX_MSGTYPE_REQUEST: set_type initializes nodeid to FLUX_NODEID_ANY
  * For FLUX_MSGTYPE_RESPONSE: set_type initializes errnum to 0
  */
-int flux_msg_set_type (flux_msg_t msg, int type);
-int flux_msg_get_type (flux_msg_t msg, int *type);
+int flux_msg_set_type (flux_msg_t *msg, int type);
+int flux_msg_get_type (const flux_msg_t *msg, int *type);
 
 /* Get/set/compare message topic string.
  * set adds/deletes/replaces topic frame as needed.
  */
-int flux_msg_set_topic (flux_msg_t msg, const char *topic);
-int flux_msg_get_topic (flux_msg_t msg, const char **topic);
+int flux_msg_set_topic (flux_msg_t *msg, const char *topic);
+int flux_msg_get_topic (const flux_msg_t *msg, const char **topic);
 
 /* Get/set payload.
  * Set function adds/deletes/replaces payload frame as needed.
@@ -75,16 +75,16 @@ int flux_msg_get_topic (flux_msg_t msg, const char **topic);
  * Get_payload returns pointer to msg-owned buf.
  * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
  */
-int flux_msg_set_payload (flux_msg_t msg, int flags, void *buf, int size);
-int flux_msg_get_payload (flux_msg_t msg, int *flags, void **buf, int *size);
-bool flux_msg_has_payload (flux_msg_t msg);
+int flux_msg_set_payload (flux_msg_t *msg, int flags, void *buf, int size);
+int flux_msg_get_payload (const flux_msg_t *msg, int *flags, void **buf, int *size);
+bool flux_msg_has_payload (const flux_msg_t *msg);
 
 /* Get/set json string payload.
  * set allows json_str to be NULL
  * get will set *json_str to NULL and return success if there is no payload.
  */
-int flux_msg_set_payload_json (flux_msg_t msg, const char *json_str);
-int flux_msg_get_payload_json (flux_msg_t msg, const char **json_str);
+int flux_msg_set_payload_json (flux_msg_t *msg, const char *json_str);
+int flux_msg_get_payload_json (const flux_msg_t *msg, const char **json_str);
 
 /* Get/set nodeid (request only)
  * If flags includes FLUX_NODEID_UPSTREAM, nodeid is the sending rank.
@@ -93,33 +93,33 @@ int flux_msg_get_payload_json (flux_msg_t msg, const char **json_str);
  */
 #define FLUX_NODEID_ANY         (~(uint32_t)0)
 #define FLUX_NODEID_UPSTREAM	(~(uint32_t)1)
-int flux_msg_set_nodeid (flux_msg_t msg, uint32_t nodeid, int flags);
-int flux_msg_get_nodeid (flux_msg_t msg, uint32_t *nodeid, int *flags);
+int flux_msg_set_nodeid (flux_msg_t *msg, uint32_t nodeid, int flags);
+int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeid, int *flags);
 
 /* Get/set errnum (response only)
  */
-int flux_msg_set_errnum (flux_msg_t msg, int errnum);
-int flux_msg_get_errnum (flux_msg_t msg, int *errnum);
+int flux_msg_set_errnum (flux_msg_t *msg, int errnum);
+int flux_msg_get_errnum (const flux_msg_t *msg, int *errnum);
 
 /* Get/set sequence number (event only)
  */
-int flux_msg_set_seq (flux_msg_t msg, uint32_t seq);
-int flux_msg_get_seq (flux_msg_t msg, uint32_t *seq);
+int flux_msg_set_seq (flux_msg_t *msg, uint32_t seq);
+int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq);
 
 /* Get/set/compare match tag (request/response only)
  */
 #define FLUX_MATCHTAG_NONE (0)
-int flux_msg_set_matchtag (flux_msg_t msg, uint32_t matchtag);
-int flux_msg_get_matchtag (flux_msg_t msg, uint32_t *matchtag);
-bool flux_msg_cmp_matchtag (flux_msg_t msg, uint32_t matchtag);
+int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t matchtag);
+int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *matchtag);
+bool flux_msg_cmp_matchtag (const flux_msg_t *msg, uint32_t matchtag);
 
 /* Match a message.
  */
-bool flux_msg_cmp (flux_msg_t msg, flux_match_t match);
+bool flux_msg_cmp (const flux_msg_t *msg, flux_match_t match);
 
 /* Print a Flux message on specified output stream.
  */
-void flux_msg_fprint (FILE *f, flux_msg_t msg);
+void flux_msg_fprint (FILE *f, const flux_msg_t *msg);
 
 /* Convert a numeric FLUX_MSGTYPE value to string,
  * or "unknown" if unrecognized.
@@ -137,52 +137,52 @@ const char *flux_msg_typestr (int type);
  * flag is already set.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_msg_enable_route (flux_msg_t msg);
+int flux_msg_enable_route (flux_msg_t *msg);
 
 /* Strip route frames, nil delimiter, and clear FLUX_MSGFLAG_ROUTE flag.
  * This function is a no-op if the flag is already clear.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_msg_clear_route (flux_msg_t msg);
+int flux_msg_clear_route (flux_msg_t *msg);
 
 /* Push a route frame onto the message (mimic what dealer socket does).
  * 'id' is copied internally.
  * Returns 0 on success, -1 with errno set (e.g. EINVAL) on failure.
  */
-int flux_msg_push_route (flux_msg_t msg, const char *id);
+int flux_msg_push_route (flux_msg_t *msg, const char *id);
 
 /* Pop a route frame off the message and return identity (or NULL) in 'id'.
  * Caller must free 'id'.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_pop_route (flux_msg_t msg, char **id);
+int flux_msg_pop_route (flux_msg_t *msg, char **id);
 
 /* Copy the first routing frame (closest to delimiter) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the sender; for responses, this is the recipient.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_first (flux_msg_t msg, char **id); /* closest to delim */
+int flux_msg_get_route_first (const flux_msg_t *msg, char **id); /* closest to delim */
 
 /* Copy the last routing frame (farthest from delimiter) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the last hop; for responses: this is the next hop.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_last (flux_msg_t msg, char **id); /* farthest from delim */
+int flux_msg_get_route_last (const flux_msg_t *msg, char **id); /* farthest from delim */
 
 /* Return the number of route frames in the message.
  * It is an EPROTO error if there is no route stack.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_count (flux_msg_t msg);
+int flux_msg_get_route_count (const flux_msg_t *msg);
 
 /* Return a string representing the route stack in message.
  * Return NULL if there is no route delimiter; empty string if
  * the route stack contains no route frames).
  * Caller must free the returned string.
  */
-char *flux_msg_get_route_string (flux_msg_t msg);
+char *flux_msg_get_route_string (const flux_msg_t *msg);
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -24,12 +24,12 @@ enum {
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
 };
 
-typedef struct {
+struct flux_match {
     int typemask;           /* bitmask of matching message types (or 0) */
     uint32_t matchtag;      /* matchtag block begin (or FLUX_MATCHTAG_NONE) */
     int bsize;              /* size of matchtag block (or 0) */
     char *topic_glob;       /* glob matching topic string (or NULL) */
-} flux_match_t;
+};
 
 #define FLUX_MATCH_ANY { \
     .typemask = FLUX_MSGTYPE_ANY, \
@@ -115,7 +115,7 @@ bool flux_msg_cmp_matchtag (const flux_msg_t *msg, uint32_t matchtag);
 
 /* Match a message.
  */
-bool flux_msg_cmp (const flux_msg_t *msg, flux_match_t match);
+bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match);
 
 /* Print a Flux message on specified output stream.
  */

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -2,9 +2,10 @@
 #define _FLUX_CORE_MESSAGE_H
 
 #include <stdbool.h>
-#include <czmq.h>
 #include <stdint.h>
 #include <stdio.h>
+
+typedef struct _zmsg_t *flux_msg_t;
 
 enum {
     FLUX_MSGTYPE_REQUEST    = 0x01,
@@ -25,44 +26,45 @@ enum {
 
 /* Create a new Flux message.
  * Returns new message or null on failure, with errno set (e.g. ENOMEM, EINVAL)
- * Caller must destroy message with zmsg_destroy() or equivalent.
+ * Caller must destroy message with flux_msg_destroy() or equivalent.
  */
-zmsg_t *flux_msg_create (int type);
+flux_msg_t flux_msg_create (int type);
+void flux_msg_destroy (flux_msg_t msg);
 
-/* Duplicate zmsg, omitting payload if 'payload' is false.
+/* Duplicate msg, omitting payload if 'payload' is false.
  */
-zmsg_t *flux_msg_copy (const zmsg_t *zmsg, bool payload);
+flux_msg_t flux_msg_copy (const flux_msg_t msg, bool payload);
 
 /* Get/set message type
  * For FLUX_MSGTYPE_REQUEST: set_type initializes nodeid to FLUX_NODEID_ANY
  * For FLUX_MSGTYPE_RESPONSE: set_type initializes errnum to 0
  */
-int flux_msg_set_type (zmsg_t *zmsg, int type);
-int flux_msg_get_type (zmsg_t *zmsg, int *type);
+int flux_msg_set_type (flux_msg_t msg, int type);
+int flux_msg_get_type (flux_msg_t msg, int *type);
 
 /* Get/set/compare message topic string.
  * set adds/deletes/replaces topic frame as needed.
  */
-int flux_msg_set_topic (zmsg_t *zmsg, const char *topic);
-int flux_msg_get_topic (zmsg_t *zmsg, const char **topic);
+int flux_msg_set_topic (flux_msg_t msg, const char *topic);
+int flux_msg_get_topic (flux_msg_t msg, const char **topic);
 
 /* Get/set payload.
  * Set function adds/deletes/replaces payload frame as needed.
  * The new payload will be copied (caller retains ownership).
  * Any old payload is deleted.
- * Get_payload returns pointer to zmsg-owned buf.
+ * Get_payload returns pointer to msg-owned buf.
  * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
  */
-int flux_msg_set_payload (zmsg_t *zmsg, int flags, void *buf, int size);
-int flux_msg_get_payload (zmsg_t *zmsg, int *flags, void **buf, int *size);
-bool flux_msg_has_payload (zmsg_t *zmsg);
+int flux_msg_set_payload (flux_msg_t msg, int flags, void *buf, int size);
+int flux_msg_get_payload (flux_msg_t msg, int *flags, void **buf, int *size);
+bool flux_msg_has_payload (flux_msg_t msg);
 
 /* Get/set json string payload.
  * set allows json_str to be NULL
  * get will set *json_str to NULL and return success if there is no payload.
  */
-int flux_msg_set_payload_json (zmsg_t *zmsg, const char *json_str);
-int flux_msg_get_payload_json (zmsg_t *zmsg, const char **json_str);
+int flux_msg_set_payload_json (flux_msg_t msg, const char *json_str);
+int flux_msg_get_payload_json (flux_msg_t msg, const char **json_str);
 
 /* Get/set nodeid (request only)
  * If flags includes FLUX_NODEID_UPSTREAM, nodeid is the sending rank.
@@ -71,25 +73,25 @@ int flux_msg_get_payload_json (zmsg_t *zmsg, const char **json_str);
  */
 #define FLUX_NODEID_ANY         (~(uint32_t)0)
 #define FLUX_NODEID_UPSTREAM	(~(uint32_t)1)
-int flux_msg_set_nodeid (zmsg_t *zmsg, uint32_t nodeid, int flags);
-int flux_msg_get_nodeid (zmsg_t *zmsg, uint32_t *nodeid, int *flags);
+int flux_msg_set_nodeid (flux_msg_t msg, uint32_t nodeid, int flags);
+int flux_msg_get_nodeid (flux_msg_t msg, uint32_t *nodeid, int *flags);
 
 /* Get/set errnum (response only)
  */
-int flux_msg_set_errnum (zmsg_t *zmsg, int errnum);
-int flux_msg_get_errnum (zmsg_t *zmsg, int *errnum);
+int flux_msg_set_errnum (flux_msg_t msg, int errnum);
+int flux_msg_get_errnum (flux_msg_t msg, int *errnum);
 
 /* Get/set sequence number (event only)
  */
-int flux_msg_set_seq (zmsg_t *zmsg, uint32_t seq);
-int flux_msg_get_seq (zmsg_t *zmsg, uint32_t *seq);
+int flux_msg_set_seq (flux_msg_t msg, uint32_t seq);
+int flux_msg_get_seq (flux_msg_t msg, uint32_t *seq);
 
 /* Get/set/compare match tag (request/response only)
  */
 #define FLUX_MATCHTAG_NONE (0)
-int flux_msg_set_matchtag (zmsg_t *zmsg, uint32_t matchtag);
-int flux_msg_get_matchtag (zmsg_t *zmsg, uint32_t *matchtag);
-bool flux_msg_cmp_matchtag (zmsg_t *zmsg, uint32_t matchtag);
+int flux_msg_set_matchtag (flux_msg_t msg, uint32_t matchtag);
+int flux_msg_get_matchtag (flux_msg_t msg, uint32_t *matchtag);
+bool flux_msg_cmp_matchtag (flux_msg_t msg, uint32_t matchtag);
 
 /* Match a message.
  */
@@ -100,11 +102,11 @@ typedef struct {
     char *topic_glob;       /* glob matching topic string (or NULL) */
 } flux_match_t;
 
-bool flux_msg_cmp (zmsg_t *zmsg, flux_match_t match);
+bool flux_msg_cmp (flux_msg_t msg, flux_match_t match);
 
 /* Print a Flux message on specified output stream.
  */
-void flux_msg_fprint (FILE *f, zmsg_t *zmsg);
+void flux_msg_fprint (FILE *f, flux_msg_t msg);
 
 /* Convert a numeric FLUX_MSGTYPE value to string,
  * or "unknown" if unrecognized.
@@ -122,52 +124,52 @@ const char *flux_msg_typestr (int type);
  * flag is already set.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_msg_enable_route (zmsg_t *zmsg);
+int flux_msg_enable_route (flux_msg_t msg);
 
 /* Strip route frames, nil delimiter, and clear FLUX_MSGFLAG_ROUTE flag.
  * This function is a no-op if the flag is already clear.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_msg_clear_route (zmsg_t *zmsg);
+int flux_msg_clear_route (flux_msg_t msg);
 
 /* Push a route frame onto the message (mimic what dealer socket does).
  * 'id' is copied internally.
  * Returns 0 on success, -1 with errno set (e.g. EINVAL) on failure.
  */
-int flux_msg_push_route (zmsg_t *zmsg, const char *id);
+int flux_msg_push_route (flux_msg_t msg, const char *id);
 
 /* Pop a route frame off the message and return identity (or NULL) in 'id'.
  * Caller must free 'id'.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_pop_route (zmsg_t *zmsg, char **id);
+int flux_msg_pop_route (flux_msg_t msg, char **id);
 
 /* Copy the first routing frame (closest to delimiter) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the sender; for responses, this is the recipient.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_first (zmsg_t *zmsg, char **id); /* closest to delim */
+int flux_msg_get_route_first (flux_msg_t msg, char **id); /* closest to delim */
 
 /* Copy the last routing frame (farthest from delimiter) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the last hop; for responses: this is the next hop.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_last (zmsg_t *zmsg, char **id); /* farthest from delim */
+int flux_msg_get_route_last (flux_msg_t msg, char **id); /* farthest from delim */
 
 /* Return the number of route frames in the message.
  * It is an EPROTO error if there is no route stack.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_count (zmsg_t *zmsg);
+int flux_msg_get_route_count (flux_msg_t msg);
 
 /* Return a string representing the route stack in message.
  * Return NULL if there is no route delimiter; empty string if
  * the route stack contains no route frames).
  * Caller must free the returned string.
  */
-char *flux_msg_get_route_string (zmsg_t *zmsg);
+char *flux_msg_get_route_string (flux_msg_t msg);
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -6,7 +6,6 @@
  */
 
 #include <stdint.h>
-#include <czmq.h>
 
 #include "handle.h"
 

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -25,6 +25,10 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <syslog.h>
+#include <unistd.h>
+#include <signal.h>
+
 #include "panic.h"
 #include "flog.h"
 #include "rpc.h"

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -44,12 +44,12 @@
 
 typedef struct {
     flux_t h;
-    flux_match_t match;
+    struct flux_match match;
     FluxMsgHandler fn;
     void *arg;
     coproc_t coproc;
     zlist_t *backlog;
-    flux_match_t wait_match;
+    struct flux_match wait_match;
 } dispatch_t;
 
 struct reactor_struct {
@@ -60,7 +60,8 @@ struct reactor_struct {
     dispatch_t *current;
 };
 
-static bool match_match (const flux_match_t m1, const flux_match_t m2)
+static bool match_match (const struct flux_match m1,
+                         const struct flux_match m2)
 {
     if (m1.typemask != m2.typemask)
         return false;
@@ -78,7 +79,8 @@ static bool match_match (const flux_match_t m1, const flux_match_t m2)
     return true;
 }
 
-static void copy_match (flux_match_t *dst, const flux_match_t src)
+static void copy_match (struct flux_match *dst,
+                        const struct flux_match src)
 {
     if (dst->topic_glob)
         free (dst->topic_glob);
@@ -86,7 +88,7 @@ static void copy_match (flux_match_t *dst, const flux_match_t src)
     dst->topic_glob = src.topic_glob ? xstrdup (src.topic_glob) : NULL;
 }
 
-static dispatch_t *dispatch_create (flux_t h, const flux_match_t match,
+static dispatch_t *dispatch_create (flux_t h, const struct flux_match match,
                                     FluxMsgHandler cb, void *arg)
 {
     dispatch_t *d = xzmalloc (sizeof (*d));
@@ -184,7 +186,7 @@ static int backlog_flush (dispatch_t *d)
     return rc;
 }
 
-int flux_sleep_on (flux_t h, flux_match_t match)
+int flux_sleep_on (flux_t h, struct flux_match match)
 {
     reactor_t r = flux_get_reactor (h);
     int rc = -1;
@@ -208,7 +210,7 @@ static int coproc_cb (coproc_t c, void *arg)
 {
     dispatch_t *d = arg;
     zmsg_t *zmsg;
-    flux_match_t match = FLUX_MATCH_ANY;
+    struct flux_match match = FLUX_MATCH_ANY;
     int type;
     int rc = -1;
     if (!(zmsg = flux_recv (d->h, match, FLUX_O_NONBLOCK))) {
@@ -270,7 +272,7 @@ static int msg_cb (flux_t h, void *arg)
 {
     reactor_t r = flux_get_reactor (h);
     dispatch_t *d;
-    flux_match_t match = FLUX_MATCH_ANY;
+    struct flux_match match = FLUX_MATCH_ANY;
     int rc = -1;
     zmsg_t *zmsg = NULL;
     int type;
@@ -330,7 +332,7 @@ done:
     return rc;
 }
 
-int flux_msghandler_add_match (flux_t h, const flux_match_t match,
+int flux_msghandler_add_match (flux_t h, const struct flux_match match,
                               FluxMsgHandler cb, void *arg)
 {
     reactor_t r = flux_get_reactor (h);
@@ -357,7 +359,7 @@ int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
 {
     int rc = -1;
 
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = typemask,
         .topic_glob = (char *)pattern,
         .matchtag = FLUX_MATCHTAG_NONE,
@@ -382,7 +384,7 @@ int flux_msghandler_addvec (flux_t h, msghandler_t *handlers, int len,
     return 0;
 }
 
-void flux_msghandler_remove_match (flux_t h, const flux_match_t match)
+void flux_msghandler_remove_match (flux_t h, const struct flux_match match)
 {
     reactor_t r = flux_get_reactor (h);
     dispatch_t *d;
@@ -402,7 +404,7 @@ void flux_msghandler_remove_match (flux_t h, const flux_match_t match)
 
 void flux_msghandler_remove (flux_t h, int typemask, const char *pattern)
 {
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = typemask,
         .matchtag = FLUX_MATCHTAG_NONE,
         .bsize = 1,

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <czmq.h>
 
 #include "handle.h"
 #include "reactor.h"

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -10,7 +10,7 @@
  * Callbacks return 0 on success, -1 on error and set errno.
  * Error terminates reactor, and flux_reactor_start() returns -1.
  */
-typedef int (*FluxMsgHandler)(flux_t h, int typemask, flux_msg_t *msg, void *arg);
+typedef int (*FluxMsgHandler)(flux_t h, int typemask, flux_msg_t **msg, void *arg);
 typedef int (*FluxFdHandler)(flux_t h, int fd, short revents, void *arg);
 typedef int (*FluxZsHandler)(flux_t h, void *zs, short revents, void *arg);
 typedef int (*FluxTmoutHandler)(flux_t h, void *arg);

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -2,15 +2,15 @@
 #define _FLUX_CORE_REACTOR_H
 
 #include <stdbool.h>
-#include <czmq.h>
 
+#include "message.h"
 #include "handle.h"
 
-/* FluxMsgHandler indicates zmsg is "consumed" by destroying it.
+/* FluxMsgHandler indicates msg is "consumed" by destroying it.
  * Callbacks return 0 on success, -1 on error and set errno.
  * Error terminates reactor, and flux_reactor_start() returns -1.
  */
-typedef int (*FluxMsgHandler)(flux_t h, int typemask, zmsg_t **zmsg, void *arg);
+typedef int (*FluxMsgHandler)(flux_t h, int typemask, flux_msg_t *msg, void *arg);
 typedef int (*FluxFdHandler)(flux_t h, int fd, short revents, void *arg);
 typedef int (*FluxZsHandler)(flux_t h, void *zs, short revents, void *arg);
 typedef int (*FluxTmoutHandler)(flux_t h, void *arg);

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -6,6 +6,24 @@
 #include "message.h"
 #include "handle.h"
 
+/* Start the flux event reactor.
+ * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
+ */
+int flux_reactor_start (flux_t h);
+
+/* Signal that the flux event reactor should stop.
+ * This may be called from within a FluxMsgHandler/FluxFdHandler callback.
+ */
+void flux_reactor_stop (flux_t h);
+
+/* Give control back to the reactor until a message matching 'match'
+ * is queued in the handle.  This will return -1 with errno = EINVAL
+ * if called from a reactor handler that is not running in as a coprocess.
+ * Currently only message handlers are started as coprocesses, if the
+ * handle has FLUX_O_COPROC set.
+ */
+int flux_sleep_on (flux_t h, struct flux_match match);
+
 /* FluxMsgHandler indicates msg is "consumed" by destroying it.
  * Callbacks return 0 on success, -1 on error and set errno.
  * Error terminates reactor, and flux_reactor_start() returns -1.
@@ -75,34 +93,6 @@ int flux_tmouthandler_add (flux_t h, unsigned long msec, bool oneshot,
 /* Unregister a FluxTmoutHandler callback.
  */
 void flux_tmouthandler_remove (flux_t h, int timer_id);
-
-/* Arm the reactor timer such that a FluxTmoutHandler,
- * if registered, will be called every 'msec' milliseconds.
- * Setting msec=0 disarms the timer.
- */
-int flux_timeout_set (flux_t h, unsigned long msec);
-
-/* Test whether the reactor timer is armed.
- */
-bool flux_timeout_isset (flux_t h);
-
-/* Start the flux event reactor.
- * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
- */
-int flux_reactor_start (flux_t h);
-
-/* Signal that the flux event reactor should stop.
- * This may be called from within a FluxMsgHandler/FluxFdHandler callback.
- */
-void flux_reactor_stop (flux_t h);
-
-/* Give control back to the reactor until a message matching 'match'
- * is queued in the handle.  This will return -1 with errno = EINVAL
- * if called from a reactor handler that is not running in as a coprocess.
- * Currently only message handlers are started as coprocesses, if the
- * handle has FLUX_O_COPROC set.
- */
-int flux_sleep_on (flux_t h, struct flux_match match);
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -39,9 +39,9 @@ int flux_msghandler_addvec (flux_t h, msghandler_t *handlers, int len,
 void flux_msghandler_remove (flux_t h, int typemask, const char *pattern);
 
 
-int flux_msghandler_add_match (flux_t h, const flux_match_t match,
+int flux_msghandler_add_match (flux_t h, const struct flux_match match,
                               FluxMsgHandler cb, void *arg);
-void flux_msghandler_remove_match (flux_t h, const flux_match_t match);
+void flux_msghandler_remove_match (flux_t h, const struct flux_match match);
 
 
 /* Register a FluxFdHandler callback to be called whenever an event
@@ -102,7 +102,7 @@ void flux_reactor_stop (flux_t h);
  * Currently only message handlers are started as coprocesses, if the
  * handle has FLUX_O_COPROC set.
  */
-int flux_sleep_on (flux_t h, flux_match_t match);
+int flux_sleep_on (flux_t h, struct flux_match match);
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libflux/reactor_impl.h
+++ b/src/common/libflux/reactor_impl.h
@@ -1,0 +1,11 @@
+#ifndef _FLUX_CORE_REACTOR_IMPL_H
+#define _FLUX_CORE_REACTOR_IMPL_H
+
+#include  "handle_impl.h"
+
+struct reactor *reactor_get (flux_t h);
+
+struct reactor *reactor_create (void *impl, const struct flux_handle_ops *ops);
+void reactor_destroy (struct reactor *r);
+
+#endif /* _FLUX_CORE_REACTOR_IMPL_H */

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -35,26 +35,26 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
 
-int flux_request_decode (zmsg_t *zmsg, const char **topic,
+int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **json_str)
 {
     int type;
     const char *ts, *js;
     int rc = -1;
 
-    if (zmsg == NULL) {
+    if (msg == NULL) {
         errno = EINVAL;
         goto done;
     }
-    if (flux_msg_get_type (zmsg, &type) < 0)
+    if (flux_msg_get_type (msg, &type) < 0)
         goto done;
     if (type != FLUX_MSGTYPE_REQUEST) {
         errno = EPROTO;
         goto done;
     }
-    if (flux_msg_get_topic (zmsg, &ts) < 0)
+    if (flux_msg_get_topic (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+    if (flux_msg_get_payload_json (msg, &js) < 0)
         goto done;
     if ((json_str && !js) || (!json_str && js)) {
         errno = EPROTO;

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -25,6 +25,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <czmq.h>
 #include "request.h"
 #include "message.h"
 #include "info.h"

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -4,9 +4,8 @@
 #include <json.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#include <czmq.h>
 
-#include "handle.h"
+#include "message.h"
 
 /* Decode a request message.
  * If topic is non-NULL, assign the request topic string.
@@ -14,13 +13,13 @@
  * payload is expected and it is an EPROTO error if expectations are not met.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_request_decode (zmsg_t *zmsg, const char **topic,
+int flux_request_decode (flux_msg_t msg, const char **topic,
                          const char **json_str);
 
 /* Encode a response message.
  * If json_str is non-NULL, assign the payload.
  */
-zmsg_t *flux_request_encode (const char *topic, const char *json_str);
+flux_msg_t flux_request_encode (const char *topic, const char *json_str);
 
 #endif /* !_FLUX_CORE_REQUEST_H */
 

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -13,13 +13,13 @@
  * payload is expected and it is an EPROTO error if expectations are not met.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_request_decode (flux_msg_t msg, const char **topic,
+int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **json_str);
 
 /* Encode a response message.
  * If json_str is non-NULL, assign the payload.
  */
-flux_msg_t flux_request_encode (const char *topic, const char *json_str);
+flux_msg_t *flux_request_encode (const char *topic, const char *json_str);
 
 #endif /* !_FLUX_CORE_REQUEST_H */
 

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -25,6 +25,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <czmq.h>
 #include "response.h"
 #include "message.h"
 
@@ -102,7 +103,7 @@ error:
     return NULL;
 }
 
-int flux_respond (flux_t h, const zmsg_t *request,
+int flux_respond (flux_t h, const flux_msg_t request,
                   int errnum, const char *json_str)
 {
     zmsg_t *zmsg = NULL;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -103,10 +103,10 @@ error:
     return NULL;
 }
 
-int flux_respond (flux_t h, const flux_msg_t request,
+int flux_respond (flux_t h, const flux_msg_t *request,
                   int errnum, const char *json_str)
 {
-    flux_msg_t msg = NULL;
+    flux_msg_t *msg = NULL;
 
     if (!request) {
         errno = EINVAL;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -106,26 +106,27 @@ error:
 int flux_respond (flux_t h, const flux_msg_t request,
                   int errnum, const char *json_str)
 {
-    zmsg_t *zmsg = NULL;
+    flux_msg_t msg = NULL;
 
     if (!request) {
         errno = EINVAL;
         goto fatal;
     }
-    if (!(zmsg = flux_msg_copy (request, false)))
+    if (!(msg = flux_msg_copy (request, false)))
         goto fatal;
-    if (flux_msg_set_type (zmsg, FLUX_MSGTYPE_RESPONSE) < 0)
+    if (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) < 0)
         goto fatal;
-    if (errnum && flux_msg_set_errnum (zmsg, errnum) < 0)
+    if (errnum && flux_msg_set_errnum (msg, errnum) < 0)
         goto fatal;
-    if (!errnum && json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+    if (!errnum && json_str && flux_msg_set_payload_json (msg, json_str) < 0)
         goto fatal;
-    if (flux_sendmsg (h, &zmsg) < 0)
+    if (flux_send (h, msg, 0) < 0)
         goto fatal;
-    zmsg_destroy (&zmsg);
+    flux_msg_destroy (msg);
     return 0;
 fatal:
-    zmsg_destroy (&zmsg);
+    if (msg)
+        flux_msg_destroy (msg);
     FLUX_FATAL (h);
     return -1;
 }

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -15,17 +15,17 @@
  * and -1 is returned with no assignments to topic or json_str.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_response_decode (flux_msg_t msg, const char **topic,
+int flux_response_decode (flux_msg_t *msg, const char **topic,
                           const char **json_str);
 
-flux_msg_t flux_response_encode (const char *topic, int errnum,
-                                 const char *json_str);
+flux_msg_t *flux_response_encode (const char *topic, int errnum,
+                                  const char *json_str);
 
 /* Create a response to the provided request message.
  * If errnum is nonzero, payload argument is ignored.
  * All errors in this function are fatal - see flux_fatal_set().
  */
-int flux_respond (flux_t h, const flux_msg_t request,
+int flux_respond (flux_t h, const flux_msg_t *request,
                   int errnum, const char *json_str);
 
 #endif /* !_FLUX_CORE_RESPONSE_H */

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -15,17 +15,17 @@
  * and -1 is returned with no assignments to topic or json_str.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_response_decode (zmsg_t *zmsg, const char **topic,
+int flux_response_decode (flux_msg_t msg, const char **topic,
                           const char **json_str);
 
-zmsg_t *flux_response_encode (const char *topic, int errnum,
-                              const char *json_str);
+flux_msg_t flux_response_encode (const char *topic, int errnum,
+                                 const char *json_str);
 
 /* Create a response to the provided request message.
  * If errnum is nonzero, payload argument is ignored.
  * All errors in this function are fatal - see flux_fatal_set().
  */
-int flux_respond (flux_t h, const zmsg_t *request,
+int flux_respond (flux_t h, const flux_msg_t request,
                   int errnum, const char *json_str);
 
 #endif /* !_FLUX_CORE_RESPONSE_H */

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -99,7 +99,7 @@ static uint32_t lookup_nodeid (flux_rpc_t rpc, uint32_t matchtag)
 static int rpc_request_send (flux_rpc_t rpc, int n, const char *topic,
                              const char *json_str, uint32_t nodeid)
 {
-    flux_msg_t msg;
+    flux_msg_t *msg;
     int flags = 0;
     int rc = -1;
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -42,7 +42,7 @@
 typedef zlist_t zmsglist_t;
 
 struct flux_rpc_struct {
-    flux_match_t m;
+    struct flux_match m;
     flux_t h;
     flux_then_f then_cb;
     void *then_arg;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -3,11 +3,8 @@
 
 #include <json.h>
 #include <stdbool.h>
-#include <stdarg.h>
-#include <czmq.h>
 
 #include "handle.h"
-#include "request.h"
 
 enum {
     FLUX_RPC_NORESPONSE = 1,

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -55,8 +55,8 @@ int flux_sec_ssockinit (flux_sec_t c, void *sock);
  * Be aware that SUB subscriptions will no longer match the message's
  * encoded topic string (you should subscribe to all).
  */
-int flux_sec_munge_zmsg (flux_sec_t c, flux_msg_t *msg);
-int flux_sec_unmunge_zmsg (flux_sec_t c, flux_msg_t *msg);
+int flux_sec_munge_zmsg (flux_sec_t c, flux_msg_t **msg);
+int flux_sec_unmunge_zmsg (flux_sec_t c, flux_msg_t **msg);
 
 /* Retrieve a string describing the last error.
  * This value is valid after one of the above calls returns -1.

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -40,7 +40,7 @@ int flux_sec_keygen (flux_sec_t c, bool force, bool verbose);
 /* Initialize ZAUTH (PLAIN or CURVE) and MUNGE security.
  * Calling these when relevant security modes are disabled is a no-op.
  */
-int flux_sec_zauth_init (flux_sec_t c, zctx_t *zctx, const char *domain);
+int flux_sec_zauth_init (flux_sec_t c, struct _zctx_t *zctx, const char *domain);
 int flux_sec_munge_init (flux_sec_t c);
 
 /* Enable client or server mode ZAUTH security on a zmq socket.

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -1,8 +1,8 @@
 #ifndef _FLUX_CORE_SECURITY_H
 #define _FLUX_CORE_SECURITY_H
 
-#include <czmq.h>
 #include <stdbool.h>
+#include "message.h"
 
 #define DEFAULT_ZAP_DOMAIN      "flux"
 
@@ -49,14 +49,14 @@ int flux_sec_munge_init (flux_sec_t c);
 int flux_sec_csockinit (flux_sec_t c, void *sock);
 int flux_sec_ssockinit (flux_sec_t c, void *sock);
 
-/* Munge/unmunge a zmsg.  The munged message is a single part
+/* Munge/unmunge a msg.  The munged message is a single part
  * containing a munge credential, with the original message encoded
  * inside.  MUNGE_OPT_UID_RESTRICTION is used to obtain privacy.
  * Be aware that SUB subscriptions will no longer match the message's
  * encoded topic string (you should subscribe to all).
  */
-int flux_sec_munge_zmsg (flux_sec_t c, zmsg_t **zmsg);
-int flux_sec_unmunge_zmsg (flux_sec_t c, zmsg_t **zmsg);
+int flux_sec_munge_zmsg (flux_sec_t c, flux_msg_t *msg);
+int flux_sec_unmunge_zmsg (flux_sec_t c, flux_msg_t *msg);
 
 /* Retrieve a string describing the last error.
  * This value is valid after one of the above calls returns -1.

--- a/src/common/libflux/tagpool.c
+++ b/src/common/libflux/tagpool.c
@@ -44,6 +44,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include "tagpool.h"
 #include "message.h"

--- a/src/common/libflux/test/conf.c
+++ b/src/common/libflux/test/conf.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+
 #include "src/common/libflux/conf.h"
 #include "src/common/libtap/tap.h"
 

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -1,4 +1,6 @@
-#include "src/common/libflux/event.h"
+#include <czmq.h>
+#include "message.h"
+#include "event.h"
 #include "src/common/libtap/tap.h"
 
 int main (int argc, char *argv[])

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -1,3 +1,5 @@
+#include <czmq.h>
+#include <errno.h>
 #include "src/common/libflux/message.h"
 #include "src/common/libtap/tap.h"
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -319,12 +319,7 @@ void check_matchtag (void)
 
 void check_cmp (void)
 {
-    flux_match_t match = {
-        .typemask = 0,
-        .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
-        .topic_glob = NULL,
-    };
+    struct flux_match match = FLUX_MATCH_ANY;
     zmsg_t *zmsg;
     ok ((zmsg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "flux_msg_create works");

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -1,4 +1,7 @@
-#include "src/common/libflux/request.h"
+#include <czmq.h>
+#include "message.h"
+#include "request.h"
+
 #include "src/common/libtap/tap.h"
 
 int main (int argc, char *argv[])

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -1,5 +1,7 @@
-#include "src/common/libflux/request.h"
-#include "src/common/libflux/response.h"
+#include <czmq.h>
+#include "message.h"
+#include "request.h"
+#include "response.h"
 #include "src/common/libtap/tap.h"
 
 int main (int argc, char *argv[])

--- a/src/common/libjsonc/rpc.c
+++ b/src/common/libjsonc/rpc.c
@@ -41,7 +41,7 @@ int flux_json_rpc (flux_t h, uint32_t nodeid, const char *topic,
                    JSON in, JSON *out)
 {
     zmsg_t *zmsg = NULL;
-    flux_match_t match = {
+    struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .matchtag = flux_matchtag_alloc (h, 1),
         .bsize = 1,

--- a/src/common/libutil/zfd.c
+++ b/src/common/libutil/zfd.c
@@ -117,13 +117,13 @@ error:
     return NULL;
 }
 
-int zfd_send (int fd, zmsg_t **msg)
+int zfd_send (int fd, zmsg_t *msg)
 {
     uint8_t *buf = NULL;
     int n, len;
     uint32_t nlen;
 
-    len = zmsg_encode (*msg, &buf);
+    len = zmsg_encode (msg, &buf);
     if (len < 0) {
         errno = EPROTO;
         goto error;
@@ -138,7 +138,6 @@ int zfd_send (int fd, zmsg_t **msg)
         goto error;
 
     free (buf);
-    zmsg_destroy (msg);
     return 0;
 error:
     if (buf)

--- a/src/common/libutil/zfd.h
+++ b/src/common/libutil/zfd.h
@@ -11,6 +11,6 @@
  * to read the complete thing.
  */
 zmsg_t *zfd_recv (int fd, bool nonblock);
-int zfd_send (int fd, zmsg_t **msg);
+int zfd_send (int fd, zmsg_t *msg);
 
 #endif /* !_UTIL_ZFD_H */

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -99,18 +99,11 @@ static void sync_msg_watchers  (ctx_t *c);
 
 static const struct flux_handle_ops handle_ops;
 
-static int op_sendmsg (void *impl, zmsg_t **zmsg)
+static int op_send (void *impl, const flux_msg_t msg, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
-    int rc = -1;
-
-    if (zfd_send (c->fd, *zmsg) < 0)
-        goto done;
-    zmsg_destroy (zmsg);
-    rc = 0;
-done:
-    return rc;
+    return zfd_send (c->fd, (flux_msg_t)msg);
 }
 
 static zmsg_t *op_recvmsg_putmsg (ctx_t *c)
@@ -546,7 +539,7 @@ error:
 }
 
 static const struct flux_handle_ops handle_ops = {
-    .sendmsg = op_sendmsg,
+    .send = op_send,
     .recvmsg = op_recvmsg,
     .requeue = op_requeue,
     .purge = op_purge,

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -103,7 +103,14 @@ static int op_sendmsg (void *impl, zmsg_t **zmsg)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
-    return zfd_send (c->fd, zmsg);
+    int rc = -1;
+
+    if (zfd_send (c->fd, *zmsg) < 0)
+        goto done;
+    zmsg_destroy (zmsg);
+    rc = 0;
+done:
+    return rc;
 }
 
 static zmsg_t *op_recvmsg_putmsg (ctx_t *c)

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -99,11 +99,11 @@ static void sync_msg_watchers  (ctx_t *c);
 
 static const struct flux_handle_ops handle_ops;
 
-static int op_send (void *impl, const flux_msg_t msg, int flags)
+static int op_send (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
-    return zfd_send (c->fd, (flux_msg_t)msg);
+    return zfd_send (c->fd, (zmsg_t *)msg);
 }
 
 static zmsg_t *op_recvmsg_putmsg (ctx_t *c)
@@ -127,12 +127,12 @@ static zmsg_t *op_recv (void *impl, int flags)
     return zmsg;
 }
 
-static int op_requeue (void *impl, const flux_msg_t msg, int flags)
+static int op_requeue (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     int rc = -1;
-    flux_msg_t cpy = NULL;
+    flux_msg_t *cpy = NULL;
     int oldcount = zlist_size (c->putmsg);
 
     if (!(cpy = flux_msg_copy (msg, true)))

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -153,7 +153,7 @@ done:
     return rc;
 }
 
-static void op_purge (void *impl, flux_match_t match)
+static void op_purge (void *impl, struct flux_match match)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -116,14 +116,14 @@ static zmsg_t *op_recvmsg_putmsg (ctx_t *c)
     return zmsg;
 }
 
-static zmsg_t *op_recvmsg (void *impl, bool nonblock)
+static zmsg_t *op_recv (void *impl, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     zmsg_t *zmsg = NULL;
 
     if (!(zmsg = op_recvmsg_putmsg (c)))
-        zmsg = zfd_recv (c->fd, nonblock);
+        zmsg = zfd_recv (c->fd, (flags & FLUX_O_NONBLOCK) ? : false);
     return zmsg;
 }
 
@@ -540,7 +540,7 @@ error:
 
 static const struct flux_handle_ops handle_ops = {
     .send = op_send,
-    .recvmsg = op_recvmsg,
+    .recv = op_recv,
     .requeue = op_requeue,
     .purge = op_purge,
     .event_subscribe = op_event_subscribe,

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -96,12 +96,12 @@ static const struct flux_handle_ops handle_ops;
 
 const char *fake_uuid = "12345678123456781234567812345678";
 
-static int op_send (void *impl, const flux_msg_t msg, int flags)
+static int op_send (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     int type;
-    flux_msg_t cpy = NULL;
+    flux_msg_t *cpy = NULL;
     int rc = -1;
 
     if (!(cpy = flux_msg_copy (msg, true)))
@@ -129,22 +129,22 @@ done:
     return rc;
 }
 
-static flux_msg_t op_recv (void *impl, int flags)
+static flux_msg_t *op_recv (void *impl, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
-    flux_msg_t msg = zlist_pop (c->queue);
+    flux_msg_t *msg = zlist_pop (c->queue);
     if (!msg)
         errno = EWOULDBLOCK;
     return msg;
 }
 
-static int op_requeue (void *impl, const flux_msg_t msg, int flags)
+static int op_requeue (void *impl, const flux_msg_t *msg, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     int rc = -1;
-    flux_msg_t cpy = NULL;
+    flux_msg_t *cpy = NULL;
 
     if (!(cpy = flux_msg_copy (msg, true)))
         goto done;

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -129,14 +129,14 @@ done:
     return rc;
 }
 
-static zmsg_t *op_recvmsg (void *impl, bool nonblock)
+static flux_msg_t op_recv (void *impl, int flags)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
-    zmsg_t *zmsg = zlist_pop (c->queue);
-    if (!zmsg)
+    flux_msg_t msg = zlist_pop (c->queue);
+    if (!msg)
         errno = EWOULDBLOCK;
-    return zmsg;
+    return msg;
 }
 
 static int op_requeue (void *impl, const flux_msg_t msg, int flags)
@@ -425,7 +425,7 @@ error:
 
 static const struct flux_handle_ops handle_ops = {
     .send = op_send,
-    .recvmsg = op_recvmsg,
+    .recv = op_recv,
     .requeue = op_requeue,
     .purge = op_purge,
     .event_subscribe = NULL,

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -162,7 +162,7 @@ done:
     return rc;
 }
 
-static void op_purge (void *impl, flux_match_t match)
+static void op_purge (void *impl, struct flux_match match)
 {
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);

--- a/src/modules/api/api.c
+++ b/src/modules/api/api.c
@@ -74,8 +74,9 @@ typedef struct {
 
 static void client_destroy (client_t *c);
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
     zlist_destroy (&ctx->clients);
     free (ctx);
 }
@@ -90,7 +91,7 @@ static ctx_t *getctx (flux_t h)
         if (!(ctx->clients = zlist_new ()))
             oom ();
         ctx->session_owner = geteuid ();
-        flux_aux_set (h, "apisrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "apisrv", ctx, freectx);
     }
 
     return ctx;

--- a/src/modules/api/api.c
+++ b/src/modules/api/api.c
@@ -330,6 +330,10 @@ static int client_cb (flux_t h, int fd, short revents, void *arg)
     return 0;
 }
 
+/* Received response message from broker.
+ * Look up the sender uuid in clients hash and deliver.
+ * Responses for disconnected clients are silently discarded.
+ */
 static int response_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -349,34 +353,33 @@ static int response_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     c = zlist_first (ctx->clients);
     while (c && *zmsg) {
         if (!strcmp (uuid, zuuid_str (c->uuid))) {
-            if (zfd_send (c->fd, zmsg) < 0)
-                zmsg_destroy (zmsg);
+            if (zfd_send (c->fd, *zmsg) < 0)
+                errno = 0; /* ignore send errors, let POLL_ERR handle */
             break;
         }
         c = zlist_next (ctx->clients);
     }
-    if (*zmsg)
-        zmsg_destroy (zmsg); /* discard response for unknown uuid */
     if (uuid)
         free (uuid);
 done:
+    zmsg_destroy (zmsg);
     return 0;
 }
 
+/* Received an event message from broker.
+ * Find all subscribers and deliver.
+ */
 static int event_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
     client_t *c;
-    zmsg_t *cpy;
 
     if (*zmsg) {
         c = zlist_first (ctx->clients);
         while (c) {
             if (subscription_match (c, FLUX_MSGTYPE_EVENT, *zmsg)) {
-                if (!(cpy = zmsg_dup (*zmsg)))
-                    oom ();
-                if (zfd_send (c->fd, &cpy) < 0)
-                    zmsg_destroy (&cpy);
+                if (zfd_send (c->fd, *zmsg) < 0)
+                    errno = 0; /* ignore send errors, let POLL_ERR handle */
             }
             c = zlist_next (ctx->clients);
         }

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -58,8 +58,9 @@ typedef struct _barrier_struct {
 static int exit_event_send (flux_t h, const char *name, int errnum);
 static int timeout_cb (flux_t h, void *arg);
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
     zhash_destroy (&ctx->barriers);
     free (ctx);
 }
@@ -73,7 +74,7 @@ static ctx_t *getctx (flux_t h)
         if (!(ctx->barriers = zhash_new ()))
             oom ();
         ctx->h = h;
-        flux_aux_set (h, "barriersrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "barriersrv", ctx, freectx);
     }
 
     return ctx;

--- a/src/modules/barrier/libbarrier.c
+++ b/src/modules/barrier/libbarrier.c
@@ -35,8 +35,9 @@ typedef struct {
     int seq;
 } ctx_t;
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
     free (ctx);
 }
 
@@ -49,7 +50,7 @@ static ctx_t *getctx (flux_t h)
             return NULL;
         ctx = xzmalloc (sizeof (*ctx));
         ctx->id = id;
-        flux_aux_set (h, "barriercli", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "barriercli", ctx, freectx);
     }
     return ctx;
 }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -178,8 +178,9 @@ static int setroot_event_send (ctx_t *ctx, const char *fence);
 static void commit_respond (ctx_t *ctx, zmsg_t **zmsg, const char *sender,
                             const char *rootdir, int rootseq);
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
     if (ctx->store)
         zhash_destroy (&ctx->store);
     if (ctx->commits)
@@ -206,7 +207,7 @@ static ctx_t *getctx (flux_t h)
         ctx->watchlist = wait_queue_create ();
         ctx->h = h;
         ctx->master = flux_treeroot (h);
-        flux_aux_set (h, "kvssrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "kvssrv", ctx, freectx);
     }
 
     return ctx;

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -83,8 +83,9 @@ typedef struct {
 
 static int watch_rep_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg);
 
-static void freectx (kvsctx_t *ctx)
+static void freectx (void *arg)
 {
+    kvsctx_t *ctx = arg;
     zhash_destroy (&ctx->watchers);
     zlist_destroy (&ctx->dirstack);
     free (ctx->cwd);
@@ -103,7 +104,7 @@ static kvsctx_t *getctx (flux_t h)
             oom ();
         if (!(ctx->cwd = xstrdup (".")))
             oom ();
-        flux_aux_set (h, "kvscli", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "kvscli", ctx, freectx);
     }
     return ctx;
 }

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -639,8 +639,8 @@ done:
 static int watch_rpc (flux_t h, const char *key, JSON *val,
                       bool once, bool directory, uint32_t *matchtag)
 {
-    flux_match_t match = { .typemask = FLUX_MSGTYPE_RESPONSE, .bsize = 0,
-                           .topic_glob = NULL };
+    struct flux_match match = { .typemask = FLUX_MSGTYPE_RESPONSE, .bsize = 0,
+                                .topic_glob = NULL };
     JSON in = NULL;
     JSON out = NULL;
     zmsg_t *zmsg = NULL;

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -110,8 +110,9 @@ static int jsc_job_state2num (const char *s)
     return -1;
 }
 
-static void freectx (jscctx_t *ctx)
+static void freectx (void *arg)
 {
+    jscctx_t *ctx = arg;
     zhash_destroy (&(ctx->active_jobs));
     zlist_destroy (&(ctx->callbacks));
 }
@@ -127,7 +128,7 @@ static jscctx_t *getctx (flux_t h)
             oom ();
         ctx->first_time = 1;
         ctx->h = h;
-        flux_aux_set (h, "jstatctrl", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "jstatctrl", ctx, freectx);
     }
     return ctx;
 }

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -141,8 +141,9 @@ static const int reduce_timeout_slave_msec = 10;
 static void ns_chg_one (ctx_t *ctx, uint32_t r, cstate_t from, cstate_t to);
 static int ns_sync (ctx_t *ctx);
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
     parent_t *p;
 
     while ((p = zlist_pop (ctx->parents)))
@@ -179,7 +180,7 @@ static ctx_t *getctx (flux_t h)
         else
             flux_red_set_timeout_msec (ctx->r, reduce_timeout_slave_msec);
         ctx->h = h;
-        flux_aux_set (h, "livesrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "livesrv", ctx, freectx);
     }
     return ctx;
 }

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -62,8 +62,9 @@ struct rexec_session {
     void *zs_rep;   /* replies to client requests (zbind) */
 };
 
-static void freectx (struct rexec_ctx *ctx)
+static void freectx (void *arg)
 {
+    struct rexec_ctx *ctx = arg;
     zlist_destroy (&ctx->session_list);
     free (ctx);
 }
@@ -91,7 +92,7 @@ static struct rexec_ctx *getctx (flux_t h)
             oom ();
         ctx->h = h;
         ctx->nodeid = flux_rank (h);
-        flux_aux_set (h, "wrexec", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "wrexec", ctx, freectx);
         kvs_watch_string (h, "config.wrexec.wrexecd_path",
             wrexec_path_set, (void *) ctx);
     }

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -369,12 +369,7 @@ enforce_c_consistency (kap_params_t *param)
     const char *tag = NULL;
     int v = 0;
     json_object *o = NULL;
-    flux_match_t match = {
-        .typemask = FLUX_MSGTYPE_EVENT,
-        .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
-        .topic_glob = NULL,
-    };
+    struct flux_match match = FLUX_MATCH_EVENT;
 
     zmsg_t * msg = flux_recvmsg_match (param->pers.handle, match, false);
     if ( ! msg ) {

--- a/src/test/request/req.c
+++ b/src/test/request/req.c
@@ -14,8 +14,9 @@ typedef struct {
     zlist_t *clog_requests;
 } ctx_t;
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
     zlist_t *keys = zhash_keys (ctx->ping_requests);
     char *key = zlist_first (keys);
     while (key) {
@@ -45,7 +46,7 @@ static ctx_t *getctx (flux_t h)
             oom ();
         if (!(ctx->clog_requests = zlist_new ()))
             oom ();
-        flux_aux_set (h, "req", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "req", ctx, freectx);
     }
     return ctx;
 }

--- a/src/test/request/treq.c
+++ b/src/test/request/treq.c
@@ -251,8 +251,9 @@ void test_putmsg (flux_t h, uint32_t nodeid)
                 oom ();
             if (seq == defer_start + defer_count - 1) {
                 while ((z = zlist_pop (defer))) {
-                    if (flux_putmsg (h, &z) < 0)
-                        err_exit ("%s: flux_putmsg", __FUNCTION__);
+                    if (flux_requeue (h, z, FLUX_RQ_TAIL) < 0)
+                        err_exit ("%s: flux_requeue", __FUNCTION__);
+                    zmsg_destroy (&z);
                 }
                 popped = true;
             }

--- a/src/test/tenc.c
+++ b/src/test/tenc.c
@@ -151,10 +151,11 @@ void encode (void)
         o = buf_to_json (seq, buf, n);
         assert (o != NULL);
         zmsg = json_to_zmsg (o);
-        if (zfd_send (STDOUT_FILENO, &zmsg) < 0) {
+        if (zfd_send (STDOUT_FILENO, zmsg) < 0) {
             perror ("zfd_send");
             exit (1);
         }
+        zmsg_destroy (&zmsg);
         json_object_put (o);
         seq++;
     }

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -1,3 +1,5 @@
+#include <czmq.h>
+#include "src/common/libflux/message.h"
 #include "src/common/libflux/handle.h"
 #include "src/common/libflux/rpc.h"
 #include "src/common/libflux/request.h"

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -1,3 +1,5 @@
+#include <czmq.h>
+#include "src/common/libflux/message.h"
 #include "src/common/libflux/handle.h"
 #include "src/common/libflux/rpc.h"
 #include "src/common/libflux/request.h"


### PR DESCRIPTION
As discussed in #168, this PR replaces `zmsg_t *` in the Flux public API with `flux_msg_t`.  This PR is for feedback not for merging.

Right now, `flux_msg_t` and `zmsg_t *` are interchangeable, both defined in terms of the same incomplete type `struct _zmsg_t`.  This makes transitioning a bit easier.  Although internally there are still a lot of zmsgs, I believe after this PR libflux-core should no longer require users to link against czmq/zeromq.

Freed from following czmq's API design so much, some public Flux interfaces were also changed (improved?)

There is one new message function:
```
void flux_msg_destroy (flux_msg_t msg); // to be used instead of zmsg_destroy
```

There are new low-level send/recv functions:
```
int flux_send (flux_t h, const flux_msg_t msg, int flags); // flags: unused
flux_msg_t flux_recv (flux_t h, flux_match_t match, int flags); // flags: FLUX_O_NONBLOCK
int flux_requeue (flux_t h, const flux_msg_t msg, int flags); // flags: FLUX_RQ_HEAD or _TAIL
```
These replace the following functions (still available during transition):
```
int flux_sendmsg (flux_t h, zmsg_t **zmsg); // free on success
zmsg_t *flux_recvmsg (flux_t h, bool nonblock);
zmsg_t *flux_recvmsg_match (flux_t h, flux_match_t match, bool nonblock);
int flux_putmsg (flux_t h, zmsg_t **zmsg); // requeue to tail, free on success
int flux_pushmsg (flux_t h, zmsg_t **zmsg);  // requeue to head, free on success
```