### PR TITLE
Support Coverity runs under Travis and fix some found issues and other cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 before_install:
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
-  - eval `./src/test/travis-dep-builder.sh --printenv`
+  - eval $(./src/test/travis-dep-builder.sh --printenv)
   - ./src/test/travis-dep-builder.sh --cachedir=$HOME/local/.cache
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,20 @@ addons:
       - aspell
       - libopenmpi-dev
       - ccache
+  coverity_scan:
+    project:
+      name: "grondo/flux-core"
+      description: "Build submitted via Travis CI"
+    notification_email: mark.grondona@gmail.com
+    build_command_prepend: "./autogen.sh && ./configure"
+    build_command:   "make -j 4"
+    branch_pattern: coverity_scan
+
+env:
+  global:
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+   - secure: "T06LmG6hAwmRculQGfmV06A0f2i9rPoc8itDwyWkmg2CbtCqDyYV93V53jsVknqKA1LA9+Yo7Q3bJnnEAWI7kWAptTcL5ipRycYkl5FqoYawkwRdQW3giZwbs9zRchrwFmZ03N0hRfl31IntXhDmj5EkHOZoduMpkQFFGo0XDC4="
 
 before_install:
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
@@ -34,9 +48,7 @@ before_install:
 script:
  - export CC="ccache $CC"
  - export FLUX_TESTS_LOGFILE=t
- - ./autogen.sh
- - ./configure --prefix=$HOME/local
- - make distcheck
+ - if test ${COVERITY_SCAN_BRANCH} != 1 ; then ./autogen.sh && ./configure --prefix=$HOME/local && make distcheck; fi
 
 after_success:
  - ccache -s

--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -25,8 +25,6 @@ dist_man_MANS = $(MAN1_FILES)
 $(MAN1_FILES): COPYRIGHT.adoc
 endif
 
-noinst_SCRIPTS = spellcheck
-
 SUFFIXES = .adoc .1
 
 STDERR_DEVNULL = $(stderr_devnull_$(V))
@@ -40,16 +38,6 @@ stderr_devnull_0 = 2>/dev/null
 	    --destination-dir=$(builddir) \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
 
-spellcheck: $(top_srcdir)/doc/test/spellcheck
-	$(LN_S) --force $< $@
-
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 
-CLEANFILES = $(MAN1_FILES) $(XML_FILES) spellcheck
-
-TESTS_ENVIRONMENT = \
-	ASPELL=$(ASPELL) \
-	pws_dict=$(abs_top_srcdir)/doc/test/spell.en.pws \
-	man_dir=$(abs_srcdir)
-
-TESTS = spellcheck
+CLEANFILES = $(MAN1_FILES) $(XML_FILES)

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -42,8 +42,6 @@ dist_man_MANS = $(MAN3_FILES)
 $(MAN3_FILES): COPYRIGHT.adoc
 endif
 
-noinst_SCRIPTS = spellcheck
-
 SUFFIXES = .adoc .3
 
 STDERR_DEVNULL = $(stderr_devnull_$(V))
@@ -77,14 +75,7 @@ flux_rpc_completed.3: flux_rpc_multi.3
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 
-CLEANFILES = $(MAN3_FILES) $(XML_FILES) spellcheck
-
-TESTS_ENVIRONMENT = \
-	ASPELL=$(ASPELL) \
-	pws_dict=$(abs_top_srcdir)/doc/test/spell.en.pws \
-	man_dir=$(abs_srcdir)
-
-TESTS = spellcheck
+CLEANFILES = $(MAN3_FILES) $(XML_FILES)
 
 AM_CFLAGS = @GCCWARN@
 

--- a/doc/test/Makefile.am
+++ b/doc/test/Makefile.am
@@ -1,3 +1,13 @@
 dist_noinst_SCRIPTS = spellcheck
 
 EXTRA_DIST = spell.en.pws
+
+TESTS_ENVIRONMENT = \
+	ASPELL=$(ASPELL) \
+	pws_dict=$(abs_top_srcdir)/doc/test/spell.en.pws \
+	man_base_dir=$(abs_top_srcdir)/doc
+
+LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+TESTS = spellcheck

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -237,3 +237,5 @@ tevent
 tsend
 trecv
 scalability
