### PR TITLE
jsc: reliable collection of job events

### DIFF
--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -35,7 +35,6 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
-//#include "src/modules/libjsc/jstatctl.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/shortjson.h"

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -188,28 +188,6 @@ static int fetch_and_update_state (zhash_t *aj , int64_t j, int64_t ns)
  *                                                                            *
  ******************************************************************************/
 
-static int parse_jobid (const char *k, int64_t *i)
-{
-    int rc = -1;
-    char *kcopy = NULL, *sptr = NULL, *j = NULL, *id = NULL;  
-
-    kcopy = xstrdup (k);
-    j = strtok_r (kcopy, ".", &sptr);
-    if (strncmp(j, "lwj", 3) != 0) 
-        goto done;
-
-    id = strtok_r (NULL, ".", &sptr);
-    errno  = 0;
-    *i = strtoul(id, (char **) NULL, 10);
-    if (errno != 0)
-        goto done;
-    rc = 0;
-
-done:
-    free (kcopy);
-    return rc;
-}
-
 static int jobid_exist (flux_t h, int64_t j)
 {
     kvsdir_t *d;
@@ -490,6 +468,33 @@ static int query_pdesc (flux_t h, int64_t j, JSON *jcb)
     return extract_raw_pdescs (h, j, ntasks, *jcb);
 }
 
+static int send_state_event (flux_t h, job_state_t st, int64_t j)
+{
+    flux_msg_t *msg;
+    char *json = NULL;
+    char *topic = NULL;
+    int rc = -1;
+
+    if ((asprintf (&json, "{\"lwj\":%ld}", j) < 0)
+        || (asprintf (&topic, "jsc.state.%s", jsc_job_num2state (st)) < 0)) {
+        flux_log (h, LOG_ERR, "create state change event: %s\n", 
+                     jsc_job_num2state (st));
+        goto done;
+    }
+    if ((msg = flux_event_encode (topic, json)) == NULL) {
+        flux_log (h, LOG_ERR, "flux_event_encode: %s\n", strerror (errno));
+        goto done;
+    }
+    if (flux_send (h, msg, 0) < 0)
+        flux_log (h, LOG_ERR, "flux_send event: %s\n", strerror (errno));
+    flux_msg_destroy (msg);
+    rc = 0;
+done:
+    free (topic);
+    free (json);
+    return rc;
+} 
+
 static int update_state (flux_t h, int64_t j, JSON o)
 {
     int rc = -1;
@@ -509,6 +514,9 @@ static int update_state (flux_t h, int64_t j, JSON o)
               jsc_job_num2state ((job_state_t)st));
         rc = 0;
     }
+
+    if (send_state_event (h, st, j) < 0)
+        flux_log (h, LOG_ERR, "send state event");
 
     return rc;
 }
@@ -726,44 +734,89 @@ static int invoke_cbs (flux_t h, int64_t j, JSON jcb, int errnum)
     return rc;
 }
 
-static int job_state_cb (const char *key, const char *val, void *arg, int errnum)
+static void fixup_newjob_event (flux_t h, int64_t nj)
 {
-    int64_t jobid = -1;
-    flux_t h = (flux_t) arg;
+    JSON ss = NULL;
+    JSON jcb = NULL;
+    int64_t js = J_NULL;
+    char k[20] = {'\0'};
+    jscctx_t *ctx = getctx (h);
 
-    if (chk_errnum (h, errnum) < 0) 
-        flux_log (h, LOG_ERR, "job_state_cb: key(%s), val(%s)", key, val);
-    else if (parse_jobid (key, &jobid) != 0) 
-        flux_log (h, LOG_ERR, "job_state_cb: key ill-formed");
-    else if (invoke_cbs (h, jobid, get_update_jcb (h, jobid, val), errnum) < 0) 
-        flux_log (h, LOG_ERR, "job_state_cb: failed to invoke callbacks");
+    snprintf (k, 20, "%ld", nj);
+    if (zhash_lookup (ctx->active_jobs, k))
+        goto done;
 
-    /* always return 0 so that reactor will not return */
-    return 0;
+    /* We fix up ordering problem only when new job
+       event hasn't been reported through a kvs watch 
+     */
+
+    jcb = Jnew ();
+    ss = Jnew ();
+    Jadd_int64 (jcb, JSC_JOBID, nj);
+    Jadd_int64 (ss, JSC_STATE_PAIR_OSTATE , (int64_t) js);
+    Jadd_int64 (ss, JSC_STATE_PAIR_NSTATE, (int64_t) js);
+    json_object_object_add (jcb, JSC_STATE_PAIR, ss);
+    if (zhash_insert (ctx->active_jobs, k, (void *)(intptr_t)js) < 0) {
+        flux_log (h, LOG_ERR, "new_job_cb: inserting a job to hash failed");
+        goto done;
+    }
+    if (invoke_cbs (h, nj, jcb, 0) < 0) {
+        flux_log (h, LOG_ERR, 
+                     "makeup_newjob_event: failed to invoke callbacks");
+        goto done;
+    }
+done:
+    return;
 }
 
