### PR TITLE
implement library for PMI simple v1 wire protocol server side

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,7 @@ AC_CONFIG_FILES( \
   src/common/libutil/Makefile \
   src/common/libev/Makefile \
   src/common/libpmi-client/Makefile \
+  src/common/libpmi-server/Makefile \
   src/common/libflux/Makefile \
   src/common/libcompat/Makefile \
   src/lib/Makefile \

--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -52,17 +52,8 @@ Be annoyingly chatty.
 *-q, --quiet*::
 Suppress messages intended for interactive users.
 
-*-S, --size*='N'::
-Set the size of this comms session.
-This is only necessary for the LOCAL boot method.
-
-*-R, --rank*='N'::
-Set the rank of this broker instance, 0 to size - 1.
-This is only necessary for the LOCAL boot method.
-
 *-N, --sid*='NAME'::
 Set the session id of this session.
-This is only necessary for the LOCAL boot method.
 
 *-k, --k-ary*='N'::
 Set the branching factor of this comms session's tree based overlay
@@ -97,7 +88,7 @@ multiple times to load multiple modules.
 Override the compiled-in module search path (colon-separated).
 The default is to search install paths.
 
-*-x,--exclude *='NAME'::
+*-x,--exclude*='NAME'::
 Do not load the specified comms module.
 
 *-s, --security*='MODE'::
@@ -106,7 +97,7 @@ Set the security mode.  The mode may be 'none', 'plain', or 'curve'
 
 *-m, --boot-method*='METHOD'::
 Select the method used to determine rank, size, session id, and
-overlay wire-up information.  Valid methods are SINGLE, LOCAL, and PMI.
+overlay wire-up information.  Valid methods are SINGLE and PMI.
 (default: PMI).
 
 *-E, --enable-epgm*::
@@ -121,9 +112,14 @@ instances launched by those instances.   The first network interface
 associated with the hostname is used, and the multicast address is
 hardwired to 239.192.1.1.
 
+*-I, --shared-ipc-namespace*::
+Enable the use of ipc:// sockets for the tree-based overlay network
+and event distribution.  This may be set if all ranks of a comms
+session share a common $TMPDIR namespace.
+
 *-D, --socket-directory*='DIR'::
-Create ipc:// sockets in this directory.
-This is only necessary for the LOCAL boot method.
+Create ipc:// sockets in this directory.  If unspecified, ranks co-located
+in the same $TMPDIR namespace will use unique socket directories.
 
 *-g, --shutdown-grace*='SECS'::
 Specify the shutdown grace period, in seconds (default: guess based

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -286,3 +286,4 @@ rstat
 prev
 nlink
 inotify
+ipc

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -845,6 +845,10 @@ static void init_shell (ctx_t *ctx)
         subprocess_setenv (ctx->init_shell, "LD_LIBRARY_PATH", ldpath, 1);
         free (ldpath);
     }
+    subprocess_unsetenv (ctx->init_shell, "PMI_FD");
+    subprocess_unsetenv (ctx->init_shell, "PMI_RANK");
+    subprocess_unsetenv (ctx->init_shell, "PMI_SIZE");
+
 
     if (!ctx->quiet)
         flux_log (ctx->h, LOG_INFO, "starting initial program");

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -639,7 +639,7 @@ int main (int argc, char *argv[])
      */
     snoop_set_zctx (ctx.snoop, ctx.zctx);
     snoop_set_sec (ctx.snoop, ctx.sec);
-    snoop_set_uri (ctx.snoop, "ipc://*");
+    snoop_set_uri (ctx.snoop, "ipc://%s/%d/snoop", ctx.socket_dir, ctx.rank);
 
     shutdown_set_handle (ctx.shutdown, ctx.h);
     shutdown_set_callback (ctx.shutdown, shutdown_cb, &ctx);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -174,7 +174,6 @@ static int create_dummyattrs (ctx_t *ctx);
 
 static int boot_pmi (ctx_t *ctx);
 static int boot_single (ctx_t *ctx);
-static int boot_local (ctx_t *ctx);
 
 static int attr_get_snoop (const char *name, const char **val, void *arg);
 static int attr_get_overlay (const char *name, const char **val, void *arg);
@@ -187,18 +186,15 @@ static const struct flux_handle_ops broker_handle_ops;
 static struct boot_method boot_table[] = {
     { "pmi", boot_pmi },
     { "single", boot_single },
-    { "local", boot_local },
     { NULL, NULL },
 };
 
-#define OPTIONS "+vqR:S:M:X:L:N:k:s:H:O:x:T:g:D:Em:l:I"
+#define OPTIONS "+vqM:X:L:N:k:s:H:O:x:T:g:D:Em:l:I"
 static const struct option longopts[] = {
     {"sid",             required_argument,  0, 'N'},
     {"verbose",         no_argument,        0, 'v'},
     {"quiet",           no_argument,        0, 'q'},
     {"security",        required_argument,  0, 's'},
-    {"rank",            required_argument,  0, 'R'},
-    {"size",            required_argument,  0, 'S'},
     {"module",          required_argument,  0, 'M'},
     {"exclude",         required_argument,  0, 'x'},
     {"modopt",          required_argument,  0, 'O'},
@@ -222,8 +218,6 @@ static void usage (void)
 "Usage: flux-broker OPTIONS [module:key=val ...]\n"
 " -v,--verbose                 Be annoyingly verbose\n"
 " -q,--quiet                   Be mysteriously taciturn\n"
-" -R,--rank N                  Set broker rank (0...size-1)\n"
-" -S,--size N                  Set number of ranks in session\n"
 " -N,--sid NAME                Set session id\n"
 " -M,--module NAME             Load module NAME (may be repeated)\n"
 " -x,--exclude NAME            Exclude module NAME\n"
@@ -240,7 +234,7 @@ static void usage (void)
 " -D,--socket-directory DIR    Create ipc sockets in DIR (local bootstrap)\n"
 " -E,--enable-epgm             Enable EPGM for events (PMI bootstrap)\n"
 " -I,--shared-ipc-namespace    Wire up session TBON over ipc sockets\n"
-" -m,--boot-method             Select bootstrap: pmi, single, local\n"
+" -m,--boot-method             Select bootstrap: pmi, single\n"
 );
     exit (1);
 }
