### PR TITLE
hwloc: add front-end support for resource-hwloc module

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -65,7 +65,8 @@ fluxcmd_PROGRAMS = \
 	flux-kvs \
 	flux-start \
 	flux-config \
-	flux-jstat
+	flux-jstat \
+	flux-hwloc
 
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \

--- a/src/cmd/flux-hwloc.c
+++ b/src/cmd/flux-hwloc.c
@@ -1,0 +1,176 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+
+#define OPTIONS "+hr:"
+static const struct option longopts[] = {
+    {"help",       no_argument,        0, 'h'},
+    {"ranks",      required_argument,  0, 'r'},
+    { 0, 0, 0, 0 },
+};
+
+static void usage (int code)
+{
+    fprintf (stderr,
+"Usage: flux-hwloc reload [OPTIONS] DIR\n"
+"where OPTIONS are:\n"
+"       -h,--help          print this message.\n"
+"       -r,--ranks=NODESET send the hwloc reload request to brokers\n"
+"                          in NODESET. NODESET is a string containing a \n"
+"                          bracketed set of ranks or \"all\" as a shorthand\n"
+"                          for all ranks in the session. Examples of NODESET\n"
+"                          strings are \"[0-255]\" and \"[1-2,5]\". If not given,\n"
+"                          NODESET is set to all.\n\n"
+"where DIR must contain one xml file per rank prefixed with the rank number \n"
+"(e.g., 0.xml, 1.xml, etc).\n"
+);
+    exit (code);
+}
+
+static int handle_hwloc_reload (flux_t h, const char *nodeset, const char *path)
+{
+    int rc = 0;
+    char *key = NULL;
+    char *val = NULL;
+    uint32_t size = 0;
+    uint32_t rank = 0;
+    flux_rpc_t *rpc = NULL;
+
+    if ((rc = flux_get_size (h, &size)) != 0) {
+        flux_log (h, LOG_ERR, "error in flux_get_size.");
+        goto done;
+    }
+
+    for (rank = 0; rank < size; rank++) {
+        key = xasprintf ("config.resource.hwloc.xml.%"PRIu32, rank);
+        val = xasprintf ("%s/%"PRIu32".xml", path, rank);
+        if ((rc = kvs_put_string (h, key, val) != 0)) {
+            flux_log (h, LOG_ERR, "flux_kvs_put: %s", strerror (errno));
+            goto done;
+        }
+        free (key);
+        free (val);
+    }
+    if ((rc = kvs_commit (h)) != 0) {
+        fprintf (stderr, "flux_kvs_commit: %s\n", strerror (errno));
+        goto done;
+    }
+
+    if (!(rpc = flux_rpc_multi (h, "resource-hwloc.reload", NULL, nodeset, 0))) {
+        fprintf (stderr, "flux_rpc_multi: %s\n", strerror (errno));
+        rc = -1;
+        goto done;
+    }
+    while (!flux_rpc_completed (rpc)) {
+        const char *json_str = NULL;
+        uint32_t nodeid;
+        if ((rc += flux_rpc_get (rpc, &nodeid, &json_str) < 0))
+            flux_log (h, LOG_ERR, "rpc(%"PRIu32"): %s", nodeid, strerror (errno));
+    }
+    flux_rpc_destroy (rpc);
+
+done:
+    return rc;
+}
+
+/******************************************************************************
+ *                                                                            *
+ *                            Main entry point                                *
+ *                                                                            *
+ ******************************************************************************/
+
+int main (int argc, char *argv[])
+{
+    flux_t h;
+    int rc = 0;
+    int ch = 0;
+    char *cmd = NULL;
+    char *nodeset = NULL;
+
+    log_init ("flux-hwloc");
+    if (argc < 2)
+        usage (1);
+    cmd = argv[1];
+    argc--;
+    argv++;
+
+    log_init ("flux-hwloc");
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'h': /* --help */
+                usage (1);
+                break;
+            case 'r': /* --rankset=NODESET */
+                nodeset = xstrdup (optarg);
+                break;
+            default:
+                usage (1);
+                break;
+        }
+    }
+
+    if (!(h = flux_open (NULL, 0)))
+        err_exit ("flux_open");
+    if (!nodeset)
+        nodeset = xasprintf ("all");
+
+    if (!strcmp ("reload", cmd)) {
+        char path[PATH_MAX] = {'\0'};
+        char **a = argv + optind;
+        if (!(*a))
+            usage (1);
+        if ( realpath (*a, path) != NULL ) {
+            rc = handle_hwloc_reload (h, (const char *)nodeset, (const char *)path);
+        } else {
+            rc = -1;
+            fprintf (stderr,
+                     "error resolving the path (%s): %s\n", *a, strerror (errno));
+        }
+    }
+    else
+        usage (1);
+
+    flux_close (h);
+    log_fini ();
+
+    if (nodeset)
+        free (nodeset);
+
+    return (!rc)? 0: 1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -46,6 +46,7 @@ TESTS = \
 	t2002-pmi.t \
 	t2003-recurse.t \
 	t2004-hydra.t \
