### PR TITLE
add interfaces that wrap the libev prepare, check, and idle watchers

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -21,7 +21,8 @@ MAN3_FILES_PRIMARY = \
 	flux_get_reactor.3 \
 	flux_reactor_create.3 \
 	flux_fd_watcher_create.3 \
-	flux_watcher_start.3
+	flux_watcher_start.3 \
+	flux_zmq_watcher_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -58,7 +59,8 @@ MAN3_FILES_SECONDARY = \
 	flux_reactor_stop_error.3 \
 	flux_fd_watcher_get_fd.3 \
 	flux_watcher_stop.3 \
-	flux_watcher_destroy.3
+	flux_watcher_destroy.3 \
+	flux_zmq_watcher_get_zsock.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -114,6 +116,7 @@ flux_reactor_error.3: flux_reactor_create.3
 flux_fd_watcher_get_fd.3: flux_fd_watcher_create.3
 flux_watcher_stop.3: flux_watcher_start.3
 flux_watcher_destroy.3: flux_watcher_start.3
+flux_zmq_watcher_get_zsock.3: flux_zmq_watcher_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -22,7 +22,8 @@ MAN3_FILES_PRIMARY = \
 	flux_reactor_create.3 \
 	flux_fd_watcher_create.3 \
 	flux_watcher_start.3 \
-	flux_zmq_watcher_create.3
+	flux_zmq_watcher_create.3 \
+	flux_handle_watcher_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -60,7 +61,8 @@ MAN3_FILES_SECONDARY = \
 	flux_fd_watcher_get_fd.3 \
 	flux_watcher_stop.3 \
 	flux_watcher_destroy.3 \
-	flux_zmq_watcher_get_zsock.3
+	flux_zmq_watcher_get_zsock.3 \
+	flux_handle_watcher_get_flux.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -117,6 +119,7 @@ flux_fd_watcher_get_fd.3: flux_fd_watcher_create.3
 flux_watcher_stop.3: flux_watcher_start.3
 flux_watcher_destroy.3: flux_watcher_start.3
 flux_zmq_watcher_get_zsock.3: flux_zmq_watcher_create.3
+flux_handle_watcher_get_flux.3: flux_handle_watcher_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -25,7 +25,8 @@ MAN3_FILES_PRIMARY = \
 	flux_zmq_watcher_create.3 \
 	flux_handle_watcher_create.3 \
 	flux_timer_watcher_create.3 \
-	flux_idle_watcher_create.3
+	flux_idle_watcher_create.3 \
+	flux_msg_handler_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -67,7 +68,10 @@ MAN3_FILES_SECONDARY = \
 	flux_handle_watcher_get_flux.3 \
 	flux_timer_watcher_reset.3 \
 	flux_prepare_watcher_create.3 \
-	flux_check_watcher_create.3
+	flux_check_watcher_create.3 \
+	flux_msg_handler_destroy.3 \
+	flux_msg_handler_start.3 \
+	flux_msg_handler_stop.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -128,6 +132,9 @@ flux_handle_watcher_get_flux.3: flux_handle_watcher_create.3
 flux_timer_watcher_reset.3: flux_timer_watcher_create.3
 flux_prepare_watcher_create.3: flux_idle_watcher_create.3
 flux_check_watcher_create.3: flux_idle_watcher_create.3
+flux_msg_handler_destroy.3: flux_msg_handler_create.3
+flux_msg_handler_start.3: flux_msg_handler_create.3
+flux_msg_handler_stop.3: flux_msg_handler_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -19,7 +19,8 @@ MAN3_FILES_PRIMARY = \
 	flux_get_rank.3 \
 	flux_attr_get.3 \
 	flux_get_reactor.3 \
-	flux_reactor_create.3
+	flux_reactor_create.3 \
+	flux_fd_watcher_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -53,7 +54,8 @@ MAN3_FILES_SECONDARY = \
 	flux_reactor_destroy.3 \
 	flux_reactor_run.3 \
 	flux_reactor_stop.3 \
-	flux_reactor_stop_error.3
+	flux_reactor_stop_error.3 \
+	flux_fd_watcher_get_fd.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -106,6 +108,7 @@ flux_reactor_destroy.3: flux_reactor_create.3
 flux_reactor_run.3: flux_reactor_create.3
 flux_reactor_stop.3: flux_reactor_create.3
 flux_reactor_error.3: flux_reactor_create.3
+flux_fd_watcher_get_fd.3: flux_fd_watcher_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -27,7 +27,8 @@ MAN3_FILES_PRIMARY = \
 	flux_timer_watcher_create.3 \
 	flux_idle_watcher_create.3 \
 	flux_msg_handler_create.3 \
-	flux_msg_cmp.3
+	flux_msg_cmp.3 \
+	flux_msg_handler_addvec.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -72,7 +73,8 @@ MAN3_FILES_SECONDARY = \
 	flux_check_watcher_create.3 \
 	flux_msg_handler_destroy.3 \
 	flux_msg_handler_start.3 \
-	flux_msg_handler_stop.3
+	flux_msg_handler_stop.3 \
+	flux_msg_handler_delvec.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -136,6 +138,7 @@ flux_check_watcher_create.3: flux_idle_watcher_create.3
 flux_msg_handler_destroy.3: flux_msg_handler_create.3
 flux_msg_handler_start.3: flux_msg_handler_create.3
 flux_msg_handler_stop.3: flux_msg_handler_create.3
+flux_msg_handler_delvec.3: flux_msg_handler_addvec.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -18,7 +18,8 @@ MAN3_FILES_PRIMARY = \
 	flux_reduce_create.3 \
 	flux_get_rank.3 \
 	flux_attr_get.3 \
-	flux_get_reactor.3
+	flux_get_reactor.3 \
+	flux_reactor_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -48,7 +49,11 @@ MAN3_FILES_SECONDARY = \
 	flux_attr_set.3 \
 	flux_attr_first.3 \
 	flux_attr_next.3 \
-	flux_set_reactor.3
+	flux_set_reactor.3 \
+	flux_reactor_destroy.3 \
+	flux_reactor_run.3 \
+	flux_reactor_stop.3 \
+	flux_reactor_stop_error.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -97,6 +102,10 @@ flux_attr_set.3: flux_attr_get.3
 flux_attr_first.3: flux_attr_get.3
 flux_attr_next.3: flux_attr_get.3
 flux_set_reactor.3: flux_get_reactor.3
+flux_reactor_destroy.3: flux_reactor_create.3
+flux_reactor_run.3: flux_reactor_create.3
+flux_reactor_stop.3: flux_reactor_create.3
+flux_reactor_error.3: flux_reactor_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -17,7 +17,8 @@ MAN3_FILES_PRIMARY = \
 	flux_rpc_multi.3 \
 	flux_reduce_create.3 \
 	flux_get_rank.3 \
-	flux_attr_get.3
+	flux_attr_get.3 \
+	flux_get_reactor.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -46,7 +47,8 @@ MAN3_FILES_SECONDARY = \
 	flux_get_arity.3 \
 	flux_attr_set.3 \
 	flux_attr_first.3 \
-	flux_attr_next.3
+	flux_attr_next.3 \
+	flux_set_reactor.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -94,6 +96,7 @@ flux_get_arity.3: flux_get_rank.3
 flux_attr_set.3: flux_attr_get.3
 flux_attr_first.3: flux_attr_get.3
 flux_attr_next.3: flux_attr_get.3
+flux_set_reactor.3: flux_get_reactor.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -24,7 +24,8 @@ MAN3_FILES_PRIMARY = \
 	flux_watcher_start.3 \
 	flux_zmq_watcher_create.3 \
 	flux_handle_watcher_create.3 \
-	flux_timer_watcher_create.3
+	flux_timer_watcher_create.3 \
+	flux_idle_watcher_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -64,7 +65,9 @@ MAN3_FILES_SECONDARY = \
 	flux_watcher_destroy.3 \
 	flux_zmq_watcher_get_zsock.3 \
 	flux_handle_watcher_get_flux.3 \
-	flux_timer_watcher_reset.3
+	flux_timer_watcher_reset.3 \
+	flux_prepare_watcher_create.3 \
+	flux_check_watcher_create.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -123,6 +126,8 @@ flux_watcher_destroy.3: flux_watcher_start.3
 flux_zmq_watcher_get_zsock.3: flux_zmq_watcher_create.3
 flux_handle_watcher_get_flux.3: flux_handle_watcher_create.3
 flux_timer_watcher_reset.3: flux_timer_watcher_create.3
+flux_prepare_watcher_create.3: flux_idle_watcher_create.3
+flux_check_watcher_create.3: flux_idle_watcher_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -20,7 +20,8 @@ MAN3_FILES_PRIMARY = \
 	flux_attr_get.3 \
 	flux_get_reactor.3 \
 	flux_reactor_create.3 \
-	flux_fd_watcher_create.3
+	flux_fd_watcher_create.3 \
+	flux_watcher_start.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -55,7 +56,9 @@ MAN3_FILES_SECONDARY = \
 	flux_reactor_run.3 \
 	flux_reactor_stop.3 \
 	flux_reactor_stop_error.3 \
-	flux_fd_watcher_get_fd.3
+	flux_fd_watcher_get_fd.3 \
+	flux_watcher_stop.3 \
+	flux_watcher_destroy.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -109,6 +112,8 @@ flux_reactor_run.3: flux_reactor_create.3
 flux_reactor_stop.3: flux_reactor_create.3
 flux_reactor_error.3: flux_reactor_create.3
 flux_fd_watcher_get_fd.3: flux_fd_watcher_create.3
+flux_watcher_stop.3: flux_watcher_start.3
+flux_watcher_destroy.3: flux_watcher_start.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -26,7 +26,8 @@ MAN3_FILES_PRIMARY = \
 	flux_handle_watcher_create.3 \
 	flux_timer_watcher_create.3 \
 	flux_idle_watcher_create.3 \
-	flux_msg_handler_create.3
+	flux_msg_handler_create.3 \
+	flux_msg_cmp.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -23,7 +23,8 @@ MAN3_FILES_PRIMARY = \
 	flux_fd_watcher_create.3 \
 	flux_watcher_start.3 \
 	flux_zmq_watcher_create.3 \
-	flux_handle_watcher_create.3
+	flux_handle_watcher_create.3 \
+	flux_timer_watcher_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -62,7 +63,8 @@ MAN3_FILES_SECONDARY = \
 	flux_watcher_stop.3 \
 	flux_watcher_destroy.3 \
 	flux_zmq_watcher_get_zsock.3 \
-	flux_handle_watcher_get_flux.3
+	flux_handle_watcher_get_flux.3 \
+	flux_timer_watcher_reset.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -120,6 +122,7 @@ flux_watcher_stop.3: flux_watcher_start.3
 flux_watcher_destroy.3: flux_watcher_start.3
 flux_zmq_watcher_get_zsock.3: flux_zmq_watcher_create.3
 flux_handle_watcher_get_flux.3: flux_handle_watcher_create.3
+flux_timer_watcher_reset.3: flux_timer_watcher_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_fd_watcher_create.adoc
+++ b/doc/man3/flux_fd_watcher_create.adoc
@@ -1,0 +1,91 @@
+flux_fd_watcher_create(3)
+=========================
+:doctype: manpage
+
+
+NAME
+----
+flux_fd_watcher_create, flux_fd_watcher_get_fd -  create file descriptor watcher
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_fd_watcher_create (flux_reactor_t *r,
+                                         int fd, int events,
+                                         flux_watcher_f callback,
+                                         void *arg);
+
+ int flux_fd_watcher_get_fd (flux_watcher_t *w);
+
+
+DESCRIPTION
+-----------
+
+`flux_fd_watcher_create()` creates a flux_watcher_t object which can be used
+to monitor for events on a file descriptor _fd_.  When events occur,
+the user-supplied _callback_ is invoked.
+
+The _events_ and _revents_ arguments are a bitmask containing a logical
+``or'' of the following bits.  If a bit is set in _events_, it indicates
+interest in this type of event.  If a bit is set in _revents_, it
+indicates that this event has occurred.
+
+FLUX_POLLIN::
+The file descriptor is ready for reading.
+
+FLUX_POLLOUT::
+The file descriptor is ready for writing.
+
+FLUX_POLLERR::
+The file descriptor has encountered an error.
+This bit is ignored if it is set in the create _events_ argument.
+
+Events are processed in a level-triggered manner.  That is, the callback
+will continue to be invoked as long as the event has not been
+fully consumed or cleared, and the watcher has not been stopped.
+
+`flux_fd_watcher_get_fd()` is used to obtain the file descriptor from
+within the flux_watcher_f callback.
+
+
+RETURN VALUE
+------------
+
+`flux_fd_watcher_create()` returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+`flux_fd_watcher_get_fd()` returns the file descriptor associated with
+the watcher.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3).

--- a/doc/man3/flux_get_reactor.adoc
+++ b/doc/man3/flux_get_reactor.adoc
@@ -1,0 +1,68 @@
+flux_get_reactor(3)
+===================
+:doctype: manpage
+
+
+NAME
+----
+flux_get_reactor, flux_set_reactor - get/set reactor associated with broker handle
+
+
+SYNOPSIS
+--------
+#include <flux/core.h>
+
+flux_reactor_t *flux_get_reactor (flux_t h);
+
+void flux_set_reactor (flux_t h, flux_reactor_t *r);
+
+
+DESCRIPTION
+-----------
+
+`flux_get_reactor()` retrieves a flux_reactor_t object previously
+associated with the broker handle _h_ by a call to `flux_set_reactor()`.
+If one has not been previously associated, a flux_reactor_t object is created
+on demand.  If the flux_reactor_t object is created on demand, it will be
+destroyed when the handle is destroyed, otherwise it is the responsibility
+of the owner to destroy it after the handle is destroyed.
+
+`flux_set_reactor()` associates a flux_reactor_t object _r_ with a broker
+handle _h_.  A flux_reactor_t object may be obtained from another handle,
+for example when events from multiple handles are to be managed using
+a common flux_reactor_t, or one may be created directly with
+`flux_reactor_create(3)`.
+
+
+RETURN VALUE
+------------
+
+`flux_get_reactor()` returns a flux_reactor_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_reactor_create(3), flux_reactor_destroy(3)

--- a/doc/man3/flux_handle_watcher_create.adoc
+++ b/doc/man3/flux_handle_watcher_create.adoc
@@ -1,0 +1,91 @@
+flux_handle_watcher_create(3)
+=============================
+:doctype: manpage
+
+
+NAME
+----
+flux_handle_watcher_create, flux_handle_watcher_get_flux -  create broker handle watcher
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
+                                             flux_t h, int events,
+                                             flux_watcher_f callback,
+                                             void *arg);
+
+ flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
+
+
+DESCRIPTION
+-----------
+
+`flux_handle_watcher_create()` creates a flux_watcher_t object which
+monitors for events on a Flux broker handle _h_.  When events occur,
+the user-supplied _callback_ is invoked.
+
+The _events_ and _revents_ arguments are a bitmask containing a
+logical ``or'' of the following bits.  If a bit is set in _events_,
+it indicates interest in this type of event.  If a bit is set in _revents_,
+it indicates that this event has occurred.
+
+FLUX_POLLIN::
+The handle is ready for reading.
+
+FLUX_POLLOUT::
+The handle is ready for writing.
+
+FLUX_POLLERR::
+The handle has encountered an error.
+This bit is ignored if it is set in _events_.
+
+Events are processed in a level-triggered manner.  That is, the
+callback will continue to be invoked as long as the event has not been
+fully consumed or cleared, and the watcher has not been stopped.
+
+`flux_handle_watcher_get_flux()` is used to obtain the handle from
+within the callback.
+
+
+RETURN VALUE
+------------
+
+`flux_handle_watcher_create()` returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+`flux_handle_watcher_get_flux()` returns the handle associated with
+the watcher.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3), flux_recv(3), flux_send(3).

