### PR TITLE
increase KVS commit window

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -34,7 +34,8 @@ MAN3_FILES_PRIMARY = \
 	flux_signal_watcher_create.3 \
 	flux_stat_watcher_create.3 \
 	flux_rpc_raw.3 \
-	flux_respond.3
+	flux_respond.3 \
+	flux_reactor_now.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -86,7 +87,8 @@ MAN3_FILES_SECONDARY = \
 	flux_child_watcher_get_rstatus.3 \
 	flux_stat_watcher_get_rstat.3 \
 	flux_rpc_get_raw.3 \
-	flux_respond_raw.3
+	flux_respond_raw.3 \
+	flux_reactor_now_update.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -157,6 +159,7 @@ flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_rpc_get_raw.3: flux_rpc_raw.3
 flux_respond_raw.3: flux_respond.3
+flux_reactor_now_update.3: flux_reactor_now.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_reactor_now.adoc
+++ b/doc/man3/flux_reactor_now.adoc
@@ -1,0 +1,58 @@
+flux_watcher_now(3)
+===================
+:doctype: manpage
+
+
+NAME
+----
+flux_reactor_now, flux_reactor_now_update - get/update reactor time
+
+
+SYNOPSIS
+--------
+
+double flux_reactor_now (flux_reactor_t *r);
+
+void flux_reactor_now_update (flux_reactor_t *r);
+
+
+DESCRIPTION
+-----------
+
+`flux_reactor_now()` returns the current reactor time, which is the time
+the reactor began processing events.  The time will not be updated until
+the reactor runs out of events and wakes up again.  This is a lighter
+weight alternative to system calls when only coarse event timing is needed,
+e.g. when all events processed in a given wakeup can be considered
+simultaneous.
+
+`flux_reactor_now_update()` forces an update to reactor time.
+This may be useful when the reactor has not run for a while and timing
+calculations relative to reactor time need to be made, for example when
+creating timer watchers.
+
+Note: the Flux reactor is based on libev.  For additional information
+on the behavior of reactor time, refer to the libev documentation on
+`ev_now` and `ev_now_update()`.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_reactor_create (3)
+
+http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/doc/man3/flux_reactor_now.adoc
+++ b/doc/man3/flux_reactor_now.adoc
@@ -15,6 +15,8 @@ double flux_reactor_now (flux_reactor_t *r);
 
 void flux_reactor_now_update (flux_reactor_t *r);
 
+double flux_reactor_time (void);
+
 
 DESCRIPTION
 -----------
@@ -30,6 +32,9 @@ simultaneous.
 This may be useful when the reactor has not run for a while and timing
 calculations relative to reactor time need to be made, for example when
 creating timer watchers.
+
+`flux_reactor_time()` returns the system time as a double.
+Reactor time is a snapshot of `flux_reactor_time()`.
 
 Note: the Flux reactor is based on libev.  For additional information
 on the behavior of reactor time, refer to the libev documentation on

--- a/doc/man3/flux_timer_watcher_create.adoc
+++ b/doc/man3/flux_timer_watcher_create.adoc
@@ -33,8 +33,16 @@ monitors for timer events.  A timer event occurs when _after_ seconds
 have elapsed, and optionally again every _repeat_ seconds.
 When events occur, the user-supplied _callback_ is invoked.
 
-If _repeat_ is 0., the flux_watcher_t will automatically be stopped
-when _after_ seconds have elapsed.
+If _after_ is 0., the flux_watcher_t will be immediately ready 
+when the reactor is started.  If _repeat_ is 0., the flux_watcher_t
+will automatically be stopped when _after_ seconds have elapsed.
+
+Note that _after_ is internally referenced to reactor time, which is
+only updated when the reactor is run/created, and therefore
+can be out of date.  Use `flux_reactor_now_update(3)` to manually
+update reactor time before creating timer watchers in such cases.
+Refer to "The special problem of time updates" in the libev manual
+for more information.
 
 To restart a timer that has been automatically stopped, you must reset
 the _after_ and _repeat_ values with `flux_timer_watcher_reset()` before
