### PR TITLE
travis-ci: upload coverage to CodeCov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ script:
 after_success:
  - ccache -s
  # Upload results to coveralls.io for first job of N
- - if test "$COVERAGE" = "t" ; then coveralls-lcov flux*-coverage.info ; fi
+ - if test "$COVERAGE" = "t" ; then coveralls-lcov flux*-coverage.info; bash <(curl -s https://codecov.io/bash) ; fi
 
 after_failure:
  - find . -name t[0-9]*.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+ precision: 2
+ round: down
+ range: "50...100"
+ ignore:
+ - ".*/test/*.c"
+ - ".*/tests/*.c"
+ - ".*/man3/*.c"
+ - ".*/libtap/*"
+ - ".*/libjsonc/*"
+ - ".*/libev/*"
+ - ".*/usr/*"
+ - ".*/bindings/python/*"
+ - ".*/common/liblsd/*"
+ - ".*/common/libutil/sds.*"
+ - ".*/common/libminilzo/*"


### PR DESCRIPTION
Add codecov.io for coverage results in addition to coveralls.io.

CodeCov seems to have a much better interface than Coveralls, and includes "coverage diffs" in PRs which I think will come in very useful.

Check out basic example [here](https://codecov.io/gh/grondo/flux-core/tree/7cea614b61dc4a998a7b66d7947e92e05d6f8da4/src)

Will rebase on #749 once that is separately merged.