### PR TITLE
cron-o-date: cron expression support for flux-cron 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ script:
  - export LIBC_FATAL_STDERR_=1
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"
+ # Ensure travis builds libev such that libfaketime will work:
+ # (force libev to *not* use syscall interface for clock_gettime())
+ - export CPPFLAGS="-DEV_USE_CLOCK_SYSCALL=0 -DEV_USE_MONOTONIC=1"
 
  # Travis has limited resources, even though number of processors might
  #  might appear to be large. Limit session size for testing to 5 to avoid

--- a/doc/man1/flux-cron.adoc
+++ b/doc/man1/flux-cron.adoc
@@ -99,6 +99,25 @@ Create a cron entry to execute 'command' after every event matching 'topic'.
  -o 'LIST':::
  Set comma separated EXTRA OPTIONS for this cron entry.
 
+*tab* [OPTIONS] ['file'] ::
+Process one or more lines containing crontab expressions from 'file'
+(stdin by default) Each valid crontab line will result in a new cron
+entry registered with the flux-cron service. The cron expression format
+supported by `flux cron tab` has 5 fields: 'minutes' (0-59), 'hours'
+(0-23), 'day of month' (1-31), 'month' (0-11), and 'day of week' (0-6).
+Everything after the day of week is considered a command to be run.
+
+ --options='LIST':::
+ -o 'LIST':::
+ Set comma separated EXTRA OPTIONS for all cron entries.
+
+*at* [OPTIONS] 'string' 'command'
+Run 'command' at specific date and time described by 'string'
+
+ --options='LIST':::
+ -o 'LIST':::
+ Set comma separated EXTRA OPTIONS for all cron entries.
+
 *list*::
 Display a list of current entries registered with the cron module and
 their current state, last run time, etc.

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -25,6 +25,7 @@ MAN3_FILES_PRIMARY = \
 	flux_zmq_watcher_create.3 \
 	flux_handle_watcher_create.3 \
 	flux_timer_watcher_create.3 \
+	flux_periodic_watcher_create.3 \
 	flux_idle_watcher_create.3 \
 	flux_msg_handler_create.3 \
 	flux_msg_cmp.3 \
@@ -70,9 +71,11 @@ MAN3_FILES_SECONDARY = \
 	flux_fd_watcher_get_fd.3 \
 	flux_watcher_stop.3 \
 	flux_watcher_destroy.3 \
+	flux_watcher_next_wakeup.3 \
 	flux_zmq_watcher_get_zsock.3 \
 	flux_handle_watcher_get_flux.3 \
 	flux_timer_watcher_reset.3 \
+	flux_periodic_watcher_reset.3 \
 	flux_prepare_watcher_create.3 \
 	flux_check_watcher_create.3 \
 	flux_msg_handler_destroy.3 \
@@ -138,9 +141,11 @@ flux_reactor_error.3: flux_reactor_create.3
 flux_fd_watcher_get_fd.3: flux_fd_watcher_create.3
 flux_watcher_stop.3: flux_watcher_start.3
 flux_watcher_destroy.3: flux_watcher_start.3
+flux_watcher_next_wakeup.3: flux_watcher_start.3
 flux_zmq_watcher_get_zsock.3: flux_zmq_watcher_create.3
 flux_handle_watcher_get_flux.3: flux_handle_watcher_create.3
 flux_timer_watcher_reset.3: flux_timer_watcher_create.3
+flux_periodic_watcher_reset.3: flux_periodic_watcher_create.3
 flux_prepare_watcher_create.3: flux_idle_watcher_create.3
 flux_check_watcher_create.3: flux_idle_watcher_create.3
 flux_msg_handler_destroy.3: flux_msg_handler_create.3

--- a/doc/man3/flux_periodic_watcher_create.adoc
+++ b/doc/man3/flux_periodic_watcher_create.adoc
@@ -1,0 +1,92 @@
+flux_periodic_watcher_create(3)
+============================
+:doctype: manpage
+
+
+NAME
+----
+flux_periodic_watcher_create, flux_periodic_watcher_reset -  set/reset a timer
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_watcher_f)(flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents, void *arg);
+
+ typedef double (*flux_reschedule_f) (flux_watcher_t *w, double now, void *arg);
+
+ flux_watcher_t *flux_periodic_watcher_create (flux_reactor_t *r,
+                                               double offset, double interval,
+                                               flux_reschedule_f reschedule_cb, 
+                                               flux_watcher_f callback,
+                                               void *arg);
+
+ void flux_periodic_watcher_reset (flux_watcher_t *w,
+                                   double offset, double interval);
+
+
+DESCRIPTION
+-----------
+
+`flux_periodic_watcher_create()` creates a flux_watcher_t object which
+monitors for periodic events.  The periodic watcher will trigger when the
+wall clock time _offset_ has elapsed, and optionally again ever _interval_
+of wall clock time thereafter. If the _reschedule_cb_ parameter is used,
+then _offset_ and _interval_ are ignored, and instead each time the
+periodic watcher is scheduled the reschedule callback will be called
+with the current time, and is expected to return the next absolute time
+at which the watcher should be scheduled.
+
+Unlike timer events, a periodic watcher monitors wall clock or system time,
+not the actual time that passes. Thus, a periodic watcher can be used
+to run a callback when system time reaches a certain point. For example,
+if a periodic watcher is set to run with an _offset_ of 10 seconds, and
+then system time is set back by 1 hour, it will take approximately 1 hour,
+10 seconds for the watcher to execute.
+
+If a periodic watcher is running in manual reschedule mode (_reschedule_cb_
+is non-NULL), and the user-provided reschedule callback returns a time
+that is before the current time, the watcher will be silently stopped.
+
+Note: the Flux reactor is based on libev.  For additional important
+information on the behavior of periodic, refer to the libev documentation
+on `ev_periodic`.
+
+
+RETURN VALUE
+------------
+
+`flux_periodic_watcher_create()` returns a flux_watcher_t object on success.
+On error, NULL is returned, and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_watcher_start(3), flux_reactor_start(3), flux_timer_watcher_create(3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_watcher_start.adoc
+++ b/doc/man3/flux_watcher_start.adoc
@@ -5,7 +5,7 @@ flux_watcher_start(3)
 
 NAME
 ----
-flux_watcher_start, flux_watcher_stop, flux_watcher_destroy -  start/stop/destroy reactor watcher
+flux_watcher_start, flux_watcher_stop, flux_watcher_destroy, flux_watcher_next_wakeup -  start/stop/destroy/query reactor watcher
 
 
 SYNOPSIS
@@ -16,6 +16,8 @@ void flux_watcher_start (flux_watcher_t *w);
 void flux_watcher_stop (flux_watcher_t *w);
 
 void flux_watcher_destroy (flux_watcher_t *w);
+
+double flux_watcher_next_wakeup (flux_watcher_t *w);
 
 
 DESCRIPTION
@@ -32,6 +34,11 @@ This may be called from within a flux_watcher_f callback.
 `flux_watcher_destroy()` destroys a flux_watcher_t object _w_,
 after stopping it.  It is not safe to destroy a watcher object within a
 flux_watcher_f callback.
+
+`flux_watcher_next_wakeup()` returns the absolute time that the watcher
+is supposed to trigger next. This function only works for _timer_ and
+_periodic_ watchers, and will return a value less than zero with errno
+set to `EINVAL` otherwise.
 
 
 AUTHOR

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -316,3 +316,5 @@ rexec
 subcommand
 stddev
 RTT
+wakeup
+crontab

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -394,7 +394,7 @@ program:SubCommand {
         local state = "Active"
         local count = e.stats.count
         if e["repeat"] > 0 then
-            count = e.count .. "/" .. e["repeat"]
+            count = e.stats.count .. "/" .. e["repeat"]
         end
         if e.stopped then state = "Stopped" end
         printf (fmt, e.id, e.name, state, count, lastrun, status)

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -254,8 +254,10 @@ program:SubCommand {
         end
         local resp, err = self:request ("datetime", args, { command })
         if not resp then self:die (err) end
-
-        self:log ("cron-%d created\n", resp.id)
+        local next_wakeup = resp.typedata.next_wakeup
+        local n = next_wakeup - now ()
+        self:log ("cron-%d created: scheduled in %.3fs at %s\n",
+                  resp.id, n, os.date ("%c", next_wakeup))
     end
  end
 }

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -211,6 +211,56 @@ program:SubCommand {
  end
 }
 
+program:SubCommand {
+ name = "tab",
+ description = "Schedule cron jobs using crontab(5) format",
+ usage = "FILE",
+ options = {
+    { name = "options", char = "o", arg = "OPTS",
+      usage = "Comma separated list of key=value options to set in request"
+    },
+ },
+ handler = function (self, arg)
+    local fp = io.stdin
+    local file = table.remove (arg, 1)
+
+    if #arg == 1 and arg[1] ~= "-" then
+        local fp, err = io.open (arg[1], "r")
+        if not fp then self:die (err) end
+    end
+
+    local function parse_crontab_line (line)
+        local s = line:match ("^(.+)#.*$") or line -- remove comments
+        local min, hr, dom, mon, dow, command =
+         s:match ("%s*(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(.+)")
+        if not min or not hr or not dom or
+           not mon or not dow or not command then
+            return nil
+        end
+        return {
+            second = 0,
+            minute = min,
+            hour = hr,
+            mday = dom,
+            month = mon,
+            weekday = dow,
+        }, command
+    end
+
+    for line in fp:lines () do
+        local args, command = parse_crontab_line (line)
+        if not args then
+            self:die ("Failed to process crontab line: %s", line)
+        end
+        local resp, err = self:request ("datetime", args, { command })
+        if not resp then self:die (err) end
+
+        self:log ("cron-%d created\n", resp.id)
+    end
+ end
+}
+
+
 --
 --  Convert date in Unix seconds (floating point) to a standard
 --   datetime string

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -263,6 +263,48 @@ program:SubCommand {
 }
 
 
+program:SubCommand {
+ name = "at",
+ description = "Schedule a cron job at a given date and time",
+ usage = "TIME COMMAND",
+ options = {
+    { name = "options", char = "o", arg = "OPTS",
+      usage = "Comma separated list of key=value options to set in request"
+    },
+ },
+ handler = function (self, arg)
+    if #arg < 2 then self:die ("TIME and COMMAND args are required") end
+    local function get_datetime (s)
+        local f, err = io.popen ("date +%s --date=\""..s.."\"")
+        local time = f:read ("*n")
+        f:close ()
+        if not time then return nil, "Failed to parse datetime" end
+        return os.date ("*t", time)
+    end
+
+    local t, err = get_datetime (table.remove (arg, 1))
+    if not t then
+        self:die ("Failed to parse datetime arg")
+    end
+    local args = {
+        second = t.sec,
+        minute = t.min,
+        hour =   t.hour,
+        mday =   t.day,
+        month =  t.month - 1, -- zero origin for months
+        year =   t.year - 1900
+    }
+    -- force only a single repeat
+    self.opt.c = 1
+
+    local resp, err = self:request ("datetime", args, arg)
+    if not resp then self:die (err) end
+    local next_wakeup = resp.typedata.next_wakeup
+    local n = next_wakeup - now ()
+    self:log ("cron-%d created: scheduled in %.3fs at %s\n",
+              resp.id, n, os.date ("%c", next_wakeup))
+ end
+}
 --
 --  Convert date in Unix seconds (floating point) to a standard
 --   datetime string

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -128,7 +128,7 @@ function Command:request (type, typeargs, arg)
         type = type,
         args = typeargs,
         command = command,
-        name = self.opt.N or arg[1],
+        name = self.opt.N or command:match("%S+"),
         ["repeat"] = self.opt.c
     }
     -- Process comma-separated list of options to add undocumented

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -459,6 +459,112 @@ void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat)
     ev_timer_set (tw, after, repeat);
 }
 
