### PR TITLE
travis: fix parsing of prefix in dep build script

### DIFF
--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -90,7 +90,7 @@ while true; do
       -v|--verbose)          verbose=t;     shift   ;;
       -c|--cachedir)         cachedir="$2"; shift 2 ;;
       -e|--max-cache-age)    cacheage="$2"; shift 2 ;;
-      -p|--prefix)           prefix="$2";   shift   ;;
+      -p|--prefix)           prefix="$2";   shift 2 ;;
       -P|--printenv)         print_env=1;   shift   ;;
       --)                    shift ; break;         ;;
       *)                     die "Invalid option '$1'\n$usage" ;;


### PR DESCRIPTION
`shift` wasn't passed any arguments, so only `--prefix` was being gobbled
up and the actual prefix path was being left to be parsed as an argument
flag.