### PR TITLE
improve kvs watch efficiency

### DIFF
--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -66,6 +66,7 @@ void cmd_dir (flux_t h, int argc, char **argv);
 void cmd_dirsize (flux_t h, int argc, char **argv);
 void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
+void cmd_getat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -93,6 +94,7 @@ void usage (void)
 "       flux-kvs dropcache-all\n"
 "       flux-kvs get-treeobj     key\n"
 "       flux-kvs put-treeobj     key=treeobj\n"
+"       flux-kvs getat           treeobj key\n"
 );
     exit (1);
 }
@@ -166,6 +168,8 @@ int main (int argc, char *argv[])
         cmd_get_treeobj (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "put-treeobj"))
         cmd_put_treeobj (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "getat"))
+        cmd_getat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -645,6 +649,17 @@ void cmd_get_treeobj (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_get_treeobj %s", argv[0]);
     printf ("%s\n", treeobj);
     free (treeobj);
+}
+
+void cmd_getat (flux_t h, int argc, char **argv)
+{
+    char *val = NULL;
+    if (argc != 2)
+        log_msg_exit ("getat: specify treeobj and key");
+    if (kvs_getat (h, argv[0], argv[1], &val) < 0)
+        log_err_exit ("kvs_getat %s %s", argv[0], argv[1]);
+    printf ("%s\n", val);
+    free (val);
 }
 
 void cmd_put_treeobj (flux_t h, int argc, char **argv)

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -48,12 +48,14 @@ libflux_kvs_la_LIBADD =  $(top_builddir)/src/common/libflux-internal.la \
 TESTS = \
 	test_waitqueue.t \
 	test_proto.t \
-	test_cache.t
+	test_cache.t \
+	test_dirent.t
 
 test_ldadd = \
         $(top_builddir)/src/modules/kvs/cache.o \
         $(top_builddir)/src/modules/kvs/waitqueue.o \
         $(top_builddir)/src/modules/kvs/proto.o \
+        $(top_builddir)/src/modules/kvs/json_dirent.o \
         $(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -81,3 +83,7 @@ test_proto_t_LDADD = $(test_ldadd)
 test_cache_t_SOURCES = test/cache.c
 test_cache_t_CPPFLAGS = $(test_cppflags)
 test_cache_t_LDADD = $(test_ldadd)
+
+test_dirent_t_SOURCES = test/dirent.c
+test_dirent_t_CPPFLAGS = $(test_cppflags)
+test_dirent_t_LDADD = $(test_ldadd)

--- a/src/modules/kvs/json_dirent.c
+++ b/src/modules/kvs/json_dirent.c
@@ -60,6 +60,17 @@ json_object *dirent_create (char *type, void *arg)
     return dirent;
 }
 
+bool dirent_match (json_object *dirent1, json_object *dirent2)
+{
+    if (!dirent1 && !dirent2)
+        return true;
+    if ((dirent1 && !dirent2) || (!dirent1 && dirent2))
+        return false;
+    if (!strcmp (Jtostr (dirent1), Jtostr (dirent2)))
+        return true;
+    return false;
+}
+
 void dirent_append (json_object **array, const char *key, json_object *dirent)
 {
     json_object *op = Jnew ();

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 
 /* Create a KVS dirent.
  * 'type' is one of { "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL" }.
@@ -13,6 +14,12 @@ json_object *dirent_create (char *type, void *arg);
  * changes/unlinks a key in KVS namespace.  This function asserts on failure.
  */
 void dirent_append (json_object **array, const char *key, json_object *dirent);
+
+/* Compare two dirents.
+ * N.B. The serialize/strcmp method used here can return false negatives,
+ * but a positive can be relied on.
+ */
+bool dirent_match (json_object *dirent1, json_object *dirent2);
 
 int dirent_validate (json_object *dirent);
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -946,11 +946,14 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
+    const char *root_dirent = NULL;
     JSON in = NULL;
     JSON out = NULL;
     int flags;
     const char *key;
     JSON val;
+    JSON root = NULL;
+    JSON root_dirent_obj = NULL;
     wait_t *wait = NULL;
     int lookup_errnum = 0;
     int rc = -1;
@@ -961,11 +964,24 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
         errno = EPROTO;
         goto done;
     }
-    if (kp_tget_dec (in, &key, &flags) < 0)
+    if (kp_tget_dec (in, &root_dirent, &key, &flags) < 0)
         goto done;
     if (!(wait = wait_create_msg_handler (h, w, msg, get_request_cb, arg)))
         goto done;
