### PR TITLE
testsuite: small fixes and debug enhancements for wreck tests

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -260,7 +260,7 @@ local function fixup_nnodes (wreck)
     if not wreck.nnodes then
         wreck.nnodes = math.min (wreck.ntasks, wreck.flux.size)
     elseif wreck.nnodes > wreck.flux.size then
-        self:die ("Requested nodes (%d) exceeds available (%d)\n",
+        wreck:die ("Requested nodes (%d) exceeds available (%d)\n",
                   wreck.nnodes, f.size)
     end
 end

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -275,8 +275,8 @@ test_expect_success 'wreckrun: --output supported' '
 test_expect_success 'wreckrun: --error supported' '
 	flux wreckrun --output=test2.out --error=test2.err \
 	    sh -c "echo >&2 this is stderr; echo this is stdout" &&
-        $WAITFILE --timeout=1 -p "this is stderr" test2.err &&
-        $WAITFILE --timeout=1 -p "this is stdout" test2.out
+        $WAITFILE -v --timeout=1 -p "this is stderr" test2.err &&
+        $WAITFILE -v --timeout=1 -p "this is stdout" test2.out
 '
 test_expect_success 'wreckrun: kvs config output for all jobs' '
 	test_when_finished "flux kvs put lwj.output=" &&


### PR DESCRIPTION
I can't get `waitfile.lua` tests to fail in travis right now, so let's just update the wreck tests to use the `-v, --verbose` flag on the script and hope that helps with diagnosis the next time there is a failure.

Also pushed a small fix for invalid reference to `self` in `src/bindings/lua/wreck.lua` uncovered by the tests.