### PR TITLE
add functions to allow stable KVS namespace traversal

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -132,6 +132,12 @@ may contain spaces.
 Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
 If nothing has been stored under 'key', display an error message.
 
+*dirat* 'treeobj' ['key']::
+Display all keys and their values under the directory 'key', starting
+lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
+display an error message.  If 'key' is not provided, "." (root of
+the namespace) is assumed.
+
 
 AUTHOR
 ------

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -128,6 +128,11 @@ Associate a new treeobj with 'key', overwriting the previous treeobj,
 if any.  A treeobj should be treated as an opaque string value, which
 may contain spaces.
 
+*getat* 'treeobj' 'key'::
+Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
+If nothing has been stored under 'key', display an error message.
+
+
 AUTHOR
 ------
 This page is maintained by the Flux community.

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -138,6 +138,10 @@ lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
 display an error message.  If 'key' is not provided, "." (root of
 the namespace) is assumed.
 
+*readlinkat* 'treeobj' 'key'::
+Retrieve the key a link refers to rather than its value, as would be
+returned by *get*, starting lookup at 'treeobj'.
+
 
 AUTHOR
 ------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -328,3 +328,4 @@ unlinked
 getat
 lookup
 dirat
+readlinkat

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -327,3 +327,4 @@ treeobj
 unlinked
 getat
 lookup
+dirat

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -325,3 +325,5 @@ hwm
 recurse
 treeobj
 unlinked
+getat
+lookup

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -262,7 +262,7 @@ static int l_flux_kvsdir_new (lua_State *L)
         path = lua_tostring (L, 2);
     }
 
-    if (kvs_get_dir (f, &dir, path) < 0)
+    if (kvs_get_dir (f, &dir, "%s", path) < 0)
         return lua_pusherror (L, (char *)flux_strerror (errno));
     return lua_push_kvsdir (L, dir);
 }
@@ -318,7 +318,7 @@ static int l_flux_kvs_type (lua_State *L)
         free (val);
         return (2);
     }
-    if (kvs_get_dir (f, &d, key) == 0) {
+    if (kvs_get_dir (f, &d, "%s", key) == 0) {
         lua_pushstring (L, "dir");
         lua_push_kvsdir (L, d);
         return (2);
@@ -1097,7 +1097,7 @@ static int l_kvswatcher_add (lua_State *L)
     kw = l_flux_ref_create (L, f, 2, "kvswatcher");
     lua_getfield (L, 2, "isdir");
     if (lua_toboolean (L, -1))
-        rc = kvs_watch_dir (f, l_kvsdir_watcher, (void *) kw, key);
+        rc = kvs_watch_dir (f, l_kvsdir_watcher, (void *) kw, "%s", key);
     else
         rc = kvs_watch (f, key, l_kvswatcher, (void *) kw);
     if (rc < 0) {

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -92,7 +92,7 @@ static int l_kvsdir_kvsdir_new (lua_State *L)
     d = lua_get_kvsdir (L, 1);
     key = luaL_checkstring (L, 2);
 
-    if (kvsdir_get_dir (d, &new, key) < 0)
+    if (kvsdir_get_dir (d, &new, "%s", key) < 0)
         return lua_pusherror (L, "kvsdir_get_dir: %s",
                               (char *)flux_strerror (errno));
 
@@ -268,7 +268,7 @@ static int l_kvsdir_watch_dir (lua_State *L)
     dir = lua_get_kvsdir (L, 1);
     h = kvsdir_handle (dir);
 
-    return l_pushresult (L, kvs_watch_once_dir (h, &dir, kvsdir_key (dir)));
+    return l_pushresult (L, kvs_watch_once_dir (h, &dir, "%s", kvsdir_key (dir)));
 }
 
 static int l_kvsdir_index (lua_State *L)

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -64,12 +64,12 @@ _barrier_la_LIBADD = $(top_builddir)/src/modules/barrier/libflux-barrier.la $(co
 _barrier_la_DEPENDENCIES = _barrier_build.py
 
 
-_kvs_build.py: $(top_srcdir)/src/modules/kvs/kvs_deprecated.h $(MAKE_BINDING) _core_build.py
+_kvs_build.py: $(top_srcdir)/src/modules/kvs/kvs.h $(MAKE_BINDING) _core_build.py
 	$(PYTHON) $(MAKE_BINDING) --path $(top_srcdir)/src/modules/kvs \
 	  			  --package flux \
 	                          --modname _kvs \
 				  --include_ffi _core_build \
-				  kvs_deprecated.h
+				  kvs.h
 
 _kvs_la_SOURCES = _kvs.c
 _kvs_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/kvs

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -66,6 +66,7 @@ void cmd_dir (flux_t h, int argc, char **argv);
 void cmd_dirsize (flux_t h, int argc, char **argv);
 void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
+void cmd_getat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -93,6 +94,7 @@ void usage (void)
 "       flux-kvs dropcache-all\n"
 "       flux-kvs get-treeobj     key\n"
 "       flux-kvs put-treeobj     key=treeobj\n"
+"       flux-kvs getat           treeobj key\n"
 );
     exit (1);
 }
@@ -166,6 +168,8 @@ int main (int argc, char *argv[])
         cmd_get_treeobj (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "put-treeobj"))
         cmd_put_treeobj (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "getat"))