+/* Periodic
+ */
+#define PERIODIC_SIG 1007
+
+struct f_periodic {
+    struct flux_watcher *w;
+    ev_periodic          evp;
+    flux_reschedule_f    reschedule_cb;
+};
+
+static struct f_periodic * f_periodic_alloc ()
+{
+    struct f_periodic *fp = xzmalloc (sizeof (*fp));
+    fp->w = NULL;
+    fp->reschedule_cb = NULL;
+
+    // Pointer from ev_periodic->data back to ourself:
+    //  required for libev callbacks.
+    fp->evp.data = fp;
+    return (fp);
+}
+
+static void f_periodic_free (struct f_periodic *fp)
+{
+    free (fp);
+}
+
+static void periodic_start (void *impl, flux_watcher_t *w)
+{
+    struct f_periodic *fp = w->impl;
+    assert (w->signature == PERIODIC_SIG);
+    ev_periodic_start (w->r->loop, &fp->evp);
+}
+
+static void periodic_stop (void *impl, flux_watcher_t *w)
+{
+    struct f_periodic *fp = w->impl;
+    assert (w->signature == PERIODIC_SIG);
+    ev_periodic_stop (w->r->loop, &fp->evp);
+}
+
+static void periodic_destroy (void *impl, flux_watcher_t *w)
+{
+    assert (w->signature == PERIODIC_SIG);
+    if (impl)
+        f_periodic_free (impl);
+}
+
+static void periodic_cb (struct ev_loop *loop, ev_periodic *pw, int revents)
+{
+    struct f_periodic *fp = pw->data;
+    struct flux_watcher *w = fp->w;
+    if (w->fn)
+        fp->w->fn (ev_userdata (loop), w, libev_to_events (revents), w->arg);
+}
+
+static ev_tstamp periodic_reschedule_cb (ev_periodic *pw, ev_tstamp now)
+{
+    ev_tstamp rc;
+    struct f_periodic *fp = pw->data;
+    assert (fp->reschedule_cb != NULL);
+    rc = (ev_tstamp) fp->reschedule_cb (fp->w, (double) now, fp->w->arg);
+    if (rc < now)
+        return (now + 1e99);
+    return rc;
+}
+
+flux_watcher_t *flux_periodic_watcher_create (flux_reactor_t *r,
+                                              double offset, double interval,
+                                              flux_reschedule_f reschedule_cb,
+                                              flux_watcher_f cb, void *arg)
+{
+    if (offset < 0 || interval < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    struct watcher_ops ops = {
+        .start = periodic_start,
+        .stop = periodic_stop,
+        .destroy = periodic_destroy,
+    };
+    flux_watcher_t *w;
+    struct f_periodic *fp = f_periodic_alloc ();
+    fp->reschedule_cb = reschedule_cb;
+
+    ev_periodic_init (&fp->evp, periodic_cb, offset, interval,
+                      reschedule_cb ? periodic_reschedule_cb : NULL);
+    w = flux_watcher_create (r, fp, ops, PERIODIC_SIG, cb, arg);
+    fp->w = w;
+
+    return w;
+}
+
+void flux_periodic_watcher_reset (flux_watcher_t *w,
+                                  double next, double interval,
+                                  flux_reschedule_f reschedule_cb)
+{
+    struct f_periodic *fp = w->impl;
+    struct ev_loop *loop = w->r->loop;
+    assert (w->signature == PERIODIC_SIG);
+    fp->reschedule_cb = reschedule_cb;
+    ev_periodic_set (&fp->evp, next, interval,
+                     reschedule_cb ? periodic_reschedule_cb : NULL);
+    ev_periodic_again (loop, &fp->evp);
+}
+
 /* Prepare
  */
 #define PREPARE_SIG 1002

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -597,6 +597,21 @@ void flux_periodic_watcher_reset (flux_watcher_t *w,
     ev_periodic_again (loop, &fp->evp);
 }
 
+double flux_watcher_next_wakeup (flux_watcher_t *w)
+{
+    if (w->signature == PERIODIC_SIG) {
+        struct f_periodic *fp = w->impl;
+        return ((double) ev_periodic_at (&fp->evp));
+    }
+    else if (w->signature == TIMER_SIG) {
+        ev_timer *tw = w->impl;
+        struct ev_loop *loop = w->r->loop;
+        return ((double) (ev_now (loop) +  ev_timer_remaining (loop, tw)));
+    }
+    errno = EINVAL;
+    return  (-1.);
+}
+
 /* Prepare
  */
 #define PREPARE_SIG 1002

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -83,6 +83,21 @@ flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
 
 void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat);
 
