### PR TITLE
bindings/lua: take reference counts on external handle and kvsdir objects

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -164,6 +164,7 @@ int lua_push_flux_handle (lua_State *L, flux_t f)
         lua_pop (L, 1);
     }
 
+    lua_settop (L, top); /* Reset stack */
     /*
      *  Otherwise create a new Lua object:
      *

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -137,7 +137,7 @@ static int l_get_flux_reftable (lua_State *L, flux_t f)
  *   a reference to the existing object. Otherwise, create the reftable
  *   and return the new object.
  */
-int lua_push_flux_handle (lua_State *L, flux_t f)
+static int lua_push_flux_handle (lua_State *L, flux_t f)
 {
     flux_t *fp;
     int top = lua_gettop (L);
@@ -201,6 +201,17 @@ int lua_push_flux_handle (lua_State *L, flux_t f)
 
     /* Return userdata as flux object */
     return (1);
+}
+
+int lua_push_flux_handle_external (lua_State *L, flux_t f)
+{
+    /*
+     *  Increase reference count on this flux handle since we are
+     *   pushing a handle opened external into Lua. We will rely on
+     *   lua gc to decref via flux_close().
+     */
+    flux_incref (f);
+    return (lua_push_flux_handle (L, f));
 }
 
 static void l_flux_reftable_unref (lua_State *L, flux_t f)

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -263,7 +263,7 @@ static int l_flux_kvsdir_new (lua_State *L)
 
     if (kvs_get_dir (f, &dir, path) < 0)
         return lua_pusherror (L, strerror (errno));
-    return l_push_kvsdir (L, dir);
+    return lua_push_kvsdir (L, dir);
 }
 
 #if 0

--- a/src/bindings/lua/flux-lua.h
+++ b/src/bindings/lua/flux-lua.h
@@ -3,6 +3,12 @@
 
 #include <flux/core.h>
 
-int lua_push_flux_handle (lua_State *L, flux_t f);
+/*
+ *  Push a flux_t object onto Lua stack for state [L]. Increases the
+ *   refcount for [f] since the flux_t object was created outside of
+ *   Lua.
+ */
+int lua_push_flux_handle_external (lua_State *L, flux_t f);
+
 int luaopen_flux (lua_State *L);
 #endif /* !HAVE_FLUX_LUA_H */

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -61,7 +61,7 @@ static int l_kvsdir_destroy (lua_State *L)
     return (0);
 }
 
-int l_push_kvsdir (lua_State *L, kvsdir_t *dir)
+int lua_push_kvsdir (lua_State *L, kvsdir_t *dir)
 {
     kvsdir_t **new;
     if (dir == NULL)
@@ -69,6 +69,16 @@ int l_push_kvsdir (lua_State *L, kvsdir_t *dir)
     new = lua_newuserdata (L, sizeof (*new));
     *new = dir;
     return l_kvsdir_instantiate (L);
+}
+
+int lua_push_kvsdir_external (lua_State *L, kvsdir_t *dir)
+{
+    /*
+     *  This kvsdir object has been created external to Lua, so take
+     *   an extra reference so we don't destroy at garbage collection.
+     */
+    kvsdir_incref (dir);
+    return lua_push_kvsdir (L, dir);
 }
 
 static int l_kvsdir_kvsdir_new (lua_State *L)
@@ -83,7 +93,7 @@ static int l_kvsdir_kvsdir_new (lua_State *L)
     if (kvsdir_get_dir (d, &new, key) < 0)
         return lua_pusherror (L, "kvsdir_get_dir: %s", strerror (errno));
 
-    return l_push_kvsdir (L, new);
+    return lua_push_kvsdir (L, new);
 }
 
 static int l_kvsdir_tostring (lua_State *L)

--- a/src/bindings/lua/kvs-lua.h
+++ b/src/bindings/lua/kvs-lua.h
@@ -5,7 +5,18 @@
 #include <lauxlib.h>
 
 int luaopen_kvs (lua_State *L);
-int l_push_kvsdir (lua_State *L, kvsdir_t *dir);
+
+/*
+ *  Push kvsdir object onto Lua stack, no external reference taken.
+ */
+int lua_push_kvsdir (lua_State *L, kvsdir_t *dir);
+
+/*
+ *  Push kvsdir object onto Lua stack and increase reference count.
+ *   This is used for pushing kvsdir_t objects whicha are created and
+ *   destroyed outside of Lua into a Lua stack.
+ */
+int lua_push_kvsdir_external (lua_State *L, kvsdir_t *dir);
 
 #endif /* !HAVE_KVS_LUA_H */
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1295,7 +1295,7 @@ static int l_wreck_index (lua_State *L)
         return (1);
     }
     if (strcmp (key, "flux") == 0) {
-        lua_push_flux_handle (L, prog_ctx_flux_handle (ctx));
+        lua_push_flux_handle_external (L, prog_ctx_flux_handle (ctx));
         return (1);
     }
     if (strcmp (key, "nodeid") == 0) {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1278,11 +1278,11 @@ static int l_wreck_index (lua_State *L)
         return (1);
     }
     if (strcmp (key, "kvsdir") == 0) {
-        l_push_kvsdir (L, ctx->kvs);
+        lua_push_kvsdir_external (L, ctx->kvs);
         return (1);
     }
     if (strcmp (key, "by_rank") == 0) {
-        l_push_kvsdir (L, ctx->resources);
+        lua_push_kvsdir_external (L, ctx->resources);
         return (1);
     }
     if (strcmp (key, "by_task") == 0) {
@@ -1291,7 +1291,7 @@ static int l_wreck_index (lua_State *L)
             return lua_pusherror (L, "Not in task context");
         if (!(d = prog_ctx_kvsdir (ctx)))
             return lua_pusherror (L, strerror (errno));
-        l_push_kvsdir (L, d);
+        lua_push_kvsdir_external (L, d);
         return (1);
     }
     if (strcmp (key, "flux") == 0) {


### PR DESCRIPTION
This is a proposed fix for #426.

Lua doesn't own `flux_t` handles or `kvsdir_t` objects "pushed" into Lua state from C context, but the metatables for these objects still had a `__gc` field causing normal garbage collection to possibly trigger early destruction and assertion failures or other crashes.

Use newly created `incref` primitives to increase reference count of these objects if they're passed in externally to Lua, thus avoiding premature destruction from Lua and/or C.

For a sanity check, I'd like to verify that `make check` passes for @garlick on toss desktop and @dongahn's sched tests pass before merging this one in.
I've verified the reproducer I had is now fixed.