-    if (!lookup (ctx, NULL, wait, flags, key, &val, &lookup_errnum))
+    /* If root dirent was specified, lookup will be relative to that.
+     */
+    if (root_dirent) {
+        const char *ref;
+
+        if (!(root_dirent_obj = Jfromstr (root_dirent))
+                || !Jget_str (root_dirent_obj, "DIRREF", &ref)) {
+            errno = EINVAL;
+            goto done;
+        }
+        if (!load (ctx, ref, wait, &root))
+            goto stall;
+    }
+    if (!lookup (ctx, root, wait, flags, key, &val, &lookup_errnum))
         goto stall;
     if (lookup_errnum != 0) {
         errno = lookup_errnum;
@@ -986,6 +1002,7 @@ done:
 stall:
     Jput (in);
     Jput (out);
+    Jput (root_dirent_obj);
 }
 
 static bool compare_json (json_object *o1, json_object *o2)

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -47,6 +47,11 @@ int kvs_get_symlink (flux_t h, const char *key, char **valp);
  */
 int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
 
+/* Like kvs_get() but lookup is relative to 'treeobj'.
+ */
+int kvs_getat (flux_t h, const char *treeobj,
+               const char *key, char **json_str);
+
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial
  * value and again each time the value changes.

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -380,6 +380,29 @@ int kvs_get (flux_t h, const char *key, char **val)
     return 0;
 }
 
