### PR TITLE
Logging cleanup

### DIFF
--- a/doc/man1/flux-logger.adoc
+++ b/doc/man1/flux-logger.adoc
@@ -11,7 +11,7 @@ flux-logger - create a Flux log entry
 
 SYNOPSIS
 --------
-*flux* *logger* ['--priority=facility'['.level']] 'message' '...'
+*flux* *logger* ['--severity SEVERITY'] ['--appname NAME'] 'message' '...'
 
 
 DESCRIPTION
@@ -19,27 +19,27 @@ DESCRIPTION
 flux-logger(1) creates Flux log entries.  Log entries are sent to
 the local Flux communications broker, then forwarded to the
 root of the overlay network, where they are disposed of according
-to the logging configuration of the communications session
-(e.g. file, stderr, or syslog).
+to the logging configuration of the communications session.
 
-Log entries are associated with a syslog(3) style 'facility.level',
-by default 'user.notice'.
+Log entries are associated with a syslog(3) style severity.
+Valid severity names are 'emerg', 'alert', 'crit', 'err',
+'warning', 'notice', 'info', 'debug'.
 
-Valid facility names are: 'daemon', 'local0', 'local1', 'local2',
-'local3', 'local4', 'local5', 'local6', 'local7', and 'user'.
+Log entries may also have an application name (default 'logger').
 
-Valid level names are 'emerg', 'alert', 'crit', 'err', 'warning',
-'notice', 'info', 'debug'.
-
-Log entries are also timestamped with the wall clock time, as
+Log entries are timestamped with the wall clock time, as
 reported by gettimeofday(2) at the point of origin, and with
 the rank of the communications broker originating the message.
 
 
 OPTIONS
 -------
-*-p, --priority*='facility'['.level']::
-Specify the 'facility', and optionally the 'level'.
+*-s, --severity*='SEVERITY'::
+Specify the log message severity.  The default severity is 'info'.
+
+*-n, --appname*='NAME'::
+Specify an application name to associate with the log message.
+The default appname is 'logger'.
 
 AUTHOR
 ------

--- a/doc/man3/tevent.c
+++ b/doc/man3/tevent.c
@@ -8,16 +8,16 @@ int main (int argc, char **argv)
     const char *topic;
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (flux_event_subscribe (h, "hb") < 0)
-        err_exit ("flux_event_subscribe");
+        log_err_exit ("flux_event_subscribe");
     if (!(msg = flux_recv (h, FLUX_MATCH_EVENT, 0)))
-        err_exit ("flux_recv");
+        log_err_exit ("flux_recv");
     if (flux_msg_get_topic (msg, &topic) < 0)
-        err_exit ("flux_msg_get_topic");
+        log_err_exit ("flux_msg_get_topic");
     printf ("Event: %s\n", topic);
     if (flux_event_unsubscribe (h, "hb") < 0)
-        err_exit ("flux_event_unsubscribe");
+        log_err_exit ("flux_event_unsubscribe");
     flux_msg_destroy (msg);
     flux_close (h);
     return (0);

--- a/doc/man3/tinfo.c
+++ b/doc/man3/tinfo.c
@@ -9,11 +9,11 @@ int main (int argc, char **argv)
     uint32_t rank, n;
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (flux_get_rank (h, &rank) < 0)
-        err_exit ("flux_get_rank");
+        log_err_exit ("flux_get_rank");
     if (flux_get_size (h, &n) < 0)
-        err_exit ("flux_get_size");
+        log_err_exit ("flux_get_size");
     flux_close (h);
     return (0);
 }

--- a/doc/man3/topen.c
+++ b/doc/man3/topen.c
@@ -7,9 +7,9 @@ int main (int argc, char **argv)
     uint32_t rank;
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (flux_get_rank (h, &rank) < 0)
-        err_exit ("flux_get_rank");
+        log_err_exit ("flux_get_rank");
     printf ("My rank is %d\n", (int)rank);
     flux_close (h);
     return (0);

--- a/doc/man3/trecv.c
+++ b/doc/man3/trecv.c
@@ -8,14 +8,14 @@ int main (int argc, char **argv)
     const char *topic;
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (flux_event_subscribe (h, "") < 0)
-        err_exit ("flux_event_subscribe");
+        log_err_exit ("flux_event_subscribe");
     for (;;) {
         if ((msg = flux_recv (h, FLUX_MATCH_EVENT, 0)))
-            err_exit ("flux_recv");
+            log_err_exit ("flux_recv");
         if (flux_msg_get_topic (msg, &topic) < 0)
-            err_exit ("flux_msg_get_topic");
+            log_err_exit ("flux_msg_get_topic");
         printf ("Event: %s\n", topic);
         flux_msg_destroy (msg);
     }

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -10,7 +10,7 @@ void get_rank (flux_rpc_t *rpc)
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
         err_exit ("flux_rpc_get");
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
-        msg_exit ("response protocol error");
+        log_msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
     Jput (o);
 }

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -8,7 +8,7 @@ void get_rank (flux_rpc_t *rpc)
     const char *rank;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
-        err_exit ("flux_rpc_get");
+        log_err_exit ("flux_rpc_get");
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
         log_msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
@@ -22,10 +22,10 @@ int main (int argc, char **argv)
     JSON o = Jnew();
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     Jadd_str (o, "name", "rank");
     if (!(rpc = flux_rpc (h, "cmb.attrget", Jtostr (o), FLUX_NODEID_ANY, 0)))
-        err_exit ("flux_rpc");
+        log_err_exit ("flux_rpc");
     get_rank (rpc);
     flux_rpc_destroy (rpc);
     flux_close (h);

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -1,5 +1,6 @@
 #include <flux/core.h>
 #include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/log.h"
 
 void get_rank (flux_rpc_t *rpc)
 {

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -1,5 +1,6 @@
 #include <flux/core.h>
 #include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/log.h"
 
 void get_rank (flux_rpc_t *rpc, void *arg)
 {

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -10,7 +10,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
         err_exit ("flux_rpc_get");
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
-        msg_exit ("response protocol error");
+        log_msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
     Jput (o);
     flux_rpc_destroy (rpc);

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -8,7 +8,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
     const char *rank;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
-        err_exit ("flux_rpc_get");
+        log_err_exit ("flux_rpc_get");
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
         log_msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
@@ -24,15 +24,15 @@ int main (int argc, char **argv)
 
     Jadd_str (o, "name", "rank");
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(rpc = flux_rpc (h, "cmb.attrget", Jtostr (o), FLUX_NODEID_ANY, 0)))
-        err_exit ("flux_rpc");
+        log_err_exit ("flux_rpc");
     if (flux_rpc_check (rpc))
         get_rank (rpc, NULL);
     else if (flux_rpc_then (rpc, get_rank, NULL))
-        err_exit ("flux_rpc_then");
+        log_err_exit ("flux_rpc_then");
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
-        err_exit ("flux_reactor_run");
+        log_err_exit ("flux_reactor_run");
 
     flux_close (h);
     Jput (o);

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -1,5 +1,6 @@
 #include <flux/core.h>
 #include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/log.h"
 
 void get_rank (flux_rpc_t *rpc, void *arg)
 {

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -11,7 +11,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
     if (flux_rpc_get (rpc, &nodeid, &json_str) < 0)
         err_exit ("flux_rpc_get");
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
-        msg_exit ("response protocol error");
+        log_msg_exit ("response protocol error");
     printf ("[%" PRIu32 "] rank is %s\n", nodeid, rank);
     Jput (o);
 }

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -9,7 +9,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
     uint32_t nodeid;
 
     if (flux_rpc_get (rpc, &nodeid, &json_str) < 0)
-        err_exit ("flux_rpc_get");
+        log_err_exit ("flux_rpc_get");
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
         log_msg_exit ("response protocol error");
     printf ("[%" PRIu32 "] rank is %s\n", nodeid, rank);
@@ -24,13 +24,13 @@ int main (int argc, char **argv)
 
     Jadd_str (o, "name", "rank");
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(rpc = flux_rpc_multi (h, "cmb.attrget", Jtostr (o), "all", 0)))
-        err_exit ("flux_rpc");
+        log_err_exit ("flux_rpc");
     if (flux_rpc_then (rpc, get_rank, NULL) < 0)
-        err_exit ("flux_rpc_then");
+        log_err_exit ("flux_rpc_then");
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
-        err_exit ("flux_reactor_run");
+        log_err_exit ("flux_reactor_run");
 
     flux_rpc_destroy (rpc);
     flux_close (h);

--- a/doc/man3/tsend.c
+++ b/doc/man3/tsend.c
@@ -7,11 +7,11 @@ int main (int argc, char **argv)
     flux_msg_t *msg;
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(msg = flux_event_encode ("snack.bar.closing", NULL)))
-        err_exit ("flux_event_encode");
+        log_err_exit ("flux_event_encode");
     if (flux_send (h, msg, 0) < 0)
-        err_exit ("flux_send");
+        log_err_exit ("flux_send");
     flux_msg_destroy (msg);
     flux_close (h);
     return (0);

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -110,6 +110,10 @@ log-stderr-level::
 value, and as filtered by log-forward-level, are copied to stderr of the
 rank zero broker.
 
+log-level::
+Log entries at syslog(3) level at or below this value are stored
+in the ring buffer.
+
 
 CONTENT ATTRIBUTES
 ------------------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -318,3 +318,4 @@ stddev
 RTT
 wakeup
 crontab
+appname

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -93,7 +93,8 @@ static int l_kvsdir_kvsdir_new (lua_State *L)
     key = luaL_checkstring (L, 2);
 
     if (kvsdir_get_dir (d, &new, key) < 0)
-        return lua_pusherror (L, "kvsdir_get_dir: %s", strerror (errno));
+        return lua_pusherror (L, "kvsdir_get_dir: %s",
+                              (char *)flux_strerror (errno));
 
     return lua_push_kvsdir (L, new);
 }
@@ -140,7 +141,7 @@ static int l_kvsdir_newindex (lua_State *L)
     if (rc < 0)
         return lua_pusherror (L, "kvsdir_put (key=%s, type=%s): %s",
                            key, lua_typename (L, lua_type (L, 3)),
-                           strerror (errno));
+                           flux_strerror (errno));
     return (0);
 }
 
@@ -206,7 +207,8 @@ static int l_kvsdir_commit (lua_State *L)
     kvsdir_t *d = lua_get_kvsdir (L, 1);
     if (lua_isnoneornil (L, 2)) {
         if (kvs_commit (kvsdir_handle (d)) < 0)
-            return lua_pusherror (L, "kvs_commit: %s", strerror (errno));
+            return lua_pusherror (L, "kvs_commit: %s",
+                                  (char *)flux_strerror (errno));
     }
     lua_pushboolean (L, true);
     return (1);
@@ -217,7 +219,8 @@ static int l_kvsdir_unlink (lua_State *L)
     kvsdir_t *d = lua_get_kvsdir (L, 1);
     const char *key = luaL_checkstring (L, 2);
     if (kvsdir_unlink (d, key) < 0)
-            return lua_pusherror (L, "unlink: %s", strerror (errno));
+            return lua_pusherror (L, "unlink: %s",
+                                  (char *)flux_strerror (errno));
     lua_pushboolean (L, true);
     return (1);
 }
@@ -249,7 +252,8 @@ static int l_kvsdir_watch (lua_State *L)
 err:
     free (key);
     if (rc < 0)
-        return lua_pusherror (L, "kvs_watch: %s", strerror (errno));
+        return lua_pusherror (L, "kvs_watch: %s",
+                              (char *)flux_strerror (errno));
 
     json_object_to_lua (L, o);
     json_object_put (o);

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -168,7 +168,8 @@ static int l_zmsg_info_index (lua_State *L)
     if (strcmp (key, "matchtag") == 0) {
         uint32_t matchtag;
         if (flux_msg_get_matchtag (zi->zmsg, &matchtag) < 0)
-            return lua_pusherror (L, "zmsg: matchtag: %s", strerror (errno));
+            return lua_pusherror (L, "zmsg: matchtag: %s",
+                                  (char *)flux_strerror (errno));
         lua_pushnumber (L, matchtag);
         return (1);
     }

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -27,7 +27,7 @@
 #endif
 #include <czmq.h>
 
-#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 
 #include "attr.h"

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -358,7 +358,7 @@ int main (int argc, char *argv[])
     if (optind < argc) {
         size_t len = 0;
         if ((e = argz_create (argv + optind, &ctx.init_shell_cmd, &len)) != 0)
-            errn_exit (e, "argz_create");
+            log_errn_exit (e, "argz_create");
         argz_stringify (ctx.init_shell_cmd, len, ' ');
     }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -2313,7 +2313,7 @@ static int cmb_sub_cb (zmsg_t **zmsg, void *arg)
     rc = module_subscribe (ctx->modhash, uuid, topic);
 done:
     if (rc < 0)
-        flux_log (ctx->h, LOG_ERR, "%s: %s", __FUNCTION__, strerror (errno));
+        FLUX_LOG_ERROR (ctx->h);
     if (uuid)
         free (uuid);
     Jput (in);
@@ -2346,7 +2346,7 @@ static int cmb_unsub_cb (zmsg_t **zmsg, void *arg)
     rc = module_unsubscribe (ctx->modhash, uuid, topic);
 done:
     if (rc < 0)
-        flux_log (ctx->h, LOG_ERR, "%s: %s", __FUNCTION__, strerror (errno));
+        FLUX_LOG_ERROR (ctx->h);
     if (uuid)
         free (uuid);
     Jput (in);
@@ -2362,8 +2362,7 @@ static int cmb_seq (zmsg_t **zmsg, void *arg)
     int rc = sequence_request_handler (ctx->seq, (flux_msg_t *) *zmsg, &out);
 
     if (flux_respond (ctx->h, *zmsg, rc < 0 ? errno : 0, Jtostr (out)) < 0)
-        flux_log (ctx->h, LOG_ERR, "cmb.seq: flux_respond: %s\n",
-                  strerror (errno));
+        flux_log_error (ctx->h, "cmb.seq: flux_respond");
     if (out)
         Jput (out);
     zmsg_destroy (zmsg);
@@ -2615,8 +2614,7 @@ static void send_mute_request (ctx_t *ctx, void *sock)
     if (flux_msg_enable_route (zmsg))
         goto done;
     if (zmsg_send (&zmsg, sock) < 0)
-        flux_log (ctx->h, LOG_ERR, "failed to send mute request: %s",
-                  strerror (errno));
+        flux_log_error (ctx->h, "failed to send mute request");
     /* No response will be sent */
 done:
     zmsg_destroy (&zmsg);
@@ -2691,9 +2689,9 @@ static void module_cb (module_t *p, void *arg)
             break;
         case FLUX_MSGTYPE_EVENT:
             if (broker_event_sendmsg (ctx, &msg) < 0) {
-                flux_log (ctx->h, LOG_ERR, "%s(%s): broker_event_sendmsg %s: %s",
-                          __FUNCTION__, module_get_name (p),
-                          flux_msg_typestr (type), strerror (errno));
+                flux_log_error (ctx->h, "%s(%s): broker_event_sendmsg %s",
+                                __FUNCTION__, module_get_name (p),
+                                flux_msg_typestr (type));
             }
             break;
         case FLUX_MSGTYPE_KEEPALIVE:

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -718,7 +718,7 @@ done:
     saved_errno = errno;
     if (rc < 0)
         flux_log (h, LOG_DEBUG, "content dropcache: %s",
-                  strerror (saved_errno));
+                  flux_strerror (saved_errno));
     else
         flux_log (h, LOG_DEBUG, "content dropcache %d/%d",
                   orig_size - (int)zhash_size (cache->entries), orig_size);
@@ -804,7 +804,7 @@ done:
     saved_errno = errno;
     if (rc < 0)
         flux_log (h, LOG_DEBUG, "content flush: %s",
-                  strerror (saved_errno));
+                  flux_strerror (saved_errno));
     else
         flux_log (h, LOG_DEBUG, "content flush");
     errno = saved_errno;

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -135,11 +135,11 @@ static void timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     flux_msg_t *msg = NULL;
 
     if (!(msg = flux_heartbeat_encode (hb->send_epoch++))) {
-        err ("heartbeat_encode");
+        log_err ("heartbeat_encode");
         goto done;
     }
     if (flux_send (hb->h, msg, 0) < 0) {
-        err ("flux_send");
+        log_err ("flux_send");
         goto done;
     }
 done:

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -420,11 +420,11 @@ int log_register_attrs (log_t *log, attr_t *attrs)
         if (attr_get (attrs, "log-filename", NULL, NULL) < 0
           && attr_get (attrs, "persist-directory", &val, NULL) == 0 && val) {
             if (snprintf (s, sizeof (s), "%s/log", val) >= sizeof (s)) {
-                err ("log-filename truncated");
+                log_err ("log-filename truncated");
                 goto done;
             }
             if (attr_add (attrs, "log-filename", s, 0) < 0) {
-                err ("could not initialize log-filename");
+                log_err ("could not initialize log-filename");
                 goto done;
             }
         }

--- a/src/broker/log.h
+++ b/src/broker/log.h
@@ -4,48 +4,49 @@
 #include <flux/core.h>
 #include "attr.h"
 
-typedef void (*log_sleeper_f)(const flux_msg_t *msg, void *arg);
+typedef void (*logbuf_sleeper_f)(const flux_msg_t *msg, void *arg);
 
-typedef struct log_struct log_t;
+typedef struct logbuf_struct logbuf_t;
 
-log_t *log_create (void);
-void log_destroy (log_t *log);
+logbuf_t *logbuf_create (void);
+void logbuf_destroy (logbuf_t *logbuf);
 
-void log_set_flux (log_t *log, flux_t h);
-void log_set_rank (log_t *log, uint32_t rank);
+void logbuf_set_flux (logbuf_t *logbuf, flux_t h);
+void logbuf_set_rank (logbuf_t *logbuf, uint32_t rank);
 
-int log_register_attrs (log_t *log, attr_t *attrs);
+int logbuf_register_attrs (logbuf_t *logbuf, attr_t *attrs);
 
 /* Clear the buffer of entries <= seq_index
  * Set seq_index = -1 to clear all.
  */
-void log_buf_clear (log_t *log, int seq_index);
+void logbuf_clear (logbuf_t *logbuf, int seq_index);
 
 /* Get next entry with seq > seq_index
  * Set seq_index = -1 to get the first entry.
  * 'seq' is assigned the sequence number of the returned entry.
  */
-int log_buf_get (log_t *log, int seq_index, int *seq,
+int logbuf_get (logbuf_t *logbuf, int seq_index, int *seq,
                  const char **buf, int *len);
 
 /* Call 'fun' when anther item is added to the ring buffer.
  * This is how we implement a "nonblocking" dmesg request.
  */
-int log_buf_sleepon (log_t *log, log_sleeper_f fun, flux_msg_t *msg, void *arg);
+int logbuf_sleepon (logbuf_t *logbuf, logbuf_sleeper_f fun,
+                    flux_msg_t *msg, void *arg);
 
 /* Handle disconnects from sleeping dmesg requestors.
  */
-void log_buf_disconnect (log_t *log, const char *uuid);
+void logbuf_disconnect (logbuf_t *logbuf, const char *uuid);
 
 /* Receive a log entry.
  */
-int log_append (log_t *log, const char *buf, int len);
+int logbuf_append (logbuf_t *logbuf, const char *buf, int len);
 
 /* Receive a log entry.
  * This is a flux_log_f that can be passed to flux_log_redirect()
  * and is used to capture log entries from the broker itself.
  */
-void log_append_redirect (const char *buf, int len, void *arg);
+void logbuf_append_redirect (const char *buf, int len, void *arg);
 
 #endif /* BROKER_LOG_H */
 

--- a/src/broker/log.h
+++ b/src/broker/log.h
@@ -21,11 +21,12 @@ int log_register_attrs (log_t *log, attr_t *attrs);
  */
 void log_buf_clear (log_t *log, int seq_index);
 
-/* Get next entry in json log format with seq > seq_index
+/* Get next entry with seq > seq_index
  * Set seq_index = -1 to get the first entry.
  * 'seq' is assigned the sequence number of the returned entry.
  */
-const char *log_buf_get (log_t *log, int seq_index, int *seq);
+int log_buf_get (log_t *log, int seq_index, int *seq,
+                 const char **buf, int *len);
 
 /* Call 'fun' when anther item is added to the ring buffer.
  * This is how we implement a "nonblocking" dmesg request.
@@ -36,16 +37,15 @@ int log_buf_sleepon (log_t *log, log_sleeper_f fun, flux_msg_t *msg, void *arg);
  */
 void log_buf_disconnect (log_t *log, const char *uuid);
 
-/* Receive a log entry in json log format.
+/* Receive a log entry.
  */
-int log_append_json (log_t *log, const char *json_str);
+int log_append (log_t *log, const char *buf, int len);
 
-/* Receive a fully decoded log entry.
+/* Receive a log entry.
  * This is a flux_log_f that can be passed to flux_log_redirect()
  * and is used to capture log entries from the broker itself.
  */
-void log_append_redirect (const char *facility, int level, uint32_t rank,
-                          struct timeval tv, const char *s, void *arg);
+void log_append_redirect (const char *buf, int len, void *arg);
 
 #endif /* BROKER_LOG_H */
 

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -210,12 +210,12 @@ static void register_event (ctx_t *ctx, const char *name,
 
     match.topic_glob = xasprintf ("%s.%s", module_get_name (ctx->p), name);
     if (!(w = flux_msg_handler_create (ctx->h, match, cb, ctx->p)))
-        err_exit ("flux_msg_handler_create");
+        log_err_exit ("flux_msg_handler_create");
     flux_msg_handler_start (w);
     if (zlist_append (ctx->handlers, w) < 0)
         oom ();
     if (flux_event_subscribe (ctx->h, match.topic_glob) < 0)
-        err_exit ("%s: flux_event_subscribe %s",
+        log_err_exit ("%s: flux_event_subscribe %s",
                   __FUNCTION__, match.topic_glob);
     free (match.topic_glob);
 }
@@ -228,7 +228,7 @@ static void register_request (ctx_t *ctx, const char *name,
 
     match.topic_glob = xasprintf ("%s.%s", module_get_name (ctx->p), name);
     if (!(w = flux_msg_handler_create (ctx->h, match, cb, ctx->p)))
-        err_exit ("flux_msg_handler_create");
+        log_err_exit ("flux_msg_handler_create");
     flux_msg_handler_start (w);
     if (zlist_append (ctx->handlers, w) < 0)
         oom ();
@@ -249,9 +249,9 @@ void modservice_register (flux_t h, module_t *p)
     register_event   (ctx, "stats.clear", stats_clear_event_cb);
 
     if (!(ctx->w_prepare = flux_prepare_watcher_create (r, prepare_cb, ctx)))
-        err_exit ("flux_prepare_watcher_create");
+        log_err_exit ("flux_prepare_watcher_create");
     if (!(ctx->w_check = flux_check_watcher_create (r, check_cb, ctx)))
-        err_exit ("flux_check_watcher_create");
+        log_err_exit ("flux_check_watcher_create");
     flux_watcher_start (ctx->w_prepare);
     flux_watcher_start (ctx->w_check);
 }

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -135,7 +135,7 @@ static void *module_thread (void *arg)
     if (sigfillset (&signal_set) < 0)
         err_exit ("%s: sigfillset", p->name);
     if ((errnum = pthread_sigmask (SIG_BLOCK, &signal_set, NULL)) != 0)
-        errn_exit (errnum, "pthread_sigmask");
+        log_errn_exit (errnum, "pthread_sigmask");
 
     /* Run the module's main().
      */
@@ -291,7 +291,7 @@ static void module_destroy (module_t *p)
     if (p->t) {
         errnum = pthread_join (p->t, NULL);
         if (errnum)
-            errn_exit (errnum, "pthread_join");
+            log_errn_exit (errnum, "pthread_join");
     }
 
     assert (p->h == NULL);
@@ -384,7 +384,7 @@ void module_set_args (module_t *p, int argc, char * const argv[])
         p->argz_len = 0;
     }
     if (argv && (e = argz_create (argv, &p->argz, &p->argz_len)) != 0)
-        errn_exit (e, "argz_create");
+        log_errn_exit (e, "argz_create");
 }
 
 void module_add_arg (module_t *p, const char *arg)
@@ -393,7 +393,7 @@ void module_add_arg (module_t *p, const char *arg)
 
     assert (p->magic == MODULE_MAGIC);
     if ((e = argz_add (&p->argz, &p->argz_len, arg)) != 0)
-        errn_exit (e, "argz_add");
+        log_errn_exit (e, "argz_add");
 }
 
 void module_set_poller_cb (module_t *p, modpoller_cb_f cb, void *arg)

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -127,7 +127,7 @@ static void *module_thread (void *arg)
         err ("%s: error faking rank attribute", p->name);
         goto done;
     }
-    flux_log_set_facility (p->h, p->name);
+    flux_log_set_appname (p->h, p->name);
     modservice_register (p->h, p);
 
     /* Block all signals

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -491,7 +491,7 @@ module_t *module_add (modhash_t *mh, const char *path)
 
     dlerror ();
     if (!(dso = dlopen (path, RTLD_NOW | RTLD_LOCAL))) {
-        msg ("%s", dlerror ());
+        log_msg ("%s", dlerror ());
         errno = ENOENT;
         return NULL;
     }

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -117,14 +117,14 @@ static void *module_thread (void *arg)
     /* Connect to broker socket, enable logging, register built-in services
      */
     if (!(p->h = flux_open (uri, 0)))
-        err_exit ("flux_open %s", uri);
+        log_err_exit ("flux_open %s", uri);
     if (flux_opt_set (p->h, FLUX_OPT_ZEROMQ_CONTEXT,
                       p->zctx, sizeof (p->zctx)) < 0)
-        err_exit ("flux_opt_set ZEROMQ_CONTEXT");
+        log_err_exit ("flux_opt_set ZEROMQ_CONTEXT");
 
     rankstr = xasprintf ("%u", p->rank);
     if (flux_attr_fake (p->h, "rank", rankstr, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
-        err ("%s: error faking rank attribute", p->name);
+        log_err ("%s: error faking rank attribute", p->name);
         goto done;
     }
     flux_log_set_appname (p->h, p->name);
@@ -133,7 +133,7 @@ static void *module_thread (void *arg)
     /* Block all signals
      */
     if (sigfillset (&signal_set) < 0)
-        err_exit ("%s: sigfillset", p->name);
+        log_err_exit ("%s: sigfillset", p->name);
     if ((errnum = pthread_sigmask (SIG_BLOCK, &signal_set, NULL)) != 0)
         log_errn_exit (errnum, "pthread_sigmask");
 
@@ -529,14 +529,14 @@ module_t *module_add (modhash_t *mh, const char *path)
     /* Broker end of PAIR socket is opened here.
      */
     if (!(p->sock = zsocket_new (p->zctx, ZMQ_PAIR)))
-        err_exit ("zsocket_new");
+        log_err_exit ("zsocket_new");
     zsocket_set_hwm (p->sock, 0);
     if (zsocket_bind (p->sock, "inproc://%s", module_get_uuid (p)) < 0)
-        err_exit ("zsock_bind inproc://%s", module_get_uuid (p));
+        log_err_exit ("zsock_bind inproc://%s", module_get_uuid (p));
     if (!(p->broker_w = flux_zmq_watcher_create (flux_get_reactor (p->broker_h),
                                                  p->sock, FLUX_POLLIN,
                                                  module_cb, p)))
-        err_exit ("flux_zmq_watcher_create");
+        log_err_exit ("flux_zmq_watcher_create");
 
     /* Update the modhash.
      */

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -479,7 +479,7 @@ static int bind_child (overlay_t *ov, struct endpoint *ep)
     if (!(ep->zs = zsocket_new (ov->zctx, ZMQ_ROUTER)))
         err_exit ("zsocket_new");
     if (flux_sec_ssockinit (ov->sec, ep->zs) < 0)
-        msg_exit ("flux_sec_ssockinit: %s", flux_sec_errstr (ov->sec));
+        log_msg_exit ("flux_sec_ssockinit: %s", flux_sec_errstr (ov->sec));
     zsocket_set_hwm (ep->zs, 0);
     if (zsocket_bind (ep->zs, "%s", ep->uri) < 0)
         err_exit ("%s", ep->uri);
@@ -499,7 +499,7 @@ static int bind_event_pub (overlay_t *ov, struct endpoint *ep)
     if (!(ep->zs = zsocket_new (ov->zctx, ZMQ_PUB)))
         err_exit ("zsocket_new");
     if (flux_sec_ssockinit (ov->sec, ep->zs) < 0) /* no-op for epgm */
-        msg_exit ("flux_sec_ssockinit: %s", flux_sec_errstr (ov->sec));
+        log_msg_exit ("flux_sec_ssockinit: %s", flux_sec_errstr (ov->sec));
     zsocket_set_sndhwm (ep->zs, 0);
     if (zsocket_bind (ep->zs, "%s", ep->uri) < 0)
         err_exit ("%s: %s", __FUNCTION__, ep->uri);
@@ -524,7 +524,7 @@ static int connect_event_sub (overlay_t *ov, struct endpoint *ep)
     if (!(ep->zs = zsocket_new (ov->zctx, ZMQ_SUB)))
         err_exit ("zsocket_new");
     if (flux_sec_csockinit (ov->sec, ep->zs) < 0) /* no-op for epgm */
-        msg_exit ("flux_sec_csockinit: %s", flux_sec_errstr (ov->sec));
+        log_msg_exit ("flux_sec_csockinit: %s", flux_sec_errstr (ov->sec));
     zsocket_set_rcvhwm (ep->zs, 0);
     if (zsocket_connect (ep->zs, "%s", ep->uri) < 0)
         err_exit ("%s", ep->uri);
@@ -553,7 +553,7 @@ static int connect_parent (overlay_t *ov, struct endpoint *ep)
         goto error;
     if (flux_sec_csockinit (ov->sec, ep->zs) < 0) {
         savederr = errno;
-        msg ("flux_sec_csockinit: %s", flux_sec_errstr (ov->sec));
+        log_msg ("flux_sec_csockinit: %s", flux_sec_errstr (ov->sec));
         errno = savederr;
         goto error;
     }

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -120,13 +120,13 @@ void shutdown_set_handle (shutdown_t *s, flux_t h)
     match.topic_glob = "shutdown";
     if (!(s->shutdown = flux_msg_handler_create (s->h, match,
                                                  shutdown_handler, s)))
-        err_exit ("flux_msg_handler_create");
+        log_err_exit ("flux_msg_handler_create");
     flux_msg_handler_start (s->shutdown);
     if (flux_event_subscribe (s->h, "shutdown") < 0)
-        err_exit ("flux_event_subscribe");
+        log_err_exit ("flux_event_subscribe");
 
     if (flux_get_rank (s->h, &s->myrank) < 0)
-        err_exit ("flux_get_rank");
+        log_err_exit ("flux_get_rank");
 }
 
 void shutdown_set_callback (shutdown_t *s, shutdown_cb_f cb, void *arg)

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -51,7 +51,7 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
 
     h = builtin_get_flux_handle (p);
     if (flux_attr_set (h, name, val) < 0)
