### PR TITLE
optparse: remove requirement for option key on long-only options (and other fixes)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,19 @@
 coverage:
- precision: 2
  round: down
  range: "50...100"
  ignore:
- - ".*/test/*.c"
- - ".*/tests/*.c"
+ - ".*/t/.*"
+ - ".*/test/.*"
+ - ".*/tests/.*"
  - ".*/man3/*.c"
- - ".*/libtap/*"
- - ".*/libjsonc/*"
- - ".*/libev/*"
- - ".*/usr/*"
- - ".*/bindings/python/*"
- - ".*/common/liblsd/*"
+ - ".*/common/libtap/.*"
+ - ".*/common/libjsonc/.*"
+ - ".*/common/liblsd/.*"
+ - ".*/common/libev/.*"
+ - ".*/bindings/python/.*"
  - ".*/common/libutil/sds.*"
- - ".*/common/libminilzo/*"
+ - ".*/common/libminilzo/.*"
+ - ".*/usr/.*"
+
+comment:
+ layout: "header, diff, changes, tree"

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -105,12 +105,12 @@ static struct optparse_option opts[] = {
       .usage = "Add comma-separated broker options, e.g. \"-o,-q\"", },
     { .name = "killer-timeout",.key = 'k', .has_arg = 1, .arginfo = "SECONDS",
       .usage = "After a broker exits, kill other brokers after SECONDS", },
