### PR TITLE
drop compat.h from internal <flux/core.h>

### DIFF
--- a/doc/man3/tinfo.c
+++ b/doc/man3/tinfo.c
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <flux/core.h>
+#include <inttypes.h>
 #include "src/common/libutil/log.h"
 
 int tree_height (uint32_t n, int k)

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -36,6 +36,7 @@
 #include <lauxlib.h>
 
 #include "flux/core.h"
+#include "src/common/libcompat/compat.h"
 
 #include "src/common/libutil/jsonutil.h"
 #include "src/modules/libmrpc/mrpc.h"

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -34,6 +34,7 @@
 #include <lauxlib.h>
 
 #include "flux/core.h"
+#include "src/common/libcompat/compat.h"
 #include "src/modules/kvs/kvs_deprecated.h"
 
 #include "json-lua.h"

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -44,6 +44,7 @@
 #include <dlfcn.h>
 #include <argz.h>
 #include <flux/core.h>
+#include <czmq.h>
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -1,3 +1,4 @@
+#include <sys/param.h>
 #include <stdio.h>
 
 #include "attr.h"

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -23,6 +23,8 @@
 \*****************************************************************************/
 #include "builtin.h"
 
+#include <unistd.h>
+
 #include "src/common/libutil/sha1.h"
 #include "src/common/libutil/shastring.h"
 #include "src/common/libutil/readall.h"

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -22,10 +22,16 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
+#include "builtin.h"
+
 #include <sys/types.h> /* WIFEXTED */
+#include <sys/wait.h>
+#include <sys/param.h>
+#include <unistd.h>
+#include <signal.h>
+#include <assert.h>
 #include <argz.h>
 
-#include "builtin.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/sds.h"
 

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -186,8 +186,8 @@ static int handle_notify_req (flux_t h, const char *ofn)
         flux_log (h, LOG_ERR, "failed to reg a job status change CB");
         return -1; 
     }
-    if (flux_reactor_start (h) < 0) 
-        flux_log (h, LOG_ERR, "error in flux_reactor_start");
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) 
+        flux_log (h, LOG_ERR, "error in flux_reactor_run");
 
     return 0;
 }

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -28,6 +28,8 @@
 #include <getopt.h>
 #include <json.h>
 #include <flux/core.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -30,6 +30,7 @@
 #include <dlfcn.h>
 #include <json.h>
 #include <flux/core.h>
+#include <czmq.h>
 #include <assert.h>
 
 #include "src/modules/modctl/modctl.h"

--- a/src/cmd/flux-mping.c
+++ b/src/cmd/flux-mping.c
@@ -25,6 +25,8 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <sys/param.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <getopt.h>
 #include <string.h>

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -31,6 +31,7 @@
 #include <libgen.h>
 #include <argz.h>
 #include <flux/core.h>
+#include <czmq.h>
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -34,6 +34,7 @@
 #include <stdbool.h>
 #include <sys/param.h>
 #include <glob.h>
+#include <assert.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -23,6 +23,7 @@
 \*****************************************************************************/
 
 #include <errno.h>
+#include <fcntl.h>
 #include <string.h>
 #include <json.h>
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -28,9 +28,14 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <sys/types.h>
+#include <sys/param.h>
 #include <sys/un.h>
 #include <sys/socket.h>
+#include <signal.h>
 #include <poll.h>
+#include <unistd.h>
+#include <fcntl.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"

--- a/src/include/flux/core.h
+++ b/src/include/flux/core.h
@@ -5,7 +5,6 @@
 #define FLUX_CORE_H
 
 #include "src/common/libflux/flux.h"
-#include "src/common/libcompat/compat.h" // temporary
 
 #include "src/modules/kvs/kvs.h"
 #include "src/modules/live/live.h"

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -675,7 +675,7 @@ static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
         if (zlist_append (ctx->clients, c) < 0)
             oom ();
     }
