### PR TITLE
some minor change related to MPI support + fixes

### DIFF
--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -79,6 +79,7 @@ parent-uri::
 The Flux URI that should be passed to flux_open(1) to establish
 a connection to the enclosing instance.
 
+
 LOGGING ATTRIBUTES
 ------------------
 
@@ -100,9 +101,14 @@ Log entries at syslog(3) level at or below this value are copied
 to stderr on the logging rank, for capture by the enclosing instance.
 
 log-filename::
-If set on rank zero, forwarded log entries are directed to this file.
-If the file name is set to "stderr", forwarded log entries are directed
-to standard error of the rank zero broker.
+(rank zero only) If set, session log entries, as filtered by log-forward-level,
+are directed to this file.  If unset, but persist-directory is set, log
+entries are directed to persist-directory/log.
+
+log-stderr-level::
+(rank zero only) Session log entries at syslog(3) level at or below this
+value, and as filtered by log-forward-level, are copied to stderr of the
+rank zero broker.
 
 
 CONTENT ATTRIBUTES

--- a/etc/flux.conf.in
+++ b/etc/flux.conf.in
@@ -8,6 +8,7 @@ general
     python_path = @abs_top_builddir@/src/bindings/python:@abs_top_srcdir@/src/bindings/python/pycotap
     module_path = @abs_top_builddir@/src/modules
     program_library_path = @abs_top_builddir@/src/lib/libpmi/.libs:@abs_top_builddir@/src/common/.libs
+    pmi_library_path = @abs_top_builddir@/src/lib/libpmi/.libs/libpmi.so
     connector_path = @abs_top_builddir@/src/connectors
     man_path = @abs_top_builddir@/doc
     rc1_path = @abs_top_srcdir@/etc/rc1

--- a/etc/rc1
+++ b/etc/rc1
@@ -5,11 +5,9 @@ pids=""
 flux module load -r all barrier
 flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
-flux module load -r 0 live
-
 flux module load -r all -x 0 kvs
-flux module load -r all -x 0 live 
 
+flux module load -r all live --barrier-count=$(flux getattr size)
 flux module load -r all resource-hwloc & pids="$pids $!"
 flux module load -r all mecho
 flux module load -r all job

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	$(JSON_CFLAGS) $(ZMQ_CFLAGS) \
 	-DMODULE_PATH=\"$(fluxmoddir)\" \
 	-DPROGRAM_LIBRARY_PATH=\"$(fluxlibdir)\" \
+	-DPMI_LIBRARY_PATH=\"$(fluxlibdir)/libpmi.so\" \
 	-DRC1=\"$(fluxrcdir)/rc1\" \
 	-DRC3=\"$(fluxrcdir)/rc3\"
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -578,6 +578,7 @@ int main (int argc, char *argv[])
         const char *rc1 = getenv ("FLUX_RC1_PATH");
         const char *rc3 = getenv ("FLUX_RC3_PATH");
         const char *local_uri;
+        const char *pmi_library_path;
 
         runlevel_set_size (ctx.runlevel, ctx.size);
         runlevel_set_subprocess_manager (ctx.runlevel, ctx.sm);
@@ -590,15 +591,16 @@ int main (int argc, char *argv[])
             rc1 = flux_conf_get (ctx.cf, "general.rc1_path");
         if (!rc3)
             rc3 = flux_conf_get (ctx.cf, "general.rc3_path");
+        pmi_library_path = flux_conf_get (ctx.cf, "general.pmi_library_path");
 
         if (runlevel_set_rc (ctx.runlevel, 1, rc1 ? rc1 : RC1,
-                             local_uri, ldpath) < 0)
+                             local_uri, ldpath, pmi_library_path) < 0)
             err_exit ("runlevel_set_rc 1");
         if (runlevel_set_rc (ctx.runlevel, 2, ctx.init_shell_cmd,
-                             local_uri, ldpath) < 0)
+                             local_uri, ldpath, pmi_library_path) < 0)
             err_exit ("runlevel_set_rc 2");
         if (runlevel_set_rc (ctx.runlevel, 3, rc3 ? rc3 : RC3,
-                             local_uri, ldpath) < 0)
+                             local_uri, ldpath, pmi_library_path) < 0)
             err_exit ("runlevel_set_rc 3");
     }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -2083,7 +2083,7 @@ static int cmb_reparent_cb (zmsg_t **zmsg, void *arg)
     }
     if (overlay_reparent (ctx->overlay, uri, &recycled) < 0)
         goto done;
-    flux_log (ctx->h, LOG_INFO, "reparent %s (%s)", uri, recycled ? "restored"
+    flux_log (ctx->h, LOG_CRIT, "reparent %s (%s)", uri, recycled ? "restored"
                                                                   : "new");
     rc = 0;
 done:

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -424,7 +424,7 @@ int log_register_attrs (log_t *log, attr_t *attrs)
                              attr_get_log, attr_set_log, log) < 0)
             goto done;
         if (attr_add_active (attrs, "log-stderr-level", 0,
-		                 attr_get_log, attr_set_log, log) < 0)
+                             attr_get_log, attr_set_log, log) < 0)
             goto done;
     } else {
         (void)attr_delete (attrs, "log-filename", true);
@@ -436,10 +436,10 @@ int log_register_attrs (log_t *log, attr_t *attrs)
     }
 
     if (attr_add_active (attrs, "log-forward-level", 0,
-		                 attr_get_log, attr_set_log, log) < 0)
+                         attr_get_log, attr_set_log, log) < 0)
         goto done;
     if (attr_add_active (attrs, "log-critical-level", 0,
-		                 attr_get_log, attr_set_log, log) < 0)
+                         attr_get_log, attr_set_log, log) < 0)
         goto done;
     if (attr_add_active (attrs, "log-ring-size", 0,
                          attr_get_log, attr_set_log, log) < 0)
