### PR TITLE
Fix wreck stdin handling

### DIFF
--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -30,9 +30,10 @@ Print help. If 'cmd' is provided, print help for that sub-command.
 Display a list of wreck jobs currently in kvs, along with their current
 states.
 
-*attach* [--status] 'jobid'::
-Attach to output of a running or completed job. With '--status', also
-report job status after dumping output.
+*attach* [--status] [--label-io] 'jobid'::
+Attach to output of a running or completed job. If input was not previously
+connected, also attach to stdin. With '--status', also report job status
+after dumping output. With '--label-io' label lines of output with taskid.
 
 *status* 'jobid'::
 Return the status of running or completed job 'jobid'. Prints the current

--- a/doc/man1/flux-wreckrun.adoc
+++ b/doc/man1/flux-wreckrun.adoc
@@ -12,7 +12,9 @@ SYNOPSIS
 --------
 [verse]
 'flux wreckrun' [-n <ntasks>] [-N <nnodes>] [-t <tasks-per-node>]
-                [-l|--label-io] [-o|--options='OPTIONS'] ['COMMANDS'...]
+                [-l|--label-io] [-d|--detach] [-o|--options='OPTIONS']
+                [-O|--output='FILENAME'] [-E|--error='FILENAME']
+                [-i|--input='HOW'] ['COMMANDS'...]
 
 
 DESCRIPTION
@@ -50,6 +52,33 @@ OPTIONS
 -l::
 	Prepend stdout and stderr output lines with the task id to which
 	the output belongs.
+
+--detach::
+-d::
+	Detach immediately after issuing a run request and print new jobid
+	to stdout.
+
+--output='FILENAME'::
+-O 'FILENAME'::
+	Duplicate stdout and stderr from tasks to a file or files. 'FILENAME'
+	is optionally a mustache template which expands the keys 'id', 'cmd'
+	and 'taskid'. (e.g. '--output=flux-{{id}}.out')
+
+--error='FILENAME'::
+-E 'FILENAME'::
+	Send stderr to a different location than stdout.
+
+--input='HOW'::
+-i 'HOW'::
+	Indicate how to deal with stdin for tasks. 'HOW' is a list of 'src:dst'
+	pairs where 'src' is a source 'FILENAME' which may optionally be a
+	mustache template as in `--output`, or the special term `stdin` to
+	indicate the stdin from a front end program, and 'dst' is a list of
+	taskids or `*` or `all` to indicate all tasks. The default is `stdin:*`.
+	If only one of 'src' or 'dst' is specified, a heuristic is used to
+	determine whether a list of tasks or an input file was meant. (e.g
+	`--input=file.in` will use `file.in` as input for all tasks, and
+	`--input=0` will send stdin to task 0 only.
 
 --options='options,...'::
 -o 'options,...'::

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -287,3 +287,7 @@ prev
 nlink
 inotify
 ipc
+FILENAME
+dst
+taskid
+taskids

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -227,7 +227,12 @@ local function inputs_table_from_args (wreck, s)
         if dst ~= "all" and dst ~= "*" then
             local h, err = cpuset.new (dst)
             if not h then
-                wreck:die ("--input: invalid dst: %s\n", dst)
+                if src ~= "" then
+                    wreck:die ("--input: invalid dst: %s\n", dst)
+                end
+                -- otherwise, assume only dst was provided
+                src = dst
+                dst = "*"
             end
         end
         if src == "" or src == "-" then src = "stdin" end

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -95,11 +95,11 @@ function wreck:usage()
                              for minutes, 'h' for hours or 'd' for days.
                              N may be an arbitrary floating point number,
                              but will be rounded up to nearest second.
-  -o, --output=FILENAME      Duplicate stdout/stderr from tasks to a file or
-                             files. FILENAME is optionally a moustache
+  -O, --output=FILENAME      Duplicate stdout/stderr from tasks to a file or
+                             files. FILENAME is optionally a mustache
                              template with keys such as id, cmd, taskid.
-                             (e.g. --tee=flux-{{id}}.out)
-  -e, --error=FILENAME       Send stderr to a different location than stdout.
+                             (e.g. --output=flux-{{id}}.out)
+  -E, --error=FILENAME       Send stderr to a different location than stdout.
   -l, --labelio              Prefix lines of output with task id
 ]])
     for _,v in pairs (self.extra_options) do

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -22,6 +22,8 @@
  *  See also:  http://www.gnu.org/licenses/
  ---------------------------------------------------------------------------]]
 local posix = require 'flux.posix'
