### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Flux Framework Contribution Guide
+
+The Flux project welcomes all contributors. This short guide details how
+to contribute to Flux Framework projects in a standardized and efficient
+manner.
+
+## Contribution RFCs
+
+Contributions to Flux projects should adhere to the rules contained
+in the following RFCs from the [flux-framework/rfc][1] project:
+
+ * [*RFC 1: Collective Code Construction Contract*][2]
+
+    Also known as *C4.1*. This RFC includes details on the construction
+    of proper commits, commit requests, and the Pull Request process
+    used by Flux Framework projects.
+
+ * [*RFC 7: Flux Coding Style Guide*][3]
+
+    This RFC details the preferred code style guidelines for contributions
+    to Flux projects.
+
+[1]: https://github.com/flux-framework/rfc
+[2]: https://github.com/flux-framework/rfc/blob/master/spec_1.adoc
+[3]: https://github.com/flux-framework/rfc/blob/master/spec_7.adoc


### PR DESCRIPTION
Add a very short guide for contributors, mainly referencing
the existing RFCs which detail coding style and git commit
rules.

I was going to add a short description of the contribution process to the top of this document as well (e.g. create changes, add tests, update documentation, ensure changes adhere to *RFC 7*, ensure commits adhere to *RFC 1*, submit PR, accept feedback), but I wanted to keep the document as short as possible. If we think more context is needed here, I could easily add that extra text.

I also tried not to reference any particular flux-framework project such that CONTRIBUTING.md could be copied directly to all flux projects, if desired.