### PR TITLE
update FLUX_MATCH_* initializers

### DIFF
--- a/doc/man3/tevent.c
+++ b/doc/man3/tevent.c
@@ -5,14 +5,13 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_msg_t *msg;
-    struct flux_match match = FLUX_MATCH_EVENT;
     const char *topic;
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
     if (flux_event_subscribe (h, "hb") < 0)
         err_exit ("flux_event_subscribe");
-    if (!(msg = flux_recv (h, match, 0)))
+    if (!(msg = flux_recv (h, FLUX_MATCH_EVENT, 0)))
         err_exit ("flux_recv");
     if (flux_msg_get_topic (msg, &topic) < 0)
         err_exit ("flux_msg_get_topic");

--- a/doc/man3/trecv.c
+++ b/doc/man3/trecv.c
@@ -5,7 +5,6 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_msg_t *msg;
-    struct flux_match match = FLUX_MATCH_EVENT;
     const char *topic;
 
     if (!(h = flux_open (NULL, 0)))
@@ -13,7 +12,7 @@ int main (int argc, char **argv)
     if (flux_event_subscribe (h, "") < 0)
         err_exit ("flux_event_subscribe");
     for (;;) {
-        if ((msg = flux_recv (h, match, 0)))
+        if ((msg = flux_recv (h, FLUX_MATCH_EVENT, 0)))
             err_exit ("flux_recv");
         if (flux_msg_get_topic (msg, &topic) < 0)
             err_exit ("flux_msg_get_topic");

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -53,7 +53,6 @@ int main (int argc, char **argv)
     flux_t h;
     heartbeat_t *hb;
     flux_msg_watcher_t *w;
-    struct flux_match matchev = FLUX_MATCH_EVENT;
 
     plan (21);
 
@@ -93,7 +92,7 @@ int main (int argc, char **argv)
         "heartbeat_get_epoch works, default is zero");
 
 
-    w = flux_msg_watcher_create (matchev, heartbeat_event_cb, hb);
+    w = flux_msg_watcher_create (FLUX_MATCH_EVENT, heartbeat_event_cb, hb);
     ok (w != NULL,
         "created event watcher");
     flux_msg_watcher_start (h, w);

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -71,7 +71,6 @@ void check_size3 (flux_t h)
 {
     hello_t *hello;
     flux_msg_watcher_t *w;
-    struct flux_match match = FLUX_MATCH_ANY;
     uint32_t size = 3;
     uint32_t rank = 0;
     char *prefix = "size=3";
@@ -86,8 +85,7 @@ void check_size3 (flux_t h)
     hello_set_callback (hello, hello_cb, prefix);
     hello_set_timeout (hello, 0.1);
 
-    match.typemask = FLUX_MSGTYPE_REQUEST;
-    w = flux_msg_watcher_create (match, hello_request_cb, hello);
+    w = flux_msg_watcher_create (FLUX_MATCH_REQUEST, hello_request_cb, hello);
     ok (w != NULL,
         "%s: created cmb.hello watcher", prefix);
     flux_msg_watcher_start (h, w);

--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -64,8 +64,7 @@ int main (int argc, char **argv)
     flux_t h;
     shutdown_t *sh;
     flux_msg_watcher_t *log_w, *ev_w;
-    struct flux_match matchev = FLUX_MATCH_EVENT;
-    struct flux_match matchlog = FLUX_MATCH_ANY;
+    struct flux_match matchlog = FLUX_MATCH_REQUEST;
 
     plan (14);
 
@@ -79,17 +78,16 @@ int main (int argc, char **argv)
     flux_fatal_set (h, fatal_err, NULL);
 
     ok ((sh = shutdown_create ()) != NULL,
-        "shutdown_create works");    
+        "shutdown_create works");
     shutdown_set_handle (sh, h);
     shutdown_set_callback (sh, shutdown_cb, NULL);
 
-    ev_w = flux_msg_watcher_create (matchev, shutdown_event_cb, sh);
+    ev_w = flux_msg_watcher_create (FLUX_MATCH_EVENT, shutdown_event_cb, sh);
     ok (ev_w != NULL,
         "created event watcher");
     flux_msg_watcher_start (h, ev_w);
 
     matchlog.topic_glob = "cmb.log";
