### PR TITLE
update travis-ci builds to new container-based builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,45 @@
 language: c
 
+sudo: false
+
 compiler:
   - gcc
   - clang
 
-install:
-  - sudo sh -c 'echo "/usr/local/lib" >/etc/ld.so.conf.d/build'
-  - sudo apt-get update -q
-  - sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks munge libmunge-dev uuid-dev aspell libopenmpi-dev
-  - sudo luarocks install luaposix
-  - git clone https://github.com/grondo/lua-hostlist
-  - (export CC=gcc; cd lua-hostlist && make LUA_VER=5.1 && sudo make install LUA_VER=5.1)
-  - wget http://download.zeromq.org/zeromq-4.0.4.tar.gz
-  - tar -xvf zeromq-4.0.4.tar.gz
-  - wget http://download.zeromq.org/czmq-3.0.0-rc1.tar.gz
-  - tar -xvf czmq-3.0.0-rc1.tar.gz
-  - wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz
-  - tar -xvf libsodium-1.0.0.tar.gz
-  - wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz
-  - tar -xvf  json-c-0.11.tar.gz
-  - ( export CC=gcc; cd json-c-0.11 && ./configure && make && sudo make install)
-  - (cd libsodium-1.0.0 && ./configure && make -j2 && sudo make install)
-  - (cd zeromq-4.0.4 && ./configure --with-libsodium && make -j2 && sudo make install)
-  - (cd czmq-3.0.0 && ./configure && make -j2 && sudo make install)
-  - sudo ldconfig
+cache:
+  directories:
+    - $HOME/local
+    - $HOME/.luarocks
+    - $HOME/.ccache
 
-script: ./autogen.sh && ./configure  && make -j2 V=1 distcheck
+addons:
+  apt:
+    sources:
+    packages:
+      - lua5.1
+      - liblua5.1-0-dev
+      - luarocks
+      - uuid-dev
+      - aspell
+      - libopenmpi-dev
+      - ccache
+
+before_install:
+  - export LD_LIBRARY_PATH=$HOME/local/lib
+  - export CPPFLAGS=-I$HOME/local/include
+  - export LDFLAGS=-L$HOME/local/lib
+  - export PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig
+  - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
+  - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
+  - eval `luarocks path`
+  - ./src/test/travis-dep-builder.sh --cachedir=$HOME/local/.cache
 
 
+script:
+ - export CC="ccache $CC"
+ - ./autogen.sh
+ - ./configure --prefix=$HOME/local
+ - make -j2 distcheck
+
+after_success:
+ - ccache -s

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -283,8 +283,11 @@ char *intree_confdir (void)
 
 static void path_push (char **path, const char *add, const char *sep)
 {
-    char *new = xasprintf ("%s%s%s", add, *path ? sep : "",
-                                          *path ? *path : "");
+    char *new;
+    if (add == NULL) /* do nothing */
+        return;
+    new = xasprintf ("%s%s%s", add, *path ? sep : "",
+            *path ? *path : "");
     free (*path);
     *path = new;
 }
@@ -295,8 +298,13 @@ void setup_lua_env (flux_conf_t cf, const char *cpath_add, const char *path_add)
     const char *cf_cpath = flux_conf_get (cf, "general.lua_cpath");
     char *path = NULL, *cpath = NULL;;
 