-        err_exit ("%s", av[1]);
+        log_err_exit ("%s", av[1]);
     flux_close (h);
     return (0);
 }
@@ -101,7 +101,7 @@ static int cmd_getattr (optparse_t *p, int ac, char *av[])
 
     h = builtin_get_flux_handle (p);
     if (!(val = flux_attr_get (h, av[n], &flags)))
-        err_exit ("%s", av[n]);
+        log_err_exit ("%s", av[n]);
     printf ("%s\n", val);
     flux_close (h);
     return (0);

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -98,7 +98,7 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
             sha1_hashtostr (hash, hashstr);
             printf ("%s\n", hashstr);
         } else
-            msg_exit ("content-store: unsupported hash function: %s", hashfun);
+            log_msg_exit ("content-store: unsupported hash function: %s", hashfun);
     } else {
         const char *blobref;
         int blobref_size;
@@ -111,7 +111,7 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
         if (flux_rpc_get_raw (rpc, NULL, &blobref, &blobref_size) < 0)
             err_exit ("%s", topic);
         if (!blobref || blobref[blobref_size - 1] != '\0')
-            msg_exit ("%s: protocol error", topic);
+            log_msg_exit ("%s: protocol error", topic);
         printf ("%s\n", blobref);
         flux_rpc_destroy (rpc);
     }
@@ -174,7 +174,7 @@ static void store_completion (flux_rpc_t *rpc, void *arg)
     if (flux_rpc_get_raw (rpc, NULL, &blobref, &blobref_size) < 0)
         err_exit ("store");
     if (!blobref || blobref[blobref_size - 1] != '\0')
-        msg_exit ("store: protocol error");
+        log_msg_exit ("store: protocol error");
     //printf ("%s\n", blobref);
     flux_rpc_destroy (rpc);
     if (--spam_cur_inflight < spam_max_inflight/2)

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -84,7 +84,7 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
         const char *hashfun;
 
         if (size > blob_size_limit)
-            errn_exit (EFBIG, "content-store");
+            log_errn_exit (EFBIG, "content-store");
         if (!(hashfun = flux_attr_get (h, "content-hash", &flags)))
             err_exit ("flux_attr_get content-hash");
         if (!strcmp (hashfun, "sha1")) {

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -42,7 +42,7 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
     flux_log_f print_cb = flux_log_fprint;
 
     if ((n = optparse_optind (p)) != ac)
-        msg_exit ("flux-dmesg accepts no free arguments");
+        log_msg_exit ("flux-dmesg accepts no free arguments");
 
     if (!(h = builtin_get_flux_handle (p)))
         err_exit ("flux_open");

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -45,7 +45,7 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
         log_msg_exit ("flux-dmesg accepts no free arguments");
 
     if (!(h = builtin_get_flux_handle (p)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (optparse_hasopt (p, "read-clear") || optparse_hasopt (p, "clear"))
         flags |= FLUX_DMESG_CLEAR;
     if (optparse_hasopt (p, "clear"))
@@ -53,7 +53,7 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
     if (optparse_hasopt (p, "follow"))
         flags |= FLUX_DMESG_FOLLOW;
     if (flux_dmesg (h, flags, print_cb, stdout) < 0)
-        err_exit ("flux_dmesg");
+        log_err_exit ("flux_dmesg");
     flux_close (h);
     return (0);
 }

--- a/src/cmd/builtin/env.c
+++ b/src/cmd/builtin/env.c
@@ -39,7 +39,7 @@ static int cmd_env (optparse_t *p, int ac, char *av[])
     int n = optparse_optind (p);
     if (av && av[n]) {
         execvp (av[n], av+n); /* no return if sucessful */
-        err_exit ("execvp (%s)", av[n]);
+        log_err_exit ("execvp (%s)", av[n]);
     } else {
         struct environment *env = optparse_get_data (p, "env");
         if (env == NULL)

--- a/src/cmd/builtin/env.c
+++ b/src/cmd/builtin/env.c
@@ -43,7 +43,7 @@ static int cmd_env (optparse_t *p, int ac, char *av[])
     } else {
         struct environment *env = optparse_get_data (p, "env");
         if (env == NULL)
-            msg_exit ("flux-env: failed to get flux envirnoment!");
+            log_msg_exit ("flux-env: failed to get flux envirnoment!");
         print_environment (env);
     }
     return (0);

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -37,11 +37,11 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
     }
     Jadd_str (in, "filename", av[ac - 1]);
     if (!(h = builtin_get_flux_handle (p)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(rpc = flux_rpc (h, "cmb.heaptrace.start", Jtostr (in),
                           FLUX_NODEID_ANY, 0))
             || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("cmb.heaptrace.start");
+        log_err_exit ("cmb.heaptrace.start");
     flux_rpc_destroy (rpc);
     flux_close (h);
     return (0);
@@ -57,10 +57,10 @@ static int internal_heaptrace_stop (optparse_t *p, int ac, char *av[])
         exit (1);
     }
     if (!(h = builtin_get_flux_handle (p)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(rpc = flux_rpc (h, "cmb.heaptrace.stop", NULL, FLUX_NODEID_ANY, 0))
             || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("cmb.heaptrace.stop");
+        log_err_exit ("cmb.heaptrace.stop");
     flux_rpc_destroy (rpc);
     flux_close (h);
     return (0);
@@ -78,11 +78,11 @@ static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
     }
     Jadd_str (in, "reason", av[ac - 1]);
     if (!(h = builtin_get_flux_handle (p)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(rpc = flux_rpc (h, "cmb.heaptrace.dump", Jtostr (in),
                           FLUX_NODEID_ANY, 0))
             || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("cmb.heaptrace.dump");
+        log_err_exit ("cmb.heaptrace.dump");
     flux_rpc_destroy (rpc);
     flux_close (h);
     return (0);

--- a/src/cmd/builtin/help.c
+++ b/src/cmd/builtin/help.c
@@ -49,7 +49,7 @@ static int cmd_help (optparse_t *p, int ac, char *av[])
             cmd = xasprintf ("man flux-%s", topic);
 
         if ((rc = system (cmd)) < 0)
-            err_exit ("man");
+            log_err_exit ("man");
         else if (WIFEXITED (rc) && ((rc = WEXITSTATUS (rc)) != 0))
             exit (rc);
         else if (WIFSIGNALED (rc))

--- a/src/cmd/builtin/help.c
+++ b/src/cmd/builtin/help.c
@@ -53,7 +53,7 @@ static int cmd_help (optparse_t *p, int ac, char *av[])
         else if (WIFEXITED (rc) && ((rc = WEXITSTATUS (rc)) != 0))
             exit (rc);
         else if (WIFSIGNALED (rc))
-            errn_exit (1, "man: %s\n", strsignal (WTERMSIG (rc)));
+            log_errn_exit (1, "man: %s\n", strsignal (WTERMSIG (rc)));
         free (cmd);
     } else
         usage (optparse_get_parent (p));

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -59,7 +59,7 @@ static struct hwloc_topo * hwloc_topo_create (optparse_t *p)
         err_exit ("flux_rpc");
 
     if (!(t->o = Jfromstr (json_str)) || !Jget_str (t->o, "topology", &t->topo))
-        msg_exit ("failed to parse json topology");
+        log_msg_exit ("failed to parse json topology");
 
     return (t);
 }
@@ -90,11 +90,11 @@ static void lstopo_argz_init (char *cmd, char **argzp, size_t *argz_lenp,
                      "--of", "console", NULL };
     if (  (e = argz_create (argv, argzp, argz_lenp)) != 0
        || (e = argz_create (extra_args, &extra, &extra_len)) != 0)
-        msg_exit ("argz_create: %s", strerror (e));
+        log_msg_exit ("argz_create: %s", strerror (e));
 
     /*  Append any extra args in av[] */
     if ((e = argz_append (argzp, argz_lenp, extra, extra_len)) != 0)
-        msg_exit ("argz_append: %s", strerror (e));
+        log_msg_exit ("argz_append: %s", strerror (e));
 
     free (extra);
 }
@@ -185,9 +185,9 @@ static int cmd_lstopo (optparse_t *p, int ac, char *av[])
     status = exec_lstopo (p, ac, av, hwloc_topo_topology (t));
     if (status) {
         if (WIFEXITED (status) && WEXITSTATUS (status) != ENOENT)
-            msg_exit ("lstopo: Exited with %d", WEXITSTATUS (status));
+            log_msg_exit ("lstopo: Exited with %d", WEXITSTATUS (status));
         if (WIFSIGNALED (status) && WTERMSIG (status) != SIGPIPE)
-            msg_exit ("lstopo: %s%s", strsignal (WTERMSIG (status)),
+            log_msg_exit ("lstopo: %s%s", strsignal (WTERMSIG (status)),
                       WCOREDUMP (status) ? " (core dumped)" : "");
     }
 

--- a/src/cmd/builtin/nodeset.c
+++ b/src/cmd/builtin/nodeset.c
@@ -117,7 +117,7 @@ static int cmd_nodeset (optparse_t *p, int ac, char *av[])
 
     for (i = 0; i < nsc; i++)
         if (!(nsv[i] = nodeset_create_string (av[ix + i])))
-            errn_exit (EINVAL, "%s", av[ix + i]);
+            log_errn_exit (EINVAL, "%s", av[ix + i]);
 
     if (optparse_hasopt (p, "intersection"))
         nsp = nsv_intersection (nsc, nsv);
@@ -128,7 +128,7 @@ static int cmd_nodeset (optparse_t *p, int ac, char *av[])
         const char *s = optparse_get_str (p, "subtract", "");
         nodeset_t *ns = nodeset_create_string (s);
         if (!ns)
-            errn_exit (EINVAL, "%s", s);
+            log_errn_exit (EINVAL, "%s", s);
         ns_subtract (nsp, ns);
     }
 

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -937,7 +937,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
          free (uri);
     }
 
-    flux_log_set_facility (h, "proxy");
+    flux_log_set_appname (h, "proxy");
     ctx = ctx_create (h);
 
     ctx->listen_fd = -1;

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -171,18 +171,18 @@ static client_t * client_create (ctx_t *ctx, int rfd, int wfd)
     c->outw = flux_fd_watcher_create (ctx->reactor, c->wfd,
                                       FLUX_POLLOUT, client_write_cb, c);
     if (!c->inw || !c->outw) {
-        flux_log (h, LOG_ERR, "flux_fd_watcher_create: %s", strerror (errno));
+        flux_log_error (h, "flux_fd_watcher_create");
         goto error;
     }
     flux_watcher_start (c->inw);
     flux_msg_iobuf_init (&c->inbuf);
     flux_msg_iobuf_init (&c->outbuf);
     if (set_nonblock (c->rfd, true) < 0) {
-        flux_log (h, LOG_ERR, "set_nonblock: %s", strerror (errno));
+        flux_log_error (h, "set_nonblock");
         goto error;
     }
     if (c->wfd != c->rfd && set_nonblock (c->wfd, true) < 0) {
-        flux_log (h, LOG_ERR, "set_nonblock: %s", strerror (errno));
+        flux_log_error (h, "set_nonblock");
         goto error;
     }
 
@@ -258,8 +258,8 @@ static int global_subscribe (ctx_t *ctx, const char *topic)
 
     if (!(sub = zhash_lookup (ctx->subscriptions, topic))) {
         if (flux_event_subscribe (ctx->h, topic) < 0) {
-            flux_log (ctx->h, LOG_ERR, "%s: flux_event_subscribe %s: %s",
-                      __FUNCTION__, topic, strerror (errno));
+            flux_log_error (ctx->h, "%s: flux_event_subscribe %s",
+                            __FUNCTION__, topic);
             goto done;
         }
         sub = subscription_create (topic);
@@ -516,12 +516,10 @@ static bool internal_request (client_t *c, const flux_msg_t *msg)
      */
     if (!(rmsg = flux_response_encode (topic, rc < 0 ? errno : 0, NULL))
                     || flux_msg_set_matchtag (rmsg, matchtag) < 0)
-        flux_log (c->ctx->h, LOG_ERR, "%s: encoding response: %s",
-                  __FUNCTION__, strerror (errno));
+        flux_log_error (c->ctx->h, "%s: encoding response", __FUNCTION__);
 
     else if (client_send_nocopy (c, &rmsg) < 0)
-        flux_log (c->ctx->h, LOG_ERR, "%s: client_send_nocopy: %s",
-                  __FUNCTION__, strerror (errno));
+        flux_log_error (c->ctx->h, "%s: client_send_nocopy", __FUNCTION__);
     flux_msg_destroy (rmsg);
     return true;
 }
@@ -549,11 +547,11 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
             return;
         }
         if (errno != ECONNRESET && errno != EPROTO)
