### PR TITLE
fix local connector reactor spin

### DIFF
--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -555,7 +555,7 @@ int flux_pollfd (flux_t h)
         struct epoll_event ev = {
             .events = EPOLLET | EPOLLIN | EPOLLOUT | EPOLLERR | EPOLLHUP,
         };
-        if ((h->pollfd = epoll_create (10)) < 0)
+        if ((h->pollfd = epoll_create1 (EPOLL_CLOEXEC)) < 0)
             goto fatal;
         /* add queue pollfd */
         ev.data.fd = msglist_pollfd (h->queue);

--- a/src/common/libutil/msglist.c
+++ b/src/common/libutil/msglist.c
@@ -182,7 +182,7 @@ int msglist_pollfd (msglist_t *l)
 int msglist_pollevents (msglist_t *l)
 {
     if (clear_event (l) < 0)
-        l->pollevents |= POLLERR;
+        return -1;
     return l->pollevents;
 }
 

--- a/src/common/libutil/msglist.c
+++ b/src/common/libutil/msglist.c
@@ -176,12 +176,6 @@ int msglist_pollfd (msglist_t *l)
 {
     if (l->pollfd < 0)
         l->pollfd = eventfd (l->pollevents, EFD_NONBLOCK);
-    if (l->pollfd < 0) {
-        int saved_errno = errno;
-        l->pollevents |= POLLERR;
-        (void)raise_event (l);
-        errno = saved_errno;
-    }
     return l->pollfd;
 }
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -171,7 +171,7 @@ flux_t connector_init (const char *path, int flags)
     c = xzmalloc (sizeof (*c));
     c->magic = CTX_MAGIC;
 
-    c->fd = socket (AF_UNIX, SOCK_STREAM, 0);
+    c->fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (c->fd < 0)
         goto error;
     for (;;) {

--- a/src/modules/api/api.c
+++ b/src/modules/api/api.c
@@ -396,7 +396,7 @@ static int listener_cb (flux_t h, int fd, short revents, void *arg)
         client_t *c;
         int cfd;
 
-        if ((cfd = accept (fd, NULL, NULL)) < 0) {
+        if ((cfd = accept4 (fd, NULL, NULL, SOCK_CLOEXEC)) < 0) {
             flux_log (h, LOG_ERR, "accept: %s", strerror (errno));
             goto done;
         }
@@ -426,7 +426,7 @@ static int listener_init (ctx_t *ctx, char *sockpath)
     struct sockaddr_un addr;
     int fd;
 
-    fd = socket (AF_UNIX, SOCK_STREAM, 0);
+    fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (fd < 0) {
         flux_log (ctx->h, LOG_ERR, "socket: %s", strerror (errno));
         goto done;


### PR DESCRIPTION
This PR corrects a very bad bug that crept into pr #225.  The local handle pollfd would remain "ready" even after its events had been consumed due to an epoll programming error.  This was causing a hang in pr #231

In addition to fixing this bug, some unnecessary reads and writes on the eventfd embedded in `msglist_t` were eliminated and some of its error handling code tightened up.

Finally, file descriptors in the handle, local connector, and api module are now opened with the close-on-exec flag to avoid leaking across exec.