### PR TITLE
environment cleanup

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -133,7 +133,6 @@ local function get_filtered_env ()
     env.ENVIRONMENT = nil
     for k,v in pairs (env) do
         if k:match ("SLURM_") then env[k] = nil end
-        if k:match ("FLUX_API") then env[k] = nil end
         if k:match ("FLUX_URI") then env[k] = nil end
     end
     -- XXX: MVAPICH2 at least requires MPIRUN_RSH_LAUNCH to be set

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -135,9 +135,6 @@ local function get_filtered_env ()
         if k:match ("SLURM_") then env[k] = nil end
         if k:match ("FLUX_URI") then env[k] = nil end
     end
-    -- XXX: MVAPICH2 at least requires MPIRUN_RSH_LAUNCH to be set
-    --  in the environment or PMI doesn't work (for unknown reason)
-    env.MPIRUN_RSH_LAUNCH = 1
     return (env)
 end
 

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -205,7 +205,7 @@ int PMI_Init (int *spawned)
     memset (ctx, 0, sizeof (pmi_ctx_t));
     ctx->magic = PMI_CTX_MAGIC;
 
-    ctx->trace = env_getint ("PMI_TRACE", 0);
+    ctx->trace = env_getint ("FLUX_PMI_TRACE", 0);
 
     ctx->size = env_getint ("FLUX_JOB_SIZE", 1);
     ctx->rank = env_getint ("FLUX_TASK_RANK", 0);

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -65,7 +65,8 @@ dist_wreckscripts_SCRIPTS = \
 	lua.d/02-affinity.lua \
 	lua.d/timeout.lua \
         lua.d/output.lua \
-        lua.d/input.lua
+        lua.d/input.lua \
+	lua.d/mvapich.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -66,7 +66,8 @@ dist_wreckscripts_SCRIPTS = \
 	lua.d/timeout.lua \
         lua.d/output.lua \
         lua.d/input.lua \
-	lua.d/mvapich.lua
+	lua.d/mvapich.lua \
+	lua.d/intel_mpi.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/lua.d/intel_mpi.lua
+++ b/src/modules/wreck/lua.d/intel_mpi.lua
@@ -1,0 +1,11 @@
+-- Set environment specific to Intel MPI
+
+
+function rexecd_init ()
+    local env = wreck.environ
+    local f = wreck.flux
+    local libpmi = f:getattr ('conf.pmi_library_path')
+    env['I_MPI_PMI_LIBRARY'] = libpmi
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/modules/wreck/lua.d/mvapich.lua
+++ b/src/modules/wreck/lua.d/mvapich.lua
@@ -1,0 +1,31 @@
+-- Set environment specific to mvapich
+
+
+local dirname = require 'flux.posix'.dirname
+
+-- XXX: MVAPICH2 at least requires MPIRUN_RSH_LAUNCH to be set
+--  in the environment or PMI doesn't work (for unknown reason)
+--
+
+function rexecd_init ()
+    local env = wreck.environ
+    local f = wreck.flux
+    local libpmi = f:getattr ('conf.pmi_library_path')
+    local ldpath = dirname (libpmi)
+
+    if (env['LD_LIBRARY_PATH'] ~= nil) then
+        ldpath = ldpath..':'..env['LD_LIBRARY_PATH']
+    end
+
+    env['LD_LIBRARY_PATH'] = ldpath
+    env['MPIRUN_NTASKS'] = wreck.kvsdir.ntasks
+    env['MPIRUN_RSH_LAUNCH'] = 1
+end
+
+
+function rexecd_task_init ()
+    local env = wreck.environ
+    env['MPIRUN_RANK'] = wreck.taskid
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1179,7 +1179,6 @@ int exec_command (struct prog_ctx *ctx, int i)
         lua_stack_call (ctx->lua_stack, "rexecd_task_init");
 
         prog_ctx_setenv  (ctx, "FLUX_URI", getenv ("FLUX_URI"));
-        prog_ctx_setenvf (ctx, "MPIRUN_RANK",     1, "%d", t->globalid);
         prog_ctx_setenvf (ctx, "FLUX_TASK_RANK", 1, "%d", t->globalid);
         prog_ctx_setenvf (ctx, "FLUX_TASK_LOCAL_ID", 1, "%d", i);
 
@@ -1634,7 +1633,6 @@ int exec_commands (struct prog_ctx *ctx)
     prog_ctx_setenvf (ctx, "FLUX_JOB_NNODES",1, "%d", ctx->nnodes);
     prog_ctx_setenvf (ctx, "FLUX_NODE_ID",   1, "%d", ctx->nodeid);
     prog_ctx_setenvf (ctx, "FLUX_JOB_SIZE",  1, "%d", ctx->total_ntasks);
