### PR TITLE
Manpage cleanup

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -95,10 +95,13 @@ AM_CPPFLAGS = \
 LDADD = \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
-        $(top_builddir)/src/common/libtap/libtap.la \
         $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD)
 
 check_PROGRAMS = \
+	topen \
+	tsend \
+	trecv \
+	tevent \
 	trpc \
 	trpc_then \
 	trpc_then_multi

--- a/doc/man3/flux_event_subscribe.adoc
+++ b/doc/man3/flux_event_subscribe.adoc
@@ -65,29 +65,9 @@ EXAMPLES
 
 This example opens the Flux broker, subscribes to heartbeat messages,
 displays one, then quits.
+
 ....
-flux_t h;
-flux_msg_t *msg;
-struct flux_match match = FLUX_MATCH_EVENT;
-const char *topic;
-
-if (!(h = flux_open (NULL, 0)))
-    err_exit ("flux_open");
-
-if (flux_event_subscribe (h, "hb") < 0)
-    err_exit ("flux_event_subscribe");
-
-if (!(msg = flux_recv (h, match, 0)))
-    err_exit ("flux_recv"):
-if (flux_msg_get_topic (msg, &topic) < 0)
-    err_exit ("flux_msg_get_topic");
-printf ("Event: %s\n", topic);
-
-if (flux_event_unsubscribe (h, "hb") < 0)
-    err_exit ("flux_event_unsubscribe");
-
-flux_msg_destroy (msg);
-flux_close (h);
+include::tevent.c[]
 ....
 
 

--- a/doc/man3/flux_open.adoc
+++ b/doc/man3/flux_open.adoc
@@ -66,15 +66,9 @@ EXAMPLES
 
 This example opens the Flux broker using the default connector
 and path, requests the broker rank, and finally closes the broker handle.
+
 ....
-flux_t h;
-
-if (!(h = flux_open (NULL, 0)))
-    err_exit ("flux_open");
-
-printf ("My rank is %d\n", flux_rank (h));
-
-flux_close (h);
+include::topen.c[]
 ....
 
 

--- a/doc/man3/flux_recv.adoc
+++ b/doc/man3/flux_recv.adoc
@@ -96,23 +96,9 @@ EXAMPLES
 
 This example opens the Flux broker and displays event messages
 as they arrive.
+
 ....
-flux_t h;
-flux_msg_t *msg;
-struct flux_match match = FLUX_MATCH_EVENT;
-const char *topic;
-
-if (!(h = flux_open (NULL, 0)))
-    err_exit ("flux_open");
-
-while ((msg = flux_recv (h, match, 0))) {
-    if (flux_msg_get_topic (msg, &topic) < 0)
-        err_exit ("flux_msg_get_topic");
-    printf ("Event: %s\n", topic);
-    flux_msg_destroy (msg);
-}
-
-flux_close (h);
+include::trecv.c[]
 ....
 
 

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -12,55 +12,67 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_rpc_t *flux_rpc (flux_t h, const char *topic, const char *json_str,
-                      uint32_t nodeid, int flags);
+flux_rpc_t *flux_rpc (flux_t h, const char *topic, const char *json_in,
+                      uint32_t nodeid_in, int flags);
 
 void flux_rpc_destroy (flux_rpc_t *rpc);
 
-int flux_rpc_get (flux_rpc_t *rpc, uint32_t *nodeid, const char **json_str);
+int flux_rpc_get (flux_rpc_t *rpc, uint32_t *nodeid_out, const char **json_out);
 
 
 DESCRIPTION
 -----------
 
-`flux_rpc()` constructs a request for the Flux service identified by
-_topic_, with optional payload _json_str_, that will routed be according
-to _nodeid_.  The request message is assigned a matchtag from the handle
-matchtag pool, and is then sent to the broker via handle _h_.
-A flux_rpc_t object is returned to the caller, used to complete the RPC.
+`flux_rpc()` encodes and sends a request message, comprising the first
+half of a remote procedure call (RPC).  A flux_rpc_t object is returned
+which can be passed to `flux_rpc_get()` to obtain the decoded response
+message, comprising the second half of the RPC.  The flux_rpc_t should
+finally be disposed of using `flux_rpc_destroy()`.
 
