### PR TITLE
update waitfile.lua, jsc, and wreck tests for robustness

### DIFF
--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -28,7 +28,7 @@ declare -A extra_configure_opts=(\
 #  Python pip packages
 #
 pips="\
-cffi \
+cffi>=1.1,<1.4 \
 coverage"
 
 #

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -270,13 +270,13 @@ WAITFILE="$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua"
 
 test_expect_success 'wreckrun: --output supported' '
 	flux wreckrun --output=test1.out echo hello &&
-        $WAITFILE 1 hello test1.out
+        $WAITFILE --timeout=1 --pattern=hello test1.out
 '
 test_expect_success 'wreckrun: --error supported' '
 	flux wreckrun --output=test2.out --error=test2.err \
 	    sh -c "echo >&2 this is stderr; echo this is stdout" &&
-        $WAITFILE 1 "this is stderr" test2.err &&
-        $WAITFILE 1 "this is stdout" test2.out
+        $WAITFILE --timeout=1 -p "this is stderr" test2.err &&
+        $WAITFILE --timeout=1 -p "this is stdout" test2.out
 '
 test_expect_success 'wreckrun: kvs config output for all jobs' '
 	test_when_finished "flux kvs put lwj.output=" &&
@@ -286,8 +286,8 @@ test_expect_success 'wreckrun: kvs config output for all jobs' '
 	for i in $(seq 0 $((${SIZE}-1)))
 		do echo "$i: foo"
 	done >expected.kvsiocfg &&
+        $WAITFILE --count=${SIZE} -t 1 -p ".+" test3.out &&
 	sort -n test3.out >output.kvsiocfg &&
-        $WAITFILE 1 "" output.kvsiocfg &&
 	test_cmp expected.kvsiocfg output.kvsiocfg
 '
 test_expect_success 'flux-wreck: exists in path' '

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -23,23 +23,11 @@ $tr4
 $tr5"
 
 run_flux_jstat () {
-    sess=$1
-    rm -f jstat$sess.pid
-    (
-        # run this in a subshell
-        flux jstat -o output.$sess notify & 
-        p=$!
-        cat <<HEREDOC > jstat$sess.pid
-$p
-HEREDOC
-        wait $p
-        #rm -f output.$sess
-    )&
-    return 0
-}
-
-sync_flux_jstat () {
-    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua 2 "" output.$1 && cat jstat$1.pid
+    ofile="output.$1"
+    rm -f ${ofile}
+    flux jstat -o ${ofile} notify >/dev/null &
+    echo $! &&
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua 2 "" ${ofile} >&2
 }
 
 overlap_flux_wreckruns () {
@@ -57,8 +45,7 @@ overlap_flux_wreckruns () {
 }
 
 test_expect_success 'jstat 1: notification works for 1 wreckrun' '
-    run_flux_jstat 1 &&
-    p=$( sync_flux_jstat 1) &&
+    p=$(run_flux_jstat 1) &&
     run_timeout 4 flux wreckrun -n4 -N4 hostname &&
     cat >expected1 <<-EOF &&
 $trans
@@ -69,8 +56,7 @@ EOF
 '
 
 test_expect_success 'jstat 2: jstat back-to-back works' '
-    run_flux_jstat 2 &&
-    p=$( sync_flux_jstat 2) &&
+    p=$(run_flux_jstat 2) &&
     run_timeout 4 flux wreckrun -n4 -N4 hostname &&
     cat >expected2 <<-EOF &&
 $trans
@@ -81,8 +67,7 @@ EOF
 '
 
 test_expect_success 'jstat 3: notification works for multiple wreckruns' '
-    run_flux_jstat 3 &&
-    p=$( sync_flux_jstat 3 ) &&
+    p=$(run_flux_jstat 3) &&
     run_timeout 4 flux wreckrun -n4 -N4 hostname &&
 	run_timeout 4 flux wreckrun -n4 -N4 hostname &&
 	run_timeout 4 flux wreckrun -n4 -N4 hostname &&
@@ -97,8 +82,7 @@ EOF
 '
 
 test_expect_success LONGTEST 'jstat 4: notification works under lock-step stress' '
-    run_flux_jstat 4 &&
-    p=$( sync_flux_jstat 4 ) &&
+    p=$(run_flux_jstat 4) &&
     for i in `seq 1 20`; do 
         run_timeout 4 flux wreckrun -n4 -N4 hostname 
     done &&
@@ -130,8 +114,7 @@ EOF
 '
 
 test_expect_success 'jstat 5: notification works for overlapping wreckruns' '
-    run_flux_jstat 5 &&
-    p=$( sync_flux_jstat 5 ) &&
+    p=$(run_flux_jstat 5) &&
     overlap_flux_wreckruns 3 &&
     cat >expected5 <<-EOF &&
 $trans
@@ -146,8 +129,7 @@ EOF
 '
 
 test_expect_success LONGTEST 'jstat 6: notification works for overlapping stress' '
-    run_flux_jstat 6 &&
-    p=$( sync_flux_jstat 6 ) &&
+    p=$(run_flux_jstat 6) &&
     overlap_flux_wreckruns 20 &&
     cat >expected6 <<-EOF &&
 $trans
@@ -257,8 +239,7 @@ test_expect_success 'jstat 14: update detects bad inputs' "
 "
 
 test_expect_success 'jstat 15: jstat detects failed state' '
-    run_flux_jstat 15 &&
-    p=$( sync_flux_jstat 15 ) &&
+    p=$(run_flux_jstat 15) &&
     test_must_fail run_timeout 4 flux wreckrun -i /bad/input -n4 -N4 hostname &&
     cat >expected15 <<-EOF &&
 	null->null

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -27,7 +27,7 @@ run_flux_jstat () {
     rm -f ${ofile}
     flux jstat -o ${ofile} notify >/dev/null &
     echo $! &&
-    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua 2 "" ${ofile} >&2
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout 2 ${ofile} >&2
 }
 
 overlap_flux_wreckruns () {


### PR DESCRIPTION
This PR makes the updates described in #498 to hopefully improve reliability of t2000-wreck.t and t2001-jsc.t.

JSC tests are simplified to remove dependence on synchronization on multiple output files (pidfile *and* output file), and `waitfile.lua` is improved for usability, and given a `--count` option, which is used in wreck tests to wait until all output lines are written (or the timeout is reached)