### PR TITLE
fix kvs walk: corrupt internal storage

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -941,8 +941,19 @@ static bool walk (ctx_t *ctx, json_object *root, const char *path,
         if (util_json_object_get_string (dirent, "DIRREF", &ref) == 0) {
             if (!load (ctx, ref, w, &dir))
                 goto stall;
-        } else
-            msg_exit ("%s: corrupt internal storage", __FUNCTION__);
+
+        } else if (json_object_object_get_ex (dirent, "DIRVAL", &dir)) {
+            /* N.B. in current code, directories are never stored by value */
+            msg_exit ("%s: unexpected DIRVAL: path=%s name=%s: dirent=%s ",
+                      __FUNCTION__, path, name, Jtostr (dirent));
+        } else if ((util_json_object_get_string (dirent, "FILEREF", NULL) == 0
+                 || json_object_object_get_ex (dirent, "FILEVAL", NULL))) {
+            errno = ENOTDIR;
+            goto error;
+        } else {
+            msg_exit ("%s: unknown dirent type: path=%s name=%s: dirent=%s ",
+                      __FUNCTION__, path, name, Jtostr (dirent));
+        }
         name = next;
     }
     /* now terminal path component */

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -12,8 +12,6 @@ AM_CPPFLAGS = \
 check_PROGRAMS = \
 	tasyncsock \
 	tcommit \
-	tkvstorture \
-	tkvswatch \
 	tmunge \
 	tbarrier \
 	tdisconnect

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -102,7 +102,9 @@ check_PROGRAMS = \
 	loop/reduce.t \
 	pmi/kvstest \
 	pmi/pminfo \
-	kz/kzutil
+	kz/kzutil \
+	kvs/torture \
+	kvs/watch
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -171,4 +173,16 @@ kz_kzutil_LDADD = \
 	$(top_builddir)/src/modules/libzio/libzio.la \
 	$(top_builddir)/src/modules/kvs/libkvs.la \
 	$(top_builddir)/src/modules/libkz/libkz.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_torture_SOURCES = kvs/torture.c
+kvs_torture_CPPFLAGS = $(test_cppflags)
+kvs_torture_LDADD = \
+	$(top_builddir)/src/modules/kvs/libkvs.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_watch_SOURCES = kvs/watch.c
+kvs_watch_CPPFLAGS = $(test_cppflags)
+kvs_watch_LDADD = \
+	$(top_builddir)/src/modules/kvs/libkvs.la \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-/* flux-kvstorture.c - flux kvstorture subcommand */
+/* torture.c - kvs torture test */
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -57,7 +57,7 @@ static void fill (char *s, int i, int len);
 void usage (void)
 {
     fprintf (stderr, 
-"Usage: flux-kvstorture [--quiet|--verbose] [--prefix NAME] [--size BYTES] [--count N]\n"
+"Usage: torture [--quiet|--verbose] [--prefix NAME] [--size BYTES] [--count N]\n"
 );
     exit (1);
 }
@@ -76,7 +76,7 @@ int main (int argc, char *argv[])
     bool verbose = false;
     const char *s;
 
-    log_init ("flux-kvstorture");
+    log_init ("torture");
 
     while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (ch) {

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -22,9 +22,9 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-/* tkvswatch.c - exercise kvs watch functions */
+/* watch.c - exercise kvs watch functions */
 
-/* Usage ./tkvswatch nthreads changes key
+/* Usage watch nthreads changes key
  * Spawn 'nthreads' threads each watching the same value.
  * Change it 'changes' times and ensure that at minimum the last
  * value is read.
@@ -179,10 +179,10 @@ done:
 void usage (void)
 {
     fprintf (stderr,
-"Usage: tkvswatch  mt         nthreads changes key\n"
-"                  selfmod    key\n"
-"                  unwatch    key\n"
-"                  unwatchloop key\n"
+"Usage: watch  mt         nthreads changes key\n"
+"              selfmod    key\n"
+"              unwatch    key\n"
+"              unwatchloop key\n"
 );
     exit (1);
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -268,23 +268,23 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 
 # watch tests
 
-test_expect_success 'kvs: tkvswatch-mt: multi-threaded kvs watch program' '
-	${FLUX_BUILD_DIR}/src/test/tkvswatch mt 100 100 $TEST.a &&
+test_expect_success 'kvs: watch-mt: multi-threaded kvs watch program' '
+	${FLUX_BUILD_DIR}/t/kvs/watch mt 100 100 $TEST.a &&
 	flux kvs unlink $TEST.a
 '
 
-test_expect_success 'kvs: tkvswatch-selfmod: watch callback modifies watched key' '
-	${FLUX_BUILD_DIR}/src/test/tkvswatch selfmod $TEST.a &&
+test_expect_success 'kvs: watch-selfmod: watch callback modifies watched key' '
+	${FLUX_BUILD_DIR}/t/kvs/watch selfmod $TEST.a &&
 	flux kvs unlink $TEST.a
 '
 
-test_expect_success 'kvs: tkvswatch-unwatch unwatch works' '
-	${FLUX_BUILD_DIR}/src/test/tkvswatch unwatch $TEST.a &&
+test_expect_success 'kvs: watch-unwatch unwatch works' '
+	${FLUX_BUILD_DIR}/t/kvs/watch unwatch $TEST.a &&
 	flux kvs unlink $TEST.a
 '
 
-test_expect_success 'kvs: tkvswatch-unwatchloop 1000 watch/unwatch ok' '
-	${FLUX_BUILD_DIR}/src/test/tkvswatch unwatchloop $TEST.a &&
+test_expect_success 'kvs: watch-unwatchloop 1000 watch/unwatch ok' '
+	${FLUX_BUILD_DIR}/t/kvs/watch unwatchloop $TEST.a &&
 	flux kvs unlink $TEST.a
 '
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -288,4 +288,12 @@ test_expect_success 'kvs: watch-unwatchloop 1000 watch/unwatch ok' '
 	flux kvs unlink $TEST.a
 '
 
+# regression tests
+
+test_expect_success 'kvs: put x=foo, get x.y fails without panic (issue 441)' '
+	flux kvs put ${TEST}.x=foo &&
+	! flux kvs get ${TEST}.x.y
+	flux kvs get ${TEST}.x   # fails if broker died
+'
+
 test_done


### PR DESCRIPTION
This fixes #441 and adds a regression test for it.

Also, kvs tests from `src/test/` were moved to `t/kvs/`  and their sharness drivers updated accordingly.