### PR TITLE
assorted bug fixes and cleanups

### DIFF
--- a/doc/cmd/flux-ping.adoc
+++ b/doc/cmd/flux-ping.adoc
@@ -10,45 +10,25 @@ flux-ping - measure round-trip latency to Flux services
 
 SYNOPSIS
 --------
-*flux* *ping* ['--pad-bytes=N'] ['--delay-msec=N'] ['--rank=N'] target
+*flux* *ping* ['--rank N'] ['--pad bytes'] ['--delay N'] ['--count N'] target
 
 
 DESCRIPTION
 -----------
-flux-ping(1) measures round-trip latency to a Flux service in a
-manner analogous to ping(8).
-
-Flux comms modules and broker instances have a built-in 'ping' operation
-that echoes the request payload back in a response.   One can ping a comms
-module, for example "flux ping kvs" and get back:
-
-  kvs.ping pad=0 seq=0 time=0.535 ms (99E61)
-  kvs.ping pad=0 seq=1 time=0.573 ms (99E61)
-  ...
-
-This tells you that the local "kvs" comms module is alive and the
-round-trip latency is about half a millisecond.
-
-It is possible to direct a ping request over the rank-request overlay
-to a specific node.  For example "flux ping --rank 6 cmb":
-
-  6!cmb.ping pad=0 seq=0 time=1.685 ms (99E61!0r!7r)
-  6!cmb.ping pad=0 seq=1 time=1.768 ms (99E61!0r!7r)
-  ...
-
-This tells you that the message broker on rank 6 is responsive and
-reachable through the rank-request ring.  It also shows you the route
-taken to get there.
+flux-ping(1) measures round-trip latency to a Flux service implementing
+the "ping" method in a manner analogous to ping(8).  The ping response is
+essentially an echo of the request, with the route taken to the service
+added by the service.  This route is displayed in the output and can
+give insight into how various addresses are routed.
 
 'target' may be the name of a comms module service, e.g. "kvs" or "live".
 flux-ping(1) will send a request to "kvs.ping" or "live.ping".
-
 As a shorthand, 'target' can include a rank prefix delimited by an
 exclamation point.  "flux ping 4!kvs" is equivalent to
 "flux ping --rank 4 kvs" (see --rank option below).
 Don't forget to quote the exclamation point if it is interpreted by your shell.
 
-As a shorthand, 'target' can simply be a rank by itself indicating 
+As a shorthand, 'target' may also simply be a rank by itself indicating 
 that the broker on that rank, rather than a comms module, is to be pinged.
 "flux ping 4" is equivalent to "flux ping --rank 4 cmb".
 
@@ -56,18 +36,56 @@ that the broker on that rank, rather than a comms module, is to be pinged.
 OPTIONS
 -------
 *-r, --rank*'=N'::
-Use the rank-request ring topology overlay to reach a specific rank node.
-Default: use the tree based overlay network to find the first node
-that will answer the request.
+Find target on a specific broker rank.
+Default: send to FLUX_NODEID_ANY.
 
-*-p, --pad-bytes*'=N'::
-Include in the payload a string of length 'N' containing the character "p",
-repeated.  The payload will be echoed back in the response.  Default:
-no padding.
+*-p, --pad*'=N'::
+Include in the payload a string of length 'N' bytes.  The payload will be
+echoed back in the response.  This option can be used to explore the
+effect of message size on latency.  Default: no padding.
 
