### PR TITLE
Fix for waitfile.lua tests and missing logfiles of tests that don't use test_under_flux

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -261,7 +261,7 @@ local function fixup_nnodes (wreck)
         wreck.nnodes = math.min (wreck.ntasks, wreck.flux.size)
     elseif wreck.nnodes > wreck.flux.size then
         wreck:die ("Requested nodes (%d) exceeds available (%d)\n",
-                  wreck.nnodes, f.size)
+                  wreck.nnodes, wreck.flux.size)
     end
 end
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -8,6 +8,8 @@ This suite verifies functionality that may be assumed working by
 other tests.
 '
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 test_expect_success 'TEST_NAME is set' '

--- a/t/t0006-build-basic.t
+++ b/t/t0006-build-basic.t
@@ -3,6 +3,8 @@
 
 test_description='Build out of tree using Makefile.inc'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 test_expect_success 'Makefile.inc is found' '

--- a/t/t2004-hydra.t
+++ b/t/t2004-hydra.t
@@ -3,6 +3,8 @@
 
 test_description='Test that MICH Hydra can launch Flux'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 if ! which mpiexec.hydra 2>/dev/null; then


### PR DESCRIPTION
This PR fixes missing logfiles for tests that don't run `test_under_flux` when `FLUX_TESTS_LOGFILE` is set (for now we do this by hand in each test), a small fix for wreck.lua error output when nnodes requested > nnodes available, and an update for the `waitfile.lua` tests that allow dynamically loaded code to actually drive the tests to avoid synchronization problems when trying to "test the test".

