### PR TITLE
fix tests for FLUX_TEST_INSTALLED_PATH

### DIFF
--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -44,6 +44,9 @@
 local top_srcdir = "@abs_top_srcdir@"
 local top_builddir = "@abs_top_builddir@"
 
+--  Default path for flux(1) binary
+local fluxbindir = top_builddir .. "/src/cmd"
+
 if os.getenv ("FLUX_TEST_INSTALLED_PATH") then
     --
     --  We are attempting to test against an installed flux(1).
@@ -51,8 +54,10 @@ if os.getenv ("FLUX_TEST_INSTALLED_PATH") then
     --   lua(1) under flux-env. We then _append_ in-tree paths so
     --   that test dependencies can be picked up such as Test/More.lua
     --   and lalarm.so
-    local path = os.getenv ("FLUX_TEST_INSTALLED_PATH")
-    local flux = path .. "/flux"
+    --
+    --  Reset fluxbindir to requested path by env variable:
+    fluxbindir = os.getenv ("FLUX_TEST_INSTALLED_PATH")
+    local flux = fluxbindir .. "/flux"
     local read_path = function (v)
         local cmd = string.format (flux.." env lua -e 'print (package.%s)'", v)
         local p = io.popen (cmd):read ("*all")
@@ -169,11 +174,10 @@ function fluxTest.init (...)
     test.log_file = "lua-"..test.prog..".broker.log"
     test.start_args = { "-o,-q,-L" .. test.log_file }
 
-    local dir = top_builddir.."/src/cmd"
-    local path = dir.."/flux"
+    local path = fluxbindir.."/flux"
     local mode = posix.stat (path, 'mode')
     if mode and mode:match('^rwx') then
-        do_path_prepend (dir)
+        do_path_prepend (fluxbindir)
         test.flux_path = path
     else
         test:die ("Failed to find flux path")

--- a/t/fluxometer.lua.in
+++ b/t/fluxometer.lua.in
@@ -137,7 +137,7 @@ end
 
 
 function fluxTest:die (...)
-    bail_out (self.prog..": "..string.format (...))
+    BAIL_OUT (self.prog..": "..string.format (...))
 end
 
 

--- a/t/t2004-hydra.t
+++ b/t/t2004-hydra.t
@@ -31,7 +31,7 @@ test_expect_success 'Flux libpmi-client wire protocol works with Hydra' '
 '
 
 test_expect_success 'Hydra can launch Flux' '
-	mpiexec.hydra -n 4 ${FLUX_BUILD_DIR}/src/cmd/flux broker \
+	mpiexec.hydra -n 4 flux broker \
 		flux comms info >flux_out &&
 	grep size=4 flux_out
 '


### PR DESCRIPTION
sharness tests in `t/` ostensibly allow testing with an installed `flux` binary by setting `FLUX_TEST_INSTALLED_PATH` (this of course doesn't work for all the build tests and built tests, but that is a slightly different issue)

When attempting to use `FLUX_TEST_INSTALLED_PATH` against the `/opt` install, I found the following minor problems and fixed them.

On this branch, a run of `FLUX_TEST_INSTALLED_PATH=/opt/flux-core/bin make check` seems to work (in this one instance, at least)