### PR TITLE
Enhancements to ease development of framework project sharness testsuites

### DIFF
--- a/doc/man1/flux.adoc
+++ b/doc/man1/flux.adoc
@@ -88,6 +88,12 @@ Set Lua binary module search path:
   [getenv FLUX_LUA_CPATH_PREPEND];[config.general.lua_cpath];\
     [getenv LUA_CPATH];install-path;;;
 
+setenv PYTHONPATH::
+Set Python module search path:
+
+  [getenv FLUX_PYTHONPATH_PREPEND]:[config.general.python_path]:\
+    [getenv PYTHONPATH];install-path
+
 setenv FLUX_BROKER_PATH::
 Set the path to the broker executable.  This environment variable is
 used by flux-start(1) and related sub-commands to launch the broker.

--- a/doc/man1/flux.adoc
+++ b/doc/man1/flux.adoc
@@ -60,30 +60,33 @@ Sub-command search path::
 Look for "flux-'CMD'" executable by searching a path constructed
 with the following prototype:
 
-  [config.general.exec_path]:install-path:[getenv FLUX_EXEC_PATH]
+  [getenv FLUX_EXEC_PATH_PREPEND]:[config.general.exec_path]:install-path:\
+    [getenv FLUX_EXEC_PATH]
 
 setenv FLUX_MODULE_PATH::
 Set up broker comms module search path according to:
 
-  [config.general.module_path]:install-path:\
+  [getenv FLUX_MODULE_PATH_PREPEND]:[config.general.module_path]:install-path:\
     [getenv FLUX_MODULE_PATH]
 
 setenv FLUX_CONNECTOR_PATH::
 Set up search path for connector modules used by libflux to open a connection
 to the broker
 
-  [config.general.connector_path]:install-path:\
-    [getenv FLUX_CONNECTOR_PATH]
+  [getenv FLUX_CONNECTOR_PATH_PREPEND]:[config.general.connector_path]:\
+    install-path:[getenv FLUX_CONNECTOR_PATH]
 
 setenv LUA_PATH::
 Set Lua module search path:
 
-  [config.general.lua_path];[getenv LUA_PATH];install-path;;;
+  [getenv FLUX_LUA_PATH_PREPEND]:[config.general.lua_path];[getenv LUA_PATH];\
+    install-path;;;
 
 setenv LUA_CPATH::
 Set Lua binary module search path:
 
-  [config.general.lua_cpath];[getenv LUA_CPATH];install-path;;;
+  [getenv FLUX_LUA_CPATH_PREPEND];[config.general.lua_cpath];\
+    [getenv LUA_CPATH];install-path;;;
 
 setenv FLUX_BROKER_PATH::
 Set the path to the broker executable.  This environment variable is

--- a/doc/man1/flux.adoc
+++ b/doc/man1/flux.adoc
@@ -49,10 +49,6 @@ Set the URI used to connect to flux-broker.
 *-t, --trace-apisock*::
 Trace API socket traffic to 'stderr'.
 
-*-x, --exec-path*='PATH'::
-Prepend 'PATH' to sub-command executable search path.
-Multiple directories may be specified, separated by colons.
-
 
 SUB-COMMAND ENVIRONMENT
 -----------------------
@@ -64,7 +60,7 @@ Sub-command search path::
 Look for "flux-'CMD'" executable by searching a path constructed
 with the following prototype:
 
-  [--exec-path PATH]:[config.general.exec_path]:install-path
+  [config.general.exec_path]:install-path:[getenv FLUX_EXEC_PATH]
 
 setenv FLUX_MODULE_PATH::
 Set up broker comms module search path according to:

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -302,3 +302,4 @@ lstopo
 xml
 filesystem
 filename
+PYTHONPATH

--- a/src/cmd/builtin.h
+++ b/src/cmd/builtin.h
@@ -35,5 +35,4 @@ struct builtin_cmd {
 };
 
 void usage (optparse_t *p);
-void print_environment (flux_conf_t cf);
 flux_t builtin_get_flux_handle (optparse_t *p);

