### PR TITLE
Enable coredumps on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ addons:
       - aspell
       - aspell-en
       - ccache
+      - apport # for coredumps
+      - gdb
+
   coverity_scan:
     project:
       name: "grondo/flux-core"
@@ -64,9 +67,7 @@ before_install:
   - echo '#error Non-build-tree flux/core.h!' > $HOME/local/include/flux/core.h
 
 script:
- - export LD_PRELOAD=libSegFault.so
- - export SEGFAULT_USE_ALTSTACK=1
- - export LIBC_FATAL_STDERR_=1
+ - ulimit -c unlimited
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"
  # Ensure travis builds libev such that libfaketime will work:
@@ -97,3 +98,4 @@ after_success:
 after_failure:
  - find . -name t[0-9]*.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - find . -name *.broker.log | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
+ - src/test/backtrace-all.sh

--- a/src/test/backtrace-all.sh
+++ b/src/test/backtrace-all.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+#  Find all possible core files under current directory. Attempt
+#  to determine exe using file(1) and dump stack trace with gdb.
+#
+say () { printf "\033[91m%s\033[39m\n" "$@" >&2; }
+die () { say "$@"; exit 1; }
+
+find . -name *.core -o -name core | while read -r line; do
+    d=$(dirname $line)
+    f=$(basename $line)
+    exe=$(file $line | sed "s/.*from '\([^ \t]*\).*'.*/\1/")
+    ( cd $d &&
+      test -x $exe || die "Failed to find executable at $exe" &&
+      say "Found corefile for $exe" &&
+      gdb --batch --quiet -ex "thread apply all bt full" $exe $f
+    )
+done


### PR DESCRIPTION
Experimental PR to support coredump backtraces in travis-ci.

The travis-ci containers have `/proc/sys/kernel/core_pattern` as `|/usr/share/apport/apport %p %s %c %P`, possibly inherited from the host kernel (See travis-ci/travis-ci#3754). When apport is not installed, all coredumps are lost. Until travis implements a method to reset core_pattern, installation of apport package seems to direct corefiles to the cwd of the dumping process so we can at least examine them.

apport also seems to respect current corefile limit, so if `ulimit -c unlimited` is also set for travis run, we do seem to be able to get corefiles inside a travis.

To analyze any coredump that might be generated during travis run, a `backtrace-all.sh` script is added and run from the `after_failure` hook.

Proof of concept can be seen from an experiment in another project [here](https://travis-ci.org/grondo/io-watchdog/jobs/139100123#L464)
