### PR TITLE
libutil/cleanup: handle undefined O_PATH flag

### DIFF
--- a/src/common/libutil/cleanup.c
+++ b/src/common/libutil/cleanup.c
@@ -41,6 +41,10 @@
 
 #include <czmq.h>
 
+#ifndef O_PATH
+#define O_PATH 0 /* O_PATH is too new for CentOS 6 - see issue #646 */
+#endif
+
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 struct cleaner {


### PR DESCRIPTION
O_PATH is unavailable on Centos 6 based distros.
If unavailable, simply define it to 0.  The openat()
call should still work fine.

Fixes #646