### PR TITLE
wreck max walltime support

### DIFF
--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -66,7 +66,8 @@ wrexecd_LDADD = \
 
 dist_wreckscripts_SCRIPTS = \
 	lua.d/01-env.lua \
-	lua.d/02-affinity.lua
+	lua.d/02-affinity.lua \
+	lua.d/timeout.lua
 
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/lua.d/timeout.lua
+++ b/src/modules/wreck/lua.d/timeout.lua
@@ -1,0 +1,61 @@
+--
+-- Register timer on nodeid 0 if kvs `walltime` is set for this job.
+--  Kill job on timeout if reached.
+--
+local posix = require 'posix'
+
+local function signal_to_number (s)
+    if not s then return nil end
+    local ret = tonumber (s)
+    if ret then return ret end
+    return posix [s]
+end
+
+local function timeout_signal (f, wreck)
+    --  If 'lwj.<id>.walltime-signal' set then return this signal number,
+    --   otherwise if 'lwj.walltime-signal' set use this number,
+    --   otherwise return default signal 'SIGALRM'
+    --
+    local s = signal_to_number (wreck.kvsdir ['walltime-signal'])
+    if s then return s end
+    local s = signal_to_number (f:kvsdir() ["lwj.walltime-signal"])
+    if s then return s end
+    return posix.SIGALRM
+end
+
+local function start_timer (f, wreck, id, walltime)
+   local to, err = f:timer {
+        timeout = walltime*1000,
+        oneshot = true,
+        handler = function (f, to)
+          local signum = timeout_signal (f, wreck)
+          wreck:log_msg ("Timeout expired! Killing job with signal %d", signum)
+          local rc,err = f:sendevent ({signal = signum}, "wreck.%d.kill", id)
+          if not rc then
+              wreck:log_msg ("Failed to send kill event: %s", err)
+          end
+        end
+    }
+end
+
+function rexecd_init ()
+    if wreck.nodeid ~= 0 then return end
+
+    local walltime = tonumber (wreck.kvsdir.walltime)
+    if not walltime or walltime <= 0 then return end
+
+    local id = wreck.id
+    local f = wreck.flux
+    -- start timer when state is running
+    local k, err = f:kvswatcher {
+        key = "lwj."..id..".state",
+        handler = function (k, result)
+            if result == "running" then
+                 wreck:log_msg ("detected job state = running, starting timer for %ds", walltime)
+                 k:remove()
+                 start_timer (f, wreck, id, walltime)
+            end
+        end
+    }
+end
+

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1589,13 +1589,14 @@ void ev_cb (flux_t f, flux_msg_handler_t *mw,
 
     base = strlen (ctx->topic);
     if (strcmp (topic+base, "kill") == 0) {
-        int sig = json_object_get_int (o);
-        if (sig == 0)
-            sig = 9;
+        json_object *ox;
+        int sig = 9;
+        if (json_object_object_get_ex (o, "signal", &ox))
+            sig = json_object_get_int (ox);
         log_msg (ctx, "Killing jobid %lu with signal %d", ctx->id, sig);
         prog_ctx_signal (ctx, sig);
     }
-
+    json_object_put (o);
 }
 
 int task_info_io_setup (struct task_info *t)

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -22,7 +22,17 @@ test_expect_success 'wreckrun: works' '
 	for i in $(seq 1 ${SIZE}); do echo $hostname; done >expected &&
 	test_cmp expected output
 '
-
+test_expect_success 'wreckrun: -T, --walltime works' '
+	test_expect_code 142 flux wreckrun --walltime=1s -n${SIZE} sleep 15
+'
+test_expect_success 'wreckrun: -T, --walltime allows override of default signal' '
+        flux kvs put lwj.walltime-signal=SIGTERM &&
+        test_when_finished flux kvs put lwj.walltime-signal= &&
+	test_expect_code 143 flux wreckrun -T 1s -n${SIZE} sleep 5
+'
+test_expect_success 'wreckrun: -T, --walltime allows per-job override of default signal' '
+	test_expect_code 130 flux wreckrun -P "lwj[\"walltime-signal\"]=\"SIGINT\"" -T 1s -n${SIZE} sleep 15
+'
 test_expect_success 'wreckrun: propagates current working directory' '
 	mkdir -p testdir &&
 	mypwd=$(pwd)/testdir &&

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -78,8 +78,7 @@ test_expect_success 'wreck: signaling wreckrun works' '
 	kill -INT $q &&
 	test_expect_code 137 wait $q
 '
-flux kvs dir -r resource >/dev/null 2>&1 && test_set_prereq RES_HWLOC
-test_expect_success RES_HWLOC 'wreckrun: oversubscription of tasks' '
+test_expect_success 'wreckrun: oversubscription of tasks' '
 	run_timeout 15 flux wreckrun -v -n$(($(nproc)*${SIZE}+1)) /bin/true
 '
 test_expect_success 'wreckrun: uneven distribution with -n, -N' '


### PR DESCRIPTION
This PR adds advisory timeout support to wreck jobs in the form of a new `timeout.lua` script under `lua.d`. If `lwj.<id>.walltime` exists the plugin starts a timer after the job reaches the `running` state. When the timer fires the job is killed with `SIGALRM`.

Additionally a `-T, --walltime` option is added to `wreck.lua` which takes walltime option in `NUMBER[SUFFIX]` form where `NUMBER` can be arbitrary floating point number and optional suffix is "s" for seconds (default), "m" for minutes, "h" for hours, or "d" for days (like GNU `sleep(1)`).

A default of `0` is used to indicate no timeout.

@surajpkn: Can you rebase #409 on top of this PR, and make any comments?

Example:
```
grondo@flux-core:~/workspace (wreck-timeout) $ flux wreckrun -N4 --walltime=.5m sleep 60
[1443326159.790466] job.info[0]: got request job.create
[1443326159.791379] job.info[0]: Setting job 2 to reserved
[1443326160.113298] lwj.2.info[1]: lwj 2: node1: nprocs=1, nnodes=4, cmdline=[ "sleep", "60" ]
[1443326160.144830] lwj.2.info[0]: lwj 2: node0: nprocs=1, nnodes=4, cmdline=[ "sleep", "60" ]
[1443326160.158572] lwj.2.info[3]: lwj 2: node3: nprocs=1, nnodes=4, cmdline=[ "sleep", "60" ]
[1443326160.322712] lwj.2.info[2]: lwj 2: node2: nprocs=1, nnodes=4, cmdline=[ "sleep", "60" ]
[1443326160.477934] lwj.2.info[0]: detected job state = running, starting timer for 30s
[1443326190.501886] lwj.2.info[0]: Timeout expired! Killing job
[1443326190.502335] lwj.2.info[0]: Killing jobid 2 with signal 14
[1443326190.502503] lwj.2.info[3]: Killing jobid 2 with signal 14
[1443326190.502735] lwj.2.info[1]: Killing jobid 2 with signal 14
[1443326190.503852] lwj.2.info[2]: Killing jobid 2 with signal 14
[1443326190.508051] lwj.2.info[2]: job complete. exiting...
[1443326190.510384] lwj.2.info[0]: job complete. exiting...
[1443326190.508217] lwj.2.info[3]: job complete. exiting...
[1443326190.514647] lwj.2.info[1]: job complete. exiting...
wreckrun: tasks [0-3]: exited with signal 14
[1443326190.556522] job.info[0]: got request job.disconnect
```