### PR TITLE
deprecate json-c API interfaces

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -507,24 +507,24 @@ static int l_flux_recv_event (lua_State *L)
 /*
  *  mrpc
  */
-static int lua_push_mrpc (lua_State *L, flux_mrpc_t mrpc)
+static int lua_push_mrpc (lua_State *L, flux_mrpc_t *mrpc)
 {
-    flux_mrpc_t *mp = lua_newuserdata (L, sizeof (*mp));
+    flux_mrpc_t **mp = lua_newuserdata (L, sizeof (*mp));
     *mp = mrpc;
     luaL_getmetatable (L, "FLUX.mrpc");
     lua_setmetatable (L, -2);
     return (1);
 }
 
-static flux_mrpc_t lua_get_mrpc (lua_State *L, int index)
+static flux_mrpc_t *lua_get_mrpc (lua_State *L, int index)
 {
-    flux_mrpc_t *mp = luaL_checkudata (L, index, "FLUX.mrpc");
+    flux_mrpc_t **mp = luaL_checkudata (L, index, "FLUX.mrpc");
     return (*mp);
 }
 
 static int l_flux_mrpc_destroy (lua_State *L)
 {
-    flux_mrpc_t m = lua_get_mrpc (L, 1);
+    flux_mrpc_t *m = lua_get_mrpc (L, 1);
     flux_mrpc_destroy (m);
     return (0);
 }
@@ -536,9 +536,9 @@ static int l_mrpc_outargs_destroy (lua_State *L)
     return (0);
 }
 
