### PR TITLE
add KVS blobref access functions

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -111,6 +111,22 @@ Tell the local KVS to drop any cache it is holding.
 Send an event across the comms session instructing all KVS instances
 to drop their caches.
 
+*copy* 'source' 'destination':: 
+Copy 'source' key to 'destination' key.  If a directory is copied, a new
+reference is created; it is unnecessary for *copy* to recurse into 'source'.
+
+*move* 'source' 'destination':: 
+Like *copy*, but 'source' is unlinked after the copy.
+
+*get-treeobj* 'key'::
+Retrieve the directory entry associated with 'key'.
+A treeobj should be treated as an opaque string value, which
+may contain spaces.
+
+*put-treeobj* 'key="treeobj"'::
+Associate a new treeobj with 'key', overwriting the previous treeobj,
+if any.  A treeobj should be treated as an opaque string value, which
+may contain spaces.
 
 AUTHOR
 ------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -322,3 +322,6 @@ appname
 maxlevel
 wireup
 hwm
+recurse
+treeobj
+unlinked

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -64,6 +64,8 @@ void cmd_copy (flux_t h, int argc, char **argv);
 void cmd_move (flux_t h, int argc, char **argv);
 void cmd_dir (flux_t h, int argc, char **argv);
 void cmd_dirsize (flux_t h, int argc, char **argv);
+void cmd_get_treeobj (flux_t h, int argc, char **argv);
+void cmd_put_treeobj (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -89,6 +91,8 @@ void usage (void)
 "       flux-kvs wait            version\n"
 "       flux-kvs dropcache\n"
 "       flux-kvs dropcache-all\n"
+"       flux-kvs get-treeobj     key\n"
+"       flux-kvs put-treeobj     key=treeobj\n"
 );
     exit (1);
 }
@@ -158,6 +162,10 @@ int main (int argc, char *argv[])
         cmd_dir (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "dirsize"))
         cmd_dirsize (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "get-treeobj"))
+        cmd_get_treeobj (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "put-treeobj"))
+        cmd_put_treeobj (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -626,6 +634,33 @@ void cmd_move (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_move %s %s", argv[0], argv[1]);
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+}
+
+void cmd_get_treeobj (flux_t h, int argc, char **argv)
+{
+    char *treeobj = NULL;
+    if (argc != 1)
+        log_msg_exit ("get-treeobj: specify key");
+    if (kvs_get_treeobj (h, argv[0], &treeobj) < 0)
+        log_err_exit ("kvs_get_treeobj %s", argv[0]);
+    printf ("%s\n", treeobj);
+    free (treeobj);
+}
+
+void cmd_put_treeobj (flux_t h, int argc, char **argv)
+{
+    if (argc != 1)
+        log_msg_exit ("put-treeobj: specify key=val");
+    char *key = xstrdup (argv[0]);
+    char *val = strchr (key, '=');
+    if (!val)
+        log_msg_exit ("put-treeobj: you must specify a value as key=val");
+    *val++ = '\0';
+    if (kvs_put_treeobj (h, key, val) < 0)
+        log_err_exit ("kvs_put_treeobj %s=%s", key, val);
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+
 }
 
 /*

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -14,6 +14,8 @@ json_object *dirent_create (char *type, void *arg);
  */
 void dirent_append (json_object **array, const char *key, json_object *dirent);
 
+int dirent_validate (json_object *dirent);
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -91,6 +91,10 @@ int kvs_put_int64 (flux_t h, const char *key, int64_t val);
 int kvs_put_double (flux_t h, const char *key, double val);
 int kvs_put_boolean (flux_t h, const char *key, bool val);
 
+/* As above but associate a preconstructed treeobj with key.
+ */
+int kvs_put_treeobj (flux_t h, const char *key, const char *treeobj);
+
 /* An iterator interface for walking the list of names in a kvsdir_t
  * returned by kvs_get_dir().  kvsitr_create() always succeeds.
  * kvsitr_next() returns NULL when the last item is reached.

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -43,6 +43,10 @@ int kvs_get_double (flux_t h, const char *key, double *valp);
 int kvs_get_boolean (flux_t h, const char *key, bool *valp);
 int kvs_get_symlink (flux_t h, const char *key, char **valp);
 
+/* Get treeobj associated with a key.  Caller must free.
+ */
+int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
+
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial
  * value and again each time the value changes.

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -42,6 +42,7 @@
 #include <stdarg.h>
 #include <flux/core.h>
 #include <czmq.h>
+#include <json.h>
 
 #include "kvs_deprecated.h"
 #include "proto.h"
@@ -442,6 +443,24 @@ int kvs_get_symlink (flux_t h, const char *key, char **val)
     }
     if (val)
         *val = xstrdup (json_object_get_string (v));
