### PR TITLE
Flux lstopo

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -33,6 +33,7 @@ dist_fluxcmd_SCRIPTS = \
 	flux-wreckrun \
 	flux-exec \
 	flux-topo \
+	flux-lstopo \
 	flux-ps
 
 if HAVE_PYTHON

--- a/src/cmd/flux-lstopo
+++ b/src/cmd/flux-lstopo
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import flux
+import tempfile
+import subprocess as sp
+import sys
+
+f = flux.Flux()
+xml_topo = f.rpc_send('resource-hwloc.topo')['topology']
+with tempfile.NamedTemporaryFile() as f:
+    f.file.write(xml_topo)
+    name = f.name
+    f.file.close()
+    sp.call(['lstopo', '-i', name] + sys.argv[1:])


### PR DESCRIPTION
This adds a flux-lstopo command, which wraps the hwloc lstopo command with some logic to get the entire topology of the current flux instance.  Arguments on the command line are passed through.