### PR TITLE
Fix PMI failsafe symbol and error codes + tests

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -49,6 +49,7 @@ libpmi_la_LIBADD = \
 	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL)
 libpmi_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libpmi.map \
+	-Wl,--defsym=flux_pmi_library=1 \
 	-shared -export-dynamic --disable-static \
 	-Wl,--no-undefined
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -51,6 +51,7 @@ libpmi_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libpmi.map \
 	-Wl,--defsym=flux_pmi_library=1 \
 	-shared -export-dynamic --disable-static \
-	-Wl,--no-undefined
+	$(san_ld_zdef_flag)
+
 
 EXTRA_DIST = libflux-core.map libflux-optparse.map libpmi.map

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -72,7 +72,7 @@ static struct pmi_context ctx = { .type = IMPL_UNKNOWN, .rank = -1 };
 
 int PMI_Init (int *spawned)
 {
-    int result = PMI_ERR_INIT;
+    int result = PMI_FAIL;
     const char *library;
     const char *debug;
 
@@ -204,7 +204,7 @@ int PMI_Finalize (void)
             ctx.cli = NULL;
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     ctx.type = IMPL_UNKNOWN;
@@ -226,7 +226,7 @@ int PMI_Abort (int exit_code, const char error_msg[])
             result = pmi_simple_client_abort (ctx.cli, exit_code, error_msg);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     /* unlikely to return */
@@ -247,7 +247,7 @@ int PMI_Get_size (int *size)
             result = pmi_simple_client_get_size (ctx.cli, size);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -267,7 +267,7 @@ int PMI_Get_rank (int *rank)
             result = pmi_simple_client_get_rank (ctx.cli, rank);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     if (result == PMI_SUCCESS)
@@ -289,7 +289,7 @@ int PMI_Get_universe_size (int *size)
             result = pmi_simple_client_get_universe_size (ctx.cli, size);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -309,7 +309,7 @@ int PMI_Get_appnum (int *appnum)
             result = pmi_simple_client_get_appnum (ctx.cli, appnum);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -330,7 +330,7 @@ int PMI_KVS_Get_my_name (char kvsname[], int length)
                                                         length);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     if (result == PMI_SUCCESS) {
@@ -358,7 +358,7 @@ int PMI_KVS_Get_name_length_max (int *length)
                                                                 length);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -378,7 +378,7 @@ int PMI_KVS_Get_key_length_max (int *length)
             result = pmi_simple_client_kvs_get_key_length_max (ctx.cli, length);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -399,7 +399,7 @@ int PMI_KVS_Get_value_length_max (int *length)
                                                                  length);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -419,7 +419,7 @@ int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
             result = pmi_simple_client_kvs_put (ctx.cli, kvsname, key, value);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DPRINTF ("%d: PMI_KVS_Put (\"%s\", \"%s\", \"%s\") rc=%d %s\n",
@@ -445,7 +445,7 @@ int PMI_KVS_Get (const char kvsname[], const char key[],
                                                 key, value, length);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     if (result == PMI_SUCCESS) {
@@ -472,7 +472,7 @@ int PMI_KVS_Commit (const char kvsname[])
             result = pmi_simple_client_kvs_commit (ctx.cli, kvsname);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -492,7 +492,7 @@ int PMI_Barrier (void)
             result = pmi_simple_client_barrier (ctx.cli);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -513,7 +513,7 @@ int PMI_Publish_name (const char service_name[], const char port[])
                                                      service_name, port);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -533,7 +533,7 @@ int PMI_Unpublish_name (const char service_name[])
             result = pmi_simple_client_unpublish_name (ctx.cli, service_name);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -554,7 +554,7 @@ int PMI_Lookup_name (const char service_name[], char port[])
                                                     service_name, port);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -596,7 +596,7 @@ int PMI_Spawn_multiple(int count,
                                                        errors);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     DRETURN (result);
@@ -613,7 +613,7 @@ int PMI_Get_clique_ranks (int ranks[], int length)
             result = pmi_wrap_get_clique_ranks (ctx.wrap, ranks, length);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     if (result == PMI_FAIL)
@@ -629,7 +629,7 @@ int PMI_Get_clique_size (int *size)
             result = pmi_wrap_get_clique_size (ctx.wrap, size);
             break;
         default:
