### PR TITLE
better user interface for launching flux under flux/slurm

### DIFF
--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -16,31 +16,55 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-flux-start(1) launches a Flux instance by starting
-Flux message brokers local, as children of flux-start(1).
-The brokers use UNIX domain sockets to communicate.
+flux-start(1) launches a new Flux instance.  If a size other than
+one is specified on the command line, it is assumed that an
+instance of that size is to be started on the local host
+with flux-start as the parent.
+
+If size is one (the default), flux-start execs a single flux-broker(1)
+directly.  If a PMI environment is available, flux-broker will
+use it to fetch job information and bootstrap a session of geometry
+determined from PMI.  If PMI is unavailable, flux-broker will run
+as a standalone, single-rank job.
+
+A failure of the initial program (such as non-zero exit code)
+causes flux-start to exit with a non-zero exit code.
 
 Note: in order to launch a Flux instance, you must have generated
-long-term CURVE keys using *flux-keygen*.
+long-term CURVE keys using flux-keygen(1).
 
 OPTIONS
 -------
 *-s, --size*='N'::
-Set the size of the comms session (number of message brokers).
+Set the size of the instance (number of message broker ranks).
 The default is 1.
 
 *-o, --broker-opts*='option_string'::
 Add options to the message broker daemon, separated by commas.
-For example, to set the branching factor of the tree-based-overlay
-network to 8 and enable verbose mode:
-
-  flux start -o"-v,--k-ary=8"
 
 *-v, --verbose*::
 Display commands before executing them.
 
 *-X, --noexec*::
 Don't execute anything.  This option is most useful with -v.
+
+EXAMPLES
+--------
+
+Launch an 8-way Flux instance with an interactive shell
+as the initial program and all logs output to stderr:
+
+  flux start -s8 -o,log-stderr-level=7
+
+Launch an 8-way Flux instance within a slurm job, with an interactive
+shell as the initial program:
+
+  srun -pty -N8 flux start
+
+Launch an 8-way Flux instance under Flux, with /bin/true as
+the initial program:
+
+  flux wreckrun -N8 flux start /bin/true
 
 
 AUTHOR
@@ -56,3 +80,8 @@ Github: <http://github.com/flux-framework>
 COPYRIGHT
 ---------
 include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux-broker(1) flux-keygen(1)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -307,3 +307,4 @@ localhost
 EEXIST
 rsh
 RCMD
+pty

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -74,7 +74,6 @@ struct client {
 void killer (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg);
 int start_session (struct context *ctx, const char *cmd);
 int exec_broker (struct context *ctx, const char *cmd);
-void remove_corelimit (void);
 char *create_scratch_dir (struct context *ctx);
 struct client *client_create (struct context *ctx, int rank, const char *cmd);
 void client_destroy (struct client *cli);
@@ -125,7 +124,6 @@ int main (int argc, char *argv[])
             errn_exit (e, "argz_creawte");
         argz_stringify (command, len, ' ');
     }
-    remove_corelimit ();
 
     if (!(searchpath = getenv ("FLUX_EXEC_PATH")))
         msg_exit ("FLUX_EXEC_PATH is not set");
@@ -150,15 +148,6 @@ int main (int argc, char *argv[])
     log_fini ();
 
     return status;
-}
-
-void remove_corelimit (void)
-{
-    struct rlimit rl;
-    rl.rlim_cur = RLIM_INFINITY;
-    rl.rlim_max = RLIM_INFINITY;
-    if (setrlimit (RLIMIT_CORE, &rl) < 0)
-        err ("setrlimit: could not remove core file size limit");
 }
 
 char *find_broker (const char *searchpath)

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -52,14 +52,6 @@ int main(int argc, char** argv)
     ok (p == NULL && errno == ENOENT,
         "popen2 /noexist failed with ENOENT");
 
-    /* open/write/close (stdin ignored by child) */
-    ok ((p = popen2 ("/bin/true", av)) != NULL,
-        "popen2 /bin/true OK");
-    ok (write_all (fd, outbuf, sizeof (outbuf)) == sizeof (outbuf),
-        "write to fd worked");
-    ok (pclose2 (p) == 0,
-        "pclose2 OK");
-
     /* open/close (child exit error) */
     ok ((p = popen2 ("/bin/false", av)) != NULL,
         "popen2 /bin/false OK");

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -571,11 +571,14 @@ int PMI_Get_id (char id_str[], int length)
         goto done;
     }
     assert (ctx->magic == PMI_CTX_MAGIC);
