### PR TITLE
Add pmi-simple server to wrexecd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,9 @@ script:
  #  spurious timeouts.
  - export FLUX_TEST_SIZE_MAX=5
 
+ # Invoke MPI tests
+ - export TEST_MPI=t
+
  # Enable coverage for $CC-coverage build
  # We can't use distcheck here, it doesn't play well with coverage testing:
  - if test "$COVERAGE" = "t" ; then ARGS="--enable-code-coverage"; MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"; fi

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -35,6 +35,7 @@ local lwj_options = {
     ['stdio-commit-on-open'] =  "Commit to kvs on stdio open in each task",
     ['stdio-commit-on-close'] = "Commit to kvs on stdio close in each task",
     ['stop-children-in-exec'] = "Start tasks in STOPPED state for debugger",
+    ['no-pmi-server'] =         "Do not start simple-pmi server",
 }
 
 local default_opts = {

--- a/src/common/libsubprocess/zio.h
+++ b/src/common/libsubprocess/zio.h
@@ -113,7 +113,13 @@ int zio_flux_attach (zio_t *z, flux_t h);
  */
 int zio_set_unbuffered (zio_t *zio);
 int zio_set_buffered (zio_t *zio, size_t bufsize);
-int zio_set_line_buffered (zio_t *zio);
+
+/*
+ *  Line buffer zio object, and send data (or invoke callback) for
+ *   every N [lines]. If lines == -1, then send as many lines as
+ *   are available (e.g. multiple lines may be received per callback)
+ */
+int zio_set_line_buffered (zio_t *zio, int lines);
 
 /*
  *  Enable zio debug output for this zio object. Optional

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -65,6 +65,7 @@ dist_wreckscripts_SCRIPTS = \
         lua.d/output.lua \
         lua.d/input.lua \
 	lua.d/mvapich.lua \
+	lua.d/pmi-mapping.lua \
 	lua.d/intel_mpi.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies

--- a/src/modules/wreck/lua.d/pmi-mapping.lua
+++ b/src/modules/wreck/lua.d/pmi-mapping.lua
@@ -1,0 +1,38 @@
+-- Set pmi.PMI_process_mapping
+
+
+-- compute blocks list as a Lua table from cores_per_node and nnodes:
+local function compute_blocks (cpn, nnodes)
+    local blocks = {}
+    local last = nil
+    for i = 0, nnodes - 1 do
+        local count = cpn [i]
+        if last and cpn[i] == last.tasks then
+            last.count = last.count + 1
+        else
+            last = { start = i, count = 1, tasks = cpn [i] }
+            table.insert (blocks, last)
+        end
+    end
+    return blocks
+end
+
+-- return 'standard' PMI_process_mapping vector as a string
+local function blocks_to_pmi_mapping (blocks)
+    if not blocks then return " " end
+    local s = "(vector"
+    for _,b in pairs (blocks) do
+        s = s .. string.format (",(%d,%d,%d)", b.start, b.count, b.tasks)
+    end
+    s = s .. ")"
+    return (s)
+end
+
+function rexecd_init ()
+    if (wreck.nodeid ~= 0) then return end
+
+    local blocks = compute_blocks (wreck.cores_per_node, wreck.nnodes)
+    local mapping = blocks_to_pmi_mapping (blocks)
+    wreck.kvsdir ["pmi.PMI_process_mapping"] = mapping
+end
+

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1499,6 +1499,20 @@ static int l_wreck_log_error (lua_State *L)
     return wreck_log_error (L, 0);
 }
 
+static int l_wreck_cores_per_node (struct prog_ctx *ctx, lua_State *L)
+{
+    int i;
+    int t;
+    lua_newtable (L);
+    t = lua_gettop (L);
+    for (i = 0; i < ctx->nnodes; i++) {
+        lua_pushnumber (L, i);
+        lua_pushnumber (L, ctx->cores_per_node [i]);
+        lua_settable (L, t);
+    }
+    return (1);
+}
+
 static int l_wreck_index (lua_State *L)
 {
     struct task_info *t;
@@ -1613,6 +1627,12 @@ static int l_wreck_index (lua_State *L)
         lua_pushcfunction (L, l_wreck_log_error);
         return (1);
     }
+    if (strcmp (key, "nnodes") == 0) {
+        lua_pushnumber (L, ctx->nnodes);
+        return (1);
+    }
+    if (strcmp (key, "cores_per_node") == 0)
+        return (l_wreck_cores_per_node (ctx, L));
     return (0);
 }
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1724,12 +1724,9 @@ int rexecd_init (struct prog_ctx *ctx)
         /*  Only update job state and print initialization error message
          *   on rank 0.
          */
-        if (ctx->nodeid == 0) {
-            if (update_job_state (ctx, "failed") < 0)
-                wlog_err (ctx, "update_job_state failed!");
-            else
-                wlog_err (ctx, "Error in initialization, terminating job");
-        }
+        if (rexec_state_change (ctx, "failed") < 0)
+            wlog_err (ctx, "failed to update job state!");
+        wlog_err (ctx, "Error in initialization, terminating job");
         ctx->errnum = errnum;
     }
     free (name);
