### PR TITLE
more cleanup in wreck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ after_success:
 
 after_failure:
  - find flux-core-[0-9]* -name *.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
+ - find flux-core-[0-9]* -name *.cmbd.log | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -37,6 +37,7 @@ local lwj_options = {
 
 local default_opts = {
     ['help']    = { char = 'h'  },
+    ['verbose'] = { char = 'v'  },
     ['ntasks']  = { char = 'n', arg = "N" },
     ['options'] = { char = 'o', arg = "OPTIONS.." },
 }
@@ -67,6 +68,12 @@ function wreck:say (...)
     io.stderr:write (self.prog..": "..string.format (...))
 end
 
+function wreck:verbose (...)
+    if self.opts.v then
+        self:say (...)
+    end
+end
+
 function wreck:die (...)
     self:say (...)
     os.exit (1)
@@ -76,6 +83,7 @@ function wreck:usage()
     io.stderr:write ("Usage: "..self.prog.." OPTIONS.. COMMANDS..\n")
     io.stderr:write ([[
   -h, --help                 Display this message
+  -v, --verbose              Be verbose
   -n, --ntasks=N             Request to run a total of N tasks
   -o, --options=OPTION,...   Set other options (See OTHER OPTIONS below)
 ]])

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -202,7 +202,7 @@ static int handle_query_req (flux_t h, int64_t j, const char *k, const char *n)
     ctx = getctx (h);
     ctx->op = n? open_test_outfile (n) : stdout;
     if (jsc_query_jcb (h, j, k, &jcbstr) != 0) {
-        flux_log (h, LOG_ERR, "jsc_query_jcb reported an error\n");
+        flux_log (h, LOG_ERR, "jsc_query_jcb reported an error");
         return -1;
     }
     jcb = Jfromstr (jcbstr);

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -54,9 +54,9 @@ local function lwj_return_code (f, wreck, id)
             end
         end
     end
+    local fn = getmetatable (wreck) [ max > 0 and "say" or "verbose" ]
     for s,h in pairs (msgs) do
-        wreck:say ("task%s %s: %s\n",
-                    #h > 1 and "s" or "", tostring (h:sort()), s)
+        fn (wreck, "task%s %s: %s", #h > 1 and "s" or "", tostring (h:sort()), s)
     end
     return max
 end
@@ -119,7 +119,7 @@ local function alloc_tasks_hack (f, wreck, lwj)
     end
 
     wreck.ntasks = tonumber (wreck.ntasks)
-    wreck:say ("Allocating %d tasks across %d available nodes..\n",
+    wreck:verbose ("Allocating %d tasks across %d available nodes..\n",
                 wreck.ntasks, size)
 
     local counts = {}
@@ -141,7 +141,7 @@ local function alloc_tasks_hack (f, wreck, lwj)
         if not r[ntasks] then r[ntasks] = {} end
         table.insert (r[ntasks], i)
     end
-    wreck:say ("tasks per node: %s\n", summarize_tasks_per_node (r))
+    wreck:verbose ("tasks per node: %s\n", summarize_tasks_per_node (r))
     lwj:commit()
 end
 
@@ -191,7 +191,7 @@ end
 --
 local jobreq = wreck:jobreq()
 
-wreck:say ("%4.03fs: Sending LWJ request for %d tasks (cmdline \"%s\")\n",
+wreck:verbose ("%4.03fs: Sending LWJ request for %d tasks (cmdline \"%s\")\n",
     tt:get0(), wreck.ntasks, table.concat (wreck.cmdline, ' '))
 
 --
@@ -206,7 +206,7 @@ if resp.errnum then
     wreck:die ("job.create message failed with errnum=%d\n", resp.errnum)
 end
 
-wreck:say ("%4.03fs: Registered jobid %d\n", tt:get0(), resp.jobid)
+wreck:verbose ("%4.03fs: Registered jobid %d\n", tt:get0(), resp.jobid)
 
 --
 --  Get a handle to this lwj kvsdir:
@@ -223,7 +223,7 @@ if true then
     wreck.nnodes = wreck:getopt ("N")
     wreck.tasks_per_node = wreck:getopt ("t")
     alloc_tasks_hack (f, wreck, lwj)
-    wreck:say ("%-4.03fs: Sending run event\n", tt:get0())
+    wreck:verbose ("%-4.03fs: Sending run event\n", tt:get0())
     local rc,err = f:sendevent ("wrexec.run.%d", resp.jobid)
     if not rc then wreck:die ("sendevent: %s\n", err) end
 else
@@ -242,7 +242,7 @@ local function check_job_completed ()
     if nio <= 0 and (state == "complete" or state == "reaped") then
         local rc = lwj_return_code (f, wreck, resp.jobid)
         if rc == 0 then
-            wreck:say ("All tasks completed successfully.\n");
+            wreck:verbose ("All tasks completed successfully.\n");
         end
         os.exit (rc)
     end
@@ -306,7 +306,7 @@ local kw, err = f:kvswatcher  {
     handler = function (kw, result)
         if result then
             state = result
-            wreck:say ("%-4.03fs: State = %s\n", tt:get0(), result)
+            wreck:verbose ("%-4.03fs: State = %s\n", tt:get0(), result)
             check_job_completed ()
         end
     end
@@ -341,7 +341,7 @@ repeat
     --   Check to see if we should terminate the job now:
     --
     if terminate then
-        wreck:say ("%4.03fs: Killing LWJ %d\n", tt:get0(), resp.jobid)
+        wreck:verbose ("%4.03fs: Killing LWJ %d\n", tt:get0(), resp.jobid)
         local rc,err = f:sendevent ("wreck.%d.kill", resp.jobid)
         if not rc then
             wreck:say ("Error: Failed to send kill event: %s", err)

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -178,6 +178,14 @@ local tt = timer.new()
 local f, err = flux.new()
 if not f then wreck:die ("Connecting to flux failed: %s\n", err) end
 
+--  Check requested "nnodes" against available:
+--
+if wreck.nnodes and wreck.nnodes > f.size then
+    wreck:die ("Error: Requested nodes (%d) exceeds available (%d)\n",
+               wreck.nnodes, f.size)
+end
+
+
 --
 --  Create a job request as Lua table:
 --

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -91,7 +91,6 @@ end
 
 local function alloc_tasks_hack (f, wreck, lwj)
     local r = {}
-    local total = 0
     local size = f.size
     local res
 
@@ -123,19 +122,27 @@ local function alloc_tasks_hack (f, wreck, lwj)
     wreck:say ("Allocating %d tasks across %d available nodes..\n",
                 wreck.ntasks, size)
 
-    for i = 0, size-1 do
-        local key = "rank."..i..".cores"
-        local n = tonumber (res[i].cores)
-        if (total + n) > wreck.ntasks then
-           n = wreck.ntasks - total
+    local counts = {}
+    local total = 0
+    while total < wreck.ntasks do
+        for i = 0, size-1 do
+            local n = tonumber (res[i].cores)
+            if (total + n) > wreck.ntasks then
+                n = wreck.ntasks - total
+            end
+            counts [i] = (counts [i] or 0) + n
+            total = total + n
+            if total == wreck.ntasks then break end
         end
-        lwj[key] = n
-        if r[n] then table.insert (r[n], i) else r[n] = { i } end
-        total = total + n
-        if total == wreck.ntasks then break end
     end
-    lwj:commit()
+    for i, ntasks in pairs (counts) do
+        local key = "rank."..i..".cores"
+        lwj [key] = ntasks
+        if not r[ntasks] then r[ntasks] = {} end
+        table.insert (r[ntasks], i)
+    end
     wreck:say ("tasks per node: %s\n", summarize_tasks_per_node (r))
+    lwj:commit()
 end
 
 -------------------------------------------------------------------------------

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -77,7 +77,7 @@ end
 local function fake_resource_array (wreck, nnodes)
     local res = {}
     local total = 0
-    local ppn = wreck.tasks_per_node or (wreck.ntasks / nnodes)
+    local ppn = wreck.tasks_per_node or math.ceil (wreck.ntasks / nnodes)
     for i = 0, nnodes - 1 do
         local n = tonumber (ppn)
         if (total + ppn) > tonumber (wreck.ntasks) then

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -324,7 +324,7 @@ local s, err = f:sighandler {
     sigmask = { posix.SIGALRM },
     handler = function (f, s, sig)
         wreck:say ("Killed by SIGALRM: state = %s, nio = %d\n", state, nio)
-	os.exit (1)
+        os.exit (128+posix.SIGALRM)
     end
 }
 

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -115,7 +115,7 @@ int mod_main (flux_t h, int argc, char **argv)
         PyObject_Print(search_path, stderr, 0);
     }
 
-    flux_log(h, LOG_INFO, "loading python module named: %s\n", module_name);
+    flux_log(h, LOG_INFO, "loading python module named: %s", module_name);
 
     PyObject *module = PyImport_ImportModule("flux.core");
     if(!module){

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -254,7 +254,7 @@ static void load_cb (flux_t h,
 
     kvs_fence (h, "resource_hwloc_loaded", flux_size (h));
 
-    flux_log (h, LOG_DEBUG, "resource_hwloc: loaded: %d\n", rank);
+    flux_log (h, LOG_DEBUG, "resource_hwloc: loaded: %d", rank);
 
     ctx->loaded = true;
 }
@@ -305,7 +305,7 @@ static void topo_cb (flux_t h,
         hwloc_topology_destroy (rank);
         free (xml);
 
-        flux_log (h, LOG_INFO, "resource_hwloc: loaded from %s\n", base_key);
+        flux_log (h, LOG_INFO, "resource_hwloc: loaded from %s", base_key);
     }
 
     kvsitr_destroy (base_iter);

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -304,7 +304,7 @@ int lwj_targets_this_node (struct rexec_ctx *ctx, int64_t id)
      *   without resource assignment so we run everywhere
      */
     if (kvs_get_dir (ctx->h, &tmp, "lwj.%ld.rank", id) < 0) {
-        flux_log (ctx->h, LOG_INFO, "No dir lwj.%ld.rank: %s\n", id, strerror (errno));
+        flux_log (ctx->h, LOG_INFO, "No dir lwj.%ld.rank: %s", id, strerror (errno));
         return (1);
     }
 

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -62,4 +62,14 @@ test_expect_success 'wreck: signaling wreckrun works' '
 	kill -INT $q &&
 	test_expect_code 137 wait $q
 '
+flux kvs dir -r resource >/dev/null 2>&1 && test_set_prereq RES_HWLOC
+test_expect_success RES_HWLOC 'wreckrun: oversubscription of tasks' '
+	run_timeout 15 flux wreckrun -v -n$(($(nproc)*4+1)) /bin/true
+'
+test_expect_success 'wreckrun: uneven distribution with -n, -N' '
+	run_timeout 10 flux wreckrun -N4 -n5 /bin/true
+'
+test_expect_success 'wreckrun: too many nodes requested fails' '
+	test_expect_code 1 run_timeout 10 flux wreckrun -N5 hostname
+'
 test_done


### PR DESCRIPTION
This PR contains a bit more cleanup and bug fixing in wreck.

Main bugs fixed are related to requesting more tasks than core available (we now oversubscribe at will by default, sorry this is just a prototype), and requesting more nodes than ranks in the instance (generates an error). New tests are included for these bugs.

flux-wreckrun by default doesn't display the various log messages it did before, to get the old behavior use a new `--verbose` flag.

Exit code on `SIGALRM` is fixed -- this is nice for testing.

Finally, the log messages were cleaned up in wrexecd as suggested by @garlick. I also include a commit that removes `\n` from `flux_log` messages so that we don't get the double newline output from rank0 broker.