### PR TITLE
modules/pymod: use argc, argv argument parsing

### DIFF
--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -18,4 +18,4 @@ def mod_main_trampoline(name, int_handle, args):
     #call into mod_main with a flux class instance and the argument dict
     #it might be more pythonic to unpack the args as keyword/positional arguments
     #to this function, but I think this is cleaner for now
-    user_mod.mod_main(flux_instance, **args)
+    user_mod.mod_main(flux_instance, *args)

--- a/src/modules/pymod/echo.py
+++ b/src/modules/pymod/echo.py
@@ -13,7 +13,7 @@ def pecho_impl(h, typemask, message, arg):
     rpc.respond()
     return 0
 
-def mod_main(h, **arg_dict):
+def mod_main(h, *args):
     if h.event_subscribe("mrpc.mecho") < 0:
         h.fatal_error("event subscription failed")
     with h.msg_watcher_create(pecho_impl,


### PR DESCRIPTION
fixes #291

The argc/argv style arguments are now packed into a Python list, compatible
with all standard python argument parsing libraries meant for `sys.argv`.