### PR TITLE
add reactor child watchers

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -28,7 +28,10 @@ MAN3_FILES_PRIMARY = \
 	flux_idle_watcher_create.3 \
 	flux_msg_handler_create.3 \
 	flux_msg_cmp.3 \
-	flux_msg_handler_addvec.3
+	flux_msg_handler_addvec.3 \
+	flux_child_watcher_create.3 \
+	flux_signal_watcher_create.3 \
+	flux_stat_watcher_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -74,7 +77,10 @@ MAN3_FILES_SECONDARY = \
 	flux_msg_handler_destroy.3 \
 	flux_msg_handler_start.3 \
 	flux_msg_handler_stop.3 \
-	flux_msg_handler_delvec.3
+	flux_msg_handler_delvec.3 \
+	flux_child_watcher_get_rpid.3 \
+	flux_child_watcher_get_rstatus.3 \
+	flux_stat_watcher_get_rstat.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -139,6 +145,9 @@ flux_msg_handler_destroy.3: flux_msg_handler_create.3
 flux_msg_handler_start.3: flux_msg_handler_create.3
 flux_msg_handler_stop.3: flux_msg_handler_create.3
 flux_msg_handler_delvec.3: flux_msg_handler_addvec.3
+flux_child_watcher_get_rpid.3: flux_child_watcher_create.3
+flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
+flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_child_watcher_create.adoc
+++ b/doc/man3/flux_child_watcher_create.adoc
@@ -1,0 +1,85 @@
+flux_child_watcher_create(3)
+============================
+:doctype: manpage
+
+
+NAME
+----
+flux_child_watcher_create, flux_child_watcher_get_rpid, flux_child_watcher_get_rstatus - create child watcher
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_child_watcher_create (flux_reactor_t *r,
+                                            int pid, bool trace,
+                                            flux_watcher_f cb, void *arg);
+
+ int flux_child_watcher_get_rpid (flux_watcher_t *w);
+
+ int flux_child_watcher_get_rstatus (flux_watcher_t *w);
+
+
+DESCRIPTION
+-----------
+
+`flux_child_watcher_create()` creates a reactor watcher that
+monitors state transitions of child processes.  If _trace_ is false,
+only child termination will trigger an event; otherwise, stop and start
+events may be generated.
+
+The callback _revents_ argument should be ignored.
+
+The process id that had a transition may be obtained by calling
+`flux_child_watcher_get_rpid()`.
+
+The status value returned by waitpid(2) may be obtained by calling
+`flux_child_watcher_get_rstatus()`.
+
+Only a Flux reactor created with the FLUX_REACTOR_SIGCHLD flag can
+be used with child watchers, as the reactor must register a SIGCHLD
+signal watcher before any processes are spawned.  Only one reactor instance
+per program may be created with this capability.
+
+
+RETURN VALUE
+------------
+
+flux_child_watcher_create() returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+EINVAL::
+Reactor was not created with FLUX_REACTOR_SIGCHLD.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_reactor_create.adoc
+++ b/doc/man3/flux_reactor_create.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_reactor_t *flux_reactor_create (void);
+flux_reactor_t *flux_reactor_create (int flags);
 
 void flux_reactor_destroy (flux_reactor_t *r);
 
@@ -48,6 +48,10 @@ If `flux_reactor_stop_error()` is called, this will cause
 `flux_reactor_run()` to return -1 indicating that an error has occurred.
 The caller should ensure that a valid error code has been assigned to
 errno(3) before calling this function.
+
+If `flux_reactor_create()` is called with the FLUX_REACTOR_SIGCHLD flag,
+the reactor will internally register a SIGCHLD handler and be capable
+of handling child watchers.
 
 
 RETURN VALUE

--- a/doc/man3/flux_signal_watcher_create.adoc
+++ b/doc/man3/flux_signal_watcher_create.adoc
@@ -1,0 +1,71 @@
+flux_signal_watcher_create(3)
+=============================
+:doctype: manpage
+
+
+NAME
+----
+flux_signal_watcher_create, flux_signal_watcher_get_signum - create signal watcher
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_signal_watcher_create (flux_reactor_t *r,
+                                             int signum,
+                                             flux_watcher_f callback,
+                                             void *arg);
+
+ int flux_signal_watcher_get_signum (flux_watcher_t *w);
+
+DESCRIPTION
+-----------
+
+`flux_signal_watcher_create()` creates a reactor watcher that
+monitors for receipt of signal _signum_.
+
+The callback _revents_ argument should be ignored.
+
+When one _callback_ is shared by multiple watchers, the signal number that
+triggered the event can be obtained with `flux_signal_watcher_get_signum()`.
+
+
+RETURN VALUE
+------------
+
+flux_signal_watcher_create() returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_stat_watcher_create.adoc
+++ b/doc/man3/flux_stat_watcher_create.adoc
@@ -1,0 +1,79 @@
+flux_stat_watcher_create(3)
+===========================
+:doctype: manpage
+
+
+NAME
+----
+flux_stat_watcher_create, flux_stat_watcher_get_rstat - create stat watcher
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r,
+                                           const char *path,
+                                           flux_watcher_f callback,
+                                           void *arg);
+
+ void flux_signal_watcher_get_rstat (flux_watcher_t *w,
+                                     struct stat *stat,
+                                     struct stat *prev);
+
+DESCRIPTION
+-----------
+
+`flux_stat_watcher_create()` creates a reactor watcher that
+monitors for changes in the status of the file system object
+represented by _path_.
+
+The callback _revents_ argument should be ignored.
+
+`flux_stat_watcher_get_rstat ()` may be used to obtain the status
+within _callback_.  If non-NULL, _stat_ receives the current status.
+If non-NULL, _prev_ receives the previous status.
+
+If the object does not exist, stat->st_nlink will be zero and other
+status fields are undefined.  The appearance/disappearance of a file
+is considered a status change like any other.
+
+
+RETURN VALUE
+------------
+
+flux_stat_watcher_create() returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3), stat(2)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -276,3 +276,4 @@ wildcards
 addvec
 delvec
 msghandler
+SIGCHLD

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -277,3 +277,11 @@ addvec
 delvec
 msghandler
 SIGCHLD
+signum
+pid
+rpid
+rstatus
+waitpid
+rstat
+prev
+nlink

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -456,14 +456,17 @@ int main (int argc, char *argv[])
         err_exit ("zctx_new");
     zctx_set_linger (ctx.zctx, 5);
 
+    /* Set up the flux reactor.
+     */
+    if (!(ctx.reactor = flux_reactor_create (0)))
+        err_exit ("flux_reactor_create");
+
     /* Set up flux handle.
-     * The handle is used for simple purposes such as logging,
-     * and also provides the main reactor loop for the broker.
+     * The handle is used for simple purposes such as logging.
      */
     if (!(ctx.h = flux_handle_create (&ctx, &broker_handle_ops, 0)))
         err_exit ("flux_handle_create");
-    if (!(ctx.reactor = flux_get_reactor (ctx.h)))
-        err_exit ("flux_get_reactor");
+    flux_set_reactor (ctx.h, ctx.reactor);
 
     subprocess_manager_set (ctx.sm, SM_FLUX, ctx.h);
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -86,7 +86,7 @@ typedef struct {
      */
     flux_t h;
     flux_reactor_t *reactor;
-    flux_watcher_t *signalfd_w;
+    zlist_t *sigwatchers;
 
     /* Sockets.
      */
@@ -151,11 +151,11 @@ static void module_cb (module_t *p, void *arg);
 static void rmmod_cb (module_t *p, void *arg);
 static void hello_update_cb (hello_t *h, void *arg);
 static void shutdown_cb (shutdown_t *s, void *arg);
-static void signalfd_cb (flux_reactor_t *r, flux_watcher_t *w,
-                         int revents, void *arg);
+static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg);
 static void broker_block_signals (void);
-
-static void broker_init_signalfd (ctx_t *ctx);
+static void broker_handle_signals (ctx_t *ctx, zlist_t *sigwatchers);
+static void broker_unhandle_signals (zlist_t *sigwatchers);
 
 static void broker_add_services (ctx_t *ctx);
 
