### PR TITLE
load content-sqlite by default

### DIFF
--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -53,9 +53,6 @@ Be annoyingly chatty.
 *-q, --quiet*::
 Suppress messages intended for interactive users.
 
-*-N, --sid*='NAME'::
-Set the session id of this session.
-
 *-k, --k-ary*='N'::
 Set the branching factor of this comms session's tree based overlay
 network (default: 2).

--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -115,10 +115,6 @@ Enable the use of ipc:// sockets for the tree-based overlay network
 and event distribution.  This may be set if all ranks of a comms
 session share a common $TMPDIR namespace.
 
-*-D, --scratch-directory*='DIR'::
-Create ipc:// sockets in this directory.  If unspecified, ranks co-located
-in the same $TMPDIR namespace will use unique scratch directories.
-
 *-g, --shutdown-grace*='SECS'::
 Specify the shutdown grace period, in seconds (default: guess based
 on session size).

--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -53,6 +53,9 @@ Be annoyingly chatty.
 *-q, --quiet*::
 Suppress messages intended for interactive users.
 
+*-S, --setattr*='ATTR=VAL'::
+Set initial value for broker attribute.
+
 *-k, --k-ary*='N'::
 Set the branching factor of this comms session's tree based overlay
 network (default: 2).

--- a/doc/man1/flux-broker.adoc
+++ b/doc/man1/flux-broker.adoc
@@ -61,15 +61,6 @@ network (default: 2).
 Set the session heartrate in seconds.  The valid range is 0.01 to 30.0
 (default: 2.0).
 
-*-L, --logdest*='DEST'::
-Set log destination.  DEST may be 'stderr' or a file name (default: stderr).
-
-*-l, --log-level*='LEVEL'::
-Log messages of LEVEL or below are forwarded to rank 0 and sent to the
-configured log destination.  LEVEL may be an integer (0-7) or the name
-of a syslog(3) level, e.g.  0=emerg, 1=alert, 2=crit, 3=err, 4=warning,
-5=notice, 6=info, 7=debug (default: 6).
-
 *-M, --module*='NAME[nodeset]'::
 Load the specified comms module.  '[nodeset]' optionally limits the
 ranks on which the module should be loaded (default all ranks).

--- a/doc/man1/flux-content.adoc
+++ b/doc/man1/flux-content.adoc
@@ -57,11 +57,17 @@ locally and displayed on standard output, but the blob is not stored.
 
 BACKING STORE
 -------------
-The rank 0 cache, by default, must retain all content,
-unless a module providing the "content-backing" service is loaded
-which can offload content to some other place.  Examples
-of modules providing this service are *content-sqlite* and
-*content-sophia*.
+The rank 0 cache retains all content until a module providing
+the "content-backing" service is loaded which can offload content
+to some other place.  Examples of modules providing this service
+are *content-sqlite* and *content-sophia*.  The *content-sqlite*
+module is loaded by default.
+
+Content database files are stored persistently on rank 0 if the
+persist-directory broker attribute is set to a directory name for
+the session.  Otherwise they are stored in the directory defined
+by the scratch-directory attribute and are cleaned up when the
+instance terminates.
 
 When one of these modules is loaded, it informs the rank 0
 cache of its availability, which triggers the cache to begin

--- a/doc/man1/flux-dmesg.adoc
+++ b/doc/man1/flux-dmesg.adoc
@@ -43,21 +43,6 @@ To dump the ring buffer on all ranks
   $ flux exec flux dmesg | sort
 
 
-BROKER ATTRIBUTES
------------------
-
-Ring buffer parameters may be accessed via the following broker attributes:
-
-log-bufcount (read-only)::
-The number of log entries currently stored in the ring buffer.
-
-log-buflimit (read-write)::
-The maximum number of log entries that can be stored in the ring buffer.
-
-log-count (read-only)::
-The number of log entries ever stored in the ring buffer.
-
-
 AUTHOR
 ------
 This page is maintained by the Flux community.
@@ -75,4 +60,4 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
-flux-setattr(1)
+flux-setattr(1), flux-broker-attributes(7)

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -33,8 +33,28 @@ tbon-arity::
 The branching factor of the tree based overlay network.
 
 scratch-directory::
-The temporary directory used for session sockets, content
-backing storage, etc..
+A temporary directory available for scratch storage within
+the session.  This directory _may_ be shared by multiple ranks.
+Cleanup of directory contents is the responsibility of
+the creator.
+
+scratch-directory-rank::
+A temporary directory available for scratch storage within
+the session.  This directory is unique to the local rank,
+and is usually a sub-directory of scratch-directory.
+Cleanup of directory contents is the responsibility of
+the creator.
+
+persist-directory::
+A persistent directory available for storage on rank 0 only.
+If persist-directory is not defined, persistence is unavailable
+and users should fall back to scratch-directory, with cleanup.
+
+persist-filesystem::
+If defined, and persist-directory is not defined, the rank
+0 broker chooses a unique name for persist-directory within
+persist-filesystem and creates it automatically.
+
 
 SOCKET ATTRIBUTES
 -----------------

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -82,18 +82,27 @@ a connection to the enclosing instance.
 LOGGING ATTRIBUTES
 ------------------
 