+int kvs_getat (flux_t h, const char *treeobj,
+               const char *key, char **val)
+{
+    JSON v = NULL;
+    JSON dirent = NULL;
+
+    if (!treeobj || !key || !(dirent = Jfromstr (treeobj))
+                         || dirent_validate (dirent) < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (getobj (h, treeobj, key, 0, &v) < 0)
+        goto error;
+    if (val)
+        *val = xstrdup (Jtostr (v));
+    Jput (dirent);
+    return 0;
+error:
+    Jput (v);
+    Jput (dirent);
+    return -1;
+}
+
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -325,7 +325,8 @@ char *kvsdir_key_at (kvsdir_t *dir, const char *name)
  ** GET
  **/
 
-static int getobj (flux_t h, const char *key, int flags, json_object **val)
+static int getobj (flux_t h, const char *rootref, const char *key,
+                   int flags, json_object **val)
 {
     flux_rpc_t *rpc = NULL;
     const char *json_str;
@@ -341,7 +342,7 @@ static int getobj (flux_t h, const char *key, int flags, json_object **val)
         goto done;
     }
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (k, flags)))
+    if (!(in = kp_tget_enc (rootref, k, flags)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -371,7 +372,7 @@ int kvs_get (flux_t h, const char *key, char **val)
 {
     JSON v;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         return -1;
     if (val)
         *val = xstrdup (Jtostr (v));
@@ -382,7 +383,7 @@ int kvs_get (flux_t h, const char *key, char **val)
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {
-    return getobj (h, key, 0, val);
+    return getobj (h, NULL, key, 0, val);
 }
 
 int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
@@ -405,7 +406,7 @@ int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
     key = xvasprintf (fmt, ap);
     va_end (ap);
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (k, KVS_PROTO_READDIR)))
+    if (!(in = kp_tget_enc (NULL, k, KVS_PROTO_READDIR)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -435,7 +436,7 @@ int kvs_get_symlink (flux_t h, const char *key, char **val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, KVS_PROTO_READLINK, &v) < 0)
+    if (getobj (h, NULL, key, KVS_PROTO_READLINK, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_string) {
         errno = EPROTO;
@@ -455,7 +456,7 @@ int kvs_get_treeobj (flux_t h, const char *key, char **val)
     const char *s;
     int rc = -1;
 
-    if (getobj (h, key, KVS_PROTO_TREEOBJ, &v) < 0)
+    if (getobj (h, NULL, key, KVS_PROTO_TREEOBJ, &v) < 0)
         goto done;
     if (val) {
         s = json_object_to_json_string_ext (v, JSON_C_TO_STRING_PLAIN);
@@ -472,7 +473,7 @@ int kvs_get_string (flux_t h, const char *key, char **val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_string) {
         errno = EPROTO;
@@ -491,7 +492,7 @@ int kvs_get_int (flux_t h, const char *key, int *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_int) {
         errno = EPROTO;
@@ -510,7 +511,7 @@ int kvs_get_int64 (flux_t h, const char *key, int64_t *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_int) {
         errno = EPROTO;
@@ -529,7 +530,7 @@ int kvs_get_double (flux_t h, const char *key, double *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_double) {
         errno = EPROTO;
@@ -548,7 +549,7 @@ int kvs_get_boolean (flux_t h, const char *key, bool *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_boolean) {
         errno = EPROTO;
@@ -1651,7 +1652,7 @@ int kvsdir_unlink (kvsdir_t *dir, const char *name)
 int kvs_copy (flux_t h, const char *from, const char *to)
 {
     JSON dirent;
-    if (getobj (h, from, KVS_PROTO_TREEOBJ, &dirent) < 0)
+    if (getobj (h, NULL, from, KVS_PROTO_TREEOBJ, &dirent) < 0)
         return -1;
     if (kvs_put_dirent (h, to, dirent) < 0) {
         Jput (dirent);

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -271,12 +271,13 @@ done:
  */
 
 JSON kp_tsetroot_enc (int rootseq, const char *rootdir, JSON root,
-                      JSON names)
+                      JSON names, JSON keys)
 {
     JSON o = NULL;
     int n;
 
-    if (!rootdir || !names || !Jget_ar_len (names, &n) || n < 1) {
+    if (!rootdir || !names || !keys
+                 || !Jget_ar_len (names, &n) || n < 1) {
         errno = EINVAL;
         goto done;
     }
@@ -284,6 +285,7 @@ JSON kp_tsetroot_enc (int rootseq, const char *rootdir, JSON root,
     Jadd_int (o, "rootseq", rootseq);
     Jadd_str (o, "rootdir", rootdir);
     Jadd_obj (o, "names", names);         /* takes a ref */
+    Jadd_obj (o, "keys", keys);           /* takes a ref */
     if (root)
         Jadd_obj (o, "rootdirval", root); /* takes a ref */
 done:
@@ -291,16 +293,16 @@ done:
 }
 
 int kp_tsetroot_dec (JSON o, int *rootseq, const char **rootdir,
-                     JSON *root, JSON *names)
+                     JSON *root, JSON *names, JSON *keys)
 {
     int rc = -1;
 
-    if (!o || !rootseq || !rootdir || !root || !names) {
+    if (!o || !rootseq || !rootdir || !root || !names | !keys) {
         errno = EINVAL;
         goto done;
     }
     if (!Jget_int (o, "rootseq", rootseq) || !Jget_str (o, "rootdir", rootdir)
-                                          || !Jget_obj (o, "names", names)) {
+         || !Jget_obj (o, "names", names) || !Jget_obj (o, "keys", keys)) {
         errno = EPROTO;
         goto done;
     }

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -44,7 +44,7 @@
 /* kvs.get
  */
 
-JSON kp_tget_enc (const char *key, int flags)
+JSON kp_tget_enc (const char *treeobj, const char *key, int flags)
 {
     JSON o = NULL;
 
@@ -53,13 +53,15 @@ JSON kp_tget_enc (const char *key, int flags)
         goto done;
     }
     o = Jnew ();
+    if (treeobj)
+        Jadd_str (o, "root", treeobj);
     Jadd_str (o, "key", key);
     Jadd_int (o, "flags", flags);
 done:
     return o;
 }
 
-int kp_tget_dec (JSON o, const char **key, int *flags)
+int kp_tget_dec (JSON o, const char **treeobj, const char **key, int *flags)
 {
     int rc = -1;
 
@@ -70,6 +72,10 @@ int kp_tget_dec (JSON o, const char **key, int *flags)
     if (!Jget_str (o, "key", key) || !Jget_int (o, "flags", flags)) {
         errno = EPROTO;
         goto done;
+    }
+    if (treeobj) {
+        *treeobj = NULL;
+        (void)Jget_str (o, "root", treeobj);
     }
     rc = 0;
 done:

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -50,9 +50,11 @@ int kp_rgetroot_dec (json_object *o, int *rootseq, const char **rootdir);
 /* kvs.setroot (event)
  */
 json_object *kp_tsetroot_enc (int rootseq, const char *rootdir,
-                              json_object *root, json_object *names);
+                              json_object *root, json_object *names,
+                              json_object *keys);
 int kp_tsetroot_dec (json_object *o, int *rootseq, const char **rootdir,
-                     json_object **root, json_object **names);
+                     json_object **root, json_object **names,
+                     json_object **keys);
 
 /* kvs.error (event)
  */

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -12,8 +12,10 @@ enum {
 
 /* kvs.get
  */
-json_object *kp_tget_enc (const char *key, int flags);
-int kp_tget_dec (json_object *o, const char **key, int *flags);
+json_object *kp_tget_enc (const char *treeobj,
+                          const char *key, int flags);
+int kp_tget_dec (json_object *o, const char **treeobj,
+                 const char **key, int *flags);
 
 json_object *kp_rget_enc (json_object *val);
 int kp_rget_dec (json_object *o, json_object **val);

--- a/src/modules/kvs/test/dirent.c
+++ b/src/modules/kvs/test/dirent.c
@@ -1,0 +1,93 @@
+#include <string.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/modules/kvs/json_dirent.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    JSON d1, d2;
+    JSON dir;
+    JSON array = NULL;
+
+    plan (NO_PLAN);
+
+    d1 = dirent_create ("FILEREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    d2 = dirent_create ("FILEREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    ok (d1 && d2,
+        "dirent_create FILEREF works");
+    ok (dirent_match (d1, d2),
+        "dirent_match says identical dirents match");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+
+    dirent_append (&array, "foo", d1);
+    dirent_append (&array, "bar", d2);
+    ok (array != NULL && json_object_array_length (array) == 2,
+        "dirent_append works"); 
+    /* ownership of d1, d2 transferred to array */
+
+    diag ("ops: %s", Jtostr (array));
+    
+    d1 = dirent_create ("DIRREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    d2 = dirent_create ("DIRREF", "sha1-aaaaa4eb241948f6f802bf47d95ec932e9d4deaf");
+    ok (d1 && d2,
+        "dirent_create DIRREF works");
+    ok (!dirent_match (d1, d2),
+        "dirent_match says different dirents are different");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+
+    dirent_append (&array, "baz", d1);
+    dirent_append (&array, "urp", d2);
+    ok (array != NULL && json_object_array_length (array) == 4,
+        "dirent_append works"); 
+    /* ownership of d1, d2 transferred to array */
+
+    diag ("ops: %s", Jtostr (array));
+
+    /* ownership of new objects transferred to dirents */
+    d1 = dirent_create ("FILEVAL", json_object_new_int (42));
+    d2 = dirent_create ("FILEVAL", json_object_new_string ("hello world"));
+    ok (d1 && d2,
+        "dirent_create FILEVAL works");
+    ok (!dirent_match (d1, d2),
+        "dirent_match says different dirents are different");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+    dirent_append (&array, "baz", d1);
+    dirent_append (&array, "urp", d2);
+    ok (array != NULL && json_object_array_length (array) == 6,
+        "dirent_append works"); 
+
+    diag ("ops: %s", Jtostr (array));
+   
+    dir = Jnew ();
+    json_object_object_add (dir, "foo", dirent_create ("FILEVAL", json_object_new_int(33)));
+    json_object_object_add (dir, "bar", dirent_create ("FILEVAL", json_object_new_string ("Mrrrrnn?")));
+    d1 = dirent_create ("DIRVAL", dir);
+    ok (d1 != NULL,
+        "dirent_create DIRVAL works");
+    ok (dirent_validate (d1) == 0,
+        "dirent_validate says it is valid");
+    dirent_append (&array, "mmm", d1);
+    ok (array != NULL && json_object_array_length (array) == 7,
+        "dirent_append works"); 
+
+    diag ("ops: %s", Jtostr (array));
+
+    dirent_append (&array, "xxx", NULL);
+    ok (array != NULL && json_object_array_length (array) == 8,
+        "dirent_append allowed op with NULL dirent (unlink op)");
+
+    diag ("ops: %s", Jtostr (array));
+
+    Jput (array);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -11,19 +11,32 @@ void test_get (void)
 {
     JSON o;
     const char *key = NULL;
+    const char *rootref = NULL;
     JSON val = NULL;
     int i, flags;
 
-    o = kp_tget_enc ("foo", 42);
+    o = kp_tget_enc (NULL, "foo", 42);
     ok (o != NULL,
         "kp_tget_enc works");
     diag ("get request: %s", Jtostr (o));
     flags = 0;
-    ok (kp_tget_dec (o, &key, &flags) == 0 && flags == 42,
+    ok (kp_tget_dec (o, NULL, &key, &flags) == 0 && flags == 42,
         "kp_tget_dec works");
     like (key, "^foo$",
         "kp_tget_dec returned encoded key");
     Jput (o);
+
+    o = kp_tget_enc ("sha1-abcdefabcdef00000", "foo", 42);
+    ok (o != NULL,
+        "kp_tget_enc works");
+    diag ("get request: %s", Jtostr (o));
+    flags = 0;
+    ok (kp_tget_dec (o, &rootref, &key, &flags) == 0 && flags == 42,
+        "kp_tget_dec works");
+    like (rootref, "^sha1-.*$",
+        "kp_tget_dec returned rootref");
+    Jput (o);
+
 
     val = Jnew ();
     Jadd_int (val, "i", 42);

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -138,20 +138,25 @@ void test_setroot (void)
     JSON o;
     const char *rootdir, *name;
     int rootseq;
-    JSON root, names;
+    const char *key;
+    JSON root, names, keys;
 
     names = Jnew_ar ();
     Jadd_ar_str (names, "foo");
-    ok ((o = kp_tsetroot_enc (42, "abc", NULL, names)) != NULL,
+    keys = Jnew_ar ();
+    Jadd_ar_str (keys, "a.b.c");
+    ok ((o = kp_tsetroot_enc (42, "abc", NULL, names, keys)) != NULL,
         "kp_tsetroot_enc works");
     Jput (names);
+    Jput (keys);
 
     diag ("setroot: %s", Jtostr (o));
 
-    ok (kp_tsetroot_dec (o, &rootseq, &rootdir, &root, &names) == 0
+    ok (kp_tsetroot_dec (o, &rootseq, &rootdir, &root, &names, &keys) == 0
         && rootseq == 42 && rootdir != NULL && !strcmp (rootdir, "abc")
         && root == NULL && names != NULL && Jget_ar_str (names, 0, &name)
-        && !strcmp (name, "foo"),
+        && keys != NULL && Jget_ar_str (keys, 0, &key)
+        && !strcmp (key, "a.b.c"),
         "kp_tsetroot_dec works");
     Jput (o);
 }

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -418,8 +418,13 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 
 # watch tests
 
-test_expect_success 'kvs: watch-mt: multi-threaded kvs watch program' '
+test_expect_success 'kvs: watch-mt: multi-threaded kvs watch works on rank 0' '
 	${FLUX_BUILD_DIR}/t/kvs/watch mt 100 100 $TEST.a &&
+	flux kvs unlink $TEST.a
+'
+
+test_expect_success 'kvs: watch-mt: multi-threaded kvs watch works on rank 1' '
+	flux exec -r1 ${FLUX_BUILD_DIR}/t/kvs/watch mt 100 100 $TEST.a &&
 	flux kvs unlink $TEST.a
 '
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -355,6 +355,34 @@ test_expect_success 'kvs: put-treeobj: fails bad dirent: bad blobref' '
 	test_must_fail flux kvs put-treeobj $TEST.a="{\"DIRREF\":\"sha1-bbb\"}"
 '
 
+test_expect_success 'kvs: getat: fails bad on dirent' '
+	flux kvs unlink $TEST &&
+	test_must_fail flux kvs getat 42 $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRREF\":\"sha2-aaa\"}" $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRREF\":\"sha1-bbb\"}" $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRVAL\":{}}" $TEST.a
+'
+
+test_expect_success 'kvs: getat: works on root from get-treeobj' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	test $(flux kvs getat $(flux kvs get-treeobj .) $TEST.a.b.c) = 42
+'
+
+test_expect_success 'kvs: getat: works on subdir from get-treeobj' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	test $(flux kvs getat $(flux kvs get-treeobj $TEST.a.b) c) = 42
+'
+
+test_expect_success 'kvs: getat: works on outdated root' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	ROOTREF=$(flux kvs get-treeobj .) &&
+	flux kvs put $TEST.a.b.c=43 &&
+	test $(flux kvs getat $ROOTREF $TEST.a.b.c) = 42
+'
+
 test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs mkdir $TEST.dirsize &&
 	flux kvs put $TEST.dirsize.a=1 &&


### PR DESCRIPTION
This PR is a speculative attempt to redesign the kvs watch machinery to make it more efficient and scalable as discussed in #803.  So far:
* the `kvs.setroot` event sends out a list of keys modified by the commit
* new function `kvs_getat()` which is like `kvs_get()` but with additional _treeobj_ argument  (think of it like a snapshot-relative `kvs_get()` as suggested in #64)
* command line `flux kvs getat treeobj key` and sharness tests

What I was thinking of doing roughly, is removing the watch machinery from the kvs module entirely, and instead have the client `kvs_watch()` implementation:
* subscribe to kvs.setroot events
* get current value of key (call user callback)
* as each event comes in, if watched key is in the list, call `kvs_getat()` on the root treeobj from the event (call user callback)

I haven't quite figured out how to synchronize the first key value with the event-based updates.  We might need to expose the root sequence number in the dirent so we can correlate a dirent obtained from `kvs_get_treeobj (".")` with one obtained from the setroot event.

There might be a bit more latency getting updates this way, since the setroot event only triggers the sequence to obtain the next item; there has to be an RTT with the local kvs module before the new value can be passed to the user callback.  I think we can hide all that so it can remain asynchronous (reactor driven) though, e.g. setroot event handler sends rpc and registers a completion, then completion calls user callback.

Work in progress, but thought I'd post for early feedback.