### PR TITLE
Mask cores outside the CPUSET of the spawning broker

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -19,6 +19,7 @@ _core_build.py: $(MAKE_BINDING)
 	                          --modname _core \
 				  --add_sub '.*va_list.*|||' \
 				  --ignore_header 'handle_impl' \
+				  --ignore_header 'macros' \
 				  --add_long_sub 'FLUX_SEC_TYPE_ALL.*\n.*\),|||FLUX_SEC_TYPE_ALL = 7,'\
 				  flux.h
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -150,6 +150,38 @@ int flux_log_error (flux_t h, const char *fmt, ...)
     return rc;
 }
 
+// Instantiate inline flux_log_check functions, this is *necessary* for
+// linking to work under C99 rules
+int flux_log_check_int (flux_t h,
+               int res,
+               const char *fmt,
+               ...  )
+{
+    if (res < 0) {
+        va_list ap;
+        va_start (ap, fmt);
+        flux_log_verror (h, fmt, ap);
+        va_end (ap);
+        exit (errno);
+    }
+    return res;
+}
+
+void *flux_log_check_ptr (flux_t h,
+                 void *res,
+                 const char *fmt,
+                 ... )
+{
+    if (res == NULL) {
+        va_list ap;
+        va_start (ap, fmt);
+        flux_log_verror (h, fmt, ap);
+        va_end (ap);
+        exit (errno);
+    }
+    return res;
+}
+
 static int dmesg_clear (flux_t h, int seq)
 {
     flux_rpc_t *rpc;

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -5,6 +5,8 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <syslog.h>
+#include <stdlib.h>
+#include <errno.h>
 
 #include "handle.h"
 
@@ -29,6 +31,34 @@ int flux_log (flux_t h, int level, const char *fmt, ...)
 int flux_log_verror (flux_t h, const char *fmt, va_list ap);
 int flux_log_error (flux_t h, const char *fmt, ...)
                  __attribute__ ((format (printf, 2, 3)));
+
+/* Check for error return codes, if one is found log an error with log_error
+ * and die with error code errno */
+__attribute__ ((format (printf, 3, 4)))
+int flux_log_check_int (flux_t h,
+               int res,
+               const char *fmt,
+               ...  );
+
+__attribute__ ((format (printf, 3, 4)))
+void *flux_log_check_ptr (flux_t h,
+                 void *res,
+                 const char *fmt,
+                 ... );
+
+#define FLOG_REAL_STRINGIFY(X) #X
+#define FLOG_STRINGIFY(X) FLOG_REAL_STRINGIFY (X)
+#define FLOG_POSITION __FILE__ ":" FLOG_STRINGIFY (__LINE__)
+
+// NOTE: FMT string *MUST* be a string literal
+#define FLUX_CHECK_INT(H, X, ...) flux_log_check_int ((H), (X), FLOG_POSITION \
+                                          ":negative integer from:" \
+                                          FLOG_STRINGIFY (X) ":" \
+                                          __VA_ARGS__)
+#define FLUX_CHECK_PTR(H, X, ...) flux_log_check_ptr ((H), (X), FLOG_POSITION \
+                                          ":null pointer from:" \
+                                          FLOG_STRINGIFY (X) ":" \
+                                          __VA_ARGS__)
 
 #define FLUX_LOG_ERROR(h) \
     (void)flux_log_error ((h), "%s::%d[%s]", __FILE__, __LINE__, __FUNCTION__)

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <errno.h>
 
