### PR TITLE
fix problems with subscription management

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -15,6 +15,8 @@ class KVSWrapper(Wrapper):
   pass
 
 _raw = KVSWrapper(ffi, lib, prefixes=['kvs', 'kvs_'])
+# override error check behavior for kvsitr_next
+_raw.kvsitr_next.set_error_check(lambda x: False)
 
 
 def get_key_direct(flux_handle, key):

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -130,6 +130,9 @@ class FunctionWrapper(object):
                                     'long long', 'int32_t', 'int64_t')]:
             self.is_error = lambda x: x < 0
 
+    def set_error_check(self, fun):
+      self.is_error = fun
+
     def build_argument_translation_list(self, t):
         alist = t.args[1:] if self.add_handle else t.args
         for i, a in enumerate(alist, start=1 if self.add_handle else 0):

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -236,6 +236,10 @@ int module_response_sendmsg (modhash_t *mh, const flux_msg_t *msg)
         return 0;
     if (flux_msg_get_route_last (msg, &uuid) < 0)
         goto done;
+    if (!uuid) {
+        errno = EPROTO;
+        goto done;
+    }
     if (!(p = zhash_lookup (mh->zh_byuuid, uuid))) {
         errno = ENOSYS;
         goto done;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -430,6 +430,8 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
         uint32_t lo = match.matchtag;
         uint32_t hi = match.bsize > 1 ? match.matchtag + match.bsize
                                       : match.matchtag;
+        if (flux_msg_get_route_count (msg) > 0)
+            return false; /* don't match in foreign matchtag domain */
         if (flux_msg_get_matchtag (msg, &matchtag) < 0)
             return false;
         if (matchtag < lo || matchtag > hi)

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -89,15 +89,6 @@ static int op_send (void *impl, const flux_msg_t *msg, int flags)
         goto done;
     if (flux_msg_get_type (cpy, &type) < 0)
         goto done;
-    switch (type) {
-        case FLUX_MSGTYPE_REQUEST:
-        case FLUX_MSGTYPE_EVENT:
-            if (flux_msg_enable_route (cpy) < 0)
-                goto done;
-            if (flux_msg_push_route (cpy, fake_uuid) < 0)
-                goto done;
-            break;
-    }
     if (msglist_append (c->queue, cpy) < 0)
         goto done;
     cpy = NULL; /* c->queue now owns cpy */

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -162,16 +162,19 @@ static int op_event_subscribe (void *impl, const char *topic)
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
     JSON in = Jnew ();
+    flux_rpc_t *rpc = NULL;
     int rc = -1;
 
     if (connect_socket (ctx) < 0)
         goto done;
     Jadd_str (in, "topic", topic);
-    if (flux_json_rpc (ctx->h, FLUX_NODEID_ANY, "cmb.sub", in, NULL) < 0)
+    if (!(rpc = flux_rpc (ctx->h, "cmb.sub", Jtostr (in), FLUX_NODEID_ANY, 0))
+                || flux_rpc_get (rpc, NULL, NULL) < 0)
         goto done;
     rc = 0;
 done:
     Jput (in);
+    flux_rpc_destroy (rpc);
     return rc;
 }
 
@@ -180,16 +183,19 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
     JSON in = Jnew ();
+    flux_rpc_t *rpc = NULL;
     int rc = -1;
 
     if (connect_socket (ctx) < 0)
         goto done;
     Jadd_str (in, "topic", topic);
-    if (flux_json_rpc (ctx->h, FLUX_NODEID_ANY, "cmb.unsub", in, NULL) < 0)
+    if (!(rpc = flux_rpc (ctx->h, "cmb.unsub", Jtostr (in), FLUX_NODEID_ANY, 0))
+                || flux_rpc_get (rpc, NULL, NULL) < 0)
         goto done;
     rc = 0;
 done:
     Jput (in);
+    flux_rpc_destroy (rpc);
     return rc;
 }
 

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -487,6 +487,13 @@ static void response_cb (flux_t h, flux_msg_watcher_t *w,
         oom ();
     if (flux_msg_pop_route (cpy, &uuid) < 0)
         goto done;
+    if (!uuid) {
+        const char *topic = NULL;
+        (void) flux_msg_get_topic (msg, &topic);
+        flux_log (h, LOG_ERR, "%s: topic %s: missing sender uuid",
+                  __FUNCTION__, topic ? topic : "NULL");
+        goto done;
+    }
     if (flux_msg_clear_route (cpy) < 0)
         goto done;
     c = zlist_first (ctx->clients);
@@ -501,9 +508,9 @@ static void response_cb (flux_t h, flux_msg_watcher_t *w,
         }
         c = zlist_next (ctx->clients);
     }
+done:
     if (uuid)
         free (uuid);
-done:
     flux_msg_destroy (cpy);
 }
 


### PR DESCRIPTION
This PR fixes several issues

1) The null uuid deref described in #378 and #379.  Make the code that was previously segfaulting (and several other areas like it) robust to a malformed message, and improve logging.

2) The cause of the null uuid deref, which was an RPC made by the shmem connector picking up a response that happened to match its matchtag, but was to be routed to a downstream handle (with a separate matchtag domain).  This was solved by tightening up `flux_msg_match()` so that it only matches matchtags when the route stack is empty.

3) The "fire and forget" subscription management in the local connector.  Close a possible race described in #375 by not returning to the caller until the subscription is in effect at the broker.

4) Improve subscription handling efficiency and clarity in the `connector-local` module.  Specifically reduce the amount of communication with the broker when there are many local clients subscribing to the same events.