### PR TITLE
broker/hello: fix leak/error detection in flux_rpc

### DIFF
--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -277,6 +277,7 @@ static void r_sink (flux_reduce_t *r, int batch, void *arg)
  */
 static void r_forward (flux_reduce_t *r, int batch, void *arg)
 {
+    flux_rpc_t *rpc;
     hello_t *hello = arg;
     int count = (uintptr_t)flux_reduce_pop (r);
     JSON in = Jnew ();
@@ -286,9 +287,10 @@ static void r_forward (flux_reduce_t *r, int batch, void *arg)
 
     Jadd_int (in, "count", count);
     Jadd_int (in, "batch", batch);
-    if (flux_rpc (hello->h, "hello.join", Jtostr (in),
-                  FLUX_NODEID_UPSTREAM, FLUX_RPC_NORESPONSE) < 0)
+    if (!(rpc = flux_rpc (hello->h, "hello.join", Jtostr (in),
+                          FLUX_NODEID_UPSTREAM, FLUX_RPC_NORESPONSE)))
         log_err_exit ("hello: flux_rpc");
+    flux_rpc_destroy (rpc);
     Jput (in);
 }
 


### PR DESCRIPTION
The flux_rpc() use in broker/hello.c seemed to assume integer return
and tested for error code `< 0`. Fix the call so that the flux_rpc_t
returned from the call is captured, and test for NULL on error.

This also allows the rpc object to be freed, fixing a small leak.

I don't know why this is not a compilation error, or why `cppcheck` didn't catch the leak. If I missed something simple there, I apologize in advance.