### PR TITLE
minor testsuite improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,11 @@ script:
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"
 
+ # Travis has limited resources, even though number of processors might
+ #  might appear to be large. Limit session size for testing to 5 to avoid
+ #  spurious timeouts.
+ - export FLUX_TEST_SIZE_MAX=5
+
  # Enable coverage for $CC-coverage build
  # We can't use distcheck here, it doesn't play well with coverage testing:
  - if test "$COVERAGE" = "t" ; then ARGS="--enable-code-coverage"; MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"; fi

--- a/t/lua/t1000-reactor.t
+++ b/t/lua/t1000-reactor.t
@@ -111,6 +111,16 @@ is (first_msghandler, true, "Message passed to first msghadler")
 todo ("All zmsgs consumed by first handler in lua code")
 is (second_msghandler, true, "Message passed to second msghadler")
 
+-- Test for setting reason on reactor_stop_error()
+local t, err = f:timer {
+    timeout = 1,
+    handler = function (f, to) return f:reactor_stop_error ("because") end
+}
+
+local r, err = f:reactor()
+is (r, nil, "reactor returned nil")
+is (err, "because", "got expected reason from reactor_stop_error()")
+
 done_testing ()
 
 -- vi: ts=4 sw=4 expandtab

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -157,10 +157,10 @@ is (kw.testkey, 'foo', "Can set arbitrary members of kvswatcher object")
 os.execute (string.format ("flux kvs put %s=%s", data.key, data.value))
 
 local to = f:timer {
-    timeout = 250,
+    timeout = 1500,
     oneshot = true,
     handler = function (f, to)
-        f:reactor_stop_error ()
+        f:reactor_stop_error ("Timed out after 1.5s!")
     end
 }
 local r, err = f:reactor()

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -40,6 +40,20 @@ run_timeout() {
 }
 
 #
+#  Echo on stdout a reasonable size for a large test session,
+#   controllable test-wide via env vars FLUX_TEST_SIZE_MIN and
+#   FLUX_TEST_SIZE_MAX.
+#
+test_size_large() {
+    min=${FLUX_TEST_SIZE_MIN:-4}
+    max=${FLUX_TEST_SIZE_MAX:-17}
+    size=$(($(nproc)+1))
+    test ${size} -lt ${min} && size=$min
+    test ${size} -gt ${max} && size=$max
+    echo ${size}
+}
+
+#
 #  Reinvoke a test file under a flux comms instance
 #
 #  Usage: test_under_flux <size>

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -126,4 +126,13 @@ test_expect_success 'flux-help command list can be extended' '
 	test_cmp help.expected help.out
 '
 
+test_expect_success 'builtin test_size_large () works' '
+    size=$(test_size_large)  &&
+    test -n "$size" &&
+    size=$(FLUX_TEST_SIZE_MAX=2 test_size_large) &&
+    test "$size" = "2" &&
+    size=$(FLUX_TEST_SIZE_MIN=123 FLUX_TEST_SIZE_MAX=1000 test_size_large) &&
+    test "$size" = "123"
+'
+
 test_done

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -9,8 +9,7 @@ if test "$TEST_LONG" = "t"; then
 fi
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(grep processor /proc/cpuinfo | wc -l)+1))
-test ${SIZE} -lt 4 && SIZE=4
+SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -9,8 +9,7 @@ if test "$TEST_LONG" = "t"; then
 fi
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(grep processor /proc/cpuinfo | wc -l)+1))
-test ${SIZE} -lt 4 && SIZE=4
+SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 

--- a/t/t0013-content-sophia.t
+++ b/t/t0013-content-sophia.t
@@ -10,8 +10,7 @@ fi
 
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(grep processor /proc/cpuinfo | wc -l)+1))
-test ${SIZE} -lt 4 && SIZE=4
+SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -15,8 +15,7 @@ if test "$TEST_LONG" = "t"; then
 fi
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(nproc)+1))
-test ${SIZE} -lt 4 && SIZE=4
+SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -9,8 +9,7 @@ Test that PMI works in a FLux-launched program
 . `dirname $0`/sharness.sh
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(nproc)+1))
-test ${SIZE} -gt 4 || SIZE=4
+SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -21,11 +21,11 @@ test_debug '
 
 #
 #  Ensure resource-hwloc is initialized here. There is currently no