-            flux_log (h, LOG_ERR, "flux_msg_recvfd: %s", strerror (errno));
+            flux_log_error (h, "flux_msg_recvfd");
         goto disconnect;
     }
     if (flux_msg_get_type (msg, &type) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_get_type: %s", strerror (errno));
+        flux_log_error (h, "flux_msg_get_type");
         goto disconnect;
     }
     switch (type) {
@@ -561,8 +559,7 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
             if (!internal_request (c, msg)) {
                 /* insert disconnect notifier before forwarding request */
                 if (c->disconnect_notify && disconnect_update (c, msg) < 0) {
-                    flux_log (h, LOG_ERR, "disconnect_update:  %s",
-                              strerror (errno));
+                    flux_log_error (h, "disconnect_update");
                     goto disconnect;
                 }
                 if (flux_msg_push_route (msg, zuuid_str (c->uuid)) < 0)
@@ -621,10 +618,9 @@ static void response_cb (flux_t h, flux_msg_handler_t *w,
                 const char *topic = "unknown";
                 (void)flux_msg_get_type (msg, &type);
                 (void)flux_msg_get_topic (msg, &topic);
-                flux_log (h, LOG_ERR, "send %s %s to client %.*s: %s",
-                          topic, flux_msg_typestr (type),
-                          5, zuuid_str (c->uuid),
-                          strerror (errno));
+                flux_log_error (h, "send %s %s to client %.*s",
+                                topic, flux_msg_typestr (type),
+                                5, zuuid_str (c->uuid));
                 errno = 0;
             }
             break;
@@ -649,8 +645,7 @@ static void event_cb (flux_t h, flux_msg_handler_t *w,
     int count = 0;
 
     if (flux_msg_get_topic (msg, &topic) < 0) {
-        flux_log (h, LOG_ERR, "%s: dropped: %s",
-                  __FUNCTION__, strerror (errno));
+        flux_log_error (h, "%s: dropped", __FUNCTION__);
         return;
     }
     c = zlist_first (ctx->clients);
@@ -661,10 +656,9 @@ static void event_cb (flux_t h, flux_msg_handler_t *w,
                 const char *topic = "unknown";
                 (void)flux_msg_get_type (msg, &type);
                 (void)flux_msg_get_topic (msg, &topic);
-                flux_log (h, LOG_ERR, "send %s %s to client %.*s: %s",
-                          topic, flux_msg_typestr (type),
-                          5, zuuid_str (c->uuid),
-                          strerror (errno));
+                flux_log_error (h, "send %s %s to client %.*s",
+                                topic, flux_msg_typestr (type),
+                                5, zuuid_str (c->uuid));
                 errno = 0;
             }
             count++;
@@ -709,7 +703,7 @@ static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
         int cfd;
 
         if ((cfd = accept4 (fd, NULL, NULL, SOCK_CLOEXEC)) < 0) {
-            flux_log (h, LOG_ERR, "accept: %s", strerror (errno));
+            flux_log_error (h, "accept");
             goto done;
         }
         if (check_cred (ctx, cfd) < 0) {
@@ -724,7 +718,7 @@ static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
             oom ();
     }
     if (revents & FLUX_POLLERR) {
-        flux_log (h, LOG_ERR, "poll listen fd: %s", strerror (errno));
+        flux_log_error (h, "poll listen fd");
     }
 done:
     return;
@@ -737,11 +731,11 @@ static int listener_init (ctx_t *ctx, char *sockpath)
 
     fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (fd < 0) {
-        flux_log (ctx->h, LOG_ERR, "socket: %s", strerror (errno));
+        flux_log_error (ctx->h, "socket");
         goto done;
     }
     if (remove (sockpath) < 0 && errno != ENOENT) {
-        flux_log (ctx->h, LOG_ERR, "remove %s: %s", sockpath, strerror (errno));
+        flux_log_error (ctx->h, "remove %s", sockpath);
         goto error_close;
     }
     memset (&addr, 0, sizeof (struct sockaddr_un));
@@ -749,11 +743,11 @@ static int listener_init (ctx_t *ctx, char *sockpath)
     strncpy (addr.sun_path, sockpath, sizeof (addr.sun_path) - 1);
 
     if (bind (fd, (struct sockaddr *)&addr, sizeof (struct sockaddr_un)) < 0) {
-        flux_log (ctx->h, LOG_ERR, "bind: %s", strerror (errno));
+        flux_log_error (ctx->h, "bind");
         goto error_close;
     }
     if (listen (fd, LISTEN_BACKLOG) < 0) {
-        flux_log (ctx->h, LOG_ERR, "listen: %s", strerror (errno));
+        flux_log_error (ctx->h, "listen");
         goto error_close;
     }
 done:
@@ -992,14 +986,14 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
     /* Create/start event/response message watchers
      */
     if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_watcher_addvec: %s", strerror (errno));
+        flux_log_error (h, "flux_msg_watcher_addvec");
         goto done;
     }
 
     /* Start reactor
      */
     if (flux_reactor_run (ctx->reactor, 0) < 0) {
-        flux_log (h, LOG_ERR, "flux_reactor_run: %s", strerror (errno));
+        flux_log_error (h, "flux_reactor_run");
         goto done;
     }
 done:
@@ -1007,7 +1001,7 @@ done:
     flux_watcher_destroy (ctx->listen_w);
     if (ctx->listen_fd >= 0) {
         if (close (ctx->listen_fd) < 0)
-            flux_log (h, LOG_ERR, "close listen_fd: %s", strerror (errno));
+            flux_log_error (h, "close listen_fd");
     }
     if (ctx->clients) {
         client_t *c;

--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -87,7 +87,7 @@ static json_object *command_list_file_read (const char *path)
     }
 
     if (!(fp = fopen (path, "r"))) {
-        err ("%s", path);
+        log_err ("%s", path);
         return (NULL);
     }
 
@@ -230,7 +230,7 @@ zhash_t *get_command_list_hash (const char *pattern)
     for (i = 0; i < gl.gl_pathc; i++) {
         const char *file = gl.gl_pathv[i];
         if (command_list_read (zh, file) < 0)
-            err_exit ("%s: failed to read content\n", file);
+            log_err_exit ("%s: failed to read content\n", file);
     }
     globfree (&gl);
 

--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -82,7 +82,7 @@ static json_object *command_list_file_read (const char *path)
     json_tokener *tok = json_tokener_new ();
 
     if (tok == NULL) {
-        msg ("json_tokener_new: Out of memory");
+        log_msg ("json_tokener_new: Out of memory");
         return (NULL);
     }
 
@@ -105,12 +105,12 @@ static json_object *command_list_file_read (const char *path)
     json_tokener_free (tok);
 
     if (!o || e != json_tokener_success) {
-        msg ("%s: %s", path, o ? json_tokener_error_desc (e) : "premature EOF");
+        log_msg ("%s: %s", path, o ? json_tokener_error_desc (e) : "premature EOF");
         return (NULL);
     }
 
     if (json_object_get_type (o) != json_type_array) {
-        msg ("%s: not a JSON array", path);
+        log_msg ("%s: not a JSON array", path);
         json_object_put (o);
         return (NULL);
     }
@@ -129,7 +129,7 @@ static int command_list_read (zhash_t *h, const char *path)
     o = command_list_file_read (path);
 
     if (!(l = json_object_get_array (o))) {
-        msg ("%s: failed to get array list from JSON", path);
+        log_msg ("%s: failed to get array list from JSON", path);
         goto out;
     }
 
@@ -143,7 +143,7 @@ static int command_list_read (zhash_t *h, const char *path)
         if (!Jget_str (entry, "category", &category)
             || !Jget_str (entry, "command", &command)
             || !Jget_str (entry, "description", &description)) {
-            msg ("%s: Missing element in JSON entry %d", path, i);
+            log_msg ("%s: Missing element in JSON entry %d", path, i);
             goto out;
         }
         if (!(zl = zhash_lookup (h, category))) {

--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -120,11 +120,11 @@ int main (int argc, char *argv[])
     if (optind != argc - 1)
         usage ();
     if (scale != 1.0 && type != json_type_int && type != json_type_double)
-        msg_exit ("Use --scale only with --type int or --type double");
+        log_msg_exit ("Use --scale only with --type int or --type double");
     target = argv[optind++];
 
     if (Copt && nodeid != FLUX_NODEID_ANY)
-        msg_exit ("Use --clear not --clear-all to clear a single node.");
+        log_msg_exit ("Use --clear not --clear-all to clear a single node.");
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");

--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -127,21 +127,21 @@ int main (int argc, char *argv[])
         log_msg_exit ("Use --clear not --clear-all to clear a single node.");
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     if (copt) {
         flux_rpc_t *rpc;
         char *topic = xasprintf ("%s.stats.clear", target);
         if (!(rpc = flux_rpc (h, topic, NULL, nodeid, 0))
                                 || flux_rpc_get (rpc, NULL, NULL) < 0)
-            err_exit ("%s", topic);
+            log_err_exit ("%s", topic);
         free (topic);
         flux_rpc_destroy (rpc);
     } else if (Copt) {
         char *topic = xasprintf ("%s.stats.clear", target);
         flux_msg_t *msg = flux_event_encode (target, NULL);
         if (!msg || flux_send (h, msg, 0) < 0)
-            err_exit ("sending event");
+            log_err_exit ("sending event");
         flux_msg_destroy (msg);
         free (topic);
     } else if (Ropt) {
@@ -150,7 +150,7 @@ int main (int argc, char *argv[])
         char *topic = xasprintf ("%s.rusage", target);
         if (!(rpc = flux_rpc (h, topic, NULL, nodeid, 0))
                                 || flux_rpc_get (rpc, NULL, &json_str) < 0)
-            err_exit ("%s", topic);
+            log_err_exit ("%s", topic);
         parse_json (objname, json_str, scale, type);
         free (topic);
         flux_rpc_destroy (rpc);
@@ -160,7 +160,7 @@ int main (int argc, char *argv[])
         char *topic = xasprintf ("%s.stats.get", target);
         if (!(rpc = flux_rpc (h, topic, NULL, nodeid, 0))
                                 || flux_rpc_get (rpc, NULL, &json_str) < 0)
-            err_exit ("%s", topic);
+            log_err_exit ("%s", topic);
         parse_json (objname, json_str, scale, type);
         free (topic);
         flux_rpc_destroy (rpc);
@@ -175,14 +175,14 @@ static void parse_json (const char *n, const char *json_str, double scale,
 {
     json_object *o = json_tokener_parse (json_str);
     if (!o)
-        err_exit ("error parsing JSON response");
+        log_err_exit ("error parsing JSON response");
     if (n) {
         char *cpy = xstrdup (n);
         char *name, *saveptr = NULL, *a1 = cpy;
 
         while ((name = strtok_r (a1, ".", &saveptr))) {
             if (!json_object_object_get_ex (o, name, &o) || o == NULL)
-                err_exit ("`%s' not found in response", n);
+                log_err_exit ("`%s' not found in response", n);
             a1 = NULL;
         }
         free (cpy);
@@ -193,7 +193,7 @@ static void parse_json (const char *n, const char *json_str, double scale,
             errno = 0;
             d = json_object_get_double (o);
             if (errno != 0)
-                err_exit ("couldn't convert value to double");
+                log_err_exit ("couldn't convert value to double");
             printf ("%lf\n", d * scale);
             break;
         }
@@ -202,7 +202,7 @@ static void parse_json (const char *n, const char *json_str, double scale,
             errno = 0;
             d = json_object_get_double (o);
             if (errno != 0)
-                err_exit ("couldn't convert value to double (en route to int)");
+                log_err_exit ("couldn't convert value to double (en route to int)");
             printf ("%d\n", (int)(d * scale));
             break;
         }

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -87,19 +87,19 @@ int main (int argc, char *argv[])
         usage ();
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     if (!strcmp (cmd, "reparent")) {
         if (optind != argc - 1)
             usage ();
         if (flux_reparent (h, rank, argv[optind]) < 0)
-            err_exit ("flux_reparent");
+            log_err_exit ("flux_reparent");
     } else if (!strcmp (cmd, "idle")) {
         if (optind != argc)
             usage ();
         char *peers;
         if (!(peers = flux_lspeer (h, rank)))
-            err_exit ("flux_peer");
+            log_err_exit ("flux_peer");
         printf ("%s\n", peers);
         free (peers);
     } else if (!strcmp (cmd, "panic")) {
@@ -117,25 +117,25 @@ int main (int argc, char *argv[])
         if (optind != argc)
             usage ();
         if (flux_failover (h, rank) < 0)
-            err_exit ("flux_failover");
+            log_err_exit ("flux_failover");
     } else if (!strcmp (cmd, "recover")) {
         if (optind != argc)
             usage ();
         if (flux_recover (h, rank) < 0)
-            err_exit ("flux_recover");
+            log_err_exit ("flux_recover");
     } else if (!strcmp (cmd, "recover-all")) {
         if (optind != argc)
             usage ();
         if (flux_recover_all (h) < 0)
-            err_exit ("flux_recover_all");
+            log_err_exit ("flux_recover_all");
     } else if (!strcmp (cmd, "info")) {
         int arity;
         uint32_t rank, size;
         const char *s;
         if (flux_get_rank (h, &rank) < 0 || flux_get_size (h, &size) < 0)
-            err_exit ("flux_get_rank/size");
+            log_err_exit ("flux_get_rank/size");
         if (!(s = flux_attr_get (h, "tbon.arity", NULL)))
-            err_exit ("flux_attr_get tbon.arity");
+            log_err_exit ("flux_attr_get tbon.arity");
         arity = strtoul (s, NULL, 10);
         printf ("rank=%d\n", rank);
         printf ("size=%d\n", size);

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -107,7 +107,7 @@ int main (int argc, char *argv[])
         size_t len = 0;
         if (optind < argc) {
             if ((e = argz_create (argv + optind, &msg, &len)) != 0)
-                errn_exit (e, "argz_create");
+                log_errn_exit (e, "argz_create");
             argz_stringify (msg, len, ' ');
         }
         flux_panic (h, rank, msg);

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -103,7 +103,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
         size_t len = 0;
         json_object *o;
         if ((e = argz_create (argv + n + 1, &json_str, &len)) != 0)
-            errn_exit (e, "argz_create");
+            log_errn_exit (e, "argz_create");
         argz_stringify (json_str, len, ' ');
         if (*json_str != '{' || !(o = json_tokener_parse (json_str)))
             log_msg_exit ("JSON argument must be a valid JSON object");

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -106,7 +106,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
             errn_exit (e, "argz_create");
         argz_stringify (json_str, len, ' ');
         if (*json_str != '{' || !(o = json_tokener_parse (json_str)))
-            msg_exit ("JSON argument must be a valid JSON object");
+            log_msg_exit ("JSON argument must be a valid JSON object");
         json_object_put (o);
     }
     if (!(msg = flux_event_encode (topic, json_str))

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -49,7 +49,7 @@ int main (int argc, char *argv[])
 
     log_init ("flux-event");
     if (!(p = optparse_create ("flux-event")))
-        err_exit ("optparse_create");
+        log_err_exit ("optparse_create");
 
     event_pub_register (p);
     event_sub_register (p);
@@ -61,11 +61,11 @@ int main (int argc, char *argv[])
     }
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     optparse_set_data (p, "handle", h);
     if (optparse_run_subcommand (p, argc, argv) < 0)
-        err_exit ("subcommand");
+        log_err_exit ("subcommand");
 
     flux_close (h);
     optparse_destroy (p);
@@ -77,9 +77,9 @@ static void event_pub_register (optparse_t *parent)
 {
     optparse_t *p = optparse_add_subcommand (parent, "pub", event_pub);
     if (p == NULL)
-        err_exit ("optparse_add_subcommand");
+        log_err_exit ("optparse_add_subcommand");
     if (optparse_set (p, OPTPARSE_USAGE, "topic [json]") != OPTPARSE_SUCCESS)
-        err_exit ("optparse_set (USAGE)");
+        log_err_exit ("optparse_set (USAGE)");
 }
 
 static int event_pub (optparse_t *p, int argc, char **argv)
@@ -96,7 +96,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
     }
 
     if (!(h = optparse_get_data (p, "handle")))
-        err_exit ("failed to get handle");
+        log_err_exit ("failed to get handle");
 
     n = optparse_optind (p);
     if (n < argc - 1) {
@@ -111,7 +111,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
     }
     if (!(msg = flux_event_encode (topic, json_str))
               || flux_send (h, msg, 0) < 0)
-        err_exit ("sending event");
+        log_err_exit ("sending event");
     if (json_str)
         free (json_str);
     flux_msg_destroy (msg);
@@ -123,7 +123,7 @@ static void subscribe_all (flux_t h, int tc, char **tv)
     int i;
     for (i = 0; i < tc; i++) {
         if (flux_event_subscribe (h, tv[i]) < 0)
-            err_exit ("flux_event_subscribe");
+            log_err_exit ("flux_event_subscribe");
     }
 }
 
@@ -132,7 +132,7 @@ static void unsubscribe_all (flux_t h, int tc, char **tv)
     int i;
     for (i = 0; i < tc; i++) {
         if (flux_event_unsubscribe (h, tv[i]) < 0)
-            err_exit ("flux_event_unsubscribe");
+            log_err_exit ("flux_event_unsubscribe");
     }
 }
 
@@ -153,14 +153,14 @@ void event_sub_register (optparse_t *op)
     };
 
     if (!(p = optparse_add_subcommand (op, "sub", event_sub)))
-        err_exit ("optparse_add_subcommand");
+        log_err_exit ("optparse_add_subcommand");
 
     if (optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS)
-        err_exit ("event sub: optparse_add_option_table");
+        log_err_exit ("event sub: optparse_add_option_table");
 
     e = optparse_set (p, OPTPARSE_USAGE, "[options] [topic...]");
     if (e != OPTPARSE_SUCCESS)
-        err_exit ("optparse_set (USAGE) failed");
+        log_err_exit ("optparse_set (USAGE) failed");
 }
 
 static int event_sub (optparse_t *p, int argc, char **argv)
@@ -171,7 +171,7 @@ static int event_sub (optparse_t *p, int argc, char **argv)
     bool raw = false;
 
     if (!(h = optparse_get_data (p, "handle")))
-        err_exit ("failed to get handle");
+        log_err_exit ("failed to get handle");
 
     /* Since output is line-based with undeterministic amount of time
      * between lines, force stdout to be line buffered so our output
@@ -183,7 +183,7 @@ static int event_sub (optparse_t *p, int argc, char **argv)
     if (n < argc)
         subscribe_all (h, argc - n, argv + n);
     else if (flux_event_subscribe (h, "") < 0)
-        err_exit ("flux_event_subscribe");
+        log_err_exit ("flux_event_subscribe");
 
     n = 0;
     count = optparse_get_int (p, "count", 0);
@@ -212,7 +212,7 @@ static int event_sub (optparse_t *p, int argc, char **argv)
     if (argc > 1)
         unsubscribe_all (h, argc - 1, argv + 1);
     else if (flux_event_unsubscribe (h, "") < 0)
-        err_exit ("flux_event_subscribe");
+        log_err_exit ("flux_event_subscribe");
     return (0);
 }
 

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -260,7 +260,7 @@ int main (int argc, char *argv[])
     if (!(h = flux_open  (NULL, 0)))
         err_exit ("flux_open");
 
-    flux_log_set_facility (h, "jstat");
+    flux_log_set_appname (h, "jstat");
     cmd = argv[optind++];
 
     if (!strcmp ("notify", cmd))

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -258,7 +258,7 @@ int main (int argc, char *argv[])
         usage (1);
 
     if (!(h = flux_open  (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     flux_log_set_appname (h, "jstat");
     cmd = argv[optind++];

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -85,9 +85,9 @@ int main (int argc, char *argv[])
     if (secdir)
         flux_sec_set_directory (sec, secdir);
     if (plain && flux_sec_enable (sec, FLUX_SEC_TYPE_PLAIN) < 0)
-        msg_exit ("PLAIN security is not available");
+        log_msg_exit ("PLAIN security is not available");
     if (flux_sec_keygen (sec, force, true) < 0)
-        msg_exit ("%s", flux_sec_errstr (sec));
+        log_msg_exit ("%s", flux_sec_errstr (sec));
     flux_sec_destroy (sec);
 
     log_fini ();

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -81,7 +81,7 @@ int main (int argc, char *argv[])
         usage ();
 
      if (!(sec = flux_sec_create ()))
-        err_exit ("flux_sec_create");
+        log_err_exit ("flux_sec_create");
     if (secdir)
         flux_sec_set_directory (sec, secdir);
     if (plain && flux_sec_enable (sec, FLUX_SEC_TYPE_PLAIN) < 0)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -566,7 +566,7 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
     rc = kvs_get_dir (h, &dir, "%s", key);
     while (rc == 0 || (rc < 0 && errno == ENOENT)) {
         if (rc < 0) {
-            printf ("%s: %s\n", key, strerror (errno));
+            printf ("%s: %s\n", key, flux_strerror (errno));
             if (dir)
                 kvsdir_destroy (dir);
             dir = NULL;

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -173,12 +173,12 @@ void cmd_type (flux_t h, int argc, char **argv)
     int i;
 
     if (argc == 0)
-        msg_exit ("get-type: specify one or more keys");
+        log_msg_exit ("get-type: specify one or more keys");
     for (i = 0; i < argc; i++) {
         if (kvs_get (h, argv[i], &json_str) < 0)
             err_exit ("%s", argv[i]);
         if (!(o = Jfromstr (json_str)))
-            msg_exit ("%s: malformed JSON", argv[i]);
+            log_msg_exit ("%s: malformed JSON", argv[i]);
         const char *type = "unknown";
         switch (json_object_get_type (o)) {
             case json_type_null:
@@ -216,12 +216,12 @@ void cmd_get (flux_t h, int argc, char **argv)
     int i;
 
     if (argc == 0)
-        msg_exit ("get: specify one or more keys");
+        log_msg_exit ("get: specify one or more keys");
     for (i = 0; i < argc; i++) {
         if (kvs_get (h, argv[i], &json_str) < 0)
             err_exit ("%s", argv[i]);
         if (!(o = Jfromstr (json_str)))
-            msg_exit ("%s: malformed JSON", argv[i]);
+            log_msg_exit ("%s: malformed JSON", argv[i]);
         switch (json_object_get_type (o)) {
             case json_type_null:
                 printf ("nil\n");
@@ -254,12 +254,12 @@ void cmd_put (flux_t h, int argc, char **argv)
     int i;
 
     if (argc == 0)
-        msg_exit ("put: specify one or more key=value pairs");
+        log_msg_exit ("put: specify one or more key=value pairs");
     for (i = 0; i < argc; i++) {
         char *key = xstrdup (argv[i]);
         char *val = strchr (key, '=');
         if (!val)
-            msg_exit ("put: you must specify a value as key=value");
+            log_msg_exit ("put: you must specify a value as key=value");
         *val++ = '\0';
         if (kvs_put (h, key, val) < 0) {
             if (errno != EINVAL || kvs_put_string (h, key, val) < 0)
@@ -276,7 +276,7 @@ void cmd_unlink (flux_t h, int argc, char **argv)
     int i;
 
     if (argc == 0)
-        msg_exit ("unlink: specify one or more keys");
+        log_msg_exit ("unlink: specify one or more keys");
     for (i = 0; i < argc; i++) {
         /* FIXME: unlink nonexistent silently fails */
         /* FIXME: unlink directory silently succedes */
@@ -290,7 +290,7 @@ void cmd_unlink (flux_t h, int argc, char **argv)
 void cmd_link (flux_t h, int argc, char **argv)
 {
     if (argc != 2)
-        msg_exit ("link: specify target and link_name");
+        log_msg_exit ("link: specify target and link_name");
     if (kvs_symlink (h, argv[1], argv[0]) < 0)
         err_exit ("%s", argv[1]);
     if (kvs_commit (h) < 0)
@@ -303,7 +303,7 @@ void cmd_readlink (flux_t h, int argc, char **argv)
     char *target;
 
     if (argc == 0)
-        msg_exit ("readlink: specify one or more keys"); 
+        log_msg_exit ("readlink: specify one or more keys"); 
     for (i = 0; i < argc; i++) {
         if (kvs_get_symlink (h, argv[i], &target) < 0)
             err_exit ("%s", argv[i]);
@@ -318,7 +318,7 @@ void cmd_mkdir (flux_t h, int argc, char **argv)
     int i;
 
     if (argc == 0)
-        msg_exit ("mkdir: specify one or more directories");
+        log_msg_exit ("mkdir: specify one or more directories");
     for (i = 0; i < argc; i++) {
         if (kvs_mkdir (h, argv[i]) < 0)
             err_exit ("%s", argv[i]);
@@ -347,7 +347,7 @@ void cmd_exists (flux_t h, int argc, char **argv)
 {
     int i;
     if (argc == 0)
-        msg_exit ("exist: specify one or more keys");
+        log_msg_exit ("exist: specify one or more keys");
     for (i = 0; i < argc; i++) {
         if (!key_exists (h, argv[i]))
             exit (1);
@@ -358,7 +358,7 @@ void cmd_version (flux_t h, int argc, char **argv)
 {
     int vers;
     if (argc != 0)
-        msg_exit ("version: takes no arguments");
+        log_msg_exit ("version: takes no arguments");
     if (kvs_get_version (h, &vers) < 0)
         err_exit ("kvs_get_version");
     printf ("%d\n", vers);
@@ -368,7 +368,7 @@ void cmd_wait (flux_t h, int argc, char **argv)
 {
     int vers;
     if (argc != 1)
-        msg_exit ("wait: specify a version");
+        log_msg_exit ("wait: specify a version");
     vers = strtoul (argv[0], NULL, 10);
     if (kvs_wait_version (h, vers) < 0)
         err_exit ("kvs_get_version");
@@ -381,7 +381,7 @@ void cmd_watch (flux_t h, int argc, char **argv)
     char *key;
 
     if (argc != 1)
-        msg_exit ("watch: specify one key");
+        log_msg_exit ("watch: specify one key");
     key = argv[0];
     if (kvs_get (h, key, &json_str) < 0 && errno != ENOENT) 
         err_exit ("%s", key);
@@ -395,7 +395,7 @@ void cmd_watch (flux_t h, int argc, char **argv)
 void cmd_dropcache (flux_t h, int argc, char **argv)
 {
     if (argc != 0)
-        msg_exit ("dropcache: takes no arguments");
+        log_msg_exit ("dropcache: takes no arguments");
     if (kvs_dropcache (h) < 0)
         err_exit ("kvs_dropcache");
 }
@@ -403,7 +403,7 @@ void cmd_dropcache (flux_t h, int argc, char **argv)
 void cmd_dropcache_all (flux_t h, int argc, char **argv)
 {
     if (argc != 0)
-        msg_exit ("dropcache-all: takes no arguments");
+        log_msg_exit ("dropcache-all: takes no arguments");
     flux_msg_t *msg = flux_event_encode ("kvs.dropcache", NULL);
     if (!msg || flux_send (h, msg, 0) < 0)
         err_exit ("flux_send");
@@ -418,7 +418,7 @@ void cmd_copy_tokvs (flux_t h, int argc, char **argv)
     JSON o;
 
     if (argc != 2)
-        msg_exit ("copy-tokvs: specify key and filename");
+        log_msg_exit ("copy-tokvs: specify key and filename");
     key = argv[0];
     file = argv[1];
     if (!strcmp (file, "-")) {
@@ -450,13 +450,13 @@ void cmd_copy_fromkvs (flux_t h, int argc, char **argv)
     char *json_str;
 
     if (argc != 2)
-        msg_exit ("copy-fromkvs: specify key and filename");
+        log_msg_exit ("copy-fromkvs: specify key and filename");
     key = argv[0];
     file = argv[1];
     if (kvs_get (h, key, &json_str) < 0)
         err_exit ("%s", key);
     if (!(o = Jfromstr (json_str)))
-        msg_exit ("%s: invalid JSON", key);
+        log_msg_exit ("%s: invalid JSON", key);
     if (base64_json_decode (Jobj_get (o, "data"), &buf, &len) < 0)
         err_exit ("%s: decode error", key);
     if (!strcmp (file, "-")) {
@@ -560,7 +560,7 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
         argv++;
     }
     if (argc != 1)
-        msg_exit ("watchdir: specify one directory");
+        log_msg_exit ("watchdir: specify one directory");
     key = argv[0];
 
     rc = kvs_get_dir (h, &dir, "%s", key);
@@ -594,14 +594,14 @@ void cmd_dir (flux_t h, int argc, char **argv)
     else if (argc == 1)
         dump_kvs_dir (h, ropt, argv[0]);
     else
-        msg_exit ("dir: specify zero or one directory");
+        log_msg_exit ("dir: specify zero or one directory");
 }
 
 void cmd_dirsize (flux_t h, int argc, char **argv)
 {
     kvsdir_t *dir = NULL;
     if (argc != 1)
-        msg_exit ("dirsize: specify one directory");
+        log_msg_exit ("dirsize: specify one directory");
     if (kvs_get_dir (h, &dir, "%s", argv[0]) < 0)
         err_exit ("%s", argv[0]);
     printf ("%d\n", kvsdir_get_size (dir));
@@ -611,7 +611,7 @@ void cmd_dirsize (flux_t h, int argc, char **argv)
 void cmd_copy (flux_t h, int argc, char **argv)
 {
     if (argc != 2)
-        msg_exit ("copy: specify srckey dstkey");
+        log_msg_exit ("copy: specify srckey dstkey");
     if (kvs_copy (h, argv[0], argv[1]) < 0)
         err_exit ("kvs_copy %s %s", argv[0], argv[1]);
     if (kvs_commit (h) < 0)
@@ -621,7 +621,7 @@ void cmd_copy (flux_t h, int argc, char **argv)
 void cmd_move (flux_t h, int argc, char **argv)
 {
     if (argc != 2)
-        msg_exit ("move: specify srckey dstkey");
+        log_msg_exit ("move: specify srckey dstkey");
     if (kvs_move (h, argv[0], argv[1]) < 0)
         err_exit ("kvs_move %s %s", argv[0], argv[1]);
     if (kvs_commit (h) < 0)

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -83,7 +83,7 @@ int main (int argc, char *argv[])
         usage ();
 
     if ((e = argz_create (argv + optind, &message, &len)) != 0)
-        errn_exit (e, "argz_create");
+        log_errn_exit (e, "argz_create");
     argz_stringify (message, len, ' ');
 
     if (!(h = flux_open (NULL, 0)))

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -87,7 +87,7 @@ int main (int argc, char *argv[])
     argz_stringify (message, len, ' ');
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     flux_log_set_appname (h, appname);
     flux_log (h, severity, "%s", message);

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -35,6 +35,7 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/readall.h"
 #include "src/common/libutil/nodeset.h"
 #include "src/common/libutil/iterators.h"

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -138,9 +138,9 @@ int main (int argc, char *argv[])
 
     if (strcmp (cmd, "info") != 0) {
         if (!(h = flux_open (NULL, 0)))
-            err_exit ("flux_open");
+            log_err_exit ("flux_open");
         if (!(opt.nodeset = flux_get_nodeset (h, rankopt, excludeopt)))
-            err_exit ("--exclude/--rank");
+            log_err_exit ("--exclude/--rank");
         if (strlen (opt.nodeset) == 0)
             exit (0);
     }
@@ -179,7 +179,7 @@ void parse_modarg (const char *arg, char **name, char **path)
 
     if (strchr (arg, '/')) {
         if (!(modpath = realpath (arg, NULL)))
-            err_exit ("%s", arg);
+            log_err_exit ("%s", arg);
         if (!(modname = flux_modname (modpath)))
             log_msg_exit ("%s", dlerror ());
     } else {
@@ -246,7 +246,7 @@ void mod_insmod (flux_t h, opt_t opt)
     assert (json_str != NULL);
     flux_rpc_t *r = flux_rpc_multi (h, topic, json_str, opt.nodeset, 0);
     if (!r)
-        err_exit ("%s", topic);
+        log_err_exit ("%s", topic);
     while (!flux_rpc_completed (r)) {
         uint32_t nodeid = FLUX_NODEID_ANY;
         if (flux_rpc_get (r, &nodeid, NULL) < 0) {
@@ -254,9 +254,9 @@ void mod_insmod (flux_t h, opt_t opt)
                 log_msg ("%s[%" PRIu32 "]: %s module/service is in use",
                      topic, nodeid, modname);
             else if (nodeid != FLUX_NODEID_ANY)
-                err ("%s[%" PRIu32 "]", topic, nodeid);
+                log_err ("%s[%" PRIu32 "]", topic, nodeid);
             else
-                err ("%s", topic);
+                log_err ("%s", topic);
             errors++;
         }
     }
@@ -284,11 +284,11 @@ void mod_rmmod (flux_t h, opt_t opt)
     assert (json_str != NULL);
     flux_rpc_t *r = flux_rpc_multi (h, topic, json_str, opt.nodeset, 0);
     if (!r)
-        err_exit ("%s %s", topic, modname);
+        log_err_exit ("%s %s", topic, modname);
     while (!flux_rpc_completed (r)) {
         uint32_t nodeid = FLUX_NODEID_ANY;
         if (flux_rpc_get (r, &nodeid, NULL) < 0)
-            err ("%s[%d] %s",
+            log_err ("%s[%d] %s",
                  topic, nodeid == FLUX_NODEID_ANY ? -1 : nodeid,
                  modname);
     }
@@ -440,16 +440,16 @@ void mod_lsmod (flux_t h, opt_t opt)
     char *topic = xasprintf ("%s.lsmod", service);
     flux_rpc_t *r = flux_rpc_multi (h, topic, NULL, opt.nodeset, 0);
     if (!r)
-        err_exit ("%s", topic);
+        log_err_exit ("%s", topic);
     while (!flux_rpc_completed (r)) {
         const char *json_str;
         uint32_t nodeid = FLUX_NODEID_ANY;
         if (flux_rpc_get (r, &nodeid, &json_str) < 0
                 || lsmod_merge_result (nodeid, json_str, mods) < 0) {
             if (nodeid != FLUX_NODEID_ANY)
-                err ("%s[%" PRIu32 "]", topic, nodeid);
+                log_err ("%s[%" PRIu32 "]", topic, nodeid);
             else
-                err ("%s", topic);
+                log_err ("%s", topic);
         }
     }
     flux_rpc_destroy (r);

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -134,7 +134,7 @@ int main (int argc, char *argv[])
     opt.argv = argv + optind;
 
     if (!(f = func_lookup (cmd)))
-        msg_exit ("unknown function '%s'", cmd);
+        log_msg_exit ("unknown function '%s'", cmd);
 
     if (strcmp (cmd, "info") != 0) {
         if (!(h = flux_open (NULL, 0)))
@@ -181,14 +181,14 @@ void parse_modarg (const char *arg, char **name, char **path)
         if (!(modpath = realpath (arg, NULL)))
             err_exit ("%s", arg);
         if (!(modname = flux_modname (modpath)))
-            msg_exit ("%s", dlerror ());
+            log_msg_exit ("%s", dlerror ());
     } else {
         char *searchpath = getenv ("FLUX_MODULE_PATH");
         if (!searchpath)
-            msg_exit ("FLUX_MODULE_PATH is not set");
+            log_msg_exit ("FLUX_MODULE_PATH is not set");
         modname = xstrdup (arg);
         if (!(modpath = flux_modfind (searchpath, modname)))
-            msg_exit ("%s: not found in module search path", modname);
+            log_msg_exit ("%s: not found in module search path", modname);
     }
     *name = modname;
     *path = modpath;
@@ -251,7 +251,7 @@ void mod_insmod (flux_t h, opt_t opt)
         uint32_t nodeid = FLUX_NODEID_ANY;
         if (flux_rpc_get (r, &nodeid, NULL) < 0) {
             if (errno == EEXIST && nodeid != FLUX_NODEID_ANY)
-                msg ("%s[%" PRIu32 "]: %s module/service is in use",
+                log_msg ("%s[%" PRIu32 "]: %s module/service is in use",
                      topic, nodeid, modname);
             else if (nodeid != FLUX_NODEID_ANY)
                 err ("%s[%" PRIu32 "]", topic, nodeid);

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -218,7 +218,7 @@ int main (int argc, char *argv[])
     if (optind != argc - 1)
         usage ();
     if (ctx.batch && ctx.count == -1)
-        msg_exit ("--batch should only be used with --count");
+        log_msg_exit ("--batch should only be used with --count");
     target = argv[optind++];
 
     /* Create null terminated pad string for reuse in each message.

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -84,7 +84,7 @@ void ping_continuation (flux_rpc_t *rpc, void *arg)
     tstat_t *tstat = flux_rpc_aux_get (rpc);
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0) {
-        err ("flux_rpc_get");
+        log_err ("flux_rpc_get");
         goto done;
     }
     if (!(out = Jfromstr (json_str))
@@ -94,7 +94,7 @@ void ping_continuation (flux_rpc_t *rpc, void *arg)
             || !Jget_str (out, "pad", &pad)
             || !Jget_str (out, "route", &route)
             || strcmp (ctx->pad, pad) != 0) {
-        err ("error decoding ping response");
+        log_err ("error decoding ping response");
         goto done;
     }
     t0.tv_sec = sec;
@@ -143,10 +143,10 @@ void send_ping (struct ping_ctx *ctx)
     else
         rpc = flux_rpc (ctx->h, ctx->topic, Jtostr (in), ctx->nodeid, 0);
     if (!rpc)
-        err_exit ("flux_rpc");
+        log_err_exit ("flux_rpc");
     flux_rpc_aux_set (rpc, tstat, free);
     if (flux_rpc_then (rpc, ping_continuation, ctx) < 0)
-        err_exit ("flux_rpc_then");
+        log_err_exit ("flux_rpc_then");
 
     Jput (in);
 
@@ -263,9 +263,9 @@ int main (int argc, char *argv[])
     ctx.topic = xasprintf ("%s.ping", target);
 
     if (!(ctx.h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(ctx.reactor = flux_get_reactor (ctx.h)))
-        err_exit ("flux_get_reactor");
+        log_err_exit ("flux_get_reactor");
 
     /* In batch mode, requests are sent before reactor is started
      * to process responses.  o/w requests are set in a timer watcher.
@@ -279,11 +279,11 @@ int main (int argc, char *argv[])
         tw = flux_timer_watcher_create (ctx.reactor, ctx.period, ctx.period,
                                         timer_cb, &ctx);
         if (!tw)
-            err_exit ("error creating watchers");
+            log_err_exit ("error creating watchers");
         flux_watcher_start (tw);
     }
     if (flux_reactor_run (ctx.reactor, 0) < 0)
-        err_exit ("flux_reactor_run");
+        log_err_exit ("flux_reactor_run");
 
     /* Clean up.
      */

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -129,15 +129,15 @@ int main (int argc, char *argv[])
         log_msg_exit ("FLUX_SEC_DIRECTORY is not set");
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!(uri = flux_attr_get (h, "snoop-uri", NULL)))
-        err_exit ("snoop-uri");
+        log_err_exit ("snoop-uri");
 
     /* N.B. flux_get_zctx () is not implemented for the API socket since
      * it has no internal zctx (despite supporting the flux reactor).
      */
     if (!(zctx = zctx_new ()))
-        err_exit ("zctx_new");
+        log_err_exit ("zctx_new");
     zctx_set_linger (zctx, 5);
 
     /* N.B. We use the zloop reactor and handle disconnects via zmonitor.
@@ -151,11 +151,11 @@ int main (int argc, char *argv[])
     /* Initialize security ctx.
      */
     if (!(sec = flux_sec_create ()))
-        err_exit ("flux_sec_create");
+        log_err_exit ("flux_sec_create");
     flux_sec_set_directory (sec, secdir);
     if (nopt) {
         if (flux_sec_disable (sec, FLUX_SEC_TYPE_ALL) < 0)
-            err_exit ("flux_sec_disable");
+            log_err_exit ("flux_sec_disable");
         log_msg ("Security is disabled");
     }
     if (flux_sec_zauth_init (sec, zctx, session) < 0)
@@ -167,25 +167,25 @@ int main (int argc, char *argv[])
         log_msg ("connecting to %s...", uri);
 
     if (!(s = connect_snoop (zctx, sec, uri)))
-        err_exit ("%s", uri);
+        log_err_exit ("%s", uri);
     zp.socket = s;
     zp.events = ZMQ_POLLIN;
     if (zloop_poller (zloop, &zp, snoop_cb, NULL) < 0)
-        err_exit ("zloop_poller");
+        log_err_exit ("zloop_poller");
     zsocket_set_subscribe (s, "");
 
     zmonitor_t *zmon;
     if (!(zmon = zmonitor_new (zctx, s, ZMQ_EVENT_DISCONNECTED)))
-        err_exit ("zmonitor_new");
+        log_err_exit ("zmonitor_new");
     if (vopt)
         zmonitor_set_verbose (zmon, true);
     zp.socket = zmonitor_socket (zmon);
     zp.events = ZMQ_POLLIN;
     if (zloop_poller (zloop, &zp, zmon_cb, NULL) < 0)
-        err_exit ("zloop_poller");
+        log_err_exit ("zloop_poller");
 
     if ((zloop_start (zloop) < 0) && (count != maxcount))
-        err_exit ("zloop_start");
+        log_err_exit ("zloop_start");
     if (vopt)
         log_msg ("disconnecting");
 
@@ -205,11 +205,11 @@ static void *connect_snoop (zctx_t *zctx, flux_sec_t sec, const char *uri)
     void *s;
 
     if (!(s = zsocket_new (zctx, ZMQ_SUB)))
-        err_exit ("zsocket_new");
+        log_err_exit ("zsocket_new");
     if (flux_sec_csockinit (sec, s) < 0)
         log_msg_exit ("flux_sec_csockinit: %s", flux_sec_errstr (sec));
     if (zsocket_connect (s, "%s", uri) < 0)
-        err_exit ("%s", uri);
+        log_err_exit ("%s", uri);
 
     return s;
 }

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -102,7 +102,7 @@ int main (int argc, char *argv[])
             case 'c': /* --count N */
                 maxcount = atoi (optarg);
                 if (maxcount < 0 || maxcount > INT_MAX)
-                    msg_exit ("--count: invalid arg: '%s'", optarg);
+                    log_msg_exit ("--count: invalid arg: '%s'", optarg);
                 break;
             case 'l': /* --long */
                 lopt = true;
@@ -126,7 +126,7 @@ int main (int argc, char *argv[])
             oom ();
     }
     if (!(secdir = getenv ("FLUX_SEC_DIRECTORY")))
-        msg_exit ("FLUX_SEC_DIRECTORY is not set");
+        log_msg_exit ("FLUX_SEC_DIRECTORY is not set");
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
@@ -156,15 +156,15 @@ int main (int argc, char *argv[])
     if (nopt) {
         if (flux_sec_disable (sec, FLUX_SEC_TYPE_ALL) < 0)
             err_exit ("flux_sec_disable");
-        msg ("Security is disabled");
+        log_msg ("Security is disabled");
     }
     if (flux_sec_zauth_init (sec, zctx, session) < 0)
-        msg_exit ("flux_sec_zinit: %s", flux_sec_errstr (sec));
+        log_msg_exit ("flux_sec_zinit: %s", flux_sec_errstr (sec));
 
     /* Connect to the snoop socket
      */
     if (vopt)
-        msg ("connecting to %s...", uri);
+        log_msg ("connecting to %s...", uri);
 
     if (!(s = connect_snoop (zctx, sec, uri)))
         err_exit ("%s", uri);
@@ -187,7 +187,7 @@ int main (int argc, char *argv[])
     if ((zloop_start (zloop) < 0) && (count != maxcount))
         err_exit ("zloop_start");
     if (vopt)
-        msg ("disconnecting");
+        log_msg ("disconnecting");
 
     zmonitor_destroy (&zmon);
 
@@ -207,7 +207,7 @@ static void *connect_snoop (zctx_t *zctx, flux_sec_t sec, const char *uri)
     if (!(s = zsocket_new (zctx, ZMQ_SUB)))
         err_exit ("zsocket_new");
     if (flux_sec_csockinit (sec, s) < 0)
-        msg_exit ("flux_sec_csockinit: %s", flux_sec_errstr (sec));
+        log_msg_exit ("flux_sec_csockinit: %s", flux_sec_errstr (sec));
     if (zsocket_connect (s, "%s", uri) < 0)
         err_exit ("%s", uri);
 
@@ -272,7 +272,7 @@ static int zmon_cb (zloop_t *zloop, zmq_pollitem_t *item, void *arg)
             free (s);
         }
         if (event == ZMQ_EVENT_DISCONNECTED)
-            msg_exit ("lost connection");
+            log_msg_exit ("lost connection");
         zmsg_destroy (&zmsg);
     }
     return 0;

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -30,6 +30,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 
 
 #define OPTIONS "hanN:vlc:"

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -35,6 +35,7 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/optparse.h"
 #include "src/common/libutil/cleanup.h"
 #include "src/common/libpmi-server/simple.h"

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -110,15 +110,15 @@ int main (int argc, char *argv[])
 
     ctx->opts = optparse_create ("flux-start");
     if (optparse_add_option_table (ctx->opts, opts) != OPTPARSE_SUCCESS)
-        msg_exit ("optparse_add_option_table");
+        log_msg_exit ("optparse_add_option_table");
     if (optparse_set (ctx->opts, OPTPARSE_USAGE, usage_msg) != OPTPARSE_SUCCESS)
-        msg_exit ("optparse_set usage");
+        log_msg_exit ("optparse_set usage");
     if ((optind = optparse_parse_args (ctx->opts, argc, argv)) < 0)
         exit (1);
     ctx->killer_timeout = strtod (optparse_get_str (ctx->opts, "killer-timeout",
                                                     default_killer_timeout), NULL);
     if (ctx->killer_timeout < 0.)
-        msg_exit ("--killer-timeout argument must be >= 0");
+        log_msg_exit ("--killer-timeout argument must be >= 0");
     if (optind < argc) {
         if ((e = argz_create (argv + optind, &command, &len)) != 0)
             errn_exit (e, "argz_creawte");
@@ -126,9 +126,9 @@ int main (int argc, char *argv[])
     }
 
     if (!(searchpath = getenv ("FLUX_EXEC_PATH")))
-        msg_exit ("FLUX_EXEC_PATH is not set");
+        log_msg_exit ("FLUX_EXEC_PATH is not set");
     if (!(ctx->broker_path = find_broker (searchpath)))
-        msg_exit ("Could not locate broker in %s", searchpath);
+        log_msg_exit ("Could not locate broker in %s", searchpath);
 
     ctx->size = optparse_get_int (ctx->opts, "size", default_size);
 
@@ -186,20 +186,20 @@ static int child_report (struct subprocess *p)
     int sig;
 
     if ((sig = subprocess_stopped (p)))
-        msg ("%d (pid %d) %s", cli->rank, pid, strsignal (sig));
+        log_msg ("%d (pid %d) %s", cli->rank, pid, strsignal (sig));
     else if ((subprocess_continued (p)))
-        msg ("%d (pid %d) %s", cli->rank, pid, strsignal (SIGCONT));
+        log_msg ("%d (pid %d) %s", cli->rank, pid, strsignal (SIGCONT));
     else if ((sig = subprocess_signaled (p)))
-        msg ("%d (pid %d) %s", cli->rank, pid, strsignal (sig));
+        log_msg ("%d (pid %d) %s", cli->rank, pid, strsignal (sig));
     else if (subprocess_exited (p)) {
         int rc = subprocess_exit_code (p);
         if (rc >= 128)
-            msg ("%d (pid %d) exited with rc=%d (%s)", cli->rank, pid, rc,
+            log_msg ("%d (pid %d) exited with rc=%d (%s)", cli->rank, pid, rc,
                                                        strsignal (rc - 128));
         else if (rc > 0)
-            msg ("%d (pid %d) exited with rc=%d", cli->rank, pid, rc);
+            log_msg ("%d (pid %d) exited with rc=%d", cli->rank, pid, rc);
     } else
-        msg ("%d (pid %d) status=%d", cli->rank, pid,
+        log_msg ("%d (pid %d) status=%d", cli->rank, pid,
                                       subprocess_exit_status (p));
     return 0;
 }
@@ -375,7 +375,7 @@ int exec_broker (struct context *ctx, const char *cmd)
             goto nomem;
         memcpy (cpy, argz, argz_len);
         argz_stringify (cpy, argz_len, ' ');
-        msg ("%s", cpy);
+        log_msg ("%s", cpy);
         free (cpy);
     }
     if (!optparse_hasopt (ctx->opts, "noexec")) {
@@ -458,7 +458,7 @@ void client_dumpargs (struct client *cli)
         if ((e = argz_add (&az, &az_len, subprocess_get_arg (cli->p, i))) != 0)
             errn_exit (e, "argz_add");
     argz_stringify (az, az_len, ' ');
-    msg ("%d: %s", cli->rank, az);
+    log_msg ("%d: %s", cli->rank, az);
     free (az);
 }
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -121,7 +121,7 @@ int main (int argc, char *argv[])
         log_msg_exit ("--killer-timeout argument must be >= 0");
     if (optind < argc) {
         if ((e = argz_create (argv + optind, &command, &len)) != 0)
-            errn_exit (e, "argz_creawte");
+            log_errn_exit (e, "argz_creawte");
         argz_stringify (command, len, ' ');
     }
 
@@ -456,7 +456,7 @@ void client_dumpargs (struct client *cli)
 
     for (i = 0; i < argc; i++)
         if ((e = argz_add (&az, &az_len, subprocess_get_arg (cli->p, i))) != 0)
-            errn_exit (e, "argz_add");
+            log_errn_exit (e, "argz_add");
     argz_stringify (az, az_len, ' ');
     log_msg ("%d: %s", cli->rank, az);
     free (az);

--- a/src/cmd/flux-up.c
+++ b/src/cmd/flux-up.c
@@ -114,7 +114,7 @@ int main (int argc, char *argv[])
         usage ();
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     if (!(ns = ns_fromkvs (h)))
         ns = ns_guess (h);
@@ -179,9 +179,9 @@ static ns_t *ns_guess (flux_t h)
     uint32_t size, rank;
 
     if (flux_get_rank (h, &rank) < 0)
-        err_exit ("flux_get_rank");
+        log_err_exit ("flux_get_rank");
     if (flux_get_size (h, &size) < 0)
-        err_exit ("flux_get_size");
+        log_err_exit ("flux_get_size");
     ns->ok = nodeset_create ();
     ns->slow = nodeset_create ();
     ns->fail = nodeset_create ();

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -96,21 +96,21 @@ static optparse_t * setup_optparse_parse_args (int argc, char *argv[])
     optparse_set (p, OPTPARSE_USAGE, "[OPTIONS] COMMAND ARGS");
     e = optparse_add_option_table (p, opts);
     if (e != OPTPARSE_SUCCESS)
-        msg_exit ("optparse_add_option_table() failed");
+        log_msg_exit ("optparse_add_option_table() failed");
 
     // Remove automatic `--help' in favor of our own usage() from above
     e = optparse_remove_option (p, "help");
     if (e != OPTPARSE_SUCCESS)
-        msg_exit ("optparse_remove_option (\"help\")");
+        log_msg_exit ("optparse_remove_option (\"help\")");
     e = optparse_add_option (p, &helpopt);
     if (e != OPTPARSE_SUCCESS)
-        msg_exit ("optparse_add_option (\"help\")");
+        log_msg_exit ("optparse_add_option (\"help\")");
 
     // Don't print internal subcommands in --help (we print subcommands using
     //  emit_command_help() above.
     e = optparse_set (p, OPTPARSE_PRINT_SUBCMDS, 0);
     if (e != OPTPARSE_SUCCESS)
-        msg_exit ("optparse_set (OPTPARSE_PRINT_SUBCMDS");
+        log_msg_exit ("optparse_set (OPTPARSE_PRINT_SUBCMDS");
 
     register_builtin_subcommands (p);
 
@@ -310,11 +310,11 @@ void setup_keydir (struct environment *env, int flags)
     if (!dir) {
         struct passwd *pw = getpwuid (getuid ());
         if (!pw)
-            msg_exit ("Who are you!?!");
+            log_msg_exit ("Who are you!?!");
         dir = new_dir = xasprintf ("%s/.flux", pw->pw_dir);
     }
     if (!dir)
-        msg_exit ("Could not determine keydir");
+        log_msg_exit ("Could not determine keydir");
     environment_set (env, "FLUX_SEC_DIRECTORY", dir, 0);
     if (new_dir)
         free (new_dir);
@@ -328,7 +328,7 @@ void exec_subcommand_dir (bool vopt, const char *dir, char *argv[],
             dir ? "/" : "",
             prefix ? prefix : "", argv[0]);
     if (vopt)
-        msg ("trying to exec %s", path);
+        log_msg ("trying to exec %s", path);
     execvp (path, argv); /* no return if successful */
     free (path);
 }
@@ -347,7 +347,7 @@ void exec_subcommand (const char *searchpath, bool vopt, char *argv[])
             a1 = NULL;
         }
         free (cpy);
-        msg_exit ("`%s' is not a flux command.  See 'flux --help'", argv[0]);
+        log_msg_exit ("`%s' is not a flux command.  See 'flux --help'", argv[0]);
     }
 }
 
@@ -375,7 +375,7 @@ static void register_builtin_subcommands (optparse_t *p)
     struct builtin_cmd *cmd = &builtin_cmds[0];
     while (cmd->reg_fn) {
         if (cmd->reg_fn (p) < 0)
-            msg_exit ("register builtin %s failed\n", cmd->name);
+            log_msg_exit ("register builtin %s failed\n", cmd->name);
         cmd++;
     }
 }

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -77,7 +77,7 @@ void usage (optparse_t *p)
                   def ? def : "",
                   val ? ":" : "",
                   val ? val : "") < 0)
-        err_exit ("faled to get command help list!");
+        log_err_exit ("faled to get command help list!");
 
     optparse_print_usage (p);
     fprintf (stderr, "\n");
@@ -92,7 +92,7 @@ static optparse_t * setup_optparse_parse_args (int argc, char *argv[])
     };
     optparse_t *p = optparse_create ("flux");
     if (p == NULL)
-        err_exit ("optparse_create");
+        log_err_exit ("optparse_create");
     optparse_set (p, OPTPARSE_USAGE, "[OPTIONS] COMMAND ARGS");
     e = optparse_add_option_table (p, opts);
     if (e != OPTPARSE_SUCCESS)
@@ -261,7 +261,7 @@ char *dir_self (void)
     if (!exe_path_valid) {
         memset (flux_exe_path, 0, MAXPATHLEN);
         if (readlink ("/proc/self/exe", flux_exe_path, MAXPATHLEN - 1) < 0)
-            err_exit ("readlink (/proc/self/exe)");
+            log_err_exit ("readlink (/proc/self/exe)");
         flux_exe_dir = strip_trailing_dot_libs (dirname (flux_exe_path));
         exe_path_valid = true;
     }
@@ -337,7 +337,7 @@ void exec_subcommand (const char *searchpath, bool vopt, char *argv[])
 {
     if (strchr (argv[0], '/')) {
         exec_subcommand_dir (vopt, NULL, argv, NULL);
-        err_exit ("%s", argv[0]);
+        log_err_exit ("%s", argv[0]);
     } else {
         char *cpy = xstrdup (searchpath);
         char *dir, *saveptr = NULL, *a1 = cpy;
@@ -365,7 +365,7 @@ flux_t builtin_get_flux_handle (optparse_t *p)
     if ((h = optparse_get_data (p, "flux_t")))
         flux_incref (h);
     else if ((h = flux_open (NULL, 0)) == NULL)
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     return h;
 }
 

--- a/src/common/libcompat/reactor.c
+++ b/src/common/libcompat/reactor.c
@@ -37,6 +37,7 @@
 #include "src/common/libflux/message.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 
 #include "compat.h"
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -30,6 +30,9 @@
 #include <stdarg.h>
 #include <syslog.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <assert.h>
 #include <zmq.h>
 
 #include "flog.h"
@@ -39,9 +42,13 @@
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/wallclock.h"
+#include "src/common/libutil/stdlog.h"
 
 typedef struct {
-    char *facility;
+    char appname[STDLOG_MAX_APPNAME + 1];
+    char procid[STDLOG_MAX_PROCID + 1];
+    char buf[FLUX_MAX_LOGBUF + 1];
     flux_log_f cb;
     void *cb_arg;
 } logctx_t;
@@ -49,8 +56,6 @@ typedef struct {
 static void freectx (void *arg)
 {
     logctx_t *ctx = arg;
-    if (ctx->facility)
-        free (ctx->facility);
     free (ctx);
 }
 
@@ -60,20 +65,25 @@ static logctx_t *getctx (flux_t h)
 
     if (!ctx) {
         ctx = xzmalloc (sizeof (*ctx));
-        ctx->facility = xstrdup ("unknown");
+        snprintf (ctx->appname, sizeof (ctx->appname), "%s", STDLOG_NILVALUE);
+        snprintf (ctx->procid, sizeof (ctx->procid), "%d", getpid ());
         flux_aux_set (h, "flux::log", ctx, freectx);
     }
     return ctx;
 }
 
-void flux_log_set_facility (flux_t h, const char *facility)
+void flux_log_set_appname (flux_t h, const char *s)
 {
     logctx_t *ctx = getctx (h);
-
-    if (ctx->facility)
-        free (ctx->facility);
-    ctx->facility = xstrdup (facility);
+    snprintf (ctx->appname, sizeof (ctx->appname), "%s", s);
 }
+
+void flux_log_set_procid (flux_t h, const char *s)
+{
+    logctx_t *ctx = getctx (h);
+    snprintf (ctx->procid, sizeof (ctx->procid), "%s", s);
+}
+
 
 void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg)
 {
@@ -84,34 +94,44 @@ void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg)
 
 void flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
 {
-    int saved_errno = errno;
     logctx_t *ctx = getctx (h);
-    char *message = xvasprintf (fmt, ap);
-    struct timeval tv = { 0, 0 };
-    JSON o = NULL;
-    uint32_t rank = FLUX_NODEID_ANY;
+    int saved_errno = errno;
+    uint32_t rank;
     flux_rpc_t *rpc = NULL;
+    int n, len;
+    char timestamp[WALLCLOCK_MAXLEN];
+    char hostname[STDLOG_MAX_HOSTNAME + 1];
+    struct stdlog_header hdr;
 
-    (void)gettimeofday (&tv, NULL);
-    (void)flux_get_rank (h, &rank);
+    stdlog_init (&hdr);
+    hdr.pri = STDLOG_PRI (level, LOG_USER);
+    if (wallclock_get_zulu (timestamp, sizeof (timestamp)) >= 0)
+        hdr.timestamp = timestamp;
+    if (flux_get_rank (h, &rank) == 0) {
+        snprintf (hostname, sizeof (hostname), "%" PRIu32, rank);
+        hdr.hostname = hostname;
+    }
+    hdr.appname = ctx->appname;
+    hdr.procid = ctx->procid;
+
+    len = stdlog_encode (ctx->buf, sizeof (ctx->buf), &hdr,
+                         STDLOG_NILVALUE, "");
+    assert (len < sizeof (ctx->buf));
+
+    n = vsnprintf (ctx->buf + len, sizeof (ctx->buf) - len, fmt, ap);
+    if (n > sizeof (ctx->buf) - len) /* ignore truncation of message */
+        n = sizeof (ctx->buf) - len;
+    len += n;
+
     if (ctx->cb) {
-        ctx->cb (ctx->facility, level, rank, tv, message, ctx->cb_arg);
+        ctx->cb (ctx->buf, len, ctx->cb_arg);
     } else {
-        o = Jnew ();
-        Jadd_str (o, "facility", ctx->facility);
-        Jadd_int (o, "level", level);
-        Jadd_int (o, "rank", rank);
-        Jadd_int (o, "timestamp_usec", tv.tv_usec);
-        Jadd_int (o, "timestamp_sec", tv.tv_sec);
-        Jadd_str (o, "message", message);
-        if (!(rpc = flux_rpc (h, "cmb.log", Jtostr (o), FLUX_NODEID_ANY,
-                                                        FLUX_RPC_NORESPONSE)))
+        if (!(rpc = flux_rpc_raw (h, "cmb.log", ctx->buf, len,
+                                  FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE)))
             goto done;
     }
 done:
     flux_rpc_destroy (rpc);
-    Jput (o);
-    free (message);
     errno = saved_errno;
 }
 
@@ -176,27 +196,18 @@ static flux_rpc_t *dmesg_rpc (flux_t h, int seq, bool follow)
 static int dmesg_rpc_get (flux_rpc_t *rpc, int *seq, flux_log_f fun, void *arg)
 {
     const char *json_str;
-    const char *facility, *message;
+    const char *buf;
     JSON o = NULL;
-    int level, rank, tv_usec, tv_sec;
-    struct timeval tv;
     int rc = -1;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
         goto done;
-    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "facility", &facility)
-                                   || !Jget_int (o, "level", &level)
-                                   || !Jget_int (o, "rank", &rank)
-                                   || !Jget_int (o, "timestamp_usec", &tv_usec)
-                                   || !Jget_int (o, "timestamp_sec", &tv_sec)
-                                   || !Jget_str (o, "message", &message)
+    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "buf", &buf)
                                    || !Jget_int (o, "seq", seq)) {
         errno = EPROTO;
         goto done;
     }
-    tv.tv_usec = tv_usec;
-    tv.tv_sec = tv_sec;
-    fun (facility, level, rank, tv, message, arg);
+    fun (buf, strlen (buf), arg);
     rc = 0;
 done:
     Jput (o);
@@ -236,20 +247,31 @@ done:
     return rc;
 }
 
-void flux_log_fprint (const char *facility, int level, uint32_t rank,
-                      struct timeval tv, const char *message, void *arg)
+
+void flux_log_fprint (const char *buf, int len, void *arg)
 {
     FILE *f = arg;
+    struct stdlog_header hdr;
+    const char *msg;
+    int msglen, severity;
+    uint32_t nodeid;
+
     if (f) {
-        const char *levelstr = log_leveltostr (level);
-        if (!levelstr)
-            levelstr = "unknown";
-        fprintf (f, "[%ld.%06ld] %s.%s[%" PRIu32 "]: %s\n",
-                 tv.tv_sec, tv.tv_usec, facility, levelstr, rank, message);
+        if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
+            fprintf (f, "%.*s\n", len, buf);
+        else {
+            nodeid = strtoul (hdr.hostname, NULL, 10);
+            severity = STDLOG_SEVERITY (hdr.pri);
+            fprintf (f, "%s %s.%s[%" PRIu32 "]: %.*s\n",
+                     hdr.timestamp,
+                     hdr.appname,
+                     stdlog_severity_to_string (severity),
+                     nodeid,
+                     msglen, msg);
+        }
         fflush (f);
     }
 }
-
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -92,6 +92,11 @@ void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg)
     ctx->cb_arg = arg;
 }
 
