### PR TITLE
flux-start: use srun --mpi=none

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -315,6 +315,7 @@ void start_slurm (optparse_t p, const char *cmd)
     add_arg (&argz, &argz_len, "--job-name=%s", "flux");
     if (partition)
         add_arg (&argz, &argz_len, "--partition=%s", partition);
+    add_arg (&argz, &argz_len, "--mpi=none");
 
     add_arg (&argz, &argz_len, "%s", broker_path);
     add_arg (&argz, &argz_len, "--pmi-boot");


### PR DESCRIPTION
This avoids a situation where an MPI program linked against the
old non-PMI mvapich and run by Flux, which is being run under Slurm,
thinks it is Slurm's job step 0, and gets the whole session killed
by connecting to srun and aborting.

The MPIRUN_* environment variables set by SLURM to facilitate PMGR
based MPI bootstrap are not set when --mpi=none is used.  This has
no impact on PMI based MPI.

Fixes issue #220