### PR TITLE
configure: switch from C (90/gnu90) default to C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_DEFINE([_GNU_SOURCE], 1,
 ##
 # Checks for programs
 ##
-AC_PROG_CC
+AC_PROG_CC_C99
 AM_PROG_CC_C_O
 if test "$GCC" = yes; then
   GCCWARN="-Wall -Werror -Wno-strict-aliasing"

--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -18,4 +18,4 @@ def mod_main_trampoline(name, int_handle, args):
     #call into mod_main with a flux class instance and the argument dict
     #it might be more pythonic to unpack the args as keyword/positional arguments
     #to this function, but I think this is cleaner for now
-    user_mod.mod_main(flux_instance, **args)
+    user_mod.mod_main(flux_instance, *args)

--- a/src/modules/pymod/echo.py
+++ b/src/modules/pymod/echo.py
@@ -13,7 +13,7 @@ def pecho_impl(h, typemask, message, arg):
     rpc.respond()
     return 0
 
-def mod_main(h, **arg_dict):
+def mod_main(h, *args):
     if h.event_subscribe("mrpc.mecho") < 0:
         h.fatal_error("event subscription failed")
     with h.msg_watcher_create(pecho_impl,


### PR DESCRIPTION
The C compiler macro has been updated to AC_PROG_CC_C99, for gcc and clang the
effect is that the C standard flag will be switched from the default
`-std=gnu90` (actually, recent GCCs use `-std=gnu11`, but whatever) to
`-std=gnu99`.  For non-gcc/clang compilers it will search for a C99 variant,
usually just the c99 binary, or the closest most extended c99 variant it can
recognize.  The AC_PROG_CC_C_O macro has also been removed, since it has been a requirement of the AC_PROG_CC and sub-macros since autoconf 1.14 anyway.