### PR TITLE
Add cppcheck run to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
   - clang
   - gcc+coverage
   - gcc+install
+  - gcc+cppcheck
 
 cache:
   directories:
@@ -46,6 +47,8 @@ before_install:
   - case "$CC" in *+coverage) CC=${CC//+*}; export COVERAGE=t;; esac
   # Check if we should test installed flux:
   - case "$CC" in *+install)  CC=${CC//+*}; export T_INSTALL=t;; esac
+  # Check if we are only running cppcheck
+  - case "$CC" in *+cppcheck)  CC=${CC//+*}; export CPPCHECK=t;; esac
 
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
@@ -80,6 +83,8 @@ script:
  - if test "$COVERAGE" = "t" ; then ARGS="--enable-code-coverage"; MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"; fi
  # Use make install for T_INSTALL:
  - if test "$T_INSTALL" = "t" ; then ARGS="--prefix=/tmp/flux"; MAKECMDS="make && make install && /tmp/flux/bin/flux keygen && FLUX_TEST_INSTALLED_PATH=/tmp/flux/bin make check"; fi
+ # Use src/test/cppcheck.sh instead of make?:
+ - if test "$CPPCHECK" = "t" ; then MAKECMDS="sh -x src/test/cppcheck.sh"; fi
 
  - export FLUX_TESTS_LOGFILE=t
  - if test "$COVERITY_SCAN_BRANCH" != "1" ; then ./autogen.sh && ./configure ${ARGS} && eval ${MAKECMDS}; fi

--- a/src/common/libutil/test/msglist.c
+++ b/src/common/libutil/test/msglist.c
@@ -39,6 +39,7 @@ int main (int argc, char *argv[])
         "msglist_pop returns 'foo'");
     ok ((e = msglist_pollevents (ml)) >= 0 && e == POLLOUT,
         "msglist_pollevents on empty msglist returns POLLOUT");
+    // cppcheck-suppress doubleFree
     free (msg);
 
     ok ((pfd.fd = msglist_pollfd (ml)) >= 0,

--- a/src/test/cppcheck.sh
+++ b/src/test/cppcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+cppcheck --force --inline-suppr -j 2 --std=c99 --quiet \
+    --error-exitcode=1 \
+    -i src/common/libev \
+    -i src/common/libsophia/ \
+    -i src/common/liblsd \
+    -i src/common/libtap \
+    -i src/bindings/python \
+    -i src/common/libutil/sds.c \
+    src

--- a/src/test/kap/kap_opts.c
+++ b/src/test/kap/kap_opts.c
@@ -199,6 +199,7 @@ print_config (kap_config_t *kap_conf)
         "   instance_num: %lu\n", kap_conf->instance_num);
     fprintf (fptr, 
         "   redundant_val: %u\n", kap_conf->redundant_val);
+    fclose (fptr);
 }
 
 

--- a/src/test/kap/kap_personality.c
+++ b/src/test/kap/kap_personality.c
@@ -451,8 +451,10 @@ kap_commfab_perf_summary (kap_config_t *kc,
         getf = fopen (GETS_OUT_FN, "w");
         wallf = fopen (WALL_CLOCK_OUT_FN, "w");
         if (!putf || !commitf 
-            || !syncf || !getf || !wallf )
-            return -1;
+            || !syncf || !getf || !wallf ) {
+            rc = -1;
+            goto out;
+        }
     }
 
     rc += metric_summary(kc, p, &Puts, "Puts", 
@@ -486,7 +488,17 @@ kap_commfab_perf_summary (kap_config_t *kc,
     rc += phase_summary (p, Begin_All, End_All,
                         "Total",
                          wallf);
-
+out:
+    if (putf)
+        fclose (putf);
+    if (commitf)
+        fclose (commitf);
+    if (syncf)
+        fclose (syncf);
+    if (getf)
+        fclose (getf);
+    if (wallf)
+        fclose (wallf);
     return (rc < 0)? -1 : 0;
 } 
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -25,14 +25,17 @@ declare -A extra_configure_opts=(\
 )
 
 checkouts="\
-https://github.com/wolfcw/libfaketime.git"
+https://github.com/wolfcw/libfaketime.git \
+https://github.com/danmar/cppcheck.git"
 
 declare -A checkout_sha1=(\
-["libfaketime"]="b68f2820c4091075fbc205965ec6976f6d241aaa"
+["libfaketime"]="b68f2820c4091075fbc205965ec6976f6d241aaa" \
+["cppcheck"]="7466a49b216d4ba5e25b48381d85a8c3b2d3a228"
 )
 
 declare -A extra_make_opts=(\
 ["libfaketime"]="LIBDIRNAME=/lib"
+["cppcheck"]="CFGDIR=/${prefix}/etc/cppcheck"
 )
 
 #


### PR DESCRIPTION
This PR adds a new `cppcheck` build to the Travis CI build matrix for flux-core.

For the cppcheck build, a trivial script in `src/test/cppcheck.sh` is run instead of the normal  build. In my short amount of testing this seemed to find some obvious errors like memory leaks, etc. A couple of these (in tests only) were fixed in this branch in order to run with a "clean" cppcheck initially.

There are also a list of paths that `cppcheck.sh` ignores by default, including upstream packages like liblsd, libsophia, and liblsd, as well as the autogenerated python bindings etc. The full list can be viewed (and updated) in the simple `cppcheck.sh` script.