+local hostlist = require 'flux.hostlist'
+local cpuset = require 'flux.affinity'.cpuset
 
 local wreck = {}
 wreck.__index = wreck;
@@ -42,6 +44,7 @@ local default_opts = {
     ['walltime'] = { char = "T", arg = "SECONDS" },
     ['output'] =   { char = "O", arg = "FILENAME" },
     ['error'] =    { char = "E", arg = "FILENAME" },
+    ['input'] =    { char = "i", arg = "HOW" },
     ['label-io'] = { char = "l", },
     ['options'] = { char = 'o', arg = "OPTIONS.." },
 }
@@ -99,6 +102,12 @@ function wreck:usage()
                              files. FILENAME is optionally a mustache
                              template with keys such as id, cmd, taskid.
                              (e.g. --output=flux-{{id}}.out)
+  -i, --input=HOW            Indicate how to deal with stdin for tasks. HOW
+                             is a list of [src:]dst pairs separated by semi-
+                             colon, where src is an optional src file
+                             (default: stdin) and dst is a list of taskids
+                             or "*" or "all". E.g. (-s0 sends stdin to task 0,
+                             -s /dev/null:* closes all stdin, etc.)
   -E, --error=FILENAME       Send stderr to a different location than stdout.
   -l, --labelio              Prefix lines of output with task id
 ]])
@@ -201,6 +210,34 @@ function wreck:parse_cmdline (arg)
     return true
 end
 
+local function inputs_table_from_args (wreck, s)
+    -- Default is to broadcast stdin to all tasks:
+    if not s then return { { src = "stdin", dst = "*" } } end
+
+    local inputs = {}
+    for m in s:gmatch ("[^;]+") do
+        local src,dst = m:match ("^([^:]-):?([^:]+)$")
+        if not src or not dst then
+            wreck:die ("Invalid argument to --input: %s\n", s)
+        end
+        --  A dst of "none" short circuits rest of entries
+        if dst == "none" then return inputs end
+
+        --  Verify the validity of dst
+        if dst ~= "all" and dst ~= "*" then
+            local h, err = cpuset.new (dst)
+            if not h then
+                wreck:die ("--input: invalid dst: %s\n", dst)
+            end
+        end
+        if src == "" or src == "-" then src = "stdin" end
+        table.insert (inputs, { src = src, dst = dst })
+    end
+    -- Add fall through option
+    table.insert (inputs, { src = "/dev/null", dst = "*" })
+    return inputs
+end
+
 function wreck:jobreq ()
     if not self.opts then return nil, "Error: cmdline not parsed" end
     local nnodes = tonumber (self.opts.N)
@@ -227,6 +264,7 @@ function wreck:jobreq ()
             labelio = self.opts.l,
         }
     end
+    jobreq ["input.config"] = inputs_table_from_args (self, self.opts.i)
     return jobreq
 end
 
@@ -275,7 +313,6 @@ end
 -- @param arg.flux  (optional) flux handle
 -- @return exit_cde, msg_list
 function wreck.status (arg)
-    local hostlist = require 'flux.hostlist'
     local f = arg.flux
     local jobid = arg.jobid
     if not jobid then return nil, "required arg jobid" end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -28,6 +28,7 @@
 local f, err = require 'flux' .new()
 local wreck = require 'wreck'
 local hostlist = require 'flux.hostlist'
