### PR TITLE
abstract wreckrun io and status code, add flux-wreck(1) command and file output

### DIFF
--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -12,6 +12,7 @@ MAN1_FILES_PRIMARY = \
 	flux-snoop.1 \
 	flux-ping.1 \
 	flux-wreckrun.1 \
+	flux-wreck.1 \
 	flux-start.1 \
 	flux-config.1 \
 	flux-module.1 \

--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -1,0 +1,58 @@
+FLUX-WRECK(1)
+===========
+:doctype: manpage
+
+
+NAME
+----
+flux-wreck - Flux wreck facility convenience utility
+
+
+SYNOPSIS
+--------
+*flux* *wreck* 'COMMAND' ['OPTIONS']
+
+
+DESCRIPTION
+-----------
+'flux wreck' is a convenience utility that operates on jobs in the
+WRECK remote execution prototype. It can be used to gather information
+about running and completed jobs directly from the Flux kvs.
+
+flux-wreck(1) operates via a series of 'COMMANDS', described below:
+
+COMMANDS
+--------
+*help* 'cmd'
+Print help. If 'cmd' is provided, print help for that sub-command.
+
+*ls*
+Display a list of wreck jobs currently in kvs, along with their current
+states.
+
+*attach* [--status] 'jobid'::
+Attach to output of a running or completed job. With '--status', also
+report job status after dumping output.
+
+*status* 'jobid'::
+Return the status of running or completed job 'jobid'. Prints the current
+job status, and if exited, the exit codes of all tasks. This command will
+exit with the highest exit code of all tasks.
+
+*kill* [--signal=N] 'jobid'::
+Send SIGTERM to running job 'jobid'. If '--signal' is used, send signal 'N'
+where 'N' may  be a signal number or name such as 'SIGKILL'.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -12,7 +12,9 @@ dist_fluxlua_SCRIPTS = \
 	flux/timer.lua \
 	flux/alt_getopt.lua \
 	flux/posix.lua \
-	flux/base64.lua
+	flux/base64.lua \
+	flux/lustache.lua \
+	flux/lustache
 
 luaexec_LTLIBRARIES = \
 	flux.la

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -14,7 +14,8 @@ dist_fluxlua_SCRIPTS = \
 	flux/posix.lua \
 	flux/base64.lua \
 	flux/lustache.lua \
-	flux/lustache
+	flux/lustache \
+	wreck/io.lua
 
 luaexec_LTLIBRARIES = \
 	flux.la

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1661,7 +1661,19 @@ static int l_signal_handler_newindex (lua_State *L)
 
 static int l_flux_reactor_start (lua_State *L)
 {
-    return l_pushresult (L, flux_reactor_start (lua_get_flux (L, 1)));
+    int rc;
+    const char *arg;
+    int mode = 0;
+    if ((lua_gettop (L) > 1) && (arg = lua_tostring (L, 2))) {
+        if (strcmp (arg, "once") == 0)
+            mode = FLUX_REACTOR_ONCE;
+        else if (strcmp (arg, "nowait") == 0)
+            mode = FLUX_REACTOR_NOWAIT;
+        else
+            return lua_pusherror (L, "flux_reactor: Invalid argument");
+    }
+    rc = flux_reactor_run (flux_get_reactor (lua_get_flux (L, 1)), mode);
+    return (l_pushresult (L, rc));
 }
 
 static int l_flux_reactor_stop (lua_State *L)