-static int reg_jobstate_hdlr (flux_t h, const char *path, kvs_set_string_f func)
+static inline void delete_jobinfo (flux_t h, int64_t jobid)
 {
-    int rc = 0;
-    char key[20] = {'\0'};
+    jscctx_t *ctx = getctx (h);
+    char k[20] = {'\0'};
+    snprintf (k, 20, "%ld", jobid);
+    zhash_delete (ctx->active_jobs, k);
+}
 
-    snprintf (key, 20, "%s.state", path);
-    if (kvs_watch_string (h, key, func, (void *)h) < 0) {
-        flux_log (h, LOG_ERR, "watch %s: %s.", key, strerror (errno));
-        rc = -1;
-    } else
-        flux_log (h, LOG_DEBUG, "registered job %s.state CB", path);
-    return rc;
+static int job_state_cb (flux_t h, int typemask, flux_msg_t **msg, void *arg)  
+{
+    int64_t jobid = -1;
+    json_object *o = NULL;
+    const char *topic = NULL;
+    const char *json_str = NULL;
+    int len = 12;
+
+    if (flux_msg_get_topic (*msg, &topic) < 0)
+        goto done;
+
+    if (flux_event_decode (*msg, NULL, &json_str) < 0
+            || !(o = Jfromstr (json_str))
+            || Jget_int64 (o, "lwj", &jobid) < 0) {
+        flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
+        goto done;
+    }
+
+    if (strncmp (topic, "jsc", 3) == 0)
+       len = 10;
+
+    if (strcmp (&(topic[len]), jsc_job_num2state (J_RESERVED)) == 0) 
+        fixup_newjob_event (h, jobid);
+
+    if (invoke_cbs (h, jobid, get_update_jcb (h, jobid, &(topic[len])), 0) < 0) 
+        flux_log (h, LOG_ERR, "job_state_cb: failed to invoke callbacks");
+
+    if (strcmp (&(topic[len]), jsc_job_num2state (J_COMPLETE)) == 0)
+        delete_jobinfo (h, jobid); 
+done:
+    return 0;
 }
 
 static int new_job_cb (const char *key, int64_t val, void *arg, int errnum)
 {
     int64_t nj = 0;
     int64_t js = 0;
+    char k[20] = {'\0'};
     JSON ss = NULL;
     JSON jcb = NULL;
-    char k[20] = {'\0'};
-    char path[20] = {'\0'};
     flux_t h = (flux_t) arg;
     jscctx_t *ctx = getctx (h);
 
@@ -782,12 +835,11 @@ static int new_job_cb (const char *key, int64_t val, void *arg, int errnum)
     js = J_NULL;
     nj = val-1;
     snprintf (k, 20, "%ld", nj);
-    snprintf (path, 20, "lwj.%ld", nj);
-    if (zhash_insert (ctx->active_jobs, k, (void *)(intptr_t)js) < 0) {
-        flux_log (h, LOG_ERR, "new_job_cb: inserting a job to hash failed");
-        goto done;
-    }
 
+    if (zhash_lookup (ctx->active_jobs, k)) 
+        goto done;
+
+    /* do this only when no later events had arrived. */
     flux_log (h, LOG_DEBUG, "jobstate_hdlr registered");
     jcb = Jnew ();
     ss = Jnew ();
@@ -795,13 +847,12 @@ static int new_job_cb (const char *key, int64_t val, void *arg, int errnum)
     Jadd_int64 (ss, JSC_STATE_PAIR_OSTATE , (int64_t) js);
     Jadd_int64 (ss, JSC_STATE_PAIR_NSTATE, (int64_t) js);
     json_object_object_add (jcb, JSC_STATE_PAIR, ss);
-
+    if (zhash_insert (ctx->active_jobs, k, (void *)(intptr_t)js) < 0) {
+        flux_log (h, LOG_ERR, "new_job_cb: inserting a job to hash failed");
+        goto done;
+    }
     if (invoke_cbs (h, nj, jcb, errnum) < 0) {
         flux_log (h, LOG_ERR, "new_job_cb: failed to invoke callbacks");
-    }
-    if (reg_jobstate_hdlr (h, path, job_state_cb) == -1) {
-        flux_log (h, LOG_ERR, "new_job_cb: reg_jobstate_hdlr: %s", 
-            strerror (errno));
     }
 
 done:
@@ -838,6 +889,34 @@ int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f func, void *d)
         flux_log (h, LOG_ERR, "jsc_notify_status: reg_newjob_hdlr failed");
         goto done;
     } 