+#include "src/common/libutil/macros.h"
+
 #include "handle.h"
 
 typedef void (*flux_log_f)(const char *facility, int level, uint32_t rank,
@@ -46,18 +48,16 @@ void *flux_log_check_ptr (flux_t h,
                  const char *fmt,
                  ... );
 
-#define FLOG_REAL_STRINGIFY(X) #X
-#define FLOG_STRINGIFY(X) FLOG_REAL_STRINGIFY (X)
-#define FLOG_POSITION __FILE__ ":" FLOG_STRINGIFY (__LINE__)
+#define FLOG_POSITION __FILE__ ":" STRINGIFY (__LINE__)
 
 // NOTE: FMT string *MUST* be a string literal
 #define FLUX_CHECK_INT(H, X, ...) flux_log_check_int ((H), (X), FLOG_POSITION \
                                           ":negative integer from:" \
-                                          FLOG_STRINGIFY (X) ":" \
+                                          STRINGIFY (X) ":" \
                                           __VA_ARGS__)
 #define FLUX_CHECK_PTR(H, X, ...) flux_log_check_ptr ((H), (X), FLOG_POSITION \
                                           ":null pointer from:" \
-                                          FLOG_STRINGIFY (X) ":" \
+                                          STRINGIFY (X) ":" \
                                           __VA_ARGS__)
 
 #define FLUX_LOG_ERROR(h) \

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -55,7 +55,8 @@ libutil_la_SOURCES = \
 	vec.h \
 	usa.c \
 	usa.h \
-	iterators.h
+	iterators.h \
+	macros.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -343,6 +343,14 @@ msg (const char *fmt, ...)
     va_end (ap);
 }
 
+int check_int (int res,
+               const char *fmt,
+               ...  );
+
+void *check_ptr (void *res,
+                 const char *fmt,
+                 ... );
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -345,11 +345,32 @@ msg (const char *fmt, ...)
 
 int check_int (int res,
                const char *fmt,
-               ...  );
+               ...  )
+{
+    if (res < 0) {
+        va_list ap;
+        va_start (ap, fmt);
+        log_msg (fmt, ap);
+        va_end (ap);
+        exit (1);
+    }
+    return res;
+}
+
 
 void *check_ptr (void *res,
                  const char *fmt,
-                 ... );
+                 ... )
+{
+    if (res == NULL) {
+        va_list ap;
+        va_start (ap, fmt);
+        log_msg (fmt, ap);
+        va_end (ap);
+        exit (1);
+    }
+    return res;
+}
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 void log_init (char *p);
 void log_fini (void);
@@ -22,6 +23,50 @@ void msg_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
 void msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
+
+__attribute__ ((format (printf, 2, 3)))
+inline int check_int (int res,
+               const char *fmt,
+               ...  )
+{
+    if (res < 0) {
+        va_list ap;
+        va_start (ap, fmt);
+        log_msg (fmt, ap);
+        va_end (ap);
+        exit (1);
+    }
+    return res;
+}
+
+__attribute__ ((format (printf, 2, 3)))
+inline void *check_ptr (void *res,
+                 const char *fmt,
+                 ... )
+{
+    if (res == NULL) {
+        va_list ap;
+        va_start (ap, fmt);
+        log_msg (fmt, ap);
+        va_end (ap);
+        exit (1);
+    }
+    return res;
+}
+
+#define REAL_STRINGIFY(X) #X
+#define STRINGIFY(X) REAL_STRINGIFY (X)
+#define POSITION __FILE__ ":" STRINGIFY (__LINE__)
+
+// NOTE: FMT string *MUST* be a string literal
+#define CHECK_INT(X, ...) check_int ((X), POSITION \
+                                          ":negative integer from:" \
+                                          STRINGIFY (X) ":" \
+                                          __VA_ARGS__)
+#define CHECK_PTR(X, ...) check_ptr ((X), POSITION \
+                                          ":null pointer from:" \
+                                          STRINGIFY (X) ":" \
+                                          __VA_ARGS__)
 
 #define oom() do { \
   errn_exit (ENOMEM, "%s::%s(), line %d", __FILE__, __FUNCTION__, __LINE__); \

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -24,48 +24,27 @@ void msg_exit (const char *fmt, ...)
 void msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 
