### PR TITLE
travis-ci: sanitize cache file name in dep-builder

### DIFF
--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -113,10 +113,16 @@ fi
 
 eval $(print_env)
 
+sanitize ()
+{
+    # Sanitize cache name
+    echo $1 | sed 's/[\t /\]/_/g'
+}
+
 check_cache ()
 {
     test -n "$cachedir" || return 1
-    local url=$1
+    local url=$(sanitize $1)
     local cachefile="${cachedir}/${url}"
     test -f "${cachefile}" || return 1
     test -n "$cacheage"    || return 0
@@ -130,7 +136,7 @@ add_cache ()
 {
     test -n "$cachedir" || return 0
     mkdir -p "${cachedir}" &&
-    touch "${cachedir}/${1}"
+    touch "${cachedir}/$(sanitize ${1})"
 }
 
 pip help >/dev/null 2>&1 || die "Required command pip not installed"


### PR DESCRIPTION
In 2cd2b95d79128453aa0d7bbc8a9ddb4a8c3c09bf, caching of checkouts
was "fixed" to include build options etc. Unfortunately, the
cache name wasn't sanitized, and includes slashes and whitespace,
causing creation of the cachefile to fail, and thus builds of checkouts are
*never* cached.

This change sanitizes the cachefile name, replacing whitespace
and slashes with `_` so at least the file can be created.

This should speed up Travis builds since they slowed after #744 