### PR TITLE
subprocess error handling, pmix launch support

### DIFF
--- a/src/common/libpmi-client/pmi.c
+++ b/src/common/libpmi-client/pmi.c
@@ -102,6 +102,8 @@ pmi_t *pmi_create_guess (void)
         return pmi_create_simple (strtol (fd_str, NULL, 10),
                                   strtol (rank_str, NULL, 10),
                                   strtol (size_str, NULL, 10));
+    else if (getenv ("PMIX_SERVER_URI"))
+        return pmi_create_dlopen ("libpmix.so");
     else
         return pmi_create_dlopen (NULL);
 }


### PR DESCRIPTION
I'm not sure how long until PR #668 will be ready, but these two commits probably are, so I broke them out to their own PR here.

When launching large (e.g. 512 - 1024) flux sessions on a single node, I ran out of file descriptors and the zio constructors in `subprocess_create()` were failing.  This patch ensures that the right error gets back to the caller.

The little hack in the pmi client would allow a PMIx enabled RM to launch flux.  Why not?  There might be one that works someday.