+local posix = require 'posix'
 
 local prog = string.match (arg[0], "([^/]+)$")
 local shortprog = prog:match ("flux%-(.+)$")
@@ -138,6 +139,16 @@ Command {
         end
     }
     if not taskio then die ("Failed to connect to job %d: %s\n", id, err) end
+    local kz, err = f:kz_open ("lwj."..id..".input.files.stdin", "w")
+    if kz then
+        f:iowatcher {
+            fd = posix.fileno (io.input()),
+            handler = function (iow, r)
+                if r.data then kz:write (r.data) end
+                if r.eof  then kz:close () end
+            end
+        }
+    end
     if not taskio:complete() then f:reactor () end
     if self.opt.s then
         Commands.status:run ({id})
@@ -147,7 +158,6 @@ Command {
 }
 
 local function opt_sig (s)
-    local posix = require 'posix'
     if not s then return posix.SIGTERM end
     if tonumber (s) then return tonumber (s) end
     if not tonumber (posix[s]) then

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -242,8 +242,9 @@ LWJ.__index = function (self, key)
         local st = self.lwj["starting-time"]
         if not st then return 0 end
         local ct = self.lwj["complete-time"]
-        if not ct then ct = now () end
-        local s = ct - st
+        local ft = self.lwj["failed-time"]
+        if not ct and not ft then ct = now () end
+        local s = (ct and ct or ft) - st
         return s > 0 and s or 0
     elseif key == "start" then
         return os.date ("%FT%T", self.lwj["starting-time"])

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -235,7 +235,7 @@ if true then
     local rc,err = f:sendevent ("wrexec.run.%d", resp.jobid)
     if not rc then wreck:die ("sendevent: %s\n", err) end
     if wreck.opts.d then
