### PR TITLE
modules/kvs: plug leak in watch_request_cb

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1171,6 +1171,7 @@ static int watch_request_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
         if (flux_json_respond (ctx->h, out, &zcpy) < 0)
             flux_log (ctx->h, LOG_ERR, "%s: flux_respond: %s",
                      __FUNCTION__, strerror (errno));
+        Jput (out);
         zmsg_destroy (&zcpy);
         reply_sent = true;
     }


### PR DESCRIPTION
I was running some valgrind tests, which seemed to indicate a small leak in the watch request callback of the kvs. I know @garlick is working in this area already, so feel free to close this PR if it is made invalid by your work, or you've already got a fix.