+	t2005-hwloc-basic.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
@@ -98,6 +99,7 @@ check_SCRIPTS = \
 	t2002-pmi.t \
 	t2003-recurse.t \
 	t2004-hydra.t \
+	t2005-hwloc-basic.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
         issues/t0441-kvs-put-get.sh \
@@ -139,7 +141,11 @@ dist_check_DATA = \
 	build/hello_czmq.c \
 	build/hello_flux_core.c \
 	build/hello_flux_internal.c \
-	build/hello_jsonc.c
+	build/hello_jsonc.c \
+	hwloc-data/1N/shared/02-brokers/0.xml \
+	hwloc-data/1N/shared/02-brokers/1.xml \
+	hwloc-data/1N/nonoverlapping/02-brokers/0.xml \
+	hwloc-data/1N/nonoverlapping/02-brokers/1.xml
 
 dist_check_SCRIPTS = \
 	scripts/event-trace.lua \

--- a/t/hwloc-data/1N/nonoverlapping/02-brokers/0.xml
+++ b/t/hwloc-data/1N/nonoverlapping/02-brokers/0.xml
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <info name="DMIProductName" value="appro-512x"/>
+    <info name="DMIProductVersion" value="...................."/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600JF"/>
+    <info name="DMIBoardVersion" value="G28033-502"/>
+    <info name="DMIBoardAssetTag" value="...................."/>
+    <info name="DMIChassisVendor" value="appro"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="appro-512x"/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corp."/>
+    <info name="DMIBIOSVersion" value="SE5C600.86B.02.03.0003.041920141333"/>
+    <info name="DMIBIOSDate" value="04/19/2014"/>
+    <info name="DMISysVendor" value="appro"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="2.6.32-573.8.1.2chaos.ch5.4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Tue Dec 1 12:16:54 PST 2015"/>
+    <info name="HostName" value="cab31"/>
+    <info name="Architecture" value="x86_64"/>
+    <object type="NUMANode" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="17097461760">
+      <page_type size="4096" count="4174185"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        </object>
+        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        </object>
+        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="QLogic Corp."/>
+            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:86:32"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="qib0" osdev_type="3"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
+        </object>
+        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
+        </object>
+        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
+        </object>
+        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
+        </object>
+        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth0" osdev_type="2">
+              <info name="Address" value="00:1e:67:29:21:64"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth1" osdev_type="2">
+              <info name="Address" value="00:1e:67:29:21:65"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
+        </object>
+        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="82801 PCI Bridge"/>
+        </object>
+        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
+        </object>
+        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+        </object>
+        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
+      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
+      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+  </object>
+</topology>
+

--- a/t/hwloc-data/1N/nonoverlapping/02-brokers/1.xml
+++ b/t/hwloc-data/1N/nonoverlapping/02-brokers/1.xml
@@ -1,0 +1,494 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <info name="DMIProductName" value="appro-512x"/>
+    <info name="DMIProductVersion" value="...................."/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600JF"/>
+    <info name="DMIBoardVersion" value="G28033-502"/>
+    <info name="DMIBoardAssetTag" value="...................."/>
+    <info name="DMIChassisVendor" value="appro"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="appro-512x"/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corp."/>
+    <info name="DMIBIOSVersion" value="SE5C600.86B.02.03.0003.041920141333"/>
+    <info name="DMIBIOSDate" value="04/19/2014"/>
+    <info name="DMISysVendor" value="appro"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="2.6.32-573.8.1.2chaos.ch5.4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Tue Dec 1 12:16:54 PST 2015"/>
+    <info name="HostName" value="cab31"/>
+    <info name="Architecture" value="x86_64"/>
+    <object type="NUMANode" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="17179869184">
+      <page_type size="4096" count="4194304"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
+      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
+      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+  </object>
+</topology>
+

