### PR TITLE
ensure all requests to modules get a response

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -434,7 +434,11 @@ static void cache_store_continuation (flux_rpc_t *rpc, void *arg)
     assert (cache->flush_batch_count >= 0);
     if (flux_rpc_get_raw (rpc, NULL, &blobref, &blobref_size) < 0) {
         saved_errno = errno;
-        flux_log_error (cache->h, "content store");
+        if (cache->rank == 0 && errno == ENOSYS)
+            flux_log (cache->h, LOG_DEBUG, "content store: %s",
+                      "backing store service unavailable");
+        else
+            flux_log_error (cache->h, "content store");
         goto done;
     }
     if (!blobref || blobref[blobref_size - 1] != '\0') {

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -939,7 +939,7 @@ int content_cache_register_attrs (content_cache_t *cache, attr_t *attr)
     /* Misc
      */
     if (attr_add_active_uint32 (attr, "content-flush-batch-limit",
-                &cache->flush_batch_limit, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                &cache->flush_batch_limit, 0) < 0)
         return -1;
     if (attr_add_active_uint32 (attr, "content-blob-size-limit",
                 &cache->blob_size_limit, FLUX_ATTRFLAG_IMMUTABLE) < 0)

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -455,7 +455,7 @@ static void cache_store_continuation (flux_rpc_t *rpc, void *arg)
 done:
     if (respond_requests_raw (&e->store_requests, cache->h,
                                         rc < 0 ? saved_errno : 0,
-                                        e->blobref, strlen (blobref) + 1) < 0)
+                                        blobref, blobref_size) < 0)
         flux_log_error (cache->h, "content store");
     flux_rpc_destroy (rpc);
 

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -138,10 +138,11 @@ static flux_msg_t *op_recv (void *impl, int flags)
         goto done;
     if ((flags & FLUX_O_NONBLOCK)) {
         int n;
-        if ((n = zmq_poll (&zp, 1, 0L)) < 0)
-            goto done; /* likely: EWOULDBLOCK | EAGAIN */
-        assert (n == 1);
-        assert (zp.revents == ZMQ_POLLIN);
+        if ((n = zmq_poll (&zp, 1, 0L)) <= 0) {
+            if (n == 0)
+                errno = EWOULDBLOCK;
+            goto done;
+        }
     }
     msg = zmsg_recv (ctx->sock);
 done:

--- a/src/modules/content-sophia/content-sophia.c
+++ b/src/modules/content-sophia/content-sophia.c
@@ -121,6 +121,7 @@ static ctx_t *getctx (flux_t h)
             cleanup = true;
         }
         ctx->dir = xasprintf ("%s/content", dir);
+        flux_log (h, LOG_DEBUG, "database start");
         if (!(ctx->env = sp_env ())
                 || sp_setstring (ctx->env, "sophia.path", ctx->dir, 0) < 0
                 || sp_setstring (ctx->env, "db", "content", 0) < 0
@@ -132,6 +133,7 @@ static ctx_t *getctx (flux_t h)
             log_sophia_error (ctx, "initialization");
             goto error;
         }
+        flux_log (h, LOG_DEBUG, "database ready");
         if (cleanup)
             cleanup_push_string (cleanup_directory_recursive, ctx->dir);
         flux_aux_set (h, "flux::content-sophia", ctx, freectx);

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -15,9 +15,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 MAXBLOB=`flux getattr content-blob-size-limit`
 
-test_expect_success 'unload backing store module if loaded' '
-	! flux getattr content-backing 2>/dev/null \
-	    || flux module remove -d `flux getattr content-backing`
+test_expect_success 'unload backing store module' '
+	flux module remove --rank 0 --direct content-sqlite
 '
 
 test_expect_success 'store 100 blobs on rank 0' '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -23,13 +23,9 @@ store_junk() {
     done
 }
 
-test_expect_success 'unload backing store module if loaded' '
-        ! flux getattr content-backing 2>/dev/null \
-            || flux module remove -d `flux getattr content-backing`
-'
 
-test_expect_success 'load content-sqlite module on rank 0' '
-	flux module load --rank 0 --direct content-sqlite
+test_expect_success 'verify that content-sqlite module is loaded' '
+	flux module list --direct --rank 0 | grep -q content-sqlite
 '
 
 test_expect_success 'store 100 blobs on rank 0' '

--- a/t/t0013-content-sophia.t
+++ b/t/t0013-content-sophia.t
@@ -16,9 +16,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 MAXBLOB=`flux getattr content-blob-size-limit`
 
-test_expect_success 'unload backing store module if loaded' '
-        ! flux getattr content-backing 2>/dev/null \
-            || flux module remove -d `flux getattr content-backing`
+test_expect_success 'unload backing store module' '
+        flux module remove --rank 0 --direct content-sqlite
 '
 
 test_expect_success 'load content-sophia module on rank 0' '


### PR DESCRIPTION
Requests might be "lost" if they arrive while a module is shutting down (e.g. while being unloaded).  This PR ensures those requests get an ENOSYS reply.  A debug message is logged for each message responded to here.

A theory for #570 is that store requests are lost and remain pending in the content-cache when the backing store module is unloaded. 