### PR TITLE
Support Caliper based profiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,17 @@ X_AC_CHECK_COND_LIB(dl, dlerror)
 X_AC_MALLOC
 AC_CHECK_LIB(m, floor)
 
+LIBCALIPER=
+AC_ARG_ENABLE(caliper,
+	[  --enable-caliper[=OPTS]   Use caliper for profiling. [default=no] [OPTS=no/yes]], ,
+	[enable_caliper="no"])
+
+if test "$enable_caliper" = "yes"; then
+    AC_SUBST([LIBCALIPER], ["-lcaliper"])
+    AC_DEFINE([HAVE_CALIPER], [1], [Define if you have libcaliper])
+    AC_DEFINE([PROFILING], [1], [Compile in profiling hooks])
+fi
+
 AC_MSG_CHECKING(--enable-python argument)
 AC_ARG_ENABLE(python,
 	[  --enable-python[=OPTS]   Include Python bindings. [default=yes] [OPTS=no/yes]], ,

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,11 @@ AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])
 
 ##
+# Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
+##
+PKG_PROG_PKG_CONFIG
+
+##
 # Checks for programs
 ##
 AC_PROG_CC_C99
@@ -69,17 +74,6 @@ X_AC_CHECK_COND_LIB(dl, dlerror)
 X_AC_MALLOC
 AC_CHECK_LIB(m, floor)
 