-    if (revents & ZMQ_POLLERR) {
+    if (revents & FLUX_POLLERR) {
         flux_log (h, LOG_ERR, "poll listen fd: %s", strerror (errno));
     }
 done:

--- a/src/modules/kvs/conf.c
+++ b/src/modules/kvs/conf.c
@@ -25,6 +25,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <assert.h>
 #include <string.h>
 #include <flux/core.h>
 

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -41,6 +41,7 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <flux/core.h>
+#include <czmq.h>
 
 #include "kvs_deprecated.h"
 #include "proto.h"

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -83,22 +83,30 @@ typedef struct {
     zhash_t *watchers; /* kvs_watch_t hashed by stringified matchtag */
     char *cwd;
     zlist_t *dirstack;
+    flux_msg_handler_t *w;
 } kvsctx_t;
 
-static int watch_rep_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg);
+static void watch_response_cb (flux_t h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg);
 
 static void freectx (void *arg)
 {
     kvsctx_t *ctx = arg;
-    zhash_destroy (&ctx->watchers);
-    zlist_destroy (&ctx->dirstack);
-    free (ctx->cwd);
-    free (ctx);
+    if (ctx) {
+        zhash_destroy (&ctx->watchers);
+        zlist_destroy (&ctx->dirstack);
+        if (ctx->w)
+            flux_msg_handler_destroy (ctx->w);
+        if (ctx->cwd)
+            free (ctx->cwd);
+        free (ctx);
+    }
 }
 
 static kvsctx_t *getctx (flux_t h)
 {
     kvsctx_t *ctx = (kvsctx_t *)flux_aux_get (h, "kvscli");
+    struct flux_match match = FLUX_MATCH_RESPONSE;
 
     if (!ctx) {
         ctx = xzmalloc (sizeof (*ctx));
@@ -107,6 +115,10 @@ static kvsctx_t *getctx (flux_t h)
         if (!(ctx->dirstack = zlist_new ()))
             oom ();
         if (!(ctx->cwd = xstrdup (".")))
+            oom ();
+        match.topic_glob = "kvs.watch";
+        if (!(ctx->w = flux_msg_handler_create (h, match, watch_response_cb,
+                                                                ctx)))
             oom ();
         flux_aux_set (h, "kvscli", ctx, freectx);
     }
@@ -627,8 +639,7 @@ static kvs_watcher_t *add_watcher (flux_t h, const char *key, watch_type_t type,
     free (k);
 
     if (lastcount == 0)
-        (void)flux_msghandler_add (h, FLUX_MSGTYPE_RESPONSE, "kvs.watch",
-                                   watch_rep_cb, ctx);
+        flux_msg_handler_start (ctx->w);
     return wp;
 }
 
@@ -666,7 +677,7 @@ int kvs_unwatch (flux_t h, const char *key)
     }
     zlist_destroy (&hashkeys);
     if (zhash_size (ctx->watchers) == 0)
-        flux_msghandler_remove (h, FLUX_MSGTYPE_RESPONSE, "kvs.watch");
+        flux_msg_handler_stop (ctx->w);
     rc = 0;
 done:
     Jput (in);
@@ -732,18 +743,18 @@ static int dispatch_watch (flux_t h, kvs_watcher_t *wp, json_object *val)
     return rc;
 }
 
