### PR TITLE
get hwloc, spell check working in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
       - aspell-en
       - libopenmpi-dev
       - ccache
-      - libhwloc-dev
   coverity_scan:
     project:
       name: "grondo/flux-core"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
       - luarocks
       - uuid-dev
       - aspell
+      - aspell-en
       - libopenmpi-dev
       - ccache
       - libhwloc-dev

--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ X_AC_ZEROMQ
 X_AC_MUNGE
 PKG_CHECK_MODULES([JSON], [json], [],
   [PKG_CHECK_MODULES([JSON], [json-c])])
-PKG_CHECK_MODULES([HWLOC], [hwloc], [], [])
+PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.4], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 AX_CODE_COVERAGE

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -115,8 +115,8 @@ A protocol error was encountered.
 EXAMPLES
 --------
 
-This example performs a synchronous RPC with the broker's "cmb.info" service
-and extracts the broker's rank.
+This example performs a synchronous RPC with the broker's "cmb.attrget"
+service to obtain the broker's rank.
 
 ....
 include::trpc.c[]

--- a/doc/man3/flux_rpc_multi.adoc
+++ b/doc/man3/flux_rpc_multi.adoc
@@ -108,7 +108,7 @@ and response payloads.
 EXAMPLE
 -------
 
-This example performs an RPC with the broker's "cmb.info" service on all
+This example performs an RPC with the broker's "cmb.attrget" service on all
 ranks.  A continuation is registered to process the responses as they arrive.
 The reactor loop terminates once the RPC is completed since the completion
 is its only event handler.

--- a/doc/man3/flux_rpc_then.adoc
+++ b/doc/man3/flux_rpc_then.adoc
@@ -59,7 +59,7 @@ Some arguments were invalid.
 EXAMPLES
 --------
 
-This example performs an RPC with the broker's "cmb.info" service
+This example performs an RPC with the broker's "cmb.attrget" service
 to obtain the broker's rank.  If the response is available immediately,
 it is processed synchronously.  Otherwise, a continuation is registered to
 process the response when it arrives, meanwhile allowing other reactor

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -5,13 +5,13 @@ void get_rank (flux_rpc_t *rpc)
 {
     const char *json_str;
     JSON o;
-    int rank;
+    const char *rank;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
         err_exit ("flux_rpc_get");
-    if (!(o = Jfromstr (json_str)) || !Jget_int (o, "rank", &rank))
+    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
         msg_exit ("response protocol error");
-    printf ("rank is %d\n", rank);
+    printf ("rank is %s\n", rank);
     Jput (o);
 }
 
@@ -19,13 +19,16 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_rpc_t *rpc;
+    JSON o = Jnew();
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
-    if (!(rpc = flux_rpc (h, "cmb.info", NULL, FLUX_NODEID_ANY, 0)))
+    Jadd_str (o, "name", "rank");
+    if (!(rpc = flux_rpc (h, "cmb.attrget", Jtostr (o), FLUX_NODEID_ANY, 0)))
         err_exit ("flux_rpc");
     get_rank (rpc);
     flux_rpc_destroy (rpc);
     flux_close (h);
+    Jput (o);
     return (0);
 }

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -5,13 +5,13 @@ void get_rank (flux_rpc_t *rpc, void *arg)
 {
     const char *json_str;
     JSON o;
-    int rank;
+    const char *rank;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
         err_exit ("flux_rpc_get");
-    if (!(o = Jfromstr (json_str)) || !Jget_int (o, "rank", &rank))
+    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
         msg_exit ("response protocol error");
-    printf ("rank is %d\n", rank);
+    printf ("rank is %s\n", rank);
     Jput (o);
 }
 
@@ -19,10 +19,12 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_rpc_t *rpc;
+    JSON o = Jnew ();
 
