### PR TITLE
add RPC functions for handling raw payloads

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -31,7 +31,8 @@ MAN3_FILES_PRIMARY = \
 	flux_msg_handler_addvec.3 \
 	flux_child_watcher_create.3 \
 	flux_signal_watcher_create.3 \
-	flux_stat_watcher_create.3
+	flux_stat_watcher_create.3 \
+	flux_rpc_raw.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -80,7 +81,8 @@ MAN3_FILES_SECONDARY = \
 	flux_msg_handler_delvec.3 \
 	flux_child_watcher_get_rpid.3 \
 	flux_child_watcher_get_rstatus.3 \
-	flux_stat_watcher_get_rstat.3
+	flux_stat_watcher_get_rstat.3 \
+	flux_rpc_get_raw.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -148,6 +150,7 @@ flux_msg_handler_delvec.3: flux_msg_handler_addvec.3
 flux_child_watcher_get_rpid.3: flux_child_watcher_create.3
 flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
+flux_rpc_get_raw.3: flux_rpc_raw.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -32,7 +32,8 @@ MAN3_FILES_PRIMARY = \
 	flux_child_watcher_create.3 \
 	flux_signal_watcher_create.3 \
 	flux_stat_watcher_create.3 \
-	flux_rpc_raw.3
+	flux_rpc_raw.3 \
+	flux_respond.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -82,7 +83,8 @@ MAN3_FILES_SECONDARY = \
 	flux_child_watcher_get_rpid.3 \
 	flux_child_watcher_get_rstatus.3 \
 	flux_stat_watcher_get_rstat.3 \
-	flux_rpc_get_raw.3
+	flux_rpc_get_raw.3 \
+	flux_respond_raw.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -151,6 +153,7 @@ flux_child_watcher_get_rpid.3: flux_child_watcher_create.3
 flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_rpc_get_raw.3: flux_rpc_raw.3
+flux_respond_raw.3: flux_respond.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -1,0 +1,79 @@
+flux_respond(3)
+===============
+:doctype: manpage
+
+
+NAME
+----
+flux_respond, flux_respond_raw - respond to a request
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ int flux_respond (flux_t h, const flux_msg_t *request,
+                   int errnum, const char *json_str);
+
+ int flux_respond_raw (flux_t h, const flux_msg_t *request,
+                       int errnum, const void *data, int length);
+
+DESCRIPTION
+-----------
+
+`flux_respond()` and `flux_respond_raw()` encode and send a response
+message on handle _h_, deriving topic string, matchtag, and route stack
+from the provided _request_.
+
+If _errnum_ is non-zero, an error is returned to the sender such that
+`flux_rpc_get(3)` or `flux_rpc_get_raw(3)` will fail, with the system
+errno set to _errnum_.  Any payload arguments are ignored in this case.
+
+If _json_str_ is non-NULL, `flux_respond()` will send it as the response
+payload, otherwise there will be no payload.  Similarly, if _data_ is
+non-NULL, `flux_respond_raw()` will send it as the response payload.
+
+
+RETURN VALUE
+------------
+
+These functions return zero on success.  On error, -1 is returned,
+and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOSYS::
+Handle has no send operation.
+
+EINVAL::
+Some arguments were invalid.
+
+EPROTO::
+A protocol error was encountered.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_rpc(3), flux_rpc_raw(3)
+
+https://github.com/flux-framework/rfc/blob/master/spec_6.adoc[RFC 6: Flux
+Remote Procedure Call Protocol]
+
+https://github.com/flux-framework/rfc/blob/master/spec_3.adoc[RFC 3: CMB1 - Flux Comms Message Broker Protocol]

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -10,14 +10,16 @@ flux_rpc, flux_rpc_get, flux_rpc_destroy - perform a remote procedure call to a 
 
 SYNOPSIS
 --------
-#include <flux/core.h>
+ #include <flux/core.h>
 
