### PR TITLE
when tagpool is exhausted, grow up to RFC 6 limits

### DIFF
--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -62,11 +62,13 @@ static void freectx (void *arg)
 static logctx_t *getctx (flux_t h)
 {
     logctx_t *ctx = (logctx_t *)flux_aux_get (h, "flux::log");
+    extern char *__progname;
+    // or glib-ism: program_invocation_short_name
 
     if (!ctx) {
         ctx = xzmalloc (sizeof (*ctx));
-        snprintf (ctx->appname, sizeof (ctx->appname), "%s", STDLOG_NILVALUE);
         snprintf (ctx->procid, sizeof (ctx->procid), "%d", getpid ());
+        snprintf (ctx->appname, sizeof (ctx->appname), "%s", __progname);
         flux_aux_set (h, "flux::log", ctx, freectx);
     }
     return ctx;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -491,8 +491,11 @@ uint32_t flux_matchtag_alloc (flux_t h, int flags)
     if ((flags & FLUX_MATCHTAG_GROUP))
         tpflags |= TAGPOOL_FLAG_GROUP;
     tag = tagpool_alloc (h->tagpool, tpflags);
-    if (tag == FLUX_MATCHTAG_NONE)
+    if (tag == FLUX_MATCHTAG_NONE) {
+        flux_log (h, LOG_ERR, "tagpool-%s temporarily out of tags",
+                  (flags & FLUX_MATCHTAG_GROUP) ? "group" : "normal");
         errno = EBUSY; /* appropriate error? */
+    }
     return tag;
 }
 

--- a/src/common/libflux/tagpool.c
+++ b/src/common/libflux/tagpool.c
@@ -51,8 +51,9 @@
 #include "src/common/libutil/veb.h"
 #include "src/common/libutil/log.h"
 
-#define TAGPOOL_COUNT_REGULAR (1UL<<16) /* consumes about 9K for 1<<16 */
+#define TAGPOOL_COUNT_REGULAR (1UL<<20)
 #define TAGPOOL_COUNT_GROUP (1UL<<12)
+#define TAGPOOL_START (1UL<<10)
 
 #define TAGPOOL_MAGIC   0x34447ff2
 struct tagpool {
@@ -63,15 +64,25 @@ struct tagpool {
     int             group_avail;
 };
 
+static void pool_set (Veb veb, uint32_t from, uint32_t to, uint8_t value)
+{
+    while (from < to) {
+        if (value)
+            vebput (veb, from);
+        else
+            vebdel (veb, from);
+        from++;
+    }
+}
+
 struct tagpool *tagpool_create (void)
 {
-    struct tagpool *t = malloc (sizeof (*t));
+    struct tagpool *t = calloc (1, sizeof (*t));
     if (!t)
         goto nomem;
-    memset (t, 0, sizeof (*t));
     t->magic = TAGPOOL_MAGIC;
-    t->R = vebnew (TAGPOOL_COUNT_REGULAR, 1);
-    t->G = vebnew (TAGPOOL_COUNT_GROUP, 1);
+    t->R = vebnew (TAGPOOL_START, 1);
+    t->G = vebnew (TAGPOOL_START, 1);
     if (!t->R.D || !t->G.D)
         goto nomem;
     vebdel (t->R, FLUX_MATCHTAG_NONE); /* allocate reserved value */
@@ -98,23 +109,45 @@ void tagpool_destroy (struct tagpool *t)
     }
 }
 
+static uint32_t alloc_with_resize (Veb *veb, uint32_t max)
+{
+    uint32_t oldsize = veb->M;
+    uint32_t newsize = oldsize << 1;
+    uint32_t tag = vebsucc (*veb, 0);
+
+    if (tag == veb->M && newsize <= max) {
+        //log_msg ("%s: resizing pool %u to %u", __FUNCTION__, oldsize, newsize);
+        Veb new = vebnew (newsize, 0);
+        if (new.D) {
+            pool_set (new, oldsize, newsize, 1);
+            free (veb->D);
+            *veb = new;
+            tag = vebsucc (*veb, oldsize);
+            assert (tag == oldsize);
+        }
+    }
+    if (tag < veb->M)
+        vebdel (*veb, tag);
+    return tag;
+}
+
 uint32_t tagpool_alloc (struct tagpool *t, int flags)
 {
     assert (t->magic == TAGPOOL_MAGIC);
     uint32_t tag;
 
     if ((flags & TAGPOOL_FLAG_GROUP)) {
-       if ((tag = vebsucc (t->G, 0)) != t->G.M) {
-            vebdel (t->G, tag);
+        tag = alloc_with_resize (&t->G, TAGPOOL_COUNT_GROUP);
+        if (tag < t->G.M) {
             t->group_avail--;
             return tag<<FLUX_MATCHTAG_GROUP_SHIFT;
-       }
+        }
     } else {
-       if ((tag = vebsucc (t->R, 0)) != t->R.M) {
-            vebdel (t->R, tag);
+        tag = alloc_with_resize (&t->R, TAGPOOL_COUNT_REGULAR);
+        if (tag < t->R.M) {
             t->reg_avail--;
             return tag;
-       }
+        }
     }
     return FLUX_MATCHTAG_NONE;
 }