+const char *flux_strerror (int errnum)
+{
+    return zmq_strerror (errnum);
+}
+
 void flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
 {
     logctx_t *ctx = getctx (h);
@@ -149,7 +154,7 @@ void flux_log_verror (flux_t h, const char *fmt, va_list ap)
     int saved_errno = errno;
     char *s = xvasprintf (fmt, ap);
 
-    flux_log (h, LOG_ERR, "%s: %s", s, zmq_strerror (errno));
+    flux_log (h, LOG_ERR, "%s: %s", s, flux_strerror (errno));
     free (s);
     errno = saved_errno;
 }
@@ -246,7 +251,6 @@ int flux_dmesg (flux_t h, int flags, flux_log_f fun, void *arg)
 done:
     return rc;
 }
-
 
 void flux_log_fprint (const char *buf, int len, void *arg)
 {

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -59,6 +59,11 @@ int flux_dmesg (flux_t h, int flags, flux_log_f fun, void *arg);
  */
 void flux_log_fprint (const char *buf, int len, void *arg);
 
+/* Convert errno to string.
+ * Flux errno space includes POSIX errno + zeromq errors.
+ */
+const char *flux_strerror (int errnum);
+
 #endif /* !_FLUX_CORE_FLOG_H */
 
 /*

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -1,7 +1,6 @@
 #ifndef _FLUX_CORE_FLOG_H
 #define _FLUX_CORE_FLOG_H
 
-#include <sys/time.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <syslog.h>
@@ -10,13 +9,19 @@
 
 #include "handle.h"
 
-typedef void (*flux_log_f)(const char *facility, int level, uint32_t rank,
-                           struct timeval tv, const char *msg, void *arg);
+#define FLUX_MAX_LOGBUF     2048
 
-/* Set log facility for handle instance.
- * Unlike syslog(3), the flux log facility is an arbitrary string.
+typedef void (*flux_log_f)(const char *buf, int len, void *arg);
+
+/* Set log appname for handle instance.
+ * Value will be truncated after FLUX_MAX_APPNAME bytes.
  */
-void flux_log_set_facility (flux_t h, const char *facility);
+void flux_log_set_appname (flux_t h, const char *s);
+
+/* Set log procid for handle instance.
+ * Value will be truncated after FLUX_MAX_PROCID bytes.
+ */
+void flux_log_set_procid (flux_t h, const char *s);
 
 /* Log a message at the specified level, as defined for syslog(3).
  */
@@ -52,9 +57,7 @@ int flux_dmesg (flux_t h, int flags, flux_log_f fun, void *arg);
 /* flux_log_f callback that prints a log message to a FILE stream
  * passed in as 'arg'.
  */
-void flux_log_fprint (const char *facility, int level, uint32_t rank,
-                      struct timeval tv, const char *message, void *arg);
-
+void flux_log_fprint (const char *buf, int len, void *arg);
 
 #endif /* !_FLUX_CORE_FLOG_H */
 

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -235,7 +235,7 @@ char *flux_modname(const char *path)
     // library dependency doesn't resolve, it really helps to know that's
     // the error.  Otherwise it prints as "invalid argument" from the
     // broker.
-    msg ("%s", dlerror ());
+    log_msg ("%s", dlerror ());
     errno = ENOENT;
     return NULL;
 }

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -36,6 +36,8 @@
 
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 
 struct flux_modlist_struct {
     json_object *o;

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -25,6 +25,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <errno.h>
 #include "reparent.h"
 #include "rpc.h"
 

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -25,6 +25,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <errno.h>
 #include "request.h"
 #include "message.h"
 #include "info.h"

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -26,6 +26,8 @@
 #include "config.h"
 #endif
 #include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
 
 #include "request.h"
 #include "response.h"
@@ -35,8 +37,6 @@
 #include "reactor.h"
 #include "dispatch.h"
 
-#include "src/common/libutil/shortjson.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/nodeset.h"
 
 struct flux_rpc_struct {
@@ -93,9 +93,14 @@ void flux_rpc_destroy (flux_rpc_t *rpc)
 
 static flux_rpc_t *rpc_create (flux_t h, int rx_expected)
 {
-    flux_rpc_t *rpc = xzmalloc (sizeof (*rpc));
+    flux_rpc_t *rpc;
     int flags = 0;
 
+    if (!(rpc = malloc (sizeof (*rpc)))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    memset (rpc, 0, sizeof (*rpc));
     if (rx_expected == 0) {
         rpc->m.matchtag = FLUX_MATCHTAG_NONE;
     } else {

--- a/src/common/libflux/security.c
+++ b/src/common/libflux/security.c
@@ -127,6 +127,7 @@
 #include <czmq.h>
 
 #include "security.h"
+#include "flog.h"
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
@@ -585,7 +586,7 @@ static zcert_t *getcurve (flux_sec_t c, const char *role)
     if (asprintf (&path, "%s/%s", c->curve_dir, role) < 0)
         oom ();
     if (!(cert = zcert_load (path)))
-        seterrstr (c, "zcert_load %s: %s", path, strerror (errno));
+        seterrstr (c, "zcert_load %s: %s", path, flux_strerror (errno));
     free (path);
     return cert;
 }
@@ -638,7 +639,7 @@ static int genpasswd (flux_sec_t c, const char *user, bool force, bool verbose)
     rc = zhash_save (passwds, c->passwd_file);
     umask (old_mask);
     if (rc < 0) {
-        seterrstr (c, "zhash_save %s: %s", c->passwd_file, strerror (errno));
+        seterrstr (c, "zhash_save %s: %s", c->passwd_file, flux_strerror (errno));
         goto done;
     }
     /* FIXME: check created file mode */
@@ -722,7 +723,7 @@ int flux_sec_unmunge_zmsg (flux_sec_t c, zmsg_t **zmsg)
     }
     zmsg_destroy (zmsg);
     if (!(*zmsg = zmsg_decode ((byte *)buf, len))) {
-        seterrstr (c, "zmsg_decode: %s", strerror (errno));
+        seterrstr (c, "zmsg_decode: %s", flux_strerror (errno));
         if (errno == 0)
             errno = EINVAL;
         goto done_unlock;

--- a/src/common/libflux/security.c
+++ b/src/common/libflux/security.c
@@ -164,14 +164,14 @@ static void lock_sec (flux_sec_t c)
 {
     int e = pthread_mutex_lock (&c->lock);
     if (e)
-        errn_exit (e, "pthread_mutex_lock");
+        log_errn_exit (e, "pthread_mutex_lock");
 }
 
 static void unlock_sec (flux_sec_t c)
 {
     int e = pthread_mutex_unlock (&c->lock);
     if (e)
-        errn_exit (e, "pthread_mutex_unlock");
+        log_errn_exit (e, "pthread_mutex_unlock");
 }
 
 const char *flux_sec_errstr (flux_sec_t c)
@@ -239,7 +239,7 @@ flux_sec_t flux_sec_create (void)
     int e;
 
     if ((e = pthread_mutex_init (&c->lock, NULL)))
-        errn_exit (e, "pthread_mutex_init");
+        log_errn_exit (e, "pthread_mutex_init");
     c->uid = getuid ();
     c->gid = getgid ();
     c->typemask = FLUX_SEC_TYPE_MUNGE | FLUX_SEC_TYPE_CURVE;

--- a/src/common/libflux/security.c
+++ b/src/common/libflux/security.c
@@ -130,6 +130,7 @@
 #include "flog.h"
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 
 

--- a/src/common/libpmi-server/simple.c
+++ b/src/common/libpmi-server/simple.c
@@ -36,7 +36,7 @@
 
 #include "simple.h"
 
-#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 
 /* N.B. These values cannot be numeric expressions as they are incorporated

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -669,7 +669,7 @@ static int sp_barrier_read_error (int fd)
     int e;
     ssize_t n = read (fd, &e, sizeof (int));
     if (n < 0) {
-        err ("sp_read_error: read: %m");
+        log_err ("sp_read_error: read: %m");
         return (-1);
     }
     else if (n == sizeof (int)) {
@@ -683,7 +683,7 @@ static int sp_barrier_signal (int fd)
 {
     char c = 0;
     if (write (fd, &c, sizeof (c)) != 1) {
-        err ("sp_barrier_signal: write: %m");
+        log_err ("sp_barrier_signal: write: %m");
         return (-1);
     }
     return (0);
@@ -694,7 +694,7 @@ static int sp_barrier_wait (int fd)
     char c;
     int n;
     if ((n = read (fd, &c, sizeof (c))) != 1) {
-        err ("sp_barrier_wait: read:fd=%d: (got %d): %m", fd, n);
+        log_err ("sp_barrier_wait: read:fd=%d: (got %d): %m", fd, n);
         return (-1);
     }
     return (0);
@@ -703,7 +703,7 @@ static int sp_barrier_wait (int fd)
 static void sp_barrier_write_error (int fd, int e)
 {
     if (write (fd, &e, sizeof (int)) != sizeof (int)) {
-        err ("sp_barrier_error: write: %m");
+        log_err ("sp_barrier_error: write: %m");
     }
 }
 
@@ -720,7 +720,7 @@ static void subprocess_child (struct subprocess *p)
         child_io_setup (p);
 
     if (p->cwd && chdir (p->cwd) < 0) {
-        err ("Couldn't change dir to %s: going to /tmp instead", p->cwd);
+        log_err ("Couldn't change dir to %s: going to /tmp instead", p->cwd);
         if (chdir ("/tmp") < 0)
             exit (1);
     }
@@ -736,12 +736,12 @@ static void subprocess_child (struct subprocess *p)
     sp_barrier_wait (p->childfd);
 
     if (preparefd_child (p) < 0) {
-        err ("Failed to prepare child fds");
+        log_err ("Failed to prepare child fds");
         exit (1);
     }
 
     if (subprocess_run_hooks (p, p->hooks [SUBPROCESS_PRE_EXEC]) < 0) {
-        err ("Failed to run subprocess hooks: %s\n", strerror (errno));
+        log_err ("Failed to run subprocess hooks: %s\n", strerror (errno));
         exit (1);
     }
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -74,7 +74,8 @@ libutil_la_SOURCES = \
 	wallclock.h \
 	wallclock.c \
 	stdlog.h \
-	stdlog.c
+	stdlog.c \
+	oom.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -70,7 +70,9 @@ libutil_la_SOURCES = \
 	approxidate.h \
 	approxidate.c \
 	cronodate.h \
-	cronodate.c
+	cronodate.c \
+	wallclock.h \
+	wallclock.c
 
 EXTRA_DIST = veb_mach.c
 
@@ -85,14 +87,15 @@ TESTS = test_nodeset.t \
 	test_popen2.t \
 	test_kary.t \
 	test_approxidate.t \
-	test_cronodate.t
+	test_cronodate.t \
+	test_wallclock.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libev/libev.la \
-	$(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD)
+	$(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBRT)
 
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \
@@ -152,3 +155,7 @@ test_kary_t_LDADD = $(test_ldadd)
 test_cronodate_t_SOURCES = test/cronodate.c
 test_cronodate_t_CPPFLAGS = $(test_cppflags)
 test_cronodate_t_LDADD = $(test_ldadd)
+
+test_wallclock_t_SOURCES = test/wallclock.c
+test_wallclock_t_CPPFLAGS = $(test_cppflags)
+test_wallclock_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -72,7 +72,9 @@ libutil_la_SOURCES = \
 	cronodate.h \
 	cronodate.c \
 	wallclock.h \
-	wallclock.c
+	wallclock.c \
+	stdlog.h \
+	stdlog.c
 
 EXTRA_DIST = veb_mach.c
 
@@ -88,7 +90,8 @@ TESTS = test_nodeset.t \
 	test_kary.t \
 	test_approxidate.t \
 	test_cronodate.t \
-	test_wallclock.t
+	test_wallclock.t \
+	test_stdlog.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -159,3 +162,7 @@ test_cronodate_t_LDADD = $(test_ldadd)
 test_wallclock_t_SOURCES = test/wallclock.c
 test_wallclock_t_CPPFLAGS = $(test_cppflags)
 test_wallclock_t_LDADD = $(test_ldadd)
+
+test_stdlog_t_SOURCES = test/stdlog.c
+test_stdlog_t_CPPFLAGS = $(test_cppflags)
+test_stdlog_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/environment.c
+++ b/src/common/libutil/environment.c
@@ -251,11 +251,11 @@ void environment_apply (struct environment *e)
     {
         if (item->unset) {
             if (unsetenv (key))
-                err_exit ("unsetenv: %s", key);
+                log_err_exit ("unsetenv: %s", key);
         } else {
             const char *value = stringify_env_item (item);
             if (setenv (key, value, 1) < 0)
-                err_exit ("setenv: %s=%s", key, value);
+                log_err_exit ("setenv: %s=%s", key, value);
         }
     }
 }

--- a/src/common/libutil/environment.c
+++ b/src/common/libutil/environment.c
@@ -34,6 +34,7 @@
 #include <argz.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/iterators.h"
 

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -48,10 +48,10 @@ void ipaddr_getprimary (char *buf, int len)
     hints.ai_family = PF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     if ((e = getaddrinfo (hostname, NULL, &hints, &res)) || res == NULL)
-        msg_exit ("getaddrinfo %s: %s", hostname, gai_strerror (e));
+        log_msg_exit ("getaddrinfo %s: %s", hostname, gai_strerror (e));
     if ((e = getnameinfo (res->ai_addr, res->ai_addrlen, buf, len,
                           NULL, 0, NI_NUMERICHOST)))
-        msg_exit ("getnameinfo %s: %s", hostname, gai_strerror (e));
+        log_msg_exit ("getnameinfo %s: %s", hostname, gai_strerror (e));
     freeaddrinfo (res);
 }
 

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -43,7 +43,7 @@ void ipaddr_getprimary (char *buf, int len)
     int e;
 
     if (gethostname (hostname, sizeof (hostname)) < 0)
-        err_exit ("gethostname");
+        log_err_exit ("gethostname");
     memset (&hints, 0, sizeof (hints));
     hints.ai_family = PF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -137,7 +137,7 @@ errn (int errnum, const char *fmt, ...)
 /* Log message, then exit.
  */
 void
-msg_exit (const char *fmt, ...)
+log_msg_exit (const char *fmt, ...)
 {
     va_list ap;
 
@@ -150,7 +150,7 @@ msg_exit (const char *fmt, ...)
 /* Log message.
  */
 void
-msg (const char *fmt, ...)
+log_msg (const char *fmt, ...)
 {
     va_list ap;
 

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -109,6 +109,32 @@ err (const char *fmt, ...)
     va_end (ap);
 }
 
+/* Log message and errno string, then exit.
+ */
+void
+log_err_exit (const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start (ap, fmt);
+    _verr (errno, fmt, ap);
+    va_end (ap);
+    exit (1);
+}
+
+/* Log message and errno string.
+ */
+void
+log_err (const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start (ap, fmt);
+    _verr (errno, fmt, ap);
+    va_end (ap);
+}
+
+
 /* Log message and errnum string, then exit.
  */
 void

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -87,31 +87,6 @@ _vlog (const char *fmt, va_list ap)
 /* Log message and errno string, then exit.
  */
 void
-err_exit (const char *fmt, ...)
-{
-    va_list ap;
-
-    va_start (ap, fmt);
-    _verr (errno, fmt, ap);
-    va_end (ap);
-    exit (1);
-}
-
-/* Log message and errno string.
- */
-void
-err (const char *fmt, ...)
-{
-    va_list ap;
-
-    va_start (ap, fmt);
-    _verr (errno, fmt, ap);
-    va_end (ap);
-}
-
-/* Log message and errno string, then exit.
- */
-void
 log_err_exit (const char *fmt, ...)
 {
     va_list ap;

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -112,7 +112,7 @@ err (const char *fmt, ...)
 /* Log message and errnum string, then exit.
  */
 void
-errn_exit (int errnum, const char *fmt, ...)
+log_errn_exit (int errnum, const char *fmt, ...)
 {
     va_list ap;
 
@@ -125,7 +125,7 @@ errn_exit (int errnum, const char *fmt, ...)
 /* Log message and errnum string.
  */
 void
-errn (int errnum, const char *fmt, ...)
+log_errn (int errnum, const char *fmt, ...)
 {
     va_list ap;
 

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -42,185 +42,21 @@
 
 static char *prog = "flux";
 
-typedef struct {
-    char *s;
-    int n;
-} match_t;
-
-static match_t facility_tab[] = {
-    { "daemon", LOG_DAEMON },
-    { "local0", LOG_LOCAL0 },
-    { "local1", LOG_LOCAL1 },
-    { "local2", LOG_LOCAL2 },
-    { "local3", LOG_LOCAL3 },
-    { "local4", LOG_LOCAL4 },
-    { "local5", LOG_LOCAL5 },
-    { "local6", LOG_LOCAL6 },
-    { "local7", LOG_LOCAL7 },
-    { "user",   LOG_USER },
-    { NULL,     0},
-};
-
-static match_t level_tab[] = {
-    { "emerg",  LOG_EMERG },
-    { "alert",  LOG_ALERT },
-    { "crit",   LOG_CRIT },
-    { "err",    LOG_ERR },
-    { "warning", LOG_WARNING },
-    { "notice", LOG_NOTICE },
-    { "info",   LOG_INFO },
-    { "debug",  LOG_DEBUG },
-    { NULL,     0},
-};
-
-typedef enum { DEST_LOGF, DEST_SYSLOG } dest_t;
-
-static dest_t dest = DEST_LOGF;
-
-static char *filename = NULL;
-static FILE *logf = NULL;
-
-static int syslog_facility = LOG_DAEMON;
-static int syslog_level = LOG_ERR;
-
-static int
-_match (const char *s, match_t *m)
-{
-    int i;
-
-    for (i = 0; m[i].s != NULL; i++)
-        if (!strcasecmp (m[i].s, s))
-            return m[i].n;
-    return -1;
-}
-
-static char *
-_rmatch (int n, match_t *m)
-{
-    int i;
-
-    for (i = 0; m[i].s != NULL; i++)
-        if (m[i].n == n)
-            return m[i].s;
-    return NULL;
-}
-
-const char *
-log_leveltostr (int n)
-{
-    return _rmatch (n, level_tab);
-}
-
-int
-log_strtolevel (const char *s)
-{
-    return _match (s, level_tab);
-}
-
 void
 log_init (char *p)
 {
     prog = basename (p);
-    logf = stderr;
-    openlog (prog, LOG_NDELAY | LOG_PID, syslog_facility);
 }
 
 void
 log_fini (void)
 {
-    closelog ();
-    if (logf != NULL)
-        fflush (logf);
-    if (logf != stdout && logf != stderr && logf != NULL)
-        fclose (logf);
-}
-
-static void
-_set_syslog_facility (char *s)
-{
-    int n = _match (s, facility_tab);
-
-    if (n < 0)
-        msg_exit ("unknown syslog facility: %s", s);
-    syslog_facility = n;
-    closelog ();
-    openlog (prog, LOG_NDELAY | LOG_PID, syslog_facility);
-}
-
-static void
-_set_syslog_level (char *s)
-{
-    int n = _match (s, level_tab);
-
-    if (n < 0)
-        msg_exit ("unknown syslog level: %s", s);
-    syslog_level = n;
-}
-
-void
-log_set_dest (char *s)
-{
-    char *fac, *lev;
-    FILE *f;
-
-    if (strcmp (s, "syslog") == 0) {
-        dest = DEST_SYSLOG;
-    } else if (strncmp (s, "syslog:", 7) == 0) {
-        if (!(fac = strdup (s + 7)))
-            msg_exit ("out of memory");
-        if ((lev = strchr (fac, ':')))
-            *lev++ = '\0';
-        _set_syslog_facility (fac);
-        if (lev)
-            _set_syslog_level (lev);
-        free (fac);
-        dest = DEST_SYSLOG;
-    } else {
-        if (strcmp (s, "stderr") == 0)
-            logf = stderr;
-        else if (strcmp (s, "stdout") == 0)
-            logf = stdout;
-        else if ((f = fopen (s, "a"))) {
-            if (logf != stdout && logf != stderr && logf != NULL)
-                fclose (logf);
-            logf = f;
-            filename = s;
-        } else
-            err_exit ("could not open %s for writing", s);
-        dest = DEST_LOGF;
-    }
-}
-
-char *
-log_get_dest (void)
-{
-    int len = PATH_MAX + 1;
-    char *res = malloc (len);
-
-    if (!res)
-        goto done;
-    switch (dest) {
-        case DEST_SYSLOG:
-            snprintf (res, PATH_MAX + 1, "syslog:%s:%s",
-                      _rmatch (syslog_facility, facility_tab),
-                      _rmatch (syslog_level, level_tab));
-            break;
-        case DEST_LOGF:
-            if (!logf)
-                logf = stderr;
-            snprintf (res, len, "%s", logf == stdout ? "stdout" :
-                                      logf == stderr ? "stderr" : 
-                                      logf == NULL   ? "unknown" : filename);
-            break;
-    }
-done:
-    return res;
 }
 
 static void
 _verr (int errnum, const char *fmt, va_list ap)
 {
-    char *msg;
+    char *msg = NULL;
     char buf[128];
     const char *s = zmq_strerror (errnum);
 
@@ -228,42 +64,22 @@ _verr (int errnum, const char *fmt, va_list ap)
         (void)vsnprintf (buf, sizeof (buf), fmt, ap);
         msg = buf;
     }
-    switch (dest) {
-        case DEST_LOGF:
-            if (!logf)
-                logf = stderr;
-            fprintf (logf, "%s: %s: %s\n", prog, msg, s);
-            fflush (logf);
-            break;
-        case DEST_SYSLOG:
-            syslog (syslog_level, "%s: %s", msg, s);
-            break;
-    }
+    fprintf (stderr, "%s: %s: %s\n", prog, msg, s);
     if (msg != buf)
         free (msg);
 }
 
-void
-log_msg (const char *fmt, va_list ap)
+static void
+_vlog (const char *fmt, va_list ap)
 {
-    char *msg;
+    char *msg = NULL;
     char buf[128];
 
     if (vasprintf (&msg, fmt, ap) < 0) {
         (void)vsnprintf (buf, sizeof (buf), fmt, ap);
         msg = buf;
     }
-    switch (dest) {
-        case DEST_LOGF:
-            if (!logf)
-                logf = stderr;
-            fprintf (logf, "%s: %s\n", prog, msg);
-            fflush (logf);
-            break;
-        case DEST_SYSLOG:
-            syslog (syslog_level, "%s", msg);
-            break;
-    }
+    fprintf (stderr, "%s: %s\n", prog, msg);
     if (msg != buf)
         free (msg);
 }
@@ -326,7 +142,7 @@ msg_exit (const char *fmt, ...)
     va_list ap;
 
     va_start (ap, fmt);
-    log_msg (fmt, ap);
+    _vlog (fmt, ap);
     va_end (ap);
     exit (1);
 }
@@ -339,37 +155,8 @@ msg (const char *fmt, ...)
     va_list ap;
 
     va_start (ap, fmt);
-    log_msg (fmt, ap);
+    _vlog (fmt, ap);
     va_end (ap);
-}
-
-int check_int (int res,
-               const char *fmt,
-               ...  )
-{
-    if (res < 0) {
-        va_list ap;
-        va_start (ap, fmt);
-        log_msg (fmt, ap);
-        va_end (ap);
-        exit (1);
-    }
-    return res;
-}
-
-
-void *check_ptr (void *res,
-                 const char *fmt,
-                 ... )
-{
-    if (res == NULL) {
-        va_list ap;
-        va_start (ap, fmt);
-        log_msg (fmt, ap);
-        va_end (ap);
-        exit (1);
-    }
-    return res;
 }
 
 /*

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -10,9 +10,15 @@
 void log_init (char *cmd_name);
 void log_fini (void);
 
+/* deprecated */
 void err_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
 void err (const char *fmt, ...)
+        __attribute__ ((format (printf, 1, 2)));
+
+void log_err_exit (const char *fmt, ...)
+        __attribute__ ((format (printf, 1, 2), noreturn));
+void log_err (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 void log_errn_exit (int errnum, const char *fmt, ...)
         __attribute__ ((format (printf, 2, 3), noreturn));

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -24,10 +24,6 @@ void log_msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 
 
-#define oom() do { \
-    log_errn_exit (ENOMEM, "%s::%s(), line %d", __FILE__, __FUNCTION__, __LINE__); \
-} while (0)
-
 #endif /* !_UTIL_LOG_H */
 
 /*

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -10,12 +10,6 @@
 void log_init (char *cmd_name);
 void log_fini (void);
 
-/* deprecated */
-void err_exit (const char *fmt, ...)
-        __attribute__ ((format (printf, 1, 2), noreturn));
-void err (const char *fmt, ...)
-        __attribute__ ((format (printf, 1, 2)));
-
 void log_err_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
 void log_err (const char *fmt, ...)

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -7,11 +7,8 @@
 
 #include "macros.h"
 
-void log_init (char *p);
+void log_init (char *cmd_name);
 void log_fini (void);
-void log_set_dest (char *dest);
-char *log_get_dest (void);
-void log_msg (const char *fmt, va_list ap);
 
 void err_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
@@ -26,33 +23,9 @@ void msg_exit (const char *fmt, ...)
 void msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 
-int check_int (int res,
-               const char *fmt,
-               ...  )
-__attribute__ ((format (printf, 2, 3)));
-void *check_ptr (void *res,
-                 const char *fmt,
-                 ... )
-__attribute__ ((format (printf, 2, 3)));
-
-#define LOG_POSITION __FILE__ ":" STRINGIFY (__LINE__)
-
-// NOTE: FMT string *MUST* be a string literal
-#define CHECK_INT(X, ...) check_int ((X), LOG_POSITION \
-                                          ":negative integer from:" \
-                                          STRINGIFY (X) ":" \
-                                          __VA_ARGS__)
-#define CHECK_PTR(X, ...) check_ptr ((X), LOG_POSITION \
-                                          ":null pointer from:" \
-                                          STRINGIFY (X) ":" \
-                                          __VA_ARGS__)
-
 #define oom() do { \
   errn_exit (ENOMEM, "%s::%s(), line %d", __FILE__, __FUNCTION__, __LINE__); \
 } while (0)
-
-const char *log_leveltostr (int level);
-int log_strtolevel (const char *s);
 
 #endif /* !_UTIL_LOG_H */
 

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -14,17 +14,18 @@ void err_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
 void err (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
-void errn_exit (int errnum, const char *fmt, ...)
+void log_errn_exit (int errnum, const char *fmt, ...)
         __attribute__ ((format (printf, 2, 3), noreturn));
-void errn (int errnum, const char *fmt, ...)
+void log_errn (int errnum, const char *fmt, ...)
         __attribute__ ((format (printf, 2, 3)));
 void log_msg_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
 void log_msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 
+
 #define oom() do { \
-  errn_exit (ENOMEM, "%s::%s(), line %d", __FILE__, __FUNCTION__, __LINE__); \
+    log_errn_exit (ENOMEM, "%s::%s(), line %d", __FILE__, __FUNCTION__, __LINE__); \
 } while (0)
 
 #endif /* !_UTIL_LOG_H */

--- a/src/common/libutil/log.h
+++ b/src/common/libutil/log.h
@@ -18,9 +18,9 @@ void errn_exit (int errnum, const char *fmt, ...)
         __attribute__ ((format (printf, 2, 3), noreturn));
 void errn (int errnum, const char *fmt, ...)
         __attribute__ ((format (printf, 2, 3)));
-void msg_exit (const char *fmt, ...)
+void log_msg_exit (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2), noreturn));
-void msg (const char *fmt, ...)
+void log_msg (const char *fmt, ...)
         __attribute__ ((format (printf, 1, 2)));
 
 #define oom() do { \

