### PR TITLE
Update lua bindings with some new watchers and low level kvs calls

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -404,17 +404,13 @@ static int l_flux_size (lua_State *L)
     return (l_pushresult (L, size));
 }
 
-static int l_flux_treeroot (lua_State *L)
+static int l_flux_arity (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
-    bool treeroot = false;
-    uint32_t rank;
-    if (flux_get_rank (f, &rank) < 0)
-        return lua_pusherror (L, "flux_get_rank error");
-    if (rank == 0)
-        treeroot = true;
-    lua_pushboolean (L, treeroot);
-    return (1);
+    int arity;
+    if (flux_get_arity (f, &arity) < 0)
+        return lua_pusherror (L, "flux_get_arity error");
+    return (l_pushresult (L, arity));
 }
 
 static int l_flux_index (lua_State *L)
@@ -428,8 +424,8 @@ static int l_flux_index (lua_State *L)
         return l_flux_size (L);
     if (strcmp (key, "rank") == 0)
         return l_flux_rank (L);
-    if (strcmp (key, "treeroot") == 0)
-        return l_flux_treeroot (L);
+    if (strcmp (key, "arity") == 0)
+        return l_flux_arity (L);
 
     lua_getmetatable (L, 1);
     lua_getfield (L, -1, key);

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1396,6 +1396,8 @@ static void iowatcher_kz_ready_cb (kz_t *kz, void *arg)
     lua_settop (L, 0);
 }
 
+static int lua_push_kz (lua_State *L, kz_t *kz);
+
 static int l_iowatcher_add (lua_State *L)
 {
     struct l_flux_ref *iow = NULL;
@@ -1432,6 +1434,8 @@ static int l_iowatcher_add (lua_State *L)
         if ((kz = kz_open (f, key, flags)) == NULL)
             return lua_pusherror (L, "kz_open: %s", strerror (errno));
         iow = l_flux_ref_create (L, f, 2, "iowatcher");
+        lua_push_kz (L, kz);
+        lua_setfield (L, 2, "kz");
         kz_set_ready_cb (kz, (kz_ready_f) iowatcher_kz_ready_cb, (void *) iow);
     }
     return (1);

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1862,6 +1862,25 @@ static int l_kz_write (lua_State *L)
     return (1); /* len */
 }
 
+static int l_kz_read (lua_State *L)
+{
+    int rc;
+    kz_t *kz = lua_get_kz (L, 1);
+    char *s = NULL;
+    if ((rc = kz_get (kz, &s)) < 0)
+        return lua_pusherror (L, "kz_get: %s", strerror (errno));
+    // return table
+    lua_newtable (L);
+    lua_pushboolean (L, rc == 0);
+    lua_setfield (L, -2, "eof");
+    if (rc != 0) {
+        lua_pushstring (L, s);
+        lua_setfield (L, -2, "data");
+    }
+    free (s);
+    return (1);
+}
+
 static const struct luaL_Reg flux_functions [] = {
     { "new",             l_flux_new         },
     { NULL,              NULL              }
@@ -1938,6 +1957,7 @@ static const struct luaL_Reg kz_methods [] = {
     { "__gc",            l_kz_gc              },
     { "close",           l_kz_close           },
     { "write",           l_kz_write           },
+    { "read",            l_kz_read            },
     { NULL,              NULL                 }
 };
 

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1839,7 +1839,8 @@ static int l_flux_kz_open (lua_State *L)
     const char *key = lua_tostring (L, 2);
     const char *mode = lua_tostring (L, 3);
     int flags;
-
+    if (mode == NULL)
+        mode = "r";
     if (mode[0] == 'r')
         flags = KZ_FLAGS_READ | KZ_FLAGS_NOEXIST | KZ_FLAGS_NONBLOCK;
     else if (mode[0] == 'w')

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1792,6 +1792,13 @@ static int l_flux_reactor_stop (lua_State *L)
     return 0;
 }
 
