### PR TITLE
travis-ci: better scheme for coverage testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 compiler:
   - gcc
   - clang
+  - gcc+coverage
 
 cache:
   directories:
@@ -41,8 +42,8 @@ env:
    - secure: "T06LmG6hAwmRculQGfmV06A0f2i9rPoc8itDwyWkmg2CbtCqDyYV93V53jsVknqKA1LA9+Yo7Q3bJnnEAWI7kWAptTcL5ipRycYkl5FqoYawkwRdQW3giZwbs9zRchrwFmZ03N0hRfl31IntXhDmj5EkHOZoduMpkQFFGo0XDC4="
 
 before_install:
-  # Capture the "jobid" of this run (i.e. "1" in Job #4.1)
-  - export JOBID=${TRAVIS_JOB_NUMBER##*.}
+  # If CC has "+coverage" appended then turn on code coverage for this build:
+  - case "$CC" in *+coverage) CC=${CC//+*}; export COVERAGE=t;; esac
 
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
@@ -50,15 +51,15 @@ before_install:
   - ./src/test/travis-dep-builder.sh --cachedir=$HOME/local/.cache
 
   # coveralls-lcov required only for coveralls upload:
-  - if test "$JOBID" = "1" ; then gem install coveralls-lcov; fi
+  - if test "$COVERAGE" = "t" ; then gem install coveralls-lcov; fi
 
 script:
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"
 
- # Enable coverage only on 1 of N builds,
+ # Enable coverage for $CC-coverage build
  # We can't use distcheck here, it doesn't play well with coverage testing:
- - if test "$JOBID" = "1" ; then ARGS="--enable-code-coverage"; MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"; fi
+ - if test "$COVERAGE" = "t" ; then ARGS="--enable-code-coverage"; MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"; fi
 
  - export FLUX_TESTS_LOGFILE=t
  - if test "$COVERITY_SCAN_BRANCH" != "1" ; then ./autogen.sh && ./configure ${ARGS} && eval ${MAKECMDS}; fi
@@ -66,7 +67,7 @@ script:
 after_success:
  - ccache -s
  # Upload results to coveralls.io for first job of N
- - if test "$JOBID" = "1" ; then coveralls-lcov flux*-coverage.info ; fi
+ - if test "$COVERAGE" = "t" ; then coveralls-lcov flux*-coverage.info ; fi
 
 after_failure:
  - find . -name *.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'


### PR DESCRIPTION
Well I didn't realize that `make check-code-coverage` explicitly doesn't fail during `make check`.
Therefore all travis-ci builds right now succeed for `gcc`, since that build by default runs `make check-code-coverage`.

Instead of doing code-coverage testing on one of the main compiler builds, this PR adds another compiler to travis-ci "gcc+coverage", which the build script checks for and enables coverage. This keeps the 2 compiler builds using `make distcheck` and adds a special purpose coverage build that always succeeds, but at least is separate.