### PR TITLE
optparse fixes

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -136,7 +136,7 @@ static optparse_t * setup_optparse_parse_args (int argc, char *argv[])
     register_builtin_subcommands (p);
 
     if (optparse_parse_args (p, argc, argv) < 0)
-        msg_exit ("argument parsing failed");
+        exit (1);
 
     return (p);
 }

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -638,6 +638,8 @@ optparse_t *optparse_create (const char *prog)
     if (!p)
         return NULL;
 
+    memset (p, 0, sizeof (*p));
+
     if (!(p->program_name = strdup (prog))) {
         free (p);
         return NULL;

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -1211,7 +1211,7 @@ int optparse_run_subcommand (optparse_t *p, int argc, char *argv[])
     optparse_t *sp;
 
     if (p->optind == -1) {
-        if (optparse_parse_args (p, argc, argv))
+        if (optparse_parse_args (p, argc, argv) < 0)
             return optparse_fatalerr (p, 1);
     }
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -1161,7 +1161,6 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
     int c;
     int li;
     const char *fullname = NULL;
-    char *saved_argv0;
     char *optstring = NULL;
     struct option *optz = option_table_create (p, &optstring);
 
@@ -1175,8 +1174,7 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
      * Disable getopt_long(3) printing errors to stderr.
      */
     opterr = 0;
-    saved_argv0 = argv[0];
-    argv[0] = (char *) fullname;
+
     while ((c = getopt_long (argc, argv, optstring, optz, &li))) {
         struct option_info *opt;
         struct optparse_option *o;
@@ -1210,8 +1208,6 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
 
     free (optz);
     free (optstring);
-
-    argv[0] = saved_argv0;
     p->optind = optind;
     return (optind);
 }

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -1245,6 +1245,7 @@ int optparse_fatal_usage (optparse_t *p, int code, const char *fmt, ...)
 {
     if (fmt) {
         va_list ap;
+        va_start (ap, fmt);
         optparse_vlog (p, fmt, ap);
         va_end (ap);
     }

--- a/src/common/libutil/optparse.h
+++ b/src/common/libutil/optparse.h
@@ -211,7 +211,6 @@ void * optparse_get_data (optparse_t *p, const char *name);
  */
 int optparse_print_usage (optparse_t *p);
 
-
 /*
  *   Print a message using [fmt, ...] using registered log function,
  *    followed by a the help message for optparse object [p],
@@ -219,6 +218,9 @@ int optparse_print_usage (optparse_t *p);
  *
  *   (By default this function will print the error to stderr, followed
  *    by the help for [p], then exit with exit status [code])
+ *
+ *   Error message, if provided, will always be prefixed with the full
+ *    "program name" for optparse object [p].
  *
  *   Returns the return value of registered fatalerr function, if the
  *    function returns at all.

--- a/src/common/libutil/test/optparse.c
+++ b/src/common/libutil/test/optparse.c
@@ -512,7 +512,7 @@ Usage: test two [OPTIONS]...\n\
 
     // Test unknown option prints expected error:
     char *av4[] = { "test", "two", "--unknown", NULL };
-    ac = sizeof (av4) / sizeof (av3[0]) - 1;
+    ac = sizeof (av4) / sizeof (av4[0]) - 1;
 
     e = optparse_set (b, OPTPARSE_FATALERR_FN, do_nothing);
 

--- a/src/common/libutil/test/optparse.c
+++ b/src/common/libutil/test/optparse.c
@@ -524,20 +524,40 @@ test two: unrecognized option '--unknown'\n\
 Try `test two --help' for more information.\n",
     "bad argument error message is expected");
 
+    // Test no subcommand (and subcommand required) prints error
+    char *av5[] = { "test", NULL };
+    ac = sizeof (av5) / sizeof (av5[0]) - 1;
+
+    // Set OPTPARSE_PRINT_SUBCMDS true:
+    e = optparse_set (a, OPTPARSE_PRINT_SUBCMDS, 1);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (PRINT_SUBCMDS, 0)");
+    // Don't exit on fatal error:
+    e = optparse_set (a, OPTPARSE_FATALERR_FN, do_nothing);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (FATALERR_FN, do_nothing)");
+    n = optparse_run_subcommand (a, ac, av5);
+    ok (n == -1, "optparse_run_subcommand with no subcommand");
+
+    usage_output_is ("\
+test: missing subcommand\n\
+Usage: test one [OPTIONS]\n\
+   or: test two [OPTIONS]\n\
+  -h, --help             Display this message.\n",
+    "missing subcommand error message is expected");
+
     optparse_destroy (a);
 }
 
 int main (int argc, char *argv[])
 {
 
-    plan (125);
+    plan (130);
 
     test_convenience_accessors (); /* 24 tests */
     test_usage_output (); /* 29 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */
     test_data (); /* 8 tests */
-    test_subcommand (); /* 34 tests */
+    test_subcommand (); /* 39 tests */
 
     done_testing ();
     return (0);


### PR DESCRIPTION
Ok, here's a series of fixes for some things I missed in the original PR. This includes a fix for segfault when running things like `flux content` with no extra args. Expected output is:
```
content: missing subcommand
Usage: flux content dropcache [OPTIONS]
   or: flux content flush [OPTIONS]
   or: flux content load [OPTIONS] BLOBREF
   or: flux content store [OPTIONS]
Access content store
  -h, --help             Display this message.
```

Hmm, should I also fix that error message to be `flux content: missing subcommand`?