### PR TITLE
clean up error paths in modules/resource-hwloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Prologue
 ##
 AC_INIT([flux-core],
-        m4_esyscmd([git describe | awk '/.*/ {printf "%s",$1; exit}']))
+        m4_esyscmd([git describe --always | awk '/.*/ {printf "%s",$1; exit}']))
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -60,7 +60,7 @@ int main (int argc, char *argv[])
 {
     flux_t h;
     int ch;
-    int rank = -1; /* local */
+    uint32_t rank = FLUX_NODEID_ANY; /* local */
     char *cmd;
     int e;
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -150,38 +150,6 @@ int flux_log_error (flux_t h, const char *fmt, ...)
     return rc;
 }
 
-// Instantiate inline flux_log_check functions, this is *necessary* for
-// linking to work under C99 rules
-int flux_log_check_int (flux_t h,
-               int res,
-               const char *fmt,
-               ...  )
-{
-    if (res < 0) {
-        va_list ap;
-        va_start (ap, fmt);
-        flux_log_verror (h, fmt, ap);
-        va_end (ap);
-        exit (errno);
-    }
-    return res;
-}
-
-void *flux_log_check_ptr (flux_t h,
-                 void *res,
-                 const char *fmt,
-                 ... )
-{
-    if (res == NULL) {
-        va_list ap;
-        va_start (ap, fmt);
-        flux_log_verror (h, fmt, ap);
-        va_end (ap);
-        exit (errno);
-    }
-    return res;
-}
-
 static int dmesg_clear (flux_t h, int seq)
 {
     flux_rpc_t *rpc;

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -32,39 +32,6 @@ int flux_log_verror (flux_t h, const char *fmt, va_list ap);
 int flux_log_error (flux_t h, const char *fmt, ...)
                  __attribute__ ((format (printf, 2, 3)));
 
-/* Check for error return codes, if one is found log an error with log_error
- * and die with error code errno */
-__attribute__ ((format (printf, 3, 4)))
-int flux_log_check_int (flux_t h,
-               int res,
-               const char *fmt,
-               ...  );
-
-__attribute__ ((format (printf, 3, 4)))
-void *flux_log_check_ptr (flux_t h,
-                 void *res,
-                 const char *fmt,
-                 ... );
-
-#ifndef STRINGIFY
-#  ifndef REAL_STRINGIFY
-#    define REAL_STRINGIFY(X) #X
-#  endif
-#  define STRINGIFY(X) REAL_STRINGIFY (X)
-#endif
-
-#define FLOG_POSITION __FILE__ ":" STRINGIFY (__LINE__)
-
-// NOTE: FMT string *MUST* be a string literal
-#define FLUX_CHECK_INT(H, X, ...) flux_log_check_int ((H), (X), FLOG_POSITION \
-                                          ":negative integer from:" \
-                                          STRINGIFY (X) ":" \
-                                          __VA_ARGS__)
-#define FLUX_CHECK_PTR(H, X, ...) flux_log_check_ptr ((H), (X), FLOG_POSITION \
-                                          ":null pointer from:" \
-                                          STRINGIFY (X) ":" \
-                                          __VA_ARGS__)
-
 #define FLUX_LOG_ERROR(h) \
     (void)flux_log_error ((h), "%s::%d[%s]", __FILE__, __LINE__, __FUNCTION__)
 

--- a/src/modules/live/live.h
+++ b/src/modules/live/live.h
@@ -3,8 +3,8 @@
 
 #include <flux/core.h>
 
-int flux_failover (flux_t h, int rank);
-int flux_recover (flux_t h, int rank);
+int flux_failover (flux_t h, uint32_t rank);
+int flux_recover (flux_t h, uint32_t rank);
 int flux_recover_all (flux_t h);
 
 #endif /* !_FLUX_CORE_LIVE_H */

--- a/src/modules/resource-hwloc/Makefile.am
+++ b/src/modules/resource-hwloc/Makefile.am
@@ -15,7 +15,7 @@ AM_CPPFLAGS = \
 fluxmod_LTLIBRARIES = resource-hwloc.la
 
 resource_hwloc_la_SOURCES = resource.c
-resource_hwloc_la_CFLAGS = $(HWLOC_CFLAGS)
+resource_hwloc_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_CFLAGS)
 resource_hwloc_la_LDFLAGS = $(fluxmod_ldflags) -module
 resource_hwloc_la_LIBADD = $(top_builddir)/src/common/libflux-core.la \
 			   $(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -117,6 +117,7 @@ void freectx (ctx_t *ctx)
     if (ctx) {
         if (ctx->topology)
             hwloc_topology_destroy (ctx->topology);
+        free (ctx);
     }
 }
 

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -124,24 +124,6 @@ static ctx_t *getctx (flux_t h)
     return ctx;
 }
 
-/* Copy input arguments to output arguments and respond to RPC.
-*/
-static void query_cb (flux_t h,
-                      flux_msg_handler_t *watcher,
-                      const flux_msg_t *msg,
-                      void *arg)
-{
-    flux_log (h, LOG_ERR, "UNIMPLEMENTED: %s", __FUNCTION__);
-}
-
-static void get_cb (flux_t h,
-                    flux_msg_handler_t *watcher,
-                    const flux_msg_t *msg,
-                    void *arg)
-{
-    flux_log (h, LOG_ERR, "UNIMPLEMENTED: %s", __FUNCTION__);
-}
-
 void unlink_if_exists (flux_t h, const char *path)
 {
     if (!kvs_unlink (h, path))  // if the unlink succeeds
@@ -440,8 +422,6 @@ static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "resource-hwloc.load", load_cb, NULL},
     {FLUX_MSGTYPE_REQUEST, "resource-hwloc.reload", reload_cb, NULL},
     {FLUX_MSGTYPE_REQUEST, "resource-hwloc.topo", topo_cb, NULL},
-    {FLUX_MSGTYPE_REQUEST, "resource-hwloc.query", query_cb, NULL},
-    {FLUX_MSGTYPE_REQUEST, "resource-hwloc.get", get_cb, NULL},
     FLUX_MSGHANDLER_TABLE_END};
 
 int mod_main (flux_t h, int argc, char **argv)

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -357,7 +357,7 @@ static void reload_request_cb (flux_t h,
                                void *arg)
 {
     ctx_t *ctx = arg;
-    int rc, errnum = 0;
+    int errnum = 0;
 
     if (ctx_hwloc_init (h, ctx) < 0 || load_hwloc (h, ctx) < 0)
         errnum = errno;

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -68,8 +68,7 @@ static int ctx_init (flux_t h, ctx_t *ctx)
     FLUX_CHECK_INT (h, hwloc_topology_init (&ctx->topology));
 
     char *path = NULL;
-    char *conf_path =
-        FLUX_CHECK_PTR (h, xasprintf ("config.resource.hwloc.xml.%" PRIu32, rank));
+    char *conf_path = xasprintf ("config.resource.hwloc.xml.%" PRIu32, rank);
     kvs_get_string (h, conf_path, &path);
     free (conf_path);
 


### PR DESCRIPTION
Replace resource-hwloc calls to `FLUX_CHECK_INT()` and `FLUX_CHECK_PTR()` with error paths that return RPC error responses or cause `mod_main()` to exit, with copious logging.  A bit of refactoring for clarity as well.

Fixes issue #536 