### PR TITLE
more testing fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
   directories:
     - $HOME/local
     - $HOME/.luarocks
-    - $HOME/.python
     - $HOME/.ccache
+    - $HOME/.local
 
 addons:
   apt:

--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -49,10 +49,10 @@ local top_builddir = "@abs_top_builddir@"
 --  to hand down to test scripts
 --
 --
-package.path = package.path ..  ';' .. top_srcdir ..
-    "/src/bindings/lua/?.lua"
-package.cpath = package.cpath .. ';' .. top_builddir ..
-    "/src/bindings/lua/.libs/?.so"
+package.path = top_srcdir .. "/src/bindings/lua/?.lua" .. ';'
+	.. package.path
+package.cpath = top_builddir .. "/src/bindings/lua/.libs/?.so" .. ';' 
+	.. package.cpath
 
 ---------------------------------------------------------------------------
 local getopt = require 'flux-lua.alt_getopt'.get_opts
@@ -72,8 +72,8 @@ local cmdline_opts = {
 ---
 --  Append path p to PATH environment variable:
 --
-local function do_path_append (p)
-    posix.setenv ("PATH", os.getenv ("PATH") .. ":" .. p)
+local function do_path_prepend (p)
+    posix.setenv ("PATH", p .. ":" .. os.getenv ("PATH"))
 end
 
 ---
@@ -142,7 +142,7 @@ function fluxTest.init (...)
     local path = dir.."/flux"
     local mode = posix.stat (path, 'mode')
     if mode and mode:match('^rwx') then
-        do_path_append (dir)
+        do_path_prepend (dir)
         test.flux_path = path
     else
         test:die ("Failed to find flux path")

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -25,17 +25,18 @@ test_expect_success 'wreckrun: propagates current working directory' '
 	mkdir -p testdir &&
 	cd testdir && 
 	mypwd=$(pwd) &&
-	flux wreckrun -N1 -n1 pwd | grep "^$mypwd$"
+	run_timeout 5 flux wreckrun -N1 -n1 pwd | grep "^$mypwd$"
 '
 test_expect_success 'wreckrun: propagates current environment' '
-	MY_UNLIKELY_ENV=0xdeadbeef \
-	flux wreckrun -N1 -n1 env | grep "MY_UNLIKELY_ENV=0xdeadbeef"
+	( export MY_UNLIKELY_ENV=0xdeadbeef &&
+	  run_timeout 5 flux wreckrun -N1 -n1 env ) | \
+           grep "MY_UNLIKELY_ENV=0xdeadbeef"
 '
 test_expect_success 'wreckrun: does not drop output' '
 	for i in `seq 0 100`; do 
 		base64 /dev/urandom | head -c77
 	done >expected &&
-	flux wreckrun -N1 -n1 cat expected >output &&
+	run_timeout 5 flux wreckrun -N1 -n1 cat expected >output &&
 	test_cmp expected output
 '
 test_done


### PR DESCRIPTION
commit e04e40b here may have a fix for #284, however I was unable to quickly reproduce the error documented therein, so I'd appreciate @garlick if you tried reproducing with this branch.

Additionally, this PR adds timeouts to all `flux-wreckrun` invocations in `t2000-wreck.t` to catch the occasional wreck hangs that we've seen in travis.

Finally, we fix up `pip` package caching.

I'm still working on enhancing the sharness based tests to somehow report more detailed errors on failure. That will come in a future PR.