### PR TITLE
header cleanup from the python binding branch

### DIFF
--- a/src/common/libflux/reduce.h
+++ b/src/common/libflux/reduce.h
@@ -54,7 +54,7 @@ int flux_red_append (flux_red_t r, void *item, int batchnum);
  */
 void *flux_redstack_pop (flux_redstack_t stack);
 void flux_redstack_push (flux_redstack_t stack, void *item);
-int flux_restack_count (flux_redstack_t stack);
+int flux_redstack_count (flux_redstack_t stack);
 
 #endif /* _FLUX_CORE_REDUCE_H */
 /*

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -28,7 +28,6 @@ void flux_sec_destroy (flux_sec_t c);
  */
 int flux_sec_enable (flux_sec_t c, int type);
 int flux_sec_disable (flux_sec_t c, int type);
-bool flux_sec_enabled (flux_sec_t c, int type);
 
 /* Get/set config directory used by security context.
  */

--- a/src/modules/barrier/barrier.h
+++ b/src/modules/barrier/barrier.h
@@ -1,6 +1,8 @@
 #ifndef _FLUX_CORE_BARRIER_H
 #define _FLUX_CORE_BARRIER_H
 
+#include <flux/core.h>
+
 /* Execute a barrier across 'nprocs' processes.
  * The 'name' must be unique across the comms session, or
  * if running in a Flux LWJ, may be NULL.


### PR DESCRIPTION
Originally part of #236.

* flux_restack_count -> flux_redstack_count
* remove flux_sec_enabled, because it does not exist
* add <flux/core.h> include to barrier.h, apparently this was never a problem
  because it was always included after flux.h in each .c file