### PR TITLE
consolidate kvs put and commit requests internally

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -38,6 +38,7 @@ fluxcoreinclude_HEADERS = kvs.h
 libflux_kvs_la_SOURCES = \
 	libkvs.c \
 	proto.c \
+	json_dirent.c \
 	kvs_deprecated.h
 libflux_kvs_la_LDFLAGS = $(fluxlib_ldflags) \
 			 -export-symbols-regex '^(kvs|kvsdir|kvsitr)_.*'

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -21,7 +21,9 @@ kvs_la_SOURCES = \
 	waitqueue.c \
 	waitqueue.h \
 	proto.c \
-	proto.h
+	proto.h \
+	json_dirent.c \
+	json_dirent.h
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/kvs/json_dirent.c
+++ b/src/modules/kvs/json_dirent.c
@@ -1,0 +1,75 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <json.h>
+#include <assert.h>
+
+#include "json_dirent.h"
+#include "src/common/libutil/shortjson.h"
+
+json_object *dirent_create (char *type, void *arg)
+{
+    json_object *dirent = Jnew ();
+    bool valid_type = false;
+
+    if (!strcmp (type, "FILEREF") || !strcmp (type, "DIRREF")) {
+        char *ref = arg;
+
+        Jadd_str (dirent, type, ref);
+        valid_type = true;
+    } else if (!strcmp (type, "FILEVAL") || !strcmp (type, "DIRVAL")
+                                         || !strcmp (type, "LINKVAL")) {
+        json_object *val = arg;
+
+        if (val)
+            json_object_get (val);
+        else
+            val = Jnew ();
+        json_object_object_add (dirent, type, val);
+        valid_type = true;
+    }
+    assert (valid_type == true);
+
+    return dirent;
+}
+
+void dirent_append (json_object **array, const char *key, json_object *dirent)
+{
+    json_object *op = Jnew ();
+
+    Jadd_str (op, "key", key);
+    json_object_object_add (op, "dirent", dirent);
+    if (!*array)
+        *array = Jnew_ar ();
+    json_object_array_add (*array, op);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -1,0 +1,19 @@
+
+/* Create a KVS dirent.
+ * 'type' is one of { "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL" }.
+ * 'arg' is dependent on the type.  This function asserts on failure.
+ */
+json_object *dirent_create (char *type, void *arg);
+
+/* Append a JSON object containing
+ *     { "key" : key, "dirent" : dirent }
+ *     { "key" : key, "dirent" : nil }
+ * to a json array, creating '*array' if necessary.  This is used to build
+ * a KVS commit, where each new object is an ordered operation that adds/
+ * changes/unlinks a key in KVS namespace.  This function asserts on failure.
+ */
+void dirent_append (json_object **array, const char *key, json_object *dirent);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -90,11 +90,6 @@
 
 typedef char href_t[SHA1_STRING_SIZE];
 
-/* Large values are stored in dirents by reference; small values by value.
- *  (-1 = all by reference, 0 = all by value)
- */
-#define LARGE_VAL (sizeof (href_t) + 1)
-
 /* Break cycles in symlink references.
  */
 #define SYMLINK_CYCLE_LIMIT 10
@@ -229,15 +224,6 @@ error:
     return NULL;
 }
 
-static bool store_by_reference (json_object *o)
-{
-    if (LARGE_VAL == -1)
-        return true;
-    if (strlen (json_object_to_json_string (o)) >= LARGE_VAL)
-        return true;
-    return false;
-}
-
 static commit_t *commit_create (void)
 {
     commit_t *c = xzmalloc (sizeof (*c));
@@ -254,11 +240,6 @@ static void commit_destroy (commit_t *c)
         flux_msg_destroy (c->request);
         free (c);
     }
-}
-
-static void commit_add (commit_t *c, const char *key, json_object *dirent)
-{
-    dirent_append (&c->ops, key, dirent);
 }
 
 static fence_t *fence_create (int nprocs)
@@ -1106,68 +1087,6 @@ done:
         free (p.sender);
 }
 
