### PR TITLE
use base64 for encoding "data" in json and kvs

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -53,7 +53,8 @@ TESTS = test_nodeset.t \
 	test_subprocess.t \
 	test_ev.t \
 	test_coproc.t \
-	test_base64.t
+	test_base64.t \
+	test_encode.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -95,3 +96,7 @@ test_coproc_t_LDADD = $(test_ldadd)
 test_base64_t_SOURCES = test/base64_test.c
 test_base64_t_CPPFLAGS = $(test_cppflags)
 test_base64_t_LDADD = $(test_ldadd)
+
+test_encode_t_SOURCES = test/encode.c
+test_encode_t_CPPFLAGS = $(test_cppflags)
+test_encode_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -52,7 +52,8 @@ TESTS = test_nodeset.t \
 	test_optparse.t \
 	test_subprocess.t \
 	test_ev.t \
-	test_coproc.t
+	test_coproc.t \
+	test_base64.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -90,3 +91,7 @@ test_ev_t_LDADD = $(test_ldadd)
 test_coproc_t_SOURCES = test/coproc.c
 test_coproc_t_CPPFLAGS = $(test_cppflags)
 test_coproc_t_LDADD = $(test_ldadd)
+
+test_base64_t_SOURCES = test/base64_test.c
+test_base64_t_CPPFLAGS = $(test_cppflags)
+test_base64_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -42,7 +42,9 @@ libutil_la_SOURCES = \
 	ev_zlist.c \
 	ev_zlist.h \
 	coproc.c \
