### PR TITLE
Allow optparse_run_subcommand to skip automatic parse_args

### DIFF
--- a/src/cmd/builtin/broker.c
+++ b/src/cmd/builtin/broker.c
@@ -43,7 +43,16 @@ int subcommand_broker_register (optparse_t *p)
         "[OPTIONS...] [COMMAND...]",
         "Run the flux broker",
         NULL);
-    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+
+    if (e != OPTPARSE_SUCCESS)
+        return (-1);
+
+    /* Do not parse options before calling cmd_broker:
+     */
+    optparse_set (optparse_get_subcommand (p, "broker"),
+                  OPTPARSE_SUBCMD_NOOPTS, 1);
+
+    return (0);
 }
 
 /*

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -62,8 +62,10 @@ struct opt_parser {
     int            left_margin;     /* Size of --help output left margin    */
     int            option_width;    /* Width of --help output for optiion   */
     int            current_group;   /* Current option group number          */
-    int            skip_subcmds;    /* Do not Print subcommands in --help   */
     List           option_list;     /* List of options for this program    */
+
+    unsigned int   skip_subcmds:1;  /* Do not Print subcommands in --help   */
+
 
     zhash_t *      dhash;           /* Hash of ancillary data               */
 

--- a/src/common/libutil/optparse.c
+++ b/src/common/libutil/optparse.c
@@ -65,7 +65,7 @@ struct opt_parser {
     List           option_list;     /* List of options for this program    */
 
     unsigned int   skip_subcmds:1;  /* Do not Print subcommands in --help   */
-
+    unsigned int   no_options:1;    /* Skip option processing for subcmd    */
 
     zhash_t *      dhash;           /* Hash of ancillary data               */
 
@@ -975,6 +975,10 @@ optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...)
         n = va_arg (vargs, int);
         p->skip_subcmds = !n;
         break;
+    case OPTPARSE_SUBCMD_NOOPTS:
+        n = va_arg (vargs, int);
+        p->no_options = n;
+        break;
     default:
         e = OPTPARSE_BAD_ARG;
     }
@@ -1236,7 +1240,7 @@ int optparse_run_subcommand (optparse_t *p, int argc, char *argv[])
         return optparse_fatal_usage (p, 1, "Unknown subcommand: %s\n", av[0]);
     }
 
-    if (optparse_parse_args (sp, ac, av) < 0)
+    if (!sp->no_options && (optparse_parse_args (sp, ac, av) < 0))
         return optparse_fatalerr (sp, 1);
 
     if (!(cb = zhash_lookup (sp->dhash, "optparse::cb"))) {

--- a/src/common/libutil/optparse.h
+++ b/src/common/libutil/optparse.h
@@ -53,6 +53,7 @@ typedef enum {
     OPTPARSE_OPTION_WIDTH, /* Width allotted to options in --help output    */
     OPTPARSE_LEFT_MARGIN,  /* Left pad for option output (default = 2)      */
     OPTPARSE_PRINT_SUBCMDS,/* Print all subcommands in --help (default = T  */
+    OPTPARSE_SUBCMD_NOOPTS,/* Don't parse options for this subcommand       */
 } optparse_item_t;
 
 /*
@@ -245,6 +246,9 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[]);
  *    sub-options already processed with optparse_parse_args(), and
  *    [argc,argv] adjusted for the subcommand (i.e. argv[0] will equal
  *    the subcommand name).
+ *
+ *   If OPTPARSE_SUBCMD_NOOPTS is set, auto optparse_parse_args()
+ *    for subcommand options is skipped.
  *
  *   This function can be called either before or after a call to
  *    optparse_parse_args (p, ...), optparse_run_subcommand() will call

--- a/src/common/libutil/test/optparse.c
+++ b/src/common/libutil/test/optparse.c
@@ -417,6 +417,18 @@ int subcmd_two (optparse_t *p, int ac, char **av)
     return (0);
 }
 
+int subcmd_three (optparse_t *p, int ac, char **av)
+{
+    int *acptr = NULL;
+    ok (p != NULL, "subcmd_three: got valid optparse structure");
+    acptr = optparse_get_data (p, "argc");
+    ok (acptr != NULL, "subcmd_three: got argc ptr");
+    *acptr = ac;
+
+    is (av[0], "three", "subcmd_three: av[0] == %s (expected 'three')", av[0]);
+    return (0);
+}
+
 
 int do_nothing (void *h, int code)
 {
@@ -544,20 +556,38 @@ Usage: test one [OPTIONS]\n\
   -h, --help             Display this message.\n",
     "missing subcommand error message is expected");
 
+
+    // Test Subcommand without option processing:
+    optparse_t *d = optparse_add_subcommand (a, "three", subcmd_three);
+    ok (d != NULL, "optparse_create()");
+    e = optparse_set (d, OPTPARSE_SUBCMD_NOOPTS, 1);
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (OPTPARSE_SUBCMD_NOOPTS)");
+
+    int value = 0;
+    optparse_set_data (d, "argc", &value);
+
+    char *av6[] = { "test", "three", "--help", NULL };
+    ac = sizeof (av6) / sizeof (av6[0]) - 1;
+
+    n = optparse_run_subcommand (a, ac, av6);
+    ok (n == 0, "optparse_run_subcommand with OPTPARSE_SUBCMD_NOOPTS");
+    ok (value == 2, "optparse_run_subcommand() run with argc = %d (expected 2)", value);
+    ok (optparse_optind (d) == -1, "optparse_run_subcommand: skipped parse_args");
+
     optparse_destroy (a);
 }
 
 int main (int argc, char *argv[])
 {
 
-    plan (130);
+    plan (138);
 
     test_convenience_accessors (); /* 24 tests */
     test_usage_output (); /* 29 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */
     test_data (); /* 8 tests */
-    test_subcommand (); /* 39 tests */
+    test_subcommand (); /* 47 tests */
 
     done_testing ();
     return (0);


### PR DESCRIPTION
As described in #531, flux `broker` subcommand was eating options before passing to `flux-broker` because `optparse_run_subcommand` always pre-parses args for all subcommands.

This PR adds a new flag `OPTPARSE_SUBCMD_NOOPTS` to skip this auto-parse, and directly calls any subcommand callback before processing args.

For demonstration, `builtin/broker.c` is changed to use this flag, even though we talked about removing that builtin cmd in #531.