### PR TITLE
Improved broker attribute interface

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -16,7 +16,7 @@ MAN3_FILES_PRIMARY = \
 	flux_rpc_then.3 \
 	flux_rpc_multi.3 \
 	flux_reduce_create.3 \
-	flux_info.3
+	flux_get_rank.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -40,7 +40,9 @@ MAN3_FILES_SECONDARY = \
 	flux_reduce_pop.3 \
 	flux_reduce_push.3 \
 	flux_reduce_opt_set.3 \
-	flux_reduce_opt_get.3
+	flux_reduce_opt_get.3 \
+	flux_get_size.3 \
+	flux_get_arity.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -83,7 +85,8 @@ flux_reduce_pop.3: flux_reduce_create.3
 flux_reduce_push.3: flux_reduce_create.3
 flux_reduce_opt_set.3: flux_reduce_create.3
 flux_reduce_opt_get.3: flux_reduce_create.3
-
+flux_get_size.3: flux_get_rank.3
+flux_get_arity.3: flux_get_rank.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c
@@ -93,7 +96,7 @@ flux_rpc.3: trpc.c
 flux_rpc_then.3: trpc_then.c
 flux_rpc_multi.3: trpc_then_multi.c
 flux_reduce_create.3: treduce.c
-flux_info.3: tinfo.c
+flux_get_rank.3: tinfo.c
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -16,7 +16,8 @@ MAN3_FILES_PRIMARY = \
 	flux_rpc_then.3 \
 	flux_rpc_multi.3 \
 	flux_reduce_create.3 \
-	flux_get_rank.3
+	flux_get_rank.3 \
+	flux_attr_get.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -42,7 +43,10 @@ MAN3_FILES_SECONDARY = \
 	flux_reduce_opt_set.3 \
 	flux_reduce_opt_get.3 \
 	flux_get_size.3 \
-	flux_get_arity.3
+	flux_get_arity.3 \
+	flux_attr_set.3 \
+	flux_attr_first.3 \
+	flux_attr_next.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -87,6 +91,9 @@ flux_reduce_opt_set.3: flux_reduce_create.3
 flux_reduce_opt_get.3: flux_reduce_create.3
 flux_get_size.3: flux_get_rank.3
 flux_get_arity.3: flux_get_rank.3
+flux_attr_set.3: flux_attr_get.3
+flux_attr_first.3: flux_attr_get.3
+flux_attr_next.3: flux_attr_get.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_attr_get.adoc
+++ b/doc/man3/flux_attr_get.adoc
@@ -1,0 +1,145 @@
+flux_attr_get(3)
+================
+:doctype: manpage
+
+
+NAME
+----
+flux_attr_get, flux_attr_set, flux_attr_first, flux_attr_next - query Flux broker attributes
+
+
+SYNOPSIS
+--------
+#include <flux/core.h>
+
+const char *flux_attr_get (flux_t h, const char *name, int *flags);
+
+int flux_attr_set (flux_t h, const char *name, const char *val);
+
+const char *flux_attr_first (flux_t h);
+
+const char *flux_attr_next (flux_t h);
+
+DESCRIPTION
+-----------
+
+Flux broker attributes are both a simple, general-purpose key-value
+store with scope limited to the local broker rank, and a method for the
+broker to export information needed by Flux comms modules and utilities.
+
+`flux_attr_get()` retrieves the value of the attribute _name_.
+If _flags_ is non-NULL, the flags associated with the attribute are
+stored there.  Flags are a mask of the following bit values:
+
+FLUX_ATTRFLAG_IMMUTABLE::
+The value of this attribute will never change.  It can be cached indefinitely.
+
+FLUX_ATTRFLAG_READONLY::
+The value of this attribute cannot be changed with `flux_attr_set()`,
+however it may change on the broker and should not be cached.
+
+FLUX_ATTRFLAG_ACTIVE::
+Getting or setting this attribute may have side effects in the broker.
+For example, retrieving the "snoop-uri" attribute triggers the creation
+of the snoop socket by the broker on the first call.
+
+Attributes that have the FLUX_ATTRFLAG_IMMUTABLE flag are cached automatically
+in the flux_t handle.  For example, the "rank" attribute is a frequently
+accessed attribute whose value never changes.  It will be cached on the first
+access and thereafter does not require an RPC to the broker to access.
+
+`flux_attr_set()` updates the value of attribute _name_ to _val_.
+If _name_ is not currently a valid attribute, it is created.
+Attributes created through this interface will have no flags set.
+If _val_ is NULL, the attribute is unset.
+
+`flux_attr_first()` and `flux_attr_next()` are used to iterate
+through the current set of valid attribute names.
+
+
+BROKER ATTRIBUTES
+-----------------
+
+The broker currently exports the following attributes:
+
+rank::
+The rank of the local broker.  This attribute is normally accessed
+via flux_get_rank(3).
+
+size::
+The number of ranks in the comms session.  This attribute is normally accessed
+via flux_get_size(3).
+
+tbon-arity::
+The branching factor of the tree based overlay network.  This attribute
+is normally accessed via flux_get_arity(3).
+
+session-id::
+The identity of the comms session.
+
+tbon-parent-uri::
+The URI of the ZeroMQ endpoint this rank is connected to in the tree
+based overlay network.  This attribute will not be set on rank zero.
+
+tbon-request-uri::
+The URI of the ZeroMQ endpoint this rank is bound to in the tree
+based overlay network.
+
+snoop-uri::
+The URI of the ZeroMQ endpoint that flux-snoop(1) should connect
+to in order to receive copies of messages passing through the broker.
+
+local-uri::
+The Flux URI that should be passed to flux_open(1) to establish
+a connection to the local broker rank.
+
+parent-uri::
+The Flux URI that should be passed to flux_open(1) to establish
+a connection to the enclosing instance.
+
+
+RETURN VALUE
+------------
+
+`flux_attr_get()` returns the requested value on success.  On error, NULL
+is returned and errno is set appropriately.
+
+`flux_attr_set()` returns zero on success.  On error, -1 is returned
+and errno is set appropriately.
+
+`flux_attr_first()` and `flux_attr_next()` return an attribute name or
+NULL to indicate that iteration is complete.
+
+
+ERRORS
+------
+
+ENOENT::
+The requested attribute is invalid or has a NULL value on the broker.
+
+EINVAL::
+Some arguments were invalid.
+
+EPERM::
+Set was attempted on an attribute with the FLUX_ATTR_IMMUTABLE or
+FLUX_ATTR_READONLY flags.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+https://github.com/flux-framework/rfc/blob/master/spec_3.adoc[RFC 3: CMB1 - Flux Comms Message Broker Protocol]

--- a/doc/man3/flux_get_rank.adoc
+++ b/doc/man3/flux_get_rank.adoc
@@ -1,26 +1,30 @@
-flux_info(3)
-============
+flux_get_rank(3)
+================
 :doctype: manpage
 
 
 NAME
 ----
-flux_info - query Flux broker comms info
+flux_get_rank, flux_get_size, flux_get_arity - query Flux broker comms info
 
 
 SYNOPSIS
 --------
 #include <flux/core.h>
 
-int flux_info (flux_t h, uint32_t *rank, uint32_t *size, int *k);
+int flux_get_rank (flux_t h, uint32_t *rank);
+
+int flux_get_size (flux_t h, uint32_t *size);
+
+int flux_get_arity (flux_t h, int *arity);
 
 
 DESCRIPTION
 -----------
 
-`flux_info()` asks the Flux broker for its rank in the comms session,
-the size of the comms session, and the branching factor (k) of
-its tree-based overlay network.
+`flux_get_rank()`, `flux_get_size()`, and `flux_get_arity()`  ask the
+Flux broker for its rank in the comms session, the size of the comms
+session, and the branching factor (k) of its tree-based overlay network.
 
 The tree-based overlay network is always rooted at rank zero.
 
@@ -28,7 +32,7 @@ The tree-based overlay network is always rooted at rank zero.
 RETURN VALUE
 ------------
 
-`flux_info()` returns  zero on success.  On error, -1 is returned, and errno
+These functions return zero on success.  On error, -1 is returned, and errno
 is set appropriately.
 
 

