### PR TITLE
More coverage tweaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,8 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"libtap/*" \
 	"libjsonc/*" \
 	"libev/*" \
-	"/usr/*"
+	"/usr/*" \
+	"bindings/python/*"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,3 +24,8 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"bindings/python/*"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
+
+# Remove other coverage files on clean:
+clean:
+	-rm $(CODE_COVERAGE_OUTPUT_FILE).initial
+	-find . -name *.gcno -delete

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,9 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"libjsonc/*" \
 	"libev/*" \
 	"/usr/*" \
-	"bindings/python/*"
+	"bindings/python/*" \
+	"common/liblsd/*" \
+	"common/libutil/sds.[ch]"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,8 +24,3 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"bindings/python/*"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
-
-# Extra code coverage checks here:
-
-code-coverage-capture-hook:
-	@cd src/cmd && $(MAKE) cmd-run-test

--- a/config/ax_code_coverage.m4
+++ b/config/ax_code_coverage.m4
@@ -183,8 +183,13 @@ code_coverage_quiet = $(code_coverage_quiet_$(V))
 code_coverage_quiet_ = $(code_coverage_quiet_$(AM_DEFAULT_VERBOSITY))
 code_coverage_quiet_0 = --quiet
 
+$(CODE_COVERAGE_OUTPUT_FILE).initial:
+ifeq ($(CODE_COVERAGE_ENABLED),yes)
+	$(LCOV) $(code_coverage_quiet) --directory $(CODE_COVERAGE_DIRECTORY) -c -i -o "$(CODE_COVERAGE_OUTPUT_FILE).initial" --no-checksum --compat-libtool $(CODE_COVERAGE_LCOV_OPTIONS)
+endif
+
 # Use recursive makes in order to ignore errors during check
-check-code-coverage:
+check-code-coverage: $(CODE_COVERAGE_OUTPUT_FILE).initial
 ifeq ($(CODE_COVERAGE_ENABLED),yes)
 	-$(MAKE) $(AM_MAKEFLAGS) -k check
 	$(MAKE) $(AM_MAKEFLAGS) code-coverage-capture
@@ -195,7 +200,9 @@ endif
 # Capture code coverage data
 code-coverage-capture: code-coverage-capture-hook
 ifeq ($(CODE_COVERAGE_ENABLED),yes)
-	$(LCOV) $(code_coverage_quiet) --directory $(CODE_COVERAGE_DIRECTORY) --capture --output-file "$(CODE_COVERAGE_OUTPUT_FILE).tmp" --test-name "$(PACKAGE_NAME)-$(PACKAGE_VERSION)" --no-checksum --compat-libtool $(CODE_COVERAGE_LCOV_OPTIONS)
+	$(LCOV) $(code_coverage_quiet) --directory $(CODE_COVERAGE_DIRECTORY) --capture --output-file "$(CODE_COVERAGE_OUTPUT_FILE).tmp1" --test-name "$(PACKAGE_NAME)-$(PACKAGE_VERSION)" --no-checksum --compat-libtool $(CODE_COVERAGE_LCOV_OPTIONS)
+	$(LCOV) $(code_coverage_quiet) -a "$(CODE_COVERAGE_OUTPUT_FILE).initial" -a "$(CODE_COVERAGE_OUTPUT_FILE).tmp1" -o "$(CODE_COVERAGE_OUTPUT_FILE).tmp" $(CODE_COVERAGE_LCOV_OPTIONS)
+	-@rm -f $(CODE_COVERAGE_OUTPUT_FILE).tmp1
 	$(LCOV) $(code_coverage_quiet) --directory $(CODE_COVERAGE_DIRECTORY) --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" "/tmp/*" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)"
 	-@rm -f $(CODE_COVERAGE_OUTPUT_FILE).tmp
 	LANG=C $(GENHTML) $(code_coverage_quiet) --prefix $(CODE_COVERAGE_DIRECTORY) --output-directory "$(CODE_COVERAGE_OUTPUT_DIRECTORY)" --title "$(PACKAGE_NAME)-$(PACKAGE_VERSION) Code Coverage" --legend --show-details "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_GENHTML_OPTIONS)

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -38,7 +38,7 @@
 static void event_pub (flux_t h, int argc, char **argv);
 static void event_sub (flux_t h, int argc, char **argv);
 
-#define OPTIONS "h"
+#define OPTIONS "+h"
 static const struct option longopts[] = {
     {"help",       no_argument,        0, 'h'},
     { 0, 0, 0, 0 },

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -73,7 +73,7 @@ int main (int argc, char *argv[])
     }
     if (optind == argc)
         usage ();
-    cmd = argv[optind++];
+    cmd = argv[optind];
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
@@ -92,13 +92,13 @@ int main (int argc, char *argv[])
 
 static void event_pub (flux_t h, int argc, char **argv)
 {
-    char *topic = argv[0];
+    char *topic = argv[1];  /* "pub" should be argv0 */
     flux_msg_t *msg = NULL;
     char *json_str = NULL;
 
