### PR TITLE
travis-ci: fix release file glob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ before_deploy:
 deploy:
   provider: releases
   skip_cleanup: true
-  file: flux-core.*.tar.gz
+  file: flux-core*.tar.gz
   prerelease: true
   body: "View [Release Notes](${TAG_URI}/NEWS.md#${ANCHOR}) for flux-core ${TRAVIS_TAG}"
   api_key:


### PR DESCRIPTION
Ok, sorry I typo'd the tarball glob and unfortunately the release didn't work. I've deleted the tag so we can try again, and hopefully this is the only issue with the travis-ci based deploy.

Apologies!