### PR TITLE
python: Several fixes for the bindings

### DIFF
--- a/src/bindings/python/flux/constants.py
+++ b/src/bindings/python/flux/constants.py
@@ -31,3 +31,8 @@ FLUX_SEC_TYPE_MUNGE = 4
 FLUX_SEC_TYPE_ALL = 7
 
 FLUX_MATCHTAG_NONE = 0
+
+# constants for FDWatchers's 'events' arg
+FLUX_POLLIN = 1
+FLUX_POLLOUT = 2
+FLUX_POLLOUT = 4

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -3,8 +3,7 @@ from flux.core.inner import raw, ffi, lib
 import flux.message
 import abc
 
-__all__ = ['MessageWatcher', 'TimerWatcher']
-
+__all__ = ['MessageWatcher', 'TimerWatcher', 'FDWatcher']
 
 class Watcher(object):
     __metaclass__ = abc.ABCMeta

--- a/src/bindings/python/flux/jsc.py
+++ b/src/bindings/python/flux/jsc.py
@@ -1,9 +1,48 @@
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux._jsc import ffi, lib
 
+# Constants taken from jstatctl.h
+JSC_STATE_PAIR                 = "state-pair"
+JSC_STATE_PAIR_OSTATE          = "ostate"
+JSC_STATE_PAIR_NSTATE          = "nstate"
+JSC_RDESC                      = "rdesc"
+JSC_RDESC_NNODES               = "nnodes"
+JSC_RDESC_NTASKS               = "ntasks"
+JSC_RDESC_WALLTIME             = "walltime"
+JSC_RDL                        = "rdl"
+JSC_RDL_ALLOC                  = "rdl_alloc"
+JSC_RDL_ALLOC_CONTAINED        = "contained"
+JSC_RDL_ALLOC_CONTAINING_RANK  = "cmbdrank"
+JSC_RDL_ALLOC_CONTAINED_NCORES = "cmbdncores"
+JSC_PDESC                      = "pdesc"
+JSC_PDESC_SIZE                 = "procsize"
+JSC_PDESC_HOSTNAMES            = "hostnames"
+JSC_PDESC_EXECS                = "executables"
+JSC_PDESC_PDARRAY              = "pdarray"
+JSC_PDESC_RANK_PDARRAY_PID     = "pid"
+JSC_PDESC_RANK_PDARRAY_HINDX   = "hindx"
+JSC_PDESC_RANK_PDARRAY_EINDX   = "eindx"
+
+J_NULL       = 1
+J_RESERVED   = 2
+J_SUBMITTED  = 3
+J_PENDING    = 4
+J_SCHEDREQ   = 5
+J_SELECTED   = 6
+J_ALLOCATED  = 7
+J_RUNREQUEST = 8
+J_STARTING   = 9
+J_STOPPED    = 10
+J_RUNNING    = 11
+J_CANCELLED  = 12
+J_COMPLETE   = 13
+J_REAPED     = 14
+J_FAILED     = 15
+J_FOR_RENT   = 16
+
 class JSCWrapper(Wrapper):
-  """ 
-  Generic JSC wrapper, you probably do not want or need one of these.
+  """
+  Generic JSC wrapper
   """
 
   def __init__(self):
@@ -14,5 +53,40 @@ class JSCWrapper(Wrapper):
           'jsc_',
           ])
 
-raw = JSCWrapper()
+_raw = JSCWrapper()
 
+def query_jcb(flux_handle, jobid, key):
+  jcb_str = ffi.new('char *[1]')
+  _raw.query_jcb(flux_handle, jobid, key, jcb_str)
+  if jcb_str[0] == ffi.NULL:
+    return None
+  else:
+    return ffi.string(jcb_str[0])
+
+def update_jcb(flux_handle, jobid, key, jcb):
+  return _raw.jsc_update_jcb(flux_handle, jobid, key, jcb)
+
+@ffi.callback('jsc_handler_f')
+def JSCNotifyWrapper(jcb, arg, errnum):
+  if jcb != ffi.NULL:
+    jcb = ffi.string(jcb)
+  cb, real_arg = ffi.from_handle(arg)
+  # TODO: necessary to check errnum?
+  ret = cb(jcb, real_arg, errnum)
+  return ret if ret is not None else 0
+
+handles = []
+
+def notify_status(flux_handle, fun, arg):
+  warg = (fun, arg)
+  whandle = ffi.new_handle(warg)
+  # TODO: another way to keep in scope to prevent GC?
+  handles.append(whandle)
+  return _raw.notify_status(flux_handle, JSCNotifyWrapper, whandle)
+
+def job_num2state(job_state):
+  ret = _raw.job_num2state(job_state)
+  if ret == ffi.NULL:
+    return None
+  else:
+    return ffi.string(ret)

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -141,6 +141,7 @@ class FunctionWrapper(object):
 
     def __call__(self, calling_object, *args_in):
         # print holder.__name__, 'got', calling_object, args_in
+        calling_object.ffi.errno = 0
         if self.trans_len == 0:
             try:
                 if self.add_handle:

--- a/src/bindings/python/test/kvs.py
+++ b/src/bindings/python/test/kvs.py
@@ -37,7 +37,7 @@ class TestKVS(unittest.TestCase):
         return kd
 
     def test_set_none(self):
-        with self.assertRaises(KeyError):
+        with self.assertRaises(EnvironmentError):
             self.set_and_check_context('None', None)
 
     def test_set_int(self):


### PR DESCRIPTION
Several python binding fixes wrapped into one PR:
- Add constants for FDWatcher
- Switch kvs.py to use the latest KVS interface (remove use of json-c)
- Add interface to JSC

Fixes #793 