-    if (argc > 1) {
+    if (argc > 2) {
         size_t len = 0;
-        if (argz_create (argv + 1, &json_str, &len) < 0)
+        if (argz_create (argv + 2, &json_str, &len) < 0)
             oom ();
         argz_stringify (json_str, len, ' ');
     }
@@ -138,8 +138,8 @@ static void event_sub (flux_t h, int argc, char **argv)
      */
     setlinebuf (stdout);
 
-    if (argc > 0)
-        subscribe_all (h, argc, argv);
+    if (argc > 1)
+        subscribe_all (h, argc-1, argv+1);
     else if (flux_event_subscribe (h, "") < 0)
         err_exit ("flux_event_subscribe");
 
@@ -156,7 +156,7 @@ static void event_sub (flux_t h, int argc, char **argv)
     }
     /* FIXME: add SIGINT handler to exit above loop and clean up.
      */
-    if (argc > 0)
+    if (argc > 1)
         unsubscribe_all (h, argc, argv);
     else if (flux_event_unsubscribe (h, "") < 0)
         err_exit ("flux_event_subscribe");

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -242,7 +242,7 @@ static int snoop_cb (zloop_t *zloop, zmq_pollitem_t *item, void *arg)
             if (lopt)
                 zmsg_dump (zmsg);
             else
-                flux_msg_fprint (stderr, zmsg);
+                flux_msg_fprint (stdout, zmsg);
         }
         zmsg_destroy (&zmsg);
     }

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -816,6 +816,7 @@ int optparse_parse_args (optparse_t p, int argc, char *argv[])
 {
     int c;
     int li;
+    char *saved_argv0;
     char *optstring = NULL;
     struct option *optz = option_table_create (p, &optstring);
 
@@ -824,6 +825,8 @@ int optparse_parse_args (optparse_t p, int argc, char *argv[])
      *  GNU options parser. See getopt_long(3) NOTES section.
      */
     optind = 0;
+    saved_argv0 = argv[0];
+    argv[0] = p->program_name;
     while ((c = getopt_long (argc, argv, optstring, optz, &li))) {
         struct option_info *opt;
         struct optparse_option *o;
@@ -858,6 +861,7 @@ int optparse_parse_args (optparse_t p, int argc, char *argv[])
     free (optz);
     free (optstring);
 
+    argv[0] = saved_argv0;
     return (optind);
 }
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -854,7 +854,8 @@ int optparse_parse_args (optparse_t p, int argc, char *argv[])
         o = opt->p_opt;
         if (o->cb && ((o->cb) (o, optarg, o->arg) < 0)) {
             fprintf (stderr, "Option \"%s\" failed\n", o->name);
-            return (-1);
+            optind = -1;
+            break;
         }
     }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -27,6 +27,7 @@ TESTS = \
 	t0006-build-basic.t \
 	t0007-ping.t \
 	t0008-attr.t \
+	t0010-generic-utils.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1002-modctl.t \
@@ -67,6 +68,7 @@ check_SCRIPTS = \
 	t0007-ping.t \
 	t0008-attr.t \
 	t1000-kvs-basic.t \
+	t0010-generic-utils.t \
 	t1001-barrier-basic.t \
 	t1002-modctl.t \
 	t1003-mecho.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -101,7 +101,8 @@ dist_check_DATA = \
 	build/hello_jsonc.c
 
 dist_check_SCRIPTS = \
-	scripts/event-trace.lua
+	scripts/event-trace.lua \
+	scripts/kvs-watch-until.lua
 
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \

