### PR TITLE
fix wreck buglets and add PMI test

### DIFF
--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -253,12 +253,14 @@ end
 --
 --  Create iowatchers for all tasks stdout/err:
 --
+--  XXX: The `nio` IO counter must be initialized before creating
+--   all IO watchers.
+nio = wreck.ntasks * 2
 for i=0, wreck.ntasks-1 do
     for _,stream in pairs{ "stdout", "stderr"} do
         iow = io_watcher_create (stream, resp.jobid, i)
     end
 end
-nio = wreck.ntasks * 2
 
 --
 --  Open stdin (to task 0 only for now)

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -299,6 +299,14 @@ local s, err = f:sighandler {
     end
 }
 
+local s, err = f:sighandler {
+    sigmask = { posix.SIGALRM },
+    handler = function (f, s, sig)
+        wreck:say ("Killed by SIGALRM: state = %s, nio = %d\n", state, nio)
+	os.exit (1)
+    end
+}
+
 --
 --  Begin reactor loop:
 --

--- a/src/common/libutil/env.c
+++ b/src/common/libutil/env.c
@@ -33,13 +33,13 @@
 int env_getint (char *name, int dflt)
 {
     char *ev = getenv (name);
-    return ev ? strtoul (ev, NULL, 10) : dflt;
+    return ev ? strtol (ev, NULL, 0) : dflt;
 }
 
 bool env_getbool (char *name, bool dflt)
 {
     char *ev = getenv (name);
-    if (ev && (ev[0] == 't' || ev[0] == 'T' || strtoul(ev, NULL, 10)))
+    if (ev && (ev[0] == 't' || ev[0] == 'T' || strtol (ev, NULL, 0) != 0))
         return true;
     return false;
 }