-flux_rpc_t *flux_rpc (flux_t h, const char *topic, const char *json_in,
-                      uint32_t nodeid_in, int flags);
+ flux_rpc_t *flux_rpc (flux_t h, const char *topic,
+                       const char *json_in,
+                       uint32_t nodeid_in, int flags);
 
-void flux_rpc_destroy (flux_rpc_t *rpc);
+ void flux_rpc_destroy (flux_rpc_t *rpc);
 
-int flux_rpc_get (flux_rpc_t *rpc, uint32_t *nodeid_out, const char **json_out);
+ int flux_rpc_get (flux_rpc_t *rpc, uint32_t *nodeid_out,
+                   const char **json_out);
 
 
 DESCRIPTION

--- a/doc/man3/flux_rpc_raw.adoc
+++ b/doc/man3/flux_rpc_raw.adoc
@@ -1,0 +1,127 @@
+flux_rpc_raw(3)
+===============
+:doctype: manpage
+
+
+NAME
+----
+flux_rpc_raw, flux_rpc_get_raw - perform a remote procedure call to a Flux service using raw payloads
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_rpc_t *flux_rpc_raw (flux_t h, const char *topic,
+                           const void *data_in, int length_in,
+                           uint32_t nodeid_in, int flags);
+
+ int flux_rpc_get_raw (flux_rpc_t *rpc, uint32_t *nodeid_out,
+                       void *data_out, int *length_out);
+
+
+DESCRIPTION
+-----------
+
+`flux_rpc_raw()` encodes and sends a request message, comprising the first
+half of a remote procedure call (RPC).  A flux_rpc_t object is returned
+which can be passed to `flux_rpc_get_raw()` to obtain the decoded response
+message, comprising the second half of the RPC.  The flux_rpc_t should
+finally be disposed of using `flux_rpc_destroy()`.
+
+The raw RPC functions may be paired with the JSON RPC functions
+`flux_rpc(3)` and `flux_rpc_get(3)`.  That is, it is valid to send
+a JSON request payload and receive a raw response payload, or the reverse.
+Both sets of functions behave identically with respect to NULL payloads.
+
+_topic_ must be set to a topic string representing the Flux
+service that will handle the request.
+
+_data_in_, if non-NULL, points to a payload of size _length_in_.
+If NULL, the request will be sent without a payload.
+
+_nodeid_in_ affects request routing, and must be set to one of the following
+values:
+
+FLUX_NODEID_ANY::
+The request is routed to the first matching service instance.
+
+FLUX_NODEID_UPSTREAM::
+The request is routed to the first matching service instance,
+skipping over the sending rank.
+
+integer::
+The request is routed to a specific rank.
+
+_flags_ may be zero or:
+
+FLUX_RPC_NORESPONSE::
+No response is expected.  The request will not be assigned a matchtag,
+and the flux_rpc_t returned by `flux_rpc()` may be immediately destroyed.
+
+`flux_rpc_get_raw()` blocks until a matching response is received, then
+decodes the result.  For asynchronous response handling, see flux_rpc_then(3).
+
+_data_out_ and _length_out_, if non-NULL, are assigned a pointer to the
+response payload and its length.  It is a protocol error if a payload that is
+expected (signified by a non-NULL _data_out_) does not arrive;
+similarly, it is a protocol error if an unexpected payload (signified
+by a NULL _data_out_) arrives.  The storage associated with _data_out_
+belongs to the flux_rpc_t object and is invalidated when that object is
+destroyed.
+
+_nodeid_out_, if non-NULL, is set to the _nodeid_in_ argument given
+to `flux_rpc_raw()`.  This is primarily useful with `flux_rpc_multi(3)`.
+
+
+RETURN VALUE
+------------
+
+`flux_rpc_raw()` returns a flux_rpc_t object on success.  On error, NULL
+is returned, and errno is set appropriately.
+
+`flux_rpc_get_raw()` returns zero on success.  On error, -1 is returned,
+and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOSYS::
+Handle has no send operation.
+
+EINVAL::
+Some arguments were invalid.
+
+EPROTO::
+A protocol error was encountered.
+
+
+CAVEATS
+-------
+
+Although `flux_rpc_get_raw()` can be used with `flux_rpc_multi()`,
+there is no `flux_rpc_multi_raw()`.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_rpc(3), flux_rpc_then(3), flux_rpc_multi(3)
+
+https://github.com/flux-framework/rfc/blob/master/spec_6.adoc[RFC 6: Flux
+Remote Procedure Call Protocol]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -291,3 +291,4 @@ FILENAME
 dst
 taskid
 taskids
