### PR TITLE
Eliminate no certificate subject alternative name matches

### DIFF
--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -143,7 +143,7 @@ for pkg in $downloads; do
     mkdir -p ${name}  || die "Failed to mkdir ${name}"
     (
       cd ${name} &&
-      wget ${pkg} || die "Failed to download ${pkg}"
+      wget --no-check-certificate ${pkg} || die "Failed to download ${pkg}"
       tar --strip-components=1 -xf *.tar.gz || die "Failed to un-tar ${name}"
       test -x configure && CC=gcc ./configure --prefix=${prefix} \
                   --sysconfdir=${prefix}/etc \


### PR DESCRIPTION
Adds the --no-check-certificate to wget in travis-dep-builder.sh to
eliminate the complaint that travis issues when onnecting to
www.open-mpi.org:
ERROR: no certificate subject alternative name matches
	requested host name `www.open-mpi.org'.
To connect to www.open-mpi.org insecurely, use `--no-check-certificate'.