-        print ("Job "..resp.jobid)
+        print (resp.jobid)
         os.exit(0)
     end
 else

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -272,9 +272,9 @@ taskio, err = ioattach {
 if not taskio then wreck:die ("error opening task io: %s\n", err) end
 
 --
---  Open stdin (to task 0 only for now)
+--  Open stdin
 --
-local kz, err = f:kz_open (tostring (lwj)..".0.stdin", "w")
+local kz, err = f:kz_open (tostring (lwj)..".input.files.stdin", "w")
 if not kz then wreck:die (err) end
 
 --

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -149,8 +149,6 @@ wreck:add_options ({
         usage = "Force number of tasks per node" },
     { name = "nnodes", char = "N", arg = "N",
         usage = "Force number of nodes" },
-    { name = 'now', char = 'i',
-        usage = "Run job immediately" },
     { name = 'pre-launch-hook', char = "P", arg = "CODE",
         usage = "execute Lua CODE before launch." },
     { name = 'detach', char = "d",

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -140,7 +140,9 @@ end
 --
 local wreck = require 'wreck' .new (shortprog)
 local ioattach = require 'wreck'.ioattach
+local logstream = require 'wreck'.logstream
 local taskio
+local log
 local sigtimer
 local state = ""
 
@@ -249,6 +251,10 @@ end
 --  Check if job state is "complete" and all IO from tasks have closed:
 --
 local function check_job_completed ()
+    if state == "failed" then
+       log:dump()
+       wreck:die ("job %d failed\n", resp.jobid)
+    end
     if taskio:complete() and
        (state == "complete" or state == "reaped") then
         local rc = lwj_return_code (f, wreck, resp.jobid)
@@ -270,6 +276,12 @@ taskio, err = ioattach {
      on_completion = check_job_completed
 }
 if not taskio then wreck:die ("error opening task io: %s\n", err) end
+
+log, err = logstream {
+     flux = f,
+     jobid = resp.jobid,
+}
+if not log then wreck:die ("error opening log stream: %s\n", err) end
 
 --
 --  Open stdin

--- a/src/modules/libjsc/README.md
+++ b/src/modules/libjsc/README.md
@@ -61,6 +61,7 @@ service.
 | J_CANCELLED  | Cancelled |
 | J_COMPLETE   | Complete |
 | J_REAPED     | Reaped to the upper-level Flux instance |
+| J_FAILED     | Failed before running |
 | J_FOR\_RENT   | To be extended |
 
 **Table 2-1** Job state elements

--- a/src/modules/libjsc/jstatctl.h
+++ b/src/modules/libjsc/jstatctl.h
@@ -50,6 +50,7 @@ typedef enum {
     J_CANCELLED, /*!< Cancelled */
     J_COMPLETE,  /*!< Completed */
     J_REAPED,    /*!< Reaped */
+    J_FAILED,    /*!< Failed */
     J_FOR_RENT   /*!< Space For Rent */
 } job_state_t;
 

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -68,7 +68,8 @@ dist_wreckscripts_SCRIPTS = \
 	lua.d/01-env.lua \
 	lua.d/02-affinity.lua \
 	lua.d/timeout.lua \
-        lua.d/output.lua
+        lua.d/output.lua \
+        lua.d/input.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/lua.d/input.lua
+++ b/src/modules/wreck/lua.d/input.lua
@@ -151,7 +151,7 @@ function rexecd_init ()
     local cfg = inputconf.create (wreck)
     local rc, err = cfg:process_config ()
     if not rc then
-        wreck:log_msg ("Error: input: %s", err)
+        wreck:die ("Error: input: %s", err)
         return
     end
     cfg:start ()

--- a/src/modules/wreck/lua.d/input.lua
+++ b/src/modules/wreck/lua.d/input.lua
@@ -1,0 +1,158 @@
+--
+--  Process any stdin configuration for a job, opening files
+--   if requested, and setting up task stdin links as
+--   directed in lwj.<id>.input.config
+--
+local posix = require 'flux.posix'
+local cpuset = require 'flux.affinity'.cpuset
+
+local function kvs_input_config (wreck)
+    local o = wreck.kvsdir ["input.config"]
+    if not o then
+         o = wreck.flux:kvsdir ("lwj.input.config")
+    end
+    return o
+end
+
+local inputconf = {}
+inputconf.__index = inputconf
+function inputconf.create (wreck)
+    local c = {
+        conf = kvs_input_config (wreck),
+        wreck = wreck,
+        maxid = wreck.kvsdir.ntasks - 1,
+        basedir = tostring (wreck.kvsdir),
+        inputsdir = tostring (wreck.kvsdir) .. ".input.files",
+	inputs = {},
+    }
+    -- Add default input config
+    if not c.conf then
+        c.conf = { { src = "stdin", dst = "*" } }
+    end
+
+    c.tasksleft, err = cpuset.new ('0-'..c.maxid)
+
+    -- Add stdin entry to inputs
+    c.inputs[1] = { filename = "stdin",
+                    kzpath = c.inputsdir .. ".stdin" }
+    return setmetatable (c, inputconf)
+end
+
+function inputconf:set (taskid)
+    if self.tasksleft[taskid] then
+        self.tasksleft [taskid] = 0
+        return false
+    end
+    return true
+end
+
+function inputconf:add_source (path)
+    local i = { filename = path }
+    local f = self.wreck.flux
+
+    -- First open file for input:
+    local fp, err = io.open (path, "r")
+    if not fp then return nil, err end
+    i.fd = posix.fileno (fp)
+    
+    -- now open kz stream for writing:
+    local basedir = self.inputsdir .. "." .. #self.inputs
+    f:kvs_put (basedir..".filename", i.filename)
+    i.kzpath = basedir .. ".kz"
+    local kz, err = f:kz_open (i.kzpath, "w")
+    if not kz then
+        io.close (fp)
+        return nil, err
+    end
+    i.kz = kz
+    table.insert (self.inputs, i)
+    return i
+end
+
+function inputconf:input (path)
+    for _,t in pairs (self.inputs) do
+        if t.filename == path then
+            return t
+        end
+    end
+    return self:add_source (path)
+end
+
+function inputconf:render (template, taskid)
+    local lustache = require 'flux.lustache'
+    local view = {
+        taskid = taskid
+    }
+    setmetatable (view, { __index = self.wreck })
+    return lustache:render (template, view)
+end
+
+
+function inputconf:task_input (template, i)
+    return self:input (self:render (template, i))
+end
+
+function inputconf:dst_to_list (dst)
+    if dst == "" or dst == "*" or dst == "all" then
+        return self.tasksleft
+    end
+    return cpuset.new (dst)
+end
+
+function inputconf:task_stdin (taskid)
+    return self.basedir .. "." .. taskid .. ".stdin"
+end
+
+-- Link stdin for task id list ids to "path"
+function inputconf:link (ids, path)
+    local f = self.wreck.flux
+    local taskids = self:dst_to_list (ids)
+    if #taskids == 0 then return true end
+    for i in taskids:iterator () do
+	if not self:set (i) then
+            local input, err = self:task_input (path, i)
+            if not input then return nil, err end
+            f:kvs_symlink (self:task_stdin (i), input.kzpath)
+        end
+    end
+    return true
+end
+
+function inputconf:process_config ()
+    for _, input in pairs (self.conf) do
+        local rc, err = self:link (input.dst, input.src)
+        if not rc then return nil, err end
+    end
+    return true
+end
+function input_start (f, input)
+    f:iowatcher {
+        fd = input.fd,
+        handler = function (iow, r)
+            input.kz:write (r.data)
+            if r.eof then input.kz:close () end
+        end
+    }
+end
+
+function inputconf:start ()
+    local f = self.wreck.flux
+    for path, input in pairs (self.inputs) do
+        if input.kz and input.fd then
+            input_start (f, input)
+       end
+    end
+end
+function rexecd_init ()
+    if wreck.nodeid ~= 0 then return end
+    local f = wreck.flux
+    local dir = tostring (wreck.kvsdir)
+
+    local cfg = inputconf.create (wreck)
+    local rc, err = cfg:process_config ()
+    if not rc then
+        wreck:log_msg ("Error: input: %s", err)
+        return
+    end
+    cfg:start ()
+end

--- a/src/modules/wreck/lua.d/output.lua
+++ b/src/modules/wreck/lua.d/output.lua
@@ -28,7 +28,7 @@ end
 local function openstream (wreck, taskio, taskid, stream, template)
     local path = render (template, wreck, taskid)
     if not path then
-        wreck:log_msg ("Failed to render template '"..template.."'")
+        wreck:die ("output: Failed to render template '"..template.."'")
         return
     end
     taskio:redirect (taskid, stream, path)

--- a/src/modules/wreck/lua.d/output.lua
+++ b/src/modules/wreck/lua.d/output.lua
@@ -35,6 +35,10 @@ local function openstream (wreck, taskio, taskid, stream, template)
     return path
 end
 
+local function log (fmt, ...)
+    wreck:log_msg (fmt, ...)
+end
+
 function rexecd_init ()
     if wreck.nodeid ~= 0 then return end
 
@@ -48,6 +52,8 @@ function rexecd_init ()
         labelio = output.labelio and output.labelio ~= false
     }
     if not taskio then wreck:log_msg ("Error: %s", err) end
+
+    ioplex:enable_debug (log)
 
     local template = output.files.stdout
     local stderr_template = output.files.stderr

--- a/src/modules/wreck/lua.d/timeout.lua
+++ b/src/modules/wreck/lua.d/timeout.lua
@@ -29,7 +29,7 @@ local function start_timer (f, wreck, id, walltime)
         oneshot = true,
         handler = function (f, to)
           local signum = timeout_signal (f, wreck)
-          wreck:log_msg ("Timeout expired! Killing job with signal %d", signum)
+          wreck:log_error ("Timeout expired! Killing job with signal %d", signum)
           local rc,err = f:sendevent ({signal = signum}, "wreck.%d.kill", id)
           if not rc then
               wreck:log_msg ("Failed to send kill event: %s", err)

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1309,7 +1309,7 @@ static int l_wreck_log_msg (lua_State *L)
     return (0);
 }
 
-static int l_wreck_die (lua_State *L)
+static int wreck_log_error (lua_State *L, int fatal)
 {
     struct prog_ctx *ctx = l_get_prog_ctx (L, 1);
     const char *s;
@@ -1317,8 +1317,18 @@ static int l_wreck_die (lua_State *L)
         return (2); /* error on stack from l_format_args */
     if (!(s = lua_tostring (L, 2)))
         return lua_pusherror (L, "required arg to die missing");
-    log_error_kvs (ctx, 1, s);
+    log_error_kvs (ctx, fatal, s);
     return (0);
+}
+
+static int l_wreck_die (lua_State *L)
+{
+    return wreck_log_error (L, 1);
+}
+
+static int l_wreck_log_error (lua_State *L)
+{
+    return wreck_log_error (L, 0);
 }
 
 static int l_wreck_index (lua_State *L)
@@ -1429,6 +1439,10 @@ static int l_wreck_index (lua_State *L)
     }
     if (strcmp (key, "die") == 0) {
         lua_pushcfunction (L, l_wreck_die);
+        return (1);
+    }
+    if (strcmp (key, "log_error") == 0) {
+        lua_pushcfunction (L, l_wreck_log_error);
         return (1);
     }
     return (0);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -295,6 +295,8 @@ void kz_stdin (kz_t *kz, struct task_info *t)
         zio_write_json (t->zio [IN], json_str);
         free (json_str);
     }