-_nodeid_ affects how the broker will route the request, and may be set
-to one of the following values:
+_topic_ must be set to a topic string representing the Flux
+service that will handle the request.
+
+_json_in_, if non-NULL, must be a string containing valid serialized
+JSON to be attached as payload to the request.  If NULL, the request
+will be sent without a payload.
+
+_nodeid_in_ affects request routing, and must be set to one of the following
+values:
 
 FLUX_NODEID_ANY::
-Route to first available matching service instance.
+The request is routed to the first matching service instance.
 
 FLUX_NODEID_UPSTREAM::
-Route upstream via the tree based overlay network, then to first available
-matching service instance, skipping any instance on the sending rank.
+The request is routed to the first matching service instance,
+skipping over the sending rank.
 
 integer::
-Route to a specific broker rank.
+The request is routed to a specific rank.
 
-If _json_str_ is non-NULL, it must represent valid serialized JSON,
-and will be attached as request payload.
-
-Flags may be zero or a mask of the following values:
+_flags_ may be zero or:
 
 FLUX_RPC_NORESPONSE::
-No response is expected, and the request will not be assigned a matchtag.
-The flux_rpc_t may be immediately destroyed.
+No response is expected.  The request will not be assigned a matchtag,
+and the flux_rpc_t returned by `flux_rpc()` may be immediately destroyed.
 
-`flux_rpc_get()` obtains the result of the RPC, blocking until the response
-is received.  If non-NULL, _nodeid_ is set to the _nodeid_ argument given
-to `flux_rpc()` -- primarily useful with `flux_rpc_multi(3)`.  Similarly,
-_json_str_, if non-NULL, is set the response payload.  The storage associated
-with _json_str_ belongs to the flux_rpc_t object.  It is a protocol error
-if _json_str_ is NULL and the response has an unexpected payload, or if
-_json_str_ is non-NULL and the payload is missing.
+`flux_rpc_get()` blocks until a matching response is received, then
+decodes the result.  For asynchronous response handling, see flux_rpc_then(3).
+
+_json_out_, if non-NULL, is assigned a string containing valid serialized
+JSON from the response payload.  It is a protocol error if a payload that is
+expected (signified by a non-NULL _json_out_) does not arrive;
+similarly, it is a protocol error if an unexpected payload (signified
+by a NULL _json_out_) arrives.  The storage associated with _json_out_
+belongs to the flux_rpc_t object and is invalidated when that object is
+destroyed.
+
+_nodeid_out_, if non-NULL, is set to the _nodeid_in_ argument given
+to `flux_rpc()`.  This is primarily useful with `flux_rpc_multi(3)`.
 
 `flux_rpc_destroy()` destroys a completed `flux_rpc_t`, invalidating 
-any payload returned by `flux_rpc_get()`, and freeing matchtags.
+payload as described above, and freeing the RPC matchtag.  Destroying
+an RPC before completion renders the matchtag associated with the RPC
+unusable; it is effectively leaked from the matchtag pool.
 
 
 CANCELLATION

--- a/doc/man3/flux_rpc_multi.adoc
+++ b/doc/man3/flux_rpc_multi.adoc
@@ -20,26 +20,34 @@ bool flux_rpc_completed (flux_rpc_t *rpc);
 DESCRIPTION
 -----------
 
-`flux_rpc_multi()` sends requests to a Flux service identified by _topic_
-via Flux broker handle _h_.   The _nodeset_ represents a set of ranks
-that will receive the request, and is specified in bracketed range format,
-e.g. "[0-255]", "[1,3,5-10]", or "all" for all ranks in the session.
+`flux_rpc_multi()` encodes and sends request messages, comprising the
+first half of a remote procedure call (RPC), to multiple ranks.
+A flux_rpc_t object is returned which can be passed repeatedly to
+`flux_rpc_get()` to obtain the decoded response messages, comprising
+the second half of the RPC.  The flux_rpc_t should finally be disposed
+of using `flux_rpc_destroy()`.
 
