### PR TITLE
fix race in signal delivery for jobs in "running" state

### DIFF
--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1118,6 +1118,9 @@ int exec_command (struct prog_ctx *ctx, int i)
     if (cpid < 0)
         log_fatal (ctx, 1, "fork: %s", strerror (errno));
     if (cpid == 0) {
+        /* give each task its own process group so we can use killpg(2) */
+        setpgrp ();
+
         child_io_setup (t);
 
         if (sigmask_unblock_all () < 0)
@@ -1141,8 +1144,6 @@ int exec_command (struct prog_ctx *ctx, int i)
             ptrace (PTRACE_TRACEME, 0, NULL, 0);
         }
 
-        /* give each task its own process group so we can use killpg(2) */
-        setpgrp();
         /*
          *  Reassign environment:
          */

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -11,7 +11,7 @@ cachedir=$HOME/local/.cache
 #
 downloads="\
 https://github.com/dun/munge/archive/munge-0.5.11.tar.gz \
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz \
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.6.tar.gz \
 http://download.zeromq.org/zeromq-4.0.4.tar.gz \
 http://download.zeromq.org/czmq-3.0.2.tar.gz \
 https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz \


### PR DESCRIPTION
This PR should resolve test failures for `flux wreck kill` as reported in #448. The problem is that the kill request is handled by sending a signal to the process group for each task, which the tasks should be moved to during startup. However, there is a small window where a job can be in "running" state, but one or more tasks has not yet been put in its own process group (this is done as a place holder for containment, and should be handled a different way in the wreck replacement). This PR addresses this race by first calling `setpgrp(2)` immediately in the child, and by falling back to a simple `kill(2)` if `killpg(2)` fails, as this likely means the task is still initializing anyway.

Also, due to missing libsodium-1.0.0 on downloads.libsodium.org, this PR also updates libsodium for travis builds to v1.0.6.
