### PR TITLE
reduce gratuitous message duplication in broker

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -45,7 +45,8 @@ endif
 flux_broker_LDFLAGS = ${broker_ldflags}
 
 TESTS = test_snoop.t \
-	test_shutdown.t
+	test_shutdown.t \
+	test_heartbeat.t
 
 test_ldadd = \
 	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
@@ -72,3 +73,7 @@ test_snoop_t_LDADD = $(test_ldadd)
 test_shutdown_t_SOURCES = test/shutdown.c shutdown.c
 test_shutdown_t_CPPFLAGS = $(test_cppflags)
 test_shutdown_t_LDADD = $(test_ldadd)
+
+test_heartbeat_t_SOURCES = test/heartbeat.c heartbeat.c
+test_heartbeat_t_CPPFLAGS = $(test_cppflags)
+test_heartbeat_t_LDADD = $(test_ldadd)

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -44,7 +44,8 @@ endif
 
 flux_broker_LDFLAGS = ${broker_ldflags}
 
-TESTS = test_snoop.t
+TESTS = test_snoop.t \
+	test_shutdown.t
 
 test_ldadd = \
 	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
@@ -55,6 +56,7 @@ test_ldadd = \
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \
         $(AM_CPPFLAGS) \
+        -DCONNECTOR_PATH=\"$(top_builddir)/src/connectors\" \
         -UMODULE_PATH -DMODULE_PATH=\"$(top_builddir)/src/modules\"
 
 check_PROGRAMS = $(TESTS)
@@ -66,3 +68,7 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 test_snoop_t_SOURCES = test/snoop.c snoop.c
 test_snoop_t_CPPFLAGS = $(test_cppflags)
 test_snoop_t_LDADD = $(test_ldadd)
+
+test_shutdown_t_SOURCES = test/shutdown.c shutdown.c
+test_shutdown_t_CPPFLAGS = $(test_cppflags)
+test_shutdown_t_LDADD = $(test_ldadd)

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -46,7 +46,8 @@ flux_broker_LDFLAGS = ${broker_ldflags}
 
 TESTS = test_snoop.t \
 	test_shutdown.t \
-	test_heartbeat.t
+	test_heartbeat.t \
+	test_hello.t
 
 test_ldadd = \
 	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
@@ -77,3 +78,7 @@ test_shutdown_t_LDADD = $(test_ldadd)
 test_heartbeat_t_SOURCES = test/heartbeat.c heartbeat.c
 test_heartbeat_t_CPPFLAGS = $(test_cppflags)
 test_heartbeat_t_LDADD = $(test_ldadd)
+
+test_hello_t_SOURCES = test/hello.c hello.c
+test_hello_t_CPPFLAGS = $(test_cppflags)
+test_hello_t_LDADD = $(test_ldadd)

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -43,3 +43,26 @@ broker_ldflags += -rpath $(PYTHON_PREFIX)/lib
 endif
 
 flux_broker_LDFLAGS = ${broker_ldflags}
+
+TESTS = test_snoop.t
+
+test_ldadd = \
+	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libtap/libtap.la 
+
+test_cppflags = \
+        -I$(top_srcdir)/src/common/libtap \
+        $(AM_CPPFLAGS) \
+        -UMODULE_PATH -DMODULE_PATH=\"$(top_builddir)/src/modules\"
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_snoop_t_SOURCES = test/snoop.c snoop.c
+test_snoop_t_CPPFLAGS = $(test_cppflags)
+test_snoop_t_LDADD = $(test_ldadd)

--- a/src/broker/heartbeat.h
+++ b/src/broker/heartbeat.h
@@ -1,39 +1,46 @@
 #ifndef _BROKER_HEARTBEAT_H
 #define _BROKER_HEARTBEAT_H
 
+/* Manage the session heartbeat.
+ *
+ * Rank 0 should call heartbeat_start() to begin sending heartbeat events.
+ * This registers a reactor timer watcher.
+ *
+ * On all ranks, "hb" event messages should be passed to heartbeat_recvmsg(),
+ * which will decode the received epoch, set it internally, and call the
+ * heartbeat_cb_f, if any.
+ *
+ * The heartbeat_get_epoch() getter obtains the most recently processed epoch.
+ *
+ * Note: rank 0's epoch update and callback are driven by the receipt of the
+ * heartbeat event, not its generation.
+ */
+
 typedef struct heartbeat_struct heartbeat_t;
-typedef void (*heartbeat_cb_f)(heartbeat_t *h, void *arg);
+typedef void (*heartbeat_cb_f)(heartbeat_t *hb, void *arg);
 
 heartbeat_t *heartbeat_create (void);
-void heartbeat_destroy (heartbeat_t *h);
+void heartbeat_destroy (heartbeat_t *hb);
 
-/* Default rate (seconds) can be overridden with set function.
- * Will return -1, errno == EINVAL if out of hardwired range.
- * set_ratestr parses a double with optional time suffix ('s' or 'ms').
+/* Default heart rate (seconds) can be set from a command line argument
+ * that includes an optional "s" or "ms" unit suffix.
+ * Returns -1, EINVAL if rate is out of range (0.1, 30).
  */
-int heartbeat_set_rate (heartbeat_t *h, double rate);
-int heartbeat_set_ratestr (heartbeat_t *h, const char *s);
-double heartbeat_get_rate (heartbeat_t *h);
+int heartbeat_set_ratestr (heartbeat_t *hb, const char *s);
 
-/* Get/set the current epoch.
- */
-void heartbeat_set_epoch (heartbeat_t *h, int epoch);
-int heartbeat_get_epoch (heartbeat_t *h);
-void heartbeat_next_epoch (heartbeat_t *h);
+int heartbeat_set_rate (heartbeat_t *hb, double rate);
+double heartbeat_get_rate (heartbeat_t *hb);
 
-/* The generator of heartbeats (rank 0) installs a timer and in
- * the handler, calls next_epoch() and event_encode().
- */
-void heartbeat_set_reactor (heartbeat_t *h, flux_t f);
-void heartbeat_set_cb (heartbeat_t *h, heartbeat_cb_f cb, void *arg);
-int heartbeat_start (heartbeat_t *h);
-void heartbeat_stop (heartbeat_t *h);
-zmsg_t *heartbeat_event_encode (heartbeat_t *h);
+void heartbeat_set_flux (heartbeat_t *hb, flux_t h);
+void heartbeat_set_callback (heartbeat_t *hb, heartbeat_cb_f cb, void *arg);
 