+env
+ENV

--- a/doc/test/spellcheck
+++ b/doc/test/spellcheck
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if test $man_dir; then
-    set ${man_dir}/*.adoc
+if test $man_base_dir; then
+    set ${man_base_dir}/man*/*.adoc
 fi
 
 if test $# == 0; then
@@ -25,12 +25,13 @@ echo "1..$#"
 count=1
 for f in $*; do
     filename=$(basename $f)
+    dir=$(basename $(dirname $f))
     tmpfile=$(mktemp)
     rc=$(cat $f | aspell -p $dict -n list | sort | uniq | tee $tmpfile | wc -l)
     if test $rc == 0; then
-        echo "ok $count - spell check $filename"
+        echo "ok $count - spell check $dir/$filename"
     else
-	echo "not ok $count - spell check $filename failed"
+	echo "not ok $count - spell check $dir/$filename failed"
         echo "---"
 	exit_val=1
     fi

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1155,6 +1155,7 @@ static int iowatcher_zio_cb (zio_t zio, json_object *o, void *arg)
         if (pp && len > 0) {
             json_object *s = json_object_new_string ((char *)pp);
             json_object_object_add (o, "data", s);
+            free (pp);
         }
         json_object_to_lua (L, o);
         json_object_put (o);

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -320,7 +320,7 @@ static int l_flux_send (lua_State *L)
 static int l_flux_recv (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
-    const char *topic;
+    const char *topic = NULL;
     const char *json_str = NULL;
     json_object *o = NULL;
     int errnum;
@@ -364,7 +364,10 @@ static int l_flux_recv (lua_State *L)
         lua_setfield (L, -1, "errnum");
     }
 
-    lua_pushstring (L, topic);
+    if (topic)
+        lua_pushstring (L, topic);
+    else
+        lua_pushnil (L);
     return (2);
 error:
     if (zmsg) {

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1158,8 +1158,8 @@ static int iowatcher_zio_cb (zio_t zio, json_object *o, void *arg)
         if (pp && len > 0) {
             json_object *s = json_object_new_string ((char *)pp);
             json_object_object_add (o, "data", s);
-            free (pp);
         }
+	free (pp);
         json_object_to_lua (L, o);
         json_object_put (o);
     }

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -965,7 +965,10 @@ static int l_msghandler_add (lua_State *L)
     lua_pop (L, 1);
 
     mh = l_flux_ref_create (L, f, 2, "msghandler");
-    flux_msghandler_add (f, typemask, pattern, msghandler, (void *) mh);
+    if (flux_msghandler_add (f, typemask, pattern, msghandler, (void *) mh) < 0) {
+        l_flux_ref_destroy (mh, "msghandler");
+        return lua_pusherror (L, "flux_msghandler_add: %s", strerror (errno));
+    }
 
     return (1);
 }

--- a/src/bindings/lua/lutil.c
+++ b/src/bindings/lua/lutil.c
@@ -44,12 +44,13 @@ int lua_pusherror (lua_State *L, char *fmt, ...)
     rc = vasprintf (&msg, fmt, ap);
     va_end (ap);
 
-    if (rc < 0)
-        msg = "error in vasprintf";
-
     lua_pushnil (L);
-    lua_pushstring (L, msg);
-    free (msg);
+    if (rc < 0)
+        lua_pushstring (L, "vasprintf error!");
+    else {
+        lua_pushstring (L, msg);
+        free (msg);
+    }
     return (2);
 }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1058,10 +1058,12 @@ static int cmb_write_cb (zmsg_t **zmsg, void *arg)
             goto out;
         if (!(p = subprocess_get_pid (ctx->sm, pid))) {
             errnum = ENOENT;
+            free (data);
             goto out;
         }
         if (subprocess_write (p, data, len, eof) < 0) {
             errnum = errno;
+            free (data);
             goto out;
         }
         free (data);

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1006,6 +1006,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
         char *rte = flux_msg_get_route_string (msg);
         assert (rte != NULL);
         fprintf (f, "%s[%3.3d] |%s|\n", prefix, len, rte);