--- a/doc/man3/flux_idle_watcher_create.adoc
+++ b/doc/man3/flux_idle_watcher_create.adoc
@@ -1,0 +1,88 @@
+flux_idle_watcher_create(3)
+===========================
+:doctype: manpage
+
+
+NAME
+----
+flux_idle_watcher_create, flux_prepare_watcher_create, flux_check_watcher_create - create prepare/check/idle watchers
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_prepare_watcher_create (flux_reactor_t *r,
+                                              flux_watcher_f callback,
+                                              void *arg);
+
+ flux_watcher_t *flux_check_watcher_create (flux_reactor_t *r,
+                                            flux_watcher_f callback,
+                                            void *arg);
+
+ flux_watcher_t *flux_idle_watcher_create (flux_reactor_t *r,
+                                           flux_watcher_f callback,
+                                           void *arg);
+
+
+DESCRIPTION
+-----------
+
+`flux_prepare_watcher_create()`, `flux_check_watcher_create()`, and
+`flux_idle_watcher_create()` create specialized reactor watchers with
+the following properties:
+
+The prepare watcher is called by the reactor loop immediately before
+blocking, while the check watcher is called by the reactor loop
+immediately after blocking.
+
+The idle watcher is always run when no other events are pending,
+excluding other idle watchers, prepare and check watchers.
+While it is active, the reactor loop does not block waiting for
+new events.
+
+The callback _revents_ argument should be ignored.
+
+Note: the Flux reactor is based on libev.  For additional information
+on the behavior of these watchers, refer to the libev documentation on
+`ev_idle`, `ev_prepare`, and `ev_check`.
+
+
+RETURN VALUE
+------------
+
+These functions return a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_msg_cmp.adoc
+++ b/doc/man3/flux_msg_cmp.adoc
@@ -1,0 +1,67 @@
+flux_msg_cmp(3)
+===============
+:doctype: manpage
+
+
+NAME
+----
+flux_msg_cmp - match a message
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ struct flux_match {
+     int typemask;
+     uint32_t matchtag;
+     int bsize;
+     char *topic_glob;
+ };
+
+ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match);
+
+DESCRIPTION
+-----------
+
+`flux_msg_match()` compares _msg_ to _match_ criteria.
+
+If _match.typemask_ is nonzero, the type of the message must match
+one of the types in the mask.
+
+If _match.matchtag_ is not FLUX_MATCHTAG_NONE, and _match.bsize_ == 0 or 1,
+then the message matchtag must be equal to _match.matchtag_.
+
+If _match.matchtag_ is not FLUX_MATCHTAG_NONE, and _match.bsize_ > 1,
+then the message matchtag must be within the range of _match.matchtag_
+and _match.matchtag_ + _match.bsize_ - 1 (inclusive).
+
+If _match.topic_glob_ is not NULL, then the message topic string must
+match _match.topic_glob_ according to the rules of shell wildcards.
+
+
+RETURN VALUE
+------------
+
+`flux_msg_cmp()` returns true on a match, otherwise false.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+
+SEE ALSO
+--------
+fnmatch(3)

--- a/doc/man3/flux_msg_handler_addvec.adoc
+++ b/doc/man3/flux_msg_handler_addvec.adoc
@@ -1,0 +1,80 @@
+flux_msg_handler_addvec(3)
+==========================
+:doctype: manpage
+
+
+NAME
+----
+flux_msg_handler_addvec, flux_msg_handler_delvec - bulk add/remove message handlers
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ struct flux_msg_handler_spec {
+     int typemask;
+     char *topic_glob;
+     flux_msg_handler_f cb;
+     flux_msg_handler_t *w;
+ };
+
+ int flux_msg_handler_addvec (flux_t h,
+                              struct flux_msg_handler_spec tab[],
+                              void *arg);
+
+ void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
+
+
+DESCRIPTION
+-----------
+
+`flux_msg_handler_addvec()` creates and starts an array of message handlers,
+terminated by FLUX_MSGHANDLER_TABLE_END.  The new message handler objects
+are stored in the array.
+
+`flux_msg_handler_delvec()` stops and destroys an array of message handler
+objects, terminated by FLUX_MSGHANDLER_TABLE_END.
+
+These functions are convenience functions which call
+`flux_msg_handler_create(3)`, `flux_msg_handler_start(3)`; and
+`flux_msg_handler_stop(3)`, `flux_msg_handler_destroy(3)` on each element
+of the array, respectively.
+
+If `flux_msg_handler_addvec()` encounters an error creating a message
+handler, all previously created message handlers in the array are destroyed
+before an error is returned.
+
+
+RETURN VALUE
+------------
+
+`flux_msg_handler_addvec()` returns zero on success.
+On error, -1 is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_msg_handler_create(3)

--- a/doc/man3/flux_msg_handler_create.adoc
+++ b/doc/man3/flux_msg_handler_create.adoc
@@ -1,0 +1,105 @@
+flux_msg_handler_create(3)
+==========================
+:doctype: manpage
+
+
+NAME
+----
+flux_msg_handler_create, flux_msg_handler_destroy,
+flux_msg_handler_start, flux_msg_handler_stop -  manage message handlers
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_msg_handler_f)(flux_t h,
+                                    flux_msg_handler_t *w,
+                                    const flux_msg_t *msg,
+                                    void *arg);
+
+ flux_msg_handler_t *
+ flux_msg_handler_create (flux_t h,
+                          const struct flux_match match,
+                          flux_msg_handler_f callback,
+                          void *arg);
+
+ void flux_msg_handler_destroy (flux_msg_handler_t *w);
+
+ void flux_msg_handler_start (flux_msg_handler_t *w);
+
+ void flux_msg_handler_stop (flux_msg_handler_t *w);
+
+
+DESCRIPTION
+-----------
+
+`flux_msg_handler_create()` registers _callback_ to be invoked when
+a message meeting _match_ criteria, as described in `flux_msg_cmp(3)`,
+is received on Flux broker handle _h_.
+
+The message handler must be started with `flux_msg_handler_start()` in
+order to receive messages.   Conversely, `flux_msg_handler_stop()` causes
+the message handler to stop receiving messages.  Starting and stopping
+are idempotent operations.
+
+The handle _h_ is monitored for FLUX_POLLIN events on the flux_reactor_t
+associated with the handle as described in `flux_set_reactor(3)`.
+This internal "handle watcher" is started when the first message handler
+is started, and stopped when the last message handler is stopped.
+
+Messages arriving on _h_ are internally read and dispatched to matching
+message handlers.  If multiple handlers match the message, the message
+is dispatched to the most recently registered handler.
+
+FLUX_MSGTYPE_REQUEST messages with no matching message handler
+are automatically sent an ENOSYS response by the dispatcher.
+
+`flux_msg_handler_destroy()` destroys a handler, after internally
+stopping it.
+
+
+CAVEATS
+-------
+
+FLUX_MSGTYPE_EVENT messages are received on the handle only as
+requested by `flux_event_subscribe(3)`.
+
+`flux-broker(1)` only routes FLUX_MSGTYPE_REQUEST messages to comms
+modules according to their registered service name, which is the same as
+the module name.  Other handle instances such as those on the local connector
+cannot yet receive requests.
+
+
+RETURN VALUE
+------------
+
+`flux_msg_handler_create()` returns a flux_msg_handler_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_get_reactor(3), flux_reactor_start(3), flux_msg_cmp(3)

--- a/doc/man3/flux_reactor_create.adoc
+++ b/doc/man3/flux_reactor_create.adoc
@@ -1,0 +1,92 @@
+flux_reactor_create(3)
+======================
+:doctype: manpage
+
+
+NAME
+----
+flux_reactor_create, flux_reactor_destroy, flux_reactor_run, flux_reactor_stop, flux_reactor_stop_error - create/destroy/control event reactor object
+
+
+SYNOPSIS
+--------
+#include <flux/core.h>
+
+flux_reactor_t *flux_reactor_create (void);
+
+void flux_reactor_destroy (flux_reactor_t *r);
+
+int flux_reactor_run (flux_reactor_t *r, int flags);
+
+void flux_reactor_stop (flux_reactor_t *r);
+
+void flux_reactor_stop_error (flux_reactor_t *r);
+
+
+DESCRIPTION
+-----------
+
+`flux_reactor_create()` creates a flux_reactor_t object which can be used
+to monitor for events on file descriptors, ZeroMQ sockets, timers, and
+flux_t broker handles.
+
+For each event source and type that is to be monitored, a flux_watcher_t
+object is created using a type-specific create function, and started
+with flux_watcher_start(3).  To receive events, control must be
+transferred to the reactor event loop by calling `flux_reactor_run()`,
+which processes events until one of the following conditions is met:
+
+* There are no more active watchers.
+* The `flux_reactor_stop()` or `flux_reactor_stop_error()` functions
+  are called by one of the watchers.
+* Flags include FLUX_REACTOR_NOWAIT and all outstanding events have
+  been consumed
+* Flags include FLUX_REACTOR_ONCE, at least one event has occurred,
+  and all outstanding events have been consumed.
+
+If `flux_reactor_stop_error()` is called, this will cause
+`flux_reactor_run()` to return -1 indicating that an error has occurred.
+The caller should ensure that a valid error code has been assigned to
+errno(3) before calling this function.
+
+
+RETURN VALUE
+------------
+
+`flux_reactor_create()` returns a flux_reactor_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+`flux_reactor_run()` returns zero on normal termination.
+On failure, or on termination by `flux_reactor_stop_error()`, -1 is returned
+with errno set.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_fd_watcher_create(3), flux_handle_watcher_create(3),
+flux_zmq_watcher_create(3), flux_timer_watcher_create(3),
+flux_watcher_start(3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_reduce_create.adoc
+++ b/doc/man3/flux_reduce_create.adoc
@@ -117,7 +117,8 @@ given by:
 t = (H - h) * (_timeout_ / H)
 
 The tree height is calculated from static tree geometry returned by
-`flux_info(3)`.  The height of rank 0 is defined to be zero.
+`flux_get_rank(3)`, `flux_get_size(3)`, and `flux_get_arity(3)`.
+The height of rank 0 is defined to be zero.
 
 `flux_reduce_opt_get()` and `flux_reduce_opt_set()` may be used to get
 or set internal options.  The valid options are:
@@ -199,4 +200,4 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
-flux_info(3)
+flux_get_rank(3)

--- a/doc/man3/flux_timer_watcher_create.adoc
+++ b/doc/man3/flux_timer_watcher_create.adoc
@@ -1,0 +1,82 @@
+flux_timer_watcher_create(3)
+============================
+:doctype: manpage
+
+
+NAME
+----
+flux_timer_watcher_create, flux_timer_watcher_reset -  set/reset a timer
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
+                                            double after, double repeat,
+                                            flux_watcher_f callback,
+                                            void *arg);
+
+ void flux_timer_watcher_reset (flux_watcher_t *w,
+                                double after, double repeat);
+
+
+DESCRIPTION
+-----------
+
+`flux_timer_watcher_create()` creates a flux_watcher_t object which
+monitors for timer events.  A timer event occurs when _after_ seconds
+have elapsed, and optionally again every _repeat_ seconds.
+When events occur, the user-supplied _callback_ is invoked.
+
+If _repeat_ is 0., the flux_watcher_t will automatically be stopped
+when _after_ seconds have elapsed.
+
+To restart a timer that has been automatically stopped, you must reset
+the _after_ and _repeat_ values with `flux_timer_watcher_reset()` before
+calling `flux_watcher_start()`.
+
+The callback _revents_ argument should be ignored.
+
+Note: the Flux reactor is based on libev.  For additional information
+on the behavior of timers, refer to the libev documentation on `ev_timer`.
+
+
+RETURN VALUE
+------------
+
+`flux_timer_watcher_create()` returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_watcher_start.adoc
+++ b/doc/man3/flux_watcher_start.adoc
@@ -1,0 +1,54 @@
+flux_watcher_start(3)
+=====================
+:doctype: manpage
+
+
+NAME
+----
+flux_watcher_start, flux_watcher_stop, flux_watcher_destroy -  start/stop/destroy reactor watcher
+
+
+SYNOPSIS
+--------
+
+void flux_watcher_start (flux_watcher_t *w);
+
+void flux_watcher_stop (flux_watcher_t *w);
+
+void flux_watcher_destroy (flux_watcher_t *w);
+
+
+DESCRIPTION
+-----------
+
+`flux_watcher_start()` activates a flux_watcher_t object _w_ so that it
+can receive events.  If _w_ is already active, the call has no effect.
+This may be called from within a flux_watcher_f callback.
+
+`flux_watcher_stop()` deactivates a flux_watcher_t object _w_ so that it
+stops receiving events.  If _w_ is already inactive, the call has no effect.
+This may be called from within a flux_watcher_f callback.
+
+`flux_watcher_destroy()` destroys a flux_watcher_t object _w_,
+after stopping it.  It is not safe to destroy a watcher object within a
+flux_watcher_f callback.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_reactor_create (3)

--- a/doc/man3/flux_zmq_watcher_create.adoc
+++ b/doc/man3/flux_zmq_watcher_create.adoc
@@ -1,0 +1,91 @@
+flux_zmq_watcher_create(3)
+==========================
+:doctype: manpage
+
+
+NAME
+----
+flux_zmq_watcher_create, flux_zmq_watcher_get_zsock -  create ZeroMQ watcher
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_zmq_watcher_create (flux_reactor_t *r,
+                                          void *zsock, int events,
+                                          flux_watcher_f callback,
+                                          void *arg);
+
+ void *flux_zmq_watcher_get_zsock (flux_watcher_t *w);
+
+
+DESCRIPTION
+-----------
+
+`flux_zmq_watcher_create()` creates a flux_watcher_t object which
+monitors for events on a ZeroMQ socket _zsock_.  When events occur,
+the user-supplied _callback_ is invoked.
+
+The _events_ and _revents_ arguments are a bitmask containing a
+logical ``or'' of the following bits.  If a bit is set in _events_,
+it indicates interest in this type of event.  If a bit is set in the
+_revents_, it indicates that this event has occurred.
+
+FLUX_POLLIN::
+The socket is ready for reading.
+
+FLUX_POLLOUT::
+The socket is ready for writing.
+
+FLUX_POLLERR::
+The socket has encountered an error.
+This bit is ignored if it is set in _events_.
+
+Events are processed in a level-triggered manner.  That is, the
+callback will continue to be invoked as long as the event has not been
+fully consumed or cleared, and the watcher has not been stopped.
+
+`flux_zmq_watcher_get_zsock()` is used to obtain the socket from
+within the callback.
+
+
+RETURN VALUE
+------------
+
+`flux_zmq_watcher_create()` returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+`flux_zmq_watcher_get_zsock()` returns the socket associated with
+the watcher.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3).

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -72,7 +72,7 @@ void reduce (flux_reduce_t *r, int batchnum, void *arg)
     }
 }
 
