### PR TITLE
cmd: support stdin broadcast for flux-exec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  - export CC="ccache $CC"
  - ./autogen.sh
  - ./configure --prefix=$HOME/local
- - make -j2 distcheck
+ - make distcheck
 
 after_success:
  - ccache -s

--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -10,7 +10,7 @@ flux-exec - Execute processes across flux ranks
 
 SYNOPSIS
 --------
-*flux* *exec* ['--labelio] ['--dir=DIR'] ['--rank=RANKS'] ['--verbose'] COMMANDS...
+*flux* *exec* [--noinput] ['--labelio] ['--dir=DIR'] ['--rank=RANKS'] ['--verbose'] COMMANDS...
 
 
 DESCRIPTION
@@ -40,6 +40,12 @@ exits with exit code 128+signo.
 
 OPTIONS
 -------
+
+*-l, --labelio*::
+Label lines of output with the source RANK.
+
+*-n, --noinput*::
+Redirect `stdin` from `/dev/null`.
 
 *-d, --dir*'=DIR'::
 Set the working directory of remote 'COMMANDS' to 'DIR'. The default is to

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -52,6 +52,7 @@
 #include "src/common/libutil/ipaddr.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/modules/libsubprocess/subprocess.h"
+#include "src/modules/libzio/zio.h"
 
 #include "heartbeat.h"
 #include "module.h"
@@ -1009,6 +1010,65 @@ static int subprocess_io_cb (struct subprocess *p, json_object *o)
     return (0);
 }
 
+static struct subprocess *
+subprocess_get_pid (struct subprocess_manager *sm, int pid)
+{
+    struct subprocess *p = NULL;
+    p = subprocess_manager_first (sm);
+    while (p) {
+        if (pid == subprocess_pid (p))
+            return (p);
+        p = subprocess_manager_next (sm);
+    }
+    return (NULL);
+}
+
+static int cmb_write_cb (zmsg_t **zmsg, void *arg)
+{
+    ctx_t *ctx = arg;
+    json_object *request = NULL;
+    json_object *response = NULL;
+    json_object *o = NULL;
+    int pid;
+    int errnum = EPROTO;
+
+    if (flux_json_request_decode (*zmsg, &request) < 0)
+        goto out;
+
+    if (Jget_int (request, "pid", &pid) &&
+        Jget_obj (request, "stdin", &o)) {
+        int len;
+        void *data = NULL;
+        bool eof;
+        struct subprocess *p;
+
+        /* XXX: We use zio_json_decode() here for convenience. Probably
+         *  this should be bubbled up as a subprocess IO json spec with
+         *  encode/decode functions.
+         */
+        if ((len = zio_json_decode (o, &data, &eof)) < 0)
+            goto out;
+        if (!(p = subprocess_get_pid (ctx->sm, pid))) {
+            errnum = ENOENT;
+            goto out;
+        }
+        if (subprocess_write (p, data, len, eof) < 0) {
+            errnum = errno;
+            goto out;
+        }
+        free (data);
+    }
+out:
+    response = util_json_object_new_object ();
+    Jadd_int (response, "code", errnum);
+    flux_json_respond (ctx->h, response, zmsg);
+    if (response)
+        json_object_put (response);
+    if (request)
+        json_object_put (request);
+    return (0);
+}
+
 static int cmb_signal_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -1592,6 +1652,7 @@ static void broker_add_services (ctx_t *ctx)
           || !svc_add (ctx->services, "cmb.event-mute", cmb_event_mute_cb, ctx)
           || !svc_add (ctx->services, "cmb.exec", cmb_exec_cb, ctx)
           || !svc_add (ctx->services, "cmb.exec.signal", cmb_signal_cb, ctx)
+          || !svc_add (ctx->services, "cmb.exec.write", cmb_write_cb, ctx)
           || !svc_add (ctx->services, "cmb.processes", cmb_ps_cb, ctx)
           || !svc_add (ctx->services, "cmb.disconnect", cmb_disconnect_cb, ctx)
           || !svc_add (ctx->services, "cmb.hello", cmb_hello_cb, ctx)

--- a/src/cmd/flux-exec
+++ b/src/cmd/flux-exec
@@ -5,6 +5,7 @@
 -------------------------------------------------------------------------------
 local flux = require 'flux'
 local decode = require 'flux-lua.base64' .decode
+local encode = require 'flux-lua.base64' .encode
 local posix = require 'flux-lua.posix'
 local timer = require 'flux-lua.timer'
 local hostlist = require 'hostlist'
@@ -39,7 +40,8 @@ local function die (fmt, ...)
     os.exit (1)
 end
 
-local function program_state_create (n)
+local function program_state_create (f, n)
+    local f = f
     local s = {
         size = n or 1,
         nexited = 0,
@@ -51,6 +53,31 @@ local function program_state_create (n)
         matchtag = {},
     }
     local T = {}
+
+    local function write (data)
+        if data.data then data.data = encode (data.data) end
+        for rank,pid in pairs(s.running) do
+            f:send ("cmb.exec.write", { pid = pid, stdin = data }, rank)
+        end
+    end
+
+    local function activate_stdin ()
+        f:iowatcher {
+         fd = posix.fileno (io.input()),
+            handler = function (iow, data)
+                write (data)
+            end
+        }
+    end
+
+    function increment_nstarted ()
+        s.nstarted = s.nstarted + 1
+        if s.nstarted == s.size then
+            activate_stdin ()
+        end
+    end
+
+
     function T.size (n)
         if n then s.size = n end
         return s.size
@@ -69,7 +96,7 @@ local function program_state_create (n)
         s.status [resp.rank] = resp.status
     end
     function T.started (rank, pid)
-        s.nstarted = s.nstarted + 1
+        increment_nstarted ()
         s.running [rank] = pid
     end
     function T.killall (f, signum)
@@ -83,7 +110,7 @@ local function program_state_create (n)
         end
     end
     function T.failed (rank, errnum)
-        s.nstarted = s.nstarted + 1
+        increment_nstarted ()
         s.nexited = s.nexited + 1
         s.nclosed.stdout = s.nclosed.stdout + 1
         s.nclosed.stderr = s.nclosed.stderr + 1
@@ -131,10 +158,12 @@ end
 --  Parse cmdline args:
 --
 local getopt = require 'flux-lua.alt_getopt' .get_opts
-local opts, optind = getopt (arg, "d:r:vl",
-                        { rank = "r", verbose = "v", dir = "d", labelio = "l" })
+local opts, optind = getopt (arg, "d:r:vln",
+                        { rank = "r", verbose = "v", dir = "d", labelio = "l",
+                          noinput = 'n' })
 
 if opts.v then verbose = true end
+if opts.n then io.input ("/dev/null") end
 if not arg[optind] then die ("Command to run required\n") end
 local cmdline = {}
 for i = optind, #arg do
@@ -153,7 +182,8 @@ local f, err = flux.new()
 if not f then die ("Connecting to flux failed: %s\n", err) end
 
 local ranks = get_ranklist (f, opts.r)
-local state = program_state_create (#ranks)
+local state = program_state_create (f, #ranks)
+
 
 --  Set up msghandler for exec responses
 --
@@ -204,6 +234,8 @@ local mh, err = f:msghandler {
             if state.complete() then
                 f:reactor_stop ()
             end
+        else
+            warn ("got unexpected msg %s\n", require 'inspect' (resp))
         end
     end
 

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -241,9 +241,12 @@ subprocess_flush_io (struct subprocess *p)
 int
 subprocess_write (struct subprocess *p, void *buf, size_t n, bool eof)
 {
+    int rc = 0;
+    if (n > 0)
+        rc = zio_write (p->zio_in, buf, n);
     if (eof)
         zio_write_eof (p->zio_in);
-    return zio_write (p->zio_in, buf, n);
+    return (rc);
 }
 
 int subprocess_io_complete (struct subprocess *p)

--- a/src/modules/libzio/zio.c
+++ b/src/modules/libzio/zio.c
@@ -818,6 +818,10 @@ int zio_write_eof (zio_t zio)
         return (-1);
     }
     zio_set_eof (zio);
+    /* If no data is buffered, then we can close the dst fd:
+     */
+    if (zio_buffer_empty (zio))
+        zio_close (zio);
     return (0);
 }
 

--- a/src/modules/libzio/zio.c
+++ b/src/modules/libzio/zio.c
@@ -637,7 +637,10 @@ static int zio_write_pending (zio_t zio)
  */
 static int zio_writer_cb (zio_t zio)
 {
-    int rc = cbuf_read_to_fd (zio->buf, zio->dstfd, -1);
+    int rc = 0;
+
+    if (cbuf_used (zio->buf))
+        rc = cbuf_read_to_fd (zio->buf, zio->dstfd, -1);
     if (rc < 0) {
         if (errno == EAGAIN)
             return (0);

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -122,7 +122,7 @@ test_expect_success 'I/O, multiple lines, no newline on last line' '
 '
 
 test_expect_success 'I/O -- long lines' '
-	dd if=/dev/urandom bs=4096 count=1 | base64 >expected &&
+	dd if=/dev/urandom bs=4096 count=1 | base64 --wrap=0 >expected &&
 	flux exec -r1 cat expected > output &&
 	test_cmp output expected
 '

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -131,7 +131,7 @@ test_expect_success 'signal forwarding works' '
 	cat >test_signal.sh <<-EOF &&
 	#!/bin/bash
 	sig=\${1-INT}
-	flux exec sleep 100 &
+	flux exec sleep 100 </dev/null &
 	sleep 1 &&
 	kill -\$sig %1 &&
 	wait %1
@@ -143,7 +143,7 @@ test_expect_success 'signal forwarding works' '
 '
 
 test_expect_success 'process listing works' '
-	flux exec -r1 sleep 100 &
+	flux exec -r1 sleep 100 </dev/null &
 	p=$! &&
 	sleep 1 &&
 	flux ps -r1 | grep ".* 1 .*sleep$" >/dev/null &&
@@ -152,7 +152,7 @@ test_expect_success 'process listing works' '
 '
 
 test_expect_success 'process listing works - multiple processes' '
-	flux exec -r0-3 sleep 100 &
+	flux exec -r0-3 sleep 100 </dev/null &
 	q=$! &&
 	sleep 1 &&
 	count=$(flux ps | grep -c sleep) &&
@@ -164,7 +164,7 @@ test_expect_success 'process listing works - multiple processes' '
 '
 
 test_expect_success 'flux-exec disconnect terminates all running processes' '
-	flux exec -r0-3 sleep 100 &
+	flux exec -r0-3 sleep 100 </dev/null &
 	q=$! &&
 	sleep 1 &&
 	count=$(flux ps | grep -c sleep) &&


### PR DESCRIPTION
For completeness, this PR adds stdin handling to `flux-exec`. The current behavior is to broadcast stdin to each process currently "running". `flux-exec` therefore waits until all tasks currently managed are either running or failed to start handling stdin.

If `flux-exec` is sent to the background, it may be stopped by `SIGTTIN` if/when it tries to read from the terminal. Therefore, it is recommended to redirect stdin from `/dev/null`, send over a pipe, or use the `-n` option when running in the background. (The tests are updated to use this approach).  However, since the `cmb.exec` service is message based, things actually turn out OK if `flux-exec` goes into the background and is stopped. Once put in the foreground and resumed, it appears that buffered messages are processed and `flux-exec` exits or continues as expected. 

The background behavior of a more user friendly version of `exec` might instead "pause" stdin reading while in the background and re-enable it upon being moved to foreground. It is possible to determine somewhat reliably if a process is in the background (`isatty(0) && (tcgetpgrp(0) != getpgrp())` or setup a handler for `SIGTTIN`), however it isn't as easy to tell when the process is moved to the foreground. Another option is to block `SIGTTIN` and check for (ignore?) `EIO` when reading stdin.

Anyway, it seemed at this point the current behavior is sufficient. We can open an issue with the above info if anyone feels that the behavior described above is desired?

Additionally, I had to remove `-j2` from the `make distcheck` in the travis tests to get this branch to pass. The build was failing during parallel `make distclean` with `make: write error`. I couldn't run down why this was happening (seems to be an IO error on make's stdout), but running serial `make distcheck` fixed it and doesn't add too much time to the build/test cycle.
