### PR TITLE
allow flux to launch flux

### DIFF
--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -10,16 +10,15 @@ flux-broker - Flux comms message broker daemon
 
 SYNOPSIS
 --------
-*flux-broker* ['OPTIONS']
+*flux-broker* ['OPTIONS'] ['initial-program' ['args...']]
 
 
 DESCRIPTION
 -----------
-flux-broker(1) is usually invoked indirectly, e.g. see flux-start(1).
-
 flux-broker(1) is a distributed message broker daemon that provides
-communications services within a Flux comms session.  Flux jobs have
-a dedicated comms session, while Flux light-weight jobs (LWJs) do not.
+communications services within a Flux comms session.  It may be
+launched as a parallel program under Flux or other resource managers
+that support PMI.
 
 Resource manager services are implemented as dynamically loadable
 plugins to flux-broker(1), termed "comms modules".
@@ -37,9 +36,10 @@ resource manager activities across the session.
 A logging service aggregates Flux log messages across the session and
 emits them to a configured destination on rank 0.
 
-If flux-broker(1) is executed with stdin attached to a tty, a shell is spawned.
-*FLUX_TMPDIR* is set in the shell's environment so Flux commands run
-by the shell can locate the Flux API socket belonging to rank 0.
+After its overlay networks have completed wire-up, flux-broker(1)
+starts the initial program on rank 0.  If none is specified on
+the broker command line, an interactive shell is launched.
+
 
 OPTIONS
 -------
@@ -52,43 +52,25 @@ Be annoyingly chatty.
 *-q, --quiet*::
 Suppress messages intended for interactive users.
 
-*-t, --child-uri*='URI'::
-Set the ZeroMQ endpoint to which this flux-broker(1) instance will bind,
-and tree based overlay network child flux-broker(1) instances will connect.
-In addition, the ring overlay network peers connect to this endpoint.
-
-*-p, --parent-uri*='URI'::
-Set the ZeroMQ endpoint to which this flux-broker(1) will connect its
-tree based overlay network.
-
-*-r, --right-uri*='URI'::
-Set the ZeroMQ endpoint to which this flux-broker(1) will connect its
-ring network.
-
-*-e, --event-uri*='URI'::
-On rank 0, set the ZeroMQ endpoint to which events will be published.
-On other ranks, set the ZeroMQ endpoint from which events will be received.
-Events are only published directly by rank 0; other ranks send a request
-over the tree-based overlay network to rank 0 to publish by proxy.
-
 *-S, --size*='N'::
 Set the size of this comms session.
+This is only necessary for the LOCAL boot method.
 
 *-R, --rank*='N'::
 Set the rank of this broker instance, 0 to size - 1.
+This is only necessary for the LOCAL boot method.
+
+*-N, --sid*='NAME'::
+Set the session id of this session.
+This is only necessary for the LOCAL boot method.
 
 *-k, --k-ary*='N'::
 Set the branching factor of this comms session's tree based overlay
-network (default 2).
+network (default: 2).
 
 *-H, --heartrate*='N.N'::
 Set the session heartrate in seconds.  The valid range is 0.01 to 30.0
-(default 2.0).
-
-*-N, --sid*='NAME'::
-Set the session id of this session (default "0").  The session id need
-not be numerical.  The base name of *FLUX_TMPDIR* will be set to
-"flux-'sid'-'rank'".
+(default: 2.0).
 
 *-L, --logdest*='DEST'::
 Set logging destination.  DEST may be 'syslog[:facility[:level]]',
@@ -110,23 +92,30 @@ multiple times to load multiple modules.
 Override the compiled-in module search path (colon-separated).
 The default is to search install paths.
 
+*-x,--exclude *='NAME'::
+Do not load the specified comms module.
+
 *-s, --security*='MODE'::
 Set the security mode.  The mode may be 'none', 'plain', or 'curve'
-(default curve).  See flux-keygen(1) for more information.
+(default: curve).  See flux-keygen(1) for more information.
 
-*-p, --pmi-boot*::
-Use PMI to obtain bootstrap configuration from a parent resource manager,
-normally Flux or SLURM.
+*-m, --boot-method*='METHOD'::
+Select the method used to determine rank, size, session id, and
+overlay wire-up information.  Valid methods are SINGLE, LOCAL, and PMI.
+(default: PMI).
 
-*-c, --command*='CMD'::
-Execute "bash -c 'CMD'" on rank 0.
+*-E, --enable-epgm*::
+Enable EPGM for event distribution.
+The interface associated with the hostname will be used.
+This only works with the PMI boot method.
 