-static flux_mrpc_t lua_get_mrpc_from_outargs (lua_State *L, int index)
+static flux_mrpc_t *lua_get_mrpc_from_outargs (lua_State *L, int index)
 {
-    flux_mrpc_t mrpc;
+    flux_mrpc_t *mrpc;
     int *refp = luaL_checkudata (L, index, "FLUX.mrpc_outarg");
 
     lua_rawgeti (L, LUA_REGISTRYINDEX, *refp);
@@ -550,11 +550,11 @@ static flux_mrpc_t lua_get_mrpc_from_outargs (lua_State *L, int index)
 static int l_mrpc_outargs_iterator (lua_State *L)
 {
     int index = lua_upvalueindex (1);
-    flux_mrpc_t m = lua_get_mrpc_from_outargs (L, index);
+    flux_mrpc_t *m = lua_get_mrpc_from_outargs (L, index);
     int n = flux_mrpc_next_outarg (m);
     if (n >= 0) {
         json_object *o;
-        if (flux_mrpc_get_outarg (m, n, &o) < 0)
+        if (flux_mrpc_get_outarg_obj (m, n, &o) < 0)
             return lua_pusherror (L, "outarg: %s", strerror (errno));
         lua_pushnumber (L, n);
         json_object_to_lua (L, o);
@@ -566,7 +566,7 @@ static int l_mrpc_outargs_iterator (lua_State *L)
 
 static int l_mrpc_outargs_next (lua_State *L)
 {
-    flux_mrpc_t m = lua_get_mrpc_from_outargs (L, 1);
+    flux_mrpc_t *m = lua_get_mrpc_from_outargs (L, 1);
     flux_mrpc_rewind_outarg (m);
 
 
@@ -583,7 +583,7 @@ static int l_mrpc_outargs_index (lua_State *L)
 {
     int rc;
     json_object *o;
-    flux_mrpc_t m = lua_get_mrpc_from_outargs (L, 1);
+    flux_mrpc_t *m = lua_get_mrpc_from_outargs (L, 1);
     int i;
 
     if (!lua_isnumber (L, 2)) {
@@ -596,7 +596,7 @@ static int l_mrpc_outargs_index (lua_State *L)
      *  Numeric index into individual nodeid outargs
      */
     i = lua_tointeger (L, 2);
-    flux_mrpc_get_outarg (m, i, &o);
+    flux_mrpc_get_outarg_obj (m, i, &o);
     rc = json_object_to_lua (L, o);
     json_object_put (o);
     return (rc);
@@ -634,13 +634,13 @@ static int lua_push_mrpc_outargs (lua_State *L, int index)
 
 static int l_flux_mrpc_index (lua_State *L)
 {
-    flux_mrpc_t m = lua_get_mrpc (L, 1);
+    flux_mrpc_t *m = lua_get_mrpc (L, 1);
     const char *key = lua_tostring (L, 2);
 
     if (strcmp (key, "inarg") == 0) {
         json_object *o;
 
-        if (flux_mrpc_get_inarg (m, &o) < 0) {
+        if (flux_mrpc_get_inarg_obj (m, &o) < 0) {
         fprintf (stderr, "get_inarg: %s\n", strerror (errno));
             return lua_pusherror (L, strerror (errno));
     }
@@ -660,14 +660,14 @@ static int l_flux_mrpc_index (lua_State *L)
 
 static int l_flux_mrpc_newindex (lua_State *L)
 {
-    flux_mrpc_t m = lua_get_mrpc (L, 1);
+    flux_mrpc_t *m = lua_get_mrpc (L, 1);
     const char *key = lua_tostring (L, 2);
 
     if (strcmp (key, "inarg") == 0) {
         json_object *o = NULL;
         if (lua_value_to_json (L, 3, &o) < 0)
             return lua_pusherror (L, "Failed to create json from argument");
-        flux_mrpc_put_inarg (m, o);
+        flux_mrpc_put_inarg_obj (m, o);
         json_object_put (o);
         return (0);
     }
@@ -675,7 +675,7 @@ static int l_flux_mrpc_newindex (lua_State *L)
         json_object *o = NULL;
         if (lua_value_to_json (L, 3, &o) < 0)
             return lua_pusherror (L, "Failed to create json from argument");
-        flux_mrpc_put_outarg (m, o);
+        flux_mrpc_put_outarg_obj (m, o);
         json_object_put (o);
         return (0);
     }
@@ -689,7 +689,7 @@ static int l_flux_mrpc_respond (lua_State *L)
 
 static int l_flux_mrpc_call (lua_State *L)
 {
-    flux_mrpc_t mrpc = lua_get_mrpc (L, 1);
+    flux_mrpc_t *mrpc = lua_get_mrpc (L, 1);
 
     if ((l_format_args (L, 2) < 0))
         return (2); /* nil, err */
@@ -700,7 +700,7 @@ static int l_flux_mrpc_call (lua_State *L)
 static int l_flux_mrpc_new (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
-    flux_mrpc_t m;
+    flux_mrpc_t *m;
 
     m = flux_mrpc_create (f, lua_tostring (L, 2));
     if (m == NULL)
@@ -709,7 +709,7 @@ static int l_flux_mrpc_new (lua_State *L)
     if (lua_istable (L, 3)) {
         json_object *o;
         lua_value_to_json (L, 3, &o);
-        flux_mrpc_put_inarg (m, o);
+        flux_mrpc_put_inarg_obj (m, o);
         json_object_put (o);
     }
 

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -220,7 +220,7 @@ static int l_flux_new (lua_State *L)
 static int l_flux_kvsdir_new (lua_State *L)
 {
     const char *path = ".";
-    kvsdir_t dir;
+    kvsdir_t *dir;
     flux_t f = lua_get_flux (L, 1);
 
     if (lua_isstring (L, 2)) {
@@ -1084,7 +1084,7 @@ static int l_kvswatcher_add (lua_State *L)
     assert (lua_isfunction (L, -1));
 
     kw = l_flux_ref_create (L, f, 2, "kvswatcher");
-    kvs_watch (f, key, l_kvswatcher, (void *) kw);
+    kvs_watch_obj (f, key, l_kvswatcher, (void *) kw);
 
     /*
      *  Return kvswatcher object to caller

--- a/src/bindings/lua/kvs-lua.h
+++ b/src/bindings/lua/kvs-lua.h
@@ -5,7 +5,7 @@
 #include <lauxlib.h>
 
 int luaopen_kvs (lua_State *L);
-int l_push_kvsdir (lua_State *L, kvsdir_t dir);
+int l_push_kvsdir (lua_State *L, kvsdir_t *dir);
 
 #endif /* !HAVE_KVS_LUA_H */
 

--- a/src/cmd/flux-mping.c
+++ b/src/cmd/flux-mping.c
@@ -67,7 +67,7 @@ int main (int argc, char *argv[])
     char *nodelist;
     json_object *inarg, *outarg;
     int id;
-    flux_mrpc_t f;
+    flux_mrpc_t *f;
     int count = INT_MAX;
 
     log_init ("flux-mping");
@@ -108,11 +108,11 @@ int main (int argc, char *argv[])
         util_json_object_add_int (inarg, "seq", seq);
         if (pad)
             util_json_object_add_string (inarg, "pad", pad);
-        flux_mrpc_put_inarg (f, inarg);
+        flux_mrpc_put_inarg_obj (f, inarg);
         if (flux_mrpc (f, "mecho") < 0)
             err_exit ("flux_mrpc");
         while ((id = flux_mrpc_next_outarg (f)) != -1) {
-            if (flux_mrpc_get_outarg (f, id, &outarg) < 0) {
+            if (flux_mrpc_get_outarg_obj (f, id, &outarg) < 0) {
                 msg ("%d: no response", id);
                 continue;
             }

--- a/src/cmd/flux-up.c
+++ b/src/cmd/flux-up.c
@@ -161,7 +161,7 @@ static ns_t *ns_fromkvs (flux_t h)
     JSON o = NULL;
     ns_t *ns = NULL;
 
-    if (kvs_get (h, "conf.live.status", &o) < 0)
+    if (kvs_get_obj (h, "conf.live.status", &o) < 0)
         goto done;
     ns = ns_fromjson (o);
 done:

--- a/src/modules/kvs/conf.c
+++ b/src/modules/kvs/conf.c
@@ -32,7 +32,7 @@
 
 const char *kvs_conf_root = "config";
 
-static int load_one (flux_conf_t cf, kvsdir_t dir, const char *name)
+static int load_one (flux_conf_t cf, kvsdir_t *dir, const char *name)
 {
     char *key = kvsdir_key_at (dir, name);
     char *skey = key + strlen (kvs_conf_root) + 1;
@@ -53,16 +53,16 @@ done:
     return rc;
 }
 
-static int load_kvsdir (flux_conf_t cf, kvsdir_t dir)
+static int load_kvsdir (flux_conf_t cf, kvsdir_t *dir)
 {
-    kvsitr_t itr;
+    kvsitr_t *itr;
     const char *name;
     int rc = -1;
 
     itr = kvsitr_create (dir);
     while ((name = kvsitr_next (itr))) {
         if (kvsdir_isdir (dir, name)) {
-            kvsdir_t ndir;
+            kvsdir_t *ndir;
             if (kvsdir_get_dir (dir, &ndir, "%s", name) < 0)
                 goto done;
             if (load_kvsdir (cf, ndir) < 0)
@@ -81,7 +81,7 @@ done:
 
 int kvs_conf_load (flux_t h, flux_conf_t cf)
 {
-    kvsdir_t dir = NULL;
+    kvsdir_t *dir = NULL;
     int rc = -1;
 
     flux_conf_clear (cf);

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -6,19 +6,27 @@
 #include <stdint.h>
 #include <flux/core.h>
 
-typedef struct kvsdir_struct *kvsdir_t;
+typedef struct kvsdir_struct kvsdir_t;
 
-typedef int (KVSSetF(const char *key, json_object *val, void *arg,int errnum));
-typedef int (KVSSetDirF(const char *key, kvsdir_t dir, void *arg, int errnum));
-typedef int (KVSSetStringF(const char *key, const char *val, void *arg, int errnum));
-typedef int (KVSSetIntF(const char *key, int val, void *arg, int errnum));
-typedef int (KVSSetInt64F(const char *key, int64_t val, void *arg,int errnum));
-typedef int (KVSSetDoubleF(const char *key, double val, void *arg,int errnum));
-typedef int (KVSSetBooleanF(const char *key, bool val, void *arg, int errnum));
+typedef int (*kvs_set_f)(const char *key, const char *json_str, void *arg,
+                         int errnum);
+typedef int (*kvs_set_obj_f)(const char *key, json_object *val, void *arg,
+                             int errnum);
+typedef int (*kvs_set_dir_f)(const char *key, kvsdir_t *dir, void *arg,
+                             int errnum);
+typedef int (*kvs_set_string_f)(const char *key, const char *val, void *arg,
+                                int errnum);
+typedef int (*kvs_set_int_f)(const char *key, int val, void *arg, int errnum);
+typedef int (*kvs_set_int64_f)(const char *key, int64_t val, void *arg,
+                               int errnum);
+typedef int (*kvs_set_double_f)(const char *key, double val, void *arg,
+                                int errnum);
+typedef int (*kvs_set_boolean_f)(const char *key, bool val, void *arg,
+                                 int errnum);
 
 /* Destroy a kvsdir object returned from kvs_get_dir() or kvsdir_get_dir()
  */
-void kvsdir_destroy (kvsdir_t dir);
+void kvsdir_destroy (kvsdir_t *dir);
 
 /* The basic get and put operations, with convenience functions
  * for simple types.  You will get an error if you call kvs_get()
@@ -28,8 +36,10 @@ void kvsdir_destroy (kvsdir_t dir);
  * kvsdir_destroy(), and free() respectively.
  * These functions return -1 on error (errno set), 0 on success.
  */
-int kvs_get (flux_t h, const char *key, json_object **valp);
-int kvs_get_dir (flux_t h, kvsdir_t *dirp, const char *fmt, ...);
+int kvs_get (flux_t h, const char *key, char **json_str);
+int kvs_get_obj (flux_t h, const char *key, json_object **valp)
+                 __attribute__ ((deprecated));
+int kvs_get_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...);
 int kvs_get_string (flux_t h, const char *key, char **valp);
 int kvs_get_int (flux_t h, const char *key, int *valp);
 int kvs_get_int64 (flux_t h, const char *key, int64_t *valp);
@@ -44,13 +54,19 @@ int kvs_get_symlink (flux_t h, const char *key, char **valp);
  * callback is freed when the callback returns.  If a value is unset, the
  * callback gets errnum = ENOENT.
  */
-int kvs_watch (flux_t h, const char *key, KVSSetF *set, void *arg);
-int kvs_watch_dir (flux_t h, KVSSetDirF *set, void *arg, const char *fmt, ...);
-int kvs_watch_string (flux_t h, const char *key, KVSSetStringF *set, void *arg);
-int kvs_watch_int (flux_t h, const char *key, KVSSetIntF *set, void *arg);
-int kvs_watch_int64 (flux_t h, const char *key, KVSSetInt64F *set, void *arg);
-int kvs_watch_double (flux_t h, const char *key, KVSSetDoubleF *set, void *arg);
-int kvs_watch_boolean (flux_t h, const char *key, KVSSetBooleanF *set,void *arg);
+int kvs_watch (flux_t h, const char *key, kvs_set_f set, void *arg);
+int kvs_watch_obj (flux_t h, const char *key, kvs_set_obj_f set, void *arg)
+                   __attribute__ ((deprecated));
+int kvs_watch_dir (flux_t h, kvs_set_dir_f set, void *arg,
+                   const char *fmt, ...);
+int kvs_watch_string (flux_t h, const char *key, kvs_set_string_f set,
+                      void *arg);
+int kvs_watch_int (flux_t h, const char *key, kvs_set_int_f set, void *arg);
+int kvs_watch_int64 (flux_t h, const char *key, kvs_set_int64_f set, void *arg);
+int kvs_watch_double (flux_t h, const char *key, kvs_set_double_f set,
+                      void *arg);
+int kvs_watch_boolean (flux_t h, const char *key, kvs_set_boolean_f set,
+                       void *arg);
 
 /* Cancel a kvs_watch, freeing server-side state, and unregistering any
  * callback.  Returns 0 on success, or -1 with errno set on error.
@@ -66,15 +82,19 @@ int kvs_unwatch (flux_t h, const char *key);
  * If the key is not set, ENOENT is returned without affecting *valp.
  * FIXME: add more types.
  */
-int kvs_watch_once (flux_t h, const char *key, json_object **valp);
-int kvs_watch_once_dir (flux_t h, kvsdir_t *dirp, const char *fmt, ...);
+int kvs_watch_once (flux_t h, const char *key, char **json_str);
+int kvs_watch_once_obj (flux_t h, const char *key, json_object **valp)
+                        __attribute__ ((deprecated));
+int kvs_watch_once_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...);
 int kvs_watch_once_int (flux_t h, const char *key, int *valp);
 
 /* kvs_put() and kvs_put_string() both make copies of the value argument
  * The caller retains ownership of the original.
  * These functions return -1 on error (errno set), 0 on success.
  */
-int kvs_put (flux_t h, const char *key, json_object *val);
+int kvs_put (flux_t h, const char *key, const char *json_str);
+int kvs_put_obj (flux_t h, const char *key, json_object *val)
+                 __attribute__ ((deprecated));
 int kvs_put_string (flux_t h, const char *key, const char *val);
 int kvs_put_int (flux_t h, const char *key, int val);
 int kvs_put_int64 (flux_t h, const char *key, int64_t val);
@@ -85,27 +105,27 @@ int kvs_put_boolean (flux_t h, const char *key, bool val);
  * returned by kvs_get_dir().  kvsitr_create() always succeeds.
  * kvsitr_next() returns NULL when the last item is reached.
  */
-typedef struct kvsdir_iterator_struct *kvsitr_t;
-kvsitr_t kvsitr_create (kvsdir_t dir);
-void kvsitr_destroy (kvsitr_t itr);
-const char *kvsitr_next (kvsitr_t itr);
-void kvsitr_rewind (kvsitr_t itr);
+typedef struct kvsdir_iterator_struct kvsitr_t;
+kvsitr_t *kvsitr_create (kvsdir_t *dir);
+void kvsitr_destroy (kvsitr_t *itr);
+const char *kvsitr_next (kvsitr_t *itr);
+void kvsitr_rewind (kvsitr_t *itr);
 
 /* Test attributes of 'name', relative to kvsdir object.
  * This is intended for testing names returned by kvsitr_next (no recursion).
  * Symlinks are not dereferenced, i.e. symlink pointing to dir will read
  * issymlink=true, isdir=false.
  */
-bool kvsdir_exists (kvsdir_t dir, const char *name);
-bool kvsdir_isdir (kvsdir_t dir, const char *name);
-bool kvsdir_issymlink (kvsdir_t dir, const char *name);
+bool kvsdir_exists (kvsdir_t *dir, const char *name);
+bool kvsdir_isdir (kvsdir_t *dir, const char *name);
+bool kvsdir_issymlink (kvsdir_t *dir, const char *name);
 
 /* Get key associated with a directory or directory entry.
  * Both functions always succeed.
  */
-const char *kvsdir_key (kvsdir_t dir);
-char *kvsdir_key_at (kvsdir_t dir, const char *key); /* caller frees result */
-void *kvsdir_handle (kvsdir_t dir);
+const char *kvsdir_key (kvsdir_t *dir);
+char *kvsdir_key_at (kvsdir_t *dir, const char *key); /* caller frees result */
+void *kvsdir_handle (kvsdir_t *dir);
 
 /* Remove a key from the namespace.  If it represents a directory,
  * its contents are also removed.  kvsdir_unlink removes it relative to 'dir'.
@@ -164,25 +184,29 @@ int kvs_dropcache (flux_t h);
  * They behave exactly like their kvs_ counterparts, except the 'key' path
  * is resolved relative to the directory.
  */
-int kvsdir_get (kvsdir_t dir, const char *key, json_object **valp);
-int kvsdir_get_dir (kvsdir_t dir, kvsdir_t *dirp, const char *fmt, ...);
-int kvsdir_get_string (kvsdir_t dir, const char *key, char **valp);
-int kvsdir_get_int (kvsdir_t dir, const char *key, int *valp);
-int kvsdir_get_int64 (kvsdir_t dir, const char *key, int64_t *valp);
-int kvsdir_get_double (kvsdir_t dir, const char *key, double *valp);
-int kvsdir_get_boolean (kvsdir_t dir, const char *key, bool *valp);
-int kvsdir_get_symlink (kvsdir_t dir, const char *key, char **valp);
+int kvsdir_get (kvsdir_t *dir, const char *key, char **json_str);
+int kvsdir_get_obj (kvsdir_t *dir, const char *key, json_object **valp)
+                    __attribute__ ((deprecated));
+int kvsdir_get_dir (kvsdir_t *dir, kvsdir_t **dirp, const char *fmt, ...);
+int kvsdir_get_string (kvsdir_t *dir, const char *key, char **valp);
+int kvsdir_get_int (kvsdir_t *dir, const char *key, int *valp);
+int kvsdir_get_int64 (kvsdir_t *dir, const char *key, int64_t *valp);
+int kvsdir_get_double (kvsdir_t *dir, const char *key, double *valp);
+int kvsdir_get_boolean (kvsdir_t *dir, const char *key, bool *valp);
+int kvsdir_get_symlink (kvsdir_t *dir, const char *key, char **valp);
 
-int kvsdir_put (kvsdir_t dir, const char *key, json_object *val);
-int kvsdir_put_string (kvsdir_t dir, const char *key, const char *val);
-int kvsdir_put_int (kvsdir_t dir, const char *key, int val);
-int kvsdir_put_int64 (kvsdir_t dir, const char *key, int64_t val);
-int kvsdir_put_double (kvsdir_t dir, const char *key, double val);
-int kvsdir_put_boolean (kvsdir_t dir, const char *key, bool val);
+int kvsdir_put (kvsdir_t *dir, const char *key, const char *json_str);
+int kvsdir_put_obj (kvsdir_t *dir, const char *key, json_object *val)
+                    __attribute__ ((deprecated));
+int kvsdir_put_string (kvsdir_t *dir, const char *key, const char *val);
+int kvsdir_put_int (kvsdir_t *dir, const char *key, int val);
+int kvsdir_put_int64 (kvsdir_t *dir, const char *key, int64_t val);
+int kvsdir_put_double (kvsdir_t *dir, const char *key, double val);
+int kvsdir_put_boolean (kvsdir_t *dir, const char *key, bool val);
 
-int kvsdir_unlink (kvsdir_t dir, const char *key);
-int kvsdir_symlink (kvsdir_t dir, const char *key, const char *target);
-int kvsdir_mkdir (kvsdir_t dir, const char *key);
+int kvsdir_unlink (kvsdir_t *dir, const char *key);
+int kvsdir_symlink (kvsdir_t *dir, const char *key, const char *target);
+int kvsdir_mkdir (kvsdir_t *dir, const char *key);
 
 /* Load flux_conf_t cache from KVS config.* namespace
  */

--- a/src/modules/libjsc/jstatctl.h
+++ b/src/modules/libjsc/jstatctl.h
@@ -53,7 +53,8 @@ typedef enum {
     J_FOR_RENT   /*!< Space For Rent */
 } job_state_t;
 
-typedef int (*jsc_handler_f)(json_object *base_jcb, void *arg, int errnum);
+typedef int (*jsc_handler_obj_f)(json_object *base_jcb, void *arg, int errnum);
+typedef int (*jsc_handler_f)(const char *base_jcb, void *arg, int errnum);
 
 /* TODO: find a better way to manage this hierarchical 
  * JCB attributes space 
@@ -92,6 +93,8 @@ typedef int (*jsc_handler_f)(json_object *base_jcb, void *arg, int errnum);
  * multiple times. The callbacks will be invoked in the order
  * they are registered. Returns 0 on success; otherwise -1.
  */
+int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f callback, void *d)
+                           __attribute__ ((deprecated));
 int jsc_notify_status (flux_t h, jsc_handler_f callback, void *d);
 
 /**
@@ -101,7 +104,10 @@ int jsc_notify_status (flux_t h, jsc_handler_f callback, void *d);
  * are trasferred to "jcb," so that json_object_put (*jcb) will free this hierarchy 
  * in its entirety.  Returns 0 on success; otherwise -1.
  */
-int jsc_query_jcb (flux_t h, int64_t jobid, const char *key, json_object **jcb);
+int jsc_query_jcb_obj (flux_t h, int64_t jobid, const char *key,
+                       json_object **jcb)
+                       __attribute__ ((deprecated));
+int jsc_query_jcb (flux_t h, int64_t jobid, const char *key, char **jcb);
 
 
 /**
@@ -110,7 +116,10 @@ int jsc_query_jcb (flux_t h, int64_t jobid, const char *key, json_object **jcb);
  * This will not release "jcb," so it is the caller's responsibility to
  * free "jcb."
  */
-int jsc_update_jcb (flux_t h, int64_t jobid, const char *key, json_object *jcb);
+int jsc_update_jcb_obj (flux_t h, int64_t jobid, const char *key,
+                        json_object *jcb)
+                       __attribute__ ((deprecated));
+int jsc_update_jcb (flux_t h, int64_t jobid, const char *key, const char *jcb);
 
 
 /** 

--- a/src/modules/libkz/kz.c
+++ b/src/modules/libkz/kz.c
@@ -82,7 +82,7 @@ struct kz_struct {
     int fencecount;
 };
 
-static void kz_destroy (kz_t kz)
+static void kz_destroy (kz_t *kz)
 {
     if (kz->name)
         free (kz->name);
@@ -93,9 +93,9 @@ static void kz_destroy (kz_t kz)
     free (kz);
 }
 
-kz_t kz_open (flux_t h, const char *name, int flags)
+kz_t *kz_open (flux_t h, const char *name, int flags)
 {
-    kz_t kz = xzmalloc (sizeof (*kz));
+    kz_t *kz = xzmalloc (sizeof (*kz));
 
     kz->flags = flags;
     kz->name = xstrdup (name);
@@ -130,7 +130,7 @@ error:
     return NULL;
 }
 
-static int kz_fence (kz_t kz)
+static int kz_fence (kz_t *kz)
 {
     char *name;
     int rc;
@@ -141,10 +141,10 @@ static int kz_fence (kz_t kz)
     return rc;
 }
 
-kz_t kz_gopen (flux_t h, const char *grpname, int nprocs,
+kz_t *kz_gopen (flux_t h, const char *grpname, int nprocs,
                const char *name, int flags)
 {
-    kz_t kz;
+    kz_t *kz;
 
     if (!(flags & KZ_FLAGS_WRITE) || !grpname || nprocs <= 0) {
         errno = EINVAL;
@@ -164,7 +164,7 @@ error:
     return NULL;
 }
 
-static int putnext (kz_t kz, json_object *val)
+static int putnext (kz_t *kz, const char *json_str)
 {
     char *key = NULL;
     int rc = -1;
@@ -175,7 +175,7 @@ static int putnext (kz_t kz, json_object *val)
     }
     if (asprintf (&key, "%s.%.6d", kz->name, kz->seq++) < 0)
         oom ();
-    if (kvs_put_obj (kz->h, key, val) < 0)
+    if (kvs_put (kz->h, key, json_str) < 0)
         goto done;
     if (!(kz->flags & KZ_FLAGS_NOCOMMIT_PUT)) {
         if (kvs_commit (kz->h) < 0)
@@ -188,40 +188,40 @@ done:
     return rc;
 }
 
-int kz_put_json (kz_t kz, json_object *val)
+int kz_put_json (kz_t *kz, const char *json_str)
 {
     if (!(kz->flags & KZ_FLAGS_RAW)) {
         errno = EINVAL;
         return -1;
     }
-    return putnext (kz, val);
+    return putnext (kz, json_str);
 }
 
-int kz_put (kz_t kz, char *data, int len)
+int kz_put (kz_t *kz, char *data, int len)
 {
-    json_object *val = NULL;
+    char *json_str = NULL;
     int rc = -1;
 
     if (len == 0 || data == NULL || (kz->flags & KZ_FLAGS_RAW)) {
         errno = EINVAL;
         goto done;
     }
-    if (!(val = zio_json_encode (data, len, false))) {
+    if (!(json_str = zio_json_encode (data, len, false))) {
         errno = EPROTO;
         goto done;
     }
-    if (putnext (kz, val) < 0)
+    if (putnext (kz, json_str) < 0)
         goto done;
     rc = len;
 done:
-    if (val)
-        json_object_put (val);
+    if (json_str)
+        free (json_str);
     return rc;
 }
 
-static json_object *getnext (kz_t kz)
+static char *getnext (kz_t *kz)
 {
-    json_object *val = NULL;
+    char *json_str = NULL;
     char *key = NULL;
 
     if (!(kz->flags & KZ_FLAGS_READ)) {
@@ -230,7 +230,7 @@ static json_object *getnext (kz_t kz)
     }
     if (asprintf (&key, "%s.%.6d", kz->name, kz->seq) < 0)
         oom ();
-    if (kvs_get_obj (kz->h, key, &val) < 0) {
+    if (kvs_get (kz->h, key, &json_str) < 0) {
         if (errno == ENOENT)
             errno = EAGAIN;
         goto done;
@@ -239,14 +239,14 @@ static json_object *getnext (kz_t kz)
 done:
     if (key)
         free (key);
-    return val;
+    return json_str;
 }
 
-static json_object *getnext_blocking (kz_t kz)
+static char *getnext_blocking (kz_t *kz)
 {
-    json_object *val;
+    char *json_str = NULL;
 
-    while (!(val = getnext (kz))) {
+    while (!(json_str = getnext (kz))) {
         if (errno != EAGAIN)
             break;
         if (kvs_watch_once_dir (kz->h, &kz->dir, "%s", kz->name) < 0) {
@@ -258,28 +258,28 @@ static json_object *getnext_blocking (kz_t kz)
             }
         }
     }
-    return val;
+    return json_str;
 }
 
-json_object *kz_get_json (kz_t kz)
+char *kz_get_json (kz_t *kz)
 {
-    json_object *val = NULL;
+    char *json_str = NULL;
 
     if (!(kz->flags & KZ_FLAGS_RAW)) {
         errno = EINVAL;
         goto done;
     }
     if ((kz->flags & KZ_FLAGS_NONBLOCK))
-        val = getnext (kz);
+        json_str = getnext (kz);
     else
-        val = getnext_blocking (kz);
+        json_str = getnext_blocking (kz);
 done:
-    return val;
+    return json_str;
 }
 
-int kz_get (kz_t kz, char **datap)
+int kz_get (kz_t *kz, char **datap)
 {
-    json_object *val = NULL;
+    char *json_str = NULL;
     char *data;
     int len = -1;
 
@@ -290,22 +290,23 @@ int kz_get (kz_t kz, char **datap)
     if (kz->eof)
         return 0;
     if ((kz->flags & KZ_FLAGS_NONBLOCK))
-        val = getnext (kz);
+        json_str = getnext (kz);
     else
-        val = getnext_blocking (kz);
-    if (!val)
+        json_str = getnext_blocking (kz);
+    if (!json_str)
         goto done;
-    if ((len = zio_json_decode (val, (void **) &data, &kz->eof)) < 0) {
+    if ((len = zio_json_decode (json_str, (void **) &data, &kz->eof)) < 0) {
         errno = EPROTO;
         goto done;
     }
-    json_object_put (val);
     *datap = data;
 done:
+    if (json_str)
+        free (json_str);
     return len;
 }
 
-int kz_flush (kz_t kz)
+int kz_flush (kz_t *kz)
 {
     int rc = 0;
     if ((kz->flags & KZ_FLAGS_WRITE))
@@ -313,21 +314,21 @@ int kz_flush (kz_t kz)
     return rc;
 }
 
-int kz_close (kz_t kz)
+int kz_close (kz_t *kz)
 {
     int rc = -1;
-    json_object *val = NULL;
+    char *json_str = NULL;
     char *key = NULL;
 
     if ((kz->flags & KZ_FLAGS_WRITE)) {
         if (!(kz->flags & KZ_FLAGS_RAW)) {
             if (asprintf (&key, "%s.%.6d", kz->name, kz->seq++) < 0)
                 oom ();
-            if (!(val = zio_json_encode (NULL, 0, true))) { /* EOF */
+            if (!(json_str = zio_json_encode (NULL, 0, true))) { /* EOF */
                 errno = EPROTO;
                 goto done;
             }
-            if (kvs_put_obj (kz->h, key, val) < 0)
+            if (kvs_put (kz->h, key, json_str) < 0)
                 goto done;
         }
         if (!(kz->flags & KZ_FLAGS_NOCOMMIT_CLOSE)) {
@@ -341,8 +342,8 @@ int kz_close (kz_t kz)
     }
     rc = 0;
 done:
-    if (val)
-        json_object_put (val);
+    if (json_str)
+        free (json_str);
     if (key)
         free (key);
     kz_destroy (kz);
@@ -351,7 +352,7 @@ done:
 
 int kvswatch_cb (const char *key, kvsdir_t *dir, void *arg, int errnum)
 {
-    kz_t kz = arg;
+    kz_t *kz = arg;
 
     if (errnum != 0 && errnum != ENOENT)
         return -1;
@@ -360,7 +361,7 @@ int kvswatch_cb (const char *key, kvsdir_t *dir, void *arg, int errnum)
     return 0;
 }
 
-int kz_set_ready_cb (kz_t kz, kz_ready_f ready_cb, void *arg)
+int kz_set_ready_cb (kz_t *kz, kz_ready_f ready_cb, void *arg)
 {
     if (!(kz->flags & KZ_FLAGS_READ)) {
         errno = EINVAL;

--- a/src/modules/libkz/kz.h
+++ b/src/modules/libkz/kz.h
@@ -4,9 +4,9 @@
 #include <json.h>
 #include <flux/core.h>
 
-typedef struct kz_struct *kz_t;
+typedef struct kz_struct kz_t;
 
-typedef void (*kz_ready_f) (kz_t kz, void *arg);
+typedef void (*kz_ready_f) (kz_t *kz, void *arg);
 
 enum {
     KZ_FLAGS_READ           = 0x0001, /* choose read or write, not both */
@@ -28,44 +28,44 @@ enum {
 
 /* Prepare to read or write a KVS stream.
  */
-kz_t kz_open (flux_t h, const char *name, int flags);
+kz_t *kz_open (flux_t h, const char *name, int flags);
 
 /* Prepare to write to one KVS stream that is a part of a group.
  * The kvs_commit()s normally issued at open and close are replaced with
  * a kvs_fence().
  */
-kz_t kz_gopen (flux_t h, const char *grpname, int nprocs,
+kz_t *kz_gopen (flux_t h, const char *grpname, int nprocs,
                const char *name, int flags);
 
 /* Write one block of data to a KVS stream.  Unless kz was opened with
  * KZ_FLAGS_DELAYCOMMIT, data will committed to the KVS.
  * Returns len (no short writes) or -1 on error with errno set.
  */
-int kz_put (kz_t kz, char *data, int len);
+int kz_put (kz_t *kz, char *data, int len);
 
 /* Read one block of data to a KVS stream.  Returns the number of bytes
  * read, 0 on EOF, or -1 on errro with errno set.  If no data is available,
  * kz_get() will return EAGAIN if kz was opened with KZ_FLAGS_NONBLOCK;
  * otherwise it will block until data is available.
  */
-int kz_get (kz_t kz, char **datap);
+int kz_get (kz_t *kz, char **datap);
 
 /* Commit any data written to the stream which has not already
  * been committed.  Calling this on a kz opened with KZ_FLAGS_READ is a no-op.
  */
-int kz_flush (kz_t kz);
+int kz_flush (kz_t *kz);
 
 /* Destroy the kz handle.  If kz was opened with KZ_FLAGS_WRITE, write
  * an EOF and commit any data written to the strewam  which has not already
  * been committed.
  */
-int kz_close (kz_t kz);
+int kz_close (kz_t *kz);
 
 /* Register a callback that will be called when data is available to
  * be read from kz.  Call kz_open with (KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK).
  * Your function should call kz_get() until it returns -1, errno = EAGAIN.
  */
-int kz_set_ready_cb (kz_t kz, kz_ready_f ready_cb, void *arg);
+int kz_set_ready_cb (kz_t *kz, kz_ready_f ready_cb, void *arg);
 
 /* "Raw" get/put methods that use JSON objects encoded/decoded with
  * zio_json_encode/zio_json_decode.  The KVS stream must have been opened
@@ -77,12 +77,12 @@ int kz_set_ready_cb (kz_t kz, kz_ready_f ready_cb, void *arg);
 /* Put a JSON object.  Returns 0 on success, -1 on failure, with errno set.
  * Caller retains ownership of 'o'.
  */
-int kz_put_json (kz_t kz, json_object *o);
+int kz_put_json (kz_t *kz, const char *json_str);
 
-/* Get a JSON object.  Returns the object or NULL on failure with errno set.
- * Caller must free the returned object.
+/* Get a JSON string.  Returns the object or NULL on failure with errno set.
+ * Caller must free the returned string.
  */
-json_object *kz_get_json (kz_t kz);
+char *kz_get_json (kz_t *kz);
 
 #endif /* !FLUX_CORE_KZ_H */
 

--- a/src/modules/libmrpc/mrpc.c
+++ b/src/modules/libmrpc/mrpc.c
@@ -75,9 +75,9 @@ struct flux_mrpc_struct {
     bool client;
 };
 
-flux_mrpc_t flux_mrpc_create (flux_t h, const char *dest)
+flux_mrpc_t *flux_mrpc_create (flux_t h, const char *dest)
 {
-    flux_mrpc_t f = xzmalloc (sizeof (*f));
+    flux_mrpc_t *f = xzmalloc (sizeof (*f));
     int maxid = flux_size (h) - 1;
 
     f->h = h;
@@ -101,7 +101,7 @@ error:
     return NULL;
 }
 
-void flux_mrpc_destroy (flux_mrpc_t f)
+void flux_mrpc_destroy (flux_mrpc_t *f)
 {
     if (f->path) {
 #if KVS_CLEANUP
@@ -125,7 +125,7 @@ void flux_mrpc_destroy (flux_mrpc_t f)
     free (f);
 }
 
-void flux_mrpc_put_inarg (flux_mrpc_t f, json_object *val)
+void flux_mrpc_put_inarg_obj (flux_mrpc_t *f, json_object *val)
 {
     char *key;
 
@@ -135,7 +135,25 @@ void flux_mrpc_put_inarg (flux_mrpc_t f, json_object *val)
     free (key);
 }
 
-int flux_mrpc_get_inarg (flux_mrpc_t f, json_object **valp)
+int flux_mrpc_put_inarg (flux_mrpc_t *f, const char *json_str)
+{
+    char *key = NULL;
+    int rc = -1;
+
+    if (asprintf (&key, "%s.in", f->path) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (kvs_put (f->h, key, json_str) < 0)
+        goto done;
+    rc = 0;
+done:
+    if (key)
+        free (key);
+    return rc;
+}
+
+int flux_mrpc_get_inarg_obj (flux_mrpc_t *f, json_object **valp)
 {
     char *key;
     int rc = -1;
@@ -150,7 +168,25 @@ done:
     return rc;
 }
 
-void flux_mrpc_put_outarg (flux_mrpc_t f, json_object *val)
+int flux_mrpc_get_inarg (flux_mrpc_t *f, char **json_str)
+{
+    char *key = NULL;
+    int rc = -1;
+
+    if (asprintf (&key, "%s.in", f->path) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (kvs_get (f->h, key, json_str) < 0)
+        goto done;
+    rc = 0;
+done:
+    if (key)
+        free (key);
+    return rc;
+}
+
+void flux_mrpc_put_outarg_obj (flux_mrpc_t *f, json_object *val)
 {
     char *key;
 
@@ -160,7 +196,25 @@ void flux_mrpc_put_outarg (flux_mrpc_t f, json_object *val)
     free (key);
 }
 
-int flux_mrpc_get_outarg (flux_mrpc_t f, int nodeid, json_object **valp)
+int flux_mrpc_put_outarg (flux_mrpc_t *f, const char *json_str)
+{
+    char *key = NULL;
+    int rc = -1;
+
+    if (asprintf (&key, "%s.out-%d", f->path, flux_rank (f->h)) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (kvs_put (f->h, key, json_str) < 0)
+        goto done;
+    rc = 0;
+done:
+    if (key)
+        free (key);
+    return rc;
+}
+
+int flux_mrpc_get_outarg_obj (flux_mrpc_t *f, int nodeid, json_object **valp)
 {
     char *key;
     int rc = -1;
@@ -175,7 +229,25 @@ done:
     return rc;
 }
 
-int flux_mrpc_next_outarg (flux_mrpc_t f)
+int flux_mrpc_get_outarg (flux_mrpc_t *f, int nodeid, char **json_str)
+{
+    char *key = NULL;
+    int rc = -1;
+
+    if (asprintf (&key, "%s.out-%d", f->path, nodeid) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (kvs_get (f->h, key, json_str) < 0)
+        goto done;
+    rc = 0;
+done:
+    if (key)
+        free (key);
+    return rc;
+}
+
+int flux_mrpc_next_outarg (flux_mrpc_t *f)
 {
     uint32_t r = -1;
 
@@ -188,7 +260,7 @@ int flux_mrpc_next_outarg (flux_mrpc_t f)
     return r;
 }
 
-void flux_mrpc_rewind_outarg (flux_mrpc_t f)
+void flux_mrpc_rewind_outarg (flux_mrpc_t *f)
 {
     if (!f->ns_itr)
         f->ns_itr = nodeset_itr_new (f->ns);
@@ -196,7 +268,7 @@ void flux_mrpc_rewind_outarg (flux_mrpc_t f)
         nodeset_itr_rewind (f->ns_itr);
 }
 
-int flux_mrpc (flux_mrpc_t f, const char *fmt, ...)
+int flux_mrpc (flux_mrpc_t *f, const char *fmt, ...)
 {
     int rc = -1;
     char *topic = NULL, *s = NULL;
@@ -235,17 +307,17 @@ done:
     return rc;
 }
 
-flux_mrpc_t flux_mrpc_create_fromevent (flux_t h, json_object *request)
+flux_mrpc_t *flux_mrpc_create_fromevent_obj (flux_t h, json_object *o)
 {
-    flux_mrpc_t f = NULL;
+    flux_mrpc_t *f = NULL;
     const char *dest, *path;
     int sender, vers;
     nodeset_t ns = NULL;
 
-    if (util_json_object_get_string (request, "dest", &dest) < 0
-            || util_json_object_get_string (request, "path", &path) < 0
-            || util_json_object_get_int (request, "sender", &sender) < 0
-            || util_json_object_get_int (request, "vers", &vers) < 0
+    if (util_json_object_get_string (o, "dest", &dest) < 0
+            || util_json_object_get_string (o, "path", &path) < 0
+            || util_json_object_get_int (o, "sender", &sender) < 0
+            || util_json_object_get_int (o, "vers", &vers) < 0
             || !(ns = nodeset_new_str (dest))) {
         errno = EPROTO;
         goto done;
@@ -273,7 +345,23 @@ done:
     return f;
 }
 
-int flux_mrpc_respond (flux_mrpc_t f)
+flux_mrpc_t *flux_mrpc_create_fromevent (flux_t h, const char *json_str)
+{
+    json_object *o;
+    flux_mrpc_t *mrpc = NULL;
+
+    if (!(o = json_tokener_parse (json_str))) {
+        errno = EPROTO;
+        goto done;
+    }
+    mrpc = flux_mrpc_create_fromevent_obj (h, o);
+done:
+    if (o)
+        json_object_put (o);
+    return mrpc;
+}
+
+int flux_mrpc_respond (flux_mrpc_t *f)
 {
     return kvs_fence (f->h, f->path, f->nprocs + 1);
 }

--- a/src/modules/libmrpc/mrpc.c
+++ b/src/modules/libmrpc/mrpc.c
@@ -131,7 +131,7 @@ void flux_mrpc_put_inarg (flux_mrpc_t f, json_object *val)
 
     if (asprintf (&key, "%s.in", f->path) < 0)
         oom ();
-    kvs_put (f->h, key, val);
+    kvs_put_obj (f->h, key, val);
     free (key);
 }
 
@@ -142,7 +142,7 @@ int flux_mrpc_get_inarg (flux_mrpc_t f, json_object **valp)
 
     if (asprintf (&key, "%s.in", f->path) < 0)
         oom ();
-    if (kvs_get (f->h, key, valp) < 0)
+    if (kvs_get_obj (f->h, key, valp) < 0)
         goto done;
     rc = 0;
 done:
@@ -156,7 +156,7 @@ void flux_mrpc_put_outarg (flux_mrpc_t f, json_object *val)
 
     if (asprintf (&key, "%s.out-%d", f->path, flux_rank (f->h)) < 0)
         oom ();
-    kvs_put (f->h, key, val);
+    kvs_put_obj (f->h, key, val);
     free (key);
 }
 
@@ -167,7 +167,7 @@ int flux_mrpc_get_outarg (flux_mrpc_t f, int nodeid, json_object **valp)
 
     if (asprintf (&key, "%s.out-%d", f->path, nodeid) < 0)
         oom ();
-    if (kvs_get (f->h, key, valp) < 0)
+    if (kvs_get_obj (f->h, key, valp) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/libmrpc/mrpc.h
+++ b/src/modules/libmrpc/mrpc.h
@@ -4,7 +4,7 @@
 #include <json.h>
 #include <flux/core.h>
 
-typedef struct flux_mrpc_struct *flux_mrpc_t;
+typedef struct flux_mrpc_struct flux_mrpc_t;
 
 /* Group RPC
  *
@@ -21,23 +21,36 @@ typedef struct flux_mrpc_struct *flux_mrpc_t;
  * - flux_mrpc_destroy()              }
  */
 
-flux_mrpc_t flux_mrpc_create (flux_t h, const char *nodelist);
-void flux_mrpc_destroy (flux_mrpc_t f);
+flux_mrpc_t *flux_mrpc_create (flux_t h, const char *nodelist);
+void flux_mrpc_destroy (flux_mrpc_t *mrpc);
 
-void flux_mrpc_put_inarg (flux_mrpc_t f, json_object *val);
-int flux_mrpc_get_inarg (flux_mrpc_t f, json_object **valp);
+void flux_mrpc_put_inarg_obj (flux_mrpc_t *mrpc, json_object *val)
+	                      __attribute__ ((deprecated));
+int flux_mrpc_put_inarg (flux_mrpc_t *mrpc, const char *json_str);
 
-void flux_mrpc_put_outarg (flux_mrpc_t f, json_object *val);
-int flux_mrpc_get_outarg (flux_mrpc_t f, int nodeid, json_object **valp);
+int flux_mrpc_get_inarg_obj (flux_mrpc_t *mrpc, json_object **valp)
+	                     __attribute__ ((deprecated));
+int flux_mrpc_get_inarg (flux_mrpc_t *mrpc, char **json_str);
+
+void flux_mrpc_put_outarg_obj (flux_mrpc_t *mrpc, json_object *val)
+	                       __attribute__ ((deprecated));
+int flux_mrpc_put_outarg (flux_mrpc_t *mrpc, const char *json_str);
+
+int flux_mrpc_get_outarg_obj (flux_mrpc_t *mrpc, int nodeid, json_object **val)
+	                      __attribute__ ((deprecated));
+int flux_mrpc_get_outarg (flux_mrpc_t *mrpc, int nodeid, char **json_str);
 
 /* returns nodeid (-1 at end)  */
-int flux_mrpc_next_outarg (flux_mrpc_t f);
-void flux_mrpc_rewind_outarg (flux_mrpc_t f);
+int flux_mrpc_next_outarg (flux_mrpc_t *mrpc);
+void flux_mrpc_rewind_outarg (flux_mrpc_t *mrpc);
 
-int flux_mrpc (flux_mrpc_t f, const char *fmt, ...);
+int flux_mrpc (flux_mrpc_t *mrpc, const char *fmt, ...);
 
 /* returns NULL, errno == EINVAL if not addressed to me */
-flux_mrpc_t flux_mrpc_create_fromevent (flux_t h, json_object *request);
-int flux_mrpc_respond (flux_mrpc_t f);
+flux_mrpc_t *flux_mrpc_create_fromevent_obj (flux_t h, json_object *request)
+	                                    __attribute__ ((deprecated));
+flux_mrpc_t *flux_mrpc_create_fromevent (flux_t h, const char *json_str);
+
+int flux_mrpc_respond (flux_mrpc_t *mrpc);
 
 #endif /* !FLUX_MRPC_H */

--- a/src/modules/libsubprocess/subprocess.h
+++ b/src/modules/libsubprocess/subprocess.h
@@ -35,7 +35,7 @@ typedef enum sm_item {
 } sm_item_t;
 
 typedef int (subprocess_cb_f) (struct subprocess *p, void *arg);
-typedef int (subprocess_io_cb_f) (struct subprocess *p, json_object *o);
+typedef int (subprocess_io_cb_f) (struct subprocess *p, const char *json_str);
 
 /*
  *  Create a subprocess manager to manage creation, destruction, and

--- a/src/modules/libsubprocess/test/loop.c
+++ b/src/modules/libsubprocess/test/loop.c
@@ -47,12 +47,11 @@ static int exit_handler (struct subprocess *p, void *arg)
     return (0);
 }
 
-static int io_cb (struct subprocess *p, json_object *o)
+static int io_cb (struct subprocess *p, const char *json_str)
 {
     ok (p != NULL, "io_cb: valid subprocess");
-    ok (o != NULL, "io_cb: valid output");
-    note ("%s", json_object_to_json_string (o));
-    json_object_put (o);
+    ok (json_str != NULL, "io_cb: valid output");
+    note ("%s", json_str);
     return (0);
 }
 

--- a/src/modules/libsubprocess/test/subprocess.c
+++ b/src/modules/libsubprocess/test/subprocess.c
@@ -39,7 +39,7 @@ void myfatal (void *h, int exit_code, const char *fmt, ...)
     myfatal_h = h;
 }
 
-static int testio_cb (struct subprocess *p, json_object *o);
+static int testio_cb (struct subprocess *p, const char *json_str);
 
 int main (int ac, char **av)
 {
@@ -314,13 +314,12 @@ int main (int ac, char **av)
     done_testing ();
 }
 
-static int testio_cb (struct subprocess *p, json_object *o)
+static int testio_cb (struct subprocess *p, const char *json_str)
 {
     char **bufp = subprocess_get_context (p, "io");
     bool eof;
     if (*bufp == NULL)
-        zio_json_decode (o, (void **) bufp, &eof);
-    json_object_put (o);
+        zio_json_decode (json_str, (void **) bufp, &eof);
     return 0;
 }
 

--- a/src/modules/libzio/zio.c
+++ b/src/modules/libzio/zio.c
@@ -81,7 +81,7 @@ struct zio_ctx {
     void *arg;          /*  Arg passed to callbacks                          */
 };
 
-static void zio_vlog (zio_t zio, const char *format, va_list ap)
+static void zio_vlog (zio_t *zio, const char *format, va_list ap)
 {
     char  buf[4096];
     char *p;
@@ -141,12 +141,12 @@ static void zio_vlog (zio_t zio, const char *format, va_list ap)
     return;
 }
 
-static int zio_verbose (zio_t zio)
+static int zio_verbose (zio_t *zio)
 {
     return (zio->flags & ZIO_VERBOSE);
 }
 
-static void zio_debug (zio_t zio, const char *fmt, ...)
+static void zio_debug (zio_t *zio, const char *fmt, ...)
 {
     if (zio_verbose (zio)) {
         va_list ap;
@@ -156,27 +156,27 @@ static void zio_debug (zio_t zio, const char *fmt, ...)
     }
 }
 
-static inline void zio_set_destroyed (zio_t zio)
+static inline void zio_set_destroyed (zio_t *zio)
 {
     zio->flags |= ZIO_DESTROYED;
 }
 
-static inline int zio_is_destroyed (zio_t zio)
+static inline int zio_is_destroyed (zio_t *zio)
 {
     return (zio->flags & ZIO_DESTROYED);
 }
 
-static inline int zio_is_in_handler (zio_t zio)
+static inline int zio_is_in_handler (zio_t *zio)
 {
     return (zio->flags & ZIO_IN_HANDLER);
 }
 
-static inline void zio_handler_start (zio_t zio)
+static inline void zio_handler_start (zio_t *zio)
 {
     zio->flags |= ZIO_IN_HANDLER;
 }
 
-static inline void zio_handler_end (zio_t zio)
+static inline void zio_handler_end (zio_t *zio)
 {
     zio->flags &= ~ZIO_IN_HANDLER;
     if (zio_is_destroyed (zio))
@@ -196,7 +196,7 @@ static int fd_set_nonblocking (int fd)
     return (0);
 }
 
-void zio_destroy (zio_t z)
+void zio_destroy (zio_t *z)
 {
     if (z == NULL)
         return;
@@ -214,7 +214,7 @@ void zio_destroy (zio_t z)
     free (z);
 }
 
-static int zio_init_buffer (zio_t zio)
+static int zio_init_buffer (zio_t *zio)
 {
     assert (zio != NULL);
     assert (zio->magic == ZIO_MAGIC);
@@ -228,9 +228,9 @@ static int zio_init_buffer (zio_t zio)
 }
 
 
-static zio_t zio_allocate (const char *name, int reader, void *arg)
+static zio_t *zio_allocate (const char *name, int reader, void *arg)
 {
-    zio_t z;
+    zio_t *z;
 
     if (!name) {
         errno = EINVAL;
@@ -264,7 +264,7 @@ static zio_t zio_allocate (const char *name, int reader, void *arg)
 /*
  *  zio reader reads from srcfd and generates json data to sendfn
  */
-int zio_reader (zio_t zio)
+int zio_reader (zio_t *zio)
 {
     return (zio->io_type == ZIO_READER);
 }
@@ -272,39 +272,39 @@ int zio_reader (zio_t zio)
 /*
  *  zio writer consumes data in json and sends to dstfd
  */
-int zio_writer (zio_t zio)
+int zio_writer (zio_t *zio)
 {
     return (zio->io_type == ZIO_WRITER);
 }
 
-static inline void zio_clear_buffered (zio_t zio)
+static inline void zio_clear_buffered (zio_t *zio)
 {
     zio->flags &= ~(ZIO_LINE_BUFFERED | ZIO_BUFFERED);
 }
 
-static inline int zio_line_buffered (zio_t zio)
+static inline int zio_line_buffered (zio_t *zio)
 {
     return (zio->flags & ZIO_LINE_BUFFERED);
 }
 
-static inline int zio_buffered (zio_t zio)
+static inline int zio_buffered (zio_t *zio)
 {
     return (zio->flags & ZIO_BUFFERED);
 }
 
 
-static inline void zio_set_eof (zio_t zio)
+static inline void zio_set_eof (zio_t *zio)
 {
     zio->flags |= ZIO_EOF;
 }
 
-static inline int zio_eof (zio_t zio)
+static inline int zio_eof (zio_t *zio)
 {
     return (zio->flags & ZIO_EOF);
 }
 
 
-static int zio_eof_pending (zio_t zio)
+static int zio_eof_pending (zio_t *zio)
 {
     /*
      *   zio object has EOF pending if EOF flag is set and either the
@@ -313,22 +313,22 @@ static int zio_eof_pending (zio_t zio)
     return (zio_eof (zio) && (!cbuf_used (zio->buf)));
 }
 
-static int zio_buffer_used (zio_t zio)
+static int zio_buffer_used (zio_t *zio)
 {
     return cbuf_used (zio->buf);
 }
 
-static int zio_buffer_empty (zio_t zio)
+static int zio_buffer_empty (zio_t *zio)
 {
     return (!zio_buffered (zio) || (cbuf_used (zio->buf) == 0));
 }
 
-static int zio_eof_sent (zio_t zio)
+static int zio_eof_sent (zio_t *zio)
 {
     return (zio->flags & ZIO_EOF_SENT);
 }
 
-int zio_set_unbuffered (zio_t zio)
+int zio_set_unbuffered (zio_t *zio)
 {
     assert (zio != NULL);
     assert (zio->magic == ZIO_MAGIC);
@@ -340,7 +340,7 @@ int zio_set_unbuffered (zio_t zio)
     return (0);
 }
 
-int zio_set_buffered (zio_t zio, size_t buffersize)
+int zio_set_buffered (zio_t *zio, size_t buffersize)
 {
     assert (zio != NULL);
     assert (zio->magic == ZIO_MAGIC);
@@ -350,26 +350,26 @@ int zio_set_buffered (zio_t zio, size_t buffersize)
     return (0);
 }
 
-int zio_set_line_buffered (zio_t zio)
+int zio_set_line_buffered (zio_t *zio)
 {
     int rc = zio_set_buffered (zio, 4096);
     zio->flags |= ZIO_LINE_BUFFERED;
     return (rc);
 }
 
-static int zio_set_verbose (zio_t zio)
+static int zio_set_verbose (zio_t *zio)
 {
     zio->flags |= ZIO_VERBOSE;
     return (0);
 }
 
-int zio_set_quiet (zio_t zio)
+int zio_set_quiet (zio_t *zio)
 {
     zio->flags &= (~ZIO_VERBOSE);
     return (0);
 }
 
-int zio_set_debug (zio_t zio, const char *prefix, zio_log_f logf)
+int zio_set_debug (zio_t *zio, const char *prefix, zio_log_f logf)
 {
     if (!zio || zio->magic != ZIO_MAGIC)
         return (-1);
@@ -382,19 +382,19 @@ int zio_set_debug (zio_t zio, const char *prefix, zio_log_f logf)
     return (0);
 }
 
-int zio_set_send_cb (zio_t zio, zio_send_f sendf)
+int zio_set_send_cb (zio_t *zio, zio_send_f sendf)
 {
     zio->send = sendf;
     return (0);
 }
 
-int zio_set_close_cb (zio_t zio, zio_close_f closef)
+int zio_set_close_cb (zio_t *zio, zio_close_f closef)
 {
     zio->close = closef;
     return (0);
 }
 
-static int zio_fd_read (zio_t zio, void *dst, int len)
+static int zio_fd_read (zio_t *zio, void *dst, int len)
 {
     assert (zio != NULL);
     assert (zio->magic == ZIO_MAGIC);
@@ -406,7 +406,7 @@ static int zio_fd_read (zio_t zio, void *dst, int len)
         return cbuf_read (zio->buf, dst, len);
 }
 
-static json_object * zio_json_object_create (zio_t zio, void *data, size_t len)
+static char *zio_json_str_create (zio_t *zio, void *data, size_t len)
 {
     bool eof = false;
     if (zio_eof_pending (zio)) {
@@ -417,20 +417,29 @@ static json_object * zio_json_object_create (zio_t zio, void *data, size_t len)
     return zio_json_encode (data, len, eof);
 }
 
-static int zio_sendmsg (zio_t zio, json_object *o)
+static int zio_sendmsg (zio_t *zio, const char *json_str)
 {
-    zio_debug (zio, "sendmsg: %s\n", json_object_to_json_string (o));
-    return (*zio->send) (zio, o, zio->arg);
+    zio_debug (zio, "sendmsg: %s\n", json_str);
+    return (*zio->send) (zio, json_str, zio->arg);
 }
 
-static int zio_send (zio_t zio, char *p, size_t len)
+static int zio_send (zio_t *zio, char *p, size_t len)
 {
+    int rc = -1;
+    char *json_str = NULL;
+
     zio_debug (zio, "zio_send (len=%d)\n", len);
-    json_object *o = zio_json_object_create (zio, p, len);
-    return (zio_sendmsg (zio, o));
+
+    if (!(json_str = zio_json_str_create (zio, p, len)))
+        goto done;
+    rc = zio_sendmsg (zio, json_str);
+done:
+    if (json_str)
+        free (json_str);
+    return rc;
 }
 
-static int zio_data_to_flush (zio_t zio)
+static int zio_data_to_flush (zio_t *zio)
 {
     int size;
 
@@ -455,14 +464,14 @@ static int zio_data_to_flush (zio_t zio)
     return (0);
 }
 
-int zio_closed (zio_t zio)
+int zio_closed (zio_t *zio)
 {
     if (zio->flags & ZIO_EOF_SENT)
         return (1);
     return (0);
 }
 
-static int zio_close (zio_t zio)
+static int zio_close (zio_t *zio)
 {
     if (zio->flags & ZIO_CLOSED) {
         /* Already closed */
@@ -485,7 +494,7 @@ static int zio_close (zio_t zio)
     return (0);
 }
 
-static int zio_writer_flush_all (zio_t zio)
+static int zio_writer_flush_all (zio_t *zio)
 {
     int n = 0;
     zio_debug (zio, "zio_writer_flush_all: used=%d\n", zio_buffer_used (zio));
@@ -507,7 +516,7 @@ static int zio_writer_flush_all (zio_t zio)
  *   Flush any buffered output and EOF from zio READER object
  *    to destination.
  */
-int zio_flush (zio_t zio)
+int zio_flush (zio_t *zio)
 {
     int len;
     int rc = 0;
@@ -565,7 +574,7 @@ int zio_flush (zio_t zio)
 }
 
 
-int zio_read (zio_t zio)
+int zio_read (zio_t *zio)
 {
     int n;
     assert ((zio != NULL) && (zio->magic == ZIO_MAGIC));
@@ -584,7 +593,7 @@ int zio_read (zio_t zio)
     return (n);
 }
 
-static int zio_read_cb_common (zio_t zio)
+static int zio_read_cb_common (zio_t *zio)
 {
     int rc = zio_read (zio);
     if ((rc < 0) && (errno == EAGAIN))
@@ -592,7 +601,7 @@ static int zio_read_cb_common (zio_t zio)
     return (rc);
 }
 
-static int zio_zloop_read_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t zio)
+static int zio_zloop_read_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t *zio)
 {
     int rc;
     zio_handler_start (zio);
@@ -606,7 +615,7 @@ static int zio_zloop_read_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t zio)
     return (rc);
 }
 
-static int zio_flux_read_cb (flux_t f, int fd, short revents, zio_t zio)
+static int zio_flux_read_cb (flux_t f, int fd, short revents, zio_t *zio)
 {
     int rc;
     zio_handler_start (zio);
@@ -620,7 +629,7 @@ static int zio_flux_read_cb (flux_t f, int fd, short revents, zio_t zio)
     return (rc);
 }
 
-static int zio_write_pending (zio_t zio)
+static int zio_write_pending (zio_t *zio)
 {
     if (zio_closed (zio))
         return (0);
@@ -635,7 +644,7 @@ static int zio_write_pending (zio_t zio)
  *  Callback when zio->dstfd is writeable. Write buffered data to
  *   file descriptor.
  */
-static int zio_writer_cb (zio_t zio)
+static int zio_writer_cb (zio_t *zio)
 {
     int rc = 0;
 
@@ -652,7 +661,7 @@ static int zio_writer_cb (zio_t zio)
     return (rc);
 }
 
-static int zio_zloop_writer_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t zio)
+static int zio_zloop_writer_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t *zio)
 {
     int rc;
     zio_handler_start (zio);
@@ -663,7 +672,7 @@ static int zio_zloop_writer_cb (zloop_t *zl, zmq_pollitem_t *zp, zio_t zio)
     return (rc);
 }
 
-static int zio_flux_writer_cb (flux_t f, int fd, short revents, zio_t zio)
+static int zio_flux_writer_cb (flux_t f, int fd, short revents, zio_t *zio)
 {
     int rc;
     zio_handler_start (zio);
@@ -674,7 +683,7 @@ static int zio_flux_writer_cb (flux_t f, int fd, short revents, zio_t zio)
     return (rc);
 }
 
-static int zio_zloop_reader_poll (zio_t zio)
+static int zio_zloop_reader_poll (zio_t *zio)
 {
     zmq_pollitem_t zp = { .fd = zio->srcfd,
                           .events = ZMQ_POLLIN | ZMQ_POLLERR,
@@ -692,7 +701,7 @@ static int zio_zloop_reader_poll (zio_t zio)
 
 /* Note: flux reactor sets ZMQ_IGNERR/zloop_set_tolerant as default in fd_add.
  */
-static int zio_flux_reader_poll (zio_t zio)
+static int zio_flux_reader_poll (zio_t *zio)
 {
     if (!zio->flux)
         return (-1);
@@ -702,7 +711,7 @@ static int zio_flux_reader_poll (zio_t zio)
             (void *) zio);
 }
 
-static int zio_reader_poll (zio_t zio)
+static int zio_reader_poll (zio_t *zio)
 {
     if (zio->zloop)
         return zio_zloop_reader_poll (zio);
@@ -714,7 +723,7 @@ static int zio_reader_poll (zio_t zio)
 /*
  *  Schedule pending data to write to zio->dstfd
  */
-static int zio_zloop_writer_schedule (zio_t zio)
+static int zio_zloop_writer_schedule (zio_t *zio)
 {
     zmq_pollitem_t zp = { .fd = zio->dstfd,
                           .events = ZMQ_POLLOUT | ZMQ_POLLERR,
@@ -726,7 +735,7 @@ static int zio_zloop_writer_schedule (zio_t zio)
         (zloop_fn *) zio_zloop_writer_cb, (void *) zio);
 }
 
-static int zio_flux_writer_schedule (zio_t zio)
+static int zio_flux_writer_schedule (zio_t *zio)
 {
     if (!zio->flux)
         return (-1);
@@ -736,7 +745,7 @@ static int zio_flux_writer_schedule (zio_t zio)
             (void *) zio);
 }
 
-static int zio_writer_schedule (zio_t zio)
+static int zio_writer_schedule (zio_t *zio)
 {
     if (zio->zloop)
         return zio_zloop_writer_schedule (zio);
@@ -748,7 +757,7 @@ static int zio_writer_schedule (zio_t zio)
 /*
  *  write data into zio buffer
  */
-static int zio_write_data (zio_t zio, void *buf, size_t len)
+static int zio_write_data (zio_t *zio, void *buf, size_t len)
 {
     int n = 0;
     int ndropped = 0;
@@ -784,7 +793,7 @@ static int zio_write_data (zio_t zio, void *buf, size_t len)
     return (0);
 }
 
-static int zio_write_internal (zio_t zio, void *data, size_t len)
+static int zio_write_internal (zio_t *zio, void *data, size_t len)
 {
     int rc;
 
@@ -796,7 +805,7 @@ static int zio_write_internal (zio_t zio, void *data, size_t len)
     return (rc);
 }
 
-int zio_write (zio_t zio, void *data, size_t len)
+int zio_write (zio_t *zio, void *data, size_t len)
 {
     if ((zio == NULL) || (zio->magic != ZIO_MAGIC) || !zio_writer (zio)) {
         errno = EINVAL;
@@ -811,7 +820,7 @@ int zio_write (zio_t zio, void *data, size_t len)
     return (zio_write_internal (zio, data, len));
 }
 
-int zio_write_eof (zio_t zio)
+int zio_write_eof (zio_t *zio)
 {
      if ((zio == NULL) || (zio->magic != ZIO_MAGIC) || !zio_writer (zio)) {
         errno = EINVAL;
@@ -826,9 +835,9 @@ int zio_write_eof (zio_t zio)
 }
 
 /*
- *  Write json object to this zio object, buffering unwritten data.
+ *  Write json string to this zio object, buffering unwritten data.
  */
-int zio_write_json (zio_t zio, json_object *o)
+int zio_write_json (zio_t *zio, const char *json_str)
 {
     char *s = NULL;
     int len, rc = 0;
@@ -838,7 +847,7 @@ int zio_write_json (zio_t zio, json_object *o)
         errno = EINVAL;
         return (-1);
     }
-    len = zio_json_decode (o, (void **)&s, &eof);
+    len = zio_json_decode (json_str, (void **)&s, &eof);
     if (len < 0) {
         errno = EINVAL;
         return (-1);
@@ -854,7 +863,7 @@ int zio_write_json (zio_t zio, json_object *o)
     return rc;
 }
 
-static int zio_bootstrap (zio_t zio)
+static int zio_bootstrap (zio_t *zio)
 {
     if (zio_reader (zio))
         zio_reader_poll (zio);
@@ -869,7 +878,7 @@ static int zio_bootstrap (zio_t zio)
     return (0);
 }
 
-int zio_zloop_attach (zio_t zio, zloop_t *zloop)
+int zio_zloop_attach (zio_t *zio, zloop_t *zloop)
 {
     errno = EINVAL;
     if ((zio == NULL) || (zio->magic != ZIO_MAGIC))
@@ -879,7 +888,7 @@ int zio_zloop_attach (zio_t zio, zloop_t *zloop)
     return (zio_bootstrap (zio));
 }
 
-int zio_flux_attach (zio_t zio, flux_t f)
+int zio_flux_attach (zio_t *zio, flux_t f)
 {
     errno = EINVAL;
     if ((zio == NULL) || (zio->magic != ZIO_MAGIC))
@@ -889,33 +898,31 @@ int zio_flux_attach (zio_t zio, flux_t f)
     return (zio_bootstrap (zio));
 }
 
-int zio_zmsg_send (zio_t zio, json_object *o, void *arg)
+int zio_zmsg_send (zio_t *zio, const char *json_str, void *arg)
 {
-    const char *s;
-    zio_debug (zio, "%s: send: %s\n", zio->name, json_object_to_json_string (o));
+    zio_debug (zio, "%s: send: %s\n", zio->name, json_str);
     if (!zio->dstsock)
         return (-1);
     zmsg_t *zmsg = zmsg_new ();
-    s = json_object_to_json_string (o);
-    zmsg_pushstr (zmsg, s);
+    zmsg_pushstr (zmsg, json_str);
     zmsg_pushstr (zmsg, zio_name (zio));
     return (zmsg_send (&zmsg, zio->dstsock));
 }
 
-zio_t zio_reader_create (const char *name, int srcfd, void *dst, void *arg)
+zio_t *zio_reader_create (const char *name, int srcfd, void *dst, void *arg)
 {
-    zio_t zio = zio_allocate (name, 1, arg);
+    zio_t *zio = zio_allocate (name, 1, arg);
 
     zio->srcfd = srcfd;
     fd_set_nonblocking (zio->srcfd);
     zio->dstsock = dst;
-    zio->send = (zio_send_f) zio_zmsg_send;
+    zio->send = zio_zmsg_send;
     return (zio);
 }
 
-zio_t zio_pipe_reader_create (const char *name, void *dst, void *arg)
+zio_t *zio_pipe_reader_create (const char *name, void *dst, void *arg)
 {
-    zio_t zio;
+    zio_t *zio;
     int pfds[2];
 
     if (pipe (pfds) < 0)
@@ -932,9 +939,9 @@ zio_t zio_pipe_reader_create (const char *name, void *dst, void *arg)
     return (zio);
 }
 
-zio_t zio_writer_create (const char *name, int dstfd, void *arg)
+zio_t *zio_writer_create (const char *name, int dstfd, void *arg)
 {
-    zio_t zio = zio_allocate (name, 0, arg);
+    zio_t *zio = zio_allocate (name, 0, arg);
     zio->dstfd = dstfd;
     fd_set_nonblocking (zio->dstfd);
 
@@ -943,9 +950,9 @@ zio_t zio_writer_create (const char *name, int dstfd, void *arg)
     return (zio);
 }
 
-zio_t zio_pipe_writer_create (const char *name, void *arg)
+zio_t *zio_pipe_writer_create (const char *name, void *arg)
 {
-    zio_t zio;
+    zio_t *zio;
     int pfds[2];
 
     if (pipe (pfds) < 0)
@@ -961,14 +968,14 @@ zio_t zio_pipe_writer_create (const char *name, void *arg)
     return (zio);
 }
 
-const char * zio_name (zio_t zio)
+const char * zio_name (zio_t *zio)
 {
     if ((zio == NULL) || (zio->magic != ZIO_MAGIC))
         return (NULL);
     return (zio->name);
 }
 
-int zio_src_fd (zio_t zio)
+int zio_src_fd (zio_t *zio)
 {
     if ((zio == NULL) || (zio->magic != ZIO_MAGIC)) {
         errno = EINVAL;
@@ -977,7 +984,7 @@ int zio_src_fd (zio_t zio)
     return (zio->srcfd);
 }
 
-int zio_dst_fd (zio_t zio)
+int zio_dst_fd (zio_t *zio)
 {
     if ((zio == NULL) || (zio->magic != ZIO_MAGIC)) {
         errno = EINVAL;
@@ -986,11 +993,12 @@ int zio_dst_fd (zio_t zio)
     return (zio->dstfd);
 }
 
-int zio_json_decode (json_object *o, void **pp, bool *eofp)
+int zio_json_decode (const char *json_str, void **pp, bool *eofp)
 {
     int len, rc = -1;
+    json_object *o = NULL;
 
-    if (o) {
+    if (json_str && (o = json_tokener_parse (json_str))) {
         if (util_json_object_get_boolean (o, "eof", eofp) == 0)
             rc = 0;
         else
@@ -998,24 +1006,43 @@ int zio_json_decode (json_object *o, void **pp, bool *eofp)
         if (util_json_object_get_data (o, "data", (uint8_t **) pp, &len) == 0)
             rc = len;
     }
+    if (o)
+        json_object_put (o);
     return rc;
 }
 
-json_object *zio_json_encode (void *p, int len, bool eof)
+char *zio_json_encode (void *p, int len, bool eof)
 {
-    json_object *o = util_json_object_new_object ();
+    json_object *o;
+    char *json_str = NULL;
 
+    if (!(o = util_json_object_new_object ())) {
+        errno = ENOMEM;
+        goto done;
+    }
     if (len && p)
         util_json_object_add_data (o, "data", (uint8_t *) p, len);
     if (eof)
         util_json_object_add_boolean (o, "eof", 1);
-    return (o);
+    if (!(json_str = strdup (json_object_to_json_string (o)))) {
+        errno = ENOMEM;
+        goto done;
+    }
+done:
+    if (o)
+        json_object_put (o);
+    return (json_str);
 }
 
-bool zio_json_eof (json_object *o)
+bool zio_json_eof (const char *json_str)
 {
     bool eof = false;
-    (void)util_json_object_get_boolean (o, "eof", &eof);
+    json_object *o;
+
+    if ((o = json_tokener_parse (json_str)))
+        util_json_object_get_boolean (o, "eof", &eof);
+    if (o)
+        json_object_put (o);
     return eof;
 }
 

--- a/src/modules/libzio/zio.h
+++ b/src/modules/libzio/zio.h
@@ -5,10 +5,10 @@
 #include <czmq.h>
 #include <flux/core.h>
 
-typedef struct zio_ctx * zio_t;
+typedef struct zio_ctx zio_t;
 
-typedef int  (*zio_send_f)   (zio_t z, json_object *o, void *arg);
-typedef int  (*zio_close_f)  (zio_t z, void *arg);
+typedef int  (*zio_send_f)   (zio_t *z, const char *json_str, void *arg);
+typedef int  (*zio_close_f)  (zio_t *z, void *arg);
 typedef void (*zio_log_f)    (const char *buf);
 
 /*
@@ -16,78 +16,77 @@ typedef void (*zio_log_f)    (const char *buf);
  *   (depending on buffer setting), and sends json-encoded output to
  *    [dst] zeromq socket.
  */
-zio_t zio_reader_create (const char *name, int src, void *dst, void *arg);
+zio_t *zio_reader_create (const char *name, int src, void *dst, void *arg);
 
 /*
  *  Create a zio reader which reads from an internal pipe and sends
  *   json-encoded output to a zmq socket. Use zio_dst_fd() to get the
  *   file descriptor for the write side of the pipe.
  */
-zio_t zio_pipe_reader_create (const char *name, void *dst, void *arg);
+zio_t *zio_pipe_reader_create (const char *name, void *dst, void *arg);
 
 /*
  *  Create a zio "writer" object, that buffers data via zio_write_* interface
  *   and sends to the fd [dstfd].
  */
-zio_t zio_writer_create (const char *name, int dstfd, void *arg);
+zio_t *zio_writer_create (const char *name, int dstfd, void *arg);
 
 /*
  *   Create a zio writer which writes to an internal pipe (e.g. for stdin).
  *   Use zio_src_fd() to get the read side of the pipe.
  */
-zio_t zio_pipe_writer_create (const char *name, void *arg);
+zio_t *zio_pipe_writer_create (const char *name, void *arg);
 
 /*
  *  Destroy a zio object.
  */
-void zio_destroy (zio_t zio);
+void zio_destroy (zio_t *zio);
 
 /*
  *  Return the name encoded with zio object.
  */
-const char * zio_name (zio_t zio);
+const char * zio_name (zio_t *zio);
 
 /*
  *  Return reader fd of a zio object. (read side of pipe)
  */
-int zio_src_fd (zio_t zio);
+int zio_src_fd (zio_t *zio);
 
 /*
  *  Return write fd of a zio object (write side of pipe).
  */
-int zio_dst_fd (zio_t zio);
+int zio_dst_fd (zio_t *zio);
 
 /*
  *  Check to see if zio object has been "closed". A zio object is closed
  *   after EOF has been read and sent (for reader) or received by writer
  *   and close(2) called on dstfd.
  */
-int zio_closed (zio_t zio);
+int zio_closed (zio_t *zio);
 
 /*
  *  Non-blocking read from zio object. Will read from zio object's src fd
  *   and buffer I/O according to buffering policy of object. Callbacks
  *   will be called synchronously if required by buffering policy.
  */
-int zio_read (zio_t zio);
+int zio_read (zio_t *zio);
 
 /*  Non-blocking write directly to zio object. Data will be buffered by
  *   zio object and written to destination fd when ready, if zio object
  *   is registered in an event loop.
  */
-int zio_write (zio_t zio, void *data, size_t len);
+int zio_write (zio_t *zio, void *data, size_t len);
 
 /*
  *  Set EOF on zio object [zio].
  */
-int zio_write_eof (zio_t zio);
+int zio_write_eof (zio_t *zio);
 
 /*
  *  Write data from json object [o] to zio object [z], data is buffered
- *   if necessary. Only data destined for specific object [z] is read,
- *   and the data is consumed after reading.
+ *   if necessary. Only data destined for specific object [z] is read.
  */
-int zio_write_json (zio_t z, json_object *o);
+int zio_write_json (zio_t *z, const char *json_str);
 
 /*
  *   Attach zio object [x] to zloop poll loop [zloop].
@@ -97,7 +96,7 @@ int zio_write_json (zio_t z, json_object *o);
  *    use zloop to schedule writes to dstfd when it is ready
  *    for writing.
  */
-int zio_zloop_attach (zio_t z, zloop_t *zloop);
+int zio_zloop_attach (zio_t *z, zloop_t *zloop);
 
 /*
  *   Attach zio object [x] to flux reactor in handle [flux].
@@ -107,14 +106,14 @@ int zio_zloop_attach (zio_t z, zloop_t *zloop);
  *    use reactor to schedule writes to dstfd when it is ready
  *    for writing.
  */
-int zio_flux_attach (zio_t z, flux_t flux);
+int zio_flux_attach (zio_t *z, flux_t flux);
 
 /*
  *  ZIO buffering options:
  */
-int zio_set_unbuffered (zio_t zio);
-int zio_set_buffered (zio_t zio, size_t bufsize);
-int zio_set_line_buffered (zio_t zio);
+int zio_set_unbuffered (zio_t *zio);
+int zio_set_buffered (zio_t *zio, size_t bufsize);
+int zio_set_line_buffered (zio_t *zio);
 
 /*
  *  Enable zio debug output for this zio object. Optional
@@ -122,41 +121,41 @@ int zio_set_line_buffered (zio_t zio);
  *   and the optional zio_log_f pointer can override the default
  *   output to stderr.
  */
-int zio_set_debug (zio_t zio, const char *prefix, zio_log_f logf);
+int zio_set_debug (zio_t *zio, const char *prefix, zio_log_f logf);
 
 /*
  *  Disable any debug for zio object [zio].
  */
-int zio_set_quiet (zio_t zio);
+int zio_set_quiet (zio_t *zio);
 
 /*
  *  Override the default send() function for ZIO readers. (Default
  *   send function uses zmsg_send() to dst sock)
  */
-int zio_set_send_cb (zio_t zio, zio_send_f sendf);
+int zio_set_send_cb (zio_t *zio, zio_send_f sendf);
 
 /*
  *  Set a callback function that is called just after a zio object
  *   is automatically "closed" (See description for zio_closed() for
  *   more info on how ZIO objects are closed)
  */
-int zio_set_close_cb (zio_t zio, zio_close_f closef);
+int zio_set_close_cb (zio_t *zio, zio_close_f closef);
 
 
-int zio_flush (zio_t zio);
+int zio_flush (zio_t *zio);
 
 /*
  *  Read data/eof from object.
  *   Returns size of data or -1 on error.
  */
-int zio_json_decode (json_object *o, void **pp, bool *eofp);
+int zio_json_decode (const char *json_str, void **pp, bool *eofp);
 
 /*  Create object.  Returns NULL on failure.
  */
-json_object *zio_json_encode (void *p, int len, bool eof);
+char *zio_json_encode (void *p, int len, bool eof);
 
 /*  Test if object has eof=true.
  */
-bool zio_json_eof (json_object *o);
+bool zio_json_eof (const char *json_str);
 
 #endif /* !_FLUX_CORE_ZIO_H */

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -635,7 +635,7 @@ static int ns_tokvs (ctx_t *ctx)
     JSON o = ns_tojson (ctx->ns);
     int rc = -1;
 
-    if (kvs_put (ctx->h, "conf.live.status", o) < 0)
+    if (kvs_put_obj (ctx->h, "conf.live.status", o) < 0)
         goto done;
     if (kvs_commit (ctx->h) < 0)
         goto done;
@@ -650,7 +650,7 @@ static int ns_fromkvs (ctx_t *ctx)
     JSON o = NULL;
     int rc = -1;
 
-    if (kvs_get (ctx->h, "conf.live.status", &o) < 0)
+    if (kvs_get_obj (ctx->h, "conf.live.status", &o) < 0)
         goto done;
     ctx->ns = ns_fromjson (o);
     rc = 0;
@@ -748,7 +748,7 @@ static int topo_fromkvs (ctx_t *ctx)
     int len, i;
     char *prank;
 
-    if (kvs_get (ctx->h, "conf.live.topology", &ar) < 0)
+    if (kvs_get_obj (ctx->h, "conf.live.topology", &ar) < 0)
         goto done;
     if (!Jget_ar_len (ar, &len))
         goto done;
@@ -779,7 +779,7 @@ static int topo_tokvs (ctx_t *ctx)
         int prank = strtoul (iter.key, NULL, 10);
         Jput_ar_obj (ar, prank, iter.val);
     }
-    if (kvs_put (ctx->h, "conf.live.topology", ar) < 0)
+    if (kvs_put_obj (ctx->h, "conf.live.topology", ar) < 0)
         goto done;
     if (kvs_commit (ctx->h) < 0)
         goto done;

--- a/src/modules/mecho/mecho.c
+++ b/src/modules/mecho/mecho.c
@@ -38,24 +38,24 @@ static int mecho_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     const char *json_str;
     json_object *request = NULL;
     json_object *inarg = NULL;
-    flux_mrpc_t f = NULL;
+    flux_mrpc_t *f = NULL;
 
     if (flux_event_decode (*zmsg, NULL, &json_str) < 0
                 || !(request = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "flux_event_decode: %s", strerror (errno));
         goto done;
     }
-    if (!(f = flux_mrpc_create_fromevent (h, request))) {
+    if (!(f = flux_mrpc_create_fromevent_obj (h, request))) {
         if (errno != EINVAL) /* EINVAL == not addressed to me */
             flux_log (h, LOG_ERR, "flux_mrpc_create_fromevent: %s",
                                     strerror (errno));
         goto done;
     }
-    if (flux_mrpc_get_inarg (f, &inarg) < 0) {
+    if (flux_mrpc_get_inarg_obj (f, &inarg) < 0) {
         flux_log (h, LOG_ERR, "flux_mrpc_get_inarg: %s", strerror (errno));
         goto done;
     }
-    flux_mrpc_put_outarg (f, inarg);
+    flux_mrpc_put_outarg_obj (f, inarg);
     if (flux_mrpc_respond (f) < 0) {
         flux_log (h, LOG_ERR, "flux_mrpc_respond: %s", strerror (errno));
         goto done;

--- a/src/modules/modctl/libmodctl.c
+++ b/src/modules/modctl/libmodctl.c
@@ -91,7 +91,7 @@ static int module_update (module_t *m, int idle, uint32_t nodeid)
     return 0;
 }
 
-static int get_rlist_result (zhash_t *mods, flux_mrpc_t mrpc,
+static int get_rlist_result (zhash_t *mods, flux_mrpc_t *mrpc,
                              uint32_t nodeid, int *ep)
 {
     JSON o = NULL;
@@ -100,7 +100,7 @@ static int get_rlist_result (zhash_t *mods, flux_mrpc_t mrpc,
     int i, len, errnum, size, idle;
     module_t *m;
 
-    if (flux_mrpc_get_outarg (mrpc, nodeid, &o) < 0)
+    if (flux_mrpc_get_outarg_obj (mrpc, nodeid, &o) < 0)
         goto done;
     if (modctl_rlist_dec (o, &errnum, &len) < 0)
         goto done;
@@ -154,7 +154,7 @@ int flux_modctl_list (flux_t h, const char *svc, const char *nodeset,
     JSON in = NULL;
     int rc = -1;
     uint32_t nodeid;
-    flux_mrpc_t mrpc = NULL;
+    flux_mrpc_t *mrpc = NULL;
     int errnum = 0;
     zhash_t *mods = NULL;
 
@@ -166,7 +166,7 @@ int flux_modctl_list (flux_t h, const char *svc, const char *nodeset,
         goto done;
     if (!(in = modctl_tlist_enc (svc)))
         goto done;
-    flux_mrpc_put_inarg (mrpc, in);
+    flux_mrpc_put_inarg_obj (mrpc, in);
     if (flux_mrpc (mrpc, "modctl.list") < 0)
         goto done;
     flux_mrpc_rewind_outarg (mrpc);
@@ -191,13 +191,13 @@ done:
     return rc;
 }
 
-static int get_rload_errnum (flux_mrpc_t mrpc, uint32_t nodeid, int *ep)
+static int get_rload_errnum (flux_mrpc_t *mrpc, uint32_t nodeid, int *ep)
 {
     JSON o = NULL;
     int rc = -1;
     int errnum;
 
-    if (flux_mrpc_get_outarg (mrpc, nodeid, &o) < 0)
+    if (flux_mrpc_get_outarg_obj (mrpc, nodeid, &o) < 0)
         goto done;
     if (modctl_rload_dec (o, &errnum) < 0)
         goto done;
@@ -213,7 +213,7 @@ int flux_modctl_load (flux_t h, const char *nodeset, const char *path,
 {
     int rc = -1;
     JSON in = NULL;
-    flux_mrpc_t mrpc = NULL;
+    flux_mrpc_t *mrpc = NULL;
     uint32_t nodeid;
     int errnum = 0;
 
@@ -225,7 +225,7 @@ int flux_modctl_load (flux_t h, const char *nodeset, const char *path,
         goto done;
     if (!(in = modctl_tload_enc (path, argc, argv)))
         goto done;
-    flux_mrpc_put_inarg (mrpc, in);
+    flux_mrpc_put_inarg_obj (mrpc, in);
     if (flux_mrpc (mrpc, "modctl.load") < 0)
         goto done;
     flux_mrpc_rewind_outarg (mrpc);
@@ -245,13 +245,13 @@ done:
     return rc;
 }
 
-static int get_runload_errnum (flux_mrpc_t mrpc, uint32_t nodeid, int *ep)
+static int get_runload_errnum (flux_mrpc_t *mrpc, uint32_t nodeid, int *ep)
 {
     JSON o = NULL;
     int rc = -1;
     int errnum;
 
-    if (flux_mrpc_get_outarg (mrpc, nodeid, &o) < 0)
+    if (flux_mrpc_get_outarg_obj (mrpc, nodeid, &o) < 0)
         goto done;
     if (modctl_runload_dec (o, &errnum) < 0)
         goto done;
@@ -264,7 +264,7 @@ done:
 
 int flux_modctl_unload (flux_t h, const char *nodeset, const char *name)
 {
-    flux_mrpc_t mrpc = NULL;
+    flux_mrpc_t *mrpc = NULL;
     JSON in = NULL;
     int rc = -1;
     uint32_t nodeid;
@@ -279,7 +279,7 @@ int flux_modctl_unload (flux_t h, const char *nodeset, const char *name)
         goto done;
     if (!(in = modctl_tunload_enc (name)))
         goto done;
-    flux_mrpc_put_inarg (mrpc, in);
+    flux_mrpc_put_inarg_obj (mrpc, in);
     if (flux_mrpc (mrpc, "modctl.unload") < 0)
         goto done;
     flux_mrpc_rewind_outarg (mrpc);

--- a/src/modules/modctl/modctl.c
+++ b/src/modules/modctl/modctl.c
@@ -47,7 +47,7 @@
 static int unload_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     JSON o = NULL;
-    flux_mrpc_t mrpc = NULL;
+    flux_mrpc_t *mrpc = NULL;
     const char *json_str;
     JSON in = NULL;
     JSON out = NULL;
@@ -61,13 +61,13 @@ static int unload_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
                   strerror (errno));
         goto done;
     }
-    if (!(mrpc = flux_mrpc_create_fromevent (h, o))) {
+    if (!(mrpc = flux_mrpc_create_fromevent_obj (h, o))) {
         if (errno != EINVAL) /* EINVAL == not addressed to me */
             flux_log (h, LOG_ERR, "%s: flux_mrpc_create_fromevent: %s",
                       __FUNCTION__, strerror (errno));
         goto done;
     }
-    if (flux_mrpc_get_inarg (mrpc, &in) < 0)
+    if (flux_mrpc_get_inarg_obj (mrpc, &in) < 0)
         errnum = errno;
     else if (modctl_tunload_dec (in, &modname) < 0)
         errnum = EPROTO;
@@ -77,7 +77,7 @@ static int unload_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         errnum = errno;
     //flux_log (h, LOG_DEBUG, "%s: result %d", __FUNCTION__, errnum);
     if ((out = modctl_runload_enc (errnum)))
-        flux_mrpc_put_outarg (mrpc, out);
+        flux_mrpc_put_outarg_obj (mrpc, out);
     else
         flux_log (h, LOG_ERR, "%s: modctl_runload_enc: %s",
                   __FUNCTION__, strerror (errno));
@@ -98,7 +98,7 @@ done:
 static int load_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     JSON o = NULL;
-    flux_mrpc_t mrpc = NULL;
+    flux_mrpc_t *mrpc = NULL;
     JSON in = NULL;
     JSON out = NULL;
     const char *json_str;
@@ -114,13 +114,13 @@ static int load_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
                   strerror (errno));
         goto done;
     }
-    if (!(mrpc = flux_mrpc_create_fromevent (h, o))) {
+    if (!(mrpc = flux_mrpc_create_fromevent_obj (h, o))) {
         if (errno != EINVAL) /* EINVAL == not addressed to me */
             flux_log (h, LOG_ERR, "%s: flux_mrpc_create_fromevent: %s",
                       __FUNCTION__, strerror (errno));
         goto done;
     }
-    if (flux_mrpc_get_inarg (mrpc, &in) < 0)
+    if (flux_mrpc_get_inarg_obj (mrpc, &in) < 0)
         errnum = errno;
     else if (modctl_tload_dec (in, &path, &argc, &argv) < 0)
         errnum = EPROTO;
@@ -128,7 +128,7 @@ static int load_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         errnum = errno;
     //flux_log (h, LOG_DEBUG, "%s: result %d", __FUNCTION__, errnum);
     if ((out = modctl_rload_enc (errnum)))
-        flux_mrpc_put_outarg (mrpc, out);
+        flux_mrpc_put_outarg_obj (mrpc, out);
     else
         flux_log (h, LOG_ERR, "%s: modctl_rload_enc: %s",
                   __FUNCTION__, strerror (errno));
@@ -158,7 +158,7 @@ static int lsmod_cb (const char *name, int size, const char *digest, int idle,
 static int list_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
     JSON o = NULL;
-    flux_mrpc_t mrpc = NULL;
+    flux_mrpc_t *mrpc = NULL;
     JSON in = NULL;
     JSON out = NULL;
     const char *json_str;
@@ -172,13 +172,13 @@ static int list_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
                   strerror (errno));
         goto done;
     }
-    if (!(mrpc = flux_mrpc_create_fromevent (h, o))) {
+    if (!(mrpc = flux_mrpc_create_fromevent_obj (h, o))) {
         if (errno != EINVAL) /* EINVAL == not addressed to me */
             flux_log (h, LOG_ERR, "%s: flux_mrpc_create_fromevent: %s",
                       __FUNCTION__, strerror (errno));
         goto done;
     }
-    if (flux_mrpc_get_inarg (mrpc, &in) < 0)
+    if (flux_mrpc_get_inarg_obj (mrpc, &in) < 0)
         errnum = errno;
     else if (modctl_tlist_dec (in, &svc) < 0)
         errnum = EPROTO;
@@ -191,7 +191,7 @@ static int list_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         flux_log (h, LOG_ERR, "%s: modctl_rlist_enc: %s",
                   __FUNCTION__, strerror (errno));
     } else
-        flux_mrpc_put_outarg (mrpc, out);
+        flux_mrpc_put_outarg_obj (mrpc, out);
     if (flux_mrpc_respond (mrpc) < 0) {
         flux_log (h, LOG_ERR, "flux_mrpc_respond: %s", strerror (errno));
         goto done;

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -265,7 +265,7 @@ static void topo_cb (flux_t h,
                      void *arg)
 {
     ctx_t *ctx = (ctx_t *)arg;
-    kvsdir_t kd = NULL;
+    kvsdir_t *kd = NULL;
     json_object *out = NULL;
     char *buffer;
     int buflen;
@@ -288,7 +288,7 @@ static void topo_cb (flux_t h,
 
     hwloc_topology_set_custom (global);
 
-    kvsitr_t base_iter = kvsitr_create (kd);
+    kvsitr_t *base_iter = kvsitr_create (kd);
     const char *base_key = NULL;
     while ((base_key = kvsitr_next (base_iter))) {
         char *xml = NULL;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -185,16 +185,16 @@ static void add_jobinfo (flux_t h, int64_t id, json_object *req)
     char buf [64];
     json_object_iter i;
     json_object *o;
-    kvsdir_t dir;
+    kvsdir_t *dir;
 
     if (kvs_get_dir (h, &dir, "lwj.%lu", id) < 0)
         err_exit ("kvs_get_dir (id=%lu)", id);
 
     json_object_object_foreachC (req, i)
-        kvsdir_put (dir, i.key, i.val);
+        kvsdir_put_obj (dir, i.key, i.val);
 
     o = json_object_new_string (ctime_iso8601_now (buf, sizeof (buf)));
-    kvsdir_put (dir, "create-time", o);
+    kvsdir_put_obj (dir, "create-time", o);
     json_object_put (o);
 
     kvsdir_destroy (dir);

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -413,11 +413,11 @@ static int rexec_kill (struct rexec_ctx *ctx, int64_t id, int sig)
     return rexec_session_kill (s, sig);
 }
 
-static int mrpc_respond_errnum (flux_mrpc_t mrpc, int errnum)
+static int mrpc_respond_errnum (flux_mrpc_t *mrpc, int errnum)
 {
     json_object *o = json_object_new_object ();
     util_json_object_add_int (o, "errnum", errnum);
-    flux_mrpc_put_outarg (mrpc, o);
+    flux_mrpc_put_outarg_obj (mrpc, o);
     json_object_put (o);
     return (0);
 }
@@ -431,21 +431,21 @@ static int mrpc_handler (struct rexec_ctx *ctx, zmsg_t *zmsg)
     json_object *request = NULL;
     int rc = -1;
     flux_t f = ctx->h;
-    flux_mrpc_t mrpc;
+    flux_mrpc_t *mrpc;
 
     if (flux_event_decode (zmsg, NULL, &json_str) < 0
                 || !(request = Jfromstr (json_str)) ) {
         flux_log (f, LOG_ERR, "flux_event_decode: %s", strerror (errno));
         return (0);
     }
-    mrpc = flux_mrpc_create_fromevent (f, request);
+    mrpc = flux_mrpc_create_fromevent_obj (f, request);
     if (mrpc == NULL) {
         if (errno != EINVAL) /* EINVAL == not addressed to me */
             flux_log (f, LOG_ERR, "flux_mrpc_create_fromevent: %s",
                       strerror (errno));
         return (0);
     }
-    if (flux_mrpc_get_inarg (mrpc, &inarg) < 0) {
+    if (flux_mrpc_get_inarg_obj (mrpc, &inarg) < 0) {
         flux_log (f, LOG_ERR, "flux_mrpc_get_inarg: %s", strerror (errno));
         goto done;
     }

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -490,7 +490,7 @@ done:
 
 int lwj_targets_this_node (struct rexec_ctx *ctx, int64_t id)
 {
-    kvsdir_t tmp;
+    kvsdir_t *tmp;
     /*
      *  If no 'rank' subdir exists for this lwj, then we are running
      *   without resource assignment so we run everywhere

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -181,7 +181,7 @@ fetch_kv_tuple (kap_params_t *param, int fet_i,
     *            MEASURE Gets LATENCY             *
     **********************************************/
     Begin = now ();
-    if ( kvs_get (param->pers.handle, k, &o) < 0) {
+    if ( kvs_get_obj (param->pers.handle, k, &o) < 0) {
         fprintf (stderr, "kvs_get failed.\n");
         goto error;
     }
@@ -277,7 +277,7 @@ put_test_obj (kap_params_t *param)
              *        MEASURE PUT LATENCY                  *
              **********************************************/
             Begin = now ();
-            if ( kvs_put (param->pers.handle, k, o) < 0) {
+            if ( kvs_put_obj (param->pers.handle, k, o) < 0) {
                 fprintf (stderr, 
                     "kvs_put failed %s", strerror(errno));
                 goto error;

--- a/src/test/tkvstorture.c
+++ b/src/test/tkvstorture.c
@@ -128,7 +128,7 @@ int main (int argc, char *argv[])
             oom ();
         fill (val, i, size);
         vo = json_object_new_string (val);
-        if (kvs_put (h, key, vo) < 0)
+        if (kvs_put_obj (h, key, vo) < 0)
             err_exit ("kvs_put %s", key);
         if (verbose)
             msg ("%s = %s", key, val);
@@ -151,7 +151,7 @@ int main (int argc, char *argv[])
         if (asprintf (&key, "%s.key%d", prefix, i) < 0)
             oom ();
         fill (val, i, size);
-        if (kvs_get (h, key, &vo) < 0)
+        if (kvs_get_obj (h, key, &vo) < 0)
             err_exit ("kvs_get '%s'", key);
         s = json_object_get_string (vo);
         if (verbose)


### PR DESCRIPTION
This PR is step one in a two step process to make our public API json-c free.

The kvs, libmrpc, and libjsc functions that accept `json_object *` arguments are renamed to have a `_obj` suffix with `__attribute__ ((deprecated))` and new functions that accept JSON string arguments replace the originals.  In tree users are modified to use the deprecated interface, basically a search and replace so risk of this change is minimal.   Exception: `flux-jstat` uses the new libjsc functions.

The libzio, libkz, and libsubprocess functions that accept `json_object *` arguments were directly modified to accept JSON string arguments.  These interfaces have no out of tree users, thus it seemed best to convert them directly and get it over with.

All typedefs in the above interfaces are fixed to be RFC 7 compliant.

There are now many deprecated function warnings emitted when building the system, but we have a clear path to fix these, one at a time if we like.

Once the warnings have been eliminated, step two is to drop the deprecated functions.

A small PR to flux-sched will need to follow this one.