--- a/t/hwloc-data/1N/shared/02-brokers/0.xml
+++ b/t/hwloc-data/1N/shared/02-brokers/0.xml
@@ -1,0 +1,701 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <info name="DMIProductName" value="appro-512x"/>
+    <info name="DMIProductVersion" value="...................."/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600JF"/>
+    <info name="DMIBoardVersion" value="G28033-502"/>
+    <info name="DMIBoardAssetTag" value="...................."/>
+    <info name="DMIChassisVendor" value="appro"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="appro-512x"/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corp."/>
+    <info name="DMIBIOSVersion" value="SE5C600.86B.02.03.0003.041920141333"/>
+    <info name="DMIBIOSDate" value="04/19/2014"/>
+    <info name="DMISysVendor" value="appro"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="2.6.32-573.8.1.2chaos.ch5.4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Tue Dec 1 12:16:54 PST 2015"/>
+    <info name="HostName" value="cab31"/>
+    <info name="Architecture" value="x86_64"/>
+    <object type="NUMANode" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="17097461760">
+      <page_type size="4096" count="4174185"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        </object>
+        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        </object>
+        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="QLogic Corp."/>
+            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:86:32"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="qib0" osdev_type="3"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
+        </object>
+        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
+        </object>
+        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
+        </object>
+        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
+        </object>
+        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth0" osdev_type="2">
+              <info name="Address" value="00:1e:67:29:21:64"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth1" osdev_type="2">
+              <info name="Address" value="00:1e:67:29:21:65"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
+        </object>
+        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="82801 PCI Bridge"/>
+        </object>
+        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
+        </object>
+        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+        </object>
+        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="17179869184">
+      <page_type size="4096" count="4194304"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
+      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
+      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+  </object>
+</topology>
+

--- a/t/hwloc-data/1N/shared/02-brokers/1.xml
+++ b/t/hwloc-data/1N/shared/02-brokers/1.xml
@@ -1,0 +1,701 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <info name="DMIProductName" value="appro-512x"/>
+    <info name="DMIProductVersion" value="...................."/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600JF"/>
+    <info name="DMIBoardVersion" value="G28033-502"/>
+    <info name="DMIBoardAssetTag" value="...................."/>
+    <info name="DMIChassisVendor" value="appro"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="appro-512x"/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corp."/>
+    <info name="DMIBIOSVersion" value="SE5C600.86B.02.03.0003.041920141333"/>
+    <info name="DMIBIOSDate" value="04/19/2014"/>
+    <info name="DMISysVendor" value="appro"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="2.6.32-573.8.1.2chaos.ch5.4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Tue Dec 1 12:16:54 PST 2015"/>
+    <info name="HostName" value="cab31"/>
+    <info name="Architecture" value="x86_64"/>
+    <object type="NUMANode" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="17097461760">
+      <page_type size="4096" count="4174185"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        </object>
+        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        </object>
+        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="QLogic Corp."/>
+            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:86:32"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="qib0" osdev_type="3"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
+        </object>
+        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
+        </object>
+        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
+        </object>
+        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
+        </object>
+        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth0" osdev_type="2">
+              <info name="Address" value="00:1e:67:29:21:64"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth1" osdev_type="2">
+              <info name="Address" value="00:1e:67:29:21:65"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
+        </object>
+        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="82801 PCI Bridge"/>
+        </object>
+        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
+        </object>
+        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+        </object>
+        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="17179869184">
+      <page_type size="4096" count="4194304"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
+      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
+      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+  </object>
+</topology>
+

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -1,0 +1,38 @@
+#!/bin/sh
+#set -x
+
+test_description='Test basics of flux-hwloc reload subcommand
+
+Ensure flux-hwloc reload subcommand works
+'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2
+
+shared2=`readlink -e ${SHARNESS_TEST_SRCDIR}/hwloc-data/1N/shared/02-brokers`
+exclu2=`readlink -e ${SHARNESS_TEST_SRCDIR}/hwloc-data/1N/nonoverlapping/02-brokers`
+
+test_debug '
+    echo ${dn} &&
+    echo ${shared} &&
+    echo ${exclu2}
+'
+
+test_expect_success 'hwloc: each rank reloads a non-overlapping set of a node ' '
+    flux hwloc reload $exclu2
+'
+
+test_expect_success 'hwloc: every rank reloads the same xml of a node' '
+    flux hwloc reload $shared2
+'
+
+test_expect_success 'hwloc: only one rank reloads an xml file' '
+    flux hwloc reload --ranks="[0]" $exclu2
+'
+
+test_expect_success 'hwloc: return an error code on an invalid DIR' '
+    test_expect_code 1 flux hwloc reload nonexistence
+'
+
+test_done


### PR DESCRIPTION
Add flux-hwloc as a high-level command to synchronously communicate with the resource-hwloc module. Add some test cases and fake hwloc data to drive testing. Details are in the commit messages. 