+    if (flux_event_subscribe (h, "wreck.state.") < 0) {
+        flux_log (h, LOG_ERR, "subscribing to job event: %s", 
+                     strerror (errno));
+        rc = -1;
+        goto done;
+    }
+    if (flux_msghandler_add (h, FLUX_MSGTYPE_EVENT, "wreck.state.*",
+                             job_state_cb, (void *)ctx) < 0) {
+        flux_log (h, LOG_ERR,
+                  "error registering resource event handler: %s",
+                  strerror (errno));
+        rc = -1;
+        goto done;
+    }
+    if (flux_event_subscribe (h, "jsc.state.") < 0) {
+        flux_log (h, LOG_ERR, "subscribing to job event: %s", 
+                     strerror (errno));
+        rc = -1;
+        goto done;
+    }
+    if (flux_msghandler_add (h, FLUX_MSGTYPE_EVENT, "jsc.state.*",
+                             job_state_cb, (void *)ctx) < 0) {
+        flux_log (h, LOG_ERR,
+                  "error registering resource event handler: %s",
+                  strerror (errno));
+        rc = -1;
+        goto done;
+    }
 
     ctx = getctx (h);
     c = (cb_pair_t *) xzmalloc (sizeof(*c));

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -286,11 +286,15 @@ static int extract_raw_state (flux_t h, int64_t j, int64_t *s)
 static int extract_raw_pdesc (flux_t h, int64_t j, int64_t i, JSON *o)
 {
     int rc = 0;
+    char *json_str = NULL; 
     char key[20] = {'\0'}; 
     snprintf (key, 20, "lwj.%ld.%ld.procdesc", j, i);
-    if (kvs_get_obj (h, key, o) < 0) {
+    if (kvs_get (h, key, &json_str) < 0 
+            || !(*o = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "extract %s: %s", key, strerror (errno));
         rc = -1;
+        if (json_str)
+            free (json_str);
         if (*o) 
             Jput (*o);
     }
@@ -614,6 +618,7 @@ static int update_1pdesc (flux_t h, int r, int64_t j, JSON o, JSON ha, JSON ea)
     int rc = -1;
     JSON d = NULL;
     char key[20] = {'\0'};;
+    char *json_str = NULL;
     const char *hn = NULL, *en = NULL;
     int64_t pid = 0, hindx = 0, eindx = 0, hrank = 0;
 
@@ -624,7 +629,8 @@ static int update_1pdesc (flux_t h, int r, int64_t j, JSON o, JSON ha, JSON ea)
     if (!Jget_ar_str (ea, (int)eindx, &en)) return -1;
 
     snprintf (key, 20, "lwj.%ld.%d.procdesc", j, r);
-    if (kvs_get_obj (h, key, &d) < 0) {
+    if (kvs_get (h, key, &json_str) < 0
+            || !(d = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "extract %s: %s", key, strerror (errno));
         goto done;
     }
@@ -637,7 +643,7 @@ static int update_1pdesc (flux_t h, int r, int64_t j, JSON o, JSON ha, JSON ea)
         goto done;
     }
     Jadd_int64 (d, "nodeid", (int64_t)hrank);
-    if (kvs_put_obj (h, key, d) < 0) {
+    if (kvs_put (h, key, Jtostr (d)) < 0) {
         flux_log (h, LOG_ERR, "put %s: %s", key, strerror (errno));
         goto done;
     }
@@ -646,6 +652,8 @@ static int update_1pdesc (flux_t h, int r, int64_t j, JSON o, JSON ha, JSON ea)
 done:
     if (d)
         Jput (d);        
+    if (json_str)
+        free (json_str);
     return rc;
 }
 
@@ -675,20 +683,6 @@ static int update_pdesc (flux_t h, int64_t j, JSON o)
 
 done:
     return rc;
-}
-
-static inline int chk_errnum (flux_t h, int errnum)
-{
-    if (errnum > 0) {
-        /* Ignore ENOENT.  It is expected when this cb is called right
-         * after registration.
-         */
-        if (errnum != ENOENT) {
-            flux_log (h, LOG_ERR, "in a callback  %s", strerror (errnum));
-        }
-        return -1;
-    }
-    return 0;
 }
 
 static JSON get_update_jcb (flux_t h, int64_t j, const char *val)
@@ -743,13 +737,10 @@ static void fixup_newjob_event (flux_t h, int64_t nj)
     jscctx_t *ctx = getctx (h);
 
     snprintf (k, 20, "%ld", nj);
-    if (zhash_lookup (ctx->active_jobs, k))
-        goto done;
 
     /* We fix up ordering problem only when new job
        event hasn't been reported through a kvs watch 
      */
-
     jcb = Jnew ();
     ss = Jnew ();
     Jadd_int64 (jcb, JSC_JOBID, nj);
@@ -777,7 +768,8 @@ static inline void delete_jobinfo (flux_t h, int64_t jobid)
     zhash_delete (ctx->active_jobs, k);
 }
 