+    rc = 0;
+done:
+    Jput (v);
+    return rc;
+}
+
+int kvs_get_treeobj (flux_t h, const char *key, char **val)
+{
+    JSON v = NULL;
+    const char *s;
+    int rc = -1;
+
+    if (getobj (h, key, KVS_PROTO_TREEOBJ, &v) < 0)
+        goto done;
+    if (val) {
+        s = json_object_to_json_string_ext (v, JSON_C_TO_STRING_PLAIN);
+        *val = xstrdup (s);
+    }
     rc = 0;
 done:
     Jput (v);

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -1116,6 +1116,17 @@ done:
     return rc;
 }
 
+int kvs_put_treeobj (flux_t h, const char *key, const char *treeobj)
+{
+    JSON dirent;
+
+    if (!treeobj || !(dirent = Jfromstr (treeobj))
+                 || dirent_validate (dirent) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return kvs_put_dirent (h, key, dirent);
+}
 
 /* Append the key and dirent value to the 'ops' array, to be sent
  * with the next commit/fence request.

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -1,23 +1,30 @@
 /* N.B. Decode functions return pointers to storage owned by the json object.
  */
 
+// flags
+enum {
+    KVS_PROTO_READDIR = 1,      /* get, watch */
+    KVS_PROTO_READLINK = 2,     /* get, watch */
+    KVS_PROTO_ONCE = 4,         /* watch */
+    KVS_PROTO_FIRST = 8,        /* watch */
+};
+
 /* kvs.get
  */
-json_object *kp_tget_enc (const char *key, bool dir, bool link);
-int kp_tget_dec (json_object *o, const char **key, bool *dir, bool *link);
+json_object *kp_tget_enc (const char *key, int flags);
+int kp_tget_dec (json_object *o, const char **key, int *flags);
 
-json_object *kp_rget_enc (const char *key, json_object *val);
+json_object *kp_rget_enc (json_object *val);
 int kp_rget_dec (json_object *o, json_object **val);
 
 
 /* kvs.watch
  */
-json_object *kp_twatch_enc (const char *key, json_object *val,
-                            bool once, bool first, bool dir, bool link);
+json_object *kp_twatch_enc (const char *key, json_object *val, int flags);
 int kp_twatch_dec (json_object *o, const char **key, json_object **val,
-                   bool *once, bool *first, bool *dir, bool *link);
+                   int *flags);
 
-json_object *kp_rwatch_enc (const char *key, json_object *val);
+json_object *kp_rwatch_enc (json_object *val);
 int kp_rwatch_dec (json_object *o, json_object **val);
 
 /* kvs.unwatch

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -7,6 +7,7 @@ enum {
     KVS_PROTO_READLINK = 2,     /* get, watch */
     KVS_PROTO_ONCE = 4,         /* watch */
     KVS_PROTO_FIRST = 8,        /* watch */
+    KVS_PROTO_TREEOBJ = 16,     /* get */
 };
 
 /* kvs.get

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -10,17 +10,16 @@
 void test_get (void)
 {
     JSON o;
-    bool dir = false;
-    bool link = false;
     const char *key = NULL;
     JSON val = NULL;
-    int i;
+    int i, flags;
 
-    o = kp_tget_enc ("foo", false, true);
+    o = kp_tget_enc ("foo", 42);
     ok (o != NULL,
         "kp_tget_enc works");
     diag ("get request: %s", Jtostr (o));
-    ok (kp_tget_dec (o, &key, &dir, &link) == 0 && dir == false && link == true,
+    flags = 0;
+    ok (kp_tget_dec (o, &key, &flags) == 0 && flags == 42,
         "kp_tget_dec works");
     like (key, "^foo$",
         "kp_tget_dec returned encoded key");
@@ -28,47 +27,37 @@ void test_get (void)
 
     val = Jnew ();
     Jadd_int (val, "i", 42);
-    o = kp_rget_enc ("foo", val);
+    o = kp_rget_enc (val);
     val = NULL; /* val now owned by o */
     ok (o != NULL,
         "kp_rget_enc works");
     diag ("get response: %s", Jtostr (o));
     ok (kp_rget_dec (o, &val) == 0,
         "kp_rget_dec works");