@@ -59,7 +59,7 @@ static int _strtoia (char *s, int *ia, int ia_len)
         return -1;
 
     while (*s) {
-        n = strtoul (s, &next, 10);
+        n = strtol (s, &next, 0);
         s = *next == '\0' ? next : next + 1;
         if (ia) {
             if (ia_len == len)

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -67,7 +67,7 @@ typedef struct {
     int cmb_rank;
     flux_t fctx;
     char kvsname[PMI_MAX_KVSNAMELEN];
-    bool trace;
+    int trace;
 } pmi_ctx_t;
 #define PMI_CTX_MAGIC 0xcafefaad
 

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -90,10 +90,10 @@ static inline void trace (int flags, const char *fmt, ...)
 
     if (ctx && (flags & ctx->trace)) {
         char buf[64];
-        snprintf (buf, sizeof (buf), "[%d.%d.%d] %s", ctx->cmb_rank,
+        snprintf (buf, sizeof (buf), "[%d.%d.%d] %s\n", ctx->cmb_rank,
                   ctx->appnum, ctx->rank, fmt);
         va_start (ap, fmt);
-        flux_vlog (ctx->fctx, LOG_DEBUG, buf, ap);
+        vfprintf (stdout, buf, ap);
         va_end (ap);
     }
 }
@@ -134,7 +134,6 @@ int PMI_Init (int *spawned)
         err ("flux_open");
         goto fail;
     }
-    flux_log_set_facility (ctx->fctx, "pmi");
     ctx->cmb_rank = flux_rank (ctx->fctx);
     trace_simple (PMI_TRACE_INIT);
     *spawned = ctx->spawned;

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -118,10 +118,10 @@ int PMI_Init (int *spawned)
 
     ctx->trace = env_getint ("PMI_TRACE", 0);
 
-    ctx->size = env_getint ("FLUX_LWJ_NTASKS", 1);
-    ctx->rank = env_getint ("FLUX_LWJ_TASK_ID", 0);
-    ctx->appnum = env_getint ("FLUX_LWJ_ID", 1);
-    if (env_getints ("FLUX_LWJ_GTIDS", &ctx->clique_ranks, &ctx->clique_size,
+    ctx->size = env_getint ("FLUX_JOB_SIZE", 1);
+    ctx->rank = env_getint ("FLUX_TASK_RANK", 0);
+    ctx->appnum = env_getint ("FLUX_JOB_ID", 1);
+    if (env_getints ("FLUX_LOCAL_RANKS", &ctx->clique_ranks, &ctx->clique_size,
                      dflt_clique_ranks, dflt_clique_size) < 0)
         goto fail;
 

--- a/src/modules/barrier/libbarrier.c
+++ b/src/modules/barrier/libbarrier.c
@@ -45,7 +45,7 @@ static ctx_t *getctx (flux_t h)
 {
     ctx_t *ctx = flux_aux_get (h, "barriercli");
     if (!ctx) {
-        const char *id = getenv ("FLUX_LWJ_ID");
+        const char *id = getenv ("FLUX_JOB_ID");
         if (!id && !(id = getenv ("SLURM_STEPID")))
             return NULL;
         ctx = xzmalloc (sizeof (*ctx));

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1045,8 +1045,8 @@ int exec_command (struct prog_ctx *ctx, int i)
         prog_ctx_setenv  (ctx, "FLUX_TMPDIR", getenv ("FLUX_TMPDIR"));
         prog_ctx_setenvf (ctx, "MPIRUN_RANK",     1, "%d", t->globalid);
         prog_ctx_setenvf (ctx, "PMI_RANK", 1, "%d", t->globalid);
-        prog_ctx_setenvf (ctx, "FLUX_LWJ_TASK_ID", 1, "%d", t->globalid);
-        prog_ctx_setenvf (ctx, "FLUX_LWJ_LOCAL_TASK_ID", 1, "%d", i);
+        prog_ctx_setenvf (ctx, "FLUX_TASK_RANK", 1, "%d", t->globalid);
+        prog_ctx_setenvf (ctx, "FLUX_TASK_LOCAL_ID", 1, "%d", i);
 
         if (prog_ctx_getopt (ctx, "stop-children-in-exec")) {
             /* Stop process on exec with parent attached */
@@ -1397,14 +1397,14 @@ int exec_commands (struct prog_ctx *ctx)
 
     lua_stack_call (ctx->lua_stack, "rexecd_init");
 
-    prog_ctx_setenvf (ctx, "FLUX_LWJ_ID",    1, "%d", ctx->id);
-    prog_ctx_setenvf (ctx, "FLUX_LWJ_NNODES",1, "%d", ctx->nnodes);
+    prog_ctx_setenvf (ctx, "FLUX_JOB_ID",    1, "%d", ctx->id);
+    prog_ctx_setenvf (ctx, "FLUX_JOB_NNODES",1, "%d", ctx->nnodes);
     prog_ctx_setenvf (ctx, "FLUX_NODE_ID",   1, "%d", ctx->nodeid);
-    prog_ctx_setenvf (ctx, "FLUX_LWJ_NTASKS",1, "%d", ctx->total_ntasks);
+    prog_ctx_setenvf (ctx, "FLUX_JOB_SIZE",  1, "%d", ctx->total_ntasks);
     prog_ctx_setenvf (ctx, "MPIRUN_NPROCS", 1, "%d", ctx->total_ntasks);
     prog_ctx_setenvf (ctx, "PMI_SIZE", 1, "%d", ctx->total_ntasks);
     gtid_list_create (ctx, buf, sizeof (buf));
-    prog_ctx_setenvf (ctx, "FLUX_LWJ_GTIDS",  1, "%s", buf);
+    prog_ctx_setenvf (ctx, "FLUX_LOCAL_RANKS",  1, "%s", buf);
 
     for (i = 0; i < ctx->nprocs; i++)
         exec_command (ctx, i);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -82,6 +82,7 @@ struct prog_ctx {
     int noderank;
 
     int64_t id;             /* id of this execution */
+    int total_ntasks;       /* Total number of tasks in job */
     int nnodes;
     int nodeid;
     int nprocs;             /* number of copies of command to execute */
@@ -656,6 +657,9 @@ int prog_ctx_load_lwj_info (struct prog_ctx *ctx, int64_t id)
         log_fatal (ctx, 1, "Failed to get cmdline from kvs");
 
     prog_ctx_get_nodeinfo (ctx);
+
+    if (kvsdir_get_int (ctx->kvs, "ntasks", &ctx->total_ntasks) < 0)
+        log_fatal (ctx, 1, "Failed to get ntasks from kvs\n");
 
     /*
      *  See if we've got 'cores' assigned for this host
@@ -1396,9 +1400,9 @@ int exec_commands (struct prog_ctx *ctx)
     prog_ctx_setenvf (ctx, "FLUX_LWJ_ID",    1, "%d", ctx->id);
     prog_ctx_setenvf (ctx, "FLUX_LWJ_NNODES",1, "%d", ctx->nnodes);
     prog_ctx_setenvf (ctx, "FLUX_NODE_ID",   1, "%d", ctx->nodeid);
-    prog_ctx_setenvf (ctx, "FLUX_LWJ_NTASKS",1, "%d", ctx->nprocs * ctx->nnodes);
-    prog_ctx_setenvf (ctx, "MPIRUN_NPROCS", 1, "%d", ctx->nprocs * ctx->nnodes);
-    prog_ctx_setenvf (ctx, "PMI_SIZE", 1, "%d", ctx->nprocs * ctx->nnodes);
+    prog_ctx_setenvf (ctx, "FLUX_LWJ_NTASKS",1, "%d", ctx->total_ntasks);
+    prog_ctx_setenvf (ctx, "MPIRUN_NPROCS", 1, "%d", ctx->total_ntasks);
+    prog_ctx_setenvf (ctx, "PMI_SIZE", 1, "%d", ctx->total_ntasks);
     gtid_list_create (ctx, buf, sizeof (buf));
     prog_ctx_setenvf (ctx, "FLUX_LWJ_GTIDS",  1, "%s", buf);
 

--- a/src/test/tpmikvs.c
+++ b/src/test/tpmikvs.c
@@ -79,8 +79,8 @@ static void timesince (int rank,  struct timeval *start, const char *s)
 
     xgettimeofday (rank, &end, NULL);
     timersub (&end, start, &t);
-    fprintf (stderr, "%d: %s: %lu.%.3lu sec\n",
-             rank, s, t.tv_sec, t.tv_usec / 1000);
+    printf ("%d: %s: %lu.%.3lu sec\n", rank, s, t.tv_sec, t.tv_usec / 1000);
+    fflush (stdout);
 }
 
 #define OPTIONS "nN:"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -30,6 +30,7 @@ TESTS = \
 	t1006-apidisconnect.t \
 	t2000-wreck.t \
 	t2001-jsc.t \
+	t2002-pmi.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
@@ -66,6 +67,7 @@ check_SCRIPTS = \
 	t1006-apidisconnect.t \
 	t2000-wreck.t \
 	t2001-jsc.t \
+	t2002-pmi.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/t1001-barrier-basic.t
+++ b/t/t1001-barrier-basic.t
@@ -28,14 +28,14 @@ test_expect_success 'barrier: blocks while incomplete' '
 '
 
 test_expect_success 'barrier: fails with name=NULL outside of LWJ' '
-	unset FLUX_LWJ_ID
+	unset FLUX_JOB_ID
 	unset SLURM_STEPID
 	test_expect_code 1 ${tbarrier} --nprocs 1
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside LWJ' '
 	unset SLURM_STEPID
-        FLUX_LWJ_ID=1; export FLUX_LWJ_ID
+        FLUX_JOB_ID=1; export FLUX_JOB_ID
 	flux exec ${tbarrier} --nprocs ${SIZE}
 '
 

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -1,0 +1,115 @@
+#!/bin/sh
+#
+
+test_description='Test that PMI works in a Flux-launched program 
+
+Test that PMI works in a FLux-launched program 
+'
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(($(nproc)+1))
+test ${SIZE} -gt 4 || SIZE=4
+test_under_flux ${SIZE}
+echo "# $0: flux session size will be ${SIZE}"
+
+# Usage: run_program timeout ntasks nnodes
+run_program() {
+	local timeout=$1
+	local ntasks=$2
+	local nnodes=$3
+	shift 3
+	export PMI_TRACE=0x38
+	run_timeout $timeout flux wreckrun -l -o stdio-delay-commit \
+		    -n${ntasks} -N${nnodes} $*
+}
+
+test_expect_success 'pmi: wreck sets FLUX_JOB_SIZE' '
+	run_program 5 ${SIZE} ${SIZE} printenv FLUX_JOB_SIZE >output_size &&
+        test `wc -l < output_size` -eq ${SIZE} &&
+	test `cut -d: -f2 output_size | uniq` -eq ${SIZE}
+'
+
+test_expect_success 'pmi: wreck sets FLUX_TASK_RANK' '
+	run_program 5 4 4 printenv FLUX_TASK_RANK | sort >output_rank &&
+	cat >expected_rank <<-EOF  &&
+	0: 0
+	1: 1
+	2: 2
+	3: 3
+	EOF
+	test_cmp expected_rank output_rank
+'
+
+# FIXME: this test hardwires the expectations that job ID's are
+# assigned in a particular sequence.  We don't really care about that,
+# just that it's set to an integer that be returned by PMI_Get_appnum().
+test_expect_success 'pmi: wreck sets FLUX_JOB_ID' '
+	run_program 5 ${SIZE} ${SIZE} printenv FLUX_JOB_ID >output_appnum &&
+        test `wc -l < output_appnum` = ${SIZE} &&
+	test `cut -d: -f2 output_appnum | uniq` -eq 3
+'
+
+test_expect_success 'pmi: wreck sets FLUX_LOCAL_RANKS multiple tasks per node' '
+	run_program 5 ${SIZE} 1 printenv FLUX_LOCAL_RANKS >output_clique &&
+	test `cut -d: -f2 output_clique | uniq` = `seq -s, 0 $((${SIZE}-1))`
+'
+
+test_expect_success 'pmi: wreck sets FLUX_LOCAL_RANKS single task per node' '
+	run_timeout 5 flux wreckrun -l -N4 printenv FLUX_LOCAL_RANKS \
+						| sort >output_clique2 &&
+	cat >expected_clique2 <<-EOF  &&
+	0: 0
+	1: 1
+	2: 2
+	3: 3
+	EOF
+	test_cmp expected_clique2 output_clique2
+'
+
+test_expect_success 'pmi: (put*1) / barrier / (get*1) pattern works' '
+	run_program 10 ${SIZE} ${SIZE} \
+	    ${FLUX_BUILD_DIR}/src/test/tpmikvs >output_tpmikvs &&
+	grep -q "put phase" output_tpmikvs &&
+	grep -q "get phase" output_tpmikvs &&
+	test `grep PMI_KVS_Put output_tpmikvs | wc -l` -eq ${SIZE} &&
+	test `grep PMI_Barrier output_tpmikvs | wc -l` -eq $((${SIZE}*2)) &&
+	test `grep PMI_KVS_Get output_tpmikvs | wc -l` -eq ${SIZE} 
+'
+
+test_expect_success 'pmi: (put*1) / barrier / (get*size) pattern works' '
+	run_program 30 ${SIZE} ${SIZE} \
+	    ${FLUX_BUILD_DIR}/src/test/tpmikvs -n >output_tpmikvs2 &&
+	grep -q "put phase" output_tpmikvs2 &&
+	grep -q "get phase" output_tpmikvs2 &&
+	test `grep PMI_KVS_Put output_tpmikvs2 | wc -l` -eq ${SIZE} &&
+	test `grep PMI_Barrier output_tpmikvs2 | wc -l` -eq $((${SIZE}*2)) &&
+	test `grep PMI_KVS_Get output_tpmikvs2 | wc -l` -eq $((${SIZE}*${SIZE}))
+'
+
+test_expect_success 'pmi: (put*16) / barrier / (get*16) pattern works' '
+	run_program 30 ${SIZE} ${SIZE} \
+	    ${FLUX_BUILD_DIR}/src/test/tpmikvs -N 16 >output_tpmikvs3 &&
+	grep -q "put phase" output_tpmikvs3 &&
+	grep -q "get phase" output_tpmikvs3 &&
+	test `grep PMI_KVS_Put output_tpmikvs3 | wc -l` -eq $((${SIZE}*16)) &&
+	test `grep PMI_Barrier output_tpmikvs3 | wc -l` -eq $((${SIZE}*2)) &&
+	test `grep PMI_KVS_Get output_tpmikvs3 | wc -l` -eq $((${SIZE}*16))
+'
+
+test_expect_success 'pmi: (put*16) / barrier / (get*16*size) pattern works' '
+	run_program 60 ${SIZE} ${SIZE} \
+	    ${FLUX_BUILD_DIR}/src/test/tpmikvs -n -N 16 >output_tpmikvs4 &&
+	grep -q "put phase" output_tpmikvs4 &&
+	grep -q "get phase" output_tpmikvs4 &&
+	test `grep PMI_KVS_Put output_tpmikvs4 | wc -l` -eq $((${SIZE}*16)) &&
+	test `grep PMI_Barrier output_tpmikvs4 | wc -l` -eq $((${SIZE}*2))  &&
+	test `grep PMI_KVS_Get output_tpmikvs4 | wc -l` -eq $((${SIZE}*16*${SIZE}))
+'
+
+test_done


### PR DESCRIPTION
Add a sharness test that drives the existing `tpmikvs` test, which simulates PMIv1 access patterns of mvapich and openpmi.  This uncovered a few wreck bugs, which were addressed by @grondo.

The test is in liu of a proper test that Flux can launch an MPI program as requested in issue #340.

We still have one test that fails in the constrained travis-ci environment, but succeeds elsewhere, that is disabled pending more wreck debug work.  We thought we should get these fixes in without further delay.

Fixes #357