-static int job_state_cb (flux_t h, int typemask, flux_msg_t **msg, void *arg)  
+static void job_state_cb (flux_t h, flux_msg_watcher_t *w, 
+                          const flux_msg_t *msg, void *arg)  
 {
     int64_t jobid = -1;
     json_object *o = NULL;
@@ -785,10 +777,10 @@ static int job_state_cb (flux_t h, int typemask, flux_msg_t **msg, void *arg)
     const char *json_str = NULL;
     int len = 12;
 
-    if (flux_msg_get_topic (*msg, &topic) < 0)
+    if (flux_msg_get_topic (msg, &topic) < 0)
         goto done;
 
-    if (flux_event_decode (*msg, NULL, &json_str) < 0
+    if (flux_event_decode (msg, NULL, &json_str) < 0
             || !(o = Jfromstr (json_str))
             || Jget_int64 (o, "lwj", &jobid) < 0) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
@@ -807,75 +799,19 @@ static int job_state_cb (flux_t h, int typemask, flux_msg_t **msg, void *arg)
     if (strcmp (&(topic[len]), jsc_job_num2state (J_COMPLETE)) == 0)
         delete_jobinfo (h, jobid); 
 done:
-    return 0;
+    return;
 }
-
-static int new_job_cb (const char *key, int64_t val, void *arg, int errnum)
-{
-    int64_t nj = 0;
-    int64_t js = 0;
-    char k[20] = {'\0'};
-    JSON ss = NULL;
-    JSON jcb = NULL;
-    flux_t h = (flux_t) arg;
-    jscctx_t *ctx = getctx (h);
-
-    if (ctx->first_time == 1) {
-        /* watch is invoked immediately and we shouldn't
-         * rely on that event at all.
-         */
-        ctx->first_time = 0;
-        return 0;
-    }
-
-    if (chk_errnum (h, errnum) < 0) return 0;
-
-    flux_log (h, LOG_DEBUG, "new_job_cb invoked: key(%s), val(%ld)", key, val);
-
-    js = J_NULL;
-    nj = val-1;
-    snprintf (k, 20, "%ld", nj);
-
-    if (zhash_lookup (ctx->active_jobs, k)) 
-        goto done;
-
-    /* do this only when no later events had arrived. */
-    flux_log (h, LOG_DEBUG, "jobstate_hdlr registered");
-    jcb = Jnew ();
-    ss = Jnew ();
-    Jadd_int64 (jcb, JSC_JOBID, nj);
-    Jadd_int64 (ss, JSC_STATE_PAIR_OSTATE , (int64_t) js);
-    Jadd_int64 (ss, JSC_STATE_PAIR_NSTATE, (int64_t) js);
-    json_object_object_add (jcb, JSC_STATE_PAIR, ss);
-    if (zhash_insert (ctx->active_jobs, k, (void *)(intptr_t)js) < 0) {
-        flux_log (h, LOG_ERR, "new_job_cb: inserting a job to hash failed");
-        goto done;
-    }
-    if (invoke_cbs (h, nj, jcb, errnum) < 0) {
-        flux_log (h, LOG_ERR, "new_job_cb: failed to invoke callbacks");
-    }
-
-done:
-    /* always return 0 so that reactor won't return */
-    return 0;
-}
-
-static int reg_newjob_hdlr (flux_t h, kvs_set_int64_f func)
-{
-    if (kvs_watch_int64 (h,"lwj.next-id", func, (void *) h) < 0) {
-        flux_log (h, LOG_ERR, "watch lwj.next-id: %s", strerror (errno));
-        return -1;
-    }
-    flux_log (h, LOG_DEBUG, "registered job creation CB");
-    return 0;
-}
-
 
 /******************************************************************************
  *                                                                            *
  *                    Public Job Status and Control API                       *
  *                                                                            *
  ******************************************************************************/
+static struct flux_msghandler htab[] = {
+    { FLUX_MSGTYPE_EVENT,     "wreck.state.*", job_state_cb},
+    { FLUX_MSGTYPE_EVENT,     "jsc.state.*",   job_state_cb},
+      FLUX_MSGHANDLER_TABLE_END
+};
 
 int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f func, void *d)
 {
@@ -885,21 +821,9 @@ int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f func, void *d)
 
     if (!func) 
         goto done;