-    matchlog.typemask = FLUX_MSGTYPE_REQUEST;
     log_w = flux_msg_watcher_create (matchlog, log_request_cb, sh);
     ok (log_w != NULL,
         "created log request watcher");

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -131,14 +131,13 @@ static void unsubscribe_all (flux_t h, int tc, char **tv)
 static void event_sub (flux_t h, int argc, char **argv)
 {
     flux_msg_t *msg;
-    struct flux_match match = FLUX_MATCH_EVENT;
 
     if (argc > 0)
         subscribe_all (h, argc, argv);
     else if (flux_event_subscribe (h, "") < 0)
         err_exit ("flux_event_subscribe");
 
-    while ((msg = flux_recv (h, match, 0))) {
+    while ((msg = flux_recv (h, FLUX_MATCH_EVENT, 0))) {
         const char *topic;
         const char *json_str;
         if (flux_msg_get_topic (msg, &topic) < 0

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -140,7 +140,6 @@ int main (int argc, char *argv[])
     char *target;
     flux_msg_watcher_t *mw;
     flux_timer_watcher_t *tw;
-    struct flux_match match_any = FLUX_MATCH_ANY;
     struct ping_ctx ctx = {
         .period = 1.0,
         .nodeid = FLUX_NODEID_ANY,
@@ -218,7 +217,7 @@ int main (int argc, char *argv[])
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
 
-    mw = flux_msg_watcher_create (match_any, response_cb, &ctx);
+    mw = flux_msg_watcher_create (FLUX_MATCH_ANY, response_cb, &ctx);
     tw = flux_timer_watcher_create (0, ctx.period, timer_cb, &ctx);
     if (!mw || !tw)
         err_exit ("error creating watchers");

--- a/src/common/libcompat/handle.c
+++ b/src/common/libcompat/handle.c
@@ -43,8 +43,7 @@ int flux_sendmsg (flux_t h, zmsg_t **zmsg)
 
 flux_msg_t *flux_recvmsg (flux_t h, bool nonblock)
 {
-    struct flux_match match = FLUX_MATCH_ANY;
-    return flux_recv (h, match, nonblock ? FLUX_O_NONBLOCK : 0);
+    return flux_recv (h, FLUX_MATCH_ANY, nonblock ? FLUX_O_NONBLOCK : 0);
 }
 
 flux_msg_t *flux_recvmsg_match (flux_t h, struct flux_match match,

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -31,14 +31,26 @@ struct flux_match {
     char *topic_glob;       /* glob matching topic string (or NULL) */
 };
 
-#define FLUX_MATCH_ANY { \
+#define FLUX_MATCH_ANY (struct flux_match){ \
     .typemask = FLUX_MSGTYPE_ANY, \
     .matchtag = FLUX_MATCHTAG_NONE, \
     .bsize = 0, \
     .topic_glob = NULL, \
 }
-#define FLUX_MATCH_EVENT { \
+#define FLUX_MATCH_EVENT (struct flux_match){ \
     .typemask = FLUX_MSGTYPE_EVENT, \
+    .matchtag = FLUX_MATCHTAG_NONE, \
+    .bsize = 0, \
+    .topic_glob = NULL, \
+}
+#define FLUX_MATCH_REQUEST (struct flux_match){ \
+    .typemask = FLUX_MSGTYPE_REQUEST, \
+    .matchtag = FLUX_MATCHTAG_NONE, \
+    .bsize = 0, \
+    .topic_glob = NULL, \
+}
+#define FLUX_MATCH_RESPONSE (struct flux_match){ \
+    .typemask = FLUX_MSGTYPE_RESPONSE, \
     .matchtag = FLUX_MATCHTAG_NONE, \
     .bsize = 0, \
     .topic_glob = NULL, \

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -258,10 +258,9 @@ static int coproc_cb (coproc_t c, void *arg)
 {
     struct flux_msg_watcher *w = arg;
     flux_msg_t *msg;
-    struct flux_match match = FLUX_MATCH_ANY;
     int type;
     int rc = -1;
-    if (!(msg = flux_recv (w->h, match, FLUX_O_NONBLOCK))) {
+    if (!(msg = flux_recv (w->h, FLUX_MATCH_ANY, FLUX_O_NONBLOCK))) {
         if (errno == EAGAIN || errno == EWOULDBLOCK)
             rc = 0;
         goto done;
@@ -322,13 +321,12 @@ static void handle_cb (struct ev_loop *loop, struct ev_flux *hw, int revents)
     void *ptr = (char *)hw - offsetof (struct reactor, handle_w);
     struct reactor *r = ptr;
     struct flux_msg_watcher *w;
-    struct flux_match match = FLUX_MATCH_ANY;
     flux_msg_t *msg = NULL;
     int type;
 
     if (revents & EV_ERROR)
         goto fatal;
-    if (!(msg = flux_recv (r->h, match, FLUX_O_NONBLOCK))) {
+    if (!(msg = flux_recv (r->h, FLUX_MATCH_ANY, FLUX_O_NONBLOCK))) {
         if (errno != EAGAIN && errno != EWOULDBLOCK)
             goto fatal;
         else

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -369,9 +369,8 @@ enforce_c_consistency (kap_params_t *param)
     const char *tag = NULL;
     int v = 0;
     json_object *o = NULL;
-    struct flux_match match = FLUX_MATCH_EVENT;
 
-    zmsg_t * msg = flux_recvmsg_match (param->pers.handle, match, false);
+    zmsg_t * msg = flux_recv (param->pers.handle, FLUX_MATCH_EVENT, 0);
     if ( ! msg ) {
         fprintf (stderr,
             "event recv failed: %s\n", strerror (errno));

--- a/t/loop/handle.c
+++ b/t/loop/handle.c
@@ -45,7 +45,6 @@ int main (int argc, char *argv[])
     char *s;
     flux_msg_t *msg;
     const char *topic;
-    const struct flux_match match_any = FLUX_MATCH_ANY;
 
     plan (33);
 
@@ -122,7 +121,7 @@ int main (int argc, char *argv[])
     flux_msg_destroy (msg);
     ok ((flux_pollevents (h) & FLUX_POLLIN) != 0,
        "flux_pollevents shows FLUX_POLLIN set on non-empty queue");
-    ok ((msg = flux_recv (h, match_any, 0)) != NULL
+    ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
         && !strcmp (topic, "foo"),
         "flux_recv works and sent message was received");
@@ -147,12 +146,12 @@ int main (int argc, char *argv[])
         "flux_requeue bar HEAD works");
     ok ((flux_pollevents (h) & FLUX_POLLIN) != 0,
        "flux_pollevents shows FLUX_POLLIN set after requeue");
-    ok ((msg = flux_recv (h, match_any, 0)) != NULL
+    ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
         && !strcmp (topic, "bar"),
         "flux_recv got bar");
     flux_msg_destroy (msg);
-    ok ((msg = flux_recv (h, match_any, 0)) != NULL
+    ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
         && !strcmp (topic, "foo"),
         "flux_recv got foo");
@@ -172,12 +171,12 @@ int main (int argc, char *argv[])
         "flux_requeue bar TAIL works");
     ok ((flux_pollevents (h) & FLUX_POLLIN) != 0,
        "flux_pollevents shows FLUX_POLLIN set after requeue");
-    ok ((msg = flux_recv (h, match_any, 0)) != NULL
+    ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
         && !strcmp (topic, "foo"),
         "flux_recv got foo");
     flux_msg_destroy (msg);
-    ok ((msg = flux_recv (h, match_any, 0)) != NULL
+    ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
         && !strcmp (topic, "bar"),
         "flux_recv got bar");

--- a/t/loop/reactor.c
+++ b/t/loop/reactor.c
@@ -88,11 +88,10 @@ static void msgreader (flux_t h, flux_msg_watcher_t *w, const flux_msg_t *msg,
 
 static void test_msg (flux_t h)
 {
-    struct flux_match match_any = FLUX_MATCH_ANY;
     flux_msg_watcher_t *w;
     int i;
 
-    ok ((w = flux_msg_watcher_create (match_any, msgreader, NULL)) != NULL,
+    ok ((w = flux_msg_watcher_create (FLUX_MATCH_ANY, msgreader, NULL)) != NULL,
         "msg: created watcher for any message");
     flux_msg_watcher_start (h, w);
     for (i = 0; i < msgwatcher_count; i++) {
@@ -365,7 +364,6 @@ static void fatal_err (const char *message, void *arg)
 int main (int argc, char *argv[])
 {
     flux_t h;
-    struct flux_match match_any = FLUX_MATCH_ANY;
 
     plan (3+11+3+4+3+5);
 
@@ -379,7 +377,7 @@ int main (int argc, char *argv[])
     ok (flux_reactor_start (h) == 0,
         "general: reactor ran to completion (no watchers)");
     errno = 0;
-    ok (flux_sleep_on (h, match_any) < 0 && errno == EINVAL,
+    ok (flux_sleep_on (h, FLUX_MATCH_ANY) < 0 && errno == EINVAL,
         "general: flux_sleep_on outside coproc fails with EINVAL");
 
     test_timer (h); // 11


### PR DESCRIPTION
By prepending the type to these preprocessor macros, they are able to be used both as static initializers  and function arguments, as discussed in #312.

In addition to updating the existing macros, add FLUX_MATCH_REQUEST and FLUX_MATCH_RESPONSE which were missing.

Update users.