-static int watch_rep_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
+static void watch_response_cb (flux_t h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
     JSON out = NULL;
     JSON val;
     uint32_t matchtag;
     kvs_watcher_t *wp;
-    int rc = 0;
 
-    if (flux_response_decode (*zmsg, NULL, &json_str) < 0)
+    if (flux_response_decode (msg, NULL, &json_str) < 0)
         goto done;
-    if (flux_msg_get_matchtag (*zmsg, &matchtag) < 0)
+    if (flux_msg_get_matchtag (msg, &matchtag) < 0)
         goto done;
     if (!(out = Jfromstr (json_str))) {
         errno = EPROTO;
@@ -752,11 +763,10 @@ static int watch_rep_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
     if (kp_rwatch_dec (out, &val) < 0)
         goto done;
     if ((wp = lookup_watcher (h, matchtag)))
-        rc = dispatch_watch (h, wp, val);
+        if (dispatch_watch (h, wp, val) < 0)
+            flux_reactor_stop_error (flux_get_reactor (h));
 done:
     Jput (out);
-    zmsg_destroy (zmsg);
-    return rc;
 }
 
 /* Not strictly an RPC since multiple replies are possible.

--- a/src/modules/libmrpc/mrpc.c
+++ b/src/modules/libmrpc/mrpc.c
@@ -288,7 +288,7 @@ int flux_mrpc (flux_mrpc_t *f, const char *fmt, ...)
     char *topic = NULL, *s = NULL;
     va_list ap;
     JSON o = NULL;
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
 
     va_start (ap, fmt);
     s = xvasprintf (fmt, ap);
@@ -304,9 +304,9 @@ int flux_mrpc (flux_mrpc_t *f, const char *fmt, ...)
     Jadd_int (o, "sender", f->sender);
     Jadd_str (o, "path", f->path);
     topic = xasprintf ("mrpc.%s", s);
-    if (!(zmsg = flux_event_encode (topic, Jtostr (o))))
+    if (!(msg = flux_event_encode (topic, Jtostr (o))))
         goto done;
-    if (flux_sendmsg (f->h, &zmsg) < 0)
+    if (flux_send (f->h, msg, 0) < 0)
         goto done;
     if (kvs_fence (f->h, f->path, f->nprocs + 1) < 0)
         goto done;
@@ -317,7 +317,8 @@ done:
     if (topic)
         free (topic);
     Jput (o);
-    zmsg_destroy (&zmsg);
+    if (msg)
+        flux_msg_destroy (msg);
     return rc;
 }
 

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -80,6 +80,7 @@
 #include <sys/time.h>
 #include <ctype.h>
 #include <flux/core.h>
+#include <czmq.h>
 
 #include "src/modules/kvs/kvs_deprecated.h"
 

--- a/src/modules/mecho/mecho.c
+++ b/src/modules/mecho/mecho.c
@@ -34,14 +34,15 @@
 
 /* Copy input arguments to output arguments and respond to RPC.
  */
-static int mecho_mrpc_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
+static void mecho_mrpc_cb (flux_t h, flux_msg_handler_t *w,
+                           const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
     json_object *request = NULL;
     json_object *inarg = NULL;
     flux_mrpc_t *f = NULL;
 
-    if (flux_event_decode (*zmsg, NULL, &json_str) < 0
+    if (flux_event_decode (msg, NULL, &json_str) < 0
                 || !(request = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "flux_event_decode: %s", strerror (errno));
         goto done;
@@ -68,26 +69,33 @@ done:
         json_object_put (inarg);
     if (f)
         flux_mrpc_destroy (f);
-    zmsg_destroy (zmsg);
-    return 0;
 }
+
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT,   "mrpc.mecho",       mecho_mrpc_cb },
+    FLUX_MSGHANDLER_TABLE_END,
+};
 
 int mod_main (flux_t h, int argc, char **argv)
 {
+    int rc = -1;
     if (flux_event_subscribe (h, "mrpc.mecho") < 0) {
-        flux_log (h, LOG_ERR, "%s: flux_event_subscribe", __FUNCTION__);
-        return -1;
+        flux_log_error (h, "flux_event_subscribe");
+        goto done;
     }
-    if (flux_msghandler_add (h, FLUX_MSGTYPE_EVENT, "mrpc.mecho",
-                                                    mecho_mrpc_cb, NULL) < 0) {
-        flux_log (h, LOG_ERR, "flux_msghandler_add: %s", strerror (errno));
-        return -1;
+    if (flux_msg_handler_addvec (h, htab, NULL) < 0) {
+        flux_log_error (h, "flux_msghandler_add");
+        goto done;
     }
-    if (flux_reactor_start (h) < 0) {
-        flux_log (h, LOG_ERR, "flux_reactor_start: %s", strerror (errno));
-        return -1;
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done_unreg;
     }
-    return 0;
+    rc = 0;
+done_unreg:
+    flux_msg_handler_delvec (htab);
+done:
+    return rc;
 }
 
 MOD_NAME ("mecho");

--- a/src/modules/modctl/libmodctl.c
+++ b/src/modules/modctl/libmodctl.c
@@ -34,6 +34,7 @@
 #include <sys/param.h>
 #include <ctype.h>
 #include <flux/core.h>
+#include <czmq.h>
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <errno.h>
 #include <flux/core.h>
+#include <czmq.h>
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/optparse.h"

--- a/src/test/kap/kap.c
+++ b/src/test/kap/kap.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <float.h>
 #include <math.h>
+#include <values.h>
 
 #include "kap.h"
 

--- a/src/test/kap/kap_personality.c
+++ b/src/test/kap/kap_personality.c
@@ -10,6 +10,9 @@
 #include <json.h>
 #include <mpi.h>
 #include <flux/core.h>
+#include <math.h>
+#include <values.h>
+#include <unistd.h>
 
 #include "kap.h"
 

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <json.h>
 #include <flux/core.h>
+#include "src/common/libcompat/compat.h"
 #include "src/modules/kvs/kvs_deprecated.h"
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/shortjson.h"

--- a/src/test/module/parent.c
+++ b/src/test/module/parent.c
@@ -8,7 +8,9 @@
 #include <dlfcn.h>
 #include <argz.h>
 #include <flux/core.h>
+#include <czmq.h>
 
+#include "src/common/libcompat/compat.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"

--- a/src/test/request/coproc.c
+++ b/src/test/request/coproc.c
@@ -2,6 +2,8 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <czmq.h>
+#include "src/common/libcompat/compat.h"
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"

--- a/src/test/request/req.c
+++ b/src/test/request/req.c
@@ -2,6 +2,8 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <czmq.h>
+#include "src/common/libcompat/compat.h"
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"

--- a/src/test/request/treq.c
+++ b/src/test/request/treq.c
@@ -32,6 +32,8 @@
 #include <czmq.h>
 #include <pthread.h>
 #include <flux/core.h>
+#include <czmq.h>
+#include "src/common/libcompat/compat.h"
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/monotime.h"

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -35,7 +35,9 @@
 #endif
 #include <json.h>
 #include <flux/core.h>
+#include <pthread.h>
 
+#include "src/common/libcompat/compat.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"


### PR DESCRIPTION
This PR contains drops compat.h from the internal `<flux/core.h>` and deals with the fallout
* add missing czmq.h and system include directives
* modernize API in remaining comms modules
* directly include compat.h in lua bindings and some tests that have yet to move forward