### PR TITLE
Walltime extension to JSC

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -158,6 +158,7 @@ function wreck:parse_cmdline (arg)
 
     self.nnodes = tonumber (self.opts.N) or 1
     self.ntasks = tonumber (self.opts.n) or 1
+    self.walltime = tonumber (self.opts.T) or 3600
 
     self.cmdline = {}
     for i = self.optind, #arg do
@@ -171,9 +172,11 @@ function wreck:jobreq ()
     if not self.opts then return nil, "Error: cmdline not parsed" end
     local nnodes = tonumber (self.opts.N)
     local ntasks = tonumber (self.opts.n)
+    local walltime = tonumber (self.opts.T)
     local jobreq = {
         nnodes =  tonumber (self.opts.N) or 1,
         ntasks =  tonumber (self.opts.n) or 1,
+        walltime = tonumber (self.opts.T) or 3600,
         cmdline = self.cmdline,
         environ = get_filtered_env (),
         cwd =     posix.getcwd (),

--- a/src/modules/libjsc/README.md
+++ b/src/modules/libjsc/README.md
@@ -90,6 +90,7 @@ service.
 |------------|------------------|-----------------|---------------|
 | nnodes     | JSC_RDESC\_NNODES | 64-bit integer | Node count    |
 | ntasks     | JSC_RDESC\_NTASKS | 64-bit integer | Process count |
+| walltime   | JSC_RDESC\_WALLTIME | 64-bit integer | Walltime    |
 
 **Table 3-3** Keys and values of *rdesc* attribute
 

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -254,6 +254,19 @@ static int extract_raw_ntasks (flux_t h, int64_t j, int64_t *ntasks)
     return rc;
 }
 
+static int extract_raw_walltime (flux_t h, int64_t j, int64_t *walltime)
+{
+    int rc = 0;
+    char *key = xasprintf ("lwj.%"PRId64".walltime", j);
+    if (kvs_get_int64 (h, key, walltime) < 0) {
+        flux_log (h, LOG_ERR, "extract %s: %s", key, strerror (errno));
+        rc = -1;
+    }
+    else
+        flux_log (h, LOG_ERR, "extract %s: %"PRId64"", key, *walltime);
+    return rc;
+}
+
 static int extract_raw_rdl (flux_t h, int64_t j, char **rdlstr)
 {
     int rc = 0;
@@ -436,14 +449,17 @@ static int query_rdesc (flux_t h, int64_t j, JSON *jcb)
     JSON o = NULL;
     int64_t nnodes = -1;
     int64_t ntasks = -1;
+    int64_t walltime = -1;
     
     if (extract_raw_nnodes (h, j, &nnodes) < 0) return -1;
     if (extract_raw_ntasks (h, j, &ntasks) < 0) return -1;
+    if (extract_raw_walltime (h, j, &walltime) < 0) return -1;
 
     *jcb = Jnew ();
     o = Jnew ();
     Jadd_int64 (o, JSC_RDESC_NNODES, nnodes);
     Jadd_int64 (o, JSC_RDESC_NTASKS, ntasks);
+    Jadd_int64 (o, JSC_RDESC_WALLTIME, walltime);
     json_object_object_add (*jcb, JSC_RDESC, o);
     return 0;
 }
@@ -537,19 +553,26 @@ static int update_rdesc (flux_t h, int64_t j, JSON o)
     int rc = -1;
     int64_t nnodes = 0;
     int64_t ntasks = 0;
+    int64_t walltime = 0;
     char *key1;
     char *key2;
+    char *key3;
 
     if (!Jget_int64 (o, JSC_RDESC_NNODES, &nnodes)) return -1;
     if (!Jget_int64 (o, JSC_RDESC_NTASKS, &ntasks)) return -1;
-    if ((nnodes < 0) || (ntasks < 0)) return -1;
+    if (!Jget_int64 (o, JSC_RDESC_WALLTIME, &walltime)) return -1;
+
+    if ((nnodes < 0) || (ntasks < 0) || (walltime < 0)) return -1;
 
     key1 = xasprintf ("lwj.%"PRId64".nnodes", j);
     key2 = xasprintf ("lwj.%"PRId64".ntasks", j);
+    key3 = xasprintf ("lwj.%"PRId64".walltime", j);
     if (kvs_put_int64 (h, key1, nnodes) < 0) 
         flux_log (h, LOG_ERR, "update %s: %s", key1, strerror (errno));
     else if (kvs_put_int64 (h, key2, ntasks) < 0) 
         flux_log (h, LOG_ERR, "update %s: %s", key2, strerror (errno));
+    else if (kvs_put_int64 (h, key3, walltime) < 0)
+        flux_log (h, LOG_ERR, "update %s: %s", key3, strerror (errno));
     else if (kvs_commit (h) < 0) 
         flux_log (h, LOG_ERR, "commit failed");
     else {

--- a/src/modules/libjsc/jstatctl.h
+++ b/src/modules/libjsc/jstatctl.h
@@ -67,6 +67,7 @@ typedef int (*jsc_handler_f)(const char *base_jcb, void *arg, int errnum);
 #define JSC_RDESC "rdesc"
 # define JSC_RDESC_NNODES "nnodes"
 # define JSC_RDESC_NTASKS "ntasks"
+# define JSC_RDESC_WALLTIME "walltime"
 #define JSC_RDL "rdl"
 #define JSC_RDL_ALLOC "rdl_alloc"
 # define JSC_RDL_ALLOC_CONTAINED "contained"

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -228,7 +228,7 @@ test_expect_success 'jstat 10: update procdescs' "
 "
 
 test_expect_success 'jstat 11: update rdesc' "
-    flux jstat update 1 rdesc '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128}}' &&
+    flux jstat update 1 rdesc '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128, \"walltime\":3600}}' &&
     flux kvs get lwj.1.ntasks > output.11.1 &&
     cat > expected.11.1 <<-EOF &&
 128
@@ -256,9 +256,9 @@ EOF
 
 test_expect_success 'jstat 14: update detects bad inputs' "
     test_expect_code 42 flux jstat update 1 jobid '{\"jobid\": 1}' &&
-    test_expect_code 42 flux jstat update 0 rdesc '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128}}' &&
-    test_expect_code 42 flux jstat update 1 rdesctypo '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128}}' &&
-    test_expect_code 42 flux jstat update 1 rdesc '{\"pdesc\": {\"nnodes\": 128, \"ntasks\": 128}}' &&
+    test_expect_code 42 flux jstat update 0 rdesc '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128, \"walltime\": 3600}}' &&
+    test_expect_code 42 flux jstat update 1 rdesctypo '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128, \"walltime\": 3600}}' &&
+    test_expect_code 42 flux jstat update 1 rdesc '{\"pdesc\": {\"nnodes\": 128, \"ntasks\": 128, \"walltime\": 3600}}' &&
     test_expect_code 42 flux jstat update 1 state-pair '{\"unknown\": {\"ostate\": 12, \"nstate\": 11}}'
 "
 


### PR DESCRIPTION
As suggested by @dongahn, this is a simple extension to JSC with walltime information. JSC_RDESC_WALLTIME has been introduced and is part of all the queries and updates made to JSC_REDSC. 