### PR TITLE
add reactor/dispatcher usecount

### DIFF
--- a/t/t0000-sharness.t
+++ b/t/t0000-sharness.t
@@ -275,7 +275,7 @@ test_expect_success 'tests clean up even on failures' "
 	EOF
 "
 
-test_expect_success 'cleanup functions tun at the end of the test' "
+test_expect_success 'cleanup functions run at the end of the test' "
 	run_sub_test_lib_test cleanup-function 'Empty test with cleanup function' <<-\\EOF &&
 	cleanup 'echo cleanup-function-called >&5'
 	test_done


### PR DESCRIPTION
This PR adds a usecount to the reactor to make it less fragile when watchers and reactor are destroyed out of order, as is prone to happen with the way the reactor and dispatcher are attached to the handle aux cache.

It also adds a couple of tests to verify that out of order destruction doesn't segfault.

Without this, flux-sched tests would segfault because the sched module does not destroy its message handlers when unloaded, so the message dispatcher was being destroyed with an active handle watcher _after_ the reactor had already been destroyed.