-*-n, --noshell*::
-Do not execute a shell on rank 0, even if stdin is a tty.
+*-D, --socket-directory*='DIR'::
+Create ipc:// sockets in this directory.
+This is only necessary for the LOCAL boot method.
 
-*-f, --force*::
-If another flux-broker is running in the same *FLUX_TMPDIR* space,
-send it a SIGKILL and continue start-up.
+*-g, --shutdown-grace*='SECS'::
+Specify the shutdown grace period, in seconds (default: guess based
+on session size).
 
 
 AUTHOR

--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -5,32 +5,21 @@ FLUX-START(1)
 
 NAME
 ----
-flux-start - bootstrap a Flux comms session
+flux-start - bootstrap a local Flux instance
 
 
 SYNOPSIS
 --------
-*flux* *start* ['OPTIONS'] [command ...]
+*flux* *start* ['OPTIONS'] [initial-program [args...]]
 
 
 DESCRIPTION
 -----------
-flux-start(1) launches a Flux comms session using SLURM or by executing
-Flux message brokers directly.  If a command is specified, the rank 0
-broker will execute it, then the session terminates.  Otherwise, rank 0
-will spawn an interactive shell where flux commands can be issued, and
-when the shell exits, the session terminates.
+flux-start(1) launches a Flux instance by starting
+Flux message brokers local, as children of flux-start(1).
+The brokers use UNIX domain sockets to communicate.
 
-In direct mode, all the message brokers are launched on the same node,
-as children of flux-start(1).  The brokers use UNIX domain sockets
-to communicate.
-
-In SLURM mode, message brokers use PMI to exchange socket info.
-TCP and EPGM are used to communicate between nodes.  If multiple brokers
-per node are spawned, UNIX domain sockets will be used to communicate
-within nodes.
-
-Note: in order to launch a Flux comms session, you must have generated
+Note: in order to launch a Flux instance, you must have generated
 long-term CURVE keys using *flux-keygen*.
 
 OPTIONS
@@ -51,22 +40,6 @@ Display commands before executing them.
 
 *-X, --noexec*::
 Don't execute anything.  This option is most useful with -v.
-
-*-S, --slurm*::
-Launch with SLURM.  The default is to launch directly.
-This option is implied if either "--partition" or "--nnodes" is used.
-
-*-p, --partition*='name'::
-Set the SLURM partition.  This option translates directly to the srun
-"--partition=name" option.  It is unnecessary if SLURM is configured
-with a default partition and you want to use that.
-
-*-N, --nnodes*='N'::
-Set the number of nodes to allocate in SLURM.  If 'N' is greater
-than the Flux comms session size, the session size is increased to 'N'
-so that one message broker is launched per node.  If 'N' is less
-than the Flux comms session size, multiple message brokers will be
-launched per node.
 
 
 AUTHOR

--- a/doc/man1/flux.adoc
+++ b/doc/man1/flux.adoc
@@ -43,13 +43,8 @@ Force configuration from file instead of KVS.
 Set the directory to be used long-term keys.
 The default is to use the config directory.
 
-*-T, --tmpdir*='PATH'::
-Run commands with 'FLUX_TMPDIR' set to 'PATH'.
-When there are multiple message brokers on a node, this selects
-which API socket to connect to.
-
 *-u, --uri*='URI'::
-Override default URI used to connect to flux-broker.
+Set the URI used to connect to flux-broker.
 
 *-t, --trace-apisock*::
 Trace API socket traffic to 'stderr'.
@@ -126,18 +121,9 @@ setenv FLUX_TRACE_APISOCK::
 Set to "1" if --trace-apisock was specified.  This causes the FLUX_FLAGS_TRACE
 flag to be set when an API socket is established by a sub-command.
 
-setenv FLUX_TMPDIR::
-Set if "--tmpdir" was specified.  The broker sets FLUX_TMPDIR when it
-spawns child processes.  It specifies the directory where the API
-socket for that broker can be found, among other things.  If running a
-Flux sub-command from "outside" of a comms session, e.g. not as a process
-descendant of the broker, you may need to set this to find the correct
-API socket.
-
 setenv FLUX_URI::
 Set if "--uri" was specified.  If flux_open(3)'s uri argument is NULL,
-it substitutes the value of FLUX_URI, if set.  Otherwise, it uses
-"local://$FLUX_TMPDIR".
+it substitutes the value of FLUX_URI, if set.  Otherwise, it fails.
 
 
 AUTHOR

