### PR TITLE
Fix or workaround Issue#522

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -184,11 +184,8 @@ int main (int argc, char *argv[])
     */
     if (optparse_getopt (p, "config", &opt))
         confdir = xstrdup (opt);
-    optparse_getopt (p, "secdir", &secdir);
     if (confdir || (confdir = intree_confdir ()))
         flux_conf_set_directory (cf, confdir);
-    flux_conf_environment_set (cf, "FLUX_SEC_DIRECTORY",
-                     secdir ? secdir : flux_conf_get_directory (cf), "");
     flux_conf_environment_unset (cf, "FLUX_CONF_USEFILE");
 
     /* Process config from the KVS if not a bootstrap instance, and not
@@ -210,6 +207,13 @@ int main (int argc, char *argv[])
         } else if (errno != ENOENT)
             err_exit ("%s", flux_conf_get_directory (cf));
     }
+
+    /*
+     *  command line options that override environment and config:
+     */
+    if (!optparse_getopt (p, "secdir", &secdir))
+        secdir = flux_conf_get_directory (cf);
+    flux_conf_environment_set (cf, "FLUX_SEC_DIRECTORY", secdir, "");
 
     /* We share a few environment variables with sub-commands, so
      * that they don't have to reprocess the config.

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -96,4 +96,11 @@ test_expect_success READLINK 'cmddriver adds its own path to PATH if called with
 	fluxdir=\$(dirname \$fluxcmd) &&
 	PATH='/bin:/usr/bin' \$fluxcmd env sh -c 'echo \$PATH' | grep ^\$fluxdir
 "
+test_expect_success 'flux --secdir overrides config' '
+	umask 077 && tmpkeydir=`mktemp -d` &&
+	flux env flux --secdir="$tmpkeydir" keygen &&
+	ls $tmpkeydir >&2 &&
+	test -f $tmpkeydir/curve/client_secret &&
+	rm -rf $tmpkeydir
+'
 test_done


### PR DESCRIPTION
This addresses, in some small part, issue #522.
It should at least allow `flux --secdir` to work as expected when running under an enclosing instance with a different secdir in the KVS config.

A test is added as well. I hope this was a good approach for now.