+    if (errno != 0 && errno != EAGAIN)
+        log_err (t->ctx, "kz_get_json: %s", strerror (errno));
     return;
 }
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -316,7 +316,8 @@ kz_t *task_kz_open (struct task_info *t, int type)
     int flags = prog_ctx_io_flags (ctx);
 
     if (type == IN)
-        flags |= KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK | KZ_FLAGS_NOEXIST;
+        flags |= KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK | KZ_FLAGS_NOEXIST
+                 | KZ_FLAGS_RAW;
     else
         flags |= KZ_FLAGS_WRITE;
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1309,6 +1309,18 @@ static int l_wreck_log_msg (lua_State *L)
     return (0);
 }
 
+static int l_wreck_die (lua_State *L)
+{
+    struct prog_ctx *ctx = l_get_prog_ctx (L, 1);
+    const char *s;
+    if (lua_gettop (L) > 2 && l_format_args (L, 2) < 0)
+        return (2); /* error on stack from l_format_args */
+    if (!(s = lua_tostring (L, 2)))
+        return lua_pusherror (L, "required arg to die missing");
+    log_error_kvs (ctx, 1, s);
+    return (0);
+}
+
 static int l_wreck_index (lua_State *L)
 {
     struct task_info *t;
@@ -1413,6 +1425,10 @@ static int l_wreck_index (lua_State *L)
     }
     if (strcmp (key, "log_msg") == 0) {
         lua_pushcfunction (L, l_wreck_log_msg);
+        return (1);
+    }
+    if (strcmp (key, "die") == 0) {
+        lua_pushcfunction (L, l_wreck_die);
         return (1);
     }
     return (0);

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -206,7 +206,7 @@ test_expect_success 'wreck plugins can use wreck:log_msg()' '
 	flux dmesg | grep "plugin test successful" || (flux dmesg | grep lwj\.$(last_job_id) && false)
 '
 test_expect_success 'wreckrun: --detach supported' '
