### PR TITLE
disable live module, require JSON payloads to be JSON objects

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -7,7 +7,7 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 
-flux module load -r all live --barrier-count=$(flux getattr size)
+#flux module load -r all live --barrier-count=$(flux getattr size)
 flux module load -r all resource-hwloc & pids="$pids $!"
 flux module load -r all mecho
 flux module load -r all job

--- a/etc/rc3
+++ b/etc/rc3
@@ -16,7 +16,7 @@ flux module remove -r all wrexec
 flux module remove -r all job
 flux module remove -r all mecho
 flux module remove -r all resource-hwloc
-flux module remove -r all live
+#flux module remove -r all live
 
 flux module remove -r all kvs
 flux module remove -r all barrier

--- a/src/bindings/python/test/handle.py
+++ b/src/bindings/python/test/handle.py
@@ -29,7 +29,7 @@ class TestHandle(unittest.TestCase):
 
     def test_rpc_ping(self):
         """Sending a ping"""
-        r = self.f.rpc_send('live.ping', {'seq': 1, 'pad': 'stuff'})
+        r = self.f.rpc_send('cmb.ping', {'seq': 1, 'pad': 'stuff'})
         self.assertEqual(r['seq'], 1)
         self.assertEqual(r['pad'], 'stuff')
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -2005,21 +2005,17 @@ static int cmb_lsmod_cb (zmsg_t **zmsg, void *arg)
     ctx_t *ctx = arg;
     flux_modlist_t mods = NULL;
     char *json_str = NULL;
-    JSON out = NULL;
     int rc = -1;
 
     if (!(mods = module_get_modlist (ctx->modhash)))
         goto done;
     if (!(json_str = flux_lsmod_json_encode (mods)))
         goto done;
-    out = Jfromstr (json_str);
-    assert (out != NULL);
-    if (flux_respond (ctx->h, *zmsg, 0, Jtostr (out)) < 0)
+    if (flux_respond (ctx->h, *zmsg, 0, json_str) < 0)
         goto done;
     rc = 0;
 done:
     zmsg_destroy (zmsg);
-    Jput (out);
     if (json_str)
         free (json_str);
     if (mods)

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -88,8 +88,6 @@ static ctx_t *getctx (flux_t h, module_t *p)
 
 
 /* Route string will not include the endpoints.
- * FIXME: t/lua/t0002-rpc.t tries to ping with an array object.
- * This should be caught at a lower level - see issue #181
  */
 static void ping_cb (flux_t h, flux_msg_handler_t *w,
                      const flux_msg_t *msg, void *arg)