-    { .name = "trace-pmi-server",.key = 1000, .has_arg = 0, .arginfo = NULL,
+    { .name = "trace-pmi-server", .has_arg = 0, .arginfo = NULL,
       .usage = "Trace pmi simple server protocol exchange", },
 
 /* Option group 1, these options will be listed after those above */
     { .group = 1,
-      .name = "caliper-profile", .key = 1001, .has_arg = 1,
+      .name = "caliper-profile", .has_arg = 1,
       .arginfo = "PROFILE",
       .usage = "Enable profiling in brokers using Caliper configuration "
                "profile named `PROFILE'",

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1181,11 +1181,9 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
      */
     opterr = 0;
 
-    while ((c = getopt_long (argc, argv, optstring, optz, &li))) {
+    while ((c = getopt_long (argc, argv, optstring, optz, &li)) >= 0) {
         struct option_info *opt;
         struct optparse_option *o;
-        if (c == -1)
-            break;
         if (c == '?') {
             (*p->log_fn) ("%s: unrecognized option '%s'\n",
                           fullname, argv[optind-1]);

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -408,7 +408,7 @@ static int get_term_columns ()
     if ((val = getenv ("COLUMNS"))) {
         char *p;
         long lval = strtol (val, &p, 10);
-        if (p && (*p != '\0'))
+        if (p && (*p == '\0'))
             cols = (int) lval;
     }
     /*

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1165,7 +1165,7 @@ static void opt_append_optarg (optparse_t *p, struct option_info *opt, const cha
 int optparse_parse_args (optparse_t *p, int argc, char *argv[])
 {
     int c;
-    int li;
+    int li = -1;
     const char *fullname = NULL;
     char *optstring = NULL;
     struct option *optz = option_table_create (p, &optstring);
@@ -1194,7 +1194,18 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
             break;
         }
 
-        opt = list_find_first (p->option_list, (ListFindF) by_val, &c);
+        /* If li is a valid index, then a long option was used and we can
+         *  use this index into optz to get corresponding option name,
+         *  otherwise, assume a short option and use returned character
+         *  to find option by its key/value.
+         */
+        if (li >= 0)
+            opt = find_option_info (p, optz[li].name);
+        else
+            opt = list_find_first (p->option_list, (ListFindF) by_val, &c);
+
+        /* Reset li for next iteration */
+        li = -1;
         if (opt == NULL) {
             (*p->log_fn) ("ugh, didn't find option associated with char %c\n", c);
             continue;

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -385,8 +385,9 @@ static char * get_next_segment (char **from, int width, char *buf, int bufsiz)
         /*
          *      Need to break up a word. Use user-supplied buffer.
          */
-        strncpy (buf, seg, width+1);
+        strncpy (buf, seg, width);
         buf [width - 1]  = '-';
+        buf [width] = '\0';
         /*
          * Adjust from to character eaten by '-'
          *  And return pointer to buf.

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -58,6 +58,10 @@ void test_usage_output (void)
     e = optparse_add_option (p, &opt);
     ok (e == OPTPARSE_SUCCESS, "optparse_add_option");
 
+    e = optparse_set (p, OPTPARSE_USAGE, "[MOAR OPTIONS]");
+    ok (e == OPTPARSE_SUCCESS, "optparse_set (USAGE)");
+
+    // Reset usage works:
     e = optparse_set (p, OPTPARSE_USAGE, "[OPTIONS]");
     ok (e == OPTPARSE_SUCCESS, "optparse_set (USAGE)");
 
@@ -722,10 +726,10 @@ Usage: test one [OPTIONS]\n\
 int main (int argc, char *argv[])
 {
 
-    plan (166);
+    plan (167);
 
     test_convenience_accessors (); /* 24 tests */
-    test_usage_output (); /* 35 tests */
+    test_usage_output (); /* 36 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */
     test_data (); /* 8 tests */

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -167,6 +167,28 @@ This is some doc for group 1\n\
                               be split across lines nicely.\n",
         "Usage output with message autosplit across lines");
 
+    // Add an option whose description will break up a word
+    opt = ((struct optparse_option) {
+            .name = "option-C", .key = 'C', .group = 1,
+            .usage = "ThisOptionHasAVeryLongWordInTheDescriptionThatShouldBeBrokenAcrossLines."
+            });
+    e = optparse_add_option (p, &opt);
+    ok (e == OPTPARSE_SUCCESS, "optparse_add_option. group 1.");
+
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N               Enable a test option N.\n\
+  -h, --help                  Display this message.\n\
+This is some doc for group 1\n\
+  -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\
+  -B, --option-B              This option has a very long description. It should\n\
+                              be split across lines nicely.\n\
+  -C, --option-C              ThisOptionHasAVeryLongWordInTheDescriptionThatSho-\n\
+                              uldBeBrokenAcrossLines.\n",
+        "Usage output with message autosplit across lines");
+
+
     optparse_destroy (p);
 }
 
@@ -687,10 +709,10 @@ Usage: test one [OPTIONS]\n\
 int main (int argc, char *argv[])
 {
 
-    plan (160);
+    plan (163);
 
     test_convenience_accessors (); /* 24 tests */
-    test_usage_output (); /* 29 tests */
+    test_usage_output (); /* 32 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */
     test_data (); /* 8 tests */

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -188,7 +188,20 @@ This is some doc for group 1\n\
                               uldBeBrokenAcrossLines.\n",
         "Usage output with message autosplit across lines");
 
+    ok (setenv ("COLUMNS", "120", 1) >= 0, "Set COLUMNS=120");
+    usage_ok (p, "\
+Usage: prog-foo [OPTIONS]\n\
+This is some doc in header\n\
+  -T, --test2=N               Enable a test option N.\n\
+  -h, --help                  Display this message.\n\
+This is some doc for group 1\n\
+  -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\
+  -B, --option-B              This option has a very long description. It should be split across lines nicely.\n\
+  -C, --option-C              ThisOptionHasAVeryLongWordInTheDescriptionThatShouldBeBrokenAcrossLines.\n",
+        "Usage output with COLUMNS=120 not split across lines");
 
+    /* Unset COLUMNS again */
+    unsetenv ("COLUMNS");
     optparse_destroy (p);
 }
 
@@ -709,10 +722,10 @@ Usage: test one [OPTIONS]\n\
 int main (int argc, char *argv[])
 {
 
-    plan (163);
+    plan (166);
 
     test_convenience_accessors (); /* 24 tests */
-    test_usage_output (); /* 32 tests */
+    test_usage_output (); /* 35 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */
     test_data (); /* 8 tests */


### PR DESCRIPTION
This is  a few minor fixes and improvements for optparse:
 
 - Remove the requirement for a non-printable option `key` for long-only options. Instead we use the `longindex` returned by `getopt_long` to find the option used

 - Fix some issues with usage output line splitting
 
 - Add tests for long-only options, usage output corner cases, and optional argument options 