### PR TITLE
Add hwloc API version check

### DIFF
--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -51,7 +51,15 @@ static int ctx_hwloc_init (flux_t h, ctx_t *ctx)
     int ret = -1;
     char *key, *path = NULL;
     hwloc_bitmap_t restrictset = NULL;
+    uint32_t hwloc_version;
 
+    hwloc_version = hwloc_get_api_version ();
+    if ((hwloc_version >> 16) != (HWLOC_API_VERSION >> 16)) {
+        flux_log (h, LOG_ERR, "%s: compiled for hwloc API 0x%x but running on "
+                        "library API 0x%x", __FUNCTION__, HWLOC_API_VERSION,
+                        hwloc_version);
+        goto done;
+    }
     if (ctx->topology) {
         hwloc_topology_destroy (ctx->topology);
         ctx->topology = NULL;


### PR DESCRIPTION
Compare at runtime the version of the hwloc library API against the
API hwloc version linked at compile time.  ctx_hwloc_init() fails if
the major release numbers do not match.

This replicates functionality added to flux-sched as part of [PR 152](https://github.com/flux-framework/flux-sched/pull/152)