### PR TITLE
autogen.sh: run libtoolize before autoreconf

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,16 +1,13 @@
 #!/bin/sh
-
-echo "Running aclocal ... "
-aclocal -I config
-echo "Running libtoolize ... "
+#
+# Run an extra libtoolize before autoreconf to ensure that
+# libtool macros can be found if libtool is in PATH, but its
+# macros are not in default aclocal search path.
+#
+echo "Running libtoolize --automake --copy ... "
 libtoolize --automake --copy 
-echo "Running autoheader ... "
-autoheader
-echo "Running automake ... "
-touch ChangeLog
-automake --copy --add-missing 
-echo "Running autoconf ... "
-autoconf
+echo "Running autoreconf --verbose --install -I config"
+autoreconf --verbose --install -I config
 echo "Cleaning up ..."
 mv aclocal.m4 config/
 rm -rf autom4te.cache


### PR DESCRIPTION
While I don't understand why it is necessary, and it might just be an artifact of the way spack works, I don't exactly see the harm in an extra call to `libtoolize` at the top of `autogen.sh`, and this also gives us an opportunity to update flux-core `autogen.sh` to use `autoreconf`.

@trws or @SteVwonder, can you see if this fixes spack build for flux-core?

Fixes #770