### PR TITLE
add custom reactor watcher capability, and buffered input watcher

### DIFF
--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -46,12 +46,6 @@ struct flux_reactor {
     int usecount;
 };
 
-struct watcher_ops {
-    void (*start)(void *impl, flux_watcher_t *w);
-    void (*stop)(void *impl, flux_watcher_t *w);
-    void (*destroy)(void *impl, flux_watcher_t *w);
-};
-
 struct flux_watcher {
     flux_reactor_t *r;
     flux_watcher_f fn;
@@ -175,10 +169,10 @@ static int libev_to_events (int events)
  ** Watchers
  **/
 
-static flux_watcher_t *flux_watcher_create (flux_reactor_t *r,
-                                            void *impl, struct watcher_ops ops,
-                                            int signature,
-                                            flux_watcher_f fun, void *arg)
+flux_watcher_t *flux_watcher_create (flux_reactor_t *r,
+                                     void *impl, struct watcher_ops ops,
+                                     int signature,
+                                     flux_watcher_f fun, void *arg)
 {
     struct flux_watcher *w = xzmalloc (sizeof (*w));
     w->r = r;
@@ -189,6 +183,27 @@ static flux_watcher_t *flux_watcher_create (flux_reactor_t *r,
     w->arg = arg;
     reactor_usecount_incr (r);
     return w;
+}
+
+int flux_watcher_get_signature (flux_watcher_t *w)
+{
+    return w->signature;
+}
+
+void *flux_watcher_get_impl (flux_watcher_t *w)
+{
+    return w->impl;
+}
+
+flux_reactor_t *flux_watcher_get_reactor (flux_watcher_t *w)
+{
+    return w->r;
+}
+
+void flux_watcher_call (flux_watcher_t *w, int revents)
+{
+    if (w->fn)
+        w->fn (w->r, w, revents, w->arg);
 }
 
 void flux_watcher_start (flux_watcher_t *w)

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -121,6 +121,26 @@ flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r,
 void flux_stat_watcher_get_rstat (flux_watcher_t *w,
                                   struct stat *stat, struct stat *prev);
 
+/* construction kit for custom watchers
+ */
+
+struct watcher_ops {
+    void (*start)(void *impl, flux_watcher_t *w);
+    void (*stop)(void *impl, flux_watcher_t *w);
+    void (*destroy)(void *impl, flux_watcher_t *w);
+};
+
+flux_watcher_t *flux_watcher_create (flux_reactor_t *r,
+                                     void *impl, struct watcher_ops ops,
+                                     int signature,
+                                     flux_watcher_f fun, void *arg);
+
+int flux_watcher_get_signature (flux_watcher_t *w);
+void *flux_watcher_get_impl (flux_watcher_t *w);
+flux_reactor_t *flux_watcher_get_reactor (flux_watcher_t *w);
+void flux_watcher_call (flux_watcher_t *w, int revents);
+
+
 #endif /* !_FLUX_CORE_REACTOR_H */
 
 /*

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -15,7 +15,9 @@ libsubprocess_la_SOURCES = \
 	zio.c \
 	zio.h \
 	subprocess.c \
-	subprocess.h
+	subprocess.h \
+	inbuf.c \
+	inbuf.h
 
 
 TESTS = \

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -24,7 +24,8 @@ TESTS = \
 	test_subprocess.t \
 	test_loop.t \
 	test_socketpair.t \
-	test_zio.t
+	test_zio.t \
+	test_inbuf.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -57,3 +58,7 @@ test_loop_t_LDADD = $(test_ldadd)
 test_zio_t_SOURCES = test/zio.c
 test_zio_t_CPPFLAGS = $(test_cppflags)
 test_zio_t_LDADD = $(test_ldadd)
+
+test_inbuf_t_SOURCES = test/inbuf.c
+test_inbuf_t_CPPFLAGS = $(test_cppflags)
+test_inbuf_t_LDADD = $(test_ldadd)

--- a/src/common/libsubprocess/inbuf.c
+++ b/src/common/libsubprocess/inbuf.c
@@ -1,0 +1,250 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include <czmq.h>
+#include <json.h>
+#include <flux/core.h>
+
+#include "src/common/liblsd/cbuf.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/jsonutil.h"
+
+#include "inbuf.h"
+
+#define INBUF_SIG  2000
+
+/* The prep/check/idle business is how we assert a level-triggered
+ * read event when there is data in the cbuf to consume.  See the note
+ * in src/common/libutil/ev_zmq.c for more explanation.
+ *
+ * The buffering strategy should not drop data or expand the cbuf.
+ * The file descriptor watcher is temporarily stopped when the cbuf is full,
+ * then started again when there is space, which makes it possible for
+ * the reader to participate in flow control, ultimately blocking the
+ * writer while a chain of readers catches up.
+ *
+ * Because the buffer size is fixed, line buffering is "best effort".
+ * When a line exceeds the size of the buffer, the line will be returned
+ * in buffer-size chunks, without dropping data.
+ */
+
+struct inbuf {
+    int fd;
+    flux_watcher_t *fd_w;
+    int bufsize;
+    int flags;
+    cbuf_t cbuf;
+    bool eof;
+    int errnum;
+    flux_watcher_t *prep_w;
+    flux_watcher_t *check_w;
+    flux_watcher_t *idle_w;
+    flux_watcher_t *inbuf_w;
+};
+
+static void inbuf_start (void *impl, flux_watcher_t *w)
+{
+    struct inbuf *inbuf = impl;
+    flux_watcher_start (inbuf->fd_w);
+    flux_watcher_start (inbuf->prep_w);
+    flux_watcher_start (inbuf->check_w);
+}
+
+static void inbuf_stop (void *impl, flux_watcher_t *w)
+{
+    struct inbuf *inbuf = impl;
+    flux_watcher_stop (inbuf->fd_w);
+    flux_watcher_stop (inbuf->prep_w);
+    flux_watcher_stop (inbuf->check_w);
+    flux_watcher_stop (inbuf->idle_w);
+}
+
+static void inbuf_destroy (void *impl, flux_watcher_t *w)
+{
+    struct inbuf *inbuf = impl;
+    if (inbuf) {
+        flux_watcher_destroy (inbuf->fd_w);
+        flux_watcher_destroy (inbuf->prep_w);
+        flux_watcher_destroy (inbuf->check_w);
+        flux_watcher_destroy (inbuf->idle_w);
+        if (inbuf->cbuf)
+            cbuf_destroy (inbuf->cbuf);
+        free (inbuf);
+    }
+}
+
+/* File descriptor is ready.
+ * Read data into the cbuf.  Set eof and errnum flags.
+ * Disable ourselves if there is no more space in the cbuf.
+ * (Re-enable in prep if reader freed some up)
+ */
+void fd_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct inbuf *inbuf = arg;
+    if ((revents & FLUX_POLLERR)) {
+        inbuf->errnum = errno;
+    }
+    if ((revents & FLUX_POLLIN) && cbuf_free (inbuf->cbuf) > 0) {
+        int rc = cbuf_write_from_fd (inbuf->cbuf, inbuf->fd, -1, NULL);
+        if (rc < 0)
+            inbuf->errnum = errno;
+        else if (rc == 0)
+            inbuf->eof = true;
+        if (cbuf_free (inbuf->cbuf) == 0)
+            flux_watcher_stop (inbuf->fd_w);
+    }
+}
+
+/* We are about to block.
+ * Enable the idle watcher iff there is data in the buffer or other events.
+ */
+void prep_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct inbuf *inbuf = arg;
+    bool linebuf = (inbuf->flags & INBUF_LINE_BUFFERED);
+
+    revents = 0;
+    if (inbuf->errnum != 0)
+        revents |= FLUX_POLLERR;
+    if (linebuf && cbuf_lines_used (inbuf->cbuf) > 0)
+        revents |= FLUX_POLLIN;
+    else if (linebuf && cbuf_free (inbuf->cbuf) == 0)
+        revents |= FLUX_POLLIN;
+    else if (!linebuf && cbuf_used (inbuf->cbuf) > 0)
+        revents |= FLUX_POLLIN;
+    else if (inbuf->eof)
+        revents |= FLUX_POLLIN;
+
+    if (revents)
+        flux_watcher_start (inbuf->idle_w);
+    if (cbuf_free (inbuf->cbuf) > 0)
+        flux_watcher_start (inbuf->fd_w);
+}
+
+/* Just unblocked.
+ * If revents, invoke the callback.
+ */
+void check_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct inbuf *inbuf = arg;
+    bool linebuf = (inbuf->flags & INBUF_LINE_BUFFERED);
+
+    flux_watcher_stop (inbuf->idle_w);
+
+    revents = 0;
+    if (inbuf->errnum != 0)
+        revents |= FLUX_POLLERR;
+    if (linebuf && cbuf_lines_used (inbuf->cbuf) > 0)
+        revents |= FLUX_POLLIN;
+    else if (linebuf && cbuf_free (inbuf->cbuf) == 0)
+        revents |= FLUX_POLLIN;
+    else if (!linebuf && cbuf_used (inbuf->cbuf) > 0)
+        revents |= FLUX_POLLIN;
+    else if (inbuf->eof)
+        revents |= FLUX_POLLIN;
+    if (revents)
+        flux_watcher_call (inbuf->inbuf_w, revents);
+}
+
+static int set_nonblocking (int fd)
+{
+    int flags;
+    if ((flags = fcntl (fd, F_GETFL, 0)) < 0
+              || fcntl (fd, F_SETFL, flags | O_NONBLOCK) < 0)
+        return -1;
+    return 0;
+}
+
+flux_watcher_t *flux_inbuf_watcher_create (flux_reactor_t *r, int fd,
+                                           int bufsize, int flags,
+                                           flux_watcher_f cb, void *arg)
+{
+    struct watcher_ops ops = {
+        .start = inbuf_start,
+        .stop = inbuf_stop,
+        .destroy = inbuf_destroy,
+    };
+
+    struct inbuf *inbuf = xzmalloc (sizeof (*inbuf));
+    inbuf->inbuf_w = flux_watcher_create (r, inbuf, ops, INBUF_SIG, cb, arg);
+    if (!inbuf->inbuf_w) {
+        free (inbuf);
+        return NULL;
+    }
+    inbuf->fd = fd;
+    if (set_nonblocking (fd) < 0)
+        goto fail;
+    inbuf->flags = flags;
+    inbuf->bufsize = bufsize;
+    inbuf->fd_w = flux_fd_watcher_create (r, fd, FLUX_POLLIN, fd_cb, inbuf);
+    inbuf->prep_w = flux_prepare_watcher_create (r, prep_cb, inbuf);
+    inbuf->check_w = flux_check_watcher_create (r, check_cb, inbuf);
+    inbuf->idle_w = flux_idle_watcher_create (r, NULL, inbuf);
+    if (!inbuf->fd_w || !inbuf->prep_w || !inbuf->check_w || !inbuf->idle_w)
+        goto fail;
+    if (!(inbuf->cbuf = cbuf_create (bufsize, bufsize)))
+        goto fail;
+    if (cbuf_opt_set (inbuf->cbuf, CBUF_OPT_OVERWRITE, CBUF_NO_DROP) < 0)
+        goto fail;
+    return inbuf->inbuf_w;
+fail:
+    flux_watcher_destroy (inbuf->inbuf_w);
+    return NULL;
+}
+
+
+int flux_inbuf_watcher_read (flux_watcher_t *w, void *buf, int len)
+{
+    if (flux_watcher_get_signature (w) != INBUF_SIG) {
+        errno = EINVAL;
+        return -1;
+    }
+    struct inbuf *inbuf = flux_watcher_get_impl (w);
+    int rc;
+
+    if (inbuf->errnum != 0) {
+        errno = inbuf->errnum;
+        return -1;
+    }
+    if ((inbuf->flags & INBUF_LINE_BUFFERED)) {
+        rc = cbuf_read_line (inbuf->cbuf, buf, len, 1);
+        if (rc == 0 && (inbuf->eof || cbuf_free (inbuf->cbuf) == 0)) {
+            rc = cbuf_read (inbuf->cbuf, buf, len - 1);
+            if (rc > 0)
+                ((char *)buf)[rc] = '\0';
+        }
+    } else
+        rc = cbuf_read (inbuf->cbuf, buf, len);
+    return rc;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsubprocess/inbuf.h
+++ b/src/common/libsubprocess/inbuf.h
@@ -1,0 +1,34 @@
+#ifndef _FLUX_INBUF_H
+#define _FLUX_INBUF_H
+
+#include <flux/core.h>
+
+enum {
+    INBUF_LINE_BUFFERED = 1,
+};
+
+/* Set 'fd' to non-blocking and read from it through an internal buffer in
+ * 'bufsize' chunks.  'cb' will be called when there is data to read,
+ * according to 'flags' (see below).
+ */
+flux_watcher_t *flux_inbuf_watcher_create (flux_reactor_t *r, int fd,
+                                           int bufsize, int flags,
+                                           flux_watcher_f cb, void *arg);
+
+/* No flags: read up to len bytes into buf.
+ *   Returns the number of bytes read, or -1 on error with errno set.
+ *   A return value of 0 indicates EOF.
+ * flags & INBUF_LINE_BUFFERED: read one line of data into buf.
+ *   'buf' will be NULL terminated and contain at most 'len' - 1 characters.
+ *   Returns the number of characters read, or -1 on error with errno set.
+ *   A return value >= len indicates that 'buf' was too short to contain
+ *   the next line;  the portion that fit was returned, the rest discarded.
+ *   A return value of 0 indicates EOF.
+ */
+int flux_inbuf_watcher_read (flux_watcher_t *w, void *buf, int len);
+
+#endif /* !_FLUX_INBUF_H */
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsubprocess/test/inbuf.c
+++ b/src/common/libsubprocess/test/inbuf.c
@@ -1,0 +1,265 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "inbuf.h"
+
+/* check some line buffering corner cases:
+ * - Residual buffer (no \n) becomes a reactor event when EOF flushes it
+ * - Line longer than buflen is returned in bufsize - 1 length chunks
+ * - Two lines in one write are two reactor events
+ * - One line in two writes is one reactor event
+ */
+
+const char *send_phrases[] = {
+    "Narf!",
+    "Zort!\nPoit!\n",
+    "Egad, Brain!\n",
+    "Gonk!\n",
+    "Come, Pinky-o. We must catch the space shuttle back to our"
+        " home planet of Acme and prepare for the next millennium.\n",
+    "Fjord!\n",
+    "Gat!\n",
+    "Zounds!",
+    NULL,
+};
+
+struct expect {
+    int rc;
+    const char *s;
+};
+
+struct expect recv_phrases_linebuf[] = {
+    { 11,   "Narf!Zort!\n" },
+    { 6,    "Poit!\n" },
+    { 13,   "Egad, Brain!\n" },
+    { 6,    "Gonk!\n" },
+    { 39,   "Come, Pinky-o. We must catch the space " }, /* truncated */
+    { 39,   "shuttle back to our home planet of Acme" },
+    { 38,   " and prepare for the next millennium.\n" },
+    { 7,    "Fjord!\n" },
+    { 5,    "Gat!\n" },
+    { 7,    "Zounds!" }, /* flushed out by eof */
+    { 0,    NULL }, /* EOF */
+};
+
+struct expect recv_phrases_regbuf[] = {
+    { 5,    "Narf!" },
+    { 12,   "Zort!\nPoit!\n" },
+    { 13,   "Egad, Brain!\n" },
+    { 6,    "Gonk!\n" },
+    { 40,   "Come, Pinky-o. We must catch the space s" },
+    { 40,   "huttle back to our home planet of Acme a" },
+    { 36,   "nd prepare for the next millennium.\n" },
+    { 7,    "Fjord!\n" },
+    { 5,    "Gat!\n" },
+    { 7,    "Zounds!" },
+    { 0,    NULL }, /* EOF */
+};
+
+const int bufsize = 40;
+
+struct ctx {
+    int fds[2];
+    int read_count;
+    int write_count;
+};
+
+const char *str_esc (const char *s, int len)
+{
+    static char buf[1024];
+    char *p = buf;
+    memset (buf, 0, sizeof (buf));
+    while (len > 0 && s && *s && p - buf < sizeof (buf)) {
+        if (*s == '\n') {
+            *p++ = '\\' ;
+            *p++ = 'n';
+        } else
+            *p++ = *s;
+        s++;
+        len--;
+    }
+    return buf;
+}
+
+void linebuf_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct ctx *ctx = arg;
+    struct expect *exp = &recv_phrases_linebuf[ctx->read_count];
+    char buf[bufsize];
+    int rc = flux_inbuf_watcher_read (w, buf, sizeof (buf));
+
+    diag ("%s: %d:'%s'", __FUNCTION__, rc,
+          rc > 0 ? str_esc (buf, rc) : rc == 0 ? "(EOF)" : strerror (errno));
+
+    ok (rc == exp->rc,
+        "%s: read expected return value", __FUNCTION__);
+    if (rc > 0)
+        ok (rc < bufsize && buf[rc] == '\0' && !strncmp (buf, exp->s, exp->rc),
+            "%s: read expected content", __FUNCTION__);
+    if (rc == 0) {
+        ok (close (ctx->fds[0]) >= 0,
+            "%s: EOF: closed read end of socketpair", __FUNCTION__);
+        flux_watcher_stop (w);
+    }
+    ctx->read_count++;
+}
+
+void regbuf_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct ctx *ctx = arg;
+    struct expect *exp = &recv_phrases_regbuf[ctx->read_count];
+    char buf[bufsize];
+    int rc = flux_inbuf_watcher_read (w, buf, sizeof (buf));
+
+    diag ("%s: %d:'%s'", __FUNCTION__, rc,
+          rc > 0 ? str_esc (buf, rc) : rc == 0 ? "(EOF)" : strerror (errno));
+
+    ok (rc == exp->rc,
+        "%s: read expected return value", __FUNCTION__);
+    if (rc > 0)
+        ok (!strncmp (buf, exp->s, exp->rc),
+            "%s: read expected content", __FUNCTION__);
+    if (rc == 0) {
+        ok (close (ctx->fds[0]) >= 0,
+            "%s: EOF: closed read end of socketpair", __FUNCTION__);
+        flux_watcher_stop (w);
+    }
+    ctx->read_count++;
+}
+
+void timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct ctx *ctx = arg;
+    const char *phrase = send_phrases[ctx->write_count];
+
+    if (phrase) {
+        int len = strlen (phrase);
+        int rc = write (ctx->fds[1], phrase, len);
+
+        ok (rc == len,
+            "%s: write '%s'", __FUNCTION__, str_esc (phrase, len));
+        if (rc >= 0 && rc < len)
+            diag ("%s: short write", __FUNCTION__);
+        else if (rc < 0)
+            diag ("%s: %s", __FUNCTION__, strerror (errno));
+        if (rc != len)
+            flux_reactor_stop_error (r);
+        ctx->write_count++;
+    } else {
+        ok (close (ctx->fds[1]) == 0,
+            "%s: closed write end of socketpair", __FUNCTION__);
+        flux_watcher_stop (w);
+    }
+}
+
+void test_linebuf (flux_reactor_t *r)
+{
+    struct ctx ctx;
+    int flags = INBUF_LINE_BUFFERED;
+    flux_watcher_t *inbuf_w;
+    flux_watcher_t *timer_w;
+
+    memset (&ctx, 0, sizeof (ctx));
+
+    ok (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, ctx.fds) == 0,
+        "obtained socketpair");
+    ok ((inbuf_w = flux_inbuf_watcher_create (r, ctx.fds[0], bufsize,
+                                              flags, linebuf_cb, &ctx)) != NULL,
+        "flux_inbuf_watcher_create worked");
+    flux_watcher_start (inbuf_w);
+
+    ok ((timer_w = flux_timer_watcher_create (r, 0.1, 0.1,
+                                              timer_cb, &ctx)) != NULL,
+        "flux_timer_watcher_create worked");
+    flux_watcher_start (timer_w);
+
+    ok (flux_reactor_run (r, 0) == 0,
+        "reactor returned normally");
+
+    flux_watcher_destroy (inbuf_w);
+    flux_watcher_destroy (timer_w);
+}
+
+void test_regbuf (flux_reactor_t *r)
+{
+    struct ctx ctx;
+    int flags = 0;
+    flux_watcher_t *inbuf_w;
+    flux_watcher_t *timer_w;
+
+    memset (&ctx, 0, sizeof (ctx));
+
+    ok (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, ctx.fds) == 0,
+        "obtained socketpair");
+    ok ((inbuf_w = flux_inbuf_watcher_create (r, ctx.fds[0], bufsize,
+                                              flags, regbuf_cb, &ctx)) != NULL,
+        "flux_inbuf_watcher_create worked");
+    flux_watcher_start (inbuf_w);
+
+    ok ((timer_w = flux_timer_watcher_create (r, 0.1, 0.1,
+                                              timer_cb, &ctx)) != NULL,
+        "flux_timer_watcher_create worked");
+    flux_watcher_start (timer_w);
+
+    ok (flux_reactor_run (r, 0) == 0,
+        "reactor returned normally");
+
+    flux_watcher_destroy (inbuf_w);
+    flux_watcher_destroy (timer_w);
+}
+
+int main (int argc, char **argv)
+{
+    struct ctx ctx;
+    flux_reactor_t *r;
+
+    plan (NO_PLAN);
+
+    memset (&ctx, 0, sizeof (ctx));
+
+    ok ((r = flux_reactor_create (0)) != NULL,
+        "flux reactor created");
+
+    test_linebuf (r);
+
+    test_regbuf (r);
+
+    flux_reactor_destroy (r);
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR is parked here for (low-priority) review.  It adds a set of interfaces to allow custom _reactor watchers_ to be created:
```C
struct watcher_ops {
    void (*start)(void *impl, flux_watcher_t *w);
    void (*stop)(void *impl, flux_watcher_t *w);
    void (*destroy)(void *impl, flux_watcher_t *w);
};

flux_watcher_t *flux_watcher_create (flux_reactor_t *r,
                                     void *impl, struct watcher_ops ops,
                                     int signature,
                                     flux_watcher_f fun, void *arg);

int flux_watcher_get_signature (flux_watcher_t *w);
void *flux_watcher_get_impl (flux_watcher_t *w);
flux_reactor_t *flux_watcher_get_reactor (flux_watcher_t *w);
void flux_watcher_call (flux_watcher_t *w, int revents);
```
I can't quite put my finger on it but the interface for creating new watchers seems off to me, and could use another set of eyes.  It gets slightly awkward due to the way we generalized the `flux_watcher_t` type.  Since the internal structure for watchers is not exposed to builders of custom watchers, we need some wierd accessors.  Is this somehow backwards?

The PR then adds  an _inbuf watcher_, a watcher for buffered input (built with `libflux-internal.la`, not exported) that calls the user callback when buffered data is ready to read (a line, or just an arbitrary chunk depending on flags):
```C
enum {
    INBUF_LINE_BUFFERED = 1,
};

flux_watcher_t *flux_inbuf_watcher_create (flux_reactor_t *r, int fd,
                                           int bufsize, int flags,
                                           flux_watcher_f cb, void *arg);

int flux_inbuf_watcher_read (flux_watcher_t *w, void *buf, int len);
```
The inbuf watcher, unlike the zio reader, presumes that the process generating the I/O should be blocked when the inbuf watcher cannot keep up, as opposed to growing the buffer.  This is implemented by stopping the fd watcher when the cbuf is full, and starting it again when there is space in the cbuf.  This choice was motivated by my recollection of this comment from @morrone to our early _vision_ document:

>  Be careful that user contributed traffic e.g. stdio doesn’t starve out system control messages. Also avoid situation encountered with srun where putting srun to sleep causes hierarchical communication to get backlogged.

Possibly I came to the wrong conclusion about how this should work based on a hazy memory of the comment, and @grondo did it differently in zio.  This needs some discussion.

Finally `flux-start` was modified to use an inbuf watcher for the PMI server interface, instead of the character-at-a-time synchronous `dgetline()` function.

We could go on to use this in other places, but I think actually this is a much lower priority than other work right now since it provides overlapping functionality with zio.  Maybe the important bit is the interface for extending reactor watchers and we should just discuss/iterate on that with the inbuf watcher as a live example?