### PR TITLE
Add flux version

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -42,7 +42,8 @@ flux_SOURCES = \
 	builtin/help.c \
 	builtin/dmesg.c \
 	builtin/env.c \
-	builtin/content.c
+	builtin/content.c \
+	builtin/version.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -1,0 +1,49 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <config.h>
+
+#include "builtin.h"
+
+static int cmd_version (optparse_t *p, int ac, char *av[])
+{
+    printf ("%s-%s\n", PACKAGE_NAME, PACKAGE_VERSION);
+    return (0);
+}
+
+int subcommand_version_register (optparse_t *p)
+{
+    optparse_err_t e;
+    e = optparse_reg_subcommand (p,
+        "version",
+        cmd_version,
+        NULL,
+        "Display flux version information",
+        NULL);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -66,4 +66,10 @@ test_expect_success 'snoop: produces output (XXX needs fixing)' '
 	head output_snoop | grep "^flux-snoop: connecting to" &&
 	head output_snoop_long | grep "^flux-snoop: connecting to"
 '
+
+test_expect_success 'version: reports an expected string' '
+        set -x
+	flux version | grep -q "flux-core-[0-9]+\.[0-9]+\.[0-9]"
+	set +x
+'
 test_done


### PR DESCRIPTION
Simply adds a `flux version` subcommand and a small test to ensure the basic functionality.