### PR TITLE
emit events for wreck job state changes

### DIFF
--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -132,6 +132,12 @@ static void event_sub (flux_t h, int argc, char **argv)
 {
     flux_msg_t *msg;
 
+    /* Since output is line-based with undeterministic amount of time
+     * between lines, force stdout to be line buffered so our output
+     * is immediately available in stream, even if stdout is not a tty.
+     */
+    setlinebuf (stdout);
+
     if (argc > 0)
         subscribe_all (h, argc, argv);
     else if (flux_event_subscribe (h, "") < 0)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -89,6 +89,9 @@ dist_check_DATA = \
 	build/hello_flux_internal.c \
 	build/hello_jsonc.c
 
+dist_check_SCRIPTS = \
+	scripts/event-trace.lua
+
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \

--- a/t/README.md
+++ b/t/README.md
@@ -197,6 +197,13 @@ following extra functions:
 	of COMMAND.
 
 ```
+Helper scripts
+--------------
+
+Utility and other helper scripts which are specific to the testsuite
+should be placed in the `./scripts` directory. This directory can
+be referenced as `$SHARNESS_TEST_SRCDIR/scripts` to run scripts
+directly, or individual tests can add this path to their `PATH`.
 
 Lua Tests
 =========

--- a/t/scripts/event-trace.lua
+++ b/t/scripts/event-trace.lua
@@ -1,0 +1,44 @@
+#!/usr/bin/lua
+local flux = require 'flux'
+local s = arg[1]
+local exitevent = arg[2]
+
+function eprintf (...) io.stderr:write (string.format (...)) end
+
+if not s or not exitevent then
+    eprintf ([[
+Usage: %s TOPIC EXIT-EVENT COMMAND
+
+Subscribe to events matching TOPIC and run COMMAND once subscribe
+is gauranteed to be active on the flux broker. If EXIT-EVENT is
+not an empty string, then exit the process once an event exactly
+matching EXIT-EVENT is received.
+]], arg[0])
+    os.exit (1)
+end
+
+local cmd = " "
+for i = 3, #arg do
+    cmd = cmd .. " " .. arg[i]
+end
+
+local f,err = flux.new()
+f:subscribe (s)
+f:sendevent (s .. ".test")
+local mh, err = f:msghandler {
+    pattern = s..".*",
+    msgtypes = { flux.MSGTYPE_EVENT },
+    
+    handler = function (f, msg, mh)
+        if msg.tag == s..".test" then
+            os.execute (cmd .. " &")
+        else
+            print (msg.tag)
+        end
+	if exitevent ~= "" and msg.tag == exitevent then
+            mh:remove ()
+	end
+    end
+}
+
+f:reactor()

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -39,4 +39,16 @@ test_expect_success 'wreckrun: does not drop output' '
 	run_timeout 5 flux wreckrun -N1 -n1 cat expected >output &&
 	test_cmp expected output
 '
+test_expect_success 'wreck: job state events emitted' '
+	run_timeout 5 \
+	  $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
+	   wreck.state wreck.state.complete \
+	   flux wreckrun -N4 -n4 /bin/true > output &&
+	cat >expected <<-EOF &&
+	wreck.state.starting
+	wreck.state.running
+	wreck.state.complete
+	EOF
+	test_cmp expected output
+'
 test_done

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -11,7 +11,7 @@ test_under_flux 4
 
 test_expect_success 'wreckrun: works' '
 	hostname=$(hostname) &&
-	run_timeout 2 flux wreckrun -n4 -N4 hostname  >output &&
+	run_timeout 5 flux wreckrun -n4 -N4 hostname  >output &&
 	cat >expected <<-EOF  &&
 	$hostname
 	$hostname

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -23,9 +23,9 @@ test_expect_success 'wreckrun: works' '
 
 test_expect_success 'wreckrun: propagates current working directory' '
 	mkdir -p testdir &&
-	cd testdir && 
-	mypwd=$(pwd) &&
-	run_timeout 5 flux wreckrun -N1 -n1 pwd | grep "^$mypwd$"
+	mypwd=$(pwd)/testdir &&
+	( cd testdir &&
+	run_timeout 5 flux wreckrun -N1 -n1 pwd ) | grep "^$mypwd$"
 '
 test_expect_success 'wreckrun: propagates current environment' '
 	( export MY_UNLIKELY_ENV=0xdeadbeef &&


### PR DESCRIPTION
As described in #337, simply emit an event for each job_state_update(). The event topic is `wreck.state.<statestring>` where statestring is starting, running, or completed. The body is simply `{ "lwj": ID}`.

In order to write a test that monitors for these events, I had to force `flux-event sub` to line-buffered output. Otherwise, no output is written to destination file when output is redirected for the 3 events of interest in the test.