### PR TITLE
fix KVS watch leak

### DIFF
--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -65,6 +65,12 @@ int cache_expire_entries (struct cache *cache, int current_epoch, int thresh);
 void cache_get_stats (struct cache *cache, tstat_t *ts, int *size,
                       int *incomplete, int *dirty);
 
+/* Destroy wait_t's on the waitqueue_t of any cache entry
+ * if they meet match criteria.
+ */
+int cache_wait_destroy_match (struct cache *cache,
+                              wait_compare_f cb, void *arg);
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1127,6 +1127,8 @@ static void unwatch_request_cb (flux_t h, flux_msg_handler_t *w,
         goto done;
     if (wait_destroy_match (ctx->watchlist, unwatch_cmp, &p) < 0)
         goto done;
+    if (cache_wait_destroy_match (ctx->cache, unwatch_cmp, &p) < 0)
+        goto done;
     rc = 0;
 done:
     if (flux_respond (h, msg, rc < 0 ? errno : 0, NULL) < 0)
@@ -1630,7 +1632,8 @@ static void disconnect_request_cb (flux_t h, flux_msg_handler_t *w,
         return;
     if (flux_msg_get_route_first (msg, &sender) < 0)
         return;
-    wait_destroy_match (ctx->watchlist, disconnect_cmp, sender);
+    (void)wait_destroy_match (ctx->watchlist, disconnect_cmp, sender);
+    (void)cache_wait_destroy_match (ctx->cache, disconnect_cmp, sender);
     zhash_delete (ctx->commits, sender);
     free (sender);
 }

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -130,7 +130,8 @@ void wait_runone (wait_t *w)
     assert (w->magic == WAIT_MAGIC);
 
     if (--w->usecount == 0) {
-        w->hand.cb (w->hand.h, w->hand.w, w->hand.msg, w->hand.arg);
+        if (w->hand.cb)
+            w->hand.cb (w->hand.h, w->hand.w, w->hand.msg, w->hand.arg);
         wait_destroy (w, NULL);
     }
 }
@@ -169,6 +170,7 @@ int wait_destroy_match (waitqueue_t *q, wait_compare_f cb, void *arg)
                 oom ();
             if (zlist_append (tmp, w) < 0)
                 oom ();
+            w->hand.cb = NULL; // prevent wait_runone from restarting handler
         }
         w = zlist_next (q->q);
     }

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -60,7 +60,7 @@ void wait_runone (wait_t *wait);
 void wait_runqueue (waitqueue_t *q);
 
 /* Destroy all wait_t's on 'q' containing messages that 'cb' returns true on.
- * Return 0 if at least one wait_t is destroyed, or -1 on error.
+ * Return the number of wait_t's matched or -1 on error.
  */
 int wait_destroy_match (waitqueue_t *q, wait_compare_f cb, void *arg);
 

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -368,6 +368,18 @@ test_expect_success 'wreck jobs are archived after failure' '
 	test_must_fail flux kvs dir lwj-active.$(flux wreck last-jobid)
 '
 
+test_expect_success 'wreck: no KVS watchers leaked after 10 jobs' '
+	flux exec -r 1-$(($SIZE-1)) -l \
+		flux comms-stats --parse "#watchers" kvs | sort -n >w.before &&
+	for i in `seq 1 10`; do
+		flux wreckrun --ntasks $SIZE /bin/true
+	done &&
+	flux exec -r 1-$(($SIZE-1)) -l \
+		flux comms-stats --parse "#watchers" kvs | sort -n >w.after &&
+	test_cmp w.before w.after
+'
+
+# Keep this test in the last position
 test_expect_success 'wreck: no jobs left in lwj-active directory' '
 	flux kvs dir lwj-active > lwj-active.listing &&
 	test_must_fail test -s lwj-active.listing


### PR DESCRIPTION
This PR fixes a `kvs_watch()` state leak.  The watch request would be removed from the "watchlist" and placed on another wait queue if it needed to wait for content to be faulted in.  If in the mean time a disconnect request was received, the watch request would not be found on the watchlist.  Then once the fault was handled, the watch request would be restarted and would place itself back on the watchlist.

The fix is to also walk the KVS internal cache looking for a match when a client disconnects, and also when a watch request is explicitly unwatched.