-            result = PMI_FAIL;
+            result = PMI_ERR_INIT;
             break;
     }
     if (result == PMI_FAIL)

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -46,8 +46,6 @@ typedef enum {
     IMPL_SINGLETON,
 } implementation_t;
 
-const char flux_pmi_library[] = PACKAGE_STRING;
-
 struct pmi_context {
     implementation_t type;
     union {
@@ -85,7 +83,6 @@ int PMI_Init (int *spawned)
         ctx.debug = strtol (debug, NULL, 0);
     else
         ctx.debug = 0;
-    DPRINTF ("%s: %s\n", __FUNCTION__, flux_pmi_library);
 
     /* If PMI_FD is set, the simple protocol service is offered.
      * Use it directly.

--- a/src/common/libpmi/wrap.c
+++ b/src/common/libpmi/wrap.c
@@ -338,7 +338,7 @@ struct pmi_wrap *pmi_wrap_create (const char *libname)
     struct pmi_wrap *pmi = calloc (1, sizeof (*pmi));
     const char *s;
     int debug = 0;
-    char *name, *libver;
+    char *name;
     zlist_t *libs = NULL;
 
     if (!pmi)
@@ -359,11 +359,9 @@ struct pmi_wrap *pmi_wrap_create (const char *libname)
                              __FUNCTION__, name);
             }
         }
-        else if ((libver = dlsym (pmi->dso, "flux_pmi_library"))) {
-            if (debug) {
-                fprintf (stderr, "%s: skipping %s (%s)\n",
-                         __FUNCTION__, name, libver);
-            }
+        else if (dlsym (pmi->dso, "flux_pmi_library")) {
+            if (debug)
+                fprintf (stderr, "%s: skipping %s\n", __FUNCTION__, name);
             dlclose (pmi->dso);
             pmi->dso = NULL;
         }

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -24,6 +24,13 @@ run_program() {
 		    -n${ntasks} -N${nnodes} $*
 }
 
+# Requires lwj == 1
+test_expect_success 'pmi: wreck sets FLUX_JOB_ID' '
+	run_program 5 ${SIZE} ${SIZE} printenv FLUX_JOB_ID >output_appnum &&
+        test `wc -l < output_appnum` = ${SIZE} &&
+	test `cut -d: -f2 output_appnum | uniq` -eq 1
+'
+
 test_expect_success 'pmi: wreck sets FLUX_JOB_SIZE' '
 	run_program 5 ${SIZE} ${SIZE} printenv FLUX_JOB_SIZE >output_size &&
         test `wc -l < output_size` -eq ${SIZE} &&
@@ -39,15 +46,6 @@ test_expect_success 'pmi: wreck sets FLUX_TASK_RANK' '
 	3: 3
 	EOF
 	test_cmp expected_rank output_rank
-'
-
-# FIXME: this test hardwires the expectations that job ID's are
-# assigned in a particular sequence.  We don't really care about that,
-# just that it's set to an integer that be returned by PMI_Get_appnum().
-test_expect_success 'pmi: wreck sets FLUX_JOB_ID' '
-	run_program 5 ${SIZE} ${SIZE} printenv FLUX_JOB_ID >output_appnum &&
-        test `wc -l < output_appnum` = ${SIZE} &&
-	test `cut -d: -f2 output_appnum | uniq` -eq 3
 '
 
 test_expect_success 'pmi: wreck sets FLUX_LOCAL_RANKS multiple tasks per node' '

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -13,6 +13,7 @@ SIZE=$(test_size_large)
 test_under_flux ${SIZE} wreck
 echo "# $0: flux session size will be ${SIZE}"
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest
+PMINFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pminfo
 
 # Usage: run_program timeout ntasks nnodes
 run_program() {
@@ -99,6 +100,18 @@ test_expect_success 'pmi: wreck preputs PMI_process_mapping into kvs' '
 	0: (vector,(0,4,1))
 	EOF
 	test_cmp expected_map output_map
+'
+
+test_expect_success 'pmi: PMI reports correct rank, size' '
+	run_program 5 4 4 ${PMINFO} | sed -e"s/ appnum.*$//" \
+				    | sort >output_pminfo &&
+	cat >expected_pminfo <<-EOF &&
+	0: 0: size=4
+	1: 1: size=4
+	2: 2: size=4
+	3: 3: size=4
+	EOF
+	test_cmp expected_pminfo output_pminfo
 '
 
 test_expect_success 'pmi: (put*1) / barrier / (get*1) pattern works' '

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -3,7 +3,7 @@
 
 test_description='Test that PMI works in a Flux-launched program 
 
-Test that PMI works in a FLux-launched program 
+Test that PMI works in a Flux-launched program 
 '
 
 . `dirname $0`/sharness.sh
@@ -63,6 +63,27 @@ test_expect_success 'pmi: wreck sets FLUX_LOCAL_RANKS single task per node' '
 	3: 3
 	EOF
 	test_cmp expected_clique2 output_clique2
+'
+
+test_expect_success 'pmi: wreck sets PMI_SIZE' '
+	run_program 5 ${SIZE} ${SIZE} printenv PMI_SIZE >output_size &&
+        test `wc -l < output_size` -eq ${SIZE} &&
+	test `cut -d: -f2 output_size | uniq` -eq ${SIZE}
+'
+
+test_expect_success 'pmi: wreck sets PMI_RANK' '
+	run_program 5 4 4 printenv PMI_RANK | sort >output_rank &&
+	cat >expected_rank <<-EOF  &&
+	0: 0
+	1: 1
+	2: 2
+	3: 3
+	EOF
+	test_cmp expected_rank output_rank
+'
+
+test_expect_success 'pmi: wreck sets PMI_FD' '
+	run_program 1 1 1 printenv PMI_FD >/dev/null
 '
 
 test_expect_success 'pmi: wreck preputs PMI_process_mapping into kvs' '

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -14,6 +14,7 @@ test_under_flux ${SIZE} wreck
 echo "# $0: flux session size will be ${SIZE}"
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest
 PMINFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pminfo
+LIBPMI=${FLUX_BUILD_DIR}/src/common/.libs/libpmi.so
 
 # Usage: run_program timeout ntasks nnodes
 run_program() {
@@ -112,6 +113,12 @@ test_expect_success 'pmi: PMI reports correct rank, size' '
 	3: 3: size=4
 	EOF
 	test_cmp expected_pminfo output_pminfo
+'
+
+test_expect_success 'pmi: dlopen failsafe works' '
+	test_must_fail run_program 5 1 1 ${PMINFO} --library ${LIBPMI} \
+					2>failsafe_output &&
+	grep -q "PMI_Init: operation failed" failsafe_output
 '
 
 test_expect_success 'pmi: (put*1) / barrier / (get*1) pattern works' '

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -121,6 +121,30 @@ test_expect_success 'pmi: dlopen failsafe works' '
 	grep -q "PMI_Init: operation failed" failsafe_output
 '
 
+test_expect_success 'pmi: wreck sets clique for multiple tasks per node' '
+	run_timeout 5 flux wreckrun -N1 -n4 ${PMINFO} --clique \
+						| sort >output_pmclique &&
+	cat >expected_pmclique <<-EOT &&
+	0: clique=0,1,2,3
+	1: clique=0,1,2,3
+	2: clique=0,1,2,3
+	3: clique=0,1,2,3
+	EOT
+	test_cmp expected_pmclique output_pmclique
+'
+
+test_expect_success 'pmi: wreck sets clique for single task per node' '
+	run_timeout 5 flux wreckrun -N4 ${PMINFO} --clique \
+						| sort >output_pmclique2 &&
+	cat >expected_pmclique2 <<-EOF  &&
+	0: clique=0
+	1: clique=1
+	2: clique=2
+	3: clique=3
+	EOF
+	test_cmp expected_pmclique2 output_pmclique2
+'
+
 test_expect_success 'pmi: (put*1) / barrier / (get*1) pattern works' '
 	run_program 10 ${SIZE} ${SIZE} ${KVSTEST} >output_kvstest &&
 	grep -q "put phase" output_kvstest &&


### PR DESCRIPTION
The `flux_pmi_library` symbol should not be exported from `libflux.so`, only `libpmi.so`, as noted in #736.

A test of the above failsafe for self-dlopen were added to the PMI sharness test.

Finally, I noticed and corrected inappropriate use of PMI_ERR_INIT in the main PMI library, and added some additional sanity checks on PMI environment variables and a run of "pminfo" to the PMI sharness test.