### PR TITLE
implement ssh connector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ AC_CONFIG_FILES( \
   src/connectors/local/Makefile \
   src/connectors/shmem/Makefile \
   src/connectors/loop/Makefile \
+  src/connectors/ssh/Makefile \
   src/modules/Makefile \
   src/modules/connector-local/Makefile \
   src/modules/kvs/Makefile \

--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -23,7 +23,8 @@ MAN1_FILES_PRIMARY = \
 	flux-getattr.1 \
 	flux-dmesg.1 \
 	flux-content.1 \
-	flux-hwloc.1
+	flux-hwloc.1 \
+	flux-proxy.1
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man1/flux-proxy.adoc
+++ b/doc/man1/flux-proxy.adoc
@@ -1,0 +1,121 @@
+// flux-help-command: proxy
+// flux-help-description: Create proxy environment for Flux instance
+FLUX-PROXY(1)
+=============
+:doctype: manpage
+
+
+NAME
+----
+flux-proxy - create proxy environment for Flux instance
+
+
+SYNOPSIS
+--------
+*flux* *proxy* [OPTIONS] job [command [args...]]
+
+
+DESCRIPTION
+-----------
+*flux proxy* connects to the Flux instance identified by _job_,
+then spawns a shell with FLUX_URI pointing to a local:// socket
+managed by the proxy program.  As long as the shell is running,
+the proxy program routes messages between the instance and the
+local:// socket.  Once the shell terminates, the proxy program
+terminates and removes the socket.
+
+The purpose of *flux proxy* is to allow a connection to be reused,
+for example where connection establishment has high latency or
+requires authentication.
+
+JOB IDENTIFIER
+--------------
+*flux proxy* requires a _job_ identifier argument.  If the
+argument is not a URI, then it is interpreted heuristically
+as a numeric Flux session-id, a session-id with a single 
+'/' character prefix, or the path component of a local:// URI.
+
+
+OPTIONS
+-------
+*-s, --stdio*::
+Instead of creating a local:// proxy socket, assume
+that a single client is already connected to stdin and
+stdout.  This mode is used by the ssh:// connector.
+
+*-e, --setenv*='NAME=VALUE'::
+Set NAME to VALUE in the environment before interpreting the
+_job_ argument or connecting to the Flux instance.  This
+is mainly useful when connecting into a remote environment
+with the ssh:// connector.
+
+
+EXAMPLES
+--------
+
+Connect to a job running on the localhost which has a FLUX_URI
+of local:///tmp/flux-123456-abcdef/0 and spawn an interactive
+shell:
+
+  $ flux proxy local:///tmp/flux-123456-abcdef/0
+
+Connect to the same job by jobid:
+
+  $ flux proxy 123456
+
+Connect to the same job remotely on host foo.com:
+
+  $ flux proxy ssh://foo.com/tmp/flux-123456-abcdef/0
+
+Connect to the same by jobid:
+
+  $ flux proxy ssh://foo.com/123456
+
+Same and also set TMPDIR in the remote `flux proxy --stdio`
+environment:
+
+  $ flux proxy ssh://foo.com/123456?setenv=TMPDIR=/var/tmp/fred
+
+USE BY SSH CONNECTOR
+--------------------
+
+The ssh:// connector spawns *flux proxy --stdio* as the remote
+command.  The ssh URI may contain the following components:
+
+  ssh://[user@]hostname[:port][/path][?setenv=NAME=VALUE]
+
+These components translate to *ssh* and *flux proxy*
+arguments as follows:
+
+  ssh [-p port] [user@]hostname flux proxy --stdio \
+         [--setenv=NAME=VAL] [/path]
+
+The ssh connector understand the following environment variables:
+
+*FLUX_SSH*::
+Override the default ssh program.  The ssh program is
+executed with only the following arguments:
+
+  ssh [-p port] [user@]hostname COMMAND ...
+
+The default ssh program is "/usr/bin/rsh".
+
+*FLUX_SSH_RCMD*::
+Set the name of the remote *flux* program.  If this is not set,
+the same path that *flux* is found locally will be used remotely.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+

--- a/doc/man3/flux_get_reactor.adoc
+++ b/doc/man3/flux_get_reactor.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
 
 flux_reactor_t *flux_get_reactor (flux_t h);
 
-void flux_set_reactor (flux_t h, flux_reactor_t *r);
+int flux_set_reactor (flux_t h, flux_reactor_t *r);
 
 
 DESCRIPTION
@@ -31,7 +31,9 @@ of the owner to destroy it after the handle is destroyed.
 handle _h_.  A flux_reactor_t object may be obtained from another handle,
 for example when events from multiple handles are to be managed using
 a common flux_reactor_t, or one may be created directly with
-`flux_reactor_create(3)`.
+`flux_reactor_create(3)`.  `flux_set_reactor()` should be called
+immediately after `flux_open(3)` to avoid conflict with other API calls
+which may internally call `flux_get_reactor()`.
 
 
 RETURN VALUE
@@ -40,12 +42,18 @@ RETURN VALUE
 `flux_get_reactor()` returns a flux_reactor_t object on success.
 On error, NULL is returned, and errno is set appropriately.
 
+`flux_set_reactor()` returns 0 on success, or -1 on failure with
+errno set appropriately.
+
 
 ERRORS
 ------
 
 ENOMEM::
 Out of memory.
+
+EEXIST::
+Handle already has a reactor association.
 
 
 AUTHOR

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -303,3 +303,5 @@ xml
 filesystem
 filename
 PYTHONPATH
+localhost
+EEXIST

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -305,3 +305,5 @@ filename
 PYTHONPATH
 localhost
 EEXIST
+rsh
+RCMD

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -422,7 +422,8 @@ int main (int argc, char *argv[])
      */
     if (!(ctx.h = flux_handle_create (&ctx, &broker_handle_ops, 0)))
         err_exit ("flux_handle_create");
-    flux_set_reactor (ctx.h, ctx.reactor);
+    if (flux_set_reactor (ctx.h, ctx.reactor) < 0)
+        err_exit ("flux_set_reactor");
 
     subprocess_manager_set (ctx.sm, SM_REACTOR, ctx.reactor);
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -46,7 +46,8 @@ flux_SOURCES = \
 	builtin/version.c \
 	builtin/hwloc.c \
 	builtin/nodeset.c \
-	builtin/heaptrace.c
+	builtin/heaptrace.c \
+	builtin/proxy.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -36,6 +36,8 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
     const char *name = NULL, *val = NULL;
     flux_t h;
 
+    log_init ("flux-setattr");
+
     n = optparse_optind (p);
     if (optparse_hasopt (p, "expunge") && n == ac - 1) {
         name = av[n];
@@ -65,6 +67,9 @@ static int cmd_lsattr (optparse_t *p, int ac, char *av[])
 {
     const char *name, *val;
     flux_t h;
+
+    log_init ("flux-lsatrr");
+
     if (optparse_optind (p) != ac)
         optparse_fatal_usage (p, 1, NULL);
     h = builtin_get_flux_handle (p);
@@ -87,6 +92,8 @@ static int cmd_getattr (optparse_t *p, int ac, char *av[])
     flux_t h = NULL;
     const char *val;
     int n, flags;
+
+    log_init ("flux-getattr");
 
     n = optparse_optind (p);
     if (n != ac - 1)

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -1,0 +1,1040 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include "builtin.h"
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <libgen.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <argz.h>
+#include <glob.h>
+#include <czmq.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/cleanup.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libsubprocess/subprocess.h"
+
+#define LISTEN_BACKLOG      5
+
+typedef struct {
+    int listen_fd;
+    flux_watcher_t *listen_w;
+    zlist_t *clients;
+    flux_t h;
+    flux_reactor_t *reactor;
+    uid_t session_owner;
+    zhash_t *subscriptions;
+    struct subprocess_manager *sm;
+    struct subprocess *p;
+    bool oneshot;
+    int exit_code;
+} ctx_t;
+
+typedef void (*unsubscribe_f)(void *handle, const char *topic);
+
+typedef struct {
+    char *topic;
+    int usecount;
+    unsubscribe_f unsubscribe;
+    void *handle;
+} subscription_t;
+
+typedef struct {
+    int rfd;
+    int wfd;
+    flux_watcher_t *inw;
+    flux_watcher_t *outw;
+    struct flux_msg_iobuf inbuf;
+    struct flux_msg_iobuf outbuf;
+    zlist_t *outqueue;  /* queue of outbound flux_msg_t */
+    ctx_t *ctx;
+    zhash_t *disconnect_notify;
+    zhash_t *subscriptions;
+    zuuid_t *uuid;
+} client_t;
+
+struct disconnect_notify {
+    char *topic;
+    uint32_t nodeid;
+    int flags;
+    client_t *c;
+};
+
+static void client_destroy (client_t *c);
+static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
+                            int revents, void *arg);
+static void client_write_cb (flux_reactor_t *r, flux_watcher_t *w,
+                            int revents, void *arg);
+
+static void ctx_destroy (ctx_t *ctx)
+{
+    if (ctx) {
+        zlist_destroy (&ctx->clients);
+        zhash_destroy (&ctx->subscriptions);
+        if (ctx->sm)
+            subprocess_manager_destroy (ctx->sm);
+        if (ctx->reactor)
+            flux_reactor_destroy (ctx->reactor);
+        free (ctx);
+    }
+}
+
+static ctx_t *ctx_create (flux_t h)
+{
+    ctx_t *ctx = xzmalloc (sizeof (*ctx));
+    ctx->h = h;
+    if (!(ctx->reactor = flux_reactor_create (SIGCHLD)))
+        err_exit ("flux_reactor_create");
+    if (flux_set_reactor (h, ctx->reactor) < 0)
+        err_exit ("flux_set_reactor");
+    if (!(ctx->clients = zlist_new ()))
+        oom ();
+    if (!(ctx->subscriptions = zhash_new ()))
+        oom ();
+    ctx->session_owner = geteuid ();
+    if (!(ctx->sm = subprocess_manager_create ()))
+        err_exit ("subprocess_manager_create");
+    if (subprocess_manager_set (ctx->sm, SM_REACTOR, ctx->reactor) < 0)
+        err_exit ("subprocess_manager_set reactor");
+    subprocess_manager_set (ctx->sm, SM_WAIT_FLAGS, WNOHANG);
+
+    return ctx;
+}
+
+static int set_nonblock (int fd, bool nonblock)
+{
+    int flags = fcntl (fd, F_GETFL);
+    if (flags < 0)
+        return -1;
+    if (nonblock)
+        flags |= O_NONBLOCK;
+    else
+        flags &= ~O_NONBLOCK;
+    if (fcntl (fd, F_SETFL, flags) < 0)
+        return -1;
+    return 0;
+}
+
+static client_t * client_create (ctx_t *ctx, int rfd, int wfd)
+{
+    client_t *c;
+    flux_t h = ctx->h;
+
+    c = xzmalloc (sizeof (*c));
+    c->rfd = rfd;
+    c->wfd = wfd;
+    if (!(c->uuid = zuuid_new ()))
+        oom ();
+    c->ctx = ctx;
+    if (!(c->disconnect_notify = zhash_new ()))
+        oom ();
+    if (!(c->subscriptions = zhash_new ()))
+        oom ();
+    if (!(c->outqueue = zlist_new ()))
+        oom ();
+    c->inw = flux_fd_watcher_create (ctx->reactor, c->rfd,
+                                     FLUX_POLLIN, client_read_cb, c);
+    c->outw = flux_fd_watcher_create (ctx->reactor, c->wfd,
+                                      FLUX_POLLOUT, client_write_cb, c);
+    if (!c->inw || !c->outw) {
+        flux_log (h, LOG_ERR, "flux_fd_watcher_create: %s", strerror (errno));
+        goto error;
+    }
+    flux_watcher_start (c->inw);
+    flux_msg_iobuf_init (&c->inbuf);
+    flux_msg_iobuf_init (&c->outbuf);
+    if (set_nonblock (c->rfd, true) < 0) {
+        flux_log (h, LOG_ERR, "set_nonblock: %s", strerror (errno));
+        goto error;
+    }
+    if (c->wfd != c->rfd && set_nonblock (c->wfd, true) < 0) {
+        flux_log (h, LOG_ERR, "set_nonblock: %s", strerror (errno));
+        goto error;
+    }
+
+    return (c);
+error:
+    client_destroy (c);
+    return NULL;
+}
+
+static int client_send_try (client_t *c)
+{
+    flux_msg_t *msg = zlist_head (c->outqueue);
+
+    if (msg) {
+        if (flux_msg_sendfd (c->wfd, msg, &c->outbuf) < 0) {
+            if (errno != EWOULDBLOCK && errno != EAGAIN)
+                return -1;
+            //flux_log (c->ctx->h, LOG_DEBUG, "send: client not ready");
+            flux_watcher_start (c->outw);
+            errno = 0;
+        } else {
+            msg = zlist_pop (c->outqueue);
+            flux_msg_destroy (msg);
+        }
+    }
+    return 0;
+}
+
+static int client_send_nocopy (client_t *c, flux_msg_t **msg)
+{
+    if (zlist_append (c->outqueue, *msg) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    *msg = NULL;
+    return client_send_try (c);
+}
+
+static int client_send (client_t *c, const flux_msg_t *msg)
+{
+    flux_msg_t *cpy = flux_msg_copy (msg, true);
+    int rc;
+
+    if (!cpy) {
+        errno = ENOMEM;
+        return -1;
+    }
+    rc = client_send_nocopy (c, &cpy);
+    flux_msg_destroy (cpy);
+    return rc;
+}
+
+static subscription_t *subscription_create (const char *topic)
+{
+    subscription_t *sub = xzmalloc (sizeof (*sub));
+    sub->topic = xstrdup (topic);
+    return sub;
+}
+
+static void subscription_destroy (void *data)
+{
+    subscription_t *sub = data;
+    if (sub->unsubscribe)
+        (void) sub->unsubscribe (sub->handle, sub->topic);
+    free (sub->topic);
+    free (sub);
+}
+
+static int global_subscribe (ctx_t *ctx, const char *topic)
+{
+    subscription_t *sub;
+    int rc = -1;
+
+    if (!(sub = zhash_lookup (ctx->subscriptions, topic))) {
+        if (flux_event_subscribe (ctx->h, topic) < 0) {
+            flux_log (ctx->h, LOG_ERR, "%s: flux_event_subscribe %s: %s",
+                      __FUNCTION__, topic, strerror (errno));
+            goto done;
+        }
+        sub = subscription_create (topic);
+        sub->unsubscribe = (unsubscribe_f) flux_event_unsubscribe;
+        sub->handle = ctx->h;
+        zhash_update (ctx->subscriptions, topic, sub);
+        zhash_freefn (ctx->subscriptions, topic, subscription_destroy);
+        /* N.B. t1008-proxy.t looks for this log message */ 
+        flux_log (ctx->h, LOG_DEBUG, "subscribe %s", topic);
+    }
+    sub->usecount++;
+    rc = 0;
+done:
+    return rc;
+}
+
+static int global_unsubscribe (ctx_t *ctx, const char *topic)
+{
+    subscription_t *sub;
+    int rc = -1;
+
+    if (!(sub = zhash_lookup (ctx->subscriptions, topic)))
+        goto done;
+    if (--sub->usecount == 0) {
+        zhash_delete (ctx->subscriptions, topic);
+        /* N.B. t1008-proxy.t looks for this log message */ 
+        flux_log (ctx->h, LOG_DEBUG, "unsubscribe %s", topic);
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+static int client_subscribe (client_t *c, const char *topic)
+{
+    subscription_t *sub;
+    int rc = -1;
+
+    if (!(sub = zhash_lookup (c->subscriptions, topic))) {
+        if (global_subscribe (c->ctx, topic) < 0)
+            goto done;
+        sub = subscription_create (topic);
+        sub->unsubscribe = (unsubscribe_f) global_unsubscribe;
+        sub->handle = c->ctx;
+        zhash_update (c->subscriptions, topic, sub);
+        zhash_freefn (c->subscriptions, topic, subscription_destroy);
+        //flux_log (c->ctx->h, LOG_DEBUG, "%s: %s", __FUNCTION__, topic);
+    }
+    sub->usecount++;
+    rc = 0;
+done:
+    return rc;
+}
+
+static int client_unsubscribe (client_t *c, const char *topic)
+{
+    subscription_t *sub;
+    int rc = -1;
+
+    if (!(sub = zhash_lookup (c->subscriptions, topic)))
+        goto done;
+    if (--sub->usecount == 0) {
+        zhash_delete (c->subscriptions, topic);
+        //flux_log (c->ctx->h, LOG_DEBUG, "%s: %s", __FUNCTION__, topic);
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+int sub_request (client_t *c, const flux_msg_t *msg, bool subscribe)
+{
+    const char *json_str, *topic;
+    JSON in = NULL;
+    int rc = -1;
+
+    if (flux_request_decode (msg, NULL, &json_str) < 0)
+        goto done;
+    if (!(in = Jfromstr (json_str)) || !Jget_str (in, "topic", &topic)) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (subscribe)
+        rc = client_subscribe (c, topic);
+    else
+        rc = client_unsubscribe (c, topic);
+done:
+    Jput (in);
+    return rc;
+}
+
+static bool client_is_subscribed (client_t *c, const char *topic)
+{
+    subscription_t *sub;
+
+    if (zhash_lookup (c->subscriptions, topic))
+        return true;
+    sub = zhash_first (c->subscriptions);
+    while (sub) {
+        if (!strncmp (topic, sub->topic, strlen (sub->topic)))
+            return true;
+        sub = zhash_next (c->subscriptions);
+    }
+    return false;
+}
+
+static int disconnect_sendmsg (struct disconnect_notify *d)
+{
+    int rc = -1;
+    flux_msg_t *msg = NULL;
+
+    if (!d || !d->topic || !d->c) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        goto done;
+    if (flux_msg_set_topic (msg, d->topic) < 0)
+        goto done;
+    if (flux_msg_enable_route (msg) < 0)
+        goto done;
+    if (flux_msg_push_route (msg, zuuid_str (d->c->uuid)) < 0)
+        goto done;
+    if (flux_msg_set_nodeid (msg, d->nodeid, d->flags) < 0)
+        goto done;
+    if (flux_send (d->c->ctx->h, msg, 0) < 0) {
+        flux_log_error (d->c->ctx->h, "%s flux_send disconnect for %s",
+                        __FUNCTION__, zuuid_str (d->c->uuid));
+    }
+    rc = 0;
+done:
+    flux_msg_destroy (msg);
+    return rc;
+}
+
+static void disconnect_destroy (void *arg)
+{
+    struct disconnect_notify *d = arg;
+
+    if (d) {
+        (void)disconnect_sendmsg (d);
+        if (d->topic)
+            free (d->topic);
+        free (d);
+    }
+}
+
+static int disconnect_update (client_t *c, const flux_msg_t *msg)
+{
+    char *p;
+    char *key = NULL;
+    char *svc = NULL;
+    const char *topic;
+    uint32_t nodeid;
+    int flags;
+    struct disconnect_notify *d;
+    int rc = -1;
+
+    if (flux_msg_get_topic (msg, &topic) < 0)
+        goto done;
+    if (flux_msg_get_nodeid (msg, &nodeid, &flags) < 0)
+        goto done;
+    svc = xstrdup (topic);
+    if ((p = strchr (svc, '.')))
+        *p = '\0';
+    key = xasprintf ("%s:%u:%d", svc, nodeid, flags);
+    if (!zhash_lookup (c->disconnect_notify, key)) {
+        d = xzmalloc (sizeof (*d));
+        d->c = c;
+        d->nodeid = nodeid;
+        d->flags = flags;
+        d->topic = xasprintf ("%s.disconnect", svc);
+        zhash_update (c->disconnect_notify, key, d);
+        zhash_freefn (c->disconnect_notify, key, disconnect_destroy);
+    }
+    rc = 0;
+done:
+    if (svc)
+        free (svc);
+    if (key)
+        free (key);
+    return rc;
+}
+
+static void client_destroy (client_t *c)
+{
+    zhash_destroy (&c->disconnect_notify);
+    zhash_destroy (&c->subscriptions);
+    if (c->uuid)
+        zuuid_destroy (&c->uuid);
+    if (c->outqueue) {
+        flux_msg_t *msg;
+        while ((msg = zlist_pop (c->outqueue)))
+            flux_msg_destroy (msg);
+        zlist_destroy (&c->outqueue);
+    }
+    flux_watcher_stop (c->outw);
+    flux_watcher_destroy (c->outw);
+    flux_msg_iobuf_clean (&c->outbuf);
+
+    flux_watcher_stop (c->inw);
+    flux_watcher_destroy (c->inw);
+    flux_msg_iobuf_clean (&c->inbuf);
+
+    if (c->rfd != -1)
+        close (c->rfd);
+    if (c->wfd != -1 && c->wfd != c->rfd)
+        close (c->wfd);
+
+    free (c);
+}
+
+static void client_write_cb (flux_reactor_t *r, flux_watcher_t *w,
+                             int revents, void *arg)
+{
+    client_t *c = arg;
+    ctx_t *ctx = c->ctx;
+
+    if (revents & FLUX_POLLERR)
+        goto disconnect;
+    if (revents & FLUX_POLLOUT) {
+        if (client_send_try (c) < 0)
+            goto disconnect;
+        //flux_log (h, LOG_DEBUG, "send: client ready");
+    }
+    if (zlist_size (c->outqueue) == 0)
+        flux_watcher_stop (w);
+    return;
+disconnect:
+    zlist_remove (c->ctx->clients, c);
+    client_destroy (c);
+    if (ctx->oneshot)
+        flux_reactor_stop (r);
+}
+
+static bool internal_request (client_t *c, const flux_msg_t *msg)
+{
+    const char *topic;
+    int rc = -1;
+    flux_msg_t *rmsg = NULL;
+    uint32_t matchtag;
+
+    if (flux_msg_get_topic (msg, &topic) < 0
+            || flux_msg_get_matchtag (msg, &matchtag) < 0)
+        return false;
+    else if (!strcmp (topic, "local.sub"))
+        rc = sub_request (c, msg, true);
+    else if (!strcmp (topic, "local.unsub"))
+        rc = sub_request (c, msg, false);
+    else
+        return false;
+
+    /* Respond to client
+     */
+    if (!(rmsg = flux_response_encode (topic, rc < 0 ? errno : 0, NULL))
+                    || flux_msg_set_matchtag (rmsg, matchtag) < 0)
+        flux_log (c->ctx->h, LOG_ERR, "%s: encoding response: %s",
+                  __FUNCTION__, strerror (errno));
+
+    else if (client_send_nocopy (c, &rmsg) < 0)
+        flux_log (c->ctx->h, LOG_ERR, "%s: client_send_nocopy: %s",
+                  __FUNCTION__, strerror (errno));
+    flux_msg_destroy (rmsg);
+    return true;
+}
+
+static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
+                            int revents, void *arg)
+{
+    client_t *c = arg;
+    ctx_t *ctx = c->ctx;
+    flux_t h = ctx->h;
+    flux_msg_t *msg = NULL;
+    int type;
+
+    if (revents & FLUX_POLLERR)
+        goto disconnect;
+    if (!(revents & FLUX_POLLIN))
+        return;
+    /* EPROTO, ECONNRESET are normal disconnect errors
+     * EWOULDBLOCK, EAGAIN stores state in c->inbuf for continuation
+     */
+    //flux_log (h, LOG_DEBUG, "recv: client ready");
+    if (!(msg = flux_msg_recvfd (c->rfd, &c->inbuf))) {
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+            //flux_log (h, LOG_DEBUG, "recv: client not ready");
+            return;
+        }
+        if (errno != ECONNRESET && errno != EPROTO)
+            flux_log (h, LOG_ERR, "flux_msg_recvfd: %s", strerror (errno));
+        goto disconnect;
+    }
+    if (flux_msg_get_type (msg, &type) < 0) {
+        flux_log (h, LOG_ERR, "flux_msg_get_type: %s", strerror (errno));
+        goto disconnect;
+    }
+    switch (type) {
+        case FLUX_MSGTYPE_REQUEST:
+            if (!internal_request (c, msg)) {
+                /* insert disconnect notifier before forwarding request */
+                if (c->disconnect_notify && disconnect_update (c, msg) < 0) {
+                    flux_log (h, LOG_ERR, "disconnect_update:  %s",
+                              strerror (errno));
+                    goto disconnect;
+                }
+                if (flux_msg_push_route (msg, zuuid_str (c->uuid)) < 0)
+                    oom (); /* FIXME */
+                if (flux_send (h, msg, 0) < 0)
+                    err ("%s: flux_send", __FUNCTION__);
+            }
+            break;
+        case FLUX_MSGTYPE_EVENT:
+            if (flux_send (h, msg, 0) < 0)
+                err ("%s: flux_send", __FUNCTION__);
+            break;
+        default:
+            flux_log (h, LOG_ERR, "drop unexpected %s",
+                      flux_msg_typestr (type));
+            break;
+    }
+    flux_msg_destroy (msg);
+    return;
+disconnect:
+    flux_msg_destroy (msg);
+    zlist_remove (ctx->clients, c);
+    client_destroy (c);
+    if (ctx->oneshot)
+        flux_reactor_stop (r);
+}
+
+/* Received response message from broker.
+ * Look up the sender uuid in clients hash and deliver.
+ * Responses for disconnected clients are silently discarded.
+ */
+static void response_cb (flux_t h, flux_msg_handler_t *w,
+                         const flux_msg_t *msg, void *arg)
+{
+    ctx_t *ctx = arg;
+    char *uuid = NULL;
+    client_t *c;
+    flux_msg_t *cpy = flux_msg_copy (msg, true);
+
+    if (!cpy)
+        oom ();
+    if (flux_msg_pop_route (cpy, &uuid) < 0)
+        goto done;
+    if (!uuid) {
+        const char *topic = NULL;
+        (void) flux_msg_get_topic (msg, &topic);
+        flux_log (h, LOG_ERR, "%s: topic %s: missing sender uuid",
+                  __FUNCTION__, topic ? topic : "NULL");
+        goto done;
+    }
+    c = zlist_first (ctx->clients);
+    while (c) {
+        if (!strcmp (uuid, zuuid_str (c->uuid))) {
+            if (client_send_nocopy (c, &cpy) < 0) { /* FIXME handle errors */
+                int type = FLUX_MSGTYPE_ANY;
+                const char *topic = "unknown";
+                (void)flux_msg_get_type (msg, &type);
+                (void)flux_msg_get_topic (msg, &topic);
+                flux_log (h, LOG_ERR, "send %s %s to client %.*s: %s",
+                          topic, flux_msg_typestr (type),
+                          5, zuuid_str (c->uuid),
+                          strerror (errno));
+                errno = 0;
+            }
+            break;
+        }
+        c = zlist_next (ctx->clients);
+    }
+done:
+    if (uuid)
+        free (uuid);
+    flux_msg_destroy (cpy);
+}
+
+/* Received an event message from broker.
+ * Find all subscribers and deliver.
+ */
+static void event_cb (flux_t h, flux_msg_handler_t *w,
+                      const flux_msg_t *msg, void *arg)
+{
+    ctx_t *ctx = arg;
+    client_t *c;
+    const char *topic;
+    int count = 0;
+
+    if (flux_msg_get_topic (msg, &topic) < 0) {
+        flux_log (h, LOG_ERR, "%s: dropped: %s",
+                  __FUNCTION__, strerror (errno));
+        return;
+    }
+    c = zlist_first (ctx->clients);
+    while (c) {
+        if (client_is_subscribed (c, topic)) {
+            if (client_send (c, msg) < 0) { /* FIXME handle errors */
+                int type = FLUX_MSGTYPE_ANY;
+                const char *topic = "unknown";
+                (void)flux_msg_get_type (msg, &type);
+                (void)flux_msg_get_topic (msg, &topic);
+                flux_log (h, LOG_ERR, "send %s %s to client %.*s: %s",
+                          topic, flux_msg_typestr (type),
+                          5, zuuid_str (c->uuid),
+                          strerror (errno));
+                errno = 0;
+            }
+            count++;
+        }
+        c = zlist_next (ctx->clients);
+    }
+    //flux_log (h, LOG_DEBUG, "%s: %s to %d clients", __FUNCTION__, topic, count);
+}
+
+static int check_cred (ctx_t *ctx, int fd)
+{
+    struct ucred ucred;
+    socklen_t crlen = sizeof (ucred);
+    int rc = -1;
+
+    if (getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &ucred, &crlen) < 0) {
+        flux_log_error (ctx->h, "getsockopt SO_PEERCRED");
+        goto done;
+    }
+    assert (crlen == sizeof (ucred));
+    if (ucred.uid != ctx->session_owner) {
+        flux_log (ctx->h, LOG_ERR, "connect by uid=%d pid=%d denied",
+                  ucred.uid, (int)ucred.pid);
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+/* Accept a connection from new client.
+ */
+static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
+                         int revents, void *arg)
+{
+    int fd = flux_fd_watcher_get_fd (w);
+    ctx_t *ctx = arg;
+    flux_t h = ctx->h;
+
+    if (revents & FLUX_POLLIN) {
+        client_t *c;
+        int cfd;
+
+        if ((cfd = accept4 (fd, NULL, NULL, SOCK_CLOEXEC)) < 0) {
+            flux_log (h, LOG_ERR, "accept: %s", strerror (errno));
+            goto done;
+        }
+        if (check_cred (ctx, cfd) < 0) {
+            close (cfd);
+            goto done;
+        }
+        if (!(c = client_create (ctx, cfd, cfd))) {
+            close (cfd);
+            goto done;
+        }
+        if (zlist_append (ctx->clients, c) < 0)
+            oom ();
+    }
+    if (revents & FLUX_POLLERR) {
+        flux_log (h, LOG_ERR, "poll listen fd: %s", strerror (errno));
+    }
+done:
+    return;
+}
+
+static int listener_init (ctx_t *ctx, char *sockpath)
+{
+    struct sockaddr_un addr;
+    int fd;
+
+    fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        flux_log (ctx->h, LOG_ERR, "socket: %s", strerror (errno));
+        goto done;
+    }
+    if (remove (sockpath) < 0 && errno != ENOENT) {
+        flux_log (ctx->h, LOG_ERR, "remove %s: %s", sockpath, strerror (errno));
+        goto error_close;
+    }
+    memset (&addr, 0, sizeof (struct sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    strncpy (addr.sun_path, sockpath, sizeof (addr.sun_path) - 1);
+
+    if (bind (fd, (struct sockaddr *)&addr, sizeof (struct sockaddr_un)) < 0) {
+        flux_log (ctx->h, LOG_ERR, "bind: %s", strerror (errno));
+        goto error_close;
+    }
+    if (listen (fd, LISTEN_BACKLOG) < 0) {
+        flux_log (ctx->h, LOG_ERR, "listen: %s", strerror (errno));
+        goto error_close;
+    }
+done:
+    cleanup_push_string(cleanup_file, sockpath);
+    return fd;
+error_close:
+    close (fd);
+    return -1;
+}
+
+static char *findlocal (const char *globstr)
+{
+    glob_t globbuf;
+    char *uri = NULL;
+
+    if (glob (globstr, GLOB_ONLYDIR, NULL, &globbuf) != 0)
+        goto done;
+    if (globbuf.gl_pathc < 1) {
+        errno = ENOENT;
+        goto done;
+    }
+    if (asprintf (&uri, "local://%s", globbuf.gl_pathv[0]) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+done:
+    return uri;
+}
+
+/* Given a JOB identifier that is not a URI, try to turn it into a URI.
+ * Returns uri on success (caller must free), or NULL on failure errno set.
+ */
+static char *findjob (const char *job)
+{
+    char *tmpdir = getenv ("TMPDIR");
+    char *uri = NULL;
+    char globstr[PATH_MAX + 1];
+
+    if (!tmpdir)
+        tmpdir = "/tmp";
+    /* Try to interpret 'job' as the path from local://
+     * as we might get from ssh://host/path/to/sockdir
+     */
+    if (access (job, F_OK) == 0) {
+        if (asprintf (&uri, "local://%s", job) < 0) {
+            errno = ENOMEM;
+            goto done;
+        }
+        goto done;
+    }
+    /* Try to interpret 'job' as the flux session-id.
+     */
+    snprintf (globstr, sizeof (globstr), "%s/flux-%s-*/0", tmpdir, job);
+    if ((uri = findlocal (globstr)))
+        goto done;
+    /* Try to interpret 'job' as "/session-id",
+     * as we might get from ssh://host/jobid
+     */
+    if (strlen (job) > 1 && job[0] == '/' && isdigit (job[1])) {
+        snprintf (globstr, sizeof (globstr), "%s/flux-%s-*/0", tmpdir, job + 1);
+        if ((uri = findlocal (globstr)))
+            goto done;
+    }
+    /* Not found, return NULL */
+    errno = ENOENT;
+done:
+    return uri;
+}
+
+static int child_cb (struct subprocess *p, void *arg)
+{
+    ctx_t *ctx = arg;
+
+    ctx->exit_code = subprocess_exit_code (p);
+    flux_reactor_stop (ctx->reactor);
+    subprocess_destroy (p);
+    return 0;
+}
+
+static int child_create (ctx_t *ctx, int ac, char **av, const char *workpath)
+{
+    const char *shell = getenv ("SHELL");
+    char *argz = NULL;
+    size_t argz_len = 0;
+    struct subprocess *p = NULL;
+    int i;
+
+    if (!shell)
+        shell = "/bin/sh";
+
+    for (i = 0; i < ac; i++) {
+        if (argz_add (&argz, &argz_len, av[i]) != 0) {
+            errno = ENOMEM;
+            goto error;
+        }
+    }
+    if (argz)
+        argz_stringify (argz, argz_len, ' ');
+
+    if (!(p = subprocess_create (ctx->sm))
+            || subprocess_set_callback (p, child_cb, ctx) < 0
+            || subprocess_argv_append (p, shell) < 0
+            || (argz && subprocess_argv_append (p, "-c") < 0)
+            || (argz && subprocess_argv_append (p, argz) < 0)
+            || subprocess_set_environ (p, environ) < 0
+            || subprocess_setenvf (p, "FLUX_URI", 1,
+                                   "local://%s", workpath) < 0
+            || subprocess_run (p) < 0)
+        goto error;
+
+    if (argz)
+        free (argz);
+    ctx->p = p;
+    return 0;
+error:
+    if (p)
+        subprocess_destroy (p);
+    if (argz)
+        free (argz);
+    return -1;
+}
+
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT,     NULL,          event_cb },
+    { FLUX_MSGTYPE_RESPONSE,  NULL,          response_cb },
+    FLUX_MSGHANDLER_TABLE_END
+};
+
+static struct optparse_option proxy_opts[] = {
+    { .name = "stdio", .key = 's', .has_arg = 0,
+      .usage = "Present proxy interface on stdio", },
+    { .name = "setenv", .key = 'e', .has_arg = 1,
+      .usage = "Set NAME=VALUE in flux-proxy environment", },
+    OPTPARSE_TABLE_END
+};
+
+static int cmd_proxy (optparse_t *p, int ac, char *av[])
+{
+    flux_t h = NULL;
+    int n;
+    ctx_t *ctx;
+    const char *tmpdir = getenv ("TMPDIR");
+    char workpath[PATH_MAX + 1];
+    char sockpath[PATH_MAX + 1];
+    char pidfile[PATH_MAX + 1];
+    const char *job;
+    const char *optarg;
+    int optind;
+
+    log_init ("flux-proxy");
+
+    optind = optparse_optind (p);
+    if (optind == ac)
+        optparse_fatal_usage (p, 1, "JOB argument is required\n");
+    job = av[optind++];
+
+    if (optparse_hasopt (p, "stdio") && optind != ac)
+        optparse_fatal_usage (p, 1, "there can be no COMMAND with --stdio\n");
+
+    while ((optarg = optparse_getopt_next (p, "setenv"))) {
+        char *name = xstrdup (optarg);
+        char *val = strchr (name, '=');
+        if (val)
+            *val++ = '\0';
+        if (!val)
+            optparse_fatal_usage (p, 1, "--setenv optarg format is NAME=VAL");
+        setenv (name, val, 1);
+        free (name);
+    }
+
+    if (strstr (job, "://")) {
+        if (!(h = flux_open (job, 0)))
+            err_exit ("%s", job);
+    } else {
+        char *uri = findjob (job);
+        if (!uri)
+            err_exit ("%s", job);
+        if (!(h = flux_open (uri, 0)))
+            err_exit ("%s", uri);
+         free (uri);
+    }
+
+    flux_log_set_facility (h, "proxy");
+    ctx = ctx_create (h);
+
+    ctx->listen_fd = -1;
+
+    if (optparse_hasopt (p, "stdio")) {
+        client_t *c;
+        if (!(c = client_create (ctx, STDIN_FILENO, STDOUT_FILENO)))
+            err_exit ("error creating stdio client");
+        if (zlist_append (ctx->clients, c) < 0)
+            oom ();
+        ctx->oneshot = true;
+    } else {
+        /* Create socket directory.
+         */
+        n = snprintf (workpath, sizeof (workpath), "%s/flux-proxy-XXXXXX",
+                                 tmpdir ? tmpdir : "/tmp");
+        assert (n < sizeof (workpath));
+        if (!mkdtemp (workpath))
+            err_exit ("error creating proxy socket directory");
+        cleanup_push_string(cleanup_directory, workpath);
+
+        /* Write proxy pid to broker.pid file.
+         * Local connector expects this.
+         */
+        n = snprintf (pidfile, sizeof (pidfile), "%s/broker.pid", workpath);
+        assert (n < sizeof (pidfile));
+        FILE *f = fopen (pidfile, "w");
+        if (!f || fprintf (f, "%d", getpid ()) < 0 || fclose (f) == EOF)
+            err_exit ("%s", pidfile);
+        cleanup_push_string(cleanup_file, pidfile);
+
+        /* Listen on socket
+         */
+        n = snprintf (sockpath, sizeof (sockpath), "%s/local", workpath);
+        assert (n < sizeof (sockpath));
+        if ((ctx->listen_fd = listener_init (ctx, sockpath)) < 0)
+            goto done;
+        if (!(ctx->listen_w = flux_fd_watcher_create (ctx->reactor,
+                                               ctx->listen_fd,
+                                               FLUX_POLLIN | FLUX_POLLERR,
+                                               listener_cb, ctx))) {
+            goto done;
+        }
+        flux_watcher_start (ctx->listen_w);
+
+        /* Create child
+         */
+        if (child_create (ctx, ac - optind, av + optind, workpath) < 0)
+            err_exit ("child_create");
+   }
+
+    /* Create/start event/response message watchers
+     */
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log (h, LOG_ERR, "flux_msg_watcher_addvec: %s", strerror (errno));
+        goto done;
+    }
+
+    /* Start reactor
+     */
+    if (flux_reactor_run (ctx->reactor, 0) < 0) {
+        flux_log (h, LOG_ERR, "flux_reactor_run: %s", strerror (errno));
+        goto done;
+    }
+done:
+    flux_msg_handler_delvec (htab);
+    flux_watcher_destroy (ctx->listen_w);
+    if (ctx->listen_fd >= 0) {
+        if (close (ctx->listen_fd) < 0)
+            flux_log (h, LOG_ERR, "close listen_fd: %s", strerror (errno));
+    }
+    if (ctx->clients) {
+        client_t *c;
+        while ((c = zlist_pop (ctx->clients)))
+            client_destroy (c);
+    }
+    if (ctx->exit_code)
+        exit (ctx->exit_code);
+
+    ctx_destroy (ctx);
+    flux_close (h);
+    return (0);
+}
+
+int subcommand_proxy_register (optparse_t *p)
+{
+    optparse_err_t e;
+
+    e = optparse_reg_subcommand (p, "proxy", cmd_proxy,
+        "[OPTIONS] JOB [COMMAND...]",
+        "Route messages to/from Flux instance",
+        proxy_opts);
+    if (e != OPTPARSE_SUCCESS)
+        return (-1);
+
+    return (0);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -504,7 +504,8 @@ flux_msg_t *flux_recv (flux_t h, struct flux_match match, int flags)
     int saved_errno;
 
     flags |= h->flags;
-    if (!(flags & FLUX_O_NONBLOCK) && flux_sleep_on (h, match) < 0) {
+    if (!(flags & FLUX_O_NONBLOCK) && (flags & FLUX_O_COPROC)
+                                   && flux_sleep_on (h, match) < 0) {
         if (errno != EINVAL)
             goto fatal;
         errno = 0;

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -57,11 +57,10 @@ struct flux_match {
 }
 
 struct flux_msg_iobuf {
-    uint32_t nsize;
-    size_t nsize_done;
-    void *buf;
+    uint8_t *buf;
     size_t size;
     size_t done;
+    uint8_t buf_fixed[4096];
 };
 
 /* Create a new Flux message.
@@ -75,11 +74,11 @@ void flux_msg_destroy (flux_msg_t *msg);
  */
 flux_msg_t *flux_msg_copy (const flux_msg_t *msg, bool payload);
 
-/* Encode a flux_msg_t to buffer.
+/* Encode a flux_msg_t to buffer (pre-sized by calling flux_msg_encode_size()).
  * Returns 0 on success, -1 on failure with errno set.
- * Caller must free buf.
  */
-int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t *size);
+size_t flux_msg_encode_size (const flux_msg_t *msg);
+int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t size);
 
 /* Decode a flux_msg_t from buffer.
  * Returns message on success, NULL on failure with errno set.

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -101,9 +101,14 @@ flux_reactor_t *flux_reactor_create (int flags)
     return r;
 }
 
-void flux_set_reactor (flux_t h, flux_reactor_t *r)
+int flux_set_reactor (flux_t h, flux_reactor_t *r)
 {
+    if (flux_aux_get (h, "flux::reactor")) {
+        errno = EEXIST;
+        return -1;
+    }
     flux_aux_set (h, "flux::reactor", r, NULL);
+    return 0;
 }
 
 flux_reactor_t *flux_get_reactor (flux_t h)

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -32,7 +32,7 @@ flux_reactor_t *flux_reactor_create (int flags);
 void flux_reactor_destroy (flux_reactor_t *r);
 
 flux_reactor_t *flux_get_reactor (flux_t h);
-void flux_set_reactor (flux_t h, flux_reactor_t *r);
+int flux_set_reactor (flux_t h, flux_reactor_t *r);
 
 int flux_reactor_run (flux_reactor_t *r, int flags);
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -394,10 +394,16 @@ void check_encode (void)
         "flux_msg_create works");
     ok (flux_msg_set_topic (msg, "foo.bar") == 0,
         "flux_msg_set_topic works");
-    ok (flux_msg_encode (msg, &buf, &size) == 0 && buf != NULL && size > 0,
+    size = flux_msg_encode_size (msg);
+    ok (size > 0,
+        "flux_msg_encode_size works");
+    buf = malloc (size);
+    assert (buf != NULL);
+    ok (flux_msg_encode (msg, buf, size) == 0,
         "flux_msg_encode works");
     ok ((msg2 = flux_msg_decode (buf, size)) != NULL,
         "flux_msg_decode works");
+    free (buf);
     ok (flux_msg_get_type (msg2, &type) == 0 && type == FLUX_MSGTYPE_REQUEST,
         "decoded expected message type");
     ok (flux_msg_get_topic (msg2, &topic) == 0 && !strcmp (topic, "foo.bar"),

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -73,7 +73,8 @@ TESTS = test_nodeset.t \
 	test_base64.t \
 	test_encode.t \
 	test_msglist.t \
-	test_sha1.t
+	test_sha1.t \
+	test_popen2.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -124,3 +125,7 @@ test_msglist_t_LDADD = $(test_ldadd)
 test_sha1_t_SOURCES = test/sha1.c
 test_sha1_t_CPPFLAGS = $(test_cppflags)
 test_sha1_t_LDADD = $(test_ldadd)
+
+test_popen2_t_SOURCES = test/popen2.c
+test_popen2_t_CPPFLAGS = $(test_cppflags)
+test_popen2_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -60,7 +60,9 @@ libutil_la_SOURCES = \
 	shastring.h \
 	shastring.c \
 	fdwalk.h \
-	fdwalk.c
+	fdwalk.c \
+	popen2.h \
+	popen2.c
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -1,0 +1,214 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#include "popen2.h"
+#include "fdwalk.h"
+
+#define PXOPEN_CHILD_MAGIC 0xc00ceeee
+
+struct popen2_child {
+    int magic;
+    int fd[2];
+    int ctl[2];
+    pid_t pid;
+};
+
+enum {
+    SP_PARENT = 0,
+    SP_CHILD = 1,
+};
+
+int popen2_get_fd (struct popen2_child *p)
+{
+    if (!p || p->magic != PXOPEN_CHILD_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+    return p->fd[SP_PARENT];
+}
+
+static void popen2_child_close_fd (void *arg, int fd)
+{
+    struct popen2_child *p = arg;
+    if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO
+                                                  && fd != p->ctl[SP_CHILD])
+        (void)close (fd);
+}
+
+static void child (struct popen2_child *p, const char *path, char *const argv[])
+{
+    int saved_errno;
+
+    (void)close (STDIN_FILENO);
+    (void)close (STDOUT_FILENO);
+    if (    dup2 (p->fd[SP_CHILD], STDIN_FILENO) < 0
+         || dup2 (p->fd[SP_CHILD], STDOUT_FILENO) < 0) {
+        saved_errno = errno;
+        goto error;
+    }
+    (void)close (p->fd[SP_CHILD]);
+
+    if (fdwalk (popen2_child_close_fd, p)) {
+        saved_errno = errno;
+        goto error;
+    }
+    execvp (path, argv);
+    saved_errno = errno;
+error:
+    if (write (p->ctl[SP_CHILD], &saved_errno, sizeof (saved_errno)) < 0)
+        fprintf (stderr, "child: write to ctl failed: %m\n");
+    (void) close (p->ctl[SP_CHILD]);
+    exit (0);
+}
+
+struct popen2_child *popen2 (const char *path, char *const argv[])
+{
+    struct popen2_child *p = NULL;
+    int n, saved_errno, flags;
+
+    if (!(p = malloc (sizeof (*p)))) {
+        saved_errno = ENOMEM;
+        goto error;
+    }
+    memset (p, 0, sizeof (*p));
+    p->magic = PXOPEN_CHILD_MAGIC;
+    p->fd[SP_CHILD] = -1;
+    p->fd[SP_PARENT] = -1;
+    p->ctl[SP_CHILD] = -1;
+    p->ctl[SP_PARENT] = -1;
+    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, p->fd) < 0) {
+        saved_errno = errno;
+        goto error;
+    }
+    if ((flags = fcntl (p->fd[SP_PARENT], F_GETFL)) < 0
+              || fcntl (p->fd[SP_PARENT], F_SETFL, flags | O_CLOEXEC) < 0) {
+        saved_errno = errno;
+        goto error;
+    }
+    if (pipe2 (p->ctl, O_CLOEXEC) < 0) {
+        saved_errno = errno;
+        goto error;
+    }
+    signal(SIGPIPE, SIG_IGN);
+    switch ((p->pid = fork ())) {
+        case -1:    /* fork error */
+            saved_errno = errno;
+            goto error;
+        case 0:     /* child */
+            child (p, path, argv);
+            /*NOTREACHED*/
+        default:    /* parent */
+            break;
+    }
+    (void)close (p->fd[SP_CHILD]);
+    (void)close (p->ctl[SP_CHILD]);
+    p->fd[SP_CHILD] = -1;
+    p->ctl[SP_CHILD] = -1;
+
+    /* Handshake on ctl pipe to make sure exec worked.
+     * If exec successful, child end will be closed with no data.
+     * If exec failed, errno will be returned on pipe.
+     */
+    n = read (p->ctl[SP_PARENT], &saved_errno, sizeof (saved_errno));
+    if (n == sizeof (saved_errno))
+        goto error;
+    if (n < 0) {
+        saved_errno = errno;
+        goto error;
+    }
+    if (n != 0) {
+        saved_errno = EPROTO;
+        goto error;
+    }
+    (void)close (p->ctl[SP_PARENT]);
+    p->ctl[SP_PARENT] = -1;
+
+    return p;
+error:
+    pclose2 (p);
+    errno = saved_errno;
+    return NULL;
+}
+
+int pclose2 (struct popen2_child *p)
+{
+    int status, saved_errno = 0;
+    int rc = 0;
+
+    if (p) {
+        if (p->magic != PXOPEN_CHILD_MAGIC) {
+            saved_errno = EINVAL;
+            rc = -1;
+            goto done;
+        }
+        if (p->fd[SP_PARENT] && shutdown (p->fd[SP_PARENT], SHUT_WR) < 0) {
+            saved_errno = errno;
+            rc = -1;
+        }
+        if (p->pid != 0) {
+            if (waitpid (p->pid, &status, 0) < 0) {
+                saved_errno = errno;
+                rc = -1;
+            } else {
+                if (!WIFEXITED (status) || WEXITSTATUS (status) != 0) {
+                    saved_errno = EIO;
+                    rc = -1;
+                }
+            }
+        }
+        if ((p->fd[SP_PARENT] >= 0 && close (p->fd[SP_PARENT]) < 0)
+         || (p->fd[SP_CHILD] >= 0 && close (p->fd[SP_CHILD]) < 0)
+         || (p->ctl[SP_PARENT] >= 0 && close (p->ctl[SP_PARENT]) < 0)
+         || (p->ctl[SP_CHILD] >= 0 && close (p->ctl[SP_CHILD]) < 0)) {
+            saved_errno = errno;
+            rc = -1;
+        }
+        p->magic = ~PXOPEN_CHILD_MAGIC;
+        free (p);
+    }
+done:
+    if (rc == -1)
+        errno = saved_errno;
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/popen2.h
+++ b/src/common/libutil/popen2.h
@@ -1,0 +1,12 @@
+#ifndef _UTIL_POPEN2_H
+#define _UTIL_POPEN2_H
+
+struct popen2_child;
+
+struct popen2_child *popen2 (const char *path, char *const argv[]);
+
+int popen2_get_fd (struct popen2_child *p);
+
+int pclose2 (struct popen2_child *p);
+
+#endif /* !_UTIL_POPEN2_H */

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -1,0 +1,75 @@
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/popen2.h"
+#include "src/common/libutil/readall.h"
+
+int main(int argc, char** argv)
+{
+    struct popen2_child *p;
+    char *av[] = { "cat", NULL };
+    uint8_t outbuf[] = "hello\n";
+    uint8_t inbuf[sizeof (outbuf)];
+    int fd;
+
+    plan (NO_PLAN);
+
+    /* open/close */
+    ok ((p = popen2 ("cat", av)) != NULL,
+        "popen2 cat worked");
+    ok (pclose2 (p) == 0,
+        "immediate pclose2 OK");
+
+    /* open/write/close */
+    ok ((p = popen2 ("cat", av)) != NULL,
+        "popen2 cat worked");
+    fd = popen2_get_fd (p);
+    ok (fd >= 0,
+        "popen2_get_fd returned %d", fd);
+    ok (write_all (fd, outbuf, sizeof (outbuf)) == sizeof (outbuf),
+        "write to fd worked");
+    ok (pclose2 (p) == 0,
+        "pclose2 with read data pending OK");
+
+    /* open/write/read/close */
+    ok ((p = popen2 ("cat", av)) != NULL,
+        "popen2 cat worked");
+    fd = popen2_get_fd (p);
+    ok (fd >= 0,
+        "popen2_get_fd returned %d", fd);
+    ok (write_all (fd, outbuf, sizeof (outbuf)) == sizeof (outbuf),
+        "write to fd worked");
+    ok (read (fd, inbuf, sizeof (inbuf)) == sizeof (outbuf)
+        && !memcmp (inbuf, outbuf, sizeof (outbuf)),
+        "read back what we wrote");
+    ok (pclose2 (p) == 0,
+        "pclose2 OK");
+
+    /* open failure */
+    errno = 0;
+    p = popen2 ("/noexist", av);
+    ok (p == NULL && errno == ENOENT,
+        "popen2 /noexist failed with ENOENT");
+
+    /* open/write/close (stdin ignored by child) */
+    ok ((p = popen2 ("/bin/true", av)) != NULL,
+        "popen2 /bin/true OK");
+    ok (write_all (fd, outbuf, sizeof (outbuf)) == sizeof (outbuf),
+        "write to fd worked");
+    ok (pclose2 (p) == 0,
+        "pclose2 OK");
+
+    /* open/close (child exit error) */
+    ok ((p = popen2 ("/bin/false", av)) != NULL,
+        "popen2 /bin/false OK");
+    errno = 0;
+    ok (pclose2 (p) < 0 && errno == EIO,
+        "pclose2 failed with EIO");
+
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = local shmem loop
+SUBDIRS = local shmem loop ssh

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -1,0 +1,22 @@
+AM_CFLAGS = \
+	@GCCWARN@ \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
+
+fluxconnector_LTLIBRARIES = ssh.la
+
+ssh_la_SOURCES = ssh.c
+
+ssh_la_LDFLAGS = -module -Wl,--no-undefined \
+	-export-symbols-regex '^connector_init$$' \
+	--disable-static -avoid-version -shared -export-dynamic \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+ssh_la_LIBADD = $(JSON_LIBS) $(ZMQ_LIBS)

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -1,0 +1,436 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+#include <signal.h>
+#include <poll.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <argz.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/popen2.h"
+
+static const char *default_ssh_cmd = "/usr/bin/rsh";
+
+#define CTX_MAGIC   0xe534babb
+typedef struct {
+    int magic;
+    int fd;
+    int fd_nonblock;
+    struct flux_msg_iobuf outbuf;
+    struct flux_msg_iobuf inbuf;
+    const char *ssh_cmd;
+    char *ssh_argz;
+    size_t ssh_argz_len;
+    char **ssh_argv;
+    int ssh_argc;
+    struct popen2_child *p;
+    flux_t h;
+} ctx_t;
+
+static const struct flux_handle_ops handle_ops;
+
+static int set_nonblock (ctx_t *c, int nonblock)
+{
+    int flags;
+    if (c->fd_nonblock != nonblock) {
+        if ((flags = fcntl (c->fd, F_GETFL)) < 0)
+            return -1;
+        if (fcntl (c->fd, F_SETFL, nonblock ? flags | O_NONBLOCK
+                                            : flags & ~O_NONBLOCK) < 0)
+            return -1;
+        c->fd_nonblock = nonblock;
+    }
+    return 0;
+}
+
+static int op_pollevents (void *impl)
+{
+    ctx_t *c = impl;
+    struct pollfd pfd = {
+        .fd = c->fd,
+        .events = POLLIN | POLLOUT | POLLERR | POLLHUP,
+        .revents = 0,
+    };
+    int revents = 0;
+    switch (poll (&pfd, 1, 0)) {
+        case 1:
+            if (pfd.revents & POLLIN)
+                revents |= FLUX_POLLIN;
+            if (pfd.revents & POLLOUT)
+                revents |= FLUX_POLLOUT;
+            if ((pfd.revents & POLLERR) || (pfd.revents & POLLHUP))
+                revents |= FLUX_POLLERR;
+            break;
+        case 0:
+            break;
+        default: /* -1 */
+            revents |= FLUX_POLLERR;
+            break;
+    }
+    return revents;
+}
+
+static int op_pollfd (void *impl)
+{
+    ctx_t *c = impl;
+    return c->fd;
+}
+
+static int op_send (void *impl, const flux_msg_t *msg, int flags)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    if (set_nonblock (c, (flags & FLUX_O_NONBLOCK)) < 0)
+        return -1;
+    if (flux_msg_sendfd (c->fd, msg, &c->outbuf) < 0)
+        return -1;
+    return 0;
+}
+
+static flux_msg_t *op_recv (void *impl, int flags)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    if (set_nonblock (c, (flags & FLUX_O_NONBLOCK)) < 0)
+        return NULL;
+    return flux_msg_recvfd (c->fd, &c->inbuf);
+}
+
+static int op_event_subscribe (void *impl, const char *topic)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    flux_rpc_t *rpc = NULL;
+    JSON in = Jnew ();
+    int rc = 0;
+
+    Jadd_str (in, "topic", topic);
+    if (!(rpc = flux_rpc (c->h, "local.sub", Jtostr (in), FLUX_NODEID_ANY, 0))
+                || flux_rpc_get (rpc, NULL, NULL) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_rpc_destroy (rpc);
+    Jput (in);
+    return rc;
+}
+
+static int op_event_unsubscribe (void *impl, const char *topic)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    flux_rpc_t *rpc = NULL;
+    JSON in = Jnew ();
+    int rc = 0;
+
+    Jadd_str (in, "topic", topic);
+    if (!(rpc = flux_rpc (c->h, "local.unsub", Jtostr (in), FLUX_NODEID_ANY, 0))
+                || flux_rpc_get (rpc, NULL, NULL) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_rpc_destroy (rpc);
+    Jput (in);
+    return rc;
+}
+
+static void op_fini (void *impl)
+{
+    ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+
+    flux_msg_iobuf_clean (&c->outbuf);
+    flux_msg_iobuf_clean (&c->inbuf);
+    if (c->fd >= 0)
+        (void)close (c->fd);
+    if (c->ssh_argz)
+        free (c->ssh_argz);
+    if (c->ssh_argv)
+        free (c->ssh_argv);
+    if (c->p)
+        pclose2 (c->p);
+    c->magic = ~CTX_MAGIC;
+    free (c);
+}
+
+static int parse_ssh_port (ctx_t *c, const char *path)
+{
+    char *p, *cpy = NULL;
+    int rc = -1;
+
+    if ((p = strchr (path, ':'))) {
+        if (!(cpy = strdup (p + 1))) {
+            errno = ENOMEM;
+            goto done;
+        }
+        if ((p = strchr (cpy, '/')) || (p = strchr (cpy, '?')))
+            *p = '\0';
+        if (argz_add (&c->ssh_argz, &c->ssh_argz_len, "-p") != 0
+         || argz_add (&c->ssh_argz, &c->ssh_argz_len, cpy) != 0) {
+            errno = ENOMEM;
+            goto done;
+        }
+    }
+    rc = 0;
+done:
+    if (cpy)
+        free (cpy);
+    return rc;
+}
+
+static int parse_ssh_user_at_host (ctx_t *c, const char *path)
+{
+    char *p, *cpy = NULL;
+    int rc = -1;
+
+    if (!(cpy = strdup (path))) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if ((p = strchr (cpy, ':')) || (p = strchr (cpy, '/'))
+                                || (p = strchr (cpy, '?')))
+        *p = '\0';
+    if (argz_add (&c->ssh_argz, &c->ssh_argz_len, cpy) != 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    rc = 0;
+done:
+    if (cpy)
+        free (cpy);
+    return rc;
+}
+
+static int parse_extra_args (char **argz, size_t *argz_len, const char *s)
+{
+    char *cpy = NULL;
+    char *tok, *a1, *saveptr = NULL;
+
+    if (!(cpy = strdup (s)))
+        goto nomem;
+    a1 = cpy;
+    while ((tok = strtok_r (a1, "?&", &saveptr))) {
+        char *arg;
+        error_t e;
+        if (asprintf (&arg, "--%s", tok) < 0)
+            goto nomem;
+        e = argz_add (argz, argz_len, arg);
+        free (arg);
+        if (e != 0)
+            goto nomem;
+        a1 = NULL;
+    }
+    free (cpy);
+    return 0;
+nomem:
+    if (cpy)
+        free (cpy);
+    errno = ENOMEM;
+    return -1;
+}
+
+static char *which (const char *prog, char *buf, size_t size)
+{
+    char *path = getenv ("PATH");
+    char *cpy = path ? strdup (path) : NULL;
+    char *dir, *saveptr = NULL, *a1 = cpy;
+    struct stat sb;
+    char *result = NULL;
+
+    if (cpy) {
+        while ((dir = strtok_r (a1, ":", &saveptr))) {
+            snprintf (buf, size, "%s/%s", dir, prog);
+            if (stat (buf, &sb) == 0 && S_ISREG (sb.st_mode)
+                                     && access (buf, X_OK) == 0) {
+                result = buf;
+                break;
+            }
+            a1 = NULL;
+        }
+    }
+    if (cpy)
+        free (cpy);
+    return result;
+}
+
+static int parse_ssh_rcmd (ctx_t *c, const char *path)
+{
+    char *cpy = NULL, *local = NULL, *extra = NULL;
+    char *proxy_argz = NULL;
+    size_t proxy_argz_len = 0;
+    const char *flux_cmd = getenv ("FLUX_SSH_RCMD");
+    char pathbuf[PATH_MAX + 1];
+    int rc = -1;
+
+    if (flux_cmd && !*flux_cmd) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!flux_cmd)
+        flux_cmd = which ("flux", pathbuf, sizeof (pathbuf));
+    if (!flux_cmd)
+        flux_cmd = "flux";
+    if (argz_add (&proxy_argz, &proxy_argz_len, flux_cmd) != 0
+     || argz_add (&proxy_argz, &proxy_argz_len, "proxy") != 0
+     || argz_add (&proxy_argz, &proxy_argz_len, "--stdio") != 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (!(cpy = strdup (path))) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (!(local = strchr (cpy, '/'))) {
+        errno = EINVAL;
+        goto done;
+    }
+    if ((extra = strchr (local, '?')))
+        *extra++ = '\0';
+    if (extra) {
+        if (parse_extra_args (&proxy_argz, &proxy_argz_len, extra) < 0)
+            goto done;
+    }
+    if (argz_add (&proxy_argz, &proxy_argz_len, local) != 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    argz_stringify (proxy_argz, proxy_argz_len, ' ');
+    if (argz_add (&c->ssh_argz, &c->ssh_argz_len, proxy_argz) != 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    rc = 0;
+done:
+    if (cpy)
+        free (cpy);
+    if (proxy_argz)
+        free (proxy_argz);
+    return rc;
+}
+
+static int test_broker_connection (ctx_t *c)
+{
+    flux_msg_t *in = NULL;
+    flux_msg_t *out = NULL;
+    struct flux_match match = FLUX_MATCH_RESPONSE;
+    const char *json_str;
+    int rc = -1;
+
+    if (!(in = flux_request_encode ("cmb.ping", "{}")))
+        goto done;
+    if (flux_send (c->h, in, 0) < 0)
+        goto done;
+    match.topic_glob = "cmb.ping";
+    if (!(out = flux_recv (c->h, match, 0)))
+        goto done;
+    if (flux_response_decode (out, NULL, &json_str) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_msg_destroy (in);
+    flux_msg_destroy (out);
+    return rc;
+}
+
+/* Path is interpreted as
+ *   [user@]hostname[:port][/unix-path][?key=val[&key=val]...]
+ */
+flux_t connector_init (const char *path, int flags)
+{
+    ctx_t *c = NULL;
+
+    if (!(c = malloc (sizeof (*c)))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    memset (c, 0, sizeof (*c));
+    c->magic = CTX_MAGIC;
+
+    if (!(c->ssh_cmd = getenv ("FLUX_SSH")))
+        c->ssh_cmd = default_ssh_cmd;
+    if (argz_add (&c->ssh_argz, &c->ssh_argz_len, c->ssh_cmd) != 0)
+        goto error;
+    if (parse_ssh_port (c, path) < 0) /* [-p port] */
+        goto error;
+    if (parse_ssh_user_at_host (c, path) < 0) /* [user@]host */
+        goto error;
+    if (parse_ssh_rcmd (c, path) < 0) /* flux-proxy --stdio JOB [args...] */
+        goto error;
+    c->ssh_argc = argz_count (c->ssh_argz, c->ssh_argz_len) + 1;
+    if (!(c->ssh_argv = malloc (sizeof (char *) * c->ssh_argc))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    argz_extract (c->ssh_argz, c->ssh_argz_len, c->ssh_argv);
+    if (!(c->p = popen2 (c->ssh_cmd, c->ssh_argv)))
+        goto error;
+    c->fd = popen2_get_fd (c->p);
+    c->fd_nonblock = -1;
+    flux_msg_iobuf_init (&c->outbuf);
+    flux_msg_iobuf_init (&c->inbuf);
+    if (!(c->h = flux_handle_create (c, &handle_ops, flags)))
+        goto error;
+    if (test_broker_connection (c) < 0)
+        goto error;
+    return c->h;
+error:
+    if (c) {
+        int saved_errno = errno;
+        if (c->h)
+            flux_handle_destroy (&c->h); /* calls op_fini */
+        else
+            op_fini (c);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+static const struct flux_handle_ops handle_ops = {
+    .pollfd = op_pollfd,
+    .pollevents = op_pollevents,
+    .send = op_send,
+    .recv = op_recv,
+    .event_subscribe = op_event_subscribe,
+    .event_unsubscribe = op_event_unsubscribe,
+    .impl_destroy = op_fini,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -81,7 +81,6 @@ typedef struct {
     zhash_t *disconnect_notify;
     zhash_t *subscriptions;
     zuuid_t *uuid;
-    int cfd_id;
     struct ucred ucred;
 } client_t;
 
@@ -604,8 +603,6 @@ static void response_cb (flux_t h, flux_msg_handler_t *w,
                   __FUNCTION__, topic ? topic : "NULL");
         goto done;
     }
-    if (flux_msg_clear_route (cpy) < 0)
-        goto done;
     c = zlist_first (ctx->clients);
     while (c) {
         if (!strcmp (uuid, zuuid_str (c->uuid))) {

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -266,7 +266,8 @@ static int global_subscribe (ctx_t *ctx, const char *topic)
         sub->handle = ctx->h;
         zhash_update (ctx->subscriptions, topic, sub);
         zhash_freefn (ctx->subscriptions, topic, subscription_destroy);
-        //flux_log (ctx->h, LOG_DEBUG, "%s: %s", __FUNCTION__, topic);
+        /* N.B. t/t1008-proxy.t looks for this log message */
+        flux_log (ctx->h, LOG_DEBUG, "subscribe %s", topic);
     }
     sub->usecount++;
     rc = 0;
@@ -283,7 +284,8 @@ static int global_unsubscribe (ctx_t *ctx, const char *topic)
         goto done;
     if (--sub->usecount == 0) {
         zhash_delete (ctx->subscriptions, topic);
-        //flux_log (ctx->h, LOG_DEBUG, "%s: %s", __FUNCTION__, topic);
+        /* N.B. t/t1008-proxy.t looks for this log message */
+        flux_log (ctx->h, LOG_DEBUG, "unsubscribe %s", topic);
     }
     rc = 0;
 done:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -51,6 +51,7 @@ TESTS = \
 	t1005-cmddriver.t \
 	t1006-apidisconnect.t \
 	t1007-kz.t \
+	t1008-proxy.t \
 	t2000-wreck.t \
 	t2001-jsc.t \
 	t2002-pmi.t \
@@ -112,6 +113,7 @@ check_SCRIPTS = \
 	t1005-cmddriver.t \
 	t1006-apidisconnect.t \
 	t1007-kz.t \
+	t1008-proxy.t \
 	t2000-wreck.t \
 	t2001-jsc.t \
 	t2002-pmi.t \
@@ -181,7 +183,8 @@ dist_check_SCRIPTS = \
 	scripts/kvs-watch-until.lua \
 	scripts/cpus-allowed.lua \
 	scripts/waitfile.lua \
-	scripts/t0004-event-helper.sh
+	scripts/t0004-event-helper.sh \
+	scripts/tssh
 
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \

--- a/t/scripts/tssh
+++ b/t/scripts/tssh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Simulated ssh command that ignores all options except the command
+# and runs it locally
+
+usage() {
+    echo "Usage: tssh [-p port] [user@]hostname command..." >&2
+    exit 1
+}
+
+#echo tssh: $* >&2
+
+while getopts "p:v" opt; do
+    case ${opt} in
+        p) port=${OPTARG} ;;
+        *) usage ;;
+    esac
+done
+shift $((${OPTIND} - 1))
+[ $# -gt 1 ] || usage
+hostname=$1
+shift
+
+unset FLUX_URI
+eval $*

--- a/t/t1008-proxy.t
+++ b/t/t1008-proxy.t
@@ -1,0 +1,158 @@
+#!/bin/sh
+#
+
+test_description='Test ssh:// connector and flux-proxy'
+
+. `dirname $0`/sharness.sh
+SIZE=4
+test_under_flux ${SIZE}
+
+export TEST_URI=$FLUX_URI
+export TEST_JOBID=$(flux getattr session-id)
+export TEST_SOCKDIR=$(echo $FLUX_URI | sed -e "s!local://!!") &&
+export TEST_FLUX=${FLUX_BUILD_DIR}/src/cmd/flux
+export TEST_TMPDIR=${TMPDIR:-/tmp}
+unset FLUX_URI
+
+export TEST_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
+
+test_expect_success 'flux-proxy creates new socket' '
+	PROXY_URI=$(flux proxy $TEST_URI printenv FLUX_URI) &&
+	test "$PROXY_URI" != "$TEST_URI"
+'
+
+test_expect_success 'flux-proxy cleans up socket' '
+	PROXY_URI=$(flux proxy $TEST_URI printenv FLUX_URI) &&
+	path=$(echo $PROXY_URI | sed -e "s!local://!!") &&
+	! test -d $path
+'
+
+test_expect_success 'flux-proxy exits with command return code' '
+	flux proxy $TEST_URI /bin/true &&
+	! flux proxy $TEST_URI /bin/false
+'
+
+test_expect_success 'flux-proxy forwards getattr request' '
+	ATTR_SIZE=$(flux proxy $TEST_URI flux getattr size) &&
+	test "$ATTR_SIZE" = "$SIZE"
+'
+
+test_expect_success 'flux-proxy JOB works with session-id' '
+	flux proxy $TEST_JOBID /bin/true
+'
+
+test_expect_success 'flux-proxy manages event redistribution' '
+	flux proxy $TEST_JOBID \
+	  "flux event sub -c1 hb& flux event sub -c1 hb& wait;wait" &&
+	FLUX_URI=$TEST_URI flux dmesg | sed -e "s/[^ ]* //" >event.out &&
+	test $(grep "connector-local.debug\[0\]: subscribe hb" event.out|wc -l) -eq 1 &&
+	test $(grep "proxy.debug\[0\]: subscribe hb" event.out|wc -l) -eq 1 &&
+	test $(grep "connector-local.debug\[0\]: unsubscribe hb" event.out|wc -l) -eq 1 &&
+	test $(grep "proxy.debug\[0\]: unsubscribe hb" event.out|wc -l) -eq 1
+'
+
+test_expect_success 'flux-proxy --setenv option works' '
+	TVAL=$(flux proxy --setenv TVAR=xxx $TEST_URI printenv TVAR) &&
+	test "$TVAL" = "xxx"
+'
+
+test_expect_success 'ssh:// with local sockdir works' '
+	FLUX_URI=ssh://localhost${TEST_SOCKDIR} FLUX_SSH=$TEST_SSH \
+	  flux getattr size
+'
+
+test_expect_success 'ssh:// with local sockdir and port works' '
+	FLUX_URI=ssh://localhost:42${TEST_SOCKDIR} FLUX_SSH=$TEST_SSH \
+	  flux getattr size
+'
+
+test_expect_success 'ssh:// with local sockdir and user works' '
+	FLUX_URI=ssh://fred@localhost${TEST_SOCKDIR} FLUX_SSH=$TEST_SSH \
+	  flux getattr size
+'
+
+test_expect_success 'ssh:// with local sockdir, user, and port works' '
+	FLUX_URI=ssh://fred@localhost:42${TEST_SOCKDIR} FLUX_SSH=$TEST_SSH \
+	  flux getattr size
+'
+
+test_expect_success 'ssh:// with jobid works' '
+	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=$TEST_SSH \
+	  flux getattr size
+'
+
+test_expect_success 'ssh:// can handle nontrivial message load' '
+	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=$TEST_SSH \
+	  flux kvs dir -r >dir.out
+'
+
+test_expect_success 'ssh:// with bad query option fails in flux_open()' '
+	FLUX_URI=ssh://localhost/$TEST_JOBID?badarg=bar FLUX_SSH=$TEST_SSH \
+	  flux getattr size 2>badarg.out; test $? -ne 0 &&
+	grep -q "flux_open:" badarg.out
+'
+
+test_expect_success 'ssh:// with bad FLUX_SSH value fails in flux_open()' '
+	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=/noexist \
+	  flux getattr size 2>noexist.out; test $? -ne 0 &&
+	grep -q "flux_open:" noexist.out
+'
+
+test_expect_success 'ssh:// with bad FLUX_SSH_RCMD value fails in flux_open()' '
+	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=$TEST_SSH \
+	  FLUX_SSH_RCMD=/nocmd flux getattr size 2>nocmd.out; test $? -ne 0 &&
+	grep -q "flux_open:" nocmd.out
+'
+
+test_expect_success 'ssh:// with missing path component fails in flux_open()' '
+	FLUX_URI=ssh://localhost FLUX_SSH=$TEST_SSH \
+	  flux getattr size 2>nopath.out; test $? -ne 0 &&
+	grep -q "flux_open:" nopath.out
+'
+
+test_expect_success 'flux proxy works with ssh:// and jobid' '
+	FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy ssh://localhost/$TEST_JOBID flux getattr size
+'
+
+test_expect_success 'flux proxy works with ssh:// and local sockdir' '
+	FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy ssh://localhost/${TEST_SOCKDIR} flux getattr size
+'
+
+test_expect_success 'flux proxy with ssh:// and bad jobid fails' '
+	! FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy ssh://localhost/0 flux getattr size
+'
+
+test_expect_success 'flux proxy with ssh:// and bad query option fails' '
+	! FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy "ssh://localhost/${TEST_JOBID}?badarg=bar" \
+	    flux getattr size
+'
+
+test_expect_success 'flux proxy with ssh:// and TMPDIR query option works' '
+        XURI="ssh://localhost/${TEST_JOBID}?setenv=TMPDIR=$TEST_TMPDIR" &&
+	FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy $XURI flux getattr size
+'
+
+test_expect_success 'flux proxy with ssh:// and wrong TMPDIR query option fails' '
+	! FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy "ssh://localhost/${TEST_JOBID}?setenv=TMPDIR=/nope" \
+	    flux getattr size
+'
+
+test_expect_success 'flux proxy with ssh:// and two env query option works' '
+        XURI="ssh://localhost/${TEST_JOBID}?setenv=TMPDIR=$TEST_TMPDIR&setenv=FOO=xyz" &&
+	FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy $XURI flux getattr size
+'
+
+test_expect_success 'flux proxy with ssh:// and second bad query option fails' '
+        XURI="ssh://localhost/${TEST_JOBID}?setenv=TMPDIR=$TEST_TMPDIR&badarg=bar" &&
+	! FLUX_SSH=$TEST_SSH FLUX_SSH_RCMD=$TEST_FLUX \
+	  flux proxy $XURI flux getattr size
+'
+
+test_done


### PR DESCRIPTION
As discussed in #644, this PR implements a new ssh:// connector.

Unfinished but wanted to get it up here for any prelim. review.

I had to create a new `popen()` like function called `pxopen()` that uses a socketpair to establish bidirectional communication with a subprocess, which will usually be /usr/bin./ssh or maybe /usr/bin/rsh on our clusters.  It seems a bit odd to have `flux_open()` behind the scenes do a fork/exec - hopefully that is not going to cause problems.

The remote command is currently `flux proxy` as proposed in #645 although maybe the first pass on this should just use netcat.