--- a/src/common/libutil/nodeset.c
+++ b/src/common/libutil/nodeset.c
@@ -37,7 +37,7 @@
 #include <stdbool.h>
 
 #include "veb.h"
-#include "log.h"
+#include "oom.h"
 #include "monotime.h"
 
 #include "nodeset.h"
@@ -492,7 +492,7 @@ static bool nodeset_op_string (nodeset_t *n, op_t op, const char *str)
 {
     char *cpy;
     int len;
-    char *p, *s, *saveptr, *a1;
+    char *p, *s, *saveptr = NULL, *a1;
     uint32_t lo, hi;
     int count = 0;
 

--- a/src/common/libutil/oom.h
+++ b/src/common/libutil/oom.h
@@ -1,0 +1,16 @@
+#ifndef _UTIL_OOM_H
+#define _UTIL_OOM_H
+
+#include <stdio.h>
+
+#define oom() do { \
+    fprintf (stderr, "%s::%s(), line %d: Out of memory\n", \
+             __FILE__, __FUNCTION__, __LINE__); \
+    exit (1); \
+} while (0)
+
+#endif /* !_UTIL_OOM_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/shortjson.h
+++ b/src/common/libutil/shortjson.h
@@ -3,7 +3,7 @@
 
 #include <json.h>
 #include <stdbool.h>
-#include "log.h" /* oom */
+#include "oom.h"
 
 typedef json_object *JSON;
 

--- a/src/common/libutil/shortjson.h
+++ b/src/common/libutil/shortjson.h
@@ -90,6 +90,15 @@ Jadd_str (JSON o, const char *name, const char *s)
     json_object_object_add (o, (char *)name, n);
 }
 
+static __inline__ void
+Jadd_str_len (JSON o, const char *name, const char *s, int len)
+{
+    JSON n = json_object_new_string_len (s, len);
+    if (!n)
+        oom ();
+    json_object_object_add (o, (char *)name, n);
+}
+
 /* Add object to JSON (caller retains ownership of original).
  */
 static __inline__ void

--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -1,0 +1,210 @@
+
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <syslog.h>
+
+#include "stdlog.h"
+
+/* Header: PRI VERSION SP TIMESTAMP SP HOSTNAME
+           SP APP-NAME SP PROCID SP MSGID
+ * Body: SP STRUCTURED-DATA SP MESSAGE
+ */
+
+static int next_int (char **p, int *ip)
+{
+    char *endptr;
+    int i = strtoul (*p, &endptr, 10);
+    if (*p == endptr)
+        return -1;
+    *p = endptr + 1;
+    *ip = i;
+    return 0;
+}
+
+static int next_str (char **p, char **result)
+{
+    char *this = *p;
+    char *next = *p;
+
+    while (*next != '\0' && *next != ' ')
+        next++;
+    if (next == *p)
+        return -1;
+    if (*next != '\0')
+        *next++ = '\0';
+    *p = next;
+    *result = this;
+    return 0;
+}
+
+static int next_structured_data (const char *buf, int len, int *offp,
+                                 const char **sp, int *slenp)
+{
+    int off = *offp;
+    int this = *offp;
+    int level = 0;
+
+    while (off < len) {
+        if (buf[off] == '[')
+            level++;
+        else if (buf[off] == ']')
+            level--;
+        else if (buf[off] == ' ' && level == 0)
+            break;
+        off++;
+    }
+    if (off == len)
+        return -1;
+    *offp = off + 1;
+    if (sp)
+        *sp = &buf[this];
+    if (slenp)
+        *slenp = off - this;
+    return 0;
+}
+
+int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
+                   const char **sdp, int *sdlenp,
+                   const char **msgp, int *msglenp)
+{
+    int hdr_len = STDLOG_MAX_HEADER;
+    char *p = &hdr->buf[0];
+    const char *sd;
+    int off, sdlen;
+
+    if (hdr_len > len)
+        hdr_len = len;
+    strncpy (hdr->buf, buf, hdr_len);
+    hdr->buf[hdr_len] = '\0';
+
+    if (*p++ != '<')
+        return -1;
+    if (next_int (&p, &hdr->pri) < 0)
+        return -1;
+    if (next_int (&p, &hdr->version) < 0)
+        return -1;
+    if (next_str (&p, &hdr->timestamp) < 0)
+        return -1;
+    if (next_str (&p, &hdr->hostname) < 0)
+        return -1;
+    if (next_str (&p, &hdr->appname) < 0)
+        return -1;
+    if (next_str (&p, &hdr->procid) < 0)
+        return -1;
+    if (next_str (&p, &hdr->msgid) < 0)
+        return -1;
+    /* Switch to original unterminated buffer
+     * (structured data and message are not copied).
+     * FIXME: handle charset and BOM in message?
+     */
+    off = p - &hdr->buf[0];
+    if (next_structured_data (buf, len, &off, &sd, &sdlen) < 0)
+        return -1;
+    if (sdp)
+        *sdp = sd;
+    if (sdlenp)
+        *sdlenp = sdlen;
+    if (msgp)
+        *msgp = &buf[off];
+    if (msglenp)
+        *msglenp = len - off;
+    return 0;
+}
+
+int stdlog_encode (char *buf, int len, struct stdlog_header *hdr,
+                   const char *sd, const char *msg)
+{
+    return snprintf (buf, len, "<%d>%d %.*s %.*s %.*s %.*s %.*s %s %s",
+                     hdr->pri, hdr->version,
+                     STDLOG_MAX_TIMESTAMP, hdr->timestamp,
+                     STDLOG_MAX_HOSTNAME, hdr->hostname,
+                     STDLOG_MAX_APPNAME, hdr->appname,
+                     STDLOG_MAX_PROCID, hdr->procid,
+                     STDLOG_MAX_MSGID, hdr->msgid,
+                     sd, msg);
+}
+
+void stdlog_init (struct stdlog_header *hdr)
+{
+    memset (hdr->buf, 0, STDLOG_MAX_HEADER + 1);
+    hdr->pri = ((LOG_INFO<<3) | LOG_USER);
+    hdr->version = 1;
+    hdr->timestamp = STDLOG_NILVALUE;
+    hdr->hostname = STDLOG_NILVALUE;
+    hdr->appname = STDLOG_NILVALUE;
+    hdr->procid = STDLOG_NILVALUE;
+    hdr->msgid = STDLOG_NILVALUE;
+}
+
+
+struct matchtab {
+    char *s;
+    int n;
+};
+
+static struct matchtab severity_tab[] = {
+    { "emerg",  LOG_EMERG },
+    { "alert",  LOG_ALERT },
+    { "crit",   LOG_CRIT },
+    { "err",    LOG_ERR },
+    { "warning", LOG_WARNING },
+    { "notice", LOG_NOTICE },
+    { "info",   LOG_INFO },
+    { "debug",  LOG_DEBUG },
+    { NULL,     0},
+};
+
+const char *
+stdlog_severity_to_string (int n)
+{
+    int i;
+
+    for (i = 0; severity_tab[i].s != NULL; i++)
+        if (severity_tab[i].n == n)
+            return severity_tab[i].s;
+    return STDLOG_NILVALUE;
+}
+
+int
+stdlog_string_to_severity (const char *s)
+{
+    int i;
+
+    for (i = 0; severity_tab[i].s != NULL; i++)
+        if (!strcasecmp (severity_tab[i].s, s))
+            return severity_tab[i].n;
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/stdlog.h
+++ b/src/common/libutil/stdlog.h
@@ -1,0 +1,50 @@
+#ifndef _UTIL_STDLOG_H
+#define _UTIL_STDLOG_H
+
+/* RFC 5424 syslog wire format */
+
+#define STDLOG_MAX_PRI          5
+#define STDLOG_MAX_VER          3
+#define STDLOG_MAX_TIMESTAMP    32
+#define STDLOG_MAX_HOSTNAME     255
+#define STDLOG_MAX_APPNAME      48
+#define STDLOG_MAX_PROCID       128
+#define STDLOG_MAX_MSGID        32
+#define STDLOG_MAX_HEADER (5 + STDLOG_MAX_PRI + STDLOG_MAX_VER \
+    + STDLOG_MAX_TIMESTAMP + STDLOG_MAX_HOSTNAME + STDLOG_MAX_APPNAME \
+    + STDLOG_MAX_PROCID + STDLOG_MAX_MSGID)
+
+#define STDLOG_NILVALUE         "-"
+
+#define STDLOG_SEVERITY(pri)    ((pri)>>3)
+#define STDLOG_FACILITY(pri)    ((pri)&7)
+#define STDLOG_PRI(sev,fac)     (((sev)<<3)|((fac)&7))
+
+struct stdlog_header {
+    char buf[STDLOG_MAX_HEADER + 1];
+    int pri;
+    int version;
+    char *timestamp;
+    char *hostname;
+    char *appname;
+    char *procid;
+    char *msgid;
+};
+
+int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
+                   const char **sd, int *sdlen, const char **msg, int *msglen);
+
+int stdlog_encode (char *buf, int len, struct stdlog_header *hdr,
+                   const char *sd, const char *msg);
+
+void stdlog_init (struct stdlog_header *hdr);
+
+
+const char *stdlog_severity_to_string (int level);
+int stdlog_string_to_severity (const char *s);
+
+#endif /* !_UTIL_STDLOG_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/ev.c
+++ b/src/common/libutil/test/ev.c
@@ -1,7 +1,7 @@
 #include <czmq.h>
 #include <poll.h>
 
