### PR TITLE
allow message handlers to start stop from message handlers

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -47,6 +47,7 @@ TESTS = \
 	t2003-recurse.t \
 	t2004-hydra.t \
 	t3000-mpi-basic.t \
+	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
@@ -98,6 +99,9 @@ check_SCRIPTS = \
 	t2003-recurse.t \
 	t2004-hydra.t \
 	t3000-mpi-basic.t \
+	t4000-issues-test-driver.t \
+        issues/t0441-kvs-put-get.sh \
+        issues/t0505-msg-handler-reg.lua \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/issues/t0441-kvs-put-get.sh
+++ b/t/issues/t0441-kvs-put-get.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+# kvs put x=foo, get x.y fails without panic
+
+TEST=issue441
+
+flux kvs put ${TEST}.x=foo
+
+flux kvs get ${TEST}.x.y && test $? -eq 1
+
+flux kvs get ${TEST}.x   # fails if broker died

--- a/t/issues/t0505-msg-handler-reg.lua
+++ b/t/issues/t0505-msg-handler-reg.lua
@@ -1,0 +1,40 @@
+#!/usr/bin/lua
+--
+-- Issue #505: Ensure msghandler can be installed from within an event handler.
+--
+local flux = require 'flux'
+local f,err = flux.new ()
+if not f then error (err) end
+
+
+local function die (...)
+    io.stderr:write (string.format (...))
+    os.exit (1)
+end
+
+local event_count = 0
+f:msghandler {
+    pattern = "testevent",
+    msgtypes = { flux.MSGTYPE_EVENT },
+    handler = function (f, msg, mh)
+        event_count = event_count + 1
+        if (event_count > 1) then
+            die ("Fatal: got more than 1 expected event\n")
+        end
+        f:send ("kvs.ping", { seq = "1", pad = "" })
+        f:msghandler {
+            pattern = "kvs.ping",
+            msgtypes = { flux.MSGTYPE_RESPONSE },
+            handler = function (f, msg, mh) f:reactor_stop () end
+        }
+    end
+}
+
+f:subscribe ("testevent")
+f:sendevent ("testevent")
+f:reactor ()
+if (event_count ~= 1) then
+    die ("Expected event_count=0 got %d\n", event_count)
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -287,13 +287,4 @@ test_expect_success 'kvs: watch-unwatchloop 1000 watch/unwatch ok' '
 	${FLUX_BUILD_DIR}/t/kvs/watch unwatchloop $TEST.a &&
 	flux kvs unlink $TEST.a
 '
-
-# regression tests
-
-test_expect_success 'kvs: put x=foo, get x.y fails without panic (issue 441)' '
-	flux kvs put ${TEST}.x=foo &&
-	! flux kvs get ${TEST}.x.y
-	flux kvs get ${TEST}.x   # fails if broker died
-'
-
 test_done

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -1,0 +1,18 @@
+
+#!/bin/sh
+#
+
+test_description='Verify that fixed issues remain fixed'
+
+. `dirname $0`/sharness.sh
+
+SIZE=4
+test_under_flux ${SIZE}
+echo "# $0: flux session size will be ${SIZE}"
+
+for testscript in ${FLUX_SOURCE_DIR}/t/issues/*; do
+    testname=`basename $testscript`
+    test_expect_success  $testname $testscript
+done
+
+test_done


### PR DESCRIPTION
This PR should address issue #505, where installing a message handler from within a message handler caused problems with message delivery.  It also addresses creating, destroying, and stopping a message handler from within a message handler.

This still needs a test but I wanted to get it out there for review.

Also, while developing this on c9.io, I began seeing intermittent failures of this test, which needs explaining:
```
$ lua/t1002-kvs.t --verbose --debugd
...
not ok 95 - reactor exited normally with Protocol error
#     Failed test (/home/ubuntu/workspace/t/lua/t1002-kvs.t at line 168)
#          got: nil
#     expected: 0
```