@@ -123,12 +156,17 @@ void tagpool_free (struct tagpool *t, uint32_t tag)
 {
     assert (t->magic == TAGPOOL_MAGIC);
     if (tag != FLUX_MATCHTAG_NONE) {
-        if ((tag>>FLUX_MATCHTAG_GROUP_SHIFT) > 0) {
-            vebput (t->G, tag>>FLUX_MATCHTAG_GROUP_SHIFT);
-            t->group_avail++;
+        uint32_t group = tag>>FLUX_MATCHTAG_GROUP_SHIFT;
+        if (group > 0) {
+            if (group < t->G.M) {
+                vebput (t->G, group);
+                t->group_avail++;
+            }
         } else {
-            vebput (t->R, tag);
-            t->reg_avail++;
+            if (tag < t->R.M) {
+                vebput (t->R, tag);
+                t->reg_avail++;
+            }
         }
     }
 }
@@ -148,9 +186,6 @@ uint32_t tagpool_getattr (struct tagpool *t, int attr)
     }
     return 0;
 }
-
-/* Possible future enhancement:  tagpool_setattr for resizing pool(s).
- */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/tagpool.h
+++ b/src/common/libflux/tagpool.h
@@ -12,6 +12,9 @@ void tagpool_destroy (struct tagpool *t);
 uint32_t tagpool_alloc (struct tagpool *t, int flags);
 void tagpool_free (struct tagpool *t, uint32_t matchtag);
 
+typedef void (*tagpool_grow_f)(void *arg, uint32_t oldsize, uint32_t newsize, int flags);
+void tagpool_set_grow_cb (struct tagpool *t, tagpool_grow_f cb, void *arg);
+
 enum {
     TAGPOOL_ATTR_REGULAR_SIZE,
     TAGPOOL_ATTR_REGULAR_AVAIL,

--- a/src/common/libflux/test/tagpool.c
+++ b/src/common/libflux/test/tagpool.c
@@ -18,22 +18,42 @@ int main (int argc, char *argv[])
 
     /* Test regular
      */
+    tags[0] = tagpool_alloc (t, 0);
+    ok (tags[0] == 1,
+        "regular: allocated first tag");
+    tags[1] = tagpool_alloc (t, 0);
+    ok (tags[1] == 2,
+        "regular: allocated second tag");
+    tagpool_free (t, tags[0]);
+    tags[2] = tagpool_alloc (t, 0);
+    ok (tags[2] == 1,
+        "regular: got first tag again after it was freed");
+    tagpool_free (t, tags[1]);
+    tags[3] = tagpool_alloc (t, 0);
+    ok (tags[3] == 2,
+        "regular: got second tag again after it was freed");
+    tagpool_free (t, tags[2]);
+    tagpool_free (t, tags[3]);
 
     norm_size = tagpool_getattr (t, TAGPOOL_ATTR_REGULAR_SIZE);
     avail = tagpool_getattr (t, TAGPOOL_ATTR_REGULAR_AVAIL);
     ok (avail == norm_size,
-        "regular: all tags available (%d/%d)", avail, norm_size);
+        "regular: all tags available");
 
+    ok (avail >= 256,
+        "regular: at least 256 tags available");
     for (i = 0; i < 256; i++) {
         tags[i] = tagpool_alloc (t, 0);
         if (tags[i] == FLUX_MATCHTAG_NONE)
             break;
     }
     ok (i == 256,
-        "regular: tagpool_alloc worked %d/256 times", i);
+        "regular: tagpool_alloc worked 256 times");
     avail = tagpool_getattr (t, TAGPOOL_ATTR_REGULAR_AVAIL);