-	coproc.h
+	coproc.h \
+	base64.c \
+	base64.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/base64.c
+++ b/src/common/libutil/base64.c
@@ -1,0 +1,441 @@
+/*****************************************************************************
+ *  $Id$
+ *****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <http://home.gna.org/munge/>.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <assert.h>
+#include <string.h>
+#include "base64.h"
+
+
+/*****************************************************************************
+ *  Notes
+ *****************************************************************************/
+/*
+ *  For details on base64 encoding/decoding, refer to
+ *    rfc2440 (OpenPGP Message Format) sections 6.3-6.5.
+ *
+ *  Why am I not using OpenSSL's base64 encoding/decoding functions?
+ *    Because they have the following fucked functionality:
+ *  For base64-encoding, use of the context results in output that is broken
+ *    into 64-character lines; however, EVP_EncodeBlock() output is not broken.
+ *  For base64-decoding, use of the context returns the correct length of the
+ *    resulting output; however, EVP_DecodeBlock() returns a length that may
+ *    be up to two characters too long.
+ *  Finally, data base64-encoded via a context has to be decoded via a context,
+ *    and data base64-encoded w/o a context has to be decoded w/o a context.
+ *  So fuck it, I wrote my own.  :-P
+ */
+
+/*****************************************************************************
+ *  Constants
+ *****************************************************************************/
+
+#define BASE64_MAGIC    0xDEADBEEF
+#define BASE64_ERR      0xFF
+#define BASE64_IGN      0xFE
+#define BASE64_PAD      0xFD
+#define BASE64_PAD_CHAR '='
+
+
+/*****************************************************************************
+ *  Static Variables
+ *****************************************************************************/
+
+static const unsigned char bin2asc[] = \
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static const unsigned char asc2bin[256] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0xfe,
+    0xfe, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3e, 0xff, 0xff, 0xff, 0x3f,
+    0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0xff, 0xff,
+    0xff, 0xfd, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+    0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12,
+    0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24,
+    0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+    0x31, 0x32, 0x33, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff
+};
+
+
+/*****************************************************************************
+ *  Extern Functions
+ *****************************************************************************/
+
+int
+base64_init (base64_ctx *x)
+{
+    assert (x != NULL);
+
+    x->num = 0;
+    x->pad = 0;
+    assert (x->magic = BASE64_MAGIC);
+    assert (!(x->finalized = 0));
+    return (0);
+}
+
+
+int
+base64_encode_update (base64_ctx *x, void *vdst, int *dstlen,
+                      const void *vsrc, int srclen)
+{
+    int n;
+    int num_read;
+    int num_write;
+    unsigned char *dst = (unsigned char *) vdst;
+    unsigned char *src = (unsigned char *) vsrc;
+
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+    assert (x->finalized != 1);
+    assert (dst != NULL);
+    assert (dstlen != NULL);
+    assert (src != NULL);
+
+    num_write = 0;
+
+    if (srclen <= 0) {
+        return (0);
+    }
+    /*  Encode leftover data if context buffer can be filled.
+     */
+    if ((x->num > 0) && (srclen >= (num_read = 3 - x->num))) {
+        memcpy (&x->buf[x->num], src, num_read);
+        src += num_read;
+        srclen -= num_read;
+        base64_encode_block (dst, &n, x->buf, 3);
+        x->num = 0;
+        dst += n;
+        num_write += n;
+    }
+    /*  Encode maximum amount of data w/o requiring a pad.
+     */
+    if (srclen >= 3) {
+        num_read = (srclen / 3) * 3;
+        base64_encode_block (dst, &n, src, num_read);
+        src += num_read;
+        srclen -= num_read;
+        num_write += n;
+    }
+    /*  Save leftover data for the next update() or final().
+     */
+    if (srclen > 0) {
+        memcpy (&x->buf[x->num], src, srclen);
+        x->num += srclen;
+    }
+    *dstlen = num_write;
+    return (0);
+}
+
+
+int
+base64_encode_final (base64_ctx *x, void *dst, int *dstlen)
+{
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+    assert (x->finalized != 1);
+    assert (dst != NULL);
+    assert (dstlen != NULL);
+
+    /*  Encode leftover data from the previous update().
+     */
+    if (x->num > 0) {
+        base64_encode_block (dst, dstlen, x->buf, x->num);
+        x->num = 0;
+    }
+    else {
+        *dstlen = 0;
+    }
+    assert (x->finalized = 1);
+    return (0);
+}
+
+
+int
+base64_decode_update (base64_ctx *x, void *dst, int *dstlen,
+                      const void *src, int srclen)
+{
+/*  Context [x] should only be NULL when called via base64_decode_block().
+ */
+    int                  i = 0;
+    int                  err = 0;
+    int                  pad = 0;
+    unsigned char       *pdst;
+    const unsigned char *psrc;
+    const unsigned char *psrc_last;
+    unsigned char        c;
+
+    assert ((x == NULL) || (x->magic == BASE64_MAGIC));
+    assert ((x == NULL) || (x->finalized != 1));
+    assert (dst != NULL);
+    assert (dstlen != NULL);
+    assert (src != NULL);
+
+    pdst = dst;
+    psrc = src;
+    psrc_last = psrc + srclen;
+
+    /*  Restore context.
+     */
+    if (x != NULL) {
+        i = x->num;
+        pad = x->pad;
+        *pdst = x->buf[0];
+    }
+    while (psrc < psrc_last) {
+        c = asc2bin[*psrc++];
+        if (c == BASE64_IGN) {
+            continue;
+        }
+        if ((c == BASE64_PAD) && (pad < 2)) {
+            pad++;
+            continue;
+        }
+        if ((c == BASE64_ERR) || (pad > 0)) {
+            err++;
+            break;
+        }
+        switch (i) {
+            case 0:
+                *pdst    = (c << 2) & 0xfc;
+                break;
+            case 1:
+                *pdst++ |= (c >> 4) & 0x03;
+                *pdst    = (c << 4) & 0xf0;
+                break;
+            case 2:
+                *pdst++ |= (c >> 2) & 0x0f;
+                *pdst    = (c << 6) & 0xc0;
+                break;
+            case 3:
+                *pdst++ |= (c     ) & 0x3f;
+                break;
+        }
+        i = (i + 1) % 4;
+    }
+    /*  Save context.
+     */
+    if (x != NULL) {
+        x->num = i;
+        x->pad = pad;
+        x->buf[0] = *pdst;
+    }
+    /*  Check for the correct amount of padding.
+     */
+    else if (!err) {
+        err = (((i + pad) % 4) != 0);
+    }
+    *pdst = '\0';
+    *dstlen = pdst - (unsigned char *) dst;
+    return (err ? -1 : 0);
+}
+
+
+int
+base64_decode_final (base64_ctx *x, void *dst, int *dstlen)
+{
+    int rc = 0;
+
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+    assert (x->finalized != 1);
+
+    if (((x->num + x->pad) % 4) != 0) {
+        rc = -1;
+    }
+    *dstlen = 0;
+    assert (x->finalized = 1);
+    return (rc);
+}
+
+
+int
+base64_cleanup (base64_ctx *x)
+{
+    assert (x != NULL);
+    assert (x->magic == BASE64_MAGIC);
+
+    memset (x, 0, sizeof (*x));
+    assert (x->magic = ~BASE64_MAGIC);
+    return (0);
+}
+
+
+int
+base64_encode_block (void *dst, int *dstlen, const void *src, int srclen)
+{
+    unsigned char       *pdst;
+    const unsigned char *psrc;
+    int                  n;
+
+    pdst = dst;
+    psrc = src;
+    n = 0;
+    while (srclen >= 3) {
+        *pdst++ = bin2asc[ (psrc[0] >> 2) & 0x3f];
+        *pdst++ = bin2asc[((psrc[0] << 4) & 0x30) | ((psrc[1] >> 4) & 0x0f)];
+        *pdst++ = bin2asc[((psrc[1] << 2) & 0x3c) | ((psrc[2] >> 6) & 0x03)];
+        *pdst++ = bin2asc[ (psrc[2]     ) & 0x3f];
+        psrc += 3;
+        srclen -= 3;
+        n += 4;
+    }
+    if (srclen == 2) {
+        *pdst++ = bin2asc[ (psrc[0] >> 2) & 0x3f];
+        *pdst++ = bin2asc[((psrc[0] << 4) & 0x30) | ((psrc[1] >> 4) & 0x0f)];
+        *pdst++ = bin2asc[ (psrc[1] << 2) & 0x3c];
+        *pdst++ = '=';
+        n += 4;
+    }
+    else if (srclen == 1) {
+        *pdst++ = bin2asc[ (psrc[0] >> 2) & 0x3f];
+        *pdst++ = bin2asc[ (psrc[0] << 4) & 0x30];
+        *pdst++ = '=';
+        *pdst++ = '=';
+        n += 4;
+    }
+    *pdst = '\0';
+    *dstlen = n;
+    return (0);
+}
+
+
+int
+base64_decode_block (void *dst, int *dstlen, const void *src, int srclen)
+{
+    return (base64_decode_update (NULL, dst, dstlen, src, srclen));
+}
+
+
+int
+base64_encode_length (int srclen)
+{
+/*  When encoding, 3 bytes are encoded into 4 characters.
+ *  Add 2 bytes to ensure a partial 3-byte chunk will be accounted for
+ *    during integer division, then add 1 byte for the terminating NUL.
+ */
+    return (((srclen + 2) / 3) * 4) + 1;
+}
+
+
+int
+base64_decode_length (int srclen)
+{
+/*  When decoding, 4 characters are decoded into 3 bytes.
+ *  Add 3 bytes to ensure a partial 4-byte chunk will be accounted for
+ *    during integer division, then add 1 byte for the terminating NUL.
+ */
+    return (((srclen + 3) / 4) * 3) + 1;
+}
+
+
+/*****************************************************************************
+ *  Table Initialization Routines
+ *****************************************************************************/
+
+#ifdef BASE64_INIT
+
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define BASE64_DEF_COLS 12
+
+
+void base64_build_table (unsigned char *data, int len);
+void base64_print_table (unsigned char *data, int len, char *name, int col);
+
+
+int
+main (int argc, char *argv[])
+{
+    int col;
+    unsigned char a2b[256];
+
+    col = (argc > 1) ? atoi (argv[1]) : BASE64_DEF_COLS;
+
+    base64_build_table (a2b, sizeof (a2b));
+    base64_print_table (a2b, sizeof (a2b), "asc2bin", col);
+    exit (EXIT_SUCCESS);
+}
+
+
+void
+base64_build_table (unsigned char *data, int len)
+{
+    int i;
+
+    for (i = 0; i < len; i++)
+        data[i] = (isspace (i)) ? BASE64_IGN : BASE64_ERR;
+    for (i = strlen (bin2asc) - 1; i >= 0; i--)
+        data[bin2asc[i]] = i;
+    data[BASE64_PAD_CHAR] = BASE64_PAD;
+    return;
+}
+
+
+void
+base64_print_table (unsigned char *data, int len, char *name, int col)
+{
+    int i;
+    int n;
+
+    if (col < 1) {
+       col = BASE64_DEF_COLS;
+    }
+    printf ("static const unsigned char %s[%d] = {", name, len);
+
+    for (i=0, n=len-1; ; i++) {
+        if ((i % col) == 0)
+            printf ("\n    ");
+        printf ("0x%02x", data[i]);
+        if (i == n)
+            break;
+        printf (", ");
+    }
+    printf ("\n};\n");
+    return;
+}
+
+
+#endif /* BASE64_INIT */

