### PR TITLE
python: kvs_watch fix

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -69,6 +69,8 @@ def put(flux_handle, key, value):
 def commit(flux_handle):
     return _raw.kvs_commit(flux_handle)
 
+def dropcache(flux_handle):
+  return _raw.dropcache(flux_handle)
 
 def watch_once(flux_handle, key):
     """ Watches the selected key until the next change, then returns the updated value of the key """

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -1,13 +1,10 @@
 from _kvs import ffi, lib
 import flux
-from flux.wrapper import Wrapper, WrapperPimpl, WrapperBase
+from flux.wrapper import Wrapper, WrapperPimpl
 import flux.json_c as json_c
 import json
 import collections
-import contextlib
 import errno
-import os
-import sys
 
 class KVSWrapper(Wrapper):
   # This empty class accepts new methods, preventing accidental overloading

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -262,7 +262,12 @@ def walk(directory, topdown=False, flux_handle=None):
 @ffi.callback('kvs_set_f')
 def KVSWatchWrapper(key, value, arg, errnum):
     (cb, real_arg) = ffi.from_handle(arg)
-    ret = cb(ffi.string(key), json.loads(ffi.string(value)), real_arg, errnum)
+    if errnum == errno.ENOENT:
+      value = None
+    else:
+      value = json.loads(ffi.string(value))
+    key = ffi.string(key)
+    ret = cb(key, value, real_arg, errnum)
     return ret if ret is not None else 0
 
 


### PR DESCRIPTION
Fixes an error that occurs when kvs_watch returns a NULL value.

Also added in the dropcache funtion to the python bindings and cleaned up some unused imports.

Fixes: #752