### PR TITLE
wreck minor updates and fixes

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1130,7 +1130,7 @@ static int l_kvswatcher_newindex (lua_State *L)
     return (0);
 }
 
-static int iowatcher_zio_cb (zio_t *zio, const char *json_str, void *arg)
+static int iowatcher_zio_cb (zio_t *zio, const char *json_str, int n, void *arg)
 {
     json_object *o = NULL;
     int rc;

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -322,7 +322,7 @@ repeat
     --
     if terminate then
         wreck:say ("%4.03fs: Killing LWJ %d\n", tt:get0(), resp.jobid)
-        local rc,err = f:sendevent ("wrexec.kill.%d", resp.jobid)
+        local rc,err = f:sendevent ("wreck.%d.kill", resp.jobid)
         if not rc then
             wreck:say ("Error: Failed to send kill event: %s", err)
         end

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -315,7 +315,8 @@ local s, err = f:sighandler {
 local sigtimer = nil
 
 repeat
-    local r = f:reactor()
+    local r, err = f:reactor()
+    if not r then wreck:die ("flux_reactor: %s", err) end
     --
     --  If we catch a signal then lwj:watch() will be interrupted.
     --   Check to see if we should terminate the job now:

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -135,7 +135,7 @@ static int check_completion (struct subprocess *p)
     return (0);
 }
 
-static int output_handler (zio_t *z, const char *json_str, void *arg)
+static int output_handler (zio_t *z, const char *json_str, int len, void *arg)
 {
     struct subprocess *p = (struct subprocess *) arg;
     json_object *o;

--- a/src/modules/libzio/zio.h
+++ b/src/modules/libzio/zio.h
@@ -7,7 +7,7 @@
 
 typedef struct zio_ctx zio_t;
 
-typedef int  (*zio_send_f)   (zio_t *z, const char *json_str, void *arg);
+typedef int  (*zio_send_f)   (zio_t *z, const char *s, int len, void *arg);
 typedef int  (*zio_close_f)  (zio_t *z, void *arg);
 typedef void (*zio_log_f)    (const char *buf);
 
@@ -127,6 +127,12 @@ int zio_set_debug (zio_t *zio, const char *prefix, zio_log_f logf);
  *  Disable any debug for zio object [zio].
  */
 int zio_set_quiet (zio_t *zio);
+
+/*
+ *  Set zio callback to return raw string data instead of json
+ *   object.
+ */
+int zio_set_raw_output (zio_t *zio);
 
 /*
  *  Override the default send() function for ZIO readers. (Default

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -222,7 +222,8 @@ void prog_ctx_signal_eof (struct prog_ctx *ctx)
      */
     kill (getpid(), SIGCHLD);
 }
-int stdout_cb (zio_t *z, const char *json_str, void *arg)
+
+int stdout_cb (zio_t *z, const char *json_str, int len, void *arg)
 {
     struct task_info *t = arg;
     int rc;
@@ -233,7 +234,7 @@ int stdout_cb (zio_t *z, const char *json_str, void *arg)
     return (rc);
 }
 
-int stderr_cb (zio_t *z, const char *json_str, void *arg)
+int stderr_cb (zio_t *z, const char *json_str, int len, void *arg)
 {
     struct task_info *t = arg;
     int rc;

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -51,4 +51,12 @@ test_expect_success 'wreck: job state events emitted' '
 	EOF
 	test_cmp expected output
 '
+test_expect_success 'wreck: signaling wreckrun works' '
+        run_timeout 5 flux wreckrun -N4 -n4 sleep 100 </dev/null &
+	q=$! &&
+	sleep 1 &&
+        echo killing $q &&
+	kill $q &&
+	test_expect_code 143 wait $q
+'
 test_done


### PR DESCRIPTION
This PR tackles two recent annoying bugs in the wreck code.

1. wrexecd now always puts individual lines in kvs. Multiple lines may be put in chunks, but only one kvs commit per chunk, therefore we shouldn't increase the number of commits due to IO with this change. I split the lines and do separate `kz_put` operations, but this could easily be moved to a `kz_put_lines` function later. As part of these changes `zio` was given a "raw" mode where we return character string to callbacks instead of JSON string (so we can process lines directly)
2. The wrexec-specific dealer router shenanigans are removed, thus closing some fd leaks and removing a lot of lame code.

A small bug in `flux-wreckrun` was also fixed (check your systems for spinning `flux-wreckrun`s), and a test added for signal handling in wreckrun.