### PR TITLE
redesign/fix flux_reduce_t handle

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -15,7 +15,8 @@ MAN3_FILES_PRIMARY = \
 	flux_rpc.3 \
 	flux_rpc_then.3 \
 	flux_rpc_multi.3 \
-	flux_reduce_create.3
+	flux_reduce_create.3 \
+	flux_info.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -92,6 +93,7 @@ flux_rpc.3: trpc.c
 flux_rpc_then.3: trpc_then.c
 flux_rpc_multi.3: trpc_then_multi.c
 flux_reduce_create.3: treduce.c
+flux_info.3: tinfo.c
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 
@@ -115,7 +117,8 @@ check_PROGRAMS = \
 	tevent \
 	trpc \
 	trpc_then \
-	trpc_then_multi
+	trpc_then_multi \
+	tinfo
 
 check_LTLIBRARIES = \
 	treduce.la

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -14,7 +14,8 @@ MAN3_FILES_PRIMARY = \
 	flux_msg_sendfd.3 \
 	flux_rpc.3 \
 	flux_rpc_then.3 \
-	flux_rpc_multi.3
+	flux_rpc_multi.3 \
+	flux_reduce_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -32,7 +33,13 @@ MAN3_FILES_SECONDARY = \
 	flux_rpc_destroy.3 \
 	flux_rpc_check.3 \
 	flux_rpc_get.3 \
-	flux_rpc_completed.3
+	flux_rpc_completed.3 \
+	flux_reduce_destroy.3 \
+	flux_reduce_append.3 \
+	flux_reduce_pop.3 \
+	flux_reduce_push.3 \
+	flux_reduce_opt_set.3 \
+	flux_reduce_opt_get.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -69,6 +76,13 @@ flux_rpc_destroy.3: flux_rpc.3
 flux_rpc_get.3: flux_rpc.3
 flux_rpc_check.3: flux_rpc_then.3
 flux_rpc_completed.3: flux_rpc_multi.3
+flux_reduce_destroy.3: flux_reduce_create.3
+flux_reduce_append.3: flux_reduce_create.3
+flux_reduce_pop.3: flux_reduce_create.3
+flux_reduce_push.3: flux_reduce_create.3
+flux_reduce_opt_set.3: flux_reduce_create.3
+flux_reduce_opt_get.3: flux_reduce_create.3
+
 
 flux_open.3: topen.c
 flux_send.3: tsend.c
@@ -77,6 +91,7 @@ flux_event_subscribe.3: tevent.c
 flux_rpc.3: trpc.c
 flux_rpc_then.3: trpc_then.c
 flux_rpc_multi.3: trpc_then_multi.c
+flux_reduce_create.3: treduce.c
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 
@@ -102,3 +117,10 @@ check_PROGRAMS = \
 	trpc_then \
 	trpc_then_multi
 
+check_LTLIBRARIES = \
+	treduce.la
+
+treduce_la_SOURCES = treduce.c
+treduce_la_LDFLAGS = -module -rpath /nowhere \
+        -export-symbols-regex '^mod_(main|name)$$' \
+	-export-sym--disable-static -avoid-version -shared -export-dynamic

--- a/doc/man3/flux_info.adoc
+++ b/doc/man3/flux_info.adoc
@@ -1,0 +1,69 @@
+flux_info(3)
+============
+:doctype: manpage
+
+
+NAME
+----
+flux_info - query Flux broker comms info
+
+
+SYNOPSIS
+--------
+#include <flux/core.h>
+
+int flux_info (flux_t h, uint32_t *rank, uint32_t *size, int *k);
+
+
+DESCRIPTION
+-----------
+
+`flux_info()` asks the Flux broker for its rank in the comms session,
+the size of the comms session, and the branching factor (k) of
+its tree-based overlay network.
+
+The tree-based overlay network is always rooted at rank zero.
+
+
+RETURN VALUE
+------------
+
+`flux_info()` returns  zero on success.  On error, -1 is returned, and errno
+is set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+Some arguments were invalid.
+
+EXAMPLES
+--------
+
+This example obtains broker comms info for the current session and uses it
+to calculate the height of the tree-based overlay network.
+
+....
+include::tinfo.c[]
+....
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+https://github.com/flux-framework/rfc/blob/master/spec_3.adoc[RFC 3: CMB1 - Flux Comms Message Broker Protocol]