--- a/t/scripts/kvs-watch-until.lua
+++ b/t/scripts/kvs-watch-until.lua
@@ -1,0 +1,82 @@
+#!/usr/bin/lua
+--
+--  Exit only if/when all ranks have exited 'unknown' state
+--
+local usage = [[
+Usage: kvs-wait-until [OPTIONS] KEY CODE
+
+Watch kvs KEY until Lua code CODE returns true.
+(CODE is supplied key value in variable 'v')
+If -t, --timeout is provided, and the timeout expires, then
+exit with non-zero exit status.
+
+ -h, --help       Display this message
+ -v, --verbose    Print value on each watch callback
+ -t, --timeout=T  Wait at most T seconds (before exiting
+]]
+
+local getopt = require 'flux-lua.alt_getopt' .get_opts
+local timer =  require 'flux-lua.timer'.new()
+local f =      require 'flux' .new()
+
+local function printf (...)
+    io.stdout:write (string.format (...))
+end
+local function log_err (...)
+    io.stdout:write (string.format (...))
+end
+
+local opts, optind = getopt (arg, "hvt:",
+                             { verbose = 'v',
+                               timeout = 't',
+                               help = 'h'
+                             }
+                            )
+if opts.h then print (usage); os.exit (0) end
+
+local key = arg [optind]
+local callback = arg [optind+1]
+
+if not key or not callback then
+    log_err ("KVS key and callback code required\n")
+    print (usage)
+    os.exit (1)
+end
+
+callback = "return function (v)  return "..callback.." end"
+local fn, err = loadstring (callback, "callback")
+if not fn then
+    log_err ("code compile error: %s", err)
+    os.exit (1)
+end
+local cb = fn ()
+
+local kw, err = f:kvswatcher {
+    key = key,
+    handler = function (kw, result)
+    if opts.v then 
+        printf ("%4.03fs: %s = %s\n",
+                timer:get0(),
+                key, require 'inspect' (result))
+    end
+    local ok, rv = pcall (cb, result)
+    if not ok then error (rv) end
+    if ok and rv then
+        os.exit (0)
+    end
+    end
+}
+
+if opts.t then
+    local tw, err = f:timer {
+        timeout = opts.t * 1000,
+        handler = function (f, to)
+               log_err ("%4.03fs: Timeout expired!\n", timer:get0())
+               os.exit (1)
+        end
+    }
+end
+
+timer:set ()
+f:reactor ()
+-- vi: ts=4 sw=4 expandtab

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -1,0 +1,69 @@
+#!/bin/sh
+#
+
+test_description='Test various flux utilities
+
+Verify basic functionality of generic flux utils
+'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+LASTRANK=$((SIZE-1))
+test_under_flux ${SIZE}
+
+#
+# Wait for all ranks to leave unknown state in live module:
+# (i.e. conf.live.status has unknown == ""), since this is required
+# for predictable results with flux-up:
+test "$debug" = "t" && ARG="--verbose"
+$SHARNESS_TEST_SRCDIR/scripts/kvs-watch-until.lua ${ARG} \
+	--timeout=5 \
+	conf.live.status 'v.unknown == ""' \
+    || die "failed to wait on live module status"
+
+test_expect_success 'up: flux up works' '
+	flux up > output_up &&
+	cat >expected_up <<-EOF &&
+	ok:     [0-${LASTRANK}]
+	slow:   
+	fail:   
+	unknown:
+	EOF
+	test_cmp expected_up output_up
+'
+test_expect_success 'up: flux up --up' '
+	OUTPUT=$(flux up --up) &&
+	test_debug say "got \"$OUTPUT\"" &&
+	test "$OUTPUT" = "[0-${LASTRANK}]"
+'
+test_expect_success 'up: flux up --down' '
+	OUTPUT=$(flux up --down) &&
+	test_debug say "got \"$OUTPUT\"" &&
+	test "$OUTPUT" = ""
+'
+test_expect_success 'event: can publish' '
+	run_timeout 5 \
+	  $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
+	    testcase testcase.foo \
+	    flux event pub testcase.foo > output_event_pub &&
+	cat >expected_event_pub <<-EOF &&
+	testcase.foo
+	EOF
+	test_cmp expected_event_pub output_event_pub
+'
+test_expect_success 'event: can subscribe' '
+	flux event sub --count=1 hb >output_event_sub &&
+	grep "^hb" output_event_sub
+'
+# for now we just ensure snoop basically works
+test_expect_success 'snoop: produces output (XXX needs fixing)' '
+	flux snoop -c 1 --verbose >output_snoop 2>&1 &
+        flux snoop -c 1 --verbose --long >output_snoop_long 2>&1 &
+	test_expect_code 0 wait &&
+	test_expect_code 0 wait &&
+	test -s output_snoop &&
+	test -s output_snoop_long &&
+	head output_snoop | grep "^flux-snoop: connecting to" &&
+	head output_snoop_long | grep "^flux-snoop: connecting to"
+'
+test_done


### PR DESCRIPTION
This PR contains a few more coverage and testing updates tweaks. The main updates include a better scheme for reporting zero coverage files (see `config/ax_code_coverage.m4` updates), addition of more external code to the ignore list (`liblsd` and `sds.[ch]`) and some basic sharness tests for commands that had no testing (`flux-event, flux-up, and flux-ping`).

I also found there must be a problem with the generated python bindings and coverage testing. They only report 1% coverage even though there is a significant amount of python tests run at `make check`. Since the generated code was about 40-50% of the total, I removed them from the reporting for now so we can get more useful results from the rest of the codebase. We can add them back later if we want but it might be more useful to report python coverage instead, which I know is already collected (but I'm not sure how to merge this into output)

While creating tests for `flux-event` and `flux-snoop`, I found it almost impossible to write reliable tests for these kinds of commands that run until interrupted. You can run in the background and sleep for a bit then signal them, but determining the amount to sleep was tricky, and causes the tests to run for longer than necessary. Therefore, I added `-c, --count` options to both of these commands. For testing these utilities can be run with `-c 1`, making it straightforward to write tests. However, this change might be controversial because I'm not sure if this option is useful for real usage so I'd like to get feedback on that.

Finally, another convenience script was added to `t/scripts` called `kvs-watch-until`. This watches a kvs value until a snipped of Lua code returns true or a timeout is reached. This is used for now to ensure all ranks have left `conf.live.status` "unknown" list, like this:
```
 kvs-watch-until.lua --timeout=5 "conf.live.status" 'v.unknown == ""'
```
(value of watched key is passed to Lua code as variable `v`)

If timeout is reached `kvs-watch-until` returns failure. It might be useful to eventually add some kind of similar ability to `flux kvs watch` and `watch-dir`.