### PR TITLE
avoid clobbering errno in flux_log() functions

### DIFF
--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -89,8 +89,7 @@ int main (int argc, char *argv[])
     if (parse_logstr (priority, &level, &facility) < 0)
         msg_exit ("bad priority argument");
     flux_log_set_facility (h, facility);
-    if (flux_log (h, level, "%s", message) < 0)
-        err_exit ("flux_log");
+    flux_log (h, level, "%s", message);
 
     flux_close (h);
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -82,7 +82,7 @@ void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg)
     ctx->cb_arg = arg;
 }
 
-int flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
+void flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
 {
     logctx_t *ctx = getctx (h);
     char *message = xvasprintf (fmt, ap);
@@ -90,7 +90,6 @@ int flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
     JSON o = NULL;
     uint32_t rank = FLUX_NODEID_ANY;
     flux_rpc_t *rpc = NULL;
-    int rc = -1;
 
     (void)gettimeofday (&tv, NULL);
     (void)flux_get_rank (h, &rank);
@@ -108,46 +107,36 @@ int flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
                                                         FLUX_RPC_NORESPONSE)))
             goto done;
     }
-    rc = 0;
 done:
     flux_rpc_destroy (rpc);
     Jput (o);
     free (message);
-    return rc;
 }
 
-int flux_log (flux_t h, int lev, const char *fmt, ...)
+void flux_log (flux_t h, int lev, const char *fmt, ...)
 {
     va_list ap;
-    int rc;
 
     va_start (ap, fmt);
-    rc = flux_vlog (h, lev, fmt, ap);
+    flux_vlog (h, lev, fmt, ap);
     va_end (ap);
-    return rc;
 }
 
-int flux_log_verror (flux_t h, const char *fmt, va_list ap)
+void flux_log_verror (flux_t h, const char *fmt, va_list ap)
 {
     char *s = xvasprintf (fmt, ap);
-    int rc;
 
-    rc = flux_log (h, LOG_ERR, "%s: %s", s, zmq_strerror (errno));
+    flux_log (h, LOG_ERR, "%s: %s", s, zmq_strerror (errno));
     free (s);
-
-    return rc;
 }
 
-int flux_log_error (flux_t h, const char *fmt, ...)
+void flux_log_error (flux_t h, const char *fmt, ...)
 {
     va_list ap;
-    int rc;
 
     va_start (ap, fmt);
-    rc = flux_log_verror (h, fmt, ap);
+    flux_log_verror (h, fmt, ap);
     va_end (ap);
-
-    return rc;
 }
 
 static int dmesg_clear (flux_t h, int seq)

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -84,6 +84,7 @@ void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg)
 
 void flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
 {
+    int saved_errno = errno;
     logctx_t *ctx = getctx (h);
     char *message = xvasprintf (fmt, ap);
     struct timeval tv = { 0, 0 };
@@ -111,6 +112,7 @@ done:
     flux_rpc_destroy (rpc);
     Jput (o);
     free (message);
+    errno = saved_errno;
 }
 
 void flux_log (flux_t h, int lev, const char *fmt, ...)
@@ -124,10 +126,12 @@ void flux_log (flux_t h, int lev, const char *fmt, ...)
 
 void flux_log_verror (flux_t h, const char *fmt, va_list ap)
 {
+    int saved_errno = errno;
     char *s = xvasprintf (fmt, ap);
 
     flux_log (h, LOG_ERR, "%s: %s", s, zmq_strerror (errno));
     free (s);
+    errno = saved_errno;
 }
 
 void flux_log_error (flux_t h, const char *fmt, ...)

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -20,16 +20,16 @@ void flux_log_set_facility (flux_t h, const char *facility);
 
 /* Log a message at the specified level, as defined for syslog(3).
  */
-int flux_vlog (flux_t h, int level, const char *fmt, va_list ap);
-int flux_log (flux_t h, int level, const char *fmt, ...)
+void flux_vlog (flux_t h, int level, const char *fmt, va_list ap);
+void flux_log (flux_t h, int level, const char *fmt, ...)
               __attribute__ ((format (printf, 3, 4)));
 
 /* Log a message at LOG_ERR level, appending a colon, space, and error string.
  * The system 'errno' is assumed to be valid and contain an error code
  * that can be decoded with zmq_strerror(3).
  */
-int flux_log_verror (flux_t h, const char *fmt, va_list ap);
-int flux_log_error (flux_t h, const char *fmt, ...)
+void flux_log_verror (flux_t h, const char *fmt, va_list ap);
+void flux_log_error (flux_t h, const char *fmt, ...)
                  __attribute__ ((format (printf, 2, 3)));
 
 #define FLUX_LOG_ERROR(h) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -28,6 +28,7 @@ TESTS = \
 	loop/rpc.t \
 	loop/multrpc.t \
 	loop/reduce.t \
+	loop/log.t \
 	pmi/simple.t \
 	t0000-sharness.t \
 	t0001-basic.t \
@@ -132,6 +133,7 @@ check_PROGRAMS = \
 	loop/rpc.t \
 	loop/multrpc.t \
 	loop/reduce.t \
+	loop/log.t \
 	pmi/kvstest \
 	pmi/simple.t \
 	pmi/pminfo \
@@ -184,6 +186,10 @@ test_cppflags = \
 loop_handle_t_SOURCES = loop/handle.c
 loop_handle_t_CPPFLAGS = $(test_cppflags)
 loop_handle_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_log_t_SOURCES = loop/log.c
+loop_log_t_CPPFLAGS = $(test_cppflags)
+loop_log_t_LDADD = $(test_ldadd) $(LIBDL)
 
 loop_reactor_t_SOURCES = loop/reactor.c
 loop_reactor_t_CPPFLAGS = $(test_cppflags)

--- a/t/loop/log.c
+++ b/t/loop/log.c
@@ -1,0 +1,38 @@
+#include <errno.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t h;
+
+    plan (NO_PLAN);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH", CONNECTOR_PATH, 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+
+    errno = 1234;
+    flux_log_error (h, "hello world");
+    ok (errno == 1234,
+        "flux_log_error didn't clobber errno");
+
+    errno = 1236;
+    flux_log (h, LOG_INFO, "errlo orlk");
+    ok (errno == 1236,
+       "flux_log didn't clobber errno");
+
+    flux_close (h);
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
Change `flux_log()` return to void, and preserve errno.