### PR TITLE
clean up LOG_INFO output, log wireup, rc1, rc3 times

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -747,6 +747,7 @@ static void hello_update_cb (hello_t *hello, void *arg)
         flux_log (ctx->h, LOG_INFO, "nodeset: %s (complete) %.1fs",
                   hello_get_nodeset (hello), hello_get_time (hello));
         flux_log (ctx->h, LOG_INFO, "Run level %d starting", 1);
+        overlay_set_idle_warning (ctx->overlay, 3);
         if (runlevel_set_level (ctx->runlevel, 1) < 0)
             log_err_exit ("runlevel_set_level 1");
     } else  {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -188,7 +188,7 @@ static void load_modules (ctx_t *ctx, const char *default_modules);
 
 static void update_proctitle (ctx_t *ctx);
 static void update_pidfile (ctx_t *ctx);
-static void runlevel_cb (runlevel_t *r, int level, int rc,
+static void runlevel_cb (runlevel_t *r, int level, int rc, double elapsed,
                          const char *state, void *arg);
 static void runlevel_io_cb (runlevel_t *r, const char *name,
                             const char *msg, void *arg);
@@ -814,14 +814,14 @@ static void runlevel_io_cb (runlevel_t *r, const char *name,
 
 /* Handle completion of runlevel subprocess.
  */
-static void runlevel_cb (runlevel_t *r, int level, int rc,
+static void runlevel_cb (runlevel_t *r, int level, int rc, double elapsed,
                          const char *exit_string, void *arg)
 {
     ctx_t *ctx = arg;
     int new_level = -1;
 
     flux_log (ctx->h, rc == 0 ? LOG_INFO : LOG_ERR,
-              "Run level %d %s (rc=%d)", level, exit_string, rc);
+              "Run level %d %s (rc=%d) %.1fs", level, exit_string, rc, elapsed);
 
     switch (level) {
         case 1: /* init completed */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -744,14 +744,14 @@ static void hello_update_cb (hello_t *hello, void *arg)
     ctx_t *ctx = arg;
 
     if (hello_complete (hello)) {
-        flux_log (ctx->h, LOG_INFO, "nodeset: %s (complete)",
-                  hello_get_nodeset (hello));
+        flux_log (ctx->h, LOG_INFO, "nodeset: %s (complete) %.1fs",
+                  hello_get_nodeset (hello), hello_get_time (hello));
         flux_log (ctx->h, LOG_INFO, "Run level %d starting", 1);
         if (runlevel_set_level (ctx->runlevel, 1) < 0)
             log_err_exit ("runlevel_set_level 1");
     } else  {
-        flux_log (ctx->h, LOG_INFO, "nodeset: %s (incomplete)",
-                  hello_get_nodeset (hello));
+        flux_log (ctx->h, LOG_INFO, "nodeset: %s (incomplete) %.1fs",
+                  hello_get_nodeset (hello), hello_get_time (hello));
     }
     if (ctx->hello_timeout != 0
                         && hello_get_time (hello) >= ctx->hello_timeout) {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -645,12 +645,12 @@ int main (int argc, char *argv[])
                   heartbeat_get_rate (ctx.heartbeat));
 
     /* Send hello message to parent.
-     * Report progress every second.
+     * Report progress every 10s.
      * Start init once wireup is complete.
      */
     hello_set_flux (ctx.hello, ctx.h);
     hello_set_callback (ctx.hello, hello_update_cb, &ctx);
-    hello_set_timeout (ctx.hello, 1.0);
+    hello_set_timeout (ctx.hello, 10.0);
     if (hello_start (ctx.hello) < 0)
         log_err_exit ("hello_start");
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1938,7 +1938,7 @@ static int cmb_rmmod_cb (zmsg_t **zmsg, void *arg)
     zmsg_destroy (zmsg); /* zmsg will be replied to later */
     if (module_stop (p) < 0)
         goto done;
-    flux_log (ctx->h, LOG_INFO, "rmmod %s", name);
+    flux_log (ctx->h, LOG_DEBUG, "rmmod %s", name);
     rc = 0;
 done:
     if (name)
@@ -1989,7 +1989,7 @@ static int cmb_insmod_cb (zmsg_t **zmsg, void *arg)
         goto done;
     }
     zmsg_destroy (zmsg); /* zmsg will be replied to later */
-    flux_log (ctx->h, LOG_INFO, "insmod %s", name);
+    flux_log (ctx->h, LOG_DEBUG, "insmod %s", name);
     rc = 0;
 done:
     if (name)
@@ -2687,7 +2687,7 @@ static void module_status_cb (module_t *p, int prev_status, void *arg)
      * and remove the module (which calls pthread_join).
      */
     if (status == FLUX_MODSTATE_EXITED) {
-        flux_log (ctx->h, LOG_INFO, "module %s exited", name);
+        flux_log (ctx->h, LOG_DEBUG, "module %s exited", name);
         svc_remove (ctx->services, module_get_name (p));
         while ((msg = module_pop_rmmod (p))) {
             if (flux_respond (ctx->h, msg, 0, NULL) < 0)

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -13,6 +13,7 @@ void overlay_set_sec (overlay_t *ov, flux_sec_t sec);
 void overlay_set_zctx (overlay_t *ov, zctx_t *zctx);
 void overlay_set_rank (overlay_t *ov, uint32_t rank);
 void overlay_set_flux (overlay_t *ov, flux_t h);
+void overlay_set_idle_warning (overlay_t *ov, int heartbeats);
 
 /* All ranks but rank 0 connect to a parent to form the main TBON.
  * Internally there is a stack of parent URI's, with top as primary.

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -39,10 +39,14 @@
 #include "attr.h"
 #include "runlevel.h"
 
+struct level {
+    struct subprocess *subprocess;
+};
+
 struct runlevel {
     int level;
     struct subprocess_manager *sm;
-    struct subprocess *rc[4];
+    struct level rc[4];
     runlevel_cb_f cb;
     void *cb_arg;
     runlevel_io_cb_f io_cb;
@@ -68,8 +72,8 @@ void runlevel_destroy (runlevel_t *r)
     if (r) {
         int i;
         for (i = 0; i < 4; i++) {
-            if (r->rc[i])
-                subprocess_destroy (r->rc[i]);
+            if (r->rc[i].subprocess)
+                subprocess_destroy (r->rc[i].subprocess);
         }
         free (r);
     }
@@ -180,8 +184,8 @@ void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg)
 
 static int runlevel_start_subprocess (runlevel_t *r, int level)
 {
-    if (r->rc[level]) {
-        if (subprocess_run (r->rc[level]) < 0)
+    if (r->rc[level].subprocess) {
+        if (subprocess_run (r->rc[level].subprocess) < 0)
             return -1;
     } else {
         if (r->cb)
@@ -227,8 +231,8 @@ static int subprocess_cb (struct subprocess *p)
     int rc = subprocess_exit_code (p);
     const char *exit_string = subprocess_exit_string (p);
 
-    assert (r->rc[r->level] == p);
-    r->rc[r->level] = NULL;
+    assert (r->rc[r->level].subprocess == p);
+    r->rc[r->level].subprocess = NULL;
 
     if (r->cb)
         r->cb (r, r->level, rc, exit_string, r->cb_arg);
@@ -283,7 +287,7 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *command,
     if (!shell)
         shell = "/bin/bash";
 
-    if (level < 1 || level > 3 || r->rc[level] != NULL || !r->sm) {
+    if (level < 1 || level > 3 || r->rc[level].subprocess != NULL || !r->sm) {
         errno = EINVAL;
         goto error;
     }
@@ -309,7 +313,7 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *command,
         if (subprocess_set_context (p, "runlevel_t", r) < 0)
             goto error;
     }
-    r->rc[level] = p;
+    r->rc[level].subprocess = p;
     return 0;
 error:
     if (p)

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -3,7 +3,7 @@
 
 typedef struct runlevel runlevel_t;
 
-typedef void (*runlevel_cb_f)(runlevel_t *r, int level, int rc,
+typedef void (*runlevel_cb_f)(runlevel_t *r, int level, int rc, double elapsed,
                               const char *exit_string, void *arg);
 typedef void (*runlevel_io_cb_f)(runlevel_t *r, const char *name,
                                  const char *msg, void *arg);

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -445,7 +445,7 @@ void shutdown_cb (flux_t h, flux_msg_handler_t *w,
         goto done;
     }
     if (ctx->broker_shutdown) {
-        flux_log (h, LOG_INFO, "shutdown: skipping");
+        flux_log (h, LOG_DEBUG, "shutdown: instance is terminating, don't reload to cache");
         goto done;
     }
     while (sqlite3_step (ctx->dump_stmt) == SQLITE_ROW) {

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -52,7 +52,7 @@ static int kvs_job_set_state (flux_t h, unsigned long jobid, const char *state)
         return (-1);
     }
 
-    flux_log (h, LOG_INFO, "Setting job %ld to %s", jobid, state);
+    flux_log (h, LOG_DEBUG, "Setting job %ld to %s", jobid, state);
     if ((rc = kvs_put_string (h, key, state)) < 0) {
         flux_log_error (h, "kvs_put_string (%s)", key);
         goto out;
@@ -232,7 +232,7 @@ static void job_request_cb (flux_t h, flux_msg_handler_t *w,
     const char *topic;
     if (flux_msg_get_topic (msg, &topic) < 0)
         goto out;
-    flux_log (h, LOG_INFO, "got request %s", topic);
+    flux_log (h, LOG_DEBUG, "got request %s", topic);
     if (flux_msg_get_payload_json (msg, &json_str) < 0)
         goto out;
     if (json_str && !(o = json_tokener_parse (json_str)))


### PR DESCRIPTION
The goal of this PR is to get useful timings and other log information out of a large session launched with
```
srun flux start -o,-Slog-stderr-level=6 [COMMAND]
```

First, some messages, especially those emitted from every rank, were changed from LOG_INFO to LOG_DEBUG.  Next, elapsed time was added to the log messages for wireup, rc1, and rc3 completion.
Finally, the "last heard from" messages from idle peers are suppressed during wireup and the wireup progress reporting interval was increased from 1s to 10s.   Net result is something like this:
```
$ ./flux start -s512 -o,-Slog-stderlevel=6 flux getattr size
2016-08-15T19:28:43.195512Z broker.info[0]: nodeset: [0-511] (complete) 0.6s
2016-08-15T19:28:43.195571Z broker.info[0]: Run level 1 starting
2016-08-15T19:28:46.642082Z cron.info[0]: synchronizing cron tasks to event hb
2016-08-15T19:28:50.545477Z broker.info[0]: Run level 1 Exited (rc=0) 7.3s
2016-08-15T19:28:50.545502Z broker.info[0]: Run level 2 starting
512
2016-08-15T19:28:50.561784Z broker.info[0]: Run level 2 Exited (rc=0) 0.0s
2016-08-15T19:28:50.562846Z broker.info[0]: Run level 3 starting
2016-08-15T19:28:50.568524Z broker.info[0]: shutdown in 2.000s: run level 2 Exited
2016-08-15T19:28:51.178605Z broker.info[0]: Run level 3 Exited (rc=0) 0.6s
```
