### PR TITLE
various minor wreck fixes

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -111,8 +111,8 @@ function wreck:usage()
                              is a list of [src:]dst pairs separated by semi-
                              colon, where src is an optional src file
                              (default: stdin) and dst is a list of taskids
-                             or "*" or "all". E.g. (-s0 sends stdin to task 0,
-                             -s /dev/null:* closes all stdin, etc.)
+                             or "*" or "all". E.g. (-i0 sends stdin to task 0,
+                             -i /dev/null:* closes all stdin, etc.)
   -E, --error=FILENAME       Send stderr to a different location than stdout.
   -l, --labelio              Prefix lines of output with task id
 ]])

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -220,8 +220,16 @@ function LWJ.open (f, id)
     return setmetatable ({id = id, lwj = lwj }, LWJ)
 end
 
+local function gettimeofday_as_table ()
+    local ts, us = require 'flux.posix'.gettimeofday ()
+    if not ts then return nil, us end
+    if type (ts) == "table" then return ts end
+    return { sec = ts, usec = us }
+end
+
 local function now ()
-    local t = require 'flux.posix'.gettimeofday()
+    local t, err = gettimeofday_as_table ()
+    if not t then error ("gettimeofday: "..err) end
     return t.sec + (t.usec / (1000 * 1000))
 end
 

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -225,6 +225,16 @@ local function now ()
     return t.sec + (t.usec / (1000 * 1000))
 end
 
+function LWJ:timediff (tstart, tend, talt)
+    local t0 = self.lwj[tstart.."-time"]
+    if not t0 then return 0 end
+    local t1 = self.lwj[tend.."-time"]
+    if not t1 then t1 = self.lwj[talt.."-time"] end
+    if not t1 then t1 = now () end
+    local s = t1 - t0
+    return s > 0 and s or 0
+end
+
 LWJ.__index = function (self, key)
     if key == "state" then
         return self.lwj.state
@@ -239,13 +249,13 @@ LWJ.__index = function (self, key)
     elseif key == "nnodes" then
         return self.lwj.nnodes
     elseif key == "runtime" then
-        local st = self.lwj["starting-time"]
-        if not st then return 0 end
-        local ct = self.lwj["complete-time"]
-        local ft = self.lwj["failed-time"]
-        if not ct and not ft then ct = now () end
-        local s = (ct and ct or ft) - st
-        return s > 0 and s or 0
+        return self:timediff ("starting", "complete", "failed")
+    elseif key == "t0" then
+        return self:timediff ("create", "starting", "failed")
+    elseif key == "t1" then
+        return self:timediff ("starting", "running", "failed")
+    elseif key == "t2" then
+        return self:timediff ("running", "complete", "failed")
     elseif key == "start" then
         return os.date ("%FT%T", self.lwj["starting-time"])
     elseif key == "end" then
@@ -255,7 +265,7 @@ LWJ.__index = function (self, key)
     elseif key == "command" then
         return self.lwj.cmdline[1]
     end
-    return nil
+    return LWJ [key]
 end
 
 local function seconds_to_string (s)
@@ -289,6 +299,30 @@ Command {
                     seconds_to_string (j.runtime),
                     tostring (j.ranks),
                     j.command:match ("([^/]+)$"))