-*-d, --delay-msec*'=N'::
-Specify the delay, in milliseconds, between successive requests.
-Default: 1000 milliseconds (1 second).
+*-d, --delay*'=N'::
+Specify the delay, in seconds, between successive requests.
+A value of zero is valid and indicates that there should be no delay.
+Requests are sent without waiting for responses.  Default: 1.0 seconds.
+
+*-c, --count*'=N'::
+Specify the number of requests to send, and terminate the command once
+responses have been received for all the requests.  Default: unlimited.
+
+EXAMPLES
+--------
+
+One can ping a service by name, e.g.
+
+  $ flux ping kvs
+  kvs.ping pad=0 seq=0 time=0.774 ms (0EB02!A3368!0!382A6)
+  kvs.ping pad=0 seq=1 time=0.686 ms (0EB02!A3368!0!382A6)
+  ...
+
+This tells you that the local "kvs" comms module is alive and the
+round-trip latency is a bit over half a millisecond.  The route hops are:
+
+  0EB02: UUID of the ping command
+  A3368: UUID of the API module
+  0:     rank of the local broker
+  382A6: UUID of the KVS module.
+
+One can direct a ping request to a specific node, e.g.
+
+  $ flux ping 6
+  6!cmb.ping pad=0 seq=0 time=1.463 ms (73C6E!1A4D9!0r!7r!6)
+  6!cmb.ping pad=0 seq=1 time=1.652 ms (73C6E!1A4D9!0r!7r!6)
+  ...
+
+This tells you that the message broker on rank 6 is responsive.
+The route hops are:
+
+  73C6E: UUID of the ping command
+  1A4D9: UUID of the API module
+  0r:    rank of the local broker (r indicates "right ring" socket)
+  7r:    rank of the next broker (r indicates "right ring" socket)
+  6:     rank of the target broker
 
 
 AUTHOR

--- a/doc/cmd/spell.en.pws
+++ b/doc/cmd/spell.en.pws
@@ -143,3 +143,4 @@ SHA
 fanout
 NOHOST
 sysexits
+NODEID

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -51,7 +51,7 @@ struct ping_ctx {
 static const struct option longopts[] = {
     {"help",       no_argument,        0, 'h'},
     {"rank",       required_argument,  0, 'r'},
-    {"pad-bytes",  required_argument,  0, 'p'},
+    {"pad",        required_argument,  0, 'p'},
     {"delay",      required_argument,  0, 'd'},
     {"count",      required_argument,  0, 'c'},
     { 0, 0, 0, 0 },
@@ -94,7 +94,7 @@ void response_cb (flux_t h, flux_msg_watcher_t *w, const flux_msg_t *msg,
     snprintf (rankprefix, sizeof (rankprefix), "%u!", ctx->nodeid);
     printf ("%s%s pad=%lu seq=%d time=%0.3f ms (%s)\n",
                 ctx->nodeid == FLUX_NODEID_ANY ? "" : rankprefix, topic,
-                strlen (ctx->pad) + 1, seq, monotime_since (t0), route);
+                strlen (ctx->pad), seq, monotime_since (t0), route);
     if (++ctx->recv_count == ctx->count)
         flux_msg_watcher_stop (h, w);
     Jput (out);
@@ -155,10 +155,10 @@ int main (int argc, char *argv[])
             case 'h': /* --help */
                 usage ();
                 break;
-            case 'p': /* --pad-bytes N */
+            case 'p': /* --pad bytes */
                 pad_bytes = strtoul (optarg, NULL, 10);
                 break;
-            case 'd': /* --delay N */
+            case 'd': /* --delay seconds */
                 ctx.period = strtod (optarg, NULL);
                 if (ctx.period < 0)
                     usage ();

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -205,7 +205,9 @@ int main (int argc, char *argv[])
      */
     if (getenv ("FLUX_TMPDIR") && !Fopt) {
         flux_t h;
-        if (!(h = flux_open (NULL, 0)))
+        if (flux_conf_load (cf) == 0)
+            setup_connector_env (cf, Oopt); /* flux_open() needs this */
+        if (!(h = flux_open (NULL, 0)))     /*   esp. for in-tree */
             err_exit ("flux_open");
         if (kvs_conf_load (h, cf) < 0 && errno != ENOENT)
             err_exit ("could not load config from KVS");

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -27,7 +27,6 @@
 #endif
 #include <errno.h>
 #include <stdbool.h>
-#include <czmq.h>
 
 #include "event.h"
 #include "message.h"
@@ -68,27 +67,27 @@ done:
     return rc;
 }
 
-zmsg_t *flux_event_encode (const char *topic, const char *json_str)
+flux_msg_t *flux_event_encode (const char *topic, const char *json_str)
 {
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
 
     if (!topic) {
         errno = EINVAL;
         goto error;
     }
-    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_EVENT)))
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_EVENT)))
         goto error;