--- a/doc/man3/flux_reduce_create.adoc
+++ b/doc/man3/flux_reduce_create.adoc
@@ -1,0 +1,202 @@
+flux_reduce_create(3)
+=====================
+:doctype: manpage
+
+
+NAME
+----
+flux_reduce_create, flux_reduce_destroy, flux_reduce_append, flux_reduce_pop, flux_reduce_push, flux_reduce_opt_get, flux_reduce_opt_set - low level support for reduction pattern
+
+
+SYNOPSIS
+--------
+
+ #include <flux/core.h>
+
+ struct flux_reduce_ops {
+     flux_free_f  destroy;
+     void         (*reduce)(flux_reduce_t *r, int batch, void *arg);
+     void         (*sink)(flux_reduce_t *r, int batch, void *arg);
+     void         (*forward)(flux_reduce_t *r, int batch, void *arg);
+     int          (*itemweight)(void *item);
+ };
+
+ flux_reduce_t *flux_reduce_create (flux_t h, flux_reduce_ops ops,
+                                    double timeout, void *arg, int flags);
+
+ void flux_reduce_destroy (flux_reduce_t *r);
+
+ int flux_reduce_append (flux_reduce_t *r, void *item, int batch);
+
+ void *flux_reduce_pop (flux_reduce_t *r);
+
+ int flux_reduce_push (flux_reduce_t *r, void *item);
+
+ int flux_reduce_opt_get (flux_reduce_t *r, int option,
+                          void *val, size_t size);
+
+ int flux_reduce_opt_set (flux_reduce_t *r, int option,
+                          void *val, size_t size);
+
+
+DESCRIPTION
+-----------
+
+`flux_reduce_create()` sets up a reduction handle, a queue with semantics
+useful for implementing hierarchical reduction patterns over the Flux tree
+based overlay network.  It is a "bare bones" interface that requires the
+user to provide callbacks via _ops_ to do the work of reducing, forwarding,
+and consuming items of an opaque, user-defined type.
+
+Items are appended to the reduction handle with `flux_reduce_append()`
+with _batch_, a monotonically increasing sequence number.  Only
+items in batches of the same number can be reduced together.  Each time an
+item is appended to the handle and two or more items are available there,
+the _op.reduce_ callback, if non-NULL, is called.
+
+_op.reduce_ should call `flux_reduce_pop()` to obtain items for the current
+_batch_, perform some operation on them, then call `flux_reduce_push()`
+to put items back.  The purpose of _op.reduce_ is to consolidate items
+so that the amount of data arriving at each node of the tree can be minimized
+to improve scalability.
+
+Depending on _flags_, the queue will be flushed periodically.  The flush
+operation empties the queue of items in the current batch by calling
+_op.forward_ (rank > 0) or  _op.sink_ (rank = 0), if defined, then internally
+popping items off and destroying them with _op.destroy_, if defined.
+
+The purpose of _op.forward_ is to forward items "upstream" towards the root
+of the tree.  _op.forward_ should call `flux_reduce_pop()` to obtain items,
+and encode each of them them in a request message with the batch number.
+The request message should be sent upstream with FLUX_NODEID_UPSTREAM
+addressing.  The upstream rank, on receipt, should decode the item and
+batch number, then call `flux_reduce_append()` to append the item to its
+reduction handle.  _op.forward_ is never called on rank zero.
+
+The purpose of _op.sink_ is to consume items in their fully reduced form.
+_op.sink_ should call `flux_reduce_pop()` to obtain items.  Depending on
+the application and the selected flush policy, _op.sink_ may need to be
+prepared to handle late arriving items from a previous batch.
+_op.sink_ is only called on rank zero.
+
+_flags_ is the logical "or" of zero or more of the following flags:
+
+FLUX_REDUCE_TIMEDFLUSH::
+When an item of a new batch is appended to the reduction handle, a reactor
+timer is started on handle _h_, by default for a fraction of the configured
+_timeout_.  When the timer expires, any items in the queue are flushed.
+
+FLUX_REDUCE_HWMFLUSH::
+A high water mark for the number of messages appended to the handle
+is, by default, "learned" on the first batch.  Thereafter, a flush occurs
+whenever the high water mark is reached.  The high water mark can be increased
+by subsequent batches, but will never decrease.  If this flag is used,
+_op.itemweight_ must be provided (see below).
+
+If no flush policy is selected, or during the learning period of
+HWMFLUSH policy, the flush is immediate and no reduction can be performed.
+
+If both TIMEDFLUSH and HWMFLUSH policy are selected, the flush will occur
+on reaching the high water mark, or timer expiration, whichever occurs first.
+
+If a straggler item from a previously flushed batch is received,
+that item is flushed immediately.  During _op.forward_ or _op.sink_
+callbacks, `flux_reduce_pop()` will return NULL after the straggler
+is popped without co-mingling any items from the current batch.
+
+The high water mark training period counts unreduced messages, while
+subsequent high water mark comparisons must count reduced messages.
+If HWMFLUSH policy is selected, _op.itemweight_ must be provided
+to interrogate an item for the number of unreduced items it represents.
+
+Under TIMEDFLUSH policy, the default _timeout_ is scaled as a linear
+function of height in the tree based overlay network.  Let H be the maximum
+tree height plus one, and h be this rank's height.  The scaled timeout t is
+given by:
+
+t = (H - h) * (_timeout_ / H)
+
+The tree height is calculated from static tree geometry returned by
+`flux_info(3)`.  The height of rank 0 is defined to be zero.
+
+`flux_reduce_opt_get()` and `flux_reduce_opt_set()` may be used to get
+or set internal options.  The valid options are:
+
+FLUX_REDUCE_OPT_TIMER::
+Get/set the calculated timeout value used for TIMEDFLUSH policy.
+The units are seconds and the value type is double.
+
+FLUX_REDUCE_OPT_HWM::
+Get/set the internal high water mark used for HWMFLUSH policy.
+The units are items and the value type is an unsigned integer.
+After the high water mark has been set manually it will not change.
+
+FLUX_REDUCE_OPT_COUNT::
+Get the unweighted item count for items queued within the handle.  The
+units are items and the value type is an unsigned integer.
+This option cannot be set.
+
+FLUX_REDUCE_OPT_WCOUNT::
+Get the weighted item count for items queued within the handle.  The
+units are items and the value type is an unsigned integer.
+This option cannot be set.
+
+
+RETURN VALUE
+------------
+
+`flux_reduce_create()` returns a flux_reduce_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+`flux_reduce_append()`, `flux_reduce_push()`, `flux_reduce_opt_set()`,
+and `flux_reduce_opt_get()` return zero on success.  On error, -1 is
+returned, and errno is set appropriately.
+
+`flux_reduce_pop()` returns an item or NULL if there are none.
+It does not report errors.
+
+
+ERRORS
+------
+
+EINVAL::
+Some arguments were invalid.
+
+
+EXAMPLES
+--------
+
+In this example comms module, an "item" is a string representation of
+a nodeset, e.g. "[0-3,5-12]".  On each heartbeat, each rank provides
+its rank number as input to the reduction handle.  The reduction consists
+of building a nodeset string which is printed on rank 0.  For example,
+in a 1024 rank session, each rank provides "0", "1", "2", ..., "1023",
+and after the reduction, rank 0 prints "[0-1023]".
+
+If a floating point argument is passed to the module, it is interpreted as
+a timeout value, and FLUX_REDUCE_TIMEDFLUSH policy is selected; otherwise,
+FLUX_REDUCE_HWMFLUSH policy is selected.
+
+....
+include::treduce.c[]
+....
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux_info(3)

