### PR TITLE
fix duplicate event issue

### DIFF
--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -651,27 +651,21 @@ static bool match_sub (module_t *p, const char *topic)
 int module_event_mcast (modhash_t *mh, const flux_msg_t *msg)
 {
     const char *topic;
-    zlist_t *uuids;
-    char *uuid;
+    module_t *p;
     int rc = -1;
 
     if (flux_msg_get_topic (msg, &topic) < 0)
         goto done;
-    if (!(uuids = zhash_keys (mh->zh_byuuid)))
-        oom ();
-    uuid = zlist_first (uuids);
-    while (uuid) {
-        module_t *p = zhash_lookup (mh->zh_byuuid, uuid);
-        assert (p != NULL);
+    p = zhash_first (mh->zh_byuuid);
+    while (p) {
         if (match_sub (p, topic)) {
             if (module_sendmsg (p, msg) < 0)
                 goto done;
         }
-        uuid = zlist_next (uuids);
+        p = zhash_next (mh->zh_byuuid);
     }
     rc = 0;
 done:
-    zlist_destroy (&uuids);
     return rc;
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -24,6 +24,7 @@ TESTS = \
 	t0001-basic.t \
 	t0002-request.t \
 	t0003-module.t \
+	t0004-event.t \
 	t0005-exec.t \
 	t0006-build-basic.t \
 	t0007-ping.t \
@@ -70,6 +71,7 @@ check_SCRIPTS = \
 	t0001-basic.t \
 	t0002-request.t \
 	t0003-module.t \
+	t0004-event.t \
 	t0005-exec.t \
 	t0006-build-basic.t \
 	t0007-ping.t \
@@ -130,7 +132,8 @@ dist_check_SCRIPTS = \
 	scripts/event-trace.lua \
 	scripts/kvs-watch-until.lua \
 	scripts/cpus-allowed.lua \
-	scripts/waitfile.lua
+	scripts/waitfile.lua \
+	scripts/t0004-event-helper.sh
 
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \

--- a/t/scripts/t0004-event-helper.sh
+++ b/t/scripts/t0004-event-helper.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# This is a helper for t0004-events.t
+
+if test $# -gt 0; then
+    rank=$1
+    flux exec -r $rank flux event pub testcase.foo
+    flux exec -r $rank flux event pub testcase.bar
+    flux exec -r $rank flux event pub testcase.baz
+    flux exec -r $rank flux event pub testcase.eof
+else
+    for suffix in foo bar baz; do
+       echo testcase.$suffix
+    done
+    echo testcase.eof
+fi

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+
+test_description='Test event propagation'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+LASTRANK=$(($SIZE-1))
+test_under_flux ${SIZE}
+
+test_expect_success 'heartbeat is received on all ranks' '
+	run_timeout 5 \
+          flux exec flux event sub --count=1 hb >output_event_sub &&
+	hb_count=`grep "^hb" output_event_sub | wc -l` &&
+        test $hb_count -eq $SIZE
+'
+
+test_expect_success 'events from rank 0 received correctly on rank 0' '
+	run_timeout 5 \
+          $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
+            testcase testcase.eof \
+	      $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh 0 >trace &&
+        $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh >trace.expected &&
+        test_cmp trace.expected trace
+'
+
+test_expect_success "events from rank $LASTRANK received correctly on rank 0" '
+	run_timeout 5 \
+          $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
+            testcase testcase.eof \
+	      $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh $LASTRANK >trace &&
+        $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh >trace.expected &&
+        test_cmp trace.expected trace
+'
+
+test_done


### PR DESCRIPTION
Avoid re-processing events that are received on rank 0 over ring network.

Add a test to ensure that events originating from all ranks are received in the proper order, without dups on rank 0.

Fixes #477 