-__attribute__ ((format (printf, 2, 3)))
-inline int check_int (int res,
+int check_int (int res,
                const char *fmt,
                ...  )
-{
-    if (res < 0) {
-        va_list ap;
-        va_start (ap, fmt);
-        log_msg (fmt, ap);
-        va_end (ap);
-        exit (1);
-    }
-    return res;
-}
-
-__attribute__ ((format (printf, 2, 3)))
-inline void *check_ptr (void *res,
+__attribute__ ((format (printf, 2, 3)));
+void *check_ptr (void *res,
                  const char *fmt,
                  ... )
-{
-    if (res == NULL) {
-        va_list ap;
-        va_start (ap, fmt);
-        log_msg (fmt, ap);
-        va_end (ap);
-        exit (1);
-    }
-    return res;
-}
+__attribute__ ((format (printf, 2, 3)));
 
-#define REAL_STRINGIFY(X) #X
-#define STRINGIFY(X) REAL_STRINGIFY (X)
-#define POSITION __FILE__ ":" STRINGIFY (__LINE__)
+#define LOG_REAL_STRINGIFY(X) #X
+#define LOG_STRINGIFY(X) LOG_REAL_STRINGIFY (X)
+#define LOG_POSITION __FILE__ ":" LOG_STRINGIFY (__LINE__)
 
 // NOTE: FMT string *MUST* be a string literal
-#define CHECK_INT(X, ...) check_int ((X), POSITION \
+#define CHECK_INT(X, ...) check_int ((X), LOG_POSITION \
                                           ":negative integer from:" \
-                                          STRINGIFY (X) ":" \
+                                          LOG_STRINGIFY (X) ":" \
                                           __VA_ARGS__)
-#define CHECK_PTR(X, ...) check_ptr ((X), POSITION \
+#define CHECK_PTR(X, ...) check_ptr ((X), LOG_POSITION \
                                           ":null pointer from:" \
-                                          STRINGIFY (X) ":" \
+                                          LOG_STRINGIFY (X) ":" \
                                           __VA_ARGS__)
 
 #define oom() do { \

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -5,6 +5,8 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
+#include "macros.h"
+
 void log_init (char *p);
 void log_fini (void);
 void log_set_dest (char *dest);
@@ -33,18 +35,16 @@ void *check_ptr (void *res,
                  ... )
 __attribute__ ((format (printf, 2, 3)));
 
-#define LOG_REAL_STRINGIFY(X) #X
-#define LOG_STRINGIFY(X) LOG_REAL_STRINGIFY (X)
-#define LOG_POSITION __FILE__ ":" LOG_STRINGIFY (__LINE__)
+#define LOG_POSITION __FILE__ ":" STRINGIFY (__LINE__)
 
 // NOTE: FMT string *MUST* be a string literal
 #define CHECK_INT(X, ...) check_int ((X), LOG_POSITION \
                                           ":negative integer from:" \
-                                          LOG_STRINGIFY (X) ":" \
+                                          STRINGIFY (X) ":" \
                                           __VA_ARGS__)
 #define CHECK_PTR(X, ...) check_ptr ((X), LOG_POSITION \
                                           ":null pointer from:" \
-                                          LOG_STRINGIFY (X) ":" \
+                                          STRINGIFY (X) ":" \
                                           __VA_ARGS__)
 
 #define oom() do { \

--- a/src/common/libutil/macros.h
+++ b/src/common/libutil/macros.h
@@ -1,0 +1,7 @@
+#ifndef LIBUTIL_MACROS_H
+#define LIBUTIL_MACROS_H 1
+
+#define REAL_STRINGIFY(X) #X
+#define STRINGIFY(X) REAL_STRINGIFY (X)
+
+#endif

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -45,15 +45,15 @@ typedef struct
     bool loaded;
 } ctx_t;
 
