### PR TITLE
implement scalable reduction for wireup protocol

### DIFF
--- a/doc/man3/flux_reduce_create.adoc
+++ b/doc/man3/flux_reduce_create.adoc
@@ -83,8 +83,8 @@ _flags_ is the logical "or" of zero or more of the following flags:
 
 FLUX_REDUCE_TIMEDFLUSH::
 When an item of a new batch is appended to the reduction handle, a reactor
-timer is started on handle _h_, by default for a fraction of the configured
-_timeout_.  When the timer expires, any items in the queue are flushed.
+timer is started on handle _h_ for _timeout_ seconds.  When the timer
+expires, any items in the queue are flushed.
 
 FLUX_REDUCE_HWMFLUSH::
 A high water mark for the number of messages appended to the handle
@@ -109,22 +109,11 @@ subsequent high water mark comparisons must count reduced messages.
 If HWMFLUSH policy is selected, _op.itemweight_ must be provided
 to interrogate an item for the number of unreduced items it represents.
 
-Under TIMEDFLUSH policy, the default _timeout_ is scaled as a linear
-function of height in the tree based overlay network.  Let H be the maximum
-tree height plus one, and h be this rank's height.  The scaled timeout t is
-given by:
-
-t = (H - h) * (_timeout_ / H)
-
-The tree height is calculated from static tree geometry returned by
-`flux_get_rank(3)`, `flux_get_size(3)`, and `flux_get_arity(3)`.
-The height of rank 0 is defined to be zero.
-
 `flux_reduce_opt_get()` and `flux_reduce_opt_set()` may be used to get
 or set internal options.  The valid options are:
 
 FLUX_REDUCE_OPT_TIMER::
-Get/set the calculated timeout value used for TIMEDFLUSH policy.
+Get/set the timeout value used for TIMEDFLUSH policy.
 The units are seconds and the value type is double.
 
 FLUX_REDUCE_OPT_HWM::

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -189,6 +189,10 @@ at each node of the tree based overlay network.  After the timeout,
 new wireup information is forwarded upstream without delay.
 Set to 0 to disable the timeout.
 
+hello.hwm::
+The reduction high water mark for the broker wireup protocol,
+normally calculated based on the topology.
+Set to 0 to disable the high water mark.
 
 AUTHOR
 ------

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -29,9 +29,6 @@ The number of ranks in the comms session.
 session-id::
 The identity of the comms session.
 
-tbon-arity::
-The branching factor of the tree based overlay network.
-
 scratch-directory::
 A temporary directory available for scratch storage within
 the session.  This directory _may_ be shared by multiple ranks.
@@ -54,6 +51,24 @@ persist-filesystem::
 If defined, and persist-directory is not defined, the rank
 0 broker chooses a unique name for persist-directory within
 persist-filesystem and creates it automatically.
+
+
+TOPOLOGY ATTRIBUTES
+-------------------
+tbon.arity::
+Branching factor of the tree based overlay network.
+
+tbon.descendants::
+Number of descendants "below" this node of the tree based
+overlay network, not including this node.
+
+tbon.level::
+The level of this node in the tree based overlay network.
+Root is level 0.
+
+tbon.maxlevel::
+The maximum level number in the tree based overlay network.
+Maxlevel is 0 for a size=1 instance.
 
 
 SOCKET ATTRIBUTES

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -175,9 +175,19 @@ content-purge-target-entries::
 If possible, the cache size purged periodically so that the total
 number of entries stays at or below this value.
 
-content-purge-target-size
+content-purge-target-size::
 If possible, the cache size purged periodically so that the total
 size of the cache stays at or below this value.
+
+
+WIREUP ATTRIBUTES
+-----------------
+hello.timeout::
+The reduction timeout (in seconds) for the broker wireup protocol.
+Before the timeout, a topology-based high water mark is applied
+at each node of the tree based overlay network.  After the timeout,
+new wireup information is forwarded upstream without delay.
+Set to 0 to disable the timeout.
 
 
 AUTHOR

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -319,3 +319,4 @@ RTT
 wakeup
 crontab
 appname
+maxlevel

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -321,3 +321,4 @@ crontab
 appname
 maxlevel
 wireup
+hwm

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -320,3 +320,4 @@ wakeup
 crontab
 appname
 maxlevel
+wireup

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -88,7 +88,7 @@ test_heartbeat_t_SOURCES = test/heartbeat.c heartbeat.c attr.c
 test_heartbeat_t_CPPFLAGS = $(test_cppflags)
 test_heartbeat_t_LDADD = $(test_ldadd)
 
