### PR TITLE
stash active jobs under alternate kvs heirarchy

### DIFF
--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -66,7 +66,8 @@ static int kvs_job_set_state (flux_t h, unsigned long jobid, const char *state)
         goto out;
     }
 
-    kvs_commit (h);
+    if ((rc = kvs_commit (h)) < 0)
+        flux_log_error (h, "kvs_job_set_state: kvs_commit");
 
 out:
     free (key);
@@ -300,7 +301,10 @@ static void job_request_cb (flux_t h, flux_msg_handler_t *w,
             goto out;
         }
 
-        kvs_commit (h);
+        if (kvs_commit (h) < 0) {
+            flux_log_error (h, "job_request: kvs_commit");
+            goto out;
+        }
 
         /* Send a wreck.state.reserved event for listeners */
         state = "reserved";

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -234,6 +234,9 @@ static void log_fatal (struct prog_ctx *ctx, int code, const char *format, ...)
         va_start (ap, format);
         vlog_error_kvs (ctx, code, format, ap);
         va_end (ap);
+
+        if (archive_lwj (ctx) < 0)
+            flux_log_error (ctx->flux, "log_fatal: archive_lwj");
     }
     if (code > 0)
         exit (code);

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -368,6 +368,11 @@ test_expect_success 'wreck jobs are archived after failure' '
 	test_must_fail flux kvs dir lwj-active.$(flux wreck last-jobid)
 '
 
+test_expect_success 'wreck: no jobs left in lwj-active directory' '
+	flux kvs dir lwj-active > lwj-active.listing &&
+	test_must_fail test -s lwj-active.listing
+'
+
 test_debug "flux wreck ls"
 
 test_done

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -363,6 +363,11 @@ test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded'
 	test_cmp expected.submit err.submit
 '
 
+test_expect_success 'wreck jobs are archived after failure' '
+	test_must_fail flux wreckrun --input=bad.file hostname &&
+	test_must_fail flux kvs dir lwj-active.$(flux wreck last-jobid)
+'
+
 test_debug "flux wreck ls"
 
 test_done


### PR DESCRIPTION
This PR implements @garlick's ideas from #614 to limit object store growth while running many jobs.

The basic changes here include 
 * The `job` module creates the new jobid entry in `lwj-active.<id>` instead of directly in `lwj.<id>`, then before the first `kvs_commit`, it creates a symlink: `lwj.<id> -> lwj-active.<id>`
 * The rest of the wreck code operates as before via the `lwj.<id>` symlink
 * At job completion, the relative rank 0 `wrexecd` uses `kvs_move` to move `lwj-active.<id>` to `lwj.<id>` replacing the destination soft link with the actual contents.