### PR TITLE
hush the testsuite

### DIFF
--- a/src/bindings/lua/Test/Builder.lua
+++ b/src/bindings/lua/Test/Builder.lua
@@ -139,6 +139,10 @@ function m:finalize ()
     self.parent = nil
 end
 
+function m:cleanup (func)
+    table.insert (self._cleanup, func)
+end
+
 function m:reset ()
     self.curr_test = 0
     self._done_testing = false
@@ -153,6 +157,7 @@ function m:reset ()
     self.indent = ''
     self.parent = false
     self.child_name = false
+    self._cleanup = {}
     self:reset_outputs()
 end
 
@@ -220,6 +225,9 @@ function m:done_testing (num_tests)
         self.is_passing = false
     end
     if not self.is_passing then os.exit (1) end
+    for _,func in pairs (self._cleanup) do
+        func ()
+    end
 end
 
 function m:has_plan ()

--- a/src/bindings/lua/Test/More.lua
+++ b/src/bindings/lua/Test/More.lua
@@ -369,6 +369,10 @@ function m.todo (reason, count)
     tb:todo(reason, count)
 end
 
+function m.cleanup (func)
+    tb:cleanup(func)
+end
+
 for k, v in pairs(m) do  -- injection
     _G[k] = v
 end

--- a/src/test/tbarrier.c
+++ b/src/test/tbarrier.c
@@ -36,9 +36,10 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/xzmalloc.h"
 