--- a/src/common/libutil/base64.h
+++ b/src/common/libutil/base64.h
@@ -1,0 +1,132 @@
+/*****************************************************************************
+ *  $Id$
+ *****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <http://home.gna.org/munge/>.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#ifndef BASE64_H
+#define BASE64_H
+
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+
+/*****************************************************************************
+ *  Data Types
+ *****************************************************************************/
+
+typedef struct {
+    unsigned char       buf[3];
+    int                 num;
+    int                 pad;
+#ifndef NDEBUG
+    int                 magic;
+    int                 finalized;
+#endif /* !NDEBUG */
+} base64_ctx;
+
+
+/*****************************************************************************
+ *  Prototypes
+ *****************************************************************************/
+
+int base64_init (base64_ctx *x);
+/*
+ *  Initializes the base64 context [x] for base64 encoding/decoding of data.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_update (base64_ctx *x, void *dst, int *dstlen,
+                          const void *src, int srclen);
+/*
+ *  Updates the base64 context [x], encoding [srclen] bytes from [src]
+ *    into [dst], and setting [dstlen] to the number of bytes written.
+ *  This can be called multiple times to process successive blocks of data.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_final (base64_ctx *x, void *dst, int *dstlen);
+/*
+ *  Finalizes the base64 context [x], encoding the "final" data remaining
+ *    in a partial block into [dst], and setting [dstlen] to the number of
+ *    bytes written.
+ *  After calling this function, no further updates should be made to [x]
+ *    without re-initializing it first.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_decode_update (base64_ctx *x, void *dst, int *dstlen,
+                          const void *src, int srclen);
+/*
+ *  Updates the base64 context [x], decoding [srclen] bytes from [src]
+ *    into [dst], and setting [dstlen] to the number of bytes written.
+ *  This can be called multiple times to process successive blocks of data.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_decode_final (base64_ctx *x, void *dst, int *dstlen);
+/*
+ *  Finalizes the base64 context [x], decoding the "final" data remaining
+ *    in a partial block into [dst], and setting [dstlen] to the number of
+ *    bytes written.
+ *  After calling this function, no further updates should be made to [x]
+ *    without re-initializing it first.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_cleanup (base64_ctx *x);
+/*
+ *  Clears the base64 context [x].
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_block (void *dst, int *dstlen, const void *src, int srclen);
+/*
+ *  Base64-encodes [srclen] bytes from the contiguous [src] into [dst].
+ *    If [dstlen] is not NULL, it will be set to the number of bytes written.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_decode_block (void *dst, int *dstlen, const void *src, int srclen);
+/*
+ *  Base64-decodes [srclen] bytes from the contiguous [src] into [dst].
+ *    If [dstlen] is not NULL, it will be set to the number of bytes written.
+ *  Returns 0 on success, or -1 on error.
+ */
+
+int base64_encode_length (int srclen);
+/*
+ *  Returns the size (in bytes) of the destination memory block required
+ *    for base64 encoding a block of [srclen] bytes.
+ */
+
+int base64_decode_length (int srclen);
+/*
+ *  Returns the size (in bytes) of the destination memory block required
+ *    for base64 decoding a block of [srclen] bytes.
+ */
+
+
+#endif /* !BASE64_H */