--- a/doc/man3/flux_open.adoc
+++ b/doc/man3/flux_open.adoc
@@ -26,8 +26,7 @@ Flux message broker.
 The _uri_ scheme (before "://") specifies the "connector"
 that will be used to establish the connection.  The _uri_ path
 (after "://") is parsed by the connector.  If _uri_ is NULL,
-the "local" connector will be used, with path taken from the $FLUX_TMPDIR
-environment variable.
+the value of $FLUX_URI is used, if set.
 
 _flags_ is the logical "or" of zero or more of the following flags:
 
@@ -55,7 +54,7 @@ ERRORS
 ------
 
 EINVAL::
-Some arguments were invalid.
+_uri_ was NULL and $FLUX_URI was not set, or other arguments were invalid.
 
 ENOMEM::
 Out of memory.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -249,3 +249,5 @@ unweighted
 WCOUNT
 tinfo
 hwloc
+epgm
+args

--- a/etc/flux.conf.in
+++ b/etc/flux.conf.in
@@ -8,6 +8,7 @@ general
     lua_path = @abs_top_srcdir@/src/bindings/lua/?.lua
     python_path = @abs_top_builddir@/src/bindings/python:@abs_top_srcdir@/src/bindings/python/pycotap
     module_path = @abs_top_builddir@/src/modules
+    program_library_path = @abs_top_builddir@/src/lib/libpmi/.libs:@abs_top_builddir@/src/common/.libs
     connector_path = @abs_top_builddir@/src/connectors
     man_path = @abs_top_builddir@/doc
 wrexec

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -3,7 +3,8 @@ AM_CFLAGS = @GCCWARN@
 AM_CPPFLAGS = \
 	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
-	-DMODULE_PATH=\"$(fluxmoddir)\"
+	-DMODULE_PATH=\"$(fluxmoddir)\" \
+	-DPROGRAM_LIBRARY_PATH=\"$(fluxlibdir)\"
 
 fluxlibexec_PROGRAMS = flux-broker
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -184,7 +184,7 @@ static struct boot_method boot_table[] = {
     { NULL, NULL },
 };
 
