### PR TITLE
recursively eval install dirs in config.h

### DIFF
--- a/config/adl_recursive_eval.m4
+++ b/config/adl_recursive_eval.m4
@@ -1,0 +1,19 @@
+dnl
+dnl  Unknown origin, but was presumably part of autoconf-archive at
+dnl   some point in the past.
+dnl
+dnl adl_RECURSIVE_EVAL(VALUE, RESULT)
+dnl =================================
+dnl Interpolate the VALUE in loop until it doesn't change,
+dnl and set the result to $RESULT.
+dnl WARNING: It's easy to get an infinite loop with some unsane input.
+AC_DEFUN([adl_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])

--- a/config/x_ac_expand_install_dirs.m4
+++ b/config/x_ac_expand_install_dirs.m4
@@ -19,72 +19,72 @@ AC_DEFUN([X_AC_EXPAND_INSTALL_DIRS], [
   _x_ac_expand_install_dirs_exec_prefix="$exec_prefix"
   test "$exec_prefix" = NONE && exec_prefix="$prefix"
 
-  eval X_PREFIX="$prefix"
+  adl_RECURSIVE_EVAL(["$prefix"], [X_PREFIX])
   AC_DEFINE_UNQUOTED([X_PREFIX], ["$X_PREFIX"],
     [Expansion of the "prefix" installation directory.])
   AC_SUBST([X_PREFIX])
 
-  eval X_EXEC_PREFIX="$exec_prefix"
+  adl_RECURSIVE_EVAL(["$exec_prefix"], [X_EXEC_PREFIX])
   AC_DEFINE_UNQUOTED([X_EXEC_PREFIX], ["$X_EXEC_PREFIX"],
     [Expansion of the "exec_prefix" installation directory.])
   AC_SUBST([X_EXEC_PREFIX])
 
-  eval X_BINDIR="$bindir"
+  adl_RECURSIVE_EVAL(["$bindir"], [X_BINDIR])
   AC_DEFINE_UNQUOTED([X_BINDIR], ["$X_BINDIR"],
     [Expansion of the "bindir" installation directory.])
   AC_SUBST([X_BINDIR])
 
-  eval X_SBINDIR="$sbindir"
+  adl_RECURSIVE_EVAL(["$sbindir"], [X_SBINDIR])
   AC_DEFINE_UNQUOTED([X_SBINDIR], ["$X_SBINDIR"],
     [Expansion of the "sbindir" installation directory.])
   AC_SUBST([X_SBINDIR])
 
-  eval X_LIBEXECDIR="$libexecdir"
+  adl_RECURSIVE_EVAL(["$libexecdir"], [X_LIBEXECDIR])
   AC_DEFINE_UNQUOTED([X_LIBEXECDIR], ["$X_LIBEXECDIR"],
     [Expansion of the "libexecdir" installation directory.])
   AC_SUBST([X_LIBEXECDIR])
 
-  eval X_DATADIR="$datadir"
+  adl_RECURSIVE_EVAL(["$datadir"], [X_DATADIR])
   AC_DEFINE_UNQUOTED([X_DATADIR], ["$X_DATADIR"],
     [Expansion of the "datadir" installation directory.])
   AC_SUBST([X_DATADIR])
 
-  eval X_SYSCONFDIR="$sysconfdir"
+  adl_RECURSIVE_EVAL(["$sysconfdir"], [X_SYSCONFDIR])
   AC_DEFINE_UNQUOTED([X_SYSCONFDIR], ["$X_SYSCONFDIR"],
     [Expansion of the "sysconfdir" installation directory.])
   AC_SUBST([X_SYSCONFDIR])
 
-  eval X_SHAREDSTATEDIR="$sharedstatedir"
+  adl_RECURSIVE_EVAL(["$sharedstatedir"], [X_SHAREDSTATEDIR])
   AC_DEFINE_UNQUOTED([X_SHAREDSTATEDIR], ["$X_SHAREDSTATEDIR"],
     [Expansion of the "sharedstatedir" installation directory.])
   AC_SUBST([X_SHAREDSTATEDIR])
 
-  eval X_LOCALSTATEDIR="$localstatedir"
+  adl_RECURSIVE_EVAL(["$localstatedir"], [X_LOCALSTATEDIR])
   AC_DEFINE_UNQUOTED([X_LOCALSTATEDIR], ["$X_LOCALSTATEDIR"],
     [Expansion of the "localstatedir" installation directory.])
   AC_SUBST([X_LOCALSTATEDIR])
 
-  eval X_LIBDIR="$libdir"
+  adl_RECURSIVE_EVAL(["$libdir"], [X_LIBDIR])
   AC_DEFINE_UNQUOTED([X_LIBDIR], ["$X_LIBDIR"],
     [Expansion of the "libdir" installation directory.])
   AC_SUBST([X_LIBDIR])
 
-  eval X_INCLUDEDIR="$includedir"
+  adl_RECURSIVE_EVAL(["$includedir"], [X_INCLUDEDIR])
   AC_DEFINE_UNQUOTED([X_INCLUDEDIR], ["$X_INCLUDEDIR"],
     [Expansion of the "includedir" installation directory.])
   AC_SUBST([X_INCLUDEDIR])
 
-  eval X_OLDINCLUDEDIR="$oldincludedir"
+  adl_RECURSIVE_EVAL(["$oldincludedir"], [X_OLDINCLUDEDIR])
   AC_DEFINE_UNQUOTED([X_OLDINCLUDEDIR], ["$X_OLDINCLUDEDIR"],
     [Expansion of the "oldincludedir" installation directory.])
   AC_SUBST([X_OLDINCLUDEDIR])
 
-  eval X_INFODIR="$infodir"
+  adl_RECURSIVE_EVAL(["$infodir"], [X_INFODIR])
   AC_DEFINE_UNQUOTED([X_INFODIR], ["$X_INFODIR"],
     [Expansion of the "infodir" installation directory.])
   AC_SUBST([X_INFODIR])
 
-  eval X_MANDIR="$mandir"
+  adl_RECURSIVE_EVAL(["$mandir"], [X_MANDIR])
   AC_DEFINE_UNQUOTED([X_MANDIR], ["$X_MANDIR"],
     [Expansion of the "mandir" installation directory.])
   AC_SUBST([X_MANDIR])


### PR DESCRIPTION
Fix/workaround for issue #22, recursively eval variables in x_ac_expand_install_dirs.m4 to ensure unexpanded vars like `${prefix}` do not appear in final macros in config.h.