### PR TITLE
libutil/veb: quiet uninitialized variable warning in vebnew

### DIFF
--- a/src/common/libutil/veb.c
+++ b/src/common/libutil/veb.c
@@ -205,6 +205,7 @@ Veb
 vebnew(uint M, int full)
 {
 	Veb T;
+	T.M = 0;
 	T.k = fls(M-1);
 	T.D = malloc(vebsize(M));
 	if (T.D) {


### PR DESCRIPTION
Quiet uninitialized variable warning in vebnew() for `T.M` by initializing it to 0.

Fixes #808