### PR TITLE
IDEA: restore kvs from persist-directory

### DIFF
--- a/etc/rc3
+++ b/etc/rc3
@@ -14,6 +14,7 @@ shopt -u nullglob
 
 if PERSISTDIR=$(flux getattr persist-directory 2>/dev/null); then
     flux wreck ls >${PERSISTDIR}/joblog 2>/dev/null || :
+    flux kvs-getroot >${PERSISTDIR}/kvsroot 2>/dev/null || :
 fi
 
 flux module remove -r 0 cron

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -551,22 +551,25 @@ static int l_flux_rpc (lua_State *L)
     json_object *resp = NULL;
     int nodeid;
 
-    if (lua_value_to_json (L, 3, &o) < 0)
-        return lua_pusherror (L, "JSON conversion error");
-
+    if (lua_gettop (L) >= 3) {
+        if (lua_value_to_json (L, 3, &o) < 0)
+            return lua_pusherror (L, "JSON conversion error");
+    }
     if (lua_gettop (L) > 3)
         nodeid = lua_tonumber (L, 4);
     else
         nodeid = FLUX_NODEID_ANY;
 
-    if (tag == NULL || o == NULL)
+    if (tag == NULL)
         return lua_pusherror (L, "Invalid args");
 
     if (flux_json_rpc (f, nodeid, tag, o, &resp) < 0) {
-        json_object_put (o);
+        if (o)
+            json_object_put (o);
         return lua_pusherror (L, (char *)flux_strerror (errno));
     }
-    json_object_put (o);
+    if (o)
+        json_object_put (o);
     json_object_to_lua (L, resp);
     json_object_put (resp);
     return (1);

--- a/src/cmd/flux-kvs-getroot
+++ b/src/cmd/flux-kvs-getroot
@@ -1,0 +1,33 @@
+#!/usr/bin/lua
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- Emit response from kvs.getroot on stdout
+--
+local f = assert (require 'flux'.new ())
+local resp = assert (f:rpc ("kvs.getroot"))
+print ("{\n"..
+       "  rootdir = \"".. resp.rootdir .. "\",\n" ..
+       "  rootseq = " .. resp.rootseq .. "\n}")
+-- vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-kvs-setroot
+++ b/src/cmd/flux-kvs-setroot
@@ -1,0 +1,48 @@
+#!/usr/bin/lua
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+--
+-- Call kvs.setroot with contents of file on cmdline
+--
+local function load_root_info (path)
+    local file = assert (io.open (path))
+    local s = file:read ("*all")
+    file:close ()
+    return assert (loadstring ("return " .. s))()
+end
+
+if not arg[1] then
+    io.stderr:write ("Usage: "..arg[0].." root-info-file\n")
+    os.exit (1)
+end
+
+local f, err = require 'flux'.new()
+if not f then error (err) end
+
+local kvsroot = load_root_info (arg[1])
+
+print ("Setting root to ".. kvsroot.rootdir)
+assert (f:sendevent (kvsroot, "kvs.setroot"))
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -42,7 +42,7 @@
 const size_t lzo_buf_chunksize = 1024*1024;
 const size_t compression_threshold = 256; /* compress blobs >= this size */
 
-const char *sql_create_table = "CREATE TABLE objects("
+const char *sql_create_table = "CREATE TABLE if not exists objects("
                                "  hash CHAR(20) PRIMARY KEY,"
                                "  size INT,"
                                "  object BLOB"

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -178,7 +178,7 @@ static ctx_t *getctx (flux_t h)
             cleanup = true;
         }
         ctx->dbdir = xasprintf ("%s/content", dir);
-        if (mkdir (ctx->dbdir, 0755) < 0) {
+        if (mkdir (ctx->dbdir, 0755) < 0 && errno != EEXIST) {
             saved_errno = errno;
             flux_log_error (h, "mkdir %s", ctx->dbdir);
             goto error;

--- a/t/t2008-getroot-setroot.t
+++ b/t/t2008-getroot-setroot.t
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+
+test_description='Test kvs-getroot/kvs-setroot
+
+Test recovery from persistdir using flux kvs-setroot.'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+
+test_expect_success 'created persistdir' '
+	PERSISTDIR=$(mktemp -d --tmpdir=$(pwd))
+'
+test_expect_success 'kvsroot exists, non-empty' '
+	rm -rf $PERSISTDIR/* &&
+	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	    flux wreckrun /bin/true &&
+	test -f $PERSISTDIR/kvsroot &&
+    grep rootdir $PERSISTDIR/kvsroot
+'
+
+test_expect_success 'recover kvs in new session from persistdir and kvsroot' '
+	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	    "flux kvs-setroot $PERSISTDIR/kvsroot ; flux wreck ls >output" &&
+    test_debug "cat output" &&
+    test -f output &&
+    test -s output
+'
+
+test_done


### PR DESCRIPTION
For testing purposes, it would be nice to be able to restore a previous kvs state to test against, instead of creating the kvs state on the fly. For example, there is a bug in `flux wreck attach` that seems to only be triggered from a lwj with >32K tasks. Rather than write a test that first runs 32K tasks (or even simulates a run of 32K tasks by writing to kvs), it would be nice to start with an existing `persist-directory` content store, and "recover" the kvs using the last know rootdir sha1 hash.

This PR is just a proof-of-concept of that idea (original credit going to @garlick for the idea).

Two new "plumbing" type commands are added `flux kvs-getroot` and `flux kvs-setroot` which are simple interfaces to `kvs.getroot` and `kvs.setroot` message/events.

If persist-directory is set, the output of `kvs.getroot` is saved to the persist-directory.

In order for the content store to "restart" from and existing sqlite db, two kind of hackish mods were made to the content-sqlite 

 * Create the objects table with 'if not exists' so that an existing objects table is not an error
 * Do not error if mkdir returns EEXIST

Once a session is started using a previous `persist-directory`, the kvs can then be "restored" with a command like:
```
flux kvs-setroot $(flux getattr persist-directory)/kvsroot
```

I'm guessing this is a bit dangerous without some further sanity checks, so I'd only propose this for testing at this point. Here's some results

```
grondo@flux-core:~/workspace (kvs-restore) $ flux wreck ls | wc -l
102
grondo@flux-core:~/workspace (kvs-restore) $ exit
exit
grondo@flux-core:~/workspace (kvs-restore) $ src/cmd/flux start -o,-Spersist-directory=/tmp/tmp.zgK84E8ouy
grondo@flux-core:~/workspace (kvs-restore) $ flux wreck ls
/home/ubuntu/workspace/src/cmd/flux-wreck ls: Failed to get lwj info: No such file or directory
grondo@flux-core:~/workspace (kvs-restore) $ flux kvs-setroot $(flux getattr persist-directory)/kvsroot
Setting root to sha1-866b6bd85ca854e7335cfd7a4b73fcba1292476e
grondo@flux-core:~/workspace (kvs-restore) $ flux wreck ls | wc -l
102
grondo@flux-core:~/workspace (kvs-restore) $ exit
exit

```