@@ -319,12 +313,6 @@ int main (int argc, char *argv[])
                 break;
             case 'q':   /* --quiet */
                 ctx.quiet = true;
-                break;
-            case 'R':   /* --rank N */
-                ctx.rank = strtoul (optarg, NULL, 10);
-                break;
-            case 'S':   /* --size N */
-                ctx.size = strtoul (optarg, NULL, 10);
                 break;
             case 'M':   /* --module NAME[nodeset] */
                 if (zlist_push (modules, xstrdup (optarg)) < 0 )
@@ -1190,42 +1178,6 @@ done:
     if (rc != 0)
         errno = EPROTO;
     return rc;
-}
-
-/* This is the boot method selected by flux-start.
- * We should have been called with --rank, --size, and --sid.
- */
-static int boot_local (ctx_t *ctx)
-{
-    if (ctx->rank == FLUX_NODEID_ANY || ctx->size == 0) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (create_socketdir (ctx) < 0 || create_rankdir (ctx) < 0)
-        return -1;
-
-    char *reqfile = xasprintf ("%s/%d/req", ctx->socket_dir, ctx->rank);
-    overlay_set_child (ctx->overlay, "ipc://%s", reqfile);
-    cleanup_push_string (cleanup_file, reqfile);
-    free (reqfile);
-
-    if (ctx->rank > 0) {
-        int parent_rank = ctx->k_ary == 0 ? 0 : (ctx->rank - 1) / ctx->k_ary;
-        overlay_push_parent (ctx->overlay, "ipc://%s/%d/req",
-                             ctx->socket_dir, parent_rank);
-    }
-
-    char *eventfile = xasprintf ("%s/event", ctx->socket_dir);
-    overlay_set_event (ctx->overlay, "ipc://%s", eventfile);
-    if (ctx->rank == 0)
-        cleanup_push_string (cleanup_file, eventfile);
-    free (eventfile);
-
-    int right_rank = ctx->rank == 0 ? ctx->size - 1 : ctx->rank - 1;
-    overlay_set_right (ctx->overlay, "ipc://%s/%d/req",
-                       ctx->socket_dir, right_rank);
-
-    return 0;
 }
 
 static int boot_single (ctx_t *ctx)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -508,7 +508,7 @@ int main (int argc, char *argv[])
     if (ctx.verbose)
         msg ("boot: %s", ctx.boot_method->name);
     if (ctx.boot_method->fun (&ctx) < 0)
