### PR TITLE
travis-ci: add quoting to test for COVERITY_SCAN_BRANCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 script:
  - export CC="ccache $CC"
  - export FLUX_TESTS_LOGFILE=t
- - if test ${COVERITY_SCAN_BRANCH} != 1 ; then ./autogen.sh && ./configure --prefix=$HOME/local && make distcheck; fi
+ - if test "$COVERITY_SCAN_BRANCH" != "1" ; then ./autogen.sh && ./configure --prefix=$HOME/local && make distcheck; fi
 
 after_success:
  - ccache -s


### PR DESCRIPTION
apparently the check in travis for "am I on the coverity_scan branch" is aborting the actual compile and test on the main repo because COVERITY_SCAN_BRANCH is unset (it works in my repo, perhaps because I do actually have a `coverity_scan` branch)

Sadly, this wasn't detected as an error by travis, but a success :-(

Anyhow, the variable should probably be quoted, so let's try this.