### PR TITLE
lua testing fixes

### DIFF
--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -84,14 +84,7 @@ end
 --
 function fluxTest:start_session (t)
     -- If fluxometer session is already active just return:
-    if self.flux_active then
-        cleanup (function ()
-                     posix.chdir (self.src_dir)
-                     os.execute ("rm "..self.log_file)
-                     os.execute ("rm -rf "..self.trash_dir)
-                 end)
-        return
-    end
+    if self.flux_active then return end
     posix.setenv ("FLUXOMETER_ACTIVE", "t")
 
     local size = t.size or 1
@@ -142,7 +135,7 @@ function fluxTest.init (...)
 
     -- Get path to current test script using debug.getinfo:
     test.arg0 = debug.getinfo (2).source:sub (2)
-    test.prog = test.arg0:match ("/*([^/.]+)%.")
+    test.prog = test.arg0:match ("/*([^/]+)%.t")
 
     local cwd, err = posix.getcwd ()
     if not cwd then error (err) end
@@ -168,12 +161,16 @@ function fluxTest.init (...)
     end
 
     test.trash_dir = "trash-directory.lua-"..test.prog
-    os.execute ("rm -rf "..test.trash_dir)
-    posix.mkdir (test.trash_dir)
     if test.flux_active then
+        os.execute ("rm -rf "..test.trash_dir)
+        posix.mkdir (test.trash_dir)
         posix.chdir (test.trash_dir)
+        cleanup (function ()
+                     posix.chdir (test.src_dir)
+                     os.execute ("rm "..test.log_file)
+                     os.execute ("rm -rf "..test.trash_dir)
+                 end)
     end
-
     return test
 end
 

--- a/t/lua/t1004-statwatcher.t
+++ b/t/lua/t1004-statwatcher.t
@@ -66,6 +66,9 @@ f:timer {
 local r, err = f:reactor ()
 ok (r, "reactor exited normally: "..tostring (err))
 
+-- Close fp so we do not carry a file reference into done_testing()
+finfo.fp:close ()
+
 done_testing ()
 
 -- vi: ts=4 sw=4 expandtab

--- a/t/lua/t1005-fdwatcher.t
+++ b/t/lua/t1005-fdwatcher.t
@@ -12,6 +12,10 @@ local data = { "Hello", "Goodbye" }
 local flux = require_ok ('flux')
 local posix = require_ok ('flux.posix')
 
+if not posix.pipe then
+    skip_all ("luaposix too old, no pipe(2) call found")
+end
+
 local f, err = flux.new()
 type_ok (f, 'userdata', "create new flux handle")
 is (err, nil, "error is nil")


### PR DESCRIPTION
Oops, this fixes a couple issues I found after the latest PR was merged:

 * subdirectory creation/removal for Lua tests wasn't working. Fixed.
 * statwatcher test was leaking a file handle so its subdirectory couldn't be removed during cleanup
 * skip all tests in fdwatcher test if `posix.pipe` binding isn't implemented.