### PR TITLE
add #include <czmq.h> to local.c

### DIFF
--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -40,6 +40,7 @@
 #include <sys/socket.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <czmq.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/xzmalloc.h"


### PR DESCRIPTION
Will someone humor me and merge this PR?  I continue to see the problem first described in [Issue 556](https://github.com/flux-framework/flux-core/issues/556).  I have no idea why this problem only appears when building flux-core under flux-sched in the flux-framework travis build.  (I don't see the problem in my corresponding travis build).

The latest example: https://travis-ci.org/flux-framework/flux-sched/jobs/108577802
The offending lines start with this:
```
make[3]: Entering directory `/home/travis/flux-core/src/modules/connector-local'
  CC     local.lo

local.c:56:5: error: unknown type name 'zlist_t'
    zlist_t *clients;
    ^
local.c:60:5: error: unknown type name 'zhash_t'
    zhash_t *subscriptions;
    ^
local.c:78:5: error: unknown type name 'zlist_t'
    zlist_t *outqueue;  /* queue of outbound flux_msg_t */
    ^
```
The PR just adds #include <czmq.h> to local.c