--- a/src/bindings/lua/flux/lustache.lua
+++ b/src/bindings/lua/flux/lustache.lua
@@ -1,0 +1,27 @@
+-- lustache: Lua mustache template parsing.
+-- Copyright 2013 Olivine Labs, LLC <projects@olivinelabs.com>
+-- MIT Licensed.
+
+local string_gmatch = string.gmatch
+
+function string.split(str, sep)
+  local out = {}
+  for m in string_gmatch(str, "[^"..sep.."]+") do out[#out+1] = m end
+  return out
+end
+
+local lustache = {
+  name     = "lustache",
+  version  = "1.3-1",
+  renderer = require("flux.lustache.renderer"):new(),
+}
+
+return setmetatable(lustache, {
+  __index = function(self, idx)
+    if self.renderer[idx] then return self.renderer[idx] end
+  end,
+  __newindex = function(self, idx, val)
+    if idx == "partials" then self.renderer.partials = val end
+    if idx == "tags" then self.renderer.tags = val end
+  end
+})

--- a/src/bindings/lua/flux/lustache/context.lua
+++ b/src/bindings/lua/flux/lustache/context.lua
@@ -1,0 +1,66 @@
+local string_find, string_split, tostring, type =
+      string.find, string.split, tostring, type
+
+local context = {}
+
+function context:clear_cache()
+  self.cache = {}
+end
+
+function context:push(view)
+  return self:new(view, self)
+end
+
+function context:lookup(name)
+  local value = self.cache[name]
+
+  if not value then
+    if name == "." then
+      value = self.view
+    else
+      local context = self
+
+      while context do
+        if string_find(name, ".") > 0 then
+          local names = string_split(name, ".")
+          local i = 0
+
+          value = context.view
+
+          if(type(value)) == "number" then
+            value = tostring(value)
+          end
+
+          while value and i < #names do
+            i = i + 1
+            value = value[names[i]]
+          end
+        else
+          value = context.view[name]
+        end
+
+        if value then
+          break
+        end
+
+        context = context.parent
+      end
+    end
+
+    self.cache[name] = value
+  end
+
+  return value
+end
+
+function context:new(view, parent)
+  local out = {
+    view   = view,
+    parent = parent,
+    cache  = {},
+    magic  = "1235123123", --ohgodwhy
+  }
+  return setmetatable(out, { __index = self })
+end
+
+return context

--- a/src/bindings/lua/flux/lustache/renderer.lua
+++ b/src/bindings/lua/flux/lustache/renderer.lua
@@ -1,0 +1,374 @@
+local Scanner  = require "flux.lustache.scanner"
+local Context  = require "flux.lustache.context"
+
+local error, ipairs, loadstring, pairs, setmetatable, tostring, type = 
+      error, ipairs, loadstring, pairs, setmetatable, tostring, type 
+local math_floor, math_max, string_find, string_gsub, string_split, string_sub, table_concat, table_insert, table_remove =
+      math.floor, math.max, string.find, string.gsub, string.split, string.sub, table.concat, table.insert, table.remove
+
+local patterns = {
+  white = "%s*",
+  space = "%s+",
+  nonSpace = "%S",
+  eq = "%s*=",
+  curly = "%s*}",
+  tag = "[#\\^/>{&=!]"
+}
+
+local html_escape_characters = {
+  ["&"] = "&amp;",
+  ["<"] = "&lt;",
+  [">"] = "&gt;",
+  ['"'] = "&quot;",
+  ["'"] = "&#39;",
+  ["/"] = "&#x2F;"
+}
+
+local function is_array(array)
+  if type(array) ~= "table" then return false end
+  local max, n = 0, 0
+  for k, _ in pairs(array) do
+    if not (type(k) == "number" and k > 0 and math_floor(k) == k) then
+      return false 
+    end
+    max = math_max(max, k)
+    n = n + 1
+  end
+  return n == max
+end
+
+-- Low-level function that compiles the given `tokens` into a
+-- function that accepts two arguments: a Context and a
+-- Renderer.
+
+local function compile_tokens(tokens, originalTemplate)
+  local subs = {}
+
+  local function subrender(i, tokens)
+    if not subs[i] then
+      local fn = compile_tokens(tokens, originalTemplate)
+      subs[i] = function(ctx, rnd) return fn(ctx, rnd) end
+    end
+    return subs[i]
+  end
+
+  local function render(ctx, rnd)
+    local buf = {}
+    local token, section
+    for i, token in ipairs(tokens) do
+      local t = token.type
+      buf[#buf+1] = 
+        t == "#" and rnd:_section(
+          token, ctx, subrender(i, token.tokens), originalTemplate
+        ) or
+        t == "^" and rnd:_inverted(
+          token.value, ctx, subrender(i, token.tokens)
+        ) or
+        t == ">" and rnd:_partial(token.value, ctx, originalTemplate) or
+        (t == "{" or t == "&") and rnd:_name(token.value, ctx, false) or
+        t == "name" and rnd:_name(token.value, ctx, true) or
+        t == "text" and token.value or ""
+    end
+    return table_concat(buf)
+  end
+  return render
+end
+
+local function escape_tags(tags)
+
+  return {
+    string_gsub(tags[1], "%%", "%%%%").."%s*",
+    "%s*"..string_gsub(tags[2], "%%", "%%%%"),
+  }
+end
+
+local function nest_tokens(tokens)
+  local tree = {}
+  local collector = tree 
+  local sections = {}
+  local token, section
+
+  for i,token in ipairs(tokens) do
+    if token.type == "#" or token.type == "^" then
+      token.tokens = {}
+      sections[#sections+1] = token
+      collector[#collector+1] = token
+      collector = token.tokens
+    elseif token.type == "/" then
+      if #sections == 0 then
+        error("Unopened section: "..token.value)
+      end
+
+      -- Make sure there are no open sections when we're done
+      section = table_remove(sections, #sections)
+
+      if not section.value == token.value then
+        error("Unclosed section: "..section.value)
+      end
+
+      section.closingTagIndex = token.startIndex
+
+      if #sections > 0 then
+        collector = sections[#sections].tokens
+      else
+        collector = tree
+      end
+    else
+      collector[#collector+1] = token
+    end
+  end
+
+  section = table_remove(sections, #sections)
+
+  if section then
+    error("Unclosed section: "..section.value)
+  end
+
+  return tree
+end
+
+-- Combines the values of consecutive text tokens in the given `tokens` array
+-- to a single token.
+local function squash_tokens(tokens)
+  local out, txt = {}, {}
+  local txtStartIndex, txtEndIndex
+  for _, v in ipairs(tokens) do
+    if v.type == "text" then
+      if #txt == 0 then
+        txtStartIndex = v.startIndex
+      end
+      txt[#txt+1] = v.value
+      txtEndIndex = v.endIndex
+    else
+      if #txt > 0 then
+        out[#out+1] = { type = "text", value = table_concat(txt), startIndex = txtStartIndex, endIndex = txtEndIndex }
+        txt = {}
+      end
+      out[#out+1] = v
+    end
+  end
+  if #txt > 0 then
+    out[#out+1] = { type = "text", value = table_concat(txt), startIndex = txtStartIndex, endIndex = txtEndIndex  }
+  end
+  return out
+end
+
+local function make_context(view)
+  if not view then return view end
+  return view.magic == "1235123123" and view or Context:new(view)
+end
+
+local renderer = { }
+
+function renderer:clear_cache()
+  self.cache = {}
+  self.partial_cache = {}
+end
+
+function renderer:compile(tokens, tags, originalTemplate)
+  tags = tags or self.tags
+  if type(tokens) == "string" then
+    tokens = self:parse(tokens, tags)
+  end
+
+  local fn = compile_tokens(tokens, originalTemplate)
+
+  return function(view)
+    return fn(make_context(view), self)
+  end
+end
+
+function renderer:render(template, view, partials)
+  if type(self) == "string" then
+    error("Call mustache:render, not mustache.render!")
+  end
+
+  if partials then
+    -- remember partial table
+    -- used for runtime lookup & compile later on
+    self.partials = partials
+  end
+
+  if not template then
+    return ""
+  end
+
+  local fn = self.cache[template]
+
+  if not fn then
+    fn = self:compile(template, self.tags, template)
+    self.cache[template] = fn
+  end
+
+  return fn(view)
+end
+
+function renderer:_section(token, context, callback, originalTemplate)
+  local value = context:lookup(token.value)
+
+  if type(value) == "table" then
+    if is_array(value) then
+      local buffer = ""
+
+      for i,v in ipairs(value) do
+        buffer = buffer .. callback(context:push(v), self)
+      end
+
+      return buffer
+    end
+
+    return callback(context:push(value), self)
+  elseif type(value) == "function" then
+    local section_text = string_sub(originalTemplate, token.endIndex+1, token.closingTagIndex - 1)
+
+    local scoped_render = function(template)
+      return self:render(template, context)
+    end
+
+    return value(section_text, scoped_render) or ""
+  else
+    if value then
+      return callback(context, self)
+    end
+  end
+
+  return ""
+end
+
+function renderer:_inverted(name, context, callback)
+  local value = context:lookup(name)
+
+  -- From the spec: inverted sections may render text once based on the
+  -- inverse value of the key. That is, they will be rendered if the key
+  -- doesn't exist, is false, or is an empty list.
+
+  if value == nil or value == false or (is_array(value) and #value == 0) then
+    return callback(context, self)
+  end
+
+  return ""
+end
+
+function renderer:_partial(name, context, originalTemplate)
+  local fn = self.partial_cache[name]
+
+  -- check if partial cache exists
+  if (not fn and self.partials) then
+
+    local partial = self.partials[name]
+    if (not partial) then
+      return ""
+    end
+    
+    -- compile partial and store result in cache
+    fn = self:compile(partial, nil, originalTemplate)
+    self.partial_cache[name] = fn
+  end
+  return fn and fn(context, self) or ""
+end
+
+function renderer:_name(name, context, escape)
+  local value = context:lookup(name)
+
+  if type(value) == "function" then
+    value = value(context.view)
+  end
+
+  local str = value == nil and "" or value
+  str = tostring(str)
+
+  if escape then
+    return string_gsub(str, '[&<>"\'/]', function(s) return html_escape_characters[s] end)
+  end
+
+  return str
+end
+
+-- Breaks up the given `template` string into a tree of token objects. If
+-- `tags` is given here it must be an array with two string values: the
+-- opening and closing tags used in the template (e.g. ["<%", "%>"]). Of
+-- course, the default is to use mustaches (i.e. Mustache.tags).
+function renderer:parse(template, tags)
+  tags = tags or self.tags
+  local tag_patterns = escape_tags(tags)
+  local scanner = Scanner:new(template)
+  local tokens = {} -- token buffer
+  local spaces = {} -- indices of whitespace tokens on the current line
+  local has_tag = false -- is there a {{tag} on the current line?
+  local non_space = false -- is there a non-space char on the current line?
+
+  -- Strips all whitespace tokens array for the current line if there was
+  -- a {{#tag}} on it and otherwise only space
+
+  local type, value, chr
+
+  while not scanner:eos() do
+    local start = scanner.pos
+
+    value = scanner:scan_until(tag_patterns[1])
+
+    if value then
+      for i = 1, #value do
+        chr = string_sub(value,i,i)
+
+        if string_find(chr, "%s+") then
+          spaces[#spaces+1] = #tokens
+        else
+          non_space = true
+        end
+
+        tokens[#tokens+1] = { type = "text", value = chr, startIndex = start, endIndex = start }
+        start = start + 1
+      end
+    end
+
+    if not scanner:scan(tag_patterns[1]) then
+      break
+    end
+
+    has_tag = true
+    type = scanner:scan(patterns.tag) or "name"
+
+    scanner:scan(patterns.white)
+
+    if type == "=" then
+      value = scanner:scan_until(patterns.eq)
+      scanner:scan(patterns.eq)
+      scanner:scan_until(tag_patterns[2])
+    elseif type == "{" then
+      local close_pattern = "%s*}"..tags[2]
+      value = scanner:scan_until(close_pattern)
+      scanner:scan(patterns.curly)
+      scanner:scan_until(tag_patterns[2])
+    else
+      value = scanner:scan_until(tag_patterns[2])
+    end
+
+    if not scanner:scan(tag_patterns[2]) then
+      error("Unclosed tag at " .. scanner.pos)
+    end
+
+    tokens[#tokens+1] = { type = type, value = value, startIndex = start, endIndex = scanner.pos - 1 }
+    if type == "name" or type == "{" or type == "&" then
+      non_space = true --> what does this do?
+    end
+
+    if type == "=" then
+      tags = string_split(value, patterns.space)
+      tag_patterns = escape_tags(tags)
+    end
+  end
+
+  return nest_tokens(squash_tokens(tokens))
+end
+
+function renderer:new()
+  local out = { 
+    cache         = {},
+    partial_cache = {},
+    tags          = {"{{", "}}"}
+  }
+  return setmetatable(out, { __index = self })
+end
+
+return renderer

--- a/src/bindings/lua/flux/lustache/scanner.lua
+++ b/src/bindings/lua/flux/lustache/scanner.lua
@@ -1,0 +1,57 @@
+local string_find, string_match, string_sub =
+      string.find, string.match, string.sub
+
+local scanner = {}
+
+-- Returns `true` if the tail is empty (end of string).
+function scanner:eos()
+  return self.tail == ""
+end
+
+-- Tries to match the given regular expression at the current position.
+-- Returns the matched text if it can match, `null` otherwise.
+function scanner:scan(pattern)
+  local match = string_match(self.tail, pattern)
+
+  if match and string_find(self.tail, pattern) == 1 then
+    self.tail = string_sub(self.tail, #match + 1)
+    self.pos = self.pos + #match
+
+    return match
+  end
+
+end
+
+-- Skips all text until the given regular expression can be matched. Returns
+-- the skipped string, which is the entire tail of this scanner if no match
+-- can be made.
+function scanner:scan_until(pattern)
+
+  local match
+  local pos = string_find(self.tail, pattern)
+
+  if pos == nil then
+    match = self.tail
+    self.pos = self.pos + #self.tail
+    self.tail = ""
+  elseif pos == 1 then
+    match = nil
+  else
+    match = string_sub(self.tail, 1, pos - 1)
+    self.tail = string_sub(self.tail, pos)
+    self.pos = self.pos + #match
+  end
+
+  return match
+end
+
+function scanner:new(str)
+  local out = {
+    str  = str,
+    tail = str,
+    pos  = 1
+  }
+  return setmetatable(out, { __index = self } )
+end
+
+return scanner

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -40,6 +40,9 @@ local default_opts = {
     ['verbose'] = { char = 'v'  },
     ['ntasks']  = { char = 'n', arg = "N" },
     ['walltime'] = { char = "T", arg = "SECONDS" },
+    ['output'] =   { char = "O", arg = "FILENAME" },
+    ['error'] =    { char = "E", arg = "FILENAME" },
+    ['label-io'] = { char = "l", },
     ['options'] = { char = 'o', arg = "OPTIONS.." },
 }
 
@@ -92,6 +95,12 @@ function wreck:usage()
                              for minutes, 'h' for hours or 'd' for days.
                              N may be an arbitrary floating point number,
                              but will be rounded up to nearest second.
+  -o, --output=FILENAME      Duplicate stdout/stderr from tasks to a file or
+                             files. FILENAME is optionally a moustache
+                             template with keys such as id, cmd, taskid.
+                             (e.g. --tee=flux-{{id}}.out)
+  -e, --error=FILENAME       Send stderr to a different location than stdout.
+  -l, --labelio              Prefix lines of output with task id
 ]])
     for _,v in pairs (self.extra_options) do
         local optstr = v.name .. (v.arg and "="..v.arg or "")
@@ -208,6 +217,15 @@ function wreck:jobreq ()
         for opt in self.opts.o:gmatch ('[^,]+') do
             jobreq['options.'..opt] = 1
         end
+    end
+    if self.opts.O or self.opts.E then
+        jobreq.output = {
+            files = {
+              stdout = self.opts.O,
+              stderr = self.opts.E,
+            },
+            labelio = self.opts.l,
+        }
     end
     return jobreq
 end

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -212,6 +212,28 @@ function wreck:jobreq ()
     return jobreq
 end
 
+function wreck.ioattach (arg)
+    local ioplex = require 'wreck.io'
+    local f = arg.flux
+    if not arg.ntasks then
+        local lwj, err = f:kvsdir ("lwj."..arg.jobid)
+        if not lwj then
+            return nil, "Error: "..err
+        end
+        arg.ntasks = lwj.ntasks
+    end
+    local taskio, err = ioplex.create (arg)
+    if not taskio then return nil, err end
+    for i = 0, arg.ntasks - 1 do
+        for _,stream in pairs {"stdout", "stderr"} do
+            local rc, err =  taskio:redirect (i, stream, stream)
+        end
+    end
+    taskio:start (arg.flux)
+
+    return taskio
+end
+
 function wreck.new (prog)
     local w = setmetatable ({extra_options = {}}, wreck) 
     w.prog = prog

--- a/src/bindings/lua/wreck/io.lua
+++ b/src/bindings/lua/wreck/io.lua
@@ -1,0 +1,207 @@
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- Task I/O library for WRECK
+--
+
+
+--
+--  ostream - simple output stream with reference count.
+-- 
+local ostream = {}
+ostream.__index = ostream
+function ostream.create (filename)
+    local s = { count = 0, filename = filename, flag = "w" }
+    setmetatable (s, ostream)
+    return s
+end
+
+function ostream:closed ()
+    return self.count == 0
+end
+
+function ostream:open ()
+    if not self.fp then
+        if self.filename == "stdout" or self.filename == "stderr" then
+            self.fp = io[self.filename]
+        else
+            self.fp, err = io.open (self.filename, self.flag)
+        end
+        if not self.fp then return nil, self.filename..": "..err end
+    end
+    self.count = self.count + 1
+    return true
+end
+
+function ostream:close ()
+    self.count = self.count - 1
+    if self.count == 0 then
+        self.fp:close ()
+        self.fp = nil
+    end
+end
+
+function ostream:write (data)
+    if not self.fp then return nil, "File not open" end
+    local rc, err = self.fp:write (data)
+    if not rc then print (err) end
+end
+
+
+--
+--  wreck job io tracking object.
+--  Direct all task io to a named set of ostream objects
+--
+local ioplex = {}
+ioplex.__index = ioplex
+
+
+--- Create a wreck i/o multiplexer
+-- ioplex objects are an abstraction of wreck reactor-driven I/O
+--  with many-to-one or many-to-many output redirection. Named
+--  output stream objects are registered with an ioplex object,
+--  and then task "stdout" and "stderr" streams are redirected
+--  onto these output streams. Output streams have reference counting
+--  and are only closed when all references have been closed.
+--  When all outputs are closed ioplex:complete() will return true.
+--@param arg a Table of named keys for arguments
+--@return ioplex object
+--
+function ioplex.create (arg)
+    if not arg.flux or not arg.jobid then
+         return nil, "Required handle or jobid arg missing!"
+    end
+
+    local io = { 
+        flux          = arg.flux,
+        id            = arg.jobid,
+        labelio       = arg.labelio,
+        on_completion = arg.on_completion,
+        removed = {},
+        output = {},
+        files = {}
+    }
+    setmetatable (io, ioplex)
+    return io
+end
+
+local function ioplex_set_stream (self, taskid, name, f)
+    if not self.output[taskid] then
+        self.output[taskid] ={}
+    end
+    self.output[taskid][name] = f
+end
+
+local function ioplex_create_stream (self, path)
+    local files = self.files
+    if not files[path] then
+        local f, err = ostream.create (path)
+        if not f then return nil, err end
+        files[path] = f
+    end
+    return files[path]
+end
+
+local function ioplex_taskid_start (self, flux, taskid, stream)
+    local of = self.output[taskid][stream]
+    if not of then return nil, "No stream "..stream.." for task " .. taskid  end
+
+    local f = flux
+    local key = string.format ("lwj.%d.%d.%s", self.id, taskid, stream)
+    local iow, err = f:iowatcher {
+        key = key,
+        handler =  function (iow, data)
+            if not data then
+                -- protect against multiple close callback calls
+	        if self.removed [key] then return end
+                of:close()
+                self.removed [key] = true
+                if self:complete() and self.on_completion then
+                    self.on_completion()
+                end
+                return
+            end
+            if self.labelio then
+                of:write (taskid..": ")
+            end
+            of:write (data)
+        end
+    }
+end
+
+--- "start" all ioplex iowatchers on reactor.
+-- @param h flux handle of reactor to use (optional)
+function ioplex:start (h)
+    local flux = h or self.flux
+    if not flux then return nil, "Error: no flux handle!" end
+
+    for taskid, t in pairs (self.output) do
+        for stream, f in pairs (t) do
+            ioplex_taskid_start (self, flux, taskid, stream)
+        end
+    end
+end
+
+--- redirect a stream from a task to named stream "path".
+-- On first reference to `path` (not including special paths "stdout"
+--  and "stderr") the referenced file will be opened with `io.open(..., "w")`
+--
+-- @param taskid task identifier
+-- @param stream name  of stream to redirect (e.g. "stdout")
+-- @param path   path of file to redirect to (or "stderr" "stdout")
+-- @return true on success, nil with error on failure
+--
+function ioplex:redirect (taskid, stream, path)
+    local f, err = ioplex_create_stream (self, path)
+    if not f then return nil, err end
+
+    ioplex_set_stream (self, taskid, stream, f)
+    return f:open()
+end
+
+--- duplicate a stream from a task onto existing stream for this task.
+-- Reference count is incremented for `dst`
+-- @param taskid task identifier
+-- @param src the source stream to duplicate (e.g. "stderr")
+-- @param dst the destination stream to copyto (e.g. "stdout")
+--
+function ioplex:dup (taskid, src, dst)
+    local f = self.output[taskid][dst]
+    if not f then
+        return nil, 'No such output stream: '..dst
+    end
+    self.output[taskid][src] = f
+    return f:open()
+end
+
+--- Check for completion of I/O on an ioplex object
+-- @return true if IO is complete, false if not
+function ioplex:complete ()
+    for _,f in pairs (self.files) do
+        if not f:closed() then return false end
+    end
+    return true
+end
+
+return ioplex

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -35,6 +35,7 @@ bin_PROGRAMS = flux
 
 dist_fluxcmd_SCRIPTS = \
 	flux-wreckrun \
+	flux-wreck \
 	flux-exec \
 	flux-topo \
 	flux-lstopo \

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -1,0 +1,330 @@
+#!/usr/bin/env lua
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- flux-wreck: simple wreck job utility
+--
+local f, err = require 'flux' .new()
+local wreck = require 'wreck'
+local hostlist = require 'flux.hostlist'
+
+local prog = string.match (arg[0], "([^/]+)$")
+local shortprog = prog:match ("flux%-(.+)$")
+
+local function eprintf (...)
+    io.stderr:write (string.format (...))
+end
+
+local function printf (...)
+    io.stdout:write (string.format (...))
+end
+
+local function die (fmt, ...)
+    eprintf (shortprog..": "..fmt, ...)
+    os.exit (1)
+end
+
+
+--- Index of all commands registered in this script
+local Commands = {}
+
+--- Command class from which all "commands" inherit
+local Command = {}
+Command.__index = Command
+
+--- Allow new commad methods to be registered by "calling" Command.
+-- a table is passed to Command with fields:
+-- @param t.name Name of the script method
+-- @param t.description Brief description of this method
+-- @param t.usage brief usage to be displayed in help
+-- @param t.handle function implementing handler with args (self, arg...)
+-- @param t.options extra options (besides --help) for this cmd
+setmetatable (Command,
+    { __call = function (_,t)
+        assert (t and t.name)
+        Commands[t.name] = t
+        return setmetatable (t, Command)
+     end
+    }
+)
+function Command:opt_table ()
+    local long_opts = { help = 'h' }
+    local short_opts = "h"
+    if not self.options then
+        return short_opts, long_opts
+    end
+    for _, t in pairs (self.options) do
+        short_opts = short_opts .. t.char .. (t.arg and ":" or "")
+        long_opts [t.name] = t.char
+    end
+    return short_opts, long_opts
+end
+
+function Command:help (code)
+    local _, opt_table = self:opt_table ()
+    eprintf ("Usage: %s %s %s\n", prog, self.name, self.usage)
+    eprintf ("  -%s, --%-20s %s\n", 'h', 'help', "Display this message.")
+    if self.options then
+        for _,t in pairs (self.options) do
+            local optstr = t.name .. (t.arg and "="..t.arg or "")
+            eprintf ("  -%s, --%-20s %s\n", t.char, optstr, t.usage)
+        end
+    end
+    if code then os.exit (code) end
+end
+
+function Command:run (args)
+    local getopts = require 'flux.alt_getopt' .get_opts
+    local opts, optind = getopts (args, self:opt_table())
+    if not opts then self:help (1) end
+    if opts.h then self:help (0) end
+    local a = {}
+    for i = optind, #args do
+        table.insert (a, args[i])
+    end
+    self.opt = opts
+    self.handler (self, a)
+end
+
+local function check_jobid_arg (self, id)
+    if not id then
+        eprintf ("Error: Job id required\n")
+        self:help (1)
+    elseif not tonumber (id) then
+        die ("Invalid Job id '%s'\n", id)
+    end
+    return id
+end
+
+Command {
+ name = "attach",
+ description = "Attach to running or completed job output",
+ usage = "[OPTIONS] JOBID",
+ options = {
+     { name = "status",  char = "s",
+       usage = "Include status after all output" },
+     { name = "label-io",  char = "l",
+       usage = "Label lines of output with task id" },
+ },
+ handler = function (self, arg)
+    local id = check_jobid_arg (self, arg[1])
+    local taskio, err = wreck.ioattach {
+        flux = f,
+        jobid = id,
+        labelio = self.opt.l,
+        on_completion = function ()
+            f:reactor_stop()
+        end
+    }
+    if not taskio then die ("Failed to connect to job %d: %s\n", id, err) end
+    if not taskio:complete() then f:reactor () end
+    if self.opt.s then
+        Commands.status:run ({id})
+    end
+    os.exit (0)
+ end
+}
+
+local function opt_sig (s)
+    local posix = require 'posix'
+    if not s then return posix.SIGTERM end
+    if tonumber (s) then return tonumber (s) end
+    if not tonumber (posix[s]) then
+        die ("Invalid signal '%s'\n", s)
+    end
+    return tonumber (posix [s])
+end
+
+Command {
+ name = "kill",
+ description = "Kill a running job",
+ usage = "[OPTIONS] JOBID",
+ options = {
+     { name = "signal",  char = "s", arg = "N",
+       usage = "Specify signal number N to be sent." }
+ },
+ handler = function (self, arg)
+    local id = check_jobid_arg (self, arg[1])
+    local lwj, err = f:kvsdir ("lwj.%d", id)
+    if not lwj then die ("Job %d: %s\n", id, err) end
+    if lwj.state ~= "running" then
+        io.stderr:write ("Job "..id..": "..lwj.state.."\n")
+        os.exit (1)
+    end
+    local sig = opt_sig (self.opt.s)
+    local rc, err = f:sendevent ({signal = sig}, "wreck.%d.kill", id)
+    if not rc then die ("signal: %s\n", err) end
+ end
+}
+
+Command {
+ name = "status",
+ description = "Return status of jobs",
+ usage = "JOBID",
+ handler = function (self, arg)
+    local jobid = check_jobid_arg (self, arg[1])
+    local lwj, err = f:kvsdir ("lwj.%d", jobid)
+    if not lwj then die ("Job %d: %s\n", jobid, err) end
+    print ("Job "..jobid.." status: "..lwj.state)
+    local code, msglist = wreck.status { flux = f, jobid = jobid }
+    if not code then die (msglist) end
+    for msg, hl in pairs (msglist) do
+        local s = string.format ("task%s: %s", tostring (hl:sort()), msg)
+        print (s)
+    end
+    os.exit (code)
+ end
+}
+
+
+local LWJ = {}
+function LWJ.open (f, id)
+    if not f or not id then
+        return nil, "Required arg missing"
+    end
+    local lwj, err = f:kvsdir ("lwj.%d", id)
+    if not lwj then
+        return nil, "Failed to get lwj info: "..err
+    end
+    return setmetatable ({id = id, lwj = lwj }, LWJ)
+end
+
+local function now ()
+    local t = require 'flux.posix'.gettimeofday()
+    return t.sec + (t.usec / (1000 * 1000))
+end
+
+LWJ.__index = function (self, key)
+    if key == "state" then
+        return self.lwj.state
+    elseif key == "ranks" then
+        local hl = hostlist.new()
+        local rank = self.lwj.rank
+        if not rank then return nil end
+        for i in rank:keys() do hl:concat (i) end
+        return hl:sort()
+    elseif key == "ntasks" then
+        return self.lwj.ntasks
+    elseif key == "nnodes" then
+        return self.lwj.nnodes
+    elseif key == "runtime" then
+        local st = self.lwj["starting-time"]
+        if not st then return 0 end
+        local ct = self.lwj["complete-time"]
+        if not ct then ct = now () end
+        local s = ct - st
+        return s > 0 and s or 0
+    elseif key == "start" then
+        return os.date ("%FT%T", self.lwj["starting-time"])
+    elseif key == "end" then
+        return os.date ("%FT%T", self.lwj["complete-time"])
+    elseif key == "created" then
+        return os.date ("%FT%T", self.lwj["create-time"])
+    elseif key == "command" then
+        return self.lwj.cmdline[1]
+    end
+    return nil
+end
+
+local function seconds_to_string (s)
+    local f = string.format
+    if s > (60*60*24) then
+        return f ("%.03fd", s / (60*60*24))
+    elseif s > (60*60) then
+        return f ("%.03fh", s / (60*60))
+    elseif s > 60 then
+        return f ("%.03fm", s / 60)
+    end
+    return f ("%.03fs", s)
+end
+
+Command {
+ name = "ls",
+ usage = "",
+ description = "List jobs in kvs",
+ handler = function (self, arg)
+    local lwj, err = f:kvsdir ("lwj")
+    if not lwj then
+        die ("Failed to get lwj info: %s\n", err)
+    end
+    local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
+    printf (fmt, "ID", "NTASKS", "STATE", "START", "RUNTIME", "RANKS", "COMMAND")
+    for id in lwj:keys() do
+        if tonumber (id) then
+            local j, err = LWJ.open (f, id)
+            if not j then die ("job%d: %s", id, err) end
+            printf (fmt, id, j.ntasks, j.state, j.start,
+                    seconds_to_string (j.runtime),
+                    tostring (j.ranks),
+                    j.command:match ("([^/]+)$"))
+        end
+    end
+ end
+}
+
+
+local function main_usage ()
+    eprintf ("Usage: %s COMMAND [OPTIONS]...\n", prog)
+    eprintf ("Supported commands: \n")
+    for name,info in pairs (Commands) do
+        eprintf (" %-12s %s\n", name, info.description)
+    end
+end
+
+Command {
+ name = "help",
+ description = "Display this help or help for a command",
+ usage = "[COMMAND]",
+ handler = function (self, arg)
+    if #arg == 0 then
+        main_usage ()
+        os.exit (0)
+    end
+    Commands[arg[1]]:help (0)
+ end
+}
+
+--
+--  Main program: Run cmd in arg[1]:
+--
+local cmd = table.remove (arg, 1)
+if not cmd then
+    main_usage ()
+    os.exit (1)
+end
+if cmd == "-h" or cmd == "--help" then
+    cmd = "help"
+end
+
+-- Check for valid connection to flux:
+if not f then die ("Connecting to flux failed: %s\n", err) end
+
+local command = Commands[cmd]
+if not command then
+     die ("Error: Unknown command: %s\n", cmd)
+end
+
+command:run (arg)
+
+--  vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -174,8 +174,6 @@ wreck:add_options ({
         usage = "Force number of nodes" },
     { name = 'now', char = 'i',
         usage = "Run job immediately" },
-    { name = 'label-io', char = 'l',
-        usage = "Label output with taskid" },
     { name = 'pre-launch-hook', char = "P", arg = "CODE",
         usage = "execute Lua CODE before launch." },
 })

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -30,33 +30,10 @@ end
 --  Get the LWJ return code as highest of all task return codes
 ---
 local function lwj_return_code (f, wreck, id)
-    local hostlist = require 'flux.hostlist'
-    local lwj = f:kvsdir ("lwj.%d", id)
-    local max = 0
-    local msgs = {}
-    for taskid in lwj:keys () do
-        if is_integer (taskid) then
-            local t = lwj[taskid]
-            local x = t.exit_code or (t.exit_sig + 128)
-            if x > 0 then
-                local s = "exited with " ..
-                          (t.exit_code and "exit code" or "signal") ..
-                          " %d\n"
-                s = s:format(t.exit_code or t.exit_sig)
-                if not msgs[s] then
-                    msgs[s] = hostlist.new(taskid)
-                else
-                    msgs[s]:concat (taskid)
-                end
-            end
-            if x > max then
-                max = x
-            end
-        end
-    end
+    local max, msgs = wreck.status { flux = f, jobid = id }
     local fn = getmetatable (wreck) [ max > 0 and "say" or "verbose" ]
     for s,h in pairs (msgs) do
-        fn (wreck, "task%s %s: %s", #h > 1 and "s" or "", tostring (h:sort()), s)
+        fn (wreck, "task%s %s: %s\n", #h > 1 and "s" or "", tostring (h:sort()), s)
     end
     return max
 end

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -176,6 +176,8 @@ wreck:add_options ({
         usage = "Run job immediately" },
     { name = 'pre-launch-hook', char = "P", arg = "CODE",
         usage = "execute Lua CODE before launch." },
+    { name = 'detach', char = "d",
+        usage = "Detach immediately after starting job" },
 })
 
 if not wreck:parse_cmdline (arg) then
@@ -255,6 +257,10 @@ if true then
     wreck:verbose ("%-4.03fs: Sending run event\n", tt:get0())
     local rc,err = f:sendevent ("wrexec.run.%d", resp.jobid)
     if not rc then wreck:die ("sendevent: %s\n", err) end
+    if wreck.opts.d then
+        print ("Job "..resp.jobid)
+        os.exit(0)
+    end
 else
     --
     --  Update job state to 'pending' to notify scheduler:

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -162,8 +162,9 @@ end
 --  Parse cmdline args:
 --
 local wreck = require 'wreck' .new (shortprog)
+local ioattach = require 'wreck'.ioattach
+local taskio
 local sigtimer
-local nio = 0
 local state = ""
 
 wreck:add_options ({
@@ -269,7 +270,8 @@ end
 --  Check if job state is "complete" and all IO from tasks have closed:
 --
 local function check_job_completed ()
-    if nio <= 0 and (state == "complete" or state == "reaped") then
+    if taskio:complete() and
+       (state == "complete" or state == "reaped") then
         local rc = lwj_return_code (f, wreck, resp.jobid)
         if rc == 0 then
             wreck:verbose ("All tasks completed successfully.\n");
@@ -278,38 +280,17 @@ local function check_job_completed ()
     end
 end
 
-
---  IO watcher creation helper function:
 --
-local function io_watcher_create (stream, jobid, taskid)
-    local s = stream == "stdout" and io.stdout or io.stderr
-    local iow,err = f:iowatcher {
-        key = string.format ("lwj.%d.%d.%s", jobid, taskid, stream),
-        handler = function (iow, data)
-            if not data then
-                nio = nio - 1
-                check_job_completed ()
-                return
-            end
-            if (wreck.opts.l) then s:write (taskid..": ") end
-            s:write (data)
-        end
-    }
-    if not iow then wreck:die (err) end
-    return iow
-end
-
+--  Open output to all tasks:
 --
---  Create iowatchers for all tasks stdout/err:
---
---  XXX: The `nio` IO counter must be initialized before creating
---   all IO watchers.
-nio = wreck.ntasks * 2
-for i=0, wreck.ntasks-1 do
-    for _,stream in pairs{ "stdout", "stderr"} do
-        iow = io_watcher_create (stream, resp.jobid, i)
-    end
-end
+taskio, err = ioattach {
+     flux = f,
+     jobid = resp.jobid,
+     ntasks = wreck.ntasks,
+     labelio = wreck.opts.l,
+     on_completion = check_job_completed
+}
+if not taskio then wreck:die ("error opening task io: %s\n", err) end
 
 --
 --  Open stdin (to task 0 only for now)
@@ -353,7 +334,7 @@ local s, err = f:sighandler {
 local s, err = f:sighandler {
     sigmask = { posix.SIGALRM },
     handler = function (f, s, sig)
-        wreck:say ("Killed by SIGALRM: state = %s, nio = %d\n", state, nio)
+        wreck:say ("Killed by SIGALRM: state = %s\n", state)
         os.exit (128+posix.SIGALRM)
     end
 }

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -67,8 +67,9 @@ wrexecd_LDADD = \
 dist_wreckscripts_SCRIPTS = \
 	lua.d/01-env.lua \
 	lua.d/02-affinity.lua \
-	lua.d/timeout.lua
-
+	lua.d/timeout.lua \
+        lua.d/output.lua
+   
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #
 $(wrexecd_LDADD):

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -180,17 +180,12 @@ static json_object *json_id (int id)
     return (o);
 }
 
-static char * ctime_iso8601_now (char *buf, size_t sz)
+static char * realtime_string (char *buf, size_t sz)
 {
-    struct tm tm;
-    time_t now = time (NULL);
-
+    struct timespec tm;
+    clock_gettime (CLOCK_REALTIME, &tm);
     memset (buf, 0, sz);
-
-    if (!localtime_r (&now, &tm))
-        err_exit ("localtime");
-    strftime (buf, sz, "%FT%T", &tm);
-
+    snprintf (buf, sz, "%ju.%06ld", (uintmax_t) tm.tv_sec, tm.tv_nsec/1000);
     return (buf);
 }
 
@@ -248,7 +243,7 @@ static void add_jobinfo (flux_t h, int64_t id, json_object *req)
     json_object_object_foreachC (req, i)
         kvsdir_put (dir, i.key, json_object_to_json_string (i.val));
 
-    o = json_object_new_string (ctime_iso8601_now (buf, sizeof (buf)));
+    o = json_object_new_string (realtime_string (buf, sizeof (buf)));
     kvsdir_put (dir, "create-time", json_object_to_json_string (o));
     json_object_put (o);
 

--- a/src/modules/wreck/lua.d/output.lua
+++ b/src/modules/wreck/lua.d/output.lua
@@ -1,0 +1,75 @@
+--
+--  Optionally write job output to file(s) if so configured in either
+--   lwj.output or lwj.<id>.output
+--
+--  Output filenames are rendered mustache templates
+--
+--
+local ioplex = require 'wreck.io'
+
+local function kvs_output_config (wreck)
+    local o = wreck.kvsdir ["output"]
+    if not o then
+       o = wreck.flux:kvsdir ("lwj.output")
+    end
+    return o
+end
+
+local function render (template, wreck, taskid)
+    local lustache = require 'flux.lustache'
+    local view = {
+        cmd = wreck.argv[0]:match("([^/]+)$"),
+        taskid = taskid
+    }
+    setmetatable (view, { __index = wreck })
+    return lustache:render (template, view)
+end
+
+local function openstream (wreck, taskio, taskid, stream, template)
+    local path = render (template, wreck, taskid)
+    if not path then
+        wreck:log_msg ("Failed to render template '"..template.."'")
+        return
+    end
+    taskio:redirect (taskid, stream, path)
+    return path
+end
+
+function rexecd_init ()
+    if wreck.nodeid ~= 0 then return end
+
+    local output = kvs_output_config (wreck)
+    if not output or not output.files then return end
+
+    local ntasks = wreck.kvsdir.ntasks
+    taskio, err = ioplex.create {
+        flux = wreck.flux,
+        jobid = wreck.id,
+        labelio = output.labelio and output.labelio ~= false
+    }
+    if not taskio then wreck:log_msg ("Error: %s", err) end
+
+    local template = output.files.stdout
+    local stderr_template = output.files.stderr
+    if not template and not stderr_template then return end
+
+    for i = 0, ntasks - 1 do
+       if template then
+          openstream (wreck, taskio, i, "stdout", template)
+       end
+       if stderr_template then
+           openstream (wreck, taskio, i, "stderr", stderr_template)
+       elseif template then
+           taskio:dup (i, "stderr", "stdout")
+       end
+    end
+    taskio:start ()
+end
+
+function rexecd_exit ()
+    if wreck.nodeid ~= 0 or not taskio then return end
+    while not taskio:complete() do
+        wreck.flux:reactor ("once")
+    end
+    wreck:log_msg ("File io complete")
+end

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -424,17 +424,12 @@ int signalfd_setup (struct prog_ctx *ctx)
     return (0);
 }
 
-static char * ctime_iso8601_now (char *buf, size_t sz)
+static char * realtime_string (char *buf, size_t sz)
 {
-    struct tm tm;
-    time_t now = time (NULL);
-
+    struct timespec tm;
+    clock_gettime (CLOCK_REALTIME, &tm);
     memset (buf, 0, sz);
-
-    if (!localtime_r (&now, &tm))
-        return (NULL);
-    strftime (buf, sz, "%FT%T", &tm);
-
+    snprintf (buf, sz, "%ju.%06ld", (uintmax_t) tm.tv_sec, tm.tv_nsec/1000);
     return (buf);
 }
 
@@ -866,7 +861,7 @@ int update_job_state (struct prog_ctx *ctx, const char *state)
     char buf [64];
     char *key;
     json_object *to =
-        json_object_new_string (ctime_iso8601_now (buf, sizeof (buf)));
+        json_object_new_string (realtime_string (buf, sizeof (buf)));
 
     assert (ctx->nodeid == 0);
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1736,6 +1736,8 @@ int main (int ac, char **av)
     rexec_state_change (ctx, "complete");
     log_msg (ctx, "job complete. exiting...");
 
+    lua_stack_call (ctx->lua_stack, "rexecd_exit");
+
     prog_ctx_destroy (ctx);
 
     return (0);

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -216,6 +216,57 @@ test_expect_success 'wreckrun: kvs config output for all jobs' '
 	sort -n test3.out >output.kvsiocfg &&
 	test_cmp expected.kvsiocfg output.kvsiocfg
 '
+test_expect_success 'flux-wreck: exists in path' '
+	flux wreck help 2>&1 | grep "^Usage: flux-wreck"
+'
+test_expect_success 'flux-wreck: attach' '
+	flux wreckrun -n4 --output=expected.attach hostname >/dev/null &&
+	flux wreck attach $(last_job_id) > output.attach &&
+        test_cmp expected.attach output.attach
+'
+test_expect_success 'flux-werck: attach --label-io' '
+	flux wreckrun -l -n4 --output=expected.attach-l echo bazz >/dev/null &&
+	flux wreck attach --label-io $(last_job_id) |sort > output.attach-l &&
+        sort expected.attach-l > x && mv x expected.attach-l &&
+        test_cmp expected.attach-l output.attach-l
+'
+test_expect_success 'flux-wreck: status' '
+        flux wreckrun -n4 /bin/true &&
+        id=$(last_job_id) &&
+	flux wreck status $id > output.status &&
+        cat >expected.status <<-EOF &&
+	Job $id status: complete
+	task[0-3]: exited with exit code 0
+	EOF
+	test_cmp expected.status output.status
+'
+test_expect_success 'flux-wreck: status with non-zero exit' '
+	test_expect_code 1 flux wreckrun -n4 /bin/false &&
+        id=$(last_job_id) &&
+	test_expect_code 1 flux wreck status $id > output.status2 &&
+        cat >expected.status2 <<-EOF &&
+	Job $id status: complete
+	task[0-3]: exited with exit code 1
+	EOF
+	test_cmp expected.status2 output.status2
 
+'
+test_expect_success 'flux-wreck: kill' '
+	run_timeout 1 flux wreckrun --detach sleep 100 &&
+	id=$(last_job_id) &&
+	flux wreck kill -s SIGINT $id &&
+	test_expect_code 130 flux wreck status $id >output.kill &&
+	cat >expected.kill <<-EOF &&
+	Job $id status: complete
+	task0: exited with signal 2
+	EOF
+	test_cmp expected.kill output.kill
+'
+test_expect_success 'flux-wreck: ls works' '
+	flux wreckrun -n2 -N2 hostname &&
+	flux wreck ls | tail -1 | grep "hostname$"
+'
+
+test_debug "flux wreck ls"
 
 test_done

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -180,7 +180,8 @@ test_expect_success 'wreckrun: top level environment' '
 '
 test_expect_success 'wreck plugins can use wreck:log_msg()' '
 	saved_pattern=$(flux kvs get config.wrexec.lua_pattern) &&
-	cleanup flux kvs put wrexec.lua_pattern="$saved_pattern" &&
+	test_when_finished \
+            "flux kvs put config.wrexec.lua_pattern=\"$saved_pattern\"" &&
 	cat <<-EOF >test.lua &&
 	function rexecd_init ()
 	    local rc, err = wreck:log_msg ("lwj.%d: plugin test successful", wreck.id)


### PR DESCRIPTION
Opening this PR for comments for now, there are still a couple items TODO.

This PR abstracts the status and stdout/err handling code from `flux-wreckrun` into `wreck.lua` module to enable multiple users of these interfaces (originally done for file output for wreckrun jobs). 

A new `wreck.io` module is used by an `output.lua` plugin for wrexecd which optionally sends output to one or more files per job. The `output.lua` plugin reads an output config block from either `lwj.<id>.output` (for job `id`), or from `lwj.output` as a default for all jobs. The config keys include:
 * `output.labelio`: Label lines of output with source task id
 * `output.files.stdout=FILE`: Copy stdout/err to `FILE`, where `FILE` may be a [mustache](http://mustache.github.io) template with keys `id` for jobid, `cmd` for `argv[0]`, and `taskid` if per-task output is desired. (e.g. `flux-{{id}}.out`) (Actually a `wreck` object is passed in to the template so you can even include data from kvs with `{{kvsdir.<key>}}` but I can't imagine how that is useful)
 * `output.files.stderr=FILE`: Separate stderr from stdout into `FILE`

So for instance to save output from every job to a file within an instance you could run something like
```
flux kvs put lwj.output.files.stdout="flux-{{idj}}.out"
```
in the initial program, or before running any jobs.

Furthermore the following other enhancements were made along the way:
 * As a convenience `-O, --output` and `-E, --error` are added to `flux-wreckrun(1)`.
 * A `--detach` option for `flux-wreckrun(1)` which detaches the command immediately after starting the job (useful in tests and with `--output`)
 * New `flux-wreck` command which exercises job output and status abstractions with `attach`, `status`, and `kill` subcommands:
```
Usage: flux-wreck COMMAND [OPTIONS]...
Supported commands: 
 attach       Attach to running or completed job output
 help         Display this help or help for a command
 kill         Kill a running job
 status       Return status of jobs
```

Still TODO:
 * Tests for `flux-wreck`
 * Update `flux-wreckrun` manpage