-test_hello_t_SOURCES = test/hello.c hello.c
+test_hello_t_SOURCES = test/hello.c hello.c attr.c
 test_hello_t_CPPFLAGS = $(test_cppflags)
 test_hello_t_LDADD = $(test_ldadd)
 

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -33,55 +33,117 @@
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/nodeset.h"
 
-#include "heartbeat.h"
 #include "hello.h"
 
+/* After this many seconds, ignore topo-based hwm.
+ * Override by setting hello.timeout broker attribute.
+ */
+static double default_reduction_timeout = 10.;
+
 struct hello_struct {
-    nodeset_t *nodeset;
+    flux_t h;
+    attr_t *attrs;
+    uint32_t rank;
+    uint32_t size;
     uint32_t count;
-    double timeout;
+
+    double start;
+
     hello_cb_f cb;
     void *cb_arg;
-    flux_t h;
-    flux_reactor_t *reactor;
-    flux_watcher_t *timer;
-    double start;
+
+    flux_reduce_t *reduce;
 };
 
+static void join_request (flux_t h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg);
+
+static void r_reduce (flux_reduce_t *r, int batch, void *arg);
+static void r_sink (flux_reduce_t *r, int batch, void *arg);
+static void r_forward (flux_reduce_t *r, int batch, void *arg);
+static int r_itemweight (void *item);
+
+
+struct flux_reduce_ops reduce_ops = {
+    .destroy = NULL,
+    .reduce = r_reduce,
+    .sink = r_sink,
+    .forward = r_forward,
+    .itemweight = r_itemweight,
+};
 
 hello_t *hello_create (void)
 {
     hello_t *hello = xzmalloc (sizeof (*hello));
+    hello->size = 1;
     return hello;
 }
 
 void hello_destroy (hello_t *hello)
 {
     if (hello) {
-        if (hello->nodeset)
-            nodeset_destroy (hello->nodeset);
-        if (hello->timer)
-            flux_watcher_destroy (hello->timer);
+        flux_reduce_destroy (hello->reduce);
         free (hello);
     }
 }
 