-If _json_str_ is non-NULL, it should represent a valid JSON string
-that will be attached as request payload.
+_topic_ must be set to a topic string representing the Flux
+service that will handle the request.
 
-Flags may be zero or a mask of the following values:
+_json_in_, if non-NULL, must be a string containing valid serialized
+JSON to be attached as payload to the request.  If NULL, the request
+will be sent without a payload.
+
+_nodeset_ is a string containing a bracketed set of ranks or "all" as a
+shorthand for all ranks in the session.  Examples of valid nodeset
+strings are "[0-255]", "[1,2.3]", and "[0,3,5-10]".
+
+_flags_ may be zero or:
 
 FLUX_RPC_NORESPONSE::
-No response will be expected to the request, and the request will not be
-assigned a matchtag.
+No response is expected.  The request will not be assigned a matchtag,
+and the flux_rpc_t returned by `flux_rpc()` may be immediately destroyed.
 
-`flux_rpc_get(3)` may be used, as with `flux_rpc(3)`, to process responses.
-Each call to `flux_rpc_get(3)` invalidates any payload obtained via a
-previous call.
-
-`flux_rpc_check(3)` may be used, as with `flux_rpc(3)`, to determine
-whether `flux_rpc_get(3)` will block.
+`flux_rpc_get()` blocks until a matching response is received, then
+decodes the result.  This function is called once for each response,
+each time invalidating the payload obtained in the previous call.
+For asynchronous response handling, see flux_rpc_then(3).
 
 `flux_rpc_completed()` returns true once all the RPC responses have been
 received and handled via `flux_rpc_get()`.  It can be used to terminate
@@ -49,12 +57,10 @@ while (!flux_rpc_completed (rpc))
     flux_rpc_get (rpc, &nodeid, &payload);
 ....
 
-`flux_rpc_then(3)` may be used, as with `flux_rpc(3)`, to register a
-reactor callback to handle each RPC responses message.
-
-`flux_rpc_destroy(3)` should be used to dispose of the flux_rpc_t object
-once the RPC has completed.  After this function is called, any payload
-returned by `flux_rpc_get()` is invalidated.
+`flux_rpc_destroy()` destroys a completed `flux_rpc_t`, invalidating 
+payload as described above, and freeing the RPC matchtag block.  Destroying
+an RPC before completion renders the matchtag block associated with the RPC
+unusable; it is effectively leaked from the matchtag pool.
 
 
 RETURN VALUE
@@ -78,6 +84,25 @@ Some arguments were invalid.
 
 EPROTO::
 A protocol error was encountered.
+
+
+IMPLEMENTATION NOTES
+--------------------
+
+In the flux-core-0.0.1 implementation of `flux_rpc_multi()`, all requests
+are sent back to back during the `flux_rpc_multi()` call, and routed
+over the flux-broker(1) ring network, which is characterized by worst-case
+latency that scales linearly with the session size.
+
+Since requests are sent back to back without waiting for a response,
+this message latency may be well hidden, but messages may flood the brokers
+and overlay channels, since there is no flow control of requests based on
+the timing of return messages.
+
+Other options with different scalability properties are available.
+For example, `flux_mrpc_*()` uses multicast events for synchronization
+and the KVS with its hierarchical object cache for exchanging request
+and response payloads.
 
 
 EXAMPLE

--- a/doc/man3/flux_rpc_then.adoc
+++ b/doc/man3/flux_rpc_then.adoc
@@ -22,9 +22,9 @@ int flux_rpc_then (flux_rpc_t *rpc, flux_then_f cb, void *arg);
 DESCRIPTION
 -----------
 
-`flux_rpc_check()` and `flux_rpc_then()` may be used to conditionally
-complete an RPC operation that was started with `flux_rpc(3)` or
-`flux_rpc_multi(3)`, asynchronously.
+`flux_rpc_check()` and `flux_rpc_then()` may be used to asynchronously
+complete the second half of a remote procedure call (RPC) that was
+started with `flux_rpc(3)` or `flux_rpc_multi(3)`.
 
 `flux_rpc_check()` returns true if the RPC response has been received
 and a call to `flux_rpc_get(3)` would not block.  It returns false if