-void forward_cb (flux_t h, flux_msg_watcher_t *w,
+void forward_cb (flux_t h, flux_msg_handler_t *w,
                  const flux_msg_t *msg, void *arg)
 {
     struct context *ctx = arg;
@@ -92,7 +92,7 @@ void forward_cb (flux_t h, flux_msg_watcher_t *w,
     Jput (in);
 }
 
-void heartbeat_cb (flux_t h, flux_msg_watcher_t *w,
+void heartbeat_cb (flux_t h, flux_msg_handler_t *w,
                    const flux_msg_t *msg, void *arg)
 {
     struct context *ctx = arg;
@@ -101,7 +101,7 @@ void heartbeat_cb (flux_t h, flux_msg_watcher_t *w,
         free (item);
 }
 
-struct flux_msghandler htab[] = {
+struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_EVENT,     "hb",              heartbeat_cb },
     { FLUX_MSGTYPE_REQUEST,   "treduce.forward", forward_cb },
     FLUX_MSGHANDLER_TABLE_END,
@@ -137,11 +137,11 @@ int mod_main (flux_t h, int argc, char **argv)
         return -1;
     if (flux_event_subscribe (h, "hb") < 0)
         return -1;
-    if (flux_msg_watcher_addvec (h, htab, &ctx) < 0)
+    if (flux_msg_handler_addvec (h, htab, &ctx) < 0)
         return -1;
-    if (flux_reactor_start (h) < 0)
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
         return -1;
-    flux_msg_watcher_delvec (h, htab);
+    flux_msg_handler_delvec (htab);
     return 0;
 }
 

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -30,8 +30,8 @@ int main (int argc, char **argv)
         get_rank (rpc, NULL);
     else if (flux_rpc_then (rpc, get_rank, NULL))
         err_exit ("flux_rpc_then");
-    if (flux_reactor_start (h) < 0)
-        err_exit ("flux_reactor_start");
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        err_exit ("flux_reactor_run");
 
     flux_rpc_destroy (rpc);
     flux_close (h);

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -29,8 +29,8 @@ int main (int argc, char **argv)
         err_exit ("flux_rpc");
     if (flux_rpc_then (rpc, get_rank, NULL) < 0)
         err_exit ("flux_rpc_then");
-    if (flux_reactor_start (h) < 0)
-        err_exit ("flux_reactor_start");
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        err_exit ("flux_reactor_run");
 
     flux_rpc_destroy (rpc);
     flux_close (h);

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -266,3 +266,13 @@ buflimit
 bufcount
 dmesg
 jitter
+zmq
+nowait
+zsock
+msgtype
+cmp
+fnmatch
+wildcards
+addvec
+delvec
+msghandler

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1637,7 +1637,7 @@ static int l_flux_reactor_start (lua_State *L)
 
 static int l_flux_reactor_stop (lua_State *L)
 {
-    flux_reactor_stop (lua_get_flux (L, 1));
+    flux_reactor_stop (flux_get_reactor (lua_get_flux (L, 1)));
     return 0;
 }
 

--- a/src/bindings/python/test/watchers.py
+++ b/src/bindings/python/test/watchers.py
@@ -44,10 +44,10 @@ class TestTimer(unittest.TestCase):
 
         def cb(x, y, z, w):
             timer_ran[0] = True
-            x.reactor_stop()
+            x.reactor_stop(self.f.get_reactor())
         with self.f.timer_watcher_create(0.1, cb) as timer:
             self.assertIsNotNone(timer, msg="timeout create")
-            ret = self.f.reactor_start()
+            ret = self.f.reactor_run(self.f.get_reactor(), 0)
             self.assertEqual(ret, 0, msg="Reactor exit")
             self.assertTrue(timer_ran[0], msg="Timer did not run successfully")
 

--- a/src/cmd/flux-zio.c
+++ b/src/cmd/flux-zio.c
@@ -214,7 +214,7 @@ static int run_zs_ready_cb (flux_t h, void *zs, short revents, void *arg)
 
     if (!zmsg || !(stream = zmsg_popstr (zmsg)) || strlen (stream) == 0
               || !(json_str = zmsg_popstr (zmsg)) || strlen (json_str) == 0) {
-        flux_reactor_stop (h);
+        flux_reactor_stop (flux_get_reactor (h));
         rc = 0;
         goto done;
     }
@@ -417,7 +417,7 @@ static void attach_stdout_ready_cb (kz_t *kz, void *arg)
     } while (len > 0);
     if (len == 0) { /* EOF */
         if (--ctx->readers == 0)
-            flux_reactor_stop (ctx->h);
+            flux_reactor_stop (flux_get_reactor (ctx->h));
     }
 }
 
@@ -439,7 +439,7 @@ static void attach_stderr_ready_cb (kz_t *kz, void *arg)
     } while (len > 0);
     if (len == 0) { /* EOF */
         if (--ctx->readers == 0)
-            flux_reactor_stop (ctx->h);
+            flux_reactor_stop (flux_get_reactor (ctx->h));
     }
 }
 

--- a/src/common/libcompat/compat.h
+++ b/src/common/libcompat/compat.h
@@ -16,6 +16,7 @@
 #define flux_zshandler_remove       compat_zshandler_remove
 #define flux_tmouthandler_add       compat_tmouthandler_add
 #define flux_tmouthandler_remove    compat_tmouthandler_remove
+#define flux_reactor_start          compat_reactor_start
 
 /* info */
 #define flux_treeroot               compat_treeroot

--- a/src/common/libcompat/reactor.h
+++ b/src/common/libcompat/reactor.h
@@ -3,6 +3,8 @@
 
 #include "src/common/libflux/message.h"
 #include "src/common/libflux/handle.h"
+#include "src/common/libflux/reactor.h"
+#include "src/common/libflux/dispatch.h"
 
 /* FluxMsgHandler indicates msg is "consumed" by destroying it.
  * Callbacks return 0 on success, -1 on error and set errno.
@@ -78,6 +80,12 @@ int flux_tmouthandler_add (flux_t h, unsigned long msec, bool oneshot,
  */
 void flux_tmouthandler_remove (flux_t h, int timer_id)
                                __attribute__ ((deprecated));
+
+
+/* Start the reactor.
+ */
+int flux_reactor_start (flux_t h)
+                        __attribute__ ((deprecated));
 
 #endif /* !_FLUX_COMPAT_REACTOR_H */
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -21,6 +21,7 @@ fluxcoreinclude_HEADERS = \
 	handle.h \
 	connector.h \
 	reactor.h \
+	dispatch.h \
 	reduce.h \
 	security.h \
 	message.h \
@@ -46,6 +47,7 @@ libflux_la_SOURCES = \
 	attr.c \
 	handle.c \
 	reactor.c \
+	dispatch.c \
 	reduce.c \
 	security.c \
 	message.c \