+static int l_flux_reactor_stop_error (lua_State *L)
+{
+    flux_reactor_stop_error (flux_get_reactor (lua_get_flux (L, 1)));
+    return 0;
+}
+
+
 static int lua_push_kz (lua_State *L, kz_t *kz)
 {
     kz_t **kzp = lua_newuserdata (L, sizeof (*kzp));
@@ -1913,6 +1920,8 @@ static const struct luaL_Reg flux_methods [] = {
     { "sighandler",      l_signal_handler_add },
     { "reactor",         l_flux_reactor_start },
     { "reactor_stop",    l_flux_reactor_stop },
+    { "reactor_stop_error",
+                         l_flux_reactor_stop_error },
     { NULL,              NULL               }
 };
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,15 +41,18 @@ TESTS = \
 	t2002-pmi.t \
 	t2003-recurse.t \
 	t2004-hydra.t \
-	t3000-mpi-basic.t
+	t3000-mpi-basic.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
 	lua/t0007-alarm.t \
+	lua/t0008-mrpc.t \
 	lua/t1000-reactor.t \
 	lua/t1001-timeouts.t \
 	lua/t1002-kvs.t \
-	lua/t1003-iowatcher.t
+	lua/t1003-iowatcher.t \
+	lua/t1004-statwatcher.t \
+	lua/t1005-fdwatcher.t
 
 EXTRA_DIST= \
 	$(check_SCRIPTS) \
@@ -89,10 +92,13 @@ check_SCRIPTS = \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
 	lua/t0007-alarm.t \
+	lua/t0008-mrpc.t \
 	lua/t1000-reactor.t \
 	lua/t1001-timeouts.t \
 	lua/t1002-kvs.t \
-	lua/t1003-iowatcher.t
+	lua/t1003-iowatcher.t \
+	lua/t1004-statwatcher.t \
+	lua/t1005-fdwatcher.t
 
 check_PROGRAMS = \
 	loop/handle.t \

--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -84,8 +84,12 @@ end
 --
 function fluxTest:start_session (t)
     -- If fluxometer session is already active just return:
-    if os.getenv ("FLUXOMETER_ACTIVE") then
-        cleanup (function () os.execute ("rm "..self.log_file) end)
+    if self.flux_active then
+        cleanup (function ()
+                     posix.chdir (self.src_dir)
+                     os.execute ("rm "..self.log_file)
+                     os.execute ("rm -rf "..self.trash_dir)
+                 end)
         return
     end
     posix.setenv ("FLUXOMETER_ACTIVE", "t")
@@ -104,6 +108,10 @@ function fluxTest:start_session (t)
 
     table.insert (cmd, self.arg0)
 
+    -- Adjust package.path so we find fluxometer.lua
+    local p = self.src_dir..'/?.lua;'..package.path
+    posix.setenv ("LUA_PATH", p)
+
     -- reexec script under flux-start if necessary:
     --  (does not return)
     local r, err = posix.exec (unpack (cmd))
@@ -120,6 +128,7 @@ function fluxTest:die (...)
     bail_out (self.prog..": "..string.format (...))
 end
 
+
 ---
 --   Create fluxometer test object
 --
@@ -127,15 +136,22 @@ function fluxTest.init (...)
     local debug = require 'debug'
     local test = setmetatable ({}, fluxTest)
 
+    if os.getenv ("FLUXOMETER_ACTIVE") then
+        test.flux_active = true
+    end
 
     -- Get path to current test script using debug.getinfo:
-	test.arg0 = debug.getinfo (2).source:sub (2)
+    test.arg0 = debug.getinfo (2).source:sub (2)
     test.prog = test.arg0:match ("/*([^/.]+)%.")
 
-    -- If arg0 doesn't contain relative or absolute path, then assume
-    --  local directory and prepend './'
-    if not test.arg0:match ('^[/.]') then
-        test.arg0 = './'..test.arg0
+    local cwd, err = posix.getcwd ()
+    if not cwd then error (err) end
+    test.src_dir = cwd
+
+    -- If arg0 doesn't contain absolute path, then assume
+    --  local directory and prepend src_dir
+    if not test.arg0:match ('^/') then
+        test.arg0 = test.src_dir..'/'..test.arg0
     end
 
     test.log_file = "lua-"..test.prog..".broker.log"
@@ -149,6 +165,13 @@ function fluxTest.init (...)
         test.flux_path = path
     else
         test:die ("Failed to find flux path")
+    end
+
+    test.trash_dir = "trash-directory.lua-"..test.prog
+    os.execute ("rm -rf "..test.trash_dir)
+    posix.mkdir (test.trash_dir)
+    if test.flux_active then
+        posix.chdir (test.trash_dir)
     end
 
     return test

--- a/t/lua/t0002-rpc.t
+++ b/t/lua/t0002-rpc.t
@@ -5,12 +5,16 @@
 local test = require 'fluxometer'.init (...)
 test:start_session { size=2 }
 
-plan (16)
+plan (19)
 
 local flux = require_ok ('flux')
 local f, err = flux.new()
 type_ok (f, 'userdata', "create new flux handle")
 is (err, nil, "error is nil")
+
+is (f.rank, 0, "running on rank 0")
+is (f.size, 2, "session size is 2")
+is (f.arity, 2, "session arity is 2")
 
 --
 --  Use 'ping' packet to test rpc

--- a/t/lua/t0008-mrpc.t
+++ b/t/lua/t0008-mrpc.t
@@ -1,0 +1,49 @@
+#!/usr/bin/lua
+--
+--  Basic flux mrpc testing using mecho service
+--
+local test = require 'fluxometer'.init (...)
+test:start_session { size=4 }
+
+plan ('no_plan')
+
+local flux = require_ok ('flux')
+local f, err = flux.new()
+type_ok (f, 'userdata', "create new flux handle")
+is (err, nil, "error is nil")
+
+--
+--  Use 'mecho' packet to test rpc
+--
+local inarg = { test = "Hello, World" }
+local m, err = f:mrpc ("0-3", inarg)
+ok (m, "mrpc created")
+
+-- Force commit so we can check inarg
+f:kvs_commit ()
+
+-- Check inarg
+is_deeply (m.inarg, inarg, "inarg set by f:mrpc")
+
+-- Check that we can put new inarg
+local inarg2 = { foo = "bar" }
+m.inarg = inarg2
+f:kvs_commit ()
+is_deeply (m.inarg, inarg2, "inarg set by newindex")
+
+m.inarg = inarg
+
+local out, err = m ("mecho")
+ok (out, "mrpc returned "..tostring (out))
+
+for i, arg in m.out:next() do
+    is_deeply (arg, inarg, i..": outarg matches")
+end
+
+-- Also try direct index into outargs
+local outargs = m.out
+ok (outargs, "index outargs")
+is_deeply (outargs[0], inarg, "direct index into outargs works")
+
+
+done_testing ()

--- a/t/lua/t1003-iowatcher.t
+++ b/t/lua/t1003-iowatcher.t
@@ -29,9 +29,14 @@ local iow, err = f:iowatcher {
 }
 type_ok (iow, 'userdata', "succesfully create iowatcher")
 is (err, nil, "error is nil")
+type_ok (iow.kz, 'userdata', "iowatcher kz available as index")
 
-os.execute ('printf "hello\nworld" | ' .. test.top_builddir .. '/t/kz/kzutil --force --copy - iowatcher.test.stdout >/dev/null 2>&1')
+os.execute ('printf "hello\nworld" | ' .. test.top_builddir .. '/t/kz/kzutil --copy - iowatcher.test.stdout')
 
+f:timer {
+    timeout = 250,
+    hander = function () f:reactor_stop_error () end
+}
 local r, err = f:reactor()
 isnt (r, -1, "Return from reactor, rc >= 0")
 is (err, nil, "error is nil")

--- a/t/lua/t1004-statwatcher.t
+++ b/t/lua/t1004-statwatcher.t
@@ -1,0 +1,71 @@
+#!/usr/bin/lua
+--
+--  Basic flux stat watcher test
+--
+local test = require 'fluxometer'.init (...)
+test:start_session {}
+
+require 'Test.More'
+
+local flux = require_ok ('flux')
+local f, err = flux.new()
+type_ok (f, 'userdata', "create new flux handle")
+is (err, nil, "error is nil")
+
+-- Test timeout: 5s
+f:timer {
+    timeout = 5000,
+    handler = function () f:reactor_stop_error () end
+}
+
+-- Create statwatcher for file "xyzzy"
+file = "xyzzy"
+local expected = { "Hello", "Goodbye", "" }
+local finfo = { line = 0 }
+
+local s, err = f:statwatcher {
+    path = file,
+    interval = 0.25,
+    handler = function (s, st, prev)
+        ok (st, "got current stat ok")
+        ok (prev, "got prev stat ok")
+        if not finfo.fp then
+            finfo.fp = io.open (file, "r")
+            ok (finfo.fp, "opened file")
+        end
+        for line in finfo.fp:lines () do
+            finfo.line = finfo.line + 1
+            is (line, expected [finfo.line], "line "..finfo.line.." matches")
+            if finfo.line == #expected then
+                f:reactor_stop ()
+            end
+        end
+    end
+}
+ok (s, "Created statwatcher")
+
+-- In 50ms create the file
+f:timer {
+    timeout = 50,
+    handler = function ()
+        local fp = assert (io.open (file, "w"))
+        fp:write ("Hello\n")
+        fp:close ()
+        f:timer {
+            timeout = 500,
+            handler = function ()
+                local fp = assert (io.open (file, "a"))
+                fp:write ("Goodbye\n")
+                fp:write ("\n")
+                fp:close()
+            end
+        }
+    end
+}
+
+local r, err = f:reactor ()
+ok (r, "reactor exited normally: "..tostring (err))
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/lua/t1005-fdwatcher.t
+++ b/t/lua/t1005-fdwatcher.t
@@ -1,0 +1,66 @@
+#!/usr/bin/lua
+--
+--  Basic flux fdwatcher test
+--
+local test = require 'fluxometer'.init (...)
+test:start_session {}
+
+require 'Test.More'
+
+local data = { "Hello", "Goodbye" }
+
+local flux = require_ok ('flux')
+local posix = require_ok ('flux.posix')
+
+local f, err = flux.new()
+type_ok (f, 'userdata', "create new flux handle")
+is (err, nil, "error is nil")
+
+local r, w = posix.pipe ()
+ok (r and w, "posix.pipe ()")
+
+local i = 1
+f:timer {
+    timeout = 100,
+    oneshot = false,
+    handler = function (f, t) 
+        if not data[i] then
+            diag ("closing pipe")
+            posix.close (w)
+            t:remove()
+            return
+        end
+        diag ("writing "..#data[i].. " bytes to pipe")
+        posix.write (w, data[i])
+        i = i + 1
+    end
+}
+
+local results = {}
+f:fdwatcher {
+    fd = r,
+    handler = function (fw)
+        local s, err = posix.read (r, 100)
+        ok (s, "read ".. #s .. " bytes")
+        if s == "" then
+            fw:remove()
+            return f:reactor_stop()
+        end
+        table.insert (results, s)
+    end
+}
+
+-- test timeout
+f:timer {
+    timeout = 1000,
+    handler = function () f:reactor_stop_error () end
+}
+
+local r, err = f:reactor()
+isnt (r, -1, "Return from reactor, rc >= 0")
+is (err, nil, "error is nil")
+is_deeply (results, data, "Results match data")
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -11,6 +11,7 @@ one line matching PATTERN. PATTERN is a Lua style pattern match.
 
 local flux = require 'flux'
 local posix = require 'flux.posix'
+
 local f, err = flux.new()
 if not f then error (err) end
 
@@ -27,34 +28,96 @@ if not timeout or not pattern or not file then
     os.exit (1)
 end
 
---- Open a file "filename" and use an iowatcher on flux handle "f"
---    to wait for pattern "p", exiting with 0 exit code if found.
-local function tail (f, filename, p)
-    local fp, err = io.open (filename)
+local filewatcher = {}
+filewatcher.__index = filewatcher
+
+function filewatcher:checklines ()
+    local fp, err = io.open (self.filename, "r")
     if not fp then return nil, err end
-    printf ("Opened file %s\n", filename)
-    return f:iowatcher {
-        fd = posix.fileno (fp),
-        handler = function (iow, r)
-            if r.data and r.data:match (p) then
-                os.exit (0)
-            end
-       end
-    }
+    local p, err = fp:seek ("set", self.position)
+    for line in fp:lines() do
+        if self.printlines then io.stdout:write (line.."\n") end
+        if line:match (self.pattern) then return true end
+    end
+    self.position = fp:seek()
+    return false
 end
 
--- Try opening file -- if it doesn't exist, set a timer for 100ms
---  and try again. Cancel the timer when file is opened successfully
---
-if not tail (f, file, pattern) then
-    f:timer {
-        timeout = 100,
-        oneshot = false,
-        handler = function (f, to)
-           if tail (f, file, pattern) then to:remove() end
+-- Make older posix stat table look like new
+local stat = {
+ __index = function (t, k)
+    local k2 = k:match ("st_(.+)")
+    local v = rawget (t, k)
+    return v and v or rawget (t, k2)
+ end
+}
+
+function filewatcher:changed ()
+    local st = self.st
+    local prev = self.prev
+    if not st then return false end -- No file yet
+    if not prev then return true end
+    if st.st_mtime > prev.st_mtime then
+        if st.st_size < prev.st_size then
+            printf ("truncated!\n")
+            self.position = 0 -- reread
+        end
+        return true
+    end
+    return false
+end
+
+function filewatcher:check ()
+    if self:changed () and (self.pattern == "" or self:checklines ()) then
+        self:on_match ()
+        return true
+    end
+    self.prev = self.st
+end
+
+function filewatcher:start ()
+    local st = posix.stat (self.filename)
+    if st then
+        self.st = setmetatable (st, stat)
+    end
+    self.flux:statwatcher {
+        path = self.filename,
+        interval = self.interval,
+        handler = function (w, st, prev)
+            printf ("wakeup\n")
+            self.st = setmetatable (st, stat)
+            self:check ()
         end
     }
+    self:check ()
 end
+
+setmetatable (filewatcher, { __call = function (t, arg)
+    if not arg.filename or not arg.pattern then
+        return nil, "Error: required argument missing"
+    end
+    if not arg.flux then
+        return nil, "Error: flux handle missing"
+    end
+    local w = {
+        flux =     arg.flux,
+        filename = arg.filename,
+        pattern  = arg.pattern,
+        interval = arg.interval and arg.interval or .25,
+        on_match = arg.on_match,
+        position = 0,
+        printlines = true,
+    }
+    setmetatable (w, filewatcher)
+    if not w.on_match then
+        w.on_match = function () os.exit (0) end
+    end
+    return w
+end
+})
+
+local fw, err = filewatcher { flux = f, filename = file, pattern = pattern }
+if not fw then printf ("%s\n", err); os.exit (1) end
 
 -- Exit with non-zero status after timeout:
 --
@@ -67,6 +130,7 @@ f:timer {
 }
 
 -- Start reactor to do the work. It is an error if we exit the reactor.
+fw:start ()
 f:reactor ()
 printf ("Unexpectedly exited reactor\n")
 os.exit (1)


### PR DESCRIPTION
This PR pulls some of the lua bindings work for #437 into a standalone PR. This is somewhat a set of changes required for stdin handling, but also various other fixes and updates found and made along the way, including:

 * Add support from Lua for `stat_watcher` as well as a simpler `fd_watcher` than the `iowatcher` currently implemented
 * Some direct bindings for kvs calls such as `kvs_symlink` and `kvs_type` as well as `kvs_put/get`
 * support `flux_reactor_stop_error`
 * support `is_dir = true` with kvswatcher to watch kvs directory
 * Fixes for iowatcher return values
 * Expand lua binding tests
 * Lua tests now run in "trash directory" like sharness tests for easy cleanup
 * Update `scripts/waitfile.lua` to use statwatcher

