### PR TITLE
testsuite: fix intermittent failures in t2000-wreck.t

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -121,7 +121,8 @@ dist_check_DATA = \
 dist_check_SCRIPTS = \
 	scripts/event-trace.lua \
 	scripts/kvs-watch-until.lua \
-	scripts/cpus-allowed.lua
+	scripts/cpus-allowed.lua \
+	scripts/waitfile.lua
 
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \

--- a/t/scripts/kvs-watch-until.lua
+++ b/t/scripts/kvs-watch-until.lua
@@ -57,7 +57,7 @@ local kw, err = f:kvswatcher {
     if opts.v then 
         printf ("%4.03fs: %s = %s\n",
                 timer:get0(),
-                key, require 'inspect' (result))
+                key, tostring (result))
     end
     local ok, rv = pcall (cb, result)
     if not ok then error (rv) end

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -1,0 +1,72 @@
+#!/usr/bin/lua
+--
+--  waitfile.lua : Wait until a named file appears and contains a pattern
+--
+local usage = [[
+Usage: waitfile.lua TIMEOUT PATTERN FILE
+
+Wait up to TIMEOUT seconds for FILE to appear and contain at least
+one line matching PATTERN. PATTERN is a Lua style pattern match.
+]]
+
+local flux = require 'flux'
+local posix = require 'flux.posix'
+local f, err = flux.new()
+if not f then error (err) end
+
+local timeout = arg[1]
+local pattern = arg[2]
+local file = arg[3]
+
+local function printf (m, ...)
+    io.stderr:write (string.format ("waitfile: "..m, ...))
+end
+
+if not timeout or not pattern or not file then
+    io.stderr:write (usage)
+    os.exit (1)
+end
+
+--- Open a file "filename" and use an iowatcher on flux handle "f"
+--    to wait for pattern "p", exiting with 0 exit code if found.
+local function tail (f, filename, p)
+    local fp, err = io.open (filename)
+    if not fp then return nil, err end
+    printf ("Opened file %s\n", filename)
+    return f:iowatcher {
+        fd = posix.fileno (fp),
+        handler = function (iow, r)
+            if r.data and r.data:match (p) then
+                os.exit (0)
+            end
+       end
+    }
+end
+
+-- Try opening file -- if it doesn't exist, set a timer for 100ms
+--  and try again. Cancel the timer when file is opened successfully
+--
+if not tail (f, file, pattern) then
+    f:timer {
+        timeout = 100,
+        oneshot = false,
+        handler = function (f, to)
+           if tail (f, file, pattern) then to:remove() end
+        end
+    }
+end
+
+-- Exit with non-zero status after timeout:
+--
+f:timer {
+    timeout = timeout * 1000,
+    handler = function ()
+        printf ("Timeout after %ds\n", timeout)
+        os.exit (1)
+    end
+}
+
+-- Start reactor to do the work. It is an error if we exit the reactor.
+f:reactor ()
+printf ("Unexpectedly exited reactor\n")
+os.exit (1)

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -254,8 +254,9 @@ test_expect_success 'flux-wreck: status with non-zero exit' '
 test_expect_success 'flux-wreck: kill' '
 	run_timeout 1 flux wreckrun --detach sleep 100 &&
 	id=$(last_job_id) &&
-	${SHARNESS_TEST_SRCDIR}/scripts/kvs-watch-until.lua lwj.$id running &&
+	${SHARNESS_TEST_SRCDIR}/scripts/kvs-watch-until.lua -vt 1 lwj.$id.state "v == \"running\"" &&
 	flux wreck kill -s SIGINT $id &&
+	${SHARNESS_TEST_SRCDIR}/scripts/kvs-watch-until.lua -vt 1 lwj.$id.state "v == \"complete\"" &&
 	test_expect_code 130 flux wreck status $id >output.kill &&
 	cat >expected.kill <<-EOF &&
 	Job $id status: complete

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -195,15 +195,18 @@ test_expect_success 'wreck plugins can use wreck:log_msg()' '
 test_expect_success 'wreckrun: --detach supported' '
 	flux wreckrun --detach /bin/true | grep ^Job
 '
+
+WAITFILE="$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua"
+
 test_expect_success 'wreckrun: --output supported' '
 	flux wreckrun --output=test1.out echo hello &&
-        grep hello test1.out
+        $WAITFILE 1 hello test1.out
 '
 test_expect_success 'wreckrun: --error supported' '
 	flux wreckrun --output=test2.out --error=test2.err \
 	    sh -c "echo >&2 this is stderr; echo this is stdout" &&
-        grep "this is stderr" test2.err &&
-        grep "this is stdout" test2.out
+        $WAITFILE 1 "this is stderr" test2.err &&
+        $WAITFILE 1 "this is stdout" test2.out
 '
 test_expect_success 'wreckrun: kvs config output for all jobs' '
 	test_when_finished "flux kvs put lwj.output=" &&
@@ -214,6 +217,7 @@ test_expect_success 'wreckrun: kvs config output for all jobs' '
 		do echo "$i: foo"
 	done >expected.kvsiocfg &&
 	sort -n test3.out >output.kvsiocfg &&
+        $WAITFILE 1 "" output.kvsiocfg &&
 	test_cmp expected.kvsiocfg output.kvsiocfg
 '
 test_expect_success 'flux-wreck: exists in path' '


### PR DESCRIPTION
This PR includes fixes (probable fixes) for two intermittent failures in wreck tests
 * failure in --error test (issue #444)
 * intermittent failures in `flux wreck kill` test