--- a/doc/man3/tinfo.c
+++ b/doc/man3/tinfo.c
@@ -1,0 +1,26 @@
+#include <math.h>
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int tree_height (uint32_t n, int k)
+{
+    return (int)floor (log (n) / log (k));
+}
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    uint32_t n, rank;
+    int k;
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    if (flux_info (h, &rank, &n, &k) < 0)
+        err_exit ("flux_info");
+    printf ("height of %d-ary tree of size %u: %d\n",
+            k, n, tree_height (n, k));
+    printf ("height of %d-ary at rank %u: %d\n",
+            k, rank, tree_height (rank + 1, k));
+    flux_close (h);
+    return (0);
+}

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -1,0 +1,147 @@
+#include <stdio.h>
+#include <flux/core.h>
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/nodeset.h"
+#include "src/common/libutil/xzmalloc.h"
+
+struct context {
+    int batchnum;
+    flux_reduce_t *r;
+    char rankstr[16];
+    flux_t h;
+};
+
+int itemweight (void *item)
+{
+    int count = 1;
+    nodeset_t nodeset;
+
+    if ((nodeset = nodeset_new_str (item))) {
+        count = nodeset_count (nodeset);
+        nodeset_destroy (nodeset);
+    }
+    return count;
+}
+
+void sink (flux_reduce_t *r, int batchnum, void *arg)
+{
+    char *item;
+
+    while ((item = flux_reduce_pop (r))) {
+        fprintf (stderr, "%d: %s\n", batchnum, item);
+        free (item);
+    }
+}
+
+void forward (flux_reduce_t *r, int batchnum, void *arg)
+{
+    struct context *ctx = arg;
+    char *item;
+    flux_rpc_t *rpc;
+
+    while ((item = flux_reduce_pop (r))) {
+        JSON out = Jnew ();
+        Jadd_int (out, "batchnum", batchnum);
+        Jadd_str (out, "nodeset", item);
+        rpc = flux_rpc (ctx->h, "treduce.forward", Jtostr (out),
+                        FLUX_NODEID_UPSTREAM, FLUX_RPC_NORESPONSE);
+        flux_rpc_destroy (rpc);
+        Jput (out);
+        free (item);
+    }
+}
+
+void reduce (flux_reduce_t *r, int batchnum, void *arg)
+{
+    nodeset_t nodeset = NULL;
+    char *item;
+
+    if ((item = flux_reduce_pop (r))) {
+        nodeset = nodeset_new_str (item);
+        free (item);
+    }
+    if (nodeset) {
+        while ((item = flux_reduce_pop (r))) {
+            nodeset_add_str (nodeset, item);
+            free (item);
+        }
+        item = xstrdup (nodeset_str (nodeset));
+        if (flux_reduce_push (r, item) < 0)
+            free (item);
+        nodeset_destroy (nodeset);
+    }
+}
+
+void forward_cb (flux_t h, flux_msg_watcher_t *w,
+                 const flux_msg_t *msg, void *arg)
+{
+    struct context *ctx = arg;
+    const char *json_str, *nodeset_str;
+    JSON in = NULL;
+    int batchnum;
+    char *item;
+
+    if (flux_request_decode (msg, NULL, &json_str) < 0
+            || !(in = Jfromstr (json_str))
+            || !Jget_int (in, "batchnum", &batchnum)
+            || !Jget_str (in, "nodeset", &nodeset_str))
+        return;
+    item = xstrdup (nodeset_str);
+    if (flux_reduce_append (ctx->r, item, batchnum) < 0)
+        free (item);
+    Jput (in);
+}
+
+void heartbeat_cb (flux_t h, flux_msg_watcher_t *w,
+                   const flux_msg_t *msg, void *arg)
+{
+    struct context *ctx = arg;
+    char *item = xstrdup (ctx->rankstr);
+    if (flux_reduce_append (ctx->r, item, ctx->batchnum++) < 0)
+        free (item);
+}
+
+struct flux_msghandler htab[] = {
+    { FLUX_MSGTYPE_EVENT,     "hb",              heartbeat_cb },
+    { FLUX_MSGTYPE_REQUEST,   "treduce.forward", forward_cb },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct flux_reduce_ops reduce_ops = {
+    .destroy = free,
+    .itemweight = itemweight,
+    .reduce = reduce,
+    .forward = forward,
+    .sink = sink,
+};
+
+int mod_main (flux_t h, int argc, char **argv)
+{
+    struct context ctx;
+    int rank = flux_rank (h);
+    double timeout = 0.;
+    int flags;
+
+    if (argc == 1) {
+        timeout = strtod (argv[0], NULL);
+        flags = FLUX_REDUCE_TIMEDFLUSH;
+    } else
+        flags = FLUX_REDUCE_HWMFLUSH;
+
+    ctx.batchnum = 0;
+    snprintf (ctx.rankstr, sizeof (ctx.rankstr), "%d", rank);
+    ctx.h = h;
+
+    if (!(ctx.r = flux_reduce_create (h, reduce_ops, timeout, &ctx, flags)))
+        return -1;
+    if (flux_event_subscribe (h, "hb") < 0)
+        return -1;
+    if (flux_msg_watcher_addvec (h, htab, &ctx) < 0)
+        return -1;
+    if (flux_reactor_start (h) < 0)
+        return -1;
+    flux_msg_watcher_delvec (h, htab);
+    return 0;
+}
+
+MOD_NAME ("treduce");

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -242,5 +242,9 @@ ENV
 TIMEDFLUSH
 HWMFLUSH
 treduce
-itemsize
+itemweight
 unreduced
+HWM
+unweighted
+WCOUNT
+tinfo

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -239,3 +239,8 @@ trecv
 scalability
 env
 ENV
+TIMEDFLUSH
+HWMFLUSH
+treduce
+itemsize
+unreduced

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1295,7 +1295,7 @@ static int cmb_info_cb (zmsg_t **zmsg, void *arg)
 
     Jadd_int (out, "rank", ctx->rank);
     Jadd_int (out, "size", ctx->size);
-    Jadd_bool (out, "treeroot", ctx->rank == 0 ? true : false);
+    Jadd_int (out, "arity", ctx->k_ary);
 
     rc = flux_json_respond (ctx->h, out, zmsg);
     Jput (out);

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -136,13 +136,13 @@ int main (int argc, char *argv[])
         if (flux_recover_all (h) < 0)
             err_exit ("flux_recover_all");
     } else if (!strcmp (cmd, "info")) {
-        int rank, size;
-        bool treeroot;
-        if (flux_info (h, &rank, &size, &treeroot) < 0)
+        int arity;
+        uint32_t rank, size;
+        if (flux_info (h, &rank, &size, &arity) < 0)
             err_exit ("flux_info");
         printf ("rank=%d\n", rank);
         printf ("size=%d\n", size);
-        printf ("treeroot=%s\n", treeroot ? "true" : "false");
+        printf ("arity=%d\n", arity);
     } else
         usage ();
 

