### PR TITLE
content-cache: improve logging, fix flush logic

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -468,7 +468,8 @@ done:
      */
     if (cache->acct_dirty == 0)
         flush_respond (cache);
-    else if (cache->flush_batch_count <= cache->flush_batch_limit / 2)
+    else if (cache->acct_dirty - cache->flush_batch_count > 0
+            && cache->flush_batch_count <= cache->flush_batch_limit / 2)
         (void)cache_flush (cache); /* resume flushing */
 }
 

--- a/src/modules/content-sophia/content-sophia.c
+++ b/src/modules/content-sophia/content-sophia.c
@@ -43,8 +43,6 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 
-const bool debug_enabled = false;
-
 typedef struct {
     char *dir;
     void *env;
@@ -185,14 +183,6 @@ void load_cb (flux_t h, flux_msg_handler_t *w,
     data = sp_getstring (result, "value", &size);
     rc = 0;
 done:
-    if (debug_enabled) {
-        int saved_errno = errno;
-        if (rc < 0)
-            flux_log (h, LOG_DEBUG, "load: %s %s", blobref, strerror (errno));
-        //else
-        //    flux_log (h, LOG_DEBUG, "load: %s size=%d", blobref, size);
-        errno = saved_errno;
-    }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,
                                   rc < 0 ? NULL : data, size) < 0)
         flux_log_error (h, "flux_respond");
@@ -245,14 +235,6 @@ void store_cb (flux_t h, flux_msg_handler_t *w,
     }
     rc = 0;
 done:
-    if (debug_enabled) {
-        int saved_errno = errno;
-        if (rc < 0)
-            flux_log (h, LOG_DEBUG, "store: %s %s", blobref, strerror (errno));
-        //else
-        //    flux_log (h, LOG_DEBUG, "store: %s size=%d", blobref, size);
-        errno = saved_errno;
-    }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,
                                   blobref, SHA1_STRING_SIZE) < 0)
         flux_log_error (h, "flux_respond");
@@ -374,9 +356,6 @@ void shutdown_cb (flux_t h, flux_msg_handler_t *w,
             flux_log (h, LOG_ERR, "dump: store returned malformed blobref");
             flux_rpc_destroy (rpc);
             continue;
-        }
-        if (debug_enabled) {
-            flux_log (h, LOG_DEBUG, "dump: %s", blobref);
         }
         flux_rpc_destroy (rpc);
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -38,8 +38,6 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 
-const bool debug_enabled = false;
-
 const char *sql_create_table = "CREATE TABLE objects("
                                "  hash CHAR(20) PRIMARY KEY,"
                                "  object BLOB"
@@ -236,14 +234,6 @@ void load_cb (flux_t h, flux_msg_handler_t *w,
     data = sqlite3_column_blob (ctx->load_stmt, 0);
     rc = 0;
 done:
-    if (debug_enabled) {
-        int saved_errno = errno;
-        if (rc < 0)
-            flux_log (h, LOG_DEBUG, "load: %s %s", blobref, strerror (errno));
-        //else
-        //    flux_log (h, LOG_DEBUG, "load: %s size=%d", blobref, size);
-        errno = saved_errno;
-    }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0, data, size) < 0)
         flux_log_error (h, "load: flux_respond");
     (void )sqlite3_reset (ctx->load_stmt);
@@ -293,14 +283,6 @@ void store_cb (flux_t h, flux_msg_handler_t *w,
     }
     rc = 0;
 done:
-    if (debug_enabled) {
-        int saved_errno = errno;
-        if (rc < 0)
-            flux_log (h, LOG_DEBUG, "store: %s %s", blobref, strerror (errno));
-        //else
-        //    flux_log (h, LOG_DEBUG, "store: %s size=%d", blobref, size);
-        errno = saved_errno;
-    }
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,
                                         blobref, SHA1_STRING_SIZE) < 0)
         flux_log_error (h, "store: flux_respond");
@@ -385,9 +367,6 @@ void shutdown_cb (flux_t h, flux_msg_handler_t *w,
             flux_log (h, LOG_ERR, "dump: store returned malformed blobref");
             flux_rpc_destroy (rpc);
             continue;
-        }
-        if (debug_enabled) {
-            flux_log (h, LOG_DEBUG, "dump: %s", blobref);
         }
         flux_rpc_destroy (rpc);
     }


### PR DESCRIPTION
This patch adds some useful debug logging to the content cache flush code, as well as the shutdown code in each of the content backing stores.

Also address a logic error in the cache flush code which was causing many iterations through the content hash looking for dirty entries.

I hope this fixes #570.  If not, it adds some logging which will help us when it occurs.