-/* A passive receiver of heartbeats (rank > 0) processes a
- * received heartbeat message with event_decode(), setting the epoch.
- */
-int heartbeat_event_decode (heartbeat_t *h, zmsg_t *zmsg);
+void heartbeat_set_epoch (heartbeat_t *hb, int epoch);
+int heartbeat_get_epoch (heartbeat_t *hb);
+
+int heartbeat_start (heartbeat_t *hb); /* rank 0 only */
+void heartbeat_stop (heartbeat_t *hb);
+
+int heartbeat_recvmsg (heartbeat_t *hb, const flux_msg_t *msg);
 
 #endif /* !_BROKER_HEARTBEAT_H */
 

--- a/src/broker/hello.h
+++ b/src/broker/hello.h
@@ -1,6 +1,8 @@
 #ifndef _BROKER_HELLO_H
 #define _BROKER_HELLO_H
 
+#include <stdbool.h>
+
 /* hello protocol is used to detect that TBON overlay has wired up.
  * All the ranks send a small hello request to rank 0.
  * When all the ranks are accounted for, the nodeset is complete.
@@ -11,54 +13,58 @@
 
 typedef struct hello_struct hello_t;
 
-typedef void (*hello_cb_f)(hello_t *h, void *arg);
+typedef void (*hello_cb_f)(hello_t *hello, void *arg);
 
 hello_t *hello_create (void);
-void hello_destroy (hello_t *h);
+void hello_destroy (hello_t *hello);
 
-void hello_set_overlay (hello_t *h, overlay_t *ov);
-void hello_set_reactor (hello_t *h, flux_t f);
-
-/* Get/set session size
+/* The flux handle is used
+ * - to obtain flux_rank() and flux_size()
+ * - to send messages to rank 0
+ * - to set up a recurring reactor timer to call hello_cb_f if any
  */
-void hello_set_size (hello_t *h, uint32_t size);
-uint32_t hello_get_size (hello_t *h);
+void hello_set_flux (hello_t *hello, flux_t h);
 
 /* If defined, callback will be called:
  * - when nodeset is complete
  * - every timeout seconds, until nodeset is complete
  */
-void hello_set_cb (hello_t *h, hello_cb_f cb, void *arg);
+void hello_set_callback (hello_t *hello, hello_cb_f cb, void *arg);
 
 /* Set the timeout period.
  * If this is not called, the callback will only be called
  * when the nodeset is complete.  This function may be called
  * with an argument of zero to disable the timeout.
  */
-void hello_set_timeout (hello_t *h, double sec);
+void hello_set_timeout (hello_t *hello, double sec);
 
 /* Get time in seconds elapsed since hello_start()
  */
-double hello_get_time (hello_t *h);
+double hello_get_time (hello_t *hello);
 
 /* Get nodeset string of nodes that have checked in.
  */
-const char *hello_get_nodeset (hello_t *h);
+const char *hello_get_nodeset (hello_t *hello);
 
-/* Get count of nodes that have checked in.
- * Nodeset is complete when hello_get_count() == hello_get_size().
+/* Get completion status
  */
-uint32_t hello_get_count (hello_t *h);
+bool hello_complete (hello_t *hello);
 
 /* Process a received cmb.hello message.
  */
-int hello_recv (hello_t *h, zmsg_t **zmsg);
+int hello_recvmsg (hello_t *hello, const flux_msg_t *msg);
 
 /* Start the hello protocol.
  * On rank 0, enable timer (if timeout value has been set)
  * On ranks > 0, send a cmb.hello message to parent.
  */
-int hello_start (hello_t *h, uint32_t rank);
+int hello_start (hello_t *hello);
+
+/* Hello request encode/decode.
+ * Used internally but exposed for testing.
+ */
+flux_msg_t *hello_encode (int rank);
+int hello_decode (const flux_msg_t *msg, int *rank);
 
 #endif /* !_BROKER_HELLO_H */
 

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -15,7 +15,7 @@ void modhash_destroy (modhash_t *mh);
 
 void modhash_set_zctx (modhash_t *mh, zctx_t *zctx);
 void modhash_set_rank (modhash_t *mh, uint32_t rank);
-void modhash_set_reactor (modhash_t *mh, flux_t h);
+void modhash_set_flux (modhash_t *mh, flux_t h);
 void modhash_set_heartbeat (modhash_t *mh, heartbeat_t *hb);
 
 /* Prepare module at 'path' for starting.
@@ -45,12 +45,12 @@ void module_set_poller_cb (module_t *p, modpoller_cb_f cb, void *arg);
 
 /* Send/recv a message for to/from a specific module.
  */
-zmsg_t *module_recvmsg (module_t *p);
-int module_sendmsg (zmsg_t **zmsg, module_t *p);
+flux_msg_t *module_recvmsg (module_t *p);
+int module_sendmsg (module_t *p, const flux_msg_t *msg);
 
 /* Send an event message to all modules that have matching subscription.
  */
-int module_event_mcast (modhash_t *mh, zmsg_t *zmsg);
+int module_event_mcast (modhash_t *mh, const flux_msg_t *msg);
 
 /* Subscribe/unsubscribe module by uuid
  */
@@ -63,12 +63,12 @@ int module_unsubscribe (modhash_t *mh, const char *uuid, const char *topic);
  * their replies.
  */
 void module_set_rmmod_cb (module_t *p, rmmod_cb_f cb, void *arg);
-zmsg_t *module_pop_rmmod (module_t *p);
+flux_msg_t *module_pop_rmmod (module_t *p);
 
 /* Send a response message to the module whose uuid matches the
  * next hop in the routing stack.
  */
-int module_response_sendmsg (modhash_t *mh, zmsg_t **zmsg);
+int module_response_sendmsg (modhash_t *mh, const flux_msg_t *msg);
 
 /* Find a module matching 'name'.
  * N.B. this is a slow linear search - keep out of crit paths
@@ -84,7 +84,7 @@ int module_start_all (modhash_t *mh);
  * If stop was instigated by an rmmod request, queue the request here
  * for reply once the module actually stops.
  */
-int module_stop (module_t *p, zmsg_t **zmsg);
+int module_stop (module_t *p, const flux_msg_t *msg);
 int module_stop_all (modhash_t *mh);
 
 /* Prepare an 'lsmod' response payload.

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -85,6 +85,7 @@ static void endpoint_destroy (struct endpoint *ep)
         if (ep->w)
             flux_zmq_watcher_destroy (ep->w);
         /* N.B. ep->zp will be cleaned up with zctx_t destroy */
+        free (ep);
     }
 }
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -154,7 +154,7 @@ void overlay_set_rank (overlay_t *ov, uint32_t rank)
     snprintf (ov->rankstr_right, sizeof (ov->rankstr), "%ur", rank);
 }
 
-void overlay_set_reactor (overlay_t *ov, flux_t h)
+void overlay_set_flux (overlay_t *ov, flux_t h)
 {
     ov->h = h;
 }