-#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libev/ev.h"
 #include "src/common/libutil/ev_zmq.h"
 #include "src/common/libutil/ev_zlist.h"

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -1,0 +1,90 @@
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/wallclock.h"
+#include "src/common/libutil/stdlog.h"
+
+#include <string.h>
+#include <ctype.h>
+
+static char *valid[] = {
+    "<1>1 - - - - - - message",
+    "<23>1 - - - - - - message",
+    "<234>111 - - - - - - message",
+    "<234>111 - - - - - - message",
+    "<42>1 1985-04-12T23:20:50.52Z - - - - - message",
+    "<42>1 1985-04-12T19:20:50.52-04:00 - - - - - message",
+    "<42>1 2003-10-11T22:14:15.003Z - - - - - message",
+    "<42>1 2003-08-24T05:14:15.000003-07:00 - - - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z - - - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 - - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 1 - - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 4294967295 - - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z this-is-a-really-long-hostname-field-well-we-have-255-chars-avaialable-so-maybe-not-that-long-huh - - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 logger - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 procid-000@@@-aaa - - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 logger procid - - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 logger - msgid - message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 logger - msgid [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 logger - msgid [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] message",
+    "<42>1 2016-06-12T22:59:59.816857Z 0 logger - msgid [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] message",
+    NULL,
+};
+
+int main(int argc, char** argv)
+{
+    char buf[2048];
+    struct stdlog_header hdr, cln;
+    int n, len;
+    const char *sd, *msg;
+    int sdlen, msglen;
+
+    plan (NO_PLAN);
+
+    stdlog_init (&hdr);
+    len = stdlog_encode (buf, sizeof (buf), &hdr,
+                         STDLOG_NILVALUE, STDLOG_NILVALUE);
+    ok (len >= 0,
+        "stdlog_init encoded defaults");
+    diag ("%.*s", len, buf);
+
+    /* Ensure that decode reverses encode for default case
+     */
+    memset (&hdr, 0, sizeof (hdr));
+    n = stdlog_decode (buf, len, &hdr, &sd, &sdlen, &msg, &msglen);
+    ok (n == 0,
+        "stdlog_decode worked on encoded buf");
+    stdlog_init (&cln);
+    ok (hdr.pri == cln.pri,
+        "stdlog_decode decoded pri");
+    ok (hdr.version == cln.version,
+        "stdlog_decode decoded version");
+    ok (strcmp (hdr.timestamp, cln.timestamp) == 0,
+        "stdlog_decode decoded timestamp");
+    ok (strcmp (hdr.hostname, cln.hostname) == 0,
+        "stdlog_decode decoded hostname") ;
+    ok (strcmp (hdr.appname, cln.appname) == 0,
+        "stdlog_decode decoded appname") ;
+    ok (strcmp (hdr.procid, cln.procid) == 0,
+        "stdlog_decode decoded procid") ;
+    ok (strcmp (hdr.msgid, cln.msgid) == 0,
+        "stdlog_decode decoded msgid") ;
+    ok (sdlen == strlen (STDLOG_NILVALUE) && strncmp (sd, STDLOG_NILVALUE, sdlen) == 0,
+        "stdlog_decode decoded structured data");
+    ok (msglen == strlen (STDLOG_NILVALUE) && strncmp (msg, STDLOG_NILVALUE, msglen) == 0,
+        "stdlog_decode decoded message");
+    
+    int i = 0;
+    while (valid[i] != NULL) {
+        n = stdlog_decode (valid[i], strlen (valid[i]), &hdr, &sd, &sdlen, &msg, &msglen);
+        ok (n == 0 && msglen == strlen ("message") && strncmp (msg, "message", msglen) == 0,
+            "successfully decoded %s", valid[i]);
+        i++;
+    }
+
+
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/wallclock.c
+++ b/src/common/libutil/test/wallclock.c
@@ -1,0 +1,36 @@
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/wallclock.h"
+#include "src/common/libutil/stdlog.h"
+
+#include <string.h>
+#include <ctype.h>
+
+int main(int argc, char** argv)
+{
+    char buf[WALLCLOCK_MAXLEN];
+    plan (NO_PLAN);
+
+    ok (wallclock_get_zulu (buf, sizeof (buf)) >= 0,
+	"wallclock_get_zulu() works: %s", buf);
+    ok (strlen (buf) < WALLCLOCK_MAXLEN,
+        "result did not overflow WALLCLOCK_MAXLEN");
+    ok (strlen (buf) < STDLOG_MAX_TIMESTAMP,
+        "result did not overflow STDLOG_MAX_TIMESTAMP");
+
+    /* example: 2016-06-10T18:01:18.479194Z */
+
+    ok (buf[10] == 'T',
+        "RFC 5424: mandatory T character present in correct position");
+    ok (strchr (buf, 'Z') != NULL || strchr (buf, 'z') == NULL,
+        "RFC 5424: optional Z character is upper case");
+
+    int count = 0;
+    char *p = strchr (buf, '.');
+    while (p && isdigit (*(++p)))
+        count++;
+    ok (count <= 6,
+	"RFC 5424: no more than 6 optional TIME-SECFRAC digits");
+
+    done_testing();
+}

--- a/src/common/libutil/wallclock.c
+++ b/src/common/libutil/wallclock.c
@@ -1,0 +1,74 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "wallclock.h"
+
+/* Generate ISO 8601 timestamp that additionally conforms to RFC 5424 (syslog).
+ *
+ * Examples from RFC 5424:
+ *   1985-04-12T23:20:50.52Z
+ *   1985-04-12T19:20:50.52-04:00
+ *   2003-10-11T22:14:15.003Z
+ *   2003-08-24T05:14:15.000003-07:00
+ */
+
+int wallclock_get_zulu (char *buf, size_t len)
+{
+    struct timespec ts;
+    struct tm tm;
+    time_t t;
+
+    if (len < WALLCLOCK_MAXLEN) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (clock_gettime (CLOCK_REALTIME, &ts) < 0)
+        return -1;
+    t = ts.tv_sec;
+    if (!gmtime_r (&t, &tm)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (strftime (buf, len, "%FT%T", &tm) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (snprintf (buf+19, len-19, ".%.6luZ", ts.tv_nsec/1000) >= len - 20) {
+        errno = EINVAL;
+        return -1;
+    }
+    return strlen (buf);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/wallclock.h
+++ b/src/common/libutil/wallclock.h
@@ -1,0 +1,12 @@
+#ifndef _UTIL_WALLCLOCK_H
+#define _UTIL_WALLCLOCK_H
+
+#define WALLCLOCK_MAXLEN    33
+
+int wallclock_get_zulu (char *buf, size_t len);
+
+#endif /* !_UTIL_WALLCLOCK_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/xzmalloc.c
+++ b/src/common/libutil/xzmalloc.c
@@ -29,8 +29,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "log.h"
 #include "xzmalloc.h"
+#include "oom.h"
 
 void *xzmalloc (size_t size)
 {

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -228,7 +228,7 @@ int PMI_Init (int *spawned)
         fprintf (stderr, "flux_get_rank: %s", strerror (errno));
         goto done_destroy;
     }
-    flux_log_set_facility (ctx->h, "libpmi");
+    flux_log_set_appname (ctx->h, "libpmi");
     *spawned = ctx->spawned;
     ret = PMI_SUCCESS;
 done:

--- a/src/lib/libpmi/pmi.c
+++ b/src/lib/libpmi/pmi.c
@@ -221,11 +221,11 @@ int PMI_Init (int *spawned)
     ctx->barrier_num = 0;
     snprintf (ctx->kvsname, sizeof (ctx->kvsname), "lwj.%d.pmi", ctx->appnum);
     if (!(ctx->h = flux_open (NULL, 0))) {
-        fprintf (stderr, "flux_open: %s", strerror (errno));
+        fprintf (stderr, "flux_open: %s", flux_strerror (errno));
         goto done_destroy;
     }
     if (flux_get_rank (ctx->h, &ctx->cmb_rank) < 0) {
-        fprintf (stderr, "flux_get_rank: %s", strerror (errno));
+        fprintf (stderr, "flux_get_rank: %s", flux_strerror (errno));
         goto done_destroy;
     }
     flux_log_set_appname (ctx->h, "libpmi");

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -216,7 +216,7 @@ static void enter_request_cb (flux_t h, flux_msg_handler_t *w,
                         "abort %s due to double entry by client %s",
                         name, sender);
             if (exit_event_send (ctx->h, b->name, ECONNABORTED) < 0)
-                flux_log (ctx->h, LOG_ERR, "exit_event_send: %s", strerror (errno));
+                flux_log_error (ctx->h, "exit_event_send");
             goto done;
         }
     }
@@ -227,7 +227,7 @@ static void enter_request_cb (flux_t h, flux_msg_handler_t *w,
     b->count += count;
     if (b->count == b->nprocs) {
         if (exit_event_send (ctx->h, b->name, 0) < 0)
-            flux_log (ctx->h, LOG_ERR, "exit_event_send: %s", strerror (errno));
+            flux_log_error (ctx->h, "exit_event_send");
     } else if (ctx->rank > 0 && !ctx->timer_armed) {
         flux_timer_watcher_reset (ctx->timer, barrier_reduction_timeout_sec, 0.);
         flux_watcher_start (ctx->timer);
@@ -252,7 +252,7 @@ static int disconnect (const char *key, void *item, void *arg)
 
     if (zhash_lookup (b->clients, sender)) {
         if (exit_event_send (ctx->h, b->name, ECONNABORTED) < 0)
-            flux_log (ctx->h, LOG_ERR, "exit_event_send: %s", strerror (errno));
+            flux_log_error (ctx->h, "exit_event_send");
     }
     return 0;
 }

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -113,7 +113,7 @@ static ctx_t *getctx (flux_t h)
         ctx = xzmalloc (sizeof (*ctx));
         ctx->h = h;
         if (!(ctx->reactor = flux_get_reactor (h)))
-            err_exit ("flux_get_reactor");
+            log_err_exit ("flux_get_reactor");
         if (!(ctx->clients = zlist_new ()))
             oom ();
         if (!(ctx->subscriptions = zhash_new ()))
@@ -557,12 +557,12 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
                 if (flux_msg_push_route (msg, zuuid_str (c->uuid)) < 0)
                     oom (); /* FIXME */
                 if (flux_send (h, msg, 0) < 0)
-                    err ("%s: flux_send", __FUNCTION__);
+                    log_err ("%s: flux_send", __FUNCTION__);
             }
             break;
         case FLUX_MSGTYPE_EVENT:
             if (flux_send (h, msg, 0) < 0)
-                err ("%s: flux_send", __FUNCTION__);
+                log_err ("%s: flux_send", __FUNCTION__);
             break;
         default:
             flux_log (h, LOG_ERR, "drop unexpected %s",

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -814,14 +814,14 @@ static bool walk (ctx_t *ctx, json_object *root, const char *path,
 
         } else if (json_object_object_get_ex (dirent, "DIRVAL", &dir)) {
             /* N.B. in current code, directories are never stored by value */
-            msg_exit ("%s: unexpected DIRVAL: path=%s name=%s: dirent=%s ",
+            log_msg_exit ("%s: unexpected DIRVAL: path=%s name=%s: dirent=%s ",
                       __FUNCTION__, path, name, Jtostr (dirent));
         } else if ((Jget_str (dirent, "FILEREF", NULL)
                  || json_object_object_get_ex (dirent, "FILEVAL", NULL))) {
             errno = ENOTDIR;
             goto error;
         } else {
-            msg_exit ("%s: unknown dirent type: path=%s name=%s: dirent=%s ",
+            log_msg_exit ("%s: unknown dirent type: path=%s name=%s: dirent=%s ",
                       __FUNCTION__, path, name, Jtostr (dirent));
         }
         name = next;
@@ -920,7 +920,7 @@ static bool lookup (ctx_t *ctx, json_object *root, wait_t *wait,
             FASSERT (ctx->h, dir == false); /* dir && readlink should never happen */
             val = vp;
         } else
-            msg_exit ("%s: corrupt internal storage", __FUNCTION__);
+            log_msg_exit ("%s: corrupt internal storage", __FUNCTION__);
     }
     /* val now contains the requested object */
     if (isdir)

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -27,7 +27,7 @@
 #endif
 #include <flux/core.h>
 
-#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/monotime.h"
 

--- a/src/modules/libkz/kz.c
+++ b/src/modules/libkz/kz.c
@@ -63,8 +63,8 @@
 
 #include "kz.h"
 
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
-#include "src/common/libutil/log.h"
 #include "src/common/libsubprocess/zio.h"
 
 struct kz_struct {

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -338,8 +338,7 @@ static int reparent (ctx_t *ctx, int oldrank, parent_t *p)
         oom ();
     goodbye (ctx, oldrank);
     if ((rc = flux_reparent (ctx->h, -1, p->uri)) < 0)
-        flux_log (ctx->h, LOG_ERR, "%s %s: %s",
-                  __FUNCTION__, p->uri, strerror (errno));
+        flux_log_error (ctx->h, "%s %s", __FUNCTION__, p->uri);
     hello (ctx);
 done:
     return rc;
@@ -431,8 +430,7 @@ static void cstate_cb (flux_t h, flux_msg_handler_t *w,
     if (ctx->rank == 0) {
         ns_chg_one (ctx, rank, ostate, nstate);
         if (ns_sync (ctx) < 0)
-            flux_log (h, LOG_ERR, "%s: ns_sync: %s",
-                      __FUNCTION__, strerror (errno));
+            flux_log_error (h, "%s: ns_sync", __FUNCTION__);
     }
 done:
     Jput (event);
@@ -484,7 +482,7 @@ static void hb_cb (flux_t h, flux_msg_handler_t *w,
         goto done;
     }
     if (!(peers_str = flux_lspeer (h, -1)) || !(peers = Jfromstr (peers_str))) {
-        flux_log (h, LOG_ERR, "flux_lspeer: %s", strerror (errno));
+        flux_log_error (h, "flux_lspeer");
         goto done;
     }
     if (!(keys = zhash_keys (ctx->children)))
@@ -534,14 +532,14 @@ static void manage_subscriptions (ctx_t *ctx)
 {
     if (ctx->hb_subscribed && zhash_size (ctx->children) == 0) {
         if (flux_event_unsubscribe (ctx->h, "hb") < 0)
-            flux_log (ctx->h, LOG_ERR, "%s: flux_event_unsubscribe hb: %s",
-                      __FUNCTION__, strerror (errno));
+            flux_log_error (ctx->h, "%s: flux_event_unsubscribe hb",
+                            __FUNCTION__);
         else
             ctx->hb_subscribed = false;
     } else if (!ctx->hb_subscribed && zhash_size (ctx->children) > 0) {
         if (flux_event_subscribe (ctx->h, "hb") < 0)
-            flux_log (ctx->h, LOG_ERR, "%s: flux_event_subscribe hb: %s",
-                      __FUNCTION__, strerror (errno));
+            flux_log_error (ctx->h, "%s: flux_event_subscribe hb",
+                            __FUNCTION__);
         else
             ctx->hb_subscribed = true;
     }
@@ -928,11 +926,9 @@ static void hello_sink (flux_reduce_t *r, int batchnum, void *arg)
         ns_chg_hello (ctx, o);
         hello_merge (ctx->topo, o);
         if (ns_sync (ctx) < 0)
-            flux_log (ctx->h, LOG_ERR, "%s: ns_sync: %s",
-                      __FUNCTION__, strerror (errno));
+            flux_log_error (ctx->h, "%s: ns_sync", __FUNCTION__);
         if (topo_sync (ctx) < 0)
-            flux_log (ctx->h, LOG_ERR, "%s: topo_sync: %s",
-                      __FUNCTION__, strerror (errno));
+            flux_log_error (ctx->h, "%s: topo_sync", __FUNCTION__);
         Jput (o);
     }
 }
@@ -1121,7 +1117,7 @@ static void recover_event_cb (flux_t h, flux_msg_handler_t *w,
         if (errno == EINVAL)
             flux_log (h, LOG_ERR, "recovery: parent is still in FAIL state");
         else
-            flux_log (h, LOG_ERR, "recover: %s", strerror (errno));
+            flux_log_error (h, "recover");
     }
 }
 

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -109,7 +109,7 @@ static int handle_client_msg (struct rexec_session *c, zmsg_t *zmsg)
     json_object *o;
 
     if (flux_msg_decode (zmsg, &tag, &o) < 0) {
-        err ("bad msg from rexec sesion %lu", c->id);
+        log_err ("bad msg from rexec sesion %lu", c->id);
         return (-1);
     }
 
@@ -152,10 +152,10 @@ static void exec_handler (struct rexec_ctx *ctx, uint64_t id, int *pfds)
     args = wrexecd_args_create (ctx, id);
 
     if ((sid = setsid ()) < 0)
-        err ("setsid");
+        log_err ("setsid");
 
     if ((pid = fork()) < 0)
-        err_exit ("fork");
+        log_err_exit ("fork");
     else if (pid > 0)
         exit (0); /* parent of grandchild == child */
 
@@ -167,10 +167,10 @@ static void exec_handler (struct rexec_ctx *ctx, uint64_t id, int *pfds)
     closeall (4);
     flux_log (ctx->h, LOG_DEBUG, "running %s %s %s", args[0], args[1], args[2]);
     if (setenv ("FLUX_URI", ctx->local_uri, 1) < 0)
-        err_exit ("setenv");
+        log_err_exit ("setenv");
     if (execvp (args[0], args) < 0) {
         close (3);
-        err_exit ("execvp");
+        log_err_exit ("execvp");
     }
     exit (255);
 }

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -153,7 +153,7 @@ static flux_t prog_ctx_flux_handle (struct prog_ctx *ctx)
         char name [128];
         t->f = flux_open (NULL, 0);
         snprintf (name, sizeof (name) - 1, "lwj.%ld.%d", ctx->id, t->globalid);
-        flux_log_set_facility (t->f, name);
+        flux_log_set_appname (t->f, name);
     }
     return (t->f);
 }
@@ -869,7 +869,7 @@ int prog_ctx_init_from_cmb (struct prog_ctx *ctx)
         log_fatal (ctx, 1, "flux_open");
 
     snprintf (name, sizeof (name) - 1, "lwj.%ld", ctx->id);
-    flux_log_set_facility (ctx->flux, name);
+    flux_log_set_appname (ctx->flux, name);
 
     if (kvs_get_dir (ctx->flux, &ctx->kvs,
                      "lwj.%lu", ctx->id) < 0) {

--- a/src/test/kap/kap.c
+++ b/src/test/kap/kap.c
@@ -13,6 +13,7 @@
 #include <float.h>
 #include <math.h>
 #include <values.h>
+#include <sys/time.h>
 
 #include "kap.h"
 

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -281,7 +281,7 @@ put_test_obj (kap_params_t *param)
             Begin = now ();
             if ( kvs_put_obj (param->pers.handle, k, o) < 0) {
                 fprintf (stderr, 
-                    "kvs_put failed %s", strerror(errno));
+                    "kvs_put failed %s", flux_strerror(errno));
                 goto error;
             }
             End = now ();
@@ -375,7 +375,7 @@ enforce_c_consistency (kap_params_t *param)
     zmsg_t * msg = flux_recv (param->pers.handle, FLUX_MATCH_EVENT, 0);
     if ( ! msg ) {
         fprintf (stderr,
-            "event recv failed: %s\n", strerror (errno));
+            "event recv failed: %s\n", flux_strerror (errno));
         goto error;
     }
     flux_msg_get_topic (msg, &tag);

--- a/src/test/tasyncsock.c
+++ b/src/test/tasyncsock.c
@@ -268,9 +268,9 @@ int main (int argc, char *argv[])
     /* Spawn thread which will be our client.
      */
     if ((rc = pthread_attr_init (&attr)))
-        errn (rc, "S: pthread_attr_init");
+        log_errn (rc, "S: pthread_attr_init");
     if ((rc = pthread_create (&tid, &attr, thread, NULL)))
-        errn (rc, "S: pthread_create");
+        log_errn (rc, "S: pthread_create");
 
     /* Handle 'iter' client messages with timeout
      */
@@ -287,7 +287,7 @@ int main (int argc, char *argv[])
     /* Wait for thread to terminate, then clean up.
      */
     if ((rc = pthread_join (tid, NULL)))
-        errn (rc, "S: pthread_join");
+        log_errn (rc, "S: pthread_join");
     zctx_destroy (&zctx); /* destroys sockets too */
 
     if (strstr (uri, "ipc://"))

--- a/src/test/tasyncsock.c
+++ b/src/test/tasyncsock.c
@@ -67,6 +67,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 
 #ifndef ZMQ_IMMEDIATE

--- a/src/test/tasyncsock.c
+++ b/src/test/tasyncsock.c
@@ -161,7 +161,7 @@ void *thread (void *arg)
         buf = xzmalloc (bufsize);
     for (i = 0; i < iter; i++) {
         if (vopt)
-            msg ("sending %d of %d", i + 1, iter);
+            log_msg ("sending %d of %d", i + 1, iter);
         if (raw)
             send_raw (buf, bufsize);
         else
@@ -281,7 +281,7 @@ int main (int argc, char *argv[])
         zmsg_destroy (&zmsg);
         alarm (0);
         if (vopt)
-            msg ("received message %d of %d", i + 1, iter);
+            log_msg ("received message %d of %d", i + 1, iter);
     }
 
     /* Wait for thread to terminate, then clean up.

--- a/src/test/tasyncsock.c
+++ b/src/test/tasyncsock.c
@@ -92,24 +92,24 @@ void send_czmq (char *buf, int len)
     zmsg_t *zmsg;
 
     if (!(zctx = zctx_new ()))
-        err_exit ("C: zctx_new");
+        log_err_exit ("C: zctx_new");
     if (lopt) /* zctx linger default = 0 (flush none) */
         zctx_set_linger (zctx, linger); 
     if (!(zs = zsocket_new (zctx, ZMQ_DEALER)))
-        err_exit ("C: zsocket_new");
+        log_err_exit ("C: zsocket_new");
     //if (lopt) // doesn't work here 
     //    zsocket_set_linger (zs, linger); 
     if (iopt)
         zsocket_set_immediate (zs, imm);
     //zsocket_set_sndhwm (zs, 0); /* unlimited */
     if (zsocket_connect (zs, "%s", uri) < 0)
-        err_exit ("C: zsocket_connect");
+        log_err_exit ("C: zsocket_connect");
     if (!(zmsg = zmsg_new ()))
         oom ();
     if (zmsg_pushmem (zmsg, buf, bufsize) < 0)
         oom ();
     if (zmsg_send (&zmsg, zs) < 0)
-        err_exit ("C: zmsg_send");
+        log_err_exit ("C: zmsg_send");
     if (sleep_usec > 0)
         usleep (sleep_usec);
     zctx_destroy (&zctx);
@@ -122,33 +122,33 @@ void send_raw (char *buf, int len)
     int hwm = 0;
 
     if (!(zctx = zmq_init (1)))
-        err_exit ("C: zmq_init");
+        log_err_exit ("C: zmq_init");
     if (!(zs = zmq_socket (zctx, ZMQ_DEALER)))
-        err_exit ("C: zmq_socket");
+        log_err_exit ("C: zmq_socket");
     if (iopt) {
         if (zmq_setsockopt (zs, ZMQ_IMMEDIATE, &imm, sizeof (imm)) < 0)
-            err_exit ("C: zmq_setsockopt ZMQ_IMMEDIATE %d", imm);
+            log_err_exit ("C: zmq_setsockopt ZMQ_IMMEDIATE %d", imm);
     }
     if (lopt) { /* zmq linger default = -1 (flush all) */
         if (zmq_setsockopt (zs, ZMQ_LINGER, &linger, sizeof (linger)) < 0)
-            err_exit ("C: zmq_setsockopt ZMQ_LINGER %d", linger);
+            log_err_exit ("C: zmq_setsockopt ZMQ_LINGER %d", linger);
     }
     if (zmq_setsockopt (zs, ZMQ_SNDHWM, &hwm, sizeof (hwm)) < 0)
-        err_exit ("C: zmq_setsockopt ZMQ_SNDHWM %d", linger);
+        log_err_exit ("C: zmq_setsockopt ZMQ_SNDHWM %d", linger);
     if (zmq_connect (zs, uri) < 0)
-        err_exit ("C: zmq_connect");
+        log_err_exit ("C: zmq_connect");
     if (zmq_send (zs, buf, bufsize, 0) < 0)
-        err_exit ("zmq_send");
+        log_err_exit ("zmq_send");
     if (sleep_usec > 0)
         usleep (sleep_usec);
     if (zmq_close (zs) < 0)
-        err_exit ("zmq_close");
+        log_err_exit ("zmq_close");
 #if ZMQ_VERSION_MAJOR < 4
     if (zmq_ctx_destroy (zctx) < 0)
-        err_exit ("zmq_ctx_destroy");
+        log_err_exit ("zmq_ctx_destroy");
 #else
     if (zmq_ctx_term (zctx) < 0)
-        err_exit ("zmq_ctx_term");
+        log_err_exit ("zmq_ctx_term");
 #endif
 }
 
@@ -257,12 +257,12 @@ int main (int argc, char *argv[])
      * Store uri in global variable.
      */
     if (!(zctx = zctx_new ()))
-        err_exit ("S: zctx_new");
+        log_err_exit ("S: zctx_new");
     if (!(zs = zsocket_new (zctx, ZMQ_ROUTER)))
-        err_exit ("S: zsocket_new");
+        log_err_exit ("S: zsocket_new");
     zsocket_set_rcvhwm (zs, 0); /* unlimited */
     if (zsocket_bind (zs, "%s", uritmpl) < 0)
-        err_exit ("S: zsocket_bind");
+        log_err_exit ("S: zsocket_bind");
     uri = zsocket_last_endpoint (zs);
 
     /* Spawn thread which will be our client.
@@ -277,7 +277,7 @@ int main (int argc, char *argv[])
     for (i = 0; i < iter; i++) {
         alarm (timeout_sec);
         if (!(zmsg = zmsg_recv (zs)))
-            err_exit ("S: zmsg_recv");
+            log_err_exit ("S: zmsg_recv");
         zmsg_destroy (&zmsg);
         alarm (0);
         if (vopt)

--- a/src/test/tbarrier.c
+++ b/src/test/tbarrier.c
@@ -92,7 +92,7 @@ int main (int argc, char *argv[])
         name = argv[optind++];
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     for (i = 0; i < iter; i++) {
         char *tname = NULL;
@@ -103,7 +103,7 @@ int main (int argc, char *argv[])
             if (errno == EINVAL && tname == NULL)
                 log_msg_exit ("%s", "provide barrier name if not running as LWJ");
             else
-                err_exit ("flux_barrier");
+                log_err_exit ("flux_barrier");
         }
         if (!quiet)
             printf ("barrier name=%s nprocs=%d time=%0.3f ms\n",

--- a/src/test/tbarrier.c
+++ b/src/test/tbarrier.c
@@ -101,7 +101,7 @@ int main (int argc, char *argv[])
             tname = xasprintf ("%s.%d", name, i);
         if (flux_barrier (h, tname, nprocs) < 0) {
             if (errno == EINVAL && tname == NULL)
-                msg_exit ("%s", "provide barrier name if not running as LWJ");
+                log_msg_exit ("%s", "provide barrier name if not running as LWJ");
             else
                 err_exit ("flux_barrier");
         }

--- a/src/test/tmunge.c
+++ b/src/test/tmunge.c
@@ -61,13 +61,13 @@ void *thread (void *arg)
     int i;
 
     if (!(sec = flux_sec_create ()))
-        err_exit ("C: flux_sec_create");
+        log_err_exit ("C: flux_sec_create");
     if (flux_sec_disable (sec, FLUX_SEC_TYPE_ALL) < 0)
-        err_exit ("C: flux_sec_disable ALL");
+        log_err_exit ("C: flux_sec_disable ALL");
     if (flux_sec_enable (sec, FLUX_SEC_TYPE_MUNGE) < 0)
-        err_exit ("C: flux_sec_enable MUNGE");
+        log_err_exit ("C: flux_sec_enable MUNGE");
     if (flux_sec_munge_init (sec) < 0)
-        err_exit ("C: flux_sec_munge_init: %s", flux_sec_errstr (sec));
+        log_err_exit ("C: flux_sec_munge_init: %s", flux_sec_errstr (sec));
 
     if (!(zmsg = zmsg_new ()))
         oom ();
@@ -76,10 +76,10 @@ void *thread (void *arg)
             oom ();
     //zmsg_dump (zmsg);
     if (flux_sec_munge_zmsg (sec, &zmsg) < 0)
-        err_exit ("C: flux_sec_munge_zmsg: %s", flux_sec_errstr (sec));
+        log_err_exit ("C: flux_sec_munge_zmsg: %s", flux_sec_errstr (sec));
     //zmsg_dump (zmsg);
     if (zmsg_send (&zmsg, cs) < 0)
-        err_exit ("C: zmsg_send");
+        log_err_exit ("C: zmsg_send");
 
     flux_sec_destroy (sec);
 
@@ -106,26 +106,26 @@ int main (int argc, char *argv[])
     nframes = strtoul (argv[1], NULL, 10);
 
     if (!(sec = flux_sec_create ()))
-        err_exit ("flux_sec_create");
+        log_err_exit ("flux_sec_create");
     if (flux_sec_disable (sec, FLUX_SEC_TYPE_ALL) < 0)
-        err_exit ("flux_sec_disable ALL");
+        log_err_exit ("flux_sec_disable ALL");
     if (flux_sec_enable (sec, FLUX_SEC_TYPE_MUNGE) < 0)
-        err_exit ("flux_sec_enable MUNGE");
+        log_err_exit ("flux_sec_enable MUNGE");
     if (flux_sec_munge_init (sec) < 0)
-        err_exit ("flux_sec_munge_init: %s", flux_sec_errstr (sec));
+        log_err_exit ("flux_sec_munge_init: %s", flux_sec_errstr (sec));
 
     if (!(zctx = zctx_new ()))
-        err_exit ("S: zctx_new");
+        log_err_exit ("S: zctx_new");
     if (!(zs = zsocket_new (zctx, ZMQ_SUB)))
-        err_exit ("S: zsocket_new");
+        log_err_exit ("S: zsocket_new");
     if (zsocket_bind (zs, "%s", uri) < 0)
-        err_exit ("S: zsocket_bind");
+        log_err_exit ("S: zsocket_bind");
     zsocket_set_subscribe (zs, "");
 
     if (!(cs = zsocket_new (zctx, ZMQ_PUB)))
-        err_exit ("S: zsocket_new");
+        log_err_exit ("S: zsocket_new");
     if (zsocket_connect (cs, "%s", uri) < 0)
-        err_exit ("S: zsocket_connect");
+        log_err_exit ("S: zsocket_connect");
 
     if ((rc = pthread_attr_init (&attr)))
         log_errn (rc, "S: pthread_attr_init");
@@ -135,10 +135,10 @@ int main (int argc, char *argv[])
     /* Handle one client message.
      */
     if (!(zmsg = zmsg_recv (zs)))