+        cmd_getat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -645,6 +649,17 @@ void cmd_get_treeobj (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_get_treeobj %s", argv[0]);
     printf ("%s\n", treeobj);
     free (treeobj);
+}
+
+void cmd_getat (flux_t h, int argc, char **argv)
+{
+    char *val = NULL;
+    if (argc != 2)
+        log_msg_exit ("getat: specify treeobj and key");
+    if (kvs_getat (h, argv[0], argv[1], &val) < 0)
+        log_err_exit ("kvs_getat %s %s", argv[0], argv[1]);
+    printf ("%s\n", val);
+    free (val);
 }
 
 void cmd_put_treeobj (flux_t h, int argc, char **argv)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -68,6 +68,7 @@ void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
 void cmd_getat (flux_t h, int argc, char **argv);
 void cmd_dirat (flux_t h, int argc, char **argv);
+void cmd_readlinkat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -97,6 +98,7 @@ void usage (void)
 "       flux-kvs put-treeobj     key=treeobj\n"
 "       flux-kvs getat           treeobj key\n"
 "       flux-kvs dirat [-r]      treeobj [key]\n"
+"       flux-kvs readlinkat      treeobj key\n"
 );
     exit (1);
 }
@@ -174,6 +176,8 @@ int main (int argc, char *argv[])
         cmd_getat (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "dirat"))
         cmd_dirat (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "readlinkat"))
+        cmd_readlinkat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -709,6 +713,22 @@ void cmd_put_treeobj (flux_t h, int argc, char **argv)
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
 