@@ -225,7 +225,7 @@ const char *overlay_get_parent (overlay_t *ov)
     return ep->uri;
 }
 
-int overlay_sendmsg_parent (overlay_t *ov, zmsg_t **zmsg)
+int overlay_sendmsg_parent (overlay_t *ov, const flux_msg_t *msg)
 {
     struct endpoint *ep = zlist_first (ov->parents);
     int rc = -1;
@@ -237,7 +237,7 @@ int overlay_sendmsg_parent (overlay_t *ov, zmsg_t **zmsg)
             errno = EHOSTUNREACH;
         goto done;
     }
-    rc = zmsg_send (zmsg, ep->zs);
+    rc = flux_msg_sendzsock (ep->zs, msg);
     if (rc == 0)
         ov->parent_lastsent = heartbeat_get_epoch (ov->heartbeat);
 done:
@@ -248,18 +248,18 @@ int overlay_keepalive_parent (overlay_t *ov)
 {
     struct endpoint *ep = zlist_first (ov->parents);
     int idle = heartbeat_get_epoch (ov->heartbeat) - ov->parent_lastsent;
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
     int rc = -1;
 
     if (!ep || !ep->zs || idle <= 1)
         return 0;
-    if (!(zmsg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)))
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)))
         goto done;
-    if (flux_msg_enable_route (zmsg) < 0)
+    if (flux_msg_enable_route (msg) < 0)
         goto done;
-    rc = zmsg_send (&zmsg, ep->zs);
+    rc = flux_msg_sendzsock (ep->zs, msg);
 done:
-    zmsg_destroy (&zmsg);
+    flux_msg_destroy (msg);
     return rc;
 }
 
@@ -273,28 +273,19 @@ void overlay_set_right (overlay_t *ov, const char *fmt, ...)
     va_end (ap);
 }
 
-static bool ring_wrap (overlay_t *ov, zmsg_t *zmsg)
-{
-    zframe_t *zf;
-
-    zf = zmsg_first (zmsg);
-    while (zf && zframe_size (zf) > 0) {
-        if (zframe_streq (zf, ov->rankstr_right)) /* cycle detected! */
-            return true;
-        zf = zmsg_next (zmsg);
-    }
-    return false;
-}
-
-int overlay_sendmsg_right (overlay_t *ov, zmsg_t **zmsg)
+/* If local uuid already appears in the route stack, the message has
+ * already gone round the ring, so return EHOSTUNREACH.
+ */
+int overlay_sendmsg_right (overlay_t *ov, const flux_msg_t *msg)
 {
     int rc = -1;
 
-    if (!ov->right || !ov->right->zs || ring_wrap (ov, *zmsg)) {
+    if (!ov->right || !ov->right->zs
+                   || flux_msg_has_route (msg, ov->rankstr_right)) {
         errno = EHOSTUNREACH;
         goto done;
     }
-    rc = zmsg_send (zmsg, ov->right->zs);
+    rc = flux_msg_sendzsock (ov->right->zs, msg);
 done:
     return rc;
 }
@@ -328,7 +319,7 @@ void overlay_set_child_cb (overlay_t *ov, overlay_cb_f cb, void *arg)
     ov->child_arg = arg;
 }
 
-int overlay_sendmsg_child (overlay_t *ov, zmsg_t **zmsg)
+int overlay_sendmsg_child (overlay_t *ov, const flux_msg_t *msg)
 {
     int rc = -1;
 
@@ -336,14 +327,14 @@ int overlay_sendmsg_child (overlay_t *ov, zmsg_t **zmsg)
         errno = EINVAL;
         goto done;
     }
-    rc = zmsg_send (zmsg, ov->child->zs);
+    rc = flux_msg_sendzsock (ov->child->zs, msg);
 done:
     return rc;
 }
 
-int overlay_mcast_child (overlay_t *ov, zmsg_t *zmsg)
+int overlay_mcast_child (overlay_t *ov, const flux_msg_t *msg)
 {
-    zmsg_t *cpy = NULL;
+    flux_msg_t *cpy = NULL;
     zlist_t *uuids = NULL;
     char *uuid;
     int rc = -1;
@@ -356,22 +347,23 @@ int overlay_mcast_child (overlay_t *ov, zmsg_t *zmsg)
     while (uuid) {
         child_t *child = zhash_lookup (ov->children, uuid);
         if (child && !child->mute) {
-            if (!(cpy = zmsg_dup (zmsg)))
+            if (!(cpy = flux_msg_copy (msg, true)))
                 oom ();
             if (flux_msg_enable_route (cpy) < 0)
                 goto done;
             if (flux_msg_push_route (cpy, uuid) < 0)
                 goto done;
-            if (zmsg_send (&cpy, ov->child->zs) < 0)
+            if (flux_msg_sendzsock (ov->child->zs, cpy) < 0)
                 goto done;
-            zmsg_destroy (&cpy);
+            flux_msg_destroy (cpy);
+            cpy = NULL;
         }
         uuid = zlist_next (uuids);
     }
     rc = 0;
 done:
     zlist_destroy (&uuids);
-    zmsg_destroy (&cpy);
+    flux_msg_destroy (cpy);
     return rc;
 }
 
@@ -400,46 +392,53 @@ void overlay_set_event_cb (overlay_t *ov, overlay_cb_f cb, void *arg)
     ov->event_arg = arg;
 }
 
-int overlay_sendmsg_event (overlay_t *ov, zmsg_t *zmsg)
+int overlay_sendmsg_event (overlay_t *ov, const flux_msg_t *msg)
 {
     int rc = -1;
-    zmsg_t *cpy = NULL;
+    flux_msg_t *cpy = NULL;
 
     if (!ov->event || !ov->event->zs)
         return 0;
-    if (!(cpy = zmsg_dup (zmsg)))
-        oom ();
     if (ov->event_munge) {
+        if (!(cpy = flux_msg_copy (msg, true)))
+            oom ();
         if (flux_sec_munge_zmsg (ov->sec, &cpy) < 0) {
             errno = EIO;
             goto done;
         }
+        if (flux_msg_sendzsock (ov->event->zs, cpy) < 0)
+            goto done;
+    } else {
+        if (flux_msg_sendzsock (ov->event->zs, msg) < 0)
+            goto done;
     }
-    rc = zmsg_send (&cpy, ov->event->zs);
+    rc = 0;
 done:
-    zmsg_destroy (&cpy);
+    flux_msg_destroy (cpy);
     return rc;
 }
 