-    path_push (&path, ";;", ";"); /* Lua replaces ;; with the default path */
-    path_push (&cpath, ";;", ";");
+    path_push (&path, getenv ("LUA_PATH"), ";");
+    path_push (&cpath, getenv ("LUA_CPATH"), ";");
+
+    if (path == NULL)
+        path_push (&path, ";;", ";"); /* Lua replaces ;; with the default path */
+    if (cpath == NULL)
+        path_push (&cpath, ";;", ";");
 
     path_push (&path, LUA_PATH_ADD, ";");
     path_push (&cpath, LUA_CPATH_ADD, ";");

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+#
+#
+
+prefix=$HOME/local
+
+#
+# Ordered list of software to download and install into $prefix.
+#  NOTE: Code currently assumes .tar.gz suffix...
+#
+downloads="\
+https://github.com/dun/munge/archive/munge-0.5.11.tar.gz \
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz \
+http://download.zeromq.org/zeromq-4.0.4.tar.gz \
+http://download.zeromq.org/czmq-3.0.0-rc1.tar.gz \
+https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz"
+
+declare -A extra_configure_opts=(\
+["zeromq-4.0.4"]="--with-libsodium --with-libsodium-include-dir=\$prefix/include" \
+)
+
+#
+#  Lua rocks files to download and install:
+#
+declare -A lua_rocks=(\
+["posix"]="luaposix" \
+)
+
+declare -r prog=${0##*/}
+declare -r long_opts="prefix:,cachedir:,verbose"
+declare -r short_opts="vp:c:"
+declare -r usage="\
+\n
+Usage: $prog [OPTIONS]\n\
+Download and install to a local prefix (default=$prefix) dependencies\n\
+for building flux-framework/flux-core\n\
+\n\
+Options:\n\
+ -v, --verbose           Be verbose.\n\
+ -c, --cachedir=DIR      Check for precompiled dependency cache in DIR\n\
+ -e, --max-cache-age=N   Expire cache in N days from creation\n\
+ -p, --prefix=DIR        Install software into prefix\n
+"
+
+die() { echo -e "$prog: $@"; exit 1; }
+say() { echo -e "$prog: $@"; }
+debug() { test "$verbose" = "t" && say "$@"; }
+
+GETOPTS=`/usr/bin/getopt -u -o $short_opts -l $long_opts -n $prog -- $@`
+if test $? != 0; then
+    die "$usage"
+fi
+
+eval set -- "$GETOPTS"
+while true; do
+    case "$1" in
+      -v|--verbose)          verbose=t;     shift   ;;
+      -c|--cachedir)         cachedir="$2"; shift 2 ;;
+      -e|--max-cache-age)    cacheage="$2"; shift 2 ;;
+      -p|--prefix)           prefix="$2";   shift   ;;
+      --)                    shift ; break;         ;;
+      *)                     die "Invalid option '$1'\n$usage" ;;
+    esac
+done
+
+check_cache ()
+{
+    test -n "$cachedir" || return 1
+    local url=$1
+    local cachefile="${cachedir}/${url}"
+    test -f "${cachefile}" || return 1
+    test -n "$cacheage"    || return 0
+
+    local ctime=$(stat -c%Y ${cachefile})
+    local maxage=$((${cacheage}*86400))
+    test $ctime -gt $maxage && return 1
+}
+
+add_cache ()
+{
+    test -n "$cachedir" || return 0
+    mkdir -p "${cachedir}" &&
+    touch "${cachedir}/${1}"
+}
+
+
+luarocks help >/dev/null 2>&1 || die "Required command luarocks not installed"
+
+# install rocks
+eval `luarocks --local path`
+for p in ${!lua_rocks[@]}; do
+    if ! lua -l$p -e '' >/dev/null 2>&1; then
+        luarocks --local install ${lua_rocks[$p]}
+    else
+        say "Using cached version of " ${lua_rocks[$p]}
+    fi
+done
+
+# special case for lua-hostlist
+if ! lua -lhostlist -e '' >/dev/null 2>&1; then
+   git clone https://github.com/grondo/lua-hostlist &&
+   ( cd lua-hostlist &&
+     export LUA_VER=5.1
+     make &&
+     make install PREFIX=$HOME/local LIBDIR=$HOME/.luarocks/lib
+   )
+else
+   say "Using cached version of lua-hostlist"
+fi
+
+# hack for 'make install' targets that force installation to
+#  /lib/systemd if $prefix/lib/systemd/system doesn't exist
+mkdir -p ${prefix}/lib/systemd/system
+
+for pkg in $downloads; do
+    name=$(basename ${pkg} .tar.gz)
+    if check_cache "$name"; then
+       say "Using cached version of ${name}"
+       continue
+    fi
+    mkdir -p ${name}  || die "Failed to mkdir ${name}"
+    (
+      cd ${name} &&
+      wget ${pkg} || die "Failed to download ${pkg}"
+      tar --strip-components=1 -xf *.tar.gz || die "Failed to un-tar ${name}"
+      ./configure --prefix=${prefix} \
+                  --sysconfdir=${prefix}/etc \
+                  ${extra_configure_opts[$name]} &&
+      make &&
+      make install
+    ) || die "Failed to build and install $name"
+    add_cache "$name"
+done
+
+


### PR DESCRIPTION
This PR updates the travis-ci builder to their new container-based infrastructure. The main benefits of this change are
 * faster build start times
 * support for cache directories (i.e. for built dependencies)

The drawback is that `sudo` is no longer supported -- however this isn't really an issue since we can install all dependencies into subdirs of `$HOME`.

This PR enables the new container based builds by adding `sudo: false` to the `.travis.yml` file.
In order to manage caching, a new script is added that handles downloading dependencies only if they are not already cached. (Unfortunately, lua dependencies have to be special cased)

The script supports a max-cache-age, but this isn't enabled yet.

In order to support builds with non-standard Lua paths, the first commit here fixes the `flux` command, which was inconsiderately blowing away the current `LUA_PATH` and `LUA_CPATH` :smile:

Additionally, for cleaner build output, I did remove `V=1` from the build. This should get us well under 10k lines again. For problems building under travis, debug can be added to builds on a case-by-case basis (especially useful in a private branch of your own repo)