-    if (reg_newjob_hdlr (h, new_job_cb) == -1) {
-        flux_log (h, LOG_ERR, "jsc_notify_status: reg_newjob_hdlr failed");
-        goto done;
-    } 
     if (flux_event_subscribe (h, "wreck.state.") < 0) {
         flux_log (h, LOG_ERR, "subscribing to job event: %s", 
                      strerror (errno));
-        rc = -1;
-        goto done;
-    }
-    if (flux_msghandler_add (h, FLUX_MSGTYPE_EVENT, "wreck.state.*",
-                             job_state_cb, (void *)ctx) < 0) {
-        flux_log (h, LOG_ERR,
-                  "error registering resource event handler: %s",
-                  strerror (errno));
         rc = -1;
         goto done;
     }
@@ -909,10 +833,8 @@ int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f func, void *d)
         rc = -1;
         goto done;
     }
-    if (flux_msghandler_add (h, FLUX_MSGTYPE_EVENT, "jsc.state.*",
-                             job_state_cb, (void *)ctx) < 0) {
-        flux_log (h, LOG_ERR,
-                  "error registering resource event handler: %s",
+    if (flux_msg_watcher_addvec (h, htab, (void *)ctx) < 0) {
+        flux_log (h, LOG_ERR, "registering resource event handler: %s",
                   strerror (errno));
         rc = -1;
         goto done;

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -62,7 +62,7 @@ overlap_flux_wreckruns () {
     return 0
 }
 
-test_expect_success RACY 'jstat 1: notification works for 1 wreckrun' '
+test_expect_success 'jstat 1: notification works for 1 wreckrun' '
     run_flux_jstat 1 &&
     p=$( sync_flux_jstat 1) &&
     run_timeout 4 flux wreckrun -n4 -N4 hostname &&
@@ -74,7 +74,7 @@ EOF
     test_cmp expected1 output.1.cp 
 '
 
-test_expect_success RACY 'jstat 2: jstat back-to-back works' '
+test_expect_success 'jstat 2: jstat back-to-back works' '
     run_flux_jstat 2 &&
     p=$( sync_flux_jstat 2) &&
     run_timeout 4 flux wreckrun -n4 -N4 hostname &&
@@ -86,7 +86,7 @@ EOF
     test_cmp expected2 output.2.cp 
 '
 
-test_expect_success RACY 'jstat 3: notification works for multiple wreckruns' '
+test_expect_success 'jstat 3: notification works for multiple wreckruns' '
     run_flux_jstat 3 &&
     p=$( sync_flux_jstat 3 ) &&
     run_timeout 4 flux wreckrun -n4 -N4 hostname &&
@@ -102,7 +102,7 @@ EOF
     test_cmp expected3 output.3.cp 
 '
 
-test_expect_success RACY,LONGTEST 'jstat 4: notification works under lock-step stress' '
+test_expect_success LONGTEST 'jstat 4: notification works under lock-step stress' '
     run_flux_jstat 4 &&
     p=$( sync_flux_jstat 4 ) &&
     for i in `seq 1 20`; do 
@@ -135,7 +135,7 @@ EOF
     test_cmp expected4 output.4.cp 
 '
 
-test_expect_success RACY 'jstat 5: notification works for overlapping wreckruns' '
+test_expect_success 'jstat 5: notification works for overlapping wreckruns' '
     run_flux_jstat 5 &&
     p=$( sync_flux_jstat 5 ) &&
     overlap_flux_wreckruns 3 &&
@@ -151,7 +151,7 @@ EOF
     test_cmp expected5.sort output.5.sort
 '
 
-test_expect_success RACY,LONGTEST 'jstat 6: notification works for overlapping stress' '
+test_expect_success LONGTEST 'jstat 6: notification works for overlapping stress' '
     run_flux_jstat 6 &&
     p=$( sync_flux_jstat 6 ) &&
     overlap_flux_wreckruns 20 &&


### PR DESCRIPTION
- jsc rework to use wreck.state.* events instead of watching-chaining. 
  As far as these job events are received by jsc in order, jsc will post 
  its own job status events sequentially as well.
- depend on the in-order multi-module events delivery mechanism as realized in issue #337 
- also use the same synchronous eventing mechanism when updating the state of a job for its client
- support for some of the new core interfaces including new message watcher interface
- very minor cleanup 