### PR TITLE
flux-cron: cron-like service

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,7 @@ AC_CONFIG_FILES( \
   src/modules/wreck/Makefile \
   src/modules/pymod/Makefile \
   src/modules/resource-hwloc/Makefile \
+  src/modules/cron/Makefile \
   src/test/Makefile \
   src/test/kap/Makefile \
   etc/Makefile \

--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -24,7 +24,8 @@ MAN1_FILES_PRIMARY = \
 	flux-dmesg.1 \
 	flux-content.1 \
 	flux-hwloc.1 \
-	flux-proxy.1
+	flux-proxy.1 \
+	flux-cron.1
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man1/flux-cron.adoc
+++ b/doc/man1/flux-cron.adoc
@@ -1,0 +1,232 @@
+// flux-help-description: Schedule tasks on timers and events
+FLUX-CRON(1)
+===========
+:doctype: manpage
+
+NAME
+----
+flux-cron - Cron-like utility for Flux
+
+SYNOPSIS
+--------
+*flux* *cron* 'COMMAND' ['OPTIONS']
+
+DESCRIPTION
+-----------
+The Flux cron service offers an interface for executing commands on
+triggers such as a time interval or Flux events. The service is
+implemented as a Flux extension module which, when loaded, manages
+a set of cron entries and uses the built-in 'cmb.exec' service to run
+a command associated with the entry each time the defined trigger is
+reached. As with 'flux-exec(1)', these tasks run as direct children
+of the flux-broker and run outside of the control of any loaded
+job scheduling service.
+
+The flux-cron(1) utility offers an interface to create, stop, start,
+query, and destroy these entries in the Flux cron service.
+
+For a detailed description of the cron service operation and how
+it executes tasks, see the OPERATION and TASK EXECUTION sections
+below.
+
+COMMANDS
+--------
+*help* 'cmd'::
+Print help. If 'cmd' is provided, print help for that sub-command.
+
+*sync* [--epsilon='delay'] ['topic']::
+Query and modify the current *sync-event* behavior for the cron module.
+If a sync-event is set, the cron module will defer all task execution
+until an event matching the sync-event 'topic' is received.  With '--epsilon'
+the cron module will *not* delay task execution if the task is normally
+scheduled to run within 'delay' of the matching event. Without any
+'topic' supplied on command line, 'flux cron sync' displays the current
+setting for sync. If a task is deferred due to sync-event, the
+'stats.deferred' statistic is incremented.
+
+*interval* [OPTIONS] 'interval' 'command'::
+Create a cron entry to execute 'command' every 'interval', where 'interval'
+is an arbitrary floating point duration with optional suffix 's' for
+seconds, 'm' for minutes, 'h' for hours and 'd' for days.
+Options:
+
+ --name='STRING':::
+ -n 'STRING':::
+ Set a name for this cron entry to 'STRING'.
+
+ --after='TIME':::
+ -a 'TIME':::
+ The first task will run after a delay of 'TIME' instead of 'interval'.
+ After the first task the entry will continue to execute every 'interval'.
+
+ --count='N':::
+ -c 'N':::
+ The entry will be run a total of 'N' times, then stopped.
+
+ --options='LIST':::
+ -o 'LIST':::
+ The '--options' option allows a comma separated list of extra options to be
+ passed to the flux-cron service. See EXTRA OPTIONS below.
+
+*event* [OPTIONS] 'topic' 'command'::
+
+Create a cron entry to execute 'command' after every event matching 'topic'.
+
+ --name='STRING':::
+ -n 'STRING':::
+ Set a name for this cron entry to 'STRING'.
+
+ --nth='N':::
+ -n 'N':::
+ If '--nth' is given then 'command' will be run after each 'N' events.
+
+ --count='N':::
+ -c 'N':::
+ With '--count', the entry is run 'N' times then stopped.
+
+ --after='N':::
+ -a 'N':::
+ Run the first task only after 'N' matching events. Then run every event
+ or 'N' events with '--nth'.
+
+ --min-interval='T':::
+ -i 'T':::
+ Set the minimum interval at which two cron jobs for this event will be run.
+ For example, with --min-interval of 1s, the cron job will be at most run
+ every 1s, even if events are generated more quickly.
+
+ --options='LIST':::
+ -o 'LIST':::
+ Set comma separated EXTRA OPTIONS for this cron entry.
+
+*list*::
+Display a list of current entries registered with the cron module and
+their current state, last run time, etc.
+
+*stop* 'id'::
+Stop cron entry 'id'. The entry will remain in the cron entry list until
+deleted.
+
+*start* 'id'::
+Start a stopped cron entry 'id'.
+
+*delete* [--kill] 'id'::
+Purge cron entry 'id' from the flux-cron entry list. If '--kill' is used,
+kill any running task associated with entry 'id'.
+
+*dump* [--key=KEY] 'id'::
+Dump all information for cron entry 'id'. With '--key' print only the value
+for key 'KEY'. For a list of keys run 'flux cron dump ID'.
+
+EXTRA OPTIONS
+-------------
+
+For `flux-cron` commands allowing `--options`, the following EXTRA OPTIONS
+are supported:
+
+timeout='N'::
+Set a timeout for tasks invoked for this cron entry to 'N' seconds, where
+N can be a floating point number. Default is no timeout.
+
+rank='R'::
+Set the rank on which to execute the cron command to 'R'. Default is rank 0.
+
+task-history-count='N'::
+Keep history for the last 'N' tasks invoked by this cron entry. Default is 1.
+
+stop-on-failure='N'::
+Automatically stop a cron entry if the failure count exceeds 'N'. If 'N' is
+zero (the default) then the cron entry will not be stopped on failure.
+
+
+OPERATION
+---------
+The Flux cron module manages the set of currently configured cron
+jobs as a set of common entries, each with a unique ID supplied by
+a global sequence number and set of common attributes, options, and
+statistics. Basic attributes of a cron job include an optional 'name',
+the 'command' to execute on the entry's trigger, the current 'state' of
+the cron entry (stopped or not stopped), a 'repeat' count indicating the
+total number of times to execute the cron job before stopping, and the
+'type' of entry.
+
+All cron entries also support a less common list of options, which may
+be set at creation time via a comma-separated list of 'option=value'
+parameters passed to the '-o', '--option=OPTS'. These options are described
+in the EXTRA OPTIONS section at the end of this document.
+
+Currently, flux-cron supports only two types of entries. The 'interval'
+entry supports executing a command once every configured duration,
+optionally starting after a different time period. More detailed
+information about the interval type can be found in the documentation for
+the flux-cron 'interval' command above. The 'event' type entry supports
+running a command once every N events matching the configured event topic.
+More information about this type can be found in the documentation for
+'flux cron event'.
+
+The Flux cron module additionally keeps a common set of statistics for
+each entry, regardless of type . These include the creation time, last
+run time, and last time the cron entry was "started", as well a count of
+total number of times the command was executed and a count of successful
+and failed runs. Currently, the stats for a cron entry may be viewed via
+the 'flux cron dump' subcommand 'stats.*' output.
+
+When registered, cron entries are automatically 'started', meaning they
+are eligible to run the configured command when the trigger condition
+is met. Entries may be 'stopped', either by use of the 'flux cron stop'
+command, or if a 'stop-on-failure' value is set. Stopped entries are
+restarted using 'flux cron start', at which point counters used for
+repeat and stop-on-failure are reset.
+
+Stopped entries are kept in the flux cron until deleted with 'flux
+cron delete'. Active cron entries may also be deleted, with currently
+executing tasks optionally killed if the '--kill' option is provided.
+
+
+TASK EXECUTION
+--------------
+
+As related above, cron entry commands are executed via the 'cmb.exec'
+service, which is a low level execution service offered outside of any
+scheduler control, described in more detail in the 'flux-exec(1)' man
+page.
+
+Standard output and error from tasks executed by the cron service are
+logged and may be viewed with 'flux-dmesg(1)'. If a cron task exits
+with non-zero status, or fails to launch under the 'cmb.exec' service,
+a message is logged and the failure is added to the failure stats.
+On task failure, the cron job is stopped if 'stop-on-failure' is set, and
+the current failure count exceeds the configured value. By default,
+'stop-on-failure' is not set.
+
+By default, flux-cron module keeps information for the last task executed
+for each cron entry. This information can be viewed either via the
+'flux cron list' or 'flux cron dump ID' subcommands. Data such as
+start and end time, exit status, rank, and PID for the task is available.
+The number of tasks kept for each cron entry may be individually tuned
+via the 'task-history-count' option, described in the EXTRA OPTIONS section.
+
+Commands are normally executed immediately on the interval or event
+trigger for which they are configured. However, if the 'sync-event'
+option is active on the cron module, tasks execution will be deferred
+until the next synchronization event. See the documentation above
+for 'flux cron sync' for more information.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+SEE ALSO
+--------
+flux-exec(1), flux-dmesg(1)

--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -45,11 +45,53 @@ exit with the highest exit code of all tasks.
 Send SIGTERM to running job 'jobid'. If '--signal' is used, send signal 'N'
 where 'N' may  be a signal number or name such as 'SIGKILL'.
 
+*timing*::
+List timing information for lwj entries in Flux KVS. This command lists
+four specific intervals in the wreck job lifecycle:
+ 'STARTING'::: Time from LWJ entry creation until the job reaches the
+              "starting" state. The "starting" state is when the first
+              rexec daemon receives the request to launch tasks.
+ 'RUNNING'::: Time from "starting" to "running". The running state is
+             reached when all rexec daemons have forked and executed
+             all tasks.
+ 'COMPLETE'::: Time from "running" to "complete". This is the nominal time
+              that tasks of the job actually ran.
+ 'TOTAL'::: This is the total time from job creation to the "completed" state.
+
+
 *last-jobid*::
 Return the current value of the 'lwj' sequence number, that is the last
 jobid allocated to a submitted wreck job. Other jobs may be started
 between the time the id is obtained and when it is displayed in this
 command, so 'last-jobid' should not be relied upon during real workloads.
+
+*purge* [OPTIONS...]::
+Purge old job entries from Flux KVS. Without any options, the 'purge'
+subcommand will print the current number of entries in the 'lwj.'
+kvs directory. Otherwise, 'flux wreck purge' walks the list of all
+completed jobs in the Flux KVS and selects the oldest (in terms of
+completion time) as candidates for removal. The number of jobs selected
+is dependent on the options below:
+
+--verbose:::
+-v:::
+	Increase verbosity.
+
+--target-size='COUNT':::
+-t 'COUNT':::
+	Set the target number of job entries to keep to 'COUNT'. The number
+	of IDs to remove will be calculated based on target size, number of
+	current job entries, and any maximum set on command line.
+
+--remove:::
+-R:::
+	Perform an unlink of all selected job entries in KVS. This option is
+	only valid if supplied with '--target-size'.
+
+--max=N:::
+-m N:::
+	Set the maximum number of entries to remove on any one run.
+
 
 AUTHOR
 ------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -308,3 +308,9 @@ EEXIST
 rsh
 RCMD
 pty
+Cron
+CRON
+cron
+lifecycle
+rexec
+subcommand

--- a/etc/rc1
+++ b/etc/rc1
@@ -12,6 +12,7 @@ flux module load -r all resource-hwloc & pids="$pids $!"
 flux module load -r all mecho
 flux module load -r all job
 flux module load -r all wrexec
+flux module load -r 0 cron sync=hb
 
 wait $pids
 

--- a/etc/rc3
+++ b/etc/rc3
@@ -12,6 +12,7 @@ for rcdir in $all_dirs; do
 done
 shopt -u nullglob
 
+flux module remove -r 0 cron
 flux module remove -r all wrexec
 flux module remove -r all job
 flux module remove -r all mecho

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -18,6 +18,7 @@ nobase_dist_lua_SCRIPTS = \
 	flux/posix.lua \
 	flux/base64.lua \
 	flux/lustache.lua \
+	flux/Subcommander.lua \
 	wreck/io.lua
 
 #  Required because install(1) doesn't seem to preserve

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -288,6 +288,21 @@ static int l_flux_kvs_symlink (lua_State *L)
     return (1);
 }
 