@@ -246,7 +246,7 @@ int main (int argc, char *argv[])
 {
     int c;
     ctx_t ctx;
-    zlist_t *modules, *modopts;
+    zlist_t *modules, *modopts, *sigwatchers;
     zhash_t *modexclude;
     char *modpath;
     const char *confdir;
@@ -270,6 +270,8 @@ int main (int argc, char *argv[])
     if (!(modopts = zlist_new ()))
         oom ();
     zlist_autofree (modopts);
+    if (!(sigwatchers = zlist_new ()))
+        oom ();
 
     ctx.rank = FLUX_NODEID_ANY;
     ctx.modhash = modhash_create ();
@@ -475,7 +477,7 @@ int main (int argc, char *argv[])
 
     /* Prepare signal handling
      */
-    broker_init_signalfd (&ctx);
+    broker_handle_signals (&ctx, sigwatchers);
 
     /* Initialize security context.
      */
@@ -692,6 +694,9 @@ int main (int argc, char *argv[])
         msg ("unloading modules");
     modhash_destroy (ctx.modhash);
 
+    broker_unhandle_signals (sigwatchers);
+    zlist_destroy (&sigwatchers);
+
     if (ctx.verbose)
         msg ("cleaning up");
     if (ctx.sec)
@@ -705,6 +710,7 @@ int main (int argc, char *argv[])
     hello_destroy (ctx.hello);
     attr_destroy (ctx.attrs);
     flux_close (ctx.h);
+    flux_reactor_destroy (ctx.reactor);
     log_destroy (ctx.log);
     if (log_f)
         fclose (log_f);
@@ -1305,27 +1311,29 @@ static void broker_block_signals (void)
         err_exit ("sigprocmask");
 }
 
-static void broker_init_signalfd (ctx_t *ctx)
+static void broker_handle_signals (ctx_t *ctx, zlist_t *sigwatchers)
 {
-    sigset_t sigmask;
-    int fd;
+    int i, sigs[] = { SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGSEGV, SIGFPE };
+    flux_watcher_t *w;
 
-    sigemptyset(&sigmask);
-    sigaddset(&sigmask, SIGHUP);
-    sigaddset(&sigmask, SIGINT);
-    sigaddset(&sigmask, SIGQUIT);
-    sigaddset(&sigmask, SIGTERM);
-    sigaddset(&sigmask, SIGSEGV);
-    sigaddset(&sigmask, SIGFPE);
-    //sigaddset(&sigmask, SIGCHLD);
+    for (i = 0; i < sizeof (sigs) / sizeof (sigs[0]); i++) {
+        w = flux_signal_watcher_create (ctx->reactor, sigs[i], signal_cb, ctx);
+        if (!w)
+            err_exit ("flux_signal_watcher_create");
+        if (zlist_push (sigwatchers, w) < 0)
+            oom ();
+        flux_watcher_start (w);
+    }
+}
 
-    if ((fd = signalfd(-1, &sigmask, SFD_NONBLOCK | SFD_CLOEXEC)) < 0)
-        err_exit ("signalfd");
-    if (!(ctx->signalfd_w = flux_fd_watcher_create (ctx->reactor,
-                                                    fd, FLUX_POLLIN,
-                                                    signalfd_cb, ctx)))
-        err_exit ("flux_fd_watcher_create");
-    flux_watcher_start (ctx->signalfd_w);
+static void broker_unhandle_signals (zlist_t *sigwatchers)
+{
+    flux_watcher_t *w;
+
+    while ((w = zlist_pop (sigwatchers))) {
+        flux_watcher_stop (w);
+        flux_watcher_destroy (w);
+    }
 }
 
 /**
@@ -2522,22 +2530,14 @@ static void heartbeat_cb (heartbeat_t *h, void *arg)
         (void) overlay_keepalive_parent (ctx->overlay);
 }
 
-static void signalfd_cb (flux_reactor_t *r, flux_watcher_t *w,
+static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
                          int revents, void *arg)
 {
-    int fd = flux_fd_watcher_get_fd (w);
     ctx_t *ctx = arg;
-    struct signalfd_siginfo fdsi;
-    ssize_t n;
+    int signum = flux_signal_watcher_get_signum (w);
 
-    if ((n = read (fd, &fdsi, sizeof (fdsi))) < 0) {
-        if (errno != EWOULDBLOCK)
-            err_exit ("read");
-    } else if (n == sizeof (fdsi)) {
-        shutdown_arm (ctx->shutdown, ctx->shutdown_grace, 0,
-                      "signal %d (%s) %d",
-                      fdsi.ssi_signo, strsignal (fdsi.ssi_signo));
-    }
+    shutdown_arm (ctx->shutdown, ctx->shutdown_grace, 0,
+                  "signal %d (%s) %d", signum, strsignal (signum));
 }
 
 static int broker_request_sendmsg (ctx_t *ctx, zmsg_t **zmsg)

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -38,18 +38,27 @@
 #include "src/common/libutil/cleanup.h"
 #include "src/modules/libsubprocess/subprocess.h"
 
-int start_direct (optparse_t *p, const char *cmd);
+struct context {
+    flux_reactor_t *reactor;
+    flux_watcher_t *timer;
+    struct subprocess_manager *sm;
+    optparse_t *opts;
+    char *session_id;
+    char *socket_dir;
+    const char *broker_path;
+    int size;
+    int count;
+    int exit_rc;
+};
+
+void killer (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg);
+int start_direct (struct context *ctx, const char *cmd);
+void remove_corelimit (void);
+char *create_socket_dir (struct context *ctx);
+
+const char *default_killer_timeout = "1.0";
 
 const int default_size = 1;
-
-struct subprocess_manager *sm;
-
-/* Workaround for shutdown bug:
- * Wait this many seconds after exit of first broker before kill -9 of
- * those that remain.  This is a temporary work-around for unreliable
- * shutdown in fast cycling comms sessions.
- */
-const int child_wait_seconds = 1;
 
 const char *usage_msg = "[OPTIONS] command ...";
 static struct optparse_option opts[] = {
@@ -61,6 +70,8 @@ static struct optparse_option opts[] = {
       .usage = "Set number of ranks in new instance", },
     { .name = "broker-opts",.key = 'o', .has_arg = 3, .arginfo = "OPTS",
       .usage = "Add comma-separated broker options, e.g. \"-o,-q\"", },
+    { .name = "killer-timeout",.key = 'k', .has_arg = 1, .arginfo = "SECONDS",
+      .usage = "After a broker exits, kill other brokers after SECONDS", },
     OPTPARSE_TABLE_END,
 };
 
@@ -69,71 +80,93 @@ int main (int argc, char *argv[])
     int e, status = 0;
     char *command = NULL;
     size_t len = 0;
-    optparse_t *p;
+    struct context *ctx = xzmalloc (sizeof (*ctx));
+    double killer_timeout;
 
     log_init ("flux-start");
 
-    p = optparse_create ("flux-start");
-    if (optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS)
+    ctx->opts = optparse_create ("flux-start");
+    if (optparse_add_option_table (ctx->opts, opts) != OPTPARSE_SUCCESS)
         msg_exit ("optparse_add_option_table");
-    if (optparse_set (p, OPTPARSE_USAGE, usage_msg) != OPTPARSE_SUCCESS)
+    if (optparse_set (ctx->opts, OPTPARSE_USAGE, usage_msg) != OPTPARSE_SUCCESS)
         msg_exit ("optparse_set usage");
-    if ((optind = optparse_parse_args (p, argc, argv)) < 0)
+    if ((optind = optparse_parse_args (ctx->opts, argc, argv)) < 0)
         exit (1);
     if (optind < argc) {
         if ((e = argz_create (argv + optind, &command, &len)) != 0)
             errn_exit (e, "argz_creawte");
         argz_stringify (command, len, ' ');
     }
+    remove_corelimit ();
 
