### PR TITLE
wreck: fix MPIRUN_RANK, set SLURM env vars for Intel MPI

### DIFF
--- a/src/modules/wreck/lua.d/intel_mpi.lua
+++ b/src/modules/wreck/lua.d/intel_mpi.lua
@@ -6,6 +6,21 @@ function rexecd_init ()
     local f = wreck.flux
     local libpmi = f:getattr ('conf.pmi_library_path')
     env['I_MPI_PMI_LIBRARY'] = libpmi
+
+    -- XXX: Unfortunately, Intel MPI doesn't seem to want to correctly
+    --  bootsrap using Flux PMI library unless SLURM_NPROCS and
+    --  SLURM_PROCID are correctly set. When Flux supports PMI-1 wire
+    --  protocol via PMI_FD, these lines should be able to go away.
+    env['SLURM_NPROCS'] = wreck.kvsdir.ntasks
 end
+
+function rexecd_task_init ()
+    --
+    -- See note above about requirement for these SLURM_* environment
+    --  variables for Intel MPI PMI-bootstrap functionality
+    --
+    wreck.environ ['SLURM_PROCID'] = wreck.globalid
+end
+
 
 -- vi: ts=4 sw=4 expandtab

--- a/src/modules/wreck/lua.d/mvapich.lua
+++ b/src/modules/wreck/lua.d/mvapich.lua
@@ -25,7 +25,7 @@ end
 
 function rexecd_task_init ()
     local env = wreck.environ
-    env['MPIRUN_RANK'] = wreck.taskid
+    env['MPIRUN_RANK'] = wreck.globalid
 end
 
 -- vi: ts=4 sw=4 expandtab

--- a/t/issues/t0704-mpirun-rank.sh
+++ b/t/issues/t0704-mpirun-rank.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+# #704: MPIRUN_RANK != FLUX_TASK_RANK on nodeid > 0
+flux wreckrun -N4 -n4 sh -c 'test $MPIRUN_RANK = $FLUX_TASK_RANK'


### PR DESCRIPTION
As noted in #630, Intel MPI seems to need some SLURM environment variables for now.

Also, we're setting MPIRUN_RANK incorrectly in the `mvapich.lua` plugin. This PR fixes that and adds a test for it.

If we want to wait on the `intel_mpi.lua` changes for now, I can back that one out.