-zmsg_t *overlay_recvmsg_event (overlay_t *ov)
+flux_msg_t *overlay_recvmsg_event (overlay_t *ov)
 {
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
     if (!ov->event || !ov->event->zs) {
         errno = EINVAL;
         goto done;
     }
-    zmsg = zmsg_recv (ov->event->zs);
+    if (!(msg = flux_msg_recvzsock (ov->event->zs)))
+        goto done;
     if (ov->event_munge) {
-        if (flux_sec_unmunge_zmsg (ov->sec, &zmsg) < 0) {
+        if (flux_sec_unmunge_zmsg (ov->sec, &msg) < 0) {
             //flux_log (ctx->h, LOG_ERR, "dropping malformed event: %s",
             //          flux_sec_errstr (ctx->sec));
-            zmsg_destroy (&zmsg);
+            flux_msg_destroy (msg);
+            msg = NULL;
             errno = EPROTO;
             goto done;
         }
     }
 done:
-    return zmsg;
+    return msg;
 }
 
 void overlay_set_relay (overlay_t *ov, const char *fmt, ...)
@@ -459,20 +458,16 @@ const char *overlay_get_relay (overlay_t *ov)
     return ov->relay->uri;
 }
 
-int overlay_sendmsg_relay (overlay_t *ov, zmsg_t *zmsg)
+int overlay_sendmsg_relay (overlay_t *ov, const flux_msg_t *msg)
 {
     int rc = -1;
-    zmsg_t *cpy = NULL;
 
     if (!ov->relay || !ov->relay->zs) {
         errno = EINVAL;
         goto done;
     }
-    if (!(cpy = zmsg_dup (zmsg)))
-        oom ();
-    rc = zmsg_send (&cpy, ov->relay->zs);
+    rc = flux_msg_sendzsock (ov->relay->zs, msg);
 done:
-    zmsg_destroy (&cpy);
     return rc;
 }
 

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -12,7 +12,7 @@ void overlay_destroy (overlay_t *ov);
 void overlay_set_sec (overlay_t *ov, flux_sec_t sec);
 void overlay_set_zctx (overlay_t *ov, zctx_t *zctx);
 void overlay_set_rank (overlay_t *ov, uint32_t rank);
-void overlay_set_reactor (overlay_t *ov, flux_t h);
+void overlay_set_flux (overlay_t *ov, flux_t h);
 void overlay_set_heartbeat (overlay_t *ov, heartbeat_t *h);
 
 /* All ranks but rank 0 connect to a parent to form the main TBON.
@@ -29,8 +29,8 @@ void overlay_push_parent (overlay_t *ov, const char *fmt, ...);
 const char *overlay_get_parent (overlay_t *ov);
 void overlay_set_right (overlay_t *ov, const char *fmt, ...);
 void overlay_set_parent_cb (overlay_t *ov, overlay_cb_f cb, void *arg);
-int overlay_sendmsg_parent (overlay_t *ov, zmsg_t **zmsg);
-int overlay_sendmsg_right (overlay_t *ov, zmsg_t **zmsg);
+int overlay_sendmsg_parent (overlay_t *ov, const flux_msg_t *msg);
+int overlay_sendmsg_right (overlay_t *ov, const flux_msg_t *msg);
 int overlay_keepalive_parent (overlay_t *ov);
 
 /* The child is where other ranks connect to send requests.
@@ -39,14 +39,14 @@ int overlay_keepalive_parent (overlay_t *ov);
 void overlay_set_child (overlay_t *ov, const char *fmt, ...);
 const char *overlay_get_child (overlay_t *ov);
 void overlay_set_child_cb (overlay_t *ov, overlay_cb_f cb, void *arg);
-int overlay_sendmsg_child (overlay_t *ov, zmsg_t **zmsg);
+int overlay_sendmsg_child (overlay_t *ov, const flux_msg_t *msg);
 /* We can "multicast" events to all child peers using mcast_child().
  * It walks the 'children' hash, finding overlay peers that have not
- * yet been "muted", and routes them a copy of zmsg.  The broker Cc's
+ * yet been "muted", and routes them a copy of msg.  The broker Cc's
  * events over the TBON using this until peers indicate that they are
  * receiving duplicate seq numbers through the normal event socket.
  */
-int overlay_mcast_child (overlay_t *ov, zmsg_t *zmsg);
+int overlay_mcast_child (overlay_t *ov, const flux_msg_t *msg);
 void overlay_mute_child (overlay_t *ov, const char *uuid);
 
 /* Call when message is received from child 'uuid'.
@@ -63,8 +63,8 @@ json_object *overlay_lspeer_encode (overlay_t *ov);
 void overlay_set_event (overlay_t *ov, const char *fmt, ...);
 const char *overlay_get_event (overlay_t *ov);
 void overlay_set_event_cb (overlay_t *ov, overlay_cb_f cb, void *arg);
-int overlay_sendmsg_event (overlay_t *ov, zmsg_t *zmsg);
-zmsg_t *overlay_recvmsg_event (overlay_t *ov);
+int overlay_sendmsg_event (overlay_t *ov, const flux_msg_t *msg);
+flux_msg_t *overlay_recvmsg_event (overlay_t *ov);
 
 /* Since an epgm:// endpoint only allows one subscriber per node,
  * when there are multiple ranks per node, arrangements must be made
@@ -74,7 +74,7 @@ zmsg_t *overlay_recvmsg_event (overlay_t *ov);
  */
 void overlay_set_relay (overlay_t *ov, const char *fmt, ...);
 const char *overlay_get_relay (overlay_t *ov);
-int overlay_sendmsg_relay (overlay_t *ov, zmsg_t *zmsg);
+int overlay_sendmsg_relay (overlay_t *ov, const flux_msg_t *msg);
 
 /* Establish connections.
  * These functions are idempotent as the bind may need to be called

--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -1,24 +1,70 @@
 #ifndef _BROKER_SHUTDOWN_H
 #define _BROKER_SHUTDOWN_H
 
-typedef struct shutdown_struct shutdown_t;
+/* Manage the shutdown process for the comms session.
+ *
+ * Design:
+ * The receipt of a "cmb.shutdown" event simultaneously initiates the
+ * clean shutdown path in the broker and arms the shutdown timer here.
+ * If the clean shutdown path succeedes, it calls shutdown_disarm() to
+ * disarm the timer before exiting.  Otherwise, the timer expires, calling
+ * the shutdown callback, which calls exit(3).
+ *
+ * Actual state of affairs:
+ * There is no clean shutdown path.  The grace period allows the comms
+ * session to propagate the shutdown event, the timer expires, and all
+ * ranks exit(3).
+ */
 
+typedef struct shutdown_struct shutdown_t;
+typedef void (*shutdown_cb_f)(shutdown_t *s, void *arg);
+
+/* Create/destroy shutdown_t.
+ */
 shutdown_t *shutdown_create (void);
 void shutdown_destroy (shutdown_t *s);
 
+/* Set the flux_t handle to be used to configure the grace timer watcher
+ * and log the shutdown message.
+ */
 void shutdown_set_handle (shutdown_t *s, flux_t h);
 
