### PR TITLE
minor bug fixes to reactor, documentation, tests

### DIFF
--- a/src/common/libcompat/reactor.c
+++ b/src/common/libcompat/reactor.c
@@ -134,7 +134,7 @@ void msg_compat_cb (flux_t h, struct flux_msg_watcher *w,
         goto done;
     if (!(cpy = flux_msg_copy (msg, true)))
         goto done;
-    if (compat->fn (h, type, &cpy, compat->arg) != 0)
+    if (compat->fn (h, type, &cpy, compat->arg) < 0)
         flux_reactor_stop_error (h);
 done:
     flux_msg_destroy (cpy);
@@ -213,7 +213,7 @@ static void fd_compat_cb (flux_t h, flux_fd_watcher_t *w,
                           int fd, int revents, void *arg)
 {
     struct fd_compat *c = arg;
-    if (c->fn (h, fd, events_to_libzmq (revents), c->arg) != 0)
+    if (c->fn (h, fd, events_to_libzmq (revents), c->arg) < 0)
         flux_reactor_stop_error (h);
 }
 
@@ -267,7 +267,7 @@ static void zmq_compat_cb (flux_t h, flux_zmq_watcher_t *w,
                            void *zsock, int revents, void *arg)
 {
     struct zmq_compat *c = arg;
-    if (c->fn (h, zsock, events_to_libzmq (revents), c->arg) != 0)
+    if (c->fn (h, zsock, events_to_libzmq (revents), c->arg) < 0)
         flux_reactor_stop_error (h);
 }
 
@@ -321,7 +321,7 @@ static void timer_compat_cb (flux_t h, flux_timer_watcher_t *w,
                                      int revents, void *arg)
 {
     struct timer_compat *c = arg;
-    if (c->fn (h, c->arg) != 0)
+    if (c->fn (h, c->arg) < 0)
         flux_reactor_stop_error (h);
 }
 

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -123,7 +123,7 @@ int flux_rank (flux_t h)
         }
         if (flux_info (h, rank, NULL, NULL) < 0)
             return -1;
-        flux_aux_set (h, "rank", rank, free);
+        flux_aux_set (h, "flux::rank", rank, free);
     }
     return *rank;
 }

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -12,7 +12,7 @@
 int flux_reactor_start (flux_t h);
 
 /* Signal that the flux event reactor should stop.
- * This may be called from within a FluxMsgHandler/FluxFdHandler callback.
+ * This may be called from within a watcher.
  */
 void flux_reactor_stop (flux_t h);
 void flux_reactor_stop_error (flux_t h);
@@ -21,11 +21,39 @@ void flux_reactor_stop_error (flux_t h);
  * is queued in the handle.  This will return -1 with errno = EINVAL
  * if called from a reactor handler that is not running in as a coprocess.
  * Currently only message handlers are started as coprocesses, if the
- * handle has FLUX_O_COPROC set.
+ * handle has FLUX_O_COPROC set.  This is used internally by flux_recv().
  */
 int flux_sleep_on (flux_t h, struct flux_match match);
 
+/* General comments on watchers:
+ * - It is safe to call a watcher's 'stop' function from a watcher callback.
+ * - It is necessary to stop a watcher before destroying it.
+ * - Once stopped, a watcher is no longer associated with the flux handle
+ *   and must be destroyed independently.
+ * - A watcher may be started/stopped more than once.
+ * - Starting a started watcher, stopping a stopped watcher, or destroying
+ *   a NULL watcher have no effect.
+ */
+
 /* Message dispatch
+ * Create/destroy/start/stop "message watchers".
+ * A message watcher handles messages received on the handle matching 'match'.
+ * Message watchers are special compared to the other watchers as they
+ * combine an internal "handle watcher" that reads new messages from the
+ * handle as they arrive, and a dispatcher that hands the message to a
+ * matching message watcher.
+ *
+ * If multiple message watchers match a given message, the most recently
+ * registered will handle it.  Thus it is possible to register handlers for
+ * "svc.*" then "svc.foo", and the former will match all methods but "foo".
+ * If a request message arrives that is not matched by a message watcher,
+ * the reactor sends a courtesy ENOSYS response.
+ *
+ * If the handle was created with FLUX_O_COPROC, message watchers will be
+ * run in a coprocess context.  If they make an RPC call or otherwise call
+ * flux_recv(), the reactor can run, handling other tasks until the desired
+ * message arrives, then the message watcher is restarted.
+ * Currently only message watchers run as coprocesses.
  */
 
 typedef struct flux_msg_watcher flux_msg_watcher_t;
@@ -38,6 +66,15 @@ void flux_msg_watcher_destroy (flux_msg_watcher_t *w);
 void flux_msg_watcher_start (flux_t h, flux_msg_watcher_t *w);
 void flux_msg_watcher_stop (flux_t h, flux_msg_watcher_t *w);
 
+/* Convenience functions for bulk add/remove of message watchers.
+ * addvec creates/adds a table of message watchers
+ * (created watchers are then stored in the table)
+ * delvec stops/destroys the table of message watchers.
+ * addvec returns 0 on success, -1 on failure with errno set.
+ * Watchers are added beginning with tab[0] (see multiple match comment above).
+ * tab[] must be terminated with FLUX_MSGHANDLER_TABLE_END.
+ */
+
 struct flux_msghandler {
     int typemask;
     char *topic_glob;
@@ -49,6 +86,12 @@ int flux_msg_watcher_addvec (flux_t h, struct flux_msghandler tab[], void *arg);
 void flux_msg_watcher_delvec (flux_t h, struct flux_msghandler tab[]);
 
 /* file descriptors
+ * Create/destroy/start/stop "fd watchers".
+ * A file descriptor watcher monitors a file descriptor for FLUX_POLLIN
+ * and/or FLUX_POLLOUT as specified in the events paramter.  The watcher
+ * is called with the events that triggered the watcher set in revents.
+ * If there was a poll or other error on the fd, revents may be called with
+ * FLUX_POLLERR set.
  */
 
 typedef struct flux_fd_watcher flux_fd_watcher_t;
@@ -61,6 +104,8 @@ void flux_fd_watcher_start (flux_t h, flux_fd_watcher_t *w);
 void flux_fd_watcher_stop (flux_t h, flux_fd_watcher_t *w);
 
 /* 0MQ sockets
+ * Create/destroy/start/stop "zmq watchers".
+ * zmq watchers behave exactly like fd watchers.
  */
 
 typedef struct flux_zmq_watcher flux_zmq_watcher_t;
@@ -73,6 +118,11 @@ void flux_zmq_watcher_start (flux_t h, flux_zmq_watcher_t *w);
 void flux_zmq_watcher_stop (flux_t h, flux_zmq_watcher_t *w);
 
 /* Timer
+ * Create/destroy/start/stop "timer watchers".
+ * A timer is set to trigger 'after' seconds from its start time.  If 'after'
+ * is zero, the timer triggers immediately.  If 'repeat' is zero, the timer
+ * only triggers once and is then automatically stopped, otherwise it triggers
+ * again every 'repeat' seconds.
  */
 
 typedef struct flux_timer_watcher flux_timer_watcher_t;


### PR DESCRIPTION
This PR fixes two bugs
* libcompat reactor handler return codes were tested for !=0 instead of old behavior of <0
* `flux_rank()` coding error prevents rank from being cached on first call

It also adds missing inline documentation for the new functions in handle.h and reactor.h, and improves the reactor loop test incrementally.