### PR TITLE
Improve PMI tracing and support PMI-2 subset for OpenMPI

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -36,6 +36,7 @@ local lwj_options = {
     ['stdio-commit-on-close'] = "Commit to kvs on stdio close in each task",
     ['stop-children-in-exec'] = "Start tasks in STOPPED state for debugger",
     ['no-pmi-server'] =         "Do not start simple-pmi server",
+    ['trace-pmi-server'] =      "Log simple-pmi server protocol exchange",
 }
 
 local default_opts = {

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -313,6 +313,12 @@ static int pmi_response_send (void *client, const char *buf)
     return dputline (cli->fd, buf);
 }
 
+static void pmi_debug_trace (void *client, const char *buf)
+{
+    struct client *cli = client;
+    fprintf (stderr, "%d: %s", cli->rank, buf);
+}
+
 void pmi_simple_cb (flux_reactor_t *r, flux_watcher_t *w,
                     int revents, void *arg)
 {
@@ -477,6 +483,7 @@ void pmi_server_initialize (struct context *ctx, int flags)
         .kvs_get = pmi_kvs_get,
         .barrier_enter = NULL,
         .response_send = pmi_response_send,
+        .debug_trace = pmi_debug_trace,
     };
     int appnum = strtol (ctx->session_id, NULL, 10);
     if (!(ctx->pmi.kvs = zhash_new()))

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -22,7 +22,7 @@ libflux_internal_la_LIBADD = \
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
 lib_LTLIBRARIES = libflux-core.la libflux-optparse.la
-fluxlib_LTLIBRARIES = libpmi.la
+fluxlib_LTLIBRARIES = libpmi.la libpmi2.la
 
 libflux_core_la_SOURCES =
 libflux_core_la_LIBADD = \
@@ -53,5 +53,14 @@ libpmi_la_LDFLAGS = \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
 
+libpmi2_la_SOURCES =
+libpmi2_la_LIBADD = \
+	$(builddir)/libpmi/libpmi.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL)
+libpmi2_la_LDFLAGS = \
+        -Wl,--version-script=$(srcdir)/libpmi2.map \
+	-shared -export-dynamic --disable-static \
+	$(san_ld_zdef_flag)
 
-EXTRA_DIST = libflux-core.map libflux-optparse.map libpmi.map
+
+EXTRA_DIST = libflux-core.map libflux-optparse.map libpmi.map libpmi2.map

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -17,6 +17,7 @@ libpmi_la_SOURCES = \
 	simple_client.c \
 	simple_client.h \
 	pmi.c \
+	pmi2.c \
 	wrap.c \
 	wrap.h \
 	single.c \
@@ -31,7 +32,8 @@ libpmi_la_SOURCES = \
 	clique.h
 
 fluxinclude_HEADERS = \
-	pmi.h
+	pmi.h \
+	pmi2.h
 
 TESTS = test_keyval.t \
 	test_simple.t \

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -158,7 +158,16 @@ int PMI_Init (int *spawned)
         }
         ctx.type = IMPL_SINGLETON;
     }
+
 done:
+    /* Cache the rank for logging.
+     */
+    if (ctx.debug && result == PMI_SUCCESS) {
+        int debug_save = ctx.debug;
+        ctx.debug = 0;
+        (void)PMI_Get_rank (&ctx.rank);
+        ctx.debug = debug_save;
+    }
     DRETURN (result);
 }
 