-#define OPTIONS "vqR:S:M:X:L:N:k:s:c:nH:O:x:T:g:D:Em:"
+#define OPTIONS "vqR:S:M:X:L:N:k:s:c:H:O:x:T:g:D:Em:"
 static const struct option longopts[] = {
     {"sid",             required_argument,  0, 'N'},
     {"verbose",         no_argument,        0, 'v'},
@@ -199,7 +199,6 @@ static const struct option longopts[] = {
     {"logdest",         required_argument,  0, 'L'},
     {"k-ary",           required_argument,  0, 'k'},
     {"command",         required_argument,  0, 'c'},
-    {"noshell",         no_argument,        0, 'n'},
     {"heartrate",       required_argument,  0, 'H'},
     {"timeout",         required_argument,  0, 'T'},
     {"shutdown-grace",  required_argument,  0, 'g'},
@@ -226,7 +225,6 @@ static void usage (void)
 " -s,--security=plain|curve|none    Select security mode (default: curve)\n"
 " -k,--k-ary K                 Wire up in a k-ary tree\n"
 " -c,--command string          Run command on rank 0\n"
-" -n,--noshell                 Do not spawn a shell even if on a tty\n"
 " -H,--heartrate SECS          Set heartrate in seconds (rank 0 only)\n"
 " -T,--timeout SECS            Set wireup timeout in seconds (rank 0 only)\n"
 " -g,--shutdown-grace SECS     Set shutdown grace period in seconds\n"
@@ -241,7 +239,6 @@ int main (int argc, char *argv[])
 {
     int c;
     ctx_t ctx;
-    bool nopt = false;
     zlist_t *modules, *modopts;
     zhash_t *modexclude;
     char *modpath;
@@ -337,9 +334,6 @@ int main (int argc, char *argv[])
                 if (ctx.shell_cmd)
                     free (ctx.shell_cmd);
                 ctx.shell_cmd = xstrdup (optarg);
-                break;
-            case 'n':   /* --noshell */
-                nopt = true;
                 break;
             case 'H':   /* --heartrate SECS */
                 if (heartbeat_set_ratestr (ctx.heartbeat, optarg) < 0)
@@ -551,7 +545,7 @@ int main (int argc, char *argv[])
     update_proctitle (&ctx);
     update_pidfile (&ctx);
 
-    if (!nopt && ctx.rank == 0) {
+    if (ctx.rank == 0) {
         ctx.shell = subprocess_create (ctx.sm);
         subprocess_set_callback (ctx.shell, rank0_shell_exit_handler, &ctx);
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1383,10 +1383,10 @@ static int cmb_getattr_cb (zmsg_t **zmsg, void *arg)
         val = ctx->local_uri;
     else if (!strcmp (name, "parent-uri"))
         val = ctx->parent_uri;
-    else
+    if (!val) {
         errno = ENOENT;
-    if (!val)
         goto done;
+    }
     Jadd_str (out, (char *)name, val);
     rc = flux_json_respond (ctx->h, out, zmsg);
 done:

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -396,11 +396,6 @@ int main (int argc, char *argv[])
         if (kvs_conf_load (h, ctx.cf) < 0)
             err_exit ("could not load config from KVS");
         flux_close (h);
-        /* Stash FLUX_URI value for later use, but unset it in the environment
-         * so a connection to the enclosing instance is not made inadvertantly.
-         */
-        ctx.parent_uri = xstrdup (getenv ("FLUX_URI"));
-        unsetenv ("FLUX_URI");
     }
 
     /* Arrange to load config entries into kvs config.*
@@ -475,6 +470,15 @@ int main (int argc, char *argv[])
     }
     if (!ctx.sid)
         ctx.sid = xstrdup ("0");
+
+    /* Now that PMI is done with it:
+     * stash FLUX_URI value for later use, but unset it in the environment
+     * so a connection to the enclosing instance is not made inadvertantly.
+     */
+    if (getenv ("FLUX_URI")) {
+        ctx.parent_uri = xstrdup (getenv ("FLUX_URI"));
+        unsetenv ("FLUX_URI");
+    }
 
     /* Now that we know the rank (either from command line or PMI,
      * create a subdirectory of socket_dir for the sockets and pidfile

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -436,6 +436,12 @@ void internal_env (flux_conf_t cf, optparse_t p, int ac, char *av[])
         print_environment(cf, "");
 }
 
+void internal_broker (flux_conf_t cf, optparse_t p, int ac, char *av[])
+{
+    const char *path = flux_conf_environment_get(cf, "FLUX_BROKER_PATH");
+    execvp (path, av); /* no return if successful */
+}
+
 struct builtin {
     const char *name;
     const char *doc;
@@ -455,6 +461,12 @@ struct builtin builtin_cmds [] = {
       "Print the flux environment or execute COMMAND inside it",
       "[OPTIONS...] [COMMAND...]",
       internal_env
+    },
+    {
+      "broker",
+      "Run the flux broker",
+      "[OPTIONS...] [COMMAND...]",
+      internal_broker
     },
     { NULL, NULL, NULL, NULL },
 };

--- a/src/common/libflux/info.h
+++ b/src/common/libflux/info.h
@@ -11,10 +11,6 @@ int flux_size (flux_t h);
 
 /* flux_getattr is used to read misc. attributes internal to the broker.
  * The caller must dispose of the returned string with free ().
- * The following attributes are valid:
- *    snoop-uri   The name of the socket to be used by flux-snoop.
- *    parent-uri  The name of parent socket.
- *    request-uri The name of request socket.
  */
 char *flux_getattr (flux_t h, int rank, const char *name);
 

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -94,6 +94,7 @@ static inline void trace (int flags, const char *fmt, ...)
                   ctx->appnum, ctx->rank, fmt);
         va_start (ap, fmt);
         vfprintf (stdout, buf, ap);
+        fflush (stdout);
         va_end (ap);
     }
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -31,6 +31,7 @@ TESTS = \
 	t2000-wreck.t \
 	t2001-jsc.t \
 	t2002-pmi.t \
+	t2003-recurse.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
@@ -68,6 +69,7 @@ check_SCRIPTS = \
 	t2000-wreck.t \
 	t2001-jsc.t \
 	t2002-pmi.t \
+	t2003-recurse.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -71,6 +71,12 @@ test_under_flux() {
       exec flux start --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
+mock_bootstrap_instance() {
+    if test -z "${TEST_UNDER_FLUX_ACTIVE}"; then
+        unset FLUX_URI
+    fi
+}
+
 #
 #  Execute arguments $2-N on rank or ranks specified in arg $1
 #   using the flux-exec utility

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -32,6 +32,10 @@ test_expect_success 'wreckrun: propagates current environment' '
 	  run_timeout 5 flux wreckrun -N1 -n1 env ) | \
            grep "MY_UNLIKELY_ENV=0xdeadbeef"
 '
+test_expect_success 'wreckrun: does not propagate FLUX_URI' '
+	run_timeout 5 flux wreckrun -n4 -N4 printenv FLUX_URI >uri_output &&
+	test `sort uri_output | uniq | wc -l` -eq 4
+'
 test_expect_success 'wreckrun: does not drop output' '
 	for i in `seq 0 100`; do 
 		base64 /dev/urandom | head -c77

--- a/t/t2003-recurse.t
+++ b/t/t2003-recurse.t
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+
+test_description='Test that Flux can launch Flux'
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+mock_bootstrap_instance
+test_under_flux 4
+
+test_expect_success 'recurse: Flux launches Flux ' '
+	printenv FLUX_URI >old_uri &&
+	test -s old_uri &&
+	flux wreckrun -n1 -N1 flux broker \
+		printenv FLUX_URI >new_uri &&
+	test -s new_uri &&
+	! test_cmp old_uri new_uri
+'
+
+test_expect_success 'recurse: local-uri is identical to FLUX_URI' '
+	printenv FLUX_URI >cur_uri &&
+	test -s cur_uri &&
+	flux comms getattr local-uri >attr_uri &&
+	test -s attr_uri &&
+	test_cmp cur_uri attr_uri
+'
+
+test_expect_success 'recurse: parent-uri is unset in bootstrap instance' '
+	! flux comms getattr parent-uri
+'
+
+test_expect_success 'recurse: local-uri != local-uri in enclosing instance' '
+	flux comms getattr local-uri >enc_uri &&
+	test -s enc_uri &&
+	flux wreckrun -n1 -N1 flux broker \
+		flux comms getattr local-uri >attr_uri &&
+	test -s attr_uri &&
+	! test_cmp enc_uri attr_uri
+'
+
+test_expect_success 'recurse: parent-uri == local-uri in enclosing instance' '
+	flux comms getattr local-uri >enc_uri &&
+	test -s enc_uri &&
+	flux wreckrun -n1 -N1 flux broker \
+		flux comms getattr parent-uri >attr_uri &&
+	test -s attr_uri &&
+	test_cmp enc_uri attr_uri
+'
+
+test_expect_success 'recurse: Flux launches Flux launches Flux' '
+	flux wreckrun -n1 -N1 flux broker \
+		flux wreckrun -n1 -N1 flux broker \
+			echo hello >hello_out &&
+	echo hello >hello_expected &&
+	test_cmp hello_expected hello_out
+'
+
+test_done


### PR DESCRIPTION
This PR is for feedback (and maybe for your amusement?) only.  It is a very simple first step towards flux launching flux as discussed in #364.

The `flux-start` command now launches Flux with `wreckrun` if $FLUX_TMPDIR is set.  It provides the `--pmi-boot` option to the broker indicating that it should dlopen a PMI library to exchange endpoint information, as it does when starting under SLURM.

The broker now sets LD_LIBRARY_PATH for the initial program to prepend the installed flux libdir, and before that, any configured `program_library_path`, which the build system sets to include the pmi library directory when running in tree.  This way the broker finds the Flux PMI library instead of SLURM's.  Perhaps this approach will also remove one obstacle to running MPI programs under Flux.

With these changes you can do stuff like this:
```
./flux start flux start flux start flux start hostname
```
or
```
$ cat doit
#/bin/bash
flux start -s1 sleep 15 &
flux start -s2 sleep 10 &
flux start -s4 sleep 5 &
flux start -s1 printenv FLUX_TMPDIR &
wait; wait; wait; wait

$ ./flux start -s8 ./doit
```

This was a quick hack to get this stuff working, but it does a few things wrong:
* It was suggested flux-start needed a better way to add bootstrap methods, such as a simple plugin system.  This was not implemented.
* `flux-start` needed to find `flux-wreckrun`.  It simply uses the `/proc/self/exe` trick that flux.c employs to find it in the same directory as itself, special casing the libtool .libs directory.  This should be done properly although I'm not sure what is proper?
* The broker needed to do all the same PATH dedup stuff that was added to `libflux/conf.c` so nicely, but using the subprocess environment accessors.  Rather than think through whether and how to use that code, I added a little function to do what I needed.
* Needs a sharness test

Obviously most of these will need to be addressed in a serious PR but first I wanted to get this out there in case others wanted to play around and weigh in on the approach or suggest ideas.

I've noted some odd things that need further investigation:
* `flux start -s2 flux start -s4 hostname` hangs, not sure why
* `flux start flux start` works as you'd expect: wreck doesn't offer a pty like srun's, the shell is line buffered, but it works; `flux start flux start flux start` seems to buffer stdin until you type ctrl-D
* haven't tried this under a slurm allocation on multiple nodes (that would be a good test!)
