### PR TITLE
Cronodate PR fixups

### DIFF
--- a/doc/man3/flux_periodic_watcher_create.adoc
+++ b/doc/man3/flux_periodic_watcher_create.adoc
@@ -1,5 +1,5 @@
 flux_periodic_watcher_create(3)
-============================
+===============================
 :doctype: manpage
 
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -395,10 +395,12 @@ static int cron_entry_defer (cron_entry_t *e)
     /* O/w, defer this task: push entry onto deferred list, and start
      *  sync event message handler if needed
      */
+    if (zlist_push (ctx->deferred, e) < 0)
+        return (-1);
     e->stats.deferred++;
     flux_log (ctx->h, LOG_DEBUG, "deferring cron-%ju to next %s event",
              e->id, ctx->sync_event);
-    zlist_push (ctx->deferred, e);
+
     if (zlist_size (ctx->deferred) == 1)
         flux_msg_handler_start (ctx->mh);
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -351,7 +351,10 @@ static int64_t next_cronid (flux_t h)
     Jadd_int64 (req, "postincrement", 0);
     Jadd_bool (req, "create", true);
 
-    rpc = flux_rpc (h, "cmb.seq.fetch", Jtostr (req), 0, 0);
+    if (!(rpc = flux_rpc (h, "cmb.seq.fetch", Jtostr (req), 0, 0))) {
+        flux_log_error (h, "flux_rpc");
+        return ret;
+    }
     Jput (req);
 
     if ((flux_rpc_get (rpc, NULL, &json_str) < 0)

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -676,7 +676,10 @@ static void cron_create_handler (flux_t h, flux_msg_handler_t *w,
         goto done;
     }
 
-    zlist_append (ctx->entries, e);
+    if (zlist_append (ctx->entries, e) < 0) {
+        saved_errno = errno;
+        goto done;
+    }
 
     rc = 0;
     out = cron_entry_to_json (e);

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -694,7 +694,7 @@ static void cron_sync_handler (flux_t h, flux_msg_handler_t *w,
     const char *topic;
     bool disable;
     double epsilon;
-    int saved_errno;
+    int saved_errno = 0;
     int rc = -1;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0


### PR DESCRIPTION
This PR fixes some oops in the recently mergeed PR #686. Most of these are the most egregious buglets found by Coverity run on recent master, however there was also a bad typo in the manpage for `flux_periodic_watcher_create` which was causing an error from asciidoc.

I quickly threw these up so as to fix the build failure in doc/man3, so there might still be more work or issues.