-    prog_ctx_setenvf (ctx, "MPIRUN_NPROCS", 1, "%d", ctx->total_ntasks);
     gtid_list_create (ctx, buf, sizeof (buf));
     prog_ctx_setenvf (ctx, "FLUX_LOCAL_RANKS",  1, "%s", buf);
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1180,7 +1180,6 @@ int exec_command (struct prog_ctx *ctx, int i)
 
         prog_ctx_setenv  (ctx, "FLUX_URI", getenv ("FLUX_URI"));
         prog_ctx_setenvf (ctx, "MPIRUN_RANK",     1, "%d", t->globalid);
-        prog_ctx_setenvf (ctx, "PMI_RANK", 1, "%d", t->globalid);
         prog_ctx_setenvf (ctx, "FLUX_TASK_RANK", 1, "%d", t->globalid);
         prog_ctx_setenvf (ctx, "FLUX_TASK_LOCAL_ID", 1, "%d", i);
 
@@ -1636,7 +1635,6 @@ int exec_commands (struct prog_ctx *ctx)
     prog_ctx_setenvf (ctx, "FLUX_NODE_ID",   1, "%d", ctx->nodeid);
     prog_ctx_setenvf (ctx, "FLUX_JOB_SIZE",  1, "%d", ctx->total_ntasks);
     prog_ctx_setenvf (ctx, "MPIRUN_NPROCS", 1, "%d", ctx->total_ntasks);
-    prog_ctx_setenvf (ctx, "PMI_SIZE", 1, "%d", ctx->total_ntasks);
     gtid_list_create (ctx, buf, sizeof (buf));
     prog_ctx_setenvf (ctx, "FLUX_LOCAL_RANKS",  1, "%s", buf);
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -63,6 +63,7 @@ TESTS = \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
+	lua/t0004-getattr.t \
 	lua/t0007-alarm.t \
 	lua/t0008-mrpc.t \
 	lua/t0009-sequences.t \
@@ -127,6 +128,7 @@ check_SCRIPTS = \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \
+	lua/t0004-getattr.t \
 	lua/t0007-alarm.t \
 	lua/t0008-mrpc.t \
 	lua/t0009-sequences.t \

--- a/t/lua/t0004-getattr.t
+++ b/t/lua/t0004-getattr.t
@@ -1,0 +1,25 @@
+#!/usr/bin/lua
+--
+--  Test getattr
+--
+local t = require 'fluxometer'.init (...)
+t:start_session { size = 1 }
+
+plan (8)
+
+local flux = require_ok ('flux')
+local f, err = flux.new()
+type_ok (f, 'userdata', "create new flux handle")
+is (err, nil, "error is nil")
+
+--
+--  Test getattr
+--
+local attrval, flags = f:getattr "size"
+is (attrval, "1", "correctly got broker size attr")
+ok (flags.FLUX_ATTRFLAG_ACTIVE, "FLUX_ATTRFLAG_ACTIVE is set")
+ok (flags.FLUX_ATTRFLAG_IMMUTABLE, "FLUX_ATTRFLAG_IMMUTABLE is set")
+
+local v,err = f:getattr "nosuchthing"
+is (v, nil, "Non-existent attr has error")
+is (err, "No such file or directory", "got expected error string")

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -20,7 +20,7 @@ run_program() {
 	local ntasks=$2
 	local nnodes=$3
 	shift 3
-	export PMI_TRACE=0x38
+	export FLUX_PMI_TRACE=0x38
 	run_timeout $timeout flux wreckrun -l -o stdio-delay-commit \
 		    -n${ntasks} -N${nnodes} $*
 }


### PR DESCRIPTION
Who would vote against cleaning up the environment?

As discussed in #669, it may be desirable to localize an environment (or other) trickery needed to run a particular MPI runtime under Flux within a wreck lua plugin.

This PR first does a tiny bit of housekeeping, then moves the setting of MPIRUN_RANK, MPIRUN_NPROCS, and MPIRUN_RSH_LAUNCH from wrexecd.c and bindings/lua/wreck.lua to a new mvapich plugin.

Todo
- [ ] create intelmpi plugin to set I_MPI_PMI_LIBRARY
- [ ]  in mvpaich plugin, prepend directory containing our libpmi.so to LD_LIBRARY_PATH (If not already present)

The todos require a way to determine the path to the Flux libpmi.so, which is currently found by first checking the config in a broker attribute, and falling back to compiled-in install paths.