### PR TITLE
build: change fluxcmddir to libexec/flux/cmd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ AC_PKGCONFIG
 AS_VAR_SET(fluxlibexecdir, $libexecdir/flux)
 AC_SUBST(fluxlibexecdir)
 
-AS_VAR_SET(fluxcmddir, $libexecdir/flux/core)
+AS_VAR_SET(fluxcmddir, $libexecdir/flux/cmd)
 AC_SUBST(fluxcmddir)
 
 AS_VAR_SET(fluxlibdir, $libdir/flux)


### PR DESCRIPTION
Change `${fluxcmddir}` from `${libexecdir}/flux/core`
to `${libexecdir}/flux/cmd`.  All framework projects can
put their subcommands in that directory.  The previous
naming implied that each would have its own sub-directory,
but that creates complications for maintaining FLUX_EXEC_PATH.

Affects flux-framework/flux-sched#115