+    Jadd_str (o, "name", "rank");
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
-    if (!(rpc = flux_rpc (h, "cmb.info", NULL, FLUX_NODEID_ANY, 0)))
+    if (!(rpc = flux_rpc (h, "cmb.attrget", Jtostr (o), FLUX_NODEID_ANY, 0)))
         err_exit ("flux_rpc");
     if (flux_rpc_check (rpc))
         get_rank (rpc, NULL);
@@ -33,5 +35,6 @@ int main (int argc, char **argv)
 
     flux_rpc_destroy (rpc);
     flux_close (h);
+    Jput (o);
     return (0);
 }

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -258,3 +258,4 @@ ENOENT
 EPERM
 READONLY
 tbon
+attrget

--- a/doc/test/spellcheck
+++ b/doc/test/spellcheck
@@ -19,6 +19,10 @@ if test  -z "$ASPELL"; then
    echo "1..$# # skip because aspell is not installed"
    exit 0
 fi
+if ! $ASPELL -n list </dev/null >/dev/null; then
+   echo "1..$# # skip because aspell dry run failed"
+   exit 0
+fi
 
 exit_val=0
 echo "1..$#"
@@ -27,7 +31,7 @@ for f in $*; do
     filename=$(basename $f)
     dir=$(basename $(dirname $f))
     tmpfile=$(mktemp)
-    rc=$(cat $f | aspell -p $dict -n list | sort | uniq | tee $tmpfile | wc -l)
+    rc=$(cat $f | $ASPELL -p $dict -n list | sort | uniq | tee $tmpfile | wc -l)
     if test $rc == 0; then
         echo "ok $count - spell check $dir/$filename"
     else

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -103,7 +103,7 @@ int attr_delete (attr_t *attrs, const char *name, bool force)
     }
     rc = 0;
 done:
-    return rc;    
+    return rc;
 }
 
 int attr_add (attr_t *attrs, const char *name, const char *val, int flags)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1465,21 +1465,6 @@ static int cmb_ps_cb (zmsg_t **zmsg, void *arg)
     return (rc);
 }
 
