### PR TITLE
fix memory leak and log decoding

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1271,9 +1271,15 @@ static int cmb_log_cb (zmsg_t **zmsg, void *arg)
     ctx_t *ctx = arg;
     const char *json_str;
 
-    if (flux_response_decode (*zmsg, NULL, &json_str) < 0)
+    if (flux_request_decode (*zmsg, NULL, &json_str) < 0) {
+        msg ("%s: decode error", __FUNCTION__);
         goto done;
-    (void)flux_log_json (ctx->h, json_str);
+    }
+    if (flux_log_json (ctx->h, json_str) < 0) {
+        msg ("%s: flux_log_json %s: %s", __FUNCTION__, json_str,
+             strerror (errno));
+        goto done;
+    }
 done:
     zmsg_destroy (zmsg); /* no reply */
     return 0;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -368,10 +368,10 @@ static int defer_requeue (zlist_t **l, flux_t h)
     flux_msg_t *msg;
     if (*l) {
         while ((msg = zlist_pop (*l))) {
-            if (flux_requeue (h, msg, FLUX_RQ_TAIL) < 0) {
-                flux_msg_destroy (msg);
+            int rc = flux_requeue (h, msg, FLUX_RQ_TAIL);
+            flux_msg_destroy (msg);
+            if (rc < 0)
                 return -1;
-            }
         }
     }
     return 0;


### PR DESCRIPTION
A couple of fixes arising from recent API rework churn:
* bad memory leak found by @grondo
* log decoding prob found by @SteVwonder 