### PR TITLE
fix invalid errors in wreckrun initialization, use flux_log instead of printf for debug in resource-hwloc

### DIFF
--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -75,8 +75,8 @@ static ctx_t *getctx (flux_t h)
     if (!path)
         path = flux_conf_get (cf, "resource.hwloc.default_xml");
 
-    fprintf(stderr, "rank %u reading from conf %s\n", rank, path);
     if (path) {
+        flux_log (h, LOG_INFO, "loading hwloc from %s", path);
         if (try_hwloc_load (ctx, path) == 0) {
             return ctx;
         } else {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1539,8 +1539,8 @@ int start_trace_task (struct task_info *t)
 
 int rexecd_init (struct prog_ctx *ctx)
 {
-    int errnum;
-    char *name;
+    int errnum = 0;
+    char *name = NULL;
     int rc = asprintf (&name, "lwj.%ju.init", (uintmax_t) ctx->id);
     if (rc < 0)
         log_fatal (ctx, 1, "rexecd_init: asprintf: %s", strerror (errno));
@@ -1556,6 +1556,7 @@ int rexecd_init (struct prog_ctx *ctx)
      *   one or more nodes encountered a fatal error and we should abort
      */
     if ((kvsdir_get_int (ctx->kvs, "fatalerror", &errnum) < 0) && errno != ENOENT) {
+        errnum = 1;
         log_msg (ctx, "Error: kvsdir_get (fatalerror): %s\n", strerror (errno));
     }
     if (errnum) {


### PR DESCRIPTION
This PR has a couple small fixes, most notably a fix for wreckrun failures Tapasya was experiencing on cab. The issue here was uninitialized `errnum` in `rexecd_init`, which when randomly initialized to non-zero would trigger global failure of job as "initialization failure".

The other fix replaces fprintf() debug with a call to flux_log() in resource-hwloc. @garlick has a similar fix sitting in #471 -- I'm fine with either version. 