-static int cmb_info_cb (zmsg_t **zmsg, void *arg)
-{
-    ctx_t *ctx = arg;
-    JSON out = Jnew ();
-    int rc;
-
-    Jadd_int (out, "rank", ctx->rank);
-    Jadd_int (out, "size", ctx->size);
-    Jadd_int (out, "arity", ctx->k_ary);
-
-    rc = flux_json_respond (ctx->h, out, zmsg);
-    Jput (out);
-    return rc;
-}
-
 static int attr_get_snoop (const char *name, const char **val, void *arg)
 {
     snoop_t *snoop = arg;
@@ -1933,8 +1918,7 @@ static int event_shutdown_cb (zmsg_t **zmsg, void *arg)
 
 static void broker_add_services (ctx_t *ctx)
 {
-    if (!svc_add (ctx->services, "cmb.info", cmb_info_cb, ctx)
-          || !svc_add (ctx->services, "cmb.attrget", cmb_attrget_cb, ctx)
+    if (!svc_add (ctx->services, "cmb.attrget", cmb_attrget_cb, ctx)
           || !svc_add (ctx->services, "cmb.attrset", cmb_attrset_cb, ctx)
           || !svc_add (ctx->services, "cmb.attrlist", cmb_attrlist_cb, ctx)
           || !svc_add (ctx->services, "cmb.rusage", cmb_rusage_cb, ctx)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -368,7 +368,7 @@ int main (int argc, char *argv[])
         size_t len = 0;
         if (argz_create (argv + optind, &ctx.init_shell_cmd, &len) < 0)
             oom ();
-        argz_stringify (ctx.init_shell_cmd, len, ' '); 
+        argz_stringify (ctx.init_shell_cmd, len, ' ');
     }
     if (boot_method) {
         struct boot_method *m;
@@ -397,7 +397,7 @@ int main (int argc, char *argv[])
     /* Get the directory for CURVE keys.
      */
     if (!(secdir = getenv ("FLUX_SEC_DIRECTORY")))
-        msg_exit ("FLUX_SEC_DIRECTORY is not set"); 
+        msg_exit ("FLUX_SEC_DIRECTORY is not set");
 
     /* Process config from the KVS of enclosing instance (if any)
      * and not forced to use a config file by the command line.
@@ -1434,7 +1434,7 @@ static JSON subprocess_json_info (struct subprocess *p)
         cwd = getcwd (buf, MAXPATHLEN-1);
     Jadd_str (o, "cwd", cwd);
     if ((sender = subprocess_sender (p))) {
-        Jadd_str (o, "sender", sender); 
+        Jadd_str (o, "sender", sender);
         free (sender);
     }
     return (o);
@@ -1511,7 +1511,7 @@ static int cmb_attrget_cb (zmsg_t **zmsg, void *arg)
         errno = ENOENT;
         goto done;
     }
-    Jadd_str (out, "value", val);    
+    Jadd_str (out, "value", val);
     Jadd_int (out, "flags", flags);
     rc = 0;
 done:

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1056,15 +1056,10 @@ static void load_modules (ctx_t *ctx, zlist_t *modules, zlist_t *modopts,
         }
         if (modexclude && zhash_lookup (modexclude, name))
             goto next;
-        if (!(p = module_add (ctx->modhash, path))) {
-            err ("%s: module_add %s", name, path);
-            goto next;
-        }
-        if (!svc_add (ctx->services, module_get_name (p), mod_svc_cb, p)) {
-            msg ("could not register service %s", module_get_name (p));
-            module_remove (ctx->modhash, p);
-            goto next;
-        }
+        if (!(p = module_add (ctx->modhash, path)))
+            err_exit ("%s: module_add %s", name, path);
+        if (!svc_add (ctx->services, module_get_name (p), mod_svc_cb, p))
+            msg_exit ("could not register service %s", module_get_name (p));
         zhash_update (mods, module_get_name (p), p);
         module_set_poller_cb (p, module_cb, ctx);
         module_set_rmmod_cb (p, rmmod_cb, ctx);

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -43,13 +43,13 @@ static const struct option longopts[] = {
     { 0, 0, 0, 0 },
 };
 
-static char *suppressed[] = { "cmb.info", "cmb.log", "cmb.pub" };
+static char *suppressed[] = { "cmb.log", "cmb.pub" };
 
 void usage (void)
 {
     fprintf (stderr,
 "Usage: flux-snoop OPTIONS [topic [topic...]]\n"
-"  -a,--all               Do not suppress cmb.info, cmb.log, cmb.pub\n"
+"  -a,--all               Do not suppress cmb.log, cmb.pub\n"
 "  -l,--long              Display long message format\n"
 #if 0 /* These options are for debugging, not generally useful */
 "  -n,--no-security       Try to connect without CURVE security\n"

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -273,7 +273,7 @@ static void load_cb (flux_t h,
 
     kvs_fence (h, "resource_hwloc_loaded", size);
 
-    flux_log (h, LOG_DEBUG, "resource_hwloc: loaded: %" PRIu32, rank);
+    flux_log (h, LOG_DEBUG, "loaded");
 
     ctx->loaded = true;
 }

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -15,7 +15,8 @@ https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz \
 http://download.zeromq.org/zeromq-4.0.4.tar.gz \
 http://download.zeromq.org/czmq-3.0.2.tar.gz \
 https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz \
-http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz"
+http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz \
+http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.0.tar.gz"
 
 declare -A extra_configure_opts=(\
 ["zeromq-4.0.4"]="--with-libsodium --with-libsodium-include-dir=\$prefix/include" \


### PR DESCRIPTION
Here's an assortment of tiny fixes:
* ensure hwloc is the right version #402
* ensure spellcheck dictionary is installed #401
* broker/doc cleanup: whitespace, remove deprecated cmb.info handler
* broker should die if it can't load its builtin modules #403
