### PR TITLE
testsuite: attempt fix of statwatcher-based waitfile script

### DIFF
--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -21,6 +21,7 @@ Options:
 local getopt = require 'flux.alt_getopt' .get_opts
 local posix  = require 'flux.posix'
 local flux   = require 'flux'
+local timer  = require 'flux.timer'
 
 local opts, optind = getopt (arg, "hvqc:t:p:",
                              { timeout = 't',
@@ -40,8 +41,10 @@ local pattern = opts.p or ""
 local count = opts.c or 1
 local file = arg[optind]
 
+local tt = timer.new()
+
 local function printf (m, ...)
-    io.stderr:write (string.format ("waitfile: "..m, ...))
+    io.stderr:write (string.format ("waitfile: %4.03fs: "..m, tt:get0(), ...))
 end
 
 local function log_verbose (m, ...)
@@ -108,7 +111,7 @@ function filewatcher:changed ()
         log_verbose ("File appeared with size %d\n", st.st_size)
         return true
     end
-    log_verbose ("File changed\n")
+    log_verbose ("File changed size %d\n", st.st_size)
     if st.st_size < prev.st_size then
         printf ("truncated!\n")
         self.position = 0 -- reread
@@ -155,7 +158,7 @@ setmetatable (filewatcher, { __call = function (t, arg)
         flux =     arg.flux,
         filename = arg.filename,
         pattern  = arg.pattern,
-	count    = tonumber (arg.count) or 1,
+	    count    = tonumber (arg.count) or 1,
         interval = arg.interval and arg.interval or .25,
         on_match = arg.on_match,
         position = 0,

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -108,15 +108,12 @@ function filewatcher:changed ()
         log_verbose ("File appeared with size %d\n", st.st_size)
         return true
     end
-    if st.st_mtime > prev.st_mtime then
-        log_verbose ("File changed\n")
-        if st.st_size < prev.st_size then
-            printf ("truncated!\n")
-            self.position = 0 -- reread
-        end
-        return true
+    log_verbose ("File changed\n")
+    if st.st_size < prev.st_size then
+        printf ("truncated!\n")
+        self.position = 0 -- reread
     end
-    return false
+    return true
 end
 
 function filewatcher:check ()

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -135,7 +135,7 @@ function filewatcher:start ()
         path = self.filename,
         interval = self.interval,
         handler = function (w, st, prev)
-            printf ("wakeup\n")
+            log_verbose ("wakeup\n")
             self.st = setmetatable (st, stat)
             self:check ()
             log_verbose ("back to sleep\n")

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -35,7 +35,7 @@ if opts.h then print (usage); os.exit (0) end
 local f, err = flux.new()
 if not f then error (err) end
 
-local timeout = opts.t or 0
+local timeout = tonumber (opts.t or 0)
 local pattern = opts.p or ""
 local count = opts.c or 1
 local file = arg[optind]
@@ -185,7 +185,7 @@ if not fw then printf ("%s\n", err); os.exit (1) end
 
 -- Exit with non-zero status after timeout:
 --
-if timeout then
+if timeout > 0 then
     f:timer {
       timeout = timeout * 1000,
       handler = function ()

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -135,4 +135,31 @@ test_expect_success 'builtin test_size_large () works' '
     test "$size" = "123"
 '
 
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+test_expect_success 'scripts/waitfile works' '
+    flux start $waitfile -v -t 5 -p "hello" waitfile.test.1 &
+    p=$! &&
+    echo "hello" > waitfile.test.1 &&
+    wait $p
+'
+
+test_expect_success 'scripts/waitfile works after <1s' '
+    flux start $waitfile -v -t 5 -p "hello" waitfile.test.2 &
+    p=$! &&
+    echo > waitfile.test.2 &&
+    sleep 1 &&
+    echo "hello" >> waitfile.test.2 &&
+    wait $p
+'
+
+test_expect_success 'scripts/waitfile works after 1s' '
+    flux start $waitfile -v -t 5 -p "hello" waitfile.test.3 &
+    p=$! &&
+    echo > waitfile.test.3 &&
+    sync &&
+    sleep 2 &&
+    echo "hello" >> waitfile.test.3 &&
+    wait $p
+'
+
 test_done


### PR DESCRIPTION
The waitfile script held a vestige of a polling mode version that checked mtime of the target compared to the previous polling interval. With statwatcher, waitfile may wake up immediately on changes to the target file, and if this happens within one second of the previous check a false negative was returned from the `check()` function.

Remove the use of mtime, which shouldn't be required anyway if statwatcher is working.

This will likely resolve false timeouts as described in #569 -- however, I'd like to make sure we don't see any other failures for awhile before calling that Issue resolved.

I'd also like to attempt to write a testsuite for the waitfile script itself.