### PR TITLE
python: add a check for invalid handle types

### DIFF
--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -288,6 +288,12 @@ class Wrapper(WrapperBase):
     @handle.setter
     def handle(self, h):
         """ Override handle setter to clean up old handle if requested """
+        if h is not None and self.match is not None:
+            if self.ffi.typeof(h) != self.match:
+                raise TypeError("Invalid handle {} of type {} assigned to "
+                                "wrapper with handle type {}".format(
+                                    h, self.ffi.typeof(h), self.match
+                                    ))
         if self._handle is not None:
             self.__clear()
         self._handle = h

--- a/src/bindings/python/test/wrapper.py
+++ b/src/bindings/python/test/wrapper.py
@@ -3,6 +3,7 @@ import errno
 import os
 import re
 import flux.core as core
+from flux.core.inner import ffi, lib
 import flux.wrapper
 
 
@@ -32,7 +33,13 @@ class TestWrapper(unittest.TestCase):
     def test_set_pimpl_handle(self):
       f = core.Flux('loop://')
       r = f.rpc_create('topic')
-      r.handle = f.rpc_create("other topic")
+      r.handle = lib.flux_rpc(f.handle, 'other topic', ffi.NULL, flux.FLUX_NODEID_ANY, 0)
+
+    def test_set_pimpl_handle_invalid(self):
+      f = core.Flux('loop://')
+      r = f.rpc_create('topic')
+      with self.assertRaisesRegexp(TypeError, r'.*expected a.*'):
+          r.handle = f.rpc_create("other topic")
 
     def test_read_basic_value(self):
       self.assertGreater(flux.core.inner.raw.FLUX_NODEID_ANY, 0)


### PR DESCRIPTION
Fixes an invalid test, adds a new test for the corrected behavior and a
check with assertions, and test, for the invalid assignment that caused
the initial issue.

fixes #818 