### PR TITLE
rc3: create joblog if persist-directory is set

### DIFF
--- a/etc/rc3
+++ b/etc/rc3
@@ -12,6 +12,10 @@ for rcdir in $all_dirs; do
 done
 shopt -u nullglob
 
+if PERSISTDIR=$(flux getattr persist-directory 2>/dev/null); then
+    flux wreck ls >${PERSISTDIR}/joblog 2>/dev/null || :
+fi
+
 flux module remove -r 0 cron
 flux module remove -r all wrexec
 flux module remove -r all job

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -57,6 +57,7 @@ TESTS = \
 	t2003-recurse.t \
 	t2004-hydra.t \
 	t2005-hwloc-basic.t \
+	t2006-joblog.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
@@ -119,6 +120,7 @@ check_SCRIPTS = \
 	t2003-recurse.t \
 	t2004-hydra.t \
 	t2005-hwloc-basic.t \
+	t2006-joblog.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
         issues/t0441-kvs-put-get.sh \

--- a/t/t2006-joblog.t
+++ b/t/t2006-joblog.t
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+
+test_description='Test job log
+
+Test job log.'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+
+test_expect_success 'created persistdir' '
+	PERSISTDIR=`mktemp -d`
+'
+
+test_expect_success 'joblog exists, non-empty if job(s) run' '
+	rm -rf $PERSISTDIR/* &&
+	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	    flux wreckrun /bin/true &&
+	test -f $PERSISTDIR/joblog &&
+	test -s $PERSISTDIR/joblog
+'
+
+test_expect_success 'joblog exists, empty if no jobs run' '
+	rm -rf $PERSISTDIR/* &&
+	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	    /bin/true &&
+	test -f $PERSISTDIR/joblog &&
+	! test -s $PERSISTDIR/joblog
+'
+
+test_expect_success 'removed persistdir' '
+	rm -rf $PERSISTDIR
+'
+
+test_done


### PR DESCRIPTION
If the persist-directory attribute is set to DIR, run
`flux wreck ls >DIR/joblog` in the rc3 teardown script.

Fixes #661