### PR TITLE
Remove some cmdline options from flux(1)

### DIFF
--- a/doc/man1/flux.adoc
+++ b/doc/man1/flux.adoc
@@ -53,21 +53,6 @@ Trace API socket traffic to 'stderr'.
 Prepend 'PATH' to sub-command executable search path.
 Multiple directories may be specified, separated by colons.
 
-*-M, --module-path*='PATH'::
-Prepend 'PATH' to the comms module search path.
-Multiple directories may be specified, separated by colons.
-
-*-L, --lua-path*='PATH'::
-Prepend 'PATH' to the Lua module search path (LUA_PATH).
-Multiple paths may be specified, separated by semicolon.
-
-*-C, --lua-cpath*='PATH'::
-Prepend 'PATH' to the Lua binary module search path (LUA_CPATH).
-Multiple paths may be specified, separated by semicolon.
-
-*-B, --broker-path*='FILE'::
-Override the path to the Flux communications broker daemon.
-
 
 SUB-COMMAND ENVIRONMENT
 -----------------------
@@ -84,25 +69,30 @@ with the following prototype:
 setenv FLUX_MODULE_PATH::
 Set up broker comms module search path according to:
 
-  [--module-path PATH]:[config.general.module_path]:install-path
+  [config.general.module_path]:install-path:\
+    [getenv FLUX_MODULE_PATH]
+
+setenv FLUX_CONNECTOR_PATH::
+Set up search path for connector modules used by libflux to open a connection
+to the broker
+
+  [config.general.connector_path]:install-path:\
+    [getenv FLUX_CONNECTOR_PATH]
 
 setenv LUA_PATH::
 Set Lua module search path:
 
-  [--lua-path PATH];[config.general.lua_path]; \
-    [getenv LUA_PATH];install-path;;;
+  [config.general.lua_path];[getenv LUA_PATH];install-path;;;
 
 setenv LUA_CPATH::
 Set Lua binary module search path:
 
-  [--lua-cpath PATH];[config.general.lua_cpath]; \
-    [getenv LUA_CPATH];install-path;;;
+  [config.general.lua_cpath];[getenv LUA_CPATH];install-path;;;
 
 setenv FLUX_BROKER_PATH::
 Set the path to the broker executable.  This environment variable is
 used by flux-start(1) and related sub-commands to launch the broker.
 The path may be set by any of the following methods, in decreasing precedence:
-- [--broker-path FILE]
 - [config.general.broker_path]
 - install-path
 

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -55,16 +55,13 @@ void setup_path (flux_conf_t cf, const char *argv0);
 static void print_environment(flux_conf_t cf, const char * prefix);
 void setup_broker_env (flux_conf_t cf, const char *path_override);
 
