### PR TITLE
Python lazyness

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -195,19 +195,19 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
             new_kvsdir.fill(contents)
 
     def files(self):
-        for k in self.keys():
+        for k in self:
             if not self.pimpl.isdir(k):
                 yield k
 
     def directories(self):
-        for k in self.keys():
+        for k in self:
             if self.pimpl.isdir(k):
                 yield k
 
     def list_all(self, topdown=False):
         files = []
         dirs = []
-        for k in self.keys():
+        for k in self:
             if self.pimpl.isdir(k):
                 dirs.append(k)
             else:
@@ -235,18 +235,16 @@ def join(*args):
 
 
 def inner_walk(kd, curr_dir, topdown=False):
-    files = kd.files()
-    dirs = kd.directories()
     if topdown:
-        yield (curr_dir, dirs, files)
+        yield (curr_dir, kd.directories(), kd.files())
 
-    for d in dirs:
+    for d in kd.directories():
         path = join(curr_dir, d)
-        for x in inner_walk(kd[d], path, topdown):
+        for x in inner_walk(get_dir(kd.fh, kd.key_at(d)), path, topdown):
             yield x
 
     if not topdown:
-        yield (curr_dir, dirs, files)
+        yield (curr_dir, kd.directories(), kd.files())
 
 
 def walk(directory, topdown=False, flux_handle=None):
@@ -256,9 +254,7 @@ def walk(directory, topdown=False, flux_handle=None):
             raise ValueError(
                 "If directory is a key, flux_handle must be specified")
         directory = KVSDir(flux_handle, directory)
-    for x in inner_walk(directory, '', topdown):
-        yield x
-
+    return inner_walk(directory, '', topdown)
 
 @ffi.callback('kvs_set_obj_f')
 def KVSWatchWrapper(key, value, arg, errnum):

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -161,11 +161,7 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
         return self.KVSDirIterator(self)
 
     def __len__(self):
-        # TODO find a less horrifyingly inefficient way to do this
-        count = 0
-        for b in self:
-            count += 1
-        return count
+        return self.pimpl.get_size()
 
     def fill(self, contents):
         """ Populate this directory with keys specified by contents, which must
@@ -198,6 +194,16 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
         if contents is not None:
             new_kvsdir.fill(contents)
 
+    def files(self):
+        for k in self.keys():
+            if not self.pimpl.isdir(k):
+                yield k
+
+    def directories(self):
+        for k in self.keys():
+            if self.pimpl.isdir(k):
+                yield k
+
     def list_all(self, topdown=False):
         files = []
         dirs = []
@@ -229,7 +235,8 @@ def join(*args):
 
 
 def inner_walk(kd, curr_dir, topdown=False):
-    (files, dirs) = kd.list_all(topdown)
+    files = kd.files()
+    dirs = kd.directories()
     if topdown:
         yield (curr_dir, dirs, files)
 

--- a/src/bindings/python/test/kvs.py
+++ b/src/bindings/python/test/kvs.py
@@ -140,8 +140,8 @@ class TestKVS(unittest.TestCase):
         (r, ds, fs) = walk_gen.next()
         print(r, ds, fs)
         self.assertEqual(r, '')
-        self.assertEqual(len(ds), 14)
-        self.assertEqual(len(fs), 14)
+        self.assertEqual(len(list(ds)), 14)
+        self.assertEqual(len(list(fs)), 14)
 
         for r, ds, fs in walk_gen:
             pass


### PR DESCRIPTION
Make use of the new `kvsdir_get_size` interface #351, and use the reduction in length calculation cost to avoid the generation of some unnecessary lists.  This also makes an adjustment to argument handling in the wrapper, which is not externally visible other than wasting significantly less cycles.