### PR TITLE
Env updates

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -231,20 +231,20 @@ int main (int argc, char *argv[])
     /* Add config items to environment variables */
     /* NOTE: I would prefer that this be in config, but kvs_load loads
      * everything out of band, preventing that */
-    flux_conf_environment_upsert_front (cf, "FLUX_CONNECTOR_PATH", flux_conf_get(cf, "general.connector_path"));
-    flux_conf_environment_upsert_front (cf, "FLUX_EXEC_PATH",      flux_conf_get(cf, "general.exec_path"));
-    flux_conf_environment_upsert_front (cf, "FLUX_MODULE_PATH",    flux_conf_get(cf, "general.module_path"));
-    flux_conf_environment_upsert_front (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"));
-    flux_conf_environment_upsert_front (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
-    flux_conf_environment_upsert_front (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
+    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", flux_conf_get(cf, "general.connector_path"));
+    flux_conf_environment_push (cf, "FLUX_EXEC_PATH",      flux_conf_get(cf, "general.exec_path"));
+    flux_conf_environment_push (cf, "FLUX_MODULE_PATH",    flux_conf_get(cf, "general.module_path"));
+    flux_conf_environment_push (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"));
+    flux_conf_environment_push (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
+    flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
 
     /* Prepend to command-line environment variables */
-    flux_conf_environment_upsert_front (cf, "FLUX_CONNECTOR_PATH", Oopt);
-    flux_conf_environment_upsert_front (cf, "FLUX_EXEC_PATH", xopt);
-    flux_conf_environment_upsert_front (cf, "FLUX_MODULE_PATH", Mopt);
-    flux_conf_environment_upsert_front (cf, "LUA_CPATH", Copt);
-    flux_conf_environment_upsert_front (cf, "LUA_PATH", Lopt);
-    flux_conf_environment_upsert_front (cf, "PYTHONPATH", Popt);
+    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", Oopt);
+    flux_conf_environment_push (cf, "FLUX_EXEC_PATH", xopt);
+    flux_conf_environment_push (cf, "FLUX_MODULE_PATH", Mopt);
+    flux_conf_environment_push (cf, "LUA_CPATH", Copt);
+    flux_conf_environment_push (cf, "LUA_PATH", Lopt);
+    flux_conf_environment_push (cf, "PYTHONPATH", Popt);
 
     if (argc == 0) {
         usage ();

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -231,20 +231,20 @@ int main (int argc, char *argv[])
     /* Add config items to environment variables */
     /* NOTE: I would prefer that this be in config, but kvs_load loads
      * everything out of band, preventing that */
-    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", flux_conf_get(cf, "general.connector_path"));
-    flux_conf_environment_push (cf, "FLUX_EXEC_PATH",      flux_conf_get(cf, "general.exec_path"));
-    flux_conf_environment_push (cf, "FLUX_MODULE_PATH",    flux_conf_get(cf, "general.module_path"));
-    flux_conf_environment_push (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"));
-    flux_conf_environment_push (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
-    flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
+    flux_conf_environment_upsert_front (cf, "FLUX_CONNECTOR_PATH", flux_conf_get(cf, "general.connector_path"));
+    flux_conf_environment_upsert_front (cf, "FLUX_EXEC_PATH",      flux_conf_get(cf, "general.exec_path"));
+    flux_conf_environment_upsert_front (cf, "FLUX_MODULE_PATH",    flux_conf_get(cf, "general.module_path"));
+    flux_conf_environment_upsert_front (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"));
+    flux_conf_environment_upsert_front (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
+    flux_conf_environment_upsert_front (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
 
     /* Prepend to command-line environment variables */
-    flux_conf_environment_push(cf, "FLUX_CONNECTOR_PATH", Oopt);
-    flux_conf_environment_push(cf, "FLUX_EXEC_PATH", xopt);
-    flux_conf_environment_push(cf, "FLUX_MODULE_PATH", Mopt);
-    flux_conf_environment_push(cf, "LUA_CPATH", Copt);
-    flux_conf_environment_push(cf, "LUA_PATH", Lopt);
-    flux_conf_environment_push(cf, "PYTHONPATH", Popt);
+    flux_conf_environment_upsert_front (cf, "FLUX_CONNECTOR_PATH", Oopt);
+    flux_conf_environment_upsert_front (cf, "FLUX_EXEC_PATH", xopt);
+    flux_conf_environment_upsert_front (cf, "FLUX_MODULE_PATH", Mopt);
+    flux_conf_environment_upsert_front (cf, "LUA_CPATH", Copt);
+    flux_conf_environment_upsert_front (cf, "LUA_PATH", Lopt);
+    flux_conf_environment_upsert_front (cf, "PYTHONPATH", Popt);
 
     if (argc == 0) {
         usage ();

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -146,12 +146,12 @@ int main (int argc, char *argv[])
             case 'T': /* --tmpdir PATH */
                 if (setenv ("FLUX_TMPDIR", optarg, 1) < 0)
                     err_exit ("setenv");
-                flux_conf_environment_set (cf, "FLUX_TMPDIR", optarg);
+                flux_conf_environment_set (cf, "FLUX_TMPDIR", optarg, "");
                 break;
             case 't': /* --trace-handle */
                 if (setenv ("FLUX_HANDLE_TRACE", "1", 1) < 0)
                     err_exit ("setenv");
-                flux_conf_environment_set (cf, "FLUX_HANDLE_TRACE", "1");
+                flux_conf_environment_set (cf, "FLUX_HANDLE_TRACE", "1", "");
                 break;
             case 'M': /* --module-path PATH */
                 Mopt = optarg;
@@ -180,7 +180,7 @@ int main (int argc, char *argv[])
             case 'u': /* --uri URI */
                 if (setenv ("FLUX_URI", optarg, 1) < 0)
                     err_exit ("setenv");
-                flux_conf_environment_set(cf, "FLUX_URI", optarg);
+                flux_conf_environment_set(cf, "FLUX_URI", optarg, "");
                 break;
             case 'h': /* --help  */
                 usage ();
@@ -199,7 +199,7 @@ int main (int argc, char *argv[])
     if (confdir || (confdir = intree_confdir ()))
         flux_conf_set_directory (cf, confdir);
     flux_conf_environment_set (cf, "FLUX_SEC_DIRECTORY",
-                     secdir ? secdir : flux_conf_get_directory (cf));
+                     secdir ? secdir : flux_conf_get_directory (cf), "");
     flux_conf_environment_unset (cf, "FLUX_CONF_USEFILE");
 
     /* Process config from the KVS if not a bootstrap instance, and not
@@ -218,7 +218,7 @@ int main (int argc, char *argv[])
         flux_close (h);
     } else {
         if (flux_conf_load (cf) == 0) {
-            flux_conf_environment_set (cf, "FLUX_CONF_USEFILE", "1");
+            flux_conf_environment_set (cf, "FLUX_CONF_USEFILE", "1", "");
         } else if (errno != ENOENT || Fopt)
             err_exit ("%s", flux_conf_get_directory (cf));
     }
@@ -231,20 +231,20 @@ int main (int argc, char *argv[])
     /* Add config items to environment variables */
     /* NOTE: I would prefer that this be in config, but kvs_load loads
      * everything out of band, preventing that */
-    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", flux_conf_get(cf, "general.connector_path"), ":");
-    flux_conf_environment_push (cf, "FLUX_EXEC_PATH",      flux_conf_get(cf, "general.exec_path"),      ":");
-    flux_conf_environment_push (cf, "FLUX_MODULE_PATH",    flux_conf_get(cf, "general.module_path"),    ":");
-    flux_conf_environment_push (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"),      ";");
-    flux_conf_environment_push (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"),       ";");
-    flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"),    ":");
+    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", flux_conf_get(cf, "general.connector_path"));
+    flux_conf_environment_push (cf, "FLUX_EXEC_PATH",      flux_conf_get(cf, "general.exec_path"));
+    flux_conf_environment_push (cf, "FLUX_MODULE_PATH",    flux_conf_get(cf, "general.module_path"));
+    flux_conf_environment_push (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"));
+    flux_conf_environment_push (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
+    flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
 
     /* Prepend to command-line environment variables */
-    flux_conf_environment_push(cf, "FLUX_CONNECTOR_PATH", Oopt, ":");
-    flux_conf_environment_push(cf, "FLUX_EXEC_PATH", xopt, ":");
-    flux_conf_environment_push(cf, "FLUX_MODULE_PATH", Mopt, ":");
-    flux_conf_environment_push(cf, "LUA_CPATH", Copt, ";");
-    flux_conf_environment_push(cf, "LUA_PATH", Lopt, ";");
-    flux_conf_environment_push(cf, "PYTHONPATH", Popt, ":");
+    flux_conf_environment_push(cf, "FLUX_CONNECTOR_PATH", Oopt);
+    flux_conf_environment_push(cf, "FLUX_EXEC_PATH", xopt);
+    flux_conf_environment_push(cf, "FLUX_MODULE_PATH", Mopt);
+    flux_conf_environment_push(cf, "LUA_CPATH", Copt);
+    flux_conf_environment_push(cf, "LUA_PATH", Lopt);
+    flux_conf_environment_push(cf, "PYTHONPATH", Popt);
 
     if (argc == 0) {
         usage ();
@@ -307,7 +307,7 @@ void setup_broker_env (flux_conf_t cf, const char *path_override)
         path = cf_path;
     if (!path)
         path = BROKER_PATH;
-    flux_conf_environment_set(cf, "FLUX_BROKER_PATH", path);
+    flux_conf_environment_set(cf, "FLUX_BROKER_PATH", path, "");
 }
 
 void exec_subcommand_dir (bool vopt, const char *dir, char *argv[],

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -97,19 +97,19 @@ static void initialize_environment (flux_conf_t cf)
     // Defaults from the environment
     flux_conf_environment_from_env (
         cf, "LUA_CPATH", "", ";"); /* Lua replaces ;; with the default path */
-    flux_conf_environment_push_back (cf, "LUA_CPATH", ";;");
+    flux_conf_environment_no_dedup_push_back (cf, "LUA_CPATH", ";;");
     flux_conf_environment_from_env (
         cf, "LUA_PATH", "", ";"); /* use a null separator to keep it intact */
-    flux_conf_environment_push_back (cf, "LUA_PATH", ";;");
+    flux_conf_environment_no_dedup_push_back (cf, "LUA_PATH", ";;");
     flux_conf_environment_from_env (cf, "PYTHONPATH", "", ":");
 
     // Build paths
     flux_conf_environment_set (cf, "FLUX_CONNECTOR_PATH", CONNECTOR_PATH, ":");
     flux_conf_environment_set (cf, "FLUX_EXEC_PATH", EXEC_PATH, ":");
     flux_conf_environment_set (cf, "FLUX_MODULE_PATH", MODULE_PATH, ":");
-    flux_conf_environment_upsert_front (cf, "LUA_CPATH", LUA_CPATH_ADD);
-    flux_conf_environment_upsert_front (cf, "LUA_PATH", LUA_PATH_ADD);
-    flux_conf_environment_upsert_front (cf, "PYTHONPATH", PYTHON_PATH);
+    flux_conf_environment_push (cf, "LUA_CPATH", LUA_CPATH_ADD);
+    flux_conf_environment_push (cf, "LUA_PATH", LUA_PATH_ADD);
+    flux_conf_environment_push (cf, "PYTHONPATH", PYTHON_PATH);
 }
 
 const char *flux_conf_get_directory (flux_conf_t cf)
@@ -345,28 +345,28 @@ static void flux_conf_environment_push_inner (flux_conf_t cf,
     }
 }
 
-void flux_conf_environment_upsert_front (flux_conf_t cf,
+void flux_conf_environment_push (flux_conf_t cf,
                                          const char *key,
                                          const char *value)
 {
     flux_conf_environment_push_inner (cf, key, value, true, true);
 }
 
-void flux_conf_environment_upsert_back (flux_conf_t cf,
+void flux_conf_environment_push_back (flux_conf_t cf,
                                         const char *key,
                                         const char *value)
 {
     flux_conf_environment_push_inner (cf, key, value, false, true);
 }
 
-void flux_conf_environment_push_front (flux_conf_t cf,
+void flux_conf_environment_no_dedup_push (flux_conf_t cf,
                                        const char *key,
                                        const char *value)
 {
     flux_conf_environment_push_inner (cf, key, value, true, false);
 }
 
-void flux_conf_environment_push_back (flux_conf_t cf,
+void flux_conf_environment_no_dedup_push_back (flux_conf_t cf,
                                       const char *key,
                                       const char *value)
 {

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -34,16 +34,25 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/iterators.h"
+#include "src/common/libutil/sds.h"
+#include "src/common/libutil/vec.h"
 
 #include "conf.h"
 
 static void initialize_environment(flux_conf_t cf); 
 
+struct env_item {
+    sds sep;
+    vec_str_t components;
+    sds string_cache;
+    bool clean;
+};
+
 struct flux_conf_struct {
     char *confdir;
     zconfig_t *z;
     zhash_t *environment;
-    zhash_t *environment_unset;
 };
 
 struct flux_conf_itr_struct {
@@ -60,8 +69,6 @@ void flux_conf_destroy (flux_conf_t cf)
         zconfig_destroy (&cf->z);
     if (cf->environment)
         zhash_destroy(&cf->environment);
-    if (cf->environment_unset)
-        zhash_destroy(&cf->environment_unset);
     free (cf);
 }
 
@@ -79,10 +86,6 @@ flux_conf_t flux_conf_create (void)
         oom ();
     if (!(cf->environment = zhash_new()))
         oom ();
-    zhash_autofree(cf->environment);
-    if (!(cf->environment_unset = zhash_new()))
-        oom ();
-    zhash_autofree(cf->environment_unset);
 
     initialize_environment(cf);
 
@@ -96,17 +99,17 @@ flux_conf_t flux_conf_create (void)
 static void initialize_environment(flux_conf_t cf)
 {
     // Defaults from the environment
-    flux_conf_environment_from_env (cf, "LUA_CPATH",  ";;"); /* Lua replaces ;; with the default path */
-    flux_conf_environment_from_env (cf, "LUA_PATH",   ";;");
-    flux_conf_environment_from_env (cf, "PYTHONPATH", "");
+    flux_conf_environment_from_env (cf, "LUA_CPATH",  ";;", ";"); /* Lua replaces ;; with the default path */
+    flux_conf_environment_from_env (cf, "LUA_PATH",   ";;", ";"); /* use a null separator to keep it intact */
+    flux_conf_environment_from_env (cf, "PYTHONPATH", "", ":");
 
     // Build paths
-    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", CONNECTOR_PATH,      ":");
-    flux_conf_environment_push (cf, "FLUX_EXEC_PATH",      EXEC_PATH,           ":");
-    flux_conf_environment_push (cf, "FLUX_MODULE_PATH",    MODULE_PATH,         ":");
-    flux_conf_environment_push (cf, "LUA_CPATH",           LUA_CPATH_ADD,       ";"); /* Lua replaces ;; with the default path */
-    flux_conf_environment_push (cf, "LUA_PATH",            LUA_PATH_ADD,        ";");
-    flux_conf_environment_push (cf, "PYTHONPATH",          PYTHON_PATH,         ":");
+    flux_conf_environment_set (cf, "FLUX_CONNECTOR_PATH", CONNECTOR_PATH,      ":");
+    flux_conf_environment_set (cf, "FLUX_EXEC_PATH",      EXEC_PATH,           ":");
+    flux_conf_environment_set (cf, "FLUX_MODULE_PATH",    MODULE_PATH,         ":");
+    flux_conf_environment_push (cf, "LUA_CPATH",          LUA_CPATH_ADD); /* Lua replaces ;; with the default path */
+    flux_conf_environment_push (cf, "LUA_PATH",           LUA_PATH_ADD);
+    flux_conf_environment_push (cf, "PYTHONPATH",         PYTHON_PATH);
 }
 
 const char *flux_conf_get_directory (flux_conf_t cf)
@@ -117,7 +120,7 @@ const char *flux_conf_get_directory (flux_conf_t cf)
 void flux_conf_set_directory (flux_conf_t cf, const char *path)
 {
     free (cf->confdir);
-    flux_conf_environment_set(cf, "FLUX_CONF_DIRECTORY", path);
+    flux_conf_environment_set(cf, "FLUX_CONF_DIRECTORY", path, "");
     cf->confdir = xstrdup (path);
 }
 
@@ -129,11 +132,6 @@ void flux_conf_clear (flux_conf_t cf)
     zhash_destroy (&cf->environment);
     if (!(cf->environment = zhash_new()))
         oom ();
-    zhash_autofree(cf->environment);
-    zhash_destroy (&cf->environment_unset);
-    if (!(cf->environment_unset = zhash_new()))
-        oom ();
-    zhash_autofree(cf->environment_unset);
     initialize_environment (cf);
 }
 
@@ -288,92 +286,158 @@ const char *flux_conf_next (flux_conf_itr_t itr)
     return item;
 }
 
+static const char * flux_conf_environment_get_inner (struct env_item *item)
+{
+    if (! item)
+        return NULL;
+
+    if (item->components.length == 1)
+        return item->components.data[0];
+
+    if (! item->clean) {
+        sdsfree(item->string_cache);
+        item->string_cache = sdsjoinsds(item->components.data, item->components.length, item->sep, sdslen(item->sep));
+    }
+
+    return item->string_cache;
+}
+
 const char * flux_conf_environment_get (flux_conf_t cf, const char *key)
 {
-    return zhash_lookup(cf->environment, key);
+    struct env_item *item = zhash_lookup(cf->environment, key);
+    return flux_conf_environment_get_inner(item);
+}
+
+static void split_and_push(struct env_item * item, const char *value, bool before)
+{
+    int value_count=0, i, j;
+    bool insert_on_blank = true;
+
+    if (!value || strlen(value) == 0)
+        return;
+
+    sds * new_parts = sdssplitlen(value, strlen(value), item->sep, strlen(item->sep), &value_count);
+
+    for (i=0; i<value_count; i++){
+        const char *old_path_part;
+        bool skip = false;
+        vec_foreach(&item->components, old_path_part, j){
+            if ( !strcmp(new_parts[i], old_path_part) ) {
+                skip = true;
+                break;
+            }
+        }
+        if (!skip) {
+            if (!sdslen(new_parts[i]) && insert_on_blank) {
+                // This odd dance is for lua's default path item
+                new_parts[i] = sdscpy(new_parts[i], item->sep);
+                insert_on_blank=false;
+            }
+            if (before)
+                vec_insert(&item->components, 0, new_parts[i]);
+            else
+                vec_push(&item->components, new_parts[i]);
+            item->clean = false;
+            new_parts[i] = NULL; // Prevent this sds from being freed by sdsfreesplitres
+        }
+    }
+
+    sdsfreesplitres(new_parts, value_count);
+}
+
+static struct env_item* env_item_new(const char *separator)
+{
+    struct env_item * item = xzmalloc(sizeof(struct env_item));
+    item->sep = sdsnew(separator);
+    item->string_cache = sdsempty();
+    vec_init(&item->components);
+    return item;
+}
+
+static void env_item_destroy(void *input)
+{
+    struct env_item *item = (struct env_item*) input;
+    vec_deinit(&item->components);
+    sdsfree(item->sep);
+    sdsfree(item->string_cache);
+    free(item);
+}
+
+static void flux_conf_environment_set_inner (flux_conf_t cf, const char *key,
+                             const sds value, const char *separator)
+{
+    struct env_item * item = env_item_new(separator);
+    item->clean = false;
+    if (sdslen(item->sep))
+        split_and_push(item, value, false);
+    else
+        vec_push(&item->components, value);
+    zhash_update(cf->environment, key, (void *)item);
+    zhash_freefn(cf->environment, key, (zhash_free_fn*)env_item_destroy);
 }
 
 void flux_conf_environment_set (flux_conf_t cf, const char *key,
-                             const char *value)
+                             const char *value, const char *separator)
 {
-    zhash_update(cf->environment, key, (void *)value);
-    zhash_delete(cf->environment_unset, key);
+    flux_conf_environment_set_inner (cf, key, sdsnew(value), separator);
 }
 
 void flux_conf_environment_unset (flux_conf_t cf, const char *key)
 {
-    zhash_update(cf->environment_unset, key, "1");
-    zhash_delete(cf->environment, key);
+    flux_conf_environment_set_inner (cf, key, sdsempty(), "");
 }
 
 static void flux_conf_environment_push_inner (flux_conf_t cf, const char *key,
-                              const char *value, const char *separator, bool before)
+                              const char *value, bool before)
 {
     if (!value || strlen(value) == 0)
         return;
 
-    const char * item = zhash_lookup(cf->environment, key);
+    struct env_item * item = zhash_lookup(cf->environment, key);
+    if (!item)
+        item = env_item_new("");
 
-    char * new_item;
-    if (!item || strlen(item) == 0){
-        new_item = xstrdup(value);
-    } else {
-        if (before)
-            new_item = xasprintf("%s%s%s", value, separator, item);
-        else
-            new_item = xasprintf("%s%s%s", item, separator, value);
-    }
-
-    flux_conf_environment_set(cf, key, new_item);
-    free(new_item);
+    split_and_push(item, value, before);
 }
 
 void flux_conf_environment_push (flux_conf_t cf, const char *key,
-                              const char *value, const char *separator)
+                              const char *value)
 {
-    flux_conf_environment_push_inner(cf, key, value, separator, true);
+    flux_conf_environment_push_inner(cf, key, value, true);
 }
 
 void flux_conf_environment_push_back (flux_conf_t cf, const char *key,
-                                   const char *value, const char *separator)
+                                   const char *value)
 {
-    flux_conf_environment_push_inner(cf, key, value, separator, false);
+    flux_conf_environment_push_inner(cf, key, value, false);
 }
 
-void flux_conf_environment_from_env(flux_conf_t cf, const char *key, const char *default_base)
+void flux_conf_environment_from_env(flux_conf_t cf, const char *key, const
+        char *default_base, const char *separator)
 {
     const char * env = getenv(key);
     if (! env)
         env = default_base;
-    flux_conf_environment_set(cf, key, env);
+    flux_conf_environment_set(cf, key, env, separator);
 }
 
-void flux_conf_environment_apply(flux_conf_t cf)
+void flux_conf_environment_set_separator(flux_conf_t cf, const char *key,
+        const char *separator)
 {
-    const char *key, *value;
-    for (value = (char*)zhash_first(cf->environment), key = (char*)zhash_cursor(cf->environment);
-            value != NULL;
-            value = zhash_next(cf->environment), key = zhash_cursor(cf->environment)) {
-        if (setenv (key, value, 1) < 0)
-            err_exit ("setenv: %s=%s", key, value);
-    }
-    for (value = (char*)zhash_first(cf->environment_unset), key = (char*)zhash_cursor(cf->environment_unset);
-            value != NULL;
-            value = zhash_next(cf->environment_unset), key = zhash_cursor(cf->environment_unset)) {
-        if(unsetenv(key)){
-            err_exit ("unsetenv: %s=%s", key, value);
-        }
+    struct env_item * item = zhash_lookup(cf->environment, key);
+    if (item) {
+        item->sep = sdscpy(item->sep, separator);
     }
 }
 
 const char *flux_conf_environment_first (flux_conf_t cf)
 {
-    return zhash_first(cf->environment);
+    return flux_conf_environment_get_inner(zhash_first(cf->environment));
 }
 
 const char *flux_conf_environment_next (flux_conf_t cf)
 {
-    return zhash_next(cf->environment);
+    return flux_conf_environment_get_inner(zhash_next(cf->environment));
 }
 
 const char *flux_conf_environment_cursor (flux_conf_t cf)
@@ -381,20 +445,22 @@ const char *flux_conf_environment_cursor (flux_conf_t cf)
     return zhash_cursor(cf->environment);
 }
 
-const char *flux_conf_environment_unset_first (flux_conf_t cf)
+void flux_conf_environment_apply(flux_conf_t cf)
 {
-    return zhash_first(cf->environment_unset);
+    const char *key, *value;
+    struct env_item *item;
+    FOREACH_ZHASH(cf->environment, key, item) {
+        value = flux_conf_environment_get_inner(item);
+        if ( sdslen((sds)value) ){
+            if (setenv (key, value, 1) < 0)
+                err_exit ("setenv: %s=%s", key, value);
+        } else {
+            if(unsetenv(key))
+                err_exit ("unsetenv: %s=%s", key, value);
+        }
+    }
 }
 
-const char *flux_conf_environment_unset_next (flux_conf_t cf)
-{
-    return zhash_next(cf->environment_unset);
-}
-
-const char *flux_conf_environment_unset_cursor (flux_conf_t cf)
-{
-    return zhash_cursor(cf->environment_unset);
-}
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -48,20 +48,31 @@ const char *flux_conf_environment_next (flux_conf_t cf);
 const char *flux_conf_environment_cursor (flux_conf_t cf);
 
 void flux_conf_environment_apply (flux_conf_t cf);
-void flux_conf_environment_push (flux_conf_t cf, const char *key,
-        const char *value);
-void flux_conf_environment_push_back (flux_conf_t cf, const char *key,
-        const char *value);
-void flux_conf_environment_set (flux_conf_t cf, const char *key,
-        const char *value, const char *separator);
+void flux_conf_environment_upsert_front (flux_conf_t cf,
+                                 const char *key,
+                                 const char *value);
+void flux_conf_environment_upsert_back (flux_conf_t cf,
+                                      const char *key,
+                                      const char *value);
+void flux_conf_environment_push_front (flux_conf_t cf,
+                                 const char *key,
+                                 const char *value);
+void flux_conf_environment_push_back (flux_conf_t cf,
+                                      const char *key,
+                                      const char *value);
+void flux_conf_environment_set (flux_conf_t cf,
+                                const char *key,
+                                const char *value,
+                                const char *separator);
 void flux_conf_environment_unset (flux_conf_t cf, const char *key);
-void flux_conf_environment_from_env(flux_conf_t cf, const char *key, const
-        char *default_base, const char *separator);
-void flux_conf_environment_set_separator(flux_conf_t cf, const char *key,
-        const char *separator);
+void flux_conf_environment_from_env (flux_conf_t cf,
+                                     const char *key,
+                                     const char *default_base,
+                                     const char *separator);
+void flux_conf_environment_set_separator (flux_conf_t cf,
+                                          const char *key,
+                                          const char *separator);
 const char *flux_conf_environment_get (flux_conf_t cf, const char *key);
-
-
 
 #endif /* !_FLUX_CORE_FCONFIG_H */
 

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -49,17 +49,17 @@ const char *flux_conf_environment_cursor (flux_conf_t cf);
 
 void flux_conf_environment_apply (flux_conf_t cf);
 void flux_conf_environment_push (flux_conf_t cf, const char *key,
-        const char *value, const char *separator);
-void flux_conf_environment_push_back (flux_conf_t cf, const char *key,
-        const char *value, const char *separator);
-void flux_conf_environment_set (flux_conf_t cf, const char *key,
         const char *value);
+void flux_conf_environment_push_back (flux_conf_t cf, const char *key,
+        const char *value);
+void flux_conf_environment_set (flux_conf_t cf, const char *key,
+        const char *value, const char *separator);
 void flux_conf_environment_unset (flux_conf_t cf, const char *key);
-void flux_conf_environment_from_env(flux_conf_t cf, const char *key, const char *default_base);
+void flux_conf_environment_from_env(flux_conf_t cf, const char *key, const
+        char *default_base, const char *separator);
+void flux_conf_environment_set_separator(flux_conf_t cf, const char *key,
+        const char *separator);
 const char *flux_conf_environment_get (flux_conf_t cf, const char *key);
-const char *flux_conf_environment_unset_cursor (flux_conf_t cf);
-const char *flux_conf_environment_unset_next (flux_conf_t cf);
-const char *flux_conf_environment_unset_first (flux_conf_t cf);
 
 
 

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -43,35 +43,154 @@ flux_conf_itr_t flux_conf_itr_create (flux_conf_t cf);
 void flux_conf_itr_destroy (flux_conf_itr_t itr);
 const char *flux_conf_next (flux_conf_itr_t itr);
 
+/**
+ * @brief Set the iteration cursor for the environment to the first element
+ *
+ * @param cf the config containing the environment to iterate over
+ *
+ * @return the key of the first element or null if the environment is empty
+ */
 const char *flux_conf_environment_first (flux_conf_t cf);
+/**
+ * @brief Get the next key in the environment
+ *
+ * @param cf the config to continue iterating over
+ *
+ * @return the key of the next element or null if iteration is complete or the
+ * environment is empty
+ */
 const char *flux_conf_environment_next (flux_conf_t cf);
+/**
+ * @brief Get the value of the current cursor element, matching the key from
+ * either *_first or *_next
+ *
+ * @param cf the config to operate on
+ *
+ * @return The value of the current environment element
+ */
 const char *flux_conf_environment_cursor (flux_conf_t cf);
 
+/**
+ * @brief Apply the changes encoded in this flux_conf_t to the environment of
+ * the current process.
+ *
+ * All keys with values of non-zero length are set to those values, keys whose
+ * values are strings of length 0 are explicitly unset.  Other keys in the
+ * environment remain unchanged.
+ *
+ * @param cf  The configuration whose environment should be applied
+ */
 void flux_conf_environment_apply (flux_conf_t cf);
-void flux_conf_environment_upsert_front (flux_conf_t cf,
+/**
+ * @brief Split, deduplicate, and push a new value onto the front of the
+ * environment variable whose key is "key."
+ *
+ * @param cf the config to add this element to
+ * @param key the environment variable name
+ * @param value The value to use, this will be split based on the separator
+ * defined for the key if one is set, otherwise it is prepended whole
+ */
+void flux_conf_environment_push (flux_conf_t cf,
                                  const char *key,
                                  const char *value);
-void flux_conf_environment_upsert_back (flux_conf_t cf,
-                                      const char *key,
-                                      const char *value);
-void flux_conf_environment_push_front (flux_conf_t cf,
-                                 const char *key,
-                                 const char *value);
+/**
+ * @brief Split, deduplicate, and push a new value onto the back of the
+ * environment variable whose key is "key."
+ *
+ * @param cf the config to add this element to
+ * @param key the environment variable name
+ * @param value The value to use, this will be split based on the separator
+ * defined for the key if one is set, otherwise it is appended whole
+ */
 void flux_conf_environment_push_back (flux_conf_t cf,
                                       const char *key,
                                       const char *value);
+/**
+ * @brief Add the specified value to the front of the target key without
+ * de-duplication, it will still be separated from the rest of the value by sep,
+ * if a sep has been set for this key.
+ *
+ * Generally, the de-duplicating functions are preferred to these, but if a
+ * value you must include contains separator characters, use these.
+ *
+ * @param cf The config to operate on
+ * @param key The key to target
+ * @param value The value to prepend
+ */
+void flux_conf_environment_no_dedup_push (flux_conf_t cf,
+                                 const char *key,
+                                 const char *value);
+/**
+ * @brief Add the specified value to the target key without de-duplication, it
+ * will still be separated from the rest of the value by sep, if a sep has
+ * been set for this key.
+ *
+ * @param cf The config to operate on
+ * @param key The key to target
+ * @param value The value to append
+ */
+void flux_conf_environment_no_dedup_push_back (flux_conf_t cf,
+                                      const char *key,
+                                      const char *value);
+/**
+ * @brief Set the environment value "key" to "value," where elements are
+ * separated by "sep," overwrites whatever value is currently set.
+ *
+ * @param cf the config to act on
+ * @param key the key to target
+ * @param value the value to set
+ * @param separator the separator used to divide elements in the value, ":"
+ * for unix paths for example, or ";" for LUA_PATH
+ */
 void flux_conf_environment_set (flux_conf_t cf,
                                 const char *key,
                                 const char *value,
                                 const char *separator);
+/**
+ * @brief Explicitly unset the environment variable "key," this will cause the
+ * variable to be cleared when this environment spec is applied.
+ *
+ * @param cf the config to act on
+ * @param key the key which should be unset on application
+ */
 void flux_conf_environment_unset (flux_conf_t cf, const char *key);
+/**
+ * @brief Initialize the environment variable "key" with the value from the
+ * enclosing environment if it is set, otherwise set it to "default_base."
+ *
+ * @param cf the config to act on
+ * @param key the key to initialize
+ * @param default_base the default value to use if the environment variable is
+ * unset
+ * @param separator the separator between tokens in the value
+ */
 void flux_conf_environment_from_env (flux_conf_t cf,
                                      const char *key,
                                      const char *default_base,
                                      const char *separator);
+/**
+ * @brief Set the separator for a given environment variable.
+ *
+ * @param cf the config to act on
+ * @param key the environment variable to update
+ * @param separator the separator to use to join components of this object and
+ * split and dedup inputs
+ */
 void flux_conf_environment_set_separator (flux_conf_t cf,
                                           const char *key,
                                           const char *separator);
+
+/**
+ * @brief Get the value of a given environment variable by name.
+ *
+ * This does *not* check the environment of the current process, but the
+ * configured environment in the passed flux_conf_t.
+ *
+ * @param cf the config to act on
+ * @param key key of the environment variable to read
+ *
+ * @return A reference to the value of the key, or null if that key is not set
+ */
 const char *flux_conf_environment_get (flux_conf_t cf, const char *key);
 
 #endif /* !_FLUX_CORE_FCONFIG_H */

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -44,7 +44,13 @@ libutil_la_SOURCES = \
 	msglist.c \
 	msglist.h \
 	cleanup.c \
-	cleanup.h
+	cleanup.h \
+	sds.c \
+	sds.h \
+	sdsalloc.h \
+	vec.c \
+	vec.h \
+	iterators.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -50,6 +50,8 @@ libutil_la_SOURCES = \
 	sdsalloc.h \
 	vec.c \
 	vec.h \
+	usa.c \
+	usa.h \
 	iterators.h
 
 EXTRA_DIST = veb_mach.c

--- a/src/common/libutil/iterators.h
+++ b/src/common/libutil/iterators.h
@@ -1,0 +1,19 @@
+#ifndef FLUX_ITERATORS_H
+#define FLUX_ITERATORS_H
+
+#define FOREACH_ZLIST(LIST, VAR)   \
+    for((VAR) = zlist_first(LIST); \
+            VAR;                   \
+            (VAR) = zlist_next(LIST))
+
+#define FOREACH_ZHASH_KEYS(HASH, KEY) \
+    FOREACH_ZLIST(zhash_keys(HASH), KEY)
+
+#define FOREACH_ZHASH(HASH, KEY, VALUE) \
+    for((VALUE) = zhash_first(HASH),    \
+        (KEY) = zhash_cursor(HASH);     \
+        (VALUE) && (KEY);               \
+        (VALUE) = zhash_next(HASH),     \
+        (KEY) = zhash_cursor(HASH))
+
+#endif /* FLUX_ITERATORS_H */

--- a/src/common/libutil/sds.c
+++ b/src/common/libutil/sds.c
@@ -1,0 +1,1265 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include "sds.h"
+#include "sdsalloc.h"
+
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
+static inline char sdsReqType(size_t string_size) {
+    if (string_size < 32)
+        return SDS_TYPE_5;
+    if (string_size < 0xff)
+        return SDS_TYPE_8;
+    if (string_size < 0xffff)
+        return SDS_TYPE_16;
+    if (string_size < 0xffffffff)
+        return SDS_TYPE_32;
+    return SDS_TYPE_64;
+}
+
+/* Create a new sds string with the content specified by the 'init' pointer
+ * and 'initlen'.
+ * If NULL is used for 'init' the string is initialized with zero bytes.
+ *
+ * The string is always null-termined (all the sds strings are, always) so
+ * even if you create an sds string with:
+ *
+ * mystring = sdsnewlen("abc",3);
+ *
+ * You can print the string with printf() as there is an implicit \0 at the
+ * end of the string. However the string is binary safe and can contain
+ * \0 characters in the middle, as the length is stored in the sds header. */
+sds sdsnewlen(const void *init, size_t initlen) {
+    void *sh;
+    sds s;
+    char type = sdsReqType(initlen);
+    /* Empty strings are usually created in order to append. Use type 8
+     * since type 5 is not good at this. */
+    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
+    int hdrlen = sdsHdrSize(type);
+    unsigned char *fp; /* flags pointer. */
+
+    sh = s_malloc(hdrlen+initlen+1);
+    if (!init)
+        memset(sh, 0, hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
+    s = (char*)sh+hdrlen;
+    fp = ((unsigned char*)s)-1;
+    switch(type) {
+        case SDS_TYPE_5: {
+            *fp = type | (initlen << SDS_TYPE_BITS);
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+    }
+    if (initlen && init)
+        memcpy(s, init, initlen);
+    s[initlen] = '\0';
+    return s;
+}
+
+/* Create an empty (zero length) sds string. Even in this case the string
+ * always has an implicit null term. */
+sds sdsempty(void) {
+    return sdsnewlen("",0);
+}
+
+/* Create a new sds string starting from a null terminated C string. */
+sds sdsnew(const char *init) {
+    size_t initlen = (init == NULL) ? 0 : strlen(init);
+    return sdsnewlen(init, initlen);
+}
+
+/* Duplicate an sds string. */
+sds sdsdup(const sds s) {
+    return sdsnewlen(s, sdslen(s));
+}
+
+/* Free an sds string. No operation is performed if 's' is NULL. */
+void sdsfree(sds s) {
+    if (s == NULL) return;
+    s_free((char*)s-sdsHdrSize(s[-1]));
+}
+
+/* Set the sds string length to the length as obtained with strlen(), so
+ * considering as content only up to the first null term character.
+ *
+ * This function is useful when the sds string is hacked manually in some
+ * way, like in the following example:
+ *
+ * s = sdsnew("foobar");
+ * s[2] = '\0';
+ * sdsupdatelen(s);
+ * printf("%d\n", sdslen(s));
+ *
+ * The output will be "2", but if we comment out the call to sdsupdatelen()
+ * the output will be "6" as the string was modified but the logical length
+ * remains 6 bytes. */
+void sdsupdatelen(sds s) {
+    int reallen = strlen(s);
+    sdssetlen(s, reallen);
+}
+
+/* Modify an sds string in-place to make it empty (zero length).
+ * However all the existing buffer is not discarded but set as free space
+ * so that next append operations will not require allocations up to the
+ * number of bytes previously available. */
+void sdsclear(sds s) {
+    sdssetlen(s, 0);
+    s[0] = '\0';
+}
+
+/* Enlarge the free space at the end of the sds string so that the caller
+ * is sure that after calling this function can overwrite up to addlen
+ * bytes after the end of the string, plus one more byte for nul term.
+ *
+ * Note: this does not change the *length* of the sds string as returned
+ * by sdslen(), but only the free buffer space we have. */
+sds sdsMakeRoomFor(sds s, size_t addlen) {
+    void *sh, *newsh;
+    size_t avail = sdsavail(s);
+    size_t len, newlen;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+
+    /* Return ASAP if there is enough space left. */
+    if (avail >= addlen) return s;
+
+    len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+    newlen = (len+addlen);
+    if (newlen < SDS_MAX_PREALLOC)
+        newlen *= 2;
+    else
+        newlen += SDS_MAX_PREALLOC;
+
+    type = sdsReqType(newlen);
+
+    /* Don't use type 5: the user is appending to the string and type 5 is
+     * not able to remember empty space, so sdsMakeRoomFor() must be called
+     * at every appending operation. */
+    if (type == SDS_TYPE_5) type = SDS_TYPE_8;
+
+    hdrlen = sdsHdrSize(type);
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        /* Since the header size changes, need to move the string forward,
+         * and can't use realloc */
+        newsh = s_malloc(hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, newlen);
+    return s;
+}
+
+/* Reallocate the sds string so that it has no free space at the end. The
+ * contained string remains not altered, but next concatenation operations
+ * will require a reallocation.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdsRemoveFreeSpace(sds s) {
+    void *sh, *newsh;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+    size_t len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+
+    type = sdsReqType(len);
+    hdrlen = sdsHdrSize(type);
+    if (oldtype==type) {
+        newsh = s_realloc(sh, hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        newsh = s_malloc(hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        s_free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, len);
+    return s;
+}
+
+/* Return the total size of the allocation of the specifed sds string,
+ * including:
+ * 1) The sds header before the pointer.
+ * 2) The string.
+ * 3) The free buffer at the end if any.
+ * 4) The implicit null term.
+ */
+size_t sdsAllocSize(sds s) {
+    size_t alloc = sdsalloc(s);
+    return sdsHdrSize(s[-1])+alloc+1;
+}
+
+/* Return the pointer of the actual SDS allocation (normally SDS strings
+ * are referenced by the start of the string buffer). */
+void *sdsAllocPtr(sds s) {
+    return (void*) (s-sdsHdrSize(s[-1]));
+}
+
+/* Increment the sds length and decrements the left free space at the
+ * end of the string according to 'incr'. Also set the null term
+ * in the new end of the string.
+ *
+ * This function is used in order to fix the string length after the
+ * user calls sdsMakeRoomFor(), writes something after the end of
+ * the current string, and finally needs to set the new length.
+ *
+ * Note: it is possible to use a negative increment in order to
+ * right-trim the string.
+ *
+ * Usage example:
+ *
+ * Using sdsIncrLen() and sdsMakeRoomFor() it is possible to mount the
+ * following schema, to cat bytes coming from the kernel to the end of an
+ * sds string without copying into an intermediate buffer:
+ *
+ * oldlen = sdslen(s);
+ * s = sdsMakeRoomFor(s, BUFFER_SIZE);
+ * nread = read(fd, s+oldlen, BUFFER_SIZE);
+ * ... check for nread <= 0 and handle it ...
+ * sdsIncrLen(s, nread);
+ */
+void sdsIncrLen(sds s, int incr) {
+    unsigned char flags = s[-1];
+    size_t len;
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            unsigned char *fp = ((unsigned char*)s)-1;
+            unsigned char oldlen = SDS_TYPE_5_LEN(flags);
+            assert((incr > 0 && oldlen+incr < 32) || (incr < 0 && oldlen >= (unsigned int)(-incr)));
+            *fp = SDS_TYPE_5 | ((oldlen+incr) << SDS_TYPE_BITS);
+            len = oldlen+incr;
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (unsigned int)incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (uint64_t)incr) || (incr < 0 && sh->len >= (uint64_t)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        default: len = 0; /* Just to avoid compilation warnings. */
+    }
+    s[len] = '\0';
+}
+
+/* Grow the sds to have the specified length. Bytes that were not part of
+ * the original length of the sds will be set to zero.
+ *
+ * if the specified length is smaller than the current length, no operation
+ * is performed. */
+sds sdsgrowzero(sds s, size_t len) {
+    size_t curlen = sdslen(s);
+
+    if (len <= curlen) return s;
+    s = sdsMakeRoomFor(s,len-curlen);
+    if (s == NULL) return NULL;
+
+    /* Make sure added region doesn't contain garbage */
+    memset(s+curlen,0,(len-curlen+1)); /* also set trailing \0 byte */
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Append the specified binary-safe string pointed by 't' of 'len' bytes to the
+ * end of the specified sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatlen(sds s, const void *t, size_t len) {
+    size_t curlen = sdslen(s);
+
+    s = sdsMakeRoomFor(s,len);
+    if (s == NULL) return NULL;
+    memcpy(s+curlen, t, len);
+    sdssetlen(s, curlen+len);
+    s[curlen+len] = '\0';
+    return s;
+}
+
+/* Append the specified null termianted C string to the sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscat(sds s, const char *t) {
+    return sdscatlen(s, t, strlen(t));
+}
+
+/* Append the specified sds 't' to the existing sds 's'.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatsds(sds s, const sds t) {
+    return sdscatlen(s, t, sdslen(t));
+}
+
+/* Destructively modify the sds string 's' to hold the specified binary
+ * safe string pointed by 't' of length 'len' bytes. */
+sds sdscpylen(sds s, const char *t, size_t len) {
+    if (sdsalloc(s) < len) {
+        s = sdsMakeRoomFor(s,len-sdslen(s));
+        if (s == NULL) return NULL;
+    }
+    memcpy(s, t, len);
+    s[len] = '\0';
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Like sdscpylen() but 't' must be a null-termined string so that the length
+ * of the string is obtained with strlen(). */
+sds sdscpy(sds s, const char *t) {
+    return sdscpylen(s, t, strlen(t));
+}
+
+/* Helper for sdscatlonglong() doing the actual number -> string
+ * conversion. 's' must point to a string with room for at least
+ * SDS_LLSTR_SIZE bytes.
+ *
+ * The function returns the length of the null-terminated string
+ * representation stored at 's'. */
+#define SDS_LLSTR_SIZE 21
+int sdsll2str(char *s, long long value) {
+    char *p, aux;
+    unsigned long long v;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    v = (value < 0) ? -value : value;
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+    if (value < 0) *p++ = '-';
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Identical sdsll2str(), but for unsigned long long type. */
+int sdsull2str(char *s, unsigned long long v) {
+    char *p, aux;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Create an sds string from a long long value. It is much faster than:
+ *
+ * sdscatprintf(sdsempty(),"%lld\n", value);
+ */
+sds sdsfromlonglong(long long value) {
+    char buf[SDS_LLSTR_SIZE];
+    int len = sdsll2str(buf,value);
+
+    return sdsnewlen(buf,len);
+}
+
+/* Like sdscatprintf() but gets va_list instead of being variadic. */
+sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
+    va_list cpy;
+    char staticbuf[1024], *buf = staticbuf, *t;
+    size_t buflen = strlen(fmt)*2;
+
+    /* We try to start using a static buffer for speed.
+     * If not possible we revert to heap allocation. */
+    if (buflen > sizeof(staticbuf)) {
+        buf = s_malloc(buflen);
+        if (buf == NULL) return NULL;
+    } else {
+        buflen = sizeof(staticbuf);
+    }
+
+    /* Try with buffers two times bigger every time we fail to
+     * fit the string in the current buffer size. */
+    while(1) {
+        buf[buflen-2] = '\0';
+        va_copy(cpy,ap);
+        vsnprintf(buf, buflen, fmt, cpy);
+        va_end(cpy);
+        if (buf[buflen-2] != '\0') {
+            if (buf != staticbuf) s_free(buf);
+            buflen *= 2;
+            buf = s_malloc(buflen);
+            if (buf == NULL) return NULL;
+            continue;
+        }
+        break;
+    }
+
+    /* Finally concat the obtained string to the SDS string and return it. */
+    t = sdscat(s, buf);
+    if (buf != staticbuf) s_free(buf);
+    return t;
+}
+
+/* Append to the sds string 's' a string obtained using printf-alike format
+ * specifier.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("Sum is: ");
+ * s = sdscatprintf(s,"%d+%d = %d",a,b,a+b).
+ *
+ * Often you need to create a string from scratch with the printf-alike
+ * format. When this is the need, just use sdsempty() as the target string:
+ *
+ * s = sdscatprintf(sdsempty(), "... your format ...", args);
+ */
+sds sdscatprintf(sds s, const char *fmt, ...) {
+    va_list ap;
+    char *t;
+    va_start(ap, fmt);
+    t = sdscatvprintf(s,fmt,ap);
+    va_end(ap);
+    return t;
+}
+
+/* This function is similar to sdscatprintf, but much faster as it does
+ * not rely on sprintf() family functions implemented by the libc that
+ * are often very slow. Moreover directly handling the sds string as
+ * new data is concatenated provides a performance improvement.
+ *
+ * However this function only handles an incompatible subset of printf-alike
+ * format specifiers:
+ *
+ * %s - C String
+ * %S - SDS string
+ * %i - signed int
+ * %I - 64 bit signed integer (long long, int64_t)
+ * %u - unsigned int
+ * %U - 64 bit unsigned integer (unsigned long long, uint64_t)
+ * %% - Verbatim "%" character.
+ */
+sds sdscatfmt(sds s, char const *fmt, ...) {
+    size_t initlen = sdslen(s);
+    const char *f = fmt;
+    int i;
+    va_list ap;
+
+    va_start(ap,fmt);
+    f = fmt;    /* Next format specifier byte to process. */
+    i = initlen; /* Position of the next byte to write to dest str. */
+    while(*f) {
+        char next, *str;
+        size_t l;
+        long long num;
+        unsigned long long unum;
+
+        /* Make sure there is always space for at least 1 char. */
+        if (sdsavail(s)==0) {
+            s = sdsMakeRoomFor(s,1);
+        }
+
+        switch(*f) {
+        case '%':
+            next = *(f+1);
+            f++;
+            switch(next) {
+            case 's':
+            case 'S':
+                str = va_arg(ap,char*);
+                l = (next == 's') ? strlen(str) : sdslen(str);
+                if (sdsavail(s) < l) {
+                    s = sdsMakeRoomFor(s,l);
+                }
+                memcpy(s+i,str,l);
+                sdsinclen(s,l);
+                i += l;
+                break;
+            case 'i':
+            case 'I':
+                if (next == 'i')
+                    num = va_arg(ap,int);
+                else
+                    num = va_arg(ap,long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsll2str(buf,num);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            case 'u':
+            case 'U':
+                if (next == 'u')
+                    unum = va_arg(ap,unsigned int);
+                else
+                    unum = va_arg(ap,unsigned long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsull2str(buf,unum);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            default: /* Handle %% and generally %<unknown>. */
+                s[i++] = next;
+                sdsinclen(s,1);
+                break;
+            }
+            break;
+        default:
+            s[i++] = *f;
+            sdsinclen(s,1);
+            break;
+        }
+        f++;
+    }
+    va_end(ap);
+
+    /* Add null-term */
+    s[i] = '\0';
+    return s;
+}
+
+/* Remove the part of the string from left and from right composed just of
+ * contiguous characters found in 'cset', that is a null terminted C string.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("AA...AA.a.aa.aHelloWorld     :::");
+ * s = sdstrim(s,"Aa. :");
+ * printf("%s\n", s);
+ *
+ * Output will be just "Hello World".
+ */
+sds sdstrim(sds s, const char *cset) {
+    char *start, *end, *sp, *ep;
+    size_t len;
+
+    sp = start = s;
+    ep = end = s+sdslen(s)-1;
+    while(sp <= end && strchr(cset, *sp)) sp++;
+    while(ep > sp && strchr(cset, *ep)) ep--;
+    len = (sp > ep) ? 0 : ((ep-sp)+1);
+    if (s != sp) memmove(s, sp, len);
+    s[len] = '\0';
+    sdssetlen(s,len);
+    return s;
+}
+
+/* Turn the string into a smaller (or equal) string containing only the
+ * substring specified by the 'start' and 'end' indexes.
+ *
+ * start and end can be negative, where -1 means the last character of the
+ * string, -2 the penultimate character, and so forth.
+ *
+ * The interval is inclusive, so the start and end characters will be part
+ * of the resulting string.
+ *
+ * The string is modified in-place.
+ *
+ * Example:
+ *
+ * s = sdsnew("Hello World");
+ * sdsrange(s,1,-1); => "ello World"
+ */
+void sdsrange(sds s, int start, int end) {
+    size_t newlen, len = sdslen(s);
+
+    if (len == 0) return;
+    if (start < 0) {
+        start = len+start;
+        if (start < 0) start = 0;
+    }
+    if (end < 0) {
+        end = len+end;
+        if (end < 0) end = 0;
+    }
+    newlen = (start > end) ? 0 : (end-start)+1;
+    if (newlen != 0) {
+        if (start >= (signed)len) {
+            newlen = 0;
+        } else if (end >= (signed)len) {
+            end = len-1;
+            newlen = (start > end) ? 0 : (end-start)+1;
+        }
+    } else {
+        start = 0;
+    }
+    if (start && newlen) memmove(s, s+start, newlen);
+    s[newlen] = 0;
+    sdssetlen(s,newlen);
+}
+
+/* Apply tolower() to every character of the sds string 's'. */
+void sdstolower(sds s) {
+    int len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = tolower(s[j]);
+}
+
+/* Apply toupper() to every character of the sds string 's'. */
+void sdstoupper(sds s) {
+    int len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = toupper(s[j]);
+}
+
+/* Compare two sds strings s1 and s2 with memcmp().
+ *
+ * Return value:
+ *
+ *     positive if s1 > s2.
+ *     negative if s1 < s2.
+ *     0 if s1 and s2 are exactly the same binary string.
+ *
+ * If two strings share exactly the same prefix, but one of the two has
+ * additional characters, the longer string is considered to be greater than
+ * the smaller one. */
+int sdscmp(const sds s1, const sds s2) {
+    size_t l1, l2, minlen;
+    int cmp;
+
+    l1 = sdslen(s1);
+    l2 = sdslen(s2);
+    minlen = (l1 < l2) ? l1 : l2;
+    cmp = memcmp(s1,s2,minlen);
+    if (cmp == 0) return l1-l2;
+    return cmp;
+}
+
+/* Split 's' with separator in 'sep'. An array
+ * of sds strings is returned. *count will be set
+ * by reference to the number of tokens returned.
+ *
+ * On out of memory, zero length string, zero length
+ * separator, NULL is returned.
+ *
+ * Note that 'sep' is able to split a string using
+ * a multi-character separator. For example
+ * sdssplit("foo_-_bar","_-_"); will return two
+ * elements "foo" and "bar".
+ *
+ * This version of the function is binary-safe but
+ * requires length arguments. sdssplit() is just the
+ * same function but for zero-terminated strings.
+ */
+sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count) {
+    int elements = 0, slots = 5, start = 0, j;
+    sds *tokens;
+
+    if (seplen < 1 || len < 0) return NULL;
+
+    tokens = s_malloc(sizeof(sds)*slots);
+    if (tokens == NULL) return NULL;
+
+    if (len == 0) {
+        *count = 0;
+        return tokens;
+    }
+    for (j = 0; j < (len-(seplen-1)); j++) {
+        /* make sure there is room for the next element and the final one */
+        if (slots < elements+2) {
+            sds *newtokens;
+
+            slots *= 2;
+            newtokens = s_realloc(tokens,sizeof(sds)*slots);
+            if (newtokens == NULL) goto cleanup;
+            tokens = newtokens;
+        }
+        /* search the separator */
+        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+            tokens[elements] = sdsnewlen(s+start,j-start);
+            if (tokens[elements] == NULL) goto cleanup;
+            elements++;
+            start = j+seplen;
+            j = j+seplen-1; /* skip the separator */
+        }
+    }
+    /* Add the final element. We are sure there is room in the tokens array. */
+    tokens[elements] = sdsnewlen(s+start,len-start);
+    if (tokens[elements] == NULL) goto cleanup;
+    elements++;
+    *count = elements;
+    return tokens;
+
+cleanup:
+    {
+        int i;
+        for (i = 0; i < elements; i++) sdsfree(tokens[i]);
+        s_free(tokens);
+        *count = 0;
+        return NULL;
+    }
+}
+
+/* Free the result returned by sdssplitlen(), or do nothing if 'tokens' is NULL. */
+void sdsfreesplitres(sds *tokens, int count) {
+    if (!tokens) return;
+    while(count--)
+        sdsfree(tokens[count]);
+    s_free(tokens);
+}
+
+/* Append to the sds string "s" an escaped string representation where
+ * all the non-printable characters (tested with isprint()) are turned into
+ * escapes in the form "\n\r\a...." or "\x<hex-number>".
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatrepr(sds s, const char *p, size_t len) {
+    s = sdscatlen(s,"\"",1);
+    while(len--) {
+        switch(*p) {
+        case '\\':
+        case '"':
+            s = sdscatprintf(s,"\\%c",*p);
+            break;
+        case '\n': s = sdscatlen(s,"\\n",2); break;
+        case '\r': s = sdscatlen(s,"\\r",2); break;
+        case '\t': s = sdscatlen(s,"\\t",2); break;
+        case '\a': s = sdscatlen(s,"\\a",2); break;
+        case '\b': s = sdscatlen(s,"\\b",2); break;
+        default:
+            if (isprint(*p))
+                s = sdscatprintf(s,"%c",*p);
+            else
+                s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
+            break;
+        }
+        p++;
+    }
+    return sdscatlen(s,"\"",1);
+}
+
+/* Helper function for sdssplitargs() that returns non zero if 'c'
+ * is a valid hex digit. */
+int is_hex_digit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+/* Helper function for sdssplitargs() that converts a hex digit into an
+ * integer from 0 to 15 */
+int hex_digit_to_int(char c) {
+    switch(c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a': case 'A': return 10;
+    case 'b': case 'B': return 11;
+    case 'c': case 'C': return 12;
+    case 'd': case 'D': return 13;
+    case 'e': case 'E': return 14;
+    case 'f': case 'F': return 15;
+    default: return 0;
+    }
+}
+
+/* Split a line into arguments, where every argument can be in the
+ * following programming-language REPL-alike form:
+ *
+ * foo bar "newline are supported\n" and "\xff\x00otherstuff"
+ *
+ * The number of arguments is stored into *argc, and an array
+ * of sds is returned.
+ *
+ * The caller should free the resulting array of sds strings with
+ * sdsfreesplitres().
+ *
+ * Note that sdscatrepr() is able to convert back a string into
+ * a quoted string in the same format sdssplitargs() is able to parse.
+ *
+ * The function returns the allocated tokens on success, even when the
+ * input string is empty, or NULL if the input contains unbalanced
+ * quotes or closed quotes followed by non space characters
+ * as in: "foo"bar or "foo'
+ */
+sds *sdssplitargs(const char *line, int *argc) {
+    const char *p = line;
+    char *current = NULL;
+    char **vector = NULL;
+
+    *argc = 0;
+    while(1) {
+        /* skip blanks */
+        while(*p && isspace(*p)) p++;
+        if (*p) {
+            /* get a token */
+            int inq=0;  /* set to 1 if we are in "quotes" */
+            int insq=0; /* set to 1 if we are in 'single quotes' */
+            int done=0;
+
+            if (current == NULL) current = sdsempty();
+            while(!done) {
+                if (inq) {
+                    if (*p == '\\' && *(p+1) == 'x' &&
+                                             is_hex_digit(*(p+2)) &&
+                                             is_hex_digit(*(p+3)))
+                    {
+                        unsigned char byte;
+
+                        byte = (hex_digit_to_int(*(p+2))*16)+
+                                hex_digit_to_int(*(p+3));
+                        current = sdscatlen(current,(char*)&byte,1);
+                        p += 3;
+                    } else if (*p == '\\' && *(p+1)) {
+                        char c;
+
+                        p++;
+                        switch(*p) {
+                        case 'n': c = '\n'; break;
+                        case 'r': c = '\r'; break;
+                        case 't': c = '\t'; break;
+                        case 'b': c = '\b'; break;
+                        case 'a': c = '\a'; break;
+                        default: c = *p; break;
+                        }
+                        current = sdscatlen(current,&c,1);
+                    } else if (*p == '"') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else if (insq) {
+                    if (*p == '\\' && *(p+1) == '\'') {
+                        p++;
+                        current = sdscatlen(current,"'",1);
+                    } else if (*p == '\'') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else {
+                    switch(*p) {
+                    case ' ':
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '\0':
+                        done=1;
+                        break;
+                    case '"':
+                        inq=1;
+                        break;
+                    case '\'':
+                        insq=1;
+                        break;
+                    default:
+                        current = sdscatlen(current,p,1);
+                        break;
+                    }
+                }
+                if (*p) p++;
+            }
+            /* add the token to the vector */
+            vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
+            vector[*argc] = current;
+            (*argc)++;
+            current = NULL;
+        } else {
+            /* Even on empty input string return something not NULL. */
+            if (vector == NULL) vector = s_malloc(sizeof(void*));
+            return vector;
+        }
+    }
+
+err:
+    while((*argc)--)
+        sdsfree(vector[*argc]);
+    s_free(vector);
+    if (current) sdsfree(current);
+    *argc = 0;
+    return NULL;
+}
+
+/* Modify the string substituting all the occurrences of the set of
+ * characters specified in the 'from' string to the corresponding character
+ * in the 'to' array.
+ *
+ * For instance: sdsmapchars(mystring, "ho", "01", 2)
+ * will have the effect of turning the string "hello" into "0ell1".
+ *
+ * The function returns the sds string pointer, that is always the same
+ * as the input pointer since no resize is needed. */
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen) {
+    size_t j, i, l = sdslen(s);
+
+    for (j = 0; j < l; j++) {
+        for (i = 0; i < setlen; i++) {
+            if (s[j] == from[i]) {
+                s[j] = to[i];
+                break;
+            }
+        }
+    }
+    return s;
+}
+
+/* Join an array of C strings using the specified separator (also a C string).
+ * Returns the result as an sds string. */
+sds sdsjoin(char **argv, int argc, const char *sep) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscat(join, argv[j]);
+        if (j != argc-1) join = sdscat(join,sep);
+    }
+    return join;
+}
+
+/* Like sdsjoin, but joins an array of SDS strings. */
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscatsds(join, argv[j]);
+        if (j != argc-1) join = sdscatlen(join,sep,seplen);
+    }
+    return join;
+}
+
+#if defined(SDS_TEST_MAIN)
+#include <stdio.h>
+#include "testhelp.h"
+#include "limits.h"
+
+#define UNUSED(x) (void)(x)
+int sdsTest(void) {
+    {
+        sds x = sdsnew("foo"), y;
+
+        test_cond("Create a string and obtain the length",
+            sdslen(x) == 3 && memcmp(x,"foo\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnewlen("foo",2);
+        test_cond("Create a string with specified length",
+            sdslen(x) == 2 && memcmp(x,"fo\0",3) == 0)
+
+        x = sdscat(x,"bar");
+        test_cond("Strings concatenation",
+            sdslen(x) == 5 && memcmp(x,"fobar\0",6) == 0);
+
+        x = sdscpy(x,"a");
+        test_cond("sdscpy() against an originally longer string",
+            sdslen(x) == 1 && memcmp(x,"a\0",2) == 0)
+
+        x = sdscpy(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk");
+        test_cond("sdscpy() against an originally shorter string",
+            sdslen(x) == 33 &&
+            memcmp(x,"xyzxxxxxxxxxxyyyyyyyyyykkkkkkkkkk\0",33) == 0)
+
+        sdsfree(x);
+        x = sdscatprintf(sdsempty(),"%d",123);
+        test_cond("sdscatprintf() seems working in the base case",
+            sdslen(x) == 3 && memcmp(x,"123\0",4) == 0)
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "Hello %s World %I,%I--", "Hi!", LLONG_MIN,LLONG_MAX);
+        test_cond("sdscatfmt() seems working in the base case",
+            sdslen(x) == 60 &&
+            memcmp(x,"--Hello Hi! World -9223372036854775808,"
+                     "9223372036854775807--",60) == 0)
+        printf("[%s]\n",x);
+
+        sdsfree(x);
+        x = sdsnew("--");
+        x = sdscatfmt(x, "%u,%U--", UINT_MAX, ULLONG_MAX);
+        test_cond("sdscatfmt() seems working with unsigned numbers",
+            sdslen(x) == 35 &&
+            memcmp(x,"--4294967295,18446744073709551615--",35) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," x");
+        test_cond("sdstrim() works when all chars match",
+            sdslen(x) == 0)
+
+        sdsfree(x);
+        x = sdsnew(" x ");
+        sdstrim(x," ");
+        test_cond("sdstrim() works when a single char remains",
+            sdslen(x) == 1 && x[0] == 'x')
+
+        sdsfree(x);
+        x = sdsnew("xxciaoyyy");
+        sdstrim(x,"xy");
+        test_cond("sdstrim() correctly trims characters",
+            sdslen(x) == 4 && memcmp(x,"ciao\0",5) == 0)
+
+        y = sdsdup(x);
+        sdsrange(y,1,1);
+        test_cond("sdsrange(...,1,1)",
+            sdslen(y) == 1 && memcmp(y,"i\0",2) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,-1);
+        test_cond("sdsrange(...,1,-1)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,-2,-1);
+        test_cond("sdsrange(...,-2,-1)",
+            sdslen(y) == 2 && memcmp(y,"ao\0",3) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,2,1);
+        test_cond("sdsrange(...,2,1)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,1,100);
+        test_cond("sdsrange(...,1,100)",
+            sdslen(y) == 3 && memcmp(y,"iao\0",4) == 0)
+
+        sdsfree(y);
+        y = sdsdup(x);
+        sdsrange(y,100,100);
+        test_cond("sdsrange(...,100,100)",
+            sdslen(y) == 0 && memcmp(y,"\0",1) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("foo");
+        y = sdsnew("foa");
+        test_cond("sdscmp(foo,foa)", sdscmp(x,y) > 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("bar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) == 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnew("aar");
+        y = sdsnew("bar");
+        test_cond("sdscmp(bar,bar)", sdscmp(x,y) < 0)
+
+        sdsfree(y);
+        sdsfree(x);
+        x = sdsnewlen("\a\n\0foo\r",7);
+        y = sdscatrepr(sdsempty(),x,sdslen(x));
+        test_cond("sdscatrepr(...data...)",
+            memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0)
+
+        {
+            unsigned int oldfree;
+            char *p;
+            int step = 10, j, i;
+
+            sdsfree(x);
+            sdsfree(y);
+            x = sdsnew("0");
+            test_cond("sdsnew() free/len buffers", sdslen(x) == 1 && sdsavail(x) == 0);
+
+            /* Run the test a few times in order to hit the first two
+             * SDS header types. */
+            for (i = 0; i < 10; i++) {
+                int oldlen = sdslen(x);
+                x = sdsMakeRoomFor(x,step);
+                int type = x[-1]&SDS_TYPE_MASK;
+
+                test_cond("sdsMakeRoomFor() len", sdslen(x) == oldlen);
+                if (type != SDS_TYPE_5) {
+                    test_cond("sdsMakeRoomFor() free", sdsavail(x) >= step);
+                    oldfree = sdsavail(x);
+                }
+                p = x+oldlen;
+                for (j = 0; j < step; j++) {
+                    p[j] = 'A'+j;
+                }
+                sdsIncrLen(x,step);
+            }
+            test_cond("sdsMakeRoomFor() content",
+                memcmp("0ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ",x,101) == 0);
+            test_cond("sdsMakeRoomFor() final length",sdslen(x)==101);
+
+            sdsfree(x);
+        }
+    }
+    test_report()
+    return 0;
+}
+#endif
+
+#ifdef SDS_TEST_MAIN
+int main(void) {
+    return sdsTest();
+}
+#endif

--- a/src/common/libutil/sds.h
+++ b/src/common/libutil/sds.h
@@ -1,0 +1,265 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __SDS_H
+#define __SDS_H
+
+#define SDS_MAX_PREALLOC (1024*1024)
+
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+typedef char *sds;
+
+/* Note: sdshdr5 is never used, we just access the flags byte directly.
+ * However is here to document the layout of type 5 SDS strings. */
+struct __attribute__ ((__packed__)) sdshdr5 {
+    unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr8 {
+    uint8_t len; /* used */
+    uint8_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr16 {
+    uint16_t len; /* used */
+    uint16_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr32 {
+    uint32_t len; /* used */
+    uint32_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+struct __attribute__ ((__packed__)) sdshdr64 {
+    uint64_t len; /* used */
+    uint64_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[];
+};
+
+#define SDS_TYPE_5  0
+#define SDS_TYPE_8  1
+#define SDS_TYPE_16 2
+#define SDS_TYPE_32 3
+#define SDS_TYPE_64 4
+#define SDS_TYPE_MASK 7
+#define SDS_TYPE_BITS 3
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
+#define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
+#define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
+
+static inline size_t sdslen(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(flags);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->len;
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->len;
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->len;
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->len;
+    }
+    return 0;
+}
+
+static inline size_t sdsavail(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            return 0;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            return sh->alloc - sh->len;
+        }
+    }
+    return 0;
+}
+
+static inline void sdssetlen(sds s, size_t newlen) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            {
+                unsigned char *fp = ((unsigned char*)s)-1;
+                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+            }
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->len = newlen;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->len = newlen;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->len = newlen;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->len = newlen;
+            break;
+    }
+}
+
+static inline void sdsinclen(sds s, size_t inc) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            {
+                unsigned char *fp = ((unsigned char*)s)-1;
+                unsigned char newlen = SDS_TYPE_5_LEN(flags)+inc;
+                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+            }
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->len += inc;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->len += inc;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->len += inc;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->len += inc;
+            break;
+    }
+}
+
+/* sdsalloc() = sdsavail() + sdslen() */
+static inline size_t sdsalloc(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(flags);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->alloc;
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->alloc;
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->alloc;
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->alloc;
+    }
+    return 0;
+}
+
+static inline void sdssetalloc(sds s, size_t newlen) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            /* Nothing to do, this type has no total allocation info. */
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->alloc = newlen;
+            break;
+    }
+}
+
+sds sdsnewlen(const void *init, size_t initlen);
+sds sdsnew(const char *init);
+sds sdsempty(void);
+sds sdsdup(const sds s);
+void sdsfree(sds s);
+sds sdsgrowzero(sds s, size_t len);
+sds sdscatlen(sds s, const void *t, size_t len);
+sds sdscat(sds s, const char *t);
+sds sdscatsds(sds s, const sds t);
+sds sdscpylen(sds s, const char *t, size_t len);
+sds sdscpy(sds s, const char *t);
+
+sds sdscatvprintf(sds s, const char *fmt, va_list ap);
+#ifdef __GNUC__
+sds sdscatprintf(sds s, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+#else
+sds sdscatprintf(sds s, const char *fmt, ...);
+#endif
+
+sds sdscatfmt(sds s, char const *fmt, ...);
+sds sdstrim(sds s, const char *cset);
+void sdsrange(sds s, int start, int end);
+void sdsupdatelen(sds s);
+void sdsclear(sds s);
+int sdscmp(const sds s1, const sds s2);
+sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count);
+void sdsfreesplitres(sds *tokens, int count);
+void sdstolower(sds s);
+void sdstoupper(sds s);
+sds sdsfromlonglong(long long value);
+sds sdscatrepr(sds s, const char *p, size_t len);
+sds *sdssplitargs(const char *line, int *argc);
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
+sds sdsjoin(char **argv, int argc, const char *sep);
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
+
+/* Low level functions exposed to the user API */
+sds sdsMakeRoomFor(sds s, size_t addlen);
+void sdsIncrLen(sds s, int incr);
+sds sdsRemoveFreeSpace(sds s);
+size_t sdsAllocSize(sds s);
+void *sdsAllocPtr(sds s);
+
+#ifdef REDIS_TEST
+int sdsTest(int argc, char *argv[]);
+#endif
+
+#endif

--- a/src/common/libutil/sdsalloc.h
+++ b/src/common/libutil/sdsalloc.h
@@ -1,0 +1,42 @@
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* SDS allocator selection.
+ *
+ * This file is used in order to change the SDS allocator at compile time.
+ * Just define the following defines to what you want to use. Also add
+ * the include of your alternate allocator if needed (not needed in order
+ * to use the default libc allocator). */
+
+#define s_malloc malloc
+#define s_realloc realloc
+#define s_free free

--- a/src/common/libutil/usa.c
+++ b/src/common/libutil/usa.c
@@ -1,0 +1,219 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "usa.h"
+
+#include "xzmalloc.h"
+
+#include <stdio.h>
+
+unique_string_array_t *usa_alloc ()
+{
+    return xzmalloc (sizeof(unique_string_array_t));
+}
+
+void usa_init (unique_string_array_t *item)
+{
+    item->clean = false;
+    item->sep = sdsempty ();
+    item->string_cache = sdsempty ();
+    vec_init (&item->components);
+}
+
+unique_string_array_t *usa_new ()
+{
+    unique_string_array_t *item = usa_alloc ();
+    usa_init (item);
+    return item;
+}
+
+void usa_clear (unique_string_array_t *item)
+{
+    int i;
+    sds to_free;
+    if (!item)
+        return;
+
+    sdsclear (item->sep);
+    sdsclear (item->string_cache);
+    vec_foreach (&item->components, to_free, i)
+    {
+        sdsfree (to_free);
+    }
+    vec_clear (&item->components);
+    item->clean = false;
+}
+
+void usa_destroy (unique_string_array_t *item)
+{
+    usa_clear (item);
+    vec_deinit (&item->components);
+    sdsfree (item->sep);
+    sdsfree (item->string_cache);
+    free (item);
+}
+
+void usa_set (unique_string_array_t *item, const char *value)
+{
+    item->clean = false;
+    usa_clear (item);
+    vec_push (&item->components, sdsnew (value));
+}
+
+void usa_push (unique_string_array_t *item, const char *str)
+{
+    vec_insert (&item->components, 0, sdsnew (str));
+}
+
+void usa_push_back (unique_string_array_t *item, const char *str)
+{
+    vec_push (&item->components, sdsnew (str));
+}
+
+#if 0
+static void usa_print_all (unique_string_array_t *item)
+{
+    int i;
+    sds part;
+    vec_foreach (&item->components, part, i)
+    {
+        printf ("%d: %s\n", i, part);
+    }
+}
+#endif
+
+int usa_remove (unique_string_array_t *item, const char *str)
+{
+    int idx = usa_find_idx (item, str);
+    if (idx >= 0) {
+        vec_splice (&item->components, idx, 1);
+    }
+    return idx;
+}
+
+void usa_split_and_set (unique_string_array_t *item, const char *value)
+{
+    item->clean = false;
+    usa_clear (item);
+    usa_split_and_push (item, value, false);
+}
+
+void usa_split_and_push (unique_string_array_t *item,
+                         const char *value,
+                         bool before)
+{
+    int value_count = 0, i;
+    bool insert_on_blank = true;
+
+    if (!value || strlen (value) == 0)
+        return;
+
+    sds part;
+    sds *new_parts = sdssplitlen (
+        value, strlen (value), item->sep, strlen (item->sep), &value_count);
+
+    for (i = 0, part = new_parts[i]; i < value_count;
+         i++, part = new_parts[i]) {
+        if (!sdslen (part) && insert_on_blank) {
+            // This odd dance is for lua's default path item
+            new_parts[i] = sdscpy (new_parts[i], item->sep);
+            insert_on_blank = false;
+        }
+
+        if (before) {
+            usa_remove (item, part);
+            usa_push (item, part);
+        } else {
+            int idx = usa_find_idx (item, part);
+            if (idx < 0)
+                usa_push_back (item, part);
+            else
+                continue;  // No update, not dirty
+        }
+        item->clean = false;
+    }
+
+    sdsfreesplitres (new_parts, value_count);
+}
+
+void usa_set_separator (unique_string_array_t *item, const char *separator)
+{
+    if (item)
+        item->sep = sdscpy (item->sep, separator);
+}
+
+const char *usa_get_joined (unique_string_array_t *item)
+{
+    if (!item)
+        return NULL;
+
+    if (usa_length (item) == 1)
+        return usa_data (item)[0];
+
+    if (!item->clean) {
+        sdsfree (item->string_cache);
+        item->string_cache = sdsjoinsds (item->components.data,
+                                         item->components.length,
+                                         item->sep,
+                                         sdslen (item->sep));
+    }
+
+    return item->string_cache;
+}
+
+const char *usa_find (unique_string_array_t *item, const char *str)
+{
+    int idx = usa_find_idx (item, str);
+    return idx >= 0 ? item->components.data[idx] : NULL;
+}
+
+int usa_find_idx (unique_string_array_t *item, const char *str)
+{
+    int i;
+    sds part;
+    vec_foreach (&item->components, part, i)
+    {
+        if (!strcmp (part, str)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void usa_deduplicate (unique_string_array_t *item)
+{
+    int i;
+    sds part;
+    vec_str_t v = item->components;
+    vec_init (&item->components);
+    vec_foreach (&v, part, i)
+    {
+        if (!usa_find (item, part)) {
+            vec_push (&item->components, part);
+        } else {
+            sdsfree (part);
+        }
+    }
+    vec_deinit (&v);
+}

--- a/src/common/libutil/usa.c
+++ b/src/common/libutil/usa.c
@@ -134,15 +134,15 @@ void usa_split_and_push (unique_string_array_t *item,
 
     for (i = 0, part = new_parts[i]; i < value_count;
          i++, part = new_parts[i]) {
+        if (!sdslen (part))
+            continue;
         if (before) {
             usa_remove (item, part);
             usa_push (item, part);
         } else {
-            int idx = usa_find_idx (item, part);
-            if (idx < 0)
-                usa_push_back (item, part);
-            else
-                continue;  // No update, not dirty
+            if (usa_find_idx (item, part) >= 0)
+                continue;
+            usa_push_back (item, part);
         }
         item->clean = false;
     }

--- a/src/common/libutil/usa.c
+++ b/src/common/libutil/usa.c
@@ -124,7 +124,6 @@ void usa_split_and_push (unique_string_array_t *item,
                          bool before)
 {
     int value_count = 0, i;
-    bool insert_on_blank = true;
 
     if (!value || strlen (value) == 0)
         return;
@@ -135,12 +134,6 @@ void usa_split_and_push (unique_string_array_t *item,
 
     for (i = 0, part = new_parts[i]; i < value_count;
          i++, part = new_parts[i]) {
-        if (!sdslen (part) && insert_on_blank) {
-            // This odd dance is for lua's default path item
-            new_parts[i] = sdscpy (new_parts[i], item->sep);
-            insert_on_blank = false;
-        }
-
         if (before) {
             usa_remove (item, part);
             usa_push (item, part);

--- a/src/common/libutil/usa.h
+++ b/src/common/libutil/usa.h
@@ -1,0 +1,213 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/*! \file usa.h
+ *  \brief Unique String Arrays
+ *
+ *  A unique_string_array_t stores a dense array of strings that can be easily
+ *  generated from output that must be split, joined, and otherwise
+ *  manipulated.  This is most useful for generating argv-style argument lists
+ *  and managing paths where input path components may not have been processed
+ *  into individual path components ahead of time.
+ *
+ *  All strings used herein are sds-based, and can be treated as such with
+ *  confidence.  The parameter types do not reflect this for interoperability
+ *  with other code.
+ */
+
+#ifndef FLUX_UNIQUE_STRING_ARRAY_H
+#define FLUX_UNIQUE_STRING_ARRAY_H
+
+#include <stdbool.h>
+
+#include "sds.h"
+#include "vec.h"
+
+/**
+ * @brief Base structure for a usa, may be stack-based, but needs init.
+ */
+typedef struct unique_string_array
+{
+    sds sep;
+    vec_str_t components;
+    sds string_cache;
+    bool clean;
+} unique_string_array_t;
+
+/**
+ * @brief Get the length of the array in number of strings.
+ *
+ * @param a The array
+ *
+ * @return The number of strings in the array
+ */
+#define usa_length(a) ((a)->components.length)
+
+/**
+ * @brief Get the underlying array, usable as an argv-style parameter.
+ *
+ * @param a The array class
+ *
+ * @return The underlying C array
+ */
+#define usa_data(a) ((a)->components.data)
+
+/**
+ * @brief Allocate, but do not initialize, a usa object.
+ *
+ * @return An un-initialized usa
+ */
+unique_string_array_t *usa_alloc ();
+/**
+ * @brief Initialize a usa, most useful for stack-allocated objects.
+ *
+ * @param item Pointer to the usa to initialize
+ */
+void usa_init (unique_string_array_t *item);
+/**
+ * @brief Allocate and initialize a new usa in one step.
+ *
+ * @return A ready-to-use usa instance, NULL on failure
+ */
+unique_string_array_t *usa_new ();
+/**
+ * @brief Re-set a usa as though it were new, keeping the storage active.
+ *
+ * @param item The usa to clear
+ */
+void usa_clear (unique_string_array_t *item);
+/**
+ * @brief Clear and deallocate the storage used by a usa.
+ *
+ * @param item The usa to be destroyed
+ */
+void usa_destroy (unique_string_array_t *item);
+
+/**
+ * @brief Set a usa to contain only the string "str," clearing the current
+ * contents, does not split its argument by separator.
+ *
+ * @param item The usa to set
+ * @param str The string to add
+ */
+void usa_set (unique_string_array_t *item, const char *str);
+/**
+ * @brief Push a new string onto the front of the array, requires a move of
+ * all other elements, not O(1) and does *not* deduplicate.
+ *
+ * @param item The usa to push into
+ * @param str The string to push
+ */
+void usa_push (unique_string_array_t *item, const char *str);
+/**
+ * @brief Push a new string onto the back of the array, this is O(1) unless
+ * an allocation is required and does *not* deduplicate.
+ *
+ * @param item The usa to push into
+ * @param str The string to push
+ */
+void usa_push_back (unique_string_array_t *item, const char *str);
+/**
+ * @brief Find and remove a string.
+ *
+ * @param item The usa to remove the string from
+ * @param str The string to remove
+ *
+ * @return On success, the index that was removed, on failure -1
+ */
+int usa_remove (unique_string_array_t *item, const char *str);
+
+/**
+ * @brief Set the separator character to be used by the split and join
+ * functions on this object.
+ *
+ * @param item The array object
+ * @param separator The separator to use
+ */
+void usa_set_separator (unique_string_array_t *item, const char *separator);
+/**
+ * @brief Split the input string by separator and set the contents of the
+ * array to the resulting tokens.
+ *
+ * This function performs de-duplication as it adds componenets to the array.
+ *
+ * @param item The array to act on
+ * @param str The string to be split and set
+ */
+void usa_split_and_set (unique_string_array_t *item, const char *str);
+/**
+ * @brief Split the input string by separator and push the resulting tokens
+ * onto the list at front or back.
+ *
+ * This function performs de-duplication as it adds componenets to the array.
+ *
+ * @param item The array to act on
+ * @param str The string to be split and pushed
+ * @param before Push to the front if true, back if false
+ */
+void usa_split_and_push (unique_string_array_t *item,
+                         const char *value,
+                         bool before);
+/**
+ * @brief Get the result of joining all strings in the array, in order, by the
+ * separator character.
+ *
+ * The returned value is owned by the array, and should not be freed. It is a
+ * cached value, so repeated calls to this function are cheap if no
+ * modifications are made inbetween.
+ *
+ * @param item The array to join.
+ *
+ * @return The joined string
+ */
+const char *usa_get_joined (unique_string_array_t *item);
+/**
+ * @brief Find a string in the array matching str, if no such match is found
+ * return NULL.
+ *
+ * @param item The array to search
+ * @param str The string to search for
+ *
+ * @return A pointer to the first match in the array or NULL
+ */
+const char *usa_find (unique_string_array_t *item, const char *str);
+/**
+ * @brief Find a string in the array matching str and return the index.
+ *
+ * @param item The array to search
+ * @param str The string to search for
+ *
+ * @return The array index of the first match or -1 if none is found
+ */
+int usa_find_idx (unique_string_array_t *item, const char *str);
+
+/**
+ * @brief Removes all duplicates in the array, leaving the left-most version
+ * of each in place.
+ *
+ * @param item The array to de-duplicate
+ */
+void usa_deduplicate (unique_string_array_t *item);
+
+#endif /* FLUX_UNIQUE_STRING_ARRAY_H */

--- a/src/common/libutil/vec.c
+++ b/src/common/libutil/vec.c
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2014 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include "vec.h"
+
+
+int vec_expand_(char **data, int *length, int *capacity, int memsz) {
+  if (*length + 1 > *capacity) {
+    void *ptr;
+    int n = (*capacity == 0) ? 1 : *capacity << 1;
+    ptr = realloc(*data, n * memsz);
+    if (ptr == NULL) return -1;
+    *data = ptr;
+    *capacity = n;
+  }
+  return 0;
+}
+
+
+int vec_reserve_(char **data, int *length, int *capacity, int memsz, int n) {
+  (void) length;
+  if (n > *capacity) {
+    void *ptr = realloc(*data, n * memsz);
+    if (ptr == NULL) return -1;
+    *data = ptr;
+    *capacity = n;
+  }
+  return 0;
+}
+
+
+int vec_reserve_po2_(
+  char **data, int *length, int *capacity, int memsz, int n
+) {
+  int n2 = 1;
+  if (n == 0) return 0;
+  while (n2 < n) n2 <<= 1;
+  return vec_reserve_(data, length, capacity, memsz, n2);
+}
+
+
+int vec_compact_(char **data, int *length, int *capacity, int memsz) {
+  if (*length == 0) {
+    free(*data);
+    *data = NULL;
+    *capacity = 0;
+    return 0;
+  } else {
+    void *ptr;
+    int n = *length;
+    ptr = realloc(*data, n * memsz);
+    if (ptr == NULL) return -1;
+    *capacity = n;
+    *data = ptr;
+  }
+  return 0;
+}
+
+
+int vec_insert_(char **data, int *length, int *capacity, int memsz,
+                 int idx
+) {
+  int err = vec_expand_(data, length, capacity, memsz);
+  if (err) return err;
+  memmove(*data + (idx + 1) * memsz,
+          *data + idx * memsz,
+          (*length - idx) * memsz);
+  return 0;
+}
+
+
+void vec_splice_(char **data, int *length, int *capacity, int memsz,
+                 int start, int count
+) {
+  (void) capacity;
+  memmove(*data + start * memsz,
+          *data + (start + count) * memsz,
+          (*length - start - count) * memsz);
+}
+
+
+void vec_swapsplice_(char **data, int *length, int *capacity, int memsz,
+                     int start, int count
+) {
+  (void) capacity;
+  memmove(*data + start * memsz,
+          *data + (*length - count) * memsz,
+          count * memsz);
+}
+
+
+void vec_swap_(char **data, int *length, int *capacity, int memsz,
+               int idx1, int idx2
+) {
+  unsigned char *a, *b, tmp;
+  int count;
+  (void) length;
+  (void) capacity;
+  if (idx1 == idx2) return;
+  a = (unsigned char*) *data + idx1 * memsz;
+  b = (unsigned char*) *data + idx2 * memsz;
+  count = memsz;
+  while (count--) {
+    tmp = *a;
+    *a = *b;
+    *b = tmp;
+    a++, b++;
+  }
+}

--- a/src/common/libutil/vec.h
+++ b/src/common/libutil/vec.h
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2014 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See LICENSE for details.
+ */
+
+#ifndef VEC_H
+#define VEC_H
+
+#include <stdlib.h>
+#include <string.h>
+
+#define VEC_VERSION "0.2.1"
+
+
+#define vec_unpack_(v)\
+  (char**)&(v)->data, &(v)->length, &(v)->capacity, sizeof(*(v)->data)
+
+
+#define vec_t(T)\
+  struct { T *data; int length, capacity; }
+
+
+#define vec_init(v)\
+  memset((v), 0, sizeof(*(v)))
+
+
+#define vec_deinit(v)\
+  ( free((v)->data),\
+    vec_init(v) )
+
+
+#define vec_push(v, val)\
+  ( vec_expand_(vec_unpack_(v)) ? -1 :\
+    ((v)->data[(v)->length++] = (val), 0), 0 )
+
+
+#define vec_pop(v)\
+  (v)->data[--(v)->length]
+
+
+#define vec_splice(v, start, count)\
+  ( vec_splice_(vec_unpack_(v), start, count),\
+    (v)->length -= (count) )
+
+
+#define vec_swapsplice(v, start, count)\
+  ( vec_swapsplice_(vec_unpack_(v), start, count),\
+    (v)->length -= (count) )
+
+
+#define vec_insert(v, idx, val)\
+  ( vec_insert_(vec_unpack_(v), idx) ? -1 :\
+    ((v)->data[idx] = (val), 0), (v)->length++, 0 )
+
+
+#define vec_sort(v, fn)\
+  qsort((v)->data, (v)->length, sizeof(*(v)->data), fn)
+
+
+#define vec_swap(v, idx1, idx2)\
+  vec_swap_(vec_unpack_(v), idx1, idx2)
+
+
+#define vec_truncate(v, len)\
+  ((v)->length = (len) < (v)->length ? (len) : (v)->length)
+
+
+#define vec_clear(v)\
+  ((v)->length = 0)
+
+
+#define vec_first(v)\
+  (v)->data[0]
+
+
+#define vec_last(v)\
+  (v)->data[(v)->length - 1]
+
+
+#define vec_reserve(v, n)\
+  vec_reserve_(vec_unpack_(v), n)
+
+
+#define vec_compact(v)\
+  vec_compact_(vec_unpack_(v))
+
+
+#define vec_pusharr(v, arr, count)\
+  do {\
+    int i__, n__ = (count);\
+    if (vec_reserve_po2_(vec_unpack_(v), (v)->length + n__) != 0) break;\
+    for (i__ = 0; i__ < n__; i__++) {\
+      (v)->data[(v)->length++] = (arr)[i__];\
+    }\
+  } while (0)
+
+
+#define vec_extend(v, v2)\
+  vec_pusharr((v), (v2)->data, (v2)->length)
+
+
+#define vec_find(v, val, idx)\
+  do {\
+    for ((idx) = 0; (idx) < (v)->length; (idx)++) {\
+      if ((v)->data[(idx)] == (val)) break;\
+    }\
+    if ((idx) == (v)->length) (idx) = -1;\
+  } while (0)
+
+
+#define vec_remove(v, val)\
+  do {\
+    int idx__;\
+    vec_find(v, val, idx__);\
+    if (idx__ != -1) vec_splice(v, idx__, 1);\
+  } while (0)
+
+
+#define vec_reverse(v)\
+  do {\
+    int i__ = (v)->length / 2;\
+    while (i__--) {\
+      vec_swap((v), i__, (v)->length - (i__ + 1));\
+    }\
+  } while (0)
+
+
+#define vec_foreach(v, var, iter)\
+  if  ( (v)->length > 0 )\
+  for ( (iter) = 0;\
+        (iter) < (v)->length && (((var) = (v)->data[(iter)]), 1);\
+        ++(iter))
+
+
+#define vec_foreach_rev(v, var, iter)\
+  if  ( (v)->length > 0 )\
+  for ( (iter) = (v)->length - 1;\
+        (iter) >= 0 && (((var) = (v)->data[(iter)]), 1);\
+        --(iter))
+
+
+#define vec_foreach_ptr(v, var, iter)\
+  if  ( (v)->length > 0 )\
+  for ( (iter) = 0;\
+        (iter) < (v)->length && (((var) = &(v)->data[(iter)]), 1);\
+        ++(iter))
+
+
+#define vec_foreach_ptr_rev(v, var, iter)\
+  if  ( (v)->length > 0 )\
+  for ( (iter) = (v)->length - 1;\
+        (iter) >= 0 && (((var) = &(v)->data[(iter)]), 1);\
+        --(iter))
+
+
+
+int vec_expand_(char **data, int *length, int *capacity, int memsz);
+int vec_reserve_(char **data, int *length, int *capacity, int memsz, int n);
+int vec_reserve_po2_(char **data, int *length, int *capacity, int memsz,
+                     int n);
+int vec_compact_(char **data, int *length, int *capacity, int memsz);
+int vec_insert_(char **data, int *length, int *capacity, int memsz,
+                int idx);
+void vec_splice_(char **data, int *length, int *capacity, int memsz,
+                 int start, int count);
+void vec_swapsplice_(char **data, int *length, int *capacity, int memsz,
+                     int start, int count);
+void vec_swap_(char **data, int *length, int *capacity, int memsz,
+               int idx1, int idx2);
+
+
+typedef vec_t(void*) vec_void_t;
+typedef vec_t(char*) vec_str_t;
+typedef vec_t(int) vec_int_t;
+typedef vec_t(char) vec_char_t;
+typedef vec_t(float) vec_float_t;
+typedef vec_t(double) vec_double_t;
+
+#endif

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -87,5 +87,15 @@ test_expect_success 'flux env passes cmddriver option to argument' "
 	flux -F --tmpdir /xyx env sh -c 'echo \$FLUX_TMPDIR' \
 		| grep ^/xyx$
 "
-
+# push /foo twice onto PYTHONPATH -- ensure it is leftmost position:
+test_expect_success 'cmddriver pushes dup path elements onto front of PATH' "
+	flux -P /foo env flux -P /bar env flux -P /foo env \
+		sh -c 'echo \$PYTHONPATH' | grep '^/foo'
+"
+# Ensure PATH-style variables are de-duplicated on push
+# Push /foo twice onto PYTHONPATH, ensure it appears only once
+test_expect_success 'cmddriver deduplicates path elements on push' "
+	flux -P /foo env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
+		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
+"
 test_done

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -98,4 +98,18 @@ test_expect_success 'cmddriver deduplicates path elements on push' "
 	flux -P /foo env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
 		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
 "
+# Ensure complex PATH-style variables are de-duplicated on push
+test_expect_success 'cmddriver deduplicates complex path elements on push' "
+	flux -P /foo:/foo:/foo:/bar:/foo:/baz env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
+		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
+"
+# External user path elements are preserved
+test_expect_success 'cmddriver preserves user path components' "
+	PYTHONPATH=/meh flux env sh -c 'echo \$PYTHONPATH' |
+		awk -F '/meh' 'NF-1 != 1 {print; exit 1}'
+"
+test_expect_success 'cmddriver removes multiple contiguous separators in input' "
+	LUA_PATH='/meh;;;' flux env sh -c 'echo \$LUA_PATH' |
+		grep -v ';;;;'
+"
 test_done


### PR DESCRIPTION
fixes #311

There are a lot more changes here than I expected to need, the main reason is
that lua paths are horrendously difficult to treat like any other kind of
path, because of the way they treat two contiguous separators as a proxy for
the default path.  As it is, this version de-duplicates all path components
from all inputs, but when it finds an empty path component `<sep><sep>` or
`;;`, it inserts the separator twice into the path and then moves on.  This
works for the lua paths, but disallows any truly empty component.  It was the
best solution I could seem to come up with.

In making this work, I ended up with what seemed like it might be a useful string array class, so that is split out in the last commit.