-        err_exit ("boot %s", ctx.boot_method->name);
+        msg_exit ("bootstrap failed");
     assert (ctx.rank != FLUX_NODEID_ANY);
     assert (ctx.size > 0);
     assert (attr_get (ctx.attrs, "session-id", NULL, NULL) == 0);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1021,8 +1021,12 @@ static int boot_pmi (ctx_t *ctx)
             for (i = 0; i < clique_size; i++)
                 if (relay_rank == -1 || clique_ranks[i] < relay_rank)
                     relay_rank = clique_ranks[i];
-            if (relay_rank >= 0 && ctx->rank == relay_rank)
-                overlay_set_relay (ctx->overlay, "ipc://*");
+            if (relay_rank >= 0 && ctx->rank == relay_rank) {
+                char *relayfile = xasprintf ("%s/relay", ctx->socket_dir);
+                overlay_set_relay (ctx->overlay, "ipc://%s", relayfile);
+                cleanup_push_string (cleanup_file, relayfile);
+                free (relayfile);
+            }
         }
     }
 

--- a/src/broker/snoop.c
+++ b/src/broker/snoop.c
@@ -27,6 +27,7 @@
 #endif
 #include <czmq.h>
 #include <errno.h>
+#include <stdarg.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/xzmalloc.h"
@@ -68,11 +69,18 @@ void snoop_set_zctx (snoop_t *sn, zctx_t *zctx)
     sn->zctx = zctx;
 }
 
-void snoop_set_uri (snoop_t *sn, const char *uri)
+void snoop_set_uri (snoop_t *sn, const char *fmt, ...)
 {
+    va_list ap;
+    char *uri;
+
+    va_start (ap, fmt);
+    uri = xvasprintf (fmt, ap);
+    va_end (ap);
+
     if (sn->uri)
         free (sn->uri);
-    sn->uri = xstrdup (uri);
+    sn->uri = uri;
 }
 
 static int snoop_bind (snoop_t *sn)

--- a/src/broker/snoop.h
+++ b/src/broker/snoop.h
@@ -28,7 +28,7 @@ void snoop_destroy (snoop_t *sn);
 
 void snoop_set_sec (snoop_t *sn, flux_sec_t sec);
 void snoop_set_zctx (snoop_t *sn, zctx_t *zctx);
-void snoop_set_uri (snoop_t *sn, const char *uri);
+void snoop_set_uri (snoop_t *sn, const char *fmt, ...);
 
 const char *snoop_get_uri (snoop_t *sn);
 int snoop_sendmsg (snoop_t *sn, const flux_msg_t *msg);

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,5 @@
-SUBDIRS = libtap libev libpmi-client liblsd libutil libflux libcompat
+SUBDIRS = libtap libev libpmi-client libpmi-server \
+	  liblsd libutil libflux libcompat
 
 AM_CFLAGS = @GCCWARN@ $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
@@ -13,6 +14,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libutil/libutil.la \
 	$(builddir)/libev/libev.la \
 	$(builddir)/libpmi-client/libpmi-client.la \
+	$(builddir)/libpmi-server/libpmi-server.la \
 	$(builddir)/libcompat/libcompat.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) -lrt

--- a/src/common/libpmi-client/pmi-client.h
+++ b/src/common/libpmi-client/pmi-client.h
@@ -47,6 +47,13 @@
 #define PMI_ERR_INVALID_SIZE        13
 #endif
 
+#ifndef PMI_FALSE
+#define PMI_FALSE                   0
+#endif
+#ifndef PMI_TRUE
+#define PMI_TRUE                    1
+#endif
+
 typedef void (*pmi_free_f)(void *impl);
 
 typedef struct pmi_struct pmi_t;

