### PR TITLE
cmd: prepend flux cmddriver directory to PATH

### DIFF
--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -112,4 +112,9 @@ test_expect_success 'cmddriver removes multiple contiguous separators in input' 
 	LUA_PATH='/meh;;;' flux env sh -c 'echo \$LUA_PATH' |
 		grep -v ';;;;'
 "
+test_expect_success 'cmddriver adds its own path to PATH if called with relative path' "
+	fluxcmd=\$(which flux) &&
+	fluxdir=\$(dirname \$fluxcmd) &&
+	PATH='/bin:/usr/bin' \$fluxcmd env sh -c 'echo \$PATH' | grep ^\$fluxdir
+"
 test_done


### PR DESCRIPTION
This is more a RFC than a real PR at this point.

I got sick of typing `src/cmd/flux` this and `src/cmd/flux` that so I wanted to work on a possible fix for #263. The changes implement the following rule:
 * If the current `argv[0]` is literally `"flux"`, then it is assumed path to  *this* `flux` is already first in `PATH` so `PATH` is not modified
 * Otherwise, directory to *this* `flux` is prepended to `PATH`, and hopefully this `flux` is found first in children of this process

The approach here could result in duplicate entries in `PATH` if flux is run with absolute or relative path even when its dir is first in PATH, but this approach simplifies the execution (Otherwise, we'd have to iterate over `PATH` entries to determine if modification is necessary or needed)

In order to handle working in a build tree, `/.libs` is always truncated from flux executable directory path.

Adding `PATH` to the flux config environment gives me pause -- though it isn't too much different than things like `PYTHONPATH` and `LUA_PATH`. And there may be corner cases I've missed where modifying `PATH` is dangerous, which is why I wanted to get comments early.