### PR TITLE
t/scripts/kvs-watch-until.lua fix

### DIFF
--- a/t/scripts/kvs-watch-until.lua
+++ b/t/scripts/kvs-watch-until.lua
@@ -54,16 +54,16 @@ local cb = fn ()
 local kw, err = f:kvswatcher {
     key = key,
     handler = function (kw, result)
-    if opts.v then 
-        printf ("%4.03fs: %s = %s\n",
-                timer:get0(),
-                key, tostring (result))
-    end
-    local ok, rv = pcall (cb, result)
-    if not ok then error (rv) end
-    if ok and rv then
-        os.exit (0)
-    end
+        if opts.v then
+            printf ("%4.03fs: %s = %s\n",
+                    timer:get0(),
+                    key, tostring (result))
+        end
+        local ok, rv = pcall (cb, result)
+        if not ok then error (rv) end
+        if ok and rv then
+            os.exit (0)
+        end
     end
 }
 

--- a/t/scripts/kvs-watch-until.lua
+++ b/t/scripts/kvs-watch-until.lua
@@ -59,6 +59,8 @@ local kw, err = f:kvswatcher {
                     timer:get0(),
                     key, tostring (result))
         end
+        -- Do not pass nil result to callback:
+        if result == nil then return end
         local ok, rv = pcall (cb, result)
         if not ok then error (rv) end
         if ok and rv then


### PR DESCRIPTION
Fix for #549: Ignore `nil` result in kvswatcher (i.e. do not pass to callback). This is an expected kvswatcher result when key does not exist, but there is no reason to pass this initial value down to the user-supplied callback.

This should resolve testsuite failures observed in #549.