### PR TITLE
allow stat watcher polling interval to be specified

### DIFF
--- a/doc/man3/flux_stat_watcher_create.adoc
+++ b/doc/man3/flux_stat_watcher_create.adoc
@@ -18,19 +18,23 @@ SYNOPSIS
 
  flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r,
                                            const char *path,
+                                           double interval,
                                            flux_watcher_f callback,
                                            void *arg);
 
- void flux_signal_watcher_get_rstat (flux_watcher_t *w,
-                                     struct stat *stat,
-                                     struct stat *prev);
+ void flux_stat_watcher_get_rstat (flux_watcher_t *w,
+                                   struct stat *stat,
+                                   struct stat *prev);
 
 DESCRIPTION
 -----------
 
 `flux_stat_watcher_create()` creates a reactor watcher that
 monitors for changes in the status of the file system object
-represented by _path_.
+represented by _path_.  If the file system object exists,
+inotify(2) is used, if available; otherwise the reactor polls
+the file every _interval_ seconds.  A value of zero selects a
+conservative default (currently five seconds).
 
 The callback _revents_ argument should be ignored.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -285,3 +285,4 @@ waitpid
 rstat
 prev
 nlink
+inotify

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -761,7 +761,8 @@ static void stat_cb (struct ev_loop *loop, ev_stat *sw, int revents)
         w->fn (ev_userdata (loop), w, libev_to_events (revents), w->arg);
 }
 
-flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r, const char *path,
+flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r,
+                                          const char *path, double interval,
                                           flux_watcher_f cb, void *arg)
 {
     struct watcher_ops ops = {
@@ -771,7 +772,7 @@ flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r, const char *path,
     };
     flux_watcher_t *w;
     ev_stat *sw = xzmalloc (sizeof (*sw));
-    ev_stat_init (sw, stat_cb, path, 0);
+    ev_stat_init (sw, stat_cb, path, interval);
     w = flux_watcher_create (r, sw, ops, STAT_SIG, cb, arg);
     sw->data = w;
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -115,8 +115,9 @@ int flux_signal_watcher_get_signum (flux_watcher_t *w);
 /* stat
  */
 
-flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r, const char *path,
-                                            flux_watcher_f cb, void *arg);
+flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r,
+                                          const char *path, double interval,
+                                          flux_watcher_f cb, void *arg);
 void flux_stat_watcher_get_rstat (flux_watcher_t *w,
                                   struct stat *stat, struct stat *prev);
 

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -487,7 +487,7 @@ static void test_stat (flux_reactor_t *reactor)
 
     ok (ctx.fd >= 0,
         "created temporary file");
-    w = flux_stat_watcher_create (reactor, ctx.path, stat_cb, NULL);
+    w = flux_stat_watcher_create (reactor, ctx.path, 0., stat_cb, NULL);
     ok (w != NULL,
         "created stat watcher");
     flux_watcher_start (w);


### PR DESCRIPTION
Add missing _interval_ parameter to `flux_stat_watcher_create()`.  If inotify is unavailable, this allows the interval between stat(2) calls to be tuned.

Update test and man page.