### PR TITLE
Fix small race in t/scripts/waitfile.lua

### DIFF
--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -48,7 +48,7 @@ local plugin = opts.P
 local tt = timer.new()
 
 local function printf (m, ...)
-    io.stderr:write (string.format ("waitfile: %4.03fs: "..m, tt:get0(), ...))
+    io.stderr:write (string.format ("waitfile: %s: %4.03fs: "..m, file, tt:get0(), ...))
 end
 
 local function log_verbose (m, ...)

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -134,10 +134,6 @@ function filewatcher:check ()
 end
 
 function filewatcher:start ()
-    local st = posix.stat (self.filename)
-    if st then
-        self.st = setmetatable (st, stat)
-    end
     self.flux:statwatcher {
         path = self.filename,
         interval = self.interval,
@@ -148,6 +144,12 @@ function filewatcher:start ()
             log_verbose ("back to sleep\n")
         end
     }
+    --  Be sure to call initial stat(2) *after*
+    --  statwatcher is started above, to avoid any race
+    local st = posix.stat (self.filename)
+    if st then
+        self.st = setmetatable (st, stat)
+    end
     self:check ()
 end
 


### PR DESCRIPTION
As described in #612, there was another race in the `waitfile.lua` script.

While the initial call to `self:check()` was done *after* the stat watcher was started, the `stat(2)` initialization in the script was for some reason done *before* the stat watcher creation. This means if a file was created or changed in the interval between that first `stat(2)` and stat watcher creation, the script would fail to detect that change.

This PR fixes that issue by moving the `stat()` call to right before the first `check()` and most importantly after the stat watcher is created.

Also, from an idea by @lipari, add the target filename to the scripts logging output -- useful for debugging.