-log-bufcount::
+log-ring-used::
 The number of log entries currently stored in the ring buffer.
 
-log-buflimit::
+log-ring-size::
 The maximum number of log entries that can be stored in the ring buffer.
 
 log-count::
 The number of log entries ever stored in the ring buffer.
 
-log-level::
+log-forward-level::
 Log entries at syslog(3) level at or below this value are forwarded
 to rank zero for permanent capture.
+
+log-critical-level::
+Log entries at syslog(3) level at or below this value are copied
+to stderr on the logging rank, for capture by the enclosing instance.
+
+log-filename::
+If set on rank zero, forwarded log entries are directed to this file.
+If the file name is set to "stderr", forwarded log entries are directed
+to standard error of the rank zero broker.
 
 
 CONTENT ATTRIBUTES

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -301,3 +301,4 @@ blobrefs
 lstopo
 xml
 filesystem
+filename

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -300,3 +300,4 @@ blobref
 blobrefs
 lstopo
 xml
+filesystem

--- a/src/bindings/python/test_commands/sideflux.py
+++ b/src/bindings/python/test_commands/sideflux.py
@@ -50,7 +50,7 @@ class SideFlux(object):
 
     def start(self):
         flux_command = [flux_exe, 'start', '--size={}'.format(self.size), '-o',
-                        '-L,stderr,--scratch-directory,' + self.tmpdir , 'bash']
+                        '-L,stderr,-S,scratch-directory=' + self.tmpdir , 'bash']
         # print ' '.join(flux_command)
         FNULL = open(os.devnull, 'w+')
         self.subenv = os.environ.copy()

--- a/src/bindings/python/test_commands/sideflux.py
+++ b/src/bindings/python/test_commands/sideflux.py
@@ -50,7 +50,7 @@ class SideFlux(object):
 
     def start(self):
         flux_command = [flux_exe, 'start', '--size={}'.format(self.size), '-o',
-                        '-L,stderr,-S,scratch-directory=' + self.tmpdir , 'bash']
+                        '-Slog-forward-level=7,-Sscratch-directory=' + self.tmpdir , 'bash']
         # print ' '.join(flux_command)
         FNULL = open(os.devnull, 'w+')
         self.subenv = os.environ.copy()

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -203,6 +203,21 @@ done:
     return rc;
 }
 