--- a/src/common/libpmi-client/pmi-simple.c
+++ b/src/common/libpmi-client/pmi-simple.c
@@ -100,6 +100,8 @@ static int simple_init (void *impl, int *spawned)
                 &s->kvsname_max, &s->keylen_max, &s->vallen_max) != 3)
         goto done;
     s->initialized = 1;
+    if (spawned)
+        *spawned = PMI_FALSE;
     result = PMI_SUCCESS;
 done:
     return result;

--- a/src/common/libpmi-server/Makefile.am
+++ b/src/common/libpmi-server/Makefile.am
@@ -1,0 +1,17 @@
+AM_CFLAGS = \
+	@GCCWARN@ \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
+	-Wno-strict-aliasing \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include
+
+noinst_LTLIBRARIES = libpmi-server.la
+
+libpmi_server_la_SOURCES = \
+	simple.h \
+	simple.c

--- a/src/common/libpmi-server/simple.c
+++ b/src/common/libpmi-server/simple.c
@@ -1,0 +1,202 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/param.h>
+#include <czmq.h>
+
+#include "simple.h"
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+/* N.B. These values cannot be numeric expressions as they are incorporated
+ * into sscanf conversion specifiers with preprocessor trick, hence these
+ * definitions may seem backwards.
+ */
+#define KVS_KEY_MAX_SCAN  63
+#define KVS_VAL_MAX_SCAN  511
+#define KVS_NAME_MAX_SCAN 63
+
+#define KVS_KEY_MAX     (KVS_KEY_MAX_SCAN+1)
+#define KVS_VAL_MAX     (KVS_VAL_MAX_SCAN+1)
+#define KVS_NAME_MAX    (KVS_NAME_MAX_SCAN+1)
+
+#define MAX_PROTO_OVERHEAD  64
+
+struct pmi_response {
+    void *client;
+    char *msg;
+};
+
+struct pmi_simple_server {
+    void *arg;
+    struct pmi_simple_ops ops;
+    int appnum;
+    char *kvsname;
+    int universe_size;
+    zlist_t *barrier;
+    zlist_t *responses;
+};
+
+struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
+                                                    int appnum,
+                                                    int universe_size,
+                                                    const char *kvsname,
+                                                    void *arg)
+{
+    struct pmi_simple_server *pmi = xzmalloc (sizeof (*pmi));
+    pmi->ops = *ops;
+    pmi->arg = arg;
+    pmi->appnum = appnum;
+    pmi->kvsname = xstrdup (kvsname);
+    pmi->universe_size = universe_size;
+    if (!(pmi->barrier = zlist_new ()))
+        oom ();
+    if (!(pmi->responses = zlist_new ()))
+        oom ();
+    return pmi;
+}
+
+static void destroy_response_list (zlist_t **l)
+{
+    if (*l) {
+        struct pmi_response *r;
+        while ((r = zlist_pop (*l))) {
+            free (r->msg);
+            free (r);
+        }
+        zlist_destroy (l);
+    }
+}
+
+void pmi_simple_server_destroy (struct pmi_simple_server *pmi)
+{
+    if (pmi) {
+        if (pmi->kvsname)
+            free (pmi->kvsname);
+        destroy_response_list (&pmi->barrier);
+        destroy_response_list (&pmi->responses);
+        free (pmi);
+    }
+}
+
+int pmi_simple_server_get_maxrequest (struct pmi_simple_server *pmi)
+{
+    return (KVS_KEY_MAX + KVS_VAL_MAX + KVS_NAME_MAX + MAX_PROTO_OVERHEAD);
+}
+
+#define S_(x) #x
+#define S(x) S_(x)
+
+int pmi_simple_server_request (struct pmi_simple_server *pmi,
+                               const char *buf, void *client)
+{
+    char key[KVS_KEY_MAX];
+    char val[KVS_VAL_MAX];
+    char name[KVS_NAME_MAX];
+    char *resp = NULL;
+    int rc = 0;
+
+    if (!strcmp (buf, "cmd=init pmi_version=1 pmi_subversion=1")) {
+        resp = xasprintf ("cmd=response_to_init"
+                            " pmi_version=1 pmi_subversion=1 rc=0\n");
+    } else if (!strcmp (buf, "cmd=get_maxes")) {
+        resp = xasprintf ("cmd=maxes kvsname_max=%d keylen_max=%d"
+                         " vallen_max=%d\n",
+                         KVS_NAME_MAX, KVS_KEY_MAX, KVS_VAL_MAX);
+    } else if (!strcmp (buf, "cmd=get_appnum")) {
+        resp = xasprintf ("cmd=appnum appnum=%d\n", pmi->appnum);
+    } else if (!strcmp (buf, "cmd=get_my_kvsname")) {
+        resp = xasprintf ("cmd=my_kvsname kvsname=%s\n", pmi->kvsname);
+    } else if (!strcmp (buf, "cmd=get_universe_size")) {
+        resp = xasprintf ("cmd=universe_size size=%d\n", pmi->universe_size);
+    } else if (sscanf (buf, "cmd=put"
+                            " kvsname=%" S(KVS_NAME_MAX_SCAN) "s"
+                            " key=%" S(KVS_KEY_MAX_SCAN) "s"
+                            " value=%" S(KVS_VAL_MAX_SCAN) "s",
+                            name, key, val) == 3) {
+        int result = pmi->ops.kvs_put (pmi->arg, name, key, val);
+        resp = xasprintf ("cmd=put_result rc=%d msg=%s\n", result,
+                          result == 0 ? "success" : "failure");
+    } else if (sscanf (buf, "cmd=get"
+                            " kvsname=%" S(KVS_NAME_MAX_SCAN) "s"
+                            " key=%" S(KVS_KEY_MAX_SCAN) "s",
+                            name, key) == 2) {
+        int result = pmi->ops.kvs_get (pmi->arg, name, key, val, KVS_VAL_MAX);
+        resp = xasprintf ("cmd=get_result rc=%d msg=%s value=%s\n", result,
+                          result == 0 ? "success" : "failure",
+                          result == 0 ? val : "");
+    } else if (!strcmp (buf, "cmd=barrier_in")) {
+        struct pmi_response *r = xzmalloc (sizeof (*r));
+        r->msg = xasprintf ("cmd=barrier_out\n");
+        r->client = client;
+        if (zlist_append (pmi->barrier, r) < 0)
+            oom ();
+        if (pmi->ops.barrier (pmi->arg) == 1) {
+            while ((r = zlist_pop (pmi->barrier)))
+                if (zlist_append (pmi->responses, r) < 0)
+                    oom ();
+        }
+    } else if (!strcmp (buf, "cmd=finalize")) {
+        resp = xasprintf ("cmd=finalize_ack\n");
+        rc = 1; /* Indicates fd should be closed */
+    } else {
+        errno = EPROTO;
+        rc = -1;
+    }
+    if (resp) {
+        struct pmi_response *r = xzmalloc (sizeof (*r));
+        r->msg = resp;
+        r->client = client;
+        if (zlist_append (pmi->responses, r) < 0)
+            oom ();
+    }
+    return rc;
+}
+
+int pmi_simple_server_response (struct pmi_simple_server *pmi,
+                                char **buf, void *client)
+{
+    struct pmi_response *r = zlist_pop (pmi->responses);
+    if (r) {
+        *buf = r->msg;
+        *(void **)client = r->client;
+        free (r);
+        return 0;
+    }
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi-server/simple.h
+++ b/src/common/libpmi-server/simple.h
@@ -1,0 +1,51 @@
+#ifndef _FLUX_CORE_PMI_SIMPLE_SERVER_H
+#define _FLUX_CORE_PMI_SIMPLE_SERVER_H
+
+struct pmi_simple_server;
+
+/* User-provided service implementation.
+ * put/get return 0 on success, -1 on failure.
+ * barrier returns 0 if incomplete, 1 if complete.
+ */
+struct pmi_simple_ops {
+    int (*kvs_put)(void *arg, const char *kvsname,
+                   const char *key, const char *val);
+    int (*kvs_get)(void *arg, const char *kvsname,
+                   const char *key, char *val, int len);
+    int (*barrier)(void *arg);
+};
+
+/* Create/destroy protocol engine.
+ */
+struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
+                                                    int appnum,
+                                                    int universe_size,
+                                                    const char *kvsname,
+                                                    void *arg);
+void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
+
+/* Max buffer size needed to read a null-terminated request line,
+ * including trailing newline.
+ */
+int pmi_simple_server_get_maxrequest (struct pmi_simple_server *pmi);
+
+/* Put null-terminated request with sending client reference to protocol
+ * engine.  Caller should remove the trailing newline.
+ * Return 0 on success, -1 on failure.
+ */
+int pmi_simple_server_request (struct pmi_simple_server *pmi,
+                               const char *buf, void *client);
+
+/* Get next null-terminated response and destination client reference
+ * from protocol engine.  Response is ready to send, trailing newline included.
+ * Caller must free response.
+ * Return 0 on success, -1 on failure (no more responses).
+ */
+int pmi_simple_server_response (struct pmi_simple_server *pmi,
+                                char **buf, void *client);
+
+#endif /* ! _FLUX_CORE_PMI_SIMPLE_SERVER_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -19,6 +19,7 @@ TESTS = \
 	loop/rpc.t \
 	loop/multrpc.t \
 	loop/reduce.t \