+        end
+    end
+ end
+}
+
+Command {
+ name = "timing",
+ usage = "",
+ description = "List timings of jobs in kvs",
+ handler = function (self, arg) 
+    local lwj, err = f:kvsdir ("lwj")
+    if not lwj then
+        die ("Failed to get lwj info: %s\n", err)
+    end
+    local fmt = "%6s %12s %12s %12s %12s\n"
+    printf (fmt, "ID", "STARTING", "RUNNING", "COMPLETE", "TOTAL")
+    for id in lwj:keys() do
+        if tonumber (id) then
+            local j, err = LWJ.open (f, id)
+            if not j then die ("job%d: %s", id, err) end
+            printf (fmt, id, seconds_to_string (j.t0),
+                    seconds_to_string (j.t1),
+                    seconds_to_string (j.t2),
+                    seconds_to_string (j.runtime))
         end
     end
  end

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -58,7 +58,9 @@ libutil_la_SOURCES = \
 	sha1.h \
 	sha1.c \
 	shastring.h \
-	shastring.c
+	shastring.c \
+	fdwalk.h \
+	fdwalk.c
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/fdwalk.c
+++ b/src/common/libutil/fdwalk.c
@@ -1,0 +1,115 @@
+/*
+ *  fdwalk.c -- originally from WebRTC linuxfdwalk.c
+ *  https://chromium.googlesource.com/external/webrtc/
+ *
+ *  Original LICENSE and Copyright follow.
+ *
+ *  Copyright (c) 2011, The WebRTC project authors. All rights reserved.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of Google nor the names of its contributors may
+ *   be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ *  Copyright 2004 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fdwalk.h"
+
+// Parses a file descriptor number in base 10, requiring the strict format used
+// in /proc/*/fd. Returns the value, or -1 if not a valid string.
+static int parse_fd(const char *s) {
+    if (!*s) {
+        // Empty string is invalid.
+        return -1;
+    }
+    int val = 0;
+    do {
+        if (*s < '0' || *s > '9') {
+            // Non-numeric characters anywhere are invalid.
+            return -1;
+        }
+        int digit = *s++ - '0';
+        val = val * 10 + digit;
+    } while (*s);
+    return val;
+}
+
+int fdwalk(void (*func)(void *, int), void *opaque) {
+    DIR *dir = opendir("/proc/self/fd");
+    if (!dir) {
+        return -1;
+    }
+    int opendirfd = dirfd(dir);
+    int parse_errors = 0;
+    struct dirent *ent;
+    // Have to clear errno to distinguish readdir() completion from failure.
+    while (errno = 0, (ent = readdir(dir)) != NULL) {
+        if (strcmp(ent->d_name, ".") == 0 ||
+                strcmp(ent->d_name, "..") == 0) {
+            continue;
+        }
+        // We avoid atoi or strtol because those are part of libc and they involve
+        // locale stuff, which is probably not safe from a post-fork context in a
+        // multi-threaded app.
+        int fd = parse_fd(ent->d_name);
+        if (fd < 0) {
+            parse_errors = 1;
+            continue;
+        }
+        if (fd != opendirfd) {
+            (*func)(opaque, fd);
+        }
+    }
+    int saved_errno = errno;
+    if (closedir(dir) < 0) {
+        if (!saved_errno) {
+            // Return the closedir error.
+            return -1;
+        }
+        // Else ignore it because we have a more relevant error to return.
+    }
+    if (saved_errno) {
+        errno = saved_errno;
+        return -1;
+    } else if (parse_errors) {
+        errno = EBADF;
+        return -1;
+    } else {
+        return 0;
+    }
+}

--- a/src/common/libutil/fdwalk.h
+++ b/src/common/libutil/fdwalk.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2004 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+#ifndef FDWALK_H_
+#define FDWALK_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Linux port of SunOS's fdwalk(3) call. It loops over all open file descriptors
+// and calls func on each one. Additionally, it is safe to use from the child
+// of a fork that hasn't exec'ed yet, so you can use it to close all open file
+// descriptors prior to exec'ing a daemon.
+// The return value is 0 if successful, or else -1 and errno is set. The
+// possible errors include any error that can be returned by opendir(),
+// readdir(), or closedir(), plus EBADF if there are problems parsing the
+// contents of /proc/self/fd.
+// The file descriptors that are enumerated will not include the file descriptor
+// used for the enumeration itself.
+int fdwalk(void (*func)(void *, int), void *opaque);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+#endif  // FDWALK_H_

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -11,7 +11,7 @@ cachedir=$HOME/local/.cache
 #
 downloads="\
 https://github.com/dun/munge/archive/munge-0.5.11.tar.gz \
-https://download.libsodium.org/libsodium/releases/libsodium-1.0.6.tar.gz \
+https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz \
 http://download.zeromq.org/zeromq-4.0.4.tar.gz \
 http://download.zeromq.org/czmq-3.0.2.tar.gz \
 https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz \

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -143,7 +143,7 @@ for pkg in $downloads; do
     mkdir -p ${name}  || die "Failed to mkdir ${name}"
     (
       cd ${name} &&
-      wget --no-check-certificate ${pkg} || die "Failed to download ${pkg}"
+      curl -L -O --insecure ${pkg} || die "Failed to download ${pkg}"
       tar --strip-components=1 -xf *.tar.gz || die "Failed to un-tar ${name}"
       test -x configure && CC=gcc ./configure --prefix=${prefix} \
                   --sysconfdir=${prefix}/etc \


### PR DESCRIPTION
this PR might still be a bit of a WIP, but posting it now in case there are comments, requirements, etc.

This PR comprises the following somewhat minor fixes:
 * in wrexecd, instead of closing all file descriptors from maxfd to `sysconf (_SC_OPEN_MAX)`, walk `/proc/self/fd` and close only open fds. Noticed on c9.io that `_SC_OPEN_MAX` was over 1M.
 * Add a `flux wreck timing` subcommand that lists the following finer granularity times recorded by wrexecd, in case they are useful:
     - STARTING: reserved->starting
     - RUNNING:  starting->running
     - COMPLETE: running->complete
     - TOTAL:    starting->complete
 * Do not use `affinity.cpuset` in `input.lua` plugin -- it doesn't support tasks > 1024
 * In travis, pull libsodium from github, older openssl version in travis container apparently doesn't support connections to download.libsodium.org anymore.