### PR TITLE
kvs integration with content store

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,7 @@ AC_CONFIG_FILES( \
   doc/Makefile \
   doc/man1/Makefile \
   doc/man3/Makefile \
+  doc/man7/Makefile \
   doc/test/Makefile \
   t/Makefile \
   t/fluxometer.lua \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = man1 man3 test
+SUBDIRS = man1 man3 man7 test

--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -140,3 +140,8 @@ Github: <http://github.com/flux-framework>
 COPYRIGHT
 ---------
 include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux-broker-attributes(7)

--- a/doc/man1/flux-getattr.adoc
+++ b/doc/man1/flux-getattr.adoc
@@ -54,4 +54,4 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
-flux_attr_get(3)
+flux_attr_get(3), flux-broker-attributes(7)

--- a/doc/man3/flux_attr_get.adoc
+++ b/doc/man3/flux_attr_get.adoc
@@ -57,60 +57,6 @@ If _val_ is NULL, the attribute is unset.
 through the current set of valid attribute names.
 
 
-BROKER ATTRIBUTES
------------------
-
-The broker currently exports the following attributes:
-
-rank::
-The rank of the local broker.  This attribute is normally accessed
-via flux_get_rank(3).
-
-size::
-The number of ranks in the comms session.  This attribute is normally accessed
-via flux_get_size(3).
-
-tbon-arity::
-The branching factor of the tree based overlay network.  This attribute
-is normally accessed via flux_get_arity(3).
-
-session-id::
-The identity of the comms session.
-
-tbon-parent-uri::
-The URI of the ZeroMQ endpoint this rank is connected to in the tree
-based overlay network.  This attribute will not be set on rank zero.
-
-tbon-request-uri::
-The URI of the ZeroMQ endpoint this rank is bound to in the tree
-based overlay network.
-
-snoop-uri::
-The URI of the ZeroMQ endpoint that flux-snoop(1) should connect
-to in order to receive copies of messages passing through the broker.
-
-local-uri::
-The Flux URI that should be passed to flux_open(1) to establish
-a connection to the local broker rank.
-
-parent-uri::
-The Flux URI that should be passed to flux_open(1) to establish
-a connection to the enclosing instance.
-
-log-bufcount::
-The number of log entries currently stored in the ring buffer.
-
-log-buflimit::
-The maximum number of log entries that can be stored in the ring buffer.
-
-log-count::
-The number of log entries ever stored in the ring buffer.
-
-log-level::
-Log entries at syslog(3) level at or below this value are forwarded
-to rank zero for permanent capture.
-
-
 RETURN VALUE
 ------------
 
@@ -155,4 +101,5 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
+flux-lsattr(1), flux-getattr(1), flux-setattr(1), flux-broker-attributes(7),
 https://github.com/flux-framework/rfc/blob/master/spec_3.adoc[RFC 3: CMB1 - Flux Comms Message Broker Protocol]

--- a/doc/man7/COPYRIGHT.adoc
+++ b/doc/man7/COPYRIGHT.adoc
@@ -1,0 +1,6 @@
+Copyright \(C) 2014 Lawrence Livermore National Security, LLC.
+
+Flux is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 2 of the license, or (at your option)
+any later version.

--- a/doc/man7/Makefile.am
+++ b/doc/man7/Makefile.am
@@ -1,0 +1,27 @@
+MAN7_FILES = \
+	flux-broker-attributes.7
+
+ADOC_FILES  = $(MAN1_FILES:%.7=%.adoc)
+XML_FILES   = $(MAN1_FILES:%.7=%.xml)
+
+if HAVE_A2X
+dist_man_MANS = $(MAN7_FILES)
+$(MAN7_FILES): COPYRIGHT.adoc
+endif
+
+SUFFIXES = .adoc .7
+
+STDERR_DEVNULL = $(stderr_devnull_$(V))
+stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
+stderr_devnull_0 = 2>/dev/null
+
+.adoc.7:
+	$(AM_V_GEN)$(A2X) --attribute mansource=$(META_NAME) \
+	    --attribute manversion=$(META_VERSION) \
+	    --attribute manmanual="Flux Command Reference" \
+	    --destination-dir=$(builddir) \
+	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
+
+EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
+
+CLEANFILES = $(MAN7_FILES) $(XML_FILES)

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -1,0 +1,146 @@
+flux-broker-attributes(7)
+=========================
+:doctype: manpage
+
+
+NAME
+----
+flux-broker-attributes - overview Flux broker attributes
+
+
+DESCRIPTION
+-----------
+
+Flux broker attributes are parameters that affect how different
+broker systems behave.  Attributes can be listed and manipulated
+with flux-getattr(1), flux-setattr(1), and flux-lsattr(1).
+
+The broker currently exports the following attributes:
+
+SESSION ATTRIBUTES
+------------------
+
+rank::
+The rank of the local broker.
+
+size::
+The number of ranks in the comms session.
+
+session-id::
+The identity of the comms session.
+
+tbon-arity::
+The branching factor of the tree based overlay network.
+
+scratch-directory::
+The temporary directory used for session sockets, content
+backing storage, etc..
+
+SOCKET ATTRIBUTES
+-----------------
+
+tbon-parent-uri::
+The URI of the ZeroMQ endpoint this rank is connected to in the tree
+based overlay network.  This attribute will not be set on rank zero.
+
+tbon-request-uri::
+The URI of the ZeroMQ endpoint this rank is bound to in the tree
+based overlay network.
+
+snoop-uri::
+The URI of the ZeroMQ endpoint that flux-snoop(1) should connect
+to in order to receive copies of messages passing through the broker.
+
+local-uri::
+The Flux URI that should be passed to flux_open(1) to establish
+a connection to the local broker rank.
+
+parent-uri::
+The Flux URI that should be passed to flux_open(1) to establish
+a connection to the enclosing instance.
+
+LOGGING ATTRIBUTES
+------------------
+
+log-bufcount::
+The number of log entries currently stored in the ring buffer.
+
+log-buflimit::
+The maximum number of log entries that can be stored in the ring buffer.
+
+log-count::
+The number of log entries ever stored in the ring buffer.
+
+log-level::
+Log entries at syslog(3) level at or below this value are forwarded
+to rank zero for permanent capture.
+
+
+CONTENT ATTRIBUTES
+------------------
+content-acct-dirty::
+The number of dirty cache entries on this rank.
+
+content-acct-entries::
+The total number of cache entries on this rank.
+
+content-acct-size::
+The estimated total size in bytes consumed by cache entries on
+this rank, excluding overhead.
+
+content-acct-valid::
+The number of valid cache entries on this rank.
+
+content-backing::
+The selected backing store, if any.  This attribute is only
+set on rank 0 where the content backing store is active.
+
+content-blob-size-limit::
+The maximum size of a blob, the basic unit of content storage.
+
+content-flush-batch-count::
+The current number of outstanding store requests, either to the
+backing store (rank 0) or upstream (rank > 0).
+
+content-flush-batch-limit::
+The maximum number of outstanding store requests that will be
+initiated when handling a flush or backing store load operation.
+
+content-hash::
+The selected hash algorithm, default sha1.
+
+content-purge-large-entry::
+When the cache size footprint needs to be reduced, first consider
+purging entries of this size or greater.
+
+content-purge-old-entry::
+When the cache size footprint needs to be reduced, only consider
+purging entries that are older than this number of heartbeats.
+
+content-purge-target-entries::
+If possible, the cache size purged periodically so that the total
+number of entries stays at or below this value.
+
+content-purge-target-size
+If possible, the cache size purged periodically so that the total
+size of the cache stays at or below this value.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux-getattr(1), flux_attr_get(3)

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -185,17 +185,16 @@ static int cache_entry_fill (struct cache_entry *e, const void *data, int len)
 {
     int rc = -1;
 
-    assert (!e->valid);
-    assert (!e->data);
-    assert (e->len == 0);
-
-    if (len > 0 && !(e->data = malloc (len))) {
-        errno = ENOMEM;
-        goto done;
+    if (!e->valid) {
+        assert (!e->data);
+        assert (e->len == 0);
+        if (len > 0 && !(e->data = malloc (len))) {
+            errno = ENOMEM;
+            goto done;
+        }
+        memcpy (e->data, data, len);
+        e->len = len;
     }
-    memcpy (e->data, data, len);
-    e->len = len;
-
     rc = 0;
 done:
     return rc;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -44,7 +44,12 @@ static const uint32_t default_cache_purge_target_size = 1024*1024*16;
 static const uint32_t default_cache_purge_old_entry = 5;
 static const uint32_t default_cache_purge_large_entry = 256;
 
-static const uint32_t default_blob_size_limit = 1048576; /* RFC 10 */
+/* Raise the max blob size value to 1GB so that large KVS values
+ * (including KVS directories) can be supported while the KVS transitions
+ * to the RFC 11 treeobj data representation.
+ */
+//static const uint32_t default_blob_size_limit = 1048576; /* RFC 10 */
+static const uint32_t default_blob_size_limit = 1048576*1024;
 
 struct cache_entry {
     void *data;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -51,6 +51,9 @@ static const uint32_t default_cache_purge_large_entry = 256;
 //static const uint32_t default_blob_size_limit = 1048576; /* RFC 10 */
 static const uint32_t default_blob_size_limit = 1048576*1024;
 
+static const uint32_t default_flush_batch_limit = 256;
+
+
 struct cache_entry {
     void *data;
     int len;
@@ -73,11 +76,12 @@ struct content_cache {
     uint8_t backing:1;              /* 'content-backing' service available */
     char *backing_name;
     char *hash_name;
-    int store_pending_count;
     zlist_t *flush_requests;
     int epoch;
 
     uint32_t blob_size_limit;
+    uint32_t flush_batch_limit;
+    uint32_t flush_batch_count;
 
     uint32_t purge_target_entries;
     uint32_t purge_target_size;
@@ -90,6 +94,7 @@ struct content_cache {
 };
 
 static void flush_respond (content_cache_t *cache);
+static int cache_flush (content_cache_t *cache);
 
 static void message_list_destroy (zlist_t **l)
 {
@@ -425,8 +430,8 @@ static void cache_store_continuation (flux_rpc_t *rpc, void *arg)
     int rc = -1;
 
     e->store_pending = 0;
-    cache->store_pending_count--;
-    assert (cache->store_pending_count >= 0);
+    cache->flush_batch_count--;
+    assert (cache->flush_batch_count >= 0);
     if (flux_rpc_get_raw (rpc, NULL, &blobref, &blobref_size) < 0) {
         saved_errno = errno;
         flux_log_error (cache->h, "content store");
@@ -453,8 +458,18 @@ done:
                                         e->blobref, strlen (blobref) + 1) < 0)
         flux_log_error (cache->h, "content store");
     flux_rpc_destroy (rpc);
-    if (cache->store_pending_count == 0)
+
+    /* If cache has been flushed, respond to flush requests, if any.
+     * If there are still dirty entries and the number of outstanding
+     * store requests would not exceed the limit, flush more entries.
+     * Optimization: since scanning for dirty entries is a linear search,
+     * only do it when the number of outstanding store requests falls to
+     * a low water mark, here hardwired to be half of the limit.
+     */
+    if (cache->acct_dirty == 0)
         flush_respond (cache);
+    else if (cache->flush_batch_count <= cache->flush_batch_limit / 2)
+        (void)cache_flush (cache); /* resume flushing */
 }
 
 static int cache_store (content_cache_t *cache, struct cache_entry *e)
@@ -486,7 +501,7 @@ static int cache_store (content_cache_t *cache, struct cache_entry *e)
         goto done;
     }
     e->store_pending = 1;
-    cache->store_pending_count++;
+    cache->flush_batch_count++;
     rc = 0;
 done:
     if (rc < 0)
@@ -583,6 +598,8 @@ static int cache_flush (content_cache_t *cache)
     int rc = 0;
 
     FOREACH_ZHASH (cache->entries, key, e) {
+        if (cache->flush_batch_count >= cache->flush_batch_limit)
+            break;
         if (e->dirty) {
             if (cache_store (cache, e) < 0) {
                 saved_errno = errno;
@@ -636,7 +653,7 @@ done:
     Jput (in);
 };
 
-/* Forceably drop all entries from the cache that can be dropped
+/* Forcibly drop all entries from the cache that can be dropped
  * without data loss.
  * N.B. this walks the entire cache in one go.
  */
@@ -735,7 +752,7 @@ static void content_flush_request (flux_t h, flux_msg_handler_t *w,
     }
     if (cache_flush (cache) < 0)
         goto done;
-    if (cache->store_pending_count > 0) {
+    if (cache->acct_dirty > 0) {
         if (defer_request (&cache->flush_requests, msg) < 0)
             goto done;
         return;
@@ -893,6 +910,9 @@ int content_cache_register_attrs (content_cache_t *cache, attr_t *attr)
         return -1;
     /* Misc
      */
+    if (attr_add_active_uint32 (attr, "content-flush-batch-limit",
+                &cache->flush_batch_limit, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
     if (attr_add_active_uint32 (attr, "content-blob-size-limit",
                 &cache->blob_size_limit, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
@@ -901,6 +921,9 @@ int content_cache_register_attrs (content_cache_t *cache, attr_t *attr)
         return -1;
     if (attr_add_active (attr, "content-backing",FLUX_ATTRFLAG_READONLY,
                  content_cache_getattr, NULL, cache) < 0)
+        return -1;
+    if (attr_add_active_uint32 (attr, "content-flush-batch-count",
+                &cache->flush_batch_count, 0) < 0)
         return -1;
     return 0;
 }
@@ -935,6 +958,7 @@ content_cache_t *content_cache_create (void)
     }
     cache->rank = FLUX_NODEID_ANY;
     cache->blob_size_limit = default_blob_size_limit;
+    cache->flush_batch_limit = default_flush_batch_limit;
     cache->purge_target_entries = default_cache_purge_target_entries;
     cache->purge_target_size = default_cache_purge_target_size;
     cache->purge_old_entry = default_cache_purge_old_entry;

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -584,7 +584,6 @@ void internal_content_store (flux_conf_t cf, optparse_t *orig,
           .usage = "Store directly to rank 0 content service", },
         OPTPARSE_TABLE_END,
     };
-    const uint32_t blob_size_limit = 1048576; /* RFC 10 */
     optparse_t *p;
     int n;
     uint8_t *data;
@@ -613,8 +612,6 @@ void internal_content_store (flux_conf_t cf, optparse_t *orig,
         int flags;
         const char *hashfun;
 
-        if (size > blob_size_limit)
-            errn_exit (EFBIG, "content-store");
         if (!(hashfun = flux_attr_get (h, "content-hash", &flags)))
             err_exit ("flux_attr_get content-hash");
         if (!strcmp (hashfun, "sha1")) {

--- a/src/modules/content-sophia/content-sophia.c
+++ b/src/modules/content-sophia/content-sophia.c
@@ -178,8 +178,8 @@ done:
         int saved_errno = errno;
         if (rc < 0)
             flux_log (h, LOG_DEBUG, "load: %s %s", blobref, strerror (errno));
-        else
-            flux_log (h, LOG_DEBUG, "load: %s size=%d", blobref, size);
+        //else
+        //    flux_log (h, LOG_DEBUG, "load: %s size=%d", blobref, size);
         errno = saved_errno;
     }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,
@@ -238,8 +238,8 @@ done:
         int saved_errno = errno;
         if (rc < 0)
             flux_log (h, LOG_DEBUG, "store: %s %s", blobref, strerror (errno));
-        else
-            flux_log (h, LOG_DEBUG, "store: %s size=%d", blobref, size);
+        //else
+        //    flux_log (h, LOG_DEBUG, "store: %s size=%d", blobref, size);
         errno = saved_errno;
     }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -38,8 +38,6 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 
-const uint32_t blob_size_limit = 1048576; /* RFC 10 */
-
 const bool debug_enabled = true;
 
 const char *sql_create_table = "CREATE TABLE objects("
@@ -60,6 +58,7 @@ typedef struct {
     flux_t h;
     bool broker_shutdown;
     const char *hashfun;
+    uint32_t blob_size_limit;
 } ctx_t;
 
 static void log_sqlite_error (ctx_t *ctx, const char *fmt, ...)
@@ -101,6 +100,7 @@ static ctx_t *getctx (flux_t h)
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "flux::content-sqlite");
     const char *scratchdir;
     const char *hashfun;
+    const char *tmp;
     int flags;
 
     if (!ctx) {
@@ -115,6 +115,11 @@ static ctx_t *getctx (flux_t h)
             flux_log_error (h, "content-hash: %s", hashfun);
             goto error;
         }
+        if (!(tmp = flux_attr_get (h, "content-blob-size-limit", NULL))) {
+            flux_log_error (h, "content-blob-size-limit");
+            goto error;
+        }
+        ctx->blob_size_limit = strtoul (tmp, NULL, 10);
         if (!(scratchdir = flux_attr_get (h, "scratch-directory", NULL))) {
             flux_log_error (h, "scratch-directory");
             goto error;
@@ -241,7 +246,7 @@ void store_cb (flux_t h, flux_msg_handler_t *w,
         flux_log_error (h, "store: request decode failed");
         goto done;
     }
-    if (size > blob_size_limit) {
+    if (size > ctx->blob_size_limit) {
         errno = EFBIG;
         goto done;
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -222,8 +222,8 @@ done:
         int saved_errno = errno;
         if (rc < 0)
             flux_log (h, LOG_DEBUG, "load: %s %s", blobref, strerror (errno));
-        else
-            flux_log (h, LOG_DEBUG, "load: %s size=%d", blobref, size);
+        //else
+        //    flux_log (h, LOG_DEBUG, "load: %s size=%d", blobref, size);
         errno = saved_errno;
     }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0, data, size) < 0)
@@ -279,8 +279,8 @@ done:
         int saved_errno = errno;
         if (rc < 0)
             flux_log (h, LOG_DEBUG, "store: %s %s", blobref, strerror (errno));
-        else
-            flux_log (h, LOG_DEBUG, "store: %s size=%d", blobref, size);
+        //else
+        //    flux_log (h, LOG_DEBUG, "store: %s size=%d", blobref, size);
         errno = saved_errno;
     }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -16,6 +16,8 @@ fluxmod_LTLIBRARIES = kvs.la
 
 kvs_la_SOURCES = \
 	kvs.c \
+	cache.c \
+	cache.h \
 	waitqueue.c \
 	waitqueue.h \
 	proto.c \

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -1,0 +1,243 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <sys/time.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/shastring.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/tstat.h"
+#include "src/common/libutil/log.h"
+
+#include "waitqueue.h"
+#include "cache.h"
+
+struct cache_entry {
+    waitqueue_t *waitlist;  /* waiters for valid or !dirty */
+    json_object *o;         /* value object */
+    int lastuse_epoch;      /* time of last use for cache expiry */
+    uint8_t dirty:1;
+};
+
+struct cache {
+    zhash_t *zh;
+};
+
+struct cache_entry *cache_entry_create (json_object *o)
+{
+    struct cache_entry *hp = xzmalloc (sizeof (*hp));
+    if (o)
+        hp->o = o;
+    return hp;
+}
+
+bool cache_entry_get_valid (struct cache_entry *hp)
+{
+    return (hp && hp->o != NULL);
+}
+
+bool cache_entry_get_dirty (struct cache_entry *hp)
+{
+    return (hp && hp->o && hp->dirty);
+}
+
+void cache_entry_set_dirty (struct cache_entry *hp, bool val)
+{
+    if (hp && hp->o) {
+        if ((val && hp->dirty) || (!val && !hp->dirty))
+            ; /* no-op */
+        else if (val && !hp->dirty)
+            hp->dirty = 1;
+        else if (!val && hp->dirty) {
+            hp->dirty = 0;
+            if (hp->waitlist)
+                wait_runqueue (hp->waitlist);
+        }
+    }
+}
+
+json_object *cache_entry_get_json (struct cache_entry *hp)
+{
+    if (!hp || !hp->o)
+        return NULL;
+    return hp->o;
+}
+
+void cache_entry_set_json (struct cache_entry *hp, json_object *o)
+{
+    if (hp) {
+        if ((o && hp->o) || (!o && !hp->o)) {
+            Jput (o); /* no-op, 'o' is assumed identical to hp->o */
+        } else if (o && !hp->o) {
+            hp->o = o;
+            if (hp->waitlist)
+                wait_runqueue (hp->waitlist);
+        } else if (!o && hp->o) {
+            Jput (hp->o);
+            hp->o = NULL;
+        }
+    }
+}
+
+void cache_entry_destroy (void *arg)
+{
+    struct cache_entry *hp = arg;
+    if (hp) {
+        if (hp->o)
+            json_object_put (hp->o);
+        if (hp->waitlist)
+            wait_queue_destroy (hp->waitlist);
+        free (hp);
+    }
+}
+
+void cache_entry_wait (struct cache_entry *hp, wait_t *wait)
+{
+    if (wait) {
+        if (!hp->waitlist)
+            hp->waitlist = wait_queue_create ();
+        wait_addqueue (hp->waitlist, wait);
+    }
+}
+
+struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
+                                  int current_epoch)
+{
+    struct cache_entry *hp = zhash_lookup (cache->zh, ref);
+    if (hp && current_epoch > hp->lastuse_epoch)
+        hp->lastuse_epoch = current_epoch;
+    return hp;
+}
+
+void cache_insert (struct cache *cache, const char *ref, struct cache_entry *hp)
+{
+    int rc = zhash_insert (cache->zh, ref, hp);
+    assert (rc == 0);
+    zhash_freefn (cache->zh, ref, cache_entry_destroy);
+}
+
+int cache_count_entries (struct cache *cache)
+{
+    return zhash_size (cache->zh);
+}
+
+static int cache_entry_age (struct cache_entry *hp, int current_epoch)
+{
+    if (!hp)
+        return -1;
+    if (hp->lastuse_epoch == 0)
+        hp->lastuse_epoch = current_epoch;
+    return current_epoch - hp->lastuse_epoch;
+}
+
+int cache_expire_entries (struct cache *cache, int current_epoch, int thresh)
+{
+    zlist_t *keys;
+    char *ref;
+    struct cache_entry *hp;
+    int count = 0;
+
+    if (!(keys = zhash_keys (cache->zh)))
+        oom ();
+    while ((ref = zlist_pop (keys))) {
+        if ((hp = zhash_lookup (cache->zh, ref))
+            && !cache_entry_get_dirty (hp)
+            && cache_entry_get_valid (hp)
+            && (thresh == 0 || cache_entry_age (hp, current_epoch) > thresh)) {
+                zhash_delete (cache->zh, ref);
+                count++;
+        }
+        free (ref);
+    }
+    zlist_destroy (&keys);
+    return count;
+}
+
+void cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
+                      int *incompletep, int *dirtyp)
+{
+    zlist_t *keys;
+    struct cache_entry *hp;
+    char *ref;
+    int size = 0;
+    int incomplete = 0;
+    int dirty = 0;
+
+    if (!(keys = zhash_keys (cache->zh)))
+        oom ();
+    while ((ref = zlist_pop (keys))) {
+        hp = zhash_lookup (cache->zh, ref);
+        if (cache_entry_get_valid (hp)) {
+            int obj_size = strlen (Jtostr (hp->o));
+            size += obj_size;
+            tstat_push (ts, obj_size);
+        } else
+            incomplete++;
+        if (cache_entry_get_dirty (hp))
+            dirty++;
+        free (ref);
+    }
+    zlist_destroy (&keys);
+    if (sizep)
+        *sizep = size;
+    if (incompletep)
+        *incompletep = incomplete;
+    if (dirtyp)
+        *dirtyp = dirty;
+}
+
+struct cache *cache_create (void)
+{
+    struct cache *cache = xzmalloc (sizeof (*cache));
+    if (!(cache->zh = zhash_new ()))
+        oom ();
+    return cache;
+}
+
+void cache_destroy (struct cache *cache)
+{
+    if (cache) {
+        zhash_destroy (&cache->zh);
+        free (cache);
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -1,0 +1,70 @@
+struct cache_entry;
+struct cache;
+
+
+/* Create/destroy cache entry.
+ * If non-NULL, create transfers ownership of 'o' to the cache entry.
+ */
+struct cache_entry *cache_entry_create (json_object *o);
+void cache_entry_destroy (void *arg);
+
+/* Return true if cache entry contains valid json.
+ * False would indicate that a load RPC is in progress.
+ */
+bool cache_entry_get_valid (struct cache_entry *hp);
+
+/* Get/set cache entry's dirty bit.
+ * The dirty bit indicates that a store RPC is in progress.
+ * A true->false transitions runs the entry's wait queue, if any.
+ */
+bool cache_entry_get_dirty (struct cache_entry *hp);
+void cache_entry_set_dirty (struct cache_entry *hp, bool val);
+
+/* Accessors for cache entry data.
+ * If non-NULL, set transfers ownership of 'o' to the cache entry.
+ * An invalid->valid transition runs the entry's wait queue, if any.
+ */
+json_object *cache_entry_get_json (struct cache_entry *hp);
+void cache_entry_set_json (struct cache_entry *hp, json_object *o);
+
+/* Arrange for message handler represented by 'wait' to be restarted
+ * once cache entry becomes valid or not dirty at completion of a
+ * load or store RPC.
+ */
+void cache_entry_wait (struct cache_entry *hp, wait_t *wait);
+
+/* Create/destroy the cache container and its contents.
+ */
+struct cache *cache_create (void);
+void cache_destroy (struct cache *cache);
+
+/* Look up a cache entry.
+ * Update the entry's "last used" time to 'current_epoch',
+ * taking care not to not run backwards.
+ */
+struct cache_entry *cache_lookup (struct cache *cache,
+                                  const char *ref, int current_epoch);
+
+/* Insert an entry in the cache by 'ref' (stringified SHA1 hash).
+ * Ownership of the cache entry is transferred to the cache.
+ */
+void cache_insert (struct cache *cache, const char *ref,
+                   struct cache_entry *hp);
+
+/* Return the number of cache entries.
+ */
+int cache_count_entries (struct cache *cache);
+
+/* Expire cache entries that are not dirty, not incomplete, and last
+ * used more than 'thresh' epoch's ago.
+ */
+int cache_expire_entries (struct cache *cache, int current_epoch, int thresh);
+
+/* Obtain statistics on the cache.
+ */
+void cache_get_stats (struct cache *cache, tstat_t *ts, int *size,
+                      int *incomplete, int *dirty);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -53,22 +53,31 @@
 
 /* kvs.put
  */
-JSON kp_tput_enc (const char *key, JSON val, bool link, bool dir)
+JSON kp_tput_enc (const char *key, const char *json_str, bool link, bool dir)
 {
     JSON o = NULL;
+    JSON val = NULL;
 
     if (!key) {
         errno = EINVAL;
-        goto done;
+        goto error;
     }
     o = Jnew ();
+    if (json_str) {
+        if (!(val = Jfromstr (json_str))) {
+            errno = EINVAL;
+            goto error;
+        }
+    }
     json_object_object_add (o, key, val);
     if (dir)
         Jadd_bool (o, ".flag_mkdir", true);
     if (link)
         Jadd_bool (o, ".flag_symlink", true);
-done:
     return o;
+error:
+    Jput (o);
+    return NULL;
 }
 
 int kp_tput_dec (JSON o, const char **key, JSON *val, bool *link, bool *dir)

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -3,7 +3,7 @@
 
 /* kvs.put
  */
-json_object *kp_tput_enc (const char *key, json_object *val,
+json_object *kp_tput_enc (const char *key, const char *json_str,
                           bool link, bool dir);
 int kp_tput_dec (json_object *o, const char **key, json_object **val,
                  bool *link, bool *dir);

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -18,7 +18,7 @@ void test_put (void)
 
     val = Jnew ();
     Jadd_int (val, "i", 2);
-    o = kp_tput_enc ("a", val, false, true);
+    o = kp_tput_enc ("a", Jtostr (val), false, true);
     ok (o != NULL,
         "kp_tput_snec works");
     val = NULL;

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -71,7 +71,6 @@ static int ctx_init (flux_t h, ctx_t *ctx)
     char *conf_path =
         FLUX_CHECK_PTR (h, xasprintf ("config.resource.hwloc.xml.%" PRIu32, rank));
     kvs_get_string (h, conf_path, &path);
-    CHECK_INT(hwloc_topology_init (&ctx->topology));
     free (conf_path);
 
     if (!path)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -126,6 +126,7 @@ check_PROGRAMS = \
 	pmi/pminfo \
 	kz/kzutil \
 	kvs/torture \
+	kvs/hashtest \
 	kvs/watch
 
 if HAVE_MPI
@@ -213,3 +214,8 @@ kvs_watch_CPPFLAGS = $(test_cppflags)
 kvs_watch_LDADD = \
 	$(top_builddir)/src/modules/kvs/libkvs.la \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_hashtest_SOURCES = kvs/hashtest.c
+kvs_hashtest_CPPFLAGS = $(test_cppflags) $(SQLITE_CFLAGS)
+kvs_hashtest_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL) $(LIBJUDY) $(SQLITE_LIBS)

--- a/t/kvs/hashtest.c
+++ b/t/kvs/hashtest.c
@@ -1,0 +1,709 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <assert.h>
+#include <stdarg.h>
+#include <czmq.h>
+#include <stdlib.h>
+#if HAVE_LIBJUDY
+#include <Judy.h>
+#endif
+#include <sqlite3.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/monotime.h"
+#include "src/common/libutil/cleanup.h"
+#include "src/common/libutil/log.h"
+#if HAVE_LSD_HASH
+#include "src/common/liblsd/hash.h"
+#endif
+#include "src/common/libsophia/sophia.h"
+#if HAVE_HATTRIE
+#include "src/common/libhat-trie/hat-trie.h"
+#endif
+
+//const int num_keys = 1024*1024;
+const int num_keys = 1024*1024*10;
+
+struct hash_impl {
+    void (*destroy)(struct hash_impl *h);
+    void (*insert)(struct hash_impl *h, zlist_t *items);
+    void (*lookup)(struct hash_impl *h, zlist_t *items);
+    void *h;
+};
+
+struct item {
+    zdigest_t *zd;
+    char data[16];
+    uint8_t key[20];
+    char skey[41];
+};
+
+void rusage (struct rusage *res)
+{
+    int rc = getrusage (RUSAGE_SELF, res);
+    assert (rc == 0);
+}
+
+long int rusage_maxrss_since (struct rusage *res)
+{
+    struct rusage new;
+    int rc = getrusage (RUSAGE_SELF, &new);
+    assert (rc == 0);
+    return new.ru_maxrss - res->ru_maxrss;
+}
+
+struct item *item_create (int id)
+{
+    struct item *item = xzmalloc (sizeof (*item));
+    assert (item != NULL);
+    snprintf (item->data, sizeof (item->data), "%d", id);
+
+    item->zd = zdigest_new ();
+    assert (item->zd != NULL);
+    zdigest_update (item->zd, (uint8_t *)item->data, sizeof (item->data));
+
+    assert (zdigest_size (item->zd) == sizeof (item->key));
+    memcpy (item->key, zdigest_data (item->zd), zdigest_size (item->zd));
+
+    assert (strlen (zdigest_string (item->zd)) == sizeof (item->skey) - 1);
+    strcpy (item->skey, zdigest_string (item->zd));
+    zdigest_destroy (&item->zd);
+
+    return item;
+}
+
+void item_destroy (void *arg)
+{
+    struct item *item = arg;
+    free (item);
+}
+
+zlist_t *create_items (void)
+{
+    zlist_t *items = zlist_new ();
+    struct item *item;
+    int i, rc;
+
+    assert (items != NULL);
+    for (i = 0; i < num_keys; i++) {
+        item = item_create (i);
+        rc = zlist_append (items, item);
+        assert (rc == 0);
+    }
+    return items;
+}
+
+/* zhash
+ */
+
+void insert_zhash (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    int rc;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        rc = zhash_insert (impl->h, item->skey, item);
+        assert (rc == 0);
+        item = zlist_next (items);
+    }
+}
+
+void lookup_zhash (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item, *ip;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        ip = zhash_lookup (impl->h, item->skey);
+        assert (ip != NULL);
+        assert (ip == item);
+        item = zlist_next (items);
+    }
+}
+
+void destroy_zhash (struct hash_impl *impl)
+{
+    zhash_t *zh = impl->h;
+    zhash_destroy (&zh);
+    free (impl);
+}
+
+struct hash_impl *create_zhash (void)
+{
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+    impl->h = zhash_new ();
+    assert (impl->h != NULL);
+    impl->insert = insert_zhash;
+    impl->lookup = lookup_zhash;
+    impl->destroy = destroy_zhash;
+    return impl;
+}
+
+/* zhashx
+ */
+#if HAVE_ZHASHX_NEW
+void insert_zhashx (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    int rc;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        rc = zhashx_insert (impl->h, item->key, item);
+        assert (rc == 0);
+        item = zlist_next (items);
+    }
+}
+
+void lookup_zhashx (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item, *ip;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        ip = zhashx_lookup (impl->h, item->key);
+        assert (ip != NULL);
+        assert (ip == item);
+        item = zlist_next (items);
+    }
+}
+
+void destroy_zhashx (struct hash_impl *impl)
+{
+    zhashx_t *zh = impl->h;
+    zhashx_destroy (&zh);
+    free (impl);
+}
+
+
+void *duplicator_zhashx (const void *item)
+{
+    return (void *)item;
+}
+
+void destructor_zhashx (void **item)
+{
+    *item = NULL;
+}
+
+int comparator_zhashx (const void *item1, const void *item2)
+{
+    return memcmp (item1, item2, 20);
+}
+
+size_t hasher_zhashx (const void *item)
+{
+    return *(size_t *)item;
+}
+
+struct hash_impl *create_zhashx (void)
+{
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+    impl->h = zhashx_new ();
+    assert (impl->h != NULL);
+
+    /* Use 20 byte keys that are not copied.
+     */
+    zhashx_set_key_duplicator (impl->h, duplicator_zhashx);
+    zhashx_set_key_destructor (impl->h, destructor_zhashx);
+    zhashx_set_key_comparator (impl->h, comparator_zhashx);
+    zhashx_set_key_hasher (impl->h, hasher_zhashx);
+
+    impl->insert = insert_zhashx;
+    impl->lookup = lookup_zhashx;
+    impl->destroy = destroy_zhashx;
+    return impl;
+}
+#endif /* HAVE_ZHASHX_NEW */
+
+/* lsd-hash
+ */
+
+#if HAVE_LSD_HASH
+void insert_lsd (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item, *ip;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        ip = hash_insert (impl->h, item->key, item);
+        assert (ip != NULL);
+        item = zlist_next (items);
+    }
+}
+
+void lookup_lsd (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item, *ip;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        ip = hash_find (impl->h, item->key);
+        assert (ip != NULL);
+        assert (ip == item);
+        item = zlist_next (items);
+    }
+}
+
+void destroy_lsd (struct hash_impl *impl)
+{
+    hash_destroy (impl->h);
+    free (impl);
+}
+
+unsigned int hash_lsd (const void *key)
+{
+    return *(unsigned int *)key; /* 1st 4 bytes of sha1 */
+}
+
+int cmp_lsd (const void *key1, const void *key2)
+{
+    return memcmp (key1, key2, 20);
+}
+
+struct hash_impl *create_lsd (void)
+{
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+    impl->h = hash_create (1024*1024*8, hash_lsd, cmp_lsd, NULL);
+    assert (impl->h != NULL);
+
+    impl->insert = insert_lsd;
+    impl->lookup = lookup_lsd;
+    impl->destroy = destroy_lsd;
+
+    return impl;
+}
+#endif
+
+/* judy
+ */
+
+#if HAVE_LIBJUDY
+void insert_judy (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    //Pvoid_t array = NULL;
+    PWord_t valp;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        JHSI (valp, impl->h, item->key, sizeof (item->key));
+        assert (valp != PJERR);
+        assert (*valp == (uintptr_t)0); /* nonzero indicates dup */
+        *valp = (uintptr_t)item;
+        item = zlist_next (items);
+    }
+}
+
+void lookup_judy (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    //Pvoid_t array = NULL;
+    PWord_t valp;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        JHSG (valp, impl->h, item->key, sizeof (item->key));
+        assert (valp != NULL);
+        assert (*valp == (uintptr_t)item);
+        item = zlist_next (items);
+    }
+}
+
+void destroy_judy (struct hash_impl *impl)
+{
+    Word_t bytes;
+    JHSFA (bytes, impl->h);
+    msg ("judy freed %lu Kbytes of memory", bytes / 1024);
+    free (impl);
+}
+
+struct hash_impl *create_judy (void)
+{
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+
+    impl->insert = insert_judy;
+    impl->lookup = lookup_judy;
+    impl->destroy = destroy_judy;
+
+    return impl;
+}
+#endif
+
+/* sophia
+ */
+
+void log_sophia_error (void *env, const char *fmt, ...)
+{
+    va_list ap;
+    va_start (ap, fmt);
+    char *s = xvasprintf (fmt, ap);
+    va_end (ap);
+
+    int error_size;
+    char *error = NULL;
+    if (env)
+        error = sp_getstring (env, "sophia.error", &error_size);
+    fprintf (stderr, "%s: %s", s, error ? error : "failure");
+    if (error)
+        free (error);
+    free (s);
+}
+
+void insert_sophia (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    void *db, *o;
+    int rc;
+
+    db = sp_getobject (impl->h, "db.test");
+    if (!db)
+        log_sophia_error (impl->h, "db.test");
+    assert (db != NULL);
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        // existence check slows down by about 23X! */
+        //o = sp_object (db);
+        //assert (o != NULL);
+        //rc = sp_setstring (o, "key", item->key, sizeof (item->key));
+        //assert (rc == 0);
+        //void *result = sp_get (db, o); /* destroys 'o' */
+        //assert (result == NULL);
+
+        o = sp_object (db);
+        assert (o != NULL);
+        rc = sp_setstring (o, "key", item->key, sizeof (item->key));
+        assert (rc == 0);
+        rc = sp_setstring (o, "value", item, sizeof (*item));
+        assert (rc == 0);
+        rc = sp_set (db, o); /* destroys 'o', copies item  */
+        assert (rc == 0);
+        item = zlist_next (items);
+    }
+
+    sp_destroy (db);
+}
+
+void lookup_sophia (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item, *ip;
+    void *db, *o, *result;
+    int rc, item_size;
+    int count = 0;
+
+    db = sp_getobject (impl->h, "db.test");
+    if (!db)
+        log_sophia_error (impl->h, "db.test");
+    assert (db != NULL);
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        o = sp_object (db);
+        assert (o != NULL);
+        rc = sp_setstring (o, "key", item->key, sizeof (item->key));
+        assert (rc == 0);
+        result = sp_get (db, o); /* destroys 'o' */
+        assert (result != NULL);
+        ip = sp_getstring (result, "value", &item_size);
+        assert (ip != NULL);
+        assert (item_size == sizeof (*item));
+        assert (memcmp (ip, item, item_size) == 0);
+        sp_destroy (result);
+        item = zlist_next (items);
+        count++;
+        //if (count % 10000 == 0)
+        //    msg ("lookup: %d of %d", count, num_keys);
+    }
+
+    sp_destroy (db);
+}
+
+void destroy_sophia (struct hash_impl *impl)
+{
+    sp_destroy (impl->h);
+    free (impl);
+}
+
+struct hash_impl *create_sophia (void)
+{
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+    char template[] = "/tmp/hashtest-sophia.XXXXXX";
+    char *path;
+    int rc;
+
+    path = mkdtemp (template);
+    assert (path != NULL);
+    cleanup_push_string (cleanup_directory_recursive, path);
+    msg ("sophia.path: %s", path);
+    impl->h = sp_env ();
+    assert (impl->h != NULL);
+    rc = sp_setstring (impl->h, "sophia.path", path, 0);
+    assert (rc == 0);
+    // 16m limit increases memory used during insert by about 2X
+    //rc = sp_setint (impl->h, "memory.limit", 1024*1024*16);
+    //assert (rc == 0);
+    rc = sp_setstring (impl->h, "db", "test", 0);
+    assert (rc == 0);
+    rc = sp_setstring (impl->h, "db.test.index.key", "string", 0);
+    assert (rc == 0);
+    // N.B. lz4 slows down lookups by about 4X
+    //rc = sp_setstring (impl->h, "db.test.compression", "lz4", 0);
+    //assert (rc == 0);
+    rc = sp_open (impl->h);
+    assert (rc == 0);
+
+    impl->insert = insert_sophia;
+    impl->lookup = lookup_sophia;
+    impl->destroy = destroy_sophia;
+
+    return impl;
+}
+
+#if HAVE_HATTRIE
+void insert_hat (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    value_t *val;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        val = hattrie_get (impl->h, (char *)item->key, sizeof (item->key));
+        assert (val != NULL);
+        assert (*val == 0);
+        *(void **)val = item;
+        item = zlist_next (items);
+    }
+}
+
+void lookup_hat (struct hash_impl *impl, zlist_t *items)
+{
+    struct item *item;
+    value_t *val;
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        val = hattrie_tryget (impl->h, (char *)item->key, sizeof (item->key));
+        assert (*(void **)val == item);
+        item = zlist_next (items);
+    }
+}
+
+void destroy_hat (struct hash_impl *impl)
+{
+    hattrie_free (impl->h);
+    free (impl);
+}
+
+struct hash_impl *create_hat (void)
+{
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+    impl->h = hattrie_create ();
+    assert (impl->h != NULL);
+    impl->insert = insert_hat;
+    impl->lookup = lookup_hat;
+    impl->destroy = destroy_hat;
+    return impl;
+}
+#endif
+
+void insert_sqlite (struct hash_impl *impl, zlist_t *items)
+{
+    const char *sql = "INSERT INTO objects (hash,object) values (?1, ?2)";
+    sqlite3_stmt *stmt;
+    int rc;
+    struct item *item;
+
+    rc = sqlite3_prepare_v2 (impl->h, sql, -1, &stmt, NULL);
+    assert (rc == SQLITE_OK);
+
+    rc = sqlite3_exec (impl->h, "BEGIN", 0, 0, 0);
+    assert (rc == SQLITE_OK);
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        rc = sqlite3_bind_text (stmt, 1, (char *)item->key,
+                                sizeof (item->key), SQLITE_STATIC);
+        assert (rc == SQLITE_OK);
+        rc = sqlite3_bind_blob (stmt, 2, item, sizeof (*item), SQLITE_STATIC);
+        assert (rc == SQLITE_OK);
+        rc = sqlite3_step (stmt);
+        assert (rc == SQLITE_DONE);
+        rc = sqlite3_reset (stmt);
+        assert (rc == SQLITE_OK);
+
+        item = zlist_next (items);
+    }
+    rc = sqlite3_exec (impl->h, "COMMIT", 0, 0, 0);
+    assert (rc == SQLITE_OK);
+
+    sqlite3_finalize (stmt);
+}
+
+void lookup_sqlite (struct hash_impl *impl, zlist_t *items)
+{
+    const char *sql = "SELECT object FROM objects WHERE hash = ?1 LIMIT 1";
+    sqlite3_stmt *stmt;
+    int rc;
+    struct item *item;
+    const void *val;
+
+    rc = sqlite3_prepare_v2 (impl->h, sql, -1, &stmt, NULL);
+    assert (rc == SQLITE_OK);
+
+    item = zlist_first (items);
+    while (item != NULL) {
+        rc = sqlite3_bind_text (stmt, 1, (char *)item->key,
+                                sizeof (item->key), SQLITE_STATIC);
+        assert (rc == SQLITE_OK);
+        rc = sqlite3_step (stmt);
+        assert (rc == SQLITE_ROW);
+        assert (sqlite3_column_type (stmt, 0) == SQLITE_BLOB);
+        assert (sqlite3_column_bytes (stmt, 0) == sizeof (*item));
+        val = sqlite3_column_blob (stmt, 0);
+        assert (val != NULL);
+        assert (memcmp (val, item, sizeof (*item)) == 0);
+
+        rc = sqlite3_step (stmt);
+        assert (rc == SQLITE_DONE);
+        rc = sqlite3_reset (stmt);
+        assert (rc == SQLITE_OK);
+
+        item = zlist_next (items);
+    }
+
+    sqlite3_finalize (stmt);
+}
+
+void destroy_sqlite (struct hash_impl *impl)
+{
+    sqlite3_close (impl->h);
+}
+
+struct hash_impl *create_sqlite (void)
+{
+    int rc;
+    sqlite3 *db;
+    char template[] = "/tmp/hashtest-sqlite.XXXXXX";
+    char *path;
+    struct hash_impl *impl = xzmalloc (sizeof (*impl));
+    char dbpath[PATH_MAX];
+
+    path = mkdtemp (template);
+    assert (path != NULL);
+    cleanup_push_string (cleanup_directory_recursive, path);
+    msg ("sqlite path: %s", path);
+
+    snprintf (dbpath, sizeof (dbpath), "%s/db", path);
+    rc = sqlite3_open (dbpath, &db);
+    assert (rc == SQLITE_OK);
+
+    // avoid creating journal
+    rc = sqlite3_exec (db, "PRAGMA journal_mode=OFF", NULL, NULL, NULL);
+    assert (rc == SQLITE_OK);
+
+    // avoid fsync
+    rc = sqlite3_exec (db, "PRAGMA synchronous=OFF", NULL, NULL, NULL);
+    assert (rc == SQLITE_OK);
+
+    // avoid mutex locking
+    rc = sqlite3_exec (db, "PRAGMA locking_mode=EXCLUSIVE", NULL, NULL, NULL);
+    assert (rc == SQLITE_OK);
+
+    // raise max db pages cached in memory from 2000
+    //rc = sqlite3_exec (db, "PRAGMA cache_size=16000", NULL, NULL, NULL);
+    //assert (rc == SQLITE_OK);
+
+    // raise db page size from default 1024 bytes
+    // N.B. must set before table create
+    //rc = sqlite3_exec (db, "PRAGMA page_size=4096", NULL, NULL, NULL);
+    //assert (rc == SQLITE_OK);
+
+    rc = sqlite3_exec (db, "CREATE TABLE objects("
+            "hash CHAR(20) PRIMARY KEY,"
+            "object BLOB"
+            ");", NULL, NULL, NULL);
+    assert (rc == SQLITE_OK);
+
+    impl->h = db;
+    impl->insert = insert_sqlite;
+    impl->lookup = lookup_sqlite;
+    impl->destroy = destroy_sqlite;
+    return impl;
+}
+
+void usage (void)
+{
+    fprintf (stderr, "Usage: hashtest zhash | zhashx | judy | lsd | hat"
+           " | sophia | sqlite\n");
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    zlist_t *items;
+    struct hash_impl *impl = NULL;
+    struct timespec t0;
+    struct rusage res;
+
+    if (argc == 1)
+        usage ();
+
+    rusage (&res);
+    monotime (&t0);
+    if (!strcmp (argv[1], "zhash"))
+        impl = create_zhash ();
+#if HAVE_ZHASHX_NEW
+    else if (!strcmp (argv[1], "zhashx"))
+        impl = create_zhashx ();
+#endif
+#if HAVE_LSD_HASH
+    else if (!strcmp (argv[1], "lsd"))
+        impl = create_lsd ();
+#endif
+#if HAVE_LIBJUDY
+    else if (!strcmp (argv[1], "judy"))
+        impl = create_judy ();
+#endif
+    else if (!strcmp (argv[1], "sophia"))
+        impl = create_sophia ();
+#if HAVE_HATTRIE
+    else if (!strcmp (argv[1], "hat"))
+        impl = create_hat ();
+#endif
+    else if (!strcmp (argv[1], "sqlite"))
+        impl = create_sqlite ();
+    if (!impl)
+        usage ();
+    msg ("create hash: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+                                       rusage_maxrss_since (&res));
+
+    rusage (&res);
+    monotime (&t0);
+    items = create_items ();
+    msg ("create items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+                                        rusage_maxrss_since (&res));
+
+    rusage (&res);
+    monotime (&t0);
+    impl->insert (impl, items);
+    msg ("insert items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+                                        rusage_maxrss_since (&res));
+
+    rusage (&res);
+    monotime (&t0);
+    impl->lookup (impl, items);
+    msg ("lookup items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+                                        rusage_maxrss_since (&res));
+
+    impl->destroy (impl);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -4,11 +4,17 @@ test_description='Test content-sqlite service'
 
 . `dirname $0`/sharness.sh
 
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(($(grep processor /proc/cpuinfo | wc -l)+1))
 test ${SIZE} -lt 4 && SIZE=4
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
+
+MAXBLOB=`flux getattr content-blob-size-limit`
 
 test_expect_success 'load content-sqlite module on rank 0' '
 	flux module load --rank 0 --direct content-sqlite
@@ -35,8 +41,9 @@ test_expect_success 'store blobs bypassing cache' '
         flux content store --bypass-cache <1m.0.store >1m.0.hash
 '
 
-test_expect_success 'cannot store blob that exceeds max size of 1m' '
-        echo x | cat 1m.0.store - >toobig &&
+test_expect_success LONGTEST "cannot store blob that exceeds max size of $MAXBLOB" '
+        dd if=/dev/zero count=$(($MAXBLOB/4096+1)) bs=4096 \
+			skip=$(($MAXBLOB/4096)) >toobig 2>/dev/null &&
         test_must_fail flux content store --bypass-cache <toobig
 '
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -11,7 +11,7 @@ before other tests that depend on kvs.
 . `dirname $0`/sharness.sh
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(grep processor /proc/cpuinfo | wc -l)+1))
+SIZE=$(($(nproc)+1))
 test ${SIZE} -lt 4 && SIZE=4
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -10,6 +10,10 @@ before other tests that depend on kvs.
 
 . `dirname $0`/sharness.sh
 
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(($(nproc)+1))
 test ${SIZE} -lt 4 && SIZE=4
@@ -287,4 +291,19 @@ test_expect_success 'kvs: watch-unwatchloop 1000 watch/unwatch ok' '
 	${FLUX_BUILD_DIR}/t/kvs/watch unwatchloop $TEST.a &&
 	flux kvs unlink $TEST.a
 '
+
+# large values/dirs
+
+test_expect_success 'kvs: store value exceeding RFC 10 max blob size of 1m' '
+	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $TEST.tortureval --count 1 --size=1048577
+'
+
+test_expect_success 'kvs: store 10,000 keys in one dir' '
+	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $TEST.bigdir --count 10000
+'
+
+test_expect_success LONGTEST 'kvs: store 1,000,000 keys in one dir' '
+	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $TEST.bigdir2 --count 1000000
+'
+
 test_done


### PR DESCRIPTION
This PR Is not complete but I thought it should get some early high level review concurrently with progress refining it.

The [sophia](http://sphia.org/) embedable database engine is imported into `libflux-internal`, then a new module `cas` (content addressable store) is added which stores arbitrary blobs persistently.  The protocol is simple:  send a blob, get back an SHA1; send an SHA1, get back a blob.  blobs and SHA1's are sent using raw message payloads to avoid the overhead of json encoding.  Files are created in the same temporary directory as the ipc sockets and persist for the lifetime of the session only.  This module is then loaded automatically on rank 0 (only).

To test the cas service, two new operations were added to `flux-kvs`:  putobj and getobj.  These behave similar to the git-hash and get-cat-file utilities, respectively:
```
$ echo hello | ./flux kvs putobj
5f273d69af9e02668217f42bec007fe2492f52f8
$ ./flux kvs getobj 5f273d69af9e02668217f42bec007fe2492f52f8
hello
```

The KVS was then modified so that the rank 0 object cache is expired temporally like other ranks, and the CAS is integrated as the "upstream" cache of rank 0.

This should get the memory utilization of the KVS on rank 0 under control, at the expense of some disk usage (which if it is a ramdisk, well...), and increased commit latency.

I'm not sure if I'm using sophia correctly, particularly with regard to error handling and memory management, as there is not much in the way of examples online.  What I have seems to work at least superficially.  I have enabled lz4 compression of objects.  Some sophia spelunking and stress testing is required to understand how it should be used to best advantage.

There is definitely some work needed to clean things up, factor out duplicated code, and adding tests, but what's here seems to work with make check and manual poking.