-#   way to synchronize, so we run `flux hwloc lstopo` repeatedly
+#   way to synchronize, so we run `flux hwloc topology` repeatedly
 #   until it succeeds.
 #
 count=0
-while ! flux hwloc lstopo > lstopo.system; do
+while ! flux hwloc topology > system.xml; do
    sleep 0.5
    count=$(expr $count + 1)
    test $count -eq 5 && break
@@ -37,9 +37,9 @@ lstopo=$(which lstopo 2>/dev/null || which lstopo-no-graphics 2>/dev/null)
 test -n "$lstopo" && test_set_prereq HAVE_LSTOPO
 
 test_expect_success 'hwloc: ensure we have system lstopo output' '
-    test -f lstopo.system &&
-    test -s lstopo.system &&
-    head -1 lstopo.system | grep ^System
+    test -f system.xml &&
+    test -s system.xml &&
+    grep "<object type=\"System\" os_index=\"0\">" system.xml
 '
 
 test_expect_success 'hwloc: each rank reloads a non-overlapping set of a node ' '
@@ -62,13 +62,13 @@ test_expect_success 'hwloc: return an error code on valid DIR, invalid files' '
     test_expect_code 1 flux hwloc reload /
 '
 
-test_expect_success 'hwloc: lstopo works' '
+test_expect_success HAVE_LSTOPO 'hwloc: lstopo works' '
     flux hwloc reload $exclu2 &&
     flux hwloc lstopo > lstopo.out1 &&
     sed -n 1p lstopo.out1 | grep "^System (32G.*"
 '
 
-test_expect_success 'hwloc: lstopo subcommand passes options to lstopo' '
+test_expect_success HAVE_LSTOPO 'hwloc: lstopo subcommand passes options to lstopo' '
     flux hwloc lstopo --help | grep ^Usage
 '
 
@@ -81,11 +81,11 @@ test_expect_success HAVE_LSTOPO 'hwloc: topology subcommand works' '
 
 test_expect_success 'hwloc: reload with no args reloads system topology' '
     flux hwloc reload &&
-    flux hwloc lstopo > lstopo.out4 &&
-    test_cmp lstopo.system lstopo.out4
+    flux hwloc topology > system.out4 &&
+    test_cmp system.xml system.out4
 '
 
-test_expect_success 'hwloc: test failure of lstopo command' '
+test_expect_success HAVE_LSTOPO 'hwloc: test failure of lstopo command' '
     test_must_fail flux hwloc lstopo --input f:g:y
 '
 

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -11,8 +11,7 @@ if test "$TEST_MPI" != "t" || ! test -x ${FLUX_BUILD_DIR}/t/mpi/hello; then
 fi
 
 # Size the session to one more than the number of cores, minimum of 4
-SIZE=$(($(nproc)+1))
-test ${SIZE} -gt 4 || SIZE=4
+SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 


### PR DESCRIPTION
Ok, I wanted to open this PR and get feedback, haven't ensured Travis will pass yet though.

 * Replace usage of `$(($(nproc)+1))` for sizing test sessions with a new function `test_size_large()` exported from th sharness suite. `test_size_large` gives a size of a "reasonably" large session for testing. The default size is `nproc+1` like before, but with a maximum of `17` and minimum of `4`. The max and min can be controlled with `FLUX_TEST_SIZE_MIN` and `FLUX_TEST_SIZE_MAX`
 * Set `FLUX_TEST_SIZE_MAX=5` for Travis builds. We could do the same for RPM builds.
 * Handle missing `lstopo` command in `t2005-hwloc-basic.t`
 * Extend timeout in Lua kvs test, this was the cause of "Protocol Error" failures.
 * Allow Lua API to return a "reason" string in `f:reactor_stop_error (reason)`, so we don't just get arbitrary `strerror (errno)` from `f:reactor()` error return.