### PR TITLE
Fix order of includes for AM_CPPFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,11 @@ before_install:
   # coveralls-lcov required only for coveralls upload:
   - if test "$COVERAGE" = "t" ; then gem install coveralls-lcov; fi
 
+  # Ensure we always use internal <flux/core.h> by placing a dummy file
+  #  in the same path as ZMQ_FLAGS:
+  - mkdir -p $HOME/local/include/flux
+  - echo '#error Non-build-tree flux/core.h!' > $HOME/local/include/flux/core.h
+
 script:
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -177,8 +177,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-        $(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-        -I$(top_srcdir) -I$(top_srcdir)/src/include
+        -I$(top_srcdir) -I$(top_srcdir)/src/include \
+        $(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 LDADD = \
         $(top_builddir)/src/common/libflux-internal.la \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -1,8 +1,15 @@
 
-AM_CFLAGS =	@GCCWARN@ -I$(top_srcdir) -I$(top_srcdir)/src/include -I$(top_srcdir)/src/common/libflux \
-		$(JSON_CFLAGS) $(ZMQ_CFLAGS) $(PYTHON_CPPFLAGS) $(CODE_COVERAGE_CFLAGS)
-AM_LDFLAGS = -avoid-version -module -Wl,--no-undefined  $(PYTHON_LDFLAGS) -Wl,-rpath,$(PYTHON_PREFIX)/lib \
-		$(CODE_COVERAGE_LDFLAGS)
+AM_CPPFLAGS = \
+	@GCCWARN@ \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libflux \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) $(PYTHON_CPPFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	-avoid-version -module -Wl,--no-undefined \
+	$(PYTHON_LDFLAGS) -Wl,-rpath,$(PYTHON_PREFIX)/lib \
+	$(CODE_COVERAGE_LDFLAGS)
 
 MAKE_BINDING=$(top_srcdir)/src/bindings/python/make_binding.py
 SUFFIXES = _build.py
@@ -40,7 +47,7 @@ _jsc_build.py: $(top_srcdir)/src/modules/libjsc/jstatctl.h $(MAKE_BINDING) _core
 				  jstatctl.h
 
 _jsc_la_SOURCES = _jsc.c
-_jsc_la_CPPFLAGS = -I$(top_srcdir)/src/modules/libjsc
+_jsc_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/libjsc
 _jsc_la_LIBADD = $(top_builddir)/src/modules/libjsc/libflux-jsc.la $(common_libs)
 _jsc_la_DEPENDENCIES = _jsc_build.py
 
@@ -52,7 +59,7 @@ _barrier_build.py: $(top_srcdir)/src/modules/barrier/barrier.h $(MAKE_BINDING) _
 				  barrier.h
 
 _barrier_la_SOURCES = _barrier.c
-_barrier_la_CPPFLAGS = -I$(top_srcdir)/src/modules/barrier
+_barrier_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/barrier
 _barrier_la_LIBADD = $(top_builddir)/src/modules/barrier/libflux-barrier.la $(common_libs)
 _barrier_la_DEPENDENCIES = _barrier_build.py
 
@@ -65,7 +72,7 @@ _mrpc_build.py: $(top_srcdir)/src/modules/libmrpc/mrpc.h $(MAKE_BINDING) _core_b
 				  mrpc.h
 
 _mrpc_la_SOURCES = _mrpc.c
-_mrpc_la_CPPFLAGS = -I$(top_srcdir)/src/modules/libmrpc
+_mrpc_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/libmrpc
 _mrpc_la_LIBADD = $(top_builddir)/src/modules/libmrpc/libflux-mrpc.la $(common_libs)
 _mrpc_la_DEPENDENCIES = _mrpc_build.py
 
@@ -77,7 +84,7 @@ _kvs_build.py: $(top_srcdir)/src/modules/kvs/kvs_deprecated.h $(MAKE_BINDING) _c
 				  kvs_deprecated.h
 
 _kvs_la_SOURCES = _kvs.c
-_kvs_la_CPPFLAGS = -I$(top_srcdir)/src/modules/kvs
+_kvs_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/kvs
 _kvs_la_LIBADD = $(top_builddir)/src/modules/kvs/libflux-kvs.la $(common_libs)
 _kvs_la_DEPENDENCIES = _kvs_build.py
 
@@ -90,7 +97,7 @@ _kz_build.py: $(top_srcdir)/src/modules/libkz/kz.h $(MAKE_BINDING) _core_build.p
 				  kz.h
 
 _kz_la_SOURCES = _kz.c $(top_srcdir)/src/modules/libkz/kz.h
-_kz_la_CPPFLAGS = -I$(top_srcdir)/src/modules/libkz
+_kz_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/libkz
 _kz_la_LIBADD = $(top_builddir)/src/modules/libkz/libkz.la $(top_builddir)/src/modules/kvs/libflux-kvs.la  $(common_libs)
 _kz_la_DEPENDENCIES = _kz_build.py
 

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -5,8 +5,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-DMODULE_PATH=\"$(fluxmoddir)\" \
 	-DPROGRAM_LIBRARY_PATH=\"$(fluxlibdir)\"
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
         -DMODULE_PATH=\"$(fluxmoddir)\" \
         -DCONNECTOR_PATH=\"$(fluxconnectordir)\" \
 	-DEXEC_PATH=\"$(fluxcmddir)\" \

--- a/src/common/libcompat/Makefile.am
+++ b/src/common/libcompat/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libcompat.la
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
         -DMODULE_PATH=\"$(fluxmoddir)\" \
         -DCONNECTOR_PATH=\"$(fluxconnectordir)\" \
 	-DEXEC_PATH=\"$(fluxcmddir)\" \

--- a/src/common/libpmi-client/Makefile.am
+++ b/src/common/libpmi-client/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libpmi-client.la
 

--- a/src/common/libpmi-server/Makefile.am
+++ b/src/common/libpmi-server/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libpmi-server.la
 

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libsubprocess.la
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -6,9 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-Wno-strict-aliasing -Wno-error=strict-aliasing \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-Wno-strict-aliasing -Wno-error=strict-aliasing
 
 noinst_LTLIBRARIES = libutil.la
 

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = local.la
 

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = loop.la
 

--- a/src/connectors/shmem/Makefile.am
+++ b/src/connectors/shmem/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = shmem.la
 

--- a/src/lib/libpmi/Makefile.am
+++ b/src/lib/libpmi/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-        -I$(top_srcdir) -I$(top_srcdir)/src/include
+        -I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 
 fluxinclude_HEADERS = \

--- a/src/modules/barrier/Makefile.am
+++ b/src/modules/barrier/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module

--- a/src/modules/connector-local/Makefile.am
+++ b/src/modules/connector-local/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module

--- a/src/modules/content-sophia/Makefile.am
+++ b/src/modules/content-sophia/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 fluxmod_LTLIBRARIES = content-sophia.la
 

--- a/src/modules/content-sqlite/Makefile.am
+++ b/src/modules/content-sqlite/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) $(SQLITE_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) $(SQLITE_CFLAGS)
 
 fluxmod_LTLIBRARIES = content-sqlite.la
 

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module
@@ -57,9 +57,9 @@ test_ldadd = \
         $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD)
 
 test_cppflags = \