+/* periodic
+ */
+
+typedef double (*flux_reschedule_f) (flux_watcher_t *w, double now, void *arg);
+
+flux_watcher_t *flux_periodic_watcher_create (flux_reactor_t *r,
+                                             double offset, double interval,
+                                             flux_reschedule_f reschedule_cb,
+                                             flux_watcher_f cb, void *arg);
+
+void flux_periodic_watcher_reset (flux_watcher_t *w,
+                                  double next_wakeup, double interval,
+                                  flux_reschedule_f reschedule_cb);
+
+
 /* prepare/check/idle
  */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -50,6 +50,7 @@ typedef void (*flux_watcher_f)(flux_reactor_t *r, flux_watcher_t *w,
 void flux_watcher_start (flux_watcher_t *w);
 void flux_watcher_stop (flux_watcher_t *w);
 void flux_watcher_destroy (flux_watcher_t *w);
+double flux_watcher_next_wakeup (flux_watcher_t *w);
 
 /* flux_t handle
  */

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -81,7 +81,8 @@ TESTS = test_nodeset.t \
 	test_msglist.t \
 	test_sha1.t \
 	test_popen2.t \
-	test_kary.t
+	test_kary.t \
+	test_approxidate.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -99,6 +100,10 @@ check_PROGRAMS = $(TESTS)
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
        $(top_srcdir)/config/tap-driver.sh
+
+test_approxidate_t_SOURCES = test/approxidate.c
+test_approxidate_t_CPPFLAGS = $(test_cppflags)
+test_approxidate_t_LDADD = $(test_ldadd)
 
 test_nodeset_t_SOURCES = test/nodeset.c
 test_nodeset_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -68,7 +68,9 @@ libutil_la_SOURCES = \
 	kary.h \
 	kary.c \
 	approxidate.h \
-	approxidate.c
+	approxidate.c \
+	cronodate.h \
+	cronodate.c
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -66,7 +66,9 @@ libutil_la_SOURCES = \
 	environment.h \
 	environment.c \
 	kary.h \
-	kary.c
+	kary.c \
+	approxidate.h \
+	approxidate.c
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -84,7 +84,8 @@ TESTS = test_nodeset.t \
 	test_sha1.t \
 	test_popen2.t \
 	test_kary.t \
-	test_approxidate.t
+	test_approxidate.t \
+	test_cronodate.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -147,3 +148,7 @@ test_popen2_t_LDADD = $(test_ldadd)
 test_kary_t_SOURCES = test/kary.c
 test_kary_t_CPPFLAGS = $(test_cppflags)
 test_kary_t_LDADD = $(test_ldadd)
+
+test_cronodate_t_SOURCES = test/cronodate.c
+test_cronodate_t_CPPFLAGS = $(test_cppflags)
+test_cronodate_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/approxidate.c
+++ b/src/common/libutil/approxidate.c
@@ -1,0 +1,929 @@
+/*
+ * This code was taken from git's source, as such it falls under git's license.
+ * Any modifications made to it carry the same license.
+ *
+ * See: https://github.com/git/git/blob/master/COPYING
+ *
+ * Copyright (C) Linus Torvalds, 2005
+ */
+
+#include "approxidate.h"
+
+#include <math.h>
+#include <string.h>
+#include <time.h>
+#include <limits.h>
+#include <stdlib.h>
+
+/**
+ * Maintains compatibility with the default struct tm,
+ * but adds a field for usec.
+ */
+struct atm {
+	int tm_sec;
+	int tm_min;
+	int tm_hour;
+	int tm_mday;
+	int tm_mon;
+	int tm_year;
+	int tm_wday;
+	int tm_yday;
+	int tm_isdst;
+	long tm_usec;
+};
+
+#define GIT_SPACE 0x01
+#define GIT_DIGIT 0x02
+#define GIT_ALPHA 0x04
+#define GIT_GLOB_SPECIAL 0x08
+#define GIT_REGEX_SPECIAL 0x10
+#define GIT_PATHSPEC_MAGIC 0x20
+#define GIT_CNTRL 0x40
+#define GIT_PUNCT 0x80
+#define sane_istest(x,mask) ((sane_ctype[(unsigned char)(x)] & (mask)) != 0)
+#define isdigit(x) sane_istest(x,GIT_DIGIT)
+#define isalpha(x) sane_istest(x,GIT_ALPHA)
+#define isalnum(x) sane_istest(x,GIT_ALPHA | GIT_DIGIT)
+#define toupper(x) sane_case((unsigned char)(x), 0)
+#define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
+
+enum {
+	S = GIT_SPACE,
+	A = GIT_ALPHA,
+	D = GIT_DIGIT,
+	G = GIT_GLOB_SPECIAL,	/* *, ?, [, \\ */
+	R = GIT_REGEX_SPECIAL,	/* $, (, ), +, ., ^, {, | */
+	P = GIT_PATHSPEC_MAGIC, /* other non-alnum, except for ] and } */
+	X = GIT_CNTRL,
+	U = GIT_PUNCT,
+	Z = GIT_CNTRL | GIT_SPACE
+};
+
+const unsigned char sane_ctype[256] = {
+	X, X, X, X, X, X, X, X, X, Z, Z, X, X, Z, X, X,		/*   0.. 15 */
+	X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X,		/*  16.. 31 */
+	S, P, P, P, R, P, P, P, R, R, G, R, P, P, R, P,		/*  32.. 47 */
+	D, D, D, D, D, D, D, D, D, D, P, P, P, P, P, G,		/*  48.. 63 */
+	P, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A,		/*  64.. 79 */
+	A, A, A, A, A, A, A, A, A, A, A, G, G, U, R, P,		/*  80.. 95 */
+	P, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A,		/*  96..111 */
+	A, A, A, A, A, A, A, A, A, A, A, R, R, U, P, X,		/* 112..127 */
+	/* Nothing in the 128.. range */
+};
+
+static inline int sane_case(int x, int high)
+{
+	if (sane_istest(x, GIT_ALPHA))
+		x = (x & ~0x20) | high;
+	return x;
+}
+
+/*
+ * This is like mktime, but without normalization of tm_wday and tm_yday.
+ */
+static time_t tm_to_time_t(const struct atm *tm)
+{
+	static const int mdays[] = {
+	    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+	};
+	int year = tm->tm_year - 70;
+	int month = tm->tm_mon;
+	int day = tm->tm_mday;
+
+	if (year < 0 || year > 129) /* algo only works for 1970-2099 */
+		return -1;
+	if (month < 0 || month > 11) /* array bounds */
+		return -1;
+	if (month < 2 || (year + 2) % 4)
+		day--;
+	if (tm->tm_hour < 0 || tm->tm_min < 0 || tm->tm_sec < 0)
+		return -1;
+	return (year * 365 + (year + 1) / 4 + mdays[month] + day) * 24*60*60UL +
+		tm->tm_hour * 60*60 + tm->tm_min * 60 + tm->tm_sec;
+}
+
+static const char *month_names[] = {
+	"January", "February", "March", "April", "May", "June",
+	"July", "August", "September", "October", "November", "December"
+};
+
+static const char *weekday_names[] = {
+	"Sundays", "Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays"
+};
+
+/*
+ * Check these. And note how it doesn't do the summer-time conversion.
+ *
+ * In my world, it's always summer, and things are probably a bit off
+ * in other ways too.
+ */
+static const struct {
+	const char *name;
+	int offset;
+	int dst;
+} timezone_names[] = {
+	{ "IDLW", -12, 0, },	/* International Date Line West */
+	{ "NT",   -11, 0, },	/* Nome */
+	{ "CAT",  -10, 0, },	/* Central Alaska */
+	{ "HST",  -10, 0, },	/* Hawaii Standard */
+	{ "HDT",  -10, 1, },	/* Hawaii Daylight */
+	{ "YST",   -9, 0, },	/* Yukon Standard */
+	{ "YDT",   -9, 1, },	/* Yukon Daylight */
+	{ "PST",   -8, 0, },	/* Pacific Standard */
+	{ "PDT",   -8, 1, },	/* Pacific Daylight */
+	{ "MST",   -7, 0, },	/* Mountain Standard */
+	{ "MDT",   -7, 1, },	/* Mountain Daylight */
+	{ "CST",   -6, 0, },	/* Central Standard */
+	{ "CDT",   -6, 1, },	/* Central Daylight */
+	{ "EST",   -5, 0, },	/* Eastern Standard */
+	{ "EDT",   -5, 1, },	/* Eastern Daylight */
+	{ "AST",   -3, 0, },	/* Atlantic Standard */
+	{ "ADT",   -3, 1, },	/* Atlantic Daylight */
+	{ "WAT",   -1, 0, },	/* West Africa */
+
+	{ "GMT",    0, 0, },	/* Greenwich Mean */
+	{ "UTC",    0, 0, },	/* Universal (Coordinated) */
+	{ "Z",      0, 0, },    /* Zulu, alias for UTC */
+
+	{ "WET",    0, 0, },	/* Western European */
+	{ "BST",    0, 1, },	/* British Summer */
+	{ "CET",   +1, 0, },	/* Central European */
+	{ "MET",   +1, 0, },	/* Middle European */
+	{ "MEWT",  +1, 0, },	/* Middle European Winter */
+	{ "MEST",  +1, 1, },	/* Middle European Summer */
+	{ "CEST",  +1, 1, },	/* Central European Summer */
+	{ "MESZ",  +1, 1, },	/* Middle European Summer */
+	{ "FWT",   +1, 0, },	/* French Winter */
+	{ "FST",   +1, 1, },	/* French Summer */
+	{ "EET",   +2, 0, },	/* Eastern Europe, USSR Zone 1 */
+	{ "EEST",  +2, 1, },	/* Eastern European Daylight */
+	{ "WAST",  +7, 0, },	/* West Australian Standard */
+	{ "WADT",  +7, 1, },	/* West Australian Daylight */
+	{ "CCT",   +8, 0, },	/* China Coast, USSR Zone 7 */
+	{ "JST",   +9, 0, },	/* Japan Standard, USSR Zone 8 */
+	{ "EAST", +10, 0, },	/* Eastern Australian Standard */
+	{ "EADT", +10, 1, },	/* Eastern Australian Daylight */
+	{ "GST",  +10, 0, },	/* Guam Standard, USSR Zone 9 */
+	{ "NZT",  +12, 0, },	/* New Zealand */
+	{ "NZST", +12, 0, },	/* New Zealand Standard */
+	{ "NZDT", +12, 1, },	/* New Zealand Daylight */
+	{ "IDLE", +12, 0, },	/* International Date Line East */
+};
+
+static int match_string(const char *date, const char *str)
+{
+	int i = 0;
+
+	for (i = 0; *date; date++, str++, i++) {
+		if (*date == *str)
+			continue;
+		if (toupper(*date) == toupper(*str))
+			continue;
+		if (!isalnum(*date))
+			break;
+		return 0;
+	}
+	return i;
+}
+
+static int skip_alpha(const char *date)
+{
+	int i = 0;
+	do {
+		i++;
+	} while (isalpha(date[i]));
+	return i;
+}
+
+/*
+* Parse month, weekday, or timezone name
+*/
+static int match_alpha(const char *date, struct atm *tm, int *offset)
+{
+	int i;
+
+	for (i = 0; i < 12; i++) {
+		int match = match_string(date, month_names[i]);
+		if (match >= 3) {
+			tm->tm_mon = i;
+			return match;
+		}
+	}
+
+	for (i = 0; i < 7; i++) {
+		int match = match_string(date, weekday_names[i]);
+		if (match >= 3) {
+			tm->tm_wday = i;
+			return match;
+		}
+	}
+
+	for (i = 0; i < ARRAY_SIZE(timezone_names); i++) {
+		int match = match_string(date, timezone_names[i].name);
+		if (match >= 3 || match == strlen(timezone_names[i].name)) {
+			int off = timezone_names[i].offset;
+
+			/* This is bogus, but we like summer */
+			off += timezone_names[i].dst;
+
+			/* Only use the tz name offset if we don't have anything better */
+			if (*offset == -1)
+				*offset = 60*off;
+
+			return match;
+		}
+	}
+
+	if (match_string(date, "PM") == 2) {
+		tm->tm_hour = (tm->tm_hour % 12) + 12;
+		return 2;
+	}
+
+	if (match_string(date, "AM") == 2) {
+		tm->tm_hour = (tm->tm_hour % 12) + 0;
+		return 2;
+	}
+
+	/* BAD CRAP */
+	return skip_alpha(date);
+}
+
+static int is_date(int year, int month, int day, struct atm *now_tm, time_t now, struct atm *tm)
+{
+	if (month > 0 && month < 13 && day > 0 && day < 32) {
+		struct atm check = *tm;
+		struct atm *r = (now_tm ? &check : tm);
+
+		r->tm_mon = month - 1;
+		r->tm_mday = day;
+		if (year == -1) {
+			if (!now_tm)
+				return 1;
+			r->tm_year = now_tm->tm_year;
+		}
+		else if (year >= 1970 && year < 2100)
+			r->tm_year = year - 1900;
+		else if (year > 70 && year < 100)
+			r->tm_year = year;
+		else if (year < 38)
+			r->tm_year = year + 100;
+		else
+			return 0;
+		if (!now_tm)
+			return 1;
+
+		tm->tm_mon = r->tm_mon;
+		tm->tm_mday = r->tm_mday;
+		if (year != -1)
+			tm->tm_year = r->tm_year;
+		return 1;
+	}
+	return 0;
+}
+
+static int match_multi_number(unsigned long num, char c, const char *date,
+			      char *end, struct atm *tm, time_t now)
+{
+	long num2, num3, num4;
+
+	num2 = strtol(end+1, &end, 10);
+	num3 = -1;
+	num4 = 0;
+	if (*end == c && isdigit(end[1])) {
+		num3 = strtol(end+1, &end, 10);
+
+		if (*end == '.') {
+			char *start = end+1;
+			num4 = strtol(end+1, &end, 10);
+			if ((end - start) < 6) {
+				num4 *= (long)pow(10, 6 - (end - start));
+			}
+		}
+	}
+
+
+	/* Time? Date? */
+	switch (c) {
+	case ':':
+		if (num3 < 0)
+			num3 = 0;
+		if (num < 25 && num2 >= 0 && num2 < 60 && num3 >= 0 && num3 <= 60) {
+			tm->tm_hour = num;
+			tm->tm_min = num2;
+			tm->tm_sec = num3;
+			tm->tm_usec = num4;
+			break;
+		}
+		return 0;
+
+	case '-':
+	case '/':
+	case '.':
+		if (!now)
+			now = time(NULL);
+		if (num > 70) {
+			/* yyyy-mm-dd? */
+			if (is_date(num, num2, num3, NULL, now, tm))
+				break;
+			/* yyyy-dd-mm? */
+			if (is_date(num, num3, num2, NULL, now, tm))
+				break;
+		}
+		/* Our eastern European friends say dd.mm.yy[yy]
+		 * is the norm there, so giving precedence to
+		 * mm/dd/yy[yy] form only when separator is not '.'
+		 */
+		if (c != '.' &&
+		    is_date(num3, num, num2, NULL, now, tm))
+			break;
+		/* European dd.mm.yy[yy] or funny US dd/mm/yy[yy] */
+		if (is_date(num3, num2, num, NULL, now, tm))
+			break;
+		/* Funny European mm.dd.yy */
+		if (c == '.' &&
+		    is_date(num3, num, num2, NULL, now, tm))
+			break;
+		return 0;
+	}
+	return end - date;
+}
+
+/*
+ * Have we filled in any part of the time/date yet?
+ * We just do a binary 'and' to see if the sign bit
+ * is set in all the values.
+ */
+static inline int nodate(struct tm *tm)
+{
+	return (tm->tm_year &
+		tm->tm_mon &
+		tm->tm_mday &
+		tm->tm_hour &
+		tm->tm_min &
+		tm->tm_sec) < 0;
+}
+
+/*
+ * We've seen a digit. Time? Year? Date?
+ */
+static int match_digit(const char *date, struct atm *tm, int *offset, int *tm_gmt)
+{
+	int n;
+	char *end;
+	unsigned long num;
+
+	num = strtoul(date, &end, 10);
+
+	/*
+	 * Seconds since 1970? We trigger on that for any numbers with
+	 * more than 8 digits. This is because we don't want to rule out
+	 * numbers like 20070606 as a YYYYMMDD date.
+	 */
+	if (num >= 100000000 && nodate((struct tm*)tm)) {
+		time_t time = num;
+		if (gmtime_r(&time, (struct tm*)tm)) {
+			*tm_gmt = 1;
+			return end - date;
+		}
+	}
+
+	/*
+	 * Check for special formats: num[-.:/]num[same]num[.secfracs]
+	 */
+	switch (*end) {
+	case ':':
+	case '.':
+	case '/':
+	case '-':
+		if (isdigit(end[1])) {
+			int match = match_multi_number(num, *end, date, end, tm, 0);
+			if (match)
+				return match;
+		}
+	}
+
+	/*
+	 * None of the special formats? Try to guess what
+	 * the number meant. We use the number of digits
+	 * to make a more educated guess..
+	 */
+	n = 0;
+	do {
+		n++;
+	} while (isdigit(date[n]));
+
+	/* Four-digit year or a timezone? */
+	if (n == 4) {
+		if (num <= 1400 && *offset == -1) {
+			unsigned int minutes = num % 100;
+			unsigned int hours = num / 100;
+			*offset = hours*60 + minutes;
+		} else if (num > 1900 && num < 2100)
+			tm->tm_year = num - 1900;
+		return n;
+	}
+
+	/*
+	 * Ignore lots of numerals. We took care of 4-digit years above.
+	 * Days or months must be one or two digits.
+	 */
+	if (n > 2)
+		return n;
+
+	/*
+	 * NOTE! We will give precedence to day-of-month over month or
+	 * year numbers in the 1-12 range. So 05 is always "mday 5",
+	 * unless we already have a mday..
+	 *
+	 * IOW, 01 Apr 05 parses as "April 1st, 2005".
+	 */
+	if (num > 0 && num < 32 && tm->tm_mday < 0) {
+		tm->tm_mday = num;
+		return n;
+	}
+
+	/* Two-digit year? */
+	if (n == 2 && tm->tm_year < 0) {
+		if (num < 10 && tm->tm_mday >= 0) {
+			tm->tm_year = num + 100;
+			return n;
+		}
+		if (num >= 70) {
+			tm->tm_year = num;
+			return n;
+		}
+	}
+
+	if (num > 0 && num < 13 && tm->tm_mon < 0)
+		tm->tm_mon = num-1;
+
+	return n;
+}
+
+static int match_tz(const char *date, int *offp)
+{
+	char *end;
+	int hour = strtoul(date + 1, &end, 10);
+	int n = end - (date + 1);
+	int min = 0;
+
+	if (n == 4) {
+		/* hhmm */
+		min = hour % 100;
+		hour = hour / 100;
+	} else if (n != 2) {
+		min = 99; /* random crap */
+	} else if (*end == ':') {
+		/* hh:mm? */
+		min = strtoul(end + 1, &end, 10);
+		if (end - (date + 1) != 5)
+			min = 99; /* random crap */
+	} /* otherwise we parsed "hh" */
+
+	/*
+	 * Don't accept any random crap. Even though some places have
+	 * offset larger than 12 hours (e.g. Pacific/Kiritimati is at
+	 * UTC+14), there is something wrong if hour part is much
+	 * larger than that. We might also want to check that the
+	 * minutes are divisible by 15 or something too. (Offset of
+	 * Kathmandu, Nepal is UTC+5:45)
+	 */
+	if (min < 60 && hour < 24) {
+		int offset = hour * 60 + min;
+		if (*date == '-')
+			offset = -offset;
+		*offp = offset;
+	}
+	return end - date;
+}
+
+/*
+ * Parse a string like "0 +0000" as ancient timestamp near epoch, but
+ * only when it appears not as part of any other string.
+ */
+static int match_object_header_date(const char *date, struct timeval *tv, int *offset)
+{
+	char *end;
+	unsigned long stamp;
+	int ofs;
+
+	if (*date < '0' || '9' < *date)
+		return -1;
+	stamp = strtoul(date, &end, 10);
+	if (*end != ' ' || stamp == ULONG_MAX || (end[1] != '+' && end[1] != '-'))
+		return -1;
+	date = end + 2;
+	ofs = strtol(date, &end, 10);
+	if ((*end != '\0' && (*end != '\n')) || end != date + 4)
+		return -1;
+	ofs = (ofs / 100) * 60 + (ofs % 100);
+	if (date[-1] == '-')
+		ofs = -ofs;
+	tv->tv_sec = stamp;
+	*offset = ofs;
+	return 0;
+}
+
+/* Gr. strptime is crap for this; it doesn't have a way to require RFC2822
+   (i.e. English) day/month names, and it doesn't work correctly with %z. */
+int parse_date_basic(const char *date, struct timeval *tv, int *offset)
+{
+	struct atm tm;
+	int tm_gmt;
+	int dummy_offset;
+
+	if (!offset)
+		offset = &dummy_offset;
+
+	memset(&tm, 0, sizeof(tm));
+	tm.tm_year = -1;
+	tm.tm_mon = -1;
+	tm.tm_mday = -1;
+	tm.tm_isdst = -1;
+	tm.tm_hour = -1;
+	tm.tm_min = -1;
+	tm.tm_sec = -1;
+	tm.tm_usec = 0;
+	*offset = -1;
+	tm_gmt = 0;
+
+	if (*date == '@' &&
+	    !match_object_header_date(date + 1, tv, offset))
+		return 0; /* success */
+	for (;;) {
+		int match = 0;
+		unsigned char c = *date;
+
+		/* Stop at end of string or newline */
+		if (!c || c == '\n')
+			break;
+
+		if (isalpha(c))
+			match = match_alpha(date, &tm, offset);
+		else if (isdigit(c))
+			match = match_digit(date, &tm, offset, &tm_gmt);
+		else if ((c == '-' || c == '+') && isdigit(date[1]))
+			match = match_tz(date, offset);
+
+		if (!match) {
+			/* BAD CRAP */
+			match = 1;
+		}
+
+		date += match;
+	}
+
+	tv->tv_usec = tm.tm_usec;
+
+	/* mktime uses local timezone */
+	tv->tv_sec = tm_to_time_t(&tm);
+	if (*offset == -1) {
+		time_t temp_time = mktime((struct tm*)&tm);
+		if (tv->tv_sec > temp_time) {
+			*offset = (tv->tv_sec - temp_time) / 60;
+		} else {
+			*offset = -(int)((temp_time - tv->tv_sec) / 60);
+		}
+	}
+
+	if (*offset == -1)
+		*offset = (((time_t)tv->tv_sec) - mktime((struct tm*)&tm)) / 60;
+
+	if (tv->tv_sec == -1)
+		return -1;
+
+	if (!tm_gmt)
+		tv->tv_sec -= *offset * 60;
+
+	return 0; /* success */
+}
+
+/*
+ * Relative time update (eg "2 days ago").  If we haven't set the time
+ * yet, we need to set it from current time.
+ */
+static unsigned long update_tm(struct atm *tm, struct atm *now, unsigned long sec)
+{
+	time_t n;
+
+	if (tm->tm_mday < 0)
+		tm->tm_mday = now->tm_mday;
+	if (tm->tm_mon < 0)
+		tm->tm_mon = now->tm_mon;
+	if (tm->tm_year < 0) {
+		tm->tm_year = now->tm_year;
+		if (tm->tm_mon > now->tm_mon)
+			tm->tm_year--;
+	}
+
+	n = mktime((struct tm*)tm) - sec;
+	localtime_r(&n, (struct tm*)tm);
+	return n;
+}
+
+static void date_now(struct atm *tm, struct atm *now, int *num)
+{
+	update_tm(tm, now, 0);
+}
+
+static void date_yesterday(struct atm *tm, struct atm *now, int *num)
+{
+	update_tm(tm, now, 24*60*60);
+}
+
+static void date_time(struct atm *tm, struct atm *now, int hour)
+{
+	if (tm->tm_hour < hour)
+		date_yesterday(tm, now, NULL);
+	tm->tm_hour = hour;
+	tm->tm_min = 0;
+	tm->tm_sec = 0;
+}
+
+static void date_midnight(struct atm *tm, struct atm *now, int *num)
+{
+	date_time(tm, now, 0);
+}
+
+static void date_noon(struct atm *tm, struct atm *now, int *num)
+{
+	date_time(tm, now, 12);
+}
+
+static void date_tea(struct atm *tm, struct atm *now, int *num)
+{
+	date_time(tm, now, 17);
+}
+
+static void date_pm(struct atm *tm, struct atm *now, int *num)
+{
+	int hour, n = *num;
+	*num = 0;
+
+	hour = tm->tm_hour;
+	if (n) {
+		hour = n;
+		tm->tm_min = 0;
+		tm->tm_sec = 0;
+	}
+	tm->tm_hour = (hour % 12) + 12;
+}
+
+static void date_am(struct atm *tm, struct atm *now, int *num)
+{
+	int hour, n = *num;
+	*num = 0;
+
+	hour = tm->tm_hour;
+	if (n) {
+		hour = n;
+		tm->tm_min = 0;
+		tm->tm_sec = 0;
+	}
+	tm->tm_hour = (hour % 12);
+}
+
+static void date_never(struct atm *tm, struct atm *now, int *num)
+{
+	time_t n = 0;
+	localtime_r(&n, (struct tm*)tm);
+}
+
+static const struct special {
+	const char *name;
+	void (*fn)(struct atm *, struct atm *, int *);
+} special[] = {
+	{ "yesterday", date_yesterday },
+	{ "noon", date_noon },
+	{ "midnight", date_midnight },
+	{ "tea", date_tea },
+	{ "PM", date_pm },
+	{ "AM", date_am },
+	{ "never", date_never },
+	{ "now", date_now },
+	{ NULL }
+};
+
+static const char *number_name[] = {
+	"zero", "one", "two", "three", "four",
+	"five", "six", "seven", "eight", "nine", "ten",
+};
+
+static const struct typelen {
+	const char *type;
+	int length;
+} typelen[] = {
+	{ "seconds", 1 },
+	{ "minutes", 60 },
+	{ "hours", 60*60 },
+	{ "days", 24*60*60 },
+	{ "weeks", 7*24*60*60 },
+	{ NULL }
+};
+
+static const char *approxidate_alpha(const char *date, struct atm *tm, struct atm *now, int *num, int *touched)
+{
+	const struct typelen *tl;
+	const struct special *s;
+	const char *end = date;
+	int i;
+
+	while (isalpha(*++end))
+		;
+
+	for (i = 0; i < 12; i++) {
+		int match = match_string(date, month_names[i]);
+		if (match >= 3) {
+			tm->tm_mon = i;
+			*touched = 1;
+			return end;
+		}
+	}
+
+	for (s = special; s->name; s++) {
+		int len = strlen(s->name);
+		if (match_string(date, s->name) == len) {
+			s->fn(tm, now, num);
+			*touched = 1;
+			return end;
+		}
+	}
+
+	if (!*num) {
+		for (i = 1; i < 11; i++) {
+			int len = strlen(number_name[i]);
+			if (match_string(date, number_name[i]) == len) {
+				*num = i;
+				*touched = 1;
+				return end;
+			}
+		}
+		if (match_string(date, "last") == 4) {
+			*num = 1;
+			*touched = 1;
+		}
+		return end;
+	}
+
+	tl = typelen;
+	while (tl->type) {
+		int len = strlen(tl->type);
+		if (match_string(date, tl->type) >= len-1) {
+			update_tm(tm, now, tl->length * *num);
+			*num = 0;
+			*touched = 1;
+			return end;
+		}
+		tl++;
+	}
+
+	for (i = 0; i < 7; i++) {
+		int match = match_string(date, weekday_names[i]);
+		if (match >= 3) {
+			int diff, n = *num -1;
+			*num = 0;
+
+			diff = tm->tm_wday - i;
+			if (diff <= 0)
+				n++;
+			diff += 7*n;
+
+			update_tm(tm, now, diff * 24 * 60 * 60);
+			*touched = 1;
+			return end;
+		}
+	}
+
+	if (match_string(date, "months") >= 5) {
+		int n;
+		update_tm(tm, now, 0); /* fill in date fields if needed */
+		n = tm->tm_mon - *num;
+		*num = 0;
+		while (n < 0) {
+			n += 12;
+			tm->tm_year--;
+		}
+		tm->tm_mon = n;
+		*touched = 1;
+		return end;
+	}
+
+	if (match_string(date, "years") >= 4) {
+		update_tm(tm, now, 0); /* fill in date fields if needed */
+		tm->tm_year -= *num;
+		*num = 0;
+		*touched = 1;
+		return end;
+	}
+
+	return end;
+}
+
+static const char *approxidate_digit(const char *date, struct atm *tm, int *num,
+				     time_t now)
+{
+	char *end;
+	unsigned long number = strtoul(date, &end, 10);
+
+	switch (*end) {
+	case ':':
+	case '.':
+	case '/':
+	case '-':
+		if (isdigit(end[1])) {
+			int match = match_multi_number(number, *end, date, end,
+						       tm, now);
+			if (match)
+				return date + match;
+		}
+	}
+
+	/* Accept zero-padding only for small numbers ("Dec 02", never "Dec 0002") */
+	if (date[0] != '0' || end - date <= 2)
+		*num = number;
+	return end;
+}
+
+/*
+ * Do we have a pending number at the end, or when
+ * we see a new one? Let's assume it's a month day,
+ * as in "Dec 6, 1992"
+ */
+static void pending_number(struct atm *tm, int *num)
+{
+	int number = *num;
+
+	if (number) {
+		*num = 0;
+		if (tm->tm_mday < 0 && number < 32)
+			tm->tm_mday = number;
+		else if (tm->tm_mon < 0 && number < 13)
+			tm->tm_mon = number-1;
+		else if (tm->tm_year < 0) {
+			if (number > 1969 && number < 2100)
+				tm->tm_year = number - 1900;
+			else if (number > 69 && number < 100)
+				tm->tm_year = number;
+			else if (number < 38)
+				tm->tm_year = 100 + number;
+			/* We screw up for number = 00 ? */
+		}
+	}
+}
+
+static int approxidate_str(const char *date, struct timeval *tv)
+{
+	int number = 0;
+	int touched = 0;
+	struct atm tm, now;
+	time_t time_sec;
+
+	time_sec = tv->tv_sec;
+	localtime_r(&time_sec, (struct tm*)&tm);
+	now = tm;
+
+	tm.tm_year = -1;
+	tm.tm_mon = -1;
+	tm.tm_mday = -1;
+	tm.tm_usec = tv->tv_usec;
+
+	for (;;) {
+		unsigned char c = *date;
+		if (!c)
+			break;
+		date++;
+		if (isdigit(c)) {
+			pending_number(&tm, &number);
+			date = approxidate_digit(date-1, &tm, &number, time_sec);
+			touched = 1;
+			continue;
+		}
+		if (isalpha(c))
+			date = approxidate_alpha(date-1, &tm, &now, &number, &touched);
+	}
+
+	pending_number(&tm, &number);
+	if (!touched)
+		return -1;
+
+	tv->tv_usec = tm.tm_usec;
+	tv->tv_sec = update_tm(&tm, &now, 0);
+
+	return 0;
+}
+
+int approxidate(const char *date, struct timeval *tv)
+{
+	int offset;
+
+	if (!parse_date_basic(date, tv, &offset)) {
+		return 0;
+	}
+
+	gettimeofday(tv, NULL);
+	if (!approxidate_str(date, tv)) {
+		return 0;
+	}
+
+	return -1;
+}

--- a/src/common/libutil/approxidate.h
+++ b/src/common/libutil/approxidate.h
@@ -1,0 +1,23 @@
+/*
+ * This code was taken from git's source, as such it falls under git's license.
+ * Any modifications made to it carry the same license.
+ *
+ * See: https://github.com/git/git/blob/master/COPYING
+ *
+ * Copyright (C) Linus Torvalds, 2005
+ */
+#ifndef APPROXIDATE_H
+#define APPROXIDATE_H
+
+#include <sys/time.h>
+
+/**
+ * @param date The date string
+ * @param tv Where the time will be placed.
+ *
+ * @return 0 on success
+ * @return 1 on error
+ */
+int approxidate(const char *date, struct timeval *tv);
+
+#endif

--- a/src/common/libutil/cronodate.c
+++ b/src/common/libutil/cronodate.c
@@ -1,0 +1,485 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <time.h>
+#include <sys/time.h>
+#include <ctype.h>
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/nodeset.h"
+#include "src/common/libutil/xzmalloc.h"
+
+#include "cronodate.h"
+
+struct cronodate {
+    nodeset_t * item [TM_MAX_ITEM];
+};
+
+static char * weekdays [] = {
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+};
+#define WEEKDAY_COUNT 7
+
+static char * months [] = {
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+};
+#define MONTH_COUNT 12
+
+
+int tm_unit_min (tm_unit_t item)
+{
+    switch (item) {
+    case TM_SEC:
+    case TM_MIN:
+    case TM_HOUR:
+    case TM_WDAY:
+    case TM_MON:
+    case TM_YEAR: // 1900
+        return 0;
+    case TM_MDAY:
+        return 1;
+    default:
+        break;
+    }
+    return (-1);
+}
+
+int tm_unit_max (tm_unit_t item)
+{
+    switch (item) {
+    case TM_SEC:
+        return 60;
+    case TM_MIN:
+        return 59;
+    case TM_HOUR:
+        return 23;
+    case TM_MDAY:
+        return 31;
+    case TM_MON:
+        return 11;
+    case TM_WDAY:
+        return 6;
+    case TM_YEAR: // 3000
+        return 3000-1900;
+    default:
+        break;
+    }
+    return (-1);
+}
+
+const char *tm_unit_string (tm_unit_t item)
+{
+    switch (item) {
+    case TM_SEC:
+        return "second";
+    case TM_MIN:
+        return "minute";
+    case TM_HOUR:
+        return "hour";
+    case TM_MDAY:
+        return "mday";
+    case TM_MON:
+        return "month";
+    case TM_WDAY:
+        return "weekday";
+    case TM_YEAR:
+        return "year";
+    default:
+        break;
+    }
+    return "unknown";
+}
+
+int tm_string_to_weekday (const char *day)
+{
+    int i;
+    if (day == NULL)
+        return -1;
+    for (i = 0; i < WEEKDAY_COUNT; i++) {
+        if (strncasecmp (weekdays [i], day, strlen (day)) == 0)
+            return i;
+    }
+    return -1;
+}
+
+const char *tm_weekday_string (int w)
+{
+    if ((w < 0) || (w > WEEKDAY_COUNT - 1))
+        return NULL;
+    return weekdays [w];
+}
+
+int tm_string_to_month (const char *mon)
+{
+    int i;
+    if (mon == NULL)
+        return -1;
+    for (i = 0; i < MONTH_COUNT; i++) {
+        if (strncasecmp (months [i], mon, strlen (mon)) == 0)
+            return i;
+    }
+    return -1;
+}
+
+const char *tm_month_string (int m)
+{
+    if ((m < 0) || (m > MONTH_COUNT - 1))
+        return NULL;
+    return months [m];
+}
+
+
+void cronodate_destroy (cronodate_t *d)
+{
+    int i;
+    for (i = 0; i < TM_MAX_ITEM; i++)
+        nodeset_destroy (d->item [i]);
+    free (d);
+}
+
+cronodate_t * cronodate_create ()
+{
+    int i;
+    cronodate_t *d = xzmalloc (sizeof (*d));
+
+    memset (d, 0, sizeof (*d));
+    for (i = 0; i < TM_MAX_ITEM; i++) {
+        nodeset_t *n = nodeset_create_size (tm_unit_max (i) + 1);
+        if (n == NULL) {
+            nodeset_destroy (n);
+            return (NULL);
+        }
+        nodeset_config_brackets (n, false);
+        d->item [i] = n;
+    }
+    return (d);
+}
+
+static int string2int (const char *s)
+{
+    char *endptr;
+    unsigned long n = strtoul (s, &endptr, 0);
+    if (n == ULONG_MAX) /* ERANGE set by strtol */
+        return (-1);
+    if (endptr == s || *endptr != '\0') {
+        errno = EINVAL;
+        return (-1);
+    }
+    return ((int) n);
+}
+
+static int tm_string2int (const char *s, tm_unit_t u)
+{
+    int n = string2int (s);
+    if (n < 0) {
+        // Not an integer: Try parsing weekday and month by name
+        if (u == TM_WDAY)
+            n = tm_string_to_weekday (s);
+        else if (u == TM_MON)
+            n = tm_string_to_month (s);
+    }
+    return n;
+}
+
+static int get_range (const char *r, tm_unit_t u, int *lo, int *hi)
+{
+    char *p;
+    if (strcmp (r, "*") == 0) {
+        *lo = tm_unit_min (u);
+        *hi = tm_unit_max (u);
+    }
+    else if ((p = strchr (r, '-'))) {
+        *(p++) = '\0';
+        // r = lo, p = hi
+        if (((*lo = tm_string2int (r, u)) < 0)
+           || ((*hi = tm_string2int (p, u)) < 0))
+            return (-1);
+    }
+    else {
+        *lo = *hi = tm_string2int (r, u);
+        if (*lo < 0)
+            return -1;
+    }
+    return (0);
+}
+
+static int range_parse (nodeset_t *n, tm_unit_t u, const char *range)
+{
+    char *cpy, *a1, *q, *s, *saveptr;
+    int hi, lo;
+    int rc = -1;
+
+    if (!(cpy = strdup (range)))
+        return (-1);
+    a1 = cpy;
+    while ((s = strtok_r (a1, ",", &saveptr))) {
+        int stride = 1;
+
+        // check for a stride and nullify trailing "/":
+        if ((q = strchr (s, '/'))) {
+            *(q++) = '\0';
+            if ((stride = string2int (q)) < 0)
+                goto out;
+        }
+
+        // get next single range or number from string:
+        if (get_range (s, u, &lo, &hi) < 0)
+            goto out;
+
+        if (lo == hi)
+            nodeset_add_rank (n, lo);
+        else if (stride == 1)
+            nodeset_add_range (n, lo, hi);
+        else {
+            while (lo <= hi) {
+                nodeset_add_rank (n, lo);
+                lo += stride;
+            }
+        }
+        a1 = NULL;
+    }
+    rc = 0;
+out:
+    free (cpy);
+    return (rc);
+}
+
+int cronodate_set (cronodate_t *d, tm_unit_t item, const char *range)
+{
+    nodeset_t *n = d->item [item];
+    assert (n != NULL);
+    /* 
+     *  Delete all existing nodeset members before setting the new range.
+     */
+    nodeset_delete_range (n, tm_unit_min (item), tm_unit_max (item));
+    return range_parse (n, item, range);
+}
+
+const char *cronodate_get (cronodate_t *d, tm_unit_t u)
+{
+    return (nodeset_string (d->item [u]));
+}
+
+void cronodate_fillset (cronodate_t *d)
+{
+    int i;
+    for (i = 0; i < TM_MAX_ITEM; i++)
+        nodeset_add_range (d->item [i], tm_unit_min (i), tm_unit_max (i));
+}
+
+void cronodate_emptyset (cronodate_t *d)
+{
+    int i;
+    for (i = 0; i < TM_MAX_ITEM; i++)
+        nodeset_delete_range (d->item [i], tm_unit_min (i), tm_unit_max (i));
+}
+
+/* Return pointer to item in struct tm that corresponds to tm_unit_t type.
+ */
+static int *tm_item (struct tm *t, tm_unit_t item)
+{
+    switch (item) {
+        case TM_SEC:
+            return &t->tm_sec;
+        case TM_MIN:
+            return &t->tm_min;
+        case TM_HOUR:
+            return &t->tm_hour;
+        case TM_MDAY:
+            return &t->tm_mday;
+        case TM_MON:
+            return &t->tm_mon;
+        case TM_WDAY:
+            return &t->tm_wday;
+        case TM_YEAR:
+            return &t->tm_year;
+        default:
+            break;
+    }
+    return (NULL);
+}
+
+static void tm_incr (struct tm *tm, tm_unit_t item)
+{
+    int *ti = tm_item (tm, item);
+    (*ti)++;
+}
+
+static void tm_set (struct tm *tm, tm_unit_t item, int val)
+{
+    int *ti = tm_item (tm, item);
+    *ti = val;
+}
+
+/*
+ *  Starting at item-1 reset all values of tm struct `tm`
+ *   to their minimum values.
+ */
+static void tm_reset (struct tm *tm, tm_unit_t item)
+{
+    int i;
+    for (i = item-1; i >= TM_SEC; i--)
+        tm_set (tm, i, tm_unit_min (i));
+}
+
+/* advance time unit `item` in tm struct `tm` to new value `val`.
+ *  if value is less than current value for the unit (e.g. for
+ *  hours tm.tm_hour is 20 and we "advance" to 2), then increment
+ *  the upper unit (e.g. mday), and reset all lower units to
+ *  zero (e.g. minutes, seconds).
+ */
+static int tm_advance (struct tm *tm, tm_unit_t item, int val)
+{
+    int *ti;
+
+    switch (item) {
+    case TM_SEC:
+    case TM_MIN:
+    case TM_HOUR:
+    case TM_MDAY:
+    case TM_MON:
+        ti = tm_item (tm, item);
+        /* If current value is greater than new value, then roll over
+         *  to the next higher time unit (e.g. for seconds add one to minutes)
+         *  and set this unit to the new "val" value.
+         */
+        if (*ti > val)
+            tm_incr (tm, item+1);
+        *ti = val;
+        tm_reset (tm, item);
+        break;
+    /* Year is special. It doesn't overflow
+     */
+    case TM_YEAR:
+        tm->tm_year = val;
+        tm_reset (tm, TM_YEAR);
+        break; 
+        
+    /* day of week is special */
+    case TM_WDAY:
+        if (tm->tm_wday > val) // into next week
+            tm->tm_mday += (7 - tm->tm_wday) + val;
+        else
+            tm->tm_mday = val - tm->tm_wday;
+        tm_reset (tm, TM_MDAY);
+        break;
+    default:
+        return (-1);
+    }
+    return (0);
+}
+
+bool cronodate_match (cronodate_t *d, struct tm *tm)
+{
+    int i;
+    for (i = 0; i < TM_MAX_ITEM; i++) {
+        nodeset_t *n = d->item [i];
+        int *ti = tm_item (tm, i);
+        if (!nodeset_test_rank (n, *ti)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int cronodate_next (cronodate_t *d, struct tm *tm)
+{
+    int i;
+    time_t t, now;
+    if (tm == NULL || d == NULL) {
+        errno = EINVAL;
+        return (-1);
+    }
+
+    /* Advance 1s into future so we get next future time
+     *  and do not match "now".
+     */
+    tm->tm_sec++;
+    now = mktime (tm);
+
+again:
+    /* Loop through configured date-time units to see if
+     *  they all fall within per-unit nodesets of `d`.
+     *  for each that does not match, advance the time by
+     *  one unit and try again.
+     *
+     * If time is advanced, check to sure we don't go more
+     *  than a year into the future. This could be fixed up
+     *  later, but for now is sufficient.
+     */
+    for (i = TM_SEC; i < TM_MAX_ITEM; i++) {
+        nodeset_t *n = d->item [i];
+        int *ti = tm_item (tm, i);
+
+        if (!nodeset_test_rank (n, *ti)) {
+            uint32_t next;
+            if ((next = nodeset_next_rank (n, *ti)) == NODESET_EOF)
+                next = nodeset_min (n);
+            tm_advance (tm, i, next);
+            // Call mktime to fix up any overflow, and check that
+            //  don't iterate more than 2 years in the future
+            if (((t = mktime (tm)) - now) > 2*60*60*24*365) {
+                errno = EOVERFLOW;
+                return -1;
+            }
+            goto again;
+        }
+    }
+    return 0;
+}
+
+double cronodate_remaining (cronodate_t *d, double now)
+{
+    struct tm tm;
+    time_t t = (time_t) now;
+    if (localtime_r (&t, &tm) == NULL)
+        return (-1.);
+    if (cronodate_next (d, &tm) < 0)
+        return (-1.);
+    t = mktime (&tm);
+    return ((double) t - now);
+}
+ /* vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/cronodate.h
+++ b/src/common/libutil/cronodate.h
@@ -1,0 +1,88 @@
+
+#ifndef HAVE_CRONODATE_H
+#define HAVE_CRONODATE_H 1
+
+#include <time.h>
+#include <sys/types.h>
+#include <stdbool.h>
+
+/* Set of time units supported for cronodate */
+typedef enum {
+    TM_SEC,
+    TM_MIN,
+    TM_HOUR,
+    TM_MDAY,
+    TM_MON,
+    TM_YEAR,
+    TM_WDAY,
+    TM_MAX_ITEM
+} tm_unit_t;
+
+typedef struct cronodate cronodate_t;
+
+/*
+ *  Return max or min value for time unit u
+ */
+int tm_unit_max (tm_unit_t u);
+int tm_unit_min (tm_unit_t u);
+const char *tm_unit_string (tm_unit_t u);
+
+int tm_string_to_weekday (const char *day);
+const char *tm_weekday_string (int w);
+
+int tm_string_to_month (const char *month);
+const char *tm_month_string (int w);
+
+/* Create an empty cronodate object that will not
+ *  match any date-time
+ */
+cronodate_t * cronodate_create (void);
+void cronodate_destroy (cronodate_t *);
+
+/*  Fill cronodate structure will all values, or
+ *   empty an existing cronodate struct.
+ */
+void cronodate_fillset (cronodate_t *);
+void cronodate_emptyset (cronodate_t *);
+
+/*  Set cronodate field for time unit u to a range
+ *  Returns EINVAL if any value of range is outside [min, max] for
+ *  time unit u, or numeric members of range cannot be parsed.
+ *
+ *  `range` supports single values, e.g. '5', ranges '2-5', and
+ *  comma separated lists of ranges '0,2-5'. For Weekday and month
+ *  ranges, named day/months are also accepted, e.g.  'Mon-Fri' or
+ *  'Jan,Mar-Jun'.
+ *
+ *  A range of '*' is used to indicate 'MIN-MAX' for the specified
+ *  time unit `u`.
+ *
+ *  A range may also be followed by '/N' where N is the stride,
+ *  e.g. 'x-y/2' indicates every other number in the range x-y.
+ */
+int cronodate_set (cronodate_t *d, tm_unit_t u, const char *range);
+
+/*  Get the current set/range for time unit `u` in cronodate object `d`
+ *   in the form of a nodeset range string.
+ */
+const char *cronodate_get (cronodate_t *d, tm_unit_t u);
+
+/*
+ *  Return true if broken down time struct `tm` matches the cronodate
+ *   expression in `m`.
+ */
+bool cronodate_match (cronodate_t *d, struct tm *tm);
+
+/* 
+ *  Advance `now` to the next date/time that will match `m`.
+ */
+int cronodate_next (cronodate_t *d, struct tm *now);
+
+/*
+ *  Given epoch in floating points seconds `now` return the time
+ *   remaining in floating point seconds until the next matching
+ *   date in cronodate object `d`, or < 0.0 if no next time.
+ */
+double cronodate_remaining (cronodate_t *d, double now);
+
+#endif /* !HAVE_CRONODATE_H */

--- a/src/common/libutil/nodeset.c
+++ b/src/common/libutil/nodeset.c
@@ -316,6 +316,12 @@ uint32_t nodeset_next (nodeset_iterator_t *itr)
     return (itr->r == NS_SIZE (itr->n) ? NODESET_EOF : itr->r);
 }
 
+uint32_t nodeset_next_rank (nodeset_t *n, uint32_t r)
+{
+    uint32_t next = NS_NEXT (n, r);
+    return (next == NS_SIZE (n) ? NODESET_EOF : next);
+}
+
 void nodeset_iterator_rewind (nodeset_iterator_t *itr)
 {
     itr->started = false;

--- a/src/common/libutil/nodeset.h
+++ b/src/common/libutil/nodeset.h
@@ -89,6 +89,10 @@ uint32_t nodeset_count (nodeset_t *n);
 uint32_t nodeset_min (nodeset_t *n);
 uint32_t nodeset_max (nodeset_t *n);
 
+/* Return next rank above r in the list, or NODESET_EOF if list is empty
+ */
+uint32_t nodeset_next_rank (nodeset_t *n, uint32_t r);
+
 /* Iteration.  Terminate when NODESET_EOF is returned.
  */
 nodeset_iterator_t *nodeset_iterator_create (nodeset_t *n);

--- a/src/common/libutil/test/approxidate.c
+++ b/src/common/libutil/test/approxidate.c
@@ -1,0 +1,121 @@
+#include <assert.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "approxidate.h"
+
+#include <src/common/libtap/tap.h>
+
+#define assert_equal(a, b) ok (a == b, "line %d: %ld = %ld\n", __LINE__, (long)a, (long)b);
+
+static time_t _start_of_day(time_t sec)
+{
+	return sec - (sec % 86400);
+}
+
+int main()
+{
+	long usec;
+	time_t ts;
+	struct tm *tm;
+	char buff[128];
+	struct timeval tv;
+
+    plan (NO_PLAN);
+
+	approxidate("10/Mar/2013:00:00:02.003 UTC", &tv);
+	assert_equal(tv.tv_sec, 1362873602);
+	assert_equal(tv.tv_usec, 3000);
+
+	approxidate("10/Mar/2013:00:00:02 UTC", &tv);
+	assert_equal(tv.tv_sec, 1362873602);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("10/Mar/2013:00:00:07 UTC", &tv);
+	assert_equal(tv.tv_sec, 1362873607);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("10/Mar/2012:00:00:07 UTC", &tv);
+	assert_equal(tv.tv_sec, 1331337607);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("10/Mar/2012:00:00:07 +0500", &tv);
+	assert_equal(tv.tv_sec, 1331319607);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("10/Mar/2012:00:00:07.657891 +0500", &tv);
+	assert_equal(tv.tv_sec, 1331319607);
+	assert_equal(tv.tv_usec, 657891);
+
+	approxidate("10/Mar/2012:00:00:07.657891 +1400", &tv);
+	assert_equal(tv.tv_sec, 1331287207);
+	assert_equal(tv.tv_usec, 657891);
+
+	approxidate("10/Mar/2012:00:00:07.657891 -0110", &tv);
+	assert_equal(tv.tv_sec, 1331341807);
+	assert_equal(tv.tv_usec, 657891);
+
+	approxidate("mar 10 2013 00:00:07 UTC", &tv);
+	assert_equal(tv.tv_sec, 1362873607);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("mar 10 2013 04:00:07 -0500", &tv);
+	assert_equal(tv.tv_sec, 1362906007);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("march 10 2013 04:00:07 -0500", &tv);
+	assert_equal(tv.tv_sec, 1362906007);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("march 10 2013 04:00:07 -0500", &tv);
+	assert_equal(tv.tv_sec, 1362906007);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("10 march 2013 04:00:07 -0500", &tv);
+	assert_equal(tv.tv_sec, 1362906007);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("2013 10 march 04:00:07 -0500", &tv);
+	assert_equal(tv.tv_sec, 1362906007);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("2013 march 10 04:00:07 -0500", &tv);
+	assert_equal(tv.tv_sec, 1362906007);
+	assert_equal(tv.tv_usec, 0);
+
+	approxidate("00:00:07.657891", &tv);
+	assert_equal(tv.tv_usec, 657891);
+
+	approxidate("23:11:07.9876 +1400", &tv);
+	assert_equal(tv.tv_usec, 987600);
+
+	approxidate("23:11:07.9876", &tv);
+	assert_equal(tv.tv_usec, 987600);
+
+	approxidate("1/1/2014", &tv);
+	assert_equal(_start_of_day(tv.tv_sec), 1388534400);
+
+	approxidate("1/1/2014 UTC", &tv);
+	assert_equal(_start_of_day(tv.tv_sec), 1388534400);
+
+	/*
+	 * Git doesn't allow dates more than 10 days in the future. Make sure
+	 * approxidate does.
+	 *   * if today is 3/15/2015
+	 *   * 8/15/2015 should parse as "Aug 15, 2015", not "Mar 8, 2015".
+	 */
+	ts = time(NULL);
+	ts += 86400 * 31 * 5;
+	tm = gmtime(&ts);
+	strftime(buff, sizeof(buff), "%m/%d/%Y", tm);
+	approxidate(buff, &tv);
+	assert_equal(_start_of_day(tv.tv_sec), _start_of_day(ts));
+
+	gettimeofday(&tv, NULL);
+	usec = tv.tv_usec;
+	approxidate("10/Mar/2012", &tv);
+
+	ok (((usec - 10000) < tv.tv_usec && (usec + 10000) > tv.tv_usec),
+        "usec calculation for anonymous time is correct");
+    done_testing ();
+}

--- a/src/common/libutil/test/cronodate.c
+++ b/src/common/libutil/test/cronodate.c
@@ -1,0 +1,219 @@
+
+#define _XOPEN_SOURCE
+#include <time.h>
+#include <sys/time.h>
+#include <math.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/approxidate.h"
+#include "src/common/libutil/cronodate.h"
+
+static int approxidate_tm (char *s, struct tm *tm)
+{
+    struct timeval tv;
+    time_t t;
+    if (approxidate (s, &tv) < 0)
+        return (-1);
+    t = tv.tv_sec;
+    if (localtime_r (&t, tm) == NULL)
+        return (-1);
+    return (0);
+}
+
+static bool cronodate_check_match (struct cronodate *d, char *s)
+{
+    struct tm tm;
+    ok (approxidate_tm (s, &tm) >= 0, "approxidate (%s)", s);
+    return cronodate_match (d, &tm);
+}
+
+static bool cronodate_check_next (struct cronodate *d,
+                                  char *start, char *expected)
+{
+    char buf [256];
+    time_t t, t_exp;
+    struct tm tm;
+    int rc;
+
+    ok (approxidate_tm (expected, &tm) >= 0,
+        "approxidate (expected=%s)", expected);
+    if ((t_exp = mktime (&tm)) < (time_t) 0)
+        return false;
+
+    ok (approxidate_tm (start, &tm) >= 0,
+        "approxidate (start=%s)", start);
+    rc = cronodate_next (d, &tm);
+    strftime (buf, sizeof (buf), "%Y-%m-%d %H:%M:%S", &tm);
+    ok (rc >= 0, "cronodate_next() = %s", buf);
+    if ((t = mktime (&tm)) < (time_t) 0)
+        return false;
+    return (t == t_exp);
+}
+
+static double tv_to_double (struct timeval *tv)
+{
+    return (tv->tv_sec + (tv->tv_usec/1e6));
+}
+
+static bool almost_is (double a, double b)
+{
+    return fabs (a - b) < 1e-6;
+}
+
+int main (int argc, char *argv[])
+{
+    int i;
+    int rc;
+    double x;
+    struct tm tm;
+    struct timeval tv;
+    struct cronodate *d;
+    
+    
+    plan (NO_PLAN);
+
+    ok (tm_unit_min (TM_SEC) == 0, "check min value for tm_sec");
+    ok (tm_unit_min (TM_MIN) == 0, "check min value for tm_min");
+    ok (tm_unit_min (TM_HOUR) == 0, "check min value for tm_hour");
+    ok (tm_unit_min (TM_MON) == 0, "check min value for tm_mon");
+    ok (tm_unit_min (TM_YEAR) == 0, "check min value for tm_year");
+    ok (tm_unit_min (TM_WDAY) == 0, "check min value for tm_wday");
+    ok (tm_unit_min (TM_MDAY) == 1, "check min value for tm_mday");
+
+    ok (tm_unit_max (TM_SEC) == 60, "check max value for tm_sec");
+    ok (tm_unit_max (TM_MIN) == 59, "check max value for tm_min");
+    ok (tm_unit_max (TM_HOUR) == 23, "check max value for tm_hour");
+    ok (tm_unit_max (TM_MON) == 11, "check max value for tm_mon");
+    ok (tm_unit_max (TM_YEAR) == 3000-1900, "check max value for tm_year");
+    ok (tm_unit_max (TM_WDAY) == 6, "check max value for tm_wday");
+    ok (tm_unit_max (TM_MDAY) == 31, "check max value for tm_mday");
+
+    is (tm_unit_string (TM_SEC),  "second", "tm_unit_string: seconds");
+    is (tm_unit_string (TM_MIN),  "minute", "tm_unit_string: minute");
+    is (tm_unit_string (TM_HOUR), "hour", "tm_unit_string: hour");
+    is (tm_unit_string (TM_MON),  "month", "tm_unit_string: month");
+    is (tm_unit_string (TM_MDAY), "mday", "tm_unit_string: mday");
+    is (tm_unit_string (TM_WDAY), "weekday", "tm_unit_string: weekday");
+    is (tm_unit_string (TM_YEAR), "year", "tm_unit_string: year");
+
+    for (i = 0; i < 12; i++)
+        ok (tm_string_to_month (tm_month_string (i)) == i, "checking %s", tm_month_string (i));
+    for (i = 0; i < 7; i++)
+        ok (tm_string_to_weekday (tm_weekday_string (i)) == i, "checking %s", tm_weekday_string (i));
+
+    ok (tm_string_to_month ("foo") == -1, "invalid month returns -1");
+    ok (tm_string_to_weekday ("foo") == -1, "invalid weekday returns -1");
+    ok (tm_month_string (12) == NULL, "invalid month returns NULL");
+    ok (tm_weekday_string (8) == NULL, "invalid weekday returns NULL");
+
+    /* Basic functionality tests */
+    d = cronodate_create ();
+
+    /* test ranges, keywords */
+    ok (cronodate_set (d, TM_MON, "Jan") >= 0, "set Jan");
+    is (cronodate_get (d, TM_MON), "0",  "got '0'");
+    ok (cronodate_set (d, TM_MON, "*/2") >= 0, "set mon = '*/2'");
+    is (cronodate_get (d, TM_MON), "0,2,4,6,8,10",  "got every other month");
+    ok (cronodate_set (d, TM_MON, "1-5,7-9") >= 0, "set mon = '1-5,7-9'");
+    is (cronodate_get (d, TM_MON), "1-5,7-9",  "got '1-5,7-9'");
+    ok (cronodate_set (d, TM_MON, "January-June") >= 0, "set January to June");
+    is (cronodate_get (d, TM_MON), "0-5", "get January to June");
+
+    ok (cronodate_set (d, TM_MON, "Mars") < 0, "bad month fails as expected");
+    ok (cronodate_set (d, TM_MON, "-/") < 0, "bad range fails as expected");
+
+    ok (cronodate_set (d, TM_WDAY, "Mon") >= 0, "set Mon");
+    is (cronodate_get (d, TM_WDAY), "1", "get Mon");
+    ok (cronodate_set (d, TM_WDAY, "*/2") >= 0, "set mon = '*/2'");
+    is (cronodate_get (d, TM_WDAY), "0,2,4,6",  "got every second day");
+    ok (cronodate_set (d, TM_WDAY, "mon-fri") >= 0, "set mon-fri");
+    is (cronodate_get (d, TM_WDAY), "1-5",  "got 0-5");
+
+    ok (d != NULL, "cronodate_create()");
+    /* match all dates */
+    cronodate_fillset (d);
+    ok (cronodate_check_match (d, "1/1/2001 12:45:33"), "date matches after fillset");
+    
+    ok (cronodate_set (d, TM_SEC, "5") >= 0, "cronodate_set, sec=5");
+    ok (cronodate_check_match (d, "oct 10, 2001 00:00:05"), "date matches");
+    ok (!cronodate_check_match (d, "oct 10, 2001 00:00:06"), "date doesn't match");
+
+    ok (cronodate_set (d, TM_MIN, "5") >= 0, "cronodate_set, min=5");
+    ok (cronodate_check_match (d, "oct 10, 2001 00:05:05"), "date matches");
+    ok (!cronodate_check_match (d, "oct 10, 2001 00:06:05"), "date doesn't match");
+
+    ok (cronodate_set (d, TM_HOUR, "5") >= 0, "cronodate_set, hour=5");
+    ok (cronodate_check_match (d, "oct 10, 2001 05:05:05"), "date matches");
+    ok (!cronodate_check_match (d, "oct 10, 2001 06:05:05"), "date doesn't match");
+
+    ok (cronodate_set (d, TM_MDAY, "10") >= 0, "cronodate_set, mday = 10");
+    ok (cronodate_check_match (d, "oct 10, 2001 05:05:05"), "date matches");
+    ok (!cronodate_check_match (d, "oct 11, 2001 05:05:05"), "date doesn't match");
+
+    ok (cronodate_set (d, TM_MON, "9") >= 0, "cronodate_set MON=9 (Oct)");
+    ok (cronodate_check_match (d, "oct 10, 2001 05:05:05"), "date matches");
+    ok (!cronodate_check_match (d, "jan 10, 2001 05:05:05"), "date doesn't match");
+
+    cronodate_fillset (d);
+
+    // Set up for next midnight
+    ok (cronodate_set (d, TM_SEC, "0") >= 0, "date glob set, sec = 0");
+    ok (cronodate_set (d, TM_MIN, "0") >= 0, "date glob set, min = 0");
+    ok (cronodate_set (d, TM_HOUR, "0") >= 0, "date glob set, hour = 0");
+    ok (cronodate_check_next (d, "may 27, 2016 3:45:22", "may 28, 2016 00:00:00"),
+        "cronodate_next returned next midnight");
+    
+    ok (cronodate_check_next (d, "dec 31, 2016 3:45:22", "jan 1, 2017 00:00:00"),
+        "cronodate_next rolled over to following year");
+
+    cronodate_fillset (d);
+    // Run every 10 min on 5s
+    ok (cronodate_set (d, TM_SEC, "5") >= 0, "set sec = 5");
+    ok (cronodate_set (d, TM_MIN, "5,15,25,35,45,55") >= 0, "set sec = 5");
+    ok (cronodate_check_next (d, "oct 10, 2016 3:00:00", "oct 10, 2016 3:05:05"),
+        "cronodate_next worked for minutes");
+    ok (cronodate_check_next (d, "oct 10, 2016 3:05:05", "oct 10, 2016 3:15:05"),
+        "cronodate_next worked for next increment");
+
+    cronodate_fillset (d);
+    // Run every monday, 8am
+    ok (cronodate_set (d, TM_SEC, "0") >= 0, "date glob set, sec = 0");
+    ok (cronodate_set (d, TM_MIN, "0") >= 0, "date glob set, min = 0");
+    ok (cronodate_set (d, TM_HOUR, "8") >= 0, "date glob set, hour = 0");
+    ok (cronodate_set (d, TM_WDAY, "1") >= 0, "date glob set, wday = 1 (Mon)");
+    ok (cronodate_check_next (d, "jun 1, 2016 10:45:00", "jun 06, 2016 08:00:00"),
+        "cronodate_next worked for next monday");
+    ok (cronodate_check_next (d, "jun 06, 2016 08:00:00", "jun 13, 2016 08:00:00"),
+        "cronodate_next returns next matching date when current matches ");
+
+    ok (cronodate_set (d, TM_MON, "6") >= 0, "date glob set, mon = 6");
+    ok (cronodate_set (d, TM_MDAY, "6") >= 0, "date glob set, mday = 6");
+    ok (cronodate_set (d, TM_YEAR, "*") >= 0, "date glob set, year = *");
+
+    // Impossible date returns error
+    ok (approxidate_tm ("jun 06, 2016 08:00:00", &tm) >= 0, "approxidate");
+    rc = cronodate_next (d, &tm);
+    ok (rc < 0, "cronodate_next() fails when now is >= matching date");
+
+    cronodate_fillset (d);
+    // test cronodate_remaining ()
+    ok (cronodate_set (d, TM_SEC, "0") >= 0, "date glob set, sec = 0");
+    ok (cronodate_set (d, TM_MIN, "0") >= 0, "date glob set, min = 0");
+    ok (cronodate_set (d, TM_HOUR, "8") >= 0, "date glob set, hour = 0");
+    ok (approxidate ("jun 06, 2016 07:00:00.3", &tv) >= 0, "approxidate");
+    
+    x = cronodate_remaining (d, tv_to_double (&tv));
+    ok (almost_is (x, 3599.700), "cronodate_remaining works: got %.3fs", x);
+    ok (approxidate ("jun 06, 2016 08:00:00.0", &tv) >= 0, "approxidate");
+    x = cronodate_remaining (d, tv_to_double (&tv));
+    ok (almost_is (x, 24*60*60), "cronodate_remaining works: got %.3fs", x);
+
+    cronodate_destroy (d);
+
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/test/nodeset.c
+++ b/src/common/libutil/test/nodeset.c
@@ -202,6 +202,26 @@ int main (int argc, char *argv[])
     nodeset_destroy (n);
 
 /********************************************/
+    /* Exercise iteration with nodeset_next_rank
+     */
+    n = nodeset_create_string ("0,2-3,7");
+    ok (n != NULL);
+    int r = nodeset_min (n);
+    ok (r == 0, "nodeset_min");
+    ok ((r = nodeset_next_rank (n, r)) == 2,
+        "nodeset_next_rank (n, min) returns second element");
+    ok ((r = nodeset_next_rank (n, r)) == 3,
+        "nodeset_next_rank works on third element");
+    ok ((r = nodeset_next_rank (n, r)) == 7,
+        "nodeset_next_rank works on fourth element");
+    ok ((r = nodeset_next_rank (n, r)) == NODESET_EOF,
+        "nodeset_next_rank detects end of nodeset");
+
+    ok ((r = nodeset_next_rank (n, 1)) == 2,
+        "nodeset_next_rank returns next rank even if arg not in set");
+
+
+/********************************************/
 
     /* Exercise nodeset_dup
      */

--- a/src/modules/cron/Makefile.am
+++ b/src/modules/cron/Makefile.am
@@ -22,6 +22,7 @@ cron_la_SOURCES = \
 	types.c \
 	interval.c \
 	event.c \
+	datetime.c \
 	cron.c
 
 cron_la_LDFLAGS = $(fluxmod_ldflags) -module

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -676,10 +676,7 @@ static void cron_create_handler (flux_t h, flux_msg_handler_t *w,
     zlist_append (ctx->entries, e);
 
     rc = 0;
-    out = Jnew ();
-    Jadd_int64 (out, "id", e->id);
-    Jadd_str (out, "name", e->name);
-
+    out = cron_entry_to_json (e);
 done:
     if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
                               rc < 0 ? NULL : Jtostr (out)) < 0)

--- a/src/modules/cron/datetime.c
+++ b/src/modules/cron/datetime.c
@@ -105,8 +105,12 @@ static double reschedule_cb (flux_watcher_t *w, double now, void *arg)
      *  and stop the cron entry in an ev_prepare callback. See ev(7).
      */
     if (next < now) {
-        flux_log_error (dt->h,
-            "cron-%ju: Unable to get next wakeup. Stopping.", e->id);
+        /*  Only issue an error if this entry has more than one repeat:
+         */
+        if (e->repeat == 0 || e->repeat < e->stats.count + 1) {
+            flux_log_error (dt->h,
+                    "cron-%ju: Unable to get next wakeup. Stopping.", e->id);
+        }
         cron_entry_stop_safe (e);
         return now + 1.e19;
     }

--- a/src/modules/cron/datetime.c
+++ b/src/modules/cron/datetime.c
@@ -1,0 +1,160 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <time.h>
+#include <sys/time.h>
+#include <ctype.h>
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/nodeset.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/cronodate.h"
+
+#include "entry.h"
+
+struct datetime_entry {
+    flux_t h;
+    flux_watcher_t *w;
+    cronodate_t *d;
+};
+
+void datetime_entry_destroy (struct datetime_entry *dt)
+{
+    dt->h = NULL;
+    flux_watcher_destroy (dt->w);
+    cronodate_destroy (dt->d);
+    free (dt);
+}
+
+struct datetime_entry * datetime_entry_create ()
+{
+    struct datetime_entry *dt = xzmalloc (sizeof (*dt));
+    dt->h = NULL;
+    dt->w = NULL;
+    dt->d = cronodate_create ();
+    return (dt);
+}
+
+static struct datetime_entry * datetime_entry_from_json (JSON o)
+{
+    int i;
+    struct datetime_entry *dt = datetime_entry_create ();
+
+    for (i = 0; i < TM_MAX_ITEM; i++) {
+        const char *range;
+        if (!Jget_str (o, tm_unit_string (i), &range))
+            range = "*";
+        if (cronodate_set (dt->d, i, range) < 0) {
+            datetime_entry_destroy (dt);
+            return (NULL);
+        }
+    }
+    return (dt);
+}
+
+static void cron_datetime_start (void *arg)
+{
+    struct datetime_entry *dt = arg;
+    flux_watcher_start (dt->w);
+}
+
+static void cron_datetime_stop (void *arg)
+{
+    struct datetime_entry *dt = arg;
+    flux_watcher_stop (dt->w);
+}
+
+void datetime_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    cron_entry_t *e = arg;
+    cron_entry_schedule_task (e);
+}
+
+static double reschedule_cb (flux_watcher_t *w, double now, void *arg)
+{
+    cron_entry_t *e = arg;
+    struct datetime_entry *dt = cron_entry_type_data (e);
+    double next = now + cronodate_remaining (dt->d, now);
+    /* If we failed to get next timestamp, push timeout far into the future
+     *  and stop the cron entry in an ev_prepare callback. See ev(7).
+     */
+    if (next < now) {
+        flux_log_error (dt->h,
+            "cron-%ju: Unable to get next wakeup. Stopping.", e->id);
+        cron_entry_stop_safe (e);
+        return now + 1.e19;
+    }
+    return (next);
+}
+
+static void *cron_datetime_create (flux_t h, cron_entry_t *e, JSON arg)
+{
+    struct datetime_entry *dt = datetime_entry_from_json (arg);
+    if (dt == NULL)
+        return (NULL);
+    dt->h = h;
+    dt->w = flux_periodic_watcher_create (flux_get_reactor (h),
+                                         0., 0.,
+                                         reschedule_cb,
+                                         datetime_cb, (void *) e);
+    if (dt->w == NULL) {
+        flux_log_error (h, "periodic_watcher_create");
+        datetime_entry_destroy (dt);
+        return (NULL);
+    }
+    return (dt);
+}
+
+static JSON cron_datetime_to_json (void *arg)
+{
+    int i;
+    struct datetime_entry *dt = arg;
+    JSON o = Jnew ();
+    if (dt->w)
+        Jadd_double (o, "next_wakeup", flux_watcher_next_wakeup (dt->w));
+    for (i = 0; i < TM_MAX_ITEM; i++)
+        Jadd_str (o, tm_unit_string (i), cronodate_get (dt->d, i));
+    return (o);
+}
+
+static void cron_datetime_destroy (void *arg)
+{
+    datetime_entry_destroy (arg);
+}
+
+struct cron_entry_ops cron_datetime_operations = {
+    .create =   cron_datetime_create,
+    .destroy =  cron_datetime_destroy,
+    .start =    cron_datetime_start,
+    .stop =     cron_datetime_stop,
+    .tojson =   cron_datetime_to_json
+};
+
+ /* vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -100,6 +100,10 @@ void *cron_entry_type_data (cron_entry_t *e);
  */
 int cron_entry_schedule_task (cron_entry_t *e);
 
+/* Stop the current entry in the next prepare watcher.
+ */
+int cron_entry_stop_safe (cron_entry_t *e);
+
 /* Retrieve current timestamp in seconds
  */
 double get_timestamp (void);

--- a/src/modules/cron/interval.c
+++ b/src/modules/cron/interval.c
@@ -95,6 +95,8 @@ static JSON cron_interval_to_json (void *arg)
     JSON o = Jnew ();
     Jadd_double (o, "interval", iv->seconds);
     Jadd_double (o, "after",    iv->after);
+    Jadd_double (o, "next_wakeup",
+                 flux_watcher_next_wakeup (iv->w));
     return (o);
 }
 

--- a/src/modules/cron/types.c
+++ b/src/modules/cron/types.c
@@ -30,6 +30,7 @@
  */
 extern struct cron_entry_ops cron_interval_operations;
 extern struct cron_entry_ops cron_event_operations;
+extern struct cron_entry_ops cron_datetime_operations;
 
 static struct cron_typeinfo {
     const char *name;
@@ -37,6 +38,7 @@ static struct cron_typeinfo {
 } cron_types[] = {
     { "interval", &cron_interval_operations },
     { "event",    &cron_event_operations    },
+    { "datetime", &cron_datetime_operations },
     { NULL, NULL }
 };
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -12,8 +12,8 @@ cachedir=$HOME/local/.cache
 downloads="\
 https://github.com/dun/munge/archive/munge-0.5.11.tar.gz \
 https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz \
-http://download.zeromq.org/zeromq-4.0.4.tar.gz \
-http://download.zeromq.org/czmq-3.0.2.tar.gz \
+https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz \
+https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz \
 https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz \
 http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz \
 http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.0.tar.gz \
@@ -145,6 +145,7 @@ for pkg in $downloads; do
       cd ${name} &&
       curl -L -O --insecure ${pkg} || die "Failed to download ${pkg}"
       tar --strip-components=1 -xf *.tar.gz || die "Failed to un-tar ${name}"
+      test -x configure || ./autogen.sh
       test -x configure && CC=gcc ./configure --prefix=${prefix} \
                   --sysconfdir=${prefix}/etc \
                   ${extra_configure_opts[$name]} || : &&

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -46,6 +46,7 @@ TESTS = \
 	t0013-content-sophia.t \
 	t0014-runlevel.t \
 	t0015-cron.t \
+	t0016-cron-faketime.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1005-cmddriver.t \
@@ -108,6 +109,7 @@ check_SCRIPTS = \
 	t0013-content-sophia.t \
 	t0014-runlevel.t \
 	t0015-cron.t \
+	t0016-cron-faketime.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1005-cmddriver.t \

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+test_description='Test flux cron service'
+
+. $(dirname $0)/sharness.sh
+
+#  Check for libfaketimeMT:
+LD_PRELOAD=libfaketimeMT.so.1 ldd /bin/date 2>/dev/null | grep -q libfaketime
+if test $? -ne 0 ; then
+    skip_all='libfaketime not found. Skipping all tests'
+    test_done
+fi
+
+SIZE=1
+export LD_PRELOAD=libfaketimeMT.so.1
+export FAKETIME_NO_CACHE=1
+export FAKETIME_TIMESTAMP_FILE=$(pwd)/faketimerc
+test_under_flux ${SIZE} minimal
+
+flux setattr log-stderr-level 1
+
+cron_entry_check() {
+    local id=$1
+    local key=$2
+    local expected="$3"
+    test -n $id || return 1
+    test -n $key || return 1
+    test -n "$expected" || return 1
+    local result="$(flux cron dump --key=${key} ${id})" || return 1
+    echo "cron-${id}: ${key}=${result}, wanted ${expected}" >&2
+    test "${result}" = "${expected}"
+}
+
+flux_cron() {
+    result=$(flux cron "$@" 2>&1) || return 1
+    id=$(echo ${result} | sed 's/^.*cron-\([0-9][0-9]*\).*/\1/')
+    test -n "$id" && echo ${id}
+}
+
+# Create a script to manipulate faketime:
+cat >make-faketime.sh <<EOF
+#!/bin/sh
+d="\$@"
+date +"@%Y-%m-%d %H:%M:%S" --date="\${d}" > ${FAKETIME_TIMESTAMP_FILE}
+sync
+echo timestamp file: \$(cat $FAKETIME_TIMESTAMP_FILE): date is now \$(date) >&2
+# Poke flux cron so libev wakes up and reifies time:
+flux cron list >/dev/null 2>&1 || :
+EOF
+chmod +x make-faketime.sh
+
+set_faketime=$(pwd)/make-faketime.sh
+event_trace="run_timeout 5 $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua"
+
+#  Why does date need to be set 1s in the future??
+test_expect_success 'libfaketime works' '
+    now=$(date +"@%Y-%m-%d %H:%M:%S") &&
+    $set_faketime Jun 4 1991 00:00:01 &&
+    flux logger "libfaketime-test" &&
+    test "$(date +%s)" = $(date +%s --date="Jun 4 1991 00:00:00") &&
+    date +%s &&
+    flux dmesg | grep libfaketime-test
+    echo $now > ${FAKETIME_TIMESTAMP_FILE}
+'
+test_expect_success 'load cron module' '
+    flux module load cron
+'
+test_expect_success 'flux-cron tab works for set minute' '
+    $set_faketime 2016-06-04 15:30:00 &&
+    id=$(echo "15 * * * * flux event pub t.cron.complete" | flux_cron tab) &&
+    next=$(date +%s --date="2016-06-04 16:15:00") &&
+    cron_entry_check ${id} type datetime &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} typedata.next_wakeup ${next} &&
+    echo sleeping at $(date) &&
+    ${event_trace} t.cron t.cron.complete \
+        $set_faketime 2016-06-04 16:15:00 &&
+    echo done at $(date) &&
+    cron_entry_check ${id} stats.count 1 &&
+    flux cron delete ${id}
+'
+test_expect_success 'flux-cron tab works for any day midnight' '
+    id=$(echo "0 0 * * * flux event pub t.cron.complete" | flux_cron tab) &&
+    next=$(date +%s --date="tomorrow 00:00") &&
+    cron_entry_check ${id} type datetime &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} typedata.next_wakeup ${next} &&
+    ${event_trace} t.cron t.cron.complete \
+        $set_faketime tomorrow 00:00 &&
+    cron_entry_check ${id} stats.count 1 &&
+    flux cron delete ${id}
+'
+test_expect_success 'flux-cron tab works for Mondays, midnight' '
+    $set_faketime Jun 4 15:45 2016 &&
+    id=$(echo "0 0 * * Mon flux event pub t.cron.complete" | flux_cron tab) &&
+    next=$(date +%s --date="Monday 00:00") &&
+    cron_entry_check ${id} type datetime &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} typedata.next_wakeup ${next} &&
+    ${event_trace} t.cron t.cron.complete \
+        $set_faketime Monday 00:00 &&
+    cron_entry_check ${id} stats.count 1 &&
+    flux cron delete ${id}
+'
+test_expect_success 'flux-cron tab works for day of month' '
+    $set_faketime Jun 5 15:45 2016 &&
+    id=$(echo "0 0 30 * * flux event pub t.cron.complete" | flux_cron tab) &&
+    next=$(date +%s --date="Jun 30 00:00") &&
+    cron_entry_check ${id} type datetime &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} typedata.next_wakeup ${next} &&
+    ${event_trace} t.cron t.cron.complete \
+        $set_faketime Jun 30 00:00 &&
+    cron_entry_check ${id} stats.count 1 &&
+    flux cron delete ${id}
+'
+test_expect_success 'flux-cron tab works for month' '
+    $set_faketime Jun 5 15:45 2016 &&
+    id=$(echo "0 0 30 Dec * flux event pub t.cron.complete" | flux_cron tab) &&
+    next=$(date +%s --date="Dec 30 00:00") &&
+    cron_entry_check ${id} type datetime &&
+    cron_entry_check ${id} stopped false &&
+    cron_entry_check ${id} typedata.next_wakeup ${next} &&
+    ${event_trace} t.cron t.cron.complete \
+        $set_faketime Dec 30 00:00 &&
+    cron_entry_check ${id} stats.count 1 &&
+    flux cron delete ${id}
+'
+test_done


