### PR TITLE
Tagged response fastpath

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -469,7 +469,9 @@ static int l_flux_send (lua_State *L)
     if (nargs >= 3)
         nodeid = lua_tointeger (L, 4);
 
-    matchtag = flux_matchtag_alloc (f, 1);
+    matchtag = flux_matchtag_alloc (f, 0);
+    if (matchtag == FLUX_MATCHTAG_NONE)
+        return lua_pusherror (L, strerror (errno));
 
     rc = flux_json_request (f, nodeid, matchtag, tag, o);
     json_object_put (o);
@@ -490,7 +492,6 @@ static int l_flux_recv (lua_State *L)
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
         .topic_glob = NULL,
     };
 
@@ -667,7 +668,6 @@ static int l_flux_recv_event (lua_State *L)
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_EVENT,
         .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
         .topic_glob = NULL,
     };
     zmsg_t *zmsg = NULL;
@@ -1050,7 +1050,6 @@ static int l_flux_recvmsg (lua_State *L)
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
         .topic_glob = NULL,
     };
 

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -83,14 +83,12 @@ class Flux(Wrapper):
              type_mask=flux.FLUX_MSGTYPE_ANY,
              match_tag=flux.FLUX_MATCHTAG_NONE,
              topic_glob=None,
-             bsize=0,
              flags=0):
         """ Receive a message, returns a flux.Message containing the result or None """
         match = ffi.new('struct flux_match *', {
             'typemask': type_mask,
             'matchtag': match_tag,
             'topic_glob': topic_glob if topic_glob is not None else ffi.NULL,
-            'bsize': bsize,
         })
         handle = self.flux_recv(match[0], flags)
         if handle is not None:
@@ -132,8 +130,7 @@ class Flux(Wrapper):
                            type_mask=lib.FLUX_MSGTYPE_ANY,
                            topic_glob='*',
                            args=None,
-                           match_tag=flux.FLUX_MATCHTAG_NONE,
-                           bsize=0):
+                           match_tag=flux.FLUX_MATCHTAG_NONE):
         return MessageWatcher(self, type_mask, callback, topic_glob, match_tag,
                               bsize, args)
 

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -51,7 +51,6 @@ class MessageWatcher(Watcher):
     def __init__(self, flux_handle, type_mask, callback,
                  topic_glob='*',
                  match_tag=flux.FLUX_MATCHTAG_NONE,
-                 bsize=0,
                  args=None):
         self.handle = None
         self.fh = flux_handle
@@ -62,7 +61,6 @@ class MessageWatcher(Watcher):
         match = ffi.new('struct flux_match *', {
             'typemask': type_mask,
             'matchtag': match_tag,
-            'bsize': bsize,
             'topic_glob': c_topic_glob,
         })
         self.handle = raw.flux_msg_handler_create(self.fh.handle, match[0],

--- a/src/common/libcompat/reactor.c
+++ b/src/common/libcompat/reactor.c
@@ -152,7 +152,6 @@ static int msghandler_add (flux_t h, int typemask, const char *pattern,
         .typemask = typemask,
         .topic_glob = (char *)pattern,
         .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 1,
     };
     char hashkey[HASHKEY_LEN];
     struct msg_compat *c = xzmalloc (sizeof (*c));

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -45,6 +45,12 @@ enum {
     FLUX_POLLERR = 4,
 };
 
+/* Flags for flux_matchtag_alloc()
+ */
+enum {
+    FLUX_MATCHTAG_GROUP = 1,
+};
+
 /* Options for flux_setopt().
  * (Connectors may define custom option names)
  */
@@ -102,12 +108,12 @@ void flux_flags_set (flux_t h, int flags);
 void flux_flags_unset (flux_t h, int flags);
 int flux_flags_get (flux_t h);
 
-/* Alloc/free a matchtag block for matched requests.
+/* Alloc/free matchtag for matched request/response.
  * This is mainly used internally by the rpc code.
  */
-uint32_t flux_matchtag_alloc (flux_t h, int size);
-void flux_matchtag_free (flux_t h, uint32_t t, int size);
-uint32_t flux_matchtag_avail (flux_t h);
+uint32_t flux_matchtag_alloc (flux_t h, int flags);
+void flux_matchtag_free (flux_t h, uint32_t matchtag);
+uint32_t flux_matchtag_avail (flux_t h, int flags);
 
 /* Send a message
  * flags may be 0 or FLUX_O_TRACE or FLUX_O_NONBLOCK (FLUX_O_COPROC is ignored)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -26,33 +26,28 @@ enum {
 
 struct flux_match {
     int typemask;           /* bitmask of matching message types (or 0) */
-    uint32_t matchtag;      /* matchtag block begin (or FLUX_MATCHTAG_NONE) */
-    int bsize;              /* size of matchtag block (or 0) */
+    uint32_t matchtag;      /* matchtag (or FLUX_MATCHTAG_NONE) */
     char *topic_glob;       /* glob matching topic string (or NULL) */
 };
 
 #define FLUX_MATCH_ANY (struct flux_match){ \
     .typemask = FLUX_MSGTYPE_ANY, \
     .matchtag = FLUX_MATCHTAG_NONE, \