+	pmi/simple.t \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -107,6 +108,7 @@ check_PROGRAMS = \
 	loop/multrpc.t \
 	loop/reduce.t \
 	pmi/kvstest \
+	pmi/simple.t \
 	pmi/pminfo \
 	kz/kzutil \
 	kvs/torture \
@@ -165,6 +167,10 @@ loop_reduce_t_LDADD = $(test_ldadd) $(LIBDL)
 pmi_kvstest_SOURCES = pmi/kvstest.c
 pmi_kvstest_CPPFLAGS = $(test_cppflags)
 pmi_kvstest_LDADD = $(test_ldadd) $(LIBRT)
+
+pmi_simple_t_SOURCES = pmi/simple.c
+pmi_simple_t_CPPFLAGS = $(test_cppflags)
+pmi_simple_t_LDADD = $(test_ldadd) $(LIBRT)
 
 pmi_pminfo_SOURCES = pmi/pminfo.c
 pmi_pminfo_CPPFLAGS = $(test_cppflags)

--- a/t/pmi/simple.c
+++ b/t/pmi/simple.c
@@ -1,0 +1,263 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <pthread.h>
+#include <czmq.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libpmi-client/pmi-client.h"
+#include "src/common/libpmi-server/simple.h"
+#include "src/common/libflux/reactor.h"
+
+#include "src/common/libtap/tap.h"
+
+struct context {
+    pthread_t t;
+    int fds[2];
+    int exit_rc;
+    zhash_t *kvs;
+    struct pmi_simple_server *pmi;
+    int barrier;
+    int size;
+    char *buf;
+    int buflen;
+};
+
+static int s_kvs_put (void *arg, const char *kvsname, const char *key,
+                 const char *val)
+{
+    diag ("%s: %s::%s", __FUNCTION__, kvsname, key);
+    struct context *ctx = arg;
+    int rc = 0;
+    zhash_update (ctx->kvs, key, xstrdup (val));
+    zhash_freefn (ctx->kvs, key, (zhash_free_fn *)free);
+
+    return rc;
+}
+
+static int s_kvs_get (void *arg, const char *kvsname, const char *key,
+                 char *val, int len)
+{
+    diag ("%s: %s::%s", __FUNCTION__, kvsname, key);
+    struct context *ctx = arg;
+    char *v = zhash_lookup (ctx->kvs, key);
+    int rc = -1;
+
+    if (v && strlen (v) < len) {
+        strcpy (val, v);
+        rc = 0;
+    }
+    return rc;
+}
+
+static int s_barrier (void *arg)
+{
+    diag ("%s", __FUNCTION__);
+    struct context *ctx = arg;
+    if (++ctx->barrier == ctx->size) {
+        ctx->barrier = 0;
+        return 1;
+    }
+    return 0;
+}
+
+static int dgetline (int fd, char *buf, int len)
+{
+    int i = 0;
+    while (i < len - 1) {
+        if (read (fd, &buf[i], 1) <= 0)
+            return -1;
+        if (buf[i] == '\n')
+            break;
+        i++;
+    }
+    if (buf[i] != '\n') {
+        errno = EPROTO;
+        return -1;
+    }
+    buf[i] = '\0';
+    return 0;
+}
+
+static int dputline (int fd, const char *buf)
+{
+    int len = strlen (buf);
+    int n, count = 0;
+    while (count < len) {
+        if ((n = write (fd, buf + count, len - count)) < 0)
+            return n;
+        count += n;
+    }
+    return count;
+}
+
+static void s_io_cb (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    struct context *ctx = arg;
+    int *rfd, fd = flux_fd_watcher_get_fd (w);
+    char *resp;
+    int rc;
+
+    if (dgetline (fd, ctx->buf, ctx->buflen) < 0) {
+        diag ("dgetline: %s", strerror (errno));
+        flux_reactor_stop_error (r);
+        return;
+    }
+    rc = pmi_simple_server_request (ctx->pmi, ctx->buf, &ctx->fds[1]);
+    if (rc < 0) {
+        diag ("pmi_simple_server_request: %s", strerror (errno));
+        flux_reactor_stop_error (r);
+        return;
+    }
+    while (pmi_simple_server_response (ctx->pmi, &resp, &rfd) == 0) {
+        if (dputline (*rfd, resp) < 0) {
+            diag ("dputline: %s", strerror (errno));
+            flux_reactor_stop_error (r);
+            return;
+        }
+        free (resp);
+    }
+    if (rc == 1) {
+        close (fd);
+        flux_watcher_stop (w);
+    }
+}
+
+void *server_thread (void *arg)
+{
+    struct context *ctx = arg;
+    flux_reactor_t *reactor = NULL;
+    flux_watcher_t *w = NULL;
+
+    if (!(reactor = flux_reactor_create (0)))
+        goto done;
+    if (!(w = flux_fd_watcher_create (reactor, ctx->fds[1],
+                                      FLUX_POLLIN, s_io_cb, ctx)))
+        goto done;
+    flux_watcher_start (w);
+
+    ctx->exit_rc = -1;
+    if (flux_reactor_run (reactor, 0) < 0)
+        goto done;
+
+    ctx->exit_rc = 0;
+done:
+    if (w)
+        flux_watcher_destroy (w);
+    if (reactor)
+        flux_reactor_destroy (reactor);
+    return NULL;
+}
+
+int main (int argc, char *argv[])
+{
+    struct context ctx;
+    struct pmi_simple_ops ops = {
+        .kvs_put = s_kvs_put,
+        .kvs_get = s_kvs_get,
+        .barrier = s_barrier,
+    };
+    pmi_t *cli;
+    int spawned = -1, initialized = -1;
+    int rank = -1, size = -1;
+    int universe_size = -1;
+    int name_len = -1, key_len = -1, val_len = -1;
+    char *name = NULL, *val = NULL, *val2 = NULL;
+
+    plan (NO_PLAN);
+
+    if (!(ctx.kvs = zhash_new ()))
+        oom ();
+    ctx.size = 1;
+    ctx.barrier = 0;
+    ok (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, ctx.fds) == 0,
+        "socketpair returned client,server file descriptors");
+    ctx.pmi = pmi_simple_server_create (&ops, 42, ctx.size, "bleepgorp", &ctx);
+    ok (ctx.pmi != NULL,
+        "created simple pmi server context");
+    ctx.buflen = pmi_simple_server_get_maxrequest (ctx.pmi);
+    ctx.buf = xzmalloc (ctx.buflen);
+    ok (pthread_create (&ctx.t, NULL, server_thread, &ctx) == 0,
+        "pthread_create successfully started server");
+
+    ok ((cli = pmi_create_simple (ctx.fds[0], 0, ctx.size)) != NULL,
+        "pmi_create_simple OK");
+    ok (pmi_initialized (cli, &initialized) == PMI_SUCCESS && initialized == 0,
+        "pmi_initialized OK, initialized=0");
+    ok (pmi_init (cli, &spawned) == PMI_SUCCESS && spawned == 0,
+        "pmi_init OK, spawned=0");
+    ok (pmi_initialized (cli, &initialized) == PMI_SUCCESS && initialized == 1,
+        "pmi_initialized OK, initialized=1");
+
+    /* retrieve basic params
+     */
+    ok (pmi_get_size (cli, &size) == PMI_SUCCESS && size == 1,
+        "pmi_get_size OK, size=%d", size);
+    ok (pmi_get_rank (cli, &rank) == PMI_SUCCESS && rank == 0,
+        "pmi_get_rank OK, rank=%d", rank);
+    ok (pmi_get_universe_size (cli, &universe_size) == PMI_SUCCESS
+        && universe_size == size,
+        "pmi_get_universe_size OK, universe_size=%d", universe_size);
+    ok (pmi_kvs_get_name_length_max (cli, &name_len) == PMI_SUCCESS
+        && name_len > 0,
+        "pmi_kvs_get_name_length_max OK, name_len=%d", name_len);
+    ok (pmi_kvs_get_key_length_max (cli, &key_len) == PMI_SUCCESS
+        && key_len > 0,
+        "pmi_kvs_get_key_length_max OK, key_len=%d", key_len);
+    ok (pmi_kvs_get_value_length_max (cli, &val_len) == PMI_SUCCESS
+        && val_len > 0,
+        "pmi_kvs_get_value_length_max OK, val_len=%d", val_len);
+    name = xzmalloc (name_len);
+    ok (pmi_kvs_get_my_name (cli, name, name_len) == PMI_SUCCESS
+        && strlen (name) > 0,
+        "pmi_kvs_get_my_name OK, name=%s", name);
+
+    /* put foo=bar / commit / barier / get foo
+     */
+    ok (pmi_kvs_put (cli, name, "foo", "bar") == PMI_SUCCESS,
+        "pmi_kvs_put foo=bar OK");
+    ok (pmi_kvs_commit (cli, name) == PMI_SUCCESS,
+        "pmi_kvs_commit OK");
+    ok (pmi_barrier (cli) == PMI_SUCCESS,
+        "pmi_barrier OK");
+    val = xzmalloc (val_len);
+    ok (pmi_kvs_get (cli, name, "foo", val, val_len) == PMI_SUCCESS
+        && !strcmp (val, "bar"),
+        "pmi_kvs_get foo OK, val=%s", val);
+
+    /* put long=... / get long
+     */
+    val2 = xzmalloc (val_len);
+    memset (val2, 'x', val_len - 1);
+    ok (pmi_kvs_put (cli, name, "long", val2) == PMI_SUCCESS,
+        "pmi_kvs_put long=xxx... OK");
+    memset (val, 'y', val_len); /* not null terminated */
+    ok (pmi_kvs_get (cli, name, "long", val, val_len) == PMI_SUCCESS
+        && strnlen (val2, val_len) < val_len
+        && strcmp (val, val2) == 0,
+        "pmi_kvs_get long OK, val=xxx...");
+
+    ok (pmi_finalize (cli) == PMI_SUCCESS,
+        "pmi_finalize OK");
+
+    ok (pthread_join (ctx.t, NULL) == 0,
+        "pthread join successfully reaped server");
+
+    free (name);
+    free (val);
+    free (val2);
+    pmi_destroy (cli);
+    if (ctx.pmi)
+        pmi_simple_server_destroy (ctx.pmi);
+    close (ctx.fds[0]);
+    close (ctx.fds[1]);
+    zhash_destroy (&ctx.kvs);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR implements a small "protocol engine" for the PMI simple v1 wire protocol, for the server side and then uses it and the recently added `subprocess_socketpair()` call to implement PMI as a bootstrap option for brokers in `flux-start`.

We could go a step further and eliminate the `--rank, --size, and --boot-method=LOCAL` code in the broker and make this the default way that `flux-start` operates, but I stopped short of that.

It's worth noting that this subset of PMI1 lacks `PMI_Get_id()` (used to communicate a non-numeric job id) and `PMI_Get_clique_ranks()` (used to determine which ranks can communicate over ipc versus tcp).  

Also, in this iteration I didn't bother implementing the protocol operations for `PMI_Publish_name()` , `PMI_Unpublish_name()`, `PMI_Lookup_name()`, or `PMI_Spawn_multiple()`.  (These are also stubbed out in libpmi-client)

A demo of `flux-start --boot-method=PMI` was added to the sharness hydra test.

Another test was added that exercises each protocol operation, pitting libpmi-client against libpmi-server over a single socketpair.