### PR TITLE
modules/resource_hwloc: new hwloc resource grokker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - aspell
       - libopenmpi-dev
       - ccache
+      - libhwloc-dev
   coverity_scan:
     project:
       name: "grondo/flux-core"

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ X_AC_ZEROMQ
 X_AC_MUNGE
 PKG_CHECK_MODULES([JSON], [json], [],
   [PKG_CHECK_MODULES([JSON], [json-c])])
+PKG_CHECK_MODULES([HWLOC], [hwloc], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 
@@ -184,6 +185,7 @@ AC_CONFIG_FILES( \
   src/modules/barrier/Makefile \
   src/modules/wreck/Makefile \
   src/modules/pymod/Makefile \
+  src/modules/resource-hwloc/Makefile \
   src/test/Makefile \
   src/test/kap/Makefile \
   src/test/request/Makefile \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -70,7 +70,7 @@
 #endif
 
 const char *default_modules =
-    "connector-local,modctl,kvs,live,mecho,job[0],wrexec,resrc,barrier";
+    "connector-local,modctl,kvs,live,mecho,job[0],wrexec,resrc,barrier,resource-hwloc";
 
 typedef struct {
     /* 0MQ

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,5 +1,5 @@
 #This order is *important* 
-SUBDIRS = connector-local kvs libmrpc libzio libsubprocess libkz modctl live mecho barrier wreck libjsc
+SUBDIRS = connector-local kvs libmrpc libzio libsubprocess libkz modctl live mecho barrier wreck libjsc resource-hwloc
 if HAVE_PYTHON
  SUBDIRS+=pymod
 endif

--- a/src/modules/resource-hwloc/Makefile.am
+++ b/src/modules/resource-hwloc/Makefile.am
@@ -1,0 +1,26 @@
+AM_CFLAGS = @GCCWARN@
+
+AM_CPPFLAGS = \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include
+
+#
+# Comms module
+#
+fluxmod_LTLIBRARIES = resource-hwloc.la
+
+fluxmod_libadd = \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/modules/kvs/libkvs.la
+
+general_ldflags = --disable-static -avoid-version -shared -export-dynamic \
+	$(LIBMUNGE) $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) $(HWLOC_LIBS)
+
+fluxmod_ldflags = -module \
+	-export-symbols-regex '^mod_(main|name)$$' \
+	$(general_ldflags)
+
+resource_hwloc_la_SOURCES = resource.c
+resource_hwloc_la_CFLAGS = $(HWLOC_CFLAGS)
+resource_hwloc_la_LDFLAGS = $(fluxmod_ldflags)
+resource_hwloc_la_LIBADD = $(fluxmod_libadd)

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -1,0 +1,389 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include <stdarg.h>
+#include <hwloc.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/modules/libmrpc/mrpc.h"
+
+typedef struct
+{
+    hwloc_topology_t topology;
+    bool loaded;
+} ctx_t;
+
+static ctx_t *getctx (flux_t h)
+{
+    ctx_t *ctx = xzmalloc (sizeof(ctx_t));
+    hwloc_topology_init (&ctx->topology);
+    hwloc_topology_set_flags (ctx->topology, HWLOC_TOPOLOGY_FLAG_WHOLE_IO);
+    hwloc_topology_load (ctx->topology);
+    ctx->loaded = false;
+    return ctx;
+}
+
+#if 0
+static void freectx(ctx_t * ctx)
+{
+    hwloc_topology_destroy(ctx->topology);
+    free(ctx);
+}
+#endif
+
+/* Copy input arguments to output arguments and respond to RPC.
+*/
+static void query_cb (flux_t h,
+                      flux_msg_watcher_t *watcher,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    flux_log (h, LOG_ERR, "UNIMPLEMENTED: %s", __FUNCTION__);
+}
+
+static void get_cb (flux_t h,
+                    flux_msg_watcher_t *watcher,
+                    const flux_msg_t *msg,
+                    void *arg)
+{
+    flux_log (h, LOG_ERR, "UNIMPLEMENTED: %s", __FUNCTION__);
+}
+
+static int load_xml_to_kvs (flux_t h, ctx_t *ctx)
+{
+    char *xml_path = xasprintf ("resource.hwloc.xml.%d", flux_rank (h));
+    char *buffer = NULL;
+    int buflen = 0, ret = -1;
+    if (hwloc_topology_export_xmlbuffer (ctx->topology, &buffer, &buflen) < 0) {
+        flux_log (h, LOG_ERR, "hwloc_topology_export_xmlbuffer");
+        goto done;
+    }
+    if (kvs_put_string (h, xml_path, buffer) < 0) {
+        flux_log (h, LOG_ERR, "kvs_put_string");
+        goto done;
+    }
+    ret = 0;
+done:
+    free (xml_path);
+    hwloc_free_xmlbuffer (ctx->topology, buffer);
+    return ret;
+}
+
+static char *escape_kvs_key (const char *key)
+{
+    char *ret_str = key ? xstrdup (key) : NULL;
+    char *s;
+    for (s = ret_str; s && *s; s++)
+        if (*s == '.')
+            *s = ':';
+    return ret_str;
+}
+
+static char *escape_and_join_kvs_path (const char *base,
+                                       int64_t num_suffixes,
+                                       ...)
+{
+    int64_t i;
+    va_list varargs;
+    char *ret_str = base ? xstrdup (base) : NULL;
+    va_start (varargs, num_suffixes);
+    for (i = 0; i < num_suffixes; i++) {
+        char *tmp = ret_str;
+        char *suffix = va_arg (varargs, char *);
+        if (!suffix || !strlen (suffix))
+            continue;
+
+        suffix = escape_kvs_key (suffix);
+
+        if (!ret_str || !strlen (ret_str))
+            ret_str = suffix;
+        else
+            ret_str = xasprintf ("%s.%s", ret_str, suffix);
+        free (suffix);
+        free (tmp);
+    }
+    va_end (varargs);
+    return ret_str;
+}
+
+static int walk_topology (flux_t h,
+                          hwloc_topology_t topology,
+                          hwloc_obj_t obj,
+                          const char *path)
+{
+    int ret = -1;
+    int size_buf = hwloc_obj_attr_snprintf (NULL, 0, obj, ":-!:", 1) + 1;
+    int size_type = hwloc_obj_type_snprintf (NULL, 0, obj, 1) + 1;
+    char *os_index_path, *new_path = NULL, *token = NULL, *end = NULL;
+    char *buf = xzmalloc (size_buf);
+    char *type = xzmalloc (size_type);
+    hwloc_obj_t prev = NULL;
+
+    hwloc_obj_attr_snprintf (buf, size_buf, obj, ":-!:", 1);
+    hwloc_obj_type_snprintf (type, size_type, obj, 1);
+
+    new_path = xasprintf ("%s.%s_%u", path, type, obj->logical_index);
+
+    os_index_path = xasprintf ("%s.os_index", new_path);
+    kvs_put_int (h, os_index_path, obj->os_index);
+
+    // Tokenize the string, break out key/value pairs and store appropriately
+    for (token = buf, end = strstr (token, ":-!:"); end && token;
+         token = end + 4, end = strstr (token, ":-!:")) {
+        end[0] = '\0';
+        char *value = strstr (token, "=");
+        if (value) {
+            value[0] = '\0';
+            {
+                char *value_path =
+                    escape_and_join_kvs_path (new_path, 1, token);
+                int kvs_ret = -1;
+                value++;
+
+                kvs_ret = kvs_put_string (h, value_path, value);
+
+                free (value_path);
+                if (kvs_ret < 0)
+                    goto done;
+            }
+        }
+    }
+
+    // Recurse into the children of this object
+    while ((prev = hwloc_get_next_child (topology, obj, prev))) {
+        if (walk_topology (h, topology, prev, new_path) < 0)
+            goto done;
+    }
+
+    ret = 0;
+done:
+    free (os_index_path);
+    free (new_path);
+    free (buf);
+    free (type);
+    return ret;
+}
+
+static int load_info_to_kvs (flux_t h, ctx_t *ctx)
+{
+    char *base_path = xasprintf ("resource.hwloc.by_rank.%d", flux_rank (h));
+    int ret = -1, i;
+    int depth = hwloc_topology_get_depth (ctx->topology);
+    for (i = 0; i < depth; ++i) {
+        int nobj = hwloc_get_nbobjs_by_depth (ctx->topology, i);
+        hwloc_obj_type_t t = hwloc_get_depth_type (ctx->topology, i);
+        char *obj_path =
+            xasprintf ("%s.%s", base_path, hwloc_obj_type_string (t));
+        kvs_put_int (h, obj_path, nobj);
+        free (obj_path);
+    }
+    if (walk_topology (h,
+                       ctx->topology,
+                       hwloc_get_root_obj (ctx->topology),
+                       base_path) < 0) {
+        flux_log (h, LOG_ERR, "walk_topology");
+        goto done;
+    }
+    hwloc_obj_t machine =
+        hwloc_get_obj_by_type (ctx->topology, HWLOC_OBJ_MACHINE, 0);
+    if (machine) {
+        const char *hostname = hwloc_obj_get_info_by_name (machine, "HostName");
+        char *kvs_hostname = escape_kvs_key (hostname);
+        char *host_path = xasprintf ("resource.hwloc.by_host.%s", kvs_hostname);
+        free (kvs_hostname);
+        if (walk_topology (h,
+                           ctx->topology,
+                           hwloc_get_root_obj (ctx->topology),
+                           host_path) < 0) {
+            flux_log (h, LOG_ERR, "walk_topology");
+            goto done;
+        }
+    }
+    ret = 0;
+done:
+    free (base_path);
+    return ret;
+}
+
+static void load_cb (flux_t h,
+                     flux_msg_watcher_t *watcher,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    int rank = flux_rank (h);
+    ctx_t *ctx = (ctx_t *)arg;
+
+    if (load_xml_to_kvs (h, ctx) < 0 || load_info_to_kvs (h, ctx) < 0) {
+        return;
+    }
+
+    char *completion_path = xasprintf ("resource.hwloc.loaded.%d", rank);
+    kvs_put_int (h, completion_path, 1);
+    free (completion_path);
+
+    kvs_fence (h, "resource_hwloc_loaded", flux_size (h));
+
+    flux_log (h, LOG_DEBUG, "resource_hwloc: loaded: %d\n", rank);
+
+    ctx->loaded = true;
+}
+
+static void topo_cb (flux_t h,
+                     flux_msg_watcher_t *watcher,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    ctx_t *ctx = (ctx_t *)arg;
+    kvsdir_t kd = NULL;
+    json_object *out = NULL;
+    char *buffer;
+    int buflen;
+    hwloc_topology_t global;
+    hwloc_topology_init (&global);
+
+    if (!ctx->loaded) {
+        flux_log (h,
+                  LOG_ERR,
+                  "topology cannot be aggregated, it has not been loaded");
+        flux_respond (h, msg, EINVAL, NULL);
+        goto done;
+    }
+
+    if (kvs_get_dir (h, &kd, "resource.hwloc.xml") < 0) {
+        flux_log (h, LOG_ERR, "xml dir is not available");
+        flux_respond (h, msg, errno, NULL);
+        goto done;
+    }
+
+    hwloc_topology_set_custom (global);
+
+    kvsitr_t base_iter = kvsitr_create (kd);
+    const char *base_key = NULL;
+    while ((base_key = kvsitr_next (base_iter))) {
+        char *xml = NULL;
+        hwloc_topology_t rank;
+        kvsdir_get_string (kd, base_key, &xml);
+
+        hwloc_topology_init (&rank);
+        hwloc_topology_set_xmlbuffer (rank, xml, strlen (xml));
+        hwloc_topology_load (rank);
+        hwloc_custom_insert_topology (global,
+                                      hwloc_get_root_obj (global),
+                                      rank,
+                                      NULL);
+        hwloc_topology_destroy (rank);
+        free (xml);
+
+        flux_log (h, LOG_INFO, "resource_hwloc: loaded from %s\n", base_key);
+    }
+
+    kvsitr_destroy (base_iter);
+    kvsdir_destroy (kd);
+
+    out = Jnew ();
+
+    hwloc_topology_load (global);
+    if (hwloc_topology_export_xmlbuffer (global, &buffer, &buflen) < 0) {
+        flux_respond (h, msg, errno, NULL);
+        goto done;
+    }
+    Jadd_str (out, "topology", buffer);
+    hwloc_free_xmlbuffer (global, buffer);
+
+    flux_respond (h, msg, 0, Jtostr (out));
+
+done:
+    hwloc_topology_destroy (global);
+    Jput (out);
+}
+
+static void start_all (flux_t h, ...)
+{
+    flux_msg_watcher_t *w;
+    va_list ap;
+    va_start (ap, h);
+    while ((w = va_arg (ap, flux_msg_watcher_t *))) {
+        flux_msg_watcher_start (h, w);
+    }
+}
+
+struct
+{
+    flux_msg_watcher_t *load;
+    flux_msg_watcher_t *query;
+    flux_msg_watcher_t *get;
+    flux_msg_watcher_t *topo;
+    flux_msg_watcher_t *END;
+} watchers = {};
+
+int mod_main (flux_t h, int argc, char **argv)
+{
+    ctx_t *ctx = getctx (h);
+
+    // Load hardware information immediately
+    load_cb (h, 0, NULL, ctx);
+
+    if (flux_event_subscribe (h, "resource-hwloc.load") < 0) {
+        flux_log (h, LOG_ERR, "%s: flux_event_subscribe", __FUNCTION__);
+        return -1;
+    }
+
+    watchers.load = flux_msg_watcher_create (FLUX_MATCH_EVENT, load_cb, ctx);
+    flux_msg_watcher_start (h, watchers.load);
+    watchers.query =
+        flux_msg_watcher_create (FLUX_MATCH_REQUEST, query_cb, ctx);
+    flux_msg_watcher_start (h, watchers.query);
+    watchers.get = flux_msg_watcher_create (FLUX_MATCH_REQUEST, get_cb, ctx);
+    flux_msg_watcher_start (h, watchers.get);
+    watchers.topo = flux_msg_watcher_create (FLUX_MATCH_REQUEST, topo_cb, ctx);
+    flux_msg_watcher_start (h, watchers.topo);
+
+    if (flux_reactor_start (h) < 0) {
+        flux_log (h, LOG_ERR, "flux_reactor_start: %s", strerror (errno));
+        return -1;
+    }
+
+    flux_msg_watcher_destroy (watchers.load);
+    flux_msg_watcher_destroy (watchers.query);
+    flux_msg_watcher_destroy (watchers.get);
+    flux_msg_watcher_destroy (watchers.topo);
+
+    return 0;
+}
+
+MOD_NAME ("resource-hwloc");
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
Currently in for discussion, not ready for general use as yet.  When loaded on
all ranks, `flux module load -r all resource_hwloc`, and loaded, `flux event
pub resource.load`, populates the KVS with resource information for the flux
instance.  The full topology for each node is stored as xml at
`resource.hwloc.xml.<rank>` in the KVS, and a complete tree of resources,
including IO and caches, by individual key and value is available at
`resource.hwloc.<rank>.[<resource_type>_<resource_logical_id>...]`. It has not
been instructed to look outside of administrative limitations, but that hasn't
been tested either.


