### PR TITLE
flux-help: better heuristic for display flux-related man pages

### DIFF
--- a/src/cmd/builtin/help.c
+++ b/src/cmd/builtin/help.c
@@ -38,7 +38,16 @@ static int cmd_help (optparse_t *p, int ac, char *av[])
         /* N.B. Flux doc dir already prepended to MANPATH if needed.
          */
 
-        cmd = xasprintf ("man flux-%s %s", topic, topic);
+        /*  If user tried 'flux help flux*' then assume we
+         *   don't need to prepend another flux.
+         *  O/w, assume user is asking for help on a flux command
+         *   so prepend flux-
+         */
+        if (strncmp (topic, "flux", 4) == 0)
+            cmd = xasprintf ("man %s", topic);
+        else
+            cmd = xasprintf ("man flux-%s", topic);
+
         if ((rc = system (cmd)) < 0)
             err_exit ("man");
         else if (WIFEXITED (rc) && ((rc = WEXITSTATUS (rc)) != 0))

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -139,6 +139,16 @@ test_expect_success 'flux-help command can display manpages for subcommands' '
 	EOF
 	MANPATH=${PWD}/man flux help foo | grep "^FOO(1)"
 '
+test_expect_success 'flux-help command can display manpages for api calls' '
+	PWD=$(pwd) &&
+	mkdir -p man/man3 &&
+	cat <<-EOF > man/man3/flux_foo.3 &&
+	.TH FOO "3" "January 1962" "Foo api call" "Flux Programming Interface"
+	.SH NAME
+	flux_foo \- Call the flux_foo interface
+	EOF
+	MANPATH=${PWD}/man flux help flux_foo | grep "^FOO(3)"
+'
 test_expect_success 'flux-help returns nonzero exit code from man(1)' '
         man notacommand >/dev/null 2>&1
         code=$?


### PR DESCRIPTION
As described in #676 we have some cases where `flux help COMMAND` will confusingly display non-flux related manpages after a user quits the flux man page. (e.g. `flux help cron`, `flux help exec`)

This PR uses a simple heuristic to determine whether to prepend `flux-` to the topic to send to `man(1)`, instead of running `man flux-%s %s`. It assumes that if the help topic already starts with `flux`, we don't need to prepend `flux-` and runs `man %s` directly. If the topic does *not* start with `flux`, then likely this is a request for help with `flux` subcommand, so we run `man flux-%s` only.

This will break if ever there is a manpage `flux-flux-something` (unlikely) or if there is a man page for a command or API function that *doesn't* start with `flux`. So far I don't think that is the case, but this may need to be revisited if it is ever so.