--- a/src/common/libpmi/pmi2.c
+++ b/src/common/libpmi/pmi2.c
@@ -1,0 +1,321 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <string.h>
+
+#include "pmi.h"
+#include "pmi2.h"
+#include "pmi_strerror.h"
+
+struct pmi2_context {
+    int name_length_max;
+    int key_length_max;
+    int value_length_max;
+    char *kvs_name;
+    char *value;
+    int debug;
+    int initialized;
+    int rank;
+    int appnum;
+};
+struct pmi2_context ctx = { .initialized = 0, .rank = -1 };
+
+#define DPRINTF(fmt,...) do { \
+        if (ctx.debug) fprintf (stderr, fmt, ##__VA_ARGS__); \
+} while (0)
+
+#define DRETURN(rc) do { \
+        DPRINTF ("%d: %s rc=%d\n", ctx.rank, __FUNCTION__, (rc)); \
+        return (rc); \
+} while (0);
+
+struct errmap {
+    int pmi_error;
+    int pmi2_error;
+};
+
+static struct errmap errmap[] = {
+
+    { PMI_SUCCESS,                  PMI2_SUCCESS },
+    { PMI_FAIL,                     PMI2_FAIL },
+    { PMI_ERR_INIT,                 PMI2_ERR_INIT },
+    { PMI_ERR_NOMEM,                PMI2_ERR_NOMEM },
+    { PMI_ERR_INVALID_ARG,          PMI2_ERR_INVALID_ARG },
+    { PMI_ERR_INVALID_KEY,          PMI2_ERR_INVALID_KEY },
+    { PMI_ERR_INVALID_KEY_LENGTH,   PMI2_ERR_INVALID_KEY_LENGTH },
+    { PMI_ERR_INVALID_VAL,          PMI2_ERR_INVALID_VAL },
+    { PMI_ERR_INVALID_VAL_LENGTH,   PMI2_ERR_INVALID_VAL_LENGTH },
+    { PMI_ERR_INVALID_LENGTH,       PMI2_ERR_INVALID_LENGTH },
+    { PMI_ERR_INVALID_NUM_ARGS,     PMI2_ERR_INVALID_NUM_ARGS },
+    { PMI_ERR_INVALID_ARGS,         PMI2_ERR_INVALID_ARGS },
+    { PMI_ERR_INVALID_NUM_PARSED,   PMI2_ERR_INVALID_NUM_PARSED },
+    { PMI_ERR_INVALID_KEYVALP,      PMI2_ERR_INVALID_KEYVALP },
+    { PMI_ERR_INVALID_SIZE,         PMI2_ERR_INVALID_SIZE },
+};
+
+static int map_pmi_error (int errnum)
+{
+    int i;
+    for (i = 0; i < sizeof (errmap) / sizeof (errmap[0]); i++)
+        if (errmap[i].pmi_error == errnum)
+            return errmap[i].pmi2_error;
+    return PMI2_ERR_OTHER;
+}
+
+int PMI2_Init (int *spawned, int *size, int *rank, int *appnum)
+{
+    const char *debug;
+    if ((debug = getenv ("FLUX_PMI2_DEBUG")))
+        ctx.debug = strtol (debug, NULL, 0);
+    else
+        ctx.debug = 0;
+    if (ctx.initialized)
+        return PMI2_FAIL;
+    int e;
+    if ((e = PMI_Init (spawned)) != PMI_SUCCESS)
+        goto done;
+    if ((e = PMI_Get_size (size)) != PMI_SUCCESS)
+        goto done;
+    if ((e = PMI_Get_rank (rank)) != PMI_SUCCESS)
+        goto done;
+    ctx.rank = *rank;
+    if ((e = PMI_Get_appnum (appnum)) != PMI_SUCCESS)
+        goto done;
+    ctx.appnum = *appnum;
+    if ((e = PMI_KVS_Get_name_length_max (&ctx.name_length_max)) != PMI_SUCCESS)
+        goto done;
+    if ((e = PMI_KVS_Get_key_length_max (&ctx.key_length_max)) != PMI_SUCCESS)
+        goto done;
+    if ((e = PMI_KVS_Get_value_length_max (&ctx.value_length_max))
+                                                            != PMI_SUCCESS)
+        goto done;
+    if (!(ctx.kvs_name = calloc (1, ctx.name_length_max)))
+        return PMI2_ERR_NOMEM;
+    if (!(ctx.value = calloc (1, ctx.value_length_max))) {
+        free (ctx.kvs_name);
+        return PMI2_ERR_NOMEM;
+    }
+    if ((e = PMI_KVS_Get_my_name (ctx.kvs_name, ctx.name_length_max))
+                                                            != PMI_SUCCESS) {
+        free (ctx.kvs_name);
+        free (ctx.value);
+        goto done;
+    }
+    ctx.initialized = 1;
+done:
+    DRETURN (map_pmi_error (e));
+}
+
+int PMI2_Finalize (void)
+{
+    if (ctx.initialized) {
+        free (ctx.value);
+        free (ctx.kvs_name);
+        ctx.initialized = 0;
+    }
+    int e = PMI_Finalize();
+    DRETURN (map_pmi_error (e));
+}
+
+int PMI2_Initialized (void)
+{
+    int initialized;
+    if (PMI_Initialized (&initialized) != PMI_SUCCESS || !initialized)
+        DRETURN (0);
+    DRETURN (1);
+}
+
+int PMI2_Abort (int flag, const char msg[])
+{
+    if (flag) { /* global abort */
+        int e;
+        e = PMI_Abort (1, msg);
+        return map_pmi_error (e);
+    } else {    /* local abort */
+        fprintf (stderr, "PMI2_Abort: %s\n", msg);
+        exit (1);
+    }
+    /*NOTREACHED*/
+}
+
+int PMI2_Job_Spawn (int count, const char * cmds[],
+                    int argcs[], const char ** argvs[],
+                    const int maxprocs[],
+                    const int info_keyval_sizes[],
+                    const struct MPID_Info *info_keyval_vectors[],
+                    int preput_keyval_size,
+                    const struct MPID_Info *preput_keyval_vector[],
+                    char jobId[], int jobIdSize,
+                    int errors[])
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Job_GetId (char jobid[], int jobid_size)
+{
+    int e = PMI_ERR_INIT;
+    if (!ctx.initialized)
+        goto done;
+    snprintf (jobid, jobid_size, "%d", ctx.appnum);
+    e = PMI_SUCCESS;
+done:
+    DRETURN (map_pmi_error (e));
+}
+
+int PMI2_Job_GetRank (int* rank)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Job_Connect (const char jobid[], PMI2_Connect_comm_t *conn)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Job_Disconnect (const char jobid[])
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_KVS_Put (const char key[], const char value[])
+{
+    int e = PMI_ERR_INIT;
+
+    if (!ctx.initialized)
+        goto done;
+    e = PMI_KVS_Put (ctx.kvs_name, key, value);
+done:
+    DRETURN (map_pmi_error (e));
+}
+
+int PMI2_KVS_Get (const char *jobid, int src_pmi_id,
+                  const char key[], char value [], int maxvalue, int *vallen)
+{
+    int e = PMI_ERR_INIT;
+    int len;
+    if (!ctx.initialized)
+        goto done;
+    if ((e = PMI_KVS_Get (ctx.kvs_name, key, ctx.value, ctx.value_length_max))
+                                                    != PMI_SUCCESS)
+        goto done;
+    len = strlen (ctx.value) + 1;
+    if (len <= maxvalue) {
+        *vallen = len;
+    } else {
+        *vallen = -1*len;
+        len = maxvalue;
+    }
+    memcpy (value, ctx.value, len);
+done:
+    DRETURN (map_pmi_error (e));
+}
+
+int PMI2_KVS_Fence (void)
+{
+    int e = PMI_ERR_INIT;
+    if (!ctx.initialized)
+        goto done;
+    if ((e = PMI_KVS_Commit (ctx.kvs_name)) != PMI_SUCCESS)
+        goto done;
+    if ((e = PMI_Barrier ()) != PMI_SUCCESS)
+        goto done;
+done:
+    DRETURN (map_pmi_error (e));
+}
+
+
+int PMI2_Info_GetSize (int* size)
+{
+    /* FIXME: return #procs on local node */
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Info_GetNodeAttr (const char name[],
+                           char value[], int valuelen, int *found, int waitfor)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Info_GetNodeAttrIntArray (const char name[], int array[],
+                                   int arraylen, int *outlen, int *found)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Info_PutNodeAttr (const char name[], const char value[])
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Info_GetJobAttr (const char name[],
+                          char value[], int valuelen, int *found)
+{
+    int e;
+    if (strcmp (name, "PMI_process_mapping") != 0) {
+        *found = 0;
+        e = PMI2_SUCCESS;
+        goto done;
+    }
+    if ((e = PMI_KVS_Get (ctx.kvs_name, name, value, valuelen)) != PMI_SUCCESS)
+        goto done;
+    *found = 1;
+done:
+    DRETURN (map_pmi_error (e));
+}
+
+int PMI2_Info_GetJobAttrIntArray (const char name[], int array[],
+                                  int arraylen, int *outlen, int *found)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Nameserv_publish (const char service_name[],
+                           const struct MPID_Info *info_ptr, const char port[])
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Nameserv_lookup (const char service_name[],
+                          const struct MPID_Info *info_ptr,
+                          char port[], int portLen)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+int PMI2_Nameserv_unpublish (const char service_name[],
+                             const struct MPID_Info *info_ptr)
+{
+    DRETURN (PMI2_FAIL);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/pmi2.h
+++ b/src/common/libpmi/pmi2.h
@@ -1,0 +1,120 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef FLUX_PMI2_H_INCLUDED
+#define FLUX_PMI2_H_INCLUDED
+
+#define PMI2_SUCCESS                0
+#define PMI2_FAIL                   -1
+#define PMI2_ERR_INIT               1
+#define PMI2_ERR_NOMEM              2
+#define PMI2_ERR_INVALID_ARG        3
+#define PMI2_ERR_INVALID_KEY        4
+#define PMI2_ERR_INVALID_KEY_LENGTH 5
+#define PMI2_ERR_INVALID_VAL        6
+#define PMI2_ERR_INVALID_VAL_LENGTH 7
+#define PMI2_ERR_INVALID_LENGTH     8
+#define PMI2_ERR_INVALID_NUM_ARGS   9
+#define PMI2_ERR_INVALID_ARGS       10
+#define PMI2_ERR_INVALID_NUM_PARSED 11
+#define PMI2_ERR_INVALID_KEYVALP    12
+#define PMI2_ERR_INVALID_SIZE       13
+#define PMI2_ERR_OTHER              14
+
+#define PMI2_MAX_KEYLEN             64
+#define PMI2_MAX_VALLEN             1024
+#define PMI2_MAX_ATTRVALUE          1024
+#define PMI2_ID_NULL                -1
+
+
+int PMI2_Init (int *spawned, int *size, int *rank, int *appnum);
+int PMI2_Finalize (void);
+int PMI2_Initialized (void);
+int PMI2_Abort (int flag, const char msg[]);
+
+
+typedef struct PMI2_Connect_comm {
+    int (*read)(void *buf, int maxlen, void *ctx);
+    int (*write)(const void *buf, int len, void *ctx);
+    void *ctx;
+    int  isMaster;
+} PMI2_Connect_comm_t;
+
+typedef struct MPID_Info {
+    int                 handle;
+    int                 pobj_mutex;
+    int                 ref_count;
+    struct MPID_Info    *next;
+    char                *key;
+    char                *value;
+} MPID_Info;
+
+int PMI2_Job_Spawn (int count, const char * cmds[],
+                    int argcs[], const char ** argvs[],
+                    const int maxprocs[],
+                    const int info_keyval_sizes[],
+                    const struct MPID_Info *info_keyval_vectors[],
+                    int preput_keyval_size,
+                    const struct MPID_Info *preput_keyval_vector[],
+                    char jobId[], int jobIdSize,
+                    int errors[]);
+int PMI2_Job_GetId (char jobid[], int jobid_size);
+int PMI2_Job_GetRank (int* rank);
+int PMI2_Job_Connect (const char jobid[], PMI2_Connect_comm_t *conn);
+int PMI2_Job_Disconnect (const char jobid[]);
+
+
+int PMI2_KVS_Put (const char key[], const char value[]);
+int PMI2_KVS_Get (const char *jobid, int src_pmi_id,
+                  const char key[], char value [], int maxvalue, int *vallen);
+int PMI2_KVS_Fence (void);
+
+
+int PMI2_Info_GetSize (int* size);
+int PMI2_Info_GetNodeAttr (const char name[],
+                           char value[], int valuelen, int *found, int waitfor);
+int PMI2_Info_GetNodeAttrIntArray (const char name[], int array[],
+                                   int arraylen, int *outlen, int *found);
+int PMI2_Info_PutNodeAttr (const char name[], const char value[]);
+int PMI2_Info_GetJobAttr (const char name[],
+                          char value[], int valuelen, int *found);
+int PMI2_Info_GetJobAttrIntArray (const char name[], int array[],
+                                  int arraylen, int *outlen, int *found);
+
+
+int PMI2_Nameserv_publish (const char service_name[],
+                           const struct MPID_Info *info_ptr, const char port[]);
+int PMI2_Nameserv_lookup (const char service_name[],
+                          const struct MPID_Info *info_ptr,
+                          char port[], int portLen);
+int PMI2_Nameserv_unpublish (const char service_name[],
+                             const struct MPID_Info *info_ptr);
+
+
+
+#endif /* !FLUX_PMI2_H_INCLUDED */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/simple_server.c
+++ b/src/common/libpmi/simple_server.c
@@ -38,14 +38,6 @@
 #include "keyval.h"
 #include "pmi.h"
 
-#define KVS_KEY_MAX         64
-#define KVS_VAL_MAX         1024
-#define KVS_NAME_MAX        64
-
-#define MAX_PROTO_OVERHEAD  64
-
-#define MAX_PROTO_LINE \
-    (KVS_KEY_MAX + KVS_VAL_MAX + KVS_NAME_MAX + MAX_PROTO_OVERHEAD)
 
 struct client {
     zlist_t *mcmd;
@@ -111,11 +103,6 @@ void pmi_simple_server_destroy (struct pmi_simple_server *pmi)
     }
 }
 
-int pmi_simple_server_get_maxrequest (struct pmi_simple_server *pmi)
-{
-    return (MAX_PROTO_LINE);
-}
-
 static void client_destroy (void *arg)
 {
     struct client *c = arg;
@@ -134,7 +121,7 @@ static void client_destroy (void *arg)
 static int mcmd_execute (struct pmi_simple_server *pmi, void *client,
                          struct client *c)
 {
-    char resp[MAX_PROTO_LINE+1];
+    char resp[SIMPLE_MAX_PROTO_LINE+1];
     char *buf = zlist_first (c->mcmd);
     int rc = 0;
 
@@ -237,7 +224,7 @@ static int barrier_enter (struct pmi_simple_server *pmi, void *client)
 
 static int barrier_exit (struct pmi_simple_server *pmi, int rc)
 {
-    char resp[MAX_PROTO_LINE+1];
+    char resp[SIMPLE_MAX_PROTO_LINE+1];
     void *client;
     int ret = 0;
 
@@ -254,7 +241,7 @@ static int barrier_exit (struct pmi_simple_server *pmi, int rc)
 int pmi_simple_server_request (struct pmi_simple_server *pmi,
                                const char *buf, void *client)
 {
-    char resp[MAX_PROTO_LINE+1];
+    char resp[SIMPLE_MAX_PROTO_LINE+1];
     int rc = 0;
 
     resp[0] = '\0';
@@ -284,7 +271,7 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
     else if (keyval_parse_isword (buf, "cmd", "get_maxes") == 0) {
         snprintf (resp, sizeof (resp), "cmd=maxes rc=0 "
                   "kvsname_max=%d keylen_max=%d vallen_max=%d\n",
-                  KVS_NAME_MAX, KVS_KEY_MAX, KVS_VAL_MAX);
+                  SIMPLE_KVS_NAME_MAX, SIMPLE_KVS_KEY_MAX, SIMPLE_KVS_VAL_MAX);
     }
     /* abort */
     else if (keyval_parse_isword (buf, "cmd", "abort") == 0) {
@@ -313,9 +300,9 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
     }
     /* put */
     else if (keyval_parse_isword (buf, "cmd", "put") == 0) {
-        char name[KVS_NAME_MAX];
-        char key[KVS_KEY_MAX];
-        char val[KVS_VAL_MAX];
+        char name[SIMPLE_KVS_NAME_MAX];
+        char key[SIMPLE_KVS_KEY_MAX];
+        char val[SIMPLE_KVS_VAL_MAX];
         int result = keyval_parse_word (buf, "kvsname", name, sizeof (name));
         if (result < 0) {
             if (result == EKV_VAL_LEN) {
@@ -347,9 +334,9 @@ put_respond:
     }
     /* get */
     else if (keyval_parse_isword (buf, "cmd", "get") == 0) {
-        char name[KVS_NAME_MAX];
-        char key[KVS_KEY_MAX];
-        char val[KVS_VAL_MAX];
+        char name[SIMPLE_KVS_NAME_MAX];
+        char key[SIMPLE_KVS_KEY_MAX];
+        char val[SIMPLE_KVS_VAL_MAX];
         int result = keyval_parse_word (buf, "kvsname", name, sizeof (name));
         if (result < 0) {
             if (result == EKV_VAL_LEN) {

--- a/src/common/libpmi/simple_server.c
+++ b/src/common/libpmi/simple_server.c
@@ -39,7 +39,7 @@
 #include "pmi.h"
 
 #define KVS_KEY_MAX         64
-#define KVS_VAL_MAX         512
+#define KVS_VAL_MAX         1024
 #define KVS_NAME_MAX        64
 
 #define MAX_PROTO_OVERHEAD  64

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -3,6 +3,18 @@
 
 struct pmi_simple_server;
 
+#define SIMPLE_KVS_KEY_MAX         64
+#define SIMPLE_KVS_VAL_MAX         1024
+#define SIMPLE_KVS_NAME_MAX        64
+
+#define SIMPLE_MAX_PROTO_OVERHEAD  64
+
+#define SIMPLE_MAX_PROTO_LINE \
+    (SIMPLE_KVS_KEY_MAX + SIMPLE_KVS_VAL_MAX \
+                        + SIMPLE_KVS_NAME_MAX \
+                        + SIMPLE_MAX_PROTO_OVERHEAD)
+
+
 /* User-provided service implementation.
  * All return 0 on success, -1 on failure.
  */
@@ -29,11 +41,6 @@ struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
                                                     int flags,
                                                     void *arg);
 void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
-
-/* Max buffer size needed to read a null-terminated request line,
- * including trailing newline.
- */
-int pmi_simple_server_get_maxrequest (struct pmi_simple_server *pmi);
 
 /* Put null-terminated request with sending client reference to protocol
  * engine.  The request should end with a newline.

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -16,7 +16,7 @@ struct pmi_simple_server;
 
 
 /* User-provided service implementation.
- * All return 0 on success, -1 on failure.
+ * Integer return: 0 on success, -1 on failure.
  */
 struct pmi_simple_ops {
     int (*kvs_put)(void *arg, const char *kvsname,
@@ -25,6 +25,7 @@ struct pmi_simple_ops {
                    const char *key, char *val, int len);
     int (*barrier_enter)(void *arg);
     int (*response_send)(void *client, const char *buf);
+    void (*debug_trace)(void *client, const char *buf);
 };
 
 enum {

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -15,6 +15,10 @@ struct pmi_simple_ops {
     int (*response_send)(void *client, const char *buf);
 };
 
+enum {
+    PMI_SIMPLE_SERVER_TRACE = 1,
+};
+
 /* Create/destroy protocol engine.
  */
 struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
@@ -22,6 +26,7 @@ struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops *ops,
                                                     int universe_size,
                                                     int local_procs,
                                                     const char *kvsname,
+                                                    int flags,
                                                     void *arg);
 void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
 

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -148,7 +148,7 @@ int main (int argc, char *argv[])
     ok (socketpair (PF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, ctx.fds) == 0,
         "socketpair returned client,server file descriptors");
     ctx.pmi = pmi_simple_server_create (&ops, 42, ctx.size, ctx.size,
-                                        "bleepgorp", &ctx);
+                                        "bleepgorp", 0, &ctx);
     ok (ctx.pmi != NULL,
         "created simple pmi server context");
     ctx.buflen = pmi_simple_server_get_maxrequest (ctx.pmi);

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -20,8 +20,7 @@ struct context {
     zhash_t *kvs;
     struct pmi_simple_server *pmi;
     int size;
-    char *buf;
-    int buflen;
+    char buf[SIMPLE_MAX_PROTO_LINE];
 };
 
 static int s_kvs_put (void *arg, const char *kvsname, const char *key,
@@ -64,7 +63,7 @@ static void s_io_cb (flux_reactor_t *r, flux_watcher_t *w,
     int fd = flux_fd_watcher_get_fd (w);
     int rc;
 
-    if (dgetline (fd, ctx->buf, ctx->buflen) < 0) {
+    if (dgetline (fd, ctx->buf, sizeof (ctx->buf)) < 0) {
         diag ("dgetline: %s", strerror (errno));
         flux_reactor_stop_error (r);
         return;
@@ -151,8 +150,6 @@ int main (int argc, char *argv[])
                                         "bleepgorp", 0, &ctx);
     ok (ctx.pmi != NULL,
         "created simple pmi server context");
-    ctx.buflen = pmi_simple_server_get_maxrequest (ctx.pmi);
-    ctx.buf = xzmalloc (ctx.buflen);
     ok (pthread_create (&ctx.t, NULL, server_thread, &ctx) == 0,
         "pthread_create successfully started server");
 

--- a/src/common/libpmi2.map
+++ b/src/common/libpmi2.map
@@ -1,0 +1,5 @@
+{ global:
+    PMI2_*;
+    local: *;
+};
+

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -66,7 +66,8 @@ dist_wreckscripts_SCRIPTS = \
         lua.d/input.lua \
 	lua.d/mvapich.lua \
 	lua.d/pmi-mapping.lua \
-	lua.d/intel_mpi.lua
+	lua.d/intel_mpi.lua \
+	lua.d/openmpi.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/lua.d/openmpi.lua
+++ b/src/modules/wreck/lua.d/openmpi.lua
@@ -1,0 +1,31 @@
+-- Set environment specific to openmpi
+--
+-- If configured for SLURM, OpenMPI links with libpmi.so or libpmi2.so
+-- (depending on options used).  Flux provides alternate versions of these
+-- libraries in a non-default location, and we must set LD_LIBRARY_PATH to
+-- point there.
+--
+-- Some versions of OpenMPI, 1.10.2 for example, set an rpath for their
+-- PMI plugins that includes /usr/lib64.  That is bug and those versions
+-- need to be patched patched to work with Flux.
+-- 
+-- If Flux supports the PMI-2 wire protocol, the SLURM libpmi.so might
+-- work with Flux.  It currently doesn't, and in fact ignores the protocol
+-- version handshake entirely.   (See flux-framework/flux-core#746)
+
+
+local dirname = require 'flux.posix'.dirname
+
+function rexecd_init ()
+    local env = wreck.environ
+    local f = wreck.flux
+    local libpmi = f:getattr ('conf.pmi_library_path')
+    local ldpath = dirname (libpmi)
+
+    if (env['LD_LIBRARY_PATH'] ~= nil) then
+        ldpath = ldpath..':'..env['LD_LIBRARY_PATH']
+    end
+    env['LD_LIBRARY_PATH'] = ldpath
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -2064,6 +2064,11 @@ out:
     return (rpc == NULL ? -1 : 0);
 }
 
+static void wreck_pmi_debug_trace (void *client, const char *buf)
+{
+    struct task_info *t = client;
+    fprintf (stderr, "%d: %s", t->globalid, buf);
+}
 
 static int prog_ctx_initialize_pmi (struct prog_ctx *ctx)
 {
@@ -2072,7 +2077,8 @@ static int prog_ctx_initialize_pmi (struct prog_ctx *ctx)
         .kvs_put = wreck_pmi_kvs_put,
         .kvs_get = wreck_pmi_kvs_get,
         .barrier_enter = wreck_pmi_barrier_enter,
-        .response_send = wreck_pmi_send
+        .response_send = wreck_pmi_send,
+        .debug_trace = wreck_pmi_debug_trace,
     };
     int flags = 0;
     if (asprintf (&kvsname, "lwj.%lu.pmi", ctx->id) < 0) {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -2074,16 +2074,20 @@ static int prog_ctx_initialize_pmi (struct prog_ctx *ctx)
         .barrier_enter = wreck_pmi_barrier_enter,
         .response_send = wreck_pmi_send
     };
+    int flags = 0;
     if (asprintf (&kvsname, "lwj.%lu.pmi", ctx->id) < 0) {
         flux_log_error (ctx->flux, "initialize_pmi: asprintf");
         return (-1);
     }
+    if (prog_ctx_getopt (ctx, "trace-pmi-server"))
+        flags |= PMI_SIMPLE_SERVER_TRACE;
     ctx->barrier_sequence = 0;
     wreck_barrier_next (ctx);
     ctx->pmi = pmi_simple_server_create (&ops, (int) ctx->id,
                                          ctx->total_ntasks,
                                          ctx->nprocs,
                                          kvsname,
+                                         flags,
                                          ctx);
     if (!ctx->pmi)
         flux_log_error (ctx->flux, "pmi_simple_server_create");


### PR DESCRIPTION
The main point of this PR is to support OpenMPI when configured for SLURM's pmi2 MPI personality.  When configured this way, OpenMPI plugins are linked against SLURM's libpmi2.so.

Although SLURM's libpmi2.so is a wire protocol client, it does not honor the protocol version negotiation as noted in #746.  To get OpenMPI working, Flux can provide a stripped down libpmi2.so, internally implemented on top of PMI-1, then set LD_LIBRARY_PATH to include this library.

This seems to circumvent the problem in tests with a hello world MPI program.