### PR TITLE
correct flux library location

### DIFF
--- a/etc/flux-core.pc.in
+++ b/etc/flux-core.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-libdir=@libdir@/flux
+libdir=@libdir@
 includedir=@includedir@
 
 Name: flux-core


### PR DESCRIPTION
Fixes a couple stragglers which should have been included with commit
96e97dea2556680fda03d04cd3c607091523be82
Addresses:  https://github.com/flux-framework/flux-core/issues/551