### PR TITLE
add reference counts to objects

### DIFF
--- a/doc/man3/flux_rpc_then.adoc
+++ b/doc/man3/flux_rpc_then.adoc
@@ -35,9 +35,9 @@ the broker handle's reactor.  The continuation will be called when the
 RPC response is received.  It should call `flux_rpc_get(3)` to obtain the
 RPC result.
 
-When the RPC is complete, the continuation is stopped as
-far as the reactor is concerned.  It is not safe to destroy the
-flux_rpc_t object from within the continuation callback.
+When the RPC is complete, the continuation stops its message handler
+for responses.  The flux_rpc_t should be destroyed.  It is safe to
+call `flux_rpc_destroy(3)` from within the continuation callback.
 
 
 RETURN VALUE

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -13,6 +13,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
         msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
     Jput (o);
+    flux_rpc_destroy (rpc);
 }
 
 int main (int argc, char **argv)
@@ -33,7 +34,6 @@ int main (int argc, char **argv)
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
         err_exit ("flux_reactor_run");
 
-    flux_rpc_destroy (rpc);
     flux_close (h);
     Jput (o);
     return (0);

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -59,6 +59,10 @@ enum {
 flux_t flux_open (const char *uri, int flags);
 void flux_close (flux_t h);
 
+/* Increment internal reference count on 'h'.
+ */
+void flux_incref (flux_t h);
+
 /* Get/set handle options.  Options are interpreted by connectors.
  * Returns 0 on success, or -1 on failure with errno set (e.g. EINVAL).
  */

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -27,6 +27,7 @@ typedef int (*kvs_set_boolean_f)(const char *key, bool val, void *arg,
 /* Destroy a kvsdir object returned from kvs_get_dir() or kvsdir_get_dir()
  */
 void kvsdir_destroy (kvsdir_t *dir);
+void kvsdir_incref (kvsdir_t *dir);
 
 /* The basic get and put operations, with convenience functions
  * for simple types.  You will get an error if you call kvs_get()


### PR DESCRIPTION
This PR adds an internal reference count to flux_rpc_t so that a flux_rpc_t object can be destroyed from within a continuation callback.  It was a nuisance that this didn't work before.

Add use reference counts to flux_t handles and flux_kvsdir_t objects, initially for use by the lua bindings as discussed in #424.