+    if (avail != norm_size - 256)
+        diag ("wrong number avail: %u of %u", avail, norm_size);
     ok (avail == norm_size - 256,
-        "regular: pool depleted by 256 (%d)", norm_size - avail);
+        "regular: pool depleted by 256");
 
     duplicates = 0;
     for (j = 0; j < i; j++) {
@@ -42,7 +62,7 @@ int main (int argc, char *argv[])
                 duplicates++;
     }
     ok (duplicates == 0,
-        "regular: allocated tags contain no duplicates (%d)", duplicates);
+        "regular: allocated tags contain no duplicates");
 
     while (--i >= 0)
         tagpool_free (t, tags[i]);
@@ -54,7 +74,7 @@ int main (int argc, char *argv[])
     while (tagpool_alloc (t, 0) != FLUX_MATCHTAG_NONE)
         count++;
     ok (count == norm_size,
-        "regular: tagpool_alloc returns FLUX_MATCHTAG_NONE eventually (%d)", count);
+        "regular: entire pool allocated by tagpool_alloc loop");
     avail = tagpool_getattr (t, TAGPOOL_ATTR_REGULAR_AVAIL);
     ok (avail == 0,
         "regular: pool is exhausted");
@@ -65,17 +85,19 @@ int main (int argc, char *argv[])
     grp_size = tagpool_getattr (t, TAGPOOL_ATTR_GROUP_SIZE);
     avail = tagpool_getattr (t, TAGPOOL_ATTR_GROUP_AVAIL);
     ok (avail == grp_size,
-        "group: all tags available (%d/%d)", avail, grp_size);
+        "group: all tags available");
 
+    ok (avail >= 256,
+        "regular: at least 256 tags available");
     for (i = 0; i < 256; i++) {
         tags[i] = tagpool_alloc (t, TAGPOOL_FLAG_GROUP);
         if (tags[i] == FLUX_MATCHTAG_NONE)
             break;
     }
     ok (i == 256,
-        "group: tagpool_alloc worked 256 times (%d)", i);
+        "group: tagpool_alloc worked 256 times", i);
     ok (tagpool_getattr (t, TAGPOOL_ATTR_GROUP_AVAIL) == grp_size - 256,
-        "group: pool depleted by 256 (%d)", grp_size - avail);
+        "group: pool depleted by 256");
 
     duplicates = 0;
     for (j = 0; j < i; j++) {
@@ -84,7 +106,7 @@ int main (int argc, char *argv[])
                 duplicates++;
     }
     ok (duplicates == 0,
-        "group: allocated tags contain no duplicates (%d)", duplicates);
+        "group: allocated tags contain no duplicates");
 
     while (--i >= 0)
         tagpool_free (t, tags[i]);
@@ -96,7 +118,7 @@ int main (int argc, char *argv[])
     while (tagpool_alloc (t, TAGPOOL_FLAG_GROUP) != FLUX_MATCHTAG_NONE)
         count++;
     ok (count == grp_size,
-        "group: tagpool_alloc returns FLUX_MATCHTAG_NONE eventually (%d)", count);
+        "group: entire poool allocated by tagpool_alloc loop");
     avail = tagpool_getattr (t, TAGPOOL_ATTR_GROUP_AVAIL);
     ok (avail == 0,
         "group: pool is exhausted");

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -86,7 +86,8 @@ TESTS = test_nodeset.t \
 	test_kary.t \
 	test_cronodate.t \
 	test_wallclock.t \
-	test_stdlog.t
+	test_stdlog.t \
+	test_veb.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -153,3 +154,7 @@ test_wallclock_t_LDADD = $(test_ldadd)
 test_stdlog_t_SOURCES = test/stdlog.c
 test_stdlog_t_CPPFLAGS = $(test_cppflags)
 test_stdlog_t_LDADD = $(test_ldadd)
+
+test_veb_t_SOURCES = test/veb.c
+test_veb_t_CPPFLAGS = $(test_cppflags)
+test_veb_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -40,12 +40,16 @@
 
 #include "log.h"
 
-static char *prog = "flux";
+extern char *__progname;
+static char *prog = NULL;
 
 void
 log_init (char *p)
 {
-    prog = basename (p);
+    if (!p)
+        prog = __progname;
+    else
+        prog = basename (p);
 }
 
 void
@@ -60,6 +64,8 @@ _verr (int errnum, const char *fmt, va_list ap)
     char buf[128];
     const char *s = zmq_strerror (errnum);
 