-        err_exit ("S: zmsg_recv");
+        log_err_exit ("S: zmsg_recv");
     //zmsg_dump (zmsg);
     if (flux_sec_unmunge_zmsg (sec, &zmsg) < 0)
-        err_exit ("S: flux_sec_unmunge_zmsg: %s", flux_sec_errstr (sec));
+        log_err_exit ("S: flux_sec_unmunge_zmsg: %s", flux_sec_errstr (sec));
     //zmsg_dump (zmsg);
     if ((n = zmsg_size (zmsg) != nframes))
         log_msg_exit ("S: expected %d frames, got %d", nframes, n);

--- a/src/test/tmunge.c
+++ b/src/test/tmunge.c
@@ -141,7 +141,7 @@ int main (int argc, char *argv[])
         err_exit ("S: flux_sec_unmunge_zmsg: %s", flux_sec_errstr (sec));
     //zmsg_dump (zmsg);
     if ((n = zmsg_size (zmsg) != nframes))
-        msg_exit ("S: expected %d frames, got %d", nframes, n);
+        log_msg_exit ("S: expected %d frames, got %d", nframes, n);
 
     /* Wait for thread to terminate, then clean up.
      */

--- a/src/test/tmunge.c
+++ b/src/test/tmunge.c
@@ -128,9 +128,9 @@ int main (int argc, char *argv[])
         err_exit ("S: zsocket_connect");
 
     if ((rc = pthread_attr_init (&attr)))
-        errn (rc, "S: pthread_attr_init");
+        log_errn (rc, "S: pthread_attr_init");
     if ((rc = pthread_create (&tid, &attr, thread, NULL)))
-        errn (rc, "S: pthread_create");
+        log_errn (rc, "S: pthread_create");
 
     /* Handle one client message.
      */
@@ -146,7 +146,7 @@ int main (int argc, char *argv[])
     /* Wait for thread to terminate, then clean up.
      */
     if ((rc = pthread_join (tid, NULL)))
-        errn (rc, "S: pthread_join");
+        log_errn (rc, "S: pthread_join");
     zctx_destroy (&zctx); /* destroys sockets too */
 
     flux_sec_destroy (sec);

--- a/src/test/tmunge.c
+++ b/src/test/tmunge.c
@@ -45,6 +45,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 
 #if CZMQ_VERSION_MAJOR < 2
 #define zmsg_pushstrf zmsg_pushstr

--- a/t/kvs/commit.c
+++ b/t/kvs/commit.c
@@ -161,14 +161,14 @@ int main (int argc, char *argv[])
         if (!(thd[i].perf = zlist_new ()))
             oom ();
         if ((rc = pthread_attr_init (&thd[i].attr)))
-            errn (rc, "pthread_attr_init");
+            log_errn (rc, "pthread_attr_init");
         if ((rc = pthread_create (&thd[i].t, &thd[i].attr, thread, &thd[i])))