-#define OPTIONS "+tx:hM:O:B:vc:L:P:C:FS:u:"
+#define OPTIONS "+tx:hM:O:B:vc:FS:u:"
 static const struct option longopts[] = {
     {"trace-handle",    no_argument,        0, 't'},
     {"exec-path",       required_argument,  0, 'x'},
     {"module-path",     required_argument,  0, 'M'},
     {"connector-path",  required_argument,  0, 'O'},
     {"broker-path",     required_argument,  0, 'B'},
-    {"lua-path",        required_argument,  0, 'L'},
-    {"python-path",     required_argument,  0, 'P'},
-    {"lua-cpath",       required_argument,  0, 'C'},
     {"config",          required_argument,  0, 'c'},
     {"secdir",          required_argument,  0, 'S'},
     {"uri",             required_argument,  0, 'u'},
@@ -98,9 +95,6 @@ static void usage (void)
 "    -x,--exec-path PATH   prepend PATH to command search path\n"
 "    -M,--module-path PATH prepend PATH to module search path\n"
 "    -O,--connector-path PATH   prepend PATH to connector search path\n"
-"    -L,--lua-path PATH    prepend PATH to LUA_PATH\n"
-"    -P,--python-path PATH prepend PATH to PYTHONPATH\n"
-"    -C,--lua-cpath PATH   prepend PATH to LUA_CPATH\n"
 "    -t,--trace-handle     set FLUX_HANDLE_TRACE=1 before executing COMMAND\n"
 "    -B,--broker-path FILE override path to flux broker\n"
 "    -c,--config DIR       set path to config directory\n"
@@ -122,11 +116,8 @@ int main (int argc, char *argv[])
     bool vopt = false;
     char *xopt = NULL;
     char *Mopt = NULL;
-    char *Popt = NULL;
     char *Oopt = NULL;
     char *Bopt = NULL;
-    char *Lopt = NULL;
-    char *Copt = NULL;
     bool Fopt = false;
     char *confdir = NULL;
     char *secdir = NULL;
@@ -168,15 +159,6 @@ int main (int argc, char *argv[])
                 break;
             case 'v': /* --verbose */
                 vopt = true;
-                break;
-            case 'L': /* --lua-path PATH */
-                Lopt = optarg;
-                break;
-            case 'P': /* --python-path PATH */
-                Popt = optarg;
-                break;
-            case 'C': /* --lua-cpath PATH */
-                Copt = optarg;
                 break;
             case 'u': /* --uri URI */
                 if (setenv ("FLUX_URI", optarg, 1) < 0)
@@ -248,9 +230,6 @@ int main (int argc, char *argv[])
     flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", Oopt);
     flux_conf_environment_push (cf, "FLUX_EXEC_PATH", xopt);
     flux_conf_environment_push (cf, "FLUX_MODULE_PATH", Mopt);
-    flux_conf_environment_push (cf, "LUA_CPATH", Copt);
-    flux_conf_environment_push (cf, "LUA_PATH", Lopt);
-    flux_conf_environment_push (cf, "PYTHONPATH", Popt);
 
     if (argc == 0) {
         usage ();

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -53,15 +53,14 @@ char *intree_confdir (void);
 void setup_path (flux_conf_t cf, const char *argv0);
 
 static void print_environment(flux_conf_t cf, const char * prefix);
-void setup_broker_env (flux_conf_t cf, const char *path_override);
+void setup_broker_env (flux_conf_t cf);
 
-#define OPTIONS "+tx:hM:O:B:vc:FS:u:"
+#define OPTIONS "+tx:hM:O:vc:FS:u:"
 static const struct option longopts[] = {
     {"trace-handle",    no_argument,        0, 't'},
     {"exec-path",       required_argument,  0, 'x'},
     {"module-path",     required_argument,  0, 'M'},
     {"connector-path",  required_argument,  0, 'O'},
-    {"broker-path",     required_argument,  0, 'B'},
     {"config",          required_argument,  0, 'c'},
     {"secdir",          required_argument,  0, 'S'},
     {"uri",             required_argument,  0, 'u'},
@@ -96,7 +95,6 @@ static void usage (void)
 "    -M,--module-path PATH prepend PATH to module search path\n"
 "    -O,--connector-path PATH   prepend PATH to connector search path\n"
 "    -t,--trace-handle     set FLUX_HANDLE_TRACE=1 before executing COMMAND\n"
-"    -B,--broker-path FILE override path to flux broker\n"
 "    -c,--config DIR       set path to config directory\n"
 "    -F,--file-config      force use of config file, even if FLUX_URI is set\n"
 "    -S,--secdir DIR       set the directory where CURVE keys will be stored\n"
@@ -117,7 +115,6 @@ int main (int argc, char *argv[])
     char *xopt = NULL;
     char *Mopt = NULL;
     char *Oopt = NULL;
-    char *Bopt = NULL;
     bool Fopt = false;
     char *confdir = NULL;
     char *secdir = NULL;
@@ -153,9 +150,6 @@ int main (int argc, char *argv[])
                 break;
             case 'x': /* --exec-path PATH */
                 xopt = optarg;
-                break;
-            case 'B': /* --broker-path PATH */
-                Bopt = optarg;
                 break;
             case 'v': /* --verbose */
                 vopt = true;
@@ -209,7 +203,7 @@ int main (int argc, char *argv[])
     /* We share a few environment variables with sub-commands, so
      * that they don't have to reprocess the config.
      */
-    setup_broker_env (cf, Bopt);    /* sets FLUX_BROKER_PATH */
+    setup_broker_env (cf);  /* set FLUX_BROKER_PATH */
 
     /* Add PATH to flux_conf_environment and prepend path to
      *  this executable if necessary.
@@ -322,13 +316,9 @@ void setup_path (flux_conf_t cf, const char *argv0)
 }
 
 
-void setup_broker_env (flux_conf_t cf, const char *path_override)
+void setup_broker_env (flux_conf_t cf)
 {
-    const char *cf_path = flux_conf_get (cf, "general.broker_path");
-    const char *path = path_override;
-
-    if (!path)
-        path = cf_path;
+    const char *path = flux_conf_get (cf, "general.broker_path");
     if (!path)
         path = BROKER_PATH;
     flux_conf_environment_set(cf, "FLUX_BROKER_PATH", path, "");

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -59,8 +59,6 @@ void setup_broker_env (flux_conf_t cf);
 static const struct option longopts[] = {
     {"trace-handle",    no_argument,        0, 't'},
     {"exec-path",       required_argument,  0, 'x'},
-    {"module-path",     required_argument,  0, 'M'},
-    {"connector-path",  required_argument,  0, 'O'},
     {"config",          required_argument,  0, 'c'},
     {"secdir",          required_argument,  0, 'S'},
     {"uri",             required_argument,  0, 'u'},
@@ -92,8 +90,6 @@ static void usage (void)
     fprintf (stderr,
 "Usage: flux [OPTIONS] COMMAND ARGS\n"
 "    -x,--exec-path PATH   prepend PATH to command search path\n"
-"    -M,--module-path PATH prepend PATH to module search path\n"
-"    -O,--connector-path PATH   prepend PATH to connector search path\n"
 "    -t,--trace-handle     set FLUX_HANDLE_TRACE=1 before executing COMMAND\n"
 "    -c,--config DIR       set path to config directory\n"
 "    -F,--file-config      force use of config file, even if FLUX_URI is set\n"
@@ -113,8 +109,6 @@ int main (int argc, char *argv[])
     int ch;
     bool vopt = false;
     char *xopt = NULL;
-    char *Mopt = NULL;
-    char *Oopt = NULL;
     bool Fopt = false;
     char *confdir = NULL;
     char *secdir = NULL;
@@ -141,12 +135,6 @@ int main (int argc, char *argv[])
                 if (setenv ("FLUX_HANDLE_TRACE", "1", 1) < 0)
                     err_exit ("setenv");
                 flux_conf_environment_set (cf, "FLUX_HANDLE_TRACE", "1", "");
-                break;
-            case 'M': /* --module-path PATH */
-                Mopt = optarg;
-                break;
-            case 'O': /* --connector-path PATH */
-                Oopt = optarg;
                 break;
             case 'x': /* --exec-path PATH */
                 xopt = optarg;
@@ -221,9 +209,7 @@ int main (int argc, char *argv[])
     flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
 
     /* Prepend to command-line environment variables */
-    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", Oopt);
     flux_conf_environment_push (cf, "FLUX_EXEC_PATH", xopt);
-    flux_conf_environment_push (cf, "FLUX_MODULE_PATH", Mopt);
 
     if (argc == 0) {
         usage ();

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -102,11 +102,14 @@ static void initialize_environment (flux_conf_t cf)
         cf, "LUA_PATH", "", ";"); /* use a null separator to keep it intact */
     flux_conf_environment_no_dedup_push_back (cf, "LUA_PATH", ";;");
     flux_conf_environment_from_env (cf, "PYTHONPATH", "", ":");
+    flux_conf_environment_from_env (cf, "FLUX_CONNECTOR_PATH", "", ":");
+    flux_conf_environment_from_env (cf, "FLUX_EXEC_PATH", "", ":");
+    flux_conf_environment_from_env (cf, "FLUX_MODULE_PATH", "", ":");
 
     // Build paths
-    flux_conf_environment_set (cf, "FLUX_CONNECTOR_PATH", CONNECTOR_PATH, ":");
-    flux_conf_environment_set (cf, "FLUX_EXEC_PATH", EXEC_PATH, ":");
-    flux_conf_environment_set (cf, "FLUX_MODULE_PATH", MODULE_PATH, ":");
+    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH", CONNECTOR_PATH);
+    flux_conf_environment_push (cf, "FLUX_EXEC_PATH", EXEC_PATH);
+    flux_conf_environment_push (cf, "FLUX_MODULE_PATH", MODULE_PATH);
     flux_conf_environment_push (cf, "LUA_CPATH", LUA_CPATH_ADD);
     flux_conf_environment_push (cf, "LUA_PATH", LUA_PATH_ADD);
     flux_conf_environment_push (cf, "PYTHONPATH", PYTHON_PATH);

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -71,26 +71,26 @@ test_expect_success 'flux env passes cmddriver option to argument' "
 		| grep ^foo://xyx$
 "
 # push /foo twice onto PYTHONPATH -- ensure it is leftmost position:
-test_expect_success 'cmddriver pushes dup path elements onto front of PATH' "
-	flux -P /foo env flux -P /bar env flux -P /foo env \
-		sh -c 'echo \$PYTHONPATH' | grep '^/foo'
-"
-# Ensure PATH-style variables are de-duplicated on push
-# Push /foo twice onto PYTHONPATH, ensure it appears only once
-test_expect_success 'cmddriver deduplicates path elements on push' "
-	flux -P /foo env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
-		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
-"
-# Ensure complex PATH-style variables are de-duplicated on push
-test_expect_success 'cmddriver deduplicates complex path elements on push' "
-	flux -P /foo:/foo:/foo:/bar:/foo:/baz env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
-		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
-"
-# External user path elements are preserved
-test_expect_success 'cmddriver preserves user path components' "
-	PYTHONPATH=/meh flux env sh -c 'echo \$PYTHONPATH' |
-		awk -F '/meh' 'NF-1 != 1 {print; exit 1}'
-"
+#test_expect_success 'cmddriver pushes dup path elements onto front of PATH' "
+#	flux -P /foo env flux -P /bar env flux -P /foo env \
+#		sh -c 'echo \$PYTHONPATH' | grep '^/foo'
+#"
+## Ensure PATH-style variables are de-duplicated on push
+## Push /foo twice onto PYTHONPATH, ensure it appears only once
+#test_expect_success 'cmddriver deduplicates path elements on push' "
+#	flux -P /foo env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
+#		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
+#"
+## Ensure complex PATH-style variables are de-duplicated on push
+#test_expect_success 'cmddriver deduplicates complex path elements on push' "
+#	flux -P /foo:/foo:/foo:/bar:/foo:/baz env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
+#		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
+#"
+## External user path elements are preserved
+#test_expect_success 'cmddriver preserves user path components' "
+#	PYTHONPATH=/meh flux env sh -c 'echo \$PYTHONPATH' |
+#		awk -F '/meh' 'NF-1 != 1 {print; exit 1}'
+#"
 test_expect_success 'cmddriver removes multiple contiguous separators in input' "
 	LUA_PATH='/meh;;;' flux env sh -c 'echo \$LUA_PATH' |
 		grep -v ';;;;'

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -14,14 +14,14 @@ test_expect_success 'baseline works' '
 	flux comms info
 '
 
-test_expect_success 'flux --module-path prepends to FLUX_MODULE_PATH' '
-	flux -F --module-path /xyz /usr/bin/printenv \
-		| grep "FLUX_MODULE_PATH=/xyz:"
+test_expect_success 'flux prepends to FLUX_MODULE_PATH' '
+	FLUX_MODULE_PATH=/xyz flux -F /usr/bin/printenv \
+		| grep "FLUX_MODULE_PATH=.*:/xyz"
 '
 
-test_expect_success 'flux --connector-path prepends to FLUX_CONNECTOR_PATH' '
-	flux -F --connector-path /xyz /usr/bin/printenv \
-		| grep "FLUX_CONNECTOR_PATH=/xyz:"
+test_expect_success 'flux prepends to FLUX_CONNECTOR_PATH' '
+        FLUX_CONNECTOR_PATH=/xyz flux -F /usr/bin/printenv \
+		| grep "FLUX_CONNECTOR_PATH=.*:/xyz"
 '
 
 test_expect_success 'flux --uri sets FLUX_URI' '

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -24,11 +24,6 @@ test_expect_success 'flux --connector-path prepends to FLUX_CONNECTOR_PATH' '
 		| grep "FLUX_CONNECTOR_PATH=/xyz:"
 '
 
-test_expect_success 'flux --broker-path sets FLUX_BROKER_PATH' '
-	flux -F --broker-path /xyz/flux-broker /usr/bin/printenv \
-		| egrep "^FLUX_BROKER_PATH=/xyz/flux-broker$"
-'
-
 test_expect_success 'flux --uri sets FLUX_URI' '
 	flux -F --uri xyz://foo /usr/bin/printenv \
 		| egrep "^FLUX_URI=xyz://foo$"


### PR DESCRIPTION
This PR implements some of what is described in #514.

These changes remove the following groups of options:

 * `--lua-path`, `--lua-cpath`, and `--python-path`: These options are simply removed. The `flux(1)` utility still reads `LUA_PATH` `LUA_CPATH` and `PYTHONPATH` from the current environment, but the values are effectively appended instead of prepended as with the (now removed) cmdline options. If required, paths can be prepended using a config file, but it didn't seem like a valid approach to keep these language-specific options on the `flux` utlity at this time.

 * `--broker-path`: I'm not sure this option was ever really used anywhere, so it is removed. `FLUX_BROKER_PATH` is still exported from the `flux` utility based on the current and built-in configuration, but this environment variable is currently only used by `flux-start`. In this case, we cannot allow `FLUX_BROKER_PATH` from the current environment to override internal/configured value, since this would break expected behavior when running a separate version of flux under flux. I toyed with the idea of allowing `FLUX_OVERRIDE_BROKER_PATH` or similar environment variable to override this path, but decided in the end it was adding functionality we do not currently need. Since `flux-start` is the only user of the current broker path, perhaps a cmdline option could be added there if necessary?

 * `--module-path` & `--connector-path`: Code was added to `libflux/conf.c` to pick up `FLUX_MODULE_PATH` and `FLUX_CONNECTOR_PATH` from the current environment and effectively append these current values as is done with Lua and Python paths. The catch is there is no way to prepend values to `CONNECTOR_PATH`, but I'm not sure this is necessary. (`FLUX_MODULE_PATH` can be extended via `flux-broker --module-path` option, I'm not sure what else besides the `flux-broker` would use this environment variable). The one problem I had with this change is that running flux under a different version of flux will end up cluttering the environment with the module and connector paths from both versions. This left me to believe the approach of ignoring the current environment might have merit. Anyone have comments?

I left `--exec-path` for now as it is the one option that is actually directly used by `flux(1)`, so it does seem appropriate to remain tied to that command.  
 
