### PR TITLE
test and build updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
   - eval `./src/test/travis-dep-builder.sh --printenv`
   - ./src/test/travis-dep-builder.sh --cachedir=$HOME/local/.cache
-  - pip install --user cffi coverage
 
 script:
  - export CC="ccache $CC"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,13 @@ before_install:
 
 script:
  - export CC="ccache $CC"
+ - export FLUX_TESTS_LOGFILE=t
  - ./autogen.sh
  - ./configure --prefix=$HOME/local
  - make distcheck
 
 after_success:
  - ccache -s
+
+after_failure:
+ - find flux-core-[0-9]* -name *.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,9 @@ addons:
       - ccache
 
 before_install:
-  - export LD_LIBRARY_PATH=$HOME/local/lib
-  - export CPPFLAGS=-I$HOME/local/include
-  - export LDFLAGS=-L$HOME/local/lib
-  - export PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
-  - eval `luarocks path`
+  - eval `./src/test/travis-dep-builder.sh --printenv`
   - ./src/test/travis-dep-builder.sh --cachedir=$HOME/local/.cache
   - pip install --user cffi coverage
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -236,3 +236,4 @@ topen
 tevent
 tsend
 trecv
+scalability

--- a/src/bindings/python/Makefile.am
+++ b/src/bindings/python/Makefile.am
@@ -32,3 +32,6 @@ clean-local:
 	-rm -f test/*.pyc test_commands/*.pyc
 	-rm -f .coverage*
 
+dist-hook:
+	-rm -f test/*.pyc test_commands/*.pyc
+	-rm -f test_commands/*.log test_commands/*.trs

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -3,6 +3,7 @@
 #
 
 prefix=$HOME/local
+cachedir=$HOME/local/.cache
 
 #
 # Ordered list of software to download and install into $prefix.

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -27,8 +27,8 @@ declare -A lua_rocks=(\
 )
 
 declare -r prog=${0##*/}
-declare -r long_opts="prefix:,cachedir:,verbose"
-declare -r short_opts="vp:c:"
+declare -r long_opts="prefix:,cachedir:,verbose,printenv"
+declare -r short_opts="vp:c:P"
 declare -r usage="\
 \n
 Usage: $prog [OPTIONS]\n\
@@ -37,6 +37,7 @@ for building flux-framework/flux-core\n\
 \n\
 Options:\n\
  -v, --verbose           Be verbose.\n\
+ -P, --printenv          Print environment variables to stdout\n\
  -c, --cachedir=DIR      Check for precompiled dependency cache in DIR\n\
  -e, --max-cache-age=N   Expire cache in N days from creation\n\
  -p, --prefix=DIR        Install software into prefix\n
@@ -58,10 +59,26 @@ while true; do
       -c|--cachedir)         cachedir="$2"; shift 2 ;;
       -e|--max-cache-age)    cacheage="$2"; shift 2 ;;
       -p|--prefix)           prefix="$2";   shift   ;;
+      -P|--printenv)         print_env=1;   shift   ;;
       --)                    shift ; break;         ;;
       *)                     die "Invalid option '$1'\n$usage" ;;
     esac
 done
+
+print_env () {
+    echo "export LD_LIBRARY_PATH=${prefix}/lib:$LD_LIBRARY_PATH"
+    echo "export CPPFLAGS=-I${prefix}/include"
+    echo "export LDFLAGS=-L${prefix}/lib"
+    echo "export PKG_CONFIG_PATH=${prefix}/lib/pkgconfig"
+    luarocks path
+}
+
+if test -n "$print_env"; then
+    print_env
+    exit 0
+fi
+
+$(print_env)
 
 check_cache ()
 {

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -21,6 +21,13 @@ declare -A extra_configure_opts=(\
 )
 
 #
+#  Python pip packages
+#
+pips="\
+cffi \
+coverage"
+
+#
 #  Lua rocks files to download and install:
 #
 declare -A lua_rocks=(\
@@ -100,6 +107,9 @@ add_cache ()
     mkdir -p "${cachedir}" &&
     touch "${cachedir}/${1}"
 }
+
+pip help >/dev/null 2>&1 || die "Required command pip not installed"
+pip install --user $pips || die "Failed to install required python packages"
 
 
 luarocks help >/dev/null 2>&1 || die "Required command luarocks not installed"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -46,7 +46,7 @@ EXTRA_DIST= \
 	$(T)
 
 clean-local:
-	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log
+	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output
 
 check_SCRIPTS = \
 	t0000-sharness.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -52,11 +52,11 @@ test_under_flux() {
         return
     fi
     quiet="-o -q,-L${log_file}"
-    if test "$verbose" = "t"; then
+    if test "$verbose" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --verbose"
         quiet=""
     fi
-    if test "$debug" = "t"; then
+    if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --debug"
     fi
     if test -n "$SHARNESS_TEST_DIRECTORY"; then

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -59,6 +59,9 @@ test_under_flux() {
     if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --debug"
     fi
+    if test -n "$logfile" -o -n "$FLUX_TESTS_LOGFILE" ; then
+        flags="${flags} --logfile"
+    fi
     if test -n "$SHARNESS_TEST_DIRECTORY"; then
         cd $SHARNESS_TEST_DIRECTORY
     fi

--- a/t/sharness.sh
+++ b/t/sharness.sh
@@ -54,6 +54,8 @@ LF='
 
 while test "$#" -ne 0; do
 	case "$1" in
+        --logfile)
+                logfile=t; shift;;
 	-d|--d|--de|--deb|--debu|--debug)
 		debug=t; shift ;;
 	-i|--i|--im|--imm|--imme|--immed|--immedi|--immedia|--immediat|--immediate)
