### PR TITLE
python: add minimal python kz support

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -7,7 +7,10 @@ AM_LDFLAGS = -avoid-version -module -Wl,--no-undefined  $(PYTHON_LDFLAGS) -Wl,-r
 MAKE_BINDING=$(top_srcdir)/src/bindings/python/make_binding.py
 SUFFIXES = _build.py
 
-common_libs = $(top_builddir)/src/common/libflux-core.la  $(JSON_LIBS) $(ZMQ_LIBS)
+common_libs = $(top_builddir)/src/common/libflux-core.la \
+	      $(top_builddir)/src/common/libflux-internal.la \
+	      $(JSON_LIBS) \
+	      $(ZMQ_LIBS)
 
 _build.py.c:
 	$(PYTHON) $*_build.py
@@ -22,7 +25,7 @@ _core_build.py: $(MAKE_BINDING)
 				  --add_long_sub 'FLUX_SEC_TYPE_ALL.*\n.*\),|||FLUX_SEC_TYPE_ALL = 7,'\
 				  flux.h
 
-fluxpy_LTLIBRARIES = _core.la _barrier.la _mrpc.la _kvs.la _jsc.la
+fluxpy_LTLIBRARIES = _core.la _barrier.la _mrpc.la _kvs.la _jsc.la _kz.la
 
 _core_la_SOURCES = _core.c
 _core_la_LIBADD = $(common_libs)
@@ -76,6 +79,19 @@ _kvs_la_SOURCES = _kvs.c
 _kvs_la_CPPFLAGS = -I$(top_srcdir)/src/modules/kvs
 _kvs_la_LIBADD = $(top_builddir)/src/modules/kvs/libkvs.la $(common_libs)
 _kvs_la_DEPENDENCIES = _kvs_build.py
+
+_kz_build.py: $(top_srcdir)/src/modules/libkz/kz.h $(MAKE_BINDING) _core_build.py
+	$(PYTHON) $(MAKE_BINDING) --path $(top_srcdir)/src/modules/libkz \
+				  --package flux \
+	                          --modname _kz \
+				  --include_ffi _core_build \
+				  --add_sub '.*KZ_FLAGS_DELAYCOMMIT.*,|||KZ_FLAGS_DELAYCOMMIT = 0x0c00' \
+				  kz.h
+
+_kz_la_SOURCES = _kz.c $(top_srcdir)/src/modules/libkz/kz.h
+_kz_la_CPPFLAGS = -I$(top_srcdir)/src/modules/libkz
+_kz_la_LIBADD = $(top_builddir)/src/modules/libkz/libkz.la $(top_builddir)/src/modules/kvs/libkvs.la  $(common_libs)
+_kz_la_DEPENDENCIES = _kz_build.py
 
 fluxpy_PYTHON=\
 	      __init__.py\

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -259,7 +259,7 @@ class Wrapper(WrapperBase):
             return getattr(self, name)
 
         if not callable(fun): # pragma: no cover
-          return new_fun
+          return fun
 
         new_fun = self.check_wrap(fun, name)
         new_method = MethodType(new_fun, None, self.__class__)

--- a/src/modules/libkz/kz.h
+++ b/src/modules/libkz/kz.h
@@ -8,7 +8,7 @@ typedef struct kz_struct kz_t;
 
 typedef void (*kz_ready_f) (kz_t *kz, void *arg);
 
-enum {
+enum kz_flags {
     KZ_FLAGS_READ           = 0x0001, /* choose read or write, not both */
     KZ_FLAGS_WRITE          = 0x0002,
     KZ_FLAGS_MODEMASK       = 0x0003,
@@ -43,7 +43,7 @@ kz_t *kz_gopen (flux_t h, const char *grpname, int nprocs,
  */
 int kz_put (kz_t *kz, char *data, int len);
 
-/* Read one block of data to a KVS stream.  Returns the number of bytes
+/* Read one block of data from a KVS stream.  Returns the number of bytes
  * read, 0 on EOF, or -1 on errro with errno set.  If no data is available,
  * kz_get() will return EAGAIN if kz was opened with KZ_FLAGS_NONBLOCK;
  * otherwise it will block until data is available.


### PR DESCRIPTION
This patch adds a kz python module with the ability to "attach" a kz stream to
an output stream or file descriptor.  No support for arbitrary interactions
with a kz stream as yet, but sufficient to support cap/ATS efforts for the
time being.

In creating this, I found that python cffi does not like unnamed enums, hence the name added to the kz.h header's enum, and accessing those enums exposed a bug in the wrapper generator's accesses of C-defined non-callable, non-define data structures.