--- a/src/common/libutil/jsonutil.h
+++ b/src/common/libutil/jsonutil.h
@@ -1,6 +1,7 @@
 #ifndef _UTIL_JSONUTIL_H
 #define _UTIL_JSONUTIL_H
 
+#include <stdbool.h>
 #include <json.h>
 
 /* Calculate encoded size of JSON object.

--- a/src/common/libutil/test/base64_test.c
+++ b/src/common/libutil/test/base64_test.c
@@ -1,0 +1,173 @@
+/*****************************************************************************
+ *  $Id$
+ *****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2010 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <http://home.gna.org/munge/>.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "base64.h"
+
+
+/*  Test cases from rfc2440 (OpenPGP Message Format)
+ *    section 6.5 (Examples of Radix-64).
+ */
+
+int validate       (const unsigned char *src, const unsigned char *dst);
+int encode_block   (unsigned char *dst, int *dstlen,
+                    const unsigned char *src, int srclen);
+int encode_context (unsigned char *dst, int *dstlen,
+                    const unsigned char *src, int srclen);
+int decode_block   (unsigned char *dst, int *dstlen,
+                    const unsigned char *src, int srclen);
+int decode_context (unsigned char *dst, int *dstlen,
+                    const unsigned char *src, int srclen);
+
+
+int
+main (int argc, char *argv[])
+{
+    const unsigned char src1[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e, 0x00 };
+    const unsigned char src2[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x00 };
+    const unsigned char src3[] = { 0x14, 0xfb, 0x9c, 0x03, 0x00 };
+
+    const unsigned char dst1[] = "FPucA9l+";
+    const unsigned char dst2[] = "FPucA9k=";
+    const unsigned char dst3[] = "FPucAw==";
+
+    if ( (validate (src1, dst1) < 0)
+      || (validate (src2, dst2) < 0)
+      || (validate (src3, dst3) < 0) ) {
+        exit (EXIT_FAILURE);
+    }
+    exit (EXIT_SUCCESS);
+}
+
+
+int
+validate (const unsigned char *src, const unsigned char *dst)
+{
+    int n;
+    unsigned char buf[9];
+
+    if (encode_block (buf, &n, src, strlen (src)) < 0)
+        return (-1);
+    if (n != strlen (dst))
+        return (-1);
+    if (strncmp (dst, buf, n))
+        return (-1);
+
+    if (decode_block (buf, &n, dst, strlen (dst)) < 0)
+        return (-1);
+    if (n != strlen (src))
+        return (-1);
+    if (strncmp (src, buf, n))
+        return (-1);
+
+    if (encode_context (buf, &n, src, strlen (src)) < 0)
+        return (-1);
+    if (n != strlen (dst))
+        return (-1);
+    if (strncmp (dst, buf, n))
+        return (-1);
+
+    if (decode_context (buf, &n, dst, strlen (dst)) < 0)
+        return (-1);
+    if (n != strlen (src))
+        return (-1);
+    if (strncmp (src, buf, n))
+        return (-1);
+
+    return (0);
+}
+
+
+int
+encode_block (unsigned char *dst, int *dstlen,
+              const unsigned char *src, int srclen)
+{
+    return (base64_encode_block (dst, dstlen, src, srclen));
+}
+
+
+int
+encode_context (unsigned char *dst, int *dstlen,
+                const unsigned char *src, int srclen)
+{
+    base64_ctx x;
+    int i;
+    int n;
+    int m;
+
+    if (base64_init (&x) < 0)
+        return (-1);
+    for (i=0, n=0; i<srclen; i++) {
+        if (base64_encode_update (&x, dst, &m, src + i, 1) < 0)
+            return (-1);
+        dst += m;
+        n += m;
+    }
+    if (base64_encode_final (&x, dst, &m) < 0)
+        return (-1);
+    if (base64_cleanup (&x) < 0)
+        return (-1);
+    n += m;
+    *dstlen = n;
+    return (0);
+}
+
+
+int
+decode_block (unsigned char *dst, int *dstlen,
+              const unsigned char *src, int srclen)
+{
+    return (base64_decode_block (dst, dstlen, src, srclen));
+}
+
+
+int
+decode_context (unsigned char *dst, int *dstlen,
+                const unsigned char *src, int srclen)
+{
+    base64_ctx x;
+    int i;
+    int n;
+    int m;
+
+    if (base64_init (&x) < 0)
+        return (-1);
+    for (i=0, n=0; i<srclen; i++) {
+        if (base64_decode_update (&x, dst, &m, src + i, 1) < 0)
+            return (-1);
+        dst += m;
+        n += m;
+    }
+    if (base64_decode_final (&x, dst, &m) < 0)
+        return (-1);
+    if (base64_cleanup (&x) < 0)
+        return (-1);
+    n += m;
+    *dstlen = n;
+    return (0);
+}