-	flux wreckrun --detach /bin/true | grep ^Job
+	flux wreckrun --detach /bin/true | grep "^[0-9]"
 '
 
 WAITFILE="$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua"

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -287,6 +287,17 @@ test_expect_success 'flux-wreck: attach' '
 	flux wreck attach $(last_job_id) > output.attach &&
         test_cmp expected.attach output.attach
 '
+test_expect_success 'flux-wreck: attach with stdin' '
+	jobid=$(flux wreckrun -n4 --detach cat) &&
+	echo foo | flux wreck attach $jobid > output.attach_in &&
+	cat >expected.attach_in <<-EOF &&
+	foo
+	foo
+	foo
+	foo
+	EOF
+	test_cmp output.attach_in expected.attach_in
+'
 test_expect_success 'flux-werck: attach --label-io' '
 	flux wreckrun -l -n4 --output=expected.attach-l echo bazz >/dev/null &&
 	flux wreck attach --label-io $(last_job_id) |sort > output.attach-l &&

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -55,6 +55,19 @@ test_expect_success 'wreckrun: does not drop output' '
 	run_timeout 5 flux wreckrun -N1 -n1 cat expected >output &&
 	test_cmp expected output
 '
+test_expect_success 'wreckrun: handles stdin' '
+	cat >expected.stdin <<-EOF &&
+	This is a test.
+
+	EOF
+	cat expected.stdin | flux wreckrun -T5s cat > output.stdin &&
+        test_cmp expected.stdin output.stdin
+'
+test_expect_success 'wreckrun: handles empty stdin' '
+	flux wreckrun -T5s cat > output.devnull </dev/null &&
+        test_must_fail test -s output.devnull
+'
+
 test_expect_success 'wreck: job state events emitted' '
 	run_timeout 5 \
 	  $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -113,6 +113,13 @@ test_expect_success 'wreckrun: --input=/dev/null:* works' '
         echo hello | flux wreckrun --input=/dev/null:* -l -n${SIZE} cat > output.devnull2 &&
 	test_must_fail test -s output.devnull2
 '