-static void put_request_cb (flux_t h, flux_msg_handler_t *w,
-                            const flux_msg_t *msg, void *arg)
-{
-    ctx_t *ctx = arg;
-    const char *json_str;
-    JSON in = NULL;
-    href_t ref;
-    const char *key;
-    JSON val = NULL;
-    bool dir = false;
-    bool link = false;
-    struct timespec t0;
-    char *sender = NULL;
-    commit_t *commit;
-    int rc = -1;
-
-    monotime (&t0);
-    if (flux_request_decode (msg, NULL, &json_str) < 0)
-        goto done;
-    if (flux_msg_get_route_first (msg, &sender) < 0)
-        goto done;
-    if (!(in = Jfromstr (json_str))) {
-        errno = EPROTO;
-        goto done;
-    }
-    if (kp_tput_dec (in, &key, &val, &link, &dir) < 0)
-        goto done;
-    if (!(commit = zhash_lookup (ctx->commits, sender))) {
-        commit = commit_create ();
-        commit->state = COMMIT_PUT;
-        zhash_insert (ctx->commits, sender, commit);
-        zhash_freefn (ctx->commits, sender, (zhash_free_fn *)commit_destroy);
-    }
-    if (commit->state != COMMIT_PUT) { /* commit already in progress */
-        errno = EINVAL;
-        goto done;
-    }
-    if (json_object_get_type (val) == json_type_null) {
-        if (dir) {
-            JSON empty_dir = Jnew ();
-            store (ctx, empty_dir, ref);
-            commit_add (commit, key, dirent_create ("DIRREF", ref));
-        } else
-            commit_add (commit, key, NULL);
-    } else if (link) {
-        commit_add (commit, key, dirent_create ("LINKVAL", val));
-    } else if (store_by_reference (val)) {
-        store (ctx, Jget (val), ref);
-        commit_add (commit, key, dirent_create ("FILEREF", ref));
-    } else {
-        commit_add (commit, key, dirent_create ("FILEVAL", val));
-    }
-    tstat_push (&ctx->stats.put_time, monotime_since (t0));
-    rc = 0;
-done:
-    if (flux_respond (h, msg, rc < 0 ? errno : 0, NULL) < 0)
-        flux_log_error (h, "%s", __FUNCTION__);
-    Jput (in);
-    if (sender)
-        free (sender);
-}
-
 static void commit_response_cb (flux_t h, flux_msg_handler_t *w,
                                 const flux_msg_t *msg, void *arg)
 {
@@ -1680,7 +1599,6 @@ static struct flux_msg_handler_spec handlers[] = {
     { FLUX_MSGTYPE_REQUEST, "kvs.disconnect",       disconnect_request_cb },
     { FLUX_MSGTYPE_REQUEST, "kvs.unwatch",          unwatch_request_cb },
     { FLUX_MSGTYPE_REQUEST, "kvs.sync",             sync_request_cb },
-    { FLUX_MSGTYPE_REQUEST, "kvs.put",              put_request_cb },
     { FLUX_MSGTYPE_REQUEST, "kvs.get",              get_request_cb },
     { FLUX_MSGTYPE_REQUEST, "kvs.watch",            watch_request_cb },
     { FLUX_MSGTYPE_REQUEST, "kvs.commit",           commit_request_cb },

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -147,12 +147,6 @@ error:
     return NULL;
 }
 
-void unlink_if_exists (flux_t h, const char *path)
-{
-    if (!kvs_unlink (h, path))  // if the unlink succeeds
-        kvs_commit (h);  // ensure the unlink is committed before proceeding
-}
-
 static int load_xml_to_kvs (flux_t h, ctx_t *ctx)
 {
     char *xml_path = NULL;
@@ -160,7 +154,7 @@ static int load_xml_to_kvs (flux_t h, ctx_t *ctx)
     int buflen = 0, ret = -1;
 
     xml_path = xasprintf ("resource.hwloc.xml.%" PRIu32, ctx->rank);
-    unlink_if_exists (h, xml_path);
+    (void)kvs_unlink (h, xml_path);
     if (hwloc_topology_export_xmlbuffer (ctx->topology, &buffer, &buflen) < 0) {
         flux_log (h, LOG_ERR, "hwloc_topology_export_xmlbuffer");
         goto done;
@@ -279,7 +273,7 @@ static int load_info_to_kvs (flux_t h, ctx_t *ctx)
     int depth = hwloc_topology_get_depth (ctx->topology);
 
     base_path = xasprintf ("resource.hwloc.by_rank.%" PRIu32, ctx->rank);
-    unlink_if_exists (h, base_path);
+    (void)kvs_unlink (h, base_path);
     for (i = 0; i < depth; ++i) {
         int nobj = hwloc_get_nbobjs_by_depth (ctx->topology, i);
         hwloc_obj_type_t t = hwloc_get_depth_type (ctx->topology, i);
@@ -303,7 +297,7 @@ static int load_info_to_kvs (flux_t h, ctx_t *ctx)
         char *kvs_hostname = escape_kvs_key (hostname);
         char *host_path = xasprintf ("resource.hwloc.by_host.%s", kvs_hostname);
         free (kvs_hostname);
-        unlink_if_exists (h, host_path);
+        (void) kvs_unlink (h, host_path);
         if (ctx->walk_topology &&
             walk_topology (h,
                            ctx->topology,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -150,6 +150,7 @@ check_PROGRAMS = \
 	pmi/pminfo \
 	kz/kzutil \
 	kvs/torture \
+	kvs/asyncfence \
 	kvs/hashtest \
 	kvs/watch \
 	kvs/watch_disconnect \
@@ -246,6 +247,12 @@ kz_kzutil_LDADD = \
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)
 kvs_torture_LDADD = \
+	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_asyncfence_SOURCES = kvs/asyncfence.c
+kvs_asyncfence_CPPFLAGS = $(test_cppflags)
+kvs_asyncfence_LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 

--- a/t/kvs/asyncfence.c
+++ b/t/kvs/asyncfence.c
@@ -1,0 +1,53 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t h;
+    flux_rpc_t *rpc;
+    int i;
+
+    log_init ("asynfence");
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (kvs_put_int (h, "test.asyncfence.a", 42) < 0)
+        log_err_exit ("kvs_put test.asyncfence.a");
+
+    if (!(rpc = kvs_fence_begin (h, "test.asyncfence.1", 1)))
+        log_err_exit ("kvs_fence_begin test.asyncfence.1");
+
+    if (kvs_put_int (h, "test.asyncfence.b", 43) < 0)
+        log_err_exit ("kvs_put test.asyncfence.b");
+
+    if (kvs_fence_finish (rpc) < 0)
+        log_err_exit ("kvs_fence_finish");
+
+    if (kvs_get_int (h, "test.asyncfence.a", &i) < 0)
+        log_err_exit ("kvs_get test.asyncfence.a");
+    if (i != 42)
+        log_msg_exit ("test.asyncfence.a has wrong value");
+
+    if (kvs_get_int (h, "test.asyncfence.b", &i) == 0)
+        log_msg_exit ("kvs_get test.asyncfence.b worked but it shouldn't have");
+
+    if (kvs_fence (h, "test.asyncfence.2", 1) < 0)
+        log_err_exit ("kvs_fence_begin test.asyncfence.2");
+
+    if (kvs_get_int (h, "test.asyncfence.b", &i) < 0)
+        log_err_exit ("kvs_get test.asyncfence.b");
+    if (i != 43)
+        log_msg_exit ("test.asyncfence.b has wrong value");
+
+    flux_close (h);
+    log_fini ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -375,4 +375,10 @@ test_expect_success LONGTEST 'kvs: store 1,000,000 keys in one dir' '
 	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $TEST.bigdir2 --count 1000000
 '
 
+# async fence
+
+test_expect_success 'kvs: async kvs_fence allows puts with fence in progress' '
+	${FLUX_BUILD_DIR}/t/kvs/asyncfence
+'
+
 test_done


### PR DESCRIPTION
This PR was created to address issue #729, where wreck's use of the async fence operations `kvs_fence_begin()`, `kvs_fence_finish()` was in rare cases allowing a put to be issued while a fence was in progress.  This was not allowed by the KVS, not for any good reason, just because of the simplistic  way client state was tracked.

In trying to decide how to fix this without destabilizing the KVS code base,  it seemed like a low-risk
approach was to move "put" processing to the client, and piggyback the put data on the commit/fence message.  This could be done without changing the protocol since the commit request already included an optional "operations" JSON array.  The put, mkdir, symlink, unlink calls now return immediately (no RPC), except in the case of a put of a value larger than its blobref; then there is a synchronous content store write (to rank 0 memory, not backing store).

This ought to improve performance in cases like the one @grondo solved with resource-hwloc in #718,
where there is a lot of put activity but not a huge amount of data. 

It may hurt performance in other cases, such as when multiple _large_ values are put sequentially.  Put was a synchronous RPC to the _local_ KVS module, with possible blocking at commit time while stores to rank 0 completed in parallel;  now they are a synchronous RPC to the content store module, which doesn't return until the value is in rank 0 memory).  This could be improved at some point by making the content store requests asynchronous from put, and finishing them in commit, before sending the commit request.  However, let's wait and see if it's a problem - the whole KVS API needs to be reworked to be asynchronous later on anyway.

For fun I repeated @grondo's quick hwloc timing test in #716 on 1024 cores (pre-salloc, warm cache)
*  walk_topology disabled: 11s (same as before)
*  walk_toplogy enabled: 23s (down from 25s)

Well that was a little disappointing.  Anyway it fixes #729 and doesn't slow that case down.



