### PR TITLE
update libtap, fix coproc test under clang

### DIFF
--- a/src/common/libtap/tap.h
+++ b/src/common/libtap/tap.h
@@ -1,7 +1,7 @@
 /*
 libtap - Write tests in C
 Copyright 2012 Jake Gelbman <gelbman@gmail.com>
-This file is licensed under the GPLv2 or any later version
+This file is licensed under the LGPL
 */
 
 #ifndef __TAP_H__
@@ -38,7 +38,6 @@ int     cmp_mem_at_loc  (const char *file, int line, const void *got,
 int     bail_out        (int ignore, const char *fmt, ...);
 void    tap_plan        (int tests, const char *fmt, ...);
 int     diag            (const char *fmt, ...);
-int     note            (const char *fmt, ...);
 int     exit_status     (void);
 void    tap_skip        (int n, const char *fmt, ...);
 void    tap_todo        (int ignore, const char *fmt, ...);
@@ -114,4 +113,3 @@ int tap_test_died (int status);
 #endif
 
 #endif
-

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -100,6 +100,7 @@ test_ev_t_LDADD = $(test_ldadd)
 
 test_coproc_t_SOURCES = test/coproc.c
 test_coproc_t_CPPFLAGS = $(test_cppflags)
+test_coproc_t_CFLAGS = $(AM_CFLAGS) -fno-builtin
 test_coproc_t_LDADD = $(test_ldadd)
 
 test_base64_t_SOURCES = test/base64_test.c

--- a/src/common/libutil/test/encode.c
+++ b/src/common/libutil/test/encode.c
@@ -17,7 +17,7 @@ static int test_encode ()
     json_object *o = json_object_new_object ();
 
     util_json_object_add_data (o, "data", (uint8_t *) p, strlen (p)+1);
-    note ("%s", json_object_to_json_string (o));
+    diag ("%s", json_object_to_json_string (o));
     util_json_object_get_data (o, "data", (uint8_t **) &r, &rlen);
 
     ok (strcmp (p, r) == 0, "'%s'='%s'", p, r);

--- a/src/modules/libsubprocess/test/loop.c
+++ b/src/modules/libsubprocess/test/loop.c
@@ -51,7 +51,7 @@ static int io_cb (struct subprocess *p, const char *json_str)
 {
     ok (p != NULL, "io_cb: valid subprocess");
     ok (json_str != NULL, "io_cb: valid output");
-    note ("%s", json_str);
+    diag ("%s", json_str);
     return (0);
 }
 
@@ -77,7 +77,7 @@ static int signal_cb (zloop_t *zl, zmq_pollitem_t *item, void *arg)
     if (read (item->fd, &fdsi, sizeof (fdsi)) < 0)
         return (-1);
 
-    note ("signal_cb signo = %d", fdsi.ssi_signo);
+    diag ("signal_cb signo = %d", fdsi.ssi_signo);
     if (fdsi.ssi_signo == SIGTERM)
         return (-1);
 

--- a/src/modules/libsubprocess/test/subprocess.c
+++ b/src/modules/libsubprocess/test/subprocess.c
@@ -59,7 +59,7 @@ int main (int ac, char **av)
         BAIL_OUT ("Failed to create subprocess manager");
     ok (sm != NULL, "create subprocess manager");
 
-    note ("subprocess accessors tests");
+    diag ("subprocess accessors tests");
     if (!(p = subprocess_create (sm)))
         BAIL_OUT ("Failed to create subprocess handle");
     ok (p != NULL, "create subprocess handle");
@@ -114,7 +114,7 @@ int main (int ac, char **av)
     subprocess_destroy (p);
 
     /* Test running an executable */
-    note ("test subprocess_manager_run");
+    diag ("test subprocess_manager_run");
     p = subprocess_manager_run (sm, 1, args3, NULL);
     ok (p != NULL, "subprocess_manager_run");
     ok (subprocess_pid (p) != (pid_t) -1, "process has valid pid");
@@ -129,7 +129,7 @@ int main (int ac, char **av)
     q = NULL;
 
     /*  Test failing program */
-    note ("test expected failure from subprocess_manager_run");
+    diag ("test expected failure from subprocess_manager_run");
     args3[0] = "/bin/false";
     p = subprocess_manager_run (sm, 1, args3, NULL);
     if (p) {
@@ -145,7 +145,7 @@ int main (int ac, char **av)
         q = NULL;
     }
 
-    note ("Test signaled program");
+    diag ("Test signaled program");
 
     /* Test signaled program */
     p = subprocess_manager_run (sm, 2, args4, NULL);
@@ -167,7 +167,7 @@ int main (int ac, char **av)
 
     q = NULL;
 
-    note ("Test fork/exec interface");
+    diag ("Test fork/exec interface");
     /* Test separate fork/exec interface */
     p = subprocess_create (sm);
     ok (p != NULL, "subprocess_create works");
@@ -195,7 +195,7 @@ int main (int ac, char **av)
     subprocess_destroy (p);
     q = NULL;
 
-    note ("Test exec failure");
+    diag ("Test exec failure");
     /* Test exec failure */
     p = subprocess_create (sm);
     ok (p != NULL, "subprocess create");
@@ -210,7 +210,7 @@ int main (int ac, char **av)
     is (subprocess_exit_string (p), "Exec Failure", "Exit state is Exec Failed");
     subprocess_destroy (p);
 
-    note ("Test set working directory");
+    diag ("Test set working directory");
     /* Test set working directory */
     p = subprocess_create (sm);
     ok (p != NULL, "subprocess create");
@@ -229,7 +229,7 @@ int main (int ac, char **av)
     ok (subprocess_exit_code (p) == 0, "subprocess successfully run in /tmp");
     subprocess_destroy (p);
 
-    note ("Test subprocess_reap interface");
+    diag ("Test subprocess_reap interface");
     /* Test subprocess_reap */
     p = subprocess_create (sm);
     q = subprocess_create (sm);
@@ -252,7 +252,7 @@ int main (int ac, char **av)
     subprocess_destroy (p);
     subprocess_destroy (q);
 
-    note ("Test subprocess I/O");
+    diag ("Test subprocess I/O");
     /* Test subprocess output */
     p = subprocess_create (sm);
     ok (p != NULL, "subprocess_create");
@@ -282,7 +282,7 @@ int main (int ac, char **av)
 
 
     /* Test subprocess input */
-    note ("test subprocess stdin");
+    diag ("test subprocess stdin");
     p = subprocess_create (sm);
     ok (p != NULL, "subprocess_create");
     ok (subprocess_argv_append (p, "/bin/cat") >= 0,  "subprocess_argv_append");


### PR DESCRIPTION
This PR fixes the uncaught coproc test failure we were seeing on clang.  There were several problems:
* clang built-in `alloca()` was subverting test case's abuse of it, so compile test with `-fno-builtin`
* test was emitting an extra ok result on failure (fixed)
* libtap exit codes were based on number of failed tests; update libtap

Then due to the libtap update, several tests that used the `note()` function had to be updated to use `diag()`.