### PR TITLE
modules/kvs: add async fence operations

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -260,11 +260,10 @@ static int dgetline (int fd, char *buf, int len)
     while (i < len - 1) {
         if (read (fd, &buf[i], 1) <= 0)
             return -1;
-        if (buf[i] == '\n')
+        if (buf[i++] == '\n')
             break;
-        i++;
     }
-    if (buf[i] != '\n') {
+    if (buf[i - 1] != '\n') {
         errno = EPROTO;
         return -1;
     }
@@ -284,23 +283,23 @@ static int dputline (int fd, const char *buf)
     return count;
 }
 
+static int pmi_response_send (void *client, const char *buf)
+{
+    struct client *cli = client;
+    return dputline (cli->fd, buf);
+}
+
 void pmi_simple_cb (flux_reactor_t *r, flux_watcher_t *w,
                     int revents, void *arg)
 {
-    struct client *rcli, *cli = arg;
+    struct client *cli = arg;
     struct context *ctx = cli->ctx;
     int rc;
-    char *resp;
     if (dgetline (cli->fd, cli->buf, cli->buflen) < 0)
         log_err_exit ("%s", __FUNCTION__);
     rc = pmi_simple_server_request (ctx->pmi.srv, cli->buf, cli);
     if (rc < 0)
         log_err_exit ("%s", __FUNCTION__);
-    while (pmi_simple_server_response (ctx->pmi.srv, &resp, &rcli) == 0) {
-        if (dputline (rcli->fd, resp) < 0)
-            log_err_exit ("%s", __FUNCTION__);
-        free (resp);
-    }
     if (rc == 1) {
         close (cli->fd);
         cli->fd = -1;
@@ -458,6 +457,7 @@ void pmi_server_initialize (struct context *ctx)
         .kvs_put = pmi_kvs_put,
         .kvs_get = pmi_kvs_get,
         .barrier_enter = NULL,
+        .response_send = pmi_response_send,
     };
     int appnum = strtol (ctx->session_id, NULL, 10);
     if (!(ctx->pmi.kvs = zhash_new()))

--- a/src/common/libpmi-server/simple.c
+++ b/src/common/libpmi-server/simple.c
@@ -7,7 +7,7 @@
  *  For details, see https://github.com/flux-framework.
  *
  *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
+ *  under the terms f the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the license, or (at your option)
  *  any later version.
  *
@@ -53,10 +53,8 @@
 
 #define MAX_PROTO_OVERHEAD  64
 
-struct pmi_response {
-    void *client;
-    char *msg;
-};
+#define MAX_PROTO_LINE \
+    (KVS_KEY_MAX + KVS_VAL_MAX + KVS_NAME_MAX + MAX_PROTO_OVERHEAD)
 
 struct pmi_simple_server {
     void *arg;
@@ -66,7 +64,7 @@ struct pmi_simple_server {
     int universe_size;
     int local_procs;
     zlist_t *barrier;
-    zlist_t *responses;
+    int debug;
 };
 
 struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
@@ -77,29 +75,19 @@ struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
                                                     void *arg)
 {
     struct pmi_simple_server *pmi = xzmalloc (sizeof (*pmi));
+    const char *s;
+
     pmi->ops = *ops;
     pmi->arg = arg;
     pmi->appnum = appnum;
     pmi->kvsname = xstrdup (kvsname);
     pmi->universe_size = universe_size;
     pmi->local_procs = local_procs;
+    if ((s = getenv ("PMI_DEBUG")))
+        pmi->debug = strtoul (s, NULL, 10);
     if (!(pmi->barrier = zlist_new ()))
         oom ();
-    if (!(pmi->responses = zlist_new ()))
-        oom ();
     return pmi;
-}
-
-static void destroy_response_list (zlist_t **l)
-{
-    if (*l) {
-        struct pmi_response *r;
-        while ((r = zlist_pop (*l))) {
-            free (r->msg);
-            free (r);
-        }
-        zlist_destroy (l);
-    }
 }
 
 void pmi_simple_server_destroy (struct pmi_simple_server *pmi)
@@ -107,33 +95,30 @@ void pmi_simple_server_destroy (struct pmi_simple_server *pmi)
     if (pmi) {
         if (pmi->kvsname)
             free (pmi->kvsname);
-        destroy_response_list (&pmi->barrier);
-        destroy_response_list (&pmi->responses);
+        zlist_destroy (&pmi->barrier);
         free (pmi);
     }
 }
 
 int pmi_simple_server_get_maxrequest (struct pmi_simple_server *pmi)
 {
-    return (KVS_KEY_MAX + KVS_VAL_MAX + KVS_NAME_MAX + MAX_PROTO_OVERHEAD);
+    return (MAX_PROTO_LINE);
 }
 
 static int barrier_enter (struct pmi_simple_server *pmi, void *client)
 {
-    struct pmi_response *r = xzmalloc (sizeof (*r));
-
-    r->msg = xasprintf ("cmd=barrier_out\n");
-    r->client = client;
-    if (zlist_append (pmi->barrier, r) < 0)
+    if (zlist_append (pmi->barrier, client) < 0)
         oom ();
     return 0;
 }
 
 static int barrier_exit (struct pmi_simple_server *pmi, int rc)
 {
-    struct pmi_response *r;
+    char resp[MAX_PROTO_LINE+1];
+    void *client;
+    int ret = 0;
 
-    while ((r = zlist_pop (pmi->barrier))) {
+    while ((client = zlist_pop (pmi->barrier))) {
         /* XXX the protocol doesn't allow an error to be returned
          * for the barrier operation, so we return "barrier_failed"
          * instead of "barrier_out", which should trigger a protocol error.
@@ -141,14 +126,16 @@ static int barrier_exit (struct pmi_simple_server *pmi, int rc)
          * going anywhere useful, unless client prints the unexpected
          * message it received.
          */
-        if (rc != 0) {
-            free (r->msg);
-            r->msg = xasprintf ("cmd=barrier_failed rc=%d\n", rc);
-        }
-        if (zlist_append (pmi->responses, r) < 0)
-            oom ();
+        if (rc != 0)
+            snprintf (resp, sizeof (resp), "cmd=barrier_failed rc=%d\n", rc);
+        else
+            snprintf (resp, sizeof (resp), "cmd=barrier_out\n");
+        if (pmi->debug)
+            fprintf (stderr, "S: (client=%p) %s", client, resp);
+        if (pmi->ops.response_send (client, resp) < 0)
+            ret = -1;
     }
-    return 0;
+    return ret;
 }
 
 #define S_(x) #x
@@ -160,59 +147,68 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
     char key[KVS_KEY_MAX];
     char val[KVS_VAL_MAX];
     char name[KVS_NAME_MAX];
-    char *resp = NULL;
+    char resp[MAX_PROTO_LINE+1];
+    int send_response = 1;
     int rc = 0;
 
-    if (!strcmp (buf, "cmd=init pmi_version=1 pmi_subversion=1")) {
-        resp = xasprintf ("cmd=response_to_init"
-                            " pmi_version=1 pmi_subversion=1 rc=0\n");
-    } else if (!strcmp (buf, "cmd=get_maxes")) {
-        resp = xasprintf ("cmd=maxes kvsname_max=%d keylen_max=%d"
-                         " vallen_max=%d\n",
-                         KVS_NAME_MAX, KVS_KEY_MAX, KVS_VAL_MAX);
-    } else if (!strcmp (buf, "cmd=get_appnum")) {
-        resp = xasprintf ("cmd=appnum appnum=%d\n", pmi->appnum);
-    } else if (!strcmp (buf, "cmd=get_my_kvsname")) {
-        resp = xasprintf ("cmd=my_kvsname kvsname=%s\n", pmi->kvsname);
-    } else if (!strcmp (buf, "cmd=get_universe_size")) {
-        resp = xasprintf ("cmd=universe_size size=%d\n", pmi->universe_size);
+    if (pmi->debug)
+        fprintf (stderr, "C: (client=%p) %s", client, buf);
+
+    if (!strcmp (buf, "cmd=init pmi_version=1 pmi_subversion=1\n")) {
+        snprintf (resp, sizeof (resp),
+                  "cmd=response_to_init pmi_version=1 pmi_subversion=1 rc=0\n");
+    } else if (!strcmp (buf, "cmd=get_maxes\n")) {
+        snprintf (resp, sizeof (resp),
+                  "cmd=maxes kvsname_max=%d keylen_max=%d vallen_max=%d\n",
+                  KVS_NAME_MAX, KVS_KEY_MAX, KVS_VAL_MAX);
+    } else if (!strcmp (buf, "cmd=get_appnum\n")) {
+        snprintf (resp, sizeof (resp), "cmd=appnum appnum=%d\n", pmi->appnum);
+    } else if (!strcmp (buf, "cmd=get_my_kvsname\n")) {
+        snprintf (resp, sizeof (resp),
+                  "cmd=my_kvsname kvsname=%s\n", pmi->kvsname);
+    } else if (!strcmp (buf, "cmd=get_universe_size\n")) {
+        snprintf (resp, sizeof (resp), "cmd=universe_size size=%d\n",
+                  pmi->universe_size);
     } else if (sscanf (buf, "cmd=put"
                             " kvsname=%" S(KVS_NAME_MAX_SCAN) "s"
                             " key=%" S(KVS_KEY_MAX_SCAN) "s"
                             " value=%" S(KVS_VAL_MAX_SCAN) "s",
                             name, key, val) == 3) {
         int result = pmi->ops.kvs_put (pmi->arg, name, key, val);
-        resp = xasprintf ("cmd=put_result rc=%d msg=%s\n", result,
-                          result == 0 ? "success" : "failure");
+        snprintf (resp, sizeof (resp), "cmd=put_result rc=%d msg=%s\n",
+                  result, result == 0 ? "success" : "failure");
     } else if (sscanf (buf, "cmd=get"
                             " kvsname=%" S(KVS_NAME_MAX_SCAN) "s"
                             " key=%" S(KVS_KEY_MAX_SCAN) "s",
                             name, key) == 2) {
         int result = pmi->ops.kvs_get (pmi->arg, name, key, val, KVS_VAL_MAX);
-        resp = xasprintf ("cmd=get_result rc=%d msg=%s value=%s\n", result,
-                          result == 0 ? "success" : "failure",
-                          result == 0 ? val : "");
-    } else if (!strcmp (buf, "cmd=barrier_in")) {
+        snprintf (resp, sizeof (resp),
+                  "cmd=get_result rc=%d msg=%s value=%s\n", result,
+                  result == 0 ? "success" : "failure",
+                  result == 0 ? val : "");
+    } else if (!strcmp (buf, "cmd=barrier_in\n")) {
         barrier_enter (pmi, client);
         if (zlist_size (pmi->barrier) == pmi->local_procs) {
             if (pmi->ops.barrier_enter)
                 pmi->ops.barrier_enter (pmi->arg);
             else
-                barrier_exit (pmi, 0);
+                if (barrier_exit (pmi, 0) < 0)
+                    rc = -1;
         }
-    } else if (!strcmp (buf, "cmd=finalize")) {
-        resp = xasprintf ("cmd=finalize_ack\n");
+        send_response = 0;
+    } else if (!strcmp (buf, "cmd=finalize\n")) {
+        snprintf (resp, sizeof (resp), "cmd=finalize_ack\n");
         rc = 1; /* Indicates fd should be closed */
     } else {
         errno = EPROTO;
         rc = -1;
+        send_response = 0;
     }
-    if (resp) {
-        struct pmi_response *r = xzmalloc (sizeof (*r));
-        r->msg = resp;
-        r->client = client;
-        if (zlist_append (pmi->responses, r) < 0)
-            oom ();
+    if (send_response) {
+        if (pmi->debug)
+            fprintf (stderr, "S: (client=%p) %s", client, resp);
+        if (pmi->ops.response_send (client, resp) < 0)
+            rc = -1;
     }
     return rc;
 }
@@ -220,19 +216,6 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
 int pmi_simple_server_barrier_complete (struct pmi_simple_server *pmi, int rc)
 {
     return barrier_exit (pmi, rc);
-}
-
-int pmi_simple_server_response (struct pmi_simple_server *pmi,
-                                char **buf, void *client)
-{
-    struct pmi_response *r = zlist_pop (pmi->responses);
-    if (r) {
-        *buf = r->msg;
-        *(void **)client = r->client;
-        free (r);
-        return 0;
-    }
-    return -1;
 }
 
 /*

--- a/src/common/libpmi-server/simple.h
+++ b/src/common/libpmi-server/simple.h
@@ -4,15 +4,14 @@
 struct pmi_simple_server;
 
 /* User-provided service implementation.
- * put/get return 0 on success, -1 on failure.
- * barrier returns 0 if incomplete, 1 if complete.
+ * All return 0 on success, -1 on failure.
  */
 struct pmi_simple_ops {
     int (*kvs_put)(void *arg, const char *kvsname,
                    const char *key, const char *val);
     int (*kvs_get)(void *arg, const char *kvsname,
                    const char *key, char *val, int len);
-    int (*barrier)(void *arg);
+    int (*barrier_enter)(void *arg);
 };
 
 /* Create/destroy protocol engine.
@@ -20,6 +19,7 @@ struct pmi_simple_ops {
 struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
                                                     int appnum,
                                                     int universe_size,
+                                                    int local_procs,
                                                     const char *kvsname,
                                                     void *arg);
 void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
@@ -43,6 +43,10 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
  */
 int pmi_simple_server_response (struct pmi_simple_server *pmi,
                                 char **buf, void *client);
+
+/* Finalize a barrier.  Set rc to 0 for success, -1 for failure.
+ */
+int pmi_simple_server_barrier_complete (struct pmi_simple_server *pmi, int rc);
 
 #endif /* ! _FLUX_CORE_PMI_SIMPLE_SERVER_H */
 

--- a/src/common/libpmi-server/simple.h
+++ b/src/common/libpmi-server/simple.h
@@ -12,6 +12,7 @@ struct pmi_simple_ops {
     int (*kvs_get)(void *arg, const char *kvsname,
                    const char *key, char *val, int len);
     int (*barrier_enter)(void *arg);
+    int (*response_send)(void *client, const char *buf);
 };
 
 /* Create/destroy protocol engine.
@@ -30,19 +31,11 @@ void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
 int pmi_simple_server_get_maxrequest (struct pmi_simple_server *pmi);
 
 /* Put null-terminated request with sending client reference to protocol
- * engine.  Caller should remove the trailing newline.
+ * engine.  The request should end with a newline.
  * Return 0 on success, -1 on failure.
  */
 int pmi_simple_server_request (struct pmi_simple_server *pmi,
                                const char *buf, void *client);
-
-/* Get next null-terminated response and destination client reference
- * from protocol engine.  Response is ready to send, trailing newline included.
- * Caller must free response.
- * Return 0 on success, -1 on failure (no more responses).
- */
-int pmi_simple_server_response (struct pmi_simple_server *pmi,
-                                char **buf, void *client);
 
 /* Finalize a barrier.  Set rc to 0 for success, -1 for failure.
  */

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -160,6 +160,13 @@ int kvs_commit (flux_t h);
  */
 int kvs_fence (flux_t h, const char *name, int nprocs);
 
+/* kvs_fence_begin() sends the fence request and returns immediately.
+ * kvs_fence_finish() blocks until the response is received, then returns.
+ * Use flux_rpc_then() to arrange for the fence to complete asynchronously.
+ */
+flux_rpc_t *kvs_fence_begin (flux_t h, const char *name, int nprocs);
+int kvs_fence_finish (flux_rpc_t *rpc);
+
 /* Synchronization:
  * Process A commits data, then gets the store version V and sends it to B.
  * Process B waits for the store version to be >= V, then reads data.

--- a/t/t2004-hydra.t
+++ b/t/t2004-hydra.t
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 
-test_description='Test that MICH Hydra can launch Flux'
+test_description='Test that MPICH Hydra can launch Flux'
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
@@ -33,7 +33,7 @@ test_expect_success 'Flux libpmi-client wire protocol works with Hydra' '
 '
 
 test_expect_success 'Hydra can launch Flux' '
-	mpiexec.hydra -n 4 flux broker \
+	mpiexec.hydra -n 4 flux start \
 		flux comms info >flux_out &&
 	grep size=4 flux_out
 '

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -30,11 +30,14 @@ test_expect_success 'mpi hello world runs as a singleton' '
 '
 
 test_expect_success 'mpi hello world runs on all ranks' '
-	run_program 5 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello
+	run_program 5 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
+		| grep -q "There are ${SIZE} tasks"
 '
 
 test_expect_success 'mpi hello world runs oversubscribed' '
-	run_program 5 $((${SIZE}*4)) ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello
+	NTASKS=$((${SIZE}*4)); \
+	run_program 5 ${NTASKS} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
+		| grep -q "There are ${NTASKS} tasks"
 '
 
 test_done


### PR DESCRIPTION
Here's the split kvs_fence call discussed in #707 and #706.

I'll add the libpmi-server barrier completion callback after lunch.