+errnum

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -79,13 +79,13 @@ flux_msg_t *flux_msg_copy (const flux_msg_t *msg, bool payload);
  * Returns 0 on success, -1 on failure with errno set.
  * Caller must free buf.
  */
-int flux_msg_encode (const flux_msg_t *msg, void **buf, size_t *size);
+int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t *size);
 
 /* Decode a flux_msg_t from buffer.
  * Returns message on success, NULL on failure with errno set.
  * Caller must destroy message with flux_msg_destroy().
  */
-flux_msg_t *flux_msg_decode (void *buf, size_t size);
+flux_msg_t *flux_msg_decode (const void *buf, size_t size);
 
 /* Send message to file descriptor.
  * iobuf captures intermediate state to make EAGAIN/EWOULDBLOCK restartable.
@@ -139,8 +139,9 @@ int flux_msg_get_topic (const flux_msg_t *msg, const char **topic);
  * Get_payload returns pointer to msg-owned buf.
  * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
  */
-int flux_msg_set_payload (flux_msg_t *msg, int flags, void *buf, int size);
-int flux_msg_get_payload (const flux_msg_t *msg, int *flags, void **buf, int *size);
+int flux_msg_set_payload (flux_msg_t *msg, int flags,
+                          const void *buf, int size);
+int flux_msg_get_payload (const flux_msg_t *msg, int *flags, void *buf, int *size);
 bool flux_msg_has_payload (const flux_msg_t *msg);
 
 /* Get/set json string payload.

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -6,19 +6,34 @@
 
 #include "message.h"
 
-/* Decode a request message.
+/* Decode a request message with optional json payload.
  * If topic is non-NULL, assign the request topic string.
- * If json_str is non-NULL, assign the payload.  json_str indicates whether
+ * If json_str is non-NULL, assign the payload.  This argument indicates whether
  * payload is expected and it is an EPROTO error if expectations are not met.
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **json_str);
 
+/* Decode a request message with optional raw payload.
+ * If topic is non-NULL, assign the request topic string.
+ * If data is non-NULL, assign the payload.  This argument indicates whether
+ * payload is expected and it is an EPROTO error if expectations are not met.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
+                             void *data, int *len);
+
 /* Encode a request message.
- * If json_str is non-NULL, assign the payload.
+ * If json_str is non-NULL, assign the json payload.
  */
 flux_msg_t *flux_request_encode (const char *topic, const char *json_str);
+
+/* Encode a request message.
+ * If data is non-NULL, assign the raw payload.
+ */
+flux_msg_t *flux_request_encode_raw (const char *topic,
+                                     const void *data, int len);
 
 #endif /* !_FLUX_CORE_REQUEST_H */
 

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -7,9 +7,9 @@
 #include "message.h"
 #include "handle.h"
 