-LIBCALIPER=
-AC_ARG_ENABLE(caliper,
-	[  --enable-caliper[=OPTS]   Use caliper for profiling. [default=no] [OPTS=no/yes]], ,
-	[enable_caliper="no"])
-
-if test "$enable_caliper" = "yes"; then
-    AC_SUBST([LIBCALIPER], ["-lcaliper"])
-    AC_DEFINE([HAVE_CALIPER], [1], [Define if you have libcaliper])
-    AC_DEFINE([PROFILING], [1], [Compile in profiling hooks])
-fi
-
 AC_MSG_CHECKING(--enable-python argument)
 AC_ARG_ENABLE(python,
 	[  --enable-python[=OPTS]   Include Python bindings. [default=yes] [OPTS=no/yes]], ,
@@ -122,6 +116,19 @@ PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 AX_CODE_COVERAGE
+
+AC_ARG_ENABLE(caliper,
+	[  --enable-caliper[=OPTS]   Use caliper for profiling. [default=no] [OPTS=no/yes]], ,
+	[enable_caliper="no"])
+
+if test "$enable_caliper" = "yes"; then
+    PKG_CHECK_MODULES([CALIPER], [caliper], [], [])
+    CFLAGS="${CFLAGS} ${CALIPER_CFLAGS} "
+    # Do not use CALIPER_LIBS, only link to libcaliper-stub
+    LIBS="${LIBS} $(pkg-config --libs-only-L caliper) -lcaliper-stub -lrt "
+    AC_DEFINE([HAVE_CALIPER], [1], [Define if you have libcaliper])
+fi
+
 
 ##
 # Embedded libev

--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -48,6 +48,12 @@ Display commands before executing them.
 *-X, --noexec*::
 Don't execute anything.  This option is most useful with -v.
 
+*--caliper-profile*='PROFILE'::
+Run brokers with Caliper profiling enabled, using a Caliper
+configuration profile named 'PROFILE'. Requires a version of Flux
+built with --enable-caliper. Unless CALI_LOG_VERBOSITY is already
+set in the environment, it will default to 0 for all brokers.
+
 EXAMPLES
 --------
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -442,6 +442,11 @@ int main (int argc, char *argv[])
     cali_begin_int_byname ("flux.tid", syscall(SYS_gettid));
     cali_begin_string_byname ("binary", argv[0]);
     cali_begin_int_byname ("flux.rank", ctx.rank);
+    // TODO: this is a stopgap until we have better control over
+    // instrumemtation in child processes. If we want to see what children
+    // that load libflux are up to, this should be disabled
+    unsetenv ("CALI_SERVICES_ENABLE");
+    unsetenv ("CALI_CONFIG_PROFILE");
 #endif
 
     /* Create directory for sockets, and a subdirectory specific

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -54,6 +54,10 @@
   #error gperftools headers not configured
 #endif
 #endif /* WITH_TCMALLOC */
+#if HAVE_CALIPER
+#include <caliper/cali.h>
+#include <sys/syscall.h>
+#endif
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
@@ -247,6 +251,7 @@ int main (int argc, char *argv[])
     int security_set = 0;
     int e;
 
+
     memset (&ctx, 0, sizeof (ctx));
     log_init (argv[0]);
 
@@ -430,6 +435,14 @@ int main (int argc, char *argv[])
 
     if (attr_set_flags (ctx.attrs, "session-id", FLUX_ATTRFLAG_IMMUTABLE) < 0)
         log_err_exit ("attr_set_flags session-id");
+
+    // Setup profiling
+#if HAVE_CALIPER
+    cali_begin_string_byname ("flux.type", "main");
+    cali_begin_int_byname ("flux.tid", syscall(SYS_gettid));
+    cali_begin_string_byname ("binary", argv[0]);
+    cali_begin_int_byname ("flux.rank", ctx.rank);
+#endif
 
     /* Create directory for sockets, and a subdirectory specific
      * to this rank that will contain the pidfile and local connector socket.

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -104,6 +104,17 @@ struct modhash_struct {
     heartbeat_t *heartbeat;
 };
 
+static int setup_module_profiling (module_t *p)
+{
+#if HAVE_CALIPER
+    cali_begin_string_byname ("flux.type", "module");
+    cali_begin_int_byname ("flux.tid", syscall (SYS_gettid));
+    cali_begin_int_byname ("flux.rank", p->rank);
+    cali_begin_string_byname ("flux.name", p->name);
+#endif
+    return (0);
+}
+
 static void *module_thread (void *arg)
 {
     module_t *p = arg;
@@ -119,12 +130,7 @@ static void *module_thread (void *arg)
 
     assert (p->zctx);
 
-#if HAVE_CALIPER
-    cali_begin_string_byname ("flux.type", "module");
-    cali_begin_int_byname ("flux.tid", syscall (SYS_gettid));
-    cali_begin_int_byname ("flux.rank", p->rank);
-    cali_begin_string_byname ("flux.name", p->name);
-#endif
+    setup_module_profiling (p);
 
     /* Connect to broker socket, enable logging, register built-in services
      */

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -42,6 +42,10 @@
 #include <argz.h>
 #include <czmq.h>
 #include <flux/core.h>
+#if HAVE_CALIPER
+#include <caliper/cali.h>
+#include <sys/syscall.h>
+#endif
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
@@ -50,6 +54,7 @@
 #include "heartbeat.h"
 #include "module.h"
 #include "modservice.h"
+
 
 #define MODULE_MAGIC    0xfeefbe01
 struct module_struct {
@@ -113,6 +118,13 @@ static void *module_thread (void *arg)
     flux_msg_t *msg;
 
     assert (p->zctx);
+
+#if HAVE_CALIPER
+    cali_begin_string_byname ("flux.type", "module");
+    cali_begin_int_byname ("flux.tid", syscall (SYS_gettid));
+    cali_begin_int_byname ("flux.rank", p->rank);
+    cali_begin_string_byname ("flux.name", p->name);
+#endif
 
     /* Connect to broker socket, enable logging, register built-in services
      */

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -28,6 +28,9 @@
 #include <assert.h>
 #include <errno.h>
 #include <czmq.h>
+#if HAVE_CALIPER
+#include <caliper/cali.h>
+#endif
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
@@ -277,6 +280,15 @@ static int connect_socket (ctx_t *ctx)
 
 flux_t connector_init (const char *path, int flags)
 {
+#if HAVE_CALIPER
+    cali_id_t uuid   = cali_create_attribute ("flux.uuid",
+                                              CALI_TYPE_STRING,
+                                              CALI_ATTR_SKIP_EVENTS);
+    size_t length = strlen(path);
+    cali_push_snapshot ( CALI_SCOPE_PROCESS | CALI_SCOPE_THREAD,
+                         1, &uuid, (const void **)&path, &length);
+#endif
+
     ctx_t *ctx = NULL;
     if (!path) {
         errno = EINVAL;


### PR DESCRIPTION
This PR is a continuation of #672, which extends the work of @garlick and @trws with

 * fix missing `pkg-config` argument when building with `libcaliper-stub`
 * New option `--caliper-profile=ARG` to `flux start`, which exports proper `LD_PRELOAD`, `CALI_CONFIG_PROFILE=ARG` and `CALI_LOG_VERBOSITY=0` to brokers (`CALI_*` vars are not overwritten)

Also, when I was working another angle I abstracted the caliper init routines for broker and modules into their own functions. I left that in here, but could easily remove it as it isn't necessary right now (thought I could get runtime initialization working)

I also realize I need to document the `--caliper-profile` option to flux-start.