-    /* Allow unlimited core dumps.
-     */
-    struct rlimit rl;
-    rl.rlim_cur = RLIM_INFINITY;
-    rl.rlim_max = RLIM_INFINITY;
-    if (setrlimit (RLIMIT_CORE, &rl) < 0)
-        err ("setrlimit: could not remove core file size limit");
+    if (!(ctx->broker_path = getenv ("FLUX_BROKER_PATH")))
+        msg_exit ("FLUX_BROKER_PATH is not set");
 
-    status = start_direct (p, command);
+    ctx->size = optparse_get_int (ctx->opts, "size", default_size);
+    if (!(ctx->reactor = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
+        err_exit ("flux_reactor_create");
+    killer_timeout = strtod (optparse_get_str (ctx->opts, "killer-timeout",
+                                               default_killer_timeout), NULL);
+    if (killer_timeout < 0.)
+        msg_exit ("--killer-timeout argument must be >= 0");
+    if (!(ctx->timer = flux_timer_watcher_create (ctx->reactor,
+                                                  killer_timeout, 0.,
+                                                  killer, ctx)))
+        err_exit ("flux_timer_watcher_create");
+    if (!(ctx->sm = subprocess_manager_create ()))
+        err_exit ("subprocess_manager_create");
+    if (subprocess_manager_set (ctx->sm, SM_REACTOR, ctx->reactor) < 0)
+        err_exit ("subprocess_manager_set reactor");
+    ctx->session_id = xasprintf ("%d", getpid ());
+    ctx->socket_dir = create_socket_dir (ctx);
 
+    status = start_direct (ctx, command);
+
+    optparse_destroy (ctx->opts);
+    flux_watcher_destroy (ctx->timer);
+    flux_reactor_destroy (ctx->reactor);
+    subprocess_manager_destroy (ctx->sm);
+    free (ctx->session_id);
+    free (ctx->socket_dir);
     if (command)
         free (command);
-    optparse_destroy (p);
+
     log_fini ();
 
     return status;
 }
 
-void alarm_handler (int a)
+void remove_corelimit (void)
 {
-    struct subprocess *p;
-    p = subprocess_manager_first (sm);
-    while (p) {
-        if (subprocess_pid (p))
-            (void)subprocess_kill (p, SIGKILL);
-        p = subprocess_manager_next (sm);
-    }
+    struct rlimit rl;
+    rl.rlim_cur = RLIM_INFINITY;
+    rl.rlim_max = RLIM_INFINITY;
+    if (setrlimit (RLIMIT_CORE, &rl) < 0)
+        err ("setrlimit: could not remove core file size limit");
 }
 
-void child_killer_arm (void)
+void killer (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
 {
-    static bool armed = false;
+    struct context *ctx = arg;
+    struct subprocess *p;
+    pid_t pid;
 
-    if (!armed) {
-        struct sigaction sa;
-        memset (&sa, 0, sizeof (sa));
-        sa.sa_handler = alarm_handler;
-        sigaction (SIGALRM, &sa, NULL);
-        alarm (child_wait_seconds);
-        armed = true;
+    p = subprocess_manager_first (ctx->sm);
+    while (p) {
+        if ((pid = subprocess_pid (p))) {
+            char *rankstr = subprocess_get_context (p, "rank");
+            int rank = strtol (rankstr, NULL, 10);
+            msg ("timeout, killing broker rank %d (pid %d)", rank, pid);
+            (void)subprocess_kill (p, SIGKILL);
+        }
+        p = subprocess_manager_next (ctx->sm);
     }
 }
 
 static int child_report (struct subprocess *p, void *arg)
 {
-    int *exit_rc = arg;
+    struct context *ctx = arg;
     char *rankstr = subprocess_get_context (p, "rank");
-    int rank = strtol (rankstr, NULL, 10);
     int status = subprocess_exit_status (p);
     pid_t pid = subprocess_pid (p);
     int rc = 0;
@@ -141,7 +174,7 @@ static int child_report (struct subprocess *p, void *arg)
     if (WIFEXITED (status)) {
         rc = WEXITSTATUS (status);
         if (rc != 0)
-            msg ("%d (pid %d) exited with rc=%d", rank, pid, rc);
+            msg ("%s (pid %d) exited with rc=%d", rankstr, pid, rc);
     } else if (WIFSIGNALED (status)) {
         int sig = WTERMSIG (status);
         /*
@@ -151,17 +184,20 @@ static int child_report (struct subprocess *p, void *arg)
          */
         if (sig != 9)
             rc = 128 + sig;
-        msg ("%d (pid %d) %s", rank, pid, strsignal (sig));
+        msg ("%s (pid %d) %s", rankstr, pid, strsignal (sig));
     } else {
-        msg ("%d (pid %d) wait status=%d", rank, pid, status);
+        msg ("%s (pid %d) wait status=%d", rankstr, pid, status);
         if (status < 256)
             rc = status;
     }
     subprocess_destroy (p);
-    child_killer_arm ();
-    if (*exit_rc < rc)
-        *exit_rc = rc;
+    if (ctx->exit_rc < rc)
+        ctx->exit_rc = rc;
     free (rankstr);
+    if (--ctx->count > 0)
+        flux_watcher_start (ctx->timer);
+    else
+        flux_watcher_stop (ctx->timer);
     return 0;
 }
 
@@ -201,11 +237,11 @@ char *args_str (struct subprocess *p)
     return az;
 }
 
-char *create_socket_dir (const char *sid)
+char *create_socket_dir (struct context *ctx)
 {
     char *tmpdir = getenv ("TMPDIR");
     char *sockdir = xasprintf ("%s/flux-%s-XXXXXX",
-                               tmpdir ? tmpdir : "/tmp", sid);
+                               tmpdir ? tmpdir : "/tmp", ctx->session_id);
 
     if (!mkdtemp (sockdir))
         err_exit ("mkdtemp %s", sockdir);
@@ -213,60 +249,44 @@ char *create_socket_dir (const char *sid)
     return sockdir;
 }
 
-int start_direct (optparse_t *opts, const char *cmd)
+int start_direct (struct context *ctx, const char *cmd)
 {
-    int size = optparse_get_int (opts, "size", default_size);
-    char *broker_path = getenv ("FLUX_BROKER_PATH");
-    char *sid = xasprintf ("%d", getpid ());
-    char *sockdir = create_socket_dir (sid);
     struct subprocess *p;
-    int rank, rc = 0;
+    int rank;
 
-    if (!broker_path)
-        msg_exit ("FLUX_BROKER_PATH is not set");
-
-    if (!(sm = subprocess_manager_create ()))
-        err_exit ("subprocess_manager_create");
-
-    for (rank = 0; rank < size; rank++) {
-        if (!(p = subprocess_create (sm)))
+    for (rank = 0; rank < ctx->size; rank++) {
+        if (!(p = subprocess_create (ctx->sm)))
             err_exit ("subprocess_create");
         subprocess_set_context (p, "rank", xasprintf ("%d", rank));
-        subprocess_set_callback (p, child_report, &rc);
+        subprocess_set_callback (p, child_report, ctx);
 
-        add_arg (p, "%s", broker_path);
+        add_arg (p, "%s", ctx->broker_path);
         add_arg (p, "--boot-method=LOCAL");
-        add_arg (p, "--size=%d", size);
+        add_arg (p, "--size=%d", ctx->size);
         add_arg (p, "--rank=%d", rank);
-        add_arg (p, "--sid=%s", sid);
-        add_arg (p, "--socket-directory=%s", sockdir);
-        add_args_list (p, opts, "broker-opts");
+        add_arg (p, "--sid=%s", ctx->session_id);
+        add_arg (p, "--socket-directory=%s", ctx->socket_dir);
+        add_args_list (p, ctx->opts, "broker-opts");
         if (rank == 0 && cmd)
             add_arg (p, "%s", cmd); /* must be last */
-
-        if (optparse_hasopt (opts, "verbose")) {
+        subprocess_set_environ (p, environ);
+        if (optparse_hasopt (ctx->opts, "verbose")) {
             char *s = args_str (p);
             msg ("%d: %s", rank, s);
             free (s);
         }
-        subprocess_set_environ (p, environ);
-        if (!optparse_hasopt (opts, "noexec")) {
-            if (subprocess_run (p) < 0)
-                err_exit ("subprocess_run");
-        }
+        if (optparse_hasopt (ctx->opts, "noexec")) {
+            char *rankstr = subprocess_get_context (p, "rank");
+            free (rankstr);
+            subprocess_destroy (p);
+        } else if (subprocess_run (p) < 0)
+            err_exit ("subprocess_run");
+        ctx->count++;
     }
+    if (flux_reactor_run (ctx->reactor, 0) < 0)
+        err_exit ("flux_reactor_run");
 
-    /* N.B. reap_all can be interrupted by SIGALRM, so keep calling
-     * it until there are no more subprocesses o/w destroy will assert.
-     */
-    while (subprocess_manager_first (sm))
-        subprocess_manager_reap_all (sm);
-
-    subprocess_manager_destroy (sm);
-
-    free (sid);
-    free (sockdir);
-    return (rc);
+    return (ctx->exit_rc);
 }
 
 /*

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -73,7 +73,8 @@ TESTS = test_conf.t \
 	test_request.t \
 	test_response.t \
 	test_event.t \
-	test_tagpool.t
+	test_tagpool.t \
+	test_reactor.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
@@ -126,3 +127,7 @@ test_request_t_LDADD = $(test_ldadd) $(LIBDL)
 test_response_t_SOURCES = test/response.c
 test_response_t_CPPFLAGS = $(test_cppflags)
 test_response_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_reactor_t_SOURCES = test/reactor.c
+test_reactor_t_CPPFLAGS = $(test_cppflags)
+test_reactor_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -1,6 +1,8 @@
 #ifndef _FLUX_CORE_REACTOR_H
 #define _FLUX_CORE_REACTOR_H
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <stdbool.h>
 
 #include "handle.h"
@@ -49,19 +51,31 @@ void flux_watcher_start (flux_watcher_t *w);
 void flux_watcher_stop (flux_watcher_t *w);
 void flux_watcher_destroy (flux_watcher_t *w);
 
+/* flux_t handle
+ */
+
 flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
                                             flux_t h, int events,
                                             flux_watcher_f cb, void *arg);
 flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
 
+/* file descriptor
+ */
+
 flux_watcher_t *flux_fd_watcher_create (flux_reactor_t *r, int fd, int events,
                                         flux_watcher_f cb, void *arg);
 int flux_fd_watcher_get_fd (flux_watcher_t *w);
+
+/* zmq socket
+ */
 
 flux_watcher_t *flux_zmq_watcher_create (flux_reactor_t *r,
                                          void *zsock, int events,
                                          flux_watcher_f cb, void *arg);
 void *flux_zmq_watcher_get_zsock (flux_watcher_t *w);
+
+/* timer
+ */
 
 flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
                                            double after, double repeat,
@@ -69,6 +83,8 @@ flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
 
 void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat);
 
+/* prepare/check/idle
+ */
 
 flux_watcher_t *flux_prepare_watcher_create (flux_reactor_t *r,
                                              flux_watcher_f cb, void *arg);
@@ -79,11 +95,30 @@ flux_watcher_t *flux_check_watcher_create (flux_reactor_t *r,
 flux_watcher_t *flux_idle_watcher_create (flux_reactor_t *r,
                                           flux_watcher_f cb, void *arg);
 
+/* child
+ */
+
 flux_watcher_t *flux_child_watcher_create (flux_reactor_t *r,
                                            int pid, bool trace,
                                            flux_watcher_f cb, void *arg);
 int flux_child_watcher_get_rpid (flux_watcher_t *w);
 int flux_child_watcher_get_rstatus (flux_watcher_t *w);
+
+/* signal
+ */
+
+flux_watcher_t *flux_signal_watcher_create (flux_reactor_t *r, int signum,
+                                            flux_watcher_f cb, void *arg);
+
+int flux_signal_watcher_get_signum (flux_watcher_t *w);
+
+/* stat
+ */
+
+flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r, const char *path,
+                                            flux_watcher_f cb, void *arg);
+void flux_stat_watcher_get_rstat (flux_watcher_t *w,
+                                  struct stat *stat, struct stat *prev);
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -10,6 +10,8 @@
 
 typedef struct flux_reactor flux_reactor_t;
 
+/* Flags for flux_reactor_run()
+ */
 enum {
     FLUX_REACTOR_NOWAIT = 1,  /* return after all new and outstanding */
                               /*     events have been hnadled */
@@ -17,7 +19,14 @@ enum {
                               /*     one event occurs */
 };
 
-flux_reactor_t *flux_reactor_create (void);
+/* Flags for flux_reactor_create()
+ */
+enum {
+    FLUX_REACTOR_SIGCHLD = 1,  /* enable use of child watchers */
+                               /*    only one thread can do this per program */
+};
+
+flux_reactor_t *flux_reactor_create (int flags);
 void flux_reactor_destroy (flux_reactor_t *r);
 
 flux_reactor_t *flux_get_reactor (flux_t h);

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -70,6 +70,11 @@ flux_watcher_t *flux_check_watcher_create (flux_reactor_t *r,
 flux_watcher_t *flux_idle_watcher_create (flux_reactor_t *r,
                                           flux_watcher_f cb, void *arg);
 
+flux_watcher_t *flux_child_watcher_create (flux_reactor_t *r,
+                                           int pid, bool trace,
+                                           flux_watcher_f cb, void *arg);
+int flux_child_watcher_get_rpid (flux_watcher_t *w);
+int flux_child_watcher_get_rstatus (flux_watcher_t *w);
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -1,0 +1,314 @@
+#include <errno.h>
+#include <czmq.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <stdlib.h>
+
+#include "src/common/libflux/reactor.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libtap/tap.h"
+
+static const size_t zmqwriter_msgcount = 1024;
+
+static void zmqwriter (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    void *sock = flux_zmq_watcher_get_zsock (w);
+    static int count = 0;
+    if (revents & FLUX_POLLERR) {
+        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
+        goto error;
+    }
+    if (revents & FLUX_POLLOUT) {
+        uint8_t blob[64];
+        zmsg_t *zmsg = zmsg_new ();
+        if (!zmsg || zmsg_addmem (zmsg, blob, sizeof (blob)) < 0) {
+            fprintf (stderr, "%s: failed to create message: %s\n",
+                     __FUNCTION__, strerror (errno));
+            goto error;
+        }
+        if (zmsg_send (&zmsg, sock) < 0) {
+            fprintf (stderr, "%s: zmsg_send: %s\n",
+                     __FUNCTION__, strerror (errno));
+            goto error;
+        }
+        count++;
+        if (count == zmqwriter_msgcount)
+            flux_watcher_stop (w);
+    }
+    return;
+error:
+    flux_reactor_stop_error (r);
+}
+
+static void zmqreader (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    void *sock = flux_zmq_watcher_get_zsock (w);
+    static int count = 0;
+    if (revents & FLUX_POLLERR) {
+        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
+        goto error;
+    }
+    if (revents & FLUX_POLLIN) {
+        zmsg_t *zmsg = zmsg_recv (sock);
+        if (!zmsg) {
+            fprintf (stderr, "%s: zmsg_recv: %s\n",
+                     __FUNCTION__, strerror (errno));
+            goto error;
+        }
+        zmsg_destroy (&zmsg);
+        count++;
+        if (count == zmqwriter_msgcount)
+            flux_watcher_stop (w);
+    }
+    return;
+error:
+    flux_reactor_stop_error (r);
+}
+
+static void test_zmq (flux_reactor_t *reactor)
+{
+    zctx_t *zctx;
+    void *zs[2];
+    flux_watcher_t *r, *w;
+
+    ok ((zctx = zctx_new ()) != NULL,
+        "zmq: created zmq context");
+    zs[0] = zsocket_new (zctx, ZMQ_PAIR);
+    zs[1] = zsocket_new (zctx, ZMQ_PAIR);
+    ok (zs[0] && zs[1]
+        && zsocket_bind (zs[0], "inproc://test_zmq") == 0
+        && zsocket_connect (zs[1], "inproc://test_zmq") == 0,
+        "zmq: connected ZMQ_PAIR sockets over inproc");
+    r = flux_zmq_watcher_create (reactor, zs[0], FLUX_POLLIN, zmqreader, NULL);
+    w = flux_zmq_watcher_create (reactor, zs[1], FLUX_POLLOUT, zmqwriter, NULL);
+    ok (r != NULL && w != NULL,
+        "zmq: nonblocking reader and writer created");
+    flux_watcher_start (r);
+    flux_watcher_start (w);
+    ok (flux_reactor_run  (reactor, 0) == 0,
+        "zmq: reactor ran to completion after %d messages", zmqwriter_msgcount);
+    flux_watcher_stop (r);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (r);
+    flux_watcher_destroy (w);
+
+    zsocket_destroy (zctx, zs[0]);
+    zsocket_destroy (zctx, zs[1]);
+    zctx_destroy (&zctx);
+}
+
+static const size_t fdwriter_bufsize = 10*1024*1024;
+
+static void fdwriter (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    int fd = flux_fd_watcher_get_fd (w);
+    static char *buf = NULL;
+    static int count = 0;
+    int n;
+
+    if (!buf)
+        buf = xzmalloc (fdwriter_bufsize);
+    if (revents & FLUX_POLLERR) {
+        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
+        goto error;
+    }
+    if (revents & FLUX_POLLOUT) {
+        if ((n = write (fd, buf + count, fdwriter_bufsize - count)) < 0
+                                && errno != EWOULDBLOCK && errno != EAGAIN) {
+            fprintf (stderr, "%s: write failed: %s\n",
+                     __FUNCTION__, strerror (errno));
+            goto error;
+        }
+        if (n > 0) {
+            count += n;
+            if (count == fdwriter_bufsize) {
+                flux_watcher_stop (w);
+                free (buf);
+            }
+        }
+    }
+    return;
+error:
+    flux_reactor_stop_error (r);
+}
+static void fdreader (flux_reactor_t *r, flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    int fd = flux_fd_watcher_get_fd (w);
+    static char *buf = NULL;
+    static int count = 0;
+    int n;
+
+    if (!buf)
+        buf = xzmalloc (fdwriter_bufsize);
+    if (revents & FLUX_POLLERR) {
+        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
+        goto error;
+    }
+    if (revents & FLUX_POLLIN) {
+        if ((n = read (fd, buf + count, fdwriter_bufsize - count)) < 0
+                            && errno != EWOULDBLOCK && errno != EAGAIN) {
+            fprintf (stderr, "%s: read failed: %s\n",
+                     __FUNCTION__, strerror (errno));
+            goto error;
+        }
+        if (n > 0) {
+            count += n;
+            if (count == fdwriter_bufsize) {
+                flux_watcher_stop (w);
+                free (buf);
+            }
+        }
+    }
+    return;
+error:
+    flux_reactor_stop_error (r);
+}
+
+static int set_nonblock (int fd)
+{
+    int flags = fcntl (fd, F_GETFL, NULL);
+    if (flags < 0 || fcntl (fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        fprintf (stderr, "fcntl: %s\n", strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+static void test_fd (flux_reactor_t *reactor)
+{
+    int fd[2];
+    flux_watcher_t *r, *w;
+
+    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0
+        && set_nonblock (fd[0]) == 0 && set_nonblock (fd[1]) == 0,
+        "fd: successfully created non-blocking socketpair");
+    r = flux_fd_watcher_create (reactor, fd[0], FLUX_POLLIN, fdreader, NULL);
+    w = flux_fd_watcher_create (reactor, fd[1], FLUX_POLLOUT, fdwriter, NULL);
+    ok (r != NULL && w != NULL,
+        "fd: reader and writer created");
+    flux_watcher_start (r);
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "fd: reactor ran to completion after %lu bytes", fdwriter_bufsize);
+    flux_watcher_stop (r);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (r);
+    flux_watcher_destroy (w);
+    close (fd[0]);
+    close (fd[1]);
+}
+
+static int repeat_countdown = 10;
+static void repeat (flux_reactor_t *r, flux_watcher_t *w,
+                    int revents, void *arg)
+{
+    repeat_countdown--;
+    if (repeat_countdown == 0)
+        flux_watcher_stop (w);
+}
+
+static bool oneshot_ran = false;
+static int oneshot_errno = 0;
+static void oneshot (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    oneshot_ran = true;
+    if (oneshot_errno != 0) {
+        errno = oneshot_errno;
+        flux_reactor_stop_error (r);
+    }
+}
+
+static void test_timer (flux_reactor_t *reactor)
+{
+    flux_watcher_t *w;
+
+    errno = 0;
+    ok (!flux_timer_watcher_create (reactor, -1, 0, oneshot, NULL)
+        && errno == EINVAL,
+        "timer: creating negative timeout fails with EINVAL");
+    ok (!flux_timer_watcher_create (reactor, 0, -1, oneshot, NULL)
+        && errno == EINVAL,
+        "timer: creating negative repeat fails with EINVAL");
+    ok ((w = flux_timer_watcher_create (reactor, 0, 0, oneshot, NULL)) != NULL,
+        "timer: creating zero timeout works");
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "timer: reactor ran to completion (single oneshot)");
+    ok (oneshot_ran == true,
+        "timer: oneshot was executed");
+    oneshot_ran = false;
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "timer: reactor ran to completion (expired oneshot)");
+    ok (oneshot_ran == false,
+        "timer: expired oneshot was not re-executed");
+
+    errno = 0;
+    oneshot_errno = ESRCH;
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) < 0 && errno == ESRCH,
+        "general: reactor stop_error worked with errno passthru");
+    flux_watcher_stop (w);
+    flux_watcher_destroy (w);
+
+    ok ((w = flux_timer_watcher_create (reactor, 0.01, 0.01, repeat, NULL))
+        != NULL,
+        "timer: creating 1ms timeout with 1ms repeat works");
+    flux_watcher_start (w);
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "timer: reactor ran to completion (single repeat)");
+    ok (repeat_countdown == 0,
+        "timer: repeat timer stopped itself after countdown");
+    flux_watcher_stop (w);
+    flux_watcher_destroy (w);
+}
+
+static void reactor_destroy_early (void)
+{
+    flux_reactor_t *r;
+    flux_watcher_t *w;
+
+    if (!(r = flux_reactor_create (0)))
+        exit (1);
+    if (!(w = flux_idle_watcher_create (r, NULL, NULL)))
+        exit (1);
+    flux_watcher_start (w);
+    flux_reactor_destroy (r);
+    flux_watcher_destroy (w);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_reactor_t *reactor;
+
+    plan (NO_PLAN);
+
+    ok ((reactor = flux_reactor_create (0)) != NULL,
+        "created reactor");
+    if (!reactor)
+        BAIL_OUT ("can't continue without reactor");
+
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "reactor ran to completion (no watchers)");
+
+    test_timer (reactor);
+    test_fd (reactor);
+    test_zmq (reactor);
+
+    flux_reactor_destroy (reactor);
+
+    lives_ok ({ reactor_destroy_early ();},
+        "destroying reactor then watcher doesn't segfault");
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/libsubprocess/Makefile.am
+++ b/src/modules/libsubprocess/Makefile.am
@@ -25,7 +25,8 @@ libsubprocess_la_LIBADD = \
 
 TESTS = \
 	test_subprocess.t \
