### PR TITLE
testsuite: fix cmd PATH test and require hostlist Lua module in testsuite

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -112,7 +112,10 @@ TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME
 
 #  Test requirements for testsuite
-if ! lua -e 'require "posix"' >/dev/null 2>&1; then
+if ! lua -e 'require "posix"'; then
+    error "failed to find lua posix module in path"
+fi
+if ! lua -e 'require "hostlist"'; then
     error "failed to find lua posix module in path"
 fi
 

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -112,8 +112,9 @@ test_expect_success 'cmddriver removes multiple contiguous separators in input' 
 	LUA_PATH='/meh;;;' flux env sh -c 'echo \$LUA_PATH' |
 		grep -v ';;;;'
 "
-test_expect_success 'cmddriver adds its own path to PATH if called with relative path' "
-	fluxcmd=\$(which flux) &&
+readlink --version >/dev/null && test_set_prereq READLINK
+test_expect_success READLINK 'cmddriver adds its own path to PATH if called with relative path' "
+	fluxcmd=\$(readlink -f \$(which flux)) &&
 	fluxdir=\$(dirname \$fluxcmd) &&
 	PATH='/bin:/usr/bin' \$fluxcmd env sh -c 'echo \$PATH' | grep ^\$fluxdir
 "


### PR DESCRIPTION
Test for flux cmd driver prepending its path to PATH was breaking
with links in the path. Use readlink to canonicalize PATH, adding
a prereq for readlink in case it is missing on the target system.