@@ -77,6 +85,6 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 ---------
-flux_watcher_start(3), flux_reactor_start(3)
+flux_watcher_start(3), flux_reactor_start(3), flux_reactor_now(3)
 
 http://software.schmorp.de/pkg/libev.html[libev home page]

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -158,8 +158,9 @@ int heartbeat_start (heartbeat_t *hb)
     if (flux_get_rank (hb->h, &rank) < 0)
         return -1;
     if (rank == 0) {
-        if (!(hb->timer = flux_timer_watcher_create (flux_get_reactor (hb->h),
-                                                     hb->rate, hb->rate,
+        flux_reactor_t *r = flux_get_reactor (hb->h);
+        flux_reactor_now_update (r);
+        if (!(hb->timer = flux_timer_watcher_create (r, hb->rate, hb->rate,
                                                      timer_cb, hb)))
             return -1;
         flux_watcher_start (hb->timer);

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -140,6 +140,11 @@ int flux_reactor_run (flux_reactor_t *r, int flags)
     return r->loop_rc;
 }
 
+double flux_reactor_time (void)
+{
+    return ev_time ();
+}
+
 double flux_reactor_now (flux_reactor_t *r)
 {
     return ev_now (r->loop);

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -145,6 +145,11 @@ double flux_reactor_now (flux_reactor_t *r)
     return ev_now (r->loop);
 }
 
+void flux_reactor_now_update (flux_reactor_t *r)
+{
+    return ev_now_update (r->loop);
+}
+
 void flux_reactor_stop (flux_reactor_t *r)
 {
     r->loop_rc = 0;

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -140,6 +140,11 @@ int flux_reactor_run (flux_reactor_t *r, int flags)
     return r->loop_rc;
 }
 
+double flux_reactor_now (flux_reactor_t *r)
+{
+    return ev_now (r->loop);
+}
+
 void flux_reactor_stop (flux_reactor_t *r)
 {
     r->loop_rc = 0;

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -39,6 +39,8 @@ int flux_reactor_run (flux_reactor_t *r, int flags);
 void flux_reactor_stop (flux_reactor_t *r);
 void flux_reactor_stop_error (flux_reactor_t *r);
 
+double flux_reactor_now (flux_reactor_t *r);
+
 /* Watchers
  */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -41,6 +41,7 @@ void flux_reactor_stop_error (flux_reactor_t *r);
 
 double flux_reactor_now (flux_reactor_t *r);
 void flux_reactor_now_update (flux_reactor_t *r);
+double flux_reactor_time (void);
 
 /* Watchers
  */

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -40,6 +40,7 @@ void flux_reactor_stop (flux_reactor_t *r);
 void flux_reactor_stop_error (flux_reactor_t *r);
 
 double flux_reactor_now (flux_reactor_t *r);
+void flux_reactor_now_update (flux_reactor_t *r);
 
 /* Watchers
  */

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -146,6 +146,12 @@ end
 is (n, #keys, "keys() iterator returned correct number of keys")
 
 -- KVS watcher creation
+
+-- Force creation of new handle and reactor here so that
+--  reactor time is guaranteed to be updated, and our timeout
+--  used below is relative to now and not last active reactor time.
+--
+local f = check_userdata_return ("flux.new", flux.new())
 local data = { key = "testkey", value = "testvalue" }
 
 local count = 0
@@ -185,6 +191,11 @@ to:remove()
 
 ok (kw:remove(), "Can remove kvswatcher without error")
 
+-- Again, force creation of new handle and reactor here so that
+--  reactor time is guarateed to be updated, and our timeout
+--  used below is relative to now and not last active reactor time.
+--
+local f = check_userdata_return ("flux.new", flux.new())
 
 --
 -- Again, but this time ensure callback is not called more than the

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -351,7 +351,8 @@ test_expect_success 'flux-wreck: kill' '
 '
 test_expect_success 'flux-wreck: ls works' '
 	flux wreckrun -n2 -N2 hostname &&
-	flux wreck ls | tail -1 | grep "hostname$"
+	flux wreck ls | sort -n >ls.out &&
+	tail -1 ls.out | grep "hostname$"
 '
 
 flux module list | grep -q sched || test_set_prereq NO_SCHED


### PR DESCRIPTION
This PR increases the KVS commit aggregation window from 1ms to 50ms and switches the timeout logic to use `flux_reactor_now()` instead of `clock_gettime()`.

There's still a problem with the lua kvs test failing on my desktop, and @grondo offered to have a look, so I'm posting this PR earlier than I normally would.

The failure is the kvs watcher test:
```
PASS: lua/t1002-kvs.t 103 - kvswatcher: 2nd callback has correct result
FAIL: lua/t1002-kvs.t 104 - reactor exited normally with Timed out after 1.5s!
PASS: lua/t1002-kvs.t 105 - Can remove kvswatcher without error
```
it's odd because the KVS watcher worked as expected, but the 1.5s timer fires also before the reactor exits, causing the error.