-    if (flux_msg_set_topic (zmsg, topic) < 0)
+    if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    if (flux_msg_enable_route (zmsg) < 0)
+    if (flux_msg_enable_route (msg) < 0)
         goto error;
-    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+    if (json_str && flux_msg_set_payload_json (msg, json_str) < 0)
         goto error;
-    return zmsg;
+    return msg;
 error:
-    if (zmsg) {
+    if (msg) {
         int saved_errno = errno;
-        zmsg_destroy (&zmsg);
+        flux_msg_destroy (msg);
         errno = saved_errno;
     }
     return NULL;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -638,7 +638,7 @@ char *flux_msg_get_route_string (const flux_msg_t *msg)
                     || (len = flux_msg_get_route_size (msg)) < 0) {
         return NULL;
     }
-    if (!(cp = buf = malloc (len + hops))) {
+    if (!(cp = buf = malloc (len + hops + 1))) {
         errno = ENOMEM;
         return NULL;
     }
@@ -655,8 +655,8 @@ char *flux_msg_get_route_string (const flux_msg_t *msg)
         assert (cp - buf + cpylen < len + hops);
         memcpy (cp, zframe_data (zf), cpylen);
         cp += cpylen;
-        *cp = '\0';
     }
+    *cp = '\0';
     return buf;
 }
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -423,9 +423,9 @@ void flux_msg_watcher_destroy (struct flux_msg_watcher *w)
         if (w->coproc)
             coproc_destroy (w->coproc);
         if (w->backlog) {
-            zmsg_t *zmsg;
-            while ((zmsg = zlist_pop (w->backlog)))
-                zmsg_destroy (&zmsg);
+            flux_msg_t *msg;
+            while ((msg = zlist_pop (w->backlog)))
+                flux_msg_destroy (msg);
             zlist_destroy (&w->backlog);
         }
         if (w->wait_match.topic_glob)

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -25,7 +25,6 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <czmq.h>
 #include "request.h"
 #include "message.h"
 #include "info.h"
@@ -69,27 +68,27 @@ done:
     return rc;
 }
 
