### PR TITLE
generalize api disconnect protocol

### DIFF
--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -12,7 +12,8 @@ check_PROGRAMS = \
 	tkvswatch \
 	tmunge \
 	tpmikvs \
-	tbarrier
+	tbarrier \
+	tdisconnect
 
 SUBDIRS = request module
 if HAVE_MPI

--- a/src/test/tdisconnect.c
+++ b/src/test/tdisconnect.c
@@ -1,0 +1,87 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <json.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+/* Current kvs_watch() API doesn't accept a rank, so we cheat and
+ * build the minimal kvs.watch request message from scratch here.
+ * Read the first response and pretend we're done.  If this key actually
+ * changes then we are screwed here because we will have recycled the
+ * matchtags but more responses will be coming.
+ */
+void send_watch_requests (flux_t h, const char *key)
+{
+    JSON in = Jnew ();
+    flux_rpc_t r;
+    const char *json_str;
+
+    json_object_object_add (in, "noexist", NULL);
+    Jadd_bool (in, ".flag_first", true);
+    if (!(r = flux_rpc_multi (h, "kvs.watch", Jtostr (in), "all", 0)))
+        err_exit ("flux_rpc_multi kvs.watch");
+    while (!flux_rpc_completed (r)) {
+        if (flux_rpc_get (r, NULL, &json_str) < 0)
+            err_exit ("kvs.watch");
+    }
+    flux_rpc_destroy (r);
+    Jput (in);
+}
+
+/* Sum #watchers over all ranks.
+ */
+int count_watchers (flux_t h)
+{
+    JSON out;
+    const char *json_str;
+    int n, count = 0;
+    flux_rpc_t r;
+
+    if (!(r = flux_rpc_multi (h, "kvs.stats.get", NULL, "all", 0)))
+        err_exit ("flux_rpc_multi kvs.stats.get");
+    while (!flux_rpc_completed (r)) {
+        if (flux_rpc_get (r, NULL, &json_str) < 0)
+            err_exit ("kvs.stats.get");
+        if (!(out = Jfromstr (json_str)) || !Jget_int (out, "#watchers", &n))
+            msg_exit ("error decoding stats payload");
+        count += n;
+        Jput (out);
+    }
+    flux_rpc_destroy (r);
+    return count;
+}
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    int w0, w1, w2;
+
+    /* Install watchers on every rank, then disconnect.
+     * The number of watchers should return to the original count.
+     */
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    w0 = count_watchers (h);
+    send_watch_requests (h, "nonexist");
+    w1 = count_watchers (h) - w0;
+    msg ("test watchers: %d", w1);
+    flux_close (h);
+    msg ("disconnected");
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    w2 = count_watchers (h) - w0;
+    msg ("test watchers: %d", w2);
+    if (w2 != 0)
+        err_exit ("Test failure, watchers were not removed on disconnect");
+
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -24,6 +24,7 @@ TESTS = \
 	t1003-mecho.t \
 	t1004-log.t \
 	t1005-cmddriver.t \
+	t1006-apidisconnect.t \
 	t2000-wreck.t \
 	t2001-jsc.t \
 	lua/t0001-send-recv.t \
@@ -57,6 +58,7 @@ check_SCRIPTS = \
 	t1003-mecho.t \
 	t1004-log.t \
 	t1005-cmddriver.t \
+	t1006-apidisconnect.t \
 	t2000-wreck.t \
 	t2001-jsc.t \
 	lua/t0001-send-recv.t \

--- a/t/t1006-apidisconnect.t
+++ b/t/t1006-apidisconnect.t
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+
+test_description='Test api disconnect generation 
+'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+test_under_flux ${SIZE}
+
+test_expect_success 'kvs watcher gets disconnected on client exit' '
+	before_watchers=`flux comms-stats --parse "#watchers" kvs` &&
+	echo "before: $before_watchers" &&
+	test_expect_code 142 run_timeout 1 flux kvs watch noexist &&
+	after_watchers=`flux comms-stats --parse "#watchers" kvs`
+	echo "after: $after_watchers" &&
+	test $before_watchers -eq $after_watchers
+'
+
+test_expect_success 'multi-node kvs watcher gets disconnected on client exit' '
+	${FLUX_BUILD_DIR}/src/test/tdisconnect
+'
+
+
+test_done


### PR DESCRIPTION
The api module was not issuing disconnects to services that were addressed by rank.  Contacting the same service on multiple ranks would only result in a single disconnect to the local rank.

A sharness test is added for the `FLUX_NODEID_ANY` and multiple ranks cases.

disconnects are described (briefly) in RFC 6.

Fixes issue #261