-#define OPTIONS "hn:t:"
+#define OPTIONS "hqn:t:"
 static const struct option longopts[] = {
     {"help",       no_argument,        0, 'h'},
+    {"quiet",      no_argument,        0, 'q'},
     {"nprocs",     required_argument,  0, 'n'},
     {"test-iterations", required_argument,  0, 't'},
     { 0, 0, 0, 0 },
@@ -48,7 +49,7 @@ static const struct option longopts[] = {
 void usage (void)
 {
     fprintf (stderr,
-"Usage: tbarrier [--nprocs N] [--test-iterations N] [name]\n"
+"Usage: tbarrier [--quiet] [--nprocs N] [--test-iterations N] [name]\n"
 );
     exit (1);
 }
@@ -59,6 +60,7 @@ int main (int argc, char *argv[])
     int ch;
     struct timespec t0;
     char *name = NULL;
+    int quiet = 0;
     int nprocs = 1;
     int iter = 1;
     int i;
@@ -69,6 +71,9 @@ int main (int argc, char *argv[])
         switch (ch) {
             case 'h': /* --help */
                 usage ();
+                break;
+            case 'q': /* --quiet */
+                quiet = 1;
                 break;
             case 'n': /* --nprocs N */
                 nprocs = strtoul (optarg, NULL, 10);
@@ -100,8 +105,9 @@ int main (int argc, char *argv[])
             else
                 err_exit ("flux_barrier");
         }
-        printf ("barrier name=%s nprocs=%d time=%0.3f ms\n",
-             tname ? tname : "NULL", nprocs, monotime_since (t0));
+        if (!quiet)
+            printf ("barrier name=%s nprocs=%d time=%0.3f ms\n",
+                    tname ? tname : "NULL", nprocs, monotime_since (t0));
         if (tname)
             free (tname);
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -43,7 +43,7 @@ EXTRA_DIST= \
 	$(T)
 
 clean-local:
-	rm -fr trash-directory.* test-results .prove
+	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log
 
 check_SCRIPTS = \
 	t0000-sharness.t \

--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -135,7 +135,7 @@ function fluxTest.init (...)
         test.arg0 = './'..test.arg0
     end
 
-    test.log_file = test.arg0..".broker.log"
+    test.log_file = "lua-"..test.prog..".broker.log"
     test.start_args = { "-o,-q,-L" .. test.log_file }
 
     local dir = top_builddir.."/src/cmd"

--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -81,7 +81,10 @@ end
 --
 function fluxTest:start_session (t)
     -- If fluxometer session is already active just return:
-    if os.getenv ("FLUXOMETER_ACTIVE") then return end
+    if os.getenv ("FLUXOMETER_ACTIVE") then
+        cleanup (function () os.execute ("rm "..self.log_file) end)
+        return
+    end
     posix.setenv ("FLUXOMETER_ACTIVE", "t")
 
     local size = t.size or 1
@@ -121,7 +124,6 @@ function fluxTest.init (...)
     local debug = require 'debug'
     local test = setmetatable ({}, fluxTest)
 
-    test.start_args = { "-o,-q" }
 
     -- Get path to current test script using debug.getinfo:
 	test.arg0 = debug.getinfo (2).source:sub (2)
@@ -132,6 +134,9 @@ function fluxTest.init (...)
     if not test.arg0:match ('^[/.]') then
         test.arg0 = './'..test.arg0
     end
+
+    test.log_file = test.arg0..".broker.log"
+    test.start_args = { "-o,-q,-L" .. test.log_file }
 
     local dir = top_builddir.."/src/cmd"
     local path = dir.."/flux"

--- a/t/lua/t0001-send-recv.t
+++ b/t/lua/t0001-send-recv.t
@@ -4,7 +4,6 @@
 --
 local t = require 'fluxometer'.init (...)
 t:start_session { size = 2}
-t:say ("starting send/recv tests")
 
 plan (22)
 

--- a/t/lua/t0007-alarm.t
+++ b/t/lua/t0007-alarm.t
@@ -6,7 +6,7 @@ local alarm = require_ok ('lalarm')
 type_ok (alarm, 'function', 'lalarm: is function')
 
 local success = false
-local rc, err = alarm (1, function () diag('in handler'); success = true end)
+local rc, err = alarm (1, function () success = true end)
 
 posix.sleep (2)
 

--- a/t/lua/t1003-iowatcher.t
+++ b/t/lua/t1003-iowatcher.t
@@ -27,7 +27,7 @@ local iow, err = f:iowatcher {
 type_ok (iow, 'userdata', "succesfully create iowatcher")
 is (err, nil, "error is nil")
 
-os.execute 'flux zio --force --key=iowatcher.test --run printf "hello\nworld"'
+os.execute 'flux zio --force --key=iowatcher.test --run printf "hello\nworld" >/dev/null 2>&1'
 
 local r, err = f:reactor()
 isnt (r, -1, "Return from reactor, rc >= 0")

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -46,10 +46,12 @@ run_timeout() {
 #
 test_under_flux() {
     size=${1:-1}
+    log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
+        cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
         return
     fi
-    quiet="-o -q"
+    quiet="-o -q,-L${log_file}"
     if test "$verbose" = "t"; then
         flags="${flags} --verbose"
         quiet=""

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -14,7 +14,7 @@ before other tests that depend on kvs.
 SIZE=$(($(grep processor /proc/cpuinfo | wc -l)+1))
 test ${SIZE} -lt 4 && SIZE=4
 test_under_flux ${SIZE}
-echo "$0: flux session size will be ${SIZE}"
+echo "# $0: flux session size will be ${SIZE}"
 
 TEST=$TEST_NAME
 KEY=test.a.b.c

--- a/t/t1001-barrier-basic.t
+++ b/t/t1001-barrier-basic.t
@@ -11,37 +11,38 @@ before other tests that depend on barriers.
 . `dirname $0`/sharness.sh
 SIZE=4
 test_under_flux ${SIZE}
+tbarrier="${FLUX_BUILD_DIR}/src/test/tbarrier"
+test "$verbose" = "t" || tbarrier="${tbarrier} -q"
 
 test_expect_success 'barrier: returns when complete' '
-	${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs 1 abc
+	${tbarrier} --nprocs 1 abc
 '
 
 test_expect_success 'barrier: returns when complete (all ranks)' '
-	flux exec ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs ${SIZE} abc
+	flux exec ${tbarrier} --nprocs ${SIZE} abc
 '
 
 test_expect_success 'barrier: blocks while incomplete' '
 	test_expect_code 142 run_timeout 1 \
-	  ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs 2 xyz
+	  ${tbarrier} --nprocs 2 xyz
 '
 
 test_expect_success 'barrier: fails with name=NULL outside of LWJ' '
 	unset FLUX_LWJ_ID
 	unset SLURM_STEPID
-	test_expect_code 1 \
-	  ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs 1
+	test_expect_code 1 ${tbarrier} --nprocs 1
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside LWJ' '
 	unset SLURM_STEPID
         FLUX_LWJ_ID=1; export FLUX_LWJ_ID
-	flux exec ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs ${SIZE}
+	flux exec ${tbarrier} --nprocs ${SIZE}
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside SLURM step' '
 	unset FLUX_LWJ_ID
         SLURM_STEPID=1; export SLURM_STEPID
-	flux exec ${FLUX_BUILD_DIR}/src/test/tbarrier --nprocs ${SIZE}
+	flux exec ${tbarrier} --nprocs ${SIZE}
 '
 
 test_done


### PR DESCRIPTION
This is a small set of patches to hush the noisy little sharness and lua tests in `/t`.

The main change is to send flux-broker log messages to files by default. During a normal run,
these logfiles are removed during `cleanup`. They are retained in the case of test failure or
a debug or verbose testsuite run. It would be nice if the logfiles could be kept in a per-test directory,
but since these directories are created after `flux-start` is run, that is not possible.

Other changes are pretty straightforward in the commit history. With the quiet output we can now run the testsuite nice and clean and in parallel with `prove`, e.g.
```
grondo@hype356:~/git/f/t$ prove -j32 *.t */*.t
loop/handle.t ........... ok                                            
loop/rpc.t .............. ok                                            
loop/multrpc.t .......... ok                                            
loop/reactor.t .......... ok                                            
lua/t0007-alarm.t ....... ok                                            
t0000-sharness.t ........ ok                                            
lua/t1000-reactor.t ..... ok                                            
lua/t0003-events.t ...... ok                                            
lua/t0001-send-recv.t ... ok                                            
lua/t0002-rpc.t ......... ok                                            
lua/t1003-iowatcher.t ... ok                                            
t1004-log.t ............. ok                                            
lua/t1004-sighandler.t .. ok                                            
t1003-mecho.t ........... ok                                            
t1005-cmddriver.t ....... ok                                            
t1002-modctl.t .......... ok                                            
t0003-module.t .......... ok                                            
lua/t1001-timeouts.t .... ok                                            
t2000-wreck.t ........... ok                                            
t0005-exec.t ............ ok                                            
t0002-request.t ......... ok                                            
t2001-jsc.t ............. ok                                            
t1001-barrier-basic.t ... ok                                            
lua/t1002-kvs.t ......... ok                                            
t0001-basic.t ........... ok                                            
t1000-kvs-basic.t ....... ok    
All tests successful.
Files=26, Tests=473, 19 wallclock secs ( 0.17 usr  0.03 sys + 74.80 cusr 142.04 csys = 217.04 CPU)
Result: PASS

```