+static int l_flux_kvs_unlink (lua_State *L)
+{
+    flux_t f;
+    const char *key;
+    if (!(f = lua_get_flux (L, 1)))
+        return lua_pusherror (L, "flux handle expected");
+    if (!(key = lua_tostring (L, 2)))
+        return lua_pusherror (L, "key expected in arg #2");
+
+    if (kvs_unlink (f, key) < 0)
+        return lua_pusherror (L, strerror (errno));
+    lua_pushboolean (L, true);
+    return (1);
+}
+
 static int l_flux_kvs_type (lua_State *L)
 {
     flux_t f;
@@ -2200,6 +2215,7 @@ static const struct luaL_Reg flux_methods [] = {
     { "kvs_commit",      l_flux_kvs_commit  },
     { "kvs_put",         l_flux_kvs_put     },
     { "kvs_get",         l_flux_kvs_get     },
+    { "kvs_unlink",      l_flux_kvs_unlink  },
 //    { "barrier",         l_flux_barrier     },
     { "send",            l_flux_send        },
     { "recv",            l_flux_recv        },

--- a/src/bindings/lua/flux/Subcommander.lua
+++ b/src/bindings/lua/flux/Subcommander.lua
@@ -1,0 +1,206 @@
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- Subcommand helper class
+--
+
+local function eprintf (...)
+    io.stderr:write (string.format (...))
+end
+
+local function die (self, fmt, ...)
+    -- Add a newline if there is not already one
+    if fmt:sub (-1) ~= "\n" then
+        fmt = fmt .. "\n"
+    end
+    eprintf (self.prog..": "..fmt, ...)
+    os.exit (1)
+end
+
+local function log (self, fmt, ...)
+    io.stdout:write (string.format (self.shortprog..": "..fmt, ...))
+end
+
+--- Command class from which all "commands" inherit
+local Command = { die = die, log = log }
+Command.__index = Command
+
+function Command:opt_table ()
+    local long_opts = { help = 'h' }
+    local short_opts = "h"
+    if not self.options then
+        return short_opts, long_opts
+    end
+    for _, t in pairs (self.options) do
+        short_opts = short_opts .. t.char .. (t.arg and ":" or "")
+        long_opts [t.name] = t.char
+    end
+    return short_opts, long_opts
+end
+
+function Command:fullname ()
+    if self.parent then
+        return self.parent:fullname () .. " " .. self.name
+    end
+    return self.prog
+end
+
+--
+-- Split line in `s` at `columns` colums assuming left pad `pad`
+--
+local function linesplit (s, columns, pad)
+    local width = columns - pad
+    local t = { "" }
+    if not pad then pad = 0 end
+    for prefix,word in s:gmatch("([ \t]*)(%S+)") do
+        local total = #(t[#t])
+        local len = #word
+        if (total + len) > width then
+            -- Add new line, pad to pad if pad is given:
+            table.insert (t, string.rep (" ", pad))
+        end
+        -- append word to current line
+        t[#t] = t[#t] .. prefix .. word
+    end
+    return table.concat (t, "\n")
+end
+
+function Command:help (code)
+    local _, opt_table = self:opt_table ()
+    local name = self:fullname ()
+    eprintf ("Usage: %s %s\n", name, tostring (self.usage))
+    if self.description then
+        eprintf ("%s\n", self.description)
+    end
+    eprintf ("Options:\n")
+    eprintf ("  -%s, --%-20s %s\n", 'h', 'help', "Display this message.")
+    if self.options then
+        local columns = os.getenv ("COLUMNS") or 80
+        for _,t in pairs (self.options) do
+            local optstr = t.name .. (t.arg and "="..t.arg or "")
+            eprintf ("  -%s, --%-20s %s\n",
+                     t.char, optstr,
+                     linesplit (t.usage, columns - 2, 29))
+        end
+    end
+    if self.CommandsList then
+        eprintf ("Supported commands:\n")
+        for _, cmd in pairs (self.CommandsList) do
+            eprintf (" %-12s %s\n", cmd.name, cmd.description)
+        end
+    end
+    if code then os.exit (code) end
+end
+
+-- Build args starting at index
+-- arg0 is a command name placed in arg[0]:
+local function rebuild_args (args, index, arg0)
+    local a = {}
+    a[0] = arg0
+    for i = index, #args do
+        table.insert (a, args[i])
+    end
+    return a
+end
+
+function Command:run (args)
+    local getopts = require 'flux.alt_getopt' .get_opts
+    local opts, optind = getopts (args, self:opt_table())
+    if not opts then self:help (1) end
+    if opts.h then self:help (0) end
+
+    self.opt = opts
+    self.args = rebuild_args (args, optind)
+
+    -- Check for a subcommand
+    local cmdname = self.args[1]
+    if self.Commands and cmdname then
+        local cmd = self:lookup (cmdname)
+        if cmd then
+            -- Run command with cmdname in arg[0] and all other args
+            --  shifted:
+            return cmd:run (rebuild_args (self.args, 2, cmdname))
+        end
+    end
+    self.handler (self, self.args)
+end
+
+function Command:lookup (name)
+    if not self.Commands then return nil end
+    return self.Commands[name]
+end
+
+-- a table is passed to Command with fields:
+-- @param t.name Name of the script method
+-- @param t.description Brief description of this method
+-- @param t.usage brief usage to be displayed in help
+-- @param t.handle function implementing handler with args (self, arg...)
+-- @param t.options extra options (besides --help) for this cmd
+function Command:SubCommand (t)
+    assert (t and t.name and t.handler)
+    t.shortprog = t.name
+    t.prog = self.name.." "..t.name
+    t.parent = self
+
+    if not self.Commands then self.Commands = {} end
+    self.Commands[t.name] = t
+
+    -- Add to ordered list of commands:
+    if not self.CommandsList then self.CommandsList = {} end
+    table.insert (self.CommandsList, t)
+    return setmetatable (t, Command)
+end
+
+-- Default "help" subcommand:
+local DefaultHelp = {
+    name = "help",
+    description = "Display this help or help for a command",
+    usage = "[COMMAND]",
+    handler = function (self, arg)
+        if #arg == 0 then
+            self.parent:help (0)
+        end
+        local cmd = self.parent:lookup (arg[1])
+        if not cmd then
+            self:die ("Unkown command %s", arg[1])
+        end
+        cmd:help (0)
+    end
+} 
+
+-- Create a new subcommand handler object
+function create (t)
+    if not t then t = {} end
+    if not t.name then t.name = arg[0] end
+    if not t.usage then t.usage = "[OPTIONS]..." end
+    t.prog = t.name:match ("([^/]+)$")
+    t.shortprog = t.prog:match ("flux%-(.+)$")
+    setmetatable (t, Command)
+    t:SubCommand (DefaultHelp)
+    return t
+end
+
+return { create = create }
+
+--  vi: ts=4 sw=4 expandtab

--- a/src/bindings/lua/json-lua.c
+++ b/src/bindings/lua/json-lua.c
@@ -112,12 +112,10 @@ static json_object * lua_table_to_json (lua_State *L, int i);
 
 static int lua_is_integer (lua_State *L, int index)
 {
-    double l;
-    if ((lua_type (L, index) == LUA_TNUMBER) &&
-        (l = lua_tonumber (L, index)) &&
-        ((int) l == l) &&
-        (l >= 1)) {
-        return (1);
+    if (lua_type (L, index) == LUA_TNUMBER) {
+        double ip, l = lua_tonumber (L, index);
+        if (modf (l, &ip) == 0.0)
+            return (1);
     }
     return (0);
 }

--- a/src/bindings/lua/json-lua.c
+++ b/src/bindings/lua/json-lua.c
@@ -110,6 +110,18 @@ static int json_object_to_lua_table (lua_State *L, json_object *o)
 
 static json_object * lua_table_to_json (lua_State *L, int i);
 
+static int lua_is_integer (lua_State *L, int index)
+{
+    double l;
+    if ((lua_type (L, index) == LUA_TNUMBER) &&
+        (l = lua_tonumber (L, index)) &&
+        ((int) l == l) &&
+        (l >= 1)) {
+        return (1);
+    }
+    return (0);
+}
+
 int lua_value_to_json (lua_State *L, int i, json_object **valp)
 {
     int index = (i < 0) ? (lua_gettop (L) + 1) + i : i;
@@ -120,7 +132,10 @@ int lua_value_to_json (lua_State *L, int i, json_object **valp)
 
     switch (lua_type (L, index)) {
         case LUA_TNUMBER:
-            o = json_object_new_int64 (lua_tointeger (L, index));
+            if (lua_is_integer (L, index))
+                o = json_object_new_int64 (lua_tointeger (L, index));
+            else
+                o = json_object_new_double (lua_tonumber (L, index));
             break;
         case LUA_TBOOLEAN:
             o = json_object_new_boolean (lua_toboolean (L, index));
@@ -144,17 +159,6 @@ int lua_value_to_json (lua_State *L, int i, json_object **valp)
             return (-1);
     }
     *valp = o;
-    return (0);
-}
-
-static int lua_is_integer (lua_State *L, int index)
-{
-    double l;
-    if ((lua_type (L, index) == LUA_TNUMBER) &&
-        (l = lua_tonumber (L, index)) &&
-        ((int) l == l) &&
-        (l >= 1))
-        return (1);
     return (0);
 }
 

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -212,6 +212,17 @@ static int l_kvsdir_commit (lua_State *L)
     return (1);
 }
 
+static int l_kvsdir_unlink (lua_State *L)
+{
+    kvsdir_t *d = lua_get_kvsdir (L, 1);
+    const char *key = luaL_checkstring (L, 2);
+    if (kvsdir_unlink (d, key) < 0)
+            return lua_pusherror (L, "unlink: %s", strerror (errno));
+    lua_pushboolean (L, true);
+    return (1);
+}
+
+
 static int l_kvsdir_watch (lua_State *L)
 {
     int rc;
@@ -320,6 +331,7 @@ static const struct luaL_Reg kvsdir_methods [] = {
     { "__newindex",      l_kvsdir_newindex },
     { "__tostring",      l_kvsdir_tostring },
     { "commit",          l_kvsdir_commit   },
+    { "unlink",          l_kvsdir_unlink   },
     { "keys",            l_kvsdir_next     },
     { "watch",           l_kvsdir_watch    },
     { "watch_dir",       l_kvsdir_watch_dir},

--- a/src/bindings/lua/tests/t0000-json.t
+++ b/src/bindings/lua/tests/t0000-json.t
@@ -88,7 +88,6 @@ is (j.runtest (1), 1,         "number 1 returns unharmed")
 is (j.runtest (0), 0,         "number 0 returns unharmed")
 is (j.runtest (1.0), 1.0,     "float value returns unharmed")
 
-todo ( "Need to investigate", 1)
 is (j.runtest (1.01), 1.01,   "float value returns unharmed (more precision)")
 
 is (j.runtest (1024000000), 1024000000,

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -84,7 +84,7 @@ test_shutdown_t_SOURCES = test/shutdown.c shutdown.c
 test_shutdown_t_CPPFLAGS = $(test_cppflags)
 test_shutdown_t_LDADD = $(test_ldadd)
 
-test_heartbeat_t_SOURCES = test/heartbeat.c heartbeat.c
+test_heartbeat_t_SOURCES = test/heartbeat.c heartbeat.c attr.c
 test_heartbeat_t_CPPFLAGS = $(test_cppflags)
 test_heartbeat_t_LDADD = $(test_ldadd)
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -627,6 +627,8 @@ int main (int argc, char *argv[])
     /* install heartbeat (including timer on rank 0)
      */
     heartbeat_set_flux (ctx.heartbeat, ctx.h);
+    if (heartbeat_set_attrs (ctx.heartbeat, ctx.attrs) < 0)
+        err_exit ("initializing heartbeat attributes");
     if (heartbeat_start (ctx.heartbeat) < 0)
         err_exit ("heartbeat_start");
     if (ctx.rank == 0 && ctx.verbose)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1479,11 +1479,10 @@ subprocess_json_resp (ctx_t *ctx, struct subprocess *p)
     return (resp);
 }
 
-static int child_exit_handler (struct subprocess *p, void *arg)
+static int child_exit_handler (struct subprocess *p)
 {
     int n;
-
-    ctx_t *ctx = (ctx_t *) arg;
+    ctx_t *ctx = (ctx_t *) subprocess_get_context (p, "ctx");
     zmsg_t *zmsg = (zmsg_t *) subprocess_get_context (p, "zmsg");
     json_object *resp;
 
@@ -1665,8 +1664,8 @@ static int cmb_exec_cb (zmsg_t **zmsg, void *arg)
     }
 
     p = subprocess_create (ctx->sm);
-    subprocess_set_callback (p, child_exit_handler, ctx);
     subprocess_set_context (p, "ctx", ctx);
+    subprocess_add_hook (p, SUBPROCESS_COMPLETE, child_exit_handler);
 
     for (i = 0; i < argc; i++) {
         json_object *ox = json_object_array_get_idx (o, i);

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -68,6 +68,14 @@ void heartbeat_set_flux (heartbeat_t *hb, flux_t h)
     hb->h = h;
 }
 
+int heartbeat_set_attrs (heartbeat_t *hb, attr_t *attrs)
+{
+    if (attr_add_active_int (attrs, "heartbeat-epoch",
+                             &hb->epoch, FLUX_ATTRFLAG_READONLY) < 0)
+        return -1;
+    return 0;
+}
+
 int heartbeat_set_rate (heartbeat_t *hb, double rate)
 {
     if (rate < min_heartrate || rate > max_heartrate)

--- a/src/broker/heartbeat.h
+++ b/src/broker/heartbeat.h
@@ -1,6 +1,8 @@
 #ifndef _BROKER_HEARTBEAT_H
 #define _BROKER_HEARTBEAT_H
 
+#include "attr.h"
+
 /* Manage the session heartbeat.
  *
  * All ranks should call heartbeat_start() to install reactor watchers.
@@ -28,6 +30,7 @@ int heartbeat_set_rate (heartbeat_t *hb, double rate);
 double heartbeat_get_rate (heartbeat_t *hb);
 
 void heartbeat_set_flux (heartbeat_t *hb, flux_t h);
+int heartbeat_set_attrs (heartbeat_t *hb, attr_t *attrs);
 
 void heartbeat_set_epoch (heartbeat_t *hb, int epoch);
 int heartbeat_get_epoch (heartbeat_t *hb);

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -221,9 +221,9 @@ int runlevel_get_level (runlevel_t *r)
 /* See POSIX 2008 Volume 3 Shell and Utilities, Issue 7
  * Section 2.8.2 Exit status for shell commands (page 2315)
  */
-static int subprocess_cb (struct subprocess *p, void *arg)
+static int subprocess_cb (struct subprocess *p)
 {
-    runlevel_t *r = arg;
+    runlevel_t *r = subprocess_get_context (p, "runlevel");
     int rc = subprocess_exit_code (p);
     const char *exit_string = subprocess_exit_string (p);
 
@@ -289,7 +289,8 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *command,
     }
 
     if (!(p = subprocess_create (r->sm))
-            || subprocess_set_callback (p, subprocess_cb, r) < 0
+            || subprocess_set_context (p, "runlevel", r) < 0
+            || subprocess_add_hook (p, SUBPROCESS_COMPLETE, subprocess_cb) < 0
             || subprocess_argv_append (p, shell) < 0
             || (command && subprocess_argv_append (p, "-c") < 0)
             || (command && subprocess_argv_append (p, command) < 0)

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -54,7 +54,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-wreck \
 	flux-exec \
 	flux-topo \
-	flux-ps
+	flux-ps \
+	flux-cron
 
 if HAVE_PYTHON
 dist_fluxcmd_SCRIPTS+= \

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -823,9 +823,9 @@ done:
     return uri;
 }
 
-static int child_cb (struct subprocess *p, void *arg)
+static int child_cb (struct subprocess *p)
 {
-    ctx_t *ctx = arg;
+    ctx_t *ctx = subprocess_get_context (p, "ctx");
 
     ctx->exit_code = subprocess_exit_code (p);
     flux_reactor_stop (ctx->reactor);
@@ -854,7 +854,8 @@ static int child_create (ctx_t *ctx, int ac, char **av, const char *workpath)
         argz_stringify (argz, argz_len, ' ');
 
     if (!(p = subprocess_create (ctx->sm))
-            || subprocess_set_callback (p, child_cb, ctx) < 0
+            || subprocess_set_context (p, "ctx", ctx) < 0
+            || subprocess_add_hook (p, SUBPROCESS_COMPLETE, child_cb) < 0
             || subprocess_argv_append (p, shell) < 0
             || (argz && subprocess_argv_append (p, "-c") < 0)
             || (argz && subprocess_argv_append (p, argz) < 0)

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -1,0 +1,465 @@
+#!/usr/bin/env lua
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- flux-cron: Flux's cron request cmdline utility
+--
+local f, err = require 'flux' .new()
+local posix = require 'posix'
+
+local program = require 'flux.Subcommander'.create {
+    name = "flux-cron",
+    description = "Schedule and manage cron-like jobs in a flux session",
+    usage = "[OPTIONS] COMMAND [OPTIONS...]",
+    handler = function (self, args)
+        if not args[1] then
+            self:log ("required COMMAND missing\n")
+            self:help (1)
+        else
+            self:die ("Unknown COMMAND `%s'", args[1])
+        end
+    end
+}
+
+local function printf (fmt, ...)
+    io.stdout:write (string.format (fmt, ...))
+end
+
+local function parse_time (s)
+    if not s then return nil end
+
+    local m = { s = 1, m = 60, h = 3600, d = 56400 }
+    local n, suffix = s:match ("^([0-9.]+)([HhMmDdSs]?)$")
+    if not tonumber (n) then
+        return nil, "Invalid duration '"..s.."'"
+    end
+    if suffix and m [suffix]  then
+        n = (n * m [suffix])
+    end
+    return (n)
+end
+
+local function now ()
+    local s, ns = posix.clock_gettime ()
+    local now = (s + (ns /1000000000))
+    return now
+end
+
+local function reladate (t)
+    local fmt = string.format
+    local now = now ()
+
+    if (t > now) then
+        return "in the future"
+    end
+
+    local diff = now - t
+
+    if (diff < 2) then
+        return fmt ("a second ago")
+    end
+
+    if (diff < 90) then
+        return fmt ("%d seconds ago", diff)
+    end
+
+    -- Convert to minutes:
+    diff = diff / 60
+    if (diff < 2) then
+        return fmt ("a minute ago")
+    end
+    if (diff < 90) then
+        return fmt ("%d minutes ago", diff)
+    end
+
+    -- Convert to hours:
+    diff = diff / 60;
+    if (diff < 36) then
+        return fmt ("%.1f hours ago", diff)
+    end
+
+    -- Convert to days:
+    diff = diff / 24;
+    if (diff < 14) then
+        return fmt ("%.1f days ago", diff)
+    end
+
+    -- weeks for past 10 weeks or so, reduce precision in output:
+    local d = math.floor (diff)
+    if (d < 70) then
+        return fmt ("%d weeks ago", (d + 3) / 7)
+    end
+    if (d < 365) then
+        return fmt ("%d months ago", (d + 15) / 30)
+    end
+
+    return fmt ("%.1f years ago", diff / 365)
+end
+
+--
+-- Extend "Command" objects adding self:request() method for common
+--  "cron.create" RPC generation:
+--
+local Command = getmetatable (program)
+function Command:request (type, typeargs, arg)
+    local command = table.concat (arg, " ")
+    local req = {
+        type = type,
+        args = typeargs,
+        command = command,
+        name = self.opt.N or arg[1],
+        ["repeat"] = self.opt.c
+    }
+    -- Process comma-separated list of options to add undocumented
+    --  members to JSON request, e.g. `-o rank=1,task-history-count=5`
+    if self.opt.o then
+        for opt in self.opt.o:gmatch ("[^,]+") do
+            local k,v = opt:match("(.+)=(.+)")
+            req[k] = v
+        end
+    end
+    return f:rpc ("cron.create", req)
+end
+
+
+program:SubCommand {
+ name = "interval",
+ description = "run COMMAND once every INTERVAL",
+ usage = "INTERVAL COMMAND",
+ options = {
+    { name = "count", char = "c", arg = "N",
+      usage = "Repeat COMMAND at most N times"
+    },
+    { name = "name", char = "N", arg = "S",
+      usage = "Name cron job string S instead of default"
+    },
+    { name = "after", char = "a", arg = "INTERVAL",
+      usage = "Set INTERVAL for initial timer"
+    },
+    { name = "options", char = "o", arg = "OPTS",
+      usage = "Comma separated list of key=value options to set in request"
+    },
+ },
+ handler = function (self, arg)
+    if #arg <  2 then self:die ("INTERVAL and COMMAND required") end
+
+    local interval, err = parse_time (table.remove (arg, 1))
+    if not interval then self:die (err) end
+    local args = { interval = interval }
+    args.after = parse_time (self.opt.a)
+
+    local resp, err = self:request ("interval", args, arg)
+    if not resp then self:die (err) end
+    self:log ("cron-%d created\n", resp.id)
+ end
+}
+
+program:SubCommand {
+ name = "event",
+ description = "run COMMAND on every event matching TOPIC",
+ usage = "TOPIC COMMAND",
+ options = {
+    { name = "nth", char = "n", arg = "N",
+      usage = "Run command every Nth matching event",
+    },
+    { name = "after", char = "a", arg = "N",
+      usage = "Run command the first time only after N events",
+    },
+    { name = "min-interval", char = "i", arg = "T",
+      usage = "Set minimum interval at which two cron jobs will execute",
+    },
+    { name = "count", char = "c", arg = "N",
+      usage = "Repeat COMMAND at most N times"
+    },
+    { name = "options", char = "o", arg = "OPTS",
+      usage = "Comma separated list of key=value options to set in request"
+    },
+    { name = "name", char = "N", arg = "S",
+      usage = "Name cron job string S instead of default"
+    }
+ },
+ handler = function (self, arg)
+    if #arg < 2 then self:die ("TOPIC and COMMAND args are required") end
+    local topic = table.remove (arg, 1)
+    local args = { topic = topic, nth = self.opt.n, after = self.opt.a }
+    args.min_interval = parse_time (self.opt.i)
+
+    local resp, err = self:request ("event", args, arg)
+    if not resp then self:die (err) end
+    self:log ("cron-%d created\n", resp.id)
+ end
+}
+
+--
+--  Convert date in Unix seconds (floating point) to a standard
+--   datetime string
+--
+local function date_string (t)
+    local sec = math.floor (t)
+    local msec = t - sec
+    local tm = posix.localtime (sec)
+    return string.format ("%d-%02d-%02dT%02d:%02d:%02d.%03d",
+            tm.year, tm.month, tm.monthday,
+            tm.hour, tm.min, tm.sec, math.floor (msec * 1000))
+end
+
+local function seconds_to_string (s)
+    local f = string.format
+    if s > (60*60*24) then
+        return f ("%.03fd", s / (60*60*24))
+    elseif s > (60*60) then
+        return f ("%.03fh", s / (60*60))
+    elseif s > 60 then
+        return f ("%.03fm", s / 60)
+    elseif s > 1 then
+        return f ("%.03fs", s)
+    end
+    return f ("%.2fms", s * 1000)
+end
+
+program:SubCommand {
+ name = "dump",
+ description = "Dump values from a cron entry",
+ usage = "[IDs]",
+ options = {
+    { name = "key", char = "k", arg = "KEY",
+      usage = "Print only KEY from the entry",
+    },
+ },
+ handler = function (self, arg)
+    local id = tonumber (arg[1])
+    if not id then self:die ("ID argument required") end
+    local req = {}
+    local resp, err = f:rpc ("cron.list", req)
+    if not resp then self:die (err) end
+
+    local function p (k, v)
+        if not self.opt.k then
+            if type (v) == "string" then v = '"'..v..'"' end
+            printf ("%s = %s\n", k, tostring (v))
+        elseif self.opt.k == k then
+            printf ("%s\n", tostring (v))
+        end
+    end
+
+    local function dump_tasks (l)
+        for i, t in pairs (l) do
+            for k,v in pairs (t) do
+                p ("task."..i.."."..k, v)
+            end
+        end
+    end
+
+    local function dump_t (name, td)
+        for k,v in pairs (td) do
+            p (name.."."..k, v)
+        end
+    end
+
+    local function dump_entry (e)
+        for k,v in pairs (e) do
+            if k == "tasks" then
+                dump_tasks (v)
+            elseif type (v) == "table" then
+                dump_t (k, v)
+            else
+                p (k, v)
+            end
+        end
+    end
+
+    for _, e in pairs (resp.entries) do
+        if tonumber (e.id) == id then
+            dump_entry (e)
+            return
+       end
+    end
+    self:die ("cron-%d: No such cron entry found", id)
+  end
+}
+
+
+program:SubCommand {
+ name = "list",
+ description = "List registered and stopped flux-cron jobs",
+ usage = "[IDs]",
+ options = {},
+ handler = function (self, arg)
+
+    local req = {}
+    local resp, err = f:rpc ("cron.list", req)
+    if not resp then self:die (err) end
+
+    local fmt = "%6s %-15s %-8s %9s %18s  %-18s\n"
+    printf (fmt, "ID", "CMD/NAME", "STATE", "#RUNS", "LASTRUN", "STATUS")
+
+
+    for _, e in pairs (resp.entries) do
+        local lastrun, runtime, status = "None", 0, "None"
+        local t = e.tasks[1]
+        local t2 = e.tasks[2] or {}
+        if t then
+            local t0 = t["start-time"] or t2["start-time"]
+            local t1 = t["end-time"] or now ()
+            if t0 then
+                lastrun = reladate (t0)
+                runtime = seconds_to_string (t1 - t0)
+            end
+            if t.state == "Failed" then
+                if t.code == 127 then
+                    status = "Exec-Error"
+                else
+                    status = string.format ("%s:rc=%d", t.state, t.code)
+                end
+            elseif t.state == "Exited" then
+                status = "Success"
+            else
+                status = t.state
+            end
+        end
+
+        local state = "Active"
+        local count = e.stats.count
+        if e["repeat"] > 0 then
+            count = e.count .. "/" .. e["repeat"]
+        end
+        if e.stopped then state = "Stopped" end
+        printf (fmt, e.id, e.name, state, count, lastrun, status)
+    end
+ end
+}
+
+program:SubCommand {
+ name = "delete",
+ description = "Delete flux cron entries",
+ usage = "IDs",
+ options = {
+   { name = "kill", char = "k",
+     usage = "Also kill any currently running task associated with"..
+             " this entry"
+   }
+ },
+ handler = function (self, arg)
+    if not arg[1] then
+        self:help()
+        os.exit (1)
+    end
+
+    for _,id in ipairs (arg) do
+        local resp, err = f:rpc ("cron.delete", { id = id, kill = self.opt.k })
+        if not resp then self:die (err) end
+
+        local t = resp.tasks [1]
+        local extra = ""
+        if t then
+            local t0 = t["start-time"]
+            local t1 = t["end-time"]
+            if t1 then
+                local runtime = seconds_to_string (t1 - t0)
+                extra = " last ran "..reladate (t1).." for "..runtime
+            else
+                extra = " still running. Started "..reladate (t0)
+            end
+        end
+        printf ("Removed cron-%d: %s%s\n", arg[1], resp.name, extra)
+    end
+ end
+}
+
+program:SubCommand {
+ name = "stop",
+ description = "Stop a flux cron job from executing",
+ usage = "IDs",
+  handler = function (self, arg)
+    if not arg[1] then
+        self:help()
+        os.exit (1)
+    end
+
+    for _,id in ipairs (arg) do
+        local resp, err = f:rpc ("cron.stop", { id = id })
+        if not resp then self:die (err) end
+        printf ("Stopped cron-%d\n", arg[1])
+    end
+ end
+}
+
+program:SubCommand {
+ name = "start",
+ description = "Start a stopped flux cron job",
+ usage = "IDs",
+  handler = function (self, arg)
+    if not arg[1] then
+        self:help()
+        os.exit (1)
+    end
+
+    for _,id in ipairs (arg) do
+        local resp, err = f:rpc ("cron.start", { id = id })
+        if not resp then self:die (err) end
+        printf ("Started cron-%d\n", arg[1])
+    end
+ end
+}
+
+program:SubCommand {
+ name = "sync",
+ description = "Query and modify sync-on-event behavior for flux-cron",
+ options = {
+   { name = "disable", char = "d",
+     usage = "Disable cron sync-event"
+   },
+   { name = "epsilon", char = "e", arg = "TIME",
+     usage = "Set amount of time after a sync-event that jobs are"..
+             " still allowed to be run."
+   }
+ },
+ usage = "IDs",
+  handler = function (self, arg)
+    local req = {}
+
+    if self.opt.d then
+        req.disable = true
+    elseif arg[1] then
+        req.topic = arg[1]
+    end
+    if self.opt.e then
+        req.sync_epsilon = parse_time (self.opt.e)
+    end
+
+    local resp, err = f:rpc ("cron.sync", req)
+    if not resp then self:die (err) end
+    if (resp.sync_disabled) then
+        self:log ("sync disabled.\n")
+    else
+        self:log ("sync to event \"%s\" epsilon=%.3fs.\n",
+                  resp.sync_event, resp.sync_epsilon)
+    end
+ end
+}
+
+
+program:run (arg)
+
+--  vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -29,96 +29,29 @@ local f, err = require 'flux' .new()
 local wreck = require 'wreck'
 local hostlist = require 'flux.hostlist'
 local posix = require 'posix'
-
-local prog = string.match (arg[0], "([^/]+)$")
-local shortprog = prog:match ("flux%-(.+)$")
-
-local function eprintf (...)
-    io.stderr:write (string.format (...))
-end
+local prog = require 'flux.Subcommander'.create {
+    usage = "COMMAND [OPTIONS]",
+    handler = function (self, arg)
+        self:log ("COMMAND required\n")
+        self:help (1)
+    end
+}
 
 local function printf (...)
     io.stdout:write (string.format (...))
 end
 
-local function die (fmt, ...)
-    eprintf (shortprog..": "..fmt, ...)
-    os.exit (1)
-end
-
-
---- Index of all commands registered in this script
-local Commands = {}
-
---- Command class from which all "commands" inherit
-local Command = {}
-Command.__index = Command
-
---- Allow new commad methods to be registered by "calling" Command.
--- a table is passed to Command with fields:
--- @param t.name Name of the script method
--- @param t.description Brief description of this method
--- @param t.usage brief usage to be displayed in help
--- @param t.handle function implementing handler with args (self, arg...)
--- @param t.options extra options (besides --help) for this cmd
-setmetatable (Command,
-    { __call = function (_,t)
-        assert (t and t.name)
-        Commands[t.name] = t
-        return setmetatable (t, Command)
-     end
-    }
-)
-function Command:opt_table ()
-    local long_opts = { help = 'h' }
-    local short_opts = "h"
-    if not self.options then
-        return short_opts, long_opts
-    end
-    for _, t in pairs (self.options) do
-        short_opts = short_opts .. t.char .. (t.arg and ":" or "")
-        long_opts [t.name] = t.char
-    end
-    return short_opts, long_opts
-end
-
-function Command:help (code)
-    local _, opt_table = self:opt_table ()
-    eprintf ("Usage: %s %s %s\n", prog, self.name, self.usage)
-    eprintf ("  -%s, --%-20s %s\n", 'h', 'help', "Display this message.")
-    if self.options then
-        for _,t in pairs (self.options) do
-            local optstr = t.name .. (t.arg and "="..t.arg or "")
-            eprintf ("  -%s, --%-20s %s\n", t.char, optstr, t.usage)
-        end
-    end
-    if code then os.exit (code) end
-end
-
-function Command:run (args)
-    local getopts = require 'flux.alt_getopt' .get_opts
-    local opts, optind = getopts (args, self:opt_table())
-    if not opts then self:help (1) end
-    if opts.h then self:help (0) end
-    local a = {}
-    for i = optind, #args do
-        table.insert (a, args[i])
-    end
-    self.opt = opts
-    self.handler (self, a)
-end
-
 local function check_jobid_arg (self, id)
     if not id then
-        eprintf ("Error: Job id required\n")
+        io.stderr:write ("Error: Job id required\n")
         self:help (1)
     elseif not tonumber (id) then
-        die ("Invalid Job id '%s'\n", id)
+        self:die ("Invalid Job id '%s'\n", id)
     end
     return id
 end
 
-Command {
+prog:SubCommand {
  name = "attach",
  description = "Attach to running or completed job output",
  usage = "[OPTIONS] JOBID",
@@ -138,7 +71,9 @@ Command {
             f:reactor_stop()
         end
     }
-    if not taskio then die ("Failed to connect to job %d: %s\n", id, err) end
+    if not taskio then
+        self:die ("Failed to connect to job %d: %s\n", id, err)
+    end
     local kz, err = f:kz_open ("lwj."..id..".input.files.stdin", "w")
     if kz then
         f:iowatcher {
@@ -151,7 +86,7 @@ Command {
     end
     if not taskio:complete() then f:reactor () end
     if self.opt.s then
-        Commands.status:run ({id})
+        self.parent:run {"status", id}
     end
     os.exit (0)
  end
@@ -161,12 +96,12 @@ local function opt_sig (s)
     if not s then return posix.SIGTERM end
     if tonumber (s) then return tonumber (s) end
     if not tonumber (posix[s]) then
-        die ("Invalid signal '%s'\n", s)
+        prog:die ("Invalid signal '%s'\n", s)
     end
     return tonumber (posix [s])
 end
 
-Command {
+prog:SubCommand {
  name = "kill",
  description = "Kill a running job",
  usage = "[OPTIONS] JOBID",
@@ -177,28 +112,28 @@ Command {
  handler = function (self, arg)
     local id = check_jobid_arg (self, arg[1])
     local lwj, err = f:kvsdir ("lwj.%d", id)
-    if not lwj then die ("Job %d: %s\n", id, err) end
+    if not lwj then self:die ("Job %d: %s\n", id, err) end
     if lwj.state ~= "running" then
         io.stderr:write ("Job "..id..": "..lwj.state.."\n")
         os.exit (1)
     end
     local sig = opt_sig (self.opt.s)
     local rc, err = f:sendevent ({signal = sig}, "wreck.%d.kill", id)
-    if not rc then die ("signal: %s\n", err) end
+    if not rc then self:die ("signal: %s\n", err) end
  end
 }
 
-Command {
+prog:SubCommand {
  name = "status",
  description = "Return status of jobs",
  usage = "JOBID",
  handler = function (self, arg)
     local jobid = check_jobid_arg (self, arg[1])
     local lwj, err = f:kvsdir ("lwj.%d", jobid)
-    if not lwj then die ("Job %d: %s\n", jobid, err) end
+    if not lwj then self:die ("Job %d: %s\n", jobid, err) end
     print ("Job "..jobid.." status: "..lwj.state)
     local code, msglist = wreck.status { flux = f, jobid = jobid }
-    if not code then die (msglist) end
+    if not code then self:die (msglist) end
     for msg, hl in pairs (msglist) do
         local s = string.format ("task%s: %s", tostring (hl:sort()), msg)
         print (s)
@@ -288,21 +223,21 @@ local function seconds_to_string (s)
     return f ("%.03fs", s)
 end
 
-Command {
+prog:SubCommand {
  name = "ls",
  usage = "",
  description = "List jobs in kvs",
  handler = function (self, arg)
     local lwj, err = f:kvsdir ("lwj")
     if not lwj then
-        die ("Failed to get lwj info: %s\n", err)
+        self:die ("Failed to get lwj info: %s\n", err)
     end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
     printf (fmt, "ID", "NTASKS", "STATE", "START", "RUNTIME", "RANKS", "COMMAND")
     for id in lwj:keys() do
         if tonumber (id) then
             local j, err = LWJ.open (f, id)
-            if not j then die ("job%d: %s", id, err) end
+            if not j then self:die ("job%d: %s", id, err) end
             printf (fmt, id, j.ntasks, j.state, j.start,
                     seconds_to_string (j.runtime),
                     tostring (j.ranks),
@@ -312,21 +247,21 @@ Command {
  end
 }
 
-Command {
+prog:SubCommand {
  name = "timing",
  usage = "",
  description = "List timings of jobs in kvs",
  handler = function (self, arg) 
     local lwj, err = f:kvsdir ("lwj")
     if not lwj then
-        die ("Failed to get lwj info: %s\n", err)
+        self:die ("Failed to get lwj info: %s\n", err)
     end
     local fmt = "%6s %12s %12s %12s %12s\n"
     printf (fmt, "ID", "STARTING", "RUNNING", "COMPLETE", "TOTAL")
     for id in lwj:keys() do
         if tonumber (id) then
             local j, err = LWJ.open (f, id)
-            if not j then die ("job%d: %s", id, err) end
+            if not j then self:die ("job%d: %s", id, err) end
             printf (fmt, id, seconds_to_string (j.t0),
                     seconds_to_string (j.t1),
                     seconds_to_string (j.t2),
@@ -336,7 +271,7 @@ Command {
  end
 }
 
-Command {
+prog:SubCommand {
  name = "last-jobid",
  description = "Display the last jobid in lwj id sequence",
  usage = "",
@@ -349,54 +284,17 @@ Command {
     }
     local resp, err = f:rpc ("cmb.seq.fetch", req)
     if not resp then
-        die ("No last jobid found: %s", err)
+        slef:die ("No last jobid found: %s", err)
     end
     print (resp.value)
  end
 }
 
 
-local function main_usage ()
-    eprintf ("Usage: %s COMMAND [OPTIONS]...\n", prog)
-    eprintf ("Supported commands: \n")
-    for name,info in pairs (Commands) do
-        eprintf (" %-12s %s\n", name, info.description)
-    end
-end
-
-Command {
- name = "help",
- description = "Display this help or help for a command",
- usage = "[COMMAND]",
- handler = function (self, arg)
-    if #arg == 0 then
-        main_usage ()
-        os.exit (0)
-    end
-    Commands[arg[1]]:help (0)
- end
-}
-
---
---  Main program: Run cmd in arg[1]:
---
-local cmd = table.remove (arg, 1)
-if not cmd then
-    main_usage ()
-    os.exit (1)
-end
-if cmd == "-h" or cmd == "--help" then
-    cmd = "help"
-end
-
 -- Check for valid connection to flux:
 if not f then die ("Connecting to flux failed: %s\n", err) end
 
-local command = Commands[cmd]
-if not command then
-     die ("Error: Unknown command: %s\n", cmd)
-end
-
-command:run (arg)
+-- Process cmdline, run any subcommand, or exit with failure:
+prog:run (arg)
 
 --  vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -290,11 +290,103 @@ prog:SubCommand {
  end
 }
 
+prog:SubCommand {
+ name = "purge",
+ usage = "[OPTIONS]",
+ options = {
+  { name = "verbose",  char = "v",
+    usage = "Increase verbosity." },
+  { name = "target-size", char = 't', arg = "N",
+    usage = "Specify a target number of lwj entries to keep"
+  },
+  { name = "remove",  char = "R",
+    usage = "Remove all eligible lwj entries." },
+  { name = "max",  char = "m", arg = "N",
+    usage = "Maximum number of entries to target." },
+ },
+ description = "Purge old jobs entries from kvs",
+ handler = function (self, arg)
+    local tt = require 'flux.timer'. new()
+    local verbose = self.opt.v
+    local lwj, err = f:kvsdir ("lwj")
+    if not lwj then
+        self:die ("kvsdir (%s): %s\n", d, err)
+    end
+
+    ---
+    -- Gather LWJ ids from kvs directory into a Lua array
+    --
+    local ids = {}
+    for x in lwj:keys () do
+        if tonumber (x) then table.insert (ids, x) end
+    end
+    if verbose then self:log ("%4.03fs: got lwj list\n", tt:get0()) end
+
+    local total = #ids
+    local target = tonumber (self.opt.t)
+    local max = tonumber (self.opt.m) or math.huge
+
+    -- Without --target-size option, just list current number of lwj entries
+    if not target then
+        self:log ("%d total job entries\n", total)
+    elseif total <= target then
+        -- If current total is less than target, then log and exit
+        self:log ("%d total jobs at or below target size of %d\n",
+                  total, target)
+    else
+        -- Otherwise, we need to purge some entries:
+        --
+        local n = math.min (total - target, max)
+
+        -- Remove the first n ids using lwj-completed directory
+        local r = {}
+        (function() -- anonymous function used for early return
+            local completed = f:kvsdir ("lwj-complete")
+            for hb in completed:keys () do
+                local d = completed [hb]
+                for id in d:keys() do
+                    table.insert (r, id)
+                    if self.opt.R then
+                        f:kvs_unlink ("lwj."..id)
+                        f:kvs_unlink ("lwj-complete."..hb.."."..id)
+                    end
+                    n = n - 1
+                    if n == 0 then return end
+                end
+                if self.opt.R then
+                    f:kvs_unlink ("lwj-complete."..hb)
+                end
+            end
+        end)()
+
+        -- gather ids to remove in hostlist for condensed output:
+        --
+        local hl = require 'flux.hostlist' .new (table.concat (r, ",")):uniq ()
+        local idstring = tostring (hl):match ("%[(.+)%]")
+
+        if self.opt.R then
+            lwj:commit()
+            if verbose then
+                self:log ("%4.03fs: unlinked %d entries\n", tt:get0(), #hl)
+            end
+        elseif verbose then
+            self:log ("%4.03fs: finished walking %d entries in lwj-complete\n",
+                      tt:get0(), #hl)
+        end
+
+        self:log ("%s %d lwj entries: %s\n",
+                  self.opt.R and "removed" or "would remove", #hl, idstring)
+        if verbose then
+            self:log ("%4.03fs: all done.\n", tt:get0());
+        end
+    end
+ end
+}
+
 
 -- Check for valid connection to flux:
-if not f then die ("Connecting to flux failed: %s\n", err) end
+if not f then prog:die ("Connecting to flux failed: %s\n", err) end
 
 -- Process cmdline, run any subcommand, or exit with failure:
 prog:run (arg)
-
 --  vi: ts=4 sw=4 expandtab

--- a/src/common/libflux/dispatch.c
+++ b/src/common/libflux/dispatch.c
@@ -487,11 +487,12 @@ void flux_msg_handler_start (flux_msg_handler_t *w)
 
 void flux_msg_handler_stop (flux_msg_handler_t *w)
 {
-    struct dispatch *d = w->d;
-
+    if (!w)
+        return;
     assert (w->magic == HANDLER_MAGIC);
     assert (w->destroyed == 0);
     if (w->running == 1) {
+        struct dispatch *d = w->d;
         w->running = 0;
         d->running_count--;
         if (d->running_count == 0)
@@ -524,6 +525,8 @@ static void free_msg_handler (flux_msg_handler_t *w)
 
 void flux_msg_handler_destroy (flux_msg_handler_t *w)
 {
+    if (!w)
+        return;
     assert (w->magic == HANDLER_MAGIC);
     if (!w->destroyed) {
         flux_msg_handler_stop (w);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -84,13 +84,13 @@ struct subprocess {
     zio_t *zio_err;
     flux_watcher_t *child_watcher;
 
-    subprocess_cb_f *exit_cb;
+    subprocess_cb_f exit_cb;
     void *exit_cb_arg;
 
-    subprocess_cb_f *status_cb;
+    subprocess_cb_f status_cb;
     void *status_cb_arg;
 
-    subprocess_io_cb_f *io_cb;
+    subprocess_io_cb_f io_cb;
 };
 
 static void fda_zero (int fda[])
@@ -178,7 +178,7 @@ static int check_completion (struct subprocess *p)
     if (subprocess_io_complete (p) && subprocess_exited (p)) {
         p->completed = 1;
         if (p->exit_cb)
-            return (*p->exit_cb) (p, p->exit_cb_arg);
+            return p->exit_cb (p, p->exit_cb_arg);
     }
     return (0);
 }
@@ -196,7 +196,7 @@ static int output_handler (zio_t *z, const char *json_str, int len, void *arg)
         Jadd_int (o, "pid", subprocess_pid (p));
         Jadd_str (o, "type", "io");
         Jadd_str (o, "name", zio_name (z));
-        (*p->io_cb) (p, json_object_to_json_string (o));
+        p->io_cb (p, json_object_to_json_string (o));
         json_object_put (o);
     }
     else

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -34,8 +34,8 @@ typedef enum sm_item {
     SM_REACTOR,
 } sm_item_t;
 
-typedef int (subprocess_cb_f) (struct subprocess *p, void *arg);
-typedef int (subprocess_io_cb_f) (struct subprocess *p, const char *json_str);
+typedef int (*subprocess_cb_f) (struct subprocess *p, void *arg);
+typedef int (*subprocess_io_cb_f) (struct subprocess *p, const char *json_str);
 
 /*
  *  Create a subprocess manager to manage creation, destruction, and

--- a/src/common/libsubprocess/test/loop.c
+++ b/src/common/libsubprocess/test/loop.c
@@ -36,12 +36,14 @@
 
 extern char **environ;
 
-static int exit_handler (struct subprocess *p, void *arg)
+static int exit_handler (struct subprocess *p)
 {
     ok (p != NULL, "exit_handler: valid subprocess");
-    ok (arg != NULL, "exit_handler: arg is expected");
+    ok (subprocess_get_context (p, "reactor") != NULL,
+        "exit_handler: context is set for subprocess");
     ok (subprocess_exited (p), "exit_handler: subprocess exited");
     ok (subprocess_exit_code (p) == 0, "exit_handler: subprocess exited normally");
+    diag ("code = %d\n", subprocess_exit_code (p));
     subprocess_destroy (p);
     return (0);
 }
@@ -77,7 +79,8 @@ int main (int ac, char **av)
 
     if (!(p = subprocess_create (sm)))
         BAIL_OUT ("Failed to create a subprocess object");
-    ok (subprocess_set_callback (p, exit_handler, r) >= 0,
+    ok (subprocess_set_context (p, "reactor", r) >= 0, "set subprocess context");
+    ok (subprocess_add_hook (p, SUBPROCESS_COMPLETE, exit_handler) >= 0,
         "set subprocess exit handler");
     ok (subprocess_set_io_callback (p, io_cb) >= 0,
         "set subprocess io callback");

--- a/src/common/libsubprocess/test/socketpair.c
+++ b/src/common/libsubprocess/test/socketpair.c
@@ -35,7 +35,7 @@
 
 extern char **environ;
 
-static int exit_handler (struct subprocess *p, void *arg)
+static int exit_handler (struct subprocess *p)
 {
     ok (subprocess_exited (p), "exit_handler: subprocess exited");
     ok (subprocess_exit_code (p) == 0, "exit_handler: subprocess exited normally");
@@ -81,7 +81,7 @@ int main (int ac, char **av)
 
     if (!(p = subprocess_create (sm)))
         BAIL_OUT ("Failed to create a subprocess object");
-    ok (subprocess_set_callback (p, exit_handler, NULL) >= 0,
+    ok (subprocess_add_hook (p, SUBPROCESS_COMPLETE, exit_handler) >= 0,
         "set subprocess exit handler");
 
     child_fd = -1;

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -66,7 +66,7 @@ int main (int ac, char **av)
 
     diag ("subprocess accessors tests");
     if (!(p = subprocess_create (sm)))
-        BAIL_OUT ("Failed to create subprocess handle");
+        BAIL_OUT ("Failed to create subprocess handle: %s", strerror (errno));
     ok (p != NULL, "create subprocess handle");
 
     rc = subprocess_set_args (p, 1, args);

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,5 +1,19 @@
 #This order is *important* 
-SUBDIRS = barrier connector-local kvs content-sophia content-sqlite libmrpc libkz live mecho wreck libjsc resource-hwloc
+SUBDIRS = \
+ barrier \
+ connector-local \
+ kvs \
+ content-sophia \
+ content-sqlite \
+ libmrpc \
+ libkz \
+ live \
+ mecho \
+ wreck \
+ libjsc \
+ resource-hwloc \
+ cron
+
 if HAVE_PYTHON
 SUBDIRS += pymod
 endif

--- a/src/modules/cron/Makefile.am
+++ b/src/modules/cron/Makefile.am
@@ -1,0 +1,31 @@
+AM_CFLAGS = \
+	@GCCWARN@ \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
+
+#
+# Comms module
+#
+fluxmod_LTLIBRARIES = cron.la
+
+cron_la_SOURCES = \
+	task.h \
+	task.c \
+	entry.h \
+	types.h \
+	types.c \
+	interval.c \
+	event.c \
+	cron.c
+
+cron_la_LDFLAGS = $(fluxmod_ldflags) -module
+cron_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
+		 $(top_builddir)/src/common/libflux-core.la \
+		 $(top_builddir)/src/modules/kvs/libflux-kvs.la \
+		 $(JSON_LIBS) $(ZMQ_LIBS)

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -1,0 +1,914 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* flux cron: cron-like service for flux */
+
+/*
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <sys/time.h>
+#include <ctype.h>
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/shortjson.h"
+
+#include "task.h"
+#include "entry.h"
+#include "types.h"
+
+struct cron_ctx {
+    flux_t                 h;
+    char *                 sync_event;      /* If set, sync entries to event */
+    flux_msg_handler_t *   mh;              /* sync event message handler    */
+    zlist_t    *           entries;
+    zlist_t    *           deferred;        /* list of deferred entries      */
+    double                 last_sync;       /* timestamp of last sync event  */
+    double                 sync_epsilon;    /* allow tasks to run for this
+                                               number of seconds after last-
+                                               sync before deferring         */
+};
+
+/**************************************************************************
+ * Forward declarations
+ */
+static cron_entry_t *cron_entry_create (cron_ctx_t *ctx,
+    const char *json);
+static void cron_entry_destroy (cron_entry_t *e);
+static int cron_entry_stop (cron_entry_t *e);
+static void cron_entry_completion_handler (flux_t h, cron_task_t *t,
+    void *arg);
+static void cron_entry_io_cb (flux_t h, cron_task_t *t, void *arg,
+    bool is_stderr, void *data, int datalen, bool eof);
+static int cron_entry_run_task (cron_entry_t *e);
+static int cron_entry_defer (cron_entry_t *e);
+
+/**************************************************************************/
+/* Public apis
+ */
+void *cron_entry_type_data (cron_entry_t *e)
+{
+    return e->data;
+}
+
+static double timespec_to_double (struct timespec *tm)
+{
+    double s = tm->tv_sec;
+    double ns = tm->tv_nsec/1.0e9 + .5e-9; // round 1/2 epsilon
+    return (s + ns);
+}
+
+double get_timestamp (void)
+{
+    struct timespec tm;
+    clock_gettime (CLOCK_REALTIME, &tm);
+    return timespec_to_double (&tm);
+}
+
+static void timeout_cb (flux_t h, cron_task_t *t, void *arg)
+{
+    cron_entry_t *e = arg;
+    flux_log (h, LOG_INFO, "cron-%ju: task timeout at %.2fs. Killing",
+              e->id, e->timeout);
+    cron_task_kill (t, SIGTERM);
+}
+
+static int cron_entry_run_task (cron_entry_t *e)
+{
+    flux_t h = e->ctx->h;
+    if (cron_task_run (e->task, e->rank, e->command, NULL, NULL) < 0) {
+        flux_log_error (h, "cron-%ju: cron_task_run", e->id);
+        /* Run "completion" handler since this task is done */
+        cron_entry_completion_handler (h, e->task, e);
+        return (-1);
+    }
+    e->stats.lastrun = get_timestamp ();
+    return (0);
+}
+
+static int cron_entry_increment (cron_entry_t *e)
+{
+    ++e->stats.total;
+    return ++e->stats.count;
+}
+
+int cron_entry_schedule_task (cron_entry_t *e)
+{
+    flux_t h = e->ctx->h;
+
+    /* Refuse to run more than one task at once
+     */
+    if (e->task) {
+        flux_log (h, LOG_INFO, "cron-%ju: %s: task still running or scheduled",
+                  e->id, e->name);
+        return (0);
+    }
+    if (!(e->task = cron_task_new (h, cron_entry_completion_handler, e))) {
+        flux_log_error (h, "cron_task_create");
+        return -1;
+    }
+    cron_task_on_io (e->task, cron_entry_io_cb);
+    if (e->timeout >= 0.0)
+        cron_task_set_timeout (e->task, e->timeout, timeout_cb);
+
+    /*   if we've reached our (non-zero) repeat count, prematurely stop
+     *     the current entry (i.e. remove it from event loop, but leave
+     *     it in ctx->entries so it can be listed/queried)
+     */
+    if (cron_entry_increment (e) == e->repeat)
+        cron_entry_stop (e);
+
+    return cron_entry_defer (e);
+}
+
+
+/**************************************************************************/
+
+static void cron_entry_loglines (flux_t h, cron_entry_t *e, int level, char *s)
+{
+    char *p, *saveptr = NULL;
+    while ((p = strtok_r (s, "\n", &saveptr))) {
+        flux_log (h, level, "cron-%ju[%s]: rank=%d: command=\"%s\": \"%s\"",
+                e->id, e->name, e->rank, e->command, p);
+        s = NULL;
+    }
+}
+
+static void cron_entry_io_cb (flux_t h, cron_task_t *t, void *arg,
+    bool is_stderr, void *data, int datalen, bool eof)
+{
+    if (data)
+        cron_entry_loglines (h, arg, is_stderr ? LOG_ERR : LOG_INFO, data);
+}
+
+/* Push task t onto the front of the completed tasks list for
+ *  entry e. If the list has grown past completed-task-size, then drop the
+ *  tail task on the list.
+ */
+int cron_entry_push_completed_task (cron_entry_t *e, struct cron_task *t)
+{
+    if (zlist_push (e->completed_tasks, t) < 0)
+        return (-1);
+    if (zlist_size (e->completed_tasks) > e->task_history_count) {
+        struct cron_task *tdel = zlist_tail (e->completed_tasks);
+        if (tdel) {
+            zlist_remove (e->completed_tasks, tdel);
+            cron_task_destroy (tdel);
+        }
+    }
+    return (0);
+}
+
+static void cron_entry_failure (cron_entry_t *e)
+{
+    e->stats.failure++;
+    e->stats.failcount++;
+    if (e->stop_on_failure && e->stats.failcount >= e->stop_on_failure) {
+        flux_log (e->ctx->h, LOG_ERR,
+                "cron-%ju: exceeded failure limit of %d. stopping",
+                e->id, e->stop_on_failure);
+        cron_entry_stop (e);
+    }
+}
+
+static void cron_entry_completion_handler (flux_t h, cron_task_t *t, void *arg)
+{
+    cron_entry_t *e = arg;
+
+    if (strcmp (cron_task_state (t), "Exec Failure") == 0) {
+        flux_log_error (h, "cron-%ju: failed to run %s", e->id, e->command);
+        cron_entry_failure (e);
+    }
+    else if (cron_task_status (t) != 0) {
+        flux_log (h, LOG_ERR, "cron-%ju: \"%s\": Failed: %s",
+                 e->id, e->command, cron_task_state (t));
+        cron_entry_failure (e);
+    }
+    else
+        e->stats.success++;
+
+    /*
+     *  Push the completed task onto the completed task list and
+     *   drop a task if needed. Reset e->task to NULL since there
+     *   is currently no active task.
+     */
+    if (cron_entry_push_completed_task (e, t) < 0)
+        return;
+    e->task = NULL;
+
+    /*
+     *   If destruction of this cron entry has been requested, complete
+     *    the destroy here.
+     */
+    if (e->destroyed)
+        cron_entry_destroy (e);
+}
+
+static int cron_entry_stop (cron_entry_t *e)
+{
+    if (!e->data || e->stopped) {
+        errno = EINVAL;
+        return (-1);
+    }
+    e->ops.stop (e->data);
+    e->stopped = 1;
+    return (0);
+}
+
+static int cron_entry_start (cron_entry_t *e)
+{
+    if (!e->data || !e->stopped) {
+        errno = EINVAL;
+        return (-1);
+    }
+    e->ops.start (e->data);
+    e->stats.starttime = get_timestamp ();
+    e->stats.count = 0;
+    e->stats.failcount = 0;
+    e->stopped = 0;
+    return (0);
+}
+
+static void cron_entry_destroy (cron_entry_t *e)
+{
+    struct cron_task *t;
+
+    if (e == NULL)
+        return;
+    /*
+     * Stop this entry first, then set a destroyed flag in the case we
+     *  still have a task running
+     */
+    cron_entry_stop (e);
+    e->destroyed = 1;
+
+    /*
+     *  If we have a task still running, we  have to leave cron_entry
+     *   around until the task is complete.
+     */
+    if (e->task)
+        return;
+
+    /*
+     *  Before destroying entry, remove it from entries list:
+     */
+    zlist_remove (e->ctx->entries, e);
+
+    if (e->data) {
+        e->ops.destroy (e->data);
+        e->data = NULL;
+    }
+
+    free (e->name);
+    free (e->command);
+
+    t = zlist_first (e->completed_tasks);
+    while (t) {
+        cron_task_destroy (t);
+        t = zlist_next (e->completed_tasks);
+    }
+    zlist_destroy (&e->completed_tasks);
+
+    free (e);
+}
+
+/*
+ *  Get the next ID from global "cron" sequence number.
+ *  This may be overkill, but is simplest so we go ahead an do it.
+ */
+static int64_t next_cronid (flux_t h)
+{
+    int64_t ret = (int64_t) -1;
+    const char *json_str;
+    JSON req, resp;
+    flux_rpc_t *rpc;
+
+    req = Jnew ();
+    Jadd_str (req, "name", "cron");
+    Jadd_int64 (req, "preincrement", 1);
+    Jadd_int64 (req, "postincrement", 0);
+    Jadd_bool (req, "create", true);
+
+    rpc = flux_rpc (h, "cmb.seq.fetch", Jtostr (req), 0, 0);
+    Jput (req);
+
+    if ((flux_rpc_get (rpc, NULL, &json_str) < 0)
+        || !(resp = Jfromstr (json_str))) {
+        flux_log_error (h, "next_cronid: rpc_get");
+        goto out;
+    }
+
+    (void) Jget_int64 (resp, "value", &ret);
+    Jput (resp);
+out:
+    flux_rpc_destroy (rpc);
+    return ret;
+}
+
+static void deferred_cb (flux_t h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg)
+{
+    cron_ctx_t *ctx = arg;
+    cron_entry_t *e;
+    while ((e = zlist_pop (ctx->deferred)))
+        cron_entry_run_task (e);
+    flux_msg_handler_stop (ctx->mh);
+    ctx->last_sync = get_timestamp ();
+}
+
+static int cron_entry_defer (cron_entry_t *e)
+{
+    cron_ctx_t *ctx = e->ctx;
+    double now = get_timestamp ();
+
+    /* If no default synchronization event or the time since the last
+     *  sync event is very short, then run task immediately
+     */
+    if (!ctx->mh || (now - ctx->last_sync) < ctx->sync_epsilon)
+        return cron_entry_run_task (e);
+
+    /* O/w, defer this task: push entry onto deferred list, and start
+     *  sync event message handler if needed
+     */
+    e->stats.deferred++;
+    flux_log (ctx->h, LOG_DEBUG, "deferring cron-%ju to next %s event",
+             e->id, ctx->sync_event);
+    zlist_push (ctx->deferred, e);
+    if (zlist_size (ctx->deferred) == 1)
+        flux_msg_handler_start (ctx->mh);
+
+    return (0);
+}
+
+static void cron_stats_init (struct cron_stats *s)
+{
+    memset (s, 0, sizeof (*s));
+    s->ctime = get_timestamp ();
+}
+
+/*
+ *  Create a new cron entry from JSON blob
+ */
+static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
+{
+    flux_t h = ctx->h;
+    cron_entry_t *e = NULL;
+    JSON in;
+    const char *name;
+    const char *command;
+    const char *type;
+    int saved_errno = EPROTO;
+
+    if (!(in = Jfromstr (json))) {
+        flux_log_error (h, "cron request decode");
+        goto done;
+    }
+
+    /* Get required fields "name" and "command" */
+    if (!Jget_str (in, "name", &name) ||
+        !Jget_str (in, "command", &command)) {
+        flux_log_error (h, "cron.create: Failed to get name/command");
+        goto done;
+    }
+
+    e = xzmalloc (sizeof (*e));
+    memset (e, 0, sizeof (*e));
+
+    /* Allocate a new ID from this cron entry:
+     */
+    if ((e->id = next_cronid (h)) < 0) {
+        cron_entry_destroy (e);
+        saved_errno = errno;
+        goto done;
+    }
+
+    e->ctx = ctx;
+    e->stopped = 1;
+    e->name = xstrdup (name);
+    e->command = xstrdup (command);
+    cron_stats_init (&e->stats);
+
+    /* Get optional fields
+     *  "repeat" -- the max number of times we'll run the target command
+     *  "rank"   -- run target command on this rank (default 0)
+     */
+    (void) Jget_int (in, "repeat", &e->repeat);
+    (void) Jget_int (in, "rank", &e->rank);
+
+    /* Check to see if we want to keep more than just the status of
+     *  previous run for this cron entry.
+     */
+    if (!Jget_int (in, "task-history-count", &e->task_history_count))
+        e->task_history_count = 1;
+
+    if (!Jget_int (in, "stop-on-failure", &e->stop_on_failure))
+        e->stop_on_failure = 0;
+
+    if (!Jget_double (in, "timeout", &e->timeout))
+        e->timeout = -1.0;
+
+    /* List for all completed tasks up to task-history-count
+     */
+    if (!(e->completed_tasks = zlist_new ())) {
+        saved_errno = errno;
+        flux_log_error (h, "cron_entry_create: zlist_new");
+        goto out_err;
+    }
+
+    /*
+     *  Now, create type-specific data for this entry from type
+     *   name and type-specific data in "args" key:
+     */
+    if (!Jget_str (in, "type", &type)
+        || (cron_type_operations_lookup (type, &e->ops) < 0)) {
+        saved_errno = ENOSYS; /* year,month,day,etc. not supported */
+        goto out_err;
+    }
+    e->typename = xstrdup (type);
+
+    if (!(e->data = e->ops.create (h, e, Jobj_get (in, "args")))) {
+        saved_errno = errno;
+        goto out_err;
+    }
+
+    // Start the entry watcher for this type:
+    cron_entry_start (e);
+
+done:
+    if (in)
+        Jput (in);
+    return (e);
+out_err:
+    cron_entry_destroy (e);
+    errno = saved_errno;
+    return (NULL);
+}
+
+static void cron_ctx_sync_event_stop (cron_ctx_t *ctx)
+{
+    if (ctx->sync_event) {
+        if (flux_event_unsubscribe (ctx->h, ctx->sync_event) < 0)
+            flux_log_error (ctx->h, "destroy: flux_event_unsubscribe\n");
+        flux_msg_handler_destroy (ctx->mh);
+        ctx->mh = NULL;
+        free (ctx->sync_event);
+        ctx->sync_event = NULL;
+    }
+}
+
+static void cron_ctx_destroy (cron_ctx_t *ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    cron_ctx_sync_event_stop (ctx);
+
+    if (ctx->entries) {
+        cron_entry_t *e;
+        while ((e = zlist_pop (ctx->entries)))
+            cron_entry_destroy (e);
+        zlist_destroy (&ctx->entries);
+    }
+    if (ctx->deferred)
+        zlist_destroy (&ctx->deferred);
+    free (ctx);
+}
+
+static int cron_ctx_sync_event_init (cron_ctx_t *ctx, const char *topic)
+{
+    struct flux_match match = FLUX_MATCH_EVENT;
+
+    flux_log (ctx->h, LOG_INFO,
+        "synchronizing cron tasks to event %s", topic);
+
+    ctx->sync_event = xstrdup (topic);
+    match.topic_glob = ctx->sync_event;
+    ctx->mh = flux_msg_handler_create (ctx->h, match,
+                                       deferred_cb, (void *) ctx);
+    if (!ctx->mh) {
+        flux_log_error (ctx->h, "sync_event_init: msg_handler_create");
+        return (-1);
+    }
+    if (flux_event_subscribe (ctx->h, topic) < 0) {
+        flux_log_error (ctx->h, "sync_event_init: subscribe (%s)", topic);
+        return (-1);
+    }
+    /* Do not start the handler until we have entries on the the list */
+    return (0);
+}
+
+static cron_ctx_t * cron_ctx_create (flux_t h)
+{
+    cron_ctx_t *ctx = xzmalloc (sizeof (*ctx));
+
+    ctx->sync_event = NULL;
+    ctx->last_sync  = 0.0;
+
+    /* Default: run synchronized events up to 15ms after sync event */
+    ctx->sync_epsilon = 0.015;
+    ctx->mh = NULL;
+
+    if (!(ctx->entries = zlist_new ())
+        || !(ctx->deferred = zlist_new ())) {
+        flux_log_error (h, "cron_ctx_create: zlist_new");
+        goto error;
+    }
+    ctx->h = h;
+    return ctx;
+error:
+    cron_ctx_destroy (ctx);
+    return (NULL);
+}
+
+/**************************************************************************/
+
+static JSON cron_stats_to_json (struct cron_stats *stats)
+{
+    JSON o = Jnew ();
+    Jadd_double (o, "ctime", stats->ctime);
+    Jadd_double (o, "starttime", stats->starttime);
+    Jadd_double (o, "lastrun", stats->lastrun);
+    Jadd_int (o, "count", stats->count);
+    Jadd_int (o, "failcount", stats->failcount);
+    Jadd_int (o, "total", stats->total);
+    Jadd_int (o, "success", stats->success);
+    Jadd_int (o, "failure", stats->failure);
+    Jadd_int (o, "deferred", stats->deferred);
+    return (o);
+}
+
+static JSON cron_entry_to_json (cron_entry_t *e)
+{
+    cron_task_t *t;
+    JSON o = Jnew ();
+    JSON to = NULL;
+    JSON tasks = Jnew_ar ();
+
+    /*
+     *  Common entry contents:
+     */
+    Jadd_int64 (o, "id", e->id);
+    Jadd_int   (o, "rank", e->rank);
+    Jadd_str   (o, "name", e->name);
+    Jadd_str   (o, "command", e->command);
+    Jadd_int   (o, "repeat", e->repeat);
+    Jadd_bool  (o, "stopped", e->stopped);
+    Jadd_str   (o, "type", e->typename);
+    if (e->timeout >= 0.0)
+        Jadd_double (o, "timeout", e->timeout);
+
+    if ((to = cron_stats_to_json (&e->stats)))
+        json_object_object_add (o, "stats", to);
+
+    /*
+     *  Add type specific json blob, under typedata key:
+     */
+    if ((to = e->ops.tojson (e->data)))
+        json_object_object_add (o, "typedata", to);
+
+    /*
+     *  Add all task information, starting with any current task:
+     */
+    if (e->task && (to = cron_task_to_json (e->task)))
+        json_object_array_add (tasks, to);
+
+    t = zlist_first (e->completed_tasks);
+    while (t) {
+        if ((to = cron_task_to_json (t)))
+            json_object_array_add (tasks, to);
+        t = zlist_next (e->completed_tasks);
+    }
+
+    json_object_object_add (o, "tasks", tasks);
+
+    return (o);
+}
+
+
+/**************************************************************************/
+
+/*
+ *  Handle cron.create: create a new cron entry
+ */
+static void cron_create_handler (flux_t h, flux_msg_handler_t *w,
+                                  const flux_msg_t *msg, void *arg)
+{
+    cron_entry_t *e;
+    cron_ctx_t *ctx = arg;
+    const char *json_str;
+    JSON out = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (flux_request_decode (msg, NULL, &json_str) < 0) {
+        flux_log_error (h, "cron request decode");
+        saved_errno = EPROTO;
+        goto done;
+    }
+
+    if (!(e = cron_entry_create (ctx, json_str))) {
+        saved_errno = errno;
+        goto done;
+    }
+
+    zlist_append (ctx->entries, e);
+
+    rc = 0;
+    out = Jnew ();
+    Jadd_int64 (out, "id", e->id);
+    Jadd_str (out, "name", e->name);
+
+done:
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
+                              rc < 0 ? NULL : Jtostr (out)) < 0)
+        flux_log_error (h, "cron.request: flux_respond");
+    Jput (out);
+}
+
+static void cron_sync_handler (flux_t h, flux_msg_handler_t *w,
+                                const flux_msg_t *msg, void *arg)
+{
+    cron_ctx_t *ctx = arg;
+    const char *json_str;
+    JSON in = NULL;
+    JSON out = NULL;
+    const char *topic;
+    bool disable;
+    double epsilon;
+    int saved_errno;
+    int rc = -1;
+
+    if (flux_request_decode (msg, NULL, &json_str) < 0
+        || !(in = Jfromstr (json_str))) {
+        flux_log_error (h, "cron request decode");
+        saved_errno = EPROTO;
+        goto done;
+    }
+    if (!Jget_str (in, "topic", &topic))
+        topic = NULL; /* Disable sync-event */
+    if (!Jget_bool (in, "disable", &disable))
+        disable = false;
+
+    if (topic || disable)
+        cron_ctx_sync_event_stop (ctx);
+    rc = topic ? cron_ctx_sync_event_init (ctx, topic) : 0;
+
+    if (Jget_double (in, "sync_epsilon", &epsilon))
+        ctx->sync_epsilon = epsilon;
+
+    out = Jnew ();
+    if (ctx->sync_event) {
+        Jadd_str (out, "sync_event", ctx->sync_event);
+        Jadd_double (out, "sync_epsilon", ctx->sync_epsilon);
+    } else
+        Jadd_bool (out, "sync_disabled", true);
+
+done:
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
+                              rc < 0 ? NULL: Jtostr (out)) < 0)
+        flux_log_error (h, "cron.request: flux_respond");
+    if (in)
+        Jput (in);
+    if (out)
+        Jput (out);
+}
+
+static cron_entry_t *cron_ctx_find_entry (cron_ctx_t *ctx, int64_t id)
+{
+    cron_entry_t *e = zlist_first (ctx->entries);
+    while (e && e->id != id)
+        e = zlist_next (ctx->entries);
+    return (e);
+}
+
+/*
+ *  Return a cron entry referenced by request in flux message msg.
+ *  [service] is name of service for logging purposes.
+ */
+static cron_entry_t *entry_from_request (flux_t h, const flux_msg_t *msg,
+                                         cron_ctx_t *ctx, JSON *r,
+                                         const char *service)
+{
+    const char *json_str;
+    JSON in = NULL;
+    int64_t id;
+
+    if ((flux_request_decode (msg, NULL, &json_str) < 0)
+        || !(in = Jfromstr (json_str))
+        || !(Jget_int64 (in, "id", &id))) {
+        flux_log_error (h, "%s: request decode", service);
+        if (in)
+            Jput (in);
+        errno = EPROTO;
+        return NULL;
+    }
+    if (r != NULL)
+        *r = in;
+    else
+        Jput (in);
+    errno = ENOENT;
+    return cron_ctx_find_entry (ctx, id);
+}
+
+/*
+ *  "cron.delete" handler
+ */
+static void cron_delete_handler (flux_t h, flux_msg_handler_t *w,
+                                 const flux_msg_t *msg, void *arg)
+{
+    cron_entry_t *e;
+    cron_ctx_t *ctx = arg;
+    JSON in = NULL;
+    JSON out = NULL;
+    bool kill = false;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(e = entry_from_request (h, msg, ctx, &in, "cron.delete"))) {
+        saved_errno = errno;
+        goto done;
+    }
+
+    rc = 0;
+    out = cron_entry_to_json (e);
+    if (e->task && Jget_bool (in, "kill", &kill) && kill == true)
+        cron_task_kill (e->task, SIGTERM);
+    cron_entry_destroy (e);
+
+done:
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
+                              rc < 0 ? NULL : Jtostr (out)) < 0)
+        flux_log_error (h, "cron.delete: flux_respond");
+    Jput (out);
+    Jput (in);
+}
+
+/*
+ *  "cron.stop" handler: stop a cron entry until restarted
+ */
+static void cron_stop_handler (flux_t h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg)
+{
+    cron_entry_t *e;
+    cron_ctx_t *ctx = arg;
+    JSON out = NULL;
+    int saved_errno = 0;
+    int rc = -1;
+
+    if (!(e = entry_from_request (h, msg, ctx, NULL, "cron.stop"))) {
+        saved_errno = errno;
+        goto done;
+    }
+    rc = cron_entry_stop (e);
+    out = cron_entry_to_json (e);
+done:
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
+                              out ? Jtostr (out) : NULL) < 0)
+        flux_log_error (h, "cron.stop: flux_respond");
+}
+
+/*
+ *  "cron.start" handler: start a stopped cron entry
+ */
+static void cron_start_handler (flux_t h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg)
+{
+    cron_entry_t *e;
+    cron_ctx_t *ctx = arg;
+    JSON out = NULL;
+    int saved_errno = 0;
+    int rc = -1;
+
+    if (!(e = entry_from_request (h, msg, ctx, NULL, "cron.start"))) {
+        saved_errno = errno;
+        goto done;
+    }
+    rc = cron_entry_start (e);
+    out = cron_entry_to_json (e);
+done:
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
+                      out ? Jtostr (out) : NULL) < 0)
+        flux_log_error (h, "cron.start: flux_respond");
+}
+
+
+/*
+ *  Handle "cron.list" -- dump a list of current cron entries via JSON
+ */
+static void cron_ls_handler (flux_t h, flux_msg_handler_t *w,
+                             const flux_msg_t *msg, void *arg)
+{
+    cron_ctx_t *ctx = arg;
+    cron_entry_t *e = NULL;
+    JSON out = Jnew ();
+    JSON entries = Jnew_ar ();
+
+    e = zlist_first (ctx->entries);
+    while (e) {
+        JSON entry = cron_entry_to_json (e);
+        if (entry == NULL)
+            flux_log_error (h, "cron_entry_to_json");
+        else
+            json_object_array_add (entries, entry);
+        e = zlist_next (ctx->entries);
+    }
+    json_object_object_add (out, "entries", entries);
+
+    if (flux_respond (h, msg, 0, Jtostr (out)) < 0)
+        flux_log_error (h, "cron.list: flux_respond");
+    Jput (out);
+}
+
+/**************************************************************************/
+
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,     "cron.create",   cron_create_handler  },
+    { FLUX_MSGTYPE_REQUEST,     "cron.delete",   cron_delete_handler  },
+    { FLUX_MSGTYPE_REQUEST,     "cron.list",     cron_ls_handler },
+    { FLUX_MSGTYPE_REQUEST,     "cron.stop",     cron_stop_handler },
+    { FLUX_MSGTYPE_REQUEST,     "cron.start",    cron_start_handler },
+    { FLUX_MSGTYPE_REQUEST,     "cron.sync",     cron_sync_handler },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void process_args (cron_ctx_t *ctx, int ac, char **av)
+{
+    int i;
+    for (i = 0; i < ac; i++) {
+        if (strncmp (av[i], "sync=", 5) == 0)
+            cron_ctx_sync_event_init (ctx, (av[i])+5);
+        else if (strncmp (av[i], "sync_epsilon=", 13) == 0) {
+            char *s = (av[i])+13;
+            char *endptr;
+            double d = strtod (s, &endptr);
+            if (d == 0 && endptr == s)
+                flux_log_error (ctx->h, "option %s ignored", av[i]);
+            else
+                ctx->sync_epsilon = d;
+        }
+        else
+            flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);
+    }
+}
+
+
+int mod_main (flux_t h, int ac, char **av)
+{
+    int rc = -1;
+    cron_ctx_t *ctx = cron_ctx_create (h);
+
+    process_args (ctx, ac, av);
+
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log_error (h, "flux_msg_handler_addvec");
+        goto done;
+    }
+    if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
+        flux_log_error (h, "flux_reactor_run");
+    flux_msg_handler_delvec (htab);
+    cron_ctx_destroy (ctx);
+done:
+    return rc;
+}
+
+MOD_NAME ("cron");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -1,0 +1,107 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef HAVE_CRON_ENTRY_H
+# define HAVE_CRON_ENTRY_H
+
+#include <czmq.h>
+#include <flux/core.h>
+#include "src/common/libutil/shortjson.h"
+
+typedef struct cron_ctx cron_ctx_t;
+typedef struct cron_entry cron_entry_t;
+
+/*
+ *  Cron entry type-specific operations
+ */
+struct cron_entry_ops {
+    // type creator from JSON request "arguments". Returns ptr to type object
+    void *(*create) (flux_t h, cron_entry_t *e, JSON arg);
+
+    // destroy type object contained in data
+    void (*destroy) (void *data);
+
+    // start the type specific watcher
+    void (*start) (void *data);
+
+    // stop the type specific watcher
+    void (*stop) (void *data);
+
+    // return data for entry type as JSON
+    JSON (*tojson) (void *data);
+};
+
+struct cron_stats {
+    double     ctime;        /* entry creation time           */
+    double     lastrun;      /* last time task was launched   */
+    double     starttime;    /* last time entry was started   */
+    uint64_t   total;        /* total number of runs          */
+    uint64_t   count;        /* number of runs since start    */
+    uint64_t   failcount;    /* number failed runs since start*/
+    uint64_t   success;      /* number of successes           */
+    uint64_t   failure;      /* number of failures            */
+    uint64_t   deferred;     /* number of times deferred      */
+};
+
+
+struct cron_entry {
+    cron_ctx_t    *     ctx;                /* cron ctx for this entry       */
+    int                 destroyed;          /* Entry is defunct              */
+
+    struct cron_stats   stats;              /* meta-stats for this entry     */
+
+    int64_t             id;                 /* Unique sequence number        */
+    int                 rank;               /* Optional rank on which to run */
+    char *              name;               /* Entry name, if given          */
+    char *              command;            /* Command to execute            */
+
+    int                 repeat;             /* Total number of times to run  */
+
+    unsigned int        stopped:1;          /* This entry is inactive        */
+
+    const char *           typename;        /* Name of this type             */
+    struct cron_entry_ops  ops;             /* Type-specific operations      */
+    void *                 data;            /* Entry type specific data      */
+
+    struct cron_task *  task;               /* Currently executing task      */
+    zlist_t          *  completed_tasks;    /* List of completed tasks       */
+    int                 task_history_count; /* Max # of tasks in history     */
+    int                 stop_on_failure;    /* Stop cron entry after failure */
+
+    double              timeout;            /* Max secs to allow task to run */
+};
+
+/* Return type data ptr for cron_entry `e`
+ */
+void *cron_entry_type_data (cron_entry_t *e);
+
+/* Schedule the task corresponding to cron entry `e` to run as soon as allowed
+ */
+int cron_entry_schedule_task (cron_entry_t *e);
+
+/* Retrieve current timestamp in seconds
+ */
+double get_timestamp (void);
+
+#endif /* !HAVE_CRON_ENTRY_H */

--- a/src/modules/cron/event.c
+++ b/src/modules/cron/event.c
@@ -1,0 +1,188 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "entry.h"
+#include "src/common/libutil/xzmalloc.h"
+
+/* event handler
+ */
+struct cron_event {
+    flux_t h;
+    flux_msg_handler_t *mh;
+    int paused;
+    double min_interval;
+    int nth;
+    int after;
+    int counter;
+    char *event;
+};
+
+static void ev_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                         int revents, void *arg)
+{
+    cron_entry_t *e = arg;
+    struct cron_event *ev = cron_entry_type_data (e);
+    cron_entry_schedule_task (e);
+    flux_watcher_stop (w);
+    flux_watcher_destroy (w);
+    ev->paused = 0;
+}
+
+static void event_handler (flux_t h, flux_msg_handler_t *w,
+                           const flux_msg_t *msg, void *arg)
+{
+    cron_entry_t *e = arg;
+    struct cron_event *ev = cron_entry_type_data (e);
+
+    ev->counter++;
+    if (ev->paused)
+        return;
+    /*
+     *  Determine if we should run the cron task on this event
+     *   based on the current values for "after" and "nth".
+     *   If ev->after is set, then only run for the first time
+     *   after we've seen this many events. If ev->nth is set,
+     *   only run every nth event starting with 'after'.
+     */
+    if (ev->counter < ev->after)
+        return;
+    if (ev->nth && ((ev->counter - ev->after) % ev->nth))
+        return;
+    if (ev->min_interval > 0.) {
+        double now = get_timestamp ();
+        double remaining = ev->min_interval - (now - e->stats.lastrun);
+        if (remaining > 1e-5) {
+            flux_reactor_t *r = flux_get_reactor (h);
+            flux_watcher_t *w;
+            if (!(w = flux_timer_watcher_create (r, remaining, 0.,
+                                                 ev_timer_cb, (void *) e)))
+                flux_log_error (h, "timer_watcher_create");
+            else {
+                /* Pause the event watcher. Continue to count events but
+                 *  don't run anything until we unpause.
+                 */
+                ev->paused = 1;
+                flux_watcher_start (w);
+                flux_log (h, LOG_DEBUG,
+                          "cron-%ju: delaying %4.03fs due to min interval",
+                          e->id, remaining);
+            }
+            return;
+        }
+    }
+    cron_entry_schedule_task (e);
+}
+
+static void *cron_event_create (flux_t h, cron_entry_t *e, JSON arg)
+{
+    struct cron_event *ev;
+    int nth;
+    int after;
+    double min_interval;
+    const char *event;
+    struct flux_match match = FLUX_MATCH_EVENT;
+
+    if (!(Jget_str (arg, "topic", &event))) {
+        errno = EPROTO;
+        return NULL;
+    }
+    if (!Jget_int (arg, "nth", &nth))
+        nth = 0;
+    if (!Jget_int (arg, "after", &after))
+        after = 0;
+    if (!Jget_double (arg, "min_interval", &min_interval))
+        min_interval = 0.;
+
+    /* Call subscribe per cron entry. Multiple event subscriptions are
+     *  allowed and each cron_event entry will have a corresponding
+     *  unsubscribe
+     */
+    if (flux_event_subscribe (h, event) < 0) {
+        flux_log_error (h, "cron_event: subscribe");
+        return (NULL);
+    }
+
+    ev = xzmalloc (sizeof (*ev));
+    /* Save a copy of this handle for event unsubscribe at destroy */
+    ev->h = h;
+    ev->event = xstrdup (event);
+    ev->nth = nth;
+    ev->after = after;
+    ev->min_interval = min_interval;
+    ev->counter = 0;
+
+    match.topic_glob = ev->event;
+    ev->mh = flux_msg_handler_create (h, match, event_handler, (void *)e);
+    if (!ev->mh) {
+        flux_log_error (h, "cron_event: flux_msg_handler_create");
+        free (ev);
+        return (NULL);
+    }
+
+    return (ev);
+}
+
+static void cron_event_destroy (void *arg)
+{
+    struct cron_event *ev = arg;
+    flux_msg_handler_destroy (ev->mh);
+    (void) flux_event_unsubscribe (ev->h, ev->event);
+    free (ev->event);
+    free (ev);
+}
+
+static void cron_event_start (void *arg)
+{
+    struct cron_event *ev = arg;
+    ev->counter = 0;
+    flux_msg_handler_start (ev->mh);
+}
+
+static void cron_event_stop (void *arg)
+{
+    flux_msg_handler_stop (((struct cron_event *)arg)->mh);
+}
+
+static JSON cron_event_to_json (void *arg)
+{
+    struct cron_event *ev = arg;
+    JSON o = Jnew ();
+    Jadd_str (o, "topic", ev->event);
+    Jadd_int (o, "nth", ev->nth);
+    Jadd_int (o, "after", ev->after);
+    Jadd_int (o, "counter", ev->counter);
+    Jadd_double (o, "min_interval", ev->min_interval);
+    return (o);
+}
+
+struct cron_entry_ops cron_event_operations = {
+    .create =  cron_event_create,
+    .destroy = cron_event_destroy,
+    .start =   cron_event_start,
+    .stop =    cron_event_stop,
+    .tojson =  cron_event_to_json
+};

--- a/src/modules/cron/interval.c
+++ b/src/modules/cron/interval.c
@@ -1,0 +1,110 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* cron interval type definition */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "entry.h"
+
+struct cron_interval {
+    flux_watcher_t *w;
+    double          after;   /* initial timeout */
+    double          seconds; /* repeat interval */
+};
+
+
+static void interval_handler (flux_reactor_t *r, flux_watcher_t *w,
+                              int revents, void *arg)
+{
+    cron_entry_schedule_task ((cron_entry_t *)arg);
+}
+
+static void *cron_interval_create (flux_t h, cron_entry_t *e, JSON arg)
+{
+    struct cron_interval *iv;
+    double i;
+    double after;
+
+    if (!(Jget_double (arg, "interval", &i)))
+        return NULL;
+    if (!(Jget_double (arg, "after", &after)))
+        after = i;
+
+    iv = xzmalloc (sizeof (*iv));
+    iv->seconds = i;
+    iv->after = after;
+    iv->w = flux_timer_watcher_create (flux_get_reactor (h),
+                                       after, i, interval_handler,
+                                       (void *) e);
+    if (!iv->w) {
+        flux_log_error (h, "cron_interval: flux_timer_watcher_create");
+        free (iv);
+        return (NULL);
+    }
+
+    return (iv);
+}
+
+static void cron_interval_destroy (void *arg)
+{
+    struct cron_interval *iv = arg;
+    flux_watcher_destroy (iv->w);
+    free (iv);
+}
+
+static void cron_interval_start (void *arg)
+{
+    flux_watcher_start (((struct cron_interval *)arg)->w);
+}
+
+static void cron_interval_stop (void *arg)
+{
+    flux_watcher_stop (((struct cron_interval *)arg)->w);
+}
+
+static JSON cron_interval_to_json (void *arg)
+{
+    struct cron_interval *iv = arg;
+    JSON o = Jnew ();
+    Jadd_double (o, "interval", iv->seconds);
+    Jadd_double (o, "after",    iv->after);
+    return (o);
+}
+
+struct cron_entry_ops cron_interval_operations = {
+    .create  = cron_interval_create,
+    .destroy = cron_interval_destroy,
+    .start =   cron_interval_start,
+    .stop =    cron_interval_stop,
+    .tojson =  cron_interval_to_json,
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -1,0 +1,467 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <signal.h>
+#include <time.h>
+#include <stdarg.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libsubprocess/zio.h"
+
+#include "task.h"
+
+struct cron_task {
+    flux_t                h;      /* flux handle used to create this task   */
+    struct flux_match     match;  /* match object for message handler       */
+    flux_msg_handler_t *  mh;     /* msg handler specific to this task      */
+
+    int                   rank;   /* rank on which task is being run        */
+    pid_t                 pid;    /* remote process id                      */
+    char *                state;  /* state string returned by cmb.exec      */
+
+    double               timeout;
+    flux_watcher_t *   timeout_w;
+
+    int                   status; /* exit status if state is Exited         */
+    int              rexec_errno; /* any errno returned by rexec service    */
+    int               exec_errno; /* any errno returned by remote exec(2)   */
+
+    struct timespec   createtime; /* Time at which task was created         */
+    struct timespec    starttime; /* Time at which exec request was sent    */
+    struct timespec  runningtime; /* Time at which task state was Running   */
+    struct timespec      endtime; /* Time at which task exited/failed       */
+
+    unsigned int       started:1;
+    unsigned int  rexec_failed:1;
+    unsigned int       running:1;
+    unsigned int      timedout:1;
+    unsigned int        exited:1;
+    unsigned int stderr_closed:1;
+    unsigned int stdout_closed:1;
+
+    cron_task_io_f       io_cb;
+    cron_task_state_f    state_cb;
+    cron_task_state_f    timeout_cb;
+    cron_task_complete_f completion_cb;
+    void *               arg;
+};
+
+
+void cron_task_destroy (cron_task_t *t)
+{
+    flux_msg_handler_stop (t->mh);
+    flux_msg_handler_destroy (t->mh);
+    t->mh = NULL;
+    flux_watcher_destroy (t->timeout_w);
+    t->timeout_w = NULL;
+    free (t->state);
+    free (t);
+}
+
+cron_task_t *cron_task_new (flux_t h, cron_task_complete_f cb, void *arg)
+{
+    cron_task_t *t = xzmalloc (sizeof (*t));
+    memset (t, 0, sizeof (*t));
+    t->h = h;
+    t->match = FLUX_MATCH_RESPONSE;
+    t->completion_cb = cb;
+    t->arg = arg;
+    t->state = xstrdup ("Initialized");
+    clock_gettime (CLOCK_REALTIME, &t->createtime);
+    t->timeout = 0.0;
+    return (t);
+}
+
+void cron_task_on_io (cron_task_t *t, cron_task_io_f cb)
+{
+    t->io_cb = cb;
+}
+
+void cron_task_on_state_change (cron_task_t *t, cron_task_state_f cb)
+{
+    t->state_cb = cb;
+}
+
+static bool cron_task_completed (cron_task_t *t)
+{
+    if (t->rexec_failed)
+        return true;
+    if (t->exited && t->stderr_closed && t->stdout_closed)
+        return true;
+    return false;
+}
+
+static void cron_task_state_update (cron_task_t *t, const char *fmt, ...)
+{
+    int rc;
+    va_list ap;
+    va_start (ap, fmt);
+    free (t->state);
+    if ((rc = vasprintf (&t->state, fmt, ap) < 0))
+        t->state = xstrdup (fmt);
+    va_end (ap);
+}
+
+static int io_handler (flux_t h, cron_task_t *t,
+    const char *json_str, JSON resp)
+{
+    const char *stream = "stdout";
+    void *data = NULL;
+    bool eof;
+    bool is_stderr = false;
+    int len;
+
+    if ((len = zio_json_decode (json_str, &data, &eof)) < 0) {
+        flux_log_error (h, "io decode");
+        return (-1);
+    }
+    (void) Jget_str (resp, "name", &stream);
+
+    if (strcmp (stream, "stderr") == 0)
+        is_stderr = true;
+
+    if (t->io_cb)
+        (*t->io_cb) (h, t, t->arg, is_stderr, data, len, eof);
+
+    if (eof) {
+        if (is_stderr)
+            t->stderr_closed = 1;
+        else
+            t->stdout_closed = 1;
+    }
+    free (data);
+    return (0);
+}
+
+static int state_handler (flux_t h, cron_task_t *t, JSON resp)
+{
+    const char *state;
+
+    if (!Jget_str (resp, "state", &state)) {
+        flux_log_error (h, "unable to get exec state");
+        return -1;
+    }
+    cron_task_state_update (t, state);
+
+    if (strcmp (state, "Running") == 0) {
+        clock_gettime (CLOCK_REALTIME, &t->runningtime);
+        t->running = 1;
+        (void) Jget_int (resp, "pid", &t->pid);
+        (void) Jget_int (resp, "rank", &t->rank);
+    }
+    else if (strcmp (state, "Exec Failure") == 0) {
+        Jget_int (resp, "exec_errno", &t->exec_errno);
+        t->exited = 1;
+        t->stderr_closed = t->stdout_closed = 1;
+        errno = t->exec_errno;
+    }
+    else if (strcmp (state, "Exited") == 0) {
+        t->exited = 1;
+        Jget_int (resp, "status", &t->status);
+        if (WIFSIGNALED (t->status))
+            cron_task_state_update (t, "%s", strsignal (WTERMSIG (t->status)));
+        else if (WEXITSTATUS (t->status) != 0)
+            cron_task_state_update (t, "Exit %d", WEXITSTATUS (t->status));
+    }
+
+    if (t->state_cb)
+        (*t->state_cb) (h, t, t->arg);
+
+    return (0);
+
+}
+
+static void cron_task_rexec_failed (cron_task_t *t, int errnum)
+{
+    t->rexec_failed = 1;
+    t->rexec_errno = errno;
+    cron_task_state_update (t, "Rexec Failure");
+}
+
+static void cron_task_handle_completion (cron_task_t *t)
+{
+    clock_gettime (CLOCK_REALTIME, &t->endtime);
+    /*
+     * Disable message handling for this task. Task will be destroyed
+     *  later.
+     */
+    flux_msg_handler_stop (t->mh);
+    flux_msg_handler_destroy (t->mh);
+    t->mh = NULL;
+    flux_watcher_destroy (t->timeout_w);
+    t->timeout_w = NULL;
+
+    /* Call completion handler for this entry */
+    if (t->completion_cb)
+        (*t->completion_cb) (t->h, t, t->arg);
+}
+
+static void exec_handler (flux_t h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct cron_task *t = arg;
+    const char *json_str;
+    const char *topic;
+    const char *type;
+    JSON resp = NULL;
+
+    if ((flux_response_decode (msg, &topic, &json_str) < 0)
+        || !(resp = Jfromstr (json_str))) {
+        cron_task_rexec_failed (t, errno);
+        flux_log_error (h, "cron_task: exec_handler");
+    }
+    else if (Jget_str (resp, "type", &type) && strcmp (type, "io") == 0) {
+        if (io_handler (h, t, json_str, resp) < 0)
+            goto out;
+    }
+    else if (state_handler (h, t, resp) < 0)
+        goto out;
+
+    if (cron_task_completed (t))
+        cron_task_handle_completion (t);
+
+out:
+    if (resp)
+        Jput (resp);
+}
+
+static flux_msg_t *kill_request_create (cron_task_t *t, int sig)
+{
+    int e = 0;
+    flux_msg_t *msg;
+    JSON o = Jnew ();
+    Jadd_int (o, "pid", t->pid);
+    Jadd_int (o, "signum", sig);
+    if (!(msg = flux_request_encode ("cmb.exec.signal", Jtostr (o)))
+        || (flux_msg_set_nodeid (msg, t->rank, 0) < 0))
+        e = errno;
+    if (o)
+        Jput (o);
+    errno = e;
+    return (msg);
+}
+
+int cron_task_kill (cron_task_t *t, int sig)
+{
+    flux_t h = t->h;
+    flux_msg_t *msg;
+
+    if (!t->started || t->exited) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    msg = kill_request_create (t, sig);
+    if (!msg || flux_send (h, msg, 0) < 0)
+        return (-1);
+    return (0);
+}
+
+static void timeout_cb (flux_reactor_t *r, flux_watcher_t *w,
+                        int revents, void *arg)
+{
+    cron_task_t *t = arg;
+    t->timedout = 1;
+    if (t->timeout_cb)
+        t->timeout_cb (t->h, t, t->arg);
+    else
+        cron_task_kill (t, SIGTERM);
+}
+
+static void cron_task_timeout_start (cron_task_t *t)
+{
+    flux_watcher_t *w;
+    flux_reactor_t *r;
+    if (t->timeout <= 0.0)
+        return;
+    r = flux_get_reactor (t->h);
+    if (!(w = flux_timer_watcher_create (r, t->timeout, 0.0, timeout_cb, t))) {
+        flux_log_error (t->h, "task_timeout_start");
+        return;
+    }
+    flux_watcher_start (w);
+    t->timeout_w = w;
+}
+
+void cron_task_set_timeout (cron_task_t *t, double to, cron_task_state_f cb)
+{
+    t->timeout_cb = cb;
+    t->timeout = to;
+    if (t->started)
+        cron_task_timeout_start (t);
+}
+
+static JSON exec_request_create (struct cron_task *t,
+    const char *command,
+    const char *cwd,
+    char *const env[])
+{
+    JSON o = Jnew ();
+    JSON cmd = Jnew_ar ();
+
+    Jadd_ar_str (cmd, "sh");
+    Jadd_ar_str (cmd, "-c");
+    Jadd_ar_str (cmd, command);
+
+    json_object_object_add (o, "cmdline", cmd);
+
+    if (cwd)
+        Jadd_str (o, "cwd", cwd);
+
+    if (env) {
+        JSON enva = Jnew_ar ();
+        const char *e = env[0];
+        while (e != NULL)
+            Jadd_ar_str (enva, e);
+        json_object_object_add (o, "environ", enva);
+    }
+    return (o);
+}
+
+int cron_task_run (cron_task_t *t,
+    int rank, const char *cmd, const char *cwd,
+    char *const env[])
+{
+    flux_t h = t->h;
+    JSON req = NULL;
+    flux_msg_t *msg = NULL;
+    int rc = -1;
+
+    t->match.matchtag = flux_matchtag_alloc (h, 1);
+    t->match.topic_glob = "cmb.exec";
+    t->mh = flux_msg_handler_create (h, t->match, exec_handler, t);
+    if (!t->mh)
+        return -1;
+
+    if (!(req = exec_request_create (t, cmd, cwd, env)))
+        goto done;
+    if (!(msg = flux_request_encode ("cmb.exec", Jtostr (req))))
+        goto done;
+    if (flux_msg_set_nodeid (msg, rank, 0) < 0)
+        goto done;
+    if (flux_msg_set_matchtag (msg, t->match.matchtag) < 0)
+        goto done;
+    if ((rc = flux_send (h, msg, 0)) < 0) {
+        flux_log_error (h, "cron_task_run: flux_send");
+        goto done;
+    }
+    t->started = 1;
+    clock_gettime (CLOCK_REALTIME, &t->starttime);
+    cron_task_state_update (t, "Started");
+    rc = 0;
+    flux_msg_handler_start (t->mh);
+
+    if (t->timeout >= 0.0)
+        cron_task_timeout_start (t);
+done:
+    if (req)
+        Jput (req);
+    if (rc < 0) {
+        t->rexec_errno = errno;
+        cron_task_state_update (t, "Rexec Failure");
+    }
+    flux_msg_destroy (msg);
+    return (rc);
+}
+
+const char *cron_task_state (cron_task_t *t)
+{
+    return (t->state);
+}
+
+int cron_task_status (cron_task_t *t)
+{
+    return (t->status);
+}
+
+static double timespec_to_double (struct timespec *tm)
+{
+    double s = tm->tv_sec;
+    double ns = tm->tv_nsec/1.0e9 + .5e-9; // round 1/2 epsilon
+    return (s + ns);
+}
+
+/*
+ *  Enhance t->state with more information in specific cases:
+ */
+static const char * cron_task_state_string (cron_task_t *t)
+{
+    if (t->rexec_errno)
+        return ("Rexec Failure");
+    if (t->exec_errno)
+        return ("Exec Failure");
+    if (!t->started)
+        return ("Deferred");
+    if (!t->exited)
+        return ("Running");
+    if (t->timedout)
+        return ("Timeout");
+    if (t->status != 0)
+        return ("Failed");
+    return ("Exited");
+}
+
+JSON cron_task_to_json (struct cron_task *t)
+{
+    JSON o = Jnew ();
+
+    Jadd_int (o, "rank", t->rank);
+    Jadd_int (o, "pid", t->pid);
+    Jadd_int (o, "status", t->status);
+    if (t->rexec_errno)
+        Jadd_int (o, "rexec_errno", t->rexec_errno);
+    if (t->exec_errno)
+        Jadd_int (o, "exec_errno", t->exec_errno);
+    if (t->timedout)
+        Jadd_bool (o, "timedout", true);
+    if (cron_task_completed (t)) {
+        int code = 0;
+        if (WIFEXITED (t->status))
+            code = WEXITSTATUS (t->status);
+        else if (WIFSIGNALED (t->status))
+            code = 128 + WTERMSIG (t->status);
+        Jadd_int (o, "code", code);
+    }
+    Jadd_str (o, "state", cron_task_state_string (t));
+    Jadd_double (o, "create-time", timespec_to_double (&t->createtime));
+    if (t->started)
+        Jadd_double (o, "start-time", timespec_to_double (&t->starttime));
+    if (t->running)
+        Jadd_double (o, "running-time", timespec_to_double (&t->runningtime));
+    if (cron_task_completed (t))
+        Jadd_double (o, "end-time", timespec_to_double (&t->endtime));
+
+    return (o);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -1,0 +1,103 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef HAVE_CRON_TASK_H
+#define HAVE_CRON_TASK_H
+
+#include <flux/core.h>
+
+/*  cron_task_t: async task handling for cron
+ */
+typedef struct cron_task cron_task_t;
+
+/*  io callback fn for cron task
+ */
+typedef void (*cron_task_io_f) (flux_t h, cron_task_t *t, void *arg,
+                                bool is_stderr, void *data, int datalen,
+                                bool eof);
+
+/*  task state change handler for cron task, check state with
+ *   cron_task_state().
+ */
+typedef void (*cron_task_state_f) (flux_t h, cron_task_t *t, void *arg);
+
+/*  task completion handler, the only required handler for cron task,
+ *   called when task and its I/O have completed.
+ */
+typedef void (*cron_task_complete_f) (flux_t h, cron_task_t *t, void *arg);
+
+/*  create a new cron task using flux handle `h`. Completion handler
+ *   `cb` will be called when cron task has fully completed. All callbacks
+ *   will be passed context `arg`.
+ */
+cron_task_t *cron_task_new (flux_t h, cron_task_complete_f cb, void *arg);
+
+/*  destroy cron task `t`
+ */
+void cron_task_destroy (cron_task_t *t);
+
+/*  call `cb` on any io for cron task `t`
+ */
+void cron_task_on_io (cron_task_t *t, cron_task_io_f cb);
+
+/*  call `cb` on any state change in cron task `t`
+ */
+void cron_task_on_state_change (cron_task_t *t, cron_task_state_f cb);
+
+/*  set a timeout on execution time of task `t` for `to` seconds.
+ *   if callback `cb` is set then it will be called at the timeout,
+ *   if cb == NULL then the task is automatically sent SIGTERM.
+ */
+void cron_task_set_timeout (cron_task_t *t, double to, cron_task_state_f cb);
+
+/*  run cron task `t` as command `cmd`, optional working directory `cwd`
+ *   and optional alternate environment `env`.
+ */
+int cron_task_run (cron_task_t *t,
+                   int rank, const char *cmd,
+                   const char *cwd,
+                   char *const env []);
+
+/*
+ *  Send signal `sig` to cron task t
+ */
+int cron_task_kill (cron_task_t *t, int sig);
+
+/*  return string representation of the current cron task state
+ */
+const char * cron_task_state (cron_task_t *t);
+
+/*  return exit status, or -1 if task not exited
+ */
+int cron_task_status (cron_task_t *t);
+
+/*  return JSON representation of cron task `t`
+ */
+JSON cron_task_to_json (cron_task_t *t);
+
+#endif /* !HAVE_CRON_TASK_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/modules/cron/types.c
+++ b/src/modules/cron/types.c
@@ -1,0 +1,56 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <string.h>
+#include "entry.h"
+
+/* List of external operations structures defined in
+ *  type-specific source files:
+ */
+extern struct cron_entry_ops cron_interval_operations;
+extern struct cron_entry_ops cron_event_operations;
+
+static struct cron_typeinfo {
+    const char *name;
+    struct cron_entry_ops *ops;
+} cron_types[] = {
+    { "interval", &cron_interval_operations },
+    { "event",    &cron_event_operations    },
+    { NULL, NULL }
+};
+
+int cron_type_operations_lookup (const char *name,
+    struct cron_entry_ops *ops)
+{
+    struct cron_typeinfo *type = cron_types;
+    while (type && type->name) {
+        if (strcmp (name, type->name) == 0) {
+            *ops = *type->ops;
+            return (0);
+        }
+        type++;
+    }
+    errno = ENOENT;
+    return (-1);
+}

--- a/src/modules/cron/types.h
+++ b/src/modules/cron/types.h
@@ -1,0 +1,35 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef HAVE_CRON_TYPES_H
+# define HAVE_CRON_TYPES_H
+#include "entry.h"
+
+/*
+ *  Lookup cron entry operations for cron entry type named "name"
+ */
+int cron_type_operations_lookup (const char *name,
+    struct cron_entry_ops *ops);
+
+#endif /* !HAVE_CRON_TYPES_H */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
 	t0012-content-sqlite.t \
 	t0013-content-sophia.t \
 	t0014-runlevel.t \
+	t0015-cron.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1003-mecho.t \
@@ -108,6 +109,7 @@ check_SCRIPTS = \
 	t0012-content-sqlite.t \
 	t0013-content-sophia.t \
 	t0014-runlevel.t \
+	t0015-cron.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1003-mecho.t \

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -48,6 +48,13 @@ kvsdir_test (dir, key, "0",   "string 0 not converted to numeric")
 kvsdir_test (dir, key, "0x1", "string 0x1 not converted to numeric")
 kvsdir_test (dir, key, "00",  "string 00 not converted to numeric")
 
+local r, err = dir:unlink (key)
+is (r, true, "kvsdir: unlink succeeds")
+is (err, nil, "kvsdir: unlink: no error")
+dir:commit()
+local r = dir [key]
+is (r, nil, "unlink: after unlink key doesn't exist")
+
 -- low-level kvs_put testing
 local tests = {
  { val = "foo", msg = "kvs_put: string" },
@@ -113,6 +120,14 @@ is (type(x), "string", "error is a string")
 dir.testkey = "foo"
 kvsdir_test (dir, 'testkey', "foo", "unlink: set known value for key")
 dir.testkey = nil
+kvsdir_test (dir, 'testkey', nil, "unlink: key is now nil")
+
+dir.testkey = "foo"
+kvsdir_test (dir, 'testkey', "foo", "unlink: set known value for key")
+local r, err = f:kvs_unlink ("testkey")
+is (r, true, "kvs_unlink: success")
+is (err, nil, "kvs_unlink: no error")
+f:kvs_commit()
 kvsdir_test (dir, 'testkey', nil, "unlink: key is now nil")
 
 

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -1,0 +1,260 @@
+#!/bin/sh
+
+test_description='Test flux cron service'
+
+. $(dirname $0)/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=4
+test_under_flux ${SIZE} minimal
+
+flux setattr log-stderr-level 1
+
+cron_entry_check() {
+    local id=$1
+    local key=$2
+    local expected="$3"
+    test -n $id || return 1
+    test -n $key || return 1
+    test -n "$expected" || return 1
+    local result="$(flux cron dump --key=${key} ${id})" || return 1
+    echo "cron-${id}: ${key}=${result}, wanted ${expected}" >&2
+    test "${result}" = "${expected}"
+}
+
+flux_cron() {
+    result=$(flux cron "$@" 2>&1) || return 1
+    id=$(echo ${result} | sed 's/^.*cron-\([0-9][0-9]*\).*/\1/')
+    test -n "$id" && echo ${id}
+}
+
+test_expect_success 'load cron module' '
+    flux module load cron
+'
+test_expect_success 'cron interval create' '
+    id=$(flux_cron interval 0.05s echo cron-test-xxx) &&
+    sleep .1 &&
+    flux cron stop ${id} &&
+    flux dmesg | grep "cron-1.*test-xxx"  &&
+    cron_entry_check ${id} stopped true
+'
+test_expect_success 'cron list' '
+    flux cron list | grep "^ *1.*echo"
+'
+test_expect_success 'cron delete' '
+    flux cron delete 1 > delete.out &&
+    grep "Removed cron-1: echo last ran" delete.out &&
+    test_expect_code 1 flux cron dump 1
+'
+test_expect_success 'cron interval --after= works' '
+    id=$(flux_cron interval --after=.01s 0 hostname) &&
+    sleep .1 &&
+    flux cron dump ${id} &&
+    cron_entry_check ${id} task.1.state Exited
+'
+test_expect_success 'cron delete leaves running task - --kill works' '
+    id=$(flux_cron interval --after=.01s 0 sleep 100) &&
+    sleep .1 &&
+    cron_entry_check ${id} task.1.state Running &&
+    flux cron delete ${id} > delete.${id}.out &&
+    grep "sleep still running" delete.${id}.out &&
+    cron_entry_check ${id} task.1.state Running &&
+    flux cron delete --kill ${id} &&
+    test_expect_code 1 flux cron dump ${id}
+'
+test_expect_success 'repeat count works' '
+    id=$(flux_cron interval -c1 .01s echo hi) &&
+    sleep .02 &&
+    cron_entry_check ${id} repeat 1 &&
+    cron_entry_check ${id} stats.count 1 &&
+    cron_entry_check ${id} stopped true
+'
+test_expect_success 'restarted job restarts repeat count' '
+    id=$(flux_cron interval -c1 .01s echo repeat-count-check) &&
+    sleep .1 &&
+    cron_entry_check ${id} stopped true &&
+    test $(flux dmesg | grep -c repeat-count-check) = 1 &&
+    flux dmesg -c &&
+    flux cron start ${id} &&
+    sleep .1 &&
+    test $(flux dmesg | grep -c repeat-count-check) = 1
+'
+test_expect_success 'rank option works' '
+    id=$(flux_cron interval -c1 -o rank=1 .01s flux getattr rank) &&
+    sleep .1 &&
+    cron_entry_check ${id} stopped true &&
+    cron_entry_check ${id} rank 1 &&
+    flux dmesg | grep "cron-${id}.*command=\"flux getattr rank\": \"1\""
+'
+test_expect_success 'cron entry exec failure is recorded' '
+    id=$(flux_cron interval -c1 0.01s notaprogram) &&
+    sleep 0.1 &&
+    test_debug "flux cron dump ${id} >&2" &&
+    cron_entry_check ${id} stopped true &&
+    cron_entry_check ${id} task.1.state "Failed" &&
+    cron_entry_check ${id} task.1.code 127
+'
+test_expect_success 'cron entry launch failure recorded' '
+    id=$(flux_cron interval -o rank=99 -c1 0.01s hostname) &&
+    sleep 0.1 &&
+    test_debug "flux cron dump ${id} >&2" &&
+    cron_entry_check ${id} stopped true &&
+    cron_entry_check ${id} task.1.state "Rexec Failure" &&
+    cron_entry_check ${id} task.1.rexec_errno 113
+'
+test_expect_success 'flux-cron event works' '
+    id=$(flux_cron event t.cron.trigger flux event pub t.cron.complete) &&
+    cron_entry_check ${id} type event &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} stats.count 0 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 1 &&
+    cron_entry_check ${id} task.1.state Exited
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 2 &&
+    cron_entry_check ${id} task.1.state Exited &&
+    flux cron stop ${id} &&
+    cron_entry_check ${id} stopped true &&
+    flux cron delete ${id} &&
+    test_expect_code 1 flux cron dump ${id}
+'
+test_expect_success 'flux-cron event --nth works' '
+    id=$(flux_cron event --nth=3 t.cron.trigger flux event pub t.cron.complete) &&
+    test_when_finished "flux cron delete ${id}" &&
+    cron_entry_check ${id} type event &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.nth 3 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.counter 1 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.counter 2 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 1 &&
+    cron_entry_check ${id} typedata.counter 3 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 1
+    cron_entry_check ${id} typedata.counter 4
+'
+
+test_expect_success 'flux-cron event --after works' '
+    id=$(flux_cron event --after=3 t.cron.trigger flux event pub t.cron.complete) &&
+    test_when_finished "flux cron delete ${id}" &&
+    cron_entry_check ${id} type event &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.after 3 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.counter 1 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.counter 2 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
+        flux event pub t.cron.trigger &&
+    flux cron dump ${id} &&
+    cron_entry_check ${id} stats.count 1 &&
+    cron_entry_check ${id} typedata.counter 3 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} typedata.counter 4 &&
+    cron_entry_check ${id} stats.count 2
+'
+test_expect_success 'flux-cron event --min-interval works' '
+    id=$(flux_cron event --min-interval=.5s t.cron.trigger hostname) &&
+    test_when_finished "flux cron delete ${id}" &&
+    cron_entry_check ${id} type event &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} stats.count 0 &&
+    cron_entry_check ${id} typedata.min_interval 0.5 &&
+    flux event pub t.cron.trigger && flux event pub t.cron.trigger &&
+    cron_entry_check ${id} stats.count 1 &&
+    sleep 0.5 &&
+    cron_entry_check ${id} stats.count 2
+'
+test_expect_success 'flux-cron can set timeout on tasks' '
+    id=$(flux_cron event -o timeout=0.1 t.cron.trigger sleep 120) &&
+    test_when_finished "flux cron delete ${id}" &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    sleep 0.1 &&
+    i=0
+    while test $i -lt 5; do
+        cron_entry_check ${id} task.1.state Timeout
+	rc=$?
+        if test $rc -eq 0; then break; fi
+	sleep 0.1
+        i=$((i+1))
+	echo "cron-${id}: $i"
+    	flux cron dump ${id}
+    done
+    test $rc -eq 0
+'
+test_expect_success 'flux-cron can set stop-on-failure' '
+    id=$(flux_cron event -o stop-on-failure=3 t2.cron.trigger \
+         "flux event pub t2.cron.complete && false" ) &&
+    cron_entry_check ${id} type event &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} stats.count 0 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t2.cron t2.cron.complete \
+        flux event pub t2.cron.trigger &&
+    flux cron dump ${id} &&
+    cron_entry_check ${id} stats.count 1 &&
+    cron_entry_check ${id} stats.failure 1 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t2.cron t2.cron.complete \
+        flux event pub t2.cron.trigger &&
+    cron_entry_check ${id} stats.count 2 &&
+    cron_entry_check ${id} stats.failure 2 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t2.cron t2.cron.complete \
+        flux event pub t2.cron.trigger &&
+    cron_entry_check ${id} stats.count 3 &&
+    cron_entry_check ${id} stats.failure 3 &&
+    cron_entry_check ${id} stopped true
+'
+
+##  Reload cron module with sync enabled
+test_expect_success 'flux module remove cron' '
+    flux module remove cron
+'
+test_expect_success 'module load with sync' '
+    flux module load cron sync=cron.sync
+'
+test_expect_success 'tasks do not run until sync event' '
+    id=$(flux_cron event t.cron.trigger flux event pub t.cron.complete)
+    test_when_finished "flux cron delete ${id}" &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} stats.count 0 &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
+        flux event pub t.cron.trigger &&
+    cron_entry_check ${id} task.1.state Deferred &&
+    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
+        flux event pub cron.sync &&
+    cron_entry_check ${id} stats.count 1
+'
+test_expect_success 'flux cron sync can disable sync' '
+    flux cron sync --disable &&
+    flux cron sync | grep disabled
+'
+test_expect_success 'flux cron sync can enable sync' '
+    flux cron sync cron.sync2 &&
+    flux cron sync | grep cron.sync2
+'
+test_expect_success 'flux cron sync can set epsilon' '
+    flux cron sync --epsilon=42s cron.sync2 &&
+    flux cron sync | grep 42.000s
+'
+test_done


### PR DESCRIPTION
This PR contains a somewhat simplified cron-like service for a flux instance.

It isn't quite ready (no tests and documentation), but I thought I'd open up the PR now for feedback, as there may be a lot.

TODO
- [x]  Tests
- [x]  Docs
- [x]  Fix cron entry counter reset on `flux cron start`
- [x]  Add entry repeat count to `flux cron list` default output
- [x]  Sync cron_entry_run() to `hb` event by default for all entries
- [x]  Fix `-r, --rank` option
- [x]  Add entry common options for `flux cron event ...`
- [x]  Load cron module in default rc1 script?
- [x]  cron task timeout support

## cron module

The cron module itself has the following components:
 - A `cron_task` type, which is an asynchronous exec abstraction built around `cmb.exec` service
 - A `cron_entry` type, which contains the data you'd expect for cron entries: unique id, name, command to run, current and historical `cron_task` information, etc
 - An "entry type" class which controls when the cron entry is executed

Current types implemented in this PR thus far are:
 * Interval: Run periodically using a `flux_timer_watcher`
 * Event: Run once per event, or optionally once every Nth event

Other types can be easily added, though all I can think of is to add a real cron-like "date&time" type built on the as-yet-unported-to-flux-handle libev [ev_periodic](http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#code_ev_periodic_code_to_cron_or_not) watcher.

Cron entries by default are run indefinitely until stopped or deleted,  but a `repeat` flag is supported which can allow an `at(1)` like service as well

## flux-cron utility

Included is a front-end `flux-cron` utility which allows the creation/deletion, start/stop, and query of flux-cron jobs. A few examples will probably sum it up nicely:
```
grondo@flux-core:~ $ flux cron help
Usage: flux-cron [OPTIONS] COMMAND [OPTIONS...]
  -h, --help                 Display this message.
Supported commands:
 delete       Delete flux cron entries
 help         Display this help or help for a command
 list         List registered and stopped fluxicron jobs
 interval     run COMMAND once every INTERVAL
 start        Start a stopped flux cron job
 event        run COMMAND on every event matching TOPIC
 stop         Stop a flux cron job from executing
```

Create a job to run every 10s:
```
grondo@flux-core:~ $ flux cron interval 10s date
interval: cron-2 created
grondo@flux-core:~ $ flux cron list
    ID CMD/NAME        STATE      #RUNS            LASTRUN             STATUS
     2 date            Active         0               None               None
grondo@flux-core:~ $ flux cron list
    ID CMD/NAME        STATE      #RUNS            LASTRUN             STATUS
     2 date            Active         1      8 seconds ago             Exited
```
```
grondo@flux-core:~ $ flux cron interval --help
Usage: flux-cron interval INTERVAL COMMAND
  -h, --help                 Display this message.
Options:
  -R, --repeat=N             Run COMMAND at most N times
  -c, --history-count=N      Save information on past N runs in cron history
  -r, --rank=RANK            target RANK for COMMAND execution (Default = 0)
  -N, --name=S               Name cron job string S instead of default
```


In one second run `false`, but only run it once:
Note non-zero exit code shows status as `FAILED`.
```
grondo@flux-core:~ $ flux cron interval --repeat=1 1s false
interval: cron-3 created
grondo@flux-core:~ $ flux cron list
    ID CMD/NAME        STATE      #RUNS            LASTRUN             STATUS
     2 date            Active         5      2 seconds ago             Exited
     3 false           Stopped        1      3 seconds ago             Failed
```

Start/stop executing jobs:
```
grondo@flux-core:~ $ flux cron stop 2
Stopped cron-2
grondo@flux-core:~ $ flux cron list
    ID CMD/NAME        STATE      #RUNS            LASTRUN             STATUS
     2 date            Stopped        6     46 seconds ago             Exited
     3 false           Stopped        1     57 seconds ago             Failed
grondo@flux-core:~ $ flux cron start 2
Started cron-2
grondo@flux-core:~ $ flux cron list
    ID CMD/NAME        STATE      #RUNS            LASTRUN             STATUS
     2 date            Active         6       a minute ago             Exited
     3 false           Stopped        1       a minute ago             Failed
```

flux-cron entries stay resident until they are deleted with `flux cron delete`
```
grondo@flux-core:~ $ flux cron delete 2
Removed cron-2: date last ran a second ago for 24.03ms
```