-/* Decode a response message.
+/* Decode a response message, with optional json payload.
  * If topic is non-NULL, assign the response topic string.
- * If json_str is non-NULL, assign the payload.  json_str indicates whether
+ * If json_str is non-NULL, assign the payload.  This argument indicates whether
  * payload is expected and it is an EPROTO error if expectations are not met.
  * If response includes a nonzero errnum, errno is set to the errnum value
  * and -1 is returned with no assignments to topic or json_str.
@@ -18,15 +18,36 @@
 int flux_response_decode (const flux_msg_t *msg, const char **topic,
                           const char **json_str);
 
+/* Decode a response message, with optional raw payload.
+ * If topic is non-NULL, assign the response topic string.
+ * If data is non-NULL, assign the payload.  This argument indicates whether
+ * payload is expected and it is an EPROTO error if expectations are not met.
+ * If response includes a nonzero errnum, errno is set to the errnum value
+ * and -1 is returned with no assignments to topic or json_str.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
+                              void *data, int *len);
+
 flux_msg_t *flux_response_encode (const char *topic, int errnum,
                                   const char *json_str);
 
-/* Create a response to the provided request message.
+flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
+                                      const void *data, int len);
+
+/* Create a response to the provided request message with optional json payload.
  * If errnum is nonzero, payload argument is ignored.
  * All errors in this function are fatal - see flux_fatal_set().
  */
 int flux_respond (flux_t h, const flux_msg_t *request,
                   int errnum, const char *json_str);
+
+/* Create a response to the provided request message with optional raw payload.
+ * If errnum is nonzero, payload argument is ignored.
+ * All errors in this function are fatal - see flux_fatal_set().
+ */
+int flux_respond_raw (flux_t h, const flux_msg_t *request,
+                      int errnum, const void *data, int len);
 
 #endif /* !_FLUX_CORE_RESPONSE_H */
 

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -12,11 +12,21 @@ enum {
 typedef struct flux_rpc_struct flux_rpc_t;
 typedef void (*flux_then_f)(flux_rpc_t *rpc, void *arg);
 
-/* Send an RPC request to 'nodeid', and return a flux_rpc_t object
- * to allow the response to be handled.  On failure return NULL with errno set.
+/* Send an RPC request to 'nodeid' with optional json payload,
+ * and return a flux_rpc_t object to allow the response to be handled.
+ * On failure return NULL with errno set.
  */
 flux_rpc_t *flux_rpc (flux_t h, const char *topic, const char *json_str,
                       uint32_t nodeid, int flags);
+
+/* Send an RPC request to 'nodeid' with optional raw paylaod,
+ * and return a flux_rpc_t object to allow the response to be handled.
+ * On failure return NULL with errno set.
+ */
+flux_rpc_t *flux_rpc_raw (flux_t h, const char *topic,
+                          const void *data, int len,
+                          uint32_t nodeid, int flags);
+
 /* Destroy an RPC, invalidating previous payload returned by flux_rpc_get().
  */
 void flux_rpc_destroy (flux_rpc_t *rpc);
@@ -31,6 +41,13 @@ bool flux_rpc_check (flux_rpc_t *rpc);
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_rpc_get (flux_rpc_t *rpc, uint32_t *nodeid, const char **json_str);
+
+/* Wait for a response if necessary, then decode it.
+ * Any returned 'data' payload is valid until the next get/check call.
+ * If 'nodeid' is non-NULL, the nodeid that the request was sent to is returned.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_rpc_get_raw (flux_rpc_t *rpc, uint32_t *nodeid, void *data, int *len);
 
 /* Arrange for reactor to handle response and call 'cb' continuation function
  * when a response is received.  The function must call flux_rpc_get().


### PR DESCRIPTION
This PR was split off from PR #471 (kvs backing store).  It adds high level message handling functions for raw payloads, which are used by the "content service" proposed in #471.  This includes variations of `flux_rpc()` and `flux_rpc_get()`:
```C
flux_rpc_t *flux_rpc_raw (flux_t h, const char *topic,
                          const void *data, int len,
                          uint32_t nodeid, int flags);
int flux_rpc_get_raw (flux_rpc_t *rpc, uint32_t *nodeid, void *data, int *len);
```
as well as a variant of `flux_respond()`:
```C
int flux_respond_raw (flux_t h, const flux_msg_t *request,
                      int errnum, const void *data, int len);
```
In addition there is some minor cleanup of low level message function prototypes, and cleanup of existing man pages.

I've added man pages and tests for the new functions.