-zmsg_t *flux_request_encode (const char *topic, const char *json_str)
+flux_msg_t *flux_request_encode (const char *topic, const char *json_str)
 {
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
 
     if (!topic) {
         errno = EINVAL;
         goto error;
     }
-    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
         goto error;
-    if (flux_msg_set_topic (zmsg, topic) < 0)
+    if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    if (flux_msg_enable_route (zmsg) < 0)
+    if (flux_msg_enable_route (msg) < 0)
         goto error;
-    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+    if (json_str && flux_msg_set_payload_json (msg, json_str) < 0)
         goto error;
-    return zmsg;
+    return msg;
 error:
-    if (zmsg) {
+    if (msg) {
         int saved_errno = errno;
-        zmsg_destroy (&zmsg);
+        flux_msg_destroy (msg);
         errno = saved_errno;
     }
     return NULL;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -34,7 +34,7 @@
 #include "src/common/libutil/nodeset.h"
 
 
-int flux_response_decode (flux_msg_t *msg, const char **topic,
+int flux_response_decode (const flux_msg_t *msg, const char **topic,
                           const char **json_str)
 {
     int type;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -25,7 +25,8 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <czmq.h>
+#include <errno.h>
+
 #include "response.h"
 #include "message.h"
 
@@ -33,7 +34,7 @@
 #include "src/common/libutil/nodeset.h"
 
 
-int flux_response_decode (zmsg_t *zmsg, const char **topic,
+int flux_response_decode (flux_msg_t *msg, const char **topic,
                           const char **json_str)
 {
     int type;
@@ -41,25 +42,25 @@ int flux_response_decode (zmsg_t *zmsg, const char **topic,
     int errnum = 0;
     int rc = -1;
 
-    if (zmsg == NULL) {
+    if (msg == NULL) {
         errno = EINVAL;
         goto done;
     }
-    if (flux_msg_get_type (zmsg, &type) < 0)
+    if (flux_msg_get_type (msg, &type) < 0)
         goto done;
     if (type != FLUX_MSGTYPE_RESPONSE) {
         errno = EPROTO;
         goto done;
     }
-    if (flux_msg_get_errnum (zmsg, &errnum) < 0)
+    if (flux_msg_get_errnum (msg, &errnum) < 0)
         goto done;
     if (errnum != 0) {
         errno = errnum;
         goto done;
     }
-    if (flux_msg_get_topic (zmsg, &ts) < 0)
+    if (flux_msg_get_topic (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload_json (zmsg, &js) < 0)
+    if (flux_msg_get_payload_json (msg, &js) < 0)
         goto done;
     if ((json_str && !js) || (!json_str && js)) {
         errno = EPROTO;
@@ -74,30 +75,30 @@ done:
     return rc;
 }
 
-zmsg_t *flux_response_encode (const char *topic, int errnum,
-                              const char *json_str)
+flux_msg_t *flux_response_encode (const char *topic, int errnum,
+                                  const char *json_str)
 {
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
 
     if (!topic || (errnum != 0 && json_str != NULL)) {
         errno = EINVAL;
         goto error;
     }
-    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)))
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)))
         goto error;
-    if (flux_msg_set_topic (zmsg, topic) < 0)
+    if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    if (flux_msg_enable_route (zmsg) < 0)
+    if (flux_msg_enable_route (msg) < 0)
         goto error;
-    if (flux_msg_set_errnum (zmsg, errnum) < 0)
+    if (flux_msg_set_errnum (msg, errnum) < 0)
         goto error;
-    if (json_str && flux_msg_set_payload_json (zmsg, json_str) < 0)
+    if (json_str && flux_msg_set_payload_json (msg, json_str) < 0)
         goto error;
-    return zmsg;
+    return msg;
 error:
-    if (zmsg) {
+    if (msg) {
         int saved_errno = errno;
-        zmsg_destroy (&zmsg);
+        flux_msg_destroy (msg);
         errno = saved_errno;
     }
     return NULL;

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -15,7 +15,7 @@
  * and -1 is returned with no assignments to topic or json_str.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_response_decode (flux_msg_t *msg, const char **topic,
+int flux_response_decode (const flux_msg_t *msg, const char **topic,
                           const char **json_str);
 
 flux_msg_t *flux_response_encode (const char *topic, int errnum,

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -154,7 +154,7 @@ EOF
 test_expect_success 'kvs: create a dir with keys and subdir' '
 	flux kvs unlink $TEST &&
 	flux kvs put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir $DIR | sort >output &&
+	flux kvs dir -r $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
 $DIR.b = 70
@@ -168,7 +168,7 @@ EOF
 test_expect_success 'kvs: directory with multiple subdirs' '
 	flux kvs unlink $TEST &&
 	flux kvs put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir $DIR | sort >output &&
+	flux kvs dir -r $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
 $DIR.b.c.d.e.f.g = 70


### PR DESCRIPTION
This PR includes an assortment of bug fixes and cleanups:

* Get rid of some internal use of `zmsg_t` in libflux-core
* Rework `flux-ping` to use new reactor API and allow request pipelining, used for test in #251
* Add `flux-kvs dir [-r]` option and `flux-kvs watch-dir [-r]` option per #256
* Change `flux_response_decode()` signature to make its msg argument a const
* Fix bug in `flux-snoop` and `flux --trace` output where unterminated string was printed
* Fix bug in `flux` command driver that prevented `flux --tmpdir` from working outside a session