+        free (rte);
     };
     /* Topic (keepalive has none)
      */

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -336,7 +336,7 @@ int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
         goto done;
     if (flux_rpc_get (r, NULL, &json_str) < 0)
         goto done;
-    if (!(mods = flux_lsmod_json_decode (json_str)) < 0)
+    if (!(mods = flux_lsmod_json_decode (json_str)))
         goto done;
     if ((len = flux_modlist_count (mods)) == -1)
         goto done;

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -383,6 +383,8 @@ int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
         goto done;
     rc = 0;
 done:
+    if (name)
+        free (name);
     if (service)
         free (service);
     if (topic)

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -289,6 +289,7 @@ flux_rpc_t *flux_rpc_multi (flux_t h, const char *topic, const char *json_str,
         if (!rpc->oneway)
             rpc->nodemap[i] = nodeid;
     }
+    nodeset_itr_destroy (itr);
     return rpc;
 error:
     if (rpc)

--- a/src/common/libutil/env.c
+++ b/src/common/libutil/env.c
@@ -73,10 +73,10 @@ static int _strtoia (char *s, int *ia, int ia_len)
 
 static int getints (char *s, int **iap, int *lenp)
 {
+    int *ia;
     int len = _strtoia (s, NULL, 0);
-    int *ia = malloc (len * sizeof (int));
 
-    if (!ia || len < 0)
+    if ((len < 0) || !(ia = malloc (len * sizeof (int))))
         return -1;
 
     (void)_strtoia (s, ia, len);

--- a/src/common/libutil/jsonutil.c
+++ b/src/common/libutil/jsonutil.c
@@ -197,8 +197,10 @@ int util_json_object_get_data (json_object *o, char *name,
 
     len = strlen (s);
     dst = xzmalloc (base64_decode_length (len));
-    if (base64_decode_block (dst, &dlen, s, len) < 0)
+    if (base64_decode_block (dst, &dlen, s, len) < 0) {
+        free (dst);
         return -1;
+    }
 
     *lenp = dlen;
     *datp = (uint8_t *) dst;

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -339,6 +339,11 @@ static int get_term_columns ()
         if (p && (*p != '\0'))
             cols = (int) lval;
     }
+    /*
+     *  Check cols for ridiculous values:
+     */
+    if (cols >= 256 || cols <= 16)
+        cols = 80;
     return (cols);
 }
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -350,7 +350,7 @@ optparse_doc_print (optparse_t p, struct optparse_option *o, int columns)
     char *s;
     char *q;
 
-    strncpy (buf, o->usage, sizeof (buf));
+    strncpy (buf, o->usage, sizeof (buf) - 1);
     q = buf;
 
     while ((s = get_next_segment (&q, columns, seg, sizeof (seg))))
@@ -396,7 +396,7 @@ optparse_option_print (optparse_t p, struct optparse_option *o, int columns)
      *  Copy "usage" string to buffer as we might modify below
      */
     q = buf;
-    strncpy (buf, o->usage, sizeof (buf));
+    strncpy (buf, o->usage, sizeof (buf) - 1);
 
     descsiz = columns - width;
     s = get_next_segment (&q, descsiz, seg, sizeof (seg));

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1835,7 +1835,7 @@ static void setargs (ctx_t *ctx, int argc, char **argv)
         href_t ref;
         char *key = xstrdup (argv[i]);
         char *val = strchr (key, '=');