@@ -2137,8 +2134,8 @@ int main (int ac, char **av)
     if (prog_ctx_init_from_cmb (ctx) < 0) /* Nothing to do here */
         exit (0);
 
-    if ((ctx->nodeid == 0) && update_job_state (ctx, "starting") < 0)
-        wlog_fatal (ctx, 1, "update_job_state");
+    if (rexec_state_change (ctx, "starting") < 0)
+        wlog_fatal (ctx, 1, "rexec_state_change");
 
     if ((parent_fd = optparse_get_int (p, "parent-fd", -1)) >= 0)
         prog_ctx_signal_parent (parent_fd);

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -68,6 +68,21 @@ test_expect_success 'pmi: wreck sets FLUX_LOCAL_RANKS single task per node' '
 	test_cmp expected_clique2 output_clique2
 '
 
+test_expect_success 'pmi: wreck preputs PMI_process_mapping into kvs' '
+	cat <<-EOF >print-pmi-map.sh &&
+	#!/bin/sh
+        if test \${FLUX_TASK_RANK} -eq 0; then
+	  flux kvs get lwj.\${FLUX_JOB_ID}.pmi.PMI_process_mapping
+        fi
+	EOF
+	chmod +x print-pmi-map.sh &&
+	run_timeout 5 flux wreckrun -l -N4 -n4 ./print-pmi-map.sh >output_map &&
+	cat >expected_map <<-EOF &&
+	0: (vector,(0,4,1))
+	EOF
+	test_cmp expected_map output_map
+'
+
 test_expect_success 'pmi: (put*1) / barrier / (get*1) pattern works' '
 	run_program 10 ${SIZE} ${SIZE} \
 	    ${FLUX_BUILD_DIR}/t/pmi/kvstest --library=${FLUX_PMI_LIBRARY} \

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -20,24 +20,27 @@ run_program() {
 	local timeout=$1
 	local ntasks=$2
 	local nnodes=$3
+        local opts=$4
 	shift 3
-	run_timeout $timeout flux wreckrun -l -o stdio-delay-commit \
+	run_timeout $timeout flux wreckrun -l -o $OPTS \
 		    -n${ntasks} -N${nnodes} $*
 }
 
-test_expect_success 'mpi hello world runs as a singleton' '
+for OPTS in "stdio-delay-commit" "stdio-delay-commit,no-pmi-server"; do
+  test_expect_success 'mpi hello world runs as a singleton' '
 	run_program 5 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello
-'
+  '
 
-test_expect_success 'mpi hello world runs on all ranks' '
+  test_expect_success 'mpi hello world runs on all ranks' '
 	run_program 5 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
 		| grep -q "There are ${SIZE} tasks"
-'
+  '
 
-test_expect_success 'mpi hello world runs oversubscribed' '
+  test_expect_success 'mpi hello world runs oversubscribed' '
 	NTASKS=$((${SIZE}*4)); \
 	run_program 5 ${NTASKS} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
 		| grep -q "There are ${NTASKS} tasks"
-'
+  '
+done
 
 test_done

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -27,19 +27,21 @@ run_program() {
 }
 
 for OPTS in "stdio-delay-commit" "stdio-delay-commit,no-pmi-server"; do
-  test_expect_success 'mpi hello world runs as a singleton' '
-	run_program 5 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello
+  test_expect_success "mpi hello singleton with $OPTS" '
+	run_program 5 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello >single.$OPTS
   '
 
-  test_expect_success 'mpi hello world runs on all ranks' '
+  test_expect_success "mpi hello all ranks with $OPTS" '
 	run_program 5 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
-		| grep -q "There are ${SIZE} tasks"
+		| tee allranks.$OPTS \
+		&& grep -q "There are ${SIZE} tasks" allranks.$OPTS
   '
 
-  test_expect_success 'mpi hello world runs oversubscribed' '
+  test_expect_success "mpi hello oversubscribed with $OPTS" '
 	NTASKS=$((${SIZE}*4)); \
 	run_program 5 ${NTASKS} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
-		| grep -q "There are ${NTASKS} tasks"
+		| tee oversub.$OPTS \
+		&& grep -q "There are ${NTASKS} tasks" oversub.$OPTS
   '
 done
 

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -26,7 +26,7 @@ run_program() {
 		    -n${ntasks} -N${nnodes} $*
 }
 
-for OPTS in "stdio-delay-commit" "stdio-delay-commit,no-pmi-server"; do
+for OPTS in "stdio-delay-commit"; do
   test_expect_success "mpi hello singleton with $OPTS" '
 	run_program 5 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello >single.$OPTS
   '


### PR DESCRIPTION
This PR is a quick and dirty addition of pmi-simple server to `wrexecd`. By default wrexec jobs will have `PMI_FD` etc set in environment and, if supported, simple-pmi enabled MPI and other programs will use PMI-1 wire protocol instead of a `libpmi.so` library.

To disable pmi-server, set `-o no-pmi-server` on `flux wreckrun` cmdline.

This has only had cursory testing at this point, but up for early review. It is based on top of #708 