--- a/src/cmd/flux-up.c
+++ b/src/cmd/flux-up.c
@@ -172,11 +172,10 @@ done:
 static ns_t *ns_guess (flux_t h)
 {
     ns_t *ns = xzmalloc (sizeof (*ns));
-    int size, rank;
-    bool treeroot;
+    uint32_t size, rank;
     uint32_t r;
 
-    if (flux_info (h, &rank, &size, &treeroot) < 0)
+    if (flux_info (h, &rank, &size, NULL) < 0)
         err_exit ("flux_info");
     ns->ok = nodeset_new ();
     ns->slow = nodeset_new ();

--- a/src/common/libflux/info.h
+++ b/src/common/libflux/info.h
@@ -5,7 +5,7 @@
 
 #include "handle.h"
 
-int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp);
+int flux_info (flux_t h, uint32_t *rankp, uint32_t *sizep, int *arityp);
 int flux_rank (flux_t h);
 int flux_size (flux_t h);
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -602,6 +602,11 @@ void flux_timer_watcher_destroy (flux_timer_watcher_t *w)
         free (w);
 }
 
+void flux_timer_watcher_reset (flux_timer_watcher_t *w,
+                               double after, double repeat)
+{
+    ev_timer_set (&w->w, after, repeat);
+}
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -134,6 +134,9 @@ flux_timer_watcher_t *flux_timer_watcher_create (double after, double repeat,
 void flux_timer_watcher_destroy (flux_timer_watcher_t *w);
 void flux_timer_watcher_start (flux_t h, flux_timer_watcher_t *w);
 void flux_timer_watcher_stop (flux_t h, flux_timer_watcher_t *w);
+void flux_timer_watcher_reset (flux_timer_watcher_t *w,
+                               double after, double repeat);
+
 
 
 #endif /* !_FLUX_CORE_REACTOR_H */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -13,6 +13,7 @@ TESTS = \
 	loop/reactor.t \
 	loop/rpc.t \
 	loop/multrpc.t \
+	loop/reduce.t \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -78,7 +79,8 @@ check_PROGRAMS = \
 	loop/handle.t \
 	loop/reactor.t \
 	loop/rpc.t \
-	loop/multrpc.t
+	loop/multrpc.t \
+	loop/reduce.t
 
 dist_check_DATA = \
 	build/hello.mk \
@@ -114,3 +116,7 @@ loop_rpc_t_LDADD = $(test_ldadd) $(LIBDL)
 loop_multrpc_t_SOURCES = loop/multrpc.c
 loop_multrpc_t_CPPFLAGS = $(test_cppflags)
 loop_multrpc_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_reduce_t_SOURCES = loop/reduce.c
+loop_reduce_t_CPPFLAGS = $(test_cppflags)
+loop_reduce_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -13,7 +13,7 @@
 
 #include "src/common/libtap/tap.h"
 
-static int fake_size = 1;
+static uint32_t fake_size = 1;
 
 /* request nodeid and flags returned in response */
 static int nodeid_fake_error = -1;

--- a/t/loop/reduce.c
+++ b/t/loop/reduce.c
@@ -1,0 +1,366 @@
+#include <errno.h>
+#include <czmq.h>
+
+#include "src/common/libflux/reduce.h"
+#include "src/common/libflux/reactor.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libtap/tap.h"
+
+int reduce_calls = 0;
+int reduce_items = 0;
+void reduce (flux_reduce_t *r, int batchnum, void *arg)
+{
+    void *item;
+    zlist_t *tmp = zlist_new ();
+
+    if (!tmp)
+        oom ();
+    reduce_calls++;
+    while ((item = flux_reduce_pop (r))) {
+        if (zlist_push (tmp, item) < 0)
+            oom ();
+        reduce_items++;
+    }
+    while ((item = zlist_pop (tmp))) {
+        if (flux_reduce_push (r, item) < 0)
+            oom ();
+    }
+    zlist_destroy (&tmp);
+}
+
+int sink_calls = 0;
+int sink_items = 0;
+void sink (flux_reduce_t *r, int batchnum, void *arg)
+{
+    void *item;
+
+    sink_calls++;
+    while ((item = flux_reduce_pop (r))) {
+        free (item);
+        sink_items++;
+    }
+}
+
+int forward_calls = 0;
+int forward_items = 0;
+void forward (flux_reduce_t *r, int batchnum, void *arg)
+{
+    void *item;
+
+    forward_calls++;
+    while ((item = flux_reduce_pop (r))) {
+        free (item);
+        forward_items++;
+    }
+}
+
+void clear_counts (void)
+{
+    sink_calls = sink_items = reduce_calls = reduce_items
+                            = forward_calls = forward_items = 0;
+}
+
+int itemweight (void *item)
+{
+    return 1;
+}
+
+static struct flux_reduce_ops reduce_ops =  {
+    .destroy = free,
+    .reduce = reduce,
+    .sink = sink,
+    .forward = forward,
+    .itemweight = itemweight,
+};
+
+void test_hwm (flux_t h)
+{
+    flux_reduce_t *r;
+    int i, errors;
+    unsigned int hwm;
+
+    clear_counts ();
+
+    ok ((r = flux_reduce_create (h, reduce_ops, 0., NULL,
+        FLUX_REDUCE_HWMFLUSH)) != NULL,
+        "hwm: flux_reduce_create works");
+
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0
+        && hwm == 0,
+        "hwm: hwm is initially zero");
+
+    /* batch 0 is a training batch.
+     * It looks just like no policy.
+     */
+    errors = 0;
+    for (i = 0; i < 100; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 0) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "hwm.0: flux_reduce_append added 100 items");
+    cmp_ok (reduce_calls, "==", 0,
+        "hwm.0: op.reduce not called (training)");
+    cmp_ok (sink_calls, "==", 100,
+        "hwm.0: op.sink called 100 times");
+    cmp_ok (sink_items, "==", 100,
+        "hwm.0: op.sink processed 100 items");
+
+    clear_counts ();
+
+    /* batch 1 has a hwm.  Put in one short of hwm items.
+     */
+    errors = 0;
+    for (i = 0; i < 99; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 1) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "hwm.1: flux_reduce_append added 99 items");
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0
+        && hwm == 100,
+        "hwm.0: hwm is 100");
+    cmp_ok (reduce_calls, "==", 98,
+        "hwm.1: op.reduce called 98 times");
+    cmp_ok (sink_calls, "==", 0,
+        "hwm.1: op.sink not called yet");
+
+    /* Now finish batch 1 with one item.  Everything should go thru.
+     */
+    ok (flux_reduce_append (r, xstrdup ("hi"), 1) == 0,
+        "hwm.1: flux_reduce_append added 1 item");
+    cmp_ok (reduce_calls, "==", 99,
+        "hwm.1: op.reduce called");
+    cmp_ok (sink_calls, "==", 1,
+        "hwm.1: op.sink called 1 time");
+    cmp_ok (sink_items, "==", 100,
+        "hwm.1: op.sink handled 100 items");
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0
+        && hwm == 100,
+        "hwm.1: hwm is 100");
+
+    clear_counts ();
+
+    /* Straggler test
+     * Start batch 2, then append one item from batch 1.
+     * This should cause last hwm to be recomputed to be 101 instead of 100.
+     * Straggler should immediately be sinked.
+     */
+    ok (flux_reduce_append (r, xstrdup ("hi"), 2) == 0,
+        "hwm.2: flux_reduce_append added 1 item");
+    cmp_ok (reduce_calls, "==", 0,
+        "hwm.2: op.reduce not called");
+    cmp_ok (sink_calls, "==", 0,
+        "hwm.2: op.sink not called");
+    ok (flux_reduce_append (r, xstrdup ("hi"), 1) == 0,
+        "hwm.1: flux_reduce_append added 1 straggler");
+    cmp_ok (reduce_calls, "==", 0,
+        "hwm.1: op.reduce not called");
+    cmp_ok (sink_calls, "==", 1,
+        "hwm.1: op.sink called 1 time");
+    cmp_ok (sink_items, "==", 1,
+        "hwm.1: op.sink handled 1 item");
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0
+        && hwm == 101,
+        "hwm.1: hwm is 101");
+
+    sink_items = sink_calls = 0; // don't count batch 1 straggler below
+
+    /* At this point we have one batch 2 item in queue.
+     * Put in 99 more and we should be one short of 101 hwm.
+     */
+    errors = 0;
+    for (i = 0; i < 99; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 2) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "hwm.2: flux_reduce_append added 99 items");
+    cmp_ok (reduce_calls, "==", 99,
+        "hwm.2: op.reduce called 99 times");
+    cmp_ok (sink_calls, "==", 0,
+        "hwm.2: op.sink not called yet");
+    ok (flux_reduce_append (r, xstrdup ("hi"), 2) == 0,
+        "hwm.2: flux_reduce_append added 1 item");
+    cmp_ok (sink_calls, "==", 1,
+        "hwm.2: op.sink called 1 time");
+    cmp_ok (sink_items, "==", 101,
+        "hwm.2: op.sink handled 101 items");
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0
+        && hwm == 101,
+        "hwm.2: hwm is 101");
+
+    clear_counts ();
+
+    /* Manually set the hwm to 10.
+     * Append 20 items to batch 3.
+     * Reduce is called on the first set of 10.
+     * The second set of 10 will be immediately flushed.
+     * Put in one batch 4 item and verify the HWM is still 10.
+     */
+    hwm = 10;
+    ok (flux_reduce_opt_set (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0,
+        "hwm.3: hwm set to 10");
+    errors = 0;
+    for (i = 0; i < 20; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 3) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "hwm.3: flux_reduce_append added 20 items");
+    cmp_ok (reduce_calls, "==", 9,
+        "hwm.3: op.reduce called 9 times");
+    cmp_ok (sink_calls, "==", 11,
+        "hwm.3: op.sink called 11 times");
+    cmp_ok (sink_items, "==", 20,
+        "hwm.3: op.sink handled 20 items");
+    ok (flux_reduce_append (r, xstrdup ("hi"), 4) == 0,
+        "hwm.4: flux_reduce_append added one item");
+    hwm = 0;
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_HWM, &hwm, sizeof (hwm)) == 0
+        && hwm == 10,
+        "hwm.4: hwm is still 10");
+
+    flux_reduce_destroy (r);
+}
+
+void test_nopolicy (flux_t h)
+{
+    flux_reduce_t *r;
+    int i, errors;
+
+    clear_counts ();
+
+    ok ((r = flux_reduce_create (h, reduce_ops, 0., NULL, 0)) != NULL,
+        "nopolicy: flux_reduce_create works");
+
+    errors = 0;
+    for (i = 0; i < 100; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 0) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "nopolicy: flux_reduce_append added 100 items in batch 0");
+    cmp_ok (forward_calls, "==", 0,
+        "nopolicy: op.forward not called as we are rank 0");
+    cmp_ok (reduce_calls, "==", 0,
+        "nopolicy: op.reduce not called as we have no flush policy");
+    cmp_ok (sink_calls, "==", 100,
+        "nopolicy: op.sink called 100 times");
+    cmp_ok (sink_items, "==", 100,
+        "nopolicy: op.sink processed 100 items");
+
+    flux_reduce_destroy (r);
+}
+
+void test_timed (flux_t h)
+{
+    flux_reduce_t *r;
+    int i, errors;
+    double timeout;
+
+    clear_counts ();
+
+    ok ((r = flux_reduce_create (h, reduce_ops, 0.1, NULL,
+                                 FLUX_REDUCE_TIMEDFLUSH)) != NULL,
+        "timed: flux_reduce_create works");
+    ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_TIMEOUT, &timeout,
+                             sizeof (timeout)) == 0 && timeout == 0.1,
+        "timed: timeout scaled by 1.0 on rank 0");
+
+    /* Append 100 items in batch 0 before starting reactor.
+     * Reduction occurs at each append.
+     * Nothing should be sinked.
+     */
+    errors = 0;
+    for (i = 0; i < 100; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 0) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "timed.0: flux_reduce_append added 100 items");
+    cmp_ok (reduce_calls, "==", 99,
+        "timed.0: op.reduce called 99 times");
+    cmp_ok (sink_calls, "==", 0,
+        "timed.0: op.sink called 0 times");
+
+    /* Start reactor so timeout handler can run.
+     * It should fire once and sink all items in one sink call.
+     */
+    ok (flux_reactor_start (h) == 0,
+        "timed.0: reactor completed normally");
+    cmp_ok (sink_calls, "==", 1,
+        "timed.0: op.sink called 1 time");
+    cmp_ok (sink_items, "==", 100,
+        "timed.0: op.sink processed 100 items");
+
+    clear_counts ();
+
+    /* Now append one more item to batch 0.
+     * It should be immediately flushed.
+     */
+    ok (flux_reduce_append (r, xstrdup ("hi"), 0) == 0,
+        "timed.0: flux_reduce_append added 1 more item");
+    cmp_ok (reduce_calls, "==", 0,
+        "timed.0: op.reduce not called");
+    cmp_ok (sink_calls, "==", 1,
+        "timed.0: op.sink called 1 time");
+    cmp_ok (sink_items, "==", 1,
+        "timed.0: op.sink processed 1 items");
+
+    clear_counts ();
+
+    /* Append 100 items to batch 1.
+     * It should behave like the first batch.
+     */
+    errors = 0;
+    for (i = 0; i < 100; i++) {
+        if (flux_reduce_append (r, xstrdup ("hi"), 1) < 0)
+            errors++;
+    }
+    ok (errors == 0,
+        "timed.1: flux_reduce_append added 100 items");
+    cmp_ok (reduce_calls, "==", 99,
+        "timed.1: op.reduce called 99 times");
+    cmp_ok (sink_calls, "==", 0,
+        "timed.1: op.sink called 0 times");
+
+    /* Start reactor so timeout handler can run.
+     * It should fire once and sink all items in one sink call.
+     */
+    ok (flux_reactor_start (h) == 0,
+        "timed.1: reactor completed normally");
+    cmp_ok (sink_calls, "==", 1,
+        "timed.1: op.sink called 1 time");
+    cmp_ok (sink_items, "==", 100,
+        "timed.1: op.sink processed 100 items");
+
+    flux_reduce_destroy (r);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t h;
+
+    plan (1+6+37+18);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+
+    test_nopolicy (h); // 6
+    test_hwm (h); // 37
+    test_timed(h); // 18
+
+    flux_close (h);
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This PR is preliminary, not for merging.  It's posted as a PR mainly to keep @dongahn up to date with what I'm doing to stuff his work depends on.  (He should feel free to redirect me if I am making life harder rather than easier):
* Rename `flux_red_t` to `flux_reduce_t` and make opaque type conformant to flux style
* Rename functions to be prefixed with `flux_reduce_`
* Drop `flux_redstack_t` and add a standalone `flux_list_t` class instead.
* Revive the `flux-mon` command and `mon` module (update to modern interfaces)
* Update the live module to use the new `flux_reduce_t` names.

See comment at the top of `src/modules/mon/mon.c` for how to demo the mon module/program.

Coming soon: man page for reduce functions.