+        $(AM_CPPFLAGS) \
         -DMODULE_PATH=\"$(top_builddir)/src/modules\" \
-        -I$(top_srcdir)/src/common/libtap \
-        $(AM_CPPFLAGS)
+        -I$(top_srcdir)/src/common/libtap
 
 check_PROGRAMS = $(TESTS)
 

--- a/src/modules/libjsc/Makefile.am
+++ b/src/modules/libjsc/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 lib_LTLIBRARIES = libflux-jsc.la 
 fluxcoreinclude_HEADERS = jstatctl.h

--- a/src/modules/libkz/Makefile.am
+++ b/src/modules/libkz/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libkz.la
 

--- a/src/modules/libmrpc/Makefile.am
+++ b/src/modules/libmrpc/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 lib_LTLIBRARIES = libflux-mrpc.la
 fluxcoreinclude_HEADERS = \

--- a/src/modules/live/Makefile.am
+++ b/src/modules/live/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module

--- a/src/modules/mecho/Makefile.am
+++ b/src/modules/mecho/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module

--- a/src/modules/modctl/Makefile.am
+++ b/src/modules/modctl/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module
@@ -52,8 +52,8 @@ test_ldadd = \
 	$(LIBDL) $(LIBRT)
 
 test_cppflags = \
-        -I$(top_srcdir)/src/common/libtap \
-        $(AM_CPPFLAGS)
+        $(AM_CPPFLAGS) \
+        -I$(top_srcdir)/src/common/libtap
 
 check_PROGRAMS = $(TESTS)
 

--- a/src/modules/pymod/Makefile.am
+++ b/src/modules/pymod/Makefile.am
@@ -5,9 +5,10 @@ AM_CFLAGS = \
 AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
-AM_CPPFLAGS = $(PYTHON_CPPFLAGS) \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
+AM_CPPFLAGS = \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
+	$(PYTHON_CPPFLAGS) \
 	"-DFLUX_PYTHON_PATH=\"${pyexecdir}\""
 
 #

--- a/src/modules/resource-hwloc/Makefile.am
+++ b/src/modules/resource-hwloc/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -6,8 +6,6 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(LUA_INCLUDE) \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/modules/libmrpc \
@@ -16,6 +14,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/modules/broker \
 	-I$(top_srcdir)/src/modules/kvs \
 	-I$(top_srcdir)/src/broker \
+	$(LUA_INCLUDE) \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-DWREXECD_BINDIR=\"$(libexecdir)/flux\" \
 	-DWRECK_LUA_PATTERN=\"$(sysconfdir)/wreck/lua.d/*.lua\"
 

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 check_PROGRAMS = \
 	tasyncsock \

--- a/src/test/kap/Makefile.am
+++ b/src/test/kap/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) $(MPI_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS) $(MPI_CFLAGS)
 
 LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \

--- a/src/test/module/Makefile.am
+++ b/src/test/module/Makefile.am
@@ -6,9 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
-
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 #
 # Comms modules
 #

--- a/src/test/request/Makefile.am
+++ b/src/test/request/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 #
 # Comms module

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -6,8 +6,8 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-        $(JSON_CFLAGS) $(ZMQ_CFLAGS) \
-        -I$(top_srcdir) -I$(top_srcdir)/src/include
+        -I$(top_srcdir) -I$(top_srcdir)/src/include \
+        $(JSON_CFLAGS) $(ZMQ_CFLAGS)
 
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \


### PR DESCRIPTION
This PR fixes the order of includes in most/all Makefile.am files throughout the project such that `-I$(top_srcdir)/src/include` is before any other CPPFLAGS. This ensures we build all source files with the build-tree `flux/core.h` instead of accidentally pulling in a system `flux/core.h`.

To reduce the likelihood we'd accidentally regress on this issue, a dummy `core.h` is copied into `$HOME/local/include/flux` before the travis build. This dummy include contains a single line that issues a preprocessor `#error`, so should break the build quite nicely.

I realize now I probably should have added a comment to all of these `Makefile.am` files explaining the importance of keeping `-I$(top_srcdir)/src/include` first in `AM_CPPFLAGS`, and explaining that `AM_CPPFLAGS` should be copied to any `x_CPPFLAGS` in the Makefile.

I also didn't look *too* hard for a better way to accomplish this...