+}
+
+void cmd_readlinkat (flux_t h, int argc, char **argv)
+{
+    int i;
+    char *target;
+
+    if (argc < 2)
+        log_msg_exit ("readlink: specify treeobj and one or more keys");
+    for (i = 1; i < argc; i++) {
+        if (kvs_get_symlinkat (h, argv[0], argv[i], &target) < 0)
+            log_err_exit ("%s", argv[i]);
+        else
+            printf ("%s\n", target);
+        free (target);
+    }
 }
 
 /*

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -67,6 +67,7 @@ void cmd_dirsize (flux_t h, int argc, char **argv);
 void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
 void cmd_getat (flux_t h, int argc, char **argv);
+void cmd_dirat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -95,6 +96,7 @@ void usage (void)
 "       flux-kvs get-treeobj     key\n"
 "       flux-kvs put-treeobj     key=treeobj\n"
 "       flux-kvs getat           treeobj key\n"
+"       flux-kvs dirat [-r]      treeobj [key]\n"
 );
     exit (1);
 }
@@ -170,6 +172,8 @@ int main (int argc, char *argv[])
         cmd_put_treeobj (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "getat"))
         cmd_getat (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dirat"))
+        cmd_dirat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -521,34 +525,34 @@ static void dump_kvs_val (const char *key, const char *json_str)
     Jput (o);
 }
 
-static void dump_kvs_dir (flux_t h, bool ropt, const char *path)
+static void dump_kvs_dir (kvsdir_t *dir, bool ropt)
 {
-    kvsdir_t *dir;
     kvsitr_t *itr;
     const char *name;
     char *key;
-
-    if (kvs_get_dir (h, &dir, "%s", path) < 0)
-        log_err_exit ("%s", path);
 
     itr = kvsitr_create (dir);
     while ((name = kvsitr_next (itr))) {
         key = kvsdir_key_at (dir, name);
         if (kvsdir_issymlink (dir, name)) {
             char *link;
-            if (kvs_get_symlink (h, key, &link) < 0)
+            if (kvsdir_get_symlink (dir, name, &link) < 0)
                 log_err_exit ("%s", key);
             printf ("%s -> %s\n", key, link);
             free (link);
 
         } else if (kvsdir_isdir (dir, name)) {
-            if (ropt)
-                dump_kvs_dir (h, ropt, key);
-            else
+            if (ropt) {
+                kvsdir_t *ndir;
+                if (kvsdir_get_dir (dir, &ndir, "%s", name) < 0)
+                    log_err_exit ("%s", key);
+                dump_kvs_dir (ndir, ropt);
+                kvsdir_destroy (ndir);
+            } else
                 printf ("%s.\n", key);
         } else {
             char *json_str;
-            if (kvs_get (h, key, &json_str) < 0)
+            if (kvsdir_get (dir, name, &json_str) < 0)
                 log_err_exit ("%s", key);
             dump_kvs_val (key, json_str);
             free (json_str);
@@ -556,7 +560,6 @@ static void dump_kvs_dir (flux_t h, bool ropt, const char *path)
         free (key);
     }
     kvsitr_destroy (itr);
-    kvsdir_destroy (dir);
 }
 
 void cmd_watch_dir (flux_t h, int argc, char **argv)
@@ -583,7 +586,8 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
                 kvsdir_destroy (dir);
             dir = NULL;
         } else {
-            dump_kvs_dir (h, ropt, key);
+            dump_kvs_dir (dir, ropt);
+            kvsdir_destroy (dir);
             printf ("======================\n");
         }
         rc = kvs_watch_once_dir (h, &dir, "%s", key);
@@ -595,6 +599,8 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
 void cmd_dir (flux_t h, int argc, char **argv)
 {
     bool ropt = false;
+    char *key;
+    kvsdir_t *dir;
 
     if (argc > 0 && !strcmp (argv[0], "-r")) {
         ropt = true;
@@ -602,11 +608,38 @@ void cmd_dir (flux_t h, int argc, char **argv)
         argv++;
     }
     if (argc == 0)
-        dump_kvs_dir (h, ropt, ".");
+        key = ".";
     else if (argc == 1)
-        dump_kvs_dir (h, ropt, argv[0]);
+        key = argv[0];
     else
         log_msg_exit ("dir: specify zero or one directory");
+    if (kvs_get_dir (h, &dir, "%s", key) < 0)
+        log_err_exit ("%s", key);
+    dump_kvs_dir (dir, ropt);
+    kvsdir_destroy (dir);
+}
+
+void cmd_dirat (flux_t h, int argc, char **argv)
+{
+    bool ropt = false;
+    char *key;
+    kvsdir_t *dir;
+
+    if (argc > 0 && !strcmp (argv[0], "-r")) {
+        ropt = true;
+        argc--;
+        argv++;
+    }
+    if (argc == 1)
+        key = ".";
+    else if (argc == 2)
+        key = argv[1];
+    else
+        log_msg_exit ("dir: specify treeobj and zero or one directory");
+    if (kvs_get_dirat (h, argv[0], key, &dir, 0) < 0)
+        log_err_exit ("%s", key);
+    dump_kvs_dir (dir, ropt);
+    kvsdir_destroy (dir);
 }
 
 void cmd_dirsize (flux_t h, int argc, char **argv)

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -48,12 +48,14 @@ libflux_kvs_la_LIBADD =  $(top_builddir)/src/common/libflux-internal.la \
 TESTS = \
 	test_waitqueue.t \
 	test_proto.t \
-	test_cache.t
+	test_cache.t \
+	test_dirent.t
 
 test_ldadd = \
         $(top_builddir)/src/modules/kvs/cache.o \
         $(top_builddir)/src/modules/kvs/waitqueue.o \
         $(top_builddir)/src/modules/kvs/proto.o \
+        $(top_builddir)/src/modules/kvs/json_dirent.o \
         $(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -81,3 +83,7 @@ test_proto_t_LDADD = $(test_ldadd)
 test_cache_t_SOURCES = test/cache.c
 test_cache_t_CPPFLAGS = $(test_cppflags)
 test_cache_t_LDADD = $(test_ldadd)
+
+test_dirent_t_SOURCES = test/dirent.c
+test_dirent_t_CPPFLAGS = $(test_cppflags)
+test_dirent_t_LDADD = $(test_ldadd)

--- a/src/modules/kvs/json_dirent.c
+++ b/src/modules/kvs/json_dirent.c
@@ -60,6 +60,17 @@ json_object *dirent_create (char *type, void *arg)
     return dirent;
 }
 
+bool dirent_match (json_object *dirent1, json_object *dirent2)
+{
+    if (!dirent1 && !dirent2)
+        return true;
+    if ((dirent1 && !dirent2) || (!dirent1 && dirent2))
+        return false;
+    if (!strcmp (Jtostr (dirent1), Jtostr (dirent2)))
+        return true;
+    return false;
+}
+
 void dirent_append (json_object **array, const char *key, json_object *dirent)
 {
     json_object *op = Jnew ();

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 
 /* Create a KVS dirent.
  * 'type' is one of { "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL" }.
@@ -13,6 +14,12 @@ json_object *dirent_create (char *type, void *arg);
  * changes/unlinks a key in KVS namespace.  This function asserts on failure.
  */
 void dirent_append (json_object **array, const char *key, json_object *dirent);
+
+/* Compare two dirents.
+ * N.B. The serialize/strcmp method used here can return false negatives,
+ * but a positive can be relied on.
+ */
+bool dirent_match (json_object *dirent1, json_object *dirent2);
 
 int dirent_validate (json_object *dirent);
 

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -1,5 +1,39 @@
 #include <stdbool.h>
 
