### PR TITLE
refactor integer array code in env.c and add test coverage

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -57,7 +57,9 @@ libutil_la_SOURCES = \
 	vec.h \
 	usa.c \
 	usa.h \
-	iterators.h
+	iterators.h \
+	intarray.h \
+	intarray.c
 
 EXTRA_DIST = veb_mach.c
 
@@ -67,7 +69,8 @@ TESTS = test_nodeset.t \
 	test_coproc.t \
 	test_base64.t \
 	test_encode.t \
-	test_msglist.t
+	test_msglist.t \
+	test_intarray.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -114,3 +117,7 @@ test_encode_t_LDADD = $(test_ldadd)
 test_msglist_t_SOURCES = test/msglist.c
 test_msglist_t_CPPFLAGS = $(test_cppflags)
 test_msglist_t_LDADD = $(test_ldadd)
+
+test_intarray_t_SOURCES = test/intarray.c
+test_intarray_t_CPPFLAGS = $(test_cppflags)
+test_intarray_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/env.c
+++ b/src/common/libutil/env.c
@@ -29,6 +29,7 @@
 
 #include "env.h"
 #include "xzmalloc.h"
+#include "intarray.h"
 
 int env_getint (char *name, int dflt)
 {
@@ -50,45 +51,6 @@ char *env_getstr (char *name, char *dflt)
     return ev ? xstrdup (ev) : xstrdup (dflt);
 }
 
-static int _strtoia (char *s, int *ia, int ia_len)
-{
-    char *next;
-    int n, len = 0;
-
-    if (!s)
-        return -1;
-
-    while (*s) {
-        n = strtol (s, &next, 0);
-        s = *next == '\0' ? next : next + 1;
-        if (ia) {
-            if (ia_len == len)
-                break;
-            ia[len] = n;
-        }
-        len++;
-    }
-    return len;
-}
-
-static int getints (char *s, int **iap, int *lenp)
-{
-    int *ia;
-    int len = _strtoia (s, NULL, 0);
-
-    if ((len < 0) || !(ia = malloc (len * sizeof (int))))
-        return -1;
-
-    (void)_strtoia (s, ia, len);
-    if (lenp)
-        *lenp = len;
-    if (iap)
-        *iap = ia;
-    else
-        free (ia);
-    return 0;
-}
-
 int env_getints (char *name, int **iap, int *lenp, int dflt_ia[], int dflt_len)
 {
     char *s = getenv (name);
@@ -96,7 +58,7 @@ int env_getints (char *name, int **iap, int *lenp, int dflt_ia[], int dflt_len)
     int len;
 
     if (s) {
-        if (getints (s, &ia, &len) < 0)
+        if (intarray_create (s, &ia, &len) < 0)
             return -1;
     } else {
         ia = malloc (dflt_len * sizeof (int));

--- a/src/common/libutil/intarray.c
+++ b/src/common/libutil/intarray.c
@@ -1,0 +1,96 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/param.h>
+
+#include "intarray.h"
+
+static int count_delimiters (const char *s, char delimiter)
+{
+    char *p = (char *)s;
+    int count = 0;
+
+    while ((p = strchr (p, delimiter))) {
+        count++;
+        p++;
+    }
+    return count;
+}
+
+static int nextint (char **s, char delimiter, int *val)
+{
+    char *endptr;
+    int i;
+
+    i = strtol (*s, &endptr, 0);
+    if (i > INT_MAX || i < INT_MIN) {
+        errno = ERANGE;
+        return -1;
+    }
+    if (endptr == *s) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (*endptr == delimiter)
+        *s = endptr + 1;
+    else if (*endptr == '\0')
+        *s = endptr;
+    else {
+        errno = EINVAL;
+        return -1;
+    }
+    *val = i;
+    return 0;
+}
+
+int intarray_create (const char *s, int **ia, int *ia_count)
+{
+    char *p = (char *)s;
+    int i, count, *a;
+
+    count = count_delimiters (s, ',') + 1;
+    if (!(a = malloc (sizeof (a[0]) * count))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    for (i = 0; i < count; i++) {
+        if (nextint (&p, ',', &a[i]) < 0) {
+            free (a);
+            return -1;
+        }
+    }
+    *ia = a;
+    *ia_count = count;
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/intarray.h
+++ b/src/common/libutil/intarray.h
@@ -1,0 +1,14 @@
+#ifndef _UTIL_INTARRAY_H
+#define _UTIL_INTARRAY_H
+
+/* Parse the string 's' into an array of integers, setting 'ia'
+ * to a malloc()ed array and 'ia_count' to its length.
+ * The string should contain integers delimited by commas.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int intarray_create (const char *s, int **ia, int *ia_count);
+
+#endif /* !_UTIL_INTARRAY_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/intarray.c
+++ b/src/common/libutil/test/intarray.c
@@ -1,0 +1,54 @@
+#include <errno.h>
+
+#include "src/common/libutil/intarray.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char **argv)
+{
+    int *ia;
+    int len;
+
+    plan (8);
+
+    ok (intarray_create ("1,2,3", &ia, &len) == 0
+        && len == 3 && ia != NULL && ia[0] == 1 && ia[1] == 2 && ia[2] == 3,
+        "intarray_create 1,2,3 works");
+    free (ia);
+
+    ok (intarray_create ("1", &ia, &len) == 0
+        && len == 1 && ia != NULL && ia[0] == 1,
+        "intarray_create 1 works");
+    free (ia);
+
+    ok (intarray_create ("-1,1", &ia, &len) == 0
+        && len == 2 && ia != NULL && ia[0] == -1 && ia[1] == 1,
+        "intarray_create -1,1 works");
+    free (ia);
+
+    errno = 0;
+    ok (intarray_create ("foo", &ia, &len) == -1 && errno == EINVAL,
+        "intarray_create foo fails with EINVAL");
+
+    errno = 0;
+    ok (intarray_create ("", &ia, &len) == -1 && errno == EINVAL,
+        "intarray_create empty string fails with EINVAL");
+
+    errno = 0;
+    ok (intarray_create ("1,,2", &ia, &len) == -1 && errno == EINVAL,
+        "intarray_create 1,,2 fails with EINVAL");
+
+    errno = 0;
+    ok (intarray_create (",", &ia, &len) == -1 && errno == EINVAL,
+        "intarray_create , fails with EINVAL");
+
+    errno = 0;
+    ok (intarray_create ("3.14", &ia, &len) == -1 && errno == EINVAL,
+        "intarray_create 3.14 fails with EINVAL");
+
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
I wrote this a while back when @trws proposed 0d8521af44234ae3e2e484993052d53096b1c4bc to fix to `libutil/env.c::env_getints()` and I noted the implementation was sloppy and had no test coverage.  However I shelved the rewrite and test thinking I was going to be able to get rid of the whole thing when reworking PMI.  That hasn't happened yet so may as well get this in.