-    .bsize = 0, \
     .topic_glob = NULL, \
 }
 #define FLUX_MATCH_EVENT (struct flux_match){ \
     .typemask = FLUX_MSGTYPE_EVENT, \
     .matchtag = FLUX_MATCHTAG_NONE, \
-    .bsize = 0, \
     .topic_glob = NULL, \
 }
 #define FLUX_MATCH_REQUEST (struct flux_match){ \
     .typemask = FLUX_MSGTYPE_REQUEST, \
     .matchtag = FLUX_MATCHTAG_NONE, \
-    .bsize = 0, \
     .topic_glob = NULL, \
 }
 #define FLUX_MATCH_RESPONSE (struct flux_match){ \
     .typemask = FLUX_MSGTYPE_RESPONSE, \
     .matchtag = FLUX_MATCHTAG_NONE, \
-    .bsize = 0, \
     .topic_glob = NULL, \
 }
 
@@ -178,6 +173,8 @@ int flux_msg_get_status (const flux_msg_t *msg, int *status);
 /* Get/set/compare match tag (request/response only)
  */
 #define FLUX_MATCHTAG_NONE (0)
+#define FLUX_MATCHTAG_GROUP_SHIFT (20)
+#define FLUX_MATCHTAG_GROUP_MASK (0xfff00000)
 int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t matchtag);
 int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *matchtag);
 bool flux_msg_cmp_matchtag (const flux_msg_t *msg, uint32_t matchtag);

--- a/src/common/libflux/tagpool.h
+++ b/src/common/libflux/tagpool.h
@@ -3,20 +3,22 @@
 
 #include <stdint.h>
 
-typedef struct tagpool_struct *tagpool_t;
+enum {
+    TAGPOOL_FLAG_GROUP = 1,
+};
 
-tagpool_t tagpool_create (void);
-void tagpool_destroy (tagpool_t t);
-uint32_t tagpool_alloc (tagpool_t t, int len);
-void tagpool_free (tagpool_t t, uint32_t matchtag, int len);
-uint32_t tagpool_avail (tagpool_t t);
+struct tagpool *tagpool_create (void);
+void tagpool_destroy (struct tagpool *t);
+uint32_t tagpool_alloc (struct tagpool *t, int flags);
+void tagpool_free (struct tagpool *t, uint32_t matchtag);
 
 enum {
-    TAGPOOL_ATTR_BLOCKS,
-    TAGPOOL_ATTR_BLOCKSIZE,
-    TAGPOOL_ATTR_SSIZE,
+    TAGPOOL_ATTR_REGULAR_SIZE,
+    TAGPOOL_ATTR_REGULAR_AVAIL,
+    TAGPOOL_ATTR_GROUP_SIZE,
+    TAGPOOL_ATTR_GROUP_AVAIL,
 };
-uint32_t tagpool_getattr (tagpool_t, int attr);
+uint32_t tagpool_getattr (struct tagpool *t, int attr);
 
 
 #endif /* _FLUX_CORE_TAGPOOL_H */

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -345,6 +345,12 @@ void check_matchtag (void)
         "flux_msg_get_matchtag returns set value");
     ok (flux_msg_cmp_matchtag (msg, 42) && !flux_msg_cmp_matchtag (msg, 0),
         "flux_msg_cmp_matchtag works");