@@ -132,6 +134,9 @@ exec 5>&1
 exec 6<&0
 if test "$verbose" = "t"; then
 	exec 4>&2 3>&1
+elif test "$logfile" = "t"; then
+        logfile=$(basename $0 .t).output
+        exec 4>${logfile} 3>&4
 else
 	exec 4>/dev/null 3>/dev/null
 fi
@@ -249,11 +254,14 @@ test_have_prereq() {
 test_ok_() {
 	test_success=$(($test_success + 1))
 	say_color "pass" "ok $test_count - $@"
+	test -n "$logfile" && say >&3 "ok $test_count - $@"
+	test -n "$logfile" && printf "%s\n" "$*" >&3
 }
 
 test_failure_() {
 	test_failure=$(($test_failure + 1))
 	say_color error "not ok $test_count - $1"
+	test -n "$logfile" && say >&3 "not ok $test_count - $1"
 	shift
 	echo "$@" | sed -e 's/^/#	/'
 	test "$immediate" = "" || { EXIT_OK=t; exit 1; }
@@ -262,11 +270,13 @@ test_failure_() {
 test_known_broken_ok_() {
 	test_fixed=$(($test_fixed + 1))
 	say_color error "ok $test_count - $@ # TODO known breakage vanished"
+	test -n "$logfile" && say >&3 "ok $test_count - $@ # TODO known breakage vanished"
 }
 
 test_known_broken_failure_() {
 	test_broken=$(($test_broken + 1))
 	say_color warn "not ok $test_count - $@ # TODO known breakage"
+	test -n "$logfile" && say >&3 "not ok $test_count - $@ # TODO known breakage"
 }
 
 # Public: Execute commands in debug mode.
@@ -633,9 +643,11 @@ test_done() {
 
 	if test "$test_fixed" != 0; then
 		say_color error "# $test_fixed known breakage(s) vanished; please update test(s)"
+		test -n "$logfile" && say >&3 "# $test_fixed known breakage(s) vanished"
 	fi
 	if test "$test_broken" != 0; then
 		say_color warn "# still have $test_broken known breakage(s)"
+		test -n "$logfile" && say >&3 "# still have $test_broken known breakage(s)"
 	fi
 	if test "$test_broken" != 0 || test "$test_fixed" != 0; then
 		test_remaining=$(( $test_count - $test_broken - $test_fixed ))
@@ -655,8 +667,10 @@ test_done() {
 
 		if test $test_remaining -gt 0; then
 			say_color pass "# passed all $msg"
+			test -n "$logfile" && say >&3 "# passed all $msg"
 		fi
 		say "1..$test_count$skip_all"
+		test -n "$logfile" && say >&3 "1..$test_count$skip_all"
 
 		test_eval_ "$final_cleanup"
 
@@ -664,11 +678,19 @@ test_done() {
 		cd "$(dirname "$remove_trash")" &&
 		rm -rf "$(basename "$remove_trash")"
 
+		test -n "$logfile" &&
+		  test -f "$logfile" &&
+		  rm -f "${logfile}"
+
 		exit 0 ;;
 
 	*)
 		say_color error "# failed $test_failure among $msg"
 		say "1..$test_count"
+		if test -n "$logfile"; then
+			say >&3 "# failed $test_failure among $msg"
+			say >&3 "1..$test_count"
+		fi
 
 		exit 1 ;;
 


### PR DESCRIPTION
A few testing, travis, and test environment updates/fixes:
 * sharness tests now can log stderr/out to a file during testing for post-mortem analysis.
 * travis tests set FLUX_TESTS_LOGFILE=t to get logs, and have an `after_failure:` hook to cat all tests output files from failures. This will hopefully help diagnose transient travis test failures.
 * `travis-dep-builder.sh` now includes pip install so `sched` and other dependent projects will get python dependencies by default
 * `travis-dep-builder.sh` has new `--printenv` option and travis-ci uses this to set the correct environment for build. (In my VM I now run
 ```
 ./src/cmd/travis-dep-builder.sh
 $(./src/cmd/travis-dep-build.sh --printenv)
 ```
 to download/build dependencies and set up my environment to use them)

 * small fix for python dist target