### PR TITLE
Add support for Sanitizer tools

### DIFF
--- a/config/x_ac_sanitize.m4
+++ b/config/x_ac_sanitize.m4
@@ -1,0 +1,35 @@
+AC_DEFUN([X_AC_ENABLE_SANITIZER], [
+    AC_MSG_CHECKING([whether to enable a sanitizer tool])
+    m4_define([san_options], [@<:@OPT=no/address/thread@:>@])
+    m4_define([cc_san], [The selected compiler does not support sanitizers])
+    m4_define([cc_san_sup], [GCC >= 4.8 or Clang >= 3.5])
+    AC_ARG_ENABLE([sanitizer],
+        [AS_HELP_STRING(--enable-sanitizer@<:@=OPT@:>@,
+            enable a sanitizer tool @<:@default=address@:>@ san_options)],
+        [san_enabled=$enableval],
+        [san_enabled="check"])    
+
+    if test "x$san_enabled" = "xcheck"; then
+        san_enabled="no"
+    elif test "x$san_enabled" = "xyes"; then
+        san_enabled="address"
+    fi
+    AC_MSG_RESULT($san_enabled)
+
+    if test "x$san_enabled" = "xaddress" -o "x$san_enabled" = "xthread" ; then 
+        CFLAGS="$CFLAGS -fsanitize=$san_enabled -fno-omit-frame-pointer"
+        LDFLAGS="$LDFLAGS -fsanitize=$san_enabled"
+        AC_MSG_CHECKING([whether CC supports -fsanitizer=$san_enabled])
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+            [AC_MSG_RESULT([yes])],
+            [AC_MSG_RESULT([no]) 
+             AC_MSG_ERROR(cc_san. Please use cc_san_sup.)])
+        AS_VAR_SET(san_ld_zdef_flag, [])
+        AC_SUBST(san_ld_zdef_flag)
+    elif test "x$san_enabled" = "xno" ; then
+        AS_VAR_SET(san_ld_zdef_flag, [-Wl,--no-undefined])
+        AC_SUBST(san_ld_zdef_flag)
+    else
+        AC_MSG_ERROR($san_enabled is a unsupported option.)
+    fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ if test "$GCC" = yes; then
   GCCWARN="-Wall -Werror -Wno-strict-aliasing -Wno-error=deprecated-declarations"
   AC_SUBST([GCCWARN])
 fi
+X_AC_ENABLE_SANITIZER
 LT_INIT
 AC_PROG_AWK
 AC_CHECK_PROG(A2X,[a2x],[a2x])
@@ -156,10 +157,10 @@ AC_SUBST(fluxluadir)
 ##
 # Macros to avoid repetition in Makefiles.am's
 ##
-fluxmod_ldflags="-Wl,--no-undefined -avoid-version -export-symbols-regex '^mod_(main|name|service)\$\$' --disable-static -shared -export-dynamic"
+fluxmod_ldflags="$san_ld_zdef_flag -avoid-version -export-symbols-regex '^mod_(main|name|service)\$\$' --disable-static -shared -export-dynamic"
 AC_SUBST(fluxmod_ldflags)
 
-fluxlib_ldflags="-shared -export-dynamic --disable-static -Wl,--no-undefined"
+fluxlib_ldflags="-shared -export-dynamic --disable-static $san_ld_zdef_flag"
 AC_SUBST(fluxlib_ldflags)
 
 ##

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -53,7 +53,7 @@ noinst_LTLIBRARIES = \
 
 luamod_ldflags = \
 	-avoid-version -module -shared --disable-static \
-	-Wl,--no-undefined
+	$(san_ld_zdef_flag)
 
 luamod_libadd = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	-avoid-version -module -Wl,--no-undefined \
+	-avoid-version -module $(san_ld_zdef_flag) \
 	$(PYTHON_LDFLAGS) -Wl,-rpath,$(PYTHON_PREFIX)/lib \
 	$(CODE_COVERAGE_LDFLAGS)
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -21,7 +21,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libcompat/libcompat.la \
 	$(LIBMUNGE) $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) $(LIBRT)
-libflux_internal_la_LDFLAGS = -Wl,--no-undefined
+libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
 lib_LTLIBRARIES = libflux-core.la libflux-optparse.la
 
@@ -32,7 +32,7 @@ libflux_core_la_LIBADD = \
 libflux_core_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libflux-core.map \
         -shared -export-dynamic --disable-static \
-        -Wl,--no-undefined
+        $(san_ld_zdef_flag)
 
 libflux_optparse_la_SOURCES =
 libflux_optparse_la_LIBADD = \
@@ -42,6 +42,6 @@ libflux_optparse_la_LIBADD = \
 libflux_optparse_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libflux-optparse.map \
 	-shared -export-dynamic --disable-static \
-	-Wl,--no-undefined
+	$(san_ld_zdef_flag)
 
 EXTRA_DIST = libflux-core.map libflux-optparse.map