@@ -103,8 +101,7 @@ static void ping_cb (flux_t h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto done;
-    if (!(o = Jfromstr (json_str))
-                    || !json_object_is_type (o, json_type_object)) {
+    if (!(o = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -452,11 +452,10 @@ flux_msg_t *overlay_recvmsg_event (overlay_t *ov)
         goto done;
     if (ov->event_munge) {
         if (flux_sec_unmunge_zmsg (ov->sec, &msg) < 0) {
-            //flux_log (ctx->h, LOG_ERR, "dropping malformed event: %s",
-            //          flux_sec_errstr (ctx->sec));
             flux_msg_destroy (msg);
-            msg = NULL;
             errno = EPROTO;
+            flux_log_error (ov->h, "dropping malformed event");
+            msg = NULL;
             goto done;
         }
     }

--- a/src/cmd/flux-up.c
+++ b/src/cmd/flux-up.c
@@ -177,7 +177,6 @@ static ns_t *ns_guess (flux_t h)
 {
     ns_t *ns = xzmalloc (sizeof (*ns));
     uint32_t size, rank;
-    uint32_t r;
 
     if (flux_get_rank (h, &rank) < 0)
         err_exit ("flux_get_rank");
@@ -189,12 +188,7 @@ static ns_t *ns_guess (flux_t h)
     ns->unknown = nodeset_create ();
     if (!ns->ok || !ns->slow || !ns->fail || !ns->unknown)
         oom ();
-
-    nodeset_add_rank (ns->ok, rank);
-    for (r = 0; r < size; r++) {
-        if (r != rank)
-            nodeset_add_rank (ns->unknown, r);
-    }
+    nodeset_add_range (ns->ok, rank, size - 1);
     return ns;
 }
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -35,8 +35,6 @@
 
 #include "message.h"
 
-#include "src/common/libutil/log.h"
-
 /* Begin manual codec
  */
 #define PROTO_MAGIC         0x8e

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -137,6 +137,28 @@ void check_payload_json (void)
     ok (flux_msg_get_payload_json (msg, &s) == 0 && s == NULL,
        "flux_msg_get_payload_json returns success with no payload");
 
+    /* RFC 3 - json payload must be an object
+     * Encoding should return EINVAL.
+     */
+    errno = 0;
+    ok (flux_msg_set_payload_json (msg, "[1,2,3]") < 0 && errno == EINVAL,
+       "flux_msg_set_payload_json array fails with EINVAL");
+    errno = 0;
+    ok (flux_msg_set_payload_json (msg, "3.14") < 0 && errno == EINVAL,
+       "flux_msg_set_payload_json scalar fails with EINVAL");
+
+    /* Using the lower level flux_msg_set_payload with FLUX_MSGFLAG_JSON
+     * we can sneak in a malformed JSON paylaod and test decoding.
+     */
+    errno = 0;
+    ok (flux_msg_set_payload (msg, FLUX_MSGFLAG_JSON, "[1,2,3]", 8) == 0
+            && flux_msg_get_payload_json (msg, &s) < 0 && errno == EPROTO,
+        "flux_msg_get_payload_json array fails with EPROTO");
+    errno = 0;
+    ok (flux_msg_set_payload (msg, FLUX_MSGFLAG_JSON, "3.14", 5) == 0
+            && flux_msg_get_payload_json (msg, &s) < 0 && errno == EPROTO,
+        "flux_msg_get_payload_json scalar fails with EPROTO");
+
     ok (flux_msg_set_payload_json (msg, json_str) == 0,
        "flux_msg_set_payload_json works");
     ok (flux_msg_get_payload_json (msg, &s) == 0 && s != NULL
@@ -469,7 +491,7 @@ void check_sendzsock (void)
 
 int main (int argc, char *argv[])
 {
-    plan (117);
+    plan (NO_PLAN);
 
     check_proto ();                 // 17
     check_routes ();                // 26

--- a/src/common/libutil/iterators.h
+++ b/src/common/libutil/iterators.h
@@ -6,9 +6,6 @@
             VAR;                   \
             (VAR) = zlist_next(LIST))
 
-#define FOREACH_ZHASH_KEYS(HASH, KEY) \
-    FOREACH_ZLIST(zhash_keys(HASH), KEY)
-
 #define FOREACH_ZHASH(HASH, KEY, VALUE) \
     for((VALUE) = zhash_first(HASH),    \
         (KEY) = zhash_cursor(HASH);     \

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -726,10 +726,8 @@ static void commit_timeout_handler (flux_reactor_t *r, flux_watcher_t *w,
     ctx->commit_timer_armed = false;
 
     count = commit_apply_all (ctx);
-    if (count > 1) {
-        flux_log (ctx->h, LOG_DEBUG, "%s: coalesced %d commits",
-                  __FUNCTION__, count);
-    }
+    if (count > 1)
+        flux_log (ctx->h, LOG_DEBUG, "coalesced %d commits", count);
 }
 
 static void dropcache_request_cb (flux_t h, flux_msg_handler_t *w,

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -101,13 +101,13 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
     const char *json_str;
 
     errno = 0;
-    ok (!(r = flux_rpc_multi (h, NULL, "foo", "all", 0)) && errno == EINVAL,
+    ok (!(r = flux_rpc_multi (h, NULL, "{}", "all", 0)) && errno == EINVAL,
         "flux_rpc_multi [0] with NULL topic fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_rpc_multi (h, "bar", "foo", NULL, 0)) && errno == EINVAL,
+    ok (!(r = flux_rpc_multi (h, "bar", "{}", NULL, 0)) && errno == EINVAL,
         "flux_rpc_multi [0] with NULL nodeset fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_rpc_multi (h, "bar", "foo", "xyz", 0)) && errno == EINVAL,
+    ok (!(r = flux_rpc_multi (h, "bar", "{}", "xyz", 0)) && errno == EINVAL,
         "flux_rpc_multi [0] with bad nodeset fails with EINVAL");
 
     /* working no-payload RPC */
@@ -125,7 +125,7 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
     flux_rpc_destroy (r);
 
     /* cause remote EPROTO (unexpected payload) - picked up in _get() */
-    ok ((r = flux_rpc_multi (h, "rpctest.hello", "foo", "all", 0)) != NULL,
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", "{}", "all", 0)) != NULL,
         "flux_rpc_multi [0] with unexpected payload works, at first");
     ok (flux_rpc_check (r) == false,
         "flux_rpc_check says get would block");
@@ -188,7 +188,7 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
     flux_rpc_destroy (r);
 
     /* same with echo payload */
-    ok ((r = flux_rpc_multi (h, "rpctest.echo", "foo", "[0-63]", 0)) != NULL,
+    ok ((r = flux_rpc_multi (h, "rpctest.echo", "{}", "[0-63]", 0)) != NULL,
         "flux_rpc_multi [0-%d] ok",
         64 - 1);
     ok (flux_rpc_check (r) == false,
@@ -196,7 +196,7 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
     errors = 0;
     for (i = 0; i < 64; i++) {
         if (flux_rpc_get (r, NULL, &json_str) < 0
-                || !json_str || strcmp (json_str, "foo") != 0)
+                || !json_str || strcmp (json_str, "{}") != 0)
             errors++;
     }
     ok (errors == 0,

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -99,7 +99,7 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
     flux_rpc_destroy (r);
 
     /* cause remote EPROTO (unexpected payload) - will be picked up in _get() */
-    ok ((r = flux_rpc (h, "rpctest.hello", "foo", FLUX_NODEID_ANY, 0)) != NULL,
+    ok ((r = flux_rpc (h, "rpctest.hello", "{}", FLUX_NODEID_ANY, 0)) != NULL,
         "flux_rpc with payload when none is expected works, at first");
     ok (flux_rpc_check (r) == false,
         "flux_rpc_check says get would block");
@@ -122,13 +122,13 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
     flux_rpc_destroy (r);
 
     /* working with-payload RPC */
-    ok ((r = flux_rpc (h, "rpctest.echo", "foo", FLUX_NODEID_ANY, 0)) != NULL,
+    ok ((r = flux_rpc (h, "rpctest.echo", "{}", FLUX_NODEID_ANY, 0)) != NULL,
         "flux_rpc with payload when payload is expected works");
     ok (flux_rpc_check (r) == false,
         "flux_rpc_check says get would block");
     json_str = NULL;
     ok (flux_rpc_get (r, NULL, &json_str) == 0
-        && json_str && !strcmp (json_str, "foo"),
+        && json_str && !strcmp (json_str, "{}"),
         "flux_rpc_get works and returned expected payload");
     flux_rpc_destroy (r);
 
@@ -158,7 +158,7 @@ static void then_cb (flux_rpc_t *r, void *arg)
         "flux_rpc_check says get won't block in then callback");
     json_str = NULL;
     ok (flux_rpc_get (r, NULL, &json_str) == 0
-        && json_str && !strcmp (json_str, "xxx"),
+        && json_str && !strcmp (json_str, "{}"),
         "flux_rpc_get works and returned expected payload in then callback");
     flux_reactor_stop (flux_get_reactor (h));
 }
@@ -225,7 +225,7 @@ int main (int argc, char *argv[])
      * will be invoked. Continuation stops the reactor.
     */
     flux_rpc_t *r;
-    ok ((r = flux_rpc (h, "rpctest.echo", "xxx", FLUX_NODEID_ANY, 0)) != NULL,
+    ok ((r = flux_rpc (h, "rpctest.echo", "{}", FLUX_NODEID_ANY, 0)) != NULL,
         "flux_rpc with payload when payload is expected works");
     ok (flux_rpc_check (r) == false,
         "flux_rpc_check says get would block");
@@ -250,7 +250,7 @@ int main (int argc, char *argv[])
      * This will hang if rpc implementation doesn't return a cached message
      * back to the handle in _then().  Else, continuation will stop reactor.
      */
-    ok ((thenbug_r = flux_rpc (h, "rpctest.echo", "xxx",
+    ok ((thenbug_r = flux_rpc (h, "rpctest.echo", "{}",
         FLUX_NODEID_ANY, 0)) != NULL,
         "thenbug: sent echo request");
     do {

--- a/t/lua/t0001-send-recv.t
+++ b/t/lua/t0001-send-recv.t
@@ -17,7 +17,7 @@ is (err, nil, "error is nil")
 --
 
 local packet = { seq = "1", pad = "xxxxxx" }
-local matchtag, err = f:send ("live.ping", packet)
+local matchtag, err = f:send ("cmb.ping", packet)
 isnt (rc, 0, "send: rc is not 0")
 is (err, nil, "send: err is nil")
 
@@ -25,27 +25,27 @@ is (err, nil, "send: err is nil")
 local msg, tag = f:recv ()
 is (msg.seq, "1", "recv: got expected ping sequence")
 is (msg.pad, "xxxxxx", "recv: got expected ping pad")
-is (tag, "live.ping", "recv: got expected tag on ping response")
+is (tag, "cmb.ping", "recv: got expected tag on ping response")
 
 for k,v in pairs(msg) do note ("msg."..k.."="..v) end
 
 --
 --  Test f:send() with rank argument
 --
-local rc, err = f:send ("live.ping", packet, 0)
+local rc, err = f:send ("cmb.ping", packet, 0)
 isnt (rc, 0, "send to rank 0: rc is not nil or zero")
 is (err, nil, "send to rank 0: err is nil")
 
 local msg, tag = f:recv ()
 is (msg.seq, "1", "recv: got expected ping sequence")
 is (msg.pad, "xxxxxx", "recv: got expected ping pad")
-is (tag, "live.ping", "recv: got expected tag on ping response")
+is (tag, "cmb.ping", "recv: got expected tag on ping response")
 
 
 ---
 ---  Test send with recvmsg()
 ---
-local matchtag, err = f:send ("live.ping", packet, 1)
+local matchtag, err = f:send ("cmb.ping", packet, 1)
 isnt (rc, 0, "send to rank 1: rc is not nil or zero")
 isnt (rc, nil, "send to rank 1: rc is not nil or zero")
 is (err, nil, "send to rank 1: err is nil")
@@ -56,7 +56,7 @@ is (msg.matchtag, matchtag, "recvmsg: matchtag matches (".. matchtag..")")
 is (msg.errnum, 0, "recvmsg: message errnum is 0")
 is (msg.data.seq, "1", "recv: got expected ping sequence")
 is (msg.data.pad, "xxxxxx", "recv: got expected ping pad")
-is (msg.tag, "live.ping", "recv: got expected tag on ping response")
+is (msg.tag, "cmb.ping", "recv: got expected tag on ping response")
 
 done_testing ()
 

--- a/t/lua/t0002-rpc.t
+++ b/t/lua/t0002-rpc.t
@@ -32,7 +32,7 @@ is (msg.pad, "xxxxxx", "recv: got expected ping pad")
 local packet = { 1, 2, 3 }  -- Force encoding to be 'array'
 local msg, err = f:rpc ("cmb.ping", packet)
 is (msg, nil, "rpc: invalid packet: nil response indicates error")
-is (err, "Protocol error", "rpc: invalid packet: err is 'Protocol error'")
+is (err, "Invalid argument", "rpc: invalid packet: err is 'Invalid argument'")
 
 --
 -- 'ping' to specfic rank

--- a/t/lua/t0002-rpc.t
+++ b/t/lua/t0002-rpc.t
@@ -20,7 +20,7 @@ is (f.arity, 2, "session arity is 2")
 --  Use 'ping' packet to test rpc
 --
 local packet = { seq = "1", pad = "xxxxxx" }
-local msg, err = f:rpc ("live.ping", packet)
+local msg, err = f:rpc ("cmb.ping", packet)
 type_ok (msg, 'table', "rpc: return type is table")
 is (err, nil, "rpc: err is nil")
 is (msg.seq, "1", "recv: got expected ping sequence")
@@ -30,7 +30,7 @@ is (msg.pad, "xxxxxx", "recv: got expected ping pad")
 --  Send invalid 'ping' packet to test response
 --
 local packet = { 1, 2, 3 }  -- Force encoding to be 'array'
-local msg, err = f:rpc ("live.ping", packet)
+local msg, err = f:rpc ("cmb.ping", packet)
 is (msg, nil, "rpc: invalid packet: nil response indicates error")
 is (err, "Protocol error", "rpc: invalid packet: err is 'Protocol error'")
 
@@ -38,7 +38,7 @@ is (err, "Protocol error", "rpc: invalid packet: err is 'Protocol error'")
 -- 'ping' to specfic rank
 --
 local packet = { seq = "1", pad = "xxxxxx" }
-local msg, err = f:rpc ("live.ping", packet, 1)
+local msg, err = f:rpc ("cmb.ping", packet, 1)
 type_ok (msg, 'table', "rpc: return type is table")
 is (err, nil, "rpc: err is nil")
 is (msg.seq, "1", "recv: got expected ping sequence")
@@ -50,7 +50,7 @@ is (msg.errnum, nil, "recv: errnum is zero")
 --
 note ("ping to non-existent rank")
 local packet = { seq = "1", pad = "xxxxxx" }
-local msg, err = f:rpc ("live.ping", packet, 99)
+local msg, err = f:rpc ("cmb.ping", packet, 99)
 is (msg, nil, "rpc: nil return indicates error")
 is (err, "No route to host", "rpc: err is 'No route to host'")
 


### PR DESCRIPTION
The main point of this PR is to comment out the live module in rc1, rc3 as proposed in #638.  Note that `flux up` still works, as it already contained fallback code to return all nodes up if the KVS key containing the live module's monitoring results is not found.

Not loading the live module broke some tests which send ping requests to the live module.  When updating those tests to ping the broker rather than a module, I hit the segfault discussed in #181, where a test was attempting to elicit EPROTO by sending a json array as payload to a ping request.  This would trigger a segfault in shortjson.h without workaround code that was added to the module ping handler but not the broker one.

It seemed like a good idea to tie up this loose end, so the few places where arrays were being sent as payloads were fixed to encapsulate those arrays in JSON objects, and the low level message payload get/set functions were updated to return EPROTO/EINVAL if the payload does not begin with the `{` character.

Some minor RFC updates will follow.