### PR TITLE
resource-hwloc: disable walk_topology() by default

### DIFF
--- a/doc/man1/flux-hwloc.adoc
+++ b/doc/man1/flux-hwloc.adoc
@@ -43,8 +43,18 @@ For graphical output, try:  *flux hwloc lstopo --of graphical*.
 
 *reload* ['OPTIONS'] ['DIR']::
 Reload hwloc topology information, optionally loading hwloc XML files
-from `DIR/<rank>.xml` files. + 
-With *-r, --rank=*['RANKS'], only reload XML on provided nodeset 'RANKS'.
+from `DIR/<rank>.xml` files.
+Options:
+
+ --rank=['RANKS']:::
+ -r 'RANKS':::
+ Only reload XML on provided nodeset 'RANKS'.
+
+ --walk-topology=['yes|no']:::
+ -t ['yes|no']:::
+ If 'yes', force resource-hwloc module to walk full topology on each reloaded
+ rank and insert broken down topology into KVS under. If 'no', force disable
+ the topology walk if enabled by default in module.
 
 *topology*::
 Dump current aggregate topology XML for the current session to stdout.

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -350,15 +350,6 @@ done:
     return rc;
 }
 
-static void load_event_cb (flux_t h,
-                           flux_msg_handler_t *watcher,
-                           const flux_msg_t *msg,
-                           void *arg)
-{
-    ctx_t *ctx = arg;
-    (void)load_hwloc (h, ctx);
-}
-
 static void reload_request_cb (flux_t h,
                                flux_msg_handler_t *watcher,
                                const flux_msg_t *msg,
@@ -465,7 +456,6 @@ done:
 }
 
 static struct flux_msg_handler_spec htab[] = {
-    {FLUX_MSGTYPE_EVENT, "resource-hwloc.load", load_event_cb, NULL},
     {FLUX_MSGTYPE_REQUEST, "resource-hwloc.reload", reload_request_cb, NULL},
     {FLUX_MSGTYPE_REQUEST, "resource-hwloc.topo", topo_request_cb, NULL},
     FLUX_MSGHANDLER_TABLE_END};

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -120,7 +120,7 @@ done:
     return ret;
 }
 
-void freectx (ctx_t *ctx)
+static void resource_hwloc_ctx_destroy (ctx_t *ctx)
 {
     if (ctx) {
         if (ctx->topology)
@@ -129,7 +129,7 @@ void freectx (ctx_t *ctx)
     }
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *resource_hwloc_ctx_create (flux_t h)
 {
     ctx_t *ctx = xzmalloc (sizeof(ctx_t));
     if (flux_get_rank (h, &ctx->rank) < 0) {
@@ -142,7 +142,7 @@ static ctx_t *getctx (flux_t h)
     }
     return ctx;
 error:
-    freectx (ctx);
+    resource_hwloc_ctx_destroy (ctx);
     return NULL;
 }
 
@@ -475,7 +475,7 @@ int mod_main (flux_t h, int argc, char **argv)
     int rc = -1;
     ctx_t *ctx;
 
-    if (!(ctx = getctx (h)))
+    if (!(ctx = resource_hwloc_ctx_create (h)))
         goto done;
 
     // Load hardware information immediately
@@ -500,7 +500,7 @@ int mod_main (flux_t h, int argc, char **argv)
 done_delvec:
     flux_msg_handler_delvec (htab);
 done:
-    freectx (ctx);
+    resource_hwloc_ctx_destroy (ctx);
     return rc;
 }
 

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -93,4 +93,17 @@ test_expect_success HAVE_LSTOPO 'hwloc: test failure of lstopo command' '
     test_must_fail flux hwloc lstopo --input f:g:y
 '
 
+test_expect_success 'hwloc: no broken down resource info by default' '
+    test_must_fail flux kvs get resource.hwloc.by_rank.0.Machine_0.OSName
+'
+
+test_expect_success 'hwloc: reload --walk-topology=yes works' '
+    flux hwloc reload --walk-topology=yes &&
+    flux kvs get resource.hwloc.by_rank.0.Machine_0.OSName
+'
+test_expect_success 'hwloc: reload --walk-topology=no removes broken down topo' '
+    flux hwloc reload --walk-topology=no &&
+    test_must_fail flux kvs get resource.hwloc.by_rank.0.Machine_0.OSName
+'
+
 test_done


### PR DESCRIPTION
Fixes #716.

This PR disables `walk_topology()` by default as described in #716, with some other minor fixes along the way. A new module option, `walk_topology`, can be used to force the topology walk and broken down entries in the kvs, or a new `flux hwloc reload --walk-topology=yes` can be used to force the behavior at reload time (this will be the default for the next reload as well).

Along the way, it seemed like the `resource-hwloc.load` request was no longer used, so it is removed. I assume the `reload` request is what we want.

Some possible weirdness that I might need to fix:
 * json payload in reload request is optional -- not sure if that is a good idea or not. If there is a payload, and `walk_topology` boolean is set, that is used as the new value for `ctx->walk_topology`
 * `flux hwloc reload --walk-topology=yes|no` actually takes any value except `false`, `0`, or `1` to be true. Should I be less lazy here?
