### PR TITLE
broker: add --shutdown-grace option

### DIFF
--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -19,7 +19,7 @@ void shutdown_set_handle (shutdown_t s, flux_t h);
  */
 void shutdown_complete (shutdown_t s);
 void shutdown_recvmsg (shutdown_t s, zmsg_t *zmsg);
-void shutdown_arm (shutdown_t s, int grace, int rc, const char *fmt, ...);
+void shutdown_arm (shutdown_t s, double grace, int rc, const char *fmt, ...);
 
 #endif /* !_BROKER_SHUTDOWN_H */
 


### PR DESCRIPTION
Change the shutdown grace period to a double, and add --shutdown-grace
command line option.

If option is not provided, choose the default based on the session size,
reducing hte default for small sizes used in our unit tests to 0.5s.

Fixes #237