+static int hwm_from_topology (attr_t *attrs)
+{
+    const char *s;
+    if (attr_get (attrs, "tbon.descendants", &s, NULL) < 0) {
+        log_err ("hello: reading tbon.descendants attribute");
+        return 1;
+    }
+    return strtoul (s, NULL, 10) + 1;
+}
+
+int hello_register_attrs (hello_t *hello, attr_t *attrs)
+{
+    const char *s;
+    double timeout = default_reduction_timeout;
+    int hwm = hwm_from_topology (attrs);
+    char num[32];
+
+    hello->attrs = attrs;
+    if (attr_get (attrs, "hello.timeout", &s, NULL) == 0) {
+        timeout = strtod (s, NULL);
+        if (attr_delete (attrs, "hello.timeout", true) < 0)
+            return -1;
+    }
+    snprintf (num, sizeof (num), "%.3f", timeout);
+    if (attr_add (attrs, "hello.timeout", num, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    if (attr_get (attrs, "hello.hwm", &s, NULL) == 0) {
+        hwm = strtoul (s, NULL, 10);
+        if (attr_delete (attrs, "hello.hwm", true) < 0)
+            return -1;
+    }
+    snprintf (num, sizeof (num), "%d", hwm);
+    if (attr_add (attrs, "hello.hwm", num, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    return 0;
+}
+
+static struct flux_msg_handler_spec handlers[] = {
+    { FLUX_MSGTYPE_REQUEST, "hello.join",     join_request },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
 void hello_set_flux (hello_t *hello, flux_t h)
 {
     hello->h = h;
-    hello->reactor = flux_get_reactor (h);
-}
-
-void hello_set_timeout (hello_t *hello, double seconds)
-{
-    hello->timeout = seconds;
 }
 
 double hello_get_time (hello_t *hello)
 {
-    if (hello->start == 0. || hello->reactor == NULL)
+    if (hello->start == 0. || hello->h == NULL)
         return 0.;
-    return flux_reactor_now (hello->reactor) - hello->start;
+    return flux_reactor_now (flux_get_reactor (hello->h)) - hello->start;
+}
+
+int hello_get_count (hello_t *hello)
+{
+    return hello->count;
 }
 
 void hello_set_callback (hello_t *hello, hello_cb_f cb, void *arg)
@@ -92,141 +154,150 @@ void hello_set_callback (hello_t *hello, hello_cb_f cb, void *arg)
 
 bool hello_complete (hello_t *hello)
 {
-    uint32_t size;
-    if (flux_get_size (hello->h, &size) < 0)
-        return false;
-    return (size == hello->count);
-}
-
-const char *hello_get_nodeset (hello_t *hello)
-{
-    if (!hello->nodeset)
-        return NULL;
-    return nodeset_string (hello->nodeset);
-}
-
-static int hello_add_rank (hello_t *hello, uint32_t rank)
-{
-    uint32_t size;
-
-    if (flux_get_size (hello->h, &size) < 0)
-        return -1;
-    if (!hello->nodeset)
-        hello->nodeset = nodeset_create_size (size);
-    if (!nodeset_add_rank (hello->nodeset, rank)) {
-        errno = EPROTO;
-        return -1;
-    }
-    hello->count++;
-    if (hello->count == size) {
-        if (hello->cb)
-            hello->cb (hello, hello->cb_arg);
-        if (hello->timer)
-            flux_watcher_stop (hello->timer);
-    }
-    return 0;
-}
-
-int hello_recvmsg (hello_t *hello, const flux_msg_t *msg)
-{
-    int rc = -1;
-    int rank;
-
-    if (hello_decode (msg, &rank) < 0)
-        goto done;
-    if (hello_add_rank (hello, rank) < 0)
-        goto done;
-    rc = 0;
-done:
-    return rc;
-}
-
-static int hello_sendmsg (hello_t *hello, uint32_t rank)
-{
-    flux_msg_t *msg;
-    int rc = -1;
-
-    if (!(msg = hello_encode (rank)))
-        goto done;
-    if (flux_send (hello->h, msg, 0) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_msg_destroy (msg);
-    return rc;
-}
-
-static void timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
-{
-    hello_t *hello = arg;
-
-    if (hello->cb)
-        hello->cb (hello, hello->cb_arg);
+    return (hello->size == hello->count);
 }
 
 int hello_start (hello_t *hello)
 {
     int rc = -1;
-    uint32_t rank;
+    int flags = 0;
+    int hwm = 1;
+    double timeout = 0.;
+    const char *s;
 
-    if (flux_get_rank (hello->h, &rank) < 0)
+    if (flux_get_rank (hello->h, &hello->rank) < 0
+                        || flux_get_size (hello->h, &hello->size) < 0) {
+        log_err ("hello: error getting rank/size");
         goto done;
-    if (rank == 0) {
-        flux_reactor_now_update (hello->reactor);
-        hello->start = flux_reactor_now (hello->reactor);
-        if (!(hello->timer = flux_timer_watcher_create (hello->reactor,
-                                                        hello->timeout,
-                                                        hello->timeout,
-                                                        timer_cb, hello)))
-            goto done;
-        flux_watcher_start (hello->timer);
-        if (hello_add_rank (hello, 0) < 0)
-            goto done;
-    } else {
-        if (hello_sendmsg (hello, rank) < 0)
-            goto done;
     }
+    if (flux_msg_handler_addvec (hello->h, handlers, hello) < 0) {
+        log_err ("hello: adding message handlers");
+        goto done;
+    }
+    if (hello->attrs) {
+        if (attr_get (hello->attrs, "hello.hwm", &s, NULL) < 0) {
+            log_err ("hello: reading hello.hwm attribute");
+            goto done;
+        }
+        hwm = strtoul (s, NULL, 10);
+        if (attr_get (hello->attrs, "hello.timeout", &s, NULL) < 0) {
+            log_err ("hello: reading hello.timeout attribute");
+            goto done;
+        }
+        timeout = strtod (s, NULL);
+    }
+    if (timeout > 0.)
+        flags |= FLUX_REDUCE_TIMEDFLUSH;
+    if (hwm > 0)
+        flags |= FLUX_REDUCE_HWMFLUSH;
+    if (!(hello->reduce = flux_reduce_create (hello->h, reduce_ops,
+                                              timeout, hello, flags))) {
+        log_err ("hello: creating reduction handle");
+        goto done;
+    }
+    if (flux_reduce_opt_set (hello->reduce, FLUX_REDUCE_OPT_HWM,
+                             &hwm, sizeof (hwm)) < 0) {
+        log_err ("hello: setting FLUX_REDUCE_OPT_HWM");
+        goto done;
+    }
+
+    flux_reactor_t *r = flux_get_reactor (hello->h);
+    flux_reactor_now_update (r);
+    hello->start = flux_reactor_now (r);
+    if (flux_reduce_append (hello->reduce, (void *)(uintptr_t)1, 0) < 0)
+        goto done;
     rc = 0;
 done:
     return rc;
 }
 
-flux_msg_t *hello_encode (int rank)
+/* handle a message sent from downstream via downstream's r_forward op.
+ */
+static void join_request (flux_t h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg)
 {
-    flux_msg_t *msg = NULL;
-    JSON out = Jnew ();
-
-    Jadd_int (out, "rank", rank);
-    if (!(msg = flux_request_encode ("cmb.hello", Jtostr (out))))
-        goto error;
-    if (flux_msg_set_nodeid (msg, 0, 0) < 0)
-        goto error;
-    Jput (out);
-    return msg;
-error:
-    flux_msg_destroy (msg);
-    Jput (out);
-    return NULL;
-}
-
-int hello_decode (const flux_msg_t *msg, int *rank)
-{
-    const char *json_str, *topic_str;
+    hello_t *hello = arg;
+    const char *json_str;
+    int count, batch;
     JSON in = NULL;
-    int rc = -1;
 
-    if (flux_request_decode (msg, &topic_str, &json_str) < 0)
-        goto done;
-    if (!(in = Jfromstr (json_str)) || !Jget_int (in, "rank", rank)
-                                    || strcmp (topic_str, "cmb.hello") != 0) {
-        errno = EPROTO;
-        goto done;
-    }
-    rc = 0;
-done:
+    if (flux_request_decode (msg, NULL, &json_str) < 0)
+        log_err_exit ("hello: flux_request_decode");
+    if (!(in = Jfromstr (json_str)) || !Jget_int (in, "count", &count)
+                                    || !Jget_int (in, "batch", &batch)
+                                    || batch != 0 || count <= 0)
+        log_msg_exit ("hello: error decoding join request");
+    if (flux_reduce_append (hello->reduce, (void *)(uintptr_t)count, batch) < 0)
+        log_err_exit ("hello: flux_reduce_append");
+}
+
+/* Reduction ops
+ * N.B. since we are reducing integers, we cheat and avoid memory
+ * allocation by stuffing the int inside the pointer value.
+ */
+
+/* Pop one or more counts, push their sum
+ */
+static void r_reduce (flux_reduce_t *r, int batch, void *arg)
+{
+    int i, count = 0;
+
+    assert (batch == 0);
+
+    while ((i = (uintptr_t)flux_reduce_pop (r)) > 0)
+        count += i;
+    if (count > 0 && flux_reduce_push (r, (void *)(uintptr_t)count) < 0)
+        log_err_exit ("hello: flux_reduce_push");
+    /* Invariant for r_sink and r_forward:
+     * after reduce, handle contains exactly one item.
+     */
+}
+
+/* (called on rank 0 only) Pop exactly one count, update global count,
+ * call the registered callback.
+ * This may be called once the total hwm is reached on rank 0,
+ * or after the timeout, as new messages arrive (after r_reduce).
+ */
+static void r_sink (flux_reduce_t *r, int batch, void *arg)
+{
+    hello_t *hello = arg;
+    int count = (uintptr_t)flux_reduce_pop (r);
+
+    assert (batch == 0);
+    assert (count > 0);
+
+    hello->count += count;
+    if (hello->cb)
+        hello->cb (hello, hello->cb_arg);
+}
+
+/* (called on rank > 0 only) Pop exactly one count, forward upstream.
+ * This may be called once the hwm is reached on this rank (based on topo),
+ * or after the timeout, as new messages arrive (after r_reduce).
+ */
+static void r_forward (flux_reduce_t *r, int batch, void *arg)
+{
+    hello_t *hello = arg;
+    int count = (uintptr_t)flux_reduce_pop (r);
+    JSON in = Jnew ();
+
+    assert (batch == 0);
+    assert (count > 0);
+
+    Jadd_int (in, "count", count);
+    Jadd_int (in, "batch", batch);
+    if (flux_rpc (hello->h, "hello.join", Jtostr (in),
+                  FLUX_NODEID_UPSTREAM, FLUX_RPC_NORESPONSE) < 0)
+        log_err_exit ("hello: flux_rpc");
     Jput (in);
-    return rc;
+}
+
+/* How many original items does this item represent after reduction?
+ * In this simple case it is just the value of the item (the count).
+ */
+static int r_itemweight (void *item)
+{
+    return (uintptr_t)item;
 }
 
 /*

--- a/src/broker/hello.h
+++ b/src/broker/hello.h
@@ -2,13 +2,9 @@
 #define _BROKER_HELLO_H
 
 #include <stdbool.h>
+#include "attr.h"
 
 /* hello protocol is used to detect that TBON overlay has wired up.
- * All the ranks send a small hello request to rank 0.
- * When all the ranks are accounted for, the nodeset is complete.
- * On rank 0, a callback is called when the nodeset is complete.
- * The callback may also be called periodically while the nodeset is
- * coming together, e.g. to report progress or enforce a timeout.
  */
 
 typedef struct hello_struct hello_t;
@@ -18,53 +14,33 @@ typedef void (*hello_cb_f)(hello_t *hello, void *arg);
 hello_t *hello_create (void);
 void hello_destroy (hello_t *hello);
 
-/* The flux handle is used
- * - to obtain flux_rank() and flux_size()
- * - to send messages to rank 0
- * - to set up a recurring reactor timer to call hello_cb_f if any
+/* Register handle
  */
 void hello_set_flux (hello_t *hello, flux_t h);
 
-/* If defined, callback will be called:
- * - when nodeset is complete
- * - every timeout seconds, until nodeset is complete
+/* Set up broker attributes
+ */
+int hello_register_attrs (hello_t *hello, attr_t *attrs);
+
+/* Register callback for completion/progress.
  */
 void hello_set_callback (hello_t *hello, hello_cb_f cb, void *arg);
-
-/* Set the timeout period.
- * If this is not called, the callback will only be called
- * when the nodeset is complete.  This function may be called
- * with an argument of zero to disable the timeout.
- */
-void hello_set_timeout (hello_t *hello, double sec);
 
 /* Get time in seconds elapsed since hello_start()
  */
 double hello_get_time (hello_t *hello);
 
-/* Get nodeset string of nodes that have checked in.
+/* Get number of ranks currently accounted for.
  */
-const char *hello_get_nodeset (hello_t *hello);
+int hello_get_count (hello_t *hello);
 
 /* Get completion status
  */
 bool hello_complete (hello_t *hello);
 
-/* Process a received cmb.hello message.
- */
-int hello_recvmsg (hello_t *hello, const flux_msg_t *msg);
-
-/* Start the hello protocol.
- * On rank 0, enable timer (if timeout value has been set)
- * On ranks > 0, send a cmb.hello message to parent.
+/* Start the hello protocol (call on all ranks).
  */
 int hello_start (hello_t *hello);
-
-/* Hello request encode/decode.
- * Used internally but exposed for testing.
- */
-flux_msg_t *hello_encode (int rank);
-int hello_decode (const flux_msg_t *msg, int *rank);
 
 #endif /* !_BROKER_HELLO_H */
 

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -196,6 +196,9 @@ static ctx_t *getctx (flux_t h)
             flux_log_error (h, "zlist_new/zhash_new");
             goto error;
         }
+        /* FIXME: reduction is no longer scaled by TBON height.
+         * If we need this, it will need to be calculated here.
+         */
         ctx->r = flux_reduce_create (h, hello_ops,
                                      reduce_timeout, ctx,
                                      FLUX_REDUCE_TIMEDFLUSH);

--- a/t/loop/reduce.c
+++ b/t/loop/reduce.c
@@ -268,7 +268,7 @@ void test_timed (flux_t h)
         BAIL_OUT();
     ok (flux_reduce_opt_get (r, FLUX_REDUCE_OPT_TIMEOUT, &timeout,
                              sizeof (timeout)) == 0 && timeout == 0.1,
-        "timed: timeout scaled by 1.0 on rank 0");
+        "timed: flux_reduce_opt_get TIMEOUT returned timeout");
 
     /* Append 100 items in batch 0 before starting reactor.
      * Reduction occurs at each append.


### PR DESCRIPTION
This PR should speed up the "hello" protocol executed during wireup a little bit.
The old protocol was for every node to send a small message directly to rank 0.
Once all the messages were received, wireup was complete.

The new protocol uses TBON topology-informed reduction to reduce a count.  Once the count reaches the target size wireup is complete.

I guess this is also another simple example of how the reduction handle works.

See long comment in ddc83ef