-	test_loop.t
+	test_loop.t \
+	test_socketpair.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -40,6 +41,17 @@ test_subprocess_t_CPPFLAGS = \
 test_subprocess_t_SOURCES = \
 	test/subprocess.c
 test_subprocess_t_LDADD = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+test_socketpair_t_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap
+test_socketpair_t_SOURCES = \
+	test/socketpair.c
+test_socketpair_t_LDADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/modules/libsubprocess/libsubprocess.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/libsubprocess/subprocess.c
+++ b/src/modules/libsubprocess/subprocess.c
@@ -27,7 +27,7 @@
 #endif
 
 #include <sys/types.h>
-#include <sys/socket.h> /* socketpair(2) */
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -40,6 +40,8 @@
 #include "src/common/libutil/shortjson.h"
 #include "src/modules/libzio/zio.h"
 #include "subprocess.h"
+
+#define FDA_LENGTH 16
 
 struct subprocess_manager {
     zlist_t *processes;
@@ -65,6 +67,8 @@ struct subprocess {
     size_t envz_len;
     char *envz;
 
+    int child_fda[FDA_LENGTH]; /* child end of subprocess_socketpair(s) */
+
     int status;
     int exec_error;
 
@@ -87,6 +91,46 @@ struct subprocess {
 
     subprocess_io_cb_f *io_cb;
 };
+
+static void fda_zero (int fda[])
+{
+    int i;
+    for (i = 0; i < FDA_LENGTH; i++)
+        fda[i] = -1;
+}
+
+static int fda_set (int fda[], int fd)
+{
+    int i;
+    for (i = 0; i < FDA_LENGTH; i++) {
+        if (fda[i] == fd || fda[i] == -1) {
+            fda[i] = fd;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static bool fda_isset (int fda[], int fd)
+{
+    int i;
+    for (i = 0; i < FDA_LENGTH; i++) {
+        if (fda[i] == fd)
+            return true;
+    }
+    return false;
+}
+
+static void fda_closeall (int fda[])
+{
+    int i;
+    for (i = 0; i < FDA_LENGTH; i++) {
+        if (fda[i] != -1) {
+            close (fda[i]);
+            fda[i] = -1;
+        }
+    }
+}
 
 static int sigmask_unblock_all (void)
 {
@@ -178,6 +222,8 @@ struct subprocess * subprocess_create (struct subprocess_manager *sm)
         return (NULL);
     }
 
+    fda_zero (p->child_fda);
+
     p->pid = (pid_t) -1;
 
     if (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, fds) < 0) {
@@ -223,6 +269,8 @@ void subprocess_destroy (struct subprocess *p)
         zlist_remove (p->sm->processes, (void *) p);
     if (p->zhash)
         zhash_destroy (&p->zhash);
+
+    fda_closeall (p->child_fda);
 
     p->sm = NULL;
     free (p->argz);
@@ -489,16 +537,44 @@ char **subprocess_env_expand (struct subprocess *p)
     return (expand_argz (p->envz, p->envz_len));
 }
 
-static void closeall (int fd, int except)
+int subprocess_socketpair (struct subprocess *p, int *child_fd)
 {
-    int fdlimit = sysconf (_SC_OPEN_MAX);
+    int fds[2];
 
-    while (fd < fdlimit) {
-        if (fd != except)
-            close (fd);
-        fd++;
+    if (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, fds) < 0)
+        return -1;
+    if (fda_set (p->child_fda, fds[1]) < 0) {
+        close (fds[0]);
+        close (fds[1]);
+        errno = ENFILE;
+        return -1;
     }
-    return;
+    if (child_fd)
+        *child_fd = fds[1];
+    return fds[0];
+}
+
+/* Close all fd's except the ones we are using.
+ * Clear the close-on-exec flag for socketpair fd's we are passing to child.
+ */
+static int preparefd_child (struct subprocess *p)
+{
+    int fd, fdlimit = sysconf (_SC_OPEN_MAX);
+
+    for (fd = 3; fd < fdlimit; fd++) {
+        if (fd == p->childfd)
+            continue;
+        if (fda_isset (p->child_fda, fd)) {
+            int flags = fcntl (fd, F_GETFD, 0);
+            if (flags < 0)
+                return -1;
+            if (fcntl (fd, F_SETFD, flags & ~FD_CLOEXEC) < 0)
+                return -1;
+            continue;
+        }
+        close (fd);
+    }
+    return 0;
 }
 
 static void close_if_valid (int fd)
@@ -619,7 +695,10 @@ static void subprocess_child (struct subprocess *p)
      */
     sp_barrier_wait (p->childfd);
 
-    closeall (3, p->childfd);
+    if (preparefd_child (p) < 0) {
+        err ("Failed to prepare child fds");
+        exit (1);
+    }
 
     environ = subprocess_env_expand (p);
     argv = subprocess_argv_expand (p);
@@ -706,8 +785,11 @@ int subprocess_fork (struct subprocess *p)
                                                       child_watcher, p);
         flux_watcher_start (p->child_watcher);
     }
+
     close (p->childfd);
     p->childfd = -1;
+
+    fda_closeall (p->child_fda);
 
     sp_barrier_wait (p->parentfd);
     p->started = 1;

--- a/src/modules/libsubprocess/subprocess.h
+++ b/src/modules/libsubprocess/subprocess.h
@@ -178,6 +178,14 @@ const char *subprocess_get_cwd (struct subprocess *p);
 int subprocess_set_environ (struct subprocess *p, char **env);
 
 /*
+ *  Set up a socketpair for communication between parent and child,
+ *   and return the parent side of it, or -1 on error (errno set).
+ *   Optionally return the child side in 'child_fd' if non-NULL.
+ *   It is the caller's responsibility to close the parent fd.
+ */
+int subprocess_socketpair (struct subprocess *p, int *child_fd);
+
+/*
  *  Setenv() equivalent with optional overwrite for subprocess [p].
  *   Returns -1 with errno set to EINVAL if subprocess has already started.
  */

--- a/src/modules/libsubprocess/subprocess.h
+++ b/src/modules/libsubprocess/subprocess.h
@@ -94,6 +94,12 @@ struct subprocess * subprocess_create (struct subprocess_manager *sm);
 int subprocess_set_callback (struct subprocess *p, subprocess_cb_f fn, void *arg);
 
 /*
+ *  Set a callback function for subprocess status change
+ */
+int subprocess_set_status_callback (struct subprocess *p,
+                                    subprocess_cb_f fn, void *arg);
+
+/*
  *  Set an IO callback
  */
 int subprocess_set_io_callback (struct subprocess *p, subprocess_io_cb_f fn);
@@ -234,6 +240,18 @@ int subprocess_exit_code (struct subprocess *p);
  *   or 0 if process was not killed by a signal.
  */
 int subprocess_signaled (struct subprocess *p);
+
+/*
+ *  Return number of the signal that caused process to stop,
+ *   or 0 if process was not stopped.
+ */
+int subprocess_stopped (struct subprocess *p);
+
+/*
+ *  Return 1 if process was continued,
+ *   or 0 if process was not contineud.
+ */
+int subprocess_continued (struct subprocess *p);
 
 /*
  *  If state == "Exec Failure" then return the errno from exec(2)

--- a/src/modules/libsubprocess/test/loop.c
+++ b/src/modules/libsubprocess/test/loop.c
@@ -110,7 +110,7 @@ int main (int ac, char **av)
         BAIL_OUT ("Failed to create subprocess manager");
     ok (sm != NULL, "create subprocess manager");
 
-    if (!(r = flux_reactor_create()))
+    if (!(r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
         BAIL_OUT ("Failed to create a reactor");
 
     sigfd = init_signalfd ();

--- a/src/modules/libsubprocess/test/socketpair.c
+++ b/src/modules/libsubprocess/test/socketpair.c
@@ -1,0 +1,123 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/signalfd.h>
+#include <json.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "tap.h"
+#include "subprocess.h"
+
+extern char **environ;
+
+static int exit_handler (struct subprocess *p, void *arg)
+{
+    ok (subprocess_exited (p), "exit_handler: subprocess exited");
+    ok (subprocess_exit_code (p) == 0, "exit_handler: subprocess exited normally");
+    subprocess_destroy (p);
+    return (0);
+}
+
+int fdcount (void)
+{
+    int fd, fdlimit = sysconf (_SC_OPEN_MAX);
+    int count = 0;
+    for (fd = 0; fd < fdlimit; fd++) {
+        if (fcntl (fd, F_GETFD) != -1)
+            count++;
+    }
+    return count;
+}
+
+int main (int ac, char **av)
+{
+    int rc;
+    struct subprocess_manager *sm;
+    struct subprocess *p;
+    flux_reactor_t *r;
+    int parent_fd, child_fd;
+    int start_fdcount, end_fdcount;
+
+    plan (NO_PLAN);
+
+    start_fdcount = fdcount ();
+    diag ("initial fd count %d", start_fdcount);
+
+    if (!(sm = subprocess_manager_create ()))
+        BAIL_OUT ("Failed to create subprocess manager");
+    ok (sm != NULL, "create subprocess manager");
+
+    if (!(r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
+        BAIL_OUT ("Failed to create a reactor");
+
+    errno = 0;
+    rc = subprocess_manager_set (sm, SM_REACTOR, r);
+    ok (rc == 0, "set subprocess manager reactor (rc=%d, %s)", rc, strerror (errno));
+
+    if (!(p = subprocess_create (sm)))
+        BAIL_OUT ("Failed to create a subprocess object");
+    ok (subprocess_set_callback (p, exit_handler, NULL) >= 0,
+        "set subprocess exit handler");
+
+    child_fd = -1;
+    ok ((parent_fd = subprocess_socketpair (p, &child_fd)) >= 0
+        && child_fd >= 0,
+        "subprocess_socketpair returned valid fd for parent + child");
+    diag ("socketpair parent %d child %d", parent_fd, child_fd);
+    ok (subprocess_set_environ (p, environ) >= 0,
+        "set subprocess environ");
+    ok (subprocess_setenvf (p, "FD", 1, "%d", child_fd) >= 0,
+        "set FD in subprocess environ");
+    // on some shells $FD must be a single digit
+    ok (subprocess_set_command (p, "bash -c \"cat <&$FD\"") >= 0,
+        "set subprocess command");
+
+    ok (subprocess_fork (p) >= 0, "subprocess_fork");
+    ok (subprocess_exec (p) >= 0, "subprocess_exec");
+
+    ok (write (parent_fd, "# hello world\n", 14) == 14,
+        "wrote to parent fd");
+    close (parent_fd);
+
+    ok (flux_reactor_run (r, 0) == 0,
+        "reactor returned normally");
+
+    subprocess_manager_destroy (sm);
+    flux_reactor_destroy (r);
+
+    end_fdcount = fdcount ();
+    diag ("final fd count %d", end_fdcount);
+    ok (start_fdcount == end_fdcount,
+        "no file descriptors were leaked");
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/libzio/zio.c
+++ b/src/modules/libzio/zio.c
@@ -211,6 +211,10 @@ void zio_destroy (zio_t *z)
         cbuf_destroy (z->buf);
     free (z->name);
     free (z->prefix);
+    if (z->srcfd >= 0)
+        close (z->srcfd);
+    if (z->dstfd >= 0)
+        close (z->dstfd);
     z->srcfd = z->dstfd = -1;
     flux_watcher_destroy (z->reader);
     flux_watcher_destroy (z->writer);

--- a/t/loop/reactor.c
+++ b/t/loop/reactor.c
@@ -390,7 +390,7 @@ static void reactor_destroy_early (void)
     flux_reactor_t *r;
     flux_watcher_t *w;
 
-    if (!(r = flux_reactor_create ()))
+    if (!(r = flux_reactor_create (0)))
         exit (1);
     if (!(w = flux_idle_watcher_create (r, NULL, NULL)))
         exit (1);

--- a/t/loop/reactor.c
+++ b/t/loop/reactor.c
@@ -108,265 +108,6 @@ static void test_msg (flux_t h)
     flux_msg_handler_destroy (w);
 }
 
-static const size_t zmqwriter_msgcount = 1024;
-
-static void zmqwriter (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
-{
-    void *sock = flux_zmq_watcher_get_zsock (w);
-    static int count = 0;
-    if (revents & FLUX_POLLERR) {
-        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
-        goto error;
-    }
-    if (revents & FLUX_POLLOUT) {
-        uint8_t blob[64];
-        zmsg_t *zmsg = zmsg_new ();
-        if (!zmsg || zmsg_addmem (zmsg, blob, sizeof (blob)) < 0) {
-            fprintf (stderr, "%s: failed to create message: %s\n",
-                     __FUNCTION__, strerror (errno));
-            goto error;
-        }
-        if (zmsg_send (&zmsg, sock) < 0) {
-            fprintf (stderr, "%s: zmsg_send: %s\n",
-                     __FUNCTION__, strerror (errno));
-            goto error;
-        }
-        count++;
-        if (count == zmqwriter_msgcount)
-            flux_watcher_stop (w);
-    }
-    return;
-error:
-    flux_reactor_stop_error (r);
-}
-
-static void zmqreader (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
-{
-    void *sock = flux_zmq_watcher_get_zsock (w);
-    static int count = 0;
-    if (revents & FLUX_POLLERR) {
-        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
-        goto error;
-    }
-    if (revents & FLUX_POLLIN) {
-        zmsg_t *zmsg = zmsg_recv (sock);
-        if (!zmsg) {
-            fprintf (stderr, "%s: zmsg_recv: %s\n",
-                     __FUNCTION__, strerror (errno));
-            goto error;
-        }
-        zmsg_destroy (&zmsg);
-        count++;
-        if (count == zmqwriter_msgcount)
-            flux_watcher_stop (w);
-    }
-    return;
-error:
-    flux_reactor_stop_error (r);
-}
-
-static void test_zmq (flux_reactor_t *reactor)
-{
-    zctx_t *zctx;
-    void *zs[2];
-    flux_watcher_t *r, *w;
-
-    ok ((zctx = zctx_new ()) != NULL,
-        "zmq: created zmq context");
-    zs[0] = zsocket_new (zctx, ZMQ_PAIR);
-    zs[1] = zsocket_new (zctx, ZMQ_PAIR);
-    ok (zs[0] && zs[1]
-        && zsocket_bind (zs[0], "inproc://test_zmq") == 0
-        && zsocket_connect (zs[1], "inproc://test_zmq") == 0,
-        "zmq: connected ZMQ_PAIR sockets over inproc");
-    r = flux_zmq_watcher_create (reactor, zs[0], FLUX_POLLIN, zmqreader, NULL);
-    w = flux_zmq_watcher_create (reactor, zs[1], FLUX_POLLOUT, zmqwriter, NULL);
-    ok (r != NULL && w != NULL,
-        "zmq: nonblocking reader and writer created");
-    flux_watcher_start (r);
-    flux_watcher_start (w);
-    ok (flux_reactor_run  (reactor, 0) == 0,
-        "zmq: reactor ran to completion after %d messages", zmqwriter_msgcount);
-    flux_watcher_stop (r);
-    flux_watcher_stop (w);
-    flux_watcher_destroy (r);
-    flux_watcher_destroy (w);
-
-    zsocket_destroy (zctx, zs[0]);
-    zsocket_destroy (zctx, zs[1]);
-    zctx_destroy (&zctx);
-}
-
-static const size_t fdwriter_bufsize = 10*1024*1024;
-
-static void fdwriter (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
-{
-    int fd = flux_fd_watcher_get_fd (w);
-    static char *buf = NULL;
-    static int count = 0;
-    int n;
-
-    if (!buf)
-        buf = xzmalloc (fdwriter_bufsize);
-    if (revents & FLUX_POLLERR) {
-        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
-        goto error;
-    }
-    if (revents & FLUX_POLLOUT) {
-        if ((n = write (fd, buf + count, fdwriter_bufsize - count)) < 0
-                                && errno != EWOULDBLOCK && errno != EAGAIN) {
-            fprintf (stderr, "%s: write failed: %s\n",
-                     __FUNCTION__, strerror (errno));
-            goto error;
-        }
-        if (n > 0) {
-            count += n;
-            if (count == fdwriter_bufsize) {
-                flux_watcher_stop (w);
-                free (buf);
-            }
-        }
-    }
-    return;
-error:
-    flux_reactor_stop_error (r);
-}
-static void fdreader (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
-{
-    int fd = flux_fd_watcher_get_fd (w);
-    static char *buf = NULL;
-    static int count = 0;
-    int n;
-
-    if (!buf)
-        buf = xzmalloc (fdwriter_bufsize);
-    if (revents & FLUX_POLLERR) {
-        fprintf (stderr, "%s: FLUX_POLLERR is set\n", __FUNCTION__);
-        goto error;
-    }
-    if (revents & FLUX_POLLIN) {
-        if ((n = read (fd, buf + count, fdwriter_bufsize - count)) < 0
-                            && errno != EWOULDBLOCK && errno != EAGAIN) {
-            fprintf (stderr, "%s: read failed: %s\n",
-                     __FUNCTION__, strerror (errno));
-            goto error;
-        }
-        if (n > 0) {
-            count += n;
-            if (count == fdwriter_bufsize) {
-                flux_watcher_stop (w);
-                free (buf);
-            }
-        }
-    }
-    return;
-error:
-    flux_reactor_stop_error (r);
-}
-
-static int set_nonblock (int fd)
-{
-    int flags = fcntl (fd, F_GETFL, NULL);
-    if (flags < 0 || fcntl (fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-        fprintf (stderr, "fcntl: %s\n", strerror (errno));
-        return -1;
-    }
-    return 0;
-}
-
-static void test_fd (flux_reactor_t *reactor)
-{
-    int fd[2];
-    flux_watcher_t *r, *w;
-
-    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0
-        && set_nonblock (fd[0]) == 0 && set_nonblock (fd[1]) == 0,
-        "fd: successfully created non-blocking socketpair");
-    r = flux_fd_watcher_create (reactor, fd[0], FLUX_POLLIN, fdreader, NULL);
-    w = flux_fd_watcher_create (reactor, fd[1], FLUX_POLLOUT, fdwriter, NULL);
-    ok (r != NULL && w != NULL,
-        "fd: reader and writer created");
-    flux_watcher_start (r);
-    flux_watcher_start (w);
-    ok (flux_reactor_run (reactor, 0) == 0,
-        "fd: reactor ran to completion after %lu bytes", fdwriter_bufsize);
-    flux_watcher_stop (r);
-    flux_watcher_stop (w);
-    flux_watcher_destroy (r);
-    flux_watcher_destroy (w);
-    close (fd[0]);
-    close (fd[1]);
-}
-
-static int repeat_countdown = 10;
-static void repeat (flux_reactor_t *r, flux_watcher_t *w,
-                    int revents, void *arg)
-{
-    repeat_countdown--;
-    if (repeat_countdown == 0)
-        flux_watcher_stop (w);
-}
-
-static bool oneshot_ran = false;
-static int oneshot_errno = 0;
-static void oneshot (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
-{
-    oneshot_ran = true;
-    if (oneshot_errno != 0) {
-        errno = oneshot_errno;
-        flux_reactor_stop_error (r);
-    }
-}
-
-static void test_timer (flux_reactor_t *reactor)
-{
-    flux_watcher_t *w;
-
-    errno = 0;
-    ok (!flux_timer_watcher_create (reactor, -1, 0, oneshot, NULL)
-        && errno == EINVAL,
-        "timer: creating negative timeout fails with EINVAL");
-    ok (!flux_timer_watcher_create (reactor, 0, -1, oneshot, NULL)
-        && errno == EINVAL,
-        "timer: creating negative repeat fails with EINVAL");
-    ok ((w = flux_timer_watcher_create (reactor, 0, 0, oneshot, NULL)) != NULL,
-        "timer: creating zero timeout works");
-    flux_watcher_start (w);
-    ok (flux_reactor_run (reactor, 0) == 0,
-        "timer: reactor ran to completion (single oneshot)");
-    ok (oneshot_ran == true,
-        "timer: oneshot was executed");
-    oneshot_ran = false;
-    ok (flux_reactor_run (reactor, 0) == 0,
-        "timer: reactor ran to completion (expired oneshot)");
-    ok (oneshot_ran == false,
-        "timer: expired oneshot was not re-executed");
-
-    errno = 0;
-    oneshot_errno = ESRCH;
-    flux_watcher_start (w);
-    ok (flux_reactor_run (reactor, 0) < 0 && errno == ESRCH,
-        "general: reactor stop_error worked with errno passthru");
-    flux_watcher_stop (w);
-    flux_watcher_destroy (w);
-
-    ok ((w = flux_timer_watcher_create (reactor, 0.01, 0.01, repeat, NULL))
-        != NULL,
-        "timer: creating 1ms timeout with 1ms repeat works");
-    flux_watcher_start (w);
-    ok (flux_reactor_run (reactor, 0) == 0,
-        "timer: reactor ran to completion (single repeat)");
-    ok (repeat_countdown == 0,
-        "timer: repeat timer stopped itself after countdown");
-    flux_watcher_stop (w);
-    flux_watcher_destroy (w);
-}
-
 static void dummy (flux_t h, flux_msg_handler_t *w,
                    const flux_msg_t *msg, void *arg)
 {
@@ -385,20 +126,6 @@ static void leak_msg_handler (void)
     flux_close (h);
 }
 
-static void reactor_destroy_early (void)
-{
-    flux_reactor_t *r;
-    flux_watcher_t *w;
-
-    if (!(r = flux_reactor_create (0)))
-        exit (1);
-    if (!(w = flux_idle_watcher_create (r, NULL, NULL)))
-        exit (1);
-    flux_watcher_start (w);
-    flux_reactor_destroy (r);
-    flux_watcher_destroy (w);
-}
-
 static void fatal_err (const char *message, void *arg)
 {
     BAIL_OUT ("fatal error: %s", message);
@@ -409,7 +136,7 @@ int main (int argc, char *argv[])
     flux_t h;
     flux_reactor_t *reactor;
 
-    plan (4+11+3+4+3+5+2);
+    plan (NO_PLAN);
 
     (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
     ok ((h = flux_open ("loop://", 0)) != NULL,
@@ -422,22 +149,15 @@ int main (int argc, char *argv[])
     if (!reactor)
         BAIL_OUT ("can't continue without reactor");
 
-    ok (flux_reactor_run (reactor, 0) == 0,
-        "general: reactor ran to completion (no watchers)");
     errno = 0;
     ok (flux_sleep_on (h, FLUX_MATCH_ANY) < 0 && errno == EINVAL,
         "general: flux_sleep_on outside coproc fails with EINVAL");
 
-    test_timer (reactor); // 11
-    test_fd (reactor); // 3
-    test_zmq (reactor); // 4
-    test_msg (h); // 3
-    test_multmatch (h); // 5
+    test_msg (h);
+    test_multmatch (h);
 
     /* Misc
      */
-    lives_ok ({ reactor_destroy_early ();},
-        "destroying reactor then watcher doesn't segfault");
     lives_ok ({ leak_msg_handler ();},
         "leaking a msg_handler_t doesn't segfault");
 


### PR DESCRIPTION
Not ready to merge  - here for early review:

This PR adds reactor child watchers, for capturing change in status of child processes.  It's a thin  wrapper around ev_child watchers.  Since child watchers are only supported in libev's "main loop", I had to add a flag to `flux_reactor_create()` so that one can pass in FLUX_REACTOR_MAIN flag if one wants to use child watchers.   The idea is that only a "main thread" in a multi-threaded application would install signal handlers, and it would create its reactor loop with this flag.  If you try to add a child watcher to a reactor without this flag it is an EINVAL error.

Child watchers are then integrated with libsubprocess, so that each subprocess internally adds a child watcher, and the subprocess exit handlers are called via the child watcher callback when a subprocess exits.  The EINVAL error described above will propagate to subprocess creation if a reactor with the wrong flags was handed to the subprocess manager.  One can start the reactor after creating a bunch of subprocesses, and the reactor will exit once all the child watchers have been stopped.

flux-start was retooled to be entirely reactor and subprocess based and is an example of how this comes together.

Still todo:
* child watcher man page
* consider if signal watchers should also be added
* unit tests
* convert broker to use child watchers for its subprocesses (working on this)
* decide if default behavior should be for child watcher to stop itself like a one-shot timer
