### PR TITLE
resource_hwloc messaging rework and reload

### DIFF
--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -36,6 +36,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/shortjson.h"
+#include "src/modules/kvs/kvs.h"
 #include "src/modules/libmrpc/mrpc.h"
 
 typedef struct
@@ -54,31 +55,27 @@ int try_hwloc_load (ctx_t *ctx, const char *const path)
     return hwloc_topology_load (ctx->topology);
 }
 
-static ctx_t *getctx (flux_t h)
+static void ctx_init (flux_t h, ctx_t *ctx)
 {
-    flux_conf_t cf = flux_conf_create ();
-    if (kvs_conf_load (h, cf) < 0)
-        err_exit ("could not load config from KVS");
-
     uint32_t rank;
     if (flux_get_rank (h, &rank) < 0) {
         err_exit ("flux_get_rank");
     }
 
-    ctx_t *ctx = xzmalloc (sizeof(ctx_t));
     hwloc_topology_init (&ctx->topology);
 
-    char *conf_path = xasprintf ("resource.hwloc.xml.%" PRIu32, rank);
-    const char *path = flux_conf_get (cf, conf_path);
+    char *path = NULL;
+    char *conf_path = xasprintf ("config.resource.hwloc.xml.%" PRIu32, rank);
+    kvs_get_string (h, conf_path, &path);
     free (conf_path);
 
     if (!path)
-        path = flux_conf_get (cf, "resource.hwloc.default_xml");
+        kvs_get_string (h, "config.resource.hwloc.default_xml", &path);
 
     if (path) {
         flux_log (h, LOG_INFO, "loading hwloc from %s", path);
         if (try_hwloc_load (ctx, path) == 0) {
-            return ctx;
+            return;  // Success!
         } else {
             err_exit ("hwloc load failed for specified path");
         }
@@ -88,16 +85,20 @@ static ctx_t *getctx (flux_t h)
         err_exit ("hwloc failed to load topology");
 
     ctx->loaded = false;
-    return ctx;
+    free (path);
 }
 
-#if 0
-static void freectx(ctx_t * ctx)
+static void ctx_deinit (ctx_t *ctx)
 {
-    hwloc_topology_destroy(ctx->topology);
-    free(ctx);
+    hwloc_topology_destroy (ctx->topology);
 }
-#endif
+
+static ctx_t *getctx (flux_t h)
+{
+    ctx_t *ctx = xzmalloc (sizeof(ctx_t));
+    ctx_init (h, ctx);
+    return ctx;
+}
 
 /* Copy input arguments to output arguments and respond to RPC.
 */
@@ -308,11 +309,22 @@ static void load_cb (flux_t h,
     kvs_put_int (h, completion_path, 1);
     free (completion_path);
 
-    kvs_fence (h, "resource_hwloc_loaded", size);
+    kvs_fence (h, "resource-hwloc_loaded", size);
 
     flux_log (h, LOG_DEBUG, "loaded");
 
     ctx->loaded = true;
+}
+
+static void reload_cb (flux_t h,
+                       flux_msg_handler_t *watcher,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    ctx_t *ctx = arg;
+    ctx_deinit (ctx);
+    ctx_init (h, ctx);
+    load_cb(h, watcher, msg, arg);
 }
 
 static void topo_cb (flux_t h,
@@ -361,7 +373,7 @@ static void topo_cb (flux_t h,
         hwloc_topology_destroy (rank);
         free (xml);
 
-        flux_log (h, LOG_INFO, "resource_hwloc: loaded from %s", base_key);
+        flux_log (h, LOG_INFO, "resource-hwloc: loaded from %s", base_key);
     }
 
     kvsitr_destroy (base_iter);
@@ -384,24 +396,14 @@ done:
     Jput (out);
 }
 
-static void start_all (flux_t h, ...)
-{
-    flux_msg_handler_t *w;
-    va_list ap;
-    va_start (ap, h);
-    while ((w = va_arg (ap, flux_msg_handler_t *))) {
-        flux_msg_handler_start (w);
-    }
-}
-
-struct
-{
-    flux_msg_handler_t *load;
-    flux_msg_handler_t *query;
-    flux_msg_handler_t *get;
-    flux_msg_handler_t *topo;
-    flux_msg_handler_t *END;
-} handlers = {};
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT,   "resource-hwloc.load",  load_cb, NULL },
+    { FLUX_MSGTYPE_EVENT,   "resource-hwloc.reload",reload_cb, NULL },
+    { FLUX_MSGTYPE_REQUEST, "resource-hwloc.topo",  topo_cb, NULL },
+    { FLUX_MSGTYPE_REQUEST, "resource-hwloc.query", query_cb, NULL },
+    { FLUX_MSGTYPE_REQUEST, "resource-hwloc.get",   get_cb, NULL },
+    FLUX_MSGHANDLER_TABLE_END
+};
 
 int mod_main (flux_t h, int argc, char **argv)
 {
@@ -415,26 +417,20 @@ int mod_main (flux_t h, int argc, char **argv)
         return -1;
     }
 
-    handlers.load = flux_msg_handler_create (h, FLUX_MATCH_EVENT, load_cb, ctx);
-    flux_msg_handler_start (handlers.load);
-    handlers.query =
-        flux_msg_handler_create (h, FLUX_MATCH_REQUEST, query_cb, ctx);
-    flux_msg_handler_start (handlers.query);
-    handlers.get = flux_msg_handler_create (h, FLUX_MATCH_REQUEST, get_cb, ctx);
-    flux_msg_handler_start (handlers.get);
-    handlers.topo =
-        flux_msg_handler_create (h, FLUX_MATCH_REQUEST, topo_cb, ctx);
-    flux_msg_handler_start (handlers.topo);
+    if (flux_event_subscribe (h, "resource-hwloc.reload") < 0) {
+        flux_log (h, LOG_ERR, "%s: flux_event_subscribe", __FUNCTION__);
+        return -1;
+    }
+
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log (h, LOG_ERR, "flux_msghandler_add: %s", strerror (errno));
+        return -1;
+    }
 
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log (h, LOG_ERR, "flux_reactor_run: %s", strerror (errno));
         return -1;
     }
-
-    flux_msg_handler_destroy (handlers.load);
-    flux_msg_handler_destroy (handlers.query);
-    flux_msg_handler_destroy (handlers.get);
-    flux_msg_handler_destroy (handlers.topo);
 
     return 0;
 }


### PR DESCRIPTION
Cleaned up the message handling in the resource-hwloc module.  This patch also
adds support for the `resource-hwloc.reload` event, which causes the module to
re-check for configured hwloc parameters in the kvs configuration and load
them in place of the current config if they exist.

This should cover the rest of #450, at least in combination with PR #475. 