-/* Any rank can call shutdown_arm() to initiate shutdown after 'grace'
- * seconds.  This generates a session-wide event which is then fed into
- * shutdown_recvmsg() on each rank, which starts the grace timeout.
- * The broker should perform graceful teardown then call shutdown_complete()
- * to disarm the timer.  If it fails to do that within the grace period,
- * the timeout handler will cal exit(rc), provided the event loop is
- * still running.
+/* Reigster a shutdown callback to be called when the grace timeout
+ * expires.  It is expected to call exit(3).
  */
-void shutdown_complete (shutdown_t *s);
-void shutdown_recvmsg (shutdown_t *s, zmsg_t *zmsg);
-void shutdown_arm (shutdown_t *s, double grace, int rc, const char *fmt, ...);
+void shutdown_set_callback (shutdown_t *s, shutdown_cb_f cb, void *arg);
+
+/* Shutdown callback may call this to obtain the broker exit code
+ * encoded in the shutdown event.
+ */
+int shutdown_get_rc (shutdown_t *s);
+
+/* Call shutdown recvmsg() on receipt of "cmb.shutdown" event.
+ * This arms the timer.  On rank 0 it also logs the shutdown message e.g.
+ * "broker: shutdown in 2s: reason..."
+ */
+int shutdown_recvmsg (shutdown_t *s, const flux_msg_t *msg);
+
+/* Call shutdown_arm() when shutdown should begin.
+ * This sends the "cmb.shutdown" event to all ranks.
+ */
+int shutdown_arm (shutdown_t *s, double grace, int rc, const char *fmt, ...);
+
+/* Call shutdown_disarm() once the clean shutdown path has succeeded.
+ * This disarms the timer on the local rank only.
+ */
+void shutdown_disarm (shutdown_t *s);
+
+/* Shutdown event encode/decode
+ * (used internally, exposed for testing)
+ */
+flux_msg_t *shutdown_vencode (double grace, int rc, int rank,
+                              const char *fmt, va_list ap);
+flux_msg_t *shutdown_encode (double grace, int rc, int rank,
+                             const char *fmt, ...);
+int shutdown_decode (const flux_msg_t *msg, double *grace, int *rc, int *rank,
+                     char *reason, int reason_len);
+
 
 #endif /* !_BROKER_SHUTDOWN_H */
 

--- a/src/broker/snoop.c
+++ b/src/broker/snoop.c
@@ -80,7 +80,7 @@ static int snoop_bind (snoop_t *sn)
     int rc = -1;
     if (!(sn->zs = zsocket_new (sn->zctx, ZMQ_PUB)))
         goto done;
-    if (flux_sec_ssockinit (sn->sec, sn->zs) < 0) {
+    if (sn->sec && flux_sec_ssockinit (sn->sec, sn->zs) < 0) {
         //msg ("flux_sec_ssockinit: %s", flux_sec_errstr (sn->sec));
         goto done;
     }
@@ -105,18 +105,11 @@ const char *snoop_get_uri (snoop_t *sn)
     return sn->uri;
 }
 
-int snoop_sendmsg (snoop_t *sn, zmsg_t *zmsg)
+int snoop_sendmsg (snoop_t *sn, const flux_msg_t *msg)
 {
-    int rc = -1;
-    zmsg_t *cpy = NULL;
-
     if (!sn->zs)
         return 0;
-    if (!(cpy = zmsg_dup (zmsg)))
-        oom ();
-    rc = zmsg_send (&cpy, sn->zs);
-    zmsg_destroy (&cpy);
-    return rc;
+    return flux_msg_sendzsock (sn->zs, msg);
 }
 
 /*

--- a/src/broker/snoop.h
+++ b/src/broker/snoop.h
@@ -1,6 +1,26 @@
 #ifndef _BROKER_SNOOP_H
 #define _BROKER_SNOOP_H
 
+/* Manage the broker "snoop socket" which is created on demand.
+ * Call snoop_create(), then
+ * snoop_set_sec()   - (optional) if security is enabled
+ * snoop_set_zctx()  - broker zctx_t needed for socket creation
+ * snoop_set_uri()   - socket URI or wildcard
+
+ * Until snoop_get_uri() is called, the PUB socket is not created and
+ * calls to snoop_sendmsg() are a no-op.
+
+ * When flux-snoop(1) requests the snoop socket URI from the broker,
+ * the broker calls snoop_get_uri() which binds the socket on the first call.
+ * Thereafter, snoop_sendmsg() publishes messages on the snoop socket.
+ *
+ * If it is a wildcard, snoop_get_uri() will return the
+ * actual URI after the socket has been bound, not the wildcard.
+ *
+ * If the snoop socket is an ipc:// socket, it is cleaned up through an
+ * exit handler.
+ */
+
 typedef struct snoop_struct snoop_t;
 
 snoop_t *snoop_create (void);
@@ -8,17 +28,10 @@ void snoop_destroy (snoop_t *sn);
 
 void snoop_set_sec (snoop_t *sn, flux_sec_t sec);
 void snoop_set_zctx (snoop_t *sn, zctx_t *zctx);
-
-/* Get/set snoop uri.  The set argument may be a URI wildcard.
- * The get triggers bind and resolution of URI wildcard on first use.
- */
 void snoop_set_uri (snoop_t *sn, const char *uri);
-const char *snoop_get_uri (snoop_t *sn);
 
