### PR TITLE
fix make clean

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,8 +26,3 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"common/libutil/sds.[ch]"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
-
-# Remove other coverage files on clean:
-clean:
-	-rm $(CODE_COVERAGE_OUTPUT_FILE).initial
-	-find . -name *.gcno -delete

--- a/config/ax_code_coverage.m4
+++ b/config/ax_code_coverage.m4
@@ -220,6 +220,8 @@ code-coverage-clean:
 	-$(LCOV) --directory $(top_builddir) -z
 	-rm -rf $(CODE_COVERAGE_OUTPUT_FILE) $(CODE_COVERAGE_OUTPUT_FILE).tmp $(CODE_COVERAGE_OUTPUT_DIRECTORY)
 	-find . -name "*.gcda" -o -name "*.gcov" -delete
+	-rm -f $(CODE_COVERAGE_OUTPUT_FILE).initial
+	-find . -name *.gcno -delete
 endif
 
 GITIGNOREFILES ?=


### PR DESCRIPTION
code coverage enhancements in this commit broke "make clean"

    commit 4fee3a722d0cc4847b7a1084ed1dfe13610ba56d
    Author: Mark Grondona <mark.grondona@gmail.com>
    Date:   Mon Sep 14 03:52:56 2015 +0000

    build: remove coverage files on clean

    Remove *.gcno and baseline coverage output file on 'make clean'
    when configured with --check-code-coverage.

because 'clean:' was used as the target instead of 'clean-local'.

But also the commands should have been wrapped in
```
 ifeq ($(CODE_COVERAGE_ENABLED),yes)
 endif
```
like the rest of the code coverage commands. However, use of `ifeq()`
doesn't work in Makefile.am files because of a conflict with Automake's
"endif" keyword.

Avoid this whole disaster and move our clean commands into the
config/ax_code_coverage.m4 so they are expanded cleanly with the
rest of `@CODE_COVERAGE_RULES@`.