### PR TITLE
python: add flake8/pylint checking

### DIFF
--- a/src/bindings/python/.pylintrc
+++ b/src/bindings/python/.pylintrc
@@ -1,0 +1,336 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# DEPRECATED
+include-ids=no
+
+# DEPRECATED
+symbols=no
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable= missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input,file
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/src/bindings/python/Makefile.am
+++ b/src/bindings/python/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS=flux
 
-EXTRA_DIST = pycotap test test_commands make_binding.py
+EXTRA_DIST = pycotap test test_commands make_binding.py .pylintrc
 
 clean-local:
 	-rm -f test/*.pyc test_commands/*.pyc

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -110,7 +110,10 @@ lib-copy: ${fluxpy_PYTHON} ${fluxpy_LTLIBRARIES}
 	[ "$(top_srcdir)" != "$(top_builddir)" ] && cp $(top_srcdir)/src/bindings/python/flux/*.py ./ || true
 
 #TODO: there must be a better way to do this
+# scan flux bindings with pylint, currently fails on any exit but 0
 check-local: lib-copy
+	if [ -x "$$( which pylint )" ] ; then  pylint --rcfile=$(top_srcdir)/src/bindings/python/.pylintrc ../flux ; fi
+
 all-local: lib-copy
 
 

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -1,4 +1,8 @@
+"""
+python bindings to flux-core, the main core of the flux resource manager
+"""
 # Import core symbols directly, allows flux.FLUX_MSGTYPE_ANY for example
+# pylint: disable=wildcard-import
 from flux.constants import *
 from flux.core import Flux
 

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -1,6 +1,6 @@
 # Import core symbols directly, allows flux.FLUX_MSGTYPE_ANY for example
 from flux.constants import *
-from flux.core import Flux, open
+from flux.core import Flux
 
 __all__ = ['core',
            'kvs',
@@ -8,8 +8,6 @@ __all__ = ['core',
            'rpc',
            'sec',
            'constants',
-           'Flux',
-           'open',
-           ]
+           'Flux', ]
 
 

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -13,5 +13,3 @@ __all__ = ['core',
            'sec',
            'constants',
            'Flux', ]
-
-

--- a/src/bindings/python/flux/command_helpers.py
+++ b/src/bindings/python/flux/command_helpers.py
@@ -10,7 +10,7 @@ def list_instances(sid=None):
 
     fdir = re.compile('flux-(?P<id>[^-]+)-')
 
-    for dirname, dirs, files in os.walk(tmpdir, topdown=True):
+    for _, dirs, _ in os.walk(tmpdir, topdown=True):
         for match in [fdir.match(d) for d in dirs]:
             if not match:
                 continue
@@ -25,6 +25,6 @@ def list_instances(sid=None):
                 os.kill(pid, 0)
                 flux.Flux(uri)
                 yield (match.group('id'), uri)
-            except:
+            except: # pylint: disable=bare-except
                 pass
         break

--- a/src/bindings/python/flux/command_helpers.py
+++ b/src/bindings/python/flux/command_helpers.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import sys, os, re, flux
+import os
+import re
+import flux
+
 
 def list_instances(sid=None):
     tmpdir = '/tmp'
@@ -8,19 +11,20 @@ def list_instances(sid=None):
     fdir = re.compile('flux-(?P<id>[^-]+)-')
 
     for dirname, dirs, files in os.walk(tmpdir, topdown=True):
-        for m in [fdir.match(d) for d in dirs]:
-            if not m: continue
-            if sid is not None and not re.search('flux-' + sid + '-',
-                                                 m.string):
+        for match in [fdir.match(d) for d in dirs]:
+            if not match:
                 continue
-            job = os.path.join (os.path.join(tmpdir, m.string), '0')
+            if sid is not None and not re.search('flux-' + sid + '-',
+                                                 match.string):
+                continue
+            job = os.path.join(os.path.join(tmpdir, match.string), '0')
             uri = 'local://' + job
             try:
-                with open(os.path.join(job, 'broker.pid')) as f:
-                    pid = int(f.readline())
+                with open(os.path.join(job, 'broker.pid')) as pidfile:
+                    pid = int(pidfile.readline())
                 os.kill(pid, 0)
-                f = flux.open(uri)
-                yield (m.group('id'), uri)
+                flux.Flux(uri)
+                yield (match.group('id'), uri)
             except:
                 pass
         break

--- a/src/bindings/python/flux/constants.py
+++ b/src/bindings/python/flux/constants.py
@@ -1,8 +1,8 @@
 """Global constants for the flux interface"""
 
-from flux._core import lib
 import sys
 import re
+from flux._core import lib
 
 MOD = sys.modules[__name__]
 # Inject enum/define names matching ^FLUX_[A-Z_]+$ into module
@@ -14,4 +14,3 @@ for k in dir(lib):
         ALL_LIST.append(k)
 
 __all__ = ALL_LIST
-

--- a/src/bindings/python/flux/constants.py
+++ b/src/bindings/python/flux/constants.py
@@ -1,17 +1,17 @@
 """Global constants for the flux interface"""
 
-from flux._core import ffi, lib
+from flux._core import lib
 import sys
 import re
 
-this_module = sys.modules[__name__]
+MOD = sys.modules[__name__]
 # Inject enum/define names matching ^FLUX_[A-Z_]+$ into module
-all_list = []
-p = re.compile("^FLUX_[A-Z_]+")
+ALL_LIST = []
+PATTERN = re.compile("^FLUX_[A-Z_]+")
 for k in dir(lib):
-    if p.match(k):
-        setattr(this_module, k, getattr(lib, k))
-        all_list.append(k)
+    if PATTERN.match(k):
+        setattr(MOD, k, getattr(lib, k))
+        ALL_LIST.append(k)
 
-__all__ = all_list
+__all__ = ALL_LIST
 

--- a/src/bindings/python/flux/core/__init__.py
+++ b/src/bindings/python/flux/core/__init__.py
@@ -1,4 +1,4 @@
-from flux.core.handle import Flux, open
+from flux.core.handle import Flux
 from flux.core.trampoline import mod_main_trampoline
-from flux.core.watchers import *
 
+__all__ = ["Flux", "mod_main_trampoline"]

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -11,7 +11,7 @@ class BarrierWrapper(Wrapper):
     pass
 
 
-_raw_barrier = BarrierWrapper(b_ffi, b_lib, prefixes=['flux_', ])
+RAW_BARRIER = BarrierWrapper(b_ffi, b_lib, prefixes=['flux_', ])
 
 
 class Flux(Wrapper):
@@ -32,7 +32,7 @@ class Flux(Wrapper):
                 'flux_',
                 'FLUX_',
             ],
-            destructor = raw.flux_close,)
+            destructor=raw.flux_close,)
 
         if handle is None:
             self.handle = raw.flux_open(url, flags)
@@ -78,8 +78,8 @@ class Flux(Wrapper):
                  nodeid=raw.FLUX_NODEID_ANY,
                  flags=0):
         """ Create and send an RPC in one step """
-        with RPC(self, topic, payload, nodeid, flags) as r:
-            return r.get()
+        with RPC(self, topic, payload, nodeid, flags) as rpc:
+            return rpc.get()
 
     def rpc_create(self, topic,
                    payload=None,
@@ -95,13 +95,14 @@ class Flux(Wrapper):
         :param payload: If a string, the payload is used unmodified, if it is
             another type json.dumps() is used to stringify it
         """
+        # pylint: disable=no-self-use
         return Message.from_event_encode(topic, payload)
 
     def event_send(self, topic, payload=None):
         """ Create and send a new event in one step """
         return self.send(self.event_create(topic, payload))
 
-    def event_recv(self, topic=None, payload=None):
+    def event_recv(self, topic=None):
         return self.recv(type_mask=raw.FLUX_MSGTYPE_EVENT, topic_glob=topic)
 
     def msg_watcher_create(self, callback,
@@ -118,7 +119,7 @@ class Flux(Wrapper):
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)
 
     def barrier(self, name, nprocs):
-        _raw_barrier.barrier(self, name, nprocs)
+        RAW_BARRIER.barrier(self, name, nprocs)
 
     def get_rank(self):
         rank = ffi.new('uint32_t [1]')

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -1,7 +1,4 @@
-import os
-import sys
-import json
-from flux.wrapper import Wrapper, WrapperPimpl
+from flux.wrapper import Wrapper
 from flux._core import ffi, lib
 from flux.core.inner import raw
 from flux.rpc import RPC
@@ -41,11 +38,13 @@ class Flux(Wrapper):
             self.handle = raw.flux_open(url, flags)
 
     def log(self, level, fstring):
-        """Log to the flux logging facility
+        """
+        Log to the flux logging facility
 
-       :param level: A syslog log-level, check the syslog module for possible values
-       :param fstring: A string to log, C-style formatting is *not* supported
-       """
+        :param level: A syslog log-level, check the syslog module for possible
+               values
+        :param fstring: A string to log, C-style formatting is *not* supported
+        """
         # Short-circuited because variadics can't be wrapped cleanly
         lib.flux_log(self.handle, level, fstring)
 
@@ -60,7 +59,9 @@ class Flux(Wrapper):
              match_tag=raw.FLUX_MATCHTAG_NONE,
              topic_glob=None,
              flags=0):
-        """ Receive a message, returns a flux.Message containing the result or None """
+        """
+        Receive a message, returns a flux.Message containing the result or None
+        """
         match = ffi.new('struct flux_match *', {
             'typemask': type_mask,
             'matchtag': match_tag,
@@ -91,7 +92,8 @@ class Flux(Wrapper):
         """ Create a new event message.
 
         :param topic: A string, the event's topic
-        :param payload: If a string, the payload is used unmodified, if it is another type json.dumps() is used to stringify it
+        :param payload: If a string, the payload is used unmodified, if it is
+            another type json.dumps() is used to stringify it
         """
         return Message.from_event_encode(topic, payload)
 
@@ -118,14 +120,7 @@ class Flux(Wrapper):
     def barrier(self, name, nprocs):
         _raw_barrier.barrier(self, name, nprocs)
 
-
     def get_rank(self):
         rank = ffi.new('uint32_t [1]')
         self.flux_get_rank(rank)
         return rank[0]
-
-def open(url, flags=0):
-    """ Open a connection to the specified flux connector """
-    return Flux(url, flags=flags)
-
-__all__ = [ 'Flux', 'open']

--- a/src/bindings/python/flux/core/inner.py
+++ b/src/bindings/python/flux/core/inner.py
@@ -1,18 +1,19 @@
 from flux._core import ffi, lib
 from flux.wrapper import Wrapper
 
-class Core(Wrapper):
-  """ 
-  Generic Core wrapper, you probably do not want or need one of these.
-  """
 
-  def __init__(self):
-    """Set up the wrapper interface for functions prefixed with flux_"""
-    super(Core, self).__init__(ffi,
-        lib,
-        prefixes=[
-          'flux_',
-          'FLUX_',
-          ])
+class Core(Wrapper):
+    """
+    Generic Core wrapper, you probably do not want or need one of these.
+    """
+
+    def __init__(self):
+        """Set up the wrapper interface for functions prefixed with flux_"""
+        super(Core, self).__init__(ffi,
+                                   lib,
+                                   prefixes=[
+                                       'flux_',
+                                       'FLUX_',
+                                   ])
 
 raw = Core()

--- a/src/bindings/python/flux/core/inner.py
+++ b/src/bindings/python/flux/core/inner.py
@@ -16,4 +16,6 @@ class Core(Wrapper):
                                        'FLUX_',
                                    ])
 
+# keeping this for compatibility
+# pylint: disable=invalid-name
 raw = Core()

--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -1,6 +1,6 @@
 import importlib
 from flux._core import lib
-from flux.core import Flux
+from flux.core.handle import Flux
 
 
 def mod_main_trampoline(name, int_handle, args):

--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -1,21 +1,23 @@
 import importlib
-from flux._core import ffi, lib
+from flux._core import lib
 from flux.core import Flux
+
 
 def mod_main_trampoline(name, int_handle, args):
     # print "trampoline entered"
-    #generate a flux wrapper class instance from the handle
-    flux_instance = Flux(handle = lib.unpack_long(int_handle))
+    # generate a flux wrapper class instance from the handle
+    flux_instance = Flux(handle=lib.unpack_long(int_handle))
     # print "flux instance retrieved, loading:", name
-    #impo__import__('flux.modules.' + name)rt the user's module dynamically
+    # impo__import__('flux.modules.' + name)rt the user's module dynamically
     user_mod = None
     try:
-      user_mod = importlib.import_module('flux.modules.' + name, 'flux.modules')
-    except ImportError: #check user paths for the module
-      user_mod = importlib.import_module(name)
+        user_mod = importlib.import_module(
+            'flux.modules.' + name, 'flux.modules')
+    except ImportError:  # check user paths for the module
+        user_mod = importlib.import_module(name)
 
     # print "user module loaded:", name
-    #call into mod_main with a flux class instance and the argument dict
-    #it might be more pythonic to unpack the args as keyword/positional arguments
-    #to this function, but I think this is cleaner for now
+    # call into mod_main with a flux class instance and the argument dict
+    # it might be more pythonic to unpack the args as keyword/positional
+    # arguments to this function, but I think this is cleaner for now
     user_mod.mod_main(flux_instance, *args)

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -1,5 +1,5 @@
-from flux.core.inner import raw, ffi
 import abc
+from flux.core.inner import raw, ffi
 
 __all__ = ['TimerWatcher', 'FDWatcher']
 

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -1,23 +1,21 @@
-import flux
 from flux.core.inner import raw, ffi
-import flux.message
 import abc
 
-__all__ = ['MessageWatcher', 'TimerWatcher', 'FDWatcher']
+__all__ = ['TimerWatcher', 'FDWatcher']
 
 
 class Watcher(object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self):
-        pass
+    def __init__(self, handle=None):
+        self.handle = handle
 
     def __enter__(self):
         """Allow this to be used as a context manager"""
         self.start()
         return self
 
-    def __exit__(self, type_arg, value, tb):
+    def __exit__(self, type_arg, value, _):
         """Allow this to be used as a context manager"""
         self.stop()
         return False
@@ -37,89 +35,55 @@ class Watcher(object):
             raw.flux_watcher_destroy(self.handle)
             self.handle = None
 
-
-@ffi.callback('flux_msg_handler_f')
-def message_handler_wrapper(handle_trash, m_watcher_t, msg_handle,
-                            opaque_handle):
-    watcher = ffi.from_handle(opaque_handle)
-    watcher.cb(watcher.fh, watcher,
-               flux.message.Message(handle=msg_handle,
-                                    destruct=False), watcher.args)
-
-
-class MessageWatcher(Watcher):
-
-    def __init__(self, flux_handle, type_mask, callback,
-                 topic_glob='*',
-                 match_tag=flux.FLUX_MATCHTAG_NONE,
-                 args=None):
-        self.handle = None
-        self.fh = flux_handle
-        self.cb = callback
-        self.args = args
-        self.wargs = ffi.new_handle(self)
-        c_topic_glob = ffi.new('char[]', topic_glob)
-        match = ffi.new('struct flux_match *', {
-            'typemask': type_mask,
-            'matchtag': match_tag,
-            'topic_glob': c_topic_glob,
-        })
-        self.handle = raw.flux_msg_handler_create(self.fh.handle, match[0],
-                                                  message_handler_wrapper,
-                                                  self.wargs)
-
-    def start(self):
-        raw.flux_msg_handler_start(self.handle)
-
-    def stop(self):
-        raw.flux_msg_handler_stop(self.handle)
-
-    def destroy(self):
-        if self.handle is not None:
-            raw.flux_handler_destroy(self.handle)
-            self.handle = None
-
-
 @ffi.callback('flux_watcher_f')
-def timeout_handler_wrapper(handle_trash, watcher_s, revents,
-                            opaque_handle):
+def timeout_handler_wrapper(unused1, unused2, revents, opaque_handle):
+    del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
-    watcher.cb(watcher.fh, watcher, revents, watcher.args)
+    watcher.callback(watcher.flux_handle, watcher, revents, watcher.args)
 
 
 class TimerWatcher(Watcher):
 
     def __init__(self, flux_handle, after, callback, repeat=0, args=None, ):
-        self.fh = flux_handle
+        self.flux_handle = flux_handle
         self.after = after
         self.repeat = repeat
-        self.cb = callback
+        self.callback = callback
         self.args = args
         self.handle = None
         self.wargs = ffi.new_handle(self)
-        self.handle = raw.flux_timer_watcher_create(
-            raw.flux_get_reactor(flux_handle),
-            float(after), float(repeat), timeout_handler_wrapper, self.wargs)
+        super(TimerWatcher, self).__init__(
+            raw.flux_timer_watcher_create(
+                raw.flux_get_reactor(flux_handle),
+                float(after),
+                float(repeat),
+                timeout_handler_wrapper,
+                self.wargs))
 
 
 @ffi.callback('flux_watcher_f')
-def fd_handler_wrapper(handle_trash, fd_watcher_s, revents,
-                       opaque_handle):
+def fd_handler_wrapper(unused1, unused2, revents, opaque_handle):
+    del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
     fd_int = raw.fd_watcher_get_fd(watcher.handle)
-    watcher.cb(watcher.fh, watcher, fd_int, revents, watcher.args)
+    watcher.callback(watcher.flux_handle, watcher,
+                     fd_int, revents, watcher.args)
 
 
 class FDWatcher(Watcher):
 
     def __init__(self, flux_handle, fd_int, events, callback, args=None):
-        self.fh = flux_handle
+        self.flux_handle = flux_handle
         self.fd_int = fd_int
         self.events = events
-        self.cb = callback
+        self.callback = callback
         self.args = args
         self.handle = None
         self.wargs = ffi.new_handle(self)
-        self.handle = raw.flux_fd_watcher_create(
-            raw.flux_get_reactor(flux_handle),
-            self.fd_int, self.events, fd_handler_wrapper, self.wargs)
+        super(FDWatcher, self).__init__(
+            raw.flux_fd_watcher_create(
+                raw.flux_get_reactor(flux_handle),
+                self.fd_int,
+                self.events,
+                fd_handler_wrapper,
+                self.wargs))

--- a/src/bindings/python/flux/jsc.py
+++ b/src/bindings/python/flux/jsc.py
@@ -1,92 +1,81 @@
-from flux.wrapper import Wrapper, WrapperPimpl
+from flux.wrapper import Wrapper
 from flux._jsc import ffi, lib
 
 # Constants taken from jstatctl.h
-JSC_STATE_PAIR                 = "state-pair"
-JSC_STATE_PAIR_OSTATE          = "ostate"
-JSC_STATE_PAIR_NSTATE          = "nstate"
-JSC_RDESC                      = "rdesc"
-JSC_RDESC_NNODES               = "nnodes"
-JSC_RDESC_NTASKS               = "ntasks"
-JSC_RDESC_WALLTIME             = "walltime"
-JSC_RDL                        = "rdl"
-JSC_RDL_ALLOC                  = "rdl_alloc"
-JSC_RDL_ALLOC_CONTAINED        = "contained"
-JSC_RDL_ALLOC_CONTAINING_RANK  = "cmbdrank"
+JSC_STATE_PAIR = "state-pair"
+JSC_STATE_PAIR_OSTATE = "ostate"
+JSC_STATE_PAIR_NSTATE = "nstate"
+JSC_RDESC = "rdesc"
+JSC_RDESC_NNODES = "nnodes"
+JSC_RDESC_NTASKS = "ntasks"
+JSC_RDESC_WALLTIME = "walltime"
+JSC_RDL = "rdl"
+JSC_RDL_ALLOC = "rdl_alloc"
+JSC_RDL_ALLOC_CONTAINED = "contained"
+JSC_RDL_ALLOC_CONTAINING_RANK = "cmbdrank"
 JSC_RDL_ALLOC_CONTAINED_NCORES = "cmbdncores"
-JSC_PDESC                      = "pdesc"
-JSC_PDESC_SIZE                 = "procsize"
-JSC_PDESC_HOSTNAMES            = "hostnames"
-JSC_PDESC_EXECS                = "executables"
-JSC_PDESC_PDARRAY              = "pdarray"
-JSC_PDESC_RANK_PDARRAY_PID     = "pid"
-JSC_PDESC_RANK_PDARRAY_HINDX   = "hindx"
-JSC_PDESC_RANK_PDARRAY_EINDX   = "eindx"
+JSC_PDESC = "pdesc"
+JSC_PDESC_SIZE = "procsize"
+JSC_PDESC_HOSTNAMES = "hostnames"
+JSC_PDESC_EXECS = "executables"
+JSC_PDESC_PDARRAY = "pdarray"
+JSC_PDESC_RANK_PDARRAY_PID = "pid"
+JSC_PDESC_RANK_PDARRAY_HINDX = "hindx"
+JSC_PDESC_RANK_PDARRAY_EINDX = "eindx"
 
-J_NULL       = 1
-J_RESERVED   = 2
-J_SUBMITTED  = 3
-J_PENDING    = 4
-J_SCHEDREQ   = 5
-J_SELECTED   = 6
-J_ALLOCATED  = 7
-J_RUNREQUEST = 8
-J_STARTING   = 9
-J_STOPPED    = 10
-J_RUNNING    = 11
-J_CANCELLED  = 12
-J_COMPLETE   = 13
-J_REAPED     = 14
-J_FAILED     = 15
-J_FOR_RENT   = 16
 
 class JSCWrapper(Wrapper):
-  """
-  Generic JSC wrapper
-  """
+    """
+    Generic JSC wrapper
+    """
 
-  def __init__(self):
-    """Set up the wrapper interface for functions prefixed with jsc_"""
-    super(JSCWrapper, self).__init__(ffi,
-        lib,
-        prefixes=[
-          'jsc_',
-          ])
+    def __init__(self):
+        """Set up the wrapper interface for functions prefixed with jsc_"""
+        super(JSCWrapper, self).__init__(ffi,
+                                         lib,
+                                         prefixes=[
+                                             'jsc_',
+                                         ])
 
 _raw = JSCWrapper()
 
+
 def query_jcb(flux_handle, jobid, key):
-  jcb_str = ffi.new('char *[1]')
-  _raw.query_jcb(flux_handle, jobid, key, jcb_str)
-  if jcb_str[0] == ffi.NULL:
-    return None
-  else:
-    return ffi.string(jcb_str[0])
+    jcb_str = ffi.new('char *[1]')
+    _raw.query_jcb(flux_handle, jobid, key, jcb_str)
+    if jcb_str[0] == ffi.NULL:
+        return None
+    else:
+        return ffi.string(jcb_str[0])
+
 
 def update_jcb(flux_handle, jobid, key, jcb):
-  return _raw.jsc_update_jcb(flux_handle, jobid, key, jcb)
+    return _raw.jsc_update_jcb(flux_handle, jobid, key, jcb)
+
 
 @ffi.callback('jsc_handler_f')
 def JSCNotifyWrapper(jcb, arg, errnum):
-  if jcb != ffi.NULL:
-    jcb = ffi.string(jcb)
-  cb, real_arg = ffi.from_handle(arg)
-  # TODO: necessary to check errnum?
-  ret = cb(jcb, real_arg, errnum)
-  return ret if ret is not None else 0
+    if jcb != ffi.NULL:
+        jcb = ffi.string(jcb)
+    cb, real_arg = ffi.from_handle(arg)
+    # TODO: necessary to check errnum?
+    ret = cb(jcb, real_arg, errnum)
+    return ret if ret is not None else 0
 
 handles = []
 
+
 def notify_status(flux_handle, fun, arg):
-  warg = (fun, arg)
-  whandle = ffi.new_handle(warg)
-  # TODO: another way to keep in scope to prevent GC?
-  handles.append(whandle)
-  return _raw.notify_status(flux_handle, JSCNotifyWrapper, whandle)
+    warg = (fun, arg)
+    whandle = ffi.new_handle(warg)
+    # TODO: another way to keep in scope to prevent GC?
+    handles.append(whandle)
+    return _raw.notify_status(flux_handle, JSCNotifyWrapper, whandle)
+
 
 def job_num2state(job_state):
-  ret = _raw.job_num2state(job_state)
-  if ret == ffi.NULL:
-    return None
-  else:
-    return ffi.string(ret)
+    ret = _raw.job_num2state(job_state)
+    if ret == ffi.NULL:
+        return None
+    else:
+        return ffi.string(ret)

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -1,8 +1,8 @@
-from _kvs import ffi, lib
-from flux.wrapper import Wrapper, WrapperPimpl
 import json
 import collections
 import errno
+from flux._kvs import ffi, lib
+from flux.wrapper import Wrapper, WrapperPimpl
 
 
 class KVSWrapper(Wrapper):

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -3,7 +3,6 @@ from flux.wrapper import Wrapper, WrapperPimpl
 import json
 import collections
 import errno
-import sys
 
 
 class KVSWrapper(Wrapper):
@@ -11,14 +10,14 @@ class KVSWrapper(Wrapper):
     # across wrappers
     pass
 
-_raw = KVSWrapper(ffi, lib, prefixes=['kvs', 'kvs_'])
+RAW = KVSWrapper(ffi, lib, prefixes=['kvs', 'kvs_'])
 # override error check behavior for kvsitr_next
-_raw.kvsitr_next.set_error_check(lambda x: False)
+RAW.kvsitr_next.set_error_check(lambda x: False)
 
 
 def get_key_direct(flux_handle, key):
     valp = ffi.new('char *[1]')
-    _raw.get(flux_handle, key, valp)
+    RAW.get(flux_handle, key, valp)
     if valp[0] == ffi.NULL:
         return None
     else:
@@ -64,15 +63,15 @@ def get(flux_handle, key):
 
 def put(flux_handle, key, value):
     json_str = json.dumps(value)
-    _raw.put(flux_handle, key, json_str)
+    RAW.put(flux_handle, key, json_str)
 
 
 def commit(flux_handle):
-    return _raw.kvs_commit(flux_handle)
+    return RAW.kvs_commit(flux_handle)
 
 
 def dropcache(flux_handle):
-    return _raw.dropcache(flux_handle)
+    return RAW.dropcache(flux_handle)
 
 
 def watch_once(flux_handle, key):
@@ -81,13 +80,13 @@ def watch_once(flux_handle, key):
     updated value of the key
     """
     if isdir(flux_handle, key):
-        d = get_dir(flux_handle)
-        # The wrapper automatically unpacks d's handle
-        _raw.watch_once_dir(flux_handle, d)
-        return d
+        directory = get_dir(flux_handle)
+        # The wrapper automatically unpacks directory's handle
+        RAW.watch_once_dir(flux_handle, directory)
+        return directory
     else:
         out_json_str = ffi.new('char *[1]')
-        _raw.watch_once(flux_handle, key, out_json_str)
+        RAW.watch_once(flux_handle, key, out_json_str)
         if out_json_str[0] == ffi.NULL:
             return None
         else:
@@ -95,10 +94,12 @@ def watch_once(flux_handle, key):
 
 
 class KVSDir(WrapperPimpl, collections.MutableMapping):
+    # pylint: disable=too-many-ancestors, too-many-public-methods
 
     class InnerWrapper(Wrapper):
 
         def __init__(self, flux_handle=None, path='.', handle=None):
+            dest = RAW.kvsdir_destroy
             super(self.__class__, self).__init__(ffi, lib,
                                                  handle=handle,
                                                  match=ffi.typeof(
@@ -106,28 +107,29 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
                                                  prefixes=[
                                                      'kvsdir_',
                                                  ],
-                                                 destructor=_raw.kvsdir_destroy)
+                                                 destructor=dest)
 
             if flux_handle is None and handle is None:  # pragma: no cover
-                raise ValueError(
-                    "flux_handle must be a valid Flux object or handle must be a valid kvsdir cdata pointer")
+                raise ValueError("flux_handle must be a valid Flux object or "
+                                 "handle must be a valid kvsdir cdata pointer")
             if handle is None:
-                d = ffi.new("kvsdir_t *[1]")
-                _raw.kvs_get_dir(flux_handle, d, path)
-                self.handle = d[0]
+                directory = ffi.new("kvsdir_t *[1]")
+                RAW.kvs_get_dir(flux_handle, directory, path)
+                self.handle = directory[0]
                 if self.handle is None or self.handle == ffi.NULL:
                     raise EnvironmentError("No such file or directory")
 
     def __init__(self, flux_handle=None, path='.', handle=None):
-        self.fh = flux_handle
+        super(KVSDir, self).__init__()
+        self.fhdl = flux_handle
         self.path = path
         if flux_handle is None and handle is None:
-            raise ValueError(
-                "flux_handle must be a valid Flux object or handle must be a valid kvsdir cdata pointer")
+            raise ValueError("flux_handle must be a valid Flux object or"
+                             "handle must be a valid kvsdir cdata pointer")
         self.pimpl = self.InnerWrapper(flux_handle, path, handle)
 
     def commit(self):
-        commit(self.fh.handle)
+        commit(self.fhdl.handle)
 
     def key_at(self, key):
         c_str = self.pimpl.key_at(key)
@@ -140,7 +142,7 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
 
     def __getitem__(self, key):
         try:
-            return get(self.fh, self.key_at(key))
+            return get(self.fhdl, self.key_at(key))
         except EnvironmentError:
             raise KeyError(
                 '{} not found under directory {}'.format(key, self.key_at('')))
@@ -155,19 +157,19 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
 
     class KVSDirIterator(collections.Iterator):
 
-        def __init__(self, kd):
-            self.kd = kd
+        def __init__(self, kvsdir):
+            self.kvsdir = kvsdir
             self.itr = None
-            self.itr = _raw.kvsitr_create(kd.handle)
+            self.itr = RAW.kvsitr_create(kvsdir.handle)
 
         def __del__(self):
-            _raw.kvsitr_destroy(self.itr)
+            RAW.kvsitr_destroy(self.itr)
 
         def __iter__(self):
             return self
 
         def __next__(self):
-            ret = _raw.kvsitr_next(self.itr)
+            ret = RAW.kvsitr_next(self.itr)
             if ret is None or ret == ffi.NULL:
                 raise StopIteration()
             return ffi.string(ret)
@@ -195,8 +197,8 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
             raise ValueError("contents must be non-None")
 
         try:
-            for k, v in contents.items():
-                self[k] = v
+            for key, val in contents.items():
+                self[key] = val
         finally:
             self.commit()
 
@@ -206,15 +208,14 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
         of `files` as would be done with `fill(contents)`
 
         :param key: Key of the directory to be created
-        :param contents: A dict of keys and values to be created in the directory
-          or None, sub-directories can be created by using `dir.file` syntax,
-          sub-dicts will be stored as json values in a single key
+        :param contents: A dict of keys and values to be created in the
+          directory or None, sub-directories can be created by using `dir.file`
+          syntax, sub-dicts will be stored as json values in a single key
         """
 
         self.pimpl.mkdir(key)
-        # TODO : find a way to aggregate past mkdir commands
         self.commit()
-        new_kvsdir = KVSDir(self.fh, key)
+        new_kvsdir = KVSDir(self.fhdl, key)
         if contents is not None:
             new_kvsdir.fill(contents)
 
@@ -229,6 +230,7 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
                 yield k
 
     def list_all(self, topdown=False):
+        # pylint: disable=unused-argument
         files = []
         dirs = []
         for k in self:
@@ -243,34 +245,37 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
         return self
 
     def __exit__(self, type_arg, value, tb):
-        """ When used as a context manager, the KVSDir commits itself on exit """
+        """
+        When used as a context manager, the KVSDir commits itself on exit
+        """
         self.commit()
         return False
 
-    def watch_once(self, flux_handle, key):
+    def watch_once(self, key):
         """
         Watches the selected key until the next change, then returns the
         updated value of the key
         """
         full_key = self.key_at(key)
-        return watch_once(self.fh, full_key)
+        return watch_once(self.fhdl, full_key)
 
 
 def join(*args):
     return ".".join([a for a in args if len(a) > 0])
 
 
-def inner_walk(kd, curr_dir, topdown=False):
+def inner_walk(kvsdir, curr_dir, topdown=False):
     if topdown:
-        yield (curr_dir, kd.directories(), kd.files())
+        yield (curr_dir, kvsdir.directories(), kvsdir.files())
 
-    for d in kd.directories():
-        path = join(curr_dir, d)
-        for x in inner_walk(get_dir(kd.fh, kd.key_at(d)), path, topdown):
-            yield x
+    for directory in kvsdir.directories():
+        path = join(curr_dir, directory)
+        key = kvsdir.key_at(directory)
+        for entry in inner_walk(get_dir(kvsdir.fhdl, key), path, topdown):
+            yield entry
 
     if not topdown:
-        yield (curr_dir, kd.directories(), kd.files())
+        yield (curr_dir, kvsdir.directories(), kvsdir.files())
 
 
 def walk(directory, topdown=False, flux_handle=None):
@@ -284,26 +289,26 @@ def walk(directory, topdown=False, flux_handle=None):
 
 
 @ffi.callback('kvs_set_f')
-def KVSWatchWrapper(key, value, arg, errnum):
-    (cb, real_arg) = ffi.from_handle(arg)
+def kvs_watch_wrapper(key, value, arg, errnum):
+    (callback, real_arg) = ffi.from_handle(arg)
     if errnum == errno.ENOENT:
         value = None
     else:
         value = json.loads(ffi.string(value))
     key = ffi.string(key)
-    ret = cb(key, value, real_arg, errnum)
+    ret = callback(key, value, real_arg, errnum)
     return ret if ret is not None else 0
 
 
-kvswatches = {}
+KVSWATCHES = {}
 
 
 def watch(flux_handle, key, fun, arg):
     warg = (fun, arg)
-    kvswatches[key] = warg
-    return _raw.watch(flux_handle, key, KVSWatchWrapper, ffi.new_handle(warg))
+    KVSWATCHES[key] = warg
+    return RAW.watch(flux_handle, key, kvs_watch_wrapper, ffi.new_handle(warg))
 
 
 def unwatch(flux_handle, key):
-    kvswatches.pop(key, None)
-    return _raw.unwatch(flux_handle, key)
+    KVSWATCHES.pop(key, None)
+    return RAW.unwatch(flux_handle, key)

--- a/src/bindings/python/flux/kz.py
+++ b/src/bindings/python/flux/kz.py
@@ -1,8 +1,9 @@
-from _kz import ffi, lib
-from flux.wrapper import Wrapper, WrapperPimpl
 import errno
 import os
 import sys
+
+from flux._kz import ffi, lib
+from flux.wrapper import Wrapper, WrapperPimpl
 
 
 class KZWrapper(Wrapper):
@@ -24,7 +25,7 @@ def generic_write(stream, string):
 
 @ffi.callback('kz_ready_f')
 def kz_stream_handler(kz_handle, arg):
-    del kz_handle # unused
+    del kz_handle  # unused
     (stream, prefix, handle) = ffi.from_handle(arg)
     buf = ffi.new('char *[1]')
     while True:
@@ -65,7 +66,7 @@ def attach(flux_handle,
 
 
 def detach(flux_handle, key):
-    del flux_handle # unused
+    del flux_handle  # unused
     (_, _, handle) = KZWATCHES.pop(key, None)
     return RAW.close(handle)
 
@@ -124,7 +125,8 @@ class KZStream(WrapperPimpl):
             raise ValueError(
                 "flux_handle must be a valid Flux object or handle must be a "
                 "valid kvsdir cdata pointer")
-        self.pimpl = self.InnerWrapper(flux_handle, name, flags, handle, prefix)
+        self.pimpl = self.InnerWrapper(
+            flux_handle, name, flags, handle, prefix)
 
     def __enter__(self):
         """Allow this to be used as a context manager"""

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -12,6 +12,7 @@ class Message(WrapperPimpl):
     """ Flux message wrapper class. """
 
     class InnerWrapper(Wrapper):
+
         def __init__(self,
                      type_id=flux.FLUX_MSGTYPE_REQUEST,
                      handle=None,
@@ -28,6 +29,10 @@ class Message(WrapperPimpl):
             if handle is None:
                 self.handle = raw.flux_msg_create(type_id)
 
+        def __del__(self):
+            if ((not self.external or self.destruct) and
+                    self.handle is not None and self.handle != ffi.NULL):
+                raw.flux_msg_destroy(self.handle)
 
     def __init__(self,
                  type_id=flux.FLUX_MSGTYPE_REQUEST,

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -1,8 +1,8 @@
+import json
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 from flux.core.watchers import Watcher
 import flux.constants
-import json
 
 __all__ = ['Message',
            'MessageWatcher',

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -1,11 +1,16 @@
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
-import flux
+from flux.core.watchers import Watcher
+import flux.constants
 import json
 
+__all__ = ['Message',
+           'MessageWatcher',
+           'msg_typestr']
 
-def msg_typestr(t):
-    return ffi.string(raw.flux_msg_typestr(t))
+
+def msg_typestr(msg_type):
+    return ffi.string(raw.flux_msg_typestr(msg_type))
 
 
 class Message(WrapperPimpl):
@@ -14,7 +19,7 @@ class Message(WrapperPimpl):
     class InnerWrapper(Wrapper):
 
         def __init__(self,
-                     type_id=flux.FLUX_MSGTYPE_REQUEST,
+                     type_id=flux.constants.FLUX_MSGTYPE_REQUEST,
                      handle=None,
                      destruct=False,):
             super(self.__class__, self).__init__(
@@ -35,9 +40,10 @@ class Message(WrapperPimpl):
                 raw.flux_msg_destroy(self.handle)
 
     def __init__(self,
-                 type_id=flux.FLUX_MSGTYPE_REQUEST,
+                 type_id=flux.constants.FLUX_MSGTYPE_REQUEST,
                  handle=None,
                  destruct=False,):
+        super(Message, self).__init__()
         self.pimpl = self.InnerWrapper(type_id, handle, destruct)
 
     @property
@@ -56,9 +62,9 @@ class Message(WrapperPimpl):
 
     @property
     def topic(self):
-        s = ffi.new('char *[1]')
-        self.pimpl.get_topic(s)
-        return ffi.string(s[0])
+        topic_string = ffi.new('char *[1]')
+        self.pimpl.get_topic(topic_string)
+        return ffi.string(topic_string[0])
 
     @topic.setter
     def topic(self, value):
@@ -66,10 +72,10 @@ class Message(WrapperPimpl):
 
     @property
     def payload_str(self):
-        s = ffi.new('char *[1]')
+        string = ffi.new('char *[1]')
         if self.pimpl.has_payload():
-            self.pimpl.get_json(ffi.cast('char**', s))
-            return ffi.string(s[0])
+            self.pimpl.get_json(ffi.cast('char**', string))
+            return ffi.string(string[0])
         else:
             return None
 
@@ -87,9 +93,9 @@ class Message(WrapperPimpl):
 
     @property
     def type(self):
-        s = ffi.new('int [1]')
-        self.pimpl.get_type(s)
-        return s[0]
+        message_type = ffi.new('int [1]')
+        self.pimpl.get_type(message_type)
+        return message_type[0]
 
     @type.setter
     def type(self, value):
@@ -98,3 +104,49 @@ class Message(WrapperPimpl):
     @property
     def type_str(self):
         return msg_typestr(self.type)
+
+# Residing here to avoid cyclic references
+
+
+@ffi.callback('flux_msg_handler_f')
+def message_handler_wrapper(unused1, unused2, msg_handle, opaque_handle):
+    del unused1, unused2  # unused arguments
+    watcher = ffi.from_handle(opaque_handle)
+    watcher.callback(watcher.flux_handle, watcher,
+                     Message(handle=msg_handle,
+                             destruct=False), watcher.args)
+
+
+class MessageWatcher(Watcher):
+
+    def __init__(self, flux_handle, type_mask, callback,
+                 topic_glob='*',
+                 match_tag=flux.constants.FLUX_MATCHTAG_NONE,
+                 args=None):
+        self.flux_handle = flux_handle
+        self.callback = callback
+        self.args = args
+        self.wargs = ffi.new_handle(self)
+        c_topic_glob = ffi.new('char[]', topic_glob)
+        match = ffi.new('struct flux_match *', {
+            'typemask': type_mask,
+            'matchtag': match_tag,
+            'topic_glob': c_topic_glob,
+        })
+        super(MessageWatcher, self).__init__(
+            raw.flux_msg_handler_create(
+                self.flux_handle.handle,
+                match[0],
+                message_handler_wrapper,
+                self.wargs))
+
+    def start(self):
+        raw.flux_msg_handler_start(self.handle)
+
+    def stop(self):
+        raw.flux_msg_handler_stop(self.handle)
+
+    def destroy(self):
+        if self.handle is not None:
+            raw.flux_handler_destroy(self.handle)
+            self.handle = None

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -1,7 +1,7 @@
+import json
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 import flux.constants
-import json
 
 
 class RPC(WrapperPimpl):

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -1,77 +1,86 @@
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
-import flux
+import flux.constants
 import json
 
+
 class RPC(WrapperPimpl):
-  """An RPC state object"""
-  class InnerWrapper(Wrapper):
+    """An RPC state object"""
+    class InnerWrapper(Wrapper):
+
+        def __init__(self,
+                     flux_handle,
+                     topic,
+                     payload=None,
+                     nodeid=flux.constants.FLUX_NODEID_ANY,
+                     flags=0,
+                     handle=None):
+            # hold a reference for destructor ordering
+            self._handle = flux_handle
+            dest = raw.flux_rpc_destroy
+            super(self.__class__, self).__init__(ffi, lib,
+                                                 handle=handle,
+                                                 match=ffi.typeof(
+                                                     lib.flux_rpc).result,
+                                                 prefixes=[
+                                                     'flux_rpc_',
+                                                 ],
+                                                 destructor=dest,)
+            if handle is None:
+                if isinstance(flux_handle, Wrapper):
+                    flux_handle = flux_handle.handle
+
+
+                if payload is None or payload == ffi.NULL:
+                    payload = ffi.NULL
+                elif not isinstance(payload, basestring):
+                    payload = json.dumps(payload)
+
+                if isinstance(nodeid, basestring):
+                    # String version is multiple nodeids
+                    self.handle = lib.flux_rpc_multi(
+                        flux_handle, topic, payload, nodeid, flags)
+                else:
+                    self.handle = lib.flux_rpc(
+                        flux_handle, topic, payload, nodeid, flags)
+
     def __init__(self,
                  flux_handle,
                  topic,
                  payload=None,
-                 nodeid=flux.FLUX_NODEID_ANY,
+                 nodeid=flux.constants.FLUX_NODEID_ANY,
                  flags=0,
                  handle=None):
-      # hold a reference for destructor ordering
-      self.fh = flux_handle
-      super(self.__class__, self).__init__(ffi, lib,
-                                       handle=handle,
-                                       match=ffi.typeof(lib.flux_rpc).result,
-                                       prefixes=[
-                                         'flux_rpc_',
-                                         ],
-                                       destructor=raw.flux_rpc_destroy,
-                                       )
-      if handle is None:
-        if isinstance(flux_handle, Wrapper):
-          flux_handle = flux_handle.handle
+        super(RPC, self).__init__()
+        self.pimpl = self.InnerWrapper(flux_handle,
+                                       topic,
+                                       payload,
+                                       nodeid,
+                                       flags,
+                                       handle)
+        self.then_args = None
+        self.then_cb = None
 
-        if payload is None:
-          payload = ffi.NULL
-        elif payload != ffi.NULL and not isinstance(payload, basestring):
-          payload = json.dumps(payload)
+    def check(self):
+        return bool(self.pimpl.check())
 
-        if isinstance(nodeid, basestring):
-          # String version is multiple nodeids
-          self.handle = lib.flux_rpc_multi(flux_handle, topic, payload, nodeid, flags)
-        else:
-          self.handle = lib.flux_rpc(flux_handle, topic, payload, nodeid, flags)
+    def completed(self):
+        return bool(self.pimpl.completed())
 
-  def __init__(self,
-               flux_handle,
-               topic,
-               payload=None,
-               nodeid=flux.FLUX_NODEID_ANY,
-               flags=0,
-               handle=None):
-    self.pimpl = self.InnerWrapper(flux_handle,
-        topic,
-        payload,
-        nodeid,
-        flags,
-        handle)
+    def get_str(self):
+        j_str = ffi.new('char *[1]')
+        self.pimpl.get(j_str)
+        return ffi.string(j_str[0])
 
-  def check(self):
-    return bool(self.pimpl.check())
+    def get(self):
+        return json.loads(self.get_str())
 
-  def completed(self):
-    return bool(self.pimpl.completed())
-
-  def get_str(self):
-    j_str = ffi.new('char *[1]')
-    self.pimpl.get(j_str)
-    return ffi.string(j_str[0])
-
-  def get(self):
-    return json.loads(self.get_str())
-
-  def then(self, cb, args):
-    def ThenWrapper(trash, arg):
-      rpc_handle = ffi.from_handle(arg)
-      cb(rpc_handle, rpc_handle.then_args)
-    # Save the callback to keep it from getting collected
-    self.then_cb = ffi.callback('flux_then_f',ThenWrapper)
-    self.then_args = args
-    return self.pimpl.then(self.then_cb, ffi.new_handle(self))
-
+    def then(self, callback, args):
+        # pylint: disable=unused-argument
+        def then_wrapper(trash, arg):
+            rpc_handle = ffi.from_handle(arg)
+            callback(rpc_handle, rpc_handle.then_args)
+        # Save the callback to keep it from getting collected
+        self.then_cb = ffi.callback('flux_then_f', then_wrapper)
+        self.then_args = args
+        return self.pimpl.then(self.then_cb, ffi.new_handle(self))

--- a/src/bindings/python/flux/sec.py
+++ b/src/bindings/python/flux/sec.py
@@ -1,13 +1,16 @@
 from flux._core import ffi, lib
 from flux.wrapper import Wrapper
 
+
 class Sec(Wrapper):
-  def __init__(self, handle=None):
-    super(self.__class__, self).__init__(ffi, lib, 
-                                     handle=handle,
-                                     match=ffi.typeof(lib.flux_sec_create).result,
-                                     prefixes=['flux_sec_'],
-                                     destructor=lib.flux_sec_destroy,
-                                     )
-    if handle is None:
-      self.handle = lib.flux_sec_create(type_id)
+
+    def __init__(self, handle=None):
+        super(self.__class__, self).__init__(ffi, lib,
+                                             handle=handle,
+                                             match=ffi.typeof(
+                                                 lib.flux_sec_create).result,
+                                             prefixes=['flux_sec_'],
+                                             destructor=lib.flux_sec_destroy,
+                                             )
+        if handle is None:
+            self.handle = lib.flux_sec_create()

--- a/src/bindings/python/flux/sec.py
+++ b/src/bindings/python/flux/sec.py
@@ -10,7 +10,6 @@ class Sec(Wrapper):
                                              match=ffi.typeof(
                                                  lib.flux_sec_create).result,
                                              prefixes=['flux_sec_'],
-                                             destructor=lib.flux_sec_destroy,
-                                             )
+                                             destructor=lib.flux_sec_destroy,)
         if handle is None:
             self.handle = lib.flux_sec_create()

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -230,9 +230,9 @@ class Wrapper(WrapperBase):
             else:
                 if self.filter_match:
                     raise AttributeError(
-                        "Flux Wrapper object {}" +
+                        "Flux Wrapper object " + str(self) +
                         "masks function {} type: {} match: {}".format(
-                            self, name, fun_type, self.match))
+                            name, fun_type, self.match))
         return False
 
     def check_wrap(self, fun, name):

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -1,12 +1,11 @@
 import re
-import errno
 import os
 import inspect
-import cffi
 from types import MethodType
 
 
 class MissingFunctionError(Exception):
+
     def __init__(self, name, c_name, name_list, arguments):
 
         call_stack = inspect.stack()
@@ -36,6 +35,7 @@ Invocation detail: inside function {outer}
 
 
 class ErrorPrinter(object):
+
     def __init__(self, name, prefixes):
         self.name = name
         self.prefixes = prefixes
@@ -100,6 +100,7 @@ Handle type: {htype}
 
 
 class InvalidArguments(ValueError):
+
     def __init__(self, name, signature, arguments, err_msg):
         message = """
 Invalid arguments passed to wrapped C function:
@@ -116,6 +117,7 @@ Arguments: {arguments}
 
 
 class FunctionWrapper(object):
+
     def __init__(self, fun, name, t, ffi, add_handle=False):
         self.arg_trans = []
         self.fun = fun
@@ -134,7 +136,7 @@ class FunctionWrapper(object):
             self.is_error = lambda x: x < 0
 
     def set_error_check(self, fun):
-      self.is_error = fun
+        self.is_error = fun
 
     def build_argument_translation_list(self, t):
         alist = t.args[1:] if self.add_handle else t.args
@@ -153,7 +155,7 @@ class FunctionWrapper(object):
                     result = self.fun(*args_in)
             except TypeError as te:
                 raise InvalidArguments(self.name, self.ffi.getctype(
-                    self.function_type), args, te.message)
+                    self.function_type), args_in, te.message)
         else:
             args = []
             if self.add_handle:
@@ -225,12 +227,13 @@ class Wrapper(WrapperBase):
         if self.match is not None and self._handle is not None:
             if t.kind == 'function' and t.args[
                 0
-            ] == self.match:  #first argument is of handle type
+            ] == self.match:  # first argument is of handle type
                 return True
             else:
                 if self.filter_match:
                     raise AttributeError(
-                        "Flux Wrapper object {} masks function {} type: {} match: {}".format(
+                        "Flux Wrapper object {}" +
+                        "masks function {} type: {} match: {}".format(
                             self, name, t, self.match))
         return False
 
@@ -244,9 +247,9 @@ class Wrapper(WrapperBase):
         fun = None
         llib = self.__getattribute__("lib")
         if re.match('__.*__', name):
-          # This is a python internal name, skip it
-          raise AttributeError
-        #try it bare
+            # This is a python internal name, skip it
+            raise AttributeError
+        # try it bare
         try:
             fun = getattr(llib, name)
         except AttributeError:
@@ -262,8 +265,8 @@ class Wrapper(WrapperBase):
             setattr(self.__class__, name, ErrorPrinter(name, self.prefixes))
             return self.__getattribute__(name)
 
-        if not callable(fun): # pragma: no cover
-          return fun
+        if not callable(fun):  # pragma: no cover
+            return fun
 
         new_fun = self.check_wrap(fun, name)
         new_method = MethodType(new_fun, None, self.__class__)

--- a/src/bindings/python/make_binding.py
+++ b/src/bindings/python/make_binding.py
@@ -1,7 +1,5 @@
-import sys
 import os
 import re
-import subprocess
 
 import argparse
 parser = argparse.ArgumentParser()
@@ -86,6 +84,8 @@ ffi.include({module}_ffi)
 
 
   print >>modfile, '''
+#pylint: disable-all
+# This is a generated file... linting is less than useful
 from cffi import FFI
 ffi = FFI()
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -47,7 +47,9 @@ declare -A extra_cmake_opts=(\
 #
 pips="\
 cffi>=1.1,<1.4 \
-coverage"
+coverage \
+pylint
+"
 
 #
 #  Lua rocks files to download and install:


### PR DESCRIPTION
This is the start of the changes mentioned in #807 to have lints for the python bindings.  I've been using flake8 as a start, because it's less freaked out by the generated modules.  So far this reformats most of the bindings, but it's waiting for the merge of #799 rather than conflicting on code that's just going to be removed.  As soon as everything passes, I'll add another commit in here to run flake8 or pylint with make check if it's available.