@@ -43,10 +43,10 @@ flux_rpc_t object from within the continuation callback.
 RETURN VALUE
 ------------
 
-`flux_rpc_check()` returns true or false and does not detect failure.
-
 `flux_rpc_then()` returns  zero on success.  On error, -1 is returned,
 and errno is set appropriately.
+
+`flux_rpc_check()` does not report errors.
 
 
 ERRORS

--- a/doc/man3/flux_send.adoc
+++ b/doc/man3/flux_send.adoc
@@ -59,21 +59,9 @@ EXAMPLES
 --------
 
 This example opens the Flux broker and publishes an event message.
+
 ....
-flux_t h;
-flux_msg_t *msg;
-
-if (!(h = flux_open (NULL, 0)))
-    err_exit ("flux_open");
-
-if (!(msg = flux_event_encode ("snack.bar.closing", NULL)))
-    err_exit ("flux_event_encode");
-
-if (flux_send (h, msg, 0) < 0)
-    err_exit ("flux_send");
-
-flux_msg_destroy (msg);
-flux_close (h);
+include::tsend.c[]
 ....
 
 

--- a/doc/man3/tevent.c
+++ b/doc/man3/tevent.c
@@ -1,0 +1,25 @@
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    flux_msg_t *msg;
+    struct flux_match match = FLUX_MATCH_EVENT;
+    const char *topic;
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    if (flux_event_subscribe (h, "hb") < 0)
+        err_exit ("flux_event_subscribe");
+    if (!(msg = flux_recv (h, match, 0)))
+        err_exit ("flux_recv");
+    if (flux_msg_get_topic (msg, &topic) < 0)
+        err_exit ("flux_msg_get_topic");
+    printf ("Event: %s\n", topic);
+    if (flux_event_unsubscribe (h, "hb") < 0)
+        err_exit ("flux_event_unsubscribe");
+    flux_msg_destroy (msg);
+    flux_close (h);
+    return (0);
+}

--- a/doc/man3/topen.c
+++ b/doc/man3/topen.c
@@ -1,0 +1,13 @@
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    printf ("My rank is %d\n", flux_rank (h));
+    flux_close (h);
+    return (0);
+}

--- a/doc/man3/trecv.c
+++ b/doc/man3/trecv.c
@@ -1,0 +1,25 @@
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    flux_msg_t *msg;
+    struct flux_match match = FLUX_MATCH_EVENT;
+    const char *topic;
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    if (flux_event_subscribe (h, "") < 0)
+        err_exit ("flux_event_subscribe");
+    for (;;) {
+        if ((msg = flux_recv (h, match, 0)))
+            err_exit ("flux_recv");
+        if (flux_msg_get_topic (msg, &topic) < 0)
+            err_exit ("flux_msg_get_topic");
+        printf ("Event: %s\n", topic);
+        flux_msg_destroy (msg);
+    }
+    flux_close (h);
+    return (0);
+}

--- a/doc/man3/tsend.c
+++ b/doc/man3/tsend.c
@@ -1,0 +1,18 @@
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    flux_msg_t *msg;
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    if (!(msg = flux_event_encode ("snack.bar.closing", NULL)))
+        err_exit ("flux_event_encode");
+    if (flux_send (h, msg, 0) < 0)
+        err_exit ("flux_send");
+    flux_msg_destroy (msg);
+    flux_close (h);
+    return (0);
+}

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -231,3 +231,4 @@ rpc
 str
 trpc
 bool
+mrpc

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -232,3 +232,7 @@ str
 trpc
 bool
 mrpc
+topen
+tevent
+tsend
+trecv


### PR DESCRIPTION
The day after writing those RPC man pages, they looked badly written to me, so here's what I hope are improved versions.

Also I took the examples in flux_open(3), flux_send(3), flux_recv(3), and flux_event_subscribe(3) and turned them into standalone C programs that are compiled as check_PROGRAMS to be sure they at least compile.