-int try_hwloc_load (ctx_t *ctx, const char *const path)
+int try_hwloc_load (flux_t h, ctx_t *ctx, const char *const path)
 {
-    CHECK_INT (
+    FLUX_CHECK_INT (h,
         hwloc_topology_set_flags (ctx->topology, HWLOC_TOPOLOGY_FLAG_WHOLE_IO));
     if (path) {
         // load my structure from the hwloc xml file at this path
-        CHECK_INT (hwloc_topology_set_xml (ctx->topology, path));
+        FLUX_CHECK_INT (h, hwloc_topology_set_xml (ctx->topology, path));
     }
-    return CHECK_INT (hwloc_topology_load (ctx->topology),
+    return FLUX_CHECK_INT (h, hwloc_topology_load (ctx->topology),
                       "failed to load hwloc topology, path=%s", path);
 }
 
@@ -64,11 +64,11 @@ static void ctx_init (flux_t h, ctx_t *ctx)
         err_exit ("flux_get_rank");
     }
 
-    CHECK_INT (hwloc_topology_init (&ctx->topology));
+    FLUX_CHECK_INT (h, hwloc_topology_init (&ctx->topology));
 
     char *path = NULL;
     char *conf_path =
-        CHECK_PTR (xasprintf ("config.resource.hwloc.xml.%" PRIu32, rank));
+        FLUX_CHECK_PTR (h, xasprintf ("config.resource.hwloc.xml.%" PRIu32, rank));
     kvs_get_string (h, conf_path, &path);
     CHECK_INT(hwloc_topology_init (&ctx->topology));
     free (conf_path);
@@ -78,20 +78,20 @@ static void ctx_init (flux_t h, ctx_t *ctx)
 
     if (path) {
         flux_log (h, LOG_INFO, "loading hwloc from %s", path);
-        if (try_hwloc_load (ctx, path) >= 0) {
+        if (try_hwloc_load (h, ctx, path) >= 0) {
             return;  // Success!
         } else {
             err_exit ("hwloc load failed for specified path");
         }
     }
 
-    if (try_hwloc_load (ctx, NULL) < 0)
+    if (try_hwloc_load (h, ctx, NULL) < 0)
         err_exit ("hwloc failed to load topology");
 
     if (!path) {  // Only restrict the topology if using the host topology
         // Mask off hardware that we can't use
-        hwloc_bitmap_t restrictset = CHECK_PTR (hwloc_bitmap_alloc ());
-        CHECK_INT (hwloc_get_cpubind (ctx->topology,
+        hwloc_bitmap_t restrictset = FLUX_CHECK_PTR (h, hwloc_bitmap_alloc ());
+        FLUX_CHECK_INT (h, hwloc_get_cpubind (ctx->topology,
                                       restrictset,
                                       HWLOC_CPUBIND_PROCESS));
         int err = hwloc_topology_restrict (ctx->topology, restrictset, 0);
@@ -332,10 +332,10 @@ static void load_cb (flux_t h,
         return;
     }
     char *completion_path = xasprintf ("resource.hwloc.loaded.%" PRIu32, rank);
-    CHECK_INT (kvs_put_int (h, completion_path, 1));
+    FLUX_CHECK_INT (h, kvs_put_int (h, completion_path, 1));
     free (completion_path);
 
-    CHECK_INT (kvs_fence (h, "resource_hwloc_loaded", size));
+    FLUX_CHECK_INT (h, kvs_fence (h, "resource_hwloc_loaded", size));
 
     flux_log (h, LOG_DEBUG, "loaded");
 

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -51,7 +51,8 @@ int try_hwloc_load (ctx_t *ctx, const char *const path)
         // load my structure from the hwloc xml file at this path
         hwloc_topology_set_xml (ctx->topology, path);
     }
-    return hwloc_topology_load (ctx->topology);
+    return CHECK_INT (hwloc_topology_load (ctx->topology),
+                      "failed to load hwloc topology, path=%s", path);
 }
 
 static ctx_t *getctx (flux_t h)


### PR DESCRIPTION
This patch masks off cores that are disallowed for scheduling due to a cpuset
mask from the hwloc resource list in the kvs and elsewhere, includes quite a few more checks for intermediate failure of hwloc as well.  Fixes #461.