### PR TITLE
experimental aggregator module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,7 @@ AC_CONFIG_FILES( \
   src/modules/wreck/Makefile \
   src/modules/resource-hwloc/Makefile \
   src/modules/cron/Makefile \
+  src/modules/aggregator/Makefile \
   src/test/Makefile \
   src/test/kap/Makefile \
   etc/Makefile \

--- a/etc/rc1
+++ b/etc/rc1
@@ -6,6 +6,7 @@ flux module load -r all barrier
 flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
+flux module load -r all aggregator
 
 #flux module load -r all live --barrier-count=$(flux getattr size)
 flux module load -r all resource-hwloc & pids="$pids $!"

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -57,6 +57,7 @@ luamod_ldflags = \
 
 luamod_libadd = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(top_builddir)/src/modules/barrier/libflux-barrier.la \
 	$(top_builddir)/src/modules/libkz/libkz.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -2012,8 +2012,34 @@ static int l_kz_read (lua_State *L)
     return (1);
 }
 
+static int l_exitstatus (lua_State *L)
+{
+    int status = lua_tointeger (L, -1);
+    if (WIFEXITED (status)) {
+        lua_pushliteral (L, "exited");
+        lua_pushinteger (L, WEXITSTATUS (status));
+        return 2;
+    }
+    else if (WIFSIGNALED (status)) {
+        lua_pushliteral (L, "killed");
+        lua_pushinteger (L, WTERMSIG (status));
+        if (WCOREDUMP (status)) {
+            lua_pushstring (L, "core dumped");
+            return 3;
+        }
+        return 2;
+    }
+    else if (WIFSTOPPED (status)) {
+        lua_pushliteral (L, "stopped");
+        lua_pushinteger (L, WSTOPSIG (status));
+        return 2;
+    }
+    return (lua_pusherror (L, "Unable to decode exit status 0x%04x", status));
+}
+
 static const struct luaL_Reg flux_functions [] = {
     { "new",             l_flux_new         },
+    { "exitstatus",      l_exitstatus       },
     { NULL,              NULL              }
 };
 

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -393,7 +393,6 @@ int l_flux_kvs_get (lua_State *L)
     return (1);
 }
 
-#if 0
 static int l_flux_barrier (lua_State *L)
 {
     flux_t f = lua_get_flux (L, 1);
@@ -401,7 +400,6 @@ static int l_flux_barrier (lua_State *L)
     int nprocs = luaL_checkinteger (L, 3);
     return (l_pushresult (L, flux_barrier (f, name, nprocs)));
 }