+/* JSON directory object:
+ * list of key-value pairs where key is a name, value is a dirent
+ *
+ * JSON dirent objects:
+ * object containing one key-value pair where key is one of
+ * "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL", and value is a SHA1
+ * hash key into ctx->store (FILEREF, DIRREF), an actual directory, file
+ * (value), or link target JSON object (FILEVAL, DIRVAL, LINKVAL).
+ *
+ * For example, consider KVS containing:
+ * a="foo"
+ * b="bar"
+ * c.d="baz"
+ * X -> c.d
+ *
+ * Root directory:
+ * {"a":{"FILEREF":"f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"},
+ *  "b":{"FILEREF","8714e0ef31edb00e33683f575274379955b3526c"},
+ *  "c":{"DIRREF","6eadd3a778e410597c85d74c287a57ad66071a45"},
+ *  "X":{"LINKVAL","c.d"}}
+ *
+ * Deep copy of root directory:
+ * {"a":{"FILEVAL":"foo"},
+ *  "b":{"FILEVAL","bar"},
+ *  "c":{"DIRVAL",{"d":{"FILEVAL":"baz"}}},
+ *  "X":{"LINKVAL","c.d"}}
+ *
+ * On LINKVAL's:
+ * - target is always fully qualified key name
+ * - links are always followed in path traversal of intermediate directories
+ * - for kvs_get, terminal links are only followed if 'readlink' flag is set
+ * - for kvs_put, terminal links are never followed
+ */
+
 /* Create a KVS dirent.
  * 'type' is one of { "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL" }.
  * 'arg' is dependent on the type.  This function asserts on failure.

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -22,40 +22,6 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-/* JSON directory object:
- * list of key-value pairs where key is a name, value is a dirent
- *
- * JSON dirent objects:
- * object containing one key-value pair where key is one of
- * "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL", and value is a SHA1
- * hash key into ctx->store (FILEREF, DIRREF), an actual directory, file
- * (value), or link target JSON object (FILEVAL, DIRVAL, LINKVAL).
- *
- * For example, consider KVS containing:
- * a="foo"
- * b="bar"
- * c.d="baz"
- * X -> c.d
- *
- * Root directory:
- * {"a":{"FILEREF":"f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"},
- *  "b":{"FILEREF","8714e0ef31edb00e33683f575274379955b3526c"},
- *  "c":{"DIRREF","6eadd3a778e410597c85d74c287a57ad66071a45"},
- *  "X":{"LINKVAL","c.d"}}
- *
- * Deep copy of root directory:
- * {"a":{"FILEVAL":"foo"},
- *  "b":{"FILEVAL","bar"},
- *  "c":{"DIRVAL",{"d":{"FILEVAL":"baz"}}},
- *  "X":{"LINKVAL","c.d"}}
- *
- * On LINKVAL's:
- * - target is always fully qualified key name
- * - links are always followed in path traversal of intermediate directories
- * - for kvs_get, terminal links are only followed if 'readlink' flag is set
- * - for kvs_put, terminal links are never followed
- */
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -296,12 +296,12 @@ static int content_store_request_send (ctx_t *ctx, const href_t ref,
     if (now) {
         if (content_store_get (rpc, ctx) < 0)
             goto error;
+    } else if (flux_rpc_then (rpc, content_store_completion, ctx) < 0) {
         flux_rpc_destroy (rpc);
-    } else if (flux_rpc_then (rpc, content_store_completion, ctx) < 0)
         goto error;
+    }
     return 0;
 error:
-    flux_rpc_destroy (rpc);
     return -1;
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -215,12 +215,12 @@ static int content_load_request_send (ctx_t *ctx, const href_t ref, bool now)
     flux_rpc_aux_set (rpc, xstrdup (ref), free);
     if (now) {
         content_load_completion (rpc, ctx);
+    } else if (flux_rpc_then (rpc, content_load_completion, ctx) < 0) {
         flux_rpc_destroy (rpc);
-    } else if (flux_rpc_then (rpc, content_load_completion, ctx) < 0)
         goto error;
+    }
     return 0;
 error:
-    flux_rpc_destroy (rpc);
     return -1;
 }
 

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -39,7 +39,8 @@ void kvsdir_incref (kvsdir_t *dir);
  * These functions return -1 on error (errno set), 0 on success.
  */
 int kvs_get (flux_t h, const char *key, char **json_str);
-int kvs_get_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...);
+int kvs_get_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
 int kvs_get_string (flux_t h, const char *key, char **valp);
 int kvs_get_int (flux_t h, const char *key, int *valp);
 int kvs_get_int64 (flux_t h, const char *key, int64_t *valp);