+
+    ok (flux_msg_set_matchtag (msg, (1<<FLUX_MATCHTAG_GROUP_SHIFT) | 55) == 0,
+        "flux_msg_set_matchtag (group part nonzero) works ");
+    ok (flux_msg_cmp_matchtag (msg, (1<<FLUX_MATCHTAG_GROUP_SHIFT | 69))
+        && !flux_msg_cmp_matchtag (msg, (3<<FLUX_MATCHTAG_GROUP_SHIFT)),
+        "flux_msg_cmp_matchtag compares only group part if nonzero");
     flux_msg_destroy (msg);
 }
 

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -355,7 +355,9 @@ int cron_task_run (cron_task_t *t,
     flux_msg_t *msg = NULL;
     int rc = -1;
 
-    t->match.matchtag = flux_matchtag_alloc (h, 1);
+    t->match.matchtag = flux_matchtag_alloc (h, FLUX_MATCHTAG_GROUP);
+    if (t->match.matchtag == FLUX_MATCHTAG_NONE)
+        return -1;
     t->match.topic_glob = "cmb.exec";
     t->mh = flux_msg_handler_create (h, t->match, exec_handler, t);
     if (!t->mh)

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -613,7 +613,7 @@ static void destroy_watcher (void *arg)
 {
     kvs_watcher_t *wp = arg;
     free (wp->key);
-    flux_matchtag_free (wp->h, wp->matchtag, 1);
+    flux_matchtag_free (wp->h, wp->matchtag);
     free (wp);
 }
 
@@ -776,7 +776,7 @@ done:
 static int watch_rpc (flux_t h, const char *key, JSON *val,
                       bool once, bool directory, uint32_t *matchtag)
 {
-    struct flux_match match = { .typemask = FLUX_MSGTYPE_RESPONSE, .bsize = 0,
+    struct flux_match match = { .typemask = FLUX_MSGTYPE_RESPONSE,
                                 .topic_glob = NULL };
     JSON in = NULL;
     JSON out = NULL;
@@ -789,7 +789,7 @@ static int watch_rpc (flux_t h, const char *key, JSON *val,
     /* Send the request.
      */
     assert (once || matchtag != NULL);
-    match.matchtag = flux_matchtag_alloc (h, 1);
+    match.matchtag = flux_matchtag_alloc (h, FLUX_MATCHTAG_GROUP);
     if (match.matchtag == FLUX_MATCHTAG_NONE) {
         errno = EAGAIN;
         goto done;
@@ -822,7 +822,7 @@ static int watch_rpc (flux_t h, const char *key, JSON *val,
 done:
     if (match.matchtag != FLUX_MATCHTAG_NONE) {
         if (!matchtag || ret == -1)
-            flux_matchtag_free (h, match.matchtag, 1);
+            flux_matchtag_free (h, match.matchtag);
     }
     Jput (in);
     Jput (out);

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -124,7 +124,6 @@ static void wait_for_event (flux_t h, int64_t id, char *topic)
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_EVENT,
         .matchtag = FLUX_MATCHTAG_NONE,
-        .bsize = 0,
     };
     match.topic_glob = topic;
     flux_msg_t *msg = flux_recv (h, match, 0);

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -393,14 +393,14 @@ void test_unwatchloop (int argc, char **argv)
     key = argv[0];
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
-    uint32_t avail = flux_matchtag_avail (h);
+    uint32_t avail = flux_matchtag_avail (h, FLUX_MATCHTAG_GROUP);
     for (i = 0; i < 1000; i++) {
         if (kvs_watch_int (h, key, unwatchloop_cb, NULL) < 0)
             err_exit ("kvs_watch_int[%d] %s", i, key);
         if (kvs_unwatch (h, key) < 0)
             err_exit ("kvs_unwatch[%d] %s", i, key);
     }
-    uint32_t leaked = avail - flux_matchtag_avail (h);
+    uint32_t leaked = avail - flux_matchtag_avail (h, FLUX_MATCHTAG_GROUP);
     if (leaked > 0)
         msg_exit ("leaked %u matchtags", leaked);
 

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -145,4 +145,14 @@ test_expect_success 'rank 0 cache is all valid' '
 	test $VALID -eq $TOTAL
 '
 
+# Write 8192 blobs, allowing 1024 requests to be outstanding
+test_expect_success 'store 8K blobs from rank 0 using async RPC' '
+	flux content spam 8192 1024
+'
+
+# Write 1024 blobs per rank
+test_expect_success 'store 1K blobs from all ranks using async RPC' '
+	flux exec flux content spam 1024 256
+'
+
 test_done


### PR DESCRIPTION
This PR replaces "matchtag blocks" with "matchtag groups" as discussed in #680.  Basically the 32 bit matchtag is divided into the high order (12 bit) group part and low order (20 bit) part.  When a `flux_rpc_multi()` call is made, instead of allocating a block of matchtags, it allocates a single "group matchtag", which has one or more high order bits set and low order bits zeroed.

The dispatcher and `flux_recv()` then simply match on the group tag, ignoring the lower order bits, rather than matching in a block (range).

Besides some cleanup/simplification, this allows the low order 20 bits to be "user defined" when a group matchtag is used.  For example, `flux_rpc_multi()` stores the nodeid in there and then doesn't have to use a lookup table to map matchtag to nodeid.

The `bsize` field is dropped from `struct flux_match`.

The public matchtag API functions now look like this:
```C
/* Flags for flux_matchtag_alloc()
 */
enum {
    FLUX_MATCHTAG_GROUP = 1,
};

/* Alloc/free matchtag for matched request/response.
 * This is mainly used internally by the rpc code.
 */
uint32_t flux_matchtag_alloc (flux_t h, int flags);
void flux_matchtag_free (flux_t h, uint32_t matchtag);
uint32_t flux_matchtag_avail (flux_t h, int flags);
```

Finally, a fastpath is implemented for tagged responses in the dispatcher, which should directly address high load in the broker when flushing the content cache to the backing store when there is high content store traffic.

Test were updated where necessary.