+test_expect_success 'wreckrun: bad input file causes failure' '
+	test_must_fail \
+	    flux wreckrun --input=/foo/badfile:* -l -n${SIZE} cat \
+	        >output.badinput 2>error.badinput &&
+	test_must_fail test -s output.badinput &&
+	grep "Error: input: /foo/badfile" error.badinput
+'
 
 test_expect_success 'wreck: job state events emitted' '
 	run_timeout 5 \

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -44,14 +44,12 @@ sync_flux_jstat () {
 
 overlap_flux_wreckruns () {
     insts=$(($1-1))
-    pids=""
     for i in `seq 0 $insts`; do
-        st=$(($insts + 3 - 2*$i))
-        flux wreckrun -n4 -N4 sleep $st  &
-        pids="$pids $!"
+        st=$(echo "$insts $i" | awk '{printf "%.2f", ($1 + 3 - 2*$2)/4}')
+        ids="$ids $(flux wreckrun --detach -n4 -N4 sleep $st)"
     done
-    for i in $pids; do 
-        wait $i
+    for i in $ids; do
+        flux wreck attach $i
     done
     return 0
 }

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -49,7 +49,9 @@ overlap_flux_wreckruns () {
         ids="$ids $(flux wreckrun --detach -n4 -N4 sleep $st)"
     done
     for i in $ids; do
+        echo "attempt to attach to job $i" >&2
         flux wreck attach $i
+        echo "attach to job $i complete with code=$?" >&2
     done
     return 0
 }


### PR DESCRIPTION
This PR includes a fix for Issue #435. The code probably never worked (as evidenced by lack of testing), but the fix was simple enough for now.

I should note that currently, `flux-wreckrun` only supports sending stdin to rank 0. Probably for completeness, stdin broadcast at least should be supported, and a `--input` option should be provided akin to `--output` to read stdin from a file.
