### PR TITLE
minor test adjustments

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -3,6 +3,7 @@ KVS
 kvs
 api
 comms
+dev
 dir
 doctype
 dropcache
@@ -87,6 +88,7 @@ lwj
 mpi
 mpicc
 nnodes
+noinput
 ntasks
 pmi
 resrc

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -184,12 +184,24 @@ EOF
     test_cmp expected6.sort output.6.sort
 '
 
-test_expect_success 'jstat 7: basic query works' '
-    run_timeout 4 flux wreckrun -n4 -N4 hostname &&  # create some state for
-    flux jstat query 1 jobid &&                      #   subsequent tests
-    flux jstat query 1 state-pair &&                 #   in case RACY not set
-    flux jstat query 1 rdesc &&
-    flux jstat query 1 pdesc 
+test_expect_success 'jstat 7.1: run hostname to create some state' '
+    run_timeout 4 flux wreckrun -n4 -N4 hostname
+'
+
+test_expect_success 'jstat 7.2: basic query works: jobid' '
+    flux jstat query 1 jobid
+'
+
+test_expect_success 'jstat 7.3: basic query works: state-pair' '
+    flux jstat query 1 state-pair
+'
+
+test_expect_success 'jstat 7.4: basic query works: rdesc' '
+    flux jstat query 1 rdesc
+'
+
+test_expect_success 'jstat 7.5: basic query works: pdesc' '
+    flux jstat query 1 pdesc
 '
 
 test_expect_success 'jstat 8: query detects bad inputs' '


### PR DESCRIPTION
For some reason, another aspell failure on Ubuntu 14.04 required dictionary additions.
Also, I split up the intermittently failing jsc tests so we can at least see which part is problematic.