### PR TITLE
fix LN issue in lua binding makefiles on LC

### DIFF
--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -154,7 +154,7 @@ TESTS_ENVIRONMENT = \
 convenience-link: $(luaexec_LTLIBRARIES) $(fluxlua_LTLIBRARIES)
 	@for f in $^; do \
 	  soname=`$(GREP) "^dlname=" $$f | $(SED) -e "s|^dlname='\(.*\)'|\1|"`; \
-	  dirname=`echo $(abs_builddir)/$$f | $(SED) -e 's|/[^/]*.la||'`; \
+	  dirname=`dirname $(abs_builddir)/$$f `; \
 	  target=$$dirname/.libs/$$soname; link=$$dirname/$$soname; \
 	  shortdir=`echo $$f | $(SED) -e 's|[^/]*.la||'`; \
 	  shorttarget="$${shortdir}.libs/$$soname"; \


### PR DESCRIPTION
The sed was not removing the last component, despite matching.  This
need not be the final solution, but with it as it was, I couldn't pass
building the lua bindings.