+    // get response: { "val": { "i": 42 } }
+    i = 0;
     ok (val && Jget_int (val, "i", &i) && i == 42,
         "kp_rget_dec returned encoded object");
     Jput (o); /* owns val */
-
-    o = kp_rget_enc ("foo", NULL);
-    ok (o != NULL,
-        "kp_rget_enc works with NULL value");
-    errno = 0;
-    diag ("get response: %s", Jtostr (o));
-    ok (kp_rget_dec (o, &val) < 0 && errno == ENOENT,
-        "kp_rget_dec returns error with errno = ENOENT if val is NULL");
-    Jput (o);
 }
 
 void test_watch (void)
 {
     JSON o;
-    bool dir = false;
-    bool once = false;
-    bool first = false;
-    bool link = false;
+    int flags;
     const char *key = NULL;
     const char *s = NULL;
     JSON val;
 
     val = Jnew ();
     Jadd_str (val, "s", "blatz");
-    o = kp_twatch_enc ("foo", val, false, true, false, true);
+    o = kp_twatch_enc ("foo", val, 42);
     ok (o != NULL,
         "kp_twatch_enc works");
     val = NULL;
     diag ("watch request: %s", Jtostr (o));
-    ok (kp_twatch_dec (o, &key, &val, &once, &first, &dir, &link) == 0
-        && once == false && first == true && dir == false && link == true,
+    flags = 0;
+    ok (kp_twatch_dec (o, &key, &val, &flags) == 0 && flags == 42,
         "kp_twatch_dec works");
     ok (key && !strcmp (key, "foo"),
         "kp_twatch_dec returned encoded key");
@@ -79,7 +68,7 @@ void test_watch (void)
 
     val = Jnew ();
     Jadd_str (val, "str", "snerg");
-    o = kp_rwatch_enc ("foo", val);
+    o = kp_rwatch_enc (val);
     ok (o != NULL,
         "kp_rwatch_enc works");
     val = NULL;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -260,6 +260,7 @@ kvs_watch_disconnect_SOURCES = kvs/watch_disconnect.c
 kvs_watch_disconnect_CPPFLAGS = $(test_cppflags)
 kvs_watch_disconnect_LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(top_builddir)/src/modules/kvs/proto.o \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 kvs_hashtest_SOURCES = kvs/hashtest.c


### PR DESCRIPTION
This PR implements the KVS functions suggested in issue #778 for accessing the blobref of a key, and for creating a key with a blobref in place of a value.  The new functions are

```C
/* Get blobref associated with a key.  Caller must free.
 * If value is stored "by value", return EINVAL.
 */
int kvs_get_value_blobref (flux_t h, const char *key, char **blobref);
int kvs_get_directory_blobref (flux_t h, const char *key, char **blobref);

/* Create a reference to a value/directory object stored in content cache.
 */
int kvs_put_value_blobref (flux_t h, const char *key, const char *blobref);
int kvs_put_directory_blobref (flux_t h, const char *key, const char *blobref);
```

In addition the kvs.get and kvs.commit protocols were cleaned up, switching from a dictionary with  a plethora of boolean flags to JSON requests more like those used in other parts of Flux, and an integer flags mask.  And the client side "get" variants were refactor a little to reduce duplication.

Commands were added for testing the new functions.  Here's a command to create a root snapshot
```
$ flux kvs put-blobref -d root-snapshot-1 `flux kvs get-blobref -d .`
$ flux kvs dir 
resource.
root-snapshot-1.
$
```

Finally `kvs_copy()` was modified to link blobrefs rather than recursively copy entire directory hierarchies.  (`kvs_move()` is implemented on `kvs_copy()` so it benefits too).

I still need to add some tests here.