-/* If snoop socket has not been bound, no-op (return 0).
- * Otherwise duplicate 'zmsg' and send it.
- */
-int snoop_sendmsg (snoop_t *sn, zmsg_t *zmsg);
+const char *snoop_get_uri (snoop_t *sn);
+int snoop_sendmsg (snoop_t *sn, const flux_msg_t *msg);
 
 #endif /* !_BROKER_SNOOP_H */
 

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -1,0 +1,117 @@
+#include <flux/core.h>
+#include <czmq.h>
+#include <stdio.h>
+
+#include "heartbeat.h"
+
+#include "src/common/libtap/tap.h"
+
+void fatal_err (const char *message, void *arg)
+{
+    BAIL_OUT ("fatal error: %s", message);
+}
+
+void heartbeat_cb (heartbeat_t *hb, void *arg)
+{
+    static int prev_epoch = -1;
+    int epoch = heartbeat_get_epoch (hb);
+
+    ok (prev_epoch == -1 || prev_epoch + 1 == epoch,
+        "heartbeat callback invoked, epoch %d (last %d)", epoch, prev_epoch);
+    prev_epoch = epoch;
+}
+
+void heartbeat_event_cb (flux_t h, flux_msg_watcher_t *w,
+                          const flux_msg_t *msg, void *arg)
+{
+    heartbeat_t *hb = arg;
+    int epoch = -1;
+    int rc = flux_heartbeat_decode (msg, &epoch);
+
+    ok (rc == 0 && heartbeat_recvmsg (hb, msg) == 0,
+        "flux_heartbeat_recvmsg works, epoch %d", epoch);
+    if (epoch == 2) {
+        flux_msg_watcher_stop (h, w);
+        heartbeat_stop (hb);
+    }
+}
+
+void check_codec (void)
+{
+    flux_msg_t *msg;
+    int epoch;
+
+    ok ((msg = flux_heartbeat_encode (44000)) != NULL,
+        "flux_heartbeat_encode works");
+    ok (flux_heartbeat_decode (msg, &epoch) == 0 && epoch == 44000,
+        "flux_heartbeat_decode works and returns encoded epoch");
+    flux_msg_destroy (msg);
+}
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    heartbeat_t *hb;
+    flux_msg_watcher_t *w;
+    struct flux_match matchev = FLUX_MATCH_EVENT;
+
+    plan (21);
+
+    check_codec ();
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    flux_fatal_set (h, fatal_err, NULL);
+
+    ok ((hb = heartbeat_create ()) != NULL,
+        "heartbeat_create works");
+
+    heartbeat_set_flux (hb, h);
+    heartbeat_set_callback (hb, heartbeat_cb, NULL);
+
+    ok (heartbeat_get_rate (hb) == 2.,
+        "heartbeat_get_rate returns default of 2s");
+    errno = 0;
+    ok (heartbeat_set_rate (hb, -1) < 1 && errno == EINVAL,
+        "heartbeat_set_rate -1 fails with EINVAL");
+    errno = 0;
+    ok (heartbeat_set_rate (hb, 1000000) < 1 && errno == EINVAL,
+        "heartbeat_set_rate 1000000 fails with EINVAL");
+    ok (heartbeat_set_ratestr (hb, "250ms") == 0,
+        "heartbeat_set_ratestr 250ms works");
+    ok (heartbeat_get_rate (hb) == 0.250,
+        "heartbeat_get_rate returns what was set");
+    ok (heartbeat_set_rate (hb, 0.1) == 0,
+        "heartbeat_set_rate 0.1 works");
+    ok (heartbeat_get_rate (hb) == 0.1,
+        "heartbeat_get_rate returns what was set");
+
+    ok (heartbeat_get_epoch (hb) == 0,
+        "heartbeat_get_epoch works, default is zero");
+
+
+    w = flux_msg_watcher_create (matchev, heartbeat_event_cb, hb);
+    ok (w != NULL,
+        "created event watcher");
+    flux_msg_watcher_start (h, w);
+
+    ok (heartbeat_start (hb) == 0,
+        "heartbeat_start works");
+
+    ok (flux_reactor_start (h) == 0,
+        "flux reactor exited normally");
+
+    heartbeat_destroy (hb);
+    flux_msg_watcher_destroy (w);
+    flux_close (h);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -1,0 +1,143 @@
+#include <flux/core.h>
+#include <czmq.h>
+#include <stdio.h>
+
+#include "hello.h"
+
+#include "src/common/libtap/tap.h"
+
+void fatal_err (const char *message, void *arg)
+{
+    BAIL_OUT ("fatal error: %s", message);
+}
+
+static int hello_count = 0;
+void hello_cb (hello_t *hello, void *arg)
+{
+    char *prefix = arg;
+    ok (hello_complete (hello) == true,
+        "%s: hello_complete returned true: %s", prefix,
+        hello_get_nodeset (hello));
+    hello_count++;
+}
+
+static int hello_request = 0;
+void hello_request_cb (flux_t h, flux_msg_watcher_t *w,
+                       const flux_msg_t *msg, void *arg)
+{
+    hello_t *hello = arg;
+    int rank;
+    int rc = hello_decode (msg, &rank);
+
+    ok (rc == 0 && hello_recvmsg (hello, msg) == 0,
+        "size=3: hello_recvmsg works, rank %d", rank);
+    if (rank == 2)
+        flux_msg_watcher_stop (h, w);
+    hello_request++;
+}
+
+void check_codec (void)
+{
+    flux_msg_t *msg;
+    int rank;
+
+    ok ((msg = hello_encode (42)) != NULL,
+        "hello_encode works");
+    ok (hello_decode (msg, &rank) == 0 && rank == 42,
+        "hello_decode works, returns encoded rank");
+    flux_msg_destroy (msg);
+}
+
+void check_size1 (flux_t h)
+{
+    hello_t *hello;
+    char *prefix = "size=1";
+
+    hello_count = 0;
+    ok ((hello = hello_create ()) != NULL,
+        "%s: hello_create works", prefix);
+    hello_set_flux (hello, h);
+    hello_set_callback (hello, hello_cb, prefix);
+    hello_set_timeout (hello, 0.1);
+    ok (hello_start (hello) == 0,
+        "%s: hello_start works", prefix);
+    ok (hello_count == 1,
+        "%s: hello callback was called once", prefix);
+
+    hello_destroy (hello);
+}
+
+void check_size3 (flux_t h)
+{
+    hello_t *hello;
+    flux_msg_watcher_t *w;
+    struct flux_match match = FLUX_MATCH_ANY;
+    uint32_t size = 3;
+    uint32_t rank = 0;
+    char *prefix = "size=3";
+
+    flux_aux_set (h, "flux::size", &size, NULL);
+    flux_aux_set (h, "flux::rank", &rank, NULL);
+
+    hello_count = hello_request = 0;
+    ok ((hello = hello_create ()) != NULL,
+        "%s: hello_create works", prefix);
+    hello_set_flux (hello, h);
+    hello_set_callback (hello, hello_cb, prefix);
+    hello_set_timeout (hello, 0.1);
+
+    match.typemask = FLUX_MSGTYPE_REQUEST;
+    w = flux_msg_watcher_create (match, hello_request_cb, hello);
+    ok (w != NULL,
+        "%s: created cmb.hello watcher", prefix);
+    flux_msg_watcher_start (h, w);
+
+    flux_aux_set (h, "flux::rank", &rank, NULL);
+    ok (hello_start (hello) == 0,
+        "%s: (rank 0) hello_start works", prefix);
+
+    rank = 1;
+    flux_aux_set (h, "flux::rank", &rank, NULL);
+    ok (hello_start (hello) == 0,
+        "%s: (rank 1) hello_start works", prefix);
+
+    rank = 2;
+    flux_aux_set (h, "flux::rank", &rank, NULL);
+    ok (hello_start (hello) == 0,
+        "%s: (rank 2) hello_start works", prefix);
+
+    ok (flux_reactor_start (h) == 0,
+        "%s: flux reactor exited normally", prefix);
+
+    flux_msg_watcher_destroy (w);
+    hello_destroy (hello);
+}
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+
+    plan (2+1+4+9);
+
+    check_codec (); // 2
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    flux_fatal_set (h, fatal_err, NULL);
+
+    check_size1 (h); // 4
+
+    check_size3 (h); // 9
+
+    flux_close (h);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -1,0 +1,123 @@
+#include <flux/core.h>
+#include <czmq.h>
+#include <stdio.h>
+
+#include "shutdown.h"
+
+#include "src/common/libtap/tap.h"
+
+void fatal_err (const char *message, void *arg)
+{
+    BAIL_OUT ("fatal error: %s", message);
+}
+
+void shutdown_cb (shutdown_t *s, void *arg)
+{
+    int rc = shutdown_get_rc (s);
+
+    ok (rc == 42,
+        "shutodwn callback retrieved exitcode");
+}
+
+void log_request_cb (flux_t h, flux_msg_watcher_t *w,
+                     const flux_msg_t *msg, void *arg)
+{
+    ok (msg != NULL,
+        "shutdown log message from rank 0 received");
+    flux_msg_watcher_stop (h, w);
+}
+
+void shutdown_event_cb (flux_t h, flux_msg_watcher_t *w,
+                        const flux_msg_t *msg, void *arg)
+{
+    shutdown_t *sh = arg;
+    char r[256];
+    int rank, exitcode;
+    double grace;
+
+    ok (shutdown_decode (msg, &grace, &exitcode, &rank, r, sizeof (r)) == 0
+        && grace == 0.1 && exitcode == 42 && rank == 0
+        && !strcmp (r, "testing 1 2 3"),
+        "shutdown event received and decoded");
+    ok (shutdown_recvmsg (sh, msg) == 0,
+        "shutdown_recvmsg works");
+    flux_msg_watcher_stop (h, w);
+}
+
+void check_codec (void)
+{
+    flux_msg_t *msg;
+    char r[256];
+    int rank, exitcode;
+    double grace;
+
+    ok ((msg = shutdown_encode (3.14, 69, 41, "%s", "foo")) != NULL,
+        "shutdown_encode works");
+    ok (shutdown_decode (msg, &grace, &exitcode, &rank, r, sizeof (r)) == 0
+        && grace == 3.14 && exitcode == 69 && rank ==41 
+        && !strcmp (r, "foo"),
+        "shutdown_decode works");
+}
+
+int main (int argc, char **argv)
+{
+    flux_t h;
+    shutdown_t *sh;
+    flux_msg_watcher_t *log_w, *ev_w;
+    struct flux_match matchev = FLUX_MATCH_EVENT;
+    struct flux_match matchlog = FLUX_MATCH_ANY;
+
+    plan (14);
+
+    check_codec ();
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    flux_fatal_set (h, fatal_err, NULL);
+
+    ok ((sh = shutdown_create ()) != NULL,
+        "shutdown_create works");    
+    shutdown_set_handle (sh, h);
+    shutdown_set_callback (sh, shutdown_cb, NULL);
+
+    ev_w = flux_msg_watcher_create (matchev, shutdown_event_cb, sh);
+    ok (ev_w != NULL,
+        "created event watcher");
+    flux_msg_watcher_start (h, ev_w);
+
+    matchlog.topic_glob = "cmb.log";
+    matchlog.typemask = FLUX_MSGTYPE_REQUEST;
+    log_w = flux_msg_watcher_create (matchlog, log_request_cb, sh);
+    ok (log_w != NULL,
+        "created log request watcher");
+    flux_msg_watcher_start (h, log_w);
+
+    ok (shutdown_arm (sh, 0.1, 42, "testing %d %d %d", 1, 2, 3) == 0,
+        "shutdown event sent, starting reactor");
+    ok (flux_reactor_start (h) == 0,
+        "flux reactor exited normally");
+
+    /* Make sure shutdown_disarm unwires timer.
+     * (other watchers have already stopped themselves above)
+     */
+    ok (shutdown_arm (sh, 0.1, 42, "testing %d %d %d", 1, 2, 3) == 0,
+        "shutdown event sent, then disarmed, starting reactor");
+    shutdown_disarm (sh);
+    ok (flux_reactor_start (h) == 0,
+        "flux reactor exited normally");
+
+    shutdown_destroy (sh);
+    flux_msg_watcher_destroy (ev_w);
+    flux_msg_watcher_destroy (log_w);
+    flux_close (h);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/broker/test/snoop.c
+++ b/src/broker/test/snoop.c
@@ -1,0 +1,70 @@
+#include <flux/core.h>
+#include <czmq.h>
+#include <stdio.h>
+
+#include "snoop.h"
+
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char **argv)
+{
+    snoop_t *snoop;
+    zctx_t *zctx;
+    const char *uri;
+    void *zs;
+    flux_msg_t *msg, *msg2;
+    int type, rc;
+
+    plan (7);
+
+    ok ((zctx = zctx_new ()) != NULL,
+        "zctx_new works");
+    ok ((snoop = snoop_create()) != NULL,
+        "snoop_create works");
+
+    snoop_set_zctx (snoop, zctx);
+    snoop_set_uri (snoop, "ipc://*");
+
+    ok ((uri = snoop_get_uri (snoop)) != NULL
+        && strcmp (uri, "ipc://*") != 0,
+        "snoop_get_uri works");
+
+    ok ((zs = zsocket_new (zctx, ZMQ_SUB))
+        && zsocket_connect (zs, "%s", uri) == 0,
+        "connected to snoop socket %s", uri);
+    zsocket_set_subscribe (zs, "");
+
+    /* connect is asynchronous and messages prior to connect/subscribe
+     * will be dropped on sender, so send messages until snoop socket
+     * starts receiving
+     */
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
+        "created test message");
+
+    rc = 0;
+    while (rc == 0) {
+        zmq_pollitem_t zp = { .socket = zs, .events = ZMQ_POLLIN };
+        if ((rc = snoop_sendmsg (snoop, msg)) < 0)
+            break;
+        if ((rc = zmq_poll (&zp, 1, 1)) < 0) /* 1ms timeout */
+            break;
+    }
+    ok (rc == 1,
+        "snoop socket is finally ready");
+    ok ((msg2 = flux_msg_recvzsock (zs)) != NULL
+        && flux_msg_get_type (msg2, &type) == 0
+        && type == FLUX_MSGTYPE_REQUEST,
+        "received test message on snoop socket");
+   
+    flux_msg_destroy (msg); 
+    flux_msg_destroy (msg2); 
+    snoop_destroy (snoop);
+    zctx_destroy (&zctx);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -29,7 +29,8 @@ fluxcoreinclude_HEADERS = \
 	info.h \
 	flog.h \
 	conf.h \