+int attr_set_flags (attr_t *attrs, const char *name, int flags)
+{
+    struct entry *e;
+    int rc = -1;
+
+    if (!(e = zhash_lookup (attrs->hash, name))) {
+        errno = ENOENT;
+        goto done;
+    }
+    e->flags = flags;
+    rc = 0;
+done:
+    return rc;
+}
+
 static int get_int (const char *name, const char **val, void *arg)
 {
     int *i = arg;

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -131,8 +131,12 @@ int attr_add_active (attr_t *attrs, const char *name, int flags,
     int rc = -1;
 
     if ((e = zhash_lookup (attrs->hash, name))) {
-        errno = EEXIST;
-        goto done;
+        if (!set) {
+            errno = EEXIST;
+            goto done;
+        }
+        if (set (name, e->val, arg) < 0)
+            goto done;
     }
     e = entry_create (name, NULL, flags);
     e->set = set;

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -31,6 +31,10 @@ int attr_get (attr_t *attrs, const char *name, const char **val, int *flags);
 
 int attr_set (attr_t *attrs, const char *name, const char *val, bool force);
 
+/* Set an attribute's flags.
+ */
+int attr_set_flags (attr_t *attrs, const char *name, int flags);
+
 /* Add an attribute with callbacks for get/set.
  */
 int attr_add_active (attr_t *attrs, const char *name, int flags,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -719,7 +719,7 @@ static void hello_update_cb (hello_t *hello, void *arg)
         if (ctx->init_shell)
             init_shell (ctx);
     } else  {
-        flux_log (ctx->h, LOG_ERR, "nodeset: %s (incomplete)",
+        flux_log (ctx->h, LOG_INFO, "nodeset: %s (incomplete)",
                   hello_get_nodeset (hello));
     }
     if (ctx->hello_timeout != 0

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -74,7 +74,7 @@
 #endif
 
 const char *default_modules =
-    "connector-local,modctl,kvs,live,mecho,job,wrexec,barrier,resource-hwloc";
+    "connector-local,modctl,kvs,content-sqlite[0],live,mecho,job,wrexec,barrier,resource-hwloc";
 
 const char *default_boot_method = "pmi";
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -396,7 +396,8 @@ int main (int argc, char *argv[])
         for (m = &boot_table[0]; m->name != NULL; m++)
             if (!strcasecmp (m->name, boot_method))
                 break;
-        ctx.boot_method = m;
+        if (m->name != NULL)
+            ctx.boot_method = m;
     }
     if (!ctx.boot_method)
         msg_exit ("invalid boot method: %s", boot_method ? boot_method

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -220,7 +220,7 @@ static const struct option longopts[] = {
 static void usage (void)
 {
     fprintf (stderr,
-"Usage: flux-broker OPTIONS [module:key=val ...]\n"
+"Usage: flux-broker OPTIONS [initial-command ...]\n"
 " -v,--verbose                 Be annoyingly verbose\n"
 " -q,--quiet                   Be mysteriously taciturn\n"
 " -N,--sid NAME                Set session id\n"

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -194,7 +194,7 @@ static struct boot_method boot_table[] = {
     { NULL, NULL },
 };
 
-#define OPTIONS "+vqM:X:L:N:k:s:H:O:x:T:g:D:Em:l:I"
+#define OPTIONS "+vqM:X:L:N:k:s:H:O:x:T:g:D:Em:l:IS:"
 static const struct option longopts[] = {
     {"sid",             required_argument,  0, 'N'},
     {"verbose",         no_argument,        0, 'v'},
@@ -214,6 +214,7 @@ static const struct option longopts[] = {
     {"shared-ipc-namespace", no_argument,   0, 'I'},
     {"boot-method",     required_argument,  0, 'm'},
     {"log-level",       required_argument,  0, 'l'},
+    {"setattr",         required_argument,  0, 'S'},
     {0, 0, 0, 0},
 };
 
@@ -240,6 +241,7 @@ static void usage (void)
 " -E,--enable-epgm             Enable EPGM for events (PMI bootstrap)\n"
 " -I,--shared-ipc-namespace    Wire up session TBON over ipc sockets\n"
 " -m,--boot-method             Select bootstrap: pmi, single\n"
+" -S,--setattr ATTR=VAL        Set broker attribute\n"
 );
     exit (1);
 }
@@ -379,6 +381,15 @@ int main (int argc, char *argv[])
                 break;
             case 'm': { /* --boot-method */
                 boot_method = optarg;
+                break;
+            }
+            case 'S': { /* --setattr ATTR=VAL */
+                char *val, *attr = xstrdup (optarg);
+                if ((val = strchr (attr, '=')))
+                    *val++ = '\0';
+                if (attr_add (ctx.attrs, attr, val, 0) < 0)
+                    err_exit ("setattr %s=%s", attr, val);
+                free (attr);
                 break;
             }
             default:

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1034,7 +1034,8 @@ static int boot_pmi (ctx_t *ctx)
                 if (relay_rank == -1 || clique_ranks[i] < relay_rank)
                     relay_rank = clique_ranks[i];
             if (relay_rank >= 0 && ctx->rank == relay_rank) {
-                char *relayfile = xasprintf ("%s/relay", ctx->scratch_dir);
+                char *relayfile = xasprintf ("%s/%d/relay",
+                                             ctx->scratch_dir, rank);
                 overlay_set_relay (ctx->overlay, "ipc://%s", relayfile);
                 cleanup_push_string (cleanup_file, relayfile);
                 free (relayfile);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -368,7 +368,8 @@ int main (int argc, char *argv[])
                 if ((val = strchr (attr, '=')))
                     *val++ = '\0';
                 if (attr_add (ctx.attrs, attr, val, 0) < 0)
-                    err_exit ("setattr %s=%s", attr, val);
+                    if (attr_set (ctx.attrs, attr, val, true) < 0)
+                        err_exit ("setattr %s=%s", attr, val);
                 free (attr);
                 break;
             }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -191,7 +191,7 @@ static struct boot_method boot_table[] = {
     { NULL, NULL },
 };
 
-#define OPTIONS "+vqM:X:L:k:s:H:O:x:T:g:Em:l:IS:"
+#define OPTIONS "+vqM:X:k:s:H:O:x:T:g:Em:IS:"
 static const struct option longopts[] = {
     {"verbose",         no_argument,        0, 'v'},
     {"quiet",           no_argument,        0, 'q'},
@@ -200,7 +200,6 @@ static const struct option longopts[] = {
     {"exclude",         required_argument,  0, 'x'},
     {"modopt",          required_argument,  0, 'O'},
     {"module-path",     required_argument,  0, 'X'},
-    {"logdest",         required_argument,  0, 'L'},
     {"k-ary",           required_argument,  0, 'k'},
     {"heartrate",       required_argument,  0, 'H'},
     {"timeout",         required_argument,  0, 'T'},
@@ -208,7 +207,6 @@ static const struct option longopts[] = {
     {"enable-epgm",     no_argument,        0, 'E'},
     {"shared-ipc-namespace", no_argument,   0, 'I'},
     {"boot-method",     required_argument,  0, 'm'},
-    {"log-level",       required_argument,  0, 'l'},
     {"setattr",         required_argument,  0, 'S'},
     {0, 0, 0, 0},
 };
@@ -223,9 +221,6 @@ static void usage (void)
 " -x,--exclude NAME            Exclude module NAME\n"
 " -O,--modopt NAME:key=val     Set option for module NAME (may be repeated)\n"
 " -X,--module-path PATH        Set module search path (colon separated)\n"
-" -L,--logdest FILE            Redirect log output to specified file\n"
-" -l,--log-level LEVEL         Set log level (default: 6/info)\n"
-"          [0=emerg 1=alert 2=crit 3=err 4=warning 5=notice 6=info 7=debug]\n"
 " -s,--security=plain|curve|none    Select security mode (default: curve)\n"
 " -k,--k-ary K                 Wire up in a k-ary tree\n"
 " -H,--heartrate SECS          Set heartrate in seconds (rank 0 only)\n"
@@ -324,16 +319,6 @@ int main (int argc, char *argv[])
                 break;
             case 'X':   /* --module-path PATH */
                 modpath = optarg;
-                break;
-            case 'L':   /* --logdest DEST */
-                if (attr_add (ctx.attrs, "log-filename", optarg, 0) < 0)
-                    if (attr_set (ctx.attrs, "log-filename", optarg, true) < 0)
-                        err_exit ("setattr %s=%s", "log-filename", optarg);
-                break;
-            case 'l':   /* --log-level 0-7 */
-                if (attr_add (ctx.attrs, "log-forward-level", optarg, 0) < 0)
-                    if (attr_set (ctx.attrs, "log-forward-level", optarg, true) < 0)
-                        err_exit ("setattr %s=%s", "log-forward-level", optarg);
                 break;
             case 'k':   /* --k-ary k */
                 ctx.k_ary = strtoul (optarg, NULL, 10);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -2571,6 +2571,7 @@ static void module_cb (module_t *p, void *arg)
         goto done;
     if (zmsg_content_size (zmsg) == 0) { /* EOF - safe to pthread_join */
         svc_remove (ctx->services, module_get_name (p));
+        flux_log (ctx->h, LOG_INFO, "module %s exited", module_get_name (p));
         module_remove (ctx->modhash, p);
         goto done;
     }

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -486,6 +486,8 @@ static int cache_store (content_cache_t *cache, struct cache_entry *e)
         rpc = flux_rpc_raw (cache->h, "content.store",
                             e->data, e->len, FLUX_NODEID_UPSTREAM, 0);
     } else {
+        if (cache->flush_batch_count >= cache->flush_batch_limit)
+            return 0;
         rpc = flux_rpc_raw (cache->h, "content-backing.store",
                             e->data, e->len, FLUX_NODEID_ANY, 0);
     }

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -565,6 +565,15 @@ static void content_store_request (flux_t h, flux_msg_handler_t *w,
                 return;
             }
         }
+    } else {
+        /* When a backing store module is unloaded, it will clear
+         * cache->backing then attempt to store all its blobs.  Any of
+         * those still in cache need to be marked dirty.
+         */
+        if (cache->rank == 0 && !cache->backing) {
+            e->dirty = 1;
+            cache->acct_dirty++;
+        }
     }
     rc = 0;
 done:

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -33,15 +33,22 @@
 
 #include "log.h"
 
+static const int default_ring_size = 1024;
+static const int default_forward_level = LOG_ERR;
+static const int default_critical_level = LOG_CRIT;
+static const char *default_filename = "stderr";
+
 #define LOG_MAGIC 0xe1e2e3e4
 struct log_struct {
     int magic;
     flux_t h;
     uint32_t rank;
+    char *filename;
     FILE *f;
-    int level;
+    int forward_level;
+    int critical_level;
     zlist_t *buf;
-    int buflimit;
+    int ring_size;
     int seq;
     zlist_t *sleepers;
 };
@@ -105,11 +112,11 @@ static struct log_entry *log_entry_create (const char *facility, int level,
     return e;
 }
 
-static void log_buf_trim (log_t *log, int limit)
+static void log_buf_trim (log_t *log, int size)
 {
     assert (log->magic == LOG_MAGIC);
     struct log_entry *e;
-    while (zlist_size (log->buf) > limit) {
+    while (zlist_size (log->buf) > size) {
         e = zlist_pop (log->buf);
         log_entry_destroy (e);
     }
@@ -189,8 +196,8 @@ static int log_buf_append (log_t *log, const char *facility, int level,
     struct log_entry *e;
     struct sleeper *s;
 
-    if (log->buflimit > 0) {
-        log_buf_trim (log, log->buflimit - 1);
+    if (log->ring_size > 0) {
+        log_buf_trim (log, log->ring_size - 1);
         e = log_entry_create (facility, level, rank, tv, message);
         e->seq = log->seq++;
         if (zlist_append (log->buf, e) < 0) {
@@ -210,8 +217,9 @@ log_t *log_create (void)
 {
     log_t *log = xzmalloc (sizeof (*log));
     log->magic = LOG_MAGIC;
-    log->f = stderr;
-    log->level = LOG_DEBUG;
+    log->forward_level = default_forward_level;
+    log->critical_level = default_critical_level;
+    log->ring_size = default_ring_size;
     if (!(log->buf = zlist_new ()))
         oom();
     if (!(log->sleepers = zlist_new ()))
@@ -234,6 +242,10 @@ void log_destroy (log_t *log)
                 sleeper_destroy (s);
             zlist_destroy (&log->sleepers);
         }
+        if (log->f && log->f != stderr)
+            (void)fclose (log->f);
+        if (log->filename)
+            free (log->filename);
         free (log);
     }
 }
@@ -249,50 +261,178 @@ void log_set_rank (log_t *log, uint32_t rank)
     log->rank = rank;
 }
 
-void log_set_file (log_t *log, FILE *f)
-{
-    log->f = f;
-}
-
-int log_set_level (log_t *log, int level)
+static int log_set_forward_level (log_t *log, int level)
 {
     if (level < LOG_EMERG || level > LOG_DEBUG) {
         errno = EINVAL;
         return -1;
     }
-    log->level = level;
+    log->forward_level = level;
     return 0;
 }
 
-int log_get_level (log_t *log)
+static int log_set_critical_level (log_t *log, int level)
 {
-    return log->level;
-}
-
-int log_set_buflimit (log_t *log, int limit)
-{
-    if (limit < 0) {
+    if (level < LOG_EMERG || level > LOG_DEBUG) {
         errno = EINVAL;
         return -1;
     }
-    log_buf_trim (log, limit);
-    log->buflimit = limit;
+    log->critical_level = level;
     return 0;
 }
 
-int log_get_buflimit (log_t *log)
+static int log_set_ring_size (log_t *log, int size)
 {
-    return log->buflimit;
+    if (size < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    log_buf_trim (log, size);
+    log->ring_size = size;
+    return 0;
 }
 
-int log_get_bufcount (log_t *log)
+/* Set the log filename (rank 0 only).
+ * Allow other ranks to try to set this without effect
+ * so that the same broker options can be used across a session.
+ */
+static int log_set_filename (log_t *log, const char *destination)
 {
-    return zlist_size (log->buf);
+    FILE *f;
+    if (log->rank > 0)
+        return 0;
+    if (!strcmp (destination, "stderr"))
+        f = stderr;
+    else if (!(f = fopen (destination, "a")))
+        return -1;
+    if (log->filename)
+        free (log->filename);
+    if (log->f && log->f != stderr)
+        fclose (log->f);
+    log->filename = xstrdup (destination);
+    log->f = f;
+    return 0;
 }
 
-int log_get_count (log_t *log)
+static int attr_get_log (const char *name, const char **val, void *arg)
 {
-    return log->seq;
+    log_t *log = arg;
+    static char s[32];
+    int n, rc = -1;
+
+    if (!strcmp (name, "log-forward-level")) {
+        n = snprintf (s, sizeof (s), "%d", log->forward_level);
+        assert (n < sizeof (s));
+        *val = s;
+    } else if (!strcmp (name, "log-critical-level")) {
+        n = snprintf (s, sizeof (s), "%d", log->critical_level);
+        assert (n < sizeof (s));
+        *val = s;
+    } else if (!strcmp (name, "log-ring-size")) {
+        n = snprintf (s, sizeof (s), "%d", log->ring_size);
+        assert (n < sizeof (s));
+        *val = s;
+    } else if (!strcmp (name, "log-ring-used")) {
+        n = snprintf (s, sizeof (s), "%d", (int)zlist_size (log->buf));
+        assert (n < sizeof (s));
+        *val = s;
+    } else if (!strcmp (name, "log-count")) {
+        n = snprintf (s, sizeof (s), "%d", log->seq);
+        assert (n < sizeof (s));
+        *val = s;
+    } else if (!strcmp (name, "log-filename")) {
+        *val = log->filename;
+    } else {
+        errno = ENOENT;
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+static int attr_set_log (const char *name, const char *val, void *arg)
+{
+    log_t *log = arg;
+    int rc = -1;
+
+    if (!strcmp (name, "log-forward-level")) {
+        int level = strtol (val, NULL, 10);
+        if (log_set_forward_level (log, level) < 0)
+            goto done;
+    } else if (!strcmp (name, "log-critical-level")) {
+        int level = strtol (val, NULL, 10);
+        if (log_set_critical_level (log, level) < 0)
+            goto done;
+    } else if (!strcmp (name, "log-ring-size")) {
+        int size = strtol (val, NULL, 10);
+        if (log_set_ring_size (log, size) < 0)
+            goto done;
+    } else if (!strcmp (name, "log-filename")) {
+        if (log_set_filename (log, val) < 0)
+            goto done;
+    } else {
+        errno = ENOENT;
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+int log_register_attrs (log_t *log, attr_t *attrs)
+{
+    char s[PATH_MAX];
+    const char *val, *log_filename = NULL;
+    int rc = -1;
+
+    /* log-filename
+     * Only allowed to be set on rank 0 (ignore initial value on rank > 0).
+     * If unset, and persist-directory is set, make it ${persist-directory}/log
+     */
+    if (log->rank == 0) {
+        if (attr_get (attrs, "log-filename", NULL, NULL) < 0) {
+            if (attr_get (attrs, "persist-directory", &val, NULL) == 0 && val) {
+                if (snprintf (s, sizeof (s), "%s/log", val) >= sizeof (s)) {
+                    err ("log-filename truncated");
+                    goto done;
+                }
+                log_filename = s;
+            }
+            if (attr_add (attrs, "log-filename",
+                          log_filename ? log_filename
+                                       : default_filename, 0) < 0) {
+                err ("could not initialize log-filename");
+                goto done;
+            }
+        }
+        if (attr_add_active (attrs, "log-filename", 0,
+                             attr_get_log, attr_set_log, log) < 0)
+            goto done;
+    } else {
+        (void)attr_delete (attrs, "log-filename", true);
+        if (attr_add (attrs, "log-filename", NULL, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+            goto done;
+    }
+
+    if (attr_add_active (attrs, "log-forward-level", 0,
+		                 attr_get_log, attr_set_log, log) < 0)
+        goto done;
+    if (attr_add_active (attrs, "log-critical-level", 0,
+		                 attr_get_log, attr_set_log, log) < 0)
+        goto done;
+    if (attr_add_active (attrs, "log-ring-size", 0,
+                         attr_get_log, attr_set_log, log) < 0)
+        goto done;
+    if (attr_add_active (attrs, "log-ring-used", 0,
+                         attr_get_log, NULL, log) < 0)
+        goto done;
+    if (attr_add_active (attrs, "log-count", 0,
+                         attr_get_log, NULL, log) < 0)
+        goto done;
+    rc = 0;
+done:
+    return rc;
 }
 
 int log_forward (log_t *log, const char *facility, int level, uint32_t rank,
@@ -323,21 +463,22 @@ int log_append (log_t *log, const char *facility, int level, uint32_t rank,
                 struct timeval tv, const char *message)
 {
     assert (log->magic == LOG_MAGIC);
-    int rc = -1;
+    int rc = 0;
 
-    if (rank == log->rank)
+    if (rank == log->rank) {
         if (log_buf_append (log, facility, level, rank, tv, message) < 0)
-            goto done;
-    if (level <= log->level) {
+            rc = -1;
+    }
+    if (level <= log->critical_level)
+        flux_log_fprint (facility, level, rank, tv, message, stderr);
+    if (level <= log->forward_level) {
         if (log->rank == 0) {
             flux_log_fprint (facility, level, rank, tv, message, log->f);
         } else {
             if (log_forward (log, facility, level, rank, tv, message) < 0)
-                goto done;
+                rc = -1;
        }
     }
-    rc = 0;
-done:
     return rc;
 }
 

--- a/src/broker/log.h
+++ b/src/broker/log.h
@@ -2,6 +2,7 @@
 #define BROKER_LOG_H
 
 #include <flux/core.h>
+#include "attr.h"
 
 typedef void (*log_sleeper_f)(const flux_msg_t *msg, void *arg);
 
@@ -12,16 +13,8 @@ void log_destroy (log_t *log);
 
 void log_set_flux (log_t *log, flux_t h);
 void log_set_rank (log_t *log, uint32_t rank);
-void log_set_file (log_t *log, FILE *f);
 
-int log_set_level (log_t *log, int level);
-int log_get_level (log_t *log);
-
-int log_set_buflimit (log_t *log, int limit);
-int log_get_buflimit (log_t *log);
-
-int log_get_bufcount (log_t *log);
-int log_get_count (log_t *log);
+int log_register_attrs (log_t *log, attr_t *attrs);
 
 /* Clear the buffer of entries <= seq_index
  * Set seq_index = -1 to clear all.

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -138,7 +138,7 @@ static void *module_thread (void *arg)
     av = xzmalloc (sizeof (av[0]) * (ac + 1));
     argz_extract (p->argz, p->argz_len, av);
     if (p->main(p->h, ac, av) < 0) {
-        err ("%s: mod_main returned error", p->name);
+        flux_log (p->h, LOG_CRIT, "fatal error: %s", strerror (errno));
         goto done;
     }
 done:

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -377,7 +377,7 @@ struct client *client_create (struct context *ctx, int rank, const char *cmd)
     add_arg (cli->p, "%s", ctx->broker_path);
     add_arg (cli->p, "--boot-method=PMI");
     add_arg (cli->p, "--shared-ipc-namespace");
-    add_arg (cli->p, "--scratch-directory=%s", ctx->scratch_dir);
+    add_arg (cli->p, "--setattr=scratch-directory=%s", ctx->scratch_dir);
     add_args_list (cli->p, ctx->opts, "broker-opts");
     if (rank == 0 && cmd)
         add_arg (cli->p, "%s", cmd); /* must be last arg */

--- a/src/modules/content-sophia/content-sophia.c
+++ b/src/modules/content-sophia/content-sophia.c
@@ -43,7 +43,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 
-const bool debug_enabled = true;
+const bool debug_enabled = false;
 
 typedef struct {
     char *dir;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -38,7 +38,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 
-const bool debug_enabled = true;
+const bool debug_enabled = false;
 
 const char *sql_create_table = "CREATE TABLE objects("
                                "  hash CHAR(20) PRIMARY KEY,"

--- a/t/fluxometer.lua
+++ b/t/fluxometer.lua
@@ -140,7 +140,7 @@ function fluxTest.init (...)
     end
 
     test.log_file = "lua-"..test.prog..".broker.log"
-    test.start_args = { "-o,-q,-L" .. test.log_file }
+    test.start_args = { "-o,-q,-Slog-filename=" .. test.log_file }
 
     local path = fluxTest.fluxbindir .. "/flux"
     local mode = posix.stat (path, 'mode')

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -51,7 +51,7 @@ test_under_flux() {
         cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
         return
     fi
-    quiet="-o -q,-L${log_file},-ldebug"
+    quiet="-o -q,-Slog-filename=${log_file},-Slog-forward-level=7"
     if test "$verbose" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --verbose"
         quiet=""

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -33,8 +33,7 @@ test_expect_success 'flux lsattr works' '
 	! grep -q attrtest.foo lsattr_out
 '
 test_expect_success 'flux lsattr -v works' '
-	flux lsattr -v | sed -e "s/[\ ]\+/\	/g" >lsattr_v_out &&
-	ATTR_VAL=`grep rank lsattr_v_out | cut -f2` &&
+	ATTR_VAL=$(flux lsattr -v | awk "/^rank / { print \$2 }") &&
 	test "${ATTR_VAL}" -eq 0
 '
 

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -12,30 +12,30 @@ test_expect_success 'flux getattr log-count counts log messages' '
 	NEW_VAL=`flux getattr log-count` &&
 	test "${OLD_VAL}" -lt "${NEW_VAL}"
 '
-test_expect_success 'flux getattr log-bufcount counts log messages' '
-	OLD_VAL=`flux getattr log-bufcount` &&
+test_expect_success 'flux getattr log-ring-used counts log messages' '
+	OLD_VAL=`flux getattr log-ring-used` &&
 	flux logger --priority test.debug hello &&
-	NEW_VAL=`flux getattr log-bufcount` &&
+	NEW_VAL=`flux getattr log-ring-used` &&
 	test "${OLD_VAL}" -lt "${NEW_VAL}"
 '
 test_expect_success 'flux dmesg -C clears, no print' '
 	flux logger --priority test.debug hello &&
-	OLD_VAL=`flux getattr log-bufcount` &&
+	OLD_VAL=`flux getattr log-ring-used` &&
 	test "${OLD_VAL}" -gt 0 &&
 	flux dmesg -C > dmesg.out &&
 	! grep -q hello_dmesg dmesg.out &&
-	NEW_VAL=`flux getattr log-bufcount` &&
+	NEW_VAL=`flux getattr log-ring-used` &&
 	test "${NEW_VAL}" -eq 0
 '
-test_expect_success 'flux setattr log-buflimit trims ring buffer' '
+test_expect_success 'flux setattr log-ring-size trims ring buffer' '
 	flux logger --priority test.debug hello &&
 	flux logger --priority test.debug hello &&
 	flux logger --priority test.debug hello &&
 	flux logger --priority test.debug hello &&
-	OLD_VAL=`flux getattr log-bufcount` &&
+	OLD_VAL=`flux getattr log-ring-used` &&
 	test "${OLD_VAL}" -ge 4 &&
-	flux setattr log-buflimit 4 &&
-	NEW_VAL=`flux getattr log-bufcount` &&
+	flux setattr log-ring-size 4 &&
+	NEW_VAL=`flux getattr log-ring-used` &&
 	test "${NEW_VAL}" -eq 4
 '
 test_expect_success 'flux dmesg prints, no clear' '
@@ -53,11 +53,11 @@ test_expect_success 'flux dmesg -c prints and clears' '
 	! grep -q hello_dmesg dmesg.out
 '
 test_expect_success 'ring buffer wraps over old entries' '
-	flux setattr log-buflimit 2 &&
+	flux setattr log-ring-size 2 &&
 	flux logger --priority test.debug hello1 &&
 	flux logger --priority test.debug hello2 &&
 	flux logger --priority test.debug hello3 &&
-	ATTR_VAL=`flux getattr log-bufcount` &&
+	ATTR_VAL=`flux getattr log-ring-used` &&
 	test "${ATTR_VAL}" -eq 2 &&
 	flux dmesg >dmesg.out &&
 	! grep -q hello1 dmesg.out &&

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -16,6 +16,11 @@ echo "# $0: flux session size will be ${SIZE}"
 
 MAXBLOB=`flux getattr content-blob-size-limit`
 
+test_expect_success 'unload backing store module if loaded' '
+	! flux getattr content-backing 2>/dev/null \
+	    || flux module remove -d `flux getattr content-backing`
+'
+
 test_expect_success 'store 100 blobs on rank 0' '
         for i in `seq 0 99`; do echo test$i | \
             flux content store >/dev/null; done &&

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -16,6 +16,11 @@ echo "# $0: flux session size will be ${SIZE}"
 
 MAXBLOB=`flux getattr content-blob-size-limit`
 
+test_expect_success 'unload backing store module if loaded' '
+        ! flux getattr content-backing 2>/dev/null \
+            || flux module remove -d `flux getattr content-backing`
+'
+
 test_expect_success 'load content-sqlite module on rank 0' '
 	flux module load --rank 0 --direct content-sqlite
 '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -108,7 +108,7 @@ test_expect_success 'load and verify 1m blob on all ranks' '
 # Verify content is not lost
 
 test_expect_success 'flush rank 0 cache' '
-        flux content flush &&
+        run_timeout 10 flux content flush &&
 	NDIRTY=`flux comms-stats --type int --parse dirty content` &&
 	test $NDIRTY -eq 0
 '
@@ -155,7 +155,7 @@ test_expect_success 'load content-sqlite module on rank 0' '
 '
 
 test_expect_success 'flush rank 0 cache' '
-        flux content flush &&
+        run_timeout 10 flux content flush &&
 	NDIRTY=`flux comms-stats --type int --parse dirty content` &&
 	test $NDIRTY -eq 0
 '

--- a/t/t0013-content-sophia.t
+++ b/t/t0013-content-sophia.t
@@ -109,7 +109,7 @@ test_expect_success 'load and verify 1m blob on all ranks' '
 # Verify content is not lost
 
 test_expect_success 'flush rank 0 cache' '
-        flux content flush &&
+        run_timeout 10 flux content flush &&
         NDIRTY=`flux comms-stats --type int --parse dirty content` &&
         test $NDIRTY -eq 0
 '
@@ -156,7 +156,7 @@ test_expect_success 'load content-sophia module on rank 0' '
 '
 
 test_expect_success 'flush rank 0 cache' '
-        flux content flush &&
+        run_timeout 10 flux content flush &&
         NDIRTY=`flux comms-stats --type int --parse dirty content` &&
         test $NDIRTY -eq 0
 '

--- a/t/t0013-content-sophia.t
+++ b/t/t0013-content-sophia.t
@@ -17,6 +17,11 @@ echo "# $0: flux session size will be ${SIZE}"
 
 MAXBLOB=`flux getattr content-blob-size-limit`
 
+test_expect_success 'unload backing store module if loaded' '
+        ! flux getattr content-backing 2>/dev/null \
+            || flux module remove -d `flux getattr content-backing`
+'
+
 test_expect_success 'load content-sophia module on rank 0' '
 	flux module load --rank 0 --direct content-sophia
 '


### PR DESCRIPTION
Rather than postpone this until #508 is resolved, add `content-sqlite` to the hardwired module list in the broker so that we can avoid taking an OOM when running many jobs.

Fixes the long standing #259