--- a/src/cmd/builtin/env.c
+++ b/src/cmd/builtin/env.c
@@ -25,6 +25,18 @@
 
 #include "builtin.h"
 
+static void print_environment (flux_conf_t cf)
+{
+    const char *key, *value;
+    for (value = (char*)flux_conf_environment_first (cf),
+         key = (char*)flux_conf_environment_cursor(cf);
+         value != NULL;
+         value = flux_conf_environment_next(cf), key = flux_conf_environment_cursor(cf)) {
+        printf ("export %s=\"%s\"\n", key, value);
+    }
+    fflush (stdout);
+}
+
 static int cmd_env (optparse_t *p, int ac, char *av[])
 {
     int n = optparse_optind (p);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -226,6 +226,20 @@ int main (int argc, char *argv[])
     flux_conf_environment_push (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
     flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
 
+    /* Prepend if FLUX_*_PATH_PREPEND is set */
+    flux_conf_environment_push (cf, "FLUX_CONNECTOR_PATH",
+                                getenv ("FLUX_CONNECTOR_PATH_PREPEND"));
+    flux_conf_environment_push (cf, "FLUX_EXEC_PATH",
+                                getenv ("FLUX_EXEC_PATH_PREPEND"));
+    flux_conf_environment_push (cf, "FLUX_MODULE_PATH",
+                                getenv ("FLUX_MODULE_PATH_PREPEND"));
+    flux_conf_environment_push (cf, "LUA_CPATH",
+                                getenv ("FLUX_LUA_CPATH_PREPEND"));
+    flux_conf_environment_push (cf, "LUA_PATH",
+                                getenv ("FLUX_LUA_PATH_PREPEND"));
+    flux_conf_environment_push (cf, "PYTHONPATH",
+                                getenv ("FLUX_PYTHONPATH_PREPEND"));
+
     if (argc - optind == 0) {
         usage (p);
         exit (1);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -54,10 +54,6 @@ static struct optparse_option opts[] = {
     { .name = "trace-handle",    .key = 't', .has_arg = 0,
       .usage = "Set FLUX_HANDLE_TRACE=1 before executing COMMAND"
     },
-    { .name = "exec-path",       .key = 'x', .has_arg = 1,
-      .arginfo = "PATH",
-      .usage = "Prepend PATH to command search path",
-    },
     { .name = "config",          .key = 'c', .has_arg = 1,
       .arginfo = "DIR",
       .usage = "Set path to config directory"
@@ -146,7 +142,6 @@ int main (int argc, char *argv[])
 {
     const char *opt;
     bool vopt = false;
-    char *xopt = NULL;
     char *confdir = NULL;
     const char *secdir = NULL;
     flux_conf_t cf;
@@ -230,9 +225,6 @@ int main (int argc, char *argv[])
     flux_conf_environment_push (cf, "LUA_CPATH",           flux_conf_get(cf, "general.lua_cpath"));
     flux_conf_environment_push (cf, "LUA_PATH",            flux_conf_get(cf, "general.lua_path"));
     flux_conf_environment_push (cf, "PYTHONPATH",          flux_conf_get(cf, "general.python_path"));
-
-    /* Prepend to command-line environment variables */
-    flux_conf_environment_push (cf, "FLUX_EXEC_PATH", xopt);
 
     if (argc - optind == 0) {
         usage (p);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -48,6 +48,7 @@
 void exec_subcommand (const char *searchpath, bool vopt, char *argv[]);
 char *intree_confdir (void);
 void setup_path (flux_conf_t cf, const char *argv0);
+static void print_environment (flux_conf_t cf);
 static void register_builtin_subcommands (optparse_t *p);
 
 static struct optparse_option opts[] = {
@@ -369,7 +370,7 @@ void exec_subcommand (const char *searchpath, bool vopt, char *argv[])
     }
 }
 
-void print_environment (flux_conf_t cf)
+static void print_environment (flux_conf_t cf)
 {
     const char *key, *value;
     for (value = (char*)flux_conf_environment_first(cf), key = (char*)flux_conf_environment_cursor(cf);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -167,6 +167,7 @@ int main (int argc, char *argv[])
         usage (p);
         exit (0);
     }
+    vopt = optparse_hasopt (p, "verbose");
     if (optparse_hasopt (p, "trace-handle")) {
         if (setenv ("FLUX_HANDLE_TRACE", "1", 1) < 0)
             err_exit ("setenv");

--- a/t/sharness.d/01-setup.sh
+++ b/t/sharness.d/01-setup.sh
@@ -1,0 +1,52 @@
+#
+#  Export some extra variables to test scripts specific to flux-core
+#   testsuite
+
+#
+#  Unset variables important to Flux
+#
+unset FLUX_CONFIG
+unset FLUX_MODULE_PATH
+unset FLUX_CMBD_PATH
+
+#
+#  FLUX_BUILD_DIR and FLUX_SOURCE_DIR are set to build and source paths
+#  (based on current directory)
+#
+if test -z "$FLUX_BUILD_DIR"; then
+    if test -z "${builddir}"; then
+        FLUX_BUILD_DIR="$(cd .. && pwd)"
+    else
+        FLUX_BUILD_DIR="$(cd ${builddir}/.. && pwd))"
+    fi
+    export FLUX_BUILD_DIR
+fi
+if test -z "$FLUX_SOURCE_DIR"; then
+    if test -z "${srcdir}"; then
+        FLUX_SOURCE_DIR="$(cd .. && pwd)"
+    else
+        FLUX_SOURCE_DIR="$(cd ${srcdir}/.. && pwd)"
+    fi
+    export FLUX_SOURCE_DIR
+fi
+
+
+#
+#  Add path to flux(1) command to PATH
+#
+if test -n "$FLUX_TEST_INSTALLED_PATH"; then
+    PATH=$FLUX_TEST_INSTALLED_PATH:$PATH
+    fluxbin=$FLUX_TEST_INSTALLED_PATH/flux
+else # normal case, use ${top_builddir}/src/cmd/flux
+    PATH=$FLUX_BUILD_DIR/src/cmd:$PATH
+    fluxbin=$FLUX_BUILD_DIR/src/cmd/flux
+fi
+export PATH
+
+if ! test -x ${fluxbin}; then
+    echo >&2 "Failed to find a flux binary in ${fluxbin}."
+    echo >&2 "Do you need to run make?"
+    return 1
+fi
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -4,35 +4,6 @@
 #
 
 #
-#  Unset variables important to Flux
-#
-unset FLUX_CONFIG
-unset FLUX_MODULE_PATH
-unset FLUX_CMBD_PATH
-
-#
-#  FLUX_BUILD_DIR and FLUX_SOURCE_DIR are set to build and source paths
-#  (based on current directory)
-#
-if test -z "$FLUX_BUILD_DIR"; then
-    if test -z "${builddir}"; then
-        FLUX_BUILD_DIR="$(cd .. && pwd)"
-    else
-        FLUX_BUILD_DIR="$(cd ${builddir}/.. && pwd))"
-    fi
-    export FLUX_BUILD_DIR
-fi
-if test -z "$FLUX_SOURCE_DIR"; then
-    if test -z "${srcdir}"; then
-        FLUX_SOURCE_DIR="$(cd .. && pwd)"
-    else
-        FLUX_SOURCE_DIR="$(cd ${srcdir}/.. && pwd)"
-    fi
-    export FLUX_SOURCE_DIR
-fi
-
-
-#
 #  Extra functions for Flux testsuite
 #
 run_timeout() {
@@ -104,28 +75,6 @@ test_on_rank() {
     ranks=$1; shift;
     flux exec --rank=${ranks} "$@"
 }
-
-
-#
-#  Export some extra variables to test scripts specific to Flux
-#   testsuite
-#
-#  Add path to flux(1) command to PATH
-#
-if test -n "$FLUX_TEST_INSTALLED_PATH"; then
-    PATH=$FLUX_TEST_INSTALLED_PATH:$PATH
-    fluxbin=$FLUX_TEST_INSTALLED_PATH/flux
-else # normal case, use ${top_builddir}/src/cmd/flux
-    PATH=$FLUX_BUILD_DIR/src/cmd:$PATH
-    fluxbin=$FLUX_BUILD_DIR/src/cmd/flux
-fi
-export PATH
-
-if ! test -x ${fluxbin}; then
-    echo >&2 "Failed to find a flux binary in ${fluxbin}."
-    echo >&2 "Do you need to run make?"
-    return 1
-fi
 
 #  Export a shorter name for this test
 TEST_NAME=$SHARNESS_TEST_NAME

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -103,4 +103,19 @@ test_expect_success 'flux --secdir overrides config' '
 	test -f $tmpkeydir/curve/client_secret &&
 	rm -rf $tmpkeydir
 '
+
+test_expect_success 'FLUX_*_PREPEND environment variables work' '
+	FLUX_CONNECTOR_PATH_PREPEND=/foo \
+	  flux env | grep "^FLUX_CONNECTOR_PATH=/foo" &&
+	FLUX_EXEC_PATH_PREPEND=/foo \
+	  flux env | grep "^FLUX_EXEC_PATH=/foo" &&
+	FLUX_MODULE_PATH_PREPEND=/foo \
+	  flux env | grep "^FLUX_MODULE_PATH=/foo" &&
+	FLUX_LUA_PATH_PREPEND=/foo \
+	  flux env | grep "^LUA_PATH=/foo" &&
+	FLUX_LUA_CPATH_PREPEND=/foo \
+	  flux env | grep "^LUA_CPATH=/foo" &&
+	FLUX_PYTHONPATH_PREPEND=/foo \
+	  flux env | grep "^PYTHONPATH=/foo"
+'
 test_done

--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -59,7 +59,7 @@ test_expect_success 'flux env runs argument' "
 		| grep /connectors
 "
 test_expect_success 'flux env passes cmddriver options' '
-	flux -F --uri foo://xyz env | grep "^FLUX_URI=foo://xyz"
+	flux -F --uri foo://xyz env | grep "^export FLUX_URI=\"foo://xyz"
 '
 test_expect_success 'flux env passes cmddriver option to argument' "
 	flux -F --uri foo://xyx env sh -c 'echo \$FLUX_URI' \
@@ -106,16 +106,19 @@ test_expect_success 'flux --secdir overrides config' '
 
 test_expect_success 'FLUX_*_PREPEND environment variables work' '
 	FLUX_CONNECTOR_PATH_PREPEND=/foo \
-	  flux env | grep "^FLUX_CONNECTOR_PATH=/foo" &&
+	  flux /usr/bin/printenv | grep "FLUX_CONNECTOR_PATH=/foo" &&
 	FLUX_EXEC_PATH_PREPEND=/foo \
-	  flux env | grep "^FLUX_EXEC_PATH=/foo" &&
+	  flux /usr/bin/printenv | grep "FLUX_EXEC_PATH=/foo" &&
 	FLUX_MODULE_PATH_PREPEND=/foo \
-	  flux env | grep "^FLUX_MODULE_PATH=/foo" &&
+	  flux /usr/bin/printenv | grep "FLUX_MODULE_PATH=/foo" &&
 	FLUX_LUA_PATH_PREPEND=/foo \
-	  flux env | grep "^LUA_PATH=/foo" &&
+	  flux /usr/bin/printenv | grep "LUA_PATH=/foo" &&
 	FLUX_LUA_CPATH_PREPEND=/foo \
-	  flux env | grep "^LUA_CPATH=/foo" &&
+	  flux /usr/bin/printenv | grep "LUA_CPATH=/foo" &&
 	FLUX_PYTHONPATH_PREPEND=/foo \
-	  flux env | grep "^PYTHONPATH=/foo"
+	  flux /usr/bin/printenv | grep "PYTHONPATH=/foo"
+'
+test_expect_success 'flux-env output can be passed to eval' '
+    eval $(flux env)
 '
 test_done


### PR DESCRIPTION
Initial proposal that adds a set of environment variables `FLUX*PATH_PREPEND` to force the prepend of FLUX variables to the final environment.

This will be used mostly for testing, or to ensure some cmd or module overrides an installed version.

I also found that I'd dropped the functionality of `-v` from `flux(1)` before, so we add that back here...