--- a/src/common/libflux/dispatch.c
+++ b/src/common/libflux/dispatch.c
@@ -1,0 +1,430 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+
+#include "message.h"
+#include "reactor.h"
+#include "dispatch.h"
+#include "response.h"
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/coproc.h"
+
+#define MSG_WATCHER_SIG 2000
+
+struct dispatch {
+    flux_t h;
+    zlist_t *msg_watchers; /* all msg_watchers are on this list */
+    zlist_t *msg_waiters;  /* waiting coproc watchers are also on this list */
+    struct msg_watcher *current;
+    flux_watcher_t *handle_w;
+};
+
+#define MSG_WATCHER_MAGIC 0x44433322
+struct msg_watcher {
+    int magic;
+    flux_t h;
+    struct flux_match match;
+    flux_msg_watcher_f fn;
+    void *arg;
+    flux_free_f arg_free;
+    flux_watcher_t *w;
+
+    /* coproc */
+    coproc_t coproc;
+    zlist_t *backlog;
+    struct flux_match wait_match;
+};
+
+static void handle_cb (flux_t h, flux_watcher_t *w, int revents, void *arg);
+
+
+static void dispatch_destroy (void *arg)
+{
+    struct dispatch *d = arg;
+
+    flux_watcher_destroy (d->handle_w);
+    zlist_destroy (&d->msg_watchers);
+    zlist_destroy (&d->msg_waiters);
+    free (d);
+}
+
+static struct dispatch *dispatch_get (flux_t h)
+{
+    struct dispatch *d = flux_aux_get (h, "flux::dispatch");
+    if (!d) {
+        d = xzmalloc (sizeof (*d));
+        d->msg_watchers = zlist_new ();
+        d->msg_waiters = zlist_new ();
+        if (!d->msg_watchers || !d->msg_waiters)
+            oom ();
+        d->h = h;
+        d->handle_w = flux_handle_watcher_create (h, FLUX_POLLIN, handle_cb, d);
+        if (!d->handle_w)
+            oom ();
+        flux_aux_set (h, "flux::dispatch", d, dispatch_destroy);
+    }
+    return d;
+}
+
+static void copy_match (struct flux_match *dst,
+                        const struct flux_match src)
+{
+    if (dst->topic_glob)
+        free (dst->topic_glob);
+    *dst = src;
+    dst->topic_glob = src.topic_glob ? xstrdup (src.topic_glob) : NULL;
+}
+
+static struct msg_watcher *find_msg_watcher (struct dispatch *d,
+                                                  const flux_msg_t *msg)
+{
+    struct msg_watcher *w = zlist_first (d->msg_watchers);
+    while (w) {
+        if (flux_msg_cmp (msg, w->match))
+            break;
+        w = zlist_next (d->msg_watchers);
+    }
+    return w;
+}
+
+static struct msg_watcher *find_waiting_msg_watcher (struct dispatch *d,
+                                                          const flux_msg_t *msg)
+{
+    struct msg_watcher *w = zlist_first (d->msg_waiters);
+    while (w) {
+        if (flux_msg_cmp (msg, w->wait_match))
+            break;
+        w = zlist_next (d->msg_waiters);
+    }
+    return w;
+}
+
+static int backlog_append (struct msg_watcher *w, flux_msg_t **msg)
+{
+    if (!w->backlog && !(w->backlog = zlist_new ()))
+        oom ();
+    if (zlist_append (w->backlog, *msg) < 0)
+        oom ();
+    *msg = NULL;
+    return 0;
+}
+
+static int backlog_flush (struct msg_watcher *w)
+{
+    int errnum = 0;
+    int rc = 0;
+
+    if (w->backlog) {
+        flux_msg_t *msg;
+        while ((msg = zlist_pop (w->backlog))) {
+            if (flux_requeue (w->h, msg, FLUX_RQ_TAIL) < 0) {
+                if (errnum < errno) {
+                    errnum = errno;
+                    rc = -1;
+                }
+                flux_msg_destroy (msg);
+            }
+        }
+    }
+    if (errnum > 0)
+        errno = errnum;
+    return rc;
+}
+
+int flux_sleep_on (flux_t h, struct flux_match match)
+{
+    struct dispatch *d = dispatch_get (h);
+    int rc = -1;
+
+    if (!d->current || !d->current->coproc) {
+        errno = EINVAL;
+        goto done;
+    }
+    struct msg_watcher *mw = d->current;
+    copy_match (&mw->wait_match, match);
+    if (zlist_append (d->msg_waiters, mw) < 0)
+        oom ();
+    if (coproc_yield (mw->coproc) < 0)
+        goto done;
+    rc = 0;
+done:
+    return rc;
+}
+
+static int coproc_cb (coproc_t c, void *arg)
+{
+    struct msg_watcher *mw = arg;
+    flux_msg_t *msg;
+    int type;
+    int rc = -1;
+    if (!(msg = flux_recv (mw->h, FLUX_MATCH_ANY, FLUX_O_NONBLOCK))) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+            rc = 0;
+        goto done;
+    }
+    if (flux_msg_get_type (msg, &type) < 0)
+        goto done;
+    mw->fn (mw->h, mw->w, msg, mw->arg);
+    rc = 0;
+done:
+    flux_msg_destroy (msg);
+    return rc;
+}
+
+static int resume_coproc (struct msg_watcher *mw)
+{
+    struct dispatch *d = dispatch_get (mw->h);
+    int coproc_rc, rc = -1;
+
+    d->current = mw;
+    if (coproc_resume (mw->coproc) < 0)
+        goto done;
+    if (!coproc_returned (mw->coproc, &coproc_rc)) {
+        rc = 0;
+        goto done;
+    }
+    if (backlog_flush (mw) < 0)
+        goto done;
+    rc = coproc_rc;
+done:
+    d->current = NULL;
+    return rc;
+}
+
+static int start_coproc (struct msg_watcher *mw)
+{
+    struct dispatch *d = dispatch_get (mw->h);
+    int coproc_rc, rc = -1;
+
+    d->current = mw;
+    if (!mw->coproc && !(mw->coproc = coproc_create (coproc_cb)))
+        goto done;
+    if (coproc_start (mw->coproc, mw) < 0)
+        goto done;
+    if (!coproc_returned (mw->coproc, &coproc_rc)) {
+        rc = 0;
+        goto done;
+    }
+    if (backlog_flush (mw) < 0)
+        goto done;
+    rc = coproc_rc;
+done:
+    d->current = NULL;
+    return rc;
+}
+
+static void handle_cb (flux_t reactor_h, flux_watcher_t *hw,
+                       int revents, void *arg)
+{
+    struct dispatch *d = arg;
+    struct msg_watcher *mw;
+    flux_msg_t *msg = NULL;
+    int type;
+
+    if (revents & FLUX_POLLERR)
+        goto fatal;
+    if (!(msg = flux_recv (d->h, FLUX_MATCH_ANY, FLUX_O_NONBLOCK))) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK)
+            goto fatal;
+        else
+            goto done;
+    }
+    if (flux_msg_get_type (msg, &type) < 0)
+        goto done;
+    /* Message matches a coproc that yielded.
+     * Resume, arranging for msg to be returned next by flux_recv().
+     */
+    if ((mw = find_waiting_msg_watcher (d, msg))) {
+        if (flux_requeue (d->h, msg, FLUX_RQ_HEAD) < 0)
+            goto fatal;
+        zlist_remove (d->msg_waiters, mw);
+        if (resume_coproc (mw) < 0)
+            goto fatal;
+    /* Message matches a handler.
+     * If coproc already running, queue message as backlog.
+     * Else if FLUX_O_COPROC, start coproc.
+     * If coprocs not enabled, call handler directly.
+     */
+    } else if ((mw = find_msg_watcher (d, msg))) {
+        if (mw->coproc && coproc_started (mw->coproc)) {
+            if (backlog_append (mw, &msg) < 0) /* msg now property of backlog */
+                goto fatal;
+        } else if ((flux_flags_get (d->h) & FLUX_O_COPROC)) {
+            if (flux_requeue (d->h, msg, FLUX_RQ_HEAD) < 0)
+                goto fatal;
+            if (start_coproc (mw) < 0)
+                goto fatal;
+        } else {
+            mw->fn (d->h, mw->w, msg, mw->arg);
+        }
+    /* Message matched nothing.
+     * Respond with ENOSYS if it was a request.
+     * Else log it if FLUX_O_TRACE
+     */
+    } else {
+        if (type == FLUX_MSGTYPE_REQUEST) {
+            if (flux_respond (d->h, msg, ENOSYS, NULL))
+                goto done;
+        } else if (flux_flags_get (d->h) & FLUX_O_TRACE) {
+            const char *topic = NULL;
+            (void)flux_msg_get_topic (msg, &topic);
+            fprintf (stderr, "nomatch: %s '%s'\n", flux_msg_typestr (type),
+                     topic ? topic : "");
+        }
+    }
+done:
+    flux_msg_destroy (msg);
+    return;
+fatal:
+    flux_msg_destroy (msg);
+    flux_reactor_stop_error (reactor_h);
+    FLUX_FATAL (d->h);
+}
+
+static void msg_watcher_start (void *impl, flux_t h, flux_watcher_t *w)
+{
+    struct dispatch *d = dispatch_get (h);
+    struct msg_watcher *mw = impl;
+
+    if (mw) {
+        assert (mw->magic == MSG_WATCHER_MAGIC);
+        flux_watcher_start (h, d->handle_w);
+        if (zlist_push (d->msg_watchers, mw) < 0)
+            oom ();
+        mw->h = h;
+    }
+}
+
+static void msg_watcher_stop (void *impl, flux_t h, flux_watcher_t *w)
+{
+    struct dispatch *d = dispatch_get (h);
+    struct msg_watcher *mw = impl;
+
+    if (mw) {
+        assert (mw->magic == MSG_WATCHER_MAGIC);
+        zlist_remove (d->msg_waiters, mw);
+        zlist_remove (d->msg_watchers, mw);
+        if (zlist_size (d->msg_watchers) == 0)
+            flux_watcher_stop (h, d->handle_w);
+    }
+}
+
+static void msg_watcher_destroy (void *impl, flux_watcher_t *w)
+{
+    struct msg_watcher *mw = impl;
+
+    if (mw) {
+        assert (mw->magic == MSG_WATCHER_MAGIC);
+        if (mw->match.topic_glob)
+            free (mw->match.topic_glob);
+        if (mw->coproc)
+            coproc_destroy (mw->coproc);
+        if (mw->backlog) {
+            flux_msg_t *msg;
+            while ((msg = zlist_pop (mw->backlog)))
+                flux_msg_destroy (msg);
+            zlist_destroy (&mw->backlog);
+        }
+        if (mw->wait_match.topic_glob)
+            free (mw->wait_match.topic_glob);
+        if (mw->arg_free)
+            mw->arg_free (mw->arg);
+        mw->magic = ~MSG_WATCHER_MAGIC;
+        free (mw);
+    }
+}
+
+flux_watcher_t *flux_msg_watcher_create (const struct flux_match match,
+                                         flux_msg_watcher_f cb, void *arg)
+{
+    struct watcher_ops ops = {
+        .start = msg_watcher_start,
+        .stop = msg_watcher_stop,
+        .destroy = msg_watcher_destroy,
+    };
+    struct msg_watcher *mw = xzmalloc (sizeof (*mw));
+    flux_watcher_t *w;
+
+    mw->magic = MSG_WATCHER_MAGIC;
+    copy_match (&mw->match, match);
+    mw->fn = cb;
+    mw->arg = arg;
+    w = flux_watcher_create (mw, ops, MSG_WATCHER_SIG, NULL, NULL);
+    mw->w = w;
+
+    return w;
+}
+
+int flux_msg_watcher_addvec (flux_t h, struct flux_msghandler tab[], void *arg)
+{
+    int i;
+    struct flux_match match = FLUX_MATCH_ANY;
+
+    for (i = 0; ; i++) {
+        if (!tab[i].typemask && !tab[i].topic_glob && !tab[i].cb)
+            break; /* FLUX_MSGHANDLER_TABLE_END */
+        match.typemask = tab[i].typemask;
+        match.topic_glob = tab[i].topic_glob;
+        tab[i].w = flux_msg_watcher_create (match, tab[i].cb, arg);
+        if (!tab[i].w)
+            goto error;
+        flux_watcher_start (h, tab[i].w);
+    }
+    return 0;
+error:
+    while (i >= 0) {
+        if (tab[i].w) {
+            flux_watcher_stop (h, tab[i].w);
+            flux_watcher_destroy (tab[i].w);
+            tab[i].w = NULL;
+        }
+        i--;
+    }
+    return -1;
+}
+
+void flux_msg_watcher_delvec (flux_t h, struct flux_msghandler tab[])
+{
+    int i;
+
+    for (i = 0; ; i++) {
+        if (!tab[i].typemask && !tab[i].topic_glob && !tab[i].cb)
+            break; /* FLUX_MSGHANDLER_TABLE_END */
+        if (tab[i].w) {
+            flux_watcher_stop (h, tab[i].w);
+            flux_watcher_destroy (tab[i].w);
+            tab[i].w = NULL;
+        }
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/dispatch.c
+++ b/src/common/libflux/dispatch.c
@@ -332,6 +332,7 @@ void flux_msg_handler_destroy (flux_msg_handler_t *w)
 {
     if (w) {
         assert (w->magic == HANDLER_MAGIC);
+        flux_msg_handler_stop (w);
         if (w->match.topic_glob)
             free (w->match.topic_glob);
         if (w->coproc)

--- a/src/common/libflux/dispatch.h
+++ b/src/common/libflux/dispatch.h
@@ -1,0 +1,67 @@
+#ifndef _FLUX_CORE_DISPATCH_H
+#define _FLUX_CORE_DISPATCH_H
+
+#include "message.h"
+#include "handle.h"
+
+
+/* Message dispatch
+ * Create/destroy/start/stop "message watchers".
+ * A message watcher handles messages received on the handle matching 'match'.
+ * Message watchers are special compared to the other watchers as they
+ * combine an internal "handle watcher" that reads new messages from the
+ * handle as they arrive, and a dispatcher that hands the message to a
+ * matching message watcher.
+ *
+ * If multiple message watchers match a given message, the most recently
+ * registered will handle it.  Thus it is possible to register handlers for
+ * "svc.*" then "svc.foo", and the former will match all methods but "foo".
+ * If a request message arrives that is not matched by a message watcher,
+ * the reactor sends a courtesy ENOSYS response.
+ *
+ * If the handle was created with FLUX_O_COPROC, message watchers will be
+ * run in a coprocess context.  If they make an RPC call or otherwise call
+ * flux_recv(), the reactor can run, handling other tasks until the desired
+ * message arrives, then the message watcher is restarted.
+ * Currently only message watchers run as coprocesses.
+ */
+
+typedef void (*flux_msg_watcher_f)(flux_t h, flux_watcher_t *w,
+                                   const flux_msg_t *msg, void *arg);
+
+flux_watcher_t *flux_msg_watcher_create (struct flux_match match,
+                                         flux_msg_watcher_f cb, void *arg);
+
+/* Convenience functions for bulk add/remove of message watchers.
+ * addvec creates/adds a table of message watchers
+ * (created watchers are then stored in the table)
+ * delvec stops/destroys the table of message watchers.
+ * addvec returns 0 on success, -1 on failure with errno set.
+ * Watchers are added beginning with tab[0] (see multiple match comment above).
+ * tab[] must be terminated with FLUX_MSGHANDLER_TABLE_END.
+ */
+
+struct flux_msghandler {
+    int typemask;
+    char *topic_glob;
+    flux_msg_watcher_f cb;
+    flux_watcher_t *w;
+};
+#define FLUX_MSGHANDLER_TABLE_END { 0, NULL, NULL }
+
+int flux_msg_watcher_addvec (flux_t h, struct flux_msghandler tab[], void *arg);
+void flux_msg_watcher_delvec (flux_t h, struct flux_msghandler tab[]);
+
+/* Give control back to the reactor until a message matching 'match'
+ * is queued in the handle.  This will return -1 with errno = EINVAL
+ * if called from a reactor handler that is not running in as a coprocess.
+ * Currently only message handlers are started as coprocesses, if the
+ * handle has FLUX_O_COPROC set.  This is used internally by flux_recv().
+ */
+int flux_sleep_on (flux_t h, struct flux_match match);
+
+#endif /* !_FLUX_CORE_DISPATCH_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/dispatch.h
+++ b/src/common/libflux/dispatch.h
@@ -4,28 +4,6 @@
 #include "message.h"
 #include "handle.h"
 
-
-/* Message dispatch
- * Create/destroy/start/stop "message watchers".
- * A message watcher handles messages received on the handle matching 'match'.
- * Message watchers are special compared to the other watchers as they
- * combine an internal "handle watcher" that reads new messages from the
- * handle as they arrive, and a dispatcher that hands the message to a
- * matching message watcher.
- *
- * If multiple message watchers match a given message, the most recently
- * registered will handle it.  Thus it is possible to register handlers for
- * "svc.*" then "svc.foo", and the former will match all methods but "foo".
- * If a request message arrives that is not matched by a message watcher,
- * the reactor sends a courtesy ENOSYS response.
- *
- * If the handle was created with FLUX_O_COPROC, message watchers will be
- * run in a coprocess context.  If they make an RPC call or otherwise call
- * flux_recv(), the reactor can run, handling other tasks until the desired
- * message arrives, then the message watcher is restarted.
- * Currently only message watchers run as coprocesses.
- */
-
 typedef struct flux_msg_handler flux_msg_handler_t;
 
 typedef void (*flux_msg_handler_f)(flux_t h, flux_msg_handler_t *w,
@@ -41,15 +19,6 @@ void flux_msg_handler_start (flux_msg_handler_t *w);
 void flux_msg_handler_stop (flux_msg_handler_t *w);
 
 
-/* Convenience functions for bulk add/remove of message watchers.
- * addvec creates/adds a table of message watchers
- * (created watchers are then stored in the table)
- * delvec stops/destroys the table of message watchers.
- * addvec returns 0 on success, -1 on failure with errno set.
- * Watchers are added beginning with tab[0] (see multiple match comment above).
- * tab[] must be terminated with FLUX_MSGHANDLER_TABLE_END.
- */
-
 struct flux_msg_handler_spec {
     int typemask;
     char *topic_glob;
@@ -61,6 +30,7 @@ struct flux_msg_handler_spec {
 int flux_msg_handler_addvec (flux_t h, struct flux_msg_handler_spec tab[],
                              void *arg);
 void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
+
 
 /* Give control back to the reactor until a message matching 'match'
  * is queued in the handle.  This will return -1 with errno = EINVAL

--- a/src/common/libflux/dispatch.h
+++ b/src/common/libflux/dispatch.h
@@ -26,11 +26,20 @@
  * Currently only message watchers run as coprocesses.
  */
 
-typedef void (*flux_msg_watcher_f)(flux_t h, flux_watcher_t *w,
+typedef struct flux_msg_handler flux_msg_handler_t;
+
+typedef void (*flux_msg_handler_f)(flux_t h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg);
 
-flux_watcher_t *flux_msg_watcher_create (struct flux_match match,
-                                         flux_msg_watcher_f cb, void *arg);
+flux_msg_handler_t *flux_msg_handler_create (flux_t h,
+                                             const struct flux_match match,
+                                             flux_msg_handler_f cb, void *arg);
+
+void flux_msg_handler_destroy (flux_msg_handler_t *w);
+
+void flux_msg_handler_start (flux_msg_handler_t *w);
+void flux_msg_handler_stop (flux_msg_handler_t *w);
+
 
 /* Convenience functions for bulk add/remove of message watchers.
  * addvec creates/adds a table of message watchers
@@ -41,16 +50,17 @@ flux_watcher_t *flux_msg_watcher_create (struct flux_match match,
  * tab[] must be terminated with FLUX_MSGHANDLER_TABLE_END.
  */
 
-struct flux_msghandler {
+struct flux_msg_handler_spec {
     int typemask;
     char *topic_glob;
-    flux_msg_watcher_f cb;
-    flux_watcher_t *w;
+    flux_msg_handler_f cb;
+    flux_msg_handler_t *w;
 };
 #define FLUX_MSGHANDLER_TABLE_END { 0, NULL, NULL }
 
-int flux_msg_watcher_addvec (flux_t h, struct flux_msghandler tab[], void *arg);
-void flux_msg_watcher_delvec (flux_t h, struct flux_msghandler tab[]);
+int flux_msg_handler_addvec (flux_t h, struct flux_msg_handler_spec tab[],
+                             void *arg);
+void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
 
 /* Give control back to the reactor until a message matching 'match'
  * is queued in the handle.  This will return -1 with errno = EINVAL

--- a/src/common/libflux/ev_flux.h
+++ b/src/common/libflux/ev_flux.h
@@ -3,7 +3,7 @@
 
 #include "src/common/libev/ev.h"
 
-struct ev_flux;
+typedef struct ev_flux ev_flux;
 
 typedef void (*ev_flux_f)(struct ev_loop *loop, struct ev_flux *w, int revents);
 

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -3,6 +3,7 @@
 
 #include "handle.h"
 #include "reactor.h"
+#include "dispatch.h"
 #include "connector.h"
 #include "security.h"
 #include "reduce.h"

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -39,7 +39,7 @@
 #include "connector.h"
 #include "message.h"
 #include "tagpool.h"
-#include "reactor.h" // for flux_sleep_on ()
+#include "dispatch.h" // for flux_sleep_on ()
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -428,7 +428,7 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
     if (match.matchtag != FLUX_MATCHTAG_NONE) {
         uint32_t matchtag;
         uint32_t lo = match.matchtag;
-        uint32_t hi = match.bsize > 1 ? match.matchtag + match.bsize
+        uint32_t hi = match.bsize > 1 ? match.matchtag + match.bsize - 1
                                       : match.matchtag;
         if (flux_msg_get_route_count (msg) > 0)
             return false; /* don't match in foreign matchtag domain */

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -81,6 +81,22 @@ flux_reactor_t *flux_reactor_create (void)
     return r;
 }
 
+void flux_set_reactor (flux_t h, flux_reactor_t *r)
+{
+    flux_aux_set (h, "flux::reactor", r, NULL);
+}
+
+flux_reactor_t *flux_get_reactor (flux_t h)
+{
+    flux_reactor_t *r = flux_aux_get (h, "flux::reactor");
+    if (!r) {
+        if ((r = flux_reactor_create ()))
+            flux_aux_set (h, "flux::reactor", r,
+                          (flux_free_f)flux_reactor_destroy);
+    }
+    return r;
+}
+
 int flux_reactor_run (flux_reactor_t *r, int flags)
 {
     int ev_flags = 0;

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -33,67 +33,35 @@
 
 #include "handle.h"
 #include "reactor.h"
-#include "message.h"
-#include "response.h"
-#include "tagpool.h"
 #include "ev_flux.h"
 
 #include "src/common/libev/ev.h"
 #include "src/common/libutil/ev_zmq.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
-#include "src/common/libutil/coproc.h"
 
 struct reactor {
-    flux_t h;
-
     struct ev_loop *loop;
     int loop_rc;
-
-    zlist_t *msg_watchers; /* all msg_watchers are on this list */
-    zlist_t *msg_waiters;  /* waiting coproc watchers are also on this list */
-    struct flux_msg_watcher *current;
-    struct ev_flux handle_w;
-};
-
-struct flux_msg_watcher {
-    flux_t h;
-    struct flux_match match;
-    flux_msg_watcher_f fn;
-    void *arg;
-    flux_free_f arg_free;
-
-    /* coproc */
-    coproc_t coproc;
-    zlist_t *backlog;
-    struct flux_match wait_match;
 };
 
 struct watcher_ops {
-    void (*start)(void *impl, flux_watcher_t *w);
-    void (*stop)(void *impl, flux_watcher_t *w);
+    void (*start)(void *impl, flux_reactor_t *r, flux_watcher_t *w);
+    void (*stop)(void *impl, flux_reactor_t *r, flux_watcher_t *w);
     void (*destroy)(void *impl, flux_watcher_t *w);
 };
 
 struct flux_watcher {
     flux_watcher_f fn;
     void *arg;
-    struct reactor *reactor;
-
     int signature;
     struct watcher_ops ops;
     void *impl;
 };
 
-static void handle_cb (struct ev_loop *loop, struct ev_flux *hw, int revents);
-
-
 static void reactor_destroy (void *arg)
 {
     struct reactor *r = arg;
-
-    zlist_destroy (&r->msg_watchers);
-    zlist_destroy (&r->msg_waiters);
     ev_loop_destroy (r->loop);
     free (r);
 }
@@ -104,12 +72,9 @@ static struct reactor *reactor_get (flux_t h)
     if (!r) {
         r = xzmalloc (sizeof (*r));
         r->loop = ev_loop_new (EVFLAG_AUTO);
-        r->msg_watchers = zlist_new ();
-        r->msg_waiters = zlist_new ();
-        if (!r->loop || !r->msg_watchers || !r->msg_waiters)
+        if (!r->loop)
             oom ();
-        r->h = h;
-        ev_flux_init (&r->handle_w, handle_cb, h, EV_READ);
+        ev_set_userdata (r->loop, h);
         flux_aux_set (h, "flux::reactor", r, reactor_destroy);
     }
     return r;
@@ -156,6 +121,11 @@ void flux_reactor_stop_error (flux_t h)
     ev_break (r->loop, EVBREAK_ALL);
 }
 
+void flux_reactor_add (flux_t h, flux_t h2)
+{
+    flux_aux_set (h2, "flux::reactor", reactor_get (h), NULL);
+}
+
 static int events_to_libev (int events)
 {
     int e = 0;
@@ -200,18 +170,16 @@ static flux_watcher_t *flux_watcher_create (void *impl, struct watcher_ops ops,
 void flux_watcher_start (flux_t h, flux_watcher_t *w)
 {
     if (w) {
-        w->reactor = reactor_get (h);
         if (w->ops.start)
-            w->ops.start (w->impl, w);
+            w->ops.start (w->impl, h, w);
     }
 }
 
 void flux_watcher_stop (flux_t h, flux_watcher_t *w)
 {
     if (w) {
-        w->reactor = reactor_get (h);
         if (w->ops.stop)
-            w->ops.stop (w->impl, w);
+            w->ops.stop (w->impl, h, w);
     }
 }
 
@@ -224,332 +192,23 @@ void flux_watcher_destroy (flux_watcher_t *w)
     }
 }
 
-/* Message watchers
- */
-
-static void copy_match (struct flux_match *dst,
-                        const struct flux_match src)
-{
-    if (dst->topic_glob)
-        free (dst->topic_glob);
-    *dst = src;
-    dst->topic_glob = src.topic_glob ? xstrdup (src.topic_glob) : NULL;
-}
-
-static struct flux_msg_watcher *find_msg_watcher (struct reactor *r,
-                                                  const flux_msg_t *msg)
-{
-    struct flux_msg_watcher *w = zlist_first (r->msg_watchers);
-    while (w) {
-        if (flux_msg_cmp (msg, w->match))
-            break;
-        w = zlist_next (r->msg_watchers);
-    }
-    return w;
-}
-
-static struct flux_msg_watcher *find_waiting_msg_watcher (struct reactor *r,
-                                                          const flux_msg_t *msg)
-{
-    struct flux_msg_watcher *w = zlist_first (r->msg_waiters);
-    while (w) {
-        if (flux_msg_cmp (msg, w->wait_match))
-            break;
-        w = zlist_next (r->msg_waiters);
-    }
-    return w;
-}
-
-static int backlog_append (struct flux_msg_watcher *w, flux_msg_t **msg)
-{
-    if (!w->backlog && !(w->backlog = zlist_new ()))
-        oom ();
-    if (zlist_append (w->backlog, *msg) < 0)
-        oom ();
-    *msg = NULL;
-    return 0;
-}
-
-static int backlog_flush (struct flux_msg_watcher *w)
-{
-    int errnum = 0;
-    int rc = 0;
-
-    if (w->backlog) {
-        flux_msg_t *msg;
-        while ((msg = zlist_pop (w->backlog))) {
-            if (flux_requeue (w->h, msg, FLUX_RQ_TAIL) < 0) {
-                if (errnum < errno) {
-                    errnum = errno;
-                    rc = -1;
-                }
-                flux_msg_destroy (msg);
-            }
-        }
-    }
-    if (errnum > 0)
-        errno = errnum;
-    return rc;
-}
-
-int flux_sleep_on (flux_t h, struct flux_match match)
-{
-    struct reactor *r = reactor_get (h);
-    int rc = -1;
-
-    if (!r->current || !r->current->coproc) {
-        errno = EINVAL;
-        goto done;
-    }
-    struct flux_msg_watcher *w = r->current;
-    copy_match (&w->wait_match, match);
-    if (zlist_append (r->msg_waiters, w) < 0)
-        oom ();
-    if (coproc_yield (w->coproc) < 0)
-        goto done;
-    rc = 0;
-done:
-    return rc;
-}
-
-static int coproc_cb (coproc_t c, void *arg)
-{
-    struct flux_msg_watcher *w = arg;
-    flux_msg_t *msg;
-    int type;
-    int rc = -1;
-    if (!(msg = flux_recv (w->h, FLUX_MATCH_ANY, FLUX_O_NONBLOCK))) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK)
-            rc = 0;
-        goto done;
-    }
-    if (flux_msg_get_type (msg, &type) < 0)
-        goto done;
-    w->fn (w->h, w, msg, w->arg);
-    rc = 0;
-done:
-    flux_msg_destroy (msg);
-    return rc;
-}
-
-static int resume_coproc (struct flux_msg_watcher *w)
-{
-    struct reactor *r = reactor_get (w->h);
-    int coproc_rc, rc = -1;
-
-    r->current = w;
-    if (coproc_resume (w->coproc) < 0)
-        goto done;
-    if (!coproc_returned (w->coproc, &coproc_rc)) {
-        rc = 0;
-        goto done;
-    }
-    if (backlog_flush (w) < 0)
-        goto done;
-    rc = coproc_rc;
-done:
-    r->current = NULL;
-    return rc;
-}
-
-static int start_coproc (struct flux_msg_watcher *w)
-{
-    struct reactor *r = reactor_get (w->h);
-    int coproc_rc, rc = -1;
-
-    r->current = w;
-    if (!w->coproc && !(w->coproc = coproc_create (coproc_cb)))
-        goto done;
-    if (coproc_start (w->coproc, w) < 0)
-        goto done;
-    if (!coproc_returned (w->coproc, &coproc_rc)) {
-        rc = 0;
-        goto done;
-    }
-    if (backlog_flush (w) < 0)
-        goto done;
-    rc = coproc_rc;
-done:
-    r->current = NULL;
-    return rc;
-}
-
-static void handle_cb (struct ev_loop *loop, struct ev_flux *hw, int revents)
-{
-    void *ptr = (char *)hw - offsetof (struct reactor, handle_w);
-    struct reactor *r = ptr;
-    struct flux_msg_watcher *w;
-    flux_msg_t *msg = NULL;
-    int type;
-
-    if (revents & EV_ERROR)
-        goto fatal;
-    if (!(msg = flux_recv (r->h, FLUX_MATCH_ANY, FLUX_O_NONBLOCK))) {
-        if (errno != EAGAIN && errno != EWOULDBLOCK)
-            goto fatal;
-        else
-            goto done;
-    }
-    if (flux_msg_get_type (msg, &type) < 0)
-        goto done;
-    /* Message matches a coproc that yielded.
-     * Resume, arranging for msg to be returned next by flux_recv().
-     */
-    if ((w = find_waiting_msg_watcher (r, msg))) {
-        if (flux_requeue (r->h, msg, FLUX_RQ_HEAD) < 0)
-            goto fatal;
-        zlist_remove (r->msg_waiters, w);
-        if (resume_coproc (w) < 0)
-            goto fatal;
-    /* Message matches a handler.
-     * If coproc already running, queue message as backlog.
-     * Else if FLUX_O_COPROC, start coproc.
-     * If coprocs not enabled, call handler directly.
-     */
-    } else if ((w = find_msg_watcher (r, msg))) {
-        if (w->coproc && coproc_started (w->coproc)) {
-            if (backlog_append (w, &msg) < 0) /* msg now property of backlog */
-                goto fatal;
-        } else if ((flux_flags_get (r->h) & FLUX_O_COPROC)) {
-            if (flux_requeue (r->h, msg, FLUX_RQ_HEAD) < 0)
-                goto fatal;
-            if (start_coproc (w) < 0)
-                goto fatal;
-        } else {
-            w->fn (r->h, w, msg, w->arg);
-        }
-    /* Message matched nothing.
-     * Respond with ENOSYS if it was a request.
-     * Else log it if FLUX_O_TRACE
-     */
-    } else {
-        if (type == FLUX_MSGTYPE_REQUEST) {
-            if (flux_respond (r->h, msg, ENOSYS, NULL))
-                goto done;
-        } else if (flux_flags_get (r->h) & FLUX_O_TRACE) {
-            const char *topic = NULL;
-            (void)flux_msg_get_topic (msg, &topic);
-            fprintf (stderr, "nomatch: %s '%s'\n", flux_msg_typestr (type),
-                     topic ? topic : "");
-        }
-    }
-done:
-    flux_msg_destroy (msg);
-    return;
-fatal:
-    flux_msg_destroy (msg);
-    flux_reactor_stop_error (r->h);
-    FLUX_FATAL (r->h);
-}
-
-flux_msg_watcher_t *flux_msg_watcher_create (const struct flux_match match,
-                                             flux_msg_watcher_f cb, void *arg)
-{
-    struct flux_msg_watcher *w = xzmalloc (sizeof (*w));
-    copy_match (&w->match, match);
-    w->fn = cb;
-    w->arg = arg;
-    return w;
-}
-
-void flux_msg_watcher_start (flux_t h, struct flux_msg_watcher *w)
-{
-    struct reactor *r = reactor_get (h);
-    ev_flux_start (r->loop, &r->handle_w);
-    if (zlist_push (r->msg_watchers, w) < 0)
-        oom ();
-    w->h = h;
-}
-
-void flux_msg_watcher_stop (flux_t h, struct flux_msg_watcher *w)
-{
-    struct reactor *r = reactor_get (h);
-
-    zlist_remove (r->msg_waiters, w);
-    zlist_remove (r->msg_watchers, w);
-    if (zlist_size (r->msg_watchers) == 0)
-        ev_flux_stop (r->loop, &r->handle_w);
-}
-
-void flux_msg_watcher_destroy (struct flux_msg_watcher *w)
-{
-    if (w) {
-        if (w->match.topic_glob)
-            free (w->match.topic_glob);
-        if (w->coproc)
-            coproc_destroy (w->coproc);
-        if (w->backlog) {
-            flux_msg_t *msg;
-            while ((msg = zlist_pop (w->backlog)))
-                flux_msg_destroy (msg);
-            zlist_destroy (&w->backlog);
-        }
-        if (w->wait_match.topic_glob)
-            free (w->wait_match.topic_glob);
-        if (w->arg_free)
-            w->arg_free (w->arg);
-        free (w);
-    }
-}
-
-int flux_msg_watcher_addvec (flux_t h, struct flux_msghandler tab[], void *arg)
-{
-    int i;
-    struct flux_match match = FLUX_MATCH_ANY;
-
-    for (i = 0; ; i++) {
-        if (!tab[i].typemask && !tab[i].topic_glob && !tab[i].cb)
-            break; /* FLUX_MSGHANDLER_TABLE_END */
-        match.typemask = tab[i].typemask;
-        match.topic_glob = tab[i].topic_glob;
-        tab[i].w = flux_msg_watcher_create (match, tab[i].cb, arg);
-        if (!tab[i].w)
-            goto error;
-        flux_msg_watcher_start (h, tab[i].w);
-    }
-    return 0;
-error:
-    while (i >= 0) {
-        if (tab[i].w) {
-            flux_msg_watcher_stop (h, tab[i].w);
-            flux_msg_watcher_destroy (tab[i].w);
-            tab[i].w = NULL;
-        }
-        i--;
-    }
-    return -1;
-}
-
-void flux_msg_watcher_delvec (flux_t h, struct flux_msghandler tab[])
-{
-    int i;
-
-    for (i = 0; ; i++) {
-        if (!tab[i].typemask && !tab[i].topic_glob && !tab[i].cb)
-            break; /* FLUX_MSGHANDLER_TABLE_END */
-        if (tab[i].w) {
-            flux_msg_watcher_stop (h, tab[i].w);
-            flux_msg_watcher_destroy (tab[i].w);
-            tab[i].w = NULL;
-        }
-    }
-}
-
 /* flux_t handle
  */
 
 #define HANDLE_SIG 1006
 
-static void handle_start (void *impl, flux_watcher_t *w)
+static void handle_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == HANDLE_SIG);
-    ev_flux_start (w->reactor->loop, (ev_flux *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_flux_start (r->loop, (ev_flux *)impl);
 }
 
-static void handle_stop (void *impl, flux_watcher_t *w)
+static void handle_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == HANDLE_SIG);
-    ev_flux_stop (w->reactor->loop, (ev_flux *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_flux_stop (r->loop, (ev_flux *)impl);
 }
 
 static void handle_destroy (void *impl, flux_watcher_t *w)
@@ -559,12 +218,13 @@ static void handle_destroy (void *impl, flux_watcher_t *w)
         free (impl);
 }
 
-static void _handle_cb (struct ev_loop *loop, ev_flux *fw, int revents)
+static void handle_cb (struct ev_loop *loop, ev_flux *fw, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = fw->data;
     assert (w->signature == HANDLE_SIG);
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_handle_watcher_create (flux_t h, int events,
@@ -578,7 +238,7 @@ flux_watcher_t *flux_handle_watcher_create (flux_t h, int events,
     ev_flux *fw = xzmalloc (sizeof (*fw));
     flux_watcher_t *w;
 
-    ev_flux_init (fw, _handle_cb, h, events_to_libev (events) & ~EV_ERROR);
+    ev_flux_init (fw, handle_cb, h, events_to_libev (events) & ~EV_ERROR);
     w = flux_watcher_create (fw, ops, HANDLE_SIG, cb, arg);
     fw->data = w;
 
@@ -597,16 +257,18 @@ flux_t flux_handle_watcher_get_flux (flux_watcher_t *w)
 
 #define FD_SIG 1005
 
-static void fd_start (void *impl, flux_watcher_t *w)
+static void fd_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == FD_SIG);
-    ev_io_start (w->reactor->loop, (ev_io *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_io_start (r->loop, (ev_io *)impl);
 }
 
-static void fd_stop (void *impl, flux_watcher_t *w)
+static void fd_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == FD_SIG);
-    ev_io_stop (w->reactor->loop, (ev_io *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_io_stop (r->loop, (ev_io *)impl);
 }
 
 static void fd_destroy (void *impl, flux_watcher_t *w)
@@ -618,10 +280,11 @@ static void fd_destroy (void *impl, flux_watcher_t *w)
 
 static void fd_cb (struct ev_loop *loop, ev_io *iow, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = iow->data;
     assert (w->signature == FD_SIG);
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_fd_watcher_create (int fd, int events,
@@ -654,16 +317,18 @@ int flux_fd_watcher_get_fd (flux_watcher_t *w)
 
 #define ZMQ_SIG 1004
 
-static void zmq_start (void *impl, flux_watcher_t *w)
+static void zmq_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == ZMQ_SIG);
-    ev_zmq_start (w->reactor->loop, (ev_zmq *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_zmq_start (r->loop, (ev_zmq *)impl);
 }
 
-static void zmq_stop (void *impl, flux_watcher_t *w)
+static void zmq_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == ZMQ_SIG);
-    ev_zmq_stop (w->reactor->loop, (ev_zmq *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_zmq_stop (r->loop, (ev_zmq *)impl);
 }
 
 static void zmq_destroy (void *impl, flux_watcher_t *w)
@@ -675,10 +340,11 @@ static void zmq_destroy (void *impl, flux_watcher_t *w)
 
 static void zmq_cb (struct ev_loop *loop, ev_zmq *pw, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = pw->data;
     assert (w->signature == ZMQ_SIG);
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_zmq_watcher_create (void *zsock, int events,
@@ -711,16 +377,18 @@ void *flux_zmq_watcher_get_zsock (flux_watcher_t *w)
 
 #define TIMER_SIG 1003
 
-static void timer_start (void *impl, flux_watcher_t *w)
+static void timer_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == TIMER_SIG);
-    ev_timer_start (w->reactor->loop, (ev_timer *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_timer_start (r->loop, (ev_timer *)impl);
 }
 
-static void timer_stop (void *impl, flux_watcher_t *w)
+static void timer_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == TIMER_SIG);
-    ev_timer_stop (w->reactor->loop, (ev_timer *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_timer_stop (r->loop, (ev_timer *)impl);
 }
 
 static void timer_destroy (void *impl, flux_watcher_t *w)
@@ -732,9 +400,10 @@ static void timer_destroy (void *impl, flux_watcher_t *w)
 
 static void timer_cb (struct ev_loop *loop, ev_timer *tw, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = tw->data;
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_timer_watcher_create (double after, double repeat,
@@ -770,16 +439,18 @@ void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat)
  */
 #define PREPARE_SIG 1002
 
-static void prepare_start (void *impl, flux_watcher_t *w)
+static void prepare_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == PREPARE_SIG);
-    ev_prepare_start (w->reactor->loop, (ev_prepare *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_prepare_start (r->loop, (ev_prepare *)impl);
 }
 
-static void prepare_stop (void *impl, flux_watcher_t *w)
+static void prepare_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == PREPARE_SIG);
-    ev_prepare_stop (w->reactor->loop, (ev_prepare *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_prepare_stop (r->loop, (ev_prepare *)impl);
 }
 
 static void prepare_destroy (void *impl, flux_watcher_t *w)
@@ -791,10 +462,11 @@ static void prepare_destroy (void *impl, flux_watcher_t *w)
 
 static void prepare_cb (struct ev_loop *loop, ev_prepare *pw, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = pw->data;
     assert (w->signature == PREPARE_SIG);
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_prepare_watcher_create (flux_watcher_f cb, void *arg)
@@ -819,16 +491,18 @@ flux_watcher_t *flux_prepare_watcher_create (flux_watcher_f cb, void *arg)
 
 #define CHECK_SIG 1001
 
-static void check_start (void *impl, flux_watcher_t *w)
+static void check_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == CHECK_SIG);
-    ev_check_start (w->reactor->loop, (ev_check *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_check_start (r->loop, (ev_check *)impl);
 }
 
-static void check_stop (void *impl, flux_watcher_t *w)
+static void check_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == CHECK_SIG);
-    ev_check_stop (w->reactor->loop, (ev_check *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_check_stop (r->loop, (ev_check *)impl);
 }
 
 static void check_destroy (void *impl, flux_watcher_t *w)
@@ -840,10 +514,11 @@ static void check_destroy (void *impl, flux_watcher_t *w)
 
 static void check_cb (struct ev_loop *loop, ev_check *cw, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = cw->data;
     assert (w->signature == CHECK_SIG);
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_check_watcher_create (flux_watcher_f cb, void *arg)
@@ -868,16 +543,18 @@ flux_watcher_t *flux_check_watcher_create (flux_watcher_f cb, void *arg)
 
 #define IDLE_SIG 1000
 
-static void idle_start (void *impl, flux_watcher_t *w)
+static void idle_start (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == IDLE_SIG);
-    ev_idle_start (w->reactor->loop, (ev_idle *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_idle_start (r->loop, (ev_idle *)impl);
 }
 
-static void idle_stop (void *impl, flux_watcher_t *w)
+static void idle_stop (void *impl, flux_t h, flux_watcher_t *w)
 {
     assert (w->signature == IDLE_SIG);
-    ev_idle_stop (w->reactor->loop, (ev_idle *)impl);
+    struct reactor *r = reactor_get (h);
+    ev_idle_stop (r->loop, (ev_idle *)impl);
 }
 
 static void idle_destroy (void *impl, flux_watcher_t *w)
@@ -889,10 +566,11 @@ static void idle_destroy (void *impl, flux_watcher_t *w)
 
 static void idle_cb (struct ev_loop *loop, ev_idle *iw, int revents)
 {
+    flux_t h = ev_userdata (loop);
     struct flux_watcher *w = iw->data;
     assert (w->signature == IDLE_SIG);
     if (w->fn)
-        w->fn (w->reactor->h, w, libev_to_events (revents), w->arg);
+        w->fn (h, w, libev_to_events (revents), w->arg);
 }
 
 flux_watcher_t *flux_idle_watcher_create (flux_watcher_f cb, void *arg)

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -190,6 +190,8 @@ void flux_watcher_stop (flux_watcher_t *w)
 void flux_watcher_destroy (flux_watcher_t *w)
 {
     if (w) {
+        if (w->ops.stop)
+            w->ops.stop (w->impl, w);
         if (w->ops.destroy)
             w->ops.destroy (w->impl, w);
         free (w);

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -128,6 +128,25 @@ int flux_reactor_start (flux_t h)
     return r->loop_rc;
 }
 
+int flux_reactor_run (flux_t h, int flags)
+{
+    struct reactor *r = reactor_get (h);
+    int ev_flags = 0;
+    int count;
+    if (flags & FLUX_REACTOR_NOWAIT)
+        ev_flags |= EVRUN_NOWAIT;
+    if (flags & FLUX_REACTOR_ONCE)
+        ev_flags |= EVRUN_ONCE;
+    r->loop_rc = 0;
+    count = ev_run (r->loop, ev_flags);
+    if (count > 0 && r->loop_rc == 0 && ((flags & FLUX_REACTOR_NOWAIT)
+                                     || (flags & FLUX_REACTOR_ONCE))) {
+        errno = EWOULDBLOCK;
+        return -1;
+    }
+    return r->loop_rc;
+}
+
 void flux_reactor_stop (flux_t h)
 {
     struct reactor *r = reactor_get (h);

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -80,14 +80,6 @@ static struct reactor *reactor_get (flux_t h)
     return r;
 }
 
-int flux_reactor_start (flux_t h)
-{
-    struct reactor *r = reactor_get (h);
-    r->loop_rc = 0;
-    ev_run (r->loop, 0);
-    return r->loop_rc;
-}
-
 int flux_reactor_run (flux_t h, int flags)
 {
     struct reactor *r = reactor_get (h);

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -16,8 +16,11 @@ enum {
                               /*     one event occurs */
 };
 
-flux_reactor_t *flux_reactor_create ();
+flux_reactor_t *flux_reactor_create (void);
 void flux_reactor_destroy (flux_reactor_t *r);
+
+flux_reactor_t *flux_get_reactor (flux_t h);
+void flux_set_reactor (flux_t h, flux_reactor_t *r);
 
 /* Start a flux event reactor, with optional flags.
  * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -14,11 +14,6 @@ enum {
                               /*     one event occurs */
 };
 
-/* Start the flux event reactor.
- * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
- */
-int flux_reactor_start (flux_t h);
-
 /* Start the flux event reactor, with optional flags.
  * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
  */

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -5,10 +5,11 @@
 
 #include "handle.h"
 
+/* Reactor
+ */
+
 typedef struct flux_reactor flux_reactor_t;
 
-/* flags for flux_reactor_run ()
- */
 enum {
     FLUX_REACTOR_NOWAIT = 1,  /* return after all new and outstanding */
                               /*     events have been hnadled */
@@ -22,80 +23,50 @@ void flux_reactor_destroy (flux_reactor_t *r);
 flux_reactor_t *flux_get_reactor (flux_t h);
 void flux_set_reactor (flux_t h, flux_reactor_t *r);
 
-/* Start a flux event reactor, with optional flags.
- * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
- */
 int flux_reactor_run (flux_reactor_t *r, int flags);
 
-/* Signal that the flux event reactor should stop.
- * This may be called from within a watcher.
- */
 void flux_reactor_stop (flux_reactor_t *r);
 void flux_reactor_stop_error (flux_reactor_t *r);
 
-/* General comments on watchers:
- * - It is safe to call a watcher's 'stop' function from a watcher callback.
- * - It is necessary to stop a watcher before destroying it.
- * - Once stopped, a watcher is no longer associated with the flux handle
- *   and must be destroyed independently.
- * - A watcher may be started/stopped more than once.
- * - Starting a started watcher, stopping a stopped watcher, or destroying
- *   a NULL watcher have no effect.
+/* Watchers
  */
 
 typedef struct flux_watcher flux_watcher_t;
+
 typedef void (*flux_watcher_f)(flux_reactor_t *r, flux_watcher_t *w,
                                int revents, void *arg);
-void flux_watcher_destroy (flux_watcher_t *w);
+
 void flux_watcher_start (flux_watcher_t *w);
 void flux_watcher_stop (flux_watcher_t *w);
+void flux_watcher_destroy (flux_watcher_t *w);
 
-/* handle - watch a flux_t handle
- */
 flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
                                             flux_t h, int events,
                                             flux_watcher_f cb, void *arg);
 flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
 
-/* fd - watch a file descriptor
- */
 flux_watcher_t *flux_fd_watcher_create (flux_reactor_t *r, int fd, int events,
                                         flux_watcher_f cb, void *arg);
 int flux_fd_watcher_get_fd (flux_watcher_t *w);
 
-/* zmq - watch a zeromq socket.
- */
 flux_watcher_t *flux_zmq_watcher_create (flux_reactor_t *r,
                                          void *zsock, int events,
                                          flux_watcher_f cb, void *arg);
 void *flux_zmq_watcher_get_zsock (flux_watcher_t *w);
 
-/* Timer - set a timer
- * Create/destroy/start/stop "timer watchers".
- * A timer is set to trigger 'after' seconds from its start time.  If 'after'
- * is zero, the timer triggers immediately.  If 'repeat' is zero, the timer
- * only triggers once and is then automatically stopped, otherwise it triggers
- * again every 'repeat' seconds.
- */
-
 flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
                                            double after, double repeat,
                                            flux_watcher_f cb, void *arg);
+
 void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat);
 
 
-/* Prepare - run immediately before blocking.
- */
 flux_watcher_t *flux_prepare_watcher_create (flux_reactor_t *r,
                                              flux_watcher_f cb, void *arg);
 
-/* Check - run immediately after blocking
- */
 flux_watcher_t *flux_check_watcher_create (flux_reactor_t *r,
                                           flux_watcher_f cb, void *arg);
 
-/* Idle - always run (event loop never blocks)
- */
 flux_watcher_t *flux_idle_watcher_create (flux_reactor_t *r,
                                           flux_watcher_f cb, void *arg);
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -47,24 +47,26 @@ typedef struct flux_watcher flux_watcher_t;
 typedef void (*flux_watcher_f)(flux_reactor_t *r, flux_watcher_t *w,
                                int revents, void *arg);
 void flux_watcher_destroy (flux_watcher_t *w);
-void flux_watcher_start (flux_reactor_t *r, flux_watcher_t *w);
-void flux_watcher_stop (flux_reactor_t *r, flux_watcher_t *w);
+void flux_watcher_start (flux_watcher_t *w);
+void flux_watcher_stop (flux_watcher_t *w);
 
 /* handle - watch a flux_t handle
  */
-flux_watcher_t *flux_handle_watcher_create (flux_t h, int events,
+flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
+                                            flux_t h, int events,
                                             flux_watcher_f cb, void *arg);
 flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
 
 /* fd - watch a file descriptor
  */
-flux_watcher_t *flux_fd_watcher_create (int fd, int events,
+flux_watcher_t *flux_fd_watcher_create (flux_reactor_t *r, int fd, int events,
                                         flux_watcher_f cb, void *arg);
 int flux_fd_watcher_get_fd (flux_watcher_t *w);
 
 /* zmq - watch a zeromq socket.
  */
-flux_watcher_t *flux_zmq_watcher_create (void *zsock, int events,
+flux_watcher_t *flux_zmq_watcher_create (flux_reactor_t *r,
+                                         void *zsock, int events,
                                          flux_watcher_f cb, void *arg);
 void *flux_zmq_watcher_get_zsock (flux_watcher_t *w);
 
@@ -76,35 +78,27 @@ void *flux_zmq_watcher_get_zsock (flux_watcher_t *w);
  * again every 'repeat' seconds.
  */
 
-flux_watcher_t *flux_timer_watcher_create (double after, double repeat,
+flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
+                                           double after, double repeat,
                                            flux_watcher_f cb, void *arg);
 void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat);
 
 
 /* Prepare - run immediately before blocking.
  */
-flux_watcher_t *flux_prepare_watcher_create (flux_watcher_f cb, void *arg);
+flux_watcher_t *flux_prepare_watcher_create (flux_reactor_t *r,
+                                             flux_watcher_f cb, void *arg);
 
 /* Check - run immediately after blocking
  */
-flux_watcher_t *flux_check_watcher_create (flux_watcher_f cb, void *arg);
+flux_watcher_t *flux_check_watcher_create (flux_reactor_t *r,
+                                          flux_watcher_f cb, void *arg);
 
 /* Idle - always run (event loop never blocks)
  */
-flux_watcher_t *flux_idle_watcher_create (flux_watcher_f cb, void *arg);
+flux_watcher_t *flux_idle_watcher_create (flux_reactor_t *r,
+                                          flux_watcher_f cb, void *arg);
 
-
-/* watcher construction set
- */
-struct watcher_ops {
-    void (*start)(void *impl, flux_reactor_t *r, flux_watcher_t *w);
-    void (*stop)(void *impl, flux_reactor_t *r, flux_watcher_t *w);
-    void (*destroy)(void *impl, flux_watcher_t *w);
-};
-
-flux_watcher_t *flux_watcher_create (void *impl, struct watcher_ops ops,
-                                     int signature, flux_watcher_f callback,
-                                     void *arg);
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -5,6 +5,8 @@
 
 #include "handle.h"
 
+typedef struct flux_reactor flux_reactor_t;
+
 /* flags for flux_reactor_run ()
  */
 enum {
@@ -13,6 +15,9 @@ enum {
     FLUX_REACTOR_ONCE = 2,    /* same as above but block until at least */
                               /*     one event occurs */
 };
+
+flux_reactor_t *flux_reactor_create (flux_t h);
+void flux_reactor_destroy (flux_reactor_t *r);
 
 /* Start the flux event reactor, with optional flags.
  * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -16,23 +16,19 @@ enum {
                               /*     one event occurs */
 };
 
-flux_reactor_t *flux_reactor_create (flux_t h);
+flux_reactor_t *flux_reactor_create ();
 void flux_reactor_destroy (flux_reactor_t *r);
 
-/* Start the flux event reactor, with optional flags.
+/* Start a flux event reactor, with optional flags.
  * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
  */
-int flux_reactor_run (flux_t h, int flags);
+int flux_reactor_run (flux_reactor_t *r, int flags);
 
 /* Signal that the flux event reactor should stop.
  * This may be called from within a watcher.
  */
-void flux_reactor_stop (flux_t h);
-void flux_reactor_stop_error (flux_t h);
-
-/* Arrange for 'h2' to use the the built-in reactor of 'h'.
- */
-void flux_reactor_add (flux_t h, flux_t h2);
+void flux_reactor_stop (flux_reactor_t *r);
+void flux_reactor_stop_error (flux_reactor_t *r);
 
 /* General comments on watchers:
  * - It is safe to call a watcher's 'stop' function from a watcher callback.
@@ -45,11 +41,11 @@ void flux_reactor_add (flux_t h, flux_t h2);
  */
 
 typedef struct flux_watcher flux_watcher_t;
-typedef void (*flux_watcher_f)(flux_t h, flux_watcher_t *w,
+typedef void (*flux_watcher_f)(flux_reactor_t *r, flux_watcher_t *w,
                                int revents, void *arg);
 void flux_watcher_destroy (flux_watcher_t *w);
-void flux_watcher_start (flux_t h, flux_watcher_t *w);
-void flux_watcher_stop (flux_t h, flux_watcher_t *w);
+void flux_watcher_start (flux_reactor_t *r, flux_watcher_t *w);
+void flux_watcher_stop (flux_reactor_t *r, flux_watcher_t *w);
 
 /* handle - watch a flux_t handle
  */
@@ -98,8 +94,8 @@ flux_watcher_t *flux_idle_watcher_create (flux_watcher_f cb, void *arg);
 /* watcher construction set
  */
 struct watcher_ops {
-    void (*start)(void *impl, flux_t h, flux_watcher_t *w);
-    void (*stop)(void *impl, flux_t h, flux_watcher_t *w);
+    void (*start)(void *impl, flux_reactor_t *r, flux_watcher_t *w);
+    void (*stop)(void *impl, flux_reactor_t *r, flux_watcher_t *w);
     void (*destroy)(void *impl, flux_watcher_t *w);
 };
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -6,10 +6,24 @@
 #include "message.h"
 #include "handle.h"
 
+/* flags for flux_reactor_run ()
+ */
+enum {
+    FLUX_REACTOR_NOWAIT = 1,  /* return after all new and outstanding */
+                              /*     events have been hnadled */
+    FLUX_REACTOR_ONCE = 2,    /* same as above but block until at least */
+                              /*     one event occurs */
+};
+
 /* Start the flux event reactor.
  * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
  */
 int flux_reactor_start (flux_t h);
+
+/* Start the flux event reactor, with optional flags.
+ * Returns 0 if flux_reactor_stop() terminated reactor; -1 if error did.
+ */
+int flux_reactor_run (flux_t h, int flags);
 
 /* Signal that the flux event reactor should stop.
  * This may be called from within a watcher.

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -107,6 +107,12 @@ struct flux_msghandler {
 int flux_msg_watcher_addvec (flux_t h, struct flux_msghandler tab[], void *arg);
 void flux_msg_watcher_delvec (flux_t h, struct flux_msghandler tab[]);
 
+/* handle - watch a flux_t handle
+ */
+flux_watcher_t *flux_handle_watcher_create (flux_t h, int events,
+                                            flux_watcher_f cb, void *arg);
+flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
+
 /* fd - watch a file descriptor
  */
 flux_watcher_t *flux_fd_watcher_create (int fd, int events,

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -152,6 +152,38 @@ void flux_timer_watcher_reset (flux_timer_watcher_t *w,
                                double after, double repeat);
 
 
+/* Prepare - run immediately before blocking.
+ */
+typedef struct flux_prepare_watcher flux_prepare_watcher_t;
+typedef void (*flux_prepare_watcher_f)(flux_t h, flux_prepare_watcher_t *w,
+                                     int revents, void *arg);
+flux_prepare_watcher_t *flux_prepare_watcher_create (flux_prepare_watcher_f cb,
+                                                     void *arg);
+void flux_prepare_watcher_destroy (flux_prepare_watcher_t *w);
+void flux_prepare_watcher_start (flux_t h, flux_prepare_watcher_t *w);
+void flux_prepare_watcher_stop (flux_t h, flux_prepare_watcher_t *w);
+
+/* Check - run immediately after blocking
+ */
+typedef struct flux_check_watcher flux_check_watcher_t;
+typedef void (*flux_check_watcher_f)(flux_t h, flux_check_watcher_t *w,
+                                     int revents, void *arg);
+flux_check_watcher_t *flux_check_watcher_create (flux_check_watcher_f cb,
+                                                     void *arg);
+void flux_check_watcher_destroy (flux_check_watcher_t *w);
+void flux_check_watcher_start (flux_t h, flux_check_watcher_t *w);
+void flux_check_watcher_stop (flux_t h, flux_check_watcher_t *w);
+
+/* Idle - always run (event loop never blocks)
+ */
+typedef struct flux_idle_watcher flux_idle_watcher_t;
+typedef void (*flux_idle_watcher_f)(flux_t h, flux_idle_watcher_t *w,
+                                     int revents, void *arg);
+flux_idle_watcher_t *flux_idle_watcher_create (flux_idle_watcher_f cb,
+                                                     void *arg);
+void flux_idle_watcher_destroy (flux_idle_watcher_t *w);
+void flux_idle_watcher_start (flux_t h, flux_idle_watcher_t *w);
+void flux_idle_watcher_stop (flux_t h, flux_idle_watcher_t *w);
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libutil/coproc.h
+++ b/src/common/libutil/coproc.h
@@ -3,45 +3,45 @@
 
 #include <stdbool.h>
 
-typedef struct coproc_struct *coproc_t;
-typedef int (*coproc_cb_t)(coproc_t c, void *arg);
+typedef struct coproc_struct coproc_t;
+typedef int (*coproc_f)(coproc_t *c, void *arg);
 
 /* Destroy a coproc, freeing its stack.
  */
-void coproc_destroy (coproc_t c);
+void coproc_destroy (coproc_t *c);
 
 /* Create a new coproc, allocating its stack.
  */
-coproc_t coproc_create (coproc_cb_t cb);
+coproc_t *coproc_create (coproc_f cb);
 
 /* Coproc calls this to yield back to coproc_start/resume caller.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int coproc_yield (coproc_t c);
+int coproc_yield (coproc_t *c);
 
 /* Start a coproc.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int coproc_start (coproc_t c, void *arg);
+int coproc_start (coproc_t *c, void *arg);
 
 /* Resume a coproc.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int coproc_resume (coproc_t c);
+int coproc_resume (coproc_t *c);
 
 /* Return true if coproc has returned (as opposed to yielded or not started).
  * If it has returned and 'rc' is non-NULL, set 'rc' to return value.
  */
-bool coproc_returned (coproc_t c, int *rc);
+bool coproc_returned (coproc_t *c, int *rc);
 
 /* Return true if coproc has been started with coproc_start(), but
  * has not yet returned.
  */
-bool coproc_started (coproc_t c);
+bool coproc_started (coproc_t *c);
 
 /* Get the size of the coproc stack in bytes.
  */
-size_t coproc_get_stacksize (coproc_t c);
+size_t coproc_get_stacksize (coproc_t *c);
 
 #endif /* !_UTIL_COPROC_H */
 

--- a/src/common/libutil/test/coproc.c
+++ b/src/common/libutil/test/coproc.c
@@ -10,7 +10,7 @@
 
 static bool death = false;
 
-coproc_t co;
+coproc_t *co;
 
 /* Handler will yield if it segfaulted; return if not.
  */
@@ -43,7 +43,7 @@ int signal_setup (void)
 
 /* Touch the stack.  If we touch guard page, we should get a SIGSEGV.
  */
-int stack_cb (coproc_t c, void *arg)
+int stack_cb (coproc_t *c, void *arg)
 {
     size_t *ssize = arg;
     void *ptr = alloca (*ssize);
@@ -52,7 +52,7 @@ int stack_cb (coproc_t c, void *arg)
     return 0;
 }
 
-int bar_cb (coproc_t c, void *arg)
+int bar_cb (coproc_t *c, void *arg)
 {
     while (!death) {
         if (coproc_yield (c) < 0)
@@ -61,7 +61,7 @@ int bar_cb (coproc_t c, void *arg)
     return 0;
 }
 
-int foo_cb (coproc_t c, void *arg)
+int foo_cb (coproc_t *c, void *arg)
 {
     int n; /* number of times to yield */
 
@@ -79,7 +79,7 @@ int foo_cb (coproc_t c, void *arg)
 
 void *threadmain (void *arg)
 {
-    coproc_t c;
+    coproc_t *c;
 
     ok ((c = coproc_create (bar_cb)) != NULL,
         "coproc_create works in a pthread");
@@ -93,7 +93,7 @@ void *threadmain (void *arg)
 
 int main (int argc, char *argv[])
 {
-    coproc_t c;
+    coproc_t *c;
     int i;
     int rc;
 
@@ -142,7 +142,7 @@ int main (int argc, char *argv[])
     ok (pthread_join (t, NULL) == 0,
         "pthread_join OK");
 
-    coproc_t cps[10000];
+    coproc_t *cps[10000];
     for (i = 0; i < 10000; i++) {
         if (!(cps[i] = coproc_create (bar_cb)))
             break;

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -777,7 +777,7 @@ static inline void delete_jobinfo (flux_t h, int64_t jobid)
     free (key);
 }
 
-static void job_state_cb (flux_t h, flux_msg_watcher_t *w, 
+static void job_state_cb (flux_t h, flux_msg_handler_t *w, 
                           const flux_msg_t *msg, void *arg)  
 {
     int64_t jobid = -1;
@@ -816,7 +816,7 @@ done:
  *                    Public Job Status and Control API                       *
  *                                                                            *
  ******************************************************************************/
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_EVENT,     "wreck.state.*", job_state_cb},
     { FLUX_MSGTYPE_EVENT,     "jsc.state.*",   job_state_cb},
       FLUX_MSGHANDLER_TABLE_END
@@ -842,7 +842,7 @@ int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f func, void *d)
         rc = -1;
         goto done;
     }
-    if (flux_msg_watcher_addvec (h, htab, (void *)ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, (void *)ctx) < 0) {
         flux_log (h, LOG_ERR, "registering resource event handler: %s",
                   strerror (errno));
         rc = -1;

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -343,7 +343,7 @@ static int request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     if (flux_msg_get_topic (*zmsg, &topic) < 0)
         goto done;
     if (!strcmp (topic, "wrexec.shutdown")) {
-        flux_reactor_stop (h);
+        flux_reactor_stop (flux_get_reactor (h));
         return 0;
     }
 done:

--- a/src/test/tkvswatch.c
+++ b/src/test/tkvswatch.c
@@ -109,7 +109,7 @@ static int mt_watch_cb (const char *k, int val, void *arg, int errnum)
 
     /* normal stop */
     if (val + 1 == changes)
-        flux_reactor_stop (t->h);
+        flux_reactor_stop (flux_get_reactor (t->h));
     t->change_count++;
     return 0;
 }
@@ -327,7 +327,7 @@ static int unwatch_timer_cb (flux_t h, void *arg)
         if (kvs_unwatch (h, key) < 0)
             err_exit ("%s: kvs_unwatch", __FUNCTION__);
     } else if (count == 20)
-        flux_reactor_stop (h);
+        flux_reactor_stop (flux_get_reactor (h));
     return 0;
 }
 

--- a/t/loop/reactor.c
+++ b/t/loop/reactor.c
@@ -7,6 +7,7 @@
 #include "src/common/libflux/message.h"
 #include "src/common/libflux/handle.h"
 #include "src/common/libflux/reactor.h"
+#include "src/common/libflux/dispatch.h"
 #include "src/common/libflux/request.h"
 
 #include "src/common/libutil/xzmalloc.h"
@@ -28,29 +29,29 @@ done:
 }
 
 static int multmatch_count = 0;
-static void multmatch1 (flux_t h, flux_msg_watcher_t *w, const flux_msg_t *msg,
+static void multmatch1 (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
                         void *arg)
 {
     const char *topic;
     if (flux_msg_get_topic (msg, &topic) < 0 || strcmp (topic, "foo.baz"))
-        flux_reactor_stop_error (h);
-    flux_msg_watcher_stop (h, w);
+        flux_reactor_stop_error (flux_get_reactor (h));
+    flux_msg_handler_stop (w);
     multmatch_count++;
 }
 
-static void multmatch2 (flux_t h, flux_msg_watcher_t *w, const flux_msg_t *msg,
+static void multmatch2 (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
                         void *arg)
 {
     const char *topic;
     if (flux_msg_get_topic (msg, &topic) < 0 || strcmp (topic, "foo.bar"))
-        flux_reactor_stop_error (h);
-    flux_msg_watcher_stop (h, w);
+        flux_reactor_stop_error (flux_get_reactor (h));
+    flux_msg_handler_stop (w);
     multmatch_count++;
 }
 
 static void test_multmatch (flux_t h)
 {
-    flux_msg_watcher_t *w1, *w2;
+    flux_msg_handler_t *w1, *w2;
     struct flux_match m1 = FLUX_MATCH_ANY;
     struct flux_match m2 = FLUX_MATCH_ANY;
 
@@ -60,57 +61,59 @@ static void test_multmatch (flux_t h)
     /* test #1: verify multiple match behaves as documented, that is,
      * a message is matched (only) by the most recently added watcher
      */
-    ok ((w1 = flux_msg_watcher_create (m1, multmatch1, NULL)) != NULL,
-        "multmatch: first added watcher for foo.*");
-    ok ((w2 = flux_msg_watcher_create (m2, multmatch2, NULL)) != NULL,
-        "multmatch: next added watcher for foo.bar");
-    flux_msg_watcher_start (h, w1);
-    flux_msg_watcher_start (h, w2);
+    ok ((w1 = flux_msg_handler_create (h, m1, multmatch1, NULL)) != NULL,
+        "multmatch: first added handler for foo.*");
+    ok ((w2 = flux_msg_handler_create (h, m2, multmatch2, NULL)) != NULL,
+        "multmatch: next added handler for foo.bar");
+    flux_msg_handler_start (w1);
+    flux_msg_handler_start (w2);
     ok (send_request (h, "foo.bar") == 0,
         "multmatch: send foo.bar msg");
     ok (send_request (h, "foo.baz") == 0,
         "multmatch: send foo.baz msg");
-    ok (flux_reactor_start (h) == 0 && multmatch_count == 2,
+    ok (flux_reactor_run (flux_get_reactor (h), 0) == 0 && multmatch_count == 2,
         "multmatch: last added watcher handled foo.bar");
-    flux_msg_watcher_destroy (w1);
-    flux_msg_watcher_destroy (w2);
+    flux_msg_handler_destroy (w1);
+    flux_msg_handler_destroy (w2);
 }
 
 static int msgwatcher_count = 100;
-static void msgreader (flux_t h, flux_msg_watcher_t *w, const flux_msg_t *msg,
+static void msgreader (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
                        void *arg)
 {
     static int count = 0;
     count++;
     if (count == msgwatcher_count)
-        flux_msg_watcher_stop (h, w);
+        flux_msg_handler_stop (w);
 }
 
 static void test_msg (flux_t h)
 {
-    flux_msg_watcher_t *w;
+    flux_msg_handler_t *w;
     int i;
 
-    ok ((w = flux_msg_watcher_create (FLUX_MATCH_ANY, msgreader, NULL)) != NULL,
-        "msg: created watcher for any message");
-    flux_msg_watcher_start (h, w);
+    ok ((w = flux_msg_handler_create (h, FLUX_MATCH_ANY, msgreader, NULL))
+        != NULL,
+        "msg: created handler for any message");
+    flux_msg_handler_start (w);
     for (i = 0; i < msgwatcher_count; i++) {
         if (send_request (h, "foo") < 0)
             break;
     }
     ok (i == msgwatcher_count,
         "msg: sent %d requests", i);
-    ok (flux_reactor_start (h) == 0,
+    ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,
         "msg: reactor ran to completion after %d requests", msgwatcher_count);
-    flux_msg_watcher_stop (h, w);
-    flux_msg_watcher_destroy (w);
+    flux_msg_handler_stop (w);
+    flux_msg_handler_destroy (w);
 }
 
 static const size_t zmqwriter_msgcount = 1024;
 
-static void zmqwriter (flux_t h, flux_zmq_watcher_t *w, void *sock,
+static void zmqwriter (flux_reactor_t *r, flux_watcher_t *w,
                        int revents, void *arg)
 {
+    void *sock = flux_zmq_watcher_get_zsock (w);
     static int count = 0;
     if (revents & FLUX_POLLERR) {
         fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
@@ -131,16 +134,17 @@ static void zmqwriter (flux_t h, flux_zmq_watcher_t *w, void *sock,
         }
         count++;
         if (count == zmqwriter_msgcount)
-            flux_zmq_watcher_stop (h, w);
+            flux_watcher_stop (w);
     }
     return;
 error:
-    flux_reactor_stop_error (h);
+    flux_reactor_stop_error (r);
 }
 
-static void zmqreader (flux_t h, flux_zmq_watcher_t *w, void *sock,
+static void zmqreader (flux_reactor_t *r, flux_watcher_t *w,
                        int revents, void *arg)
 {
+    void *sock = flux_zmq_watcher_get_zsock (w);
     static int count = 0;
     if (revents & FLUX_POLLERR) {
         fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
@@ -156,18 +160,18 @@ static void zmqreader (flux_t h, flux_zmq_watcher_t *w, void *sock,
         zmsg_destroy (&zmsg);
         count++;
         if (count == zmqwriter_msgcount)
-            flux_zmq_watcher_stop (h, w);
+            flux_watcher_stop (w);
     }
     return;
 error:
-    flux_reactor_stop_error (h);
+    flux_reactor_stop_error (r);
 }
 
-static void test_zmq (flux_t h)
+static void test_zmq (flux_reactor_t *reactor)
 {
     zctx_t *zctx;
     void *zs[2];
-    flux_zmq_watcher_t *r, *w;
+    flux_watcher_t *r, *w;
 
     ok ((zctx = zctx_new ()) != NULL,
         "zmq: created zmq context");
@@ -177,18 +181,18 @@ static void test_zmq (flux_t h)
         && zsocket_bind (zs[0], "inproc://test_zmq") == 0
         && zsocket_connect (zs[1], "inproc://test_zmq") == 0,
         "zmq: connected ZMQ_PAIR sockets over inproc");
-    r = flux_zmq_watcher_create (zs[0], FLUX_POLLIN, zmqreader, NULL);
-    w = flux_zmq_watcher_create (zs[1], FLUX_POLLOUT, zmqwriter, NULL);
+    r = flux_zmq_watcher_create (reactor, zs[0], FLUX_POLLIN, zmqreader, NULL);
+    w = flux_zmq_watcher_create (reactor, zs[1], FLUX_POLLOUT, zmqwriter, NULL);
     ok (r != NULL && w != NULL,
         "zmq: nonblocking reader and writer created");
-    flux_zmq_watcher_start (h, r);
-    flux_zmq_watcher_start (h, w);
-    ok (flux_reactor_start (h) == 0,
+    flux_watcher_start (r);
+    flux_watcher_start (w);
+    ok (flux_reactor_run  (reactor, 0) == 0,
         "zmq: reactor ran to completion after %d messages", zmqwriter_msgcount);
-    flux_zmq_watcher_stop (h, r);
-    flux_zmq_watcher_stop (h, w);
-    flux_zmq_watcher_destroy (r);
-    flux_zmq_watcher_destroy (w);
+    flux_watcher_stop (r);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (r);
+    flux_watcher_destroy (w);
 
     zsocket_destroy (zctx, zs[0]);
     zsocket_destroy (zctx, zs[1]);
@@ -197,9 +201,10 @@ static void test_zmq (flux_t h)
 
 static const size_t fdwriter_bufsize = 10*1024*1024;
 
-static void fdwriter (flux_t h, flux_fd_watcher_t *w, int fd,
-                      int revents, void *arg)
+static void fdwriter (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
 {
+    int fd = flux_fd_watcher_get_fd (w);
     static char *buf = NULL;
     static int count = 0;
     int n;
@@ -220,18 +225,19 @@ static void fdwriter (flux_t h, flux_fd_watcher_t *w, int fd,
         if (n > 0) {
             count += n;
             if (count == fdwriter_bufsize) {
-                flux_fd_watcher_stop (h, w);
+                flux_watcher_stop (w);
                 free (buf);
             }
         }
     }
     return;
 error:
-    flux_reactor_stop_error (h);
+    flux_reactor_stop_error (r);
 }
-static void fdreader (flux_t h, flux_fd_watcher_t *w, int fd,
+static void fdreader (flux_reactor_t *r, flux_watcher_t *w,
                       int revents, void *arg)
 {
+    int fd = flux_fd_watcher_get_fd (w);
     static char *buf = NULL;
     static int count = 0;
     int n;
@@ -252,14 +258,14 @@ static void fdreader (flux_t h, flux_fd_watcher_t *w, int fd,
         if (n > 0) {
             count += n;
             if (count == fdwriter_bufsize) {
-                flux_fd_watcher_stop (h, w);
+                flux_watcher_stop (w);
                 free (buf);
             }
         }
     }
     return;
 error:
-    flux_reactor_stop_error (h);
+    flux_reactor_stop_error (r);
 }
 
 static int set_nonblock (int fd)
@@ -272,88 +278,93 @@ static int set_nonblock (int fd)
     return 0;
 }
 
-static void test_fd (flux_t h)
+static void test_fd (flux_reactor_t *reactor)
 {
     int fd[2];
-    flux_fd_watcher_t *r, *w;
+    flux_watcher_t *r, *w;
 
     ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0
         && set_nonblock (fd[0]) == 0 && set_nonblock (fd[1]) == 0,
         "fd: successfully created non-blocking socketpair");
-    r = flux_fd_watcher_create (fd[0], FLUX_POLLIN, fdreader, NULL);
-    w = flux_fd_watcher_create (fd[1], FLUX_POLLOUT, fdwriter, NULL);
+    r = flux_fd_watcher_create (reactor, fd[0], FLUX_POLLIN, fdreader, NULL);
+    w = flux_fd_watcher_create (reactor, fd[1], FLUX_POLLOUT, fdwriter, NULL);
     ok (r != NULL && w != NULL,
         "fd: reader and writer created");
-    flux_fd_watcher_start (h, r);
-    flux_fd_watcher_start (h, w);
-    ok (flux_reactor_start (h) == 0,
+    flux_watcher_start (r);
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) == 0,
         "fd: reactor ran to completion after %lu bytes", fdwriter_bufsize);
-    flux_fd_watcher_stop (h, r);
-    flux_fd_watcher_stop (h, w);
-    flux_fd_watcher_destroy (r);
-    flux_fd_watcher_destroy (w);
+    flux_watcher_stop (r);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (r);
+    flux_watcher_destroy (w);
     close (fd[0]);
     close (fd[1]);
 }
 
 static int repeat_countdown = 10;
-static void repeat (flux_t h, flux_timer_watcher_t *w, int revents, void *arg)
+static void repeat (flux_reactor_t *r, flux_watcher_t *w,
+                    int revents, void *arg)
 {
     repeat_countdown--;
     if (repeat_countdown == 0)
-        flux_timer_watcher_stop (h, w);
+        flux_watcher_stop (w);
 }
 
 static bool oneshot_ran = false;
 static int oneshot_errno = 0;
-static void oneshot (flux_t h, flux_timer_watcher_t *w, int revents, void *arg)
+static void oneshot (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
 {
     oneshot_ran = true;
     if (oneshot_errno != 0) {
         errno = oneshot_errno;
-        flux_reactor_stop_error (h);
+        flux_reactor_stop_error (r);
     }
 }
 
-static void test_timer (flux_t h)
+static void test_timer (flux_reactor_t *reactor)
 {
-    flux_timer_watcher_t *w;
+    flux_watcher_t *w;
 
     errno = 0;
-    ok (!flux_timer_watcher_create (-1, 0, oneshot, NULL) && errno == EINVAL,
+    ok (!flux_timer_watcher_create (reactor, -1, 0, oneshot, NULL)
+        && errno == EINVAL,
         "timer: creating negative timeout fails with EINVAL");
-    ok (!flux_timer_watcher_create (0, -1, oneshot, NULL) && errno == EINVAL,
+    ok (!flux_timer_watcher_create (reactor, 0, -1, oneshot, NULL)
+        && errno == EINVAL,
         "timer: creating negative repeat fails with EINVAL");
-    ok ((w = flux_timer_watcher_create (0, 0, oneshot, NULL)) != NULL,
+    ok ((w = flux_timer_watcher_create (reactor, 0, 0, oneshot, NULL)) != NULL,
         "timer: creating zero timeout works");
-    flux_timer_watcher_start (h, w);
-    ok (flux_reactor_start (h) == 0,
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) == 0,
         "timer: reactor ran to completion (single oneshot)");
     ok (oneshot_ran == true,
         "timer: oneshot was executed");
     oneshot_ran = false;
-    ok (flux_reactor_start (h) == 0,
+    ok (flux_reactor_run (reactor, 0) == 0,
         "timer: reactor ran to completion (expired oneshot)");
     ok (oneshot_ran == false,
         "timer: expired oneshot was not re-executed");
 
     errno = 0;
     oneshot_errno = ESRCH;
-    flux_timer_watcher_start (h, w);
-    ok (flux_reactor_start (h) < 0 && errno == ESRCH,
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) < 0 && errno == ESRCH,
         "general: reactor stop_error worked with errno passthru");
-    flux_timer_watcher_stop (h, w);
-    flux_timer_watcher_destroy (w);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (w);
 
-    ok ((w = flux_timer_watcher_create (0.01, 0.01, repeat, NULL)) != NULL,
+    ok ((w = flux_timer_watcher_create (reactor, 0.01, 0.01, repeat, NULL))
+        != NULL,
         "timer: creating 1ms timeout with 1ms repeat works");
-    flux_timer_watcher_start (h, w);
-    ok (flux_reactor_start (h) == 0,
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) == 0,
         "timer: reactor ran to completion (single repeat)");
     ok (repeat_countdown == 0,
         "timer: repeat timer stopped itself after countdown");
-    flux_timer_watcher_stop (h, w);
-    flux_timer_watcher_destroy (w);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (w);
 }
 
 static void fatal_err (const char *message, void *arg)
@@ -364,8 +375,9 @@ static void fatal_err (const char *message, void *arg)
 int main (int argc, char *argv[])
 {
     flux_t h;
+    flux_reactor_t *reactor;
 
-    plan (3+11+3+4+3+5);
+    plan (4+11+3+4+3+5);
 
     (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
     ok ((h = flux_open ("loop://", 0)) != NULL,
@@ -373,16 +385,20 @@ int main (int argc, char *argv[])
     if (!h)
         BAIL_OUT ("can't continue without loop handle");
     flux_fatal_set (h, fatal_err, NULL);
+    ok ((reactor = flux_get_reactor (h)) != NULL,
+        "obtained reactor");
+    if (!reactor)
+        BAIL_OUT ("can't continue without reactor");
 
-    ok (flux_reactor_start (h) == 0,
+    ok (flux_reactor_run (reactor, 0) == 0,
         "general: reactor ran to completion (no watchers)");
     errno = 0;
     ok (flux_sleep_on (h, FLUX_MATCH_ANY) < 0 && errno == EINVAL,
         "general: flux_sleep_on outside coproc fails with EINVAL");
 
-    test_timer (h); // 11
-    test_fd (h); // 3
-    test_zmq (h); // 4
+    test_timer (reactor); // 11
+    test_fd (reactor); // 3
+    test_zmq (reactor); // 4
     test_msg (h); // 3
     test_multmatch (h); // 5
 

--- a/t/loop/reduce.c
+++ b/t/loop/reduce.c
@@ -288,7 +288,7 @@ void test_timed (flux_t h)
     /* Start reactor so timeout handler can run.
      * It should fire once and sink all items in one sink call.
      */
-    ok (flux_reactor_start (h) == 0,
+    ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,
         "timed.0: reactor completed normally");
     cmp_ok (sink_calls, "==", 1,
         "timed.0: op.sink called 1 time");
@@ -329,7 +329,7 @@ void test_timed (flux_t h)
     /* Start reactor so timeout handler can run.
      * It should fire once and sink all items in one sink call.
      */
-    ok (flux_reactor_start (h) == 0,
+    ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,
         "timed.1: reactor completed normally");
     cmp_ok (sink_calls, "==", 1,
         "timed.1: op.sink called 1 time");


### PR DESCRIPTION
This PR tentatively implements prepare, check, and idle watchers directly wrapping the libev ones.  See [libev docs](http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod) for how these work.

I've also added a variant of `flux_reactor_start()` called `flux_reactor_run()` which optionally takes the FLUX_REACTOR_NONBLOCK flag.  If this flag is passed, the reactor handles all outstanding events and, if there are still active watchers, returns -1 with errno set to EWOULDBLOCK.

This is in response to issues raised in #362.  I took the shotgun approached and provided all three of the watchers discussed plus the "run once" interface.  I'm not sure if all of this is needed.  Perhaps @trws can play around with this branch and see what really works for his use case and then we can decide what makes the cut, what to do with `flux_reactor_start()` etc.