### PR TITLE
cmd/flux: env builtin tests and builtin updates

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -340,6 +340,14 @@ void exec_subcommand (const char *searchpath, bool vopt, char *argv[])
     }
 }
 
+optparse_t internal_cmd_optparse_create (const char *cmd)
+{
+    optparse_t p = optparse_create (cmd);
+    if (!p)
+        err_exit ("%s: optparse_create", cmd);
+    return (p);
+}
+
 void internal_help (flux_conf_t cf, const char *topic)
 {
     const char *cf_path = flux_conf_get (cf, "general.man_path");

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -480,6 +480,8 @@ void optparse_destroy (optparse_t p)
     if (p == NULL)
         return;
     list_destroy (p->option_list);
+    free (p->program_name);
+    free (p->usage);
     free (p);
 }
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -662,6 +662,10 @@ optparse_err_t optparse_add_doc (optparse_t p, const char *doc, int group)
     if (p == NULL || !p->option_list)
         return OPTPARSE_BAD_ARG;
 
+    o.has_arg = 0;
+    o.arginfo = NULL;
+    o.arg   = NULL;
+    o.cb    = NULL;
     o.name  = NULL;
     o.key   = 0;
     o.usage = doc;

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -722,10 +722,11 @@ optparse_err_t optparse_get (optparse_t p, optparse_item_t item, ...)
 }
 static char * optstring_create ()
 {
-    char *optstring = malloc (1);
+    char *optstring = malloc (2);
     if (optstring == NULL)
         return (NULL);
-    *optstring = '\0';
+    optstring[0] = '+';
+    optstring[1] = '\0';
     return (optstring);
 }
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -814,6 +814,10 @@ int optparse_parse_args (optparse_t p, int argc, char *argv[])
     struct option *optz = option_table_create (p, &optstring);
 
 
+    /* Always set optind = 0 here to force internal initialization of
+     *  GNU options parser. See getopt_long(3) NOTES section.
+     */
+    optind = 0;
     while ((c = getopt_long (argc, argv, optstring, optz, &li))) {
         struct option_info *opt;
         struct optparse_option *o;

--- a/src/common/libutil/optparse.h
+++ b/src/common/libutil/optparse.h
@@ -127,7 +127,7 @@ optparse_err_t optparse_get (optparse_t p, optparse_item_t item, ...);
  *   Print the usage output for program options object [p] using the
  *    registered output function.
  */
-int optparse_print_help (optparse_t p);
+int optparse_print_usage (optparse_t p);
 
 /*
  *   Process command line args in [argc] and [argv] using the options

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -72,4 +72,20 @@ test_expect_success 'cmddriver: --uri fails for non-connector dso' '
 			       --uri kvs:// comms info
 '
 
+# Test flux 'env' builtin
+test_expect_success 'flux env works' '
+	flux env | grep ${FLUX_BUILD_DIR}/src/connectors
+'
+test_expect_success 'flux env runs argument' "
+	flux env sh -c 'echo \$FLUX_CONNECTOR_PATH' \
+		| grep ${FLUX_BUILD_DIR}/src/connectors
+"
+test_expect_success 'flux env passes cmddriver options' '
+	flux -F --tmpdir /xyz env | grep "^FLUX_TMPDIR=/xyz"
+'
+test_expect_success 'flux env passes cmddriver option to argument' "
+	flux -F --tmpdir /xyx env sh -c 'echo \$FLUX_TMPDIR' \
+		| grep ^/xyx$
+"
+
 test_done


### PR DESCRIPTION
This PR starts with some simple functionality tests for the `flux-env` builtin in `t1005-cmddriver.t`.

During this work, I wanted to see `flux env --help` work so I started importing the `optparse` parser for builtin `flux(1)` commands to rerun option parsing on their own arguments. This led to the discovery of some fixes required for `optparse.[ch]`, which are included here.

The cleanest way to handle >1 internal command seemed to be to have a table of builtins, so I eventually settled on that. This approach makes it easy to add new builtins if need be, but also just maximizes the reduction of the now common code (and standardizes builtin cmd interface).