-        if (*val) {
+        if (val && *val != '\0') {
             *val++ = '\0';
             if (!(o = json_tokener_parse (val)))
                 o = json_object_new_string (val);

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -478,6 +478,13 @@ static void close_if_valid (int fd)
     close (fd);
 }
 
+static int dup2_fd (int fd, int newfd)
+{
+    assert (fd >= 0);
+    assert (newfd >= 0);
+    return dup2 (fd, newfd);
+}
+
 static int child_io_setup (struct subprocess *p)
 {
     /*
@@ -490,9 +497,9 @@ static int child_io_setup (struct subprocess *p)
     /*
      *  Dup this process' fds onto zio
      */
-    if (  (dup2 (zio_src_fd (p->zio_in), STDIN_FILENO) < 0)
-       || (dup2 (zio_dst_fd (p->zio_out), STDOUT_FILENO) < 0)
-       || (dup2 (zio_dst_fd (p->zio_err), STDERR_FILENO) < 0))
+    if (  (dup2_fd (zio_src_fd (p->zio_in), STDIN_FILENO) < 0)
+       || (dup2_fd (zio_dst_fd (p->zio_out), STDOUT_FILENO) < 0)
+       || (dup2_fd (zio_dst_fd (p->zio_err), STDERR_FILENO) < 0))
         return (-1);
 
     return (0);

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -98,7 +98,7 @@ static int sigmask_unblock_all (void)
 static int send_output_to_stream (const char *name, json_object *o)
 {
     FILE *fp = stdout;
-    char *s;
+    char *s = NULL;
     bool eof;
 
     int len = zio_json_decode (o, (void **) &s, &eof);
@@ -106,13 +106,12 @@ static int send_output_to_stream (const char *name, json_object *o)
     if (strcmp (name, "stderr") == 0)
         fp = stderr;
 
-    if (len < 0)
-        return (-1);
     if (len > 0)
         fputs (s, fp);
     if (eof)
         fclose (fp);
 
+    free (s);
     return (len);
 }
 

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -468,14 +468,21 @@ static void closeall (int fd, int except)
     return;
 }
 
+static void close_if_valid (int fd)
+{
+    if (fd < 0)
+        return;
+    close (fd);
+}
+
 static int child_io_setup (struct subprocess *p)
 {
     /*
      *  Close paretn end of stdio in child:
      */
-    close (zio_dst_fd (p->zio_in));
-    close (zio_src_fd (p->zio_out));
-    close (zio_src_fd (p->zio_err));
+    close_if_valid (zio_dst_fd (p->zio_in));
+    close_if_valid (zio_src_fd (p->zio_out));
+    close_if_valid (zio_src_fd (p->zio_err));
 
     /*
      *  Dup this process' fds onto zio
@@ -493,9 +500,9 @@ static int parent_io_setup (struct subprocess *p)
     /*
      *  Close child end of stdio in parent:
      */
-    close (zio_src_fd (p->zio_in));
-    close (zio_dst_fd (p->zio_out));
-    close (zio_dst_fd (p->zio_err));
+    close_if_valid (zio_src_fd (p->zio_in));
+    close_if_valid (zio_dst_fd (p->zio_out));
+    close_if_valid (zio_dst_fd (p->zio_err));
 
     return (0);
 }

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -222,7 +222,7 @@ void subprocess_destroy (struct subprocess *p)
     zio_destroy (p->zio_err);
 
     if (p->parentfd > 0)
-        close (p->childfd);
+        close (p->parentfd);
     if (p->childfd > 0)
         close (p->childfd);
 

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -186,7 +186,11 @@ struct subprocess * subprocess_create (struct subprocess_manager *sm)
     zio_set_send_cb (p->zio_out, (zio_send_f) output_handler);
     zio_set_send_cb (p->zio_err, (zio_send_f) output_handler);
 
-    zlist_append (sm->processes, (void *)p);
+    if (zlist_append (sm->processes, (void *)p) < 0) {
+        subprocess_destroy (p);
+        errno = ENOMEM;
+        return (NULL);
+    }
 
     if (sm->zloop) {
         zio_zloop_attach (p->zio_in, sm->zloop);

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -209,9 +209,11 @@ static int wait_for_lwj_watch_init (flux_t h, int64_t id)
     rpc_o = util_json_object_new_object ();
     util_json_object_add_string (rpc_o, "key", "lwj.next-id");
     util_json_object_add_int64 (rpc_o, "val", id);
-    flux_json_rpc (h, FLUX_NODEID_ANY, "sim_sched.lwj-watch", rpc_o, &rpc_resp);
-    util_json_object_get_int (rpc_resp, "rc", &rc);
-    json_object_put (rpc_resp);
+    rc = flux_json_rpc (h, FLUX_NODEID_ANY, "sim_sched.lwj-watch", rpc_o, &rpc_resp);
+    if (rc >= 0) {
+        util_json_object_get_int (rpc_resp, "rc", &rc);
+        json_object_put (rpc_resp);
+    }
     json_object_put (rpc_o);
     return rc;
 }

--- a/src/modules/wreck/luastack.c
+++ b/src/modules/wreck/luastack.c
@@ -223,6 +223,7 @@ int lua_script_list_append (lua_stack_t st, const char *pattern)
                 if (!(s = lua_script_create (st, type, gl.gl_pathv[i])) ||
                      (lua_script_compile (st, s) < 0)) {
                     (*st->errf) ("%s: Failed. Skipping.\n", gl.gl_pathv[i]);
+                    lua_script_destroy (s);
                     continue;
                 }
                 list_append (st->script_list, s);

--- a/src/modules/wreck/luastack.c
+++ b/src/modules/wreck/luastack.c
@@ -311,7 +311,12 @@ int lua_stack_append_script (lua_stack_t st, const char *script,
 
     s->label = label ? strdup (label) : strdup ("<script>");
 
-    lua_script_compile (st, s);
+    if (lua_script_compile (st, s) < 0) {
+        lua_script_destroy (s);
+	return (-1);
+    }
+
+    list_append (st->script_list, s);
 
     return (0);
 }

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -301,7 +301,8 @@ static int spawn_exec_handler (struct rexec_ctx *ctx, int64_t id)
     /*
      *  Wait for child to exit
      */
-    waitpid (pid, &status, 0);
+    if (waitpid (pid, &status, 0) < 0)
+        err ("waitpid");
 
     /*
      *  Close child side of socketpair and send zmsg to (grand)child

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -208,6 +208,7 @@ static int client_cb (flux_t h, void *zs, short revents, void *arg)
 
     if (revents & ZMQ_POLLERR) {
         rexec_session_remove (c);
+        return 0;
     }
     new = zmsg_recv (c->zs_rep);
     if (new) {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -149,10 +149,10 @@ static flux_t prog_ctx_flux_handle (struct prog_ctx *ctx)
 
 static void log_fatal (struct prog_ctx *ctx, int code, char *format, ...)
 {
-    flux_t c = prog_ctx_flux_handle (ctx);
+    flux_t c;
     va_list ap;
     va_start (ap, format);
-    if ((ctx != NULL) && ((c = ctx->flux) != NULL))
+    if ((ctx != NULL) && ((c = prog_ctx_flux_handle (ctx)) != NULL))
         flux_vlog (c, LOG_EMERG, format, ap);
     else
         vfprintf (stderr, format, ap);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -400,10 +400,10 @@ static char * ctime_iso8601_now (char *buf, size_t sz)
 static int get_executable_path (char *buf, size_t len)
 {
     char *p;
-    if (readlink ("/proc/self/exe", buf, len) < 0)
+    ssize_t n = readlink ("/proc/self/exe", buf, len);
+    if (n < 0)
         return (-1);
-
-    p = buf + strlen (buf) - 1;
+    p = buf + n;
     while (*p == '/')
         p--;
     while (*p != '/')
@@ -462,7 +462,7 @@ struct prog_ctx * prog_ctx_create (void)
     ctx->envref = -1;
 
     if (get_executable_path (ctx->exedir, sizeof (ctx->exedir)) < 0)
-        log_fatal (ctx, 1, "get_executable_path");
+        log_fatal (ctx, 1, "get_executable_path: %s\n", strerror (errno));
 
     ctx->lua_stack = lua_stack_create ();
     ctx->lua_pattern = xstrdup (WRECK_LUA_PATTERN);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -760,6 +760,13 @@ static void close_fd (int fd)
     close (fd);
 }
 
+static int dup_fd (int fd, int newfd)
+{
+   assert (fd >= 0);
+   assert (newfd >= 0);
+   return dup2 (fd, newfd);
+}
+
 void child_io_setup (struct task_info *t)
 {
     /*
@@ -772,9 +779,9 @@ void child_io_setup (struct task_info *t)
     /*
      *  Dup appropriate fds onto child STDIN/STDOUT/STDERR
      */
-    if (  (dup2 (zio_src_fd (t->zio [IN]), STDIN_FILENO) < 0)
-       || (dup2 (zio_dst_fd (t->zio [OUT]), STDOUT_FILENO) < 0)
-       || (dup2 (zio_dst_fd (t->zio [ERR]), STDERR_FILENO) < 0))
+    if (  (dup_fd (zio_src_fd (t->zio [IN]), STDIN_FILENO) < 0)
+       || (dup_fd (zio_dst_fd (t->zio [OUT]), STDOUT_FILENO) < 0)
+       || (dup_fd (zio_dst_fd (t->zio [ERR]), STDERR_FILENO) < 0))
         log_fatal (t->ctx, 1, "dup2: %s", strerror (errno));
 
     closeall (3);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -562,6 +562,8 @@ int prog_ctx_get_nodeinfo (struct prog_ctx *ctx)
     int *nodeids;
 
     nodeids = malloc (flux_size (ctx->flux) * sizeof (int));
+    if (nodeids == NULL)
+        return (-1);
 
     if (kvsdir_get_dir (ctx->kvs, &rank, "rank") < 0) {
         log_msg (ctx, "get_dir (%s.rank): %s",

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1031,7 +1031,6 @@ int exec_command (struct prog_ctx *ctx, int i)
 
 char *gtid_list_create (struct prog_ctx *ctx, char *buf, size_t len)
 {
-    char *str = NULL;
     int i, n = 0;
     int truncated = 0;
 
@@ -1050,7 +1049,7 @@ char *gtid_list_create (struct prog_ctx *ctx, char *buf, size_t len)
                 n += count;
         }
         else
-            n += strlen (str) + 1;
+            n += strlen (buf) + 1;
     }
 
     if (truncated)

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -445,11 +445,11 @@ void prog_ctx_destroy (struct prog_ctx *ctx)
 struct prog_ctx * prog_ctx_create (void)
 {
     struct prog_ctx *ctx = malloc (sizeof (*ctx));
-    memset (ctx, 0, sizeof (*ctx));
     zsys_handler_set (NULL); /* Disable czmq SIGINT/SIGTERM handlers */
     if (!ctx)
         log_fatal (ctx, 1, "malloc");
 
+    memset (ctx, 0, sizeof (*ctx));
     ctx->options = zhash_new ();
 
     ctx->envz = NULL;

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -78,7 +78,7 @@ print_env () {
     echo "export CPPFLAGS=-I${prefix}/include"
     echo "export LDFLAGS=-L${prefix}/lib"
     echo "export PKG_CONFIG_PATH=${prefix}/lib/pkgconfig"
-    luarocks path
+    luarocks path --bin
 }
 
 if test -n "$print_env"; then

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -86,7 +86,7 @@ if test -n "$print_env"; then
     exit 0
 fi
 
-$(print_env)
+eval $(print_env)
 
 check_cache ()
 {

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -111,5 +111,10 @@ fi
 TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME
 
+#  Test requirements for testsuite
+if ! lua -e 'require "posix"' >/dev/null 2>&1; then
+    error "failed to find lua posix module in path"
+fi
+
 
 # vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This PR adds support for  [Travis integrated Coverity scan](https://scan.coverity.com/travis_ci) in `.travis.yml`, and then subsequently fixes a few of the most egregious and easy to fix defects that were detected.

Currently I've only subscribed my personal fork to the free Coverity Scan service, but for now this will be sufficient and I can periodically push to my `coverity_scan` branch to enable checks. However, keeping the coverity settings in `.travis.yml` will make it much easier to do that, so hopefully that will be acceptable.

I can also send invites to project members so you can view the defect reports on the Scan website, take ownership of defects and mark them as false positives, etc. For now I'm just trying out the free service.

I considered squashing all these fixes together into one big "Coverity cleanup" commit, but I leave the separate commits here for now because that will make it much easier to review. Someone let me know if you'd rather have everything squashed.

One other fix near the end of this branch is to simplify the `spellcheck` tests by running them all from `doc/tests`. This reduces the duplicated `Makefile.am` boilerplate and removes the need to link spellcheck everywhere, etc.

