### PR TITLE
optparse_t rfc 7 compliance, argument list support, test updates, and related fixes

### DIFF
--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -130,10 +130,10 @@ static void unsubscribe_all (flux_t h, int tc, char **tv)
     }
 }
 
-static optparse_t event_sub_get_options (int *argcp, char ***argvp)
+static optparse_t *event_sub_get_options (int *argcp, char ***argvp)
 {
     int n, e;
-    optparse_t p;
+    optparse_t *p;
     struct optparse_option opts [] = {
         {
          .name = "count", .key = 'c', .group = 1,
@@ -164,7 +164,7 @@ static void event_sub (flux_t h, int argc, char **argv)
 {
     flux_msg_t *msg;
     int n, count;
-    optparse_t p = event_sub_get_options (&argc, &argv);
+    optparse_t *p = event_sub_get_options (&argc, &argv);
 
 
     /* Since output is line-based with undeterministic amount of time

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -38,7 +38,7 @@
 #include "src/common/libutil/cleanup.h"
 #include "src/modules/libsubprocess/subprocess.h"
 
-int start_direct (optparse_t p, const char *cmd);
+int start_direct (optparse_t *p, const char *cmd);
 
 const int default_size = 1;
 
@@ -69,7 +69,7 @@ int main (int argc, char *argv[])
     int e, status = 0;
     char *command = NULL;
     size_t len = 0;
-    optparse_t p;
+    optparse_t *p;
 
     log_init ("flux-start");
 
@@ -221,7 +221,7 @@ char *create_socket_dir (const char *sid)
     return sockdir;
 }
 
-int start_direct (optparse_t opts, const char *cmd)
+int start_direct (optparse_t *opts, const char *cmd)
 {
     int size = optparse_get_int (opts, "size", default_size);
     const char *broker_opts = optparse_get_str (opts, "broker-opts", NULL);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -495,7 +495,8 @@ void internal_getattr (flux_conf_t cf, optparse_t *p, int ac, char *av[])
         printf ("%s\n", val);
         flux_close (h);
     } else {
-        usage ();
+        optparse_print_usage (p);
+        exit (1);
     }
 }
 
@@ -519,8 +520,10 @@ void internal_setattr (flux_conf_t cf, optparse_t *p, int ac, char *av[])
     } else if (!optparse_hasopt (p, "expunge") && n == ac - 2) {
         name = av[n];
         val = av[n + 1];
-    } else
-        usage ();
+    } else {
+        optparse_print_usage (p);
+        exit (1);
+    }
     if (!(h = flux_open (NULL, 0)))
             err_exit ("flux_open");
     if (flux_attr_set (h, name, val) < 0)
@@ -558,7 +561,8 @@ void internal_lsattr (flux_conf_t cf, optparse_t *p, int ac, char *av[])
         }
         flux_close (h);
     } else {
-        usage ();
+        optparse_print_usage (p);
+        exit (1);
     }
 }
 

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -380,15 +380,15 @@ void exec_subcommand (const char *searchpath, bool vopt, char *argv[])
     }
 }
 
-optparse_t internal_cmd_optparse_create (const char *cmd)
+optparse_t *internal_cmd_optparse_create (const char *cmd)
 {
-    optparse_t p = optparse_create (cmd);
+    optparse_t *p = optparse_create (cmd);
     if (!p)
         err_exit ("%s: optparse_create", cmd);
     return (p);
 }
 
-void internal_help (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_help (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     int n = 1;
     char *cmd;
@@ -422,7 +422,7 @@ static void print_environment(flux_conf_t cf, const char * prefix)
     fflush(stdout);
 }
 
-void internal_env (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_env (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     int n = 1;
 
@@ -436,13 +436,13 @@ void internal_env (flux_conf_t cf, optparse_t p, int ac, char *av[])
         print_environment(cf, "");
 }
 
-void internal_broker (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_broker (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     const char *path = flux_conf_environment_get(cf, "FLUX_BROKER_PATH");
     execvp (path, av); /* no return if successful */
 }
 
-void internal_dmesg (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_dmesg (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     struct optparse_option opts[] = {
         { .name = "clear",  .key = 'C',  .has_arg = 0,
@@ -478,7 +478,7 @@ void internal_dmesg (flux_conf_t cf, optparse_t p, int ac, char *av[])
     flux_close (h);
 }
 
-void internal_getattr (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_getattr (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     int n;
 
@@ -499,7 +499,7 @@ void internal_getattr (flux_conf_t cf, optparse_t p, int ac, char *av[])
     }
 }
 
-void internal_setattr (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_setattr (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     struct optparse_option opts[] = {
         { .name = "expunge",  .key = 'e',  .has_arg = 0,
@@ -528,7 +528,7 @@ void internal_setattr (flux_conf_t cf, optparse_t p, int ac, char *av[])
     flux_close (h);
 }
 
-void internal_lsattr (flux_conf_t cf, optparse_t p, int ac, char *av[])
+void internal_lsattr (flux_conf_t cf, optparse_t *p, int ac, char *av[])
 {
     struct optparse_option opts[] = {
         { .name = "values",  .key = 'v',  .has_arg = 0,
@@ -566,7 +566,7 @@ struct builtin {
     const char *name;
     const char *doc;
     const char *usage;
-    void       (*fn) (flux_conf_t, optparse_t, int ac, char *av[]);
+    void       (*fn) (flux_conf_t, optparse_t *, int ac, char *av[]);
 };
 
 struct builtin builtin_cmds [] = {
@@ -618,7 +618,7 @@ struct builtin builtin_cmds [] = {
 
 void run_builtin (struct builtin *cmd, flux_conf_t cf, int ac, char *av[])
 {
-    optparse_t p;
+    optparse_t *p;
     char prog [66] = "flux-";
 
     /* cat command name onto 'flux-' prefix to get program name for

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -540,6 +540,9 @@ optparse_t *optparse_create (const char *prog)
 int optparse_getopt (optparse_t *p, const char *name, const char **optargp)
 {
     struct option_info *c;
+    if (optargp)
+        *optargp = NULL;
+
     if (!(c = find_option_info (p, name)))
         return (-1);
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -414,7 +414,7 @@ optparse_option_print (optparse_t *p, struct optparse_option *o, int columns)
     if (n < width)
         (*p->log_fn) ("%-*s%s\n", width, info, s);
     else
-        (*p->log_fn) ("\n%s\n%*s%s\n", info, width, "", s);
+        (*p->log_fn) ("%s\n%*s%s\n", info, width, "", s);
 
     /*  Get remaining usage lines (line-wrapped)
      */

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -143,9 +143,9 @@ static int option_info_cmp (struct option_info *x, struct option_info *y)
         if (x->isdoc && y->isdoc)
             return (0);
         else if (x->isdoc)
-            return (1);
-        else if (y->isdoc)
             return (-1);
+        else if (y->isdoc)
+            return (1);
         else if (isalnum (o1->key) && isalnum (o2->key))
             return (o1->key - o2->key);
         else

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -168,7 +168,7 @@ static int option_info_cmp_name (struct option_info *o, const char *name)
 /*
  *  Return option_info structure for option with [name]
  */
-static struct option_info *find_option_info (optparse_t p, const char *name)
+static struct option_info *find_option_info (optparse_t *p, const char *name)
 {
     return (list_find_first (p->option_list,
                              (ListFindF) option_info_cmp_name,
@@ -178,7 +178,7 @@ static struct option_info *find_option_info (optparse_t p, const char *name)
 /*   Remove the options in table [opts], up to but not including [end]
  *    If [end] is NULL, remove all options.
  */
-static void option_table_remove (optparse_t p,
+static void option_table_remove (optparse_t *p,
         struct optparse_option const opts[],
         const struct optparse_option *end)
 {
@@ -190,7 +190,7 @@ static void option_table_remove (optparse_t p,
     return;
 }
 
-static int optparse_set_usage (optparse_t p, const char *usage)
+static int optparse_set_usage (optparse_t *p, const char *usage)
 {
     if (p->usage)
         free (p->usage);
@@ -198,19 +198,19 @@ static int optparse_set_usage (optparse_t p, const char *usage)
     return (0);
 }
 
-static optparse_err_t optparse_set_log_fn (optparse_t p, opt_log_f fn)
+static optparse_err_t optparse_set_log_fn (optparse_t *p, opt_log_f fn)
 {
     p->log_fn = fn;
     return (0);
 }
 
-static optparse_err_t optparse_set_fatalerr_fn (optparse_t p, opt_fatalerr_f fn)
+static optparse_err_t optparse_set_fatalerr_fn (optparse_t *p, opt_fatalerr_f fn)
 {
     p->fatalerr_fn = fn;
     return (0);
 }
 
-static optparse_err_t optparse_set_fatalerr_handle (optparse_t p, void *handle)
+static optparse_err_t optparse_set_fatalerr_handle (optparse_t *p, void *handle)
 {
     p->fatalerr_handle = handle;
     return (0);
@@ -348,7 +348,7 @@ static int get_term_columns ()
 }
 
 static void
-optparse_doc_print (optparse_t p, struct optparse_option *o, int columns)
+optparse_doc_print (optparse_t *p, struct optparse_option *o, int columns)
 {
     char seg [128];
     char buf [4096];
@@ -365,7 +365,7 @@ optparse_doc_print (optparse_t p, struct optparse_option *o, int columns)
 }
 
 static void
-optparse_option_print (optparse_t p, struct optparse_option *o, int columns)
+optparse_option_print (optparse_t *p, struct optparse_option *o, int columns)
 {
     int n;
     char *equals = "";
@@ -424,7 +424,7 @@ optparse_option_print (optparse_t p, struct optparse_option *o, int columns)
     return;
 }
 
-static int optparse_print_options (optparse_t p)
+static int optparse_print_options (optparse_t *p)
 {
     int columns;
     struct option_info *o;
@@ -451,7 +451,7 @@ static int optparse_print_options (optparse_t p)
     return (0);
 }
 
-static int print_usage (optparse_t p)
+static int print_usage (optparse_t *p)
 {
     if (p->usage)
         (*p->log_fn) ("Usage: %s %s\n", p->program_name, p->usage);
@@ -475,7 +475,7 @@ static int display_help (struct optparse_option *o, const char *optarg)
 /*
  *  Destroy option parser [p]
  */
-void optparse_destroy (optparse_t p)
+void optparse_destroy (optparse_t *p)
 {
     if (p == NULL)
         return;
@@ -488,7 +488,7 @@ void optparse_destroy (optparse_t p)
 /*
  *   Create option parser for program named [prog]
  */
-optparse_t optparse_create (const char *prog)
+optparse_t *optparse_create (const char *prog)
 {
     struct optparse_option help = {
         .name = "help",
@@ -537,7 +537,7 @@ optparse_t optparse_create (const char *prog)
  *   and 1 if option was specified in args. Returns pointer to optargp
  *   if non-NULL.
  */
-int optparse_getopt (optparse_t p, const char *name, const char **optargp)
+int optparse_getopt (optparse_t *p, const char *name, const char **optargp)
 {
     struct option_info *c;
     if (!(c = find_option_info (p, name)))
@@ -551,7 +551,7 @@ int optparse_getopt (optparse_t p, const char *name, const char **optargp)
     return (0);
 }
 
-bool optparse_hasopt (optparse_t p, const char *name)
+bool optparse_hasopt (optparse_t *p, const char *name)
 {
     int n;
     if ((n = optparse_getopt (p, name, NULL)) < 0) {
@@ -563,7 +563,7 @@ bool optparse_hasopt (optparse_t p, const char *name)
     return (n > 0);
 }
 
-int optparse_get_int (optparse_t p, const char *name, int default_value)
+int optparse_get_int (optparse_t *p, const char *name, int default_value)
 {
     int n;
     long l;
@@ -591,7 +591,7 @@ badarg:
     return -1;
 }
 
-const char *optparse_get_str (optparse_t p, const char *name,
+const char *optparse_get_str (optparse_t *p, const char *name,
                               const char *default_value)
 {
     int n;
@@ -608,7 +608,7 @@ const char *optparse_get_str (optparse_t p, const char *name,
     return s;
 }
 
-optparse_err_t optparse_add_option (optparse_t p,
+optparse_err_t optparse_add_option (optparse_t *p,
         const struct optparse_option *o)
 {
     struct option_info *c;
@@ -628,7 +628,7 @@ optparse_err_t optparse_add_option (optparse_t p,
     return (OPTPARSE_SUCCESS);
 }
 
-optparse_err_t optparse_remove_option (optparse_t p, const char *name)
+optparse_err_t optparse_remove_option (optparse_t *p, const char *name)
 {
     optparse_err_t rc = OPTPARSE_SUCCESS;
 
@@ -642,7 +642,7 @@ optparse_err_t optparse_remove_option (optparse_t p, const char *name)
     return (rc);
 }
 
-optparse_err_t optparse_add_option_table (optparse_t p,
+optparse_err_t optparse_add_option_table (optparse_t *p,
         struct optparse_option const opts[])
 {
     optparse_err_t rc = OPTPARSE_SUCCESS;
@@ -657,7 +657,7 @@ optparse_err_t optparse_add_option_table (optparse_t p,
     return (rc);
 }
 
-optparse_err_t optparse_add_doc (optparse_t p, const char *doc, int group)
+optparse_err_t optparse_add_doc (optparse_t *p, const char *doc, int group)
 {
     struct optparse_option o;
 
@@ -675,7 +675,7 @@ optparse_err_t optparse_add_doc (optparse_t p, const char *doc, int group)
     return optparse_add_option (p, &o);
 }
 
-optparse_err_t optparse_set (optparse_t p, optparse_item_t item, ...)
+optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...)
 {
     optparse_err_t e = OPTPARSE_SUCCESS;
     va_list vargs;
@@ -719,7 +719,7 @@ optparse_err_t optparse_set (optparse_t p, optparse_item_t item, ...)
     return e;
 }
 
-optparse_err_t optparse_get (optparse_t p, optparse_item_t item, ...)
+optparse_err_t optparse_get (optparse_t *p, optparse_item_t item, ...)
 {
     /*
      *  Not implemented yet...
@@ -772,7 +772,7 @@ static char * optstring_append (char *optstring, struct optparse_option *o)
  *  Create getopt_long(3) option table and return.
  *  Also create shortopts table if sp != NULL and return by value.
  */
-static struct option * option_table_create (optparse_t p, char **sp)
+static struct option * option_table_create (optparse_t *p, char **sp)
 {
     struct option_info *o;
     struct option *opts;
@@ -812,7 +812,7 @@ static int by_val (struct option_info *c, int *val)
     return (c->p_opt->key == *val);
 }
 
-int optparse_parse_args (optparse_t p, int argc, char *argv[])
+int optparse_parse_args (optparse_t *p, int argc, char *argv[])
 {
     int c;
     int li;
@@ -866,7 +866,7 @@ int optparse_parse_args (optparse_t p, int argc, char *argv[])
     return (optind);
 }
 
-int optparse_print_usage (optparse_t p)
+int optparse_print_usage (optparse_t *p)
 {
     return print_usage (p);
 }

--- a/src/common/libutil/optparse.h
+++ b/src/common/libutil/optparse.h
@@ -51,13 +51,15 @@ typedef enum {
 /*
  *  Description of an option:
  */
+#define list_argument 3
 struct optparse_option {
     const char *  name;    /*  Option name (e.g. "help" for --help)         */
     int           key;     /*  Option key  (e.g. 'h', or other number).
 				If !isalnum(key), then this option is
                                 assumed to be a long option only.           */
 
-    int           has_arg; /*  0: no arg, 1: req'd arg, 2: optional arg     */
+    int           has_arg; /*  0: no arg, 1: req'd arg, 2: optional arg
+                               3: list-arg (split on comma separate values) */
     int           group;   /*  Grouping in --help output                    */
     const char *  arginfo; /*  arg info displayed after = in help output    */
     const char *  usage;   /*  String for usage/help output                 */

--- a/src/common/libutil/optparse.h
+++ b/src/common/libutil/optparse.h
@@ -147,6 +147,22 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[]);
  */
 int optparse_getopt (optparse_t *p, const char *name, const char **optargp);
 
+
+/*
+ *   Iterate over multiple optarg values for options that were provided
+ *    more than once. Returns NULL at end of list, or if option "name"
+ *    was not found (in which case optparse_getopt_iterator_reset()
+ *    for "name" will return -1).
+ */
+const char *optparse_getopt_next (optparse_t *p, const char *name);
+
+/*
+ *   Reset internal iterator so that optparse_getopt_next() will return the
+ *    first argument from the list. Returns the number of items to iterate, or
+ *    -1 if option "name" not found.
+ */
+int optparse_getopt_iterator_reset (optparse_t *p, const char *name);
+
 /*
  *   Return true if the option 'name' was used, false if not.
  *    If the option is unknown, log an error and call exit (1).

--- a/src/common/libutil/optparse.h
+++ b/src/common/libutil/optparse.h
@@ -7,7 +7,7 @@
  *  Datatypes:
  *****************************************************************************/
 struct optparse_option;
-typedef struct opt_parser * optparse_t;
+typedef struct opt_parser optparse_t;
 
 /*
  *  prototype for output function used by optparser
@@ -74,12 +74,12 @@ struct optparse_option {
 /*
  *   Create an optparse object for program named [program_name]
  */
-optparse_t optparse_create (const char *program_name);
+optparse_t *optparse_create (const char *program_name);
 
 /*
  *   Destroy program options handle [p].
  */
-void optparse_destroy (optparse_t p);
+void optparse_destroy (optparse_t *p);
 
 /*
  *   Register the option [o] with the program options object [p].
@@ -90,15 +90,15 @@ void optparse_destroy (optparse_t p);
  *
  *    OPTPARSE_NOMEM:  Failed to allocate memory for some options.
  *    OPTPARSE_EEXIST: An attempt to register a duplicate option was detected.
- *    OPTPARSE_EINVAL: The optparse_t object is currupt or invalid.
+ *    OPTPARSE_EINVAL: The optparse_t *object is currupt or invalid.
  */
-optparse_err_t optparse_add_option (optparse_t p,
+optparse_err_t optparse_add_option (optparse_t *p,
                                     const struct optparse_option *o);
 
 /*
  *   Remove option [name] from parser [p].
  */
-optparse_err_t optparse_remove_option (optparse_t p, const char *name);
+optparse_err_t optparse_remove_option (optparse_t *p, const char *name);
 
 /*
  *   Register all program options in table [opts] to the program options
@@ -109,7 +109,7 @@ optparse_err_t optparse_remove_option (optparse_t p, const char *name);
  *    with the parser [p]. Otherwise returns an error as in
  *    optparse_add_option().
  */
-optparse_err_t optparse_add_option_table (optparse_t p,
+optparse_err_t optparse_add_option_table (optparse_t *p,
 	                                  struct optparse_option const opts[]);
 
 /*
@@ -117,17 +117,17 @@ optparse_err_t optparse_add_option_table (optparse_t p,
  *    for program options object [p]. The doc string will preceed the
  *    option output for group [group].
  */
-optparse_err_t optparse_add_doc (optparse_t p, const char *doc, int group);
+optparse_err_t optparse_add_doc (optparse_t *p, const char *doc, int group);
 
-optparse_err_t optparse_set (optparse_t p, optparse_item_t item, ...);
+optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...);
 
-optparse_err_t optparse_get (optparse_t p, optparse_item_t item, ...);
+optparse_err_t optparse_get (optparse_t *p, optparse_item_t item, ...);
 
 /*
  *   Print the usage output for program options object [p] using the
  *    registered output function.
  */
-int optparse_print_usage (optparse_t p);
+int optparse_print_usage (optparse_t *p);
 
 /*
  *   Process command line args in [argc] and [argv] using the options
@@ -138,33 +138,33 @@ int optparse_print_usage (optparse_t p);
  *
  *   Returns -1 on failure, first non-option index in argv on success.
  */
-int optparse_parse_args (optparse_t p, int argc, char *argv[]);
+int optparse_parse_args (optparse_t *p, int argc, char *argv[]);
 
 /*
  *   After a call to optparse_parse_args (), return the number of times the
  *     option 'name' was used, or 0 if not. If the option was used and it takes
  *    an argument, then that argument is passed back in [optargp].
  */
-int optparse_getopt (optparse_t p, const char *name, const char **optargp);
+int optparse_getopt (optparse_t *p, const char *name, const char **optargp);
 
 /*
  *   Return true if the option 'name' was used, false if not.
  *    If the option is unknown, log an error and call exit (1).
  */
-bool optparse_hasopt (optparse_t p, const char *name);
+bool optparse_hasopt (optparse_t *p, const char *name);
 
 /*
  *   Return the option argument as an integer if 'name' was used,
  *    'default_value' if not.  If the option is unknown, or the argument
  *    could not be converted to an integer, call the fatal error function.
  */
-int optparse_get_int (optparse_t p, const char *name, int default_value);
+int optparse_get_int (optparse_t *p, const char *name, int default_value);
 
 /*
  *   Return the option argument as a string if 'name' was used, 'default_value'
  *    if not.  If the option is unknown, call the fatal error function.
  */
-const char *optparse_get_str (optparse_t p, const char *name,
+const char *optparse_get_str (optparse_t *p, const char *name,
                               const char *default_value);
 
 #endif /* _UTIL_OPTPARSE_H */

--- a/src/common/libutil/test/optparse.c
+++ b/src/common/libutil/test/optparse.c
@@ -23,7 +23,7 @@ void test_convenience_accessors (void)
     int ac = sizeof (av) / sizeof (av[0]) - 1;
     int rc, optind;
 
-    optparse_t p = optparse_create ("test");
+    optparse_t *p = optparse_create ("test");
     ok (p != NULL, "create object");
 
     rc = optparse_add_option_table (p, opts);

--- a/src/common/libutil/test/optparse.c
+++ b/src/common/libutil/test/optparse.c
@@ -1,11 +1,167 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/optparse.h"
+#include "src/common/libutil/sds.h"
 
 static void *myfatal_h = NULL;
 
 void myfatal (void *h, int exit_code, const char *fmt, ...)
 {
     myfatal_h = h;
+}
+
+sds usage_out = NULL;
+void output_f (const char *fmt, ...)
+{
+    va_list ap;
+    sds s = usage_out ? usage_out : sdsempty();
+    va_start (ap, fmt);
+    usage_out = sdscatvprintf (s, fmt, ap);
+    va_end (ap);
+}
+
+void usage_ok (optparse_t *p, const char *expected, const char *msg)
+{
+    optparse_print_usage (p);
+    ok (usage_out != NULL, "optparse_print_usage");
+    is (usage_out, expected, msg);
+    sdsfree (usage_out);
+    usage_out = NULL;
+}
+
+void test_usage_output (void)
+{
+    optparse_err_t e;
+    optparse_t *p = optparse_create ("prog-foo");
+    struct optparse_option opt;
+    ok (p != NULL, "optparse_create");
+
+    // Ensure we use default term columns:
+    unsetenv ("COLUMNS");
+
+    opt = ((struct optparse_option) {
+            .name = "test", .key = 't', .has_arg = 0,
+            .usage = "Enable a test option."
+            });
+    e = optparse_add_option (p, &opt);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_option");
+    opt = ((struct optparse_option) {
+            .name = "test2", .key = 'T', .has_arg = 1,
+            .arginfo = "N",
+            .usage = "Enable a test option N."
+            });
+    e = optparse_add_option (p, &opt);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_option");
+
+    e = optparse_set (p, OPTPARSE_USAGE, "[OPTIONS]");
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (USAGE)");
+
+    e = optparse_set (p, OPTPARSE_LOG_FN, output_f);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (LOG_FN)");
+
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+  -T, --test2=N          Enable a test option N.\n\
+  -h, --help             Display this message.\n\
+  -t, --test             Enable a test option.\n",
+        "Usage output as expected");
+
+    e = optparse_set (p, OPTPARSE_LEFT_MARGIN, 0);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (LEFT_MARGIN)");
+
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+-T, --test2=N            Enable a test option N.\n\
+-h, --help               Display this message.\n\
+-t, --test               Enable a test option.\n",
+        "Usage output as expected w/ left margin");
+
+    e = optparse_set (p, OPTPARSE_LEFT_MARGIN, 2);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (LEFT_MARGIN)");
+
+    // Remove options
+    e = optparse_remove_option (p, "test");
+    ok (e == OPTPARSE_SUCCESS, "optparse_remove_option (\"test\")");
+
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+  -T, --test2=N          Enable a test option N.\n\
+  -h, --help             Display this message.\n",
+        "Usage output as expected after option removal");
+
+    // Add doc sections
+    e = optparse_add_doc (p, "This is some doc in header", 0);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_doc (group=0)");
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N          Enable a test option N.\n\
+  -h, --help             Display this message.\n",
+        "Usage output as with doc");
+
+    // Add a longer option in group 1:
+    opt = ((struct optparse_option) {
+            .name = "long-option", .key = 'A', .has_arg = 1, .group = 1,
+            .arginfo = "ARGINFO",
+            .usage = "Enable a long option with argument info ARGINFO."
+            });
+    e = optparse_add_option (p, &opt);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_option. group 1.");
+
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N          Enable a test option N.\n\
+  -h, --help             Display this message.\n\
+  -A, --long-option=ARGINFO\n\
+                         Enable a long option with argument info ARGINFO.\n",
+        "Usage output with option in group 1");
+
+    // Add doc for group 1.
+    e = optparse_add_doc (p, "This is some doc for group 1", 1);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_doc (group = 1)");
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N          Enable a test option N.\n\
+  -h, --help             Display this message.\n\
+This is some doc for group 1\n\
+  -A, --long-option=ARGINFO\n\
+                         Enable a long option with argument info ARGINFO.\n",
+        "Usage output with option in group 1");
+
+
+    // Increase option width:
+    e = optparse_set (p, OPTPARSE_OPTION_WIDTH, 30);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (OPTION_WIDTH)");
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N               Enable a test option N.\n\
+  -h, --help                  Display this message.\n\
+This is some doc for group 1\n\
+  -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n",
+        "Usage output with increased option width");
+
+    // Add an option with very long description in group 1:
+    opt = ((struct optparse_option) {
+            .name = "option-B", .key = 'B', .group = 1,
+            .usage = "This option has a very long description. It should be split across lines nicely."
+            });
+    e = optparse_add_option (p, &opt);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_option. group 1.");
+
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N               Enable a test option N.\n\
+  -h, --help                  Display this message.\n\
+This is some doc for group 1\n\
+  -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\
+  -B, --option-B              This option has a very long description. It should\n\
+                              be split across lines nicely.\n",
+        "Usage output with message autosplit across lines");
+
+    optparse_destroy (p);
 }
 
 void test_convenience_accessors (void)
@@ -85,12 +241,52 @@ void test_convenience_accessors (void)
     optparse_destroy (p);
 }
 
+void test_errors (void)
+{
+    optparse_err_t e;
+    struct optparse_option opt;
+    optparse_t *p = optparse_create ("errors-test");
+    ok (p != NULL, "optparse_create");
+
+    opt = ((struct optparse_option) {
+            .name = "help", .key = 'h',
+            .usage = "Conflicting option"
+            });
+
+    e = optparse_add_option (p, &opt);
+    ok (e == OPTPARSE_EEXIST, "optparse_add_option: Errror with EEXIST");
+    e = optparse_add_option (NULL, &opt);
+    ok (e == OPTPARSE_BAD_ARG, "optparse_add_option: BAD_ARG with invalid optparse_t");
+
+    e = optparse_remove_option (p, "foo");
+    ok (e == OPTPARSE_FAILURE, "optparse_remove_option: FAILURE if option not found");
+
+    // optparse_set error cases:
+    e = optparse_set (p, 1000, 1);
+    ok (e == OPTPARSE_BAD_ARG, "optparse_set (invalid item) returns BAD_ARG");
+
+    e = optparse_set (p, OPTPARSE_LEFT_MARGIN, 2000);
+    ok (e == OPTPARSE_BAD_ARG, "optparse_set (LEFT_MARGIN, 2000) returns BAD_ARG");
+    e = optparse_set (p, OPTPARSE_LEFT_MARGIN, -1);
+    ok (e == OPTPARSE_BAD_ARG, "optparse_set (LEFT_MARGIN, -1) returns BAD_ARG");
+
+    e = optparse_set (p, OPTPARSE_OPTION_WIDTH, 2000);
+    ok (e == OPTPARSE_BAD_ARG, "optparse_set (OPTION_WIDTH, 2000) returns BAD_ARG");
+    e = optparse_set (p, OPTPARSE_OPTION_WIDTH, -1);
+    ok (e == OPTPARSE_BAD_ARG, "optparse_set (OPTION_WIDTH, -1) returns BAD_ARG");
+
+
+    optparse_destroy (p);
+}
+
 int main (int argc, char *argv[])
 {
 
-    plan (24);
+    plan (62);
 
     test_convenience_accessors (); /* 24 tests */
+    test_usage_output (); /* 29 tests */
+    test_errors (); /* 9 tests */
 
     done_testing ();
     return (0);

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -89,7 +89,7 @@ static struct optparse_option opts[] = {
 
 int mod_main (flux_t h, int argc, char **argv)
 {
-    optparse_t p = optparse_create ("pymod");
+    optparse_t *p = optparse_create ("pymod");
     if (optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS)
         msg_exit ("optparse_add_option_table");
     if (optparse_set (p, OPTPARSE_USAGE, usage_msg) != OPTPARSE_SUCCESS)

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1656,7 +1656,7 @@ static void daemonize ()
     }
 }
 
-int prog_ctx_get_id (struct prog_ctx *ctx, optparse_t p)
+int prog_ctx_get_id (struct prog_ctx *ctx, optparse_t *p)
 {
     const char *id;
     char *end;
@@ -1679,7 +1679,7 @@ int main (int ac, char **av)
 {
     int parent_fd = -1;
     struct prog_ctx *ctx = NULL;
-    optparse_t p;
+    optparse_t *p;
     struct optparse_option opts [] = {
         { .name =    "lwj-id",
           .key =     1000,

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -254,6 +254,7 @@ test_expect_success 'flux-wreck: status with non-zero exit' '
 test_expect_success 'flux-wreck: kill' '
 	run_timeout 1 flux wreckrun --detach sleep 100 &&
 	id=$(last_job_id) &&
+	${SHARNESS_TEST_SRCDIR}/scripts/kvs-watch-until.lua lwj.$id running &&
 	flux wreck kill -s SIGINT $id &&
 	test_expect_code 130 flux wreck status $id >output.kill &&
 	cat >expected.kill <<-EOF &&


### PR DESCRIPTION
This work started as a fix for some `flux(1)` builtins that were emitting the wrong usage message, e.g.
```
grondo@flux-core:~/workspace (master) $ src/cmd/flux lsattr foo
Usage: flux [OPTIONS] COMMAND ARGS
    -x,--exec-path PATH   prepend PATH to command search path
    -M,--module-path PATH prepend PATH to module search path
    -O,--connector-path PATH   prepend PATH to connector search path
...
```

In the meantime I decided it was a good time to convert `optparse_t` to rfc 7 compliance, as well as expand the testuite, which uncovered other minor issues. While I was in there I fixed an annoying problem with `optparse_t` where all information from options used more than once was simply discarded with the last usage winning.

Now an `optparse_t` object tracks the number of times an option was provided (whether it takes an arg or not) and returns this number with `optparse_getopt()`. (Useful for `-v -v -v` usage). Additionally, a list of args provided for each option is kept, and can be iterated with `optparse_getopt_next()`. The iterator may be reset with `optparse_getopt_iterator_reset()`.

Finally, a new `has_arg` mode `list_argument (= 3)` is provided to allow multiple args to be provided either via a comma separated list or multiple options or any combination of either. (Somewhat like perl's `Getopt::Long` `@s` mode). 

Experimentally, this is applied to `flux-start` to allow multiple `-o` options *and* comma separated args, e.g.
```
 flux start --size=4 -o -Lbroker.log -o -q,-l5
```

This will need to be rebased on top of #434 once it is merged, but I post this now to get any feedback.