-            errn (rc, "pthread_create");
+            log_errn (rc, "pthread_create");
     }
 
     for (i = 0; i < nthreads; i++) {
         if ((rc = pthread_join (thd[i].t, NULL)))
-            errn (rc, "pthread_join");
+            log_errn (rc, "pthread_join");
         if (sopt) {
             double *e;
             while ((e = zlist_pop (thd[i].perf))) {

--- a/t/kvs/commit.c
+++ b/t/kvs/commit.c
@@ -85,11 +85,11 @@ void *thread (void *arg)
     uint32_t rank;
 
     if (!(t->h = flux_open (NULL, 0))) {
-        err ("%d: flux_open", t->n);
+        log_err ("%d: flux_open", t->n);
         goto done;
     }
     if (flux_get_rank (t->h, &rank) < 0) {
-        err ("%d: flux_get_rank", t->n);
+        log_err ("%d: flux_get_rank", t->n);
         goto done;
     }
     for (i = 0; i < count; i++) {
@@ -99,13 +99,13 @@ void *thread (void *arg)
         if (sopt)
             monotime (&t0);
         if (kvs_put_int (t->h, key, 42) < 0)
-            err_exit ("%s", key);
+            log_err_exit ("%s", key);
         if (fopt) {
             if (kvs_fence (t->h, fence, fence_nprocs) < 0)
-                err_exit ("kvs_fence");
+                log_err_exit ("kvs_fence");
         } else {
             if (kvs_commit (t->h) < 0)
-                err_exit ("kvs_commit");
+                log_err_exit ("kvs_commit");
         }
         if (sopt && zlist_append (t->perf, ddup (monotime_since (t0))) < 0)
             oom ();

--- a/t/kvs/hashtest.c
+++ b/t/kvs/hashtest.c
@@ -439,7 +439,7 @@ struct hash_impl *create_sophia (void)
     path = mkdtemp (template);
     assert (path != NULL);
     cleanup_push_string (cleanup_directory_recursive, path);
-    msg ("sophia.path: %s", path);
+    log_msg ("sophia.path: %s", path);
     impl->h = sp_env ();
     assert (impl->h != NULL);
     rc = sp_setstring (impl->h, "sophia.path", path, 0);
@@ -596,7 +596,7 @@ struct hash_impl *create_sqlite (void)
     path = mkdtemp (template);
     assert (path != NULL);
     cleanup_push_string (cleanup_directory_recursive, path);
-    msg ("sqlite path: %s", path);
+    log_msg ("sqlite path: %s", path);
 
     snprintf (dbpath, sizeof (dbpath), "%s/db", path);
     rc = sqlite3_open (dbpath, &db);
@@ -679,25 +679,25 @@ int main (int argc, char *argv[])
         impl = create_sqlite ();
     if (!impl)
         usage ();
-    msg ("create hash: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+    log_msg ("create hash: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
                                        rusage_maxrss_since (&res));
 
     rusage (&res);
     monotime (&t0);
     items = create_items ();
-    msg ("create items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+    log_msg ("create items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
                                         rusage_maxrss_since (&res));
 
     rusage (&res);
     monotime (&t0);
     impl->insert (impl, items);
-    msg ("insert items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+    log_msg ("insert items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
                                         rusage_maxrss_since (&res));
 
     rusage (&res);
     monotime (&t0);
     impl->lookup (impl, items);
-    msg ("lookup items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
+    log_msg ("lookup items: %.2fs (%+ldK)", monotime_since (t0) * 1E-3,
                                         rusage_maxrss_since (&res));
 
     impl->destroy (impl);

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -134,20 +134,20 @@ int main (int argc, char *argv[])
         if (kvs_put (h, key, json_object_to_json_string (vo)) < 0)
             err_exit ("kvs_put %s", key);
         if (verbose)
-            msg ("%s = %s", key, val);
+            log_msg ("%s = %s", key, val);
         if (vo)
             json_object_put (vo);
         free (key);
     }
     if (!quiet)
-        msg ("kvs_put:    time=%0.3f s (%d keys of size %d)",
+        log_msg ("kvs_put:    time=%0.3f s (%d keys of size %d)",
              monotime_since (t0)/1000, count, size);
 
     monotime (&t0);
     if (kvs_commit (h) < 0)
         err_exit ("kvs_commit");
     if (!quiet)
-        msg ("kvs_commit: time=%0.3f s", monotime_since (t0)/1000);
+        log_msg ("kvs_commit: time=%0.3f s", monotime_since (t0)/1000);
 
     monotime (&t0);
     for (i = 0; i < count; i++) {
@@ -157,20 +157,20 @@ int main (int argc, char *argv[])
         if (kvs_get (h, key, &json_str) < 0)
             err_exit ("kvs_get '%s'", key);
         if (!(vo = json_tokener_parse (json_str)))
-            msg_exit ("json_tokener_parse");
+            log_msg_exit ("json_tokener_parse");
         free (json_str);
         s = json_object_get_string (vo);
         if (verbose)
-            msg ("%s = %s", key, s);
+            log_msg ("%s = %s", key, s);
         if (strcmp (s, val) != 0)
-            msg_exit ("kvs_get: key '%s' wrong value '%s'",
+            log_msg_exit ("kvs_get: key '%s' wrong value '%s'",
                       key, json_object_get_string (vo));
         if (vo)
             json_object_put (vo);
         free (key);
     }
     if (!quiet)
-        msg ("kvs_get:    time=%0.3f s (%d keys of size %d)",
+        log_msg ("kvs_get:    time=%0.3f s (%d keys of size %d)",
              monotime_since (t0)/1000, count, size);
 
     if (prefix)

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -39,6 +39,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 
 
 #define OPTIONS "hc:s:p:qv"

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -110,18 +110,18 @@ int main (int argc, char *argv[])
         usage ();
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (!prefix) {
         uint32_t rank;
         if (flux_get_rank (h, &rank) < 0)
-            err_exit ("flux_get_rank");
+            log_err_exit ("flux_get_rank");
         prefix = xasprintf ("kvstorture-%u", rank);
     }
 
     if (kvs_unlink (h, prefix) < 0)
-        err_exit ("kvs_unlink %s", prefix);
+        log_err_exit ("kvs_unlink %s", prefix);
     if (kvs_commit (h) < 0)
-        err_exit ("kvs_commit");
+        log_err_exit ("kvs_commit");
 
     val = xzmalloc (size);
 
@@ -132,7 +132,7 @@ int main (int argc, char *argv[])
         fill (val, i, size);
         vo = json_object_new_string (val);
         if (kvs_put (h, key, json_object_to_json_string (vo)) < 0)
-            err_exit ("kvs_put %s", key);
+            log_err_exit ("kvs_put %s", key);
         if (verbose)
             log_msg ("%s = %s", key, val);
         if (vo)
@@ -145,7 +145,7 @@ int main (int argc, char *argv[])
 
     monotime (&t0);
     if (kvs_commit (h) < 0)
-        err_exit ("kvs_commit");
+        log_err_exit ("kvs_commit");
     if (!quiet)
         log_msg ("kvs_commit: time=%0.3f s", monotime_since (t0)/1000);
 
@@ -155,7 +155,7 @@ int main (int argc, char *argv[])
             oom ();
         fill (val, i, size);
         if (kvs_get (h, key, &json_str) < 0)
-            err_exit ("kvs_get '%s'", key);
+            log_err_exit ("kvs_get '%s'", key);
         if (!(vo = json_tokener_parse (json_str)))
             log_msg_exit ("json_tokener_parse");
         free (json_str);

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -69,12 +69,12 @@ static void signal_ready (void)
     int rc;
 
     if ((rc = pthread_mutex_lock (&start_lock)))
-        errn_exit (rc, "pthread_mutex_lock");
+        log_errn_exit (rc, "pthread_mutex_lock");
     start_count++;
     if ((rc = pthread_mutex_unlock (&start_lock)))
-        errn_exit (rc, "pthread_mutex_unlock");
+        log_errn_exit (rc, "pthread_mutex_unlock");
     if ((rc = pthread_cond_signal (&start_cond)))
-        errn_exit (rc, "pthread_cond_signal");
+        log_errn_exit (rc, "pthread_cond_signal");
 }
 
 static void wait_ready (void)
@@ -82,13 +82,13 @@ static void wait_ready (void)
     int rc;
 
     if ((rc = pthread_mutex_lock (&start_lock)))
-        errn_exit (rc, "pthread_mutex_lock");
+        log_errn_exit (rc, "pthread_mutex_lock");
     while (start_count < nthreads) {
         if ((rc = pthread_cond_wait (&start_cond, &start_lock)))
-            errn_exit (rc, "pthread_cond_wait");
+            log_errn_exit (rc, "pthread_cond_wait");
     }
     if ((rc = pthread_mutex_unlock (&start_lock)))
-        errn_exit (rc, "pthread_mutex_unlock");
+        log_errn_exit (rc, "pthread_mutex_unlock");
 }
 
 /* expect val: {-1,0,1,...,(changes - 1)}
@@ -98,7 +98,7 @@ static int mt_watch_cb (const char *k, int val, void *arg, int errnum)
 {
     thd_t *t = arg;
     if (errnum != 0) {
-        errn (errnum, "%d: %s", t->n, __FUNCTION__);
+        log_errn (errnum, "%d: %s", t->n, __FUNCTION__);
         return -1;
     }
     if (val == t->last_val) {
@@ -121,7 +121,7 @@ static int mt_watchnil_cb (const char *k, int val, void *arg, int errnum)
 {
     thd_t *t = arg;
     if (errnum != ENOENT) {
-        errn (errnum, "%d: %s", t->n, __FUNCTION__);
+        log_errn (errnum, "%d: %s", t->n, __FUNCTION__);
         return -1;
     }
     t->nil_count++;
@@ -135,7 +135,7 @@ static int mt_watchstable_cb (const char *k, int val, void *arg, int errnum)
     thd_t *t = arg;
 
     if (errnum != 0) {
-        errn (errnum, "%d: %s", t->n, __FUNCTION__);
+        log_errn (errnum, "%d: %s", t->n, __FUNCTION__);
         return -1;
     }
     t->stable_count++;
@@ -223,9 +223,9 @@ void test_mt (int argc, char **argv)
         thd[i].n = i;
         thd[i].last_val = -42;
         if ((rc = pthread_attr_init (&thd[i].attr)))
-            errn (rc, "pthread_attr_init");
+            log_errn (rc, "pthread_attr_init");
         if ((rc = pthread_create (&thd[i].tid, &thd[i].attr, thread, &thd[i])))
-            errn (rc, "pthread_create");
+            log_errn (rc, "pthread_create");
     }
     wait_ready ();
 
@@ -244,7 +244,7 @@ void test_mt (int argc, char **argv)
      */
     for (i = 0; i < nthreads; i++) {
         if ((rc = pthread_join (thd[i].tid, NULL)))
-            errn (rc, "pthread_join");
+            log_errn (rc, "pthread_join");
         if (thd[i].nil_count != 1) {
             log_msg ("%d: nil callback called %d times (expected one)",
                  i, thd[i].nil_count);

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -102,7 +102,7 @@ static int mt_watch_cb (const char *k, int val, void *arg, int errnum)
         return -1;
     }
     if (val == t->last_val) {
-        msg ("%d: %s: called with same value as last time: %d", t->n,
+        log_msg ("%d: %s: called with same value as last time: %d", t->n,
             __FUNCTION__, val);
         return -1;
     }
@@ -246,17 +246,17 @@ void test_mt (int argc, char **argv)
         if ((rc = pthread_join (thd[i].tid, NULL)))
             errn (rc, "pthread_join");
         if (thd[i].nil_count != 1) {
-            msg ("%d: nil callback called %d times (expected one)",
+            log_msg ("%d: nil callback called %d times (expected one)",
                  i, thd[i].nil_count);
             errors++;
         }
         if (thd[i].stable_count != 1) {
-            msg ("%d: stable callback called %d times (expected one)",
+            log_msg ("%d: stable callback called %d times (expected one)",
                  i, thd[i].stable_count);
             errors++;
         }
         if (thd[i].change_count > changes + 1) {
-            msg ("%d: changing callback called %d times (expected <= %d)",
+            log_msg ("%d: changing callback called %d times (expected <= %d)",
                  i, thd[i].change_count, changes + 1);
             errors++;
         }
@@ -272,7 +272,7 @@ void test_mt (int argc, char **argv)
 
 static int selfmod_watch_cb (const char *key, int val, void *arg, int errnum)
 {
-    msg ("%s: value = %d errnum = %d", __FUNCTION__, val, errnum);
+    log_msg ("%s: value = %d errnum = %d", __FUNCTION__, val, errnum);
 
     flux_t h = arg;
     if (kvs_put_int (h, key, val + 1) < 0)
@@ -302,9 +302,9 @@ void test_selfmod (int argc, char **argv)
     if (kvs_watch_int (h, key, selfmod_watch_cb, h) < 0)
         err_exit ("kvs_watch_int");
 
-    msg ("reactor: start");
+    log_msg ("reactor: start");
     flux_reactor_run (flux_get_reactor (h), 0);
-    msg ("reactor: end");
+    log_msg ("reactor: end");
 
     flux_close (h);
 }
@@ -326,7 +326,7 @@ static void unwatch_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
 {
     struct timer_ctx *ctx = arg;
     static int count = 0;
-    msg ("%s", __FUNCTION__);
+    log_msg ("%s", __FUNCTION__);
     if (kvs_put_int (ctx->h, ctx->key, count++) < 0)
         err_exit ("%s: kvs_put_int", __FUNCTION__);
     if (kvs_commit (ctx->h) < 0)
@@ -367,7 +367,7 @@ void test_unwatch (int argc, char **argv)
     if (flux_reactor_run (r, 0) < 0)
         err_exit ("flux_reactor_run");
     if (count != 10)
-        msg_exit ("watch called %d times (should be 10)", count);
+        log_msg_exit ("watch called %d times (should be 10)", count);
     flux_watcher_destroy (timer);
     flux_close (ctx.h);
 }
@@ -402,7 +402,7 @@ void test_unwatchloop (int argc, char **argv)
     }
     uint32_t leaked = avail - flux_matchtag_avail (h, FLUX_MATCHTAG_GROUP);
     if (leaked > 0)
-        msg_exit ("leaked %u matchtags", leaked);
+        log_msg_exit ("leaked %u matchtags", leaked);
 
     flux_close (h);
 }

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -23,10 +23,10 @@ void send_watch_requests (flux_t h, const char *key)
     json_object_object_add (in, "noexist", NULL);
     Jadd_bool (in, ".flag_first", true);
     if (!(r = flux_rpc_multi (h, "kvs.watch", Jtostr (in), "all", 0)))
-        err_exit ("flux_rpc_multi kvs.watch");
+        log_err_exit ("flux_rpc_multi kvs.watch");
     while (!flux_rpc_completed (r)) {
         if (flux_rpc_get (r, NULL, &json_str) < 0)
-            err_exit ("kvs.watch");
+            log_err_exit ("kvs.watch");
     }
     flux_rpc_destroy (r);
     Jput (in);
@@ -42,10 +42,10 @@ int count_watchers (flux_t h)
     flux_rpc_t *r;
 
     if (!(r = flux_rpc_multi (h, "kvs.stats.get", NULL, "all", 0)))
-        err_exit ("flux_rpc_multi kvs.stats.get");
+        log_err_exit ("flux_rpc_multi kvs.stats.get");
     while (!flux_rpc_completed (r)) {
         if (flux_rpc_get (r, NULL, &json_str) < 0)
-            err_exit ("kvs.stats.get");
+            log_err_exit ("kvs.stats.get");
         if (!(out = Jfromstr (json_str)) || !Jget_int (out, "#watchers", &n))
             log_msg_exit ("error decoding stats payload");
         count += n;
@@ -64,7 +64,7 @@ int main (int argc, char **argv)
      * The number of watchers should return to the original count.
      */
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     w0 = count_watchers (h);
     send_watch_requests (h, "nonexist");
     w1 = count_watchers (h) - w0;
@@ -73,11 +73,11 @@ int main (int argc, char **argv)
     log_msg ("disconnected");
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     w2 = count_watchers (h) - w0;
     log_msg ("test watchers: %d", w2);
     if (w2 != 0)
-        err_exit ("Test failure, watchers were not removed on disconnect");
+        log_err_exit ("Test failure, watchers were not removed on disconnect");
 
     return (0);
 }

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -47,7 +47,7 @@ int count_watchers (flux_t h)
         if (flux_rpc_get (r, NULL, &json_str) < 0)
             err_exit ("kvs.stats.get");
         if (!(out = Jfromstr (json_str)) || !Jget_int (out, "#watchers", &n))
-            msg_exit ("error decoding stats payload");
+            log_msg_exit ("error decoding stats payload");
         count += n;
         Jput (out);
     }
@@ -68,14 +68,14 @@ int main (int argc, char **argv)
     w0 = count_watchers (h);
     send_watch_requests (h, "nonexist");
     w1 = count_watchers (h) - w0;
-    msg ("test watchers: %d", w1);
+    log_msg ("test watchers: %d", w1);
     flux_close (h);
-    msg ("disconnected");
+    log_msg ("disconnected");
 
     if (!(h = flux_open (NULL, 0)))
         err_exit ("flux_open");
     w2 = count_watchers (h) - w0;
-    msg ("test watchers: %d", w2);
+    log_msg ("test watchers: %d", w2);
     if (w2 != 0)
         err_exit ("Test failure, watchers were not removed on disconnect");
 

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -278,7 +278,7 @@ static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
     flux_reactor_t *r = flux_get_reactor (h);
     flux_watcher_t *w = NULL;
 
-    msg ("process attached to %s", key);
+    log_msg ("process attached to %s", key);
 
     ctx->h = h;
     ctx->blocksize = blocksize;

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -34,6 +34,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libsubprocess/zio.h"
 #include "src/modules/libkz/kz.h"

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -136,9 +136,9 @@ int main (int argc, char *argv[])
     }
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
     if (flux_get_rank (h, &rank) < 0)
-        err_exit ("flux_get_rank");
+        log_err_exit ("flux_get_rank");
 
     if (aopt) {
         attach (h, key, rawtty, kzoutflags, blocksize);
@@ -209,10 +209,10 @@ static void attach_stdout_ready_cb (kz_t *kz, void *arg)
     do {
         if ((len = kz_get (kz, &data)) < 0) {
             if (errno != EAGAIN)
-                err_exit ("kz_get stdout");
+                log_err_exit ("kz_get stdout");
         } else if (len > 0) {
             if (write_all (STDOUT_FILENO, data, len) < 0)
-                err_exit ("write_all stdout");
+                log_err_exit ("write_all stdout");
             free (data);
         }
     } while (len > 0);
@@ -231,10 +231,10 @@ static void attach_stderr_ready_cb (kz_t *kz, void *arg)
     do {
         if ((len = kz_get (kz, &data)) < 0) {
             if (errno != EAGAIN)
-                err_exit ("kz_get stderr");
+                log_err_exit ("kz_get stderr");
         } else if (len > 0) {
             if (write_all (STDERR_FILENO, data, len) < 0)
-                err_exit ("write_all stderr");
+                log_err_exit ("write_all stderr");
             free (data);
         }
     } while (len > 0);
@@ -255,15 +255,15 @@ static void attach_stdin_ready_cb (flux_reactor_t *r, flux_watcher_t *w,
     do  {
         if ((len = read (fd, buf, ctx->blocksize)) < 0) {
             if (errno != EAGAIN)
-                err_exit ("read stdin");
+                log_err_exit ("read stdin");
         } else if (len > 0) {
             if (kz_put (ctx->kz[0], buf, len) < 0)
-                err_exit ("kz_put");
+                log_err_exit ("kz_put");
         }
     } while (len > 0);
     if (len == 0) { /* EOF */
         if (kz_close (ctx->kz[0]) < 0)
-            err_exit ("kz_close");
+            log_err_exit ("kz_close");
     }
     free (buf);
 }
@@ -288,22 +288,22 @@ static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
      */
     if (rawtty) {
         if (fd_set_raw (fdin, &saved_tio, true) < 0)
-            err_exit ("fd_set_raw stdin");
+            log_err_exit ("fd_set_raw stdin");
     }
     if (fd_set_nonblocking (fdin, true) < 0)
-        err_exit ("fd_set_nonblocking stdin");
+        log_err_exit ("fd_set_nonblocking stdin");
 
     if (asprintf (&name, "%s.stdin", key) < 0)
         oom ();
     if (!(ctx->kz[0] = kz_open (h, name, kzoutflags)))
         if (errno == EEXIST)
-            err ("disabling stdin");
+            log_err ("disabling stdin");
         else
-            err_exit ("%s", name);
+            log_err_exit ("%s", name);
     else {
         if (!(w = flux_fd_watcher_create (r, fdin, FLUX_POLLIN,
                                 attach_stdin_ready_cb, ctx)))
-            err_exit ("flux_fd_watcher_create %s", name);
+            log_err_exit ("flux_fd_watcher_create %s", name);
         flux_watcher_start (w);
     }
     free (name);
@@ -311,18 +311,18 @@ static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
     if (asprintf (&name, "%s.stdout", key) < 0)
         oom ();
     if (!(ctx->kz[1] = kz_open (h, name, KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK)))
-        err_exit ("kz_open %s", name);
+        log_err_exit ("kz_open %s", name);
     if (kz_set_ready_cb (ctx->kz[1], attach_stdout_ready_cb, ctx) < 0)
-        err_exit ("kz_set_ready_cb %s", name);
+        log_err_exit ("kz_set_ready_cb %s", name);
     free (name);
     ctx->readers++;
 
     if (asprintf (&name, "%s.stderr", key) < 0)
         oom ();
     if (!(ctx->kz[2] = kz_open (h, name, KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK)))
-        err_exit ("kz_open %s", name);
+        log_err_exit ("kz_open %s", name);
     if (kz_set_ready_cb (ctx->kz[2], attach_stderr_ready_cb, ctx) < 0)
-        err_exit ("kz_set_ready_cb %s", name);
+        log_err_exit ("kz_set_ready_cb %s", name);
     free (name);
     ctx->readers++;
 
@@ -334,7 +334,7 @@ static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
      */
     if (ctx->readers > 0) {
         if (flux_reactor_run (r, 0) < 0)
-            err_exit ("flux_reactor_run");
+            log_err_exit ("flux_reactor_run");
     }
 
     (void)kz_close (ctx->kz[1]);
@@ -344,7 +344,7 @@ static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
      */
     if (rawtty) {
         if (fd_set_raw (fdin, &saved_tio, false) < 0)
-            err_exit ("fd_set_raw stdin");
+            log_err_exit ("fd_set_raw stdin");
     }
 
     flux_watcher_destroy (w);
@@ -359,21 +359,21 @@ static void copy_k2k (flux_t h, const char *src, const char *dst,
     bool eof = false;
 
     if (!(kzin = kz_open (h, src, KZ_FLAGS_READ | KZ_FLAGS_RAW)))
-        err_exit ("kz_open %s", src);
+        log_err_exit ("kz_open %s", src);
     if (!(kzout = kz_open (h, dst, kzoutflags | KZ_FLAGS_RAW)))
-        err_exit ("kz_open %s", dst);
+        log_err_exit ("kz_open %s", dst);
     while (!eof && (json_str = kz_get_json (kzin))) {
         if (kz_put_json (kzout, json_str) < 0)
-            err_exit ("kz_put_json %s", dst);
+            log_err_exit ("kz_put_json %s", dst);
         eof = zio_json_eof (json_str);
         free (json_str);
     }
     if (json_str == NULL)
-        err_exit ("kz_get %s", src);
+        log_err_exit ("kz_get %s", src);
     if (kz_close (kzin) < 0) 
-        err_exit ("kz_close %s", src);
+        log_err_exit ("kz_close %s", src);
     if (kz_close (kzout) < 0) 
-        err_exit ("kz_close %s", dst);
+        log_err_exit ("kz_close %s", dst);
 }
 
 static void copy_f2k (flux_t h, const char *src, const char *dst,
@@ -386,20 +386,20 @@ static void copy_f2k (flux_t h, const char *src, const char *dst,
 
     if (strcmp (src, "-") != 0) {
         if ((srcfd = open (src, O_RDONLY)) < 0)
-            err_exit ("%s", src);
+            log_err_exit ("%s", src);
     }
     if (!(kzout = kz_open (h, dst, kzoutflags)))
-        err_exit ("kz_open %s", dst);
+        log_err_exit ("kz_open %s", dst);
     data = xzmalloc (blocksize);
     while ((len = read (srcfd, data, blocksize)) > 0) {
         if (kz_put (kzout, data, len) < 0)
-            err_exit ("kz_put %s", dst);
+            log_err_exit ("kz_put %s", dst);
     }
     if (len < 0)
-        err_exit ("read %s", src);
+        log_err_exit ("read %s", src);
     free (data);
     if (kz_close (kzout) < 0) 
-        err_exit ("kz_close %s", dst);
+        log_err_exit ("kz_close %s", dst);
 }
 
 static void copy_k2f (flux_t h, const char *src, const char *dst)
@@ -410,23 +410,23 @@ static void copy_k2f (flux_t h, const char *src, const char *dst)
     int len;
 
     if (!(kzin = kz_open (h, src, KZ_FLAGS_READ)))
-        err_exit ("kz_open %s", src);
+        log_err_exit ("kz_open %s", src);
     if (strcmp (dst, "-") != 0) {
         if ((dstfd = creat (dst, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0)
-            err_exit ("%s", dst);
+            log_err_exit ("%s", dst);
     }
     while ((len = kz_get (kzin, &data)) > 0) {
         if (write_all (dstfd, data, len) < 0)
-            err_exit ("write_all %s", dst);
+            log_err_exit ("write_all %s", dst);
         free (data);
     }
     if (len < 0)
-        err_exit ("kz_get %s", src);
+        log_err_exit ("kz_get %s", src);
     if (kz_close (kzin) < 0) 
-        err_exit ("kz_close %s", src);
+        log_err_exit ("kz_close %s", src);
     if (dstfd != STDOUT_FILENO) {
         if (close (dstfd) < 0)
-            err_exit ("close %s", dst);
+            log_err_exit ("close %s", dst);
     }
 }
 
@@ -445,7 +445,7 @@ static void copy (flux_t h, const char *src, const char *dst, int kzoutflags,
     } else if (!isfile (src) && isfile (dst)) {
         copy_k2f (h, src, dst);
     } else {
-        err_exit ("copy src and dst cannot both be file");
+        log_err_exit ("copy src and dst cannot both be file");
     }
 }
 

--- a/t/loop/reduce.c
+++ b/t/loop/reduce.c
@@ -3,7 +3,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/xzmalloc.h"
-#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libtap/tap.h"
 
 int reduce_calls = 0;

--- a/t/module/parent.c
+++ b/t/module/parent.c
@@ -12,6 +12,7 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 
 typedef struct {
     char *name;

--- a/t/pmi/kvstest.c
+++ b/t/pmi/kvstest.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     else
         pmi = pmi_create_guess ();
     if (!pmi)
-        err_exit ("pmi_create");
+        log_err_exit ("pmi_create");
     e = pmi_init (pmi, &spawned);
     if (e != PMI_SUCCESS)
         log_msg_exit ("pmi_init: %s", pmi_strerror (e));

--- a/t/pmi/kvstest.c
+++ b/t/pmi/kvstest.c
@@ -57,30 +57,30 @@ int main(int argc, char *argv[])
         err_exit ("pmi_create");
     e = pmi_init (pmi, &spawned);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_init: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_init: %s", pmi_strerror (e));
     e = pmi_initialized (pmi, &initialized);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_initialized: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_initialized: %s", pmi_strerror (e));
     if (initialized == 0)
-        msg_exit ("pmi_initialized says nope!");
+        log_msg_exit ("pmi_initialized says nope!");
     e = pmi_get_rank (pmi, &rank);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_get_rank: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_get_rank: %s", pmi_strerror (e));
     e = pmi_get_size (pmi, &size);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_get_size: %s",
+        log_msg_exit ("%d: pmi_get_size: %s",
                 rank, pmi_strerror (e));
     e = pmi_kvs_get_name_length_max (pmi, &kvsname_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_name_length_max: %s",
+        log_msg_exit ("%d: pmi_kvs_get_name_length_max: %s",
                 rank, pmi_strerror (e));
     e = pmi_kvs_get_key_length_max (pmi, &key_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_key_length_max: %s",
+        log_msg_exit ("%d: pmi_kvs_get_key_length_max: %s",
                 rank, pmi_strerror (e));
     e = pmi_kvs_get_value_length_max (pmi, &val_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_value_length_max: %s",
+        log_msg_exit ("%d: pmi_kvs_get_value_length_max: %s",
                 rank, pmi_strerror (e));
 
     kvsname = xzmalloc (kvsname_len);
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 
     e = pmi_kvs_get_my_name (pmi, kvsname, kvsname_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_my_name: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_kvs_get_my_name: %s", rank, pmi_strerror (e));
 
     /* Put phase
      * (keycount * PUT) + COMMIT + BARRIER
@@ -101,14 +101,14 @@ int main(int argc, char *argv[])
         snprintf (val, val_len, "sandwich.%d.%d", rank, i);
         e = pmi_kvs_put (pmi, kvsname, key, val);
         if (e != PMI_SUCCESS)
-            msg_exit ("%d: pmi_kvs_put: %s", rank, pmi_strerror (e));
+            log_msg_exit ("%d: pmi_kvs_put: %s", rank, pmi_strerror (e));
     }
     e = pmi_kvs_commit (pmi, kvsname);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_commit: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_kvs_commit: %s", rank, pmi_strerror (e));
     e = pmi_barrier (pmi);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_barrier: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_barrier: %s", rank, pmi_strerror (e));
     if (rank == 0)
         printf ("%d: put phase: %.3f sec\n", rank, monotime_since (t));
 
@@ -123,10 +123,10 @@ int main(int argc, char *argv[])
                 snprintf (key, key_len, "kvstest-%d-%d", j, i);
                 e = pmi_kvs_get (pmi, kvsname, key, val, val_len);
                 if (e != PMI_SUCCESS)
-                    msg_exit ("%d: pmi_kvs_get: %s", rank, pmi_strerror (e));
+                    log_msg_exit ("%d: pmi_kvs_get: %s", rank, pmi_strerror (e));
                 snprintf (val2, val_len, "sandwich.%d.%d", j, i);
                 if (strcmp (val, val2) != 0)
-                    msg_exit ("%d: pmi_kvs_get: exp %s got %s\n",
+                    log_msg_exit ("%d: pmi_kvs_get: exp %s got %s\n",
                              rank, val2, val);
             }
         } else {
@@ -134,22 +134,22 @@ int main(int argc, char *argv[])
                       rank > 0 ? rank - 1 : size - 1, i);
             e = pmi_kvs_get (pmi, kvsname, key, val, val_len);
             if (e != PMI_SUCCESS)
-                msg_exit ("%d: pmi_kvs_get: %s", rank, pmi_strerror (e));
+                log_msg_exit ("%d: pmi_kvs_get: %s", rank, pmi_strerror (e));
             snprintf (val2, val_len, "sandwich.%d.%d",
                       rank > 0 ? rank - 1 : size - 1, i);
             if (strcmp (val, val2) != 0)
-                msg_exit ("%d: pmi_kvs_get: exp %s got %s\n", rank, val2, val);
+                log_msg_exit ("%d: pmi_kvs_get: exp %s got %s\n", rank, val2, val);
         }
     }
     e = pmi_barrier (pmi);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_barrier: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_barrier: %s", rank, pmi_strerror (e));
     if (rank == 0)
         printf ("%d: get phase: %.3f sec\n", rank, monotime_since (t));
 
     e = pmi_finalize (pmi);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_finalize: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_finalize: %s", rank, pmi_strerror (e));
 
     free (val);
     free (val2);

--- a/t/pmi/pminfo.c
+++ b/t/pmi/pminfo.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     else
         pmi = pmi_create_guess ();
     if (!pmi)
-        err_exit ("pmi_create");
+        log_err_exit ("pmi_create");
     e = pmi_init (pmi, &spawned);
     if (e != PMI_SUCCESS)
         log_msg_exit ("pmi_init: %s", pmi_strerror (e));

--- a/t/pmi/pminfo.c
+++ b/t/pmi/pminfo.c
@@ -41,46 +41,46 @@ int main(int argc, char *argv[])
         err_exit ("pmi_create");
     e = pmi_init (pmi, &spawned);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_init: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_init: %s", pmi_strerror (e));
     e = pmi_initialized (pmi, &initialized);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_initialized: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_initialized: %s", pmi_strerror (e));
     if (initialized == 0)
-        msg_exit ("pmi_initialized says nope!");
+        log_msg_exit ("pmi_initialized says nope!");
     e = pmi_get_rank (pmi, &rank);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_get_rank: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_get_rank: %s", pmi_strerror (e));
     e = pmi_get_size (pmi, &size);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_get_size: %s",
+        log_msg_exit ("%d: pmi_get_size: %s",
                 rank, pmi_strerror (e));
     e = pmi_kvs_get_name_length_max (pmi, &kvsname_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_name_length_max: %s",
+        log_msg_exit ("%d: pmi_kvs_get_name_length_max: %s",
                 rank, pmi_strerror (e));
     e = pmi_kvs_get_key_length_max (pmi, &key_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_key_length_max: %s",
+        log_msg_exit ("%d: pmi_kvs_get_key_length_max: %s",
                 rank, pmi_strerror (e));
     e = pmi_kvs_get_value_length_max (pmi, &val_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_value_length_max: %s",
+        log_msg_exit ("%d: pmi_kvs_get_value_length_max: %s",
                 rank, pmi_strerror (e));
     e = pmi_get_appnum (pmi, &appnum);
     if (e != PMI_SUCCESS)
-        msg_exit ("pmi_get_appnum: %s", pmi_strerror (e));
+        log_msg_exit ("pmi_get_appnum: %s", pmi_strerror (e));
 
     kvsname = xzmalloc (kvsname_len);
     e = pmi_kvs_get_my_name (pmi, kvsname, kvsname_len);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_kvs_get_my_name: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_kvs_get_my_name: %s", rank, pmi_strerror (e));
 
     printf ("%d: size=%d appnum=%d maxes=%d:%d:%d kvsname=%s\n",
             rank, size, appnum, kvsname_len, key_len, val_len, kvsname);
 
     e = pmi_finalize (pmi);
     if (e != PMI_SUCCESS)
-        msg_exit ("%d: pmi_finalize: %s", rank, pmi_strerror (e));
+        log_msg_exit ("%d: pmi_finalize: %s", rank, pmi_strerror (e));
 
     free (kvsname);
     pmi_destroy (pmi);

--- a/t/pmi/simple.c
+++ b/t/pmi/simple.c
@@ -3,7 +3,7 @@
 #include <pthread.h>
 #include <czmq.h>
 
-#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libpmi-client/pmi-client.h"
 #include "src/common/libpmi-server/simple.h"

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -321,7 +321,7 @@ static void xping (flux_t h, uint32_t nodeid, uint32_t xnodeid, const char *svc)
             || flux_rpc_get (rpc, NULL, &json_str) < 0)
         err_exit ("req.xping");
     if (!(out = Jfromstr (json_str)) || !Jget_str (out, "route", &route))
-        errn_exit (EPROTO, "req.xping");
+        log_errn_exit (EPROTO, "req.xping");
     printf ("hops=%d\n", count_hops (route));
     Jput (out);
     Jput (in);
@@ -420,7 +420,7 @@ void test_coproc (flux_t h, uint32_t nodeid)
         err_exit ("req.count");
 
     if ((rc = pthread_create (&t, NULL, thd, &nodeid)))
-        errn_exit (rc, "pthread_create");
+        log_errn_exit (rc, "pthread_create");
 
     do {
         //usleep (100*1000); /* 100ms */
@@ -445,7 +445,7 @@ void test_coproc (flux_t h, uint32_t nodeid)
         log_msg_exit ("request was not flushed");
 
     if ((rc = pthread_join (t, NULL)))
-        errn_exit (rc, "pthread_join");
+        log_errn_exit (rc, "pthread_join");
     log_msg ("thread finished");
 }
 

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -160,7 +160,7 @@ void test_echo (flux_t h, uint32_t nodeid)
         err_exit ("%s", __FUNCTION__);
     if (!(out = Jfromstr (json_str)) || !Jget_str (out, "mumble", &s)
                                      || strcmp (s, "burble") != 0)
-        msg_exit ("%s: returned payload wasn't an echo", __FUNCTION__);
+        log_msg_exit ("%s: returned payload wasn't an echo", __FUNCTION__);
     Jput (in);
     Jput (out);
     flux_rpc_destroy (rpc);
@@ -173,9 +173,9 @@ void test_err (flux_t h, uint32_t nodeid)
     if (!(rpc = flux_rpc (h, "req.err", NULL, nodeid, 0)))
         err_exit ("error sending request");
     if (flux_rpc_get (rpc, NULL, NULL) == 0)
-        msg_exit ("%s: succeeded when should've failed", __FUNCTION__);
+        log_msg_exit ("%s: succeeded when should've failed", __FUNCTION__);
     if (errno != 42)
-        msg_exit ("%s: got errno %d instead of 42", __FUNCTION__, errno);
+        log_msg_exit ("%s: got errno %d instead of 42", __FUNCTION__, errno);
     flux_rpc_destroy (rpc);
 }
 
@@ -190,7 +190,7 @@ void test_src (flux_t h, uint32_t nodeid)
              || flux_rpc_get (rpc, NULL, &json_str) < 0)
         err_exit ("%s", __FUNCTION__);
     if (!(out = Jfromstr (json_str)) || !Jget_int (out, "wormz", &i) || i != 42)
-        msg_exit ("%s: didn't get expected payload", __FUNCTION__);
+        log_msg_exit ("%s: didn't get expected payload", __FUNCTION__);
     Jput (out);
     flux_rpc_destroy (rpc);
 }
@@ -227,11 +227,11 @@ void test_nsrc (flux_t h, uint32_t nodeid)
         if (!msg)
             err_exit ("%s", __FUNCTION__);
         if (flux_response_decode (msg, NULL, &json_str) < 0)
-            msg_exit ("%s: decode %d", __FUNCTION__, i);
+            log_msg_exit ("%s: decode %d", __FUNCTION__, i);
         if (!(out = Jfromstr (json_str)) || !Jget_int (out, "seq", &seq))
-            msg_exit ("%s: decode %d payload", __FUNCTION__, i);
+            log_msg_exit ("%s: decode %d payload", __FUNCTION__, i);
         if (seq != i)
-            msg_exit ("%s: decode %d - seq mismatch %d", __FUNCTION__, i, seq);
+            log_msg_exit ("%s: decode %d - seq mismatch %d", __FUNCTION__, i, seq);
         Jput (out);
         flux_msg_destroy (msg);
     }
@@ -269,9 +269,9 @@ void test_putmsg (flux_t h, uint32_t nodeid)
         if (!msg)
             err_exit ("%s", __FUNCTION__);
         if (flux_response_decode (msg, NULL, &json_str) < 0)
-            msg_exit ("%s: decode", __FUNCTION__);
+            log_msg_exit ("%s: decode", __FUNCTION__);
         if (!(out = Jfromstr (json_str)) || !Jget_int (out, "seq", &seq))
-            msg_exit ("%s: decode - payload", __FUNCTION__);
+            log_msg_exit ("%s: decode - payload", __FUNCTION__);
         Jput (out);
         if (seq >= defer_start && seq < defer_start + defer_count && !popped) {
             if (zlist_append (defer, msg) < 0)
@@ -287,7 +287,7 @@ void test_putmsg (flux_t h, uint32_t nodeid)
             continue;
         }
         if (seq != myseq)
-            msg_exit ("%s: expected %d got %d", __FUNCTION__, myseq, seq);
+            log_msg_exit ("%s: expected %d got %d", __FUNCTION__, myseq, seq);
         myseq++;
         flux_msg_destroy (msg);
     } while (myseq < count);
@@ -427,13 +427,13 @@ void test_coproc (flux_t h, uint32_t nodeid)
         if ((count = req_count (h, nodeid)) < 0)
             err_exit ("req.count");
     } while (count - count0 < 1);
-    msg ("%d requests are stuck", count - count0);
+    log_msg ("%d requests are stuck", count - count0);
 
     if (!(rpc = flux_rpc (h, "coproc.hi", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
         err_exit ("coproc.hi");
     flux_rpc_destroy (rpc);
-    msg ("hi request was answered");
+    log_msg ("hi request was answered");
 
     if (!(rpc = flux_rpc (h, "req.flush", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
@@ -442,11 +442,11 @@ void test_coproc (flux_t h, uint32_t nodeid)
     if ((count = req_count (h, nodeid)) < 0)
         err_exit ("req.count");
     if (count != 0)
-        msg_exit ("request was not flushed");
+        log_msg_exit ("request was not flushed");
 
     if ((rc = pthread_join (t, NULL)))
         errn_exit (rc, "pthread_join");
-    msg ("thread finished");
+    log_msg ("thread finished");
 }
 
 /*

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -126,7 +126,7 @@ int main (int argc, char *argv[])
         usage ();
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     t->fun (h, nodeid);
 
@@ -142,7 +142,7 @@ void test_null (flux_t h, uint32_t nodeid)
 
     if (!(rpc = flux_rpc (h, "req.null", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("req.null");
+        log_err_exit ("req.null");
     flux_rpc_destroy (rpc);
 }
 
@@ -157,7 +157,7 @@ void test_echo (flux_t h, uint32_t nodeid)
     Jadd_str (in, "mumble", "burble");
     if (!(rpc = flux_rpc (h, "req.echo", Jtostr (in), nodeid, 0))
              || flux_rpc_get (rpc, NULL, &json_str) < 0)
-        err_exit ("%s", __FUNCTION__);
+        log_err_exit ("%s", __FUNCTION__);
     if (!(out = Jfromstr (json_str)) || !Jget_str (out, "mumble", &s)
                                      || strcmp (s, "burble") != 0)
         log_msg_exit ("%s: returned payload wasn't an echo", __FUNCTION__);
@@ -171,7 +171,7 @@ void test_err (flux_t h, uint32_t nodeid)
     flux_rpc_t *rpc;
 
     if (!(rpc = flux_rpc (h, "req.err", NULL, nodeid, 0)))
-        err_exit ("error sending request");
+        log_err_exit ("error sending request");
     if (flux_rpc_get (rpc, NULL, NULL) == 0)
         log_msg_exit ("%s: succeeded when should've failed", __FUNCTION__);
     if (errno != 42)
@@ -188,7 +188,7 @@ void test_src (flux_t h, uint32_t nodeid)
 
     if (!(rpc = flux_rpc (h, "req.src", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, &json_str) < 0)
-        err_exit ("%s", __FUNCTION__);
+        log_err_exit ("%s", __FUNCTION__);
     if (!(out = Jfromstr (json_str)) || !Jget_int (out, "wormz", &i) || i != 42)
         log_msg_exit ("%s: didn't get expected payload", __FUNCTION__);
     Jput (out);
@@ -203,7 +203,7 @@ void test_sink (flux_t h, uint32_t nodeid)
     Jadd_double (in, "pi", 3.14);
     if (!(rpc = flux_rpc (h, "req.sink", Jtostr (in), nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("%s", __FUNCTION__);
+        log_err_exit ("%s", __FUNCTION__);
     Jput (in);
     flux_rpc_destroy (rpc);
 }
@@ -220,12 +220,12 @@ void test_nsrc (flux_t h, uint32_t nodeid)
     Jadd_int (in, "count", count);
     if (!(rpc = flux_rpc (h, "req.nsrc", Jtostr (in), FLUX_NODEID_ANY,
                                                       FLUX_RPC_NORESPONSE)))
-        err_exit ("%s", __FUNCTION__);
+        log_err_exit ("%s", __FUNCTION__);
 
     for (i = 0; i < count; i++) {
         flux_msg_t *msg = flux_recv (h, FLUX_MATCH_ANY, 0);
         if (!msg)
-            err_exit ("%s", __FUNCTION__);
+            log_err_exit ("%s", __FUNCTION__);
         if (flux_response_decode (msg, NULL, &json_str) < 0)
             log_msg_exit ("%s: decode %d", __FUNCTION__, i);
         if (!(out = Jfromstr (json_str)) || !Jget_int (out, "seq", &seq))
@@ -262,12 +262,12 @@ void test_putmsg (flux_t h, uint32_t nodeid)
     Jadd_int (in, "count", count);
     if (!(rpc = flux_rpc (h, "req.nsrc", Jtostr (in), FLUX_NODEID_ANY,
                                                       FLUX_RPC_NORESPONSE)))
-        err_exit ("%s", __FUNCTION__);
+        log_err_exit ("%s", __FUNCTION__);
     flux_rpc_destroy (rpc);
     do {
         flux_msg_t *msg = flux_recv (h, FLUX_MATCH_ANY, 0);
         if (!msg)
-            err_exit ("%s", __FUNCTION__);
+            log_err_exit ("%s", __FUNCTION__);
         if (flux_response_decode (msg, NULL, &json_str) < 0)
             log_msg_exit ("%s: decode", __FUNCTION__);
         if (!(out = Jfromstr (json_str)) || !Jget_int (out, "seq", &seq))
@@ -279,7 +279,7 @@ void test_putmsg (flux_t h, uint32_t nodeid)
             if (seq == defer_start + defer_count - 1) {
                 while ((z = zlist_pop (defer))) {
                     if (flux_requeue (h, z, FLUX_RQ_TAIL) < 0)
-                        err_exit ("%s: flux_requeue", __FUNCTION__);
+                        log_err_exit ("%s: flux_requeue", __FUNCTION__);
                     flux_msg_destroy (z);
                 }
                 popped = true;
@@ -319,7 +319,7 @@ static void xping (flux_t h, uint32_t nodeid, uint32_t xnodeid, const char *svc)
     Jadd_str (in, "service", svc);
     if (!(rpc = flux_rpc (h, "req.xping", Jtostr (in), nodeid, 0))
             || flux_rpc_get (rpc, NULL, &json_str) < 0)
-        err_exit ("req.xping");
+        log_err_exit ("req.xping");
     if (!(out = Jfromstr (json_str)) || !Jget_str (out, "route", &route))
         log_errn_exit (EPROTO, "req.xping");
     printf ("hops=%d\n", count_hops (route));
@@ -348,7 +348,7 @@ void test_flush (flux_t h, uint32_t nodeid)
     flux_rpc_t *rpc;
     if (!(rpc = flux_rpc (h, "req.flush", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("req.flush");
+        log_err_exit ("req.flush");
     flux_rpc_destroy (rpc);
 }
 
@@ -357,7 +357,7 @@ void test_clog (flux_t h, uint32_t nodeid)
     flux_rpc_t *rpc;
     if (!(rpc = flux_rpc (h, "req.clog", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("req.clog");
+        log_err_exit ("req.clog");
     flux_rpc_destroy (rpc);
 }
 
@@ -376,11 +376,11 @@ void *thd (void *arg)
     flux_t h;
 
     if (!(h = flux_open (NULL, 0)))
-        err_exit ("flux_open");
+        log_err_exit ("flux_open");
 
     if (!(rpc = flux_rpc (h, "coproc.stuck", NULL, *nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("coproc.stuck");
+        log_err_exit ("coproc.stuck");
 
     flux_rpc_destroy (rpc);
     flux_close (h);
@@ -417,7 +417,7 @@ void test_coproc (flux_t h, uint32_t nodeid)
     flux_rpc_t *rpc;
 
     if ((count0 = req_count (h, nodeid)) < 0)
-        err_exit ("req.count");
+        log_err_exit ("req.count");
 
     if ((rc = pthread_create (&t, NULL, thd, &nodeid)))
         log_errn_exit (rc, "pthread_create");
@@ -425,22 +425,22 @@ void test_coproc (flux_t h, uint32_t nodeid)
     do {
         //usleep (100*1000); /* 100ms */
         if ((count = req_count (h, nodeid)) < 0)
-            err_exit ("req.count");
+            log_err_exit ("req.count");
     } while (count - count0 < 1);
     log_msg ("%d requests are stuck", count - count0);
 
     if (!(rpc = flux_rpc (h, "coproc.hi", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("coproc.hi");
+        log_err_exit ("coproc.hi");
     flux_rpc_destroy (rpc);
     log_msg ("hi request was answered");
 
     if (!(rpc = flux_rpc (h, "req.flush", NULL, nodeid, 0))
              || flux_rpc_get (rpc, NULL, NULL) < 0)
-        err_exit ("req.flush");
+        log_err_exit ("req.flush");
     flux_rpc_destroy (rpc);
     if ((count = req_count (h, nodeid)) < 0)
-        err_exit ("req.count");
+        log_err_exit ("req.count");
     if (count != 0)
         log_msg_exit ("request was not flushed");
 

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -8,30 +8,30 @@ test_under_flux 4 minimal
 
 test_expect_success 'flux getattr log-count counts log messages' '
 	OLD_VAL=`flux getattr log-count` &&
-	flux logger --priority test.debug hello &&
+	flux logger hello &&
 	NEW_VAL=`flux getattr log-count` &&
 	test "${OLD_VAL}" -lt "${NEW_VAL}"
 '
 test_expect_success 'flux getattr log-ring-used counts log messages' '
 	OLD_VAL=`flux getattr log-ring-used` &&
-	flux logger --priority test.debug hello &&
+	flux logger hello &&
 	NEW_VAL=`flux getattr log-ring-used` &&
 	test "${OLD_VAL}" -lt "${NEW_VAL}"
 '
 test_expect_success 'flux dmesg -C clears ring buffer' '
-	flux logger --priority test.debug hello_dmesg &&
+	flux logger hello_dmesg &&
 	flux dmesg | grep -q hello_dmesg &&
 	flux dmesg -C &&
 	! flux dmesg | grep -q hello_dmesg
 '
 test_expect_success 'flux setattr log-ring-size trims ring buffer' '
 	OLD_RINGSIZE=`flux getattr log-ring-size` &&
-	flux logger --priority test.debug hello1 &&
-	flux logger --priority test.debug hello2 &&
-	flux logger --priority test.debug hello3 &&
-	flux logger --priority test.debug hello4 &&
-	flux logger --priority test.debug hello5 &&
-	flux logger --priority test.debug hello6 &&
+	flux logger hello1 &&
+	flux logger hello2 &&
+	flux logger hello3 &&
+	flux logger hello4 &&
+	flux logger hello5 &&
+	flux logger hello6 &&
 	flux setattr log-ring-size 4 &&
 	test `flux dmesg | wc -l` -eq 4 &&
 	! flux dmesg | grep -q hello_dmesg1 &&
@@ -39,21 +39,21 @@ test_expect_success 'flux setattr log-ring-size trims ring buffer' '
 	flux setattr log-ring-size $OLD_RINGSIZE
 '
 test_expect_success 'flux dmesg prints, no clear' '
-	flux logger --priority test.debug hello_dmesg_pnc &&
+	flux logger hello_dmesg_pnc &&
 	flux dmesg | grep -q hello_dmesg_pnc &&
 	flux dmesg | grep -q hello_dmesg_pnc
 '
 test_expect_success 'flux dmesg -c prints and clears' '
-	flux logger --priority test.debug hello_dmesg_pc &&
+	flux logger hello_dmesg_pc &&
 	flux dmesg -c | grep -q hello_dmesg_pc &&
 	! flux dmesg | grep -q hello_dmesg_pc
 '
 test_expect_success 'ring buffer wraps over old entries' '
 	OLD_RINGSIZE=`flux getattr log-ring-size` &&
 	flux setattr log-ring-size 2 &&
-	flux logger --priority test.debug hello_wrap1 &&
-	flux logger --priority test.debug hello_wrap2 &&
-	flux logger --priority test.debug hello_wrap3 &&
+	flux logger hello_wrap1 &&
+	flux logger hello_wrap2 &&
+	flux logger hello_wrap3 &&
 	! flux dmesg | grep -q hello_wrap1
 	flux setattr log-ring-size $OLD_RINGSIZE
 '

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -85,8 +85,8 @@ test_expect_success 'rc1 environment is as expected' '
 	FLUX_RC1_PATH=${FLUX_SOURCE_DIR}/t/rc/rc1-testenv flux start \
 		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
 		/bin/true 2>&1 | tee rc1-test.log &&
-	grep "stderr-" rc1-test.log | grep -q broker.err &&
-	grep "stdout-" rc1-test.log | grep -q broker.info
+	grep "stderr-" rc1-test.log | egrep -q broker.*err &&
+	grep "stdout-" rc1-test.log | egrep -q broker.*info
 '
 
 test_done

--- a/t/t1008-proxy.t
+++ b/t/t1008-proxy.t
@@ -45,10 +45,10 @@ test_expect_success 'flux-proxy manages event redistribution' '
 	flux proxy $TEST_JOBID \
 	  "flux event sub -c1 hb& flux event sub -c1 hb& wait;wait" &&
 	FLUX_URI=$TEST_URI flux dmesg | sed -e "s/[^ ]* //" >event.out &&
-	test $(grep "connector-local.debug\[0\]: subscribe hb" event.out|wc -l) -eq 1 &&
-	test $(grep "proxy.debug\[0\]: subscribe hb" event.out|wc -l) -eq 1 &&
-	test $(grep "connector-local.debug\[0\]: unsubscribe hb" event.out|wc -l) -eq 1 &&
-	test $(grep "proxy.debug\[0\]: unsubscribe hb" event.out|wc -l) -eq 1
+	test $(egrep "connector-local.*debug\[0\]: subscribe hb" event.out|wc -l) -eq 1 &&
+	test $(egrep "proxy.*debug\[0\]: subscribe hb" event.out|wc -l) -eq 1 &&
+	test $(egrep "connector-local.*debug\[0\]: unsubscribe hb" event.out|wc -l) -eq 1 &&
+	test $(egrep "proxy.*debug\[0\]: unsubscribe hb" event.out|wc -l) -eq 1
 '
 
 test_expect_success 'flux-proxy --setenv option works' '


### PR DESCRIPTION
This is some minor clean-up to logging functions.

The prototypish libutil/log.c is stripped down to the bare minimum and functions were renamed to have a `log_` prefix.  I stopped short of converting all the `err()` and `err_exit()` users, so left the old names still working for those.

Adopt some RFC 5424 logging conventions in `flux_log()`, including ISO 8601 date strings, procid, and appname.