### PR TITLE
t/t0016-cron-faketime.t: improve faketime check

### DIFF
--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -4,9 +4,9 @@ test_description='Test flux cron service'
 
 . $(dirname $0)/sharness.sh
 
-#  Check for libfaketimeMT:
-LD_PRELOAD=libfaketimeMT.so.1 ldd /bin/date 2>/dev/null | grep -q libfaketime
-if test $? -ne 0 ; then
+#  Check for libfaketimeMT using known epoch with /bin/date:
+t=$(LD_PRELOAD=libfaketimeMT.so.1 FAKETIME="1973-11-29 21:33:09 UTC" date +%s)
+if test "$t" != "123456789" ; then
     skip_all='libfaketime not found. Skipping all tests'
     test_done
 fi


### PR DESCRIPTION
Instead of using ldd to check to see if libfaketime.so
can be found, try a test by setting a faketime for /bin/date
using a known epoch and check for expected result.

This should be more reliable than the previous test.

@garlick can you give this commit a test on your desktop? Thanks!