### PR TITLE
hacky jansson experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
   apt:
     sources:
     packages:
+      - libjansson-dev
       - lua5.1
       - liblua5.1-0-dev
       - luarocks

--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,7 @@ X_AC_ZEROMQ
 X_AC_MUNGE
 PKG_CHECK_MODULES([JSON], [json], [],
   [PKG_CHECK_MODULES([JSON], [json-c])])
+PKG_CHECK_MODULES([JANSSON], [jansson])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 

--- a/src/bindings/python/make_binding.py
+++ b/src/bindings/python/make_binding.py
@@ -96,10 +96,7 @@ ffi.set_source('{full_mod}',
 {extra_source}
 
 //TODO: REMOVE THIS when the json_obj stuff goes away
-struct json_object;
-extern struct json_object* json_tokener_parse(const char *str);
-extern int json_object_put(struct json_object *obj);
-extern const char *  json_object_to_json_string (struct json_object *obj);
+#include <json.h>
 
 void * unpack_long(ptrdiff_t num){{
   return (void*)num;

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = @GCCWARN@
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
+	$(JSON_CFLAGS) $(JANSSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
         -DMODULE_PATH=\"$(fluxmoddir)\" \
         -DCONNECTOR_PATH=\"$(fluxconnectordir)\" \

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -31,7 +31,6 @@
 #include "event.h"
 #include "message.h"
 
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
 int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **json_str)

--- a/src/common/libflux/reduce.c
+++ b/src/common/libflux/reduce.c
@@ -30,7 +30,6 @@
 #include "reactor.h"
 
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
 

--- a/src/common/libflux/reparent.h
+++ b/src/common/libflux/reparent.h
@@ -1,7 +1,6 @@
 #ifndef _FLUX_CORE_REPARENT_H
 #define _FLUX_CORE_REPARENT_H
 
-#include <json.h>
 #include "handle.h"
 
 char *flux_lspeer (flux_t h, int rank);

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -25,14 +25,11 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <errno.h>
+
 #include "request.h"
 #include "message.h"
 #include "info.h"
-
-#include "src/common/libutil/shortjson.h"
-#include "src/common/libutil/jsonutil.h"
-#include "src/common/libutil/xzmalloc.h"
-#include "src/common/libutil/nodeset.h"
 
 int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **json_str)

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -1,7 +1,6 @@
 #ifndef _FLUX_CORE_REQUEST_H
 #define _FLUX_CORE_REQUEST_H
 
-#include <json.h>
 #include <stdbool.h>
 #include <stdarg.h>
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -38,6 +38,8 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
+#include "src/common/libutil/libjansson.h"
+
 
 struct flux_rpc_struct {
     struct flux_match m;
@@ -48,11 +50,14 @@ struct flux_rpc_struct {
     uint32_t *nodemap;          /* nodeid indexed by matchtag */
     flux_msg_t *rx_msg;
     flux_msg_t *rx_msg_consumed;
+    json_t *rx_json;
     int rx_count;
     bool oneway;
     void *aux;
     flux_free_f aux_destroy;
     const char *type;
+
+    struct jansson_struct *jansson;
 };
 
 void flux_rpc_destroy (flux_rpc_t *rpc)
@@ -76,6 +81,11 @@ void flux_rpc_destroy (flux_rpc_t *rpc)
             free (rpc->nodemap);
         if (rpc->aux && rpc->aux_destroy)
             rpc->aux_destroy (rpc->aux);
+        if (rpc->jansson) {
+            if (rpc->rx_json)
+                jansson_decref (rpc->jansson, rpc->rx_json);
+            jansson_destroy (rpc->jansson);
+        }
         free (rpc);
     }
 }
@@ -323,6 +333,94 @@ void flux_rpc_aux_set (flux_rpc_t *rpc, void *aux, flux_free_f destroy)
     rpc->aux = aux;
     rpc->aux_destroy = destroy;
 }
