### PR TITLE
util/env: fix infinite loop in getints

### DIFF
--- a/src/common/libutil/env.c
+++ b/src/common/libutil/env.c
@@ -58,7 +58,7 @@ static int _strtoia (char *s, int *ia, int ia_len)
     if (!s)
         return -1;
 
-    while (s) {
+    while (*s) {
         n = strtoul (s, &next, 10);
         s = *next == '\0' ? next : next + 1;
         if (ia) {


### PR DESCRIPTION
Not sure how long this has been lurking, but the _strtoia check for done
under getints becomes an infinite loop when used in counting mode.  This
came up when trying to use the PMI interface, which relies on this.