### PR TITLE
python: minor fixes and addition to the bindings

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -131,8 +131,8 @@ class Flux(Wrapper):
                            topic_glob='*',
                            args=None,
                            match_tag=flux.FLUX_MATCHTAG_NONE):
-        return MessageWatcher(self, type_mask, callback, topic_glob, match_tag,
-                              bsize, args)
+        return MessageWatcher(self, type_mask, callback, topic_glob,
+                              match_tag, args)
 
     def timer_watcher_create(self, after, callback, repeat=0.0, args=None):
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)
@@ -140,6 +140,11 @@ class Flux(Wrapper):
     def barrier(self, name, nprocs):
         _raw_barrier.barrier(self, name, nprocs)
 
+
+    def get_rank(self):
+        rank = ffi.new('uint32_t [1]')
+        self.flux_get_rank(rank)
+        return rank[0]
 
 def open(url, flags=0):
     """ Open a connection to the specified flux connector """

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -65,9 +65,8 @@ class RPC(WrapperPimpl):
     return bool(self.pimpl.completed())
 
   def get_str(self):
-    c_nodeid = ffi.new('uint32_t [1]')
     j_str = ffi.new('char *[1]')
-    self.pimpl.get(c_nodeid, j_str)
+    self.pimpl.get(ffi.NULL, j_str)
     return ffi.string(j_str[0])
 
   def get(self):

--- a/src/bindings/python/test/handle.py
+++ b/src/bindings/python/test/handle.py
@@ -33,3 +33,7 @@ class TestHandle(unittest.TestCase):
         self.assertEqual(r['seq'], 1)
         self.assertEqual(r['pad'], 'stuff')
 
+    def test_get_rank(self):
+      """Get flux rank"""
+      rank = self.f.get_rank()
+      self.assertEqual(rank, 0)


### PR DESCRIPTION
rpc.py:
- flux_rpc_get allows a NULL to be passed in for nodeid, so for
rpc.get_str (in python), don't allocate space for an additional uint
that ends up being free'd immediately after the function call, just pass
in NULL

handle.py:
- remove erroneous bsize argument from MessageWatcher constructor call
- Add a get_rank method/interface to the handle