### PR TITLE
adds code formatters for c and python

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+BasedOnStyle : google
+SpaceBeforeParens : Always
+IndentWidth : 4
+BreakBeforeBraces : Linux
+UseTab: Never
+AllowShortIfStatementsOnASingleLine : false
+ConstructorInitializerAllOnOneLineOrOnePerLine : true
+AllowShortFunctionsOnASingleLine : false
+AllowShortLoopsOnASingleLine : false
+BinPackParameters : false
+AllowAllParametersOfDeclarationOnNextLine : false
+AlignTrailingComments : true
+ColumnLimit : 80
+PenaltyBreakBeforeFirstCallParameter : 100
+PenaltyReturnTypeOnItsOwnLine : 65000
+PenaltyBreakString : 10
+
+# These improve formatting results but require clang 3.6/7 or higher
+# BreakBeforeBinaryOperators : NonAssignment
+# AlignAfterOpenBracket: true
+# BinPackArguments : false
+# AlignOperands : true

--- a/src/bindings/python/.style.yapf
+++ b/src/bindings/python/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = pep8
+spaces_before_comment = 4
+split_before_logical_operator = true
+align_closing_bracket_with_visual_indent = true


### PR DESCRIPTION
The .clang-format file defines a style following the rules set down in our RFC
on the subject, and enforcing them across an entire file.  If possible, the
lines at the bottom should be uncommented to get the best alignment results,
but this requires a newer clang than we have on LC machines by default.  The
file as committed is compatible with the default clang 3.5 that is generally
available.  Use it just by running clang-format on a file, or a piped input
stream, from any directory below the file, it will be found and used as the
configuration automatically.  If possible, it would be nice to use this by
default, but for a while it will cause ancillary changes on pull-requests to
do that unless we do a global re-format at the start.

The .style.yapf file is an equivalent system for python, it requires the yapf
(Yet Another Python Formatter) program to be available, which is easily
installed via pip or spack.  It works the same way that clang-format does for
the C code, and enforces a PEP8-compatible style that uses the same spacing
and general rules as our C style where possible, and as close as feasible
where the rules conflict with python language requirements.

As an example, starting with a C block using a format very different from ours:

```c
if (x < foo(y, z))
  haha = bar[4]+ 5;
else
  { while (z)
      { haha +=foo(z, z);
        z--; }
    mode = (inmode[j] == VOIDmode || GET_MODE_SIZE(outmode[j])>GET_MODE_SIZE(inmode[j])
            ? outmode[j]:inmode[j]);
    do
      { a = foo (a); }
    while (a > 0);
    return ++x + bar (); }
```

After formatting, we get this:

```c
if (x < foo (y, z))
    haha = bar[4] + 5;
else {
    while (z) {
        haha += foo (z, z);
        z--;
    }
    mode = (inmode[j] == VOIDmode ||
                    GET_MODE_SIZE (outmode[j]) > GET_MODE_SIZE (inmode[j])
                ? outmode[j]
                : inmode[j]);
    do {
        a = foo (a);
    } while (a > 0);
    return ++x + bar ();
}
```

For vim users, I highly recommend [vim-autoformat](https://github.com/Chiel92/vim-autoformat) which can very easily be configured to use these formatters, or astyle if you prefer or can't use clang.  Unfortunately the astyle style is slightly different, and may cause oscillating changes between the two, if you want to try that anyway, the appropriate flags are in the RFC.