-#endif
 
 static int l_flux_rank (lua_State *L)
 {
@@ -2029,7 +2027,7 @@ static const struct luaL_Reg flux_methods [] = {
     { "kvs_put",         l_flux_kvs_put     },
     { "kvs_get",         l_flux_kvs_get     },
     { "kvs_unlink",      l_flux_kvs_unlink  },
-//    { "barrier",         l_flux_barrier     },
+    { "barrier",         l_flux_barrier     },
     { "send",            l_flux_send        },
     { "recv",            l_flux_recv        },
     { "recvmsg",         l_flux_recvmsg     },

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -37,6 +37,7 @@ local lwj_options = {
     ['stop-children-in-exec'] = "Start tasks in STOPPED state for debugger",
     ['no-pmi-server'] =         "Do not start simple-pmi server",
     ['trace-pmi-server'] =      "Log simple-pmi server protocol exchange",
+    ['no-aggregate-task-exit'] ="Do not use aggregator for task exit messages",
 }
 
 local default_opts = {

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -420,11 +420,11 @@ local function exit_status_aggregate (arg)
     local s, max, core = flux.exitstatus (exit_status.max)
     if s == "killed" then max = max + 128 end
 
-    for v in exit_status.values:keys () do
+    for ids,v in pairs (exit_status.entries) do
         local msg, code, core = flux.exitstatus (v)
         s = "exited with "
         s = s .. (msg == "exited" and "exit code " or "signal ") .. code
-        msgs [s] = hostlist.new (exit_status.values [v])
+        msgs [s] = hostlist.new (ids)
     end
 
     return max, msgs

--- a/src/bindings/lua/wreck/io.lua
+++ b/src/bindings/lua/wreck/io.lua
@@ -169,7 +169,7 @@ local function ioplex_taskid_start (self, flux, taskid, stream)
     if not iow then
         self:log ("ignoring %s: %s", key, err)
         -- remove reference count
-        f:close ()
+        of:close ()
     end
 end
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -56,7 +56,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-exec \
 	flux-topo \
 	flux-ps \
-	flux-cron
+	flux-cron \
+	flux-aggregate
 
 if HAVE_PYTHON
 dist_fluxcmd_SCRIPTS+= \

--- a/src/cmd/flux-aggregate
+++ b/src/cmd/flux-aggregate
@@ -1,0 +1,150 @@
+#!/usr/bin/env lua
+--[[--------------------------------------------------------------------------
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ ---------------------------------------------------------------------------]]
+ --
+ -- flux-aggregate: test aggregator module
+ --
+local flux = require 'flux'
+local timer = require 'flux.timer'
+local getopt = require 'flux.alt_getopt'.get_opts
+
+local prog = string.match (arg[0], "([^/]+)$")
+local shortprog = prog:match ("flux%-(.+)$")
+
+local function printf (...)
+    io.stdout:write (string.format (...))
+end
+
+local function die (...)
+    io.stderr:write (prog..": " .. string.format (...))
+    os.exit (1)
+end
+
+---
+-- Synchronously subscribe to topic on flux handle f
+--
+local function synchronous_subscribe (f, topic)
+    f:subscribe (topic)
+    f:sendevent (topic .. ".test")
+    local msg, t = f:recv_event ()
+    if not msg or t ~= topic..".test" then
+        die ("error waiting for event subscribe: %s\n", t)
+    end
+end
+
+--
+--  parse options, get key and value
+--
+local opts, optind = getopt (arg, "ht:c:",
+                             { help = "h", timeout = "t", count = "c" })
+local key = arg[optind]
+local value = arg[optind+1]
+
+if opts.h then
+    printf ("Usage: %s [OPTIONS] KEY VALUE\n", prog)
+    printf (" -h, --help         Display this message.\n")
+    printf (" -t, --timeout=T    Set reduction timeout to T seconds.\n")
+    printf (" -c, --fwd-count=N  Forward aggregate upstream after N.\n")
+    os.exit (0)
+end
+
+if not key or not value then
+    die ("Usage: %s [OPTIONS] KEY VALUE\n", prog)
+end
+
+
+io.stdout:setvbuf ('line')
+
+local tt
+local f, err = flux.new ()
+if not f then die ("flux_open: %s\n", err) end
+
+-- 
+-- rank 0: Watch for result in KVS
+--
+if tonumber (f.rank) == 0 then
+  -- unlink target, then install watcher
+  -- Ignore `.` which is special case for testing
+  if key ~= "." then
+      f:kvs_unlink (key)
+      f:kvs_commit ()
+  end
+
+  local topic = "aggregator.abort."..key
+  tt = timer.new ()
+  synchronous_subscribe (f, topic)
+  printf ("%s: synchronous subscribe took %.3fms\n", shortprog, 1000*tt:get0 ())
+
+  tt = timer.new ()
+  local mw, err = f:msghandler {
+      pattern = "aggregator.abort." .. key,
+      msgtypes = { flux.MSGTYPE_EVENT },
+      handler = function (f, msg, mh)
+        die ("aggregate to `%s` aborted!\n", key)
+      end
+  }
+  if not mw then die (err) end
+
+  local kw, err = f:kvswatcher {
+    key = key,
+    isdir = (f:kvs_type (key) == "dir"), -- mainly for testing
+    handler = function (kw, result)
+        if result and not kw.isdir and result.total == result.count then
+            for ids,value in pairs (result.entries) do
+              printf ("%s: %d\n", ids, value)
+            end
+            f:reactor_stop ()
+        end
+    end
+  }
+  if not kw then error (err) end
+  printf ("%s: rank 0 setup took %.3fms\n", shortprog, 1000*tt:get0 ())
+end
+
+tt = timer.new ()
+local rc, err = f:barrier (key, f.size)
+if not rc then die ("barrier: %s\n", err) end
+if f.rank == 0 then
+    printf ("%s: barrier took %.3fs\n", shortprog, tt:get0 ())
+end
+
+tt = timer.new ()
+f:rpc ("aggregator.push", {
+  key = key,
+  total = f.size,
+  timeout = opts.t,
+  fwd_count = opts.c,
+  entries = {
+      [tostring (f.rank)] = tonumber (value),
+  }
+})
+if f.rank == 0 then
+    printf ("%s: push took %.3fms\n", shortprog, tt:get0() * 1000)
+    local tt = timer.new ()
+    local r, err = f:reactor ()
+    if not r then error (err) end
+    printf ("%s: Took %.3fs\n", shortprog, tt:get0())
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -190,7 +190,8 @@ local function check_job_completed ()
        (state == "complete" or state == "reaped") then
         local rc = lwj_return_code (f, wreck, jobid)
         if rc == 0 then
-            wreck:verbose ("All tasks completed successfully.\n");
+            wreck:verbose ("%.3fs: All tasks completed successfully.\n",
+                           tt:get0 ());
         end
         os.exit (rc)
     end

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -9,7 +9,8 @@ SUBDIRS = \
  wreck \
  libjsc \
  resource-hwloc \
- cron
+ cron \
+ aggregator
 
 if HAVE_PYTHON
 # SUBDIRS += pymod

--- a/src/modules/aggregator/Makefile.am
+++ b/src/modules/aggregator/Makefile.am
@@ -1,0 +1,23 @@
+AM_CFLAGS = \
+	@GCCWARN@ \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(JSON_CFLAGS) $(ZMQ_CFLAGS)
+
+#
+# Comms module
+#
+fluxmod_LTLIBRARIES = aggregator.la
+
+aggregator_la_SOURCES = aggregator.c
+aggregator_la_LDFLAGS = $(fluxmod_ldflags) -module
+aggregator_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
+		 $(top_builddir)/src/common/libflux-core.la \
+		 $(top_builddir)/src/modules/kvs/libflux-kvs.la \
+		 $(top_builddir)/src/modules/barrier/libflux-barrier.la \
+		 $(JSON_LIBS) $(ZMQ_LIBS)

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -1,0 +1,554 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* aggregator.c - reduction based numerical aggreagator */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/nodeset.h"
+
+struct aggregator {
+    flux_t h;
+    uint32_t rank;
+    double default_timeout;
+    double timer_scale;
+    zhash_t *aggregates;
+};
+
+/*
+ *  Single entry in an aggregate: a list of ids with a common value.
+ */
+struct aggregate_entry {
+    nodeset_t *ids;
+    int64_t value;
+};
+
+
+/*
+ *  Representation of an aggregate. A unique kvs key, along with a
+ *   list of aggregate entries as above. Each aggregate tracks its
+ *   minimum, maximum, current count and expected total of entries.
+ */
+struct aggregate {
+    struct aggregator *ctx;  /* Pointer back to containing aggregator        */
+    flux_watcher_t *tw;      /* timeout watcher                              */
+    double timeout;          /* timeout                                      */
+    uint32_t fwd_count;      /* forward at this many                         */
+    char *key;               /* KVS key into which to sink the aggregate     */
+    int64_t max;             /* current max value                            */
+    int64_t min;             /* current minimum value                        */
+    uint32_t count;          /* count of current total entries               */
+    uint32_t total;          /* expected total entries (used for sink)       */
+    zlist_t *entries;        /* list of individual entries                   */
+};
+
+static void aggregate_entry_destroy (struct aggregate_entry *ae)
+{
+    if (ae) {
+        nodeset_destroy (ae->ids);
+        free (ae);
+    }
+}
+
+static struct aggregate_entry * aggregate_entry_create (void)
+{
+    struct aggregate_entry *ae = calloc (1, sizeof (*ae));
+    if (ae != NULL)
+        ae->ids = nodeset_create ();
+    return (ae);
+}
+
+
+/*  Search this aggregates entries for a value. Return entry if found
+ */
+static struct aggregate_entry *
+    aggregate_entry_find (struct aggregate *ag, int64_t value)
+{
+    struct aggregate_entry *ae = zlist_first (ag->entries);
+    while (ae) {
+        if (ae->value == value)
+            return (ae);
+        ae = zlist_next (ag->entries);
+    }
+    return (NULL);
+}
+
+
+/*  Add a new entry to this aggregate. Update minimum, maximum.
+ */
+static struct aggregate_entry *
+    aggregate_entry_add (struct aggregate *ag, int64_t value)
+{
+    struct aggregate_entry *ae = aggregate_entry_create ();
+    if (ae) {
+        ae->value = value;
+        if (ag->max < value)
+            ag->max = value;
+        if (ag->min > value)
+            ag->min = value;
+        zlist_push (ag->entries, ae);
+    }
+    return (ae);
+}
+
+/*  Push a new (ids, value) pair onto aggregate `ag`.
+ *   If an existing matching entry is found, add ids to its nodeset.
+ *   o/w, add a new entry. In either case update current count with
+ *   the number of `ids` added.
+ */
+static int aggregate_push (struct aggregate *ag, int64_t value, const char *ids)
+{
+    int count;
+    struct aggregate_entry *ae = aggregate_entry_find (ag, value);
+    if ((ae == NULL) && !(ae = aggregate_entry_add (ag, value)))
+        return (-1);
+
+    count = nodeset_count (ae->ids);
+    if (!nodeset_add_string (ae->ids, ids))
+        return (-1);
+
+    /* Update count */
+    ag->count += (nodeset_count (ae->ids) - count);
+
+    return (0);
+}
+
+/*  Push JSON represenation of an aggregate onto existing aggregate `ag`
+ */
+static int aggregate_push_json (struct aggregate *ag, JSON o)
+{
+    json_object_iter i;
+    int64_t n64;
+    JSON entries = NULL;
+
+    if (ag->total == 0 && (Jget_int64 (o, "total", &n64)))
+        ag->total = n64;
+
+    if (!Jget_obj (o, "entries", &entries)) {
+        flux_log_error (ag->ctx->h, "No object 'entries'");
+        return (-1);
+    }
+
+    json_object_object_foreachC (entries, i) {
+        int64_t val = json_object_get_int64 (i.val);
+        if (aggregate_push (ag, val, i.key) < 0) {
+            flux_log_error (ag->ctx->h, "aggregate_push failed");
+            return (-1);
+        }
+    }
+
+    return (0);
+}
+
+static JSON aggregate_tojson (struct aggregate *ag)
+{
+    struct aggregate_entry *ae;
+    JSON entries, o = Jnew ();
+    Jadd_str (o, "key", ag->key);
+    Jadd_int (o, "count", ag->count);
+    Jadd_int (o, "total", ag->total);
+    Jadd_double (o, "timeout", ag->timeout);
+    Jadd_int64 (o, "min", ag->min);
+    Jadd_int64 (o, "max", ag->max);
+
+    entries = Jnew ();
+    ae = zlist_first (ag->entries);
+    while (ae) {
+        Jadd_int64 (entries, nodeset_string (ae->ids), ae->value);
+        ae = zlist_next (ag->entries);
+    }
+    json_object_object_add (o, "entries", entries);
+
+    return (o);
+}
+
+/*
+ *  Forward aggregate `ag` upstream
+ */
+static int aggregate_forward (flux_t h, struct aggregate *ag)
+{
+    int rc = 0;
+    flux_rpc_t *rpc;
+    uint32_t nodeid = FLUX_NODEID_UPSTREAM;
+    JSON o = aggregate_tojson (ag);
+    flux_log (h, LOG_INFO, "forward: %s: count=%d total=%d\n",
+                 ag->key, ag->count, ag->total);
+    if (!(rpc = flux_rpc (h, "aggregator.push", Jtostr (o),
+                             FLUX_NODEID_UPSTREAM, 0)) ||
+        (flux_rpc_get (rpc, &nodeid, NULL) < 0)) {
+        flux_log_error (h, "flux_rpc (from=%d): aggregator.push", nodeid);
+        rc = -1;
+    }
+    Jput (o);
+    flux_rpc_destroy (rpc);
+    return (rc);
+}
+
+static void aggregate_sink_abort (flux_t h, struct aggregate *ag)
+{
+    flux_msg_t *msg = NULL;
+    char *topic = NULL;
+
+    flux_log (h, LOG_ERR, "sink: aborting aggregate %s\n", ag->key);
+
+    if ((asprintf (&topic, "aggregator.abort.%s", ag->key)) < 0) {
+        flux_log_error (h, "sink_abort: asprintf");
+        goto out;
+    }
+    if ((msg = flux_event_encode (topic, "{ }")) == NULL) {
+        flux_log_error (h, "flux_event_encode");
+        goto out;
+    }
+    if (flux_send (h, msg, 0) < 0)
+        flux_log_error (h, "flux_event_encode");
+out:
+    free (topic);
+    flux_msg_destroy (msg);
+}
+
+static int aggregate_sink (flux_t h, struct aggregate *ag)
+{
+    int rc = 0;
+    JSON o;
+
+    flux_log (h, LOG_INFO, "sink: %s: count=%d total=%d",
+                ag->key, ag->count, ag->total);
+
+    /* Fail on key == "." */
+    if (strcmp (ag->key, ".") == 0) {
+        flux_log (h, LOG_ERR, "sink: refusing to sink to rootdir");
+        return (-1);
+    }
+    if (!(o = aggregate_tojson (ag))) {
+        flux_log (h, LOG_ERR, "sink: aggregate_tojson failed");
+        return (-1);
+    }
+    if ((rc = kvs_put (h, ag->key, Jtostr (o))) < 0) {
+        flux_log_error (h, "sink: kvs_put");
+        goto out;
+    }
+    if ((rc = kvs_commit (h)) < 0)
+        flux_log_error (h, "sink: kvs_commit");
+out:
+    Jput (o);
+    return (rc);
+}
+
+static void aggregate_sink_again (flux_reactor_t *r, flux_watcher_t *w,
+                                  int revents, void *arg)
+{
+    struct aggregate *ag = arg;
+    flux_t h = ag->ctx->h;
+    if (aggregate_sink (h, ag) < 0)
+        aggregate_sink_abort (h, ag);
+    flux_watcher_destroy (w);
+    zhash_delete (ag->ctx->aggregates, ag->key);
+}
+
+
+/*
+ *   Push aggregate to kvs.
+ */
+static void aggregate_try_sink (flux_t h, struct aggregate *ag)
+{
+    if (aggregate_sink (h, ag) < 0) {
+        flux_watcher_t *w;
+        double t = ag->timeout;
+        if (t <= 1e-3)
+            t = .250;
+        flux_log (h, LOG_INFO, "sink: %s: retry  in %.3fs", ag->key, t);
+        /* On failure, retry just once, then abort */
+        w = flux_timer_watcher_create (flux_get_reactor (h),
+                                       t, 0.,
+                                       aggregate_sink_again,
+                                       (void *) ag);
+        if (w == NULL) {
+            flux_log_error (h, "flux_timer_watcher_create");
+            /* Force abort now */
+            aggregate_sink_abort (h, ag);
+            return;
+        }
+        flux_watcher_start (w);
+        return;
+    }
+    zhash_delete (ag->ctx->aggregates, ag->key);
+    return;
+}
+
+/*
+ *  Flush aggregate `ag` -- forward entry upstream and destroy it locally.
+ */
+static int aggregate_flush (struct aggregate *ag)
+{
+    flux_t h = ag->ctx->h;
+    int rc;
+    assert (ag->ctx->rank != 0);
+    rc = aggregate_forward (h, ag);
+    zhash_delete (ag->ctx->aggregates, ag->key);
+    return (rc);
+}
+
+static void aggregate_destroy (struct aggregate *ag)
+{
+    struct aggregate_entry *ae = zlist_first (ag->entries);
+    while (ae) {
+        aggregate_entry_destroy (ae);
+        ae = zlist_next (ag->entries);
+    }
+    zlist_destroy (&ag->entries);
+    flux_watcher_destroy (ag->tw);
+    free (ag->key);
+    free (ag);
+}
+
+static void timer_cb (flux_reactor_t *r, flux_watcher_t *tw,
+                      int revents, void *arg)
+{
+    if (aggregate_flush (arg) < 0) {
+        flux_t h = ((struct aggregate *) arg)->ctx->h;
+        flux_log_error (h, "aggregate_flush");
+    }
+}
+
+static void aggregate_timer_start (struct aggregator *ctx,
+                                   struct aggregate *ag,
+                                   double timeout)
+{
+    if (ctx->rank != 0) {
+        flux_t h = ctx->h;
+        flux_reactor_t *r = flux_get_reactor (h);
+        ag->tw = flux_timer_watcher_create (r, timeout, 0.,
+                                            timer_cb, (void *) ag);
+        if (ag->tw == NULL)
+            flux_log_error (h, "flux_timer_watcher_create");
+        flux_watcher_start (ag->tw);
+    }
+}
+
+static struct aggregate *
+    aggregate_create (struct aggregator *ctx, const char *key)
+{
+    flux_t h = ctx->h;
+
+    struct aggregate *ag = calloc (1, sizeof (*ag));
+    if (ag == NULL)
+        return NULL;
+
+    ag->ctx = ctx;
+    if (!(ag->key = strdup (key)) || !(ag->entries = zlist_new ())) {
+        flux_log_error (h, "aggregate_create: memory allocation error");
+        aggregate_destroy (ag);
+        return (NULL);
+    }
+    return (ag);
+}
+
+static void aggregator_destroy (struct aggregator *ctx)
+{
+    if (ctx) {
+        zhash_destroy (&ctx->aggregates);
+        free (ctx);
+    }
+}
+
+static int attr_get_int (flux_t h, const char *attr)
+{
+    unsigned long l;
+    char *p;
+    const char *s = flux_attr_get (h, attr, 0);
+    if (!s)
+        return (-1);
+    errno = 0;
+    l = strtoul (s, &p, 10);
+    if (*p != '\0' || errno != 0) {
+        flux_log_error (h, "flux_attr_get (%s) = %s", attr, s);
+        return (-1);
+    }
+    return (l);
+}
+
+static double timer_scale (flux_t h)
+{
+    long level, maxlevel;
+    if (((level = attr_get_int (h, "tbon.level")) < 0) ||
+        ((maxlevel = attr_get_int (h, "tbon.maxlevel")) < 0)) {
+        return (1.);
+    }
+    return (maxlevel - level + 1.);
+}
+
+static struct aggregator * aggregator_create (flux_t h)
+{
+    struct aggregator * ctx = calloc (1, sizeof (*ctx));
+    if (ctx == NULL)
+        return (NULL);
+    ctx->h = h;
+    if (flux_get_rank (h, &ctx->rank) < 0) {
+        flux_log_error (h, "flux_get_rank");
+        goto error;
+    }
+    ctx->default_timeout = 0.01;
+    ctx->timer_scale = timer_scale (h);
+    if (!(ctx->aggregates = zhash_new ())) {
+        flux_log_error (h, "zhash_new");
+        goto error;
+    }
+    return (ctx);
+error:
+    aggregator_destroy (ctx);
+    return (NULL);
+}
+
+/*
+ *  Add a new aggregate to aggregator `ctx`. Insert into entries
+ *   hash and set default minimum and maximum. Start the aggregate
+ *   timeout, scaled by the current aggregator timeout scale.
+ */
+static struct aggregate *
+aggregator_new_aggregate (struct aggregator *ctx, const char *key,
+                          double timeout)
+{
+    struct aggregate *ag = aggregate_create (ctx, key);
+    if (ag == NULL)
+        return (NULL);
+
+    if (zhash_insert (ctx->aggregates, key, ag) < 0) {
+        aggregate_destroy (ag);
+        return (NULL);
+    }
+    zhash_freefn (ctx->aggregates, key, (zhash_free_fn *) aggregate_destroy);
+    ag->min = LLONG_MAX;
+    ag->max = LLONG_MIN;
+    ag->timeout = timeout;
+    aggregate_timer_start (ctx, ag, timeout * ctx->timer_scale);
+    return (ag);
+}
+
+
+/*
+ *  Callback for "aggregator.push"
+ */
+static void push_cb (flux_t h, flux_msg_handler_t *w,
+                     const flux_msg_t *msg, void *arg)
+{
+    int rc = -1;
+    struct aggregator *ctx = arg;
+    struct aggregate *ag = NULL;
+    const char *json_str;
+    JSON in = NULL;
+    const char *key;
+    double timeout = ctx->default_timeout;
+    int64_t fwd_count = 0;
+    int saved_errno = 0;
+
+    if (flux_request_decode (msg, NULL, &json_str) < 0) {
+        saved_errno = EPROTO;
+        flux_log_error (h, "push: request decode");
+        goto done;
+    }
+    if (!(in = Jfromstr (json_str))) {
+        saved_errno = EPROTO;
+        flux_log_error (h, "push: json decode");
+        goto done;
+    }
+    if (!(Jget_str (in, "key", &key))) {
+        saved_errno = EPROTO;
+        flux_log_error (h, "push: key missing");
+        goto done;
+    }
+    // Allow request to override default aggregate timeout
+    Jget_double (in,  "timeout", &timeout);
+    Jget_int64 (in, "fwd_count", &fwd_count);
+
+    if (!(ag = zhash_lookup (ctx->aggregates, key)) &&
+        !(ag = aggregator_new_aggregate (ctx, key, timeout))) {
+        flux_log_error (ctx->h, "failed to get new aggregate");
+        saved_errno = errno;
+        goto done;
+    }
+
+    if (fwd_count > 0)
+        ag->fwd_count = fwd_count;
+
+    if ((rc = aggregate_push_json (ag, in)) < 0)
+        goto done;
+
+    flux_log (ctx->h, LOG_INFO, "push: %s: count=%d fwd_count=%d total=%d",
+                      ag->key, ag->count, ag->fwd_count, ag->total);
+    if (ctx->rank > 0) {
+        if ((ag->count == ag->total
+            || ag->count == ag->fwd_count
+            || timeout == 0.)
+            && (rc = aggregate_flush (ag)))
+            goto done;
+    }
+    else if (ag->count == ag->total)
+        aggregate_try_sink (h, ag);
+    rc = 0;
+done:
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, NULL) < 0)
+        flux_log_error (h, "aggregator.push: flux_respond");
+    Jput (in);
+}
+
+
+static struct flux_msg_handler_spec htab[] = {
+    //{ FLUX_MSGTYPE_EVENT,      "hb",               hb_cb },
+    { FLUX_MSGTYPE_REQUEST,   "aggregator.push",  push_cb },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int mod_main (flux_t h, int argc, char **argv)
+{
+    int rc = -1;
+    struct aggregator *ctx = aggregator_create (h);
+    if (!ctx)
+        goto done;
+
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log_error (h, "flux_msg_handler_advec");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done_delvec;
+    }
+    rc = 0;
+done_delvec:
+    flux_msg_handler_delvec (htab);
+done:
+    return rc;
+}
+
+MOD_NAME ("aggregator");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -52,7 +52,8 @@ wrexecd_libs = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/modules/libkz/libkz.la \
-	$(top_builddir)/src/modules/kvs/libflux-kvs.la
+	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(top_builddir)/src/modules/barrier/libflux-barrier.la
 
 wrexecd_LDADD = \
 	$(wrexecd_libs) \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -59,6 +59,7 @@ TESTS = \
 	t2005-hwloc-basic.t \
 	t2006-joblog.t \
 	t2007-caliper.t \
+	t2100-aggregate.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
@@ -123,6 +124,7 @@ check_SCRIPTS = \
 	t2005-hwloc-basic.t \
 	t2006-joblog.t \
 	t2007-caliper.t \
+	t2100-aggregate.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
         issues/t0441-kvs-put-get.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -184,6 +184,7 @@ dist_check_DATA = \
 dist_check_SCRIPTS = \
 	scripts/event-trace.lua \
 	scripts/kvs-watch-until.lua \
+	scripts/kvs-get-ex.lua \
 	scripts/cpus-allowed.lua \
 	scripts/waitfile.lua \
 	scripts/t0004-event-helper.sh \

--- a/t/rc/rc1-wreck
+++ b/t/rc/rc1-wreck
@@ -6,6 +6,7 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 
+flux module load -r all barrier
 flux module load -r all aggregator
 flux module load -r all job
 flux module load -r all wrexec

--- a/t/rc/rc1-wreck
+++ b/t/rc/rc1-wreck
@@ -6,5 +6,6 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 
+flux module load -r all aggregator
 flux module load -r all job
 flux module load -r all wrexec

--- a/t/scripts/kvs-get-ex.lua
+++ b/t/scripts/kvs-get-ex.lua
@@ -1,0 +1,47 @@
+#!/usr/bin/env lua
+--
+--  Get a json key from kvs and execute Lua CODE on result
+--
+local usage = [[
+Usage: kvs-get-ex KEY CODE
+
+Get kvs key KEY and execute Lua CODE where x == result.
+]]
+
+local f =      require 'flux' .new()
+
+local function printf (...)
+    io.stdout:write (string.format (...))
+end
+local function die (...)
+    io.stderr:write (string.format (...))
+    os.exit (1)
+end
+
+local optind = 1
+local key = arg [optind]
+local callback = arg [optind+1]
+
+if not key or not callback then
+    die ("Failed to get KEY or CODE\n%s", usage)
+end
+
+callback = "return function (x)  return "..callback.." end"
+local fn, err = loadstring (callback, "callback")
+if not fn then
+    die ("code compile error: %s", err)
+end
+local cb = fn ()
+
+local result, err = f:kvs_get (key)
+if not result then
+    die ("kvs_get (%s): %s\n", key, err)
+end
+
+local ok, rv = pcall (cb, result)
+if not ok then error (rv) end
+if not ok or rv == false then
+    os.exit (1)
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/t2100-aggregate.t
+++ b/t/t2100-aggregate.t
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+test_description='Test basic flux aggreagation via aggregator module'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 8 wreck
+
+kvscheck="$SHARNESS_TEST_SRCDIR/scripts/kvs-get-ex.lua"
+
+test_expect_success 'have aggregator module' '
+    flux module list -r all | grep aggregator
+'
+
+test_expect_success 'flux-aggreagate: works' '
+    run_timeout 2 flux exec -r 0-7 flux aggregate test 1 &&
+    $kvscheck test "x.count == 8"
+'
+
+test_expect_success 'flux-aggregate: abort works' '
+    test_expect_code 1 run_timeout 5 flux exec -r 0-7 flux aggregate . 1
+'
+
+test_expect_success 'flux-aggregate: different value per rank' '
+    run_timeout 2 flux exec -r 0-7 bash -c "flux aggregate test \$(flux getattr rank)" &&
+    $kvstest test "x.count == 8" &&
+    $kvstest test "x.min == 0" &&
+    $kvstest test "x.max == 7"
+'
+
+test_expect_success 'flux-aggregate: --timeout=0. - immediate forward' '
+    run_timeout 2 flux exec -r 0-7 flux aggregate -t 0. test 1 &&
+    $kvstest test "x.count == 8" &&
+    $kvstest test "x.total == 8" &&
+    $kvstest test "x.min == 1" &&
+    $kvstest test "x.max == 1"
+'
+
+test_expect_success 'flux-aggregate: --fwd-count works' '
+    run_timeout 2 flux exec -r 0-7 bash -c \
+     "flux aggregate -t10 -c \$((1+\$(flux getattr tbon.descendants))) test 1" &&
+    $kvstest test "x.count == 8" &&
+    $kvstest test "x.total == 8" &&
+    $kvstest test "x.min == 1" &&
+    $kvstest test "x.max == 1"
+'
+
+
+test_done
+
+# vi: ts=4 sw=4 expandtab
+


### PR DESCRIPTION
For comment only. The purpose of this experiment is to play with the reduction/aggregation interface for possible use with wrexec task exit status. The PR is posted early to assist with design of generic reduction handle, get early feedback,e tc.

The current `aggregator` module reduces set of `id, value` pairs into a kvs directory with the contents:
```
key.max
key.min
key.count
key.values.
```
Where the `key.values` directory has one entry per value, with the contents of each values entry a nodelist of ids that reported that value.

A `flux-aggregate` test command is also available for testing aggregation of a value across a session (currently version assumes one value per rank, i.e. run `flux aggregate <key> <value>` once per rank) The `flux-aggregate` command running on rank 0 waits for the result in the given key and reports the result e.g:
```
$ flux exec -r 0-127 sh -c 'flux aggregate test1 $(flux getattr size)'
[0-127]: 128

$ flux exec -r 0-127 sh -c 'flux aggregate testkey $(flux getattr tbon.level)' | sort -k2,2n
0: 0
[1-2]: 1
[3-6]: 2
[7-14]: 3
[15-30]: 4
[31-62]: 5
[63-126]: 6
127: 7

$ flux kvs dir -r testkey
testkey.min = 0
testkey.max = 7
testkey.count = 128
testkey.values.7 = 127
testkey.values.1 = [1-2]
testkey.values.5 = [31-62]
testkey.values.6 = [63-126]
testkey.values.3 = [7-14]
testkey.values.4 = [15-30]
testkey.values.2 = [3-6]
testkey.values.0 = 0
```

The module is designed to have a single service `aggregator.push`, which accepts a JSON representation of an "aggregate" and either creates a new aggregate and hashes it by kvs key, or merges the incoming JSON with an existing matching aggregate. 

When a new aggregate is seen, this starts a timer, after which the current aggregate is forwarded upstream and its state is immediately destroyed.

On rank 0, a timer is not used, instead the aggregate is written to the kvs once `aggregate->count == aggregate->total`.