### PR DESCRIPTION
This isn't quite ready yet, but I'm throwing it up here now because it may need more than usual review.

The main purpose of this work was to support cron-like date&time matching for flux-cron. Along the way a lot of other "improvements"(?)(remains to be seen) were developed to support the main goal of calculating the amount of time until the next scheduled wakeup for a datetime matching interface such as that cron expressions provide.

Furthermore, to ensure wakeup on the scheduled datetime, the [`ev_periodic`](http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#code_ev_periodic_code_to_cron_or_not) watcher is now exposed via a `flux_periodic_watcher`.

The kind of "date and time cron expression matching" interface is abstracted here into a small module called `cronodate`, which is simply a wrapper around an array of `nodeset_t`, one for each of the time units of interest: second, minute, hour, day-of-month, month, and day-of-week. The nodeset for each time unit can be populated with a `cronodate_set ()` using typical nodeset range expressions, or special "cron" expressions like `"*"`, `"*/2"`, etc. and for weekday and month entries, names of the days and months are accepted (like normal vixie-cron). `cronodate` then offers a `cronodate_next()` function to return the date and time of the next scheduled wakeup based on the set of times registered with the `cronodate` object.

The `cronodate` interface is then used in a new `datetime` cron entry type, and as a demonstration, a `flux-cron tab` subcommand has been added which can process crontab lines and register flux-cron jobs based on them.

e.g.
```
$ echo "25 17 * * * hostname -s # comments" | flux cron tab                                                                      
tab: cron-4 created: scheduled in 86074.583s at Sat Jun  4 17:25:00 2016
$ echo "25 17 * * Mon hostname -s # comments" | flux cron tab                                                 
tab: cron-5 created: scheduled in 258247.385s at Mon Jun  6 17:25:00 2016d
```

The `cronodate` code was placed into libutil, though I'm still not convinced that is the right choice. I'm not sure I can think of any other use cases for it, so perhaps it should go into `modules/cron` directly.

I also added a date parsing  based on `git/date.c` called [`approxidate`](https://github.com/thatguystone/approxidate). Currently it is only used for the `cronodate` tests. However, I was thinking of binding a Lua module to it and using that for a `flux cron at` interface that runs a job once at a specific time.

For `cronodate` I also needed to add one call to the `nodeset` interface. I required a way to get the next rank from a nodeset given a current rank (which may or may not be set in the nodeset), and added `nodeset_next_rank (n, r)` for this purpose.


Still TODO (at the very least) :
 - [x] man page for `flux cron tab`
 - [x] add `flux cron at`
 - [x] tests for `flux_periodic_watcher`, may need help from [faketime](https://github.com/wolfcw/libfaketime)
 - [x] tests for `flux cron tab`