@@ -69,7 +70,8 @@ int kvs_get_symlinkat (flux_t h, const char *treeobj,
  */
 int kvs_watch (flux_t h, const char *key, kvs_set_f set, void *arg);
 int kvs_watch_dir (flux_t h, kvs_set_dir_f set, void *arg,
-                   const char *fmt, ...);
+                   const char *fmt, ...)
+        __attribute__ ((format (printf, 4, 5)));
 int kvs_watch_string (flux_t h, const char *key, kvs_set_string_f set,
                       void *arg);
 int kvs_watch_int (flux_t h, const char *key, kvs_set_int_f set, void *arg);
@@ -94,7 +96,8 @@ int kvs_unwatch (flux_t h, const char *key);
  * FIXME: add more types.
  */
 int kvs_watch_once (flux_t h, const char *key, char **json_str);
-int kvs_watch_once_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...);
+int kvs_watch_once_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
 int kvs_watch_once_int (flux_t h, const char *key, int *valp);
 
 /* kvs_put() and kvs_put_string() both make copies of the value argument
@@ -225,7 +228,8 @@ int kvs_dropcache (flux_t h);
  * is resolved relative to the directory.
  */
 int kvsdir_get (kvsdir_t *dir, const char *key, char **json_str);
-int kvsdir_get_dir (kvsdir_t *dir, kvsdir_t **dirp, const char *fmt, ...);
+int kvsdir_get_dir (kvsdir_t *dir, kvsdir_t **dirp, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
 int kvsdir_get_string (kvsdir_t *dir, const char *key, char **valp);
 int kvsdir_get_int (kvsdir_t *dir, const char *key, int *valp);
 int kvsdir_get_int64 (kvsdir_t *dir, const char *key, int64_t *valp);

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -5,6 +5,10 @@
 #include <stdint.h>
 #include <flux/core.h>
 
+enum {
+    FLUX_KVSDIR_SNAPSHOT = 1,
+};
+
 typedef struct kvsdir_struct kvsdir_t;
 
 typedef int (*kvs_set_f)(const char *key, const char *json_str, void *arg,
@@ -51,6 +55,10 @@ int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
  */
 int kvs_getat (flux_t h, const char *treeobj,
                const char *key, char **json_str);
+int kvs_get_dirat (flux_t h, const char *treeobj,
+                   const char *key, kvsdir_t **dirp, int flags);
+int kvs_get_symlinkat (flux_t h, const char *treeobj,
+                               const char *key, char **val);
 
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -47,6 +47,11 @@ int kvs_get_symlink (flux_t h, const char *key, char **valp);
  */
 int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
 
+/* Like kvs_get() but lookup is relative to 'treeobj'.
+ */
+int kvs_getat (flux_t h, const char *treeobj,
+               const char *key, char **json_str);
+
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial
  * value and again each time the value changes.

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -380,6 +380,29 @@ int kvs_get (flux_t h, const char *key, char **val)
     return 0;
 }
 
+int kvs_getat (flux_t h, const char *treeobj,
+               const char *key, char **val)
+{
+    JSON v = NULL;
+    JSON dirent = NULL;
+
+    if (!treeobj || !key || !(dirent = Jfromstr (treeobj))
+                         || dirent_validate (dirent) < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (getobj (h, dirent, key, 0, &v) < 0)
+        goto error;
+    if (val)
+        *val = xstrdup (Jtostr (v));
+    Jput (dirent);
+    return 0;
+error:
+    Jput (v);
+    Jput (dirent);
+    return -1;
+}
+
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -325,7 +325,8 @@ char *kvsdir_key_at (kvsdir_t *dir, const char *name)
  ** GET
  **/
 
-static int getobj (flux_t h, const char *key, int flags, json_object **val)
+static int getobj (flux_t h, json_object *rootdir, const char *key,
+                   int flags, json_object **val)
 {
     flux_rpc_t *rpc = NULL;
     const char *json_str;
@@ -341,7 +342,7 @@ static int getobj (flux_t h, const char *key, int flags, json_object **val)
         goto done;
     }
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (k, flags)))
+    if (!(in = kp_tget_enc (rootdir, k, flags)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -371,7 +372,7 @@ int kvs_get (flux_t h, const char *key, char **val)
 {
     JSON v;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         return -1;
     if (val)
         *val = xstrdup (Jtostr (v));
@@ -382,7 +383,7 @@ int kvs_get (flux_t h, const char *key, char **val)
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {
-    return getobj (h, key, 0, val);
+    return getobj (h, NULL, key, 0, val);
 }
 
 int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
@@ -405,7 +406,7 @@ int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
     key = xvasprintf (fmt, ap);
     va_end (ap);
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (k, KVS_PROTO_READDIR)))
+    if (!(in = kp_tget_enc (NULL, k, KVS_PROTO_READDIR)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -435,7 +436,7 @@ int kvs_get_symlink (flux_t h, const char *key, char **val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, KVS_PROTO_READLINK, &v) < 0)
+    if (getobj (h, NULL, key, KVS_PROTO_READLINK, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_string) {
         errno = EPROTO;
@@ -455,7 +456,7 @@ int kvs_get_treeobj (flux_t h, const char *key, char **val)
     const char *s;
     int rc = -1;
 
-    if (getobj (h, key, KVS_PROTO_TREEOBJ, &v) < 0)
+    if (getobj (h, NULL, key, KVS_PROTO_TREEOBJ, &v) < 0)
         goto done;
     if (val) {
         s = json_object_to_json_string_ext (v, JSON_C_TO_STRING_PLAIN);
@@ -472,7 +473,7 @@ int kvs_get_string (flux_t h, const char *key, char **val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_string) {
         errno = EPROTO;
@@ -491,7 +492,7 @@ int kvs_get_int (flux_t h, const char *key, int *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_int) {
         errno = EPROTO;
@@ -510,7 +511,7 @@ int kvs_get_int64 (flux_t h, const char *key, int64_t *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_int) {
         errno = EPROTO;
@@ -529,7 +530,7 @@ int kvs_get_double (flux_t h, const char *key, double *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_double) {
         errno = EPROTO;
@@ -548,7 +549,7 @@ int kvs_get_boolean (flux_t h, const char *key, bool *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_boolean) {
         errno = EPROTO;
@@ -1651,7 +1652,7 @@ int kvsdir_unlink (kvsdir_t *dir, const char *name)
 int kvs_copy (flux_t h, const char *from, const char *to)
 {
     JSON dirent;
-    if (getobj (h, from, KVS_PROTO_TREEOBJ, &dirent) < 0)
+    if (getobj (h, NULL, from, KVS_PROTO_TREEOBJ, &dirent) < 0)
         return -1;
     if (kvs_put_dirent (h, to, dirent) < 0) {
         Jput (dirent);

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -44,7 +44,7 @@
 /* kvs.get
  */
 
-JSON kp_tget_enc (const char *key, int flags)
+JSON kp_tget_enc (JSON rootdir, const char *key, int flags)
 {
     JSON o = NULL;
 
@@ -53,13 +53,15 @@ JSON kp_tget_enc (const char *key, int flags)
         goto done;
     }
     o = Jnew ();
+    if (rootdir)
+        Jadd_obj (o, "rootdir", rootdir); /* takes a ref on rootdir */
     Jadd_str (o, "key", key);
     Jadd_int (o, "flags", flags);
 done:
     return o;
 }
 
-int kp_tget_dec (JSON o, const char **key, int *flags)
+int kp_tget_dec (JSON o, JSON *rootdir, const char **key, int *flags)
 {
     int rc = -1;
 
@@ -71,6 +73,8 @@ int kp_tget_dec (JSON o, const char **key, int *flags)
         errno = EPROTO;
         goto done;
     }
+    if (rootdir)
+        *rootdir = Jobj_get (o, "rootdir");
     rc = 0;
 done:
     return rc;

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -12,8 +12,10 @@ enum {
 
 /* kvs.get
  */
-json_object *kp_tget_enc (const char *key, int flags);
-int kp_tget_dec (json_object *o, const char **key, int *flags);
+json_object *kp_tget_enc (json_object *rootdir,
+                          const char *key, int flags);
+int kp_tget_dec (json_object *o, json_object **rootdir,
+                 const char **key, int *flags);
 
 json_object *kp_rget_enc (json_object *val);
 int kp_rget_dec (json_object *o, json_object **val);

--- a/src/modules/kvs/test/dirent.c
+++ b/src/modules/kvs/test/dirent.c
@@ -1,0 +1,93 @@
+#include <string.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/modules/kvs/json_dirent.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    JSON d1, d2;
+    JSON dir;
+    JSON array = NULL;
+
+    plan (NO_PLAN);
+
+    d1 = dirent_create ("FILEREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    d2 = dirent_create ("FILEREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    ok (d1 && d2,
+        "dirent_create FILEREF works");
+    ok (dirent_match (d1, d2),
+        "dirent_match says identical dirents match");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+
+    dirent_append (&array, "foo", d1);
+    dirent_append (&array, "bar", d2);
+    ok (array != NULL && json_object_array_length (array) == 2,
+        "dirent_append works"); 
+    /* ownership of d1, d2 transferred to array */
+
+    diag ("ops: %s", Jtostr (array));
+    
+    d1 = dirent_create ("DIRREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    d2 = dirent_create ("DIRREF", "sha1-aaaaa4eb241948f6f802bf47d95ec932e9d4deaf");
+    ok (d1 && d2,
+        "dirent_create DIRREF works");
+    ok (!dirent_match (d1, d2),
+        "dirent_match says different dirents are different");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+
+    dirent_append (&array, "baz", d1);
+    dirent_append (&array, "urp", d2);
+    ok (array != NULL && json_object_array_length (array) == 4,
+        "dirent_append works"); 
+    /* ownership of d1, d2 transferred to array */
+
+    diag ("ops: %s", Jtostr (array));
+
+    /* ownership of new objects transferred to dirents */
+    d1 = dirent_create ("FILEVAL", json_object_new_int (42));
+    d2 = dirent_create ("FILEVAL", json_object_new_string ("hello world"));
+    ok (d1 && d2,
+        "dirent_create FILEVAL works");
+    ok (!dirent_match (d1, d2),
+        "dirent_match says different dirents are different");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+    dirent_append (&array, "baz", d1);
+    dirent_append (&array, "urp", d2);
+    ok (array != NULL && json_object_array_length (array) == 6,
+        "dirent_append works"); 
+
+    diag ("ops: %s", Jtostr (array));
+   
+    dir = Jnew ();
+    json_object_object_add (dir, "foo", dirent_create ("FILEVAL", json_object_new_int(33)));
+    json_object_object_add (dir, "bar", dirent_create ("FILEVAL", json_object_new_string ("Mrrrrnn?")));
+    d1 = dirent_create ("DIRVAL", dir);
+    ok (d1 != NULL,
+        "dirent_create DIRVAL works");
+    ok (dirent_validate (d1) == 0,
+        "dirent_validate says it is valid");
+    dirent_append (&array, "mmm", d1);
+    ok (array != NULL && json_object_array_length (array) == 7,
+        "dirent_append works"); 
+
+    diag ("ops: %s", Jtostr (array));
+
+    dirent_append (&array, "xxx", NULL);
+    ok (array != NULL && json_object_array_length (array) == 8,
+        "dirent_append allowed op with NULL dirent (unlink op)");
+
+    diag ("ops: %s", Jtostr (array));
+
+    Jput (array);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/test/valgrind.sh
+++ b/src/test/valgrind.sh
@@ -16,5 +16,5 @@ ${top_srcdir}/src/cmd/flux /usr/bin/valgrind \
     --num-callers=30 \
     --leak-resolution=med \
     --suppressions=valgrind.supp \
-    ${top_srcdir}/src/broker/.libs/lt-flux-broker --boot-method=single \
+    ${top_srcdir}/src/broker/.libs/lt-flux-broker \
     ./valgrind-workload.sh ${NJOBS}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -151,6 +151,7 @@ check_PROGRAMS = \
 	loop/log.t \
 	kz/kzutil \
 	kvs/torture \
+	kvs/dtree \
 	kvs/asyncfence \
 	kvs/hashtest \
 	kvs/watch \
@@ -236,6 +237,12 @@ kz_kzutil_LDADD = \
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)
 kvs_torture_LDADD = \
+	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_dtree_SOURCES = kvs/dtree.c
+kvs_dtree_CPPFLAGS = $(test_cppflags)
+kvs_dtree_LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 

--- a/t/kvs/dtree.c
+++ b/t/kvs/dtree.c
@@ -1,0 +1,111 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* dtree.c - create HxW KVS directory tree */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <getopt.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+
+
+#define OPTIONS "p:w:h:"
+static const struct option longopts[] = {
+    {"prefix",          required_argument,  0, 'p'},
+    {"width",           required_argument,  0, 'w'},
+    {"height",          required_argument,  0, 'h'},
+    { 0, 0, 0, 0 },
+};
+
+void dtree (flux_t h, const char *prefix, int width, int height);
+
+void usage (void)
+{
+    fprintf (stderr,
+"Usage: dtree [--prefix NAME] [--width N] [--height N]\n"
+);
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    int ch;
+    int width = 1;
+    int height = 1;
+    char *prefix = "dtree";
+    flux_t h;
+
+    log_init ("dtree");
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'w': /* --width N */
+                width = strtoul (optarg, NULL, 10);
+                break;
+            case 'h': /* --height N */
+                height = strtoul (optarg, NULL, 10);
+                break;
+            case 'p': /* --prefix NAME */
+                prefix = optarg;
+                break;
+            default:
+                usage ();
+                break;
+        }
+    }
+    if (optind != argc)
+        usage ();
+    if (width < 1 || height < 1)
+        usage ();
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    dtree (h, prefix, width, height);
+    if (kvs_commit (h) < 0)
+       log_err_exit ("kvs_commit");
+    flux_close (h);
+}
+
+void dtree (flux_t h, const char *prefix, int width, int height)
+{
+    int i;
+    char *key;
+
+    for (i = 0; i < width; i++) {
+        key = xasprintf ("%s.%.4x", prefix, i);
+        if (height == 1) {
+            if (kvs_put_int (h, key, 1) < 0)
+                log_err_exit ("kvs_put %s", key);
+        } else
+            dtree (h, key, width, height - 1);
+        free (key);
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -392,6 +392,22 @@ test_expect_success 'kvs: kvsdir_get_size works' '
 	test "$OUTPUT" = "3"
 '
 
+test_expect_success 'kvs: store 16x3 directory tree' '
+	${FLUX_BUILD_DIR}/t/kvs/dtree -h3 -w16 --prefix $TEST.dtree
+'
+
+test_expect_success 'kvs: walk 16x3 directory tree' '
+	test $(flux kvs dir -r $TEST.dtree | wc -l) = 4096
+'
+
+test_expect_success 'kvs: walk after unlink with dirat from root and from test dir' '
+	DTREEREF=$(flux kvs get-treeobj $TEST.dtree) &&
+	ROOTREF=$(flux kvs get-treeobj .) &&
+	flux kvs unlink $TEST.dtree &&
+	test $(flux kvs dirat -r $DTREEREF .| wc -l) = 4096 &&
+	test $(flux kvs dirat -r $ROOTREF $TEST.dtree | wc -l) = 4096
+'
+
 test_expect_success 'kvs: put key of . fails' '
 	test_must_fail flux kvs put .=1
 '
@@ -485,6 +501,7 @@ test_expect_success 'kvs: store 10,000 keys in one dir' '
 test_expect_success LONGTEST 'kvs: store 1,000,000 keys in one dir' '
 	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $TEST.bigdir2 --count 1000000
 '
+
 
 # async fence
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -282,6 +282,15 @@ test_expect_success 'kvs: symlink: kvs_copy does not follow symlinks (bottom)' '
 	test "$LINKVAL" = "$TEST.a.b.X"
 '
 
+test_expect_success 'kvs: get_symlinkat works after symlink unlinked' '
+	flux kvs unlink $TEST &&
+	flux kvs link $TEST.a.b.X $TEST.a.b.link &&
+	ROOTREF=$(flux kvs get-treeobj .) &&
+	flux kvs unlink $TEST &&
+	LINKVAL=$(flux kvs readlinkat $ROOTREF $TEST.a.b.link) &&
+	test "$LINKVAL" = "$TEST.a.b.X"
+'
+
 test_expect_success 'kvs: get-treeobj: returns directory reference for root' '
 	flux kvs unlink $TEST &&
 	flux kvs get-treeobj . | grep -q "DIRREF"

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -355,6 +355,34 @@ test_expect_success 'kvs: put-treeobj: fails bad dirent: bad blobref' '
 	test_must_fail flux kvs put-treeobj $TEST.a="{\"DIRREF\":\"sha1-bbb\"}"
 '
 
+test_expect_success 'kvs: getat: fails bad on dirent' '
+	flux kvs unlink $TEST &&
+	test_must_fail flux kvs getat 42 $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRREF\":\"sha2-aaa\"}" $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRREF\":\"sha1-bbb\"}" $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRVAL\":{}}" $TEST.a
+'
+
+test_expect_success 'kvs: getat: works on root from get-treeobj' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	test $(flux kvs getat $(flux kvs get-treeobj .) $TEST.a.b.c) = 42
+'
+
+test_expect_success 'kvs: getat: works on subdir from get-treeobj' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	test $(flux kvs getat $(flux kvs get-treeobj $TEST.a.b) c) = 42
+'
+
+test_expect_success 'kvs: getat: works on outdated root' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	ROOTREF=$(flux kvs get-treeobj .) &&
+	flux kvs put $TEST.a.b.c=43 &&
+	test $(flux kvs getat $ROOTREF $TEST.a.b.c) = 42
+'
+
 test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs mkdir $TEST.dirsize &&
 	flux kvs put $TEST.dirsize.a=1 &&


### PR DESCRIPTION
This PR introduces the `kvs_getat()` function, which allows a key to be retrieved relative to a "treeobj" directory reference obtained with `kvs_get_treeobj()`.  As described in pr #810, this allows a key to be fetched relative to a "snapshot" of the KVS namespace, either the root or a sub-directory.

In order to support recursively walking a directory relative to a treeobj, we also needed `kvs_get_dirat()` and `kvs_get_symlinkat()`.  Collectively these new functions solve #64.

For convenience, to allow a snapshot of a namespace to be recursively followed using the `kvsdir_*()` functions without breaking existing users, I made it so a `kvsdir_t` established using `kvs_get_dirat()`  retains the treeobj reference so that subsequent `kvsdir_get_*()` calls, including `kvsdir_get_dir()`, are also tied to the treeobj.  A `kvsdir_t` obtained with `kvs_get_dir()` does not have this reference and thus tracks the live KVS namespace.

The requirement that `kvs_get_dirat()` be used in order to establish a `kvsdir_t` tied to a treeobj seems sort of wrong.  Should this be the default behavior for `kvs_get_dir()`?  I thought so but I don't think this is consistent with the way `kvsdir_t` is used in the lua bindings, wreck, and perhaps elsewhere.  Any thoughts especially from @grondo?

`flux-kvs` `getat` and `dirat` subcommands are added, as are some tests.  There's a bit of gratuitous kvs cleanup and testing thrown in.

I'm still tracking down one bit of behavior that I don't understand, but thought I'd post this early to get any feedback.