-    if (id_str == NULL || length < strlen (ctx->kvsname) + 1) {
+    if (id_str == NULL || length <= 1) {
         ret = PMI_ERR_INVALID_ARG;
         goto done;
     }
-    snprintf (id_str, length + 1, "%s", ctx->kvsname);
+    if (snprintf (id_str, length + 1, "%d", ctx->appnum) == length + 1) {
+        ret = PMI_ERR_INVALID_ARG;
+        goto done;
+    }
     ret = PMI_SUCCESS;
 done:
     return_trace (PMI_TRACE_PARAM, ret);

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -114,9 +114,11 @@ static const char *pmi_strerror (int errnum)
 {
     int i = 0;
     static char buf[16];
-    while (pmi_errstr[i].s != NULL)
+    while (pmi_errstr[i].s != NULL) {
         if (errnum == pmi_errstr[i].err)
             return pmi_errstr[i].s;
+        i++;
+    }
     snprintf (buf, sizeof (buf), "%d", errnum);
     return buf;
 }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -29,7 +29,10 @@ test_expect_success 'flux-keygen works' '
 	flux --secdir $tmpkeydir keygen --force &&
 	rm -rf $tmpkeydir
 '
-test_expect_success 'flux-start works' "
+test_expect_success 'flux-start in exec mode works' "
+	flux start --size=1 'flux comms info' | grep 'size=1'
+"
+test_expect_success 'flux-start in subprocess/pmi mode works' "
 	flux start --size=2 'flux comms info' | grep 'size=2'
 "
 test_expect_success 'flux-start passes through errors from command' "
@@ -38,6 +41,13 @@ test_expect_success 'flux-start passes through errors from command' "
 test_expect_success 'flux-start passes exit code due to signal' "
 	test_expect_code 130 flux start --size=1 'kill -INT \$\$'
 "
+test_expect_success 'flux-start in exec mode works as initial program' "
+	flux start --size=2 flux start --size=1 flux comms info | grep size=1
+"
+test_expect_success 'flux-start in subprocess/pmi mode works as initial program' "
+	flux start --size=2 flux start --size=1 flux comms info | grep size=1
+"
+
 test_expect_success 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&
 	mkdir -p test-under-flux && (

--- a/t/t2003-recurse.t
+++ b/t/t2003-recurse.t
@@ -11,7 +11,7 @@ test_under_flux 4 wreck
 test_expect_success 'recurse: Flux launches Flux ' '
 	printenv FLUX_URI >old_uri &&
 	test -s old_uri &&
-	flux wreckrun -n1 -N1 flux broker \
+	flux wreckrun -n1 -N1 flux start \
 		printenv FLUX_URI >new_uri &&
 	test -s new_uri &&
 	! test_cmp old_uri new_uri
@@ -32,7 +32,7 @@ test_expect_success 'recurse: parent-uri is unset in bootstrap instance' '
 test_expect_success 'recurse: local-uri != local-uri in enclosing instance' '
 	flux getattr local-uri >enc_uri &&
 	test -s enc_uri &&
-	flux wreckrun -n1 -N1 flux broker \
+	flux wreckrun -n1 -N1 flux start \
 		flux getattr local-uri >attr_uri &&
 	test -s attr_uri &&
 	! test_cmp enc_uri attr_uri
@@ -41,15 +41,15 @@ test_expect_success 'recurse: local-uri != local-uri in enclosing instance' '
 test_expect_success 'recurse: parent-uri == local-uri in enclosing instance' '
 	flux getattr local-uri >enc_uri &&
 	test -s enc_uri &&
-	flux wreckrun -n1 -N1 flux broker \
+	flux wreckrun -n1 -N1 flux start \
 		flux getattr parent-uri >attr_uri &&
 	test -s attr_uri &&
 	test_cmp enc_uri attr_uri
 '
 
 test_expect_success 'recurse: Flux launches Flux launches Flux' '
-	flux wreckrun -n1 -N1 flux broker \
-		flux wreckrun -n1 -N1 flux broker \
+	flux wreckrun -n1 -N1 flux start \
+		flux wreckrun -n1 -N1 flux start \
 			echo hello >hello_out &&
 	echo hello >hello_expected &&
 	test_cmp hello_expected hello_out


### PR DESCRIPTION
As discussed in #643, the current usage for starting Flux under slurm is a bit awkward:
```
srun -N8 flux broker initial-program
```
If `flux-start` simply execs the broker whenever size=1 (the default size), and the broker attempts to bootstrap first with PMI, then with "local", we should be able to support
```
srun -N8 flux start initial-program
```
without needing to probe PMI from flux-start.

This PR takes that approach.   Apparently something in it has made the sharness runlevel tests sad as they seem to hang now, but I wanted to post this to get a little feedback as to whether this seems like the right approach.