### PR TITLE
wreck: minor enhancements for scale testing

### DIFF
--- a/doc/man1/flux-wreckrun.adoc
+++ b/doc/man1/flux-wreckrun.adoc
@@ -59,6 +59,12 @@ OPTIONS
 	Detach immediately after issuing a run request and print new jobid
 	to stdout.
 
+--wait-until='state'::
+-w 'state'::
+	Ignore all stdio, and instead just wait until the job reaches
+        a state of 'state' (i.e. "starting", "running", or "complete") and
+        exit immediately.
+
 --output='FILENAME'::
 -O 'FILENAME'::
 	Duplicate stdout and stderr from tasks to a file or files. 'FILENAME'

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1970,7 +1970,13 @@ static int l_kz_write (lua_State *L)
 {
     kz_t *kz = lua_get_kz (L, 1);
     size_t len;
-    const char *s = lua_tolstring (L, 2, &len);
+    const char *s = luaL_checkstring (L, 2);
+    len = strlen (s);
+
+    if (kz == NULL) {
+        fprintf (stderr, "kz_write: kz == NULL!\n ");
+        return lua_pusherror (L, "kz_write: no such kz object!\n");
+    }
 
     if (kz_put (kz, (char *) s, len) < 0)
         return lua_pusherror (L, (char *)flux_strerror (errno));

--- a/src/bindings/lua/lua-hostlist/hostlist.c
+++ b/src/bindings/lua/lua-hostlist/hostlist.c
@@ -95,7 +95,7 @@
 #define HOSTLIST_CHUNK    16
 
 /* max host range: anything larger will be assumed to be an error */
-#define MAX_RANGE    16384    /* 16K Hosts */
+#define MAX_RANGE    1048576    /* 16K Hosts */
 
 /* max host suffix value */
 #define MAX_HOST_SUFFIX 1<<25

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -256,13 +256,15 @@ prog:SubCommand {
     if not lwj then
         self:die ("Failed to get lwj info: %s\n", err)
     end
-    local fmt = "%6s %12s %12s %12s %12s\n"
-    printf (fmt, "ID", "STARTING", "RUNNING", "COMPLETE", "TOTAL")
+    local fmt = "%6s %12s %12s %12s %12s %12s\n"
+    printf (fmt, "ID", "NTASKS", "STARTING", "RUNNING", "COMPLETE", "TOTAL")
     for id in lwj:keys() do
         if tonumber (id) then
             local j, err = LWJ.open (f, id)
             if not j then self:die ("job%d: %s", id, err) end
-            printf (fmt, id, seconds_to_string (j.t0),
+            printf (fmt, id,
+                    j.ntasks,
+                    seconds_to_string (j.t0),
                     seconds_to_string (j.t1),
                     seconds_to_string (j.t2),
                     seconds_to_string (j.runtime))

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -139,6 +139,8 @@ wreck:add_options ({
         usage = "execute Lua CODE before launch." },
     { name = 'detach', char = "d",
         usage = "Detach immediately after starting job" },
+    { name = 'wait-until', char = "w", arg = "STATE",
+        usage = "Do not process stdio, but block until 'STATE'" },
 })
 
 if not wreck:parse_cmdline (arg) then
@@ -205,6 +207,9 @@ local kw, err = f:kvswatcher  {
         if result then
             state = result
             wreck:verbose ("%-4.03fs: State = %s\n", tt:get0(), result)
+            if wreck.opts.w and state == wreck.opts.w then
+                os.exit (0)
+            end
             check_job_completed ()
         end
     end
@@ -249,40 +254,43 @@ else
     lwj:commit()
 end
 
---
---  Open output to all tasks:
---
-taskio, err = ioattach {
+-- Only process stdio if no --wait-until option used
+if not wreck.opts.w then
+  --
+  --  Open output to all tasks:
+  --
+  taskio, err = ioattach {
      flux = f,
      jobid = jobid,
      ntasks = wreck.ntasks,
      labelio = wreck.opts.l,
      on_completion = check_job_completed
-}
-if not taskio then wreck:die ("error opening task io: %s\n", err) end
+  }
+  if not taskio then wreck:die ("error opening task io: %s\n", err) end
+
+  --
+  --  Open stdin
+  --
+  local kz, err = f:kz_open (tostring (lwj)..".input.files.stdin", "w")
+  if not kz then wreck:die (err) end
+
+  --
+  --  Add a file descriptor iowatcher for this script's stdin:
+  --
+  f:iowatcher {
+    fd = posix.fileno (io.input()),
+    handler = function (iow, data)
+        if data.data then kz:write (data.data) end
+        if data.eof  then kz:close ()          end
+    end
+  }
+end
 
 log, err = logstream {
      flux = f,
      jobid = jobid,
 }
 if not log then wreck:die ("error opening log stream: %s\n", err) end
-
---
---  Open stdin
---
-local kz, err = f:kz_open (tostring (lwj)..".input.files.stdin", "w")
-if not kz then wreck:die (err) end
-
---
---  Add a file descriptor iowatcher for this script's stdin:
---
-f:iowatcher {
-    fd = posix.fileno (io.input()),
-    handler = function (iow, data)
-        if data.data then kz:write (data.data) end
-        if data.eof  then kz:close ()          end
-    end
-}
 
 local s, err = f:sighandler {
     sigmask = { posix.SIGINT, posix.SIGTERM },

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -176,6 +176,41 @@ wreck:verbose ("%4.03fs: Registered jobid %d\n", tt:get0(), jobid)
 local lwj, err = f:kvsdir ("lwj.%d", jobid)
 if not lwj then wreck:die ("f:kvsdir(lwj.%d): %s\n", jobid, err) end
 
+--
+--  Check if job state is "complete" and all IO from tasks have closed:
+--
+local function check_job_completed ()
+    if state == "failed" then
+       log:dump()
+       wreck:die ("job %d failed\n", jobid)
+    end
+    if (not taskio or taskio:complete()) and
+       (state == "complete" or state == "reaped") then
+        local rc = lwj_return_code (f, wreck, jobid)
+        if rc == 0 then
+            wreck:verbose ("All tasks completed successfully.\n");
+        end
+        os.exit (rc)
+    end
+end
+
+
+--
+--  Install watcher for this job's state before issuing any run request,
+--  (So that no state events are missed)
+--
+local kw, err = f:kvswatcher  {
+    key = string.format ("lwj.%d.state", jobid),
+    handler = function (kw, result)
+        if result then
+            state = result
+            wreck:verbose ("%-4.03fs: State = %s\n", tt:get0(), result)
+            check_job_completed ()
+        end
+    end
+}
+
+
 --if wreck:getopt ("i") then
 -- Always run in "immediate" mode for now:
 if true then
@@ -215,24 +250,6 @@ else
 end
 
 --
---  Check if job state is "complete" and all IO from tasks have closed:
---
-local function check_job_completed ()
-    if state == "failed" then
-       log:dump()
-       wreck:die ("job %d failed\n", jobid)
-    end
-    if taskio:complete() and
-       (state == "complete" or state == "reaped") then
-        local rc = lwj_return_code (f, wreck, jobid)
-        if rc == 0 then
-            wreck:verbose ("All tasks completed successfully.\n");
-        end
-        os.exit (rc)
-    end
-end
-
---
 --  Open output to all tasks:
 --
 taskio, err = ioattach {
@@ -264,20 +281,6 @@ f:iowatcher {
     handler = function (iow, data)
         if data.data then kz:write (data.data) end
         if data.eof  then kz:close ()          end
-    end
-}
-
---
---  Finally, a kvswatcher for the LWJ state:
---
-local kw, err = f:kvswatcher  {
-    key = string.format ("lwj.%d.state", jobid),
-    handler = function (kw, result)
-        if result then
-            state = result
-            wreck:verbose ("%-4.03fs: State = %s\n", tt:get0(), result)
-            check_job_completed ()
-        end
     end
 }
 

--- a/src/modules/wreck/lua.d/input.lua
+++ b/src/modules/wreck/lua.d/input.lua
@@ -173,7 +173,7 @@ function input_start (f, input)
     f:iowatcher {
         fd = input.fd,
         handler = function (iow, r)
-            input.kz:write (r.data)
+            if r.data then input.kz:write (r.data) end
             if r.eof then input.kz:close () end
         end
     }

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -872,12 +872,16 @@ static void prog_ctx_kz_err_open (struct prog_ctx *ctx)
 {
     int n;
     char key [64];
+    int kz_flags =
+        KZ_FLAGS_NOCOMMIT_OPEN |
+        KZ_FLAGS_NOCOMMIT_CLOSE |
+        KZ_FLAGS_WRITE;
 
     n = snprintf (key, sizeof (key), "lwj.%ju.log.%d",
                   (uintmax_t) ctx->id, ctx->nodeid);
     if ((n < 0) || (n > sizeof (key)))
         wlog_fatal (ctx, 1, "snprintf: %s", flux_strerror (errno));
-    if (!(ctx->kz_err = kz_open (ctx->flux, key, KZ_FLAGS_WRITE)))
+    if (!(ctx->kz_err = kz_open (ctx->flux, key, kz_flags)))
         wlog_fatal (ctx, 1, "kz_open (%s): %s", key, flux_strerror (errno));
 }
 

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -265,6 +265,10 @@ test_expect_success 'wreck plugins can use wreck:log_msg()' '
 test_expect_success 'wreckrun: --detach supported' '
 	flux wreckrun --detach /bin/true | grep "^[0-9]"
 '
+test_expect_success 'wreckrun: --wait-until supported' '
+	flux wreckrun -v --wait-until=complete /bin/true >wuntil.out 2>wuntil.err &&
+	tail -1 wuntil.err | grep "complete"
+'
 
 WAITFILE="$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua"
 


### PR DESCRIPTION
This is a list of minor fixes and workarounds encountered during scale testing of program launch. Most notable is the kludge to workaround use of hostlist for lists of tasks (eventually we'll use something more apt), and a convenience option for `flux wreckrun` to avoid processing stdio and task exit states, but simply wait until a job reaches a given state (`--wait-until=state`).

The kvs_watch for lwj.state is moved before the run request event, mainly to support `--wait-until` but also because it was found to be confusing to have "missing" states in verbose output during large scale program launch.