--- a/src/common/libutil/test/cronodate.c
+++ b/src/common/libutil/test/cronodate.c
@@ -56,12 +56,12 @@ static bool cronodate_check_next (struct cronodate *d,
     struct tm tm;
     int rc;
 
-    ok (string_to_tm (expected, &tm) >= 0,
+    ok (string_to_tm (expected, &tm),
         "string_to_tm (expected=%s)", expected);
     if ((t_exp = mktime (&tm)) < (time_t) 0)
         return false;
 
-    ok (string_to_tm (start, &tm) >= 0,
+    ok (string_to_tm (start, &tm),
         "string_to_tm (start=%s)", start);
     strftime (buf, sizeof (buf), "%Y-%m-%d %H:%M:%S %Z", &tm);
     diag ("start = %s", buf);
@@ -219,7 +219,7 @@ int main (int argc, char *argv[])
     ok (cronodate_set (d, TM_YEAR, "*") >= 0, "date glob set, year = *");
 
     // Impossible date returns error
-    ok (string_to_tm ("2016-06-06 08:00:00", &tm) >= 0, "string_to_tm");
+    ok (string_to_tm ("2016-06-06 08:00:00", &tm), "string_to_tm");
     rc = cronodate_next (d, &tm);
     ok (rc < 0, "cronodate_next() fails when now is >= matching date");
 
@@ -228,11 +228,11 @@ int main (int argc, char *argv[])
     ok (cronodate_set (d, TM_SEC, "0") >= 0, "date glob set, sec = 0");
     ok (cronodate_set (d, TM_MIN, "0") >= 0, "date glob set, min = 0");
     ok (cronodate_set (d, TM_HOUR, "8") >= 0, "date glob set, hour = 0");
-    ok (string_to_tv ("2016-06-06 07:00:00.3", &tv) >= 0, "string_to_tv");
+    ok (string_to_tv ("2016-06-06 07:00:00.3", &tv), "string_to_tv");
 
     x = cronodate_remaining (d, tv_to_double (&tv));
     ok (almost_is (x, 3599.700), "cronodate_remaining works: got %.3fs", x);
-    ok (string_to_tv ("2016-06-06 08:00:00", &tv) >= 0, "string_to_tv");
+    ok (string_to_tv ("2016-06-06 08:00:00", &tv), "string_to_tv");
     x = cronodate_remaining (d, tv_to_double (&tv));
     ok (almost_is (x, 24*60*60), "cronodate_remaining works: got %.3fs", x);
 

--- a/src/common/libutil/test/nodeset.c
+++ b/src/common/libutil/test/nodeset.c
@@ -219,7 +219,7 @@ int main (int argc, char *argv[])
 
     ok ((r = nodeset_next_rank (n, 1)) == 2,
         "nodeset_next_rank returns next rank even if arg not in set");
-
+    nodeset_destroy (n);
 
 /********************************************/
 

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -13,7 +13,7 @@ fluxconnector_LTLIBRARIES = local.la
 
 local_la_SOURCES = local.c
 
-local_la_LDFLAGS = -module -Wl,--no-undefined \
+local_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
 	--disable-static -avoid-version -shared -export-dynamic \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -13,7 +13,7 @@ fluxconnector_LTLIBRARIES = loop.la
 
 loop_la_SOURCES = loop.c
 
-loop_la_LDFLAGS = -module -Wl,--no-undefined \
+loop_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
 	--disable-static -avoid-version -shared -export-dynamic \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/connectors/shmem/Makefile.am
+++ b/src/connectors/shmem/Makefile.am
@@ -13,7 +13,7 @@ fluxconnector_LTLIBRARIES = shmem.la
 
 shmem_la_SOURCES = shmem.c
 
-shmem_la_LDFLAGS = -module -Wl,--no-undefined \
+shmem_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
 	--disable-static -avoid-version -shared -export-dynamic \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -13,7 +13,7 @@ fluxconnector_LTLIBRARIES = ssh.la
 
 ssh_la_SOURCES = ssh.c
 
-ssh_la_LDFLAGS = -module -Wl,--no-undefined \
+ssh_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
 	--disable-static -avoid-version -shared -export-dynamic \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -852,7 +852,7 @@ static void job_state_cb (flux_t h, flux_msg_handler_t *w,
 
     if (flux_event_decode (msg, NULL, &json_str) < 0
             || !(o = Jfromstr (json_str))
-            || Jget_int64 (o, "lwj", &jobid) < 0) {
+            || !Jget_int64 (o, "lwj", &jobid)) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }


### PR DESCRIPTION
Initial support for AddressSanitizer (ASan) and ThreadSanitizer (TSan).

This is tested with `clang-omp-3.5.0` installed at LLNL TOSS2 systems (e.g., Cab). For example, 
```
% use clang-omp-3.5.0
% ./configure CC=clang
```

Also mildly tested with `gcc 4.9.3p.` For example, 
```
% use gcc 4.9.3p
% ./configure
```