+
+static flux_rpc_t *flux_vrpcf (flux_t h, const char *topic, uint32_t nodeid,
+                               int flags, const char *fmt, va_list ap)
+{
+    json_error_t error;
+    json_t *in = NULL;
+    char *s = NULL;
+    struct jansson_struct *js;
+    flux_rpc_t *rpc = NULL;
+
+    if (!(js = jansson_create ())) {
+        errno = ENOENT;
+        goto done;
+    }
+    if (!(in = js->vpack_ex (&error, 0, fmt, ap))) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(s = js->dumps (in, JSON_COMPACT))) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (!(rpc = flux_rpc (h, topic, s, nodeid, flags)))
+        goto done;
+    rpc->jansson = js;
+done:
+    if (s)
+        free (s);
+    if (in)
+        jansson_decref (js, in);
+    if (!rpc && js)
+        jansson_destroy (js);
+    return rpc;
+}
+
+flux_rpc_t *flux_rpcf (flux_t h, const char *topic, uint32_t nodeid,
+                       int flags, const char *fmt, ...)
+{
+    va_list ap;
+    flux_rpc_t *rpc;
+
+    va_start (ap, fmt);
+    rpc = flux_vrpcf (h, topic, nodeid, flags, fmt, ap);
+    va_end (ap);
+
+    return rpc;
+}
+
+static int flux_rpc_vgetf (flux_rpc_t *rpc, uint32_t *nodeid,
+                           const char *fmt, va_list ap)
+{
+    const char *json_str;
+    json_error_t error;
+    int rc = -1;
+
+    if (!rpc->jansson && !(rpc->jansson = jansson_create ())) {
+        errno = ENOENT;
+        goto done;
+    }
+    if (flux_rpc_get (rpc, nodeid, &json_str) < 0)
+        goto done;
+    if (rpc->rx_json)
+        jansson_decref (rpc->jansson, rpc->rx_json);
+    if (!(rpc->rx_json = rpc->jansson->loads (json_str, 0, &error))) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (rpc->jansson->vunpack_ex (rpc->rx_json, &error, 0, fmt, ap) < 0) {
+        errno = EPROTO;
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+int flux_rpc_getf (flux_rpc_t *rpc, uint32_t *nodeid, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = flux_rpc_vgetf (rpc, nodeid, fmt, ap);
+    va_end (ap);
+
+    return rc;
+}
+
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -26,6 +26,8 @@
 #include "config.h"
 #endif
 #include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
 
 #include "request.h"
 #include "response.h"
@@ -34,8 +36,6 @@
 #include "rpc.h"
 #include "reactor.h"
 
-#include "src/common/libutil/shortjson.h"
-#include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
 

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -59,6 +59,14 @@ void flux_rpc_type_set (flux_rpc_t *rpc, const char *type);
 void *flux_rpc_aux_get (flux_rpc_t *rpc);
 void flux_rpc_aux_set (flux_rpc_t *rpc, void *aux, flux_free_f destroy);
 
+/* Variants of flux_rpc and flux_rpc_get that encode/decode json payloads
+ * using jansson pack/unpack format strings.
+ */
+flux_rpc_t *flux_rpcf (flux_t h, const char *topic, uint32_t nodeid,
+                       int flags, const char *fmt, ...);
+
+int flux_rpc_getf (flux_rpc_t *rpc, uint32_t *nodeid, const char *fmt, ...);
+
 #endif /* !_FLUX_CORE_RPC_H */
 
 /*

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -1,7 +1,6 @@
 #ifndef _FLUX_CORE_RPC_H
 #define _FLUX_CORE_RPC_H
 
-#include <json.h>
 #include <stdbool.h>
 
 #include "handle.h"
@@ -18,6 +17,7 @@ typedef void (*flux_then_f)(flux_rpc_t *rpc, void *arg);
  */
 flux_rpc_t *flux_rpc (flux_t h, const char *topic, const char *json_str,
                       uint32_t nodeid, int flags);
+
 /* Destroy an RPC, invalidating previous payload returned by flux_rpc_get().
  */
 void flux_rpc_destroy (flux_rpc_t *rpc);

--- a/src/common/libflux/security.c
+++ b/src/common/libflux/security.c
@@ -123,7 +123,6 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <munge.h>
-#include <json.h>
 #include <czmq.h>
 
 #include "security.h"

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS = @GCCWARN@
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
+	$(JSON_CFLAGS) $(JANSSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-Wno-strict-aliasing \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include
 
@@ -44,7 +44,9 @@ libutil_la_SOURCES = \
 	msglist.c \
 	msglist.h \
 	cleanup.c \
-	cleanup.h
+	cleanup.h \
+	libjansson.c \
+	libjansson.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/libjansson.c
+++ b/src/common/libutil/libjansson.c
@@ -1,0 +1,80 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <dlfcn.h>
+
+#include "libjansson.h"
+#include "xzmalloc.h"
+
+
+/* This replicates the inline function json_decref() in <jansson.h>,
+ * but uses our dlopened delete function.
+ */
+void jansson_decref (struct jansson_struct *js, json_t *json)
+{
+    if (json && json->refcount != (size_t)-1 && --json->refcount == 0)
+        js->delete (json);
+}
+
+void jansson_destroy (struct jansson_struct *js)
+{
+    if (js) {
+        if (js->dso)
+            dlclose (js->dso);
+        free (js);
+    }
+}
+
+struct jansson_struct *jansson_create (void)
+{
+    struct jansson_struct *js = xzmalloc (sizeof (*js));
+
+    if (!(js->dso = dlopen ("libjansson.so", RTLD_LAZY | RTLD_LOCAL))) {
+        char *errstr = dlerror ();
+        fprintf (stderr, "%s: %s\n", __FUNCTION__,
+                 errstr ? errstr : "dlopen libjansson.so failed");
+        jansson_destroy (js);
+        return NULL;
+    }
+    if (!(js->vunpack_ex = dlsym (js->dso, "json_vunpack_ex"))
+            || !(js->vpack_ex = dlsym (js->dso, "json_vpack_ex"))
+            || !(js->loads = dlsym (js->dso, "json_loads"))
+            || !(js->dumps = dlsym (js->dso, "json_dumps"))
+            || !(js->delete = dlsym (js->dso, "json_delete"))) {
+        char *errstr = dlerror ();
+        fprintf (stderr, "%s: %s\n", __FUNCTION__,
+                 errstr ? errstr : "dlsym failed");
+        jansson_destroy (js);
+        return NULL;
+    }
+    return js;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/libjansson.h
+++ b/src/common/libutil/libjansson.h
@@ -1,0 +1,27 @@
+#ifndef _UTIL_LIBJANSSON_H
+#define _UTIL_LIBJANSSON_H
+
+#include <jansson.h>
+
+struct jansson_struct {
+    int         (*vunpack_ex)(json_t *root, json_error_t *error, size_t flags,
+                                const char *fmt, va_list ap);
+    json_t *    (*vpack_ex)(json_error_t *error, size_t flags,
+                                const char *fmt, va_list ap);
+    char *      (*dumps)(const json_t *root, size_t flags);
+    json_t *    (*loads)(const char *input, size_t flags, json_error_t *error);
+    void        (*delete)(json_t *json); /* do not use directly */
+
+    void *dso;
+};
+
+void jansson_decref (struct jansson_struct *json, json_t *obj);
+
+struct jansson_struct *jansson_create (void);
+void jansson_destroy (struct jansson_struct *js);
+
+#endif /* _UTIL_JANSSON_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR is an experiment with jansson (not merge-ready) in which two new RPC functions were added:
```C
flux_rpc_t *flux_rpcf (flux_t h, const char *topic, uint32_t nodeid,
                        int flags, const char *fmt, ...);

int flux_rpc_getf (flux_rpc_t *rpc, uint32_t *nodeid, const char *fmt, ...);
```

These are based on `json_pack()` and `json_unpack()` from [jansson](http://jansson.readthedocs.org/en/latest/apiref.html).  The intent was to play around a bit with these interfaces to get some experience that might advance issue #301.

The libflux/info code was converted to use the new rpc interfaces.  This code is representative of many similar examples in which JSON payloads are encoded/decoded using intermediate json objects.  With this change, there is no need to create intermediate json objects, and all storage associated with payloads is kept inside the flux_rpc_t where it can be freed in one go.
```C
char *flux_getattr (flux_t h, int rank, const char *name)
{
    uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
    flux_rpc_t *r = NULL;
    const char *val;
    char *ret = NULL;

    if (!(r = flux_rpcf (h, "cmb.getattr", nodeid, 0, "{s:s}", "name", name)))
        goto done;
    if (flux_rpc_getf (r, NULL, "{s:s}", name, &val) < 0)
        goto done;
    ret = xstrdup (val);
done:
    flux_rpc_destroy (r);
    return ret;
}

int flux_info (flux_t h, int *rankp, int *sizep, bool *treerootp)
{
    flux_rpc_t *r = NULL;
    int rank, size;
    bool treeroot;
    int ret = -1;

    if (!(r = flux_rpc (h, "cmb.info", NULL, FLUX_NODEID_ANY, 0)))
        goto done;
    if (flux_rpc_getf (r, NULL, "{s:b, s:i, s:i}",
                        "treeroot", &treeroot,
                        "rank", &rank,
                        "size", &size) < 0)
        goto done;
    if (rankp)
        *rankp = rank;
    if (sizep)
        *sizep = size;
    if (treerootp)
        *treerootp = treeroot;
    ret = 0;
done:
    flux_rpc_destroy (r);
    return ret;
}
```

Since json-c and jansson namespaces collide (for example `json_object_get()` is exported by both), for this experiment I added a wrapper that dlopens jansson and provides a very abbreviated set of function pointers.  I was not too sure how to successfully isolate the jansson stuff from the rest of the code by linking it in the usual way but maybe I did not spend enough time researching options.  What's proposed here is an awful kludge that only works if libjansson.so is in the default library search path, only provides a tiny subset of jansson, and includes an inelegant workaround for an jansson inline function that could not be dlsym()ed.  I am not happy with it, but wanted to get on with the experiment.

Anyway, if we think jansson is worth pursuing, we might see about how to link with it properly.  At minimum the proposed RPC changes would eliminate a lot of users of the json apis.