--- a/src/common/libutil/test/base64_test.c
+++ b/src/common/libutil/test/base64_test.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include "base64.h"
 
+#include <src/common/libtap/tap.h>
+
 
 /*  Test cases from rfc2440 (OpenPGP Message Format)
  *    section 6.5 (Examples of Radix-64).
@@ -56,12 +58,13 @@ main (int argc, char *argv[])
     const  char dst2[] = "FPucA9k=";
     const  char dst3[] = "FPucAw==";
 
-    if ( (validate (src1, dst1) < 0)
-      || (validate (src2, dst2) < 0)
-      || (validate (src3, dst3) < 0) ) {
-        exit (EXIT_FAILURE);
-    }
-    exit (EXIT_SUCCESS);
+    plan (3);
+
+    ok (validate (src1, dst1) >= 0, "checking base64 pattern 1");
+    ok (validate (src2, dst2) >= 0, "checking base64 pattern 2");
+    ok (validate (src3, dst3) >= 0, "checking base64 pattern 3");
+
+    done_testing ();
 }
 
 

--- a/src/common/libutil/test/base64_test.c
+++ b/src/common/libutil/test/base64_test.c
@@ -34,27 +34,27 @@
  *    section 6.5 (Examples of Radix-64).
  */
 
-int validate       (const unsigned char *src, const unsigned char *dst);
-int encode_block   (unsigned char *dst, int *dstlen,
-                    const unsigned char *src, int srclen);
-int encode_context (unsigned char *dst, int *dstlen,
-                    const unsigned char *src, int srclen);
-int decode_block   (unsigned char *dst, int *dstlen,
-                    const unsigned char *src, int srclen);
-int decode_context (unsigned char *dst, int *dstlen,
-                    const unsigned char *src, int srclen);
+int validate       (const  char *src, const  char *dst);
+int encode_block   ( char *dst, int *dstlen,
+                    const  char *src, int srclen);
+int encode_context ( char *dst, int *dstlen,
+                    const  char *src, int srclen);
+int decode_block   ( char *dst, int *dstlen,
+                    const  char *src, int srclen);
+int decode_context ( char *dst, int *dstlen,
+                    const  char *src, int srclen);
 
 
 int
 main (int argc, char *argv[])
 {
-    const unsigned char src1[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e, 0x00 };
-    const unsigned char src2[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x00 };
-    const unsigned char src3[] = { 0x14, 0xfb, 0x9c, 0x03, 0x00 };
+    const  char src1[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e, 0x00 };
+    const  char src2[] = { 0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x00 };
+    const  char src3[] = { 0x14, 0xfb, 0x9c, 0x03, 0x00 };
 
-    const unsigned char dst1[] = "FPucA9l+";
-    const unsigned char dst2[] = "FPucA9k=";
-    const unsigned char dst3[] = "FPucAw==";
+    const  char dst1[] = "FPucA9l+";
+    const  char dst2[] = "FPucA9k=";
+    const  char dst3[] = "FPucAw==";
 
     if ( (validate (src1, dst1) < 0)
       || (validate (src2, dst2) < 0)
@@ -66,10 +66,10 @@ main (int argc, char *argv[])
 
 
 int
-validate (const unsigned char *src, const unsigned char *dst)
+validate (const  char *src, const  char *dst)
 {
     int n;
-    unsigned char buf[9];
+     char buf[9];
 
     if (encode_block (buf, &n, src, strlen (src)) < 0)
         return (-1);
@@ -104,16 +104,16 @@ validate (const unsigned char *src, const unsigned char *dst)
 
 
 int
-encode_block (unsigned char *dst, int *dstlen,
-              const unsigned char *src, int srclen)
+encode_block ( char *dst, int *dstlen,
+              const  char *src, int srclen)
 {
     return (base64_encode_block (dst, dstlen, src, srclen));
 }
 
 
 int
-encode_context (unsigned char *dst, int *dstlen,
-                const unsigned char *src, int srclen)
+encode_context ( char *dst, int *dstlen,
+                const  char *src, int srclen)
 {
     base64_ctx x;
     int i;
@@ -139,16 +139,16 @@ encode_context (unsigned char *dst, int *dstlen,
 
 
 int
-decode_block (unsigned char *dst, int *dstlen,
-              const unsigned char *src, int srclen)
+decode_block ( char *dst, int *dstlen,
+              const  char *src, int srclen)
 {
     return (base64_decode_block (dst, dstlen, src, srclen));
 }
 
 
 int
-decode_context (unsigned char *dst, int *dstlen,
-                const unsigned char *src, int srclen)
+decode_context ( char *dst, int *dstlen,
+                const  char *src, int srclen)
 {
     base64_ctx x;
     int i;

--- a/src/common/libutil/test/encode.c
+++ b/src/common/libutil/test/encode.c
@@ -1,0 +1,42 @@
+#include <string.h>
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/jsonutil.h"
+
+static void *myfatal_h = NULL;
+
+void myfatal (void *h, int exit_code, const char *fmt, ...)
+{
+    myfatal_h = h;
+}
+
+static int test_encode ()
+{
+    int rlen;
+    char *r;
+    char p[] = "abcdefghijklmnop";
+    json_object *o = json_object_new_object ();
+
+    util_json_object_add_data (o, "data", (uint8_t *) p, strlen (p)+1);
+    note ("%s", json_object_to_json_string (o));
+    util_json_object_get_data (o, "data", (uint8_t **) &r, &rlen);
+
+    ok (strcmp (p, r) == 0, "'%s'='%s'", p, r);
+    ok (strlen(p)+1 == rlen, "lengths match");
+    free (r);
+    json_object_put (o);
+
+    return (0);
+}
+
+int main (int argc, char *argv[])
+{
+
+    plan (NO_PLAN);
+    test_encode ();
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR switches data encoding via `util_json_object_add_data` to base64 from the one-off Z85 implementation. This means that the following now works:
```
(flux-51954-0) grondo@hype356:~/git/flux-core.git$ src/cmd/flux kvs dir lwj.1.0.stdout
lwj.1.0.stdout.000000 = { "data": "SGksIFRoaXMgaXMgc29tZSBqb2Igb3V0cHV0Cg==" }
lwj.1.0.stdout.000001 = { "eof": true }
(flux-51954-0) grondo@hype356:~/git/flux-core.git$ echo SGksIFRoaXMgaXMgc29tZSBqb2Igb3V0cHV0Cg== | base64 -d 
Hi, This is some job output
```

I grabbed a standalone base64 implementation from @dun's MUNGE project and dropped it into libutil, along with Chris' existing test. This seems to work, but was quickly hacked up and could use another set of eyes. (Also need to wait for Travis)

Any other comments welcome. I was actually thinking that one day it would be interesting if the encoding could be configured per-instance, or like @garlick mentioned -- perhaps the KVS could store raw binary data.