--- a/doc/man3/tinfo.c
+++ b/doc/man3/tinfo.c
@@ -10,16 +10,20 @@ int tree_height (uint32_t n, int k)
 int main (int argc, char **argv)
 {
     flux_t h;
-    uint32_t n, rank;
+    uint32_t rank, n;
     int k;
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
-    if (flux_info (h, &rank, &n, &k) < 0)
-        err_exit ("flux_info");
-    printf ("height of %d-ary tree of size %u: %d\n",
+    if (flux_get_rank (h, &rank) < 0)
+        err_exit ("flux_get_rank");
+    if (flux_get_size (h, &n) < 0)
+        err_exit ("flux_get_size");
+    if (flux_get_arity (h, &k) < 0)
+        err_exit ("flux_get_arity");
+    printf ("height of %d-ary tree of size %" PRIu32 ": %d\n",
             k, n, tree_height (n, k));
-    printf ("height of %d-ary at rank %u: %d\n",
+    printf ("height of %d-ary at rank %" PRIu32 ": %d\n",
             k, rank, tree_height (rank + 1, k));
     flux_close (h);
     return (0);

--- a/doc/man3/topen.c
+++ b/doc/man3/topen.c
@@ -4,10 +4,13 @@
 int main (int argc, char **argv)
 {
     flux_t h;
+    uint32_t rank;
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
-    printf ("My rank is %d\n", flux_rank (h));
+    if (flux_get_rank (h, &rank) < 0)
+        err_exit ("flux_get_rank");
+    printf ("My rank is %d\n", (int)rank);
     flux_close (h);
     return (0);
 }

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -118,7 +118,7 @@ struct flux_reduce_ops reduce_ops = {
 int mod_main (flux_t h, int argc, char **argv)
 {
     struct context ctx;
-    int rank = flux_rank (h);
+    uint32_t rank;
     double timeout = 0.;
     int flags;
 
@@ -127,8 +127,9 @@ int mod_main (flux_t h, int argc, char **argv)
         flags = FLUX_REDUCE_TIMEDFLUSH;
     } else
         flags = FLUX_REDUCE_HWMFLUSH;
-
     ctx.batchnum = 0;
+    if (flux_get_rank (h, &rank) < 0)
+        return -1;
     snprintf (ctx.rankstr, sizeof (ctx.rankstr), "%d", rank);
     ctx.h = h;
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -252,3 +252,9 @@ hwloc
 epgm
 args
 arity
+attr
+ATTRFLAG
+ENOENT
+EPERM
+READONLY
+tbon

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -251,3 +251,4 @@ tinfo
 hwloc
 epgm
 args
+arity

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -250,20 +250,29 @@ static int l_flux_barrier (lua_State *L)
 static int l_flux_rank (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
-    return (l_pushresult (L, flux_rank (f)));
+    uint32_t rank;
+    if (flux_get_rank (f, &rank) < 0)
+        return lua_pusherror (L, "flux_get_rank error");
+    return (l_pushresult (L, rank));
 }
 
 static int l_flux_size (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
-    return (l_pushresult (L, flux_size (f)));
+    uint32_t size;
+    if (flux_get_size (f, &size) < 0)
+        return lua_pusherror (L, "flux_get_size error");
+    return (l_pushresult (L, size));
 }
 
 static int l_flux_treeroot (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
     bool treeroot = false;
-    if (flux_rank (f) == 0)
+    uint32_t rank;
+    if (flux_get_rank (f, &rank) < 0)
+        return lua_pusherror (L, "flux_get_rank error");
+    if (rank == 0)
         treeroot = true;
     lua_pushboolean (L, treeroot);
     return (1);

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -27,7 +27,9 @@ flux_broker_SOURCES = \
 	hello.h \
 	hello.c \
 	shutdown.h \
-	shutdown.c
+	shutdown.c \
+	attr.h \
+	attr.c
 
 
 flux_broker_LDADD = \

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -50,7 +50,8 @@ flux_broker_LDFLAGS = ${broker_ldflags}
 TESTS = test_snoop.t \
 	test_shutdown.t \
 	test_heartbeat.t \
-	test_hello.t
+	test_hello.t \
+	test_attr.t
 
 test_ldadd = \
 	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
@@ -85,3 +86,7 @@ test_heartbeat_t_LDADD = $(test_ldadd)
 test_hello_t_SOURCES = test/hello.c hello.c
 test_hello_t_CPPFLAGS = $(test_cppflags)
 test_hello_t_LDADD = $(test_ldadd)
+
+test_attr_t_SOURCES = test/attr.c attr.c
+test_attr_t_CPPFLAGS = $(test_cppflags)
+test_attr_t_LDADD = $(test_ldadd)

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -1,0 +1,289 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+#include "attr.h"
+
+struct attr_struct {
+    zhash_t *hash;
+};
+
+struct entry {
+    char *name;
+    char *val;
+    int flags;
+    attr_set_f set;
+    attr_get_f get;
+    void *arg;
+};
+
+static void entry_destroy (void *arg)
+{
+    struct entry *e = arg;
+    if (e) {
+        if (e->val)
+            free (e->val);
+        if (e->name)
+            free (e->name);
+        free (e);
+    }
+}
+
+static struct entry *entry_create (const char *name, const char *val, int flags)
+{
+    struct entry *e = xzmalloc (sizeof (*e));
+    if (name)
+        e->name = xstrdup (name);
+    if (val)
+        e->val = xstrdup (val);
+    e->flags = flags;
+    return e;
+}
+
+attr_t *attr_create (void)
+{
+    attr_t *attrs = xzmalloc (sizeof (*attrs));
+    if (!(attrs->hash = zhash_new ()))
+        oom ();
+    return attrs;
+}
+
+void attr_destroy (attr_t *attrs)
+{
+    if (attrs) {
+        zhash_destroy (&attrs->hash);
+        free (attrs);
+    }
+}
+
+int attr_delete (attr_t *attrs, const char *name, bool force)
+{
+    struct entry *e;
+    int rc = -1;
+
+    if ((e = zhash_lookup (attrs->hash, name))) {
+        if ((e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+            errno = EPERM;
+            goto done;
+        }
+        if (((e->flags & FLUX_ATTRFLAG_READONLY)
+                            || (e->flags & FLUX_ATTRFLAG_ACTIVE)) && !force) {
+            errno = EPERM;
+            goto done;
+        }
+        zhash_delete (attrs->hash, name);
+    }
+    rc = 0;
+done:
+    return rc;    
+}
+
+int attr_add (attr_t *attrs, const char *name, const char *val, int flags)
+{
+    struct entry *e;
+
+    if (name == NULL || (flags & FLUX_ATTRFLAG_ACTIVE)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((e = zhash_lookup (attrs->hash, name))) {
+        errno = EEXIST;
+        return -1;
+    }
+    e = entry_create (name, val, flags);
+    zhash_update (attrs->hash, name, e);
+    zhash_freefn (attrs->hash, name, entry_destroy);
+    return 0;
+}
+
+int attr_add_active (attr_t *attrs, const char *name, int flags,
+                        attr_get_f get, attr_set_f set, void *arg)
+{
+    struct entry *e;
+    int rc = -1;
+
+    if ((e = zhash_lookup (attrs->hash, name))) {
+        errno = EEXIST;
+        goto done;
+    }
+    e = entry_create (name, NULL, flags);
+    e->set = set;
+    e->get = get;
+    e->arg = arg;
+    e->flags |= FLUX_ATTRFLAG_ACTIVE;
+    zhash_update (attrs->hash, name, e);
+    zhash_freefn (attrs->hash, name, entry_destroy);
+    rc = 0;
+done:
+    return rc;
+}
+
+int attr_get (attr_t *attrs, const char *name, const char **val, int *flags)
+{
+    struct entry *e;
+    int rc = -1;
+
+    if (!(e = zhash_lookup (attrs->hash, name))) {
+        errno = ENOENT;
+        goto done;
+    }
+    if (e->get) {
+        if (!e->val || !(e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+            const char *tmp;
+            if (e->get (name, &tmp, e->arg) < 0)
+                goto done;
+            if (e->val)
+                free (e->val);
+            e->val = tmp ? xstrdup (tmp) : NULL;
+        }
+    }
+    if (val)
+        *val = e->val;
+    if (flags)
+        *flags = e->flags;
+    rc = 0;
+done:
+    return rc;
+}
+
+int attr_set (attr_t *attrs, const char *name, const char *val, bool force)
+{
+    struct entry *e;
+    int rc = -1;
+
+    if (!(e = zhash_lookup (attrs->hash, name))) {
+        errno = ENOENT;
+        goto done;
+    }
+    if ((e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+        errno = EPERM;
+        goto done;
+    }
+    if ((e->flags & FLUX_ATTRFLAG_READONLY) && !force) {
+        errno = EPERM;
+        goto done;
+    }
+    if (e->set) {
+        if (e->set (name, val, e->arg) < 0)
+            goto done;
+    }
+    if (e->val)
+        free (e->val);
+    e->val = val ? xstrdup (val) : NULL;
+    rc = 0;
+done:
+    return rc;
+}
+
+static int get_int (const char *name, const char **val, void *arg)
+{
+    int *i = arg;
+    static char s[32];
+    int n = snprintf (s, sizeof (s), "%d", *i);
+
+    assert (n <= sizeof (s));
+    *val = s;
+    return 0;
+}
+
+static int set_int (const char *name, const char *val, void *arg)
+{
+    int *i = arg;
+    char *endptr;
+    long n;
+
+    n = strtol (val, &endptr, 0);
+    if (n <= INT_MIN || n >= INT_MAX) {
+        errno = ERANGE;
+        return -1;
+    }
+    if (val && *endptr != '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    *i = (int)n;
+    return 0;
+}
+
+int attr_add_active_int (attr_t *attrs, const char *name, int *val, int flags)
+{
+    return attr_add_active (attrs, name, flags, get_int, set_int, val);
+}
+
+static int get_uint32 (const char *name, const char **val, void *arg)
+{
+    uint32_t *i = arg;
+    static char s[32];
+    int n = snprintf (s, sizeof (s), "%" PRIu32, *i);
+
+    assert (n <= sizeof (s));
+    *val = s;
+    return 0;
+}
+
+static int set_uint32 (const char *name, const char *val, void *arg)
+{
+    uint32_t *i = arg;
+    char *endptr;
+    unsigned long n;
+
+    n = strtoul (val, &endptr, 0);
+    if (n == ULONG_MAX) /* ERANGE set by strtol */
+        return -1;
+    if (endptr == val || *endptr != '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    *i = n;
+    return 0;
+}
+
+int attr_add_active_uint32 (attr_t *attrs, const char *name, uint32_t *val,
+                            int flags)
+{
+    return attr_add_active (attrs, name, flags, get_uint32, set_uint32, val);
+}
+
+const char *attr_first (attr_t *attrs)
+{
+    struct entry *e = zhash_first (attrs->hash);
+    return e ? e->name : NULL;
+}
+
+const char *attr_next (attr_t *attrs)
+{
+    struct entry *e = zhash_next (attrs->hash);
+    return e ? e->name : NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -1,0 +1,55 @@
+#ifndef BROKER_ATTR_H
+#define BROKER_ATTR_H
+
+#include <stdint.h>
+#include <flux/core.h>
+
+/* Callbacks for active values.  Return 0 on succes, -1 on eror with
+ * errno set.  Errors are propagated to the return of attr_set() and attr_get().
+ */
+typedef int (*attr_get_f)(const char *name, const char **val, void *arg);
+typedef int (*attr_set_f)(const char *name, const char *val, void *arg);
+
+typedef struct attr_struct attr_t;
+
+/* Create/destroy attribute cache
+ */
+attr_t *attr_create (void);
+void attr_destroy (attr_t *attrs);
+
+/* Delete an attribute
+ */
+int attr_delete (attr_t *attrs, const char *name, bool force);
+
+/* Add an attribute
+ */
+int attr_add (attr_t *attrs, const char *name, const char *val, int flags);
+
+/* Get/set an attribute.
+ */
+int attr_get (attr_t *attrs, const char *name, const char **val, int *flags);
+
+int attr_set (attr_t *attrs, const char *name, const char *val, bool force);
+
+/* Add an attribute with callbacks for get/set.
+ */
+int attr_add_active (attr_t *attrs, const char *name, int flags,
+                     attr_get_f get, attr_set_f set, void *arg);
+
+/* Add an attribute that tracks an integer value
+ */
+int attr_add_active_int (attr_t *attrs, const char *name, int *val,
+                         int flags);
+int attr_add_active_uint32 (attr_t *attrs, const char *name, uint32_t *val,
+                            int flags);
+
+/* Iterate over attribute names with internal cursor.
+ */
+const char *attr_first (attr_t *attrs);
+const char *attr_next (attr_t *attrs);
+
+#endif /* BROKER_ATTR_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1466,35 +1466,6 @@ static int cmb_info_cb (zmsg_t **zmsg, void *arg)
     return rc;
 }
 
-static int cmb_getattr_cb (zmsg_t **zmsg, void *arg)
-{
-    ctx_t *ctx = arg;
-    JSON out = Jnew ();
-    JSON in = NULL;
-    const char *name = NULL;
-    const char *val = NULL;
-    int rc = -1;
-
-    if (flux_json_request_decode (*zmsg, &in) < 0)
-        goto done;
-    if (!Jget_str (in, "name", &name)) {
-        errno = EPROTO;
-        goto done;
-    }
-    if (attr_get (ctx->attrs, name, &val, NULL) < 0)
-        goto done;
-    if (!val) {
-        errno = ENOENT;
-        goto done;
-    }
-    Jadd_str (out, (char *)name, val);
-    rc = flux_json_respond (ctx->h, out, zmsg);
-done:
-    Jput (in);
-    Jput (out);
-    return rc;
-}
-
 static int attr_get_snoop (const char *name, const char **val, void *arg)
 {
     snoop_t *snoop = arg;
@@ -1952,7 +1923,6 @@ static void broker_add_services (ctx_t *ctx)
           || !svc_add (ctx->services, "cmb.attrget", cmb_attrget_cb, ctx)
           || !svc_add (ctx->services, "cmb.attrset", cmb_attrset_cb, ctx)
           || !svc_add (ctx->services, "cmb.attrlist", cmb_attrlist_cb, ctx)
-          || !svc_add (ctx->services, "cmb.getattr", cmb_getattr_cb, ctx)
           || !svc_add (ctx->services, "cmb.rusage", cmb_rusage_cb, ctx)
           || !svc_add (ctx->services, "cmb.rmmod", cmb_rmmod_cb, ctx)
           || !svc_add (ctx->services, "cmb.insmod", cmb_insmod_cb, ctx)

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -134,7 +134,14 @@ done:
 
 int heartbeat_start (heartbeat_t *hb)
 {
-    if (!hb->h || flux_rank (hb->h) != 0) {
+    uint32_t rank;
+    if (!hb->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_get_rank (hb->h, &rank) < 0)
+        return -1;
+    if (rank != 0) {
         errno = EINVAL;
         return -1;
     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -220,8 +220,10 @@ void overlay_push_parent (overlay_t *ov, const char *fmt, ...)
 const char *overlay_get_parent (overlay_t *ov)
 {
     struct endpoint *ep = zlist_first (ov->parents);
-    if (!ep)
+    if (!ep) {
+        errno = ENOENT;
         return NULL;
+    }
     return ep->uri;
 }
 

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -1,0 +1,208 @@
+#include <stdio.h>
+
+#include "attr.h"
+
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char **argv)
+{
+    attr_t *attrs;
+    const char *val;
+    int flags;
+    int a, c;
+    uint32_t b;
+
+    plan (53);
+
+    ok ((attrs = attr_create ()) != NULL,
+        "attr_create works");
+
+    /* attr_get, attr_set on unknown fails
+     */
+    errno = 0;
+    ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
+        "attr_get on unknown attr fails with errno == ENOENT");
+    errno = 0;
+    ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == ENOENT,
+        "attr_set on unknown attr fails with errno == ENOENT");
+
+    /* attr_add, attr_get works
+     */
+    ok ((attr_add (attrs, "foo", "bar", 0) == 0),
+        "attr_add works");
+    errno = 0;
+    ok ((attr_add (attrs, "foo", "bar", 0) < 0 && errno == EEXIST),
+        "attr_add on existing attr fails with EEXIST");
+    ok (attr_get (attrs, "foo", NULL, NULL) == 0,
+        "attr_get on new attr works with NULL args");
+    val = NULL;
+    flags = 0;
+    ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "bar")
+        && flags == 0,
+        "attr_get on new attr works returns correct val,flags");
+
+    /* attr_delete works
+     */
+    ok (attr_delete (attrs, "foo", false) == 0,
+        "attr_delete works");
+    errno = 0;
+    ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
+        "attr_get on deleted attr fails with errno == ENOENT");
+
+    /* FLUX_ATTRFLAG_READONLY protects against update/delete from users;
+     * update/delete can be forced on broker.
+     */
+    ok (attr_add (attrs, "foo", "baz", FLUX_ATTRFLAG_READONLY) == 0,
+        "attr_add FLUX_ATTRFLAG_READONLY works");
+    flags = 0;
+    val = NULL;
+    ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "baz")
+        && flags == FLUX_ATTRFLAG_READONLY,
+        "attr_get returns correct value and flags");
+    errno = 0;
+    ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == EPERM,
+        "attr_set on readonly attr fails with EPERM");
+    ok (attr_set (attrs, "foo", "baz", true) == 0,
+        "attr_set (force) on readonly attr works");
+    errno = 0;
+    ok (attr_delete (attrs, "foo", false) < 0 && errno == EPERM,
+        "attr_delete on readonly attr fails with EPERM");
+    ok (attr_delete (attrs, "foo", true) == 0,
+        "attr_delete (force) works on readonly attr");
+    errno = 0;
+    ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
+        "attr_get on deleted attr fails with errno == ENOENT");
+
+    /* FLUX_ATTRFLAG_IMMUTABLE protects against update/delete from user;
+     * update/delete can NOT be forced on broker.
+     */
+    ok (attr_add (attrs, "foo", "baz", FLUX_ATTRFLAG_IMMUTABLE) == 0,
+        "attr_add FLUX_ATTRFLAG_IMMUTABLE works");
+    flags = 0;
+    val = NULL;
+    ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "baz")
+        && flags == FLUX_ATTRFLAG_IMMUTABLE,
+        "attr_get returns correct value and flags");
+    errno = 0;
+    ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == EPERM,
+        "attr_set on immutable attr fails with EPERM");
+    errno = 0;
+    ok (attr_set (attrs, "foo", "baz", true)  < 0 && errno == EPERM,
+        "attr_set (force) on immutable fails with EPERM");
+    errno = 0;
+    ok (attr_delete (attrs, "foo", false) < 0 && errno == EPERM,
+        "attr_delete on immutable attr fails with EPERM");
+    errno = 0;
+    ok (attr_delete (attrs, "foo", true) < 0 && errno == EPERM,
+        "attr_delete (force) on immutable fails with EPERM");
+
+    /* Add couple more attributes and exercise iterator.
+     * initial hash contents: foo=bar
+     */
+    val = attr_first (attrs);
+    ok (val && !strcmp (val, "foo"),
+        "attr_first returned %s", val);
+    ok (attr_next (attrs) == NULL,
+        "attr_next returned NULL");
+    ok (attr_add (attrs, "foo1", "42", 0) == 0
+        && attr_add (attrs, "foo2", "43", 0) == 0
+        && attr_add (attrs, "foo3", "44", 0) == 0
+        && attr_add (attrs, "foo4", "44", 0) == 0,
+        "attr_add foo1, foo2, foo3, foo4 works");
+    val = attr_first (attrs);
+    ok (val && !strncmp (val, "foo", 3),
+        "attr_first returned %s", val);
+    val = attr_next (attrs);
+    ok (val && !strncmp (val, "foo", 3),
+        "attr_next returned %s", val);
+    val = attr_next (attrs);
+    ok (val && !strncmp (val, "foo", 3),
+        "attr_next returned %s", val);
+    val = attr_next (attrs);
+    ok (val && !strncmp (val, "foo", 3),
+        "attr_next returned %s", val);
+    val = attr_next (attrs);
+    ok (val && !strncmp (val, "foo", 3),
+        "attr_next returned %s", val);
+    ok (attr_next (attrs) == NULL,
+        "attr_next returned NULL");
+
+    /* attr_add_active (int helper)
+     */
+    ok (attr_add_active_int (attrs, "a", &a, 0) == 0,
+        "attr_add_active_int works");
+    a = 0;
+    ok (attr_get (attrs, "a", &val, NULL) == 0 && val && !strcmp (val, "0"),
+        "attr_get on active int tracks value: %s", val);
+    a = 1;
+    ok (attr_get (attrs, "a", &val, NULL) == 0 && !strcmp (val, "1"),
+        "attr_get on active int tracks value: %s", val);
+    a = -1;
+    ok (attr_get (attrs, "a", &val, NULL) == 0 && !strcmp (val, "-1"),
+        "attr_get on active int tracks value: %s", val);
+    a = INT_MAX - 1;
+    ok (attr_get (attrs, "a", &val, NULL) == 0
+        && strtol (val, NULL, 10) == INT_MAX - 1,
+        "attr_get on active int tracks value: %s", val);
+    a = INT_MIN + 1;
+    ok (attr_get (attrs, "a", &val, NULL) == 0
+        && strtol (val, NULL, 10) == INT_MIN + 1,
+        "attr_get on active int tracks value: %s", val);
+
+    ok (attr_set (attrs, "a", "0", false) == 0 && a == 0,
+        "attr_set on active int sets value: %d", a);
+    ok (attr_set (attrs, "a", "1", false) == 0 && a == 1,
+        "attr_set on active int sets value: %d", a);
+    ok (attr_set (attrs, "a", "-1", false) == 0 && a == -1,
+        "attr_set on active int sets value: %d", a);
+    errno = 0;
+    ok (attr_delete (attrs, "a", false) < 0 && errno == EPERM,
+        "attr_delete on active attr fails with EPERM");
+    ok (attr_delete (attrs, "a", true) == 0,
+        "attr_delete (force) works on active attr");
+
+    /* attr_add_active (uint32_t helper)
+     */
+    ok (attr_add_active_uint32 (attrs, "b", &b, 0) == 0,
+        "attr_add_active_uint32 works");
+    b = 0;
+    ok (attr_get (attrs, "b", &val, NULL) == 0 && val && !strcmp (val, "0"),
+        "attr_get on active uin32_t tracks value: %s", val);
+    b = 1;
+    ok (attr_get (attrs, "b", &val, NULL) == 0 && !strcmp (val, "1"),
+        "attr_get on active uint32_t tracks value: %s", val);
+    b = UINT_MAX - 1;
+    ok (attr_get (attrs, "b", &val, NULL) == 0
+        && strtol (val, NULL, 10) == UINT_MAX - 1,
+        "attr_get on active uint32_t tracks value: %s", val);
+
+    ok (attr_set (attrs, "b", "0", false) == 0 && b == 0,
+        "attr_set on active uint32_t sets value: %d", b);
+    ok (attr_set (attrs, "b", "1", false) == 0 && b == 1,
+        "attr_set on active uint32_t sets value: %d", b);
+    ok (attr_delete (attrs, "b", true) == 0,
+        "attr_delete (force) works on active attr");
+
+    /* immutable active int works as expected
+     */
+    ok (attr_add_active_int (attrs, "c", &c, FLUX_ATTRFLAG_IMMUTABLE) == 0,
+        "attr_add_active_int FLUX_ATTRFLAG_IMMUTABLE works");
+    c = 42;
+    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && !strcmp (val, "42"),
+        "attr_get returns initial value: %s", val);
+    c = 43;
+    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && !strcmp (val, "42"),
+        "attr_get ignores value changes: %s", val);
+    errno = 0;
+    ok (attr_delete (attrs, "c", true) < 0 && errno == EPERM,
+        "attr_delete (force) fails with EPERM");
+
+    attr_destroy (attrs);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -71,12 +71,10 @@ void check_size3 (flux_t h)
 {
     hello_t *hello;
     flux_msg_watcher_t *w;
-    uint32_t size = 3;
-    uint32_t rank = 0;
     char *prefix = "size=3";
 
-    flux_aux_set (h, "flux::size", &size, NULL);
-    flux_aux_set (h, "flux::rank", &rank, NULL);
+    flux_attr_fake (h, "size", "3", FLUX_ATTRFLAG_IMMUTABLE);
+    flux_attr_fake (h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE);
 
     hello_count = hello_request = 0;
     ok ((hello = hello_create ()) != NULL,
@@ -90,17 +88,15 @@ void check_size3 (flux_t h)
         "%s: created cmb.hello watcher", prefix);
     flux_msg_watcher_start (h, w);
 
-    flux_aux_set (h, "flux::rank", &rank, NULL);
+    flux_attr_fake (h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE);
     ok (hello_start (hello) == 0,
         "%s: (rank 0) hello_start works", prefix);
 
-    rank = 1;
-    flux_aux_set (h, "flux::rank", &rank, NULL);
+    flux_attr_fake (h, "rank", "1", FLUX_ATTRFLAG_IMMUTABLE);
     ok (hello_start (hello) == 0,
         "%s: (rank 1) hello_start works", prefix);
 
-    rank = 2;
-    flux_aux_set (h, "flux::rank", &rank, NULL);
+    flux_attr_fake (h, "rank", "2", FLUX_ATTRFLAG_IMMUTABLE);
     ok (hello_start (hello) == 0,
         "%s: (rank 2) hello_start works", prefix);
 

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -129,8 +129,9 @@ int main (int argc, char *argv[])
     } else if (!strcmp (cmd, "info")) {
         int arity;
         uint32_t rank, size;
-        if (flux_info (h, &rank, &size, &arity) < 0)
-            err_exit ("flux_info");
+        if (flux_get_rank (h, &rank) < 0 || flux_get_size (h, &size) < 0
+                                         || flux_get_arity (h, &arity) < 0)
+            err_exit ("flux_get_rank/size/arity");
         printf ("rank=%d\n", rank);
         printf ("size=%d\n", size);
         printf ("arity=%d\n", arity);

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -46,7 +46,6 @@ void usage (void)
 {
     fprintf (stderr,
 "Usage: flux-comms [-r N] idle\n"
-"       flux-comms [-r N] getattr attr\n"
 "       flux-comms        info\n"
 "       flux-comms [-r N] reparent new-uri\n"
 "       flux-comms [-r N] panic [msg ...]\n"
@@ -101,14 +100,6 @@ int main (int argc, char *argv[])
             err_exit ("flux_peer");
         printf ("%s\n", peers);
         free (peers);
-    } else if (!strcmp (cmd, "getattr")) {
-        char *s;
-        if (optind != argc - 1)
-            msg_exit ("Usage: flux comms getattr attrname");
-        if (!(s = flux_getattr (h, rank, argv[optind])))
-            err_exit ("%s", argv[optind]);
-        printf ("%s\n", s);
-        free (s);
     } else if (!strcmp (cmd, "panic")) {
         char *msg = NULL;
         size_t len = 0;

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -110,6 +110,7 @@ int main (int argc, char *argv[])
         .fanout = 1024,
         .nodeset = NULL,
     };
+    uint32_t rank, size;
 
     log_init ("flux-module");
 
@@ -149,14 +150,16 @@ int main (int argc, char *argv[])
     if (strcmp (cmd, "info") != 0) {
         if (!(h = flux_open (NULL, 0)))
             err_exit ("flux_open");
+        if (flux_get_rank (h, &rank) < 0 || flux_get_size (h, &size))
+            err_exit ("flux_get_rank/size");
         if (!opt.nodeset) {
-            opt.nodeset = xasprintf ("%d", flux_rank (h));
-        } else if (!strcmp (opt.nodeset, "all") && flux_size (h) == 1) {
+            opt.nodeset = xasprintf ("%d", rank);
+        } else if (!strcmp (opt.nodeset, "all") && size == 1) {
             free (opt.nodeset);
-            opt.nodeset= xasprintf ("%d", flux_rank (h));
+            opt.nodeset= xasprintf ("%d", rank);
         } else if (!strcmp (opt.nodeset, "all")) {
             free (opt.nodeset);
-            opt.nodeset = xasprintf ("[0-%d]", flux_size (h) - 1);
+            opt.nodeset = xasprintf ("[0-%d]", size - 1);
         }
     }
 

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -72,7 +72,7 @@ int main (int argc, char *argv[])
 {
     flux_t h;
     int ch;
-    char *uri = NULL;
+    const char *uri = NULL;
     bool vopt = false;
     bool nopt = false;
     char *session = "flux";
@@ -81,7 +81,6 @@ int main (int argc, char *argv[])
     zloop_t *zloop;
     zmq_pollitem_t zp;
     flux_sec_t sec;
-    int rank = -1;
     const char *secdir;
 
     log_init ("flux-snoop");
@@ -122,7 +121,7 @@ int main (int argc, char *argv[])
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
-    if (!(uri = flux_getattr (h, rank, "snoop-uri")))
+    if (!(uri = flux_attr_get (h, "snoop-uri", NULL)))
         err_exit ("snoop-uri");
 
     /* N.B. flux_get_zctx () is not implemented for the API socket since
@@ -187,7 +186,6 @@ int main (int argc, char *argv[])
     zctx_destroy (&zctx); /* destroys 's' and 'zp.socket' */
 
     zlist_destroy (&subscriptions);
-    free (uri);
     flux_close (h);
     log_fini ();
     return 0;

--- a/src/cmd/flux-zio.c
+++ b/src/cmd/flux-zio.c
@@ -100,6 +100,7 @@ int main (int argc, char *argv[])
     int blocksize = 4096;
     int flags = 0;
     flux_t h;
+    uint32_t rank;
 
     log_init ("flux-zio");
 
@@ -155,9 +156,11 @@ int main (int argc, char *argv[])
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
+    if (flux_get_rank (h, &rank) < 0)
+        err_exit ("flux_get_rank");
 
     if ((aopt || ropt) && !key) {
-        if (asprintf (&key, "zio.%d.%d", flux_rank (h), (int)getpid ()) < 0)
+        if (asprintf (&key, "zio.%d.%d", rank, (int)getpid ()) < 0)
             oom ();
     }
 

--- a/src/common/libcompat/info.c
+++ b/src/common/libcompat/info.c
@@ -29,7 +29,8 @@
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
-#include <czmq.h>
+#include <stdint.h>
+#include <sys/param.h>
 
 #include "src/common/libflux/handle.h"
 #include "src/common/libflux/info.h"
@@ -38,9 +39,45 @@
 
 bool flux_treeroot (flux_t h)
 {
-    if (flux_rank (h) == 0)
+    uint32_t rank;
+    if (flux_get_rank (h, &rank) == 0 && rank == 0)
         return true;
     return false;
+}
+
+int flux_info (flux_t h, uint32_t *rank, uint32_t *size, int *arity)
+{
+    if (rank && flux_get_rank (h, rank) < 0)
+        return -1;
+    if (size && flux_get_size (h, size) < 0)
+        return -1;
+    if (arity && flux_get_arity (h, arity) < 0)
+        return -1;
+    return 0;
+}
+
+int flux_rank (flux_t h)
+{
+    uint32_t rank;
+    if (flux_get_rank (h, &rank) < 0)
+        return -1;
+    if (rank >= INT_MAX) {
+        errno = ERANGE;
+        return -1;
+    }
+    return rank;
+}
+
+int flux_size (flux_t h)
+{
+    uint32_t size;
+    if (flux_get_size (h, &size) < 0)
+        return -1;
+    if (size >= INT_MAX) {
+        errno = ERANGE;
+        return -1;
+    }
+    return size;
 }
 
 /*

--- a/src/common/libcompat/info.h
+++ b/src/common/libcompat/info.h
@@ -7,6 +7,12 @@
 
 bool flux_treeroot (flux_t h)
                     __attribute__ ((deprecated));
+int flux_rank (flux_t h)
+                    __attribute__ ((deprecated));
+int flux_size (flux_t h)
+                    __attribute__ ((deprecated));
+int flux_info (flux_t h, uint32_t *rank, uint32_t *size, int *arity)
+                    __attribute__ ((deprecated));
 
 #endif /* !_FLUX_COMPAT_INFO_H */
 

--- a/src/common/libcompat/reactor.c
+++ b/src/common/libcompat/reactor.c
@@ -148,7 +148,7 @@ static void msg_compat_free (struct msg_compat *c)
     }
 }
 
-int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
+static int msghandler_add (flux_t h, int typemask, const char *pattern,
                          FluxMsgHandler cb, void *arg)
 {
     struct ctx *ctx = getctx (h);
@@ -174,12 +174,18 @@ int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
     return 0;
 }
 
+int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
+                         FluxMsgHandler cb, void *arg)
+{
+    return msghandler_add (h, typemask, pattern, cb, arg);
+}
+
 int flux_msghandler_addvec (flux_t h, msghandler_t *hv, int len, void *arg)
 {
     int i;
 
     for (i = 0; i < len; i++)
-        if (flux_msghandler_add (h, hv[i].typemask, hv[i].pattern,
+        if (msghandler_add (h, hv[i].typemask, hv[i].pattern,
                                     hv[i].cb, arg) < 0)
             return -1;
     return 0;

--- a/src/common/libcompat/request.c
+++ b/src/common/libcompat/request.c
@@ -109,7 +109,8 @@ int flux_json_request (flux_t h, uint32_t nodeid, uint32_t matchtag,
         goto done;
     if (nodeid == FLUX_NODEID_UPSTREAM) {
         flags |= FLUX_MSGFLAG_UPSTREAM;
-        nodeid = flux_rank (h);
+        if (flux_get_rank (h, &nodeid) < 0)
+            goto done;
     }
     if (flux_msg_set_nodeid (zmsg, nodeid, flags) < 0)
         goto done;

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -27,6 +27,7 @@ fluxcoreinclude_HEADERS = \
 	module.h \
 	reparent.h \
 	info.h \
+	attr.h \
 	flog.h \
 	conf.h \
 	heartbeat.h
@@ -37,6 +38,7 @@ noinst_LTLIBRARIES = \
 libflux_la_SOURCES = \
 	flog.c \
 	info.c \
+	attr.c \
 	handle.c \
 	reactor.c \
 	reduce.c \

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -1,0 +1,247 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <stdbool.h>
+#include <czmq.h>
+
+#include "attr.h"
+#include "rpc.h"
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/xzmalloc.h"
+
+typedef struct {
+    zhash_t *hash;
+    zlist_t *names;
+    flux_t h;
+} ctx_t;
+
+typedef struct {
+    char *val;
+    int flags;
+} attr_t;
+
+static void freectx (void *arg)
+{
+    ctx_t *ctx = arg;
+    zhash_destroy (&ctx->hash);
+    zlist_destroy (&ctx->names);
+    free (ctx);
+}
+
+static ctx_t *getctx (flux_t h)
+{
+    ctx_t *ctx = flux_aux_get (h, "flux::attr");
+
+    if (!ctx) {
+        ctx = xzmalloc (sizeof (*ctx));
+        if (!(ctx->hash = zhash_new ()))
+            oom ();
+        ctx->h = h;
+        flux_aux_set (h, "flux::attr", ctx, freectx);
+    }
+    return ctx;
+}
+
+static void attr_destroy (void *arg)
+{
+    attr_t *attr = arg;
+    free (attr->val);
+    free (attr);
+}
+
+static attr_t *attr_create (const char *val, int flags)
+{
+    attr_t *attr = xzmalloc (sizeof (*attr));
+    attr->val = xstrdup (val);
+    attr->flags = flags;
+    return attr;
+}
+
+static int attr_get_rpc (ctx_t *ctx, const char *name, attr_t **attrp)
+{
+    flux_rpc_t *r;
+    JSON in = Jnew ();
+    JSON out = NULL;
+    const char *json_str, *val;
+    int flags;
+    attr_t *attr;
+    int rc = -1;
+
+    Jadd_str (in, "name", name);
+    if (!(r = flux_rpc (ctx->h, "cmb.attrget", Jtostr (in),
+                        FLUX_NODEID_ANY, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, &json_str) < 0)
+        goto done;
+    if (!(out = Jfromstr (json_str)) || !Jget_str (out, "value", &val)
+                                     || !Jget_int (out, "flags", &flags)) {
+        errno = EPROTO;
+        goto done;
+    }
+    attr = attr_create (val, flags);
+    zhash_update (ctx->hash, name, attr);
+    zhash_freefn (ctx->hash, name, attr_destroy);
+    *attrp = attr;
+    rc = 0;
+done:
+    Jput (in);
+    Jput (out);
+    flux_rpc_destroy (r);
+    return rc;
+}
+
+static int attr_set_rpc (ctx_t *ctx, const char *name, const char *val)
+{
+    flux_rpc_t *r;
+    JSON in = Jnew ();
+    attr_t *attr;
+    int rc = -1;
+
+    Jadd_str (in, "name", name);
+    if (val)
+        Jadd_str (in, "value", val);
+    else
+        Jadd_obj (in, "value", NULL);
+    if (!(r = flux_rpc (ctx->h, "cmb.attrset", Jtostr (in),
+                        FLUX_NODEID_ANY, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, NULL) < 0)
+        goto done;
+    if (val) {
+        attr = attr_create (val, 0);
+        zhash_update (ctx->hash, name, attr);
+        zhash_freefn (ctx->hash, name, attr_destroy);
+    } else
+        zhash_delete (ctx->hash, name);
+    rc = 0;
+done:
+    Jput (in);
+    flux_rpc_destroy (r);
+    return rc;
+}
+
+#if CZMQ_VERSION < CZMQ_MAKE_VERSION(3,0,1)
+static bool attr_strcmp (const char *s1, const char *s2)
+{
+    return (strcmp (s1, s2) > 0);
+}
+#else
+static bool attr_strcmp (const char *s1, const char *s2)
+{
+    return strcmp (s1, s2);
+}
+#endif
+
+static int attr_list_rpc (ctx_t *ctx)
+{
+    flux_rpc_t *r;
+    const char *json_str;
+    JSON array, out = NULL;
+    int len, i, rc = -1;
+
+    if (!(r = flux_rpc (ctx->h, "cmb.attrlist", NULL, FLUX_NODEID_ANY, 0)))
+        goto done;
+    if (flux_rpc_get (r, NULL, &json_str) < 0)
+        goto done;
+    if (!(out = Jfromstr (json_str)) || !Jget_obj (out, "names", &array)
+                                     || !Jget_ar_len (array, &len)) {
+        errno = EPROTO;
+        goto done;
+    }
+    zlist_destroy (&ctx->names);
+    if (!(ctx->names = zlist_new ()))
+        oom ();
+    for (i = 0; i < len; i++) {
+        const char *name;
+        if (!Jget_ar_str (array, i, &name)) {
+            errno = EPROTO;
+            goto done;
+        }
+        if (zlist_append (ctx->names, xstrdup (name)) < 0)
+            oom ();
+    }
+    zlist_sort (ctx->names, (zlist_compare_fn *)attr_strcmp);
+    rc = 0;
+done:
+    Jput (out);
+    flux_rpc_destroy (r);
+    return rc;
+}
+
+const char *flux_attr_get (flux_t h, const char *name, int *flags)
+{
+    ctx_t *ctx = getctx (h);
+    attr_t *attr;
+
+    if (!(attr = zhash_lookup (ctx->hash, name))
+                        || !(attr->flags & FLUX_ATTRFLAG_IMMUTABLE))
+        if (attr_get_rpc (ctx, name, &attr) < 0)
+            return NULL;
+    if (flags && attr)
+        *flags = attr->flags;
+    return attr ? attr->val : NULL;
+}
+
+int flux_attr_set (flux_t h, const char *name, const char *val)
+{
+    ctx_t *ctx = getctx (h);
+
+    if (attr_set_rpc (ctx, name, val) < 0)
+        return -1;
+    return 0;
+}
+
+int flux_attr_fake (flux_t h, const char *name, const char *val, int flags)
+{
+    ctx_t *ctx = getctx (h);
+    attr_t *attr = attr_create (val, flags);
+    zhash_update (ctx->hash, name, attr);
+    zhash_freefn (ctx->hash, name, attr_destroy);
+    return 0;
+}
+
+const char *flux_attr_first (flux_t h)
+{
+    ctx_t *ctx = getctx (h);
+
+    if (attr_list_rpc (ctx) < 0)
+        return NULL;
+    return ctx->names ? zlist_first (ctx->names) : NULL;
+}
+
+const char *flux_attr_next (flux_t h)
+{
+    ctx_t *ctx = flux_aux_get (h, "flux::attr");
+
+    return ctx->names ? zlist_next (ctx->names) : NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -1,0 +1,32 @@
+#ifndef _FLUX_CORE_ATTR_H
+#define _FLUX_CORE_ATTR_H
+
+#include <stdbool.h>
+
+#include "handle.h"
+
+/* Flags can only be set by the broker.
+ */
+enum {
+    FLUX_ATTRFLAG_IMMUTABLE = 1,    /* attribute is cacheable */
+    FLUX_ATTRFLAG_READONLY = 2,     /* attribute cannot be written */
+                                    /*   but may change on broker */
+    FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
+};
+
+const char *flux_attr_get (flux_t h, const char *name, int *flags);
+
+int flux_attr_set (flux_t h, const char *name, const char *val);
+
+int flux_attr_fake (flux_t h, const char *name, const char *val, int flags);
+
+const char *flux_attr_first (flux_t h);
+
+const char *flux_attr_next (flux_t h);
+
+
+#endif /* !_FLUX_CORE_ATTR_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -123,18 +123,23 @@ int flux_vlog (flux_t h, int lev, const char *fmt, va_list ap)
     char *s = xvasprintf (fmt, ap);
     struct timeval tv;
     JSON o = Jnew ();
+    uint32_t rank;
     int rc = -1;
 
     if (gettimeofday (&tv, NULL) < 0)
         err_exit ("gettimeofday");
+    if (flux_get_rank (h, &rank) < 0)
+        goto done;
     Jadd_str (o, "facility", ctx->facility);
     Jadd_int (o, "level", lev);
-    Jadd_int (o, "rank", flux_rank (h));
+    Jadd_int (o, "rank", rank);
     Jadd_int (o, "timestamp_usec", (int)tv.tv_usec);
     Jadd_int (o, "timestamp_sec", (int)tv.tv_sec);
     Jadd_str (o, "message", s);
     rc = flux_log_json (h, Jtostr (o));
-    free (s);
+done:
+    if (s)
+        free (s);
     Jput (o);
     return rc;
 }

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -15,6 +15,7 @@
 #include "module.h"
 #include "reparent.h"
 #include "info.h"
+#include "attr.h"
 #include "flog.h"
 #include "conf.h"
 #include "heartbeat.h"

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -34,34 +34,6 @@
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
-char *flux_getattr (flux_t h, int rank, const char *name)
-{
-    uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
-    JSON in = Jnew ();
-    flux_rpc_t *r = NULL;
-    const char *json_str;
-    JSON out = NULL;
-    char *ret = NULL;
-    const char *val = NULL;
-
-    Jadd_str (in, "name", name);
-    if (!(r = flux_rpc (h, "cmb.getattr", Jtostr (in), nodeid, 0)))
-        goto done;
-    if (flux_rpc_get (r, NULL, &json_str) < 0)
-        goto done;
-    if (!(out = Jfromstr (json_str)) || !Jget_str (out, (char *)name, &val)) {
-        errno = EPROTO;
-        goto done;
-    }
-    ret = xstrdup (val);
-done:
-    Jput (in);
-    Jput (out);
-    if (r)
-        flux_rpc_destroy (r);
-    return ret;
-}
-
 int flux_info (flux_t h, uint32_t *rankp, uint32_t *sizep, int *arityp)
 {
     flux_rpc_t *r = NULL;

--- a/src/common/libflux/info.h
+++ b/src/common/libflux/info.h
@@ -5,9 +5,11 @@
 
 #include "handle.h"
 
-int flux_info (flux_t h, uint32_t *rankp, uint32_t *sizep, int *arityp);
-int flux_rank (flux_t h);
-int flux_size (flux_t h);
+int flux_get_rank (flux_t h, uint32_t *rank);
+
+int flux_get_size (flux_t h, uint32_t *size);
+
+int flux_get_arity (flux_t h, int *arity);
 
 #endif /* !_FLUX_CORE_INFO_H */
 

--- a/src/common/libflux/info.h
+++ b/src/common/libflux/info.h
@@ -9,11 +9,6 @@ int flux_info (flux_t h, uint32_t *rankp, uint32_t *sizep, int *arityp);
 int flux_rank (flux_t h);
 int flux_size (flux_t h);
 
-/* flux_getattr is used to read misc. attributes internal to the broker.
- * The caller must dispose of the returned string with free ().
- */
-char *flux_getattr (flux_t h, int rank, const char *name);
-
 #endif /* !_FLUX_CORE_INFO_H */
 
 /*

--- a/src/common/libflux/reduce.c
+++ b/src/common/libflux/reduce.c
@@ -86,7 +86,13 @@ flux_reduce_t *flux_reduce_create (flux_t h, struct flux_reduce_ops ops,
     r->h = h;
     r->ops = ops;
     r->rank = 0;
-    (void) flux_info (h, &r->rank, &size, &arity);
+    if (flux_get_rank (h, &r->rank) < 0 || flux_get_size (h, &size) < 0
+                                        || flux_get_arity (h, &arity) < 0) {
+        flux_reduce_destroy (r);
+        return NULL;
+    }
+        
+    //(void) flux_info (h, &r->rank, &size, &arity);
     r->arg = arg;
     r->flags = flags;
     if (!(r->items = zlist_new ()))

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -22,14 +22,6 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-/* To use this connector:
- *   int rank;
- *   zctx_t *zctx;
- *   flux_t h = flux_open ("shmem://myuuid", flags)
- *   flux_setopt (h, FLUX_OPT_ZEROMQ_CONTEXT, zctx);
- *   flux_aux_set (h, "flux::rank", &rank, NULL);
- */
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -64,7 +64,7 @@ typedef struct {
     int universe_size;
     int appnum;
     int barrier_num;
-    int cmb_rank;
+    uint32_t cmb_rank;
     flux_t fctx;
     char kvsname[PMI_MAX_KVSNAMELEN];
     int trace;
@@ -90,7 +90,7 @@ static inline void trace (int flags, const char *fmt, ...)
 
     if (ctx && (flags & ctx->trace)) {
         char buf[64];
-        snprintf (buf, sizeof (buf), "[%d.%d.%d] %s\n", ctx->cmb_rank,
+        snprintf (buf, sizeof (buf), "[%" PRIu32 ".%d.%d] %s\n", ctx->cmb_rank,
                   ctx->appnum, ctx->rank, fmt);
         va_start (ap, fmt);
         vfprintf (stdout, buf, ap);
@@ -135,7 +135,10 @@ int PMI_Init (int *spawned)
         err ("flux_open");
         goto fail;
     }
-    ctx->cmb_rank = flux_rank (ctx->fctx);
+    if (flux_get_rank (ctx->fctx, &ctx->cmb_rank) < 0) {
+        err ("flux_get_rank");
+        goto fail;
+    }
     trace_simple (PMI_TRACE_INIT);
     *spawned = ctx->spawned;
     return PMI_SUCCESS;

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -708,12 +708,12 @@ int mod_main (flux_t h, int argc, char **argv)
 {
     ctx_t *ctx = getctx (h);
     char sockpath[PATH_MAX + 1];
-    char *local_uri = NULL;
+    const char *local_uri = NULL;
     char *tmpdir;
     int rc = -1;
 
-    if (!(local_uri = flux_getattr (h, FLUX_NODEID_ANY, "local-uri"))) {
-        flux_log (h, LOG_ERR, "flux_getattr local-uri: %s", strerror (errno));
+    if (!(local_uri = flux_attr_get (h, "local-uri", NULL))) {
+        flux_log (h, LOG_ERR, "flux_attr_get local-uri: %s", strerror (errno));
         goto done;
     }
     if (!(tmpdir = strstr (local_uri, "local://"))) {
@@ -750,8 +750,6 @@ int mod_main (flux_t h, int argc, char **argv)
     }
     rc = 0;
 done:
-    if (local_uri)
-        free (local_uri);
     flux_msg_watcher_delvec (h, htab);
     flux_fd_watcher_destroy (ctx->listen_w);
     if (ctx->listen_fd >= 0) {

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -163,7 +163,7 @@ typedef struct {
     int watchlist_lastrun_epoch;
     stats_t stats;
     flux_t h;
-    bool master;            /* for now minimize flux_rank() calls */
+    bool master;            /* for now minimize flux_get_rank() calls */
     int epoch;              /* tracks current heartbeat epoch */
     struct timespec commit_time; /* time of most recent commit */
     bool timer_armed;
@@ -195,6 +195,7 @@ static void freectx (void *arg)
 static ctx_t *getctx (flux_t h)
 {
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "kvssrv");
+    uint32_t rank;
 
     if (!ctx) {
         ctx = xzmalloc (sizeof (*ctx));
@@ -206,7 +207,7 @@ static ctx_t *getctx (flux_t h)
             oom ();
         ctx->watchlist = wait_queue_create ();
         ctx->h = h;
-        if (flux_rank (h) == 0)
+        if (flux_get_rank (h, &rank) == 0 && rank == 0)
             ctx->master = true;
         flux_aux_set (h, "kvssrv", ctx, freectx);
     }

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -97,13 +97,13 @@ typedef struct {
 } ns_t;
 
 typedef struct {
-    int rank;
+    uint32_t rank;
     const char *uri;
     cstate_t state;
 } parent_t;
 
 typedef struct {
-    int rank;
+    uint32_t rank;
     char *rankstr;
     cstate_t state;
 } child_t;
@@ -112,7 +112,7 @@ typedef struct {
     int max_idle;
     int slow_idle;
     int epoch;
-    int rank;
+    uint32_t rank;
     char *rankstr;
     zlist_t *parents;   /* current parent is first in list */
     zhash_t *children;
@@ -172,7 +172,8 @@ static ctx_t *getctx (flux_t h)
         ctx = xzmalloc (sizeof (*ctx));
         ctx->max_idle = default_max_idle;
         ctx->slow_idle = default_slow_idle;
-        ctx->rank = flux_rank (h);
+        if (flux_get_rank (h, &ctx->rank) < 0)
+            err_exit ("flux_get_rank");
         if (asprintf (&ctx->rankstr, "%d", ctx->rank) < 0)
             oom ();
         if (!(ctx->parents = zlist_new ()))
@@ -661,14 +662,15 @@ static int ns_sync (ctx_t *ctx)
 {
     int rc = -1;
     bool writekvs = false;
-
     if (ctx->ns) {
         writekvs = true;
     } else if (ns_fromkvs (ctx) < 0) {
         char *ok = ctx->rankstr, *fail = "", *slow = "", *unknown = "";
-        int size = flux_size (ctx->h);
+        uint32_t size;
+        if (flux_get_size (ctx->h, &size) < 0)
+            goto done;
         if (size > 1)
-            if (asprintf (&unknown, "1-%d", flux_size (ctx->h) - 1) < 0)
+            if (asprintf (&unknown, "1-%d", size - 1) < 0)
                 oom ();
         ctx->ns = ns_create (ok, fail, slow, unknown);
         if (size > 1)

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -98,7 +98,7 @@ typedef struct {
 
 typedef struct {
     int rank;
-    char *uri;
+    const char *uri;
     cstate_t state;
 } parent_t;
 
@@ -207,8 +207,6 @@ static child_t *child_create (int rank)
 
 static void parent_destroy (parent_t *p)
 {
-    if (p->uri)
-        free (p->uri);
     free (p);
 }
 
@@ -216,8 +214,7 @@ static parent_t *parent_create (int rank, const char *uri)
 {
     parent_t *p = xzmalloc (sizeof (*p));
     p->rank = rank;
-    if (uri)
-        p->uri = xstrdup (uri);
+    p->uri = uri;
     return p;
 }
 
@@ -273,9 +270,7 @@ static void parents_fromjson (ctx_t *ctx, JSON ar)
         for (i = 0; i < len; i++) {
             if (Jget_ar_obj (ar, i, &el) && (p = parent_fromjson (el))) {
                 if (i == 0) {
-                    if (p->uri) /* unlikely */
-                        free (p->uri);
-                    p->uri = flux_getattr (ctx->h, -1, "tbon-parent-uri");
+                    p->uri = flux_attr_get (ctx->h, "tbon-parent-uri", NULL);
                 }
                 if (zlist_append (ctx->parents, p) < 0)
                     oom ();

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -43,7 +43,7 @@ struct rexec_ctx {
     int nodeid;
     flux_t h;
     char *wrexecd_path;
-    char *local_uri;
+    const char *local_uri;
 };
 
 struct rexec_session {
@@ -58,8 +58,6 @@ struct rexec_session {
 static void freectx (void *arg)
 {
     struct rexec_ctx *ctx = arg;
-    if (ctx->local_uri)
-        free (ctx->local_uri);
     free (ctx);
 }
 
@@ -84,8 +82,8 @@ static struct rexec_ctx *getctx (flux_t h)
         ctx = xzmalloc (sizeof (*ctx));
         ctx->h = h;
         ctx->nodeid = flux_rank (h);
-        if (!(ctx->local_uri = flux_getattr (h, FLUX_NODEID_ANY, "local-uri")))
-            err_exit ("flux_getattr local-uri");
+        if (!(ctx->local_uri = flux_attr_get (h, "local-uri", NULL)))
+            err_exit ("flux_attr_get local-uri");
         flux_aux_set (h, "wrexec", ctx, freectx);
         kvs_watch_string (h, "config.wrexec.wrexecd_path",
             wrexec_path_set, (void *) ctx);

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -40,7 +40,7 @@
 
 
 struct rexec_ctx {
-    int nodeid;
+    uint32_t nodeid;
     flux_t h;
     char *wrexecd_path;
     const char *local_uri;
@@ -81,7 +81,8 @@ static struct rexec_ctx *getctx (flux_t h)
     if (!ctx) {
         ctx = xzmalloc (sizeof (*ctx));
         ctx->h = h;
-        ctx->nodeid = flux_rank (h);
+        if (flux_get_rank (h, &ctx->nodeid) < 0)
+            err_exit ("flux_get_rank");
         if (!(ctx->local_uri = flux_attr_get (h, "local-uri", NULL)))
             err_exit ("flux_attr_get local-uri");
         flux_aux_set (h, "wrexec", ctx, freectx);

--- a/src/test/request/req.c
+++ b/src/test/request/req.c
@@ -308,6 +308,7 @@ static int null_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     int rc = -1;
     void *buf;
     uint32_t nodeid;
+    uint32_t rank;
 
     if (!zmsg || !*zmsg) {
         flux_log (h, LOG_ERR, "%s: got NULL zmsg!", __FUNCTION__);
@@ -328,7 +329,12 @@ static int null_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
                   strerror (errno));
         goto done;
     }
-    if (nodeid != FLUX_NODEID_ANY && nodeid != flux_rank (h)) {
+    if (flux_get_rank (h, &rank) < 0) {
+        flux_log (h, LOG_ERR, "%s: flux_get_rank: %s", __FUNCTION__,
+                  strerror (errno));
+        goto done;
+    }
+    if (nodeid != FLUX_NODEID_ANY && nodeid != rank) {
         flux_log (h, LOG_ERR, "%s: unexpected nodeid: %"PRIu32"", __FUNCTION__,
                   nodeid);
         goto done;

--- a/src/test/tcommit.c
+++ b/src/test/tcommit.c
@@ -88,7 +88,10 @@ void *thread (void *arg)
         err ("%d: flux_open", t->n);
         goto done;
     }
-    rank = flux_rank (t->h);
+    if (flux_get_rank (t->h, &rank) < 0) {
+        err ("%d: flux_get_rank", t->n);
+        goto done;
+    }
     for (i = 0; i < count; i++) {
         key = xasprintf ("%s.%u.%d.%d", prefix, rank, t->n, i);
         if (fopt)

--- a/src/test/tkvstorture.c
+++ b/src/test/tkvstorture.c
@@ -111,7 +111,9 @@ int main (int argc, char *argv[])
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
     if (!prefix) {
-        uint32_t rank = flux_rank (h);
+        uint32_t rank;
+        if (flux_get_rank (h, &rank) < 0)
+            err_exit ("flux_get_rank");
         prefix = xasprintf ("kvstorture-%u", rank);
     }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -21,6 +21,7 @@ TESTS = \
 	t0005-exec.t \
 	t0006-build-basic.t \
 	t0007-ping.t \
+	t0008-attr.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1002-modctl.t \
@@ -59,6 +60,7 @@ check_SCRIPTS = \
 	t0005-exec.t \
 	t0006-build-basic.t \
 	t0007-ping.t \
+	t0008-attr.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1002-modctl.t \

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -140,10 +140,12 @@ int rpctest_begin_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
     /* fake that we have a larger session */
     fake_size = 128;
     char s[16];
+    uint32_t size = 0;
     snprintf (s, sizeof (s), "%u", fake_size);
     flux_attr_fake (h, "size", s, FLUX_ATTRFLAG_IMMUTABLE);
-    cmp_ok (flux_size (h), "==", fake_size,
-        "successfully faked flux_size() of %d", fake_size);
+    flux_get_size (h, &size);
+    cmp_ok (size, "==", fake_size,
+        "successfully faked flux_get_size() of %d", fake_size);
 
     /* repeat working no-payload RPC test (now with 128 nodes) */
     old_count = hello_count;

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -6,6 +6,7 @@
 #include "src/common/libflux/response.h"
 #include "src/common/libflux/reactor.h"
 #include "src/common/libflux/info.h"
+#include "src/common/libflux/attr.h"
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/nodeset.h"
@@ -138,7 +139,9 @@ int rpctest_begin_cb (flux_t h, int type, zmsg_t **zmsg, void *arg)
 
     /* fake that we have a larger session */
     fake_size = 128;
-    flux_aux_set (h, "flux::size", &fake_size, NULL);
+    char s[16];
+    snprintf (s, sizeof (s), "%u", fake_size);
+    flux_attr_fake (h, "size", s, FLUX_ATTRFLAG_IMMUTABLE);
     cmp_ok (flux_size (h), "==", fake_size,
         "successfully faked flux_size() of %d", fake_size);
 

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+
+
+test_description='Test broker attrbitues' 
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4
+
+test_expect_success 'flux getattr rank works' '
+	ATTR_VAL=`flux getattr rank` &&
+	test "${ATTR_VAL}" -eq 0
+'
+test_expect_success 'flux setattr rank fails (immutable)' '
+	! flux setattr rank 42
+'
+test_expect_success 'flux getattr attrtest.nonexist fails' '
+	! flux getattr nonexist
+'
+test_expect_success 'flux setattr works' '
+	flux setattr attrtest.foo bar &&
+	ATTR_VAL=`flux getattr attrtest.foo` &&
+	test "${ATTR_VAL}" = "bar"
+'
+test_expect_success 'flux setattr -e works' '
+	flux setattr -e attrtest.foo &&
+	! flux getattr attrtest.foo
+'
+test_expect_success 'flux lsattr works' '
+	flux lsattr >lsattr_out &&
+	grep -q rank lsattr_out &&
+	! grep -q attrtest.foo lsattr_out
+'
+test_expect_success 'flux lsattr -v works' '
+	flux lsattr -v | sed -e "s/[\ ]\+/\	/g" >lsattr_v_out &&
+	ATTR_VAL=`grep rank lsattr_v_out | cut -f2` &&
+	test "${ATTR_VAL}" -eq 0
+'
+
+test_done

--- a/t/t2003-recurse.t
+++ b/t/t2003-recurse.t
@@ -24,29 +24,29 @@ test_expect_success 'recurse: Flux launches Flux ' '
 test_expect_success 'recurse: local-uri is identical to FLUX_URI' '
 	printenv FLUX_URI >cur_uri &&
 	test -s cur_uri &&
-	flux comms getattr local-uri >attr_uri &&
+	flux getattr local-uri >attr_uri &&
 	test -s attr_uri &&
 	test_cmp cur_uri attr_uri
 '
 
 test_expect_success 'recurse: parent-uri is unset in bootstrap instance' '
-	! flux comms getattr parent-uri
+	! flux getattr parent-uri
 '
 
 test_expect_success 'recurse: local-uri != local-uri in enclosing instance' '
-	flux comms getattr local-uri >enc_uri &&
+	flux getattr local-uri >enc_uri &&
 	test -s enc_uri &&
 	flux wreckrun -n1 -N1 flux broker \
-		flux comms getattr local-uri >attr_uri &&
+		flux getattr local-uri >attr_uri &&
 	test -s attr_uri &&
 	! test_cmp enc_uri attr_uri
 '
 
 test_expect_success 'recurse: parent-uri == local-uri in enclosing instance' '
-	flux comms getattr local-uri >enc_uri &&
+	flux getattr local-uri >enc_uri &&
 	test -s enc_uri &&
 	flux wreckrun -n1 -N1 flux broker \
-		flux comms getattr parent-uri >attr_uri &&
+		flux getattr parent-uri >attr_uri &&
 	test -s attr_uri &&
 	test_cmp enc_uri attr_uri
 '


### PR DESCRIPTION
As discussed in #390, `flux_getattr()` was a weak attempt at a generic interface for reading broker attributes such as the URI's for overlay sockets.   The broker had a hardwired list of attributes that it could respond to.  They could not be listed or set.

This PR replaces that interface with a generic attribute hash with get, set, and list API interfaces as well as getattr, setattr, and lsattr builtins in the command driver.

An attribute can have flags for readonly or immutability.  These are used by the broker to prevent its state from being written to, and to indicate to users whether a value might change on the broker so that it can be cached.  The API implementation includes a cache that retains immutable values and allows the API to return `const char *` (no free required).

On the broker side, attributes can be "active".  That is, they can have get/set callbacks associated with them so their values can be computed, or the act of setting them can have side effects.

This PR converts in-tree users to the new interface and deprecates `flux_getattr()`.

Todo:
* subsume `flux_info()`
* tests
* man pages


