### PR TITLE
libsubprocess/zio: remove ancient zmq socket arg

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1261,7 +1261,7 @@ static int l_iowatcher_add (lua_State *L)
             return lua_pusherror (L, "Invalid fd=%d", fd);
         fd = dup (fd);
         iow = l_flux_ref_create (L, f, 2, "iowatcher");
-        zio = zio_reader_create ("", fd, NULL, iow);
+        zio = zio_reader_create ("", fd, iow);
         iow->arg = (void *) zio;
         if (!zio)
             fprintf (stderr, "failed to create zio!\n");

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -287,9 +287,9 @@ struct subprocess * subprocess_create (struct subprocess_manager *sm)
 
     if (!(p->zio_in = zio_pipe_writer_create ("stdin", (void *) p)))
         goto error;
-    if (!(p->zio_out = zio_pipe_reader_create ("stdout", NULL, (void *) p)))
+    if (!(p->zio_out = zio_pipe_reader_create ("stdout", (void *) p)))
         goto error;
-    if (!(p->zio_err = zio_pipe_reader_create ("stderr", NULL, (void *) p)))
+    if (!(p->zio_err = zio_pipe_reader_create ("stderr", (void *) p)))
         goto error;
 
     zio_set_send_cb (p->zio_out, output_handler);

--- a/src/common/libsubprocess/test/zio.c
+++ b/src/common/libsubprocess/test/zio.c
@@ -124,7 +124,7 @@ int main (int argc, char **argv)
 
     /* simple reader tests
      */
-    ok ((zio = zio_pipe_reader_create ("test1", NULL, &c)) != NULL,
+    ok ((zio = zio_pipe_reader_create ("test1", &c)) != NULL,
         "reader: zio_pipe_reader_create works");
     ok ((name = zio_name (zio)) != NULL && !strcmp (name, "test1"),
         "reader: zio_name returns correct name");

--- a/src/common/libsubprocess/zio.h
+++ b/src/common/libsubprocess/zio.h
@@ -15,14 +15,14 @@ typedef void (*zio_log_f)    (const char *buf);
  *   (depending on buffer setting), and sends json-encoded output to
  *    [dst] zeromq socket.
  */
-zio_t *zio_reader_create (const char *name, int src, void *dst, void *arg);
+zio_t *zio_reader_create (const char *name, int srcfd, void *arg);
 
 /*
  *  Create a zio reader which reads from an internal pipe and sends
  *   json-encoded output to a zmq socket. Use zio_dst_fd() to get the
  *   file descriptor for the write side of the pipe.
  */
-zio_t *zio_pipe_reader_create (const char *name, void *dst, void *arg);
+zio_t *zio_pipe_reader_create (const char *name, void *arg);
 
 /*
  *  Create a zio "writer" object, that buffers data via zio_write_* interface

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -488,7 +488,7 @@ static void task_pmi_setup (struct task_info *t)
         wlog_fatal (t->ctx, 1, "socketpair: %s", strerror (errno));
 
     /* ZIO object for reading pmi-simple server requests */
-    t->pmi_zio = zio_reader_create ("pmi", t->pmi_fds[0], NULL, (void *) t);
+    t->pmi_zio = zio_reader_create ("pmi", t->pmi_fds[0], (void *) t);
     if (t->pmi_zio == NULL)
         wlog_fatal (t->ctx, 1, "zio_reader_create: %s", strerror (errno));
 
@@ -516,11 +516,11 @@ struct task_info * task_info_create (struct prog_ctx *ctx, int id)
     t->f = NULL;
     t->kvs = NULL;
 
-    t->zio [OUT] = zio_pipe_reader_create ("stdout", NULL, (void *) t);
+    t->zio [OUT] = zio_pipe_reader_create ("stdout", (void *) t);
     zio_set_send_cb (t->zio [OUT], io_cb);
     zio_set_raw_output (t->zio [OUT]);
 
-    t->zio [ERR] = zio_pipe_reader_create ("stderr", NULL, (void *) t);
+    t->zio [ERR] = zio_pipe_reader_create ("stderr", (void *) t);
     zio_set_send_cb (t->zio [ERR], io_cb);
     zio_set_raw_output (t->zio [ERR]);
 


### PR DESCRIPTION
I was going to wait to include this commit in a future PR with zio work/replacement, but this is a needed cleanup and standalone, so I'm just including it now. It removes a bit of unused code, and an unnecessary argument/member to the zio struct.