-	tmpdir.h
+	tmpdir.h \
+	heartbeat.h
 
 noinst_LTLIBRARIES = \
 	libflux.la
@@ -54,7 +55,8 @@ libflux_la_SOURCES = \
 	tagpool.c \
 	ev_flux.h \
 	ev_flux.c \
-	tmpdir.c
+	tmpdir.c \
+	heartbeat.c
 
 libflux_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
 

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -18,6 +18,7 @@
 #include "flog.h"
 #include "conf.h"
 #include "tmpdir.h"
+#include "heartbeat.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/heartbeat.c
+++ b/src/common/libflux/heartbeat.c
@@ -1,0 +1,68 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+
+#include "event.h"
+#include "message.h"
+
+#include "src/common/libutil/shortjson.h"
+
+flux_msg_t *flux_heartbeat_encode (int epoch)
+{
+    flux_msg_t *msg;
+    JSON o = Jnew ();
+
+    Jadd_int (o, "epoch", epoch);
+    msg = flux_event_encode ("hb", Jtostr (o));
+    Jput (o);
+    return msg;
+}
+
+int flux_heartbeat_decode (const flux_msg_t *msg, int *epoch)
+{
+    const char *json_str, *topic_str;
+    JSON out = NULL;
+    int rc = -1;
+
+    if (flux_event_decode (msg, &topic_str, &json_str) < 0)
+        goto done;
+    if (strcmp (topic_str, "hb") != 0 || !(out = Jfromstr (json_str))
+                                      || !Jget_int (out, "epoch", epoch)) {
+        errno = EPROTO;
+        goto done;
+    }
+    rc = 0;
+done:
+    Jput (out);
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/heartbeat.h
+++ b/src/common/libflux/heartbeat.h
@@ -1,0 +1,14 @@
+#ifndef _FLUX_CORE_HEARTBEAT
+#define _FLUX_CORE_HEARTBEAT
+
+#include "message.h"
+
+flux_msg_t *flux_heartbeat_encode (int epoch);
+int flux_heartbeat_decode (const flux_msg_t *msg, int *epoch);
+
+#endif /* !_FLUX_CORE_HEARTBEAT */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -606,6 +606,20 @@ int flux_msg_get_route_count (const flux_msg_t *msg)
     return count;
 }
 
