### PR TITLE
Fix missing error checks in Lua bindings, flux-wreckrun, flux-wreck

### DIFF
--- a/src/bindings/lua/wreck/io.lua
+++ b/src/bindings/lua/wreck/io.lua
@@ -166,6 +166,11 @@ local function ioplex_taskid_start (self, flux, taskid, stream)
             of:write (data)
         end
     }
+    if not iow then
+        self:log ("ignoring %s: %s", key, err)
+        -- remove reference count
+        f:close ()
+    end
 end
 
 --- "start" all ioplex iowatchers on reactor.

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -63,6 +63,7 @@ prog:SubCommand {
  },
  handler = function (self, arg)
     local id = check_jobid_arg (self, arg[1])
+    local state = f:kvs_get ("lwj.%d.state")
     local taskio, err = wreck.ioattach {
         flux = f,
         jobid = id,
@@ -74,15 +75,18 @@ prog:SubCommand {
     if not taskio then
         self:die ("Failed to connect to job %d: %s\n", id, err)
     end
-    local kz, err = f:kz_open ("lwj."..id..".input.files.stdin", "w")
-    if kz then
-        f:iowatcher {
-            fd = posix.fileno (io.input()),
-            handler = function (iow, r)
-                if r.data then kz:write (r.data) end
-                if r.eof  then kz:close () end
-            end
-        }
+    if state ~= "complete" and state ~= "reaped" then
+        local kz, err = f:kz_open ("lwj."..id..".input.files.stdin", "w")
+        if kz then
+            local iow, err = f:iowatcher {
+                fd = posix.fileno (io.input()),
+                handler = function (iow, r)
+                    if r.data then kz:write (r.data) end
+                    if r.eof  then kz:close () end
+                end
+            }
+            if not iow then self:die ("error opening stdin: %s\n", err) end
+        end
     end
     if not taskio:complete() then f:reactor () end
     if self.opt.s then

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -214,6 +214,7 @@ local kw, err = f:kvswatcher  {
         end
     end
 }
+if not kw then wreck:die ("kvs watch: %s\n", err) end
 
 
 --if wreck:getopt ("i") then
@@ -277,13 +278,14 @@ if not wreck.opts.w then
   --
   --  Add a file descriptor iowatcher for this script's stdin:
   --
-  f:iowatcher {
+  local iow, err = f:iowatcher {
     fd = posix.fileno (io.input()),
     handler = function (iow, data)
         if data.data then kz:write (data.data) end
         if data.eof  then kz:close ()          end
     end
   }
+  if not iow then wreck:die ("error opening stdin: %s\n", err) end
 end
 
 log, err = logstream {

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -147,6 +147,27 @@ is (n, #keys, "keys() iterator returned correct number of keys")
 
 -- KVS watcher creation
 
+-- kvswatch on directory should fail:
+f:kvs_put ("testdir.value", 42)
+f:kvs_commit ()
+local kw, err = f:kvswatcher {
+    key = "testdir",
+    handler = function () end
+}
+is (kw, nil, 'Error expected with kvswatch on directory')
+is (err, "Is a directory", 'Error message matches')
+
+local kw, err = f:kvswatcher {
+    key = "testdir",
+    isdir = true,
+    handler = function (kw, result)
+        type_ok (result, 'userdata', "result is kvsdir")
+        is (result.value, 42, "directory contents are as expected")
+    end
+}
+type_ok (kw, 'userdata', "f:kvswatcher with isdir kvswatcher object")
+is (err, nil, "no error from kvswatcher with isdir")
+
 -- Force creation of new handle and reactor here so that
 --  reactor time is guaranteed to be updated, and our timeout
 --  used below is relative to now and not last active reactor time.

--- a/t/lua/t1003-iowatcher.t
+++ b/t/lua/t1003-iowatcher.t
@@ -13,6 +13,14 @@ type_ok (f, 'userdata', "create new flux handle")
 is (err, nil, "error is nil")
 
 local dir = f:kvsdir()
+dir['simpleval'] = "xxx"
+dir:commit()
+local iow, err = f:iowatcher {
+    key = "simpleval",
+    handler = function (iow, lines) end
+}
+is (iow, nil, "iowatcher returns error correctly")
+
 dir['iowatcher'] = nil
 dir:commit()
 


### PR DESCRIPTION
This PR adds some lamentably missing error checks in the Lua bindings, as well as `flux-wreckrun` and `flux-wreck`. The end result is that in specific cases of kvs and fd watch failures, wreck and wreckrun will emit errors instead of mysterious hangs.
