### PR TITLE
flux-help: allow command help search pattern to be extended

### DIFF
--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -238,7 +238,7 @@ out:
     return (zh);
 }
 
-void emit_command_help (const char *pattern, FILE *fp)
+static void emit_command_help_from_pattern (const char *pattern, FILE *fp)
 {
     zhash_t *zh = NULL;
     zlist_t *keys = NULL;
@@ -260,6 +260,17 @@ void emit_command_help (const char *pattern, FILE *fp)
     zlist_destroy (&keys);
     zhash_destroy (&zh);
     return;
+}
+
+void emit_command_help (const char *plist, FILE *fp)
+{
+    int i, count;
+    sds *p;
+    if (!(p = sdssplitlen (plist, strlen (plist), ":", 1, &count)))
+        return;
+    for (i = 0; i < count; i++)
+        emit_command_help_from_pattern (p[i], fp);
+    sdsfreesplitres (p, count);
 }
 
 /*

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -61,14 +61,23 @@ static struct optparse_option opts[] = {
     OPTPARSE_TABLE_END
 };
 
+static const char *default_cmdhelp_pattern (optparse_t *p)
+{
+    int *flags = optparse_get_data (p, "conf_flags");
+    return flux_conf_get ("cmdhelp_pattern", *flags);
+}
+
 void usage (optparse_t *p)
 {
-    const char *help_pattern = getenv ("FLUX_CMDHELP_PATTERN");
-    if (!help_pattern) {
-        int *flags = optparse_get_data (p, "conf_flags");
-        help_pattern = flux_conf_get ("cmdhelp_pattern", *flags);
-    }
-    assert (help_pattern != NULL);
+    char *help_pattern;
+    const char *val = getenv ("FLUX_CMDHELP_PATTERN");
+    const char *def = default_cmdhelp_pattern (p);
+
+    if (asprintf (&help_pattern, "%s%s%s",
+                  def ? def : "",
+                  val ? ":" : "",
+                  val ? val : "") < 0)
+        err_exit ("faled to get command help list!");
 
     optparse_print_usage (p);
     fprintf (stderr, "\n");

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -112,7 +112,8 @@ test_expect_success 'flux-help command list can be extended' '
 	cat <<-EOF  > help.d/test.json &&
 	[{ "category": "test", "command": "test", "description": "a test" }]
 	EOF
-	cat <<-EOF  > help.expected &&
+	flux help 2>&1 | sed "0,/^$/d" >help.expected &&
+	cat <<-EOF  >>help.expected &&
 	Common commands from flux-test:
 	   test               a test
 	EOF
@@ -121,7 +122,7 @@ test_expect_success 'flux-help command list can be extended' '
 	cat <<-EOF  > help.d/test2.json &&
 	[{ "category": "test2", "command": "test2", "description": "a test two" }]
 	EOF
-	cat <<-EOF  >> help.expected &&
+	cat <<-EOF  >>help.expected &&
 
 	Common commands from flux-test2:
 	   test2              a test two


### PR DESCRIPTION
As described in #655, `flux-help` search pattern for command list needs a way to be extended, for cases where flux framework projects are installed in a separate directory structure from flux-core.

This PR changes the function of the `FLUX_CMDHELP_PATTERN` environment variable, from replacing a default single search pattern, to appending a *list* of patterns separated by `":"`. There wasn't a use case for replacing the default pattern, so I don't think this change will have any negative effect.