+bool flux_msg_has_route (const flux_msg_t *msg, const char *s)
+{
+    zmsg_t *zmsg = (zmsg_t *)msg; /* drop const qualifier */
+    zframe_t *zf;
+
+    zf = zmsg_first (zmsg);
+    while (zf && zframe_size (zf) > 0) {
+        if (zframe_streq (zf, s))
+            return true;
+        zf = zmsg_next (zmsg);
+    }
+    return false;
+}
+
 /* Get sum of size in bytes of route frames
  */
 static int flux_msg_get_route_size (const flux_msg_t *msg)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -226,6 +226,9 @@ int flux_msg_get_route_count (const flux_msg_t *msg);
  */
 char *flux_msg_get_route_string (const flux_msg_t *msg);
 
+/* Return true if route stack contains a frame matching 's'
+ */
+bool flux_msg_has_route (const flux_msg_t *msg, const char *s);
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -139,7 +139,7 @@ int flux_msg_set_payload_json (flux_msg_t *msg, const char *json_str);
 int flux_msg_get_payload_json (const flux_msg_t *msg, const char **json_str);
 
 /* Get/set nodeid (request only)
- * If flags includes FLUX_NODEID_UPSTREAM, nodeid is the sending rank.
+ * If flags includes FLUX_MSGFLAG_UPSTREAM, nodeid is the sending rank.
  * FLUX_NODEID_UPSTREAM is a stand in for this flag + sending rank in
  * higher level functions (not to be used here).
  */

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -88,6 +88,16 @@ int flux_msg_sendfd (int fd, const flux_msg_t *msg,
  */
 flux_msg_t *flux_msg_recvfd (int fd, struct flux_msg_iobuf *iobuf);
 
+/* Send message to zeromq socket.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int flux_msg_sendzsock (void *dest, const flux_msg_t *msg);
+
+/* Receive a message from zeromq socket.
+ * Returns message on success, NULL on failure with errno set.
+ */
+flux_msg_t *flux_msg_recvzsock (void *dest);
+
 /* Initialize iobuf members.
  */
 void flux_msg_iobuf_init (struct flux_msg_iobuf *iobuf);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -888,12 +888,8 @@ static int dropcache_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 static int hb_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
-    const char *json_str;
-    json_object *event = NULL;
 
-    if (flux_event_decode (*zmsg, NULL, &json_str) < 0
-                || !(event = Jfromstr (json_str))
-                || util_json_object_get_int (event, "epoch", &ctx->epoch) < 0) {
+    if (flux_heartbeat_decode (*zmsg, &ctx->epoch) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -911,8 +907,6 @@ static int hb_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         expire_cache (ctx, max_lastuse_age);
     }
 done:
-    if (event)
-        json_object_put (event);
     return 0;
 }
 

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -429,16 +429,12 @@ static void cstate_change (ctx_t *ctx, child_t *c, cstate_t newstate)
 static int hb_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
-    const char *json_str;
-    JSON event = NULL;
     char *peers_str = NULL;
     JSON peers = NULL;
     zlist_t *keys = NULL;
     char *key;
 
-    if (flux_event_decode (*zmsg, NULL, &json_str) < 0
-            || !(event = Jfromstr (json_str))
-            || !Jget_int (event, "epoch", &ctx->epoch)) {
+    if (flux_heartbeat_decode (*zmsg, &ctx->epoch) < 0) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
@@ -484,7 +480,6 @@ static int hb_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 done:
     if (keys)
         zlist_destroy (&keys);
-    Jput (event);
     Jput (peers);
     if (peers_str)
         free (peers_str);


### PR DESCRIPTION
This is not quite ready but I wanted to get it posted for early review.

This PR adds `flux_msg_sendzsock()` which takes a `const flux_msg_t *` argument.  This facilitates 
migration from `zmsg_send()` and its "destroy message on success" behavior.

The broker private classes, especially those for handling the overlay networks and comms modules, were converted, and in the process several spots where messages had to be duplicated in order to avoid getting them destroyed by `zmsg_send()` were revisted and copies avoided.  Probably not any big performance gains here but perhaps a little (I did not attempt to measure this).

This also moves some of our internals to the new `flux_msg_t` API.  A `flux_msg_recvzsock()` to match the sending function was added, as was `flux_msg_has_route()` which allowed some zframe munging to detect cycles in the ring network to be dropped from the broker.

Still todo:
* unit tests for broker private classes that changed
* convert the service class
* spend some more time cleaning up the broker routing logic