@@ -471,7 +471,7 @@ int log_forward (log_t *log, const char *facility, int level, uint32_t rank,
     Jadd_str (o, "message", message);
     if (!(rpc = flux_rpc (log->h, "cmb.log", Jtostr (o), FLUX_NODEID_UPSTREAM,
                                                          FLUX_RPC_NORESPONSE)))
-                                                                                        goto done;
+        goto done;
     rc = 0;
 done:
     Jput (o);
@@ -489,8 +489,8 @@ int log_append (log_t *log, const char *facility, int level, uint32_t rank,
     if (rank == log->rank) {
         if (log_buf_append (log, facility, level, rank, tv, message) < 0)
             rc = -1;
-	if (level <= log->critical_level) {
-	    flux_log_fprint (facility, level, rank, tv, message, stderr);
+        if (level <= log->critical_level) {
+            flux_log_fprint (facility, level, rank, tv, message, stderr);
             logged_stderr = true;
         }
     }

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -299,7 +299,8 @@ static void path_prepend (char **s1, const char *s2)
 }
 
 int runlevel_set_rc (runlevel_t *r, int level, const char *command,
-                     const char *local_uri, const char *library_path)
+                     const char *local_uri, const char *library_path,
+                     const char *pmi_library_path)
 {
     struct subprocess *p = NULL;
     char *ldpath = NULL;
@@ -311,6 +312,9 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *command,
         errno = EINVAL;
         goto error;
     }
+
+    if (!pmi_library_path)
+        pmi_library_path = PMI_LIBRARY_PATH;
 
     path_prepend (&ldpath, getenv ("LD_LIBRARY_PATH"));
     path_prepend (&ldpath, PROGRAM_LIBRARY_PATH);
@@ -325,6 +329,8 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *command,
             || subprocess_unsetenv (p, "PMI_FD") < 0
             || subprocess_unsetenv (p, "PMI_RANK") < 0
             || subprocess_unsetenv (p, "PMI_SIZE") < 0
+            || subprocess_setenv (p, "I_MPI_PMI_LIBRARY",
+                                  pmi_library_path, 1) < 0
             || (local_uri && subprocess_setenv (p, "FLUX_URI",
                                                 local_uri, 1) < 0)
             || (ldpath && subprocess_setenv (p, "LD_LIBRARY_PATH",

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -29,7 +29,8 @@ void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg);
  * used to set FLUX_URI and LD_LIBRARY_PATH in the subprocess environment.
  */
 int runlevel_set_rc (runlevel_t *r, int level, const char *command,
-                     const char *local_uri, const char *library_path);
+                     const char *local_uri, const char *library_path,
+                     const char *pmi_library_path);
 
 /* Change the runlevel.  It is assumed that the previous run level (if any)
  * has completed and this is being called from the runlevel callback.

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -82,7 +82,8 @@ int main (int argc, char *argv[])
     if (optind == argc)
         usage ();
     cmd = argv[optind++];
-    if (rank != -1 && (!strcmp (cmd, "recover-all") || !strcmp (cmd, "info")))
+    if (rank != FLUX_NODEID_ANY
+            && (!strcmp (cmd, "recover-all") || !strcmp (cmd, "info")))
         usage ();
 
     if (!(h = flux_open (NULL, 0)))
@@ -122,7 +123,7 @@ int main (int argc, char *argv[])
             usage ();
         if (flux_recover (h, rank) < 0)
             err_exit ("flux_recover");
-    } else if (!strcmp (cmd, "allrecover")) {
+    } else if (!strcmp (cmd, "recover-all")) {
         if (optind != argc)
             usage ();
         if (flux_recover_all (h) < 0)

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -63,9 +63,12 @@ typedef struct {
     int universe_size;
     int appnum;
     int barrier_num;
+    char barrier_name[PMI_MAX_KVSNAMELEN + 16];
     uint32_t cmb_rank;
     flux_t h;
     char kvsname[PMI_MAX_KVSNAMELEN];
+    char key[PMI_MAX_KVSNAMELEN + PMI_MAX_KEYLEN + 2];
+    char val[PMI_MAX_VALLEN + 1];
     int trace;
 } pmi_ctx_t;
 #define PMI_CTX_MAGIC 0xcafefaad
@@ -83,23 +86,81 @@ enum {
     PMI_TRACE_UNIMPL        = 0x80,
 };
 
-static inline void trace (int flags, const char *fmt, ...)
-{
-    va_list ap;
+struct errmap {
+    int err;
+    const char *s;
+};
 
-    if (ctx && (flags & ctx->trace)) {
-        char buf[64];
-        snprintf (buf, sizeof (buf), "[%" PRIu32 ".%d.%d] %s\n", ctx->cmb_rank,
-                  ctx->appnum, ctx->rank, fmt);
-        va_start (ap, fmt);
-        vfprintf (stdout, buf, ap);
-        fflush (stdout);
-        va_end (ap);
+static struct errmap pmi_errstr[] = {
+    { PMI_SUCCESS,                  "SUCCESS" },
+    { PMI_FAIL,                     "FAIL" },
+    { PMI_ERR_INIT,                 "ERR_INIT" },
+    { PMI_ERR_NOMEM,                "ERR_NOMEM" },
+    { PMI_ERR_INVALID_ARG,          "ERR_INVALID_ARG" },
+    { PMI_ERR_INVALID_KEY,          "ERR_INVALID_KEY" },
+    { PMI_ERR_INVALID_KEY_LENGTH,   "ERR_INVALID_KEY_LENGTH" },
+    { PMI_ERR_INVALID_VAL,          "ERR_INVALID_VAL" },
+    { PMI_ERR_INVALID_VAL_LENGTH,   "ERR_INVALID_VAL_LENGTH" },
+    { PMI_ERR_INVALID_LENGTH,       "ERR_INVALID_LENGTH" },
+    { PMI_ERR_INVALID_NUM_ARGS,     "ERR_INVALID_NUM_ARGS" },
+    { PMI_ERR_INVALID_ARGS,         "ERR_INVALID_ARGS" },
+    { PMI_ERR_INVALID_NUM_PARSED,   "ERR_INVALID_NUM_PARSED" },
+    { PMI_ERR_INVALID_KEYVALP,      "ERR_INVALID_KEYVALP" },
+    { PMI_ERR_INVALID_SIZE,         "ERR_INVALID_SIZE" },
+    { -1, NULL },
+};
+
+static const char *pmi_strerror (int errnum)
+{
+    int i = 0;
+    static char buf[16];
+    while (pmi_errstr[i].s != NULL)
+        if (errnum == pmi_errstr[i].err)
+            return pmi_errstr[i].s;
+    snprintf (buf, sizeof (buf), "%d", errnum);
+    return buf;
+}
+
+static inline void trace (int tracebit, int ret, const char *func)
+{
+    const char *s = pmi_strerror (ret);
+
+    if (ctx == NULL) {
+        if (ret != PMI_SUCCESS ) {
+            fprintf (stderr, "%s (pre-init) rc=%s", func, s);
+            fflush (stderr);
+        }
+        return;
+    }
+    if (!(tracebit & ctx->trace))
+        return;
+
+    switch (tracebit) {
+        case PMI_TRACE_KVS_GET:
+        case PMI_TRACE_KVS_PUT:
+            flux_log (ctx->h, LOG_DEBUG, "%s (%s = \"%s\") = %s",
+                      func, ctx->key, ctx->val, s);
+            break;
+        case PMI_TRACE_BARRIER:
+            flux_log (ctx->h, LOG_DEBUG, "%s (%s, %d) = %s",
+                      func, ctx->barrier_name, ctx->universe_size, s);
+            break;
+        case PMI_TRACE_INIT:
+        case PMI_TRACE_PARAM:
+        case PMI_TRACE_KVS:
+        case PMI_TRACE_CLIQUE:
+            flux_log (ctx->h, LOG_DEBUG, "%s = %s", func, s);
+            break;
+        case PMI_TRACE_UNIMPL:
+            flux_log (ctx->h, LOG_DEBUG, "%s = %s (unimplemented)", func, s);
+            break;
     }
 }
-#define trace_simple(n) do { \
-    trace ((n), "%s", __FUNCTION__);\
-} while (0)
+
+#define return_trace(n,ret) do { \
+    trace ((n), (ret), __FUNCTION__);\
+    return (ret);\
+} while (0);
 
 static int env_getint (char *name, int dflt)
 {
@@ -107,17 +168,38 @@ static int env_getint (char *name, int dflt)
     return s ? strtol (s, NULL, 0) : dflt;
 }
 
+static void destroy_ctx (void)
+{
+    if (ctx) {
+        assert (ctx->magic == PMI_CTX_MAGIC);
+        if (ctx->h)
+            flux_close (ctx->h);
+        if (ctx->clique)
+            nodeset_destroy (ctx->clique);
+        memset (ctx, 0, sizeof (pmi_ctx_t));
+        free (ctx);
+        ctx = NULL;
+    }
+}
+
 int PMI_Init (int *spawned)
 {
+    int ret = PMI_FAIL;
     const char *local_ranks;
-    log_init ("flux-pmi");
-    if (spawned == NULL)
-        return PMI_ERR_INVALID_ARG;
-    if (ctx)
-        goto fail;
+
+    if (ctx) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    if (spawned == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     ctx = malloc (sizeof (pmi_ctx_t));
-    if (ctx == NULL)
-        goto nomem;
+    if (ctx == NULL) {
+        ret = PMI_ERR_NOMEM;
+        goto done;
+    }
     memset (ctx, 0, sizeof (pmi_ctx_t));
     ctx->magic = PMI_CTX_MAGIC;
 
@@ -128,233 +210,269 @@ int PMI_Init (int *spawned)
     ctx->appnum = env_getint ("FLUX_JOB_ID", 1);
     if (!(local_ranks = getenv ("FLUX_LOCAL_RANKS")))
         local_ranks = "[0]";
-    if (!(ctx->clique = nodeset_create_string (local_ranks)))
-        goto fail;
+    if (!(ctx->clique = nodeset_create_string (local_ranks))) {
+        fprintf (stderr, "nodeset_create_string failed: %s", local_ranks);
+        goto done_destroy;
+    }
     ctx->spawned = PMI_FALSE;
     ctx->universe_size = ctx->size;
     ctx->barrier_num = 0;
     snprintf (ctx->kvsname, sizeof (ctx->kvsname), "lwj.%d.pmi", ctx->appnum);
     if (!(ctx->h = flux_open (NULL, 0))) {
-        err ("flux_open");
-        goto fail;
+        fprintf (stderr, "flux_open: %s", strerror (errno));
+        goto done_destroy;
     }
     if (flux_get_rank (ctx->h, &ctx->cmb_rank) < 0) {
-        err ("flux_get_rank");
-        goto fail;
+        fprintf (stderr, "flux_get_rank: %s", strerror (errno));
+        goto done_destroy;
     }
-    trace_simple (PMI_TRACE_INIT);
+    flux_log_set_facility (ctx->h, "libpmi");
     *spawned = ctx->spawned;
-    return PMI_SUCCESS;
-nomem:
-    if (ctx)
-        PMI_Finalize ();
-    return PMI_ERR_NOMEM;
-fail:
-    if (ctx)
-        PMI_Finalize ();
-    return PMI_FAIL;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_INIT, ret);
+done_destroy:
+    destroy_ctx ();
+    return_trace (PMI_TRACE_INIT, ret);
 }
 
 int PMI_Initialized (int *initialized)
 {
-    trace_simple (PMI_TRACE_INIT);
-    if (initialized == NULL)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
 
+    if (initialized == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *initialized = ctx ? PMI_TRUE : PMI_FALSE;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_INIT, ret);
 }
 
 int PMI_Finalize (void)
 {
-    trace_simple (PMI_TRACE_INIT);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    assert (ctx->magic == PMI_CTX_MAGIC);
-    if (ctx->h)
-        flux_close (ctx->h);
-    if (ctx->clique)
-        nodeset_destroy (ctx->clique);
-    memset (ctx, 0, sizeof (pmi_ctx_t));
-    free (ctx);
-    ctx = NULL;
+    int ret = PMI_FAIL;
 
-    return PMI_SUCCESS;
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    ret = PMI_SUCCESS;
+done:
+    trace (PMI_TRACE_INIT, ret, __FUNCTION__);
+    destroy_ctx ();
+    return ret;
 }
 
 int PMI_Get_size (int *size)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    if (size == NULL)
-        return PMI_ERR_INVALID_ARG;
-    assert (ctx->magic == PMI_CTX_MAGIC);
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (size == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *size = ctx->size;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Get_rank (int *rank)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    if (rank == NULL)
-        return PMI_ERR_INVALID_ARG;
-    assert (ctx->magic == PMI_CTX_MAGIC);
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (rank == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *rank = ctx->rank;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Get_universe_size (int *size)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    if (size == NULL)
-        return PMI_ERR_INVALID_ARG;
-    assert (ctx->magic == PMI_CTX_MAGIC);
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (size == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *size = ctx->universe_size;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Get_appnum (int *appnum)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    if (appnum == NULL)
-        return PMI_ERR_INVALID_ARG;
-    assert (ctx->magic == PMI_CTX_MAGIC);
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (appnum == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *appnum = ctx->appnum;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Publish_name (const char service_name[], const char port[])
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_Unpublish_name (const char service_name[])
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_Lookup_name (const char service_name[], char port[])
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 /* PMI_Barrier is co-opted as the KVS collective fence (citation required).
  */
 int PMI_Barrier (void)
 {
-    char *name = NULL;
-    int rc = PMI_SUCCESS;
+    int ret = PMI_FAIL;
+    int n;
 
-    trace_simple (PMI_TRACE_BARRIER);
     if (ctx == NULL) {
-        rc = PMI_ERR_INIT;
+        ret = PMI_ERR_INIT;
         goto done;
     }
     assert (ctx->magic == PMI_CTX_MAGIC);
 
-    if (asprintf (&name, "%s:%d", ctx->kvsname, ctx->barrier_num++) < 0) {
-        rc = PMI_ERR_NOMEM;
+    n = snprintf (ctx->barrier_name, sizeof (ctx->barrier_name), "%s:%d",
+                        ctx->kvsname, ctx->barrier_num++);
+    assert (n < sizeof (ctx->barrier_name));
+    if (kvs_fence (ctx->h, ctx->barrier_name, ctx->universe_size) < 0)
         goto done;
-    }
-    if (kvs_fence (ctx->h, name, ctx->universe_size) < 0) {
-        rc = PMI_FAIL;
-        goto done;
-    }
+    ret = PMI_SUCCESS;
 done:
-    if (name)
-        free (name);
-    return rc;
+    return_trace (PMI_TRACE_BARRIER, ret);
 }
 
 int PMI_Abort (int exit_code, const char error_msg[])
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_KVS_Get_my_name (char kvsname[], int length)
 {
-    trace_simple (PMI_TRACE_KVS);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    assert (ctx->magic == PMI_CTX_MAGIC);
-    if (kvsname == NULL || length < strlen (ctx->kvsname) + 1)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (kvsname == NULL || length < strlen (ctx->kvsname) + 1) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     strcpy (kvsname, ctx->kvsname);
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_KVS, ret);
 }
 
 int PMI_KVS_Get_name_length_max (int *length)
 {
-    trace_simple (PMI_TRACE_KVS);
-    if (length == NULL)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
+
+    if (length == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *length = PMI_MAX_KVSNAMELEN;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_KVS, ret);
 }
 
 int PMI_KVS_Get_key_length_max (int *length)
 {
-    trace_simple (PMI_TRACE_KVS);
-    if (length == NULL)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
+
+    if (length == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *length = PMI_MAX_KEYLEN;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_KVS, ret);
 }
 
 int PMI_KVS_Get_value_length_max (int *length)
 {
-    trace_simple (PMI_TRACE_KVS);
-    if (length == NULL)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
+
+    if (length == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *length = PMI_MAX_VALLEN;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_KVS, ret);
 }
 
 int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
 {
-    char *xkey = NULL;
-    int rc = PMI_SUCCESS;
-
-    trace (PMI_TRACE_KVS_PUT, "%s %s.%s = %s",
-           __FUNCTION__, kvsname, key, value);
+    int ret = PMI_FAIL;
 
     if (ctx == NULL) {
-        rc = PMI_ERR_INIT;
+        ret = PMI_ERR_INIT;
         goto done;
     }
     assert (ctx->magic == PMI_CTX_MAGIC);
     if (kvsname == NULL || key == NULL || value == NULL) {
-        rc = PMI_ERR_INVALID_ARG;
+        ret = PMI_ERR_INVALID_ARG;
         goto done;
     }
-    if (asprintf (&xkey, "%s.%s", kvsname, key) < 0) {
-        rc = PMI_ERR_NOMEM;
+    if (snprintf (ctx->key, sizeof (ctx->key), "%s.%s",
+                                    kvsname, key) >= sizeof (ctx->key)) {
+        ret = PMI_ERR_INVALID_KEY_LENGTH;
         goto done;
     }
-    if (kvs_put_string (ctx->h, xkey, value) < 0) {
-        rc = PMI_FAIL;
+    if (snprintf (ctx->val, sizeof (ctx->val), "%s",
+                                    value) >= sizeof (ctx->val)) {
+        ret = PMI_ERR_INVALID_VAL_LENGTH;
         goto done;
     }
+    if (kvs_put_string (ctx->h, ctx->key, value) < 0)
+        goto done;
+    ret = PMI_SUCCESS;
 done:
-    if (xkey)
-        free (xkey);
-    return rc;
+    return_trace (PMI_TRACE_KVS_PUT, ret);
 }
 
 /* This is a no-op.  The "commit" actually takes place in PMI_Barrier
@@ -362,50 +480,57 @@ done:
  */
 int PMI_KVS_Commit (const char kvsname[])
 {
-    trace (PMI_TRACE_KVS_PUT, "%s %s", __FUNCTION__, kvsname);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
+    int ret = PMI_FAIL;
+
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
     assert (ctx->magic == PMI_CTX_MAGIC);
-    if (kvsname == NULL)
-        return PMI_ERR_INVALID_ARG;
-    return PMI_SUCCESS;
+    if (kvsname == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_KVS, ret);
 }
 
 int PMI_KVS_Get (const char kvsname[], const char key[], char value[],
                  int length)
 {
-    char *xkey = NULL;
-    int rc = PMI_SUCCESS;
+    int ret = PMI_FAIL;
     char *val = NULL;
 
-    trace (PMI_TRACE_KVS_GET, "%s %s.%s", __FUNCTION__, kvsname, key);
     if (ctx == NULL) {
-        rc = PMI_ERR_INIT;
+        ret = PMI_ERR_INIT;
         goto done;
     }
     assert (ctx->magic == PMI_CTX_MAGIC);
     if (kvsname == NULL || key == NULL || value == NULL) {
-        rc = PMI_ERR_INVALID_ARG;
+        ret = PMI_ERR_INVALID_ARG;
         goto done;
     }
-    if (asprintf (&xkey, "%s.%s", kvsname, key) < 0) {
-        rc = PMI_ERR_NOMEM;
+    if (snprintf (ctx->key, sizeof (ctx->key), "%s.%s",
+                                kvsname, key) >= sizeof (ctx->key)) {
+        ret = PMI_ERR_INVALID_KEY_LENGTH;
         goto done;
     }
-    if (kvs_get_string (ctx->h, xkey, &val) < 0) {
+    if (kvs_get_string (ctx->h, ctx->key, &val) < 0) {
         if (errno == ENOENT)
-            rc = PMI_ERR_INVALID_KEY;
-        else
-            rc = PMI_FAIL;
+            ret = PMI_ERR_INVALID_KEY;
         goto done;
     }
-    snprintf (value, length, "%s", val);
+    if (snprintf (ctx->val, sizeof (ctx->val), "%s", val) >= sizeof (ctx->val)
+            || snprintf (value, length, "%s", val) >= length) {
+        ret = PMI_ERR_INVALID_VAL_LENGTH;
+        goto done;
+    }
+    ret = PMI_SUCCESS;
 done:
-    if (xkey)
-        free (xkey);
     if (val)
         free (val);
-    return rc;
+    return_trace (PMI_TRACE_KVS_GET, ret);
 }
 
 int PMI_Spawn_multiple(int count,
@@ -418,8 +543,7 @@ int PMI_Spawn_multiple(int count,
                        const PMI_keyval_t preput_keyval_vector[],
                        int errors[])
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 /* These functions were removed from the MPICH pmi.h by
@@ -438,65 +562,91 @@ int PMI_Spawn_multiple(int count,
 
 int PMI_Get_id (char id_str[], int length)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    assert (ctx->magic == PMI_CTX_MAGIC);
-    if (id_str == NULL || length < strlen (ctx->kvsname) + 1)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (id_str == NULL || length < strlen (ctx->kvsname) + 1) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     snprintf (id_str, length + 1, "%s", ctx->kvsname);
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Get_kvs_domain_id (char id_str[], int length)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    assert (ctx->magic == PMI_CTX_MAGIC);
-    if (id_str == NULL || length < strlen (ctx->kvsname) + 1)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (id_str == NULL || length < strlen (ctx->kvsname) + 1) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     snprintf (id_str, length + 1, "%s", ctx->kvsname);
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Get_id_length_max (int *length)
 {
-    trace_simple (PMI_TRACE_PARAM);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
-    assert (ctx->magic == PMI_CTX_MAGIC);
-    if (length == NULL)
-        return PMI_ERR_INVALID_ARG;
+    int ret = PMI_FAIL;
 
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
+    assert (ctx->magic == PMI_CTX_MAGIC);
+    if (length == NULL) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     *length = strlen (ctx->kvsname) + 1;
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_PARAM, ret);
 }
 
 int PMI_Get_clique_size (int *size)
 {
-    trace_simple (PMI_TRACE_CLIQUE);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
+    int ret = PMI_FAIL;
+
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
     assert (ctx->magic == PMI_CTX_MAGIC);
     *size = nodeset_count (ctx->clique);
-    return PMI_SUCCESS;
+    ret = PMI_SUCCESS;
+done:
+    return_trace (PMI_TRACE_CLIQUE, ret);
 }
 
 int PMI_Get_clique_ranks (int ranks[], int length)
 {
     int i;
-    nodeset_iterator_t *itr;
+    nodeset_iterator_t *itr = NULL;
     int ret = PMI_FAIL;
 
-    trace_simple (PMI_TRACE_CLIQUE);
-    if (ctx == NULL)
-        return PMI_ERR_INIT;
+    if (ctx == NULL) {
+        ret = PMI_ERR_INIT;
+        goto done;
+    }
     assert (ctx->magic == PMI_CTX_MAGIC);
-    if (length < nodeset_count (ctx->clique))
-        return PMI_ERR_INVALID_ARG;
+    if (length < nodeset_count (ctx->clique)) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     itr = nodeset_iterator_create (ctx->clique);
     for (i = 0; i < length; i++) {
         ranks[i] = nodeset_next (itr);
@@ -505,34 +655,31 @@ int PMI_Get_clique_ranks (int ranks[], int length)
     }
     ret = PMI_SUCCESS;
 done:
-    nodeset_iterator_destroy (itr);
-    return ret;
+    if (itr)
+        nodeset_iterator_destroy (itr);
+    return_trace (PMI_TRACE_CLIQUE, ret);
 }
 
 int PMI_KVS_Create (char kvsname[], int length)
 {
-    trace_simple (PMI_TRACE_KVS);
-    return PMI_SUCCESS;
+    return_trace (PMI_TRACE_KVS, PMI_SUCCESS);
 }
 
 int PMI_KVS_Destroy (const char kvsname[])
 {
-    trace_simple (PMI_TRACE_KVS);
-    return PMI_SUCCESS;
+    return_trace (PMI_TRACE_KVS, PMI_SUCCESS);
 }
 
 int PMI_KVS_Iter_first (const char kvsname[], char key[], int key_len,
                         char val[], int val_len)
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_KVS_Iter_next (const char kvsname[], char key[], int key_len,
                        char val[], int val_len)
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 /* These functions were removed from the MPICH pmi.h by
@@ -547,27 +694,23 @@ int PMI_KVS_Iter_next (const char kvsname[], char key[], int key_len,
 int PMI_Parse_option (int num_args, char *args[], int *num_parsed,
                       PMI_keyval_t **keyvalp, int *size)
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_Args_to_keyval (int *argcp, char *((*argvp)[]),
                         PMI_keyval_t **keyvalp, int *size)
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_Free_keyvals (PMI_keyval_t keyvalp[], int size)
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 int PMI_Get_options (char *str, int *length)
 {
-    trace_simple (PMI_TRACE_UNIMPL);
-    return PMI_FAIL;
+    return_trace (PMI_TRACE_UNIMPL, PMI_FAIL);
 }
 
 /*

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -133,7 +133,7 @@ int PMI_Init (int *spawned)
     ctx->spawned = PMI_FALSE;
     ctx->universe_size = ctx->size;
     ctx->barrier_num = 0;
-    snprintf (ctx->kvsname, sizeof (ctx->kvsname), "%d", ctx->appnum);
+    snprintf (ctx->kvsname, sizeof (ctx->kvsname), "lwj.%d.pmi", ctx->appnum);
     if (!(ctx->fctx = flux_open (NULL, 0))) {
         err ("flux_open");
         goto fail;
@@ -331,7 +331,7 @@ int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
     char *xkey = NULL;
     int rc = PMI_SUCCESS;
 
-    trace (PMI_TRACE_KVS_PUT, "%s pmi.%s.%s = %s",
+    trace (PMI_TRACE_KVS_PUT, "%s %s.%s = %s",
            __FUNCTION__, kvsname, key, value);
 
     if (ctx == NULL) {
@@ -343,7 +343,7 @@ int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
         rc = PMI_ERR_INVALID_ARG;
         goto done;
     }
-    if (asprintf (&xkey, "pmi.%s.%s", kvsname, key) < 0) {
+    if (asprintf (&xkey, "%s.%s", kvsname, key) < 0) {
         rc = PMI_ERR_NOMEM;
         goto done;
     }
@@ -362,7 +362,7 @@ done:
  */
 int PMI_KVS_Commit (const char kvsname[])
 {
-    trace (PMI_TRACE_KVS_PUT, "%s pmi.%s", __FUNCTION__, kvsname);
+    trace (PMI_TRACE_KVS_PUT, "%s %s", __FUNCTION__, kvsname);
     if (ctx == NULL)
         return PMI_ERR_INIT;
     assert (ctx->magic == PMI_CTX_MAGIC);
@@ -378,7 +378,7 @@ int PMI_KVS_Get (const char kvsname[], const char key[], char value[],
     int rc = PMI_SUCCESS;
     char *val = NULL;
 
-    trace (PMI_TRACE_KVS_GET, "%s pmi.%s.%s", __FUNCTION__, kvsname, key);
+    trace (PMI_TRACE_KVS_GET, "%s %s.%s", __FUNCTION__, kvsname, key);
     if (ctx == NULL) {
         rc = PMI_ERR_INIT;
         goto done;
@@ -388,7 +388,7 @@ int PMI_KVS_Get (const char kvsname[], const char key[], char value[],
         rc = PMI_ERR_INVALID_ARG;
         goto done;
     }
-    if (asprintf (&xkey, "pmi.%s.%s", kvsname, key) < 0) {
+    if (asprintf (&xkey, "%s.%s", kvsname, key) < 0) {
         rc = PMI_ERR_NOMEM;
         goto done;
     }

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,5 +1,5 @@
 #This order is *important* 
-SUBDIRS = connector-local kvs content-sophia content-sqlite libmrpc libkz live mecho barrier wreck libjsc resource-hwloc
+SUBDIRS = barrier connector-local kvs content-sophia content-sqlite libmrpc libkz live mecho wreck libjsc resource-hwloc
 if HAVE_PYTHON
 SUBDIRS += pymod
 endif

--- a/src/modules/live/Makefile.am
+++ b/src/modules/live/Makefile.am
@@ -19,6 +19,7 @@ live_la_LDFLAGS = $(fluxmod_ldflags) -module
 live_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
 		 $(top_builddir)/src/common/libflux-core.la \
 		 $(top_builddir)/src/modules/kvs/libflux-kvs.la \
+		 $(top_builddir)/src/modules/barrier/libflux-barrier.la \
 		 $(JSON_LIBS) $(ZMQ_LIBS)
 
 #

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -431,6 +431,14 @@ static void cstate_change (ctx_t *ctx, child_t *c, cstate_t newstate)
     JSON event = Jnew ();
     flux_msg_t *msg;
 
+    flux_log (ctx->h, LOG_CRIT, "transitioning %d from %s to %s", c->rank,
+                c->state == CS_OK ? "OK" :
+                c->state == CS_SLOW ? "SLOW" :
+                c->state == CS_FAIL ? "FAIL" : "UNKNOWN",
+                newstate == CS_OK ? "OK" :
+                newstate == CS_SLOW ? "SLOW" :
+                newstate == CS_FAIL ? "FAIL" : "UNKNOWN");
+
     Jadd_int (event, "rank", c->rank);
     Jadd_int (event, "ostate", c->state);
     c->state = newstate;

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -29,15 +29,17 @@
  *   cmb.failover - switch to new parent
  * The cmbd expects failover to be driven externally (e.g. by us).
  * The cmbd maintains a hash of peers and their idle time, and also sends
- * a cmb.ping upstream on the heartbeat if nothing else has been sent in the
- * previous epoch, as a keep-alive.  So if the idle time for a child is > 1,
- * something is probably wrong.
+ * a keepalive upstream on the heartbeat if nothing else has been sent in the
+ * previous epoch.  So if the idle time for a child is > 1, something is
+ * probably wrong.
  *
  * In this module, parents monitor their children on the heartbeat.  That is,
  * we call cmb.peers (locally) and check the idle time of our children.
  * If a child changes state, we publish a live.cstate event, intended to
  * reach grandchildren so they can failover to new parent without relying on
  * upstream services which would be unavailable to them for the moment.
+ * (N.B. Reaching grandchildren is problematic if events are being
+ * distributed only via the TBON)
  *
  * Monitoring does not begin until children check in the first time
  * with a live.hello.  Parents discover their children via the live.hello
@@ -1000,6 +1002,7 @@ static void hello_request_cb (flux_t h, flux_msg_handler_t *w,
         flux_log_error (h, "%s: request decode", __FUNCTION__);
         goto done;
     }
+    flux_log (h, LOG_DEBUG, "hello from %" PRIu32, rank);
     /* Create a record for this child, unless already seen.
      * Also send rank upstream (reduced) to update conf.live.state.
      */

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -304,6 +304,8 @@ static void parents_fromjson (ctx_t *ctx, JSON ar)
                                                      "tbon-parent-uri", NULL);
                     parent_set_uri (p, uri);
                 }
+                flux_log (ctx->h, LOG_DEBUG, "parent[%d] %d %s",
+                          i, p->rank, p->uri ? p->uri : "NULL");
                 if (zlist_append (ctx->parents, p) < 0)
                     oom ();
             }

--- a/src/test/soak.sh
+++ b/src/test/soak.sh
@@ -111,6 +111,8 @@ plot \
   "${DATFILE}" using 1:(\$4/1000000) with linespoints title 'sqlite db' axes x1y2
 EOT
 
+R -q -e "x <- read.delim('${DATFILE}', header = T, sep = ' '); summary(x[ , 2])" || :
+
 echo Displaying ${PNGFILE}
 eog ${PNGFILE}
 

--- a/t/mpi/hello.c
+++ b/t/mpi/hello.c
@@ -31,30 +31,33 @@ int
 main(int argc, char *argv[])
 {
         int id, ntasks;
-	struct timespec ts0;
-        //char hostname[64];
+	struct timespec t;
 
-	clock_gettime (CLOCK_MONOTONIC, &ts0);
-
+	clock_gettime (CLOCK_MONOTONIC, &t);
         MPI_Init(&argc, &argv);
         MPI_Comm_rank(MPI_COMM_WORLD, &id);
         MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
         if (id == 0) {
-                fprintf(stderr,
-		  "0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
-		   time_since (ts0)/1000, ntasks);
+                printf("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
+		   time_since (t)/1000, ntasks);
                 fflush(stdout);
         }
 
+	if (id == 0)
+		clock_gettime (CLOCK_MONOTONIC, &t);
         MPI_Barrier(MPI_COMM_WORLD);
         if (id == 0) {
-                printf("0: completed first barrier\n");
+                printf("0: completed first barrier in %0.3fs\n",
+				time_since (t) / 1000);
                 fflush(stdout);
         }
 
+	if (id == 0)
+		clock_gettime (CLOCK_MONOTONIC, &t);
         MPI_Finalize();
         if (id == 0) {
-                printf("0: completed MPI_Finalize\n");
+                printf("0: completed MPI_Finalize in %0.3fs\n",
+				time_since (t) / 1000);
                 fflush(stdout);
         }
         return 0;

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -12,8 +12,8 @@ LASTRANK=$((SIZE-1))
 test_under_flux ${SIZE} kvs
 
 test_expect_success 'up: load live module' '
-	flux module load -r 0 live &&
-	flux module load -r all -x 0 live
+	flux module load -r all barrier &&
+	flux module load -r all live --barrier-count=${SIZE}
 '
 #
 # Wait for all ranks to leave unknown state in live module:

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -71,40 +71,28 @@ test_expect_success 'pmi: (put*1) / barrier / (get*1) pattern works' '
 	run_program 10 ${SIZE} ${SIZE} \
 	    ${FLUX_BUILD_DIR}/t/pmi/kvstest >output_kvstest &&
 	grep -q "put phase" output_kvstest &&
-	grep -q "get phase" output_kvstest &&
-	test `grep PMI_KVS_Put output_kvstest | wc -l` -eq ${SIZE} &&
-	test `grep PMI_Barrier output_kvstest | wc -l` -eq $((${SIZE}*2)) &&
-	test `grep PMI_KVS_Get output_kvstest | wc -l` -eq ${SIZE} 
+	grep -q "get phase" output_kvstest
 '
 
 test_expect_success 'pmi: (put*1) / barrier / (get*size) pattern works' '
 	run_program 30 ${SIZE} ${SIZE} \
 	    ${FLUX_BUILD_DIR}/t/pmi/kvstest -n >output_kvstest2 &&
 	grep -q "put phase" output_kvstest2 &&
-	grep -q "get phase" output_kvstest2 &&
-	test `grep PMI_KVS_Put output_kvstest2 | wc -l` -eq ${SIZE} &&
-	test `grep PMI_Barrier output_kvstest2 | wc -l` -eq $((${SIZE}*2)) &&
-	test `grep PMI_KVS_Get output_kvstest2 | wc -l` -eq $((${SIZE}*${SIZE}))
+	grep -q "get phase" output_kvstest2
 '
 
 test_expect_success 'pmi: (put*16) / barrier / (get*16) pattern works' '
 	run_program 30 ${SIZE} ${SIZE} \
 	    ${FLUX_BUILD_DIR}/t/pmi/kvstest -N 16 >output_kvstest3 &&
 	grep -q "put phase" output_kvstest3 &&
-	grep -q "get phase" output_kvstest3 &&
-	test `grep PMI_KVS_Put output_kvstest3 | wc -l` -eq $((${SIZE}*16)) &&
-	test `grep PMI_Barrier output_kvstest3 | wc -l` -eq $((${SIZE}*2)) &&
-	test `grep PMI_KVS_Get output_kvstest3 | wc -l` -eq $((${SIZE}*16))
+	grep -q "get phase" output_kvstest3
 '
 
 test_expect_success 'pmi: (put*16) / barrier / (get*16*size) pattern works' '
 	run_program 60 ${SIZE} ${SIZE} \
 	    ${FLUX_BUILD_DIR}/t/pmi/kvstest -n -N 16 >output_kvstest4 &&
 	grep -q "put phase" output_kvstest4 &&
-	grep -q "get phase" output_kvstest4 &&
-	test `grep PMI_KVS_Put output_kvstest4 | wc -l` -eq $((${SIZE}*16)) &&
-	test `grep PMI_Barrier output_kvstest4 | wc -l` -eq $((${SIZE}*2))  &&
-	test `grep PMI_KVS_Get output_kvstest4 | wc -l` -eq $((${SIZE}*16*${SIZE}))
+	grep -q "get phase" output_kvstest4
 '
 
 test_done


### PR DESCRIPTION
In this PR
* pmi tracing is improved, and redirected to the flux_log at LOG_DEBUG level
* a logic error in broker logging is fixed, and logging attribute docs updated
* set I_MPI_PMI_LIBRARY in environment for Intel MPI support

It seems a little wrong to always set the environment variable specific to the Intel MPI runtime, so wanted to get some feedback on that.  (Maybe it is OK for the short term, but what is the correct long term way to do this?)