+    if (!prog)
+        log_init (NULL);
     if (vasprintf (&msg, fmt, ap) < 0) {
         (void)vsnprintf (buf, sizeof (buf), fmt, ap);
         msg = buf;
@@ -75,6 +81,8 @@ _vlog (const char *fmt, va_list ap)
     char *msg = NULL;
     char buf[128];
 
+    if (!prog)
+        log_init (NULL);
     if (vasprintf (&msg, fmt, ap) < 0) {
         (void)vsnprintf (buf, sizeof (buf), fmt, ap);
         msg = buf;

--- a/src/common/libutil/test/veb.c
+++ b/src/common/libutil/test/veb.c
@@ -1,0 +1,445 @@
+/* adapted for TAP from plan9 style tests provided with libveb */
+#include <string.h>
+#include <stdlib.h>
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/veb.h"
+
+void empty_pred_test1 (void)
+{
+    uint M = 1<<16;
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_pred_test1 vebnew OK");
+    vebput(T,0xf000);
+    ok (vebpred(T,0xf000) == 0xf000);
+    vebput(T,0x0f00);
+    ok (vebpred(T,0x0f00) == 0x0f00);
+    vebput(T,0x00f0);
+    ok (vebpred(T,0x00f0) == 0x00f0);
+    vebput(T,0x000f);
+    ok (vebpred(T,0x000f) == 0x000f);
+    vebdel(T,0xf000);
+    ok (vebpred(T,0xf000) != 0xf000);
+    vebdel(T,0x0f00);
+    ok (vebpred(T,0x0f00) != 0x0f00);
+    vebdel(T,0x00f0);
+    ok (vebpred(T,0x00f0) != 0x00f0);
+    vebdel(T,0x000f);
+    ok (vebpred(T,0x000f) != 0x000f);
+    free(T.D);
+}
+
+void empty_pred_test2 (void)
+{
+    uint M = 1<<16;
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_pred_test2 vebnew OK");
+    vebput(T,0xf000);
+    ok (vebpred(T,0xf000) == 0xf000);
+    vebput(T,0x0f00);
+    ok (vebpred(T,0x0f00) == 0x0f00);
+    vebput(T,0x00f0);
+    ok (vebpred(T,0x00f0) == 0x00f0);
+    vebput(T,0x000f);
+    ok (vebpred(T,0x000f) == 0x000f);
+    uint x = vebpred(T,M-1);
+    ok (x == 0xf000);
+    x = vebpred(T,x-1);
+    ok (x == 0x0f00);
+    x = vebpred(T,x-1);
+    ok (x == 0x00f0);
+    x = vebpred(T,x-1);
+    ok (x == 0x000f);
+    x = vebpred(T,x-1);
+    ok (x == M);
+    free(T.D);
+}
+
+Veb
+empty_pred_load_test1_fill (uint M)
+{
+    Veb T = vebnew(M,0);
+    if (T.D) {
+        for (int i = 0; i < 1000; ++i) {
+            uint x = rand()%M;
+            vebput(T,x);
+        }
+    }
+    return T;
+}
+
+void empty_pred_load_test1 (void)
+{
+    int errors = 0;
+    srand(433849);
+    uint M = rand()%(1<<16);
+    Veb T = empty_pred_load_test1_fill(M);
+    ok (T.D != NULL, "empty_pred_load_test1 vebnew OK");
+    uint i = i = vebpred(T,M-1);
+    while (i < M) {
+        vebdel(T,i);
+        uint j = vebpred(T,i);
+        if (i == j)
+            errors++;
+        i = j;
+    }
+    ok (errors == 0, "empty_pred_load_test1 no errors");
+    free(T.D);
+}
+
+
+uint
+empty_pred_load_test2_fill(Veb T, uint m)
+{
+    uint n = 0;
+    for (int i = 0; i < m; ++i) {
+        uint x = rand()%T.M;
+        if (vebpred(T,x) != x) {
+            vebput(T,x);
+            ++n;
+        }
+    }
+    return n;
+}
+
+void empty_pred_load_test2 (void)
+{
+    srand(83843);
+    uint M = rand()%(1<<16);
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_pred_load_test2 vebnew OK");
+    uint m = empty_pred_load_test2_fill(T,1000);
+    uint n = 0;
+    uint i = vebpred(T,M-1);
+    while (i != M) {
+        ++n;
+        i = vebpred(T,i-1);
+    }
+    ok (n == m, "empty_pred_load_test2 correct count");
+    free(T.D);
+}
+
+void empty_succ_test1 (void)
+{
+    uint M = 1<<16;
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_succ_test1 vebnew OK");
+    vebput(T,0x000f);
+    ok (vebsucc(T,0x000f) == 0x000f);
+    vebput(T,0x00f0);
+    ok (vebsucc(T,0x00f0) == 0x00f0);
+    vebput(T,0x0f00);
+    ok (vebsucc(T,0x0f00) == 0x0f00);
+    vebput(T,0xf000);
+    ok (vebsucc(T,0xf000) == 0xf000);
+    vebdel(T,0x000f);
+    ok (vebsucc(T,0x000f) != 0x000f);
+    vebdel(T,0x00f0);
+    ok (vebsucc(T,0x00f0) != 0x00f0);
+    vebdel(T,0x0f00);
+    ok (vebsucc(T,0x0f00) != 0x0f00);
+    vebdel(T,0xf000);
+    ok (vebsucc(T,0xf000) != 0xf000);
+    free(T.D);
+}
+
+void empty_succ_test2 (void)
+{
+    uint M = 1<<16;
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_succ_test2 vebnew OK");
+    vebput(T,0x000f);
+    ok (vebsucc(T,0x000f) == 0x000f);
+    vebput(T,0x00f0);
+    ok (vebsucc(T,0x00f0) == 0x00f0);
+    vebput(T,0x0f00);
+    ok (vebsucc(T,0x0f00) == 0x0f00);
+    vebput(T,0xf000);
+    ok (vebsucc(T,0xf000) == 0xf000);
+    uint x = vebsucc(T,0);
+    ok (x == 0x000f);
+    x = vebsucc(T,x+1);
+    ok (x == 0x00f0);
+    x = vebsucc(T,x+1);
+    ok (x == 0x0f00);
+    x = vebsucc(T,x+1);
+    ok (x == 0xf000);
+    x = vebsucc(T,x+1);
+    ok (x == M);
+    free(T.D);
+}
+
+Veb
+empty_succ_load_test1_fill(uint M)
+{
+    int errors = 0;
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_succ_load_test1 vebnew OK");
+    for (int i = 0; i < 0xff; ++i) {
+        uint x = rand()%M;
+        vebput(T,x);
+        if (vebsucc(T,x) != x)
+            errors++;
+    }
+    ok (errors == 0, "empty_succ_load_test1 random fill OK");
+    return T;
+}
+
+void empty_succ_load_test1 (void)
+{
+    int errors = 0;
+    srand(438749);
+    uint M = rand()%(1<<16);
+    Veb T = empty_succ_load_test1_fill(M);
+    uint i = i = vebsucc(T,0);
+    while (i < M) {
+        vebdel(T,i);
+        uint j = vebsucc(T,i);
+        if (i == j)
+            errors++;
+        i = j;
+    }
+    ok (errors == 0, "empty_succ_load_test1 no errors");
+    free(T.D);
+}
+
+uint
+empty_succ_load_test2_fill(Veb T, uint m)
+{
+    uint n = 0;
+    for (int i = 0; i < m; ++i) {
+        uint x = rand()%T.M;
+        if (vebsucc(T,x) != x) {
+            vebput(T,x);
+            ++n;
+        }
+    }
+    return n;
+}
+
+void empty_succ_load_test2 (void)
+{
+    srand(83843);
+    uint M = rand()%(1<<16);
+    Veb T = vebnew(M,0);
+    ok (T.D != NULL, "empty_succ_load_test2 vebnew OK");
+    uint m = empty_succ_load_test2_fill(T,1000);
+    uint n = 0;
+    uint i = vebsucc(T,0);
+    while (i != M) {
+        ++n;
+        i = vebsucc(T,i+1);
+    }
+    ok (n == m, "empty_succ_load_test2 correct count");
+    free(T.D);
+}
+
+void full_pred_test1 (void)
+{
+    uint M = 1<<16;
+    Veb T = vebnew(M,1);
+    ok (T.D != NULL, "full_pred_test1 vebnew OK");
+    vebdel(T,0xf000);
+    ok (vebpred(T,0xf000) != 0xf000);
+    vebdel(T,0x0f00);
+    ok (vebpred(T,0x0f00) != 0x0f00);
+    vebdel(T,0x00f0);
+    ok (vebpred(T,0x00f0) != 0x00f0);
+    vebdel(T,0x000f);
+    ok (vebpred(T,0x000f) != 0x000f);
+    vebput(T,0xf000);
+    ok (vebpred(T,0xf000) == 0xf000);
+    vebput(T,0x0f00);
+    ok (vebpred(T,0x0f00) == 0x0f00);
+    vebput(T,0x00f0);
+    ok (vebpred(T,0x00f0) == 0x00f0);
+    vebput(T,0x000f);
+    ok (vebpred(T,0x000f) == 0x000f);
+    free(T.D);
+}
+
+
+Veb
+full_pred_load_test1_fill(uint M)
+{
+    int errors = 0;
+    Veb T = vebnew(M,1);
+    ok (T.D != NULL, "full_pred_load_test1 vebnew OK");
+    for (int i = 0; i < 0xff; ++i) {
+        uint x = rand()%M;
+        vebdel(T,x);
+        if (vebpred(T,x) == x)
+            errors++;
+    }
+    ok (errors == 0, "full_pred_load_test1 random fill OK");
+    return T;
+}
+
+void full_pred_load_test1 (void)
+{
+    int errors = 0;
+    srand(438749);
+    uint M = rand()%(1<<16);
+    Veb T = full_pred_load_test1_fill (M);
+    uint i = i = vebpred(T,M-1);
+    while (i < M) {
+        vebdel(T,i);
+        uint j = vebpred(T,i);
+        if (i == j)
+            errors++;
+        i = j;
+    }
+    ok (errors == 0, "full_pred_load_test1 no errors");
+    free(T.D);
+}
+
+uint
+full_pred_load_test2_reduce(Veb T, uint m)
+{
+    uint n = 0;
+    for (int i = 0; i < m; ++i) {
+        uint x = rand()%T.M;
+        if (vebpred(T,x) == x) {
+            vebdel(T,x);
+            ++n;
+        }
+    }
+    return n;
+}
+
+void full_pred_load_test2 (void)
+{
+    srand(83843);
+    uint M = rand()%(1<<16);
+    Veb T = vebnew(M,1);
+    ok (T.D != NULL, "full_pred_load_test2 vebnew OK");
+    uint m = full_pred_load_test2_reduce(T,1000);
+    uint n = 0;
+    uint i = vebpred(T,M-1);
+    while (i != M) {
+        ++n;
+        i = vebpred(T,i-1);
+    }
+    ok (n == M-m, "full_pred_load_test2 correct count");
+    free(T.D);
+}
+
+void full_succ_test1 (void)
+{
+    uint M = 1<<16;
+    Veb T = vebnew(M,1);
+    ok (T.D != NULL, "full_succ_test1 vebnew OK");
+    vebdel(T,0x000f);
+    ok (vebsucc(T,0x000f) != 0x000f);
+    vebdel(T,0x00f0);
+    ok (vebsucc(T,0x00f0) != 0x00f0);
+    vebdel(T,0x0f00);
+    ok (vebsucc(T,0x0f00) != 0x0f00);
+    vebdel(T,0xf000);
+    ok (vebsucc(T,0xf000) != 0xf000);
+    vebput(T,0x000f);
+    ok (vebsucc(T,0x000f) == 0x000f);
+    vebput(T,0x00f0);
+    ok (vebsucc(T,0x00f0) == 0x00f0);
+    vebput(T,0x0f00);
+    ok (vebsucc(T,0x0f00) == 0x0f00);
+    vebput(T,0xf000);
+    ok (vebsucc(T,0xf000) == 0xf000);
+    free(T.D);
+}
+
+
+Veb
+full_succ_load_test1_fill(uint M)
+{
+    int errors = 0;
+    Veb T = vebnew(M,1);
+    ok (T.D != NULL, "full_succ_load_test1 vebnew OK");
+    for (int i = 0; i < 0xff; ++i) {
+        uint x = rand()%M;
+        vebdel(T,x);
+        if (vebsucc(T,x) == x)
+            errors++;
+    }
+    ok (errors == 0, "full_succ_load_test1 random fill OK");
+    return T;
+}
+
+void full_succ_load_test1 (void)
+{
+    int errors = 0;
+    srand(438749);
+    uint M = rand()%(1<<16);
+    Veb T = full_succ_load_test1_fill(M);
+    uint i = i = vebsucc(T,0);
+    while (i < M) {
+        vebdel(T,i);
+        uint j = vebsucc(T,i);
+        if (i == j)
+            errors++;
+        i = j;
+    }
+    ok (errors == 0, "full_succ_load_test1 no errors");
+    free(T.D);
+}
+
+
+uint
+full_succ_load_test2_reduce(Veb T, uint m)
+{
+    uint n = 0;
+    for (int i = 0; i < m; ++i) {
+        uint x = rand()%T.M;
+        if (vebsucc(T,x) == x) {
+            vebdel(T,x);
+            ++n;
+        }
+    }
+    return n;
+}
+
+void full_succ_load_test2 (void)
+{
+    srand(83843);
+    uint M = rand()%(1<<16);
+    Veb T = vebnew(M,1);
+    ok (T.D != NULL, "full_succ_load_test2 vebnew OK");
+    uint m = full_succ_load_test2_reduce(T,1000);
+    uint n = 0;
+    uint i = vebsucc(T,0);
+    while (i != M) {
+        ++n;
+        i = vebsucc(T,i+1);
+    }
+    ok (n == M-m, "full_succ_load_test2 correct count");
+    free(T.D);
+}
+
+int main(int argc, char** argv)
+{
+    plan (NO_PLAN);
+
+    empty_pred_test1();
+    empty_pred_test2();
+    empty_pred_load_test1();
+    empty_pred_load_test2();
+
+    empty_succ_test1();
+    empty_succ_test2();
+    empty_succ_load_test1();
+    empty_succ_load_test2();
+
+    full_pred_test1();
+    full_pred_load_test1();
+    full_pred_load_test2();
+
+    full_succ_test1();
+    full_succ_load_test1();
+    full_succ_load_test2();
+
+    done_testing();
+}
+
+
+/*
+  vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/veb.c
+++ b/src/common/libutil/veb.c
@@ -201,28 +201,6 @@ mkempty(Veb T)
 		mkempty(branch(T,i));
 }
 
-static void
-mkfull(Veb T)
-{
-	int i;
-	if (T.M <= WORD) {
-		encode(T.D,bytes(T.M),ones(T.M));
-		return;
-	}
-	setlow(T,0);
-	sethigh(T,T.M-1);
-	mkfull(aux(T));
-	uint m = highbits(T.M-1,T.k/2)+1;
-	for (i = 0; i < m; ++i) {
-		Veb B = branch(T,i);
-		mkfull(B);
-		if (i == 0)
-			vebdel(B,0);
-		if (i == m-1)
-			vebdel(B,lowbits(T.M-1,T.k/2));
-	}
-}
-
 Veb
 vebnew(uint M, int full)
 {
@@ -231,10 +209,11 @@ vebnew(uint M, int full)
 	T.D = malloc(vebsize(M));
 	if (T.D) {
 		T.M = M;
-		if (full)
-			mkfull(T);
-		else
-			mkempty(T);
+		mkempty(T);
+		if (full) {
+			for (uint m=0; m < T.M; m++)
+				vebput(T,m);
+		}
 	}
 	return T;
 }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1033,8 +1033,9 @@ static bool unwatch_cmp (const flux_msg_t *msg, void *arg)
 {
     unwatch_param_t *p = arg;
     char *sender = NULL;
-    JSON o = NULL;
-    const char *topic, *json_str;
+    JSON o = NULL, val;
+    const char *key, *topic, *json_str;
+    int flags;
     bool match = false;
 
     if (flux_request_decode (msg, &topic, &json_str) < 0)
@@ -1047,7 +1048,9 @@ static bool unwatch_cmp (const flux_msg_t *msg, void *arg)
         goto done;
     if (!(o = Jfromstr (json_str)))
         goto done;
-    if (!json_object_object_get_ex (o, p->key, NULL))
+    if (kp_twatch_dec (o, &key, &val, &flags) <  0)
+        goto done;
+    if (strcmp (p->key, key) != 0)
         goto done;
     match = true;
 done:

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -746,7 +746,7 @@ static int watch_rpc (flux_t h, const char *key, JSON *val,
     /* Send the request.
      */
     assert ((flags & KVS_PROTO_ONCE) || matchtag != NULL);
-    match.matchtag = flux_matchtag_alloc (h, FLUX_MATCHTAG_GROUP);
+    match.matchtag = flux_matchtag_alloc (h, 0);
     if (match.matchtag == FLUX_MATCHTAG_NONE) {
         errno = EAGAIN;
         goto done;

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -415,12 +415,35 @@ static int simulwatch_cb (const char *key, int val, void *arg, int errnum)
     return 0;
 }
 
+int get_watch_stats (flux_t h, int *count)
+{
+    flux_rpc_t *rpc;
+    const char *json_str;
+    JSON o = NULL;
+    int rc = -1;
+
+    if (!(rpc = flux_rpc (h, "kvs.stats.get", NULL, FLUX_NODEID_ANY, 0)))
+        goto done;
+    if (flux_rpc_get (rpc, NULL, &json_str) < 0)
+        goto done;
+    if (!(o = Jfromstr (json_str)) || !Jget_int (o, "#watchers", count)) {
+        errno = EPROTO;
+        goto done;
+    }
+    rc = 0;
+done:
+    flux_rpc_destroy (rpc);
+    Jput (o);
+    return rc;
+}
+
 void test_simulwatch (int argc, char **argv)
 {
     int i, max;
     const char *key;
     flux_t h;
-    int count = 0;
+    int start, fin, count = 0;
+    int exit_rc = 0;
 
     if (argc != 2) {
         fprintf (stderr, "Usage: simulwatch key count\n");
@@ -430,16 +453,34 @@ void test_simulwatch (int argc, char **argv)
     max = strtoul (argv[1], NULL, 10);
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
+    if (get_watch_stats (h, &start) < 0)
+        log_err_exit ("kvs.stats.get");
     for (i = 0; i < max; i++) {
         if (kvs_watch_int (h, key, simulwatch_cb, &count) < 0)
             log_err_exit ("kvs_watch_int[%d] %s", i, key);
-        if ((i % 1024 == 0 && i > 0) || i == max - 1 )
-            log_msg ("kvs_watch_int[%d]", i); // show progress
+        if ((i % 4096 == 0 && i > 0 && i + 4096 < max))
+            log_msg ("%d of %d watchers registered (continuing)", i, max);
     }
+    log_msg ("%d of %d watchers registered", i, max);
     if (count != max)
-        log_msg_exit ("callback called %d not %d times", count, max);
-    log_msg ("callback called %d times", count);
+        exit_rc = 1;
+    log_msg ("callback called %d of %d times", count, max);
+    if (get_watch_stats (h, &fin) < 0)
+        log_err_exit ("kvs.stats.get");
+    if (fin - start != count)
+        exit_rc = 1;
+    log_msg ("%d of %d watchers running", fin - start, count);
+    if (kvs_unwatch (h, key) < 0)
+        log_err_exit ("kvs.unwatch");
+    if (get_watch_stats (h, &fin) < 0)
+        log_err_exit ("kvs.stats.get");
+    if (fin - start != 0)
+        exit_rc = 1;
+    log_msg ("%d of %d watchers running after unwatch",
+             fin - start, count);
     flux_close (h);
+    if (exit_rc != 0)
+        exit (exit_rc);
 }
 
 int main (int argc, char *argv[])

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -393,14 +393,14 @@ void test_unwatchloop (int argc, char **argv)
     key = argv[0];
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
-    uint32_t avail = flux_matchtag_avail (h, FLUX_MATCHTAG_GROUP);
+    uint32_t avail = flux_matchtag_avail (h, 0);
     for (i = 0; i < 1000; i++) {
         if (kvs_watch_int (h, key, unwatchloop_cb, NULL) < 0)
             log_err_exit ("kvs_watch_int[%d] %s", i, key);
         if (kvs_unwatch (h, key) < 0)
             log_err_exit ("kvs_unwatch[%d] %s", i, key);
     }
-    uint32_t leaked = avail - flux_matchtag_avail (h, FLUX_MATCHTAG_GROUP);
+    uint32_t leaked = avail - flux_matchtag_avail (h, 0);
     if (leaked > 0)
         log_msg_exit ("leaked %u matchtags", leaked);
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -438,6 +438,12 @@ test_expect_success 'kvs: watch-unwatchloop 1000 watch/unwatch ok' '
 	flux kvs unlink $TEST.a
 '
 
+test_expect_success 'kvs: 8192 simultaneous watches works' '
+	${FLUX_BUILD_DIR}/t/kvs/watch simulwatch $TEST.a 8192 &&
+	flux kvs unlink $TEST.a
+'
+
+
 # large values/dirs
 
 test_expect_success 'kvs: store value exceeding RFC 10 max blob size of 1m' '


### PR DESCRIPTION
Rather than failing at 64K matchtags, allow the non-group tagpool to grow up to 1M in size.

Also: change kvs_watch to use the non-group tagpool to hopefully address wreck scalability issues discussed in #802.

This took a while due to some disturbing behavior by libveb where initialization to "allocated" did not work, depending on the size of the veb tree - this is why I've added so many assertions to the code.  I did verify that the old implementation worked as it should.  In fact this condition was caught by an existing unit test that tries to run out the pool and verify that it really got all the tags.  I couldn't find any memory clobbering with valgrind, so I assume this is an internal bug in libveb, and it doesn't seem to occur when the tree is initialized to "not allocated".  That is how it's used in nodeset.c and here now as well.