### PR TITLE
broker: suppress config failed to load message

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -376,7 +376,8 @@ int main (int argc, char *argv[])
     if (ctx.verbose)
         msg ("Loading config from %s", confdir);
     if (flux_conf_load (ctx.cf) < 0 && errno != ESRCH) {
-        msg("Configuration failed to load: %s, falling back", confdir);
+        if (ctx.verbose)
+            msg ("Configuration failed to load from %s, falling back", confdir);
     }
 
     /* Arrange to load config entries into broker attrs


### PR DESCRIPTION
Since the config file is optional, it's not appropriate to
complain if there isn't one.  Suppress the message unless
running with --verbose.

Fixes #602