### PR TITLE
add job.sumbit service, flux-submit(1) command, and global sequences for jobids

### DIFF
--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -11,6 +11,7 @@ MAN1_FILES_PRIMARY = \
 	flux-topo.1 \
 	flux-snoop.1 \
 	flux-ping.1 \
+	flux-submit.1 \
 	flux-wreckrun.1 \
 	flux-wreck.1 \
 	flux-start.1 \

--- a/doc/man1/flux-submit.adoc
+++ b/doc/man1/flux-submit.adoc
@@ -1,0 +1,138 @@
+FLUX-SUBMIT(1)
+================
+:doctype: manpage
+
+
+NAME
+----
+flux-submit - Flux utility for submitting job requests to a scheduler
+
+
+SYNOPSIS
+--------
+[verse]
+'flux submit' [-n <ntasks>] [-N <nnodes>] [-t <tasks-per-node>]
+                [-o|--options='OPTIONS']
+                [-O|--output='FILENAME'] [-E|--error='FILENAME']
+                [-i|--input='HOW'] ['COMMANDS'...]
+
+
+DESCRIPTION
+-----------
+
+'flux submit' is the front-end command for submitting jobs to
+a Flux comms session for eventual execution by a Flux scheduler.
+Once a job has been scheduled for execution, it will be executed
+using the WRECK remote execution prototype. 
+
+See flux-wreckrun(1) for more information about execution
+method.
+
+OPTIONS
+-------
+
+--ntasks='ntasks'::
+-n 'ntasks'::
+	Request to run a total of 'ntasks' tasks. If '--ntasks' is used alone,
+	i.e. without '--nnodes', then 'flux submit' will attempt to
+	distribute the 'ntasks' tasks across all nodes of the Flux comms
+	session.
+
+--nnodes='nnodes'::
+-N 'nnodes'::
+	Request to run across 'nnodes' nodes in the current comms session.
+	
+--tasks-per-node='tpn'::
+-t 'tpn'::
+	Set the number of tasks to run per node to 'tpn'. The default is
+	--tasks-per-node=1. This value is overridden by '--ntasks' if used.
+
+--output='FILENAME'::
+-O 'FILENAME'::
+	Duplicate stdout and stderr from tasks to a file or files. 'FILENAME'
+	is optionally a mustache template which expands the keys 'id', 'cmd'
+	and 'taskid'. (e.g. '--output=flux-{{id}}.out')
+
+--error='FILENAME'::
+-E 'FILENAME'::
+	Send stderr to a different location than stdout.
+
+--input='HOW'::
+-i 'HOW'::
+	Indicate how to deal with stdin for tasks. 'HOW' is a list of 'src:dst'
+	pairs where 'src' is a source 'FILENAME' which may optionally be a
+	mustache template as in `--output`, or the special term `stdin` to
+	indicate the stdin from a front end program, and 'dst' is a list of
+	taskids or `*` or `all` to indicate all tasks. The default is `stdin:*`.
+	If only one of 'src' or 'dst' is specified, a heuristic is used to
+	determine whether a list of tasks or an input file was meant. (e.g
+	`--input=file.in` will use `file.in` as input for all tasks, and
+	`--input=0` will send stdin to task 0 only.
+
+--options='options,...'::
+-o 'options,...'::
+	Apply extended job options to the current execution. Examples of
+	these options are described in the xref:extra-options[].
+
+EXTRA OPTIONS
+-------------
+[[extra-options]]
+
+Extra options can be supplied on the `flux submit` command via the
+'--options' command line option. Multiple options should be separated
+via commas. Currently available options include:
+
+'stdio-commit-on-open'::
+	Commit to kvs on stdio open in each task. The default is to
+	delay commit. Without this option, stdio files for jobs will
+	not appear in KVS on all nodes until the next KVS commit.
+	The default behavior avoids a kvs commit storm as stdout and
+	stderr files are opened for every task.
+
+'stdio-commit-on-close'::
+	Commit to kvs for each stdio stream as it gets EOF. The default
+	is to delay the commit. Without this option, stdio files for
+	jobs will not appear to close until after the next natural
+	KVS commit. The default behavior avoids a kvs commit storm
+	as stdout and stderr files are closed from many tasks. This
+	option may need to be enabled if you need to detect immediately
+	when a stdout or stderr stream is closed from a task.
+
+'stdio-delay-commit'::
+	Disable commit to kvs for each line of output. The default
+	behavior is to call kvs_commit() after each line of output
+	from every task. If many tasks are writing multiple lines
+	of output and it is not necessary to see lines of output
+	as they are generated, it will speed up job execution to
+	enable this option.
+
+'commit-on-task-exit'::
+	Commit to the kvs for each task exit event. The default behavior
+	is to write the task exit status to the kvs as each task in
+	a lightweight job exits, but delay kvs commit. This avoids
+	a kvs commit storm when many tasks are exiting simultaneously.
+	This option may need to be enabled if knowlege of exit status or
+	fact that tasks have exited is required in real time.
+
+'stop-children-in-exec'::
+	Start tasks in a STOPPED state waiting for attach from a
+	debugger. This option is provided for use with parallel
+	debuggers such as TotalView.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+SEE ALSO
+--------
+flux-wreckrun(1), flux-wreck(1)

--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -44,6 +44,12 @@ exit with the highest exit code of all tasks.
 Send SIGTERM to running job 'jobid'. If '--signal' is used, send signal 'N'
 where 'N' may  be a signal number or name such as 'SIGKILL'.
 
+*last-jobid*::
+Return the current value of the 'lwj' sequence number, that is the last
+jobid allocated to a submitted wreck job. Other jobs may be started
+between the time the id is obtained and when it is displayed in this
+command, so 'last-jobid' should not be relied upon during real workloads.
+
 AUTHOR
 ------
 This page is maintained by the Flux community.

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -32,6 +32,8 @@ flux_broker_SOURCES = \
 	shutdown.c \
 	attr.h \
 	attr.c \
+	sequence.h \
+	sequence.c \
 	log.h \
 	log.c
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -64,6 +64,7 @@
 #include "hello.h"
 #include "shutdown.h"
 #include "attr.h"
+#include "sequence.h"
 #include "log.h"
 
 #ifndef ZMQ_IMMEDIATE
@@ -115,6 +116,7 @@ typedef struct {
     bool event_active;          /* primary event source is active */
     svchash_t *services;
     svchash_t *eventsvc;
+    seqhash_t *seq;
     heartbeat_t *heartbeat;
     shutdown_t *shutdown;
     double shutdown_grace;
@@ -275,6 +277,8 @@ int main (int argc, char *argv[])
     ctx.modhash = modhash_create ();
     ctx.services = svchash_create ();
     ctx.eventsvc = svchash_create ();
+    if (!(ctx.seq = sequence_hash_create ()))
+	oom ();
     ctx.overlay = overlay_create ();
     ctx.snoop = snoop_create ();
     ctx.hello = hello_create ();
@@ -702,6 +706,7 @@ int main (int argc, char *argv[])
     snoop_destroy (ctx.snoop);
     svchash_destroy (ctx.services);
     svchash_destroy (ctx.eventsvc);
+    sequence_hash_destroy (ctx.seq);
     hello_destroy (ctx.hello);
     attr_destroy (ctx.attrs);
     flux_close (ctx.h);
@@ -2259,6 +2264,21 @@ static int event_hb_cb (zmsg_t **zmsg, void *arg)
     return 0;
 }
 
+static int cmb_seq (zmsg_t **zmsg, void *arg)
+{
+    ctx_t *ctx = arg;
+    JSON out = NULL;
+    int rc = sequence_request_handler (ctx->seq, (flux_msg_t *) *zmsg, &out);
+
+    if (flux_respond (ctx->h, *zmsg, rc < 0 ? errno : 0, Jtostr (out)) < 0)
+        flux_log (ctx->h, LOG_ERR, "cmb.seq: flux_respond: %s\n",
+                  strerror (errno));
+    if (out)
+        Jput (out);
+    zmsg_destroy (zmsg);
+    return (rc);
+}
+
 /* Shutdown:
  * - start the shutdown timer
  * - send shutdown message to all modules
@@ -2300,6 +2320,15 @@ static void broker_add_services (ctx_t *ctx)
           || !svc_add (ctx->eventsvc, "hb", event_hb_cb, ctx)
           || !svc_add (ctx->eventsvc, "shutdown", event_shutdown_cb, ctx))
         err_exit ("can't register internal services");
+
+    if (ctx->rank == 0) {
+        /* Add rank 0 only services:
+         */
+        if (!svc_add (ctx->services, "cmb.seq.fetch", cmb_seq, ctx)
+                || !svc_add (ctx->services, "cmb.seq.set", cmb_seq, ctx)
+                || !svc_add (ctx->services, "cmb.seq.destroy", cmb_seq, ctx))
+            err_exit ("can't register rank 0 internal services");
+    }
 }
 
 /**

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -73,7 +73,7 @@
 #endif
 
 const char *default_modules =
-    "connector-local,modctl,kvs,live,mecho,job[0],wrexec,barrier,resource-hwloc";
+    "connector-local,modctl,kvs,live,mecho,job,wrexec,barrier,resource-hwloc";
 
 const char *default_boot_method = "pmi";
 

--- a/src/broker/sequence.c
+++ b/src/broker/sequence.c
@@ -1,0 +1,236 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+/*
+ *  Simple class for named sequences service
+ */
+#ifndef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <czmq.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/shortjson.h"
+#include "sequence.h"
+
+struct seq_struct {
+    zhash_t *vhash;
+};
+
+seqhash_t * sequence_hash_create (void)
+{
+    seqhash_t *s;
+    zhash_t *zh;
+    if ((zh = zhash_new ()) == NULL)
+        return (NULL);
+    s = xzmalloc (sizeof (*s));
+    s->vhash = zh;
+    return (s);
+}
+
+void sequence_hash_destroy (seqhash_t *s)
+{
+    zhash_destroy (&s->vhash);
+    free (s);
+}
+
+static int64_t * seq_new (void)
+{
+    int64_t *v = xzmalloc (sizeof (*v));
+    *v = 0;
+    return (v);
+}
+
+static int64_t * seq_create (seqhash_t *s, const char *name)
+{
+    int rc;
+    int64_t *v = seq_new ();
+
+    if (zhash_lookup (s->vhash, name)) {
+        errno = EEXIST;
+        return (NULL);
+    }
+    v = seq_new ();
+    rc = zhash_insert (s->vhash, xstrdup (name), v);
+    assert (rc >= 0);
+    zhash_freefn (s->vhash, name, free);
+    return (v);
+}
+
+static int seq_destroy (seqhash_t *s, const char *name)
+{
+    if (!zhash_lookup (s->vhash, name)) {
+        errno = ENOENT;
+        return (-1);
+    }
+    zhash_delete (s->vhash, name);
+    return (0);
+}
+
+static int seq_fetch_and_add (seqhash_t *s, const char *name,
+                              int64_t preinc, int64_t postinc,
+                              int64_t *valp)
+{
+    int64_t *v = zhash_lookup (s->vhash, name);
+    if (v == NULL) {
+        errno = ENOENT;
+        return (-1);
+    }
+    *v += preinc;
+    *valp = *v;
+    *v += postinc;
+    return (0);
+}
+
+
+static int seq_set (seqhash_t *s, const char *name, int64_t val)
+{
+    int64_t *v = zhash_lookup (s->vhash, name);
+    if (v == NULL) {
+        errno = ENOENT;
+        return (-1);
+    }
+    *v = val;
+    return (0);
+}
+
+static int seq_cmp_and_set (seqhash_t *s, const char *name,
+                            int64_t oldval, int64_t newval)
+{
+    int64_t *v = zhash_lookup (s->vhash, name);
+    if (v == NULL) {
+        errno = ENOENT;
+        return (-1);
+    }
+    if (*v != oldval) {
+        errno = EAGAIN;
+        return (-1);
+    }
+    *v = newval;
+    return (0);
+}
+
+static int handle_seq_destroy (seqhash_t *s, JSON in, JSON *outp)
+{
+    const char *name;
+    if (!Jget_str (in, "name", &name)) {
+        errno = EPROTO;
+        return (-1);
+    }
+    if (seq_destroy (s, name) < 0)
+        return (-1);
+    *outp = Jnew ();
+    Jadd_str (*outp, "name", name);
+    Jadd_bool (*outp, "destroyed", true);
+    return (0);
+}
+
+static int handle_seq_set (seqhash_t *s, JSON in, JSON *outp)
+{
+    const char *name;
+    int64_t old, v;
+    if (!Jget_str (in, "name", &name)
+        || !Jget_int64 (in, "value", &v)) {
+        errno = EPROTO;
+        return (-1);
+    }
+    if ((Jget_int64 (in, "oldvalue", &old)
+        && (seq_cmp_and_set (s, name, old, v) < 0))
+        || (seq_set (s, name, v) < 0))
+            return (-1);
+
+    *outp = Jnew ();
+    Jadd_str (*outp, "name", name);
+    Jadd_bool (*outp, "set", true);
+    Jadd_int64 (*outp, "value", v);
+    return (0);
+}
+
+static int handle_seq_fetch (seqhash_t *s, JSON in, JSON *outp)
+{
+    const char *name;
+    bool create = false;
+    bool created = false;
+    int64_t v, pre, post, *valp;
+
+    if (!Jget_str (in, "name", &name)
+        || !Jget_bool (in, "create", &create)
+        || !Jget_int64 (in, "preincrement", &pre)
+        || !Jget_int64 (in, "postincrement", &post)) {
+        errno = EPROTO;
+        return (-1);
+    }
+    if (seq_fetch_and_add (s, name, pre, post, &v) < 0) {
+        if (!create || (errno != ENOENT))
+            return (-1);
+        /*  Create and initialize
+         */
+        valp = seq_create (s, name);
+        *valp += pre;
+        v = *valp;
+        *valp += post;
+        created = true;
+    }
+
+    *outp = Jnew ();
+    Jadd_str (*outp, "name", name);
+    Jadd_int64 (*outp, "value", v);
+    if (create && created)
+        Jadd_bool (*outp, "created", true);
+    return (0);
+}
+
+int sequence_request_handler (seqhash_t *s, const flux_msg_t *msg, JSON *outp)
+{
+    const char *json_str, *topic;
+    const char *method;
+    JSON in = NULL;
+    int rc = -1;
+
+    *outp = NULL;
+    if (flux_request_decode (msg, &topic, &json_str) < 0)
+        goto done;
+    if (!(in = Jfromstr (json_str))) {
+        errno = EPROTO;
+        goto done;
+    }
+
+    method = topic + 8;
+    if (strcmp (method, "fetch") == 0)
+        rc = handle_seq_fetch (s, in, outp);
+    else if (strcmp (method, "set") == 0)
+        rc = handle_seq_set (s, in, outp);
+    else if (strcmp (method, "destroy") == 0)
+        rc = handle_seq_destroy (s, in, outp);
+    else
+        errno = ENOSYS;
+done:
+    Jput (in);
+    return (rc);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/broker/sequence.h
+++ b/src/broker/sequence.h
@@ -1,0 +1,43 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+#ifndef BROKER_SEQUENCE_H
+#define BROKER_SEQUENCE_H
+
+#include <flux/core.h>
+#include "src/common/libutil/shortjson.h"
+
+typedef struct seq_struct seqhash_t;
+
+/* Create/destroy sequence generator handle
+ */
+seqhash_t *sequence_hash_create (void);
+void sequence_hash_destroy (seqhash_t *seq);
+
+int sequence_request_handler (seqhash_t *seq, const flux_msg_t *msg, JSON *op);
+
+#endif /* BROKER_SEQUENCE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -34,6 +34,7 @@ bin_PROGRAMS = flux
 #
 
 dist_fluxcmd_SCRIPTS = \
+	flux-submit \
 	flux-wreckrun \
 	flux-wreck \
 	flux-exec \

--- a/src/cmd/flux-submit
+++ b/src/cmd/flux-submit
@@ -1,0 +1,36 @@
+#!/usr/bin/env lua
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- flux-submit: submit jobs using job.submit interface
+--
+local wreck = require 'wreck' .new ()
+if not wreck:parse_cmdline (arg) then
+    wreck:die ("Failed to process cmdline args\n")
+end
+local id, err = wreck:submit ()
+if not id then wreck:die ("%s\n", err) end
+wreck:say ("Submitted jobid %d\n", id)
+os.exit (0)
+-- vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -294,6 +294,25 @@ Command {
  end
 }
 
+Command {
+ name = "last-jobid",
+ description = "Display the last jobid in lwj id sequence",
+ usage = "",
+ handler = function (self, arg)
+    local req = {
+       name = "lwj",
+       preincrement = 0,
+       postincrement = 0,
+       create = false
+    }
+    local resp, err = f:rpc ("cmb.seq.fetch", req)
+    if not resp then
+        die ("No last jobid found: %s", err)
+    end
+    print (resp.value)
+ end
+}
+
 
 local function main_usage ()
     eprintf ("Usage: %s COMMAND [OPTIONS]...\n", prog)

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -163,24 +163,18 @@ wreck:verbose ("%4.03fs: Sending LWJ request for %d tasks (cmdline \"%s\")\n",
     tt:get0(), wreck.ntasks, table.concat (wreck.cmdline, ' '))
 
 --
---  Send job request message with tag="job.create"
+--  Create a new job in kvs
 --
-local resp, err = f:rpc ('job.create', jobreq)
-if not resp then
-    wreck:die ("job.create: %s. Is the `job' module loaded?\n", err)
-end
+local jobid, err = wreck:createjob ()
+if not jobid then wreck:die ("%s\n", err) end
 
-if resp.errnum then
-    wreck:die ("job.create message failed with errnum=%d\n", resp.errnum)
-end
-
-wreck:verbose ("%4.03fs: Registered jobid %d\n", tt:get0(), resp.jobid)
+wreck:verbose ("%4.03fs: Registered jobid %d\n", tt:get0(), jobid)
 
 --
 --  Get a handle to this lwj kvsdir:
 --
-local lwj, err = f:kvsdir ("lwj.%d", resp.jobid)
-if not lwj then wreck:die ("f:kvsdir(lwj.%d): %s\n", resp.jobid, err) end
+local lwj, err = f:kvsdir ("lwj.%d", jobid)
+if not lwj then wreck:die ("f:kvsdir(lwj.%d): %s\n", jobid, err) end
 
 --if wreck:getopt ("i") then
 -- Always run in "immediate" mode for now:
@@ -205,10 +199,10 @@ if true then
 
     -- Now send run event:
     wreck:verbose ("%-4.03fs: Sending run event\n", tt:get0())
-    local rc,err = f:sendevent ("wrexec.run.%d", resp.jobid)
+    local rc,err = f:sendevent ("wrexec.run.%d", jobid)
     if not rc then wreck:die ("sendevent: %s\n", err) end
     if wreck.opts.d then
-        print (resp.jobid)
+        print (jobid)
         os.exit(0)
     end
 else
@@ -226,11 +220,11 @@ end
 local function check_job_completed ()
     if state == "failed" then
        log:dump()
-       wreck:die ("job %d failed\n", resp.jobid)
+       wreck:die ("job %d failed\n", jobid)
     end
     if taskio:complete() and
        (state == "complete" or state == "reaped") then
-        local rc = lwj_return_code (f, wreck, resp.jobid)
+        local rc = lwj_return_code (f, wreck, jobid)
         if rc == 0 then
             wreck:verbose ("All tasks completed successfully.\n");
         end
@@ -243,7 +237,7 @@ end
 --
 taskio, err = ioattach {
      flux = f,
-     jobid = resp.jobid,
+     jobid = jobid,
      ntasks = wreck.ntasks,
      labelio = wreck.opts.l,
      on_completion = check_job_completed
@@ -252,7 +246,7 @@ if not taskio then wreck:die ("error opening task io: %s\n", err) end
 
 log, err = logstream {
      flux = f,
-     jobid = resp.jobid,
+     jobid = jobid,
 }
 if not log then wreck:die ("error opening log stream: %s\n", err) end
 
@@ -277,7 +271,7 @@ f:iowatcher {
 --  Finally, a kvswatcher for the LWJ state:
 --
 local kw, err = f:kvswatcher  {
-    key = string.format ("lwj.%d.state", resp.jobid),
+    key = string.format ("lwj.%d.state", jobid),
     handler = function (kw, result)
         if result then
             state = result
@@ -316,8 +310,8 @@ repeat
     --   Check to see if we should terminate the job now:
     --
     if terminate then
-        wreck:verbose ("%4.03fs: Killing LWJ %d\n", tt:get0(), resp.jobid)
-        local rc,err = f:sendevent ("wreck.%d.kill", resp.jobid)
+        wreck:verbose ("%4.03fs: Killing LWJ %d\n", tt:get0(), jobid)
+        local rc,err = f:sendevent ("wreck.%d.kill", jobid)
         if not rc then
             wreck:say ("Error: Failed to send kill event: %s", err)
         end

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -71,18 +71,6 @@ local function alloc_tasks (f, wreck, lwj)
     local size = f.size
     local res
 
-    -- If nnodes was provided but -n, --ntasks not set, then
-    --  set ntasks to nnodes
-    if not wreck:getopt ('n') and wreck.nnodes then
-        wreck.ntasks = wreck.nnodes
-    end
-    wreck.ntasks = tonumber (wreck.ntasks)
-
-    -- If nnodes was not provided set it to the lesser of
-    --  session size and ntasks
-    if not wreck.nnodes then
-        wreck.nnodes = math.min (wreck.ntasks, f.size)
-    end
     res = fake_resource_array (wreck, wreck.nnodes or f.size)
     wreck:verbose ("Allocating %d tasks across %d available nodes..\n",
                 wreck.ntasks, size)
@@ -147,10 +135,6 @@ local sigtimer
 local state = ""
 
 wreck:add_options ({
-    { name = "tasks-per-node", char = "t", arg = "N",
-        usage = "Force number of tasks per node" },
-    { name = "nnodes", char = "N", arg = "N",
-        usage = "Force number of nodes" },
     { name = 'pre-launch-hook', char = "P", arg = "CODE",
         usage = "execute Lua CODE before launch." },
     { name = 'detach', char = "d",
@@ -171,19 +155,10 @@ local tt = timer.new()
 local f, err = flux.new()
 if not f then wreck:die ("Connecting to flux failed: %s\n", err) end
 
---  Check requested "nnodes" against available:
---
-if wreck.nnodes and wreck.nnodes > f.size then
-    wreck:die ("Error: Requested nodes (%d) exceeds available (%d)\n",
-               wreck.nnodes, f.size)
-end
-
-
 --
 --  Create a job request as Lua table:
 --
-local jobreq = wreck:jobreq()
-
+local jobreq = wreck:jobreq (f)
 wreck:verbose ("%4.03fs: Sending LWJ request for %d tasks (cmdline \"%s\")\n",
     tt:get0(), wreck.ntasks, table.concat (wreck.cmdline, ' '))
 
@@ -213,8 +188,6 @@ if true then
     --
     --  Send event to run the job
     --
-    wreck.nnodes = wreck:getopt ("N")
-    wreck.tasks_per_node = wreck:getopt ("t")
     alloc_tasks (f, wreck, lwj)
     -- Ensure lwj nnodes matches fake allocation
     lwj.nnodes = tonumber (wreck.nnodes)

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -304,15 +304,6 @@ struct flux_msg_handler_spec mtab[] = {
 
 int mod_main (flux_t h, int argc, char **argv)
 {
-    uint32_t rank;
-    if (flux_get_rank (h, &rank) < 0) {
-        flux_log (h, LOG_ERR, "flux_get_rank: %s", strerror (errno));
-        return (-1);
-    }
-    if (rank != 0) {
-        flux_log (h, LOG_INFO, "job module only runs on rank 0. Exiting...");
-        return (0);
-    }
     if (flux_msg_handler_addvec (h, mtab, NULL) < 0) {
         flux_log (h, LOG_ERR, "flux_msg_handler_addvec: %s", strerror (errno));
         return (-1);

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -239,6 +239,15 @@ struct flux_msg_handler_spec mtab[] = {
 
 int mod_main (flux_t h, int argc, char **argv)
 {
+    uint32_t rank;
+    if (flux_get_rank (h, &rank) < 0) {
+        flux_log (h, LOG_ERR, "flux_get_rank: %s", strerror (errno));
+        return (-1);
+    }
+    if (rank != 0) {
+        flux_log (h, LOG_INFO, "job module only runs on rank 0. Exiting...");
+        return (0);
+    }
     if (flux_msg_handler_addvec (h, mtab, NULL) < 0) {
         flux_log (h, LOG_ERR, "flux_msg_handler_addvec: %s", strerror (errno));
         return (-1);

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -279,7 +279,9 @@ out:
 }
 
 struct flux_msg_handler_spec mtab[] = {
-    { FLUX_MSGTYPE_REQUEST, "job.*", job_request_cb },
+    { FLUX_MSGTYPE_REQUEST, "job.create", job_request_cb },
+    { FLUX_MSGTYPE_REQUEST, "job.submit", job_request_cb },
+    { FLUX_MSGTYPE_REQUEST, "job.shutdown", job_request_cb },
     FLUX_MSGHANDLER_TABLE_END
 };
 

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -36,7 +36,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/jsonutil.h"
 
-static int kvs_job_new (flux_t h, unsigned long jobid)
+static int kvs_job_set_state (flux_t h, unsigned long jobid, const char *state)
 {
     int rc;
     char *key;
@@ -44,12 +44,17 @@ static int kvs_job_new (flux_t h, unsigned long jobid)
     if (asprintf (&key, "lwj.%lu.state", jobid) < 0)
         return (-1);
 
-    flux_log (h, LOG_INFO, "Setting job %ld to reserved", jobid);
-    rc = kvs_put_string (h, key, "reserved");
+    flux_log (h, LOG_INFO, "Setting job %ld to %s", jobid, state);
+    rc = kvs_put_string (h, key, state);
     kvs_commit (h);
 
     free (key);
     return rc;
+}
+
+static int kvs_job_new (flux_t h, unsigned long jobid)
+{
+    return kvs_job_set_state (h, jobid, "reserved");
 }
 
 /*

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -49,6 +49,7 @@ TESTS = \
 	lua/t0003-events.t \
 	lua/t0007-alarm.t \
 	lua/t0008-mrpc.t \
+	lua/t0009-sequences.t \
 	lua/t1000-reactor.t \
 	lua/t1001-timeouts.t \
 	lua/t1002-kvs.t \
@@ -96,6 +97,7 @@ check_SCRIPTS = \
 	lua/t0003-events.t \
 	lua/t0007-alarm.t \
 	lua/t0008-mrpc.t \
+	lua/t0009-sequences.t \
 	lua/t1000-reactor.t \
 	lua/t1001-timeouts.t \
 	lua/t1002-kvs.t \

--- a/t/lua/t0009-sequences.t
+++ b/t/lua/t0009-sequences.t
@@ -1,0 +1,143 @@
+#!/usr/bin/lua
+--
+--  Basic cmb.seq testing
+--
+local test = require 'fluxometer'.init (...)
+test:start_session { size=1 }
+
+plan (54)
+
+local flux = require_ok ('flux')
+local f, err = flux.new()
+type_ok (f, 'userdata', "create new flux handle")
+is (err, nil, "error is nil")
+
+is (f.rank, 0, "running on rank 0")
+
+--
+--  fetch and create
+--
+local request = { name = "foo",
+		  create = true,
+                  preincrement = 0,
+                  postincrement = 0 }
+local r, err = f:rpc ("cmb.seq.fetch", request)
+type_ok (r, 'table', "seq.create: returned table")
+is (err, nil, "seq.create: err is nil")
+is (r.name, "foo", "seq.create: name is correct")
+is (r.value, 0, "seq.create: initial value is 0")
+is (r.created, true, "seq.create: created = true")
+
+local r, err = f:rpc ("cmb.seq.fetch", request)
+type_ok (r, 'table', "seq.create: returned table")
+is (err, nil, "seq.create: err is nil")
+is (r.name, "foo", "seq.create: name is correct")
+is (r.value, 0, "seq.create: initial value is 0")
+is (r.created, nil, "seq.create: created = false")
+
+--
+--  cmb.seq.destroy
+--
+local r, err = f:rpc ("cmb.seq.destroy", { name = "foo" })
+type_ok (r, 'table', "seq.destroy: returned table")
+is (err, nil, "seq.destroy: err is nil")
+is (r.name, "foo", "seq.destroy: name is correct")
+is (r.destroyed, true, "seq.destroy: got true return code")
+
+local r, err = f:rpc ("cmb.seq.destroy", { name = "foo" })
+is (r, nil, "seq.destroy: nil return value")
+is (err, "No such file or directory", "seq.destroy: ENOENT")
+
+--
+--  cmb.seq.fetch
+--
+local request = { name = "xxx",
+		  create = false,
+                  preincrement = 0,
+                  postincrement = 0 }
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (r, nil, "seq.fetch: nil return value")
+is (err, "No such file or directory", "seq.fetch: error with ENOENT")
+
+-- fetch and create with initial value
+local request = { name = "aaa",
+		  create = true,
+                  preincrement = 9,
+                  postincrement = 0 }
+local r, err = f:rpc ("cmb.seq.fetch", request)
+type_ok (r, 'table', "seq.fetch: returned table")
+is (err, nil, "seq.fetch: err is nil")
+is (r.name, "aaa", "seq.fetch: name is correct")
+is (r.value, 9, "seq.fetch (new): got 9 as initial value")
+is (r.created, true, "seq.fetch (new): got created")
+
+-- increment and fetch
+request.preincrement = 1
+request.postincrement = 0
+request.create = false
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (r.value, 10, "seq.fetch (increment)")
+is (r.created, nil, "seq.fetch (increment): r.created is false")
+
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (r.value, 11, "seq.fetch (increment)")
+is (r.created, nil, "seq.fetch (increment): r.created is false")
+
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (r.value, 12, "seq.fetch (increment)")
+is (r.created, nil, "seq.fetch (increment): r.created is false")
+
+-- decrement and fetch
+request.preincrement = -1
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (err, nil, "seq.fetch (decrement) nil err")
+is (r.value, 11, "seq.fetch (decrement)")
+is (r.created, nil, "seq.fetch (decrement): r.created is false")
+
+-- fetch and decrement
+request.preincrement = 0
+request.postincrement = -1
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (err, nil, "seq.fetch (decrement) nil err")
+is (r.value, 11, "seq.fetch (decrement)")
+
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (err, nil, "seq.fetch (decrement) nil err")
+is (r.value, 10, "seq.fetch (decrement)")
+
+-- fetch
+request.preincrement = 0
+request.postincrement = 0
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (err, nil, "seq.fetch (after increment) nil err")
+is (r.value, 9, "seq.fetch (after increment)")
+
+-- set
+local r, err = f:rpc ("cmb.seq.set", { name = "aaa", value = 0 })
+is (err, nil, "seq.set: nil err")
+is (r.name, "aaa", "seq.set: got expected name")
+is (r.value, 0, "seq.set: new value = 0")
+
+local r, err = f:rpc ("cmb.seq.set", { name = "aaa", value = 0, oldvalue = 11 })
+is (err, "Resource temporarily unavailable", "seq.set: with oldvalue: error")
+
+local r, err = f:rpc ("cmb.seq.set", { name = "aaa", value = 22, oldvalue = 0 })
+is (err, nil, "seq.set: with correct oldvalue: no error")
+is (r.name, "aaa", "seq.set: got expected name")
+is (r.value, 22, "seq.set: new value = 22")
+
+local r, err = f:rpc ("cmb.seq.set", { name = "aaa", value = 0, oldvalue = 22 })
+is (r.value, 0, "seq.set: swap back to zero")
+
+-- negative values work
+request.preincrement = -1
+local r, err = f:rpc ("cmb.seq.fetch", request)
+is (err, nil, "seq.fetch (negative) nil err")
+is (r.value, -1, "seq.fetch (after decrement)")
+
+-- missing JSON members return errors
+local r, err = f:rpc ("cmb.seq.fetch", { name = "bbb", create = true, preincrement = 0 })
+is (r, nil, "seq.fetch: missing members return error")
+is (err, "Protocol error", "seq.fetch: missing members return Protocol error")
+
+done_testing ()

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -350,6 +350,15 @@ test_expect_success 'flux-wreck: ls works' '
 	flux wreck ls | tail -1 | grep "hostname$"
 '
 
+flux module list | grep -q sched || test_set_prereq NO_SCHED
+test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded' '
+	test_must_fail flux submit -n2 hostname 2>err.submit &&
+	cat >expected.submit <<-EOF &&
+	submit: flux.rpc: Function not implemented
+	EOF
+	test_cmp expected.submit err.submit
+'
+
 test_debug "flux wreck ls"
 
 test_done

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -12,8 +12,7 @@ test_under_flux ${SIZE}
 
 #  Return the previous jobid
 last_job_id() {
-	local n=$(flux kvs get "lwj.next-id")
-	echo $((n-1))
+	flux wreck last-jobid
 }
 
 test_expect_success 'wreckrun: works' '


### PR DESCRIPTION
This PR is still a bit of a work in progress, but I wanted to open it and get early comments.

This PR reworks the `job` module a bit and adds a simple `job.submit` service. The `job.submit` service simply creates a new job entry and sets the `submitted` state, iff the `sched` module is loaded -- returning ENOSYS otherwise.

New bindings are included in the `wreck.lua` module for `wreck:createjob()` and `wreck:submit()` to abstract common code, and a `flux-submit` command has been added directly to core. The `submit` command in flux-sched will still work, but can be removed once tests are updated to use the builtin submit command.

This PR also adds a simple named sequence service directly to the broker, and uses a `"lwj"` sequence to allocate jobids instead of using the `lwj.next-id` kvs entry. A new `flux wreck last-jobid` command is added to return the current value of the `lwj` sequence number.

Migrating to a global sequence id also allows the job module to now be loaded on every rank.

Still TODO:
 - Is it ok for simple sequence service to be implemented directly in the broker, or should this be another module?
 - If we want `job.submit` to be functional without sched loaded, and instead move jobs directly to `runrequest`, then a task layout service will have to be added to assign the jobs tasks to ranks. This could be something simple, but I wonder if it is necessary if flux-core will eventually have its own simple sched?
 - man page for flux-submit(1) 
 - flux-sched tests appear to pass against this branch, however, there is still a watch used in `simulator/scheduler.c` against `lwj.next-id` that probably needs to be addressed. Also, I left in the code that implements the `race_workaround` for the simulator -- but I wonder if this is still needed?