### PR TITLE
Trial move of python test execution to ./t/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,11 @@ AC_CONFIG_FILES( \
   t/fluxometer/conf.lua.installed \
 )
 
+AC_CONFIG_FILES(
+  [t/t9990-python-tests.t:t/t9990-python-tests.t.in],
+  [chmod +x t/t9990-python-tests.t]
+                )
+
 AC_CONFIG_LINKS([ \
   t/fluxometer.lua:t/fluxometer.lua \
 ])

--- a/src/bindings/python/Makefile.am
+++ b/src/bindings/python/Makefile.am
@@ -1,32 +1,7 @@
 
 SUBDIRS=flux
 
-# Expand python path to find cffi modules during in-tree check
-
-TESTS = \
-	test_commands/test_runner.t
-
-TEST_EXTENSIONS = .t
-T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
-	$(top_srcdir)/config/tap-driver.sh
-LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
-	$(top_srcdir)/config/tap-driver.sh
-
-TESTS_ENVIRONMENT = \
-	PYTHONPATH=$(top_builddir)/src/bindings/python:$(top_srcdir)/src/bindings/python/pycotap:$(top_srcdir)/src/bindings/python/:$$PYTHONPATH \
-	CHECK_BUILDDIR=$(top_builddir) \
-        FLUX_CONNECTOR_PATH="$(top_builddir)/src/connectors"
-
 EXTRA_DIST = pycotap test test_commands make_binding.py
-
-test-coverage: check
-	env ${TESTS_ENVIRONMENT} \
-	$(PYTHON) -m coverage run --source `pwd`/flux \
-				  --concurrency multiprocessing \
-				  $(top_srcdir)/src/bindings/python/test_commands/test_runner.t
-	$(PYTHON) -m coverage combine
-	$(PYTHON) -m coverage report -m \
-				  --omit '*_*_build.py,*pycotap*,*test/*,*test_commands/*'
 
 clean-local:
 	-rm -f test/*.pyc test_commands/*.pyc

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -22,11 +22,6 @@ install-data-local:
 uninstall-local:
 	$(RM) $(DESTDIR)$(luadir)/fluxometer/conf.lua
 
-AM_TESTS_ENVIRONMENT = \
-	PYTHONPATH=$(top_builddir)/src/bindings/python:$(top_srcdir)/src/bindings/python/pycotap:$(top_srcdir)/src/bindings/python/:$$PYTHONPATH \
-	CHECK_BUILDDIR=$(top_builddir) \
-        FLUX_CONNECTOR_PATH="$(top_builddir)/src/connectors"
-
 TESTS = \
 	loop/handle.t \
 	loop/reactor.t \
@@ -75,7 +70,7 @@ TESTS = \
 	lua/t1003-iowatcher.t \
 	lua/t1004-statwatcher.t \
 	lua/t1005-fdwatcher.t \
-	$(top_builddir)/src/bindings/python/test_commands/test_runner.t
+	$(top_builddir)/t/t9990-python-tests.t
 
 EXTRA_DIST= \
 	$(check_SCRIPTS) \
@@ -131,7 +126,7 @@ check_SCRIPTS = \
 	lua/t1003-iowatcher.t \
 	lua/t1004-statwatcher.t \
 	lua/t1005-fdwatcher.t \
-	$(top_builddir)/src/bindings/python/test_commands/test_runner.t
+	$(top_builddir)/t/t9990-python-tests.t
 
 check_PROGRAMS = \
 	loop/handle.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -22,6 +22,10 @@ install-data-local:
 uninstall-local:
 	$(RM) $(DESTDIR)$(luadir)/fluxometer/conf.lua
 
+AM_TESTS_ENVIRONMENT = \
+	PYTHONPATH=$(top_builddir)/src/bindings/python:$(top_srcdir)/src/bindings/python/pycotap:$(top_srcdir)/src/bindings/python/:$$PYTHONPATH \
+	CHECK_BUILDDIR=$(top_builddir) \
+        FLUX_CONNECTOR_PATH="$(top_builddir)/src/connectors"
 
 TESTS = \
 	loop/handle.t \
@@ -70,7 +74,8 @@ TESTS = \
 	lua/t1002-kvs.t \
 	lua/t1003-iowatcher.t \
 	lua/t1004-statwatcher.t \
-	lua/t1005-fdwatcher.t
+	lua/t1005-fdwatcher.t \
+	$(top_builddir)/src/bindings/python/test_commands/test_runner.t
 
 EXTRA_DIST= \
 	$(check_SCRIPTS) \
@@ -125,7 +130,8 @@ check_SCRIPTS = \
 	lua/t1002-kvs.t \
 	lua/t1003-iowatcher.t \
 	lua/t1004-statwatcher.t \
-	lua/t1005-fdwatcher.t
+	lua/t1005-fdwatcher.t \
+	$(top_builddir)/src/bindings/python/test_commands/test_runner.t
 
 check_PROGRAMS = \
 	loop/handle.t \

--- a/t/t9990-python-tests.t.in
+++ b/t/t9990-python-tests.t.in
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export PYTHONPATH=@abs_top_builddir@/src/bindings/python:@abs_top_srcdir@/src/bindings/python/pycotap:@abs_top_srcdir@/src/bindings/python/:$PYTHONPATH
+export CHECK_BUILDDIR=@abs_top_builddir@
+export FLUX_CONNECTOR_PATH="@abs_top_builddir@/src/connectors"
+export FLUX_PYTHON_DIR="@abs_top_builddir@/src/bindings/python"
+
+@top_srcdir@/src/bindings/python/test_commands/test_runner.t
+
+


### PR DESCRIPTION
The python tests are running to early, and making debugging difficult
for other parts of the system.  This patch moves the python test
execution to the end of the sharness tests.  It may need more
massaging, but seems to work for basic cases in my (partly
non-working) environment.
fixes #527 ?