### PR TITLE
kvs: testing, fix use-after-free, streamline python bindings

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -262,7 +262,7 @@ static int l_flux_kvsdir_new (lua_State *L)
         path = lua_tostring (L, 2);
     }
 
-    if (kvs_get_dir (f, &dir, path) < 0)
+    if (kvs_get_dir (f, &dir, "%s", path) < 0)
         return lua_pusherror (L, (char *)flux_strerror (errno));
     return lua_push_kvsdir (L, dir);
 }
@@ -318,7 +318,7 @@ static int l_flux_kvs_type (lua_State *L)
         free (val);
         return (2);
     }
-    if (kvs_get_dir (f, &d, key) == 0) {
+    if (kvs_get_dir (f, &d, "%s", key) == 0) {
         lua_pushstring (L, "dir");
         lua_push_kvsdir (L, d);
         return (2);
@@ -1097,7 +1097,7 @@ static int l_kvswatcher_add (lua_State *L)
     kw = l_flux_ref_create (L, f, 2, "kvswatcher");
     lua_getfield (L, 2, "isdir");
     if (lua_toboolean (L, -1))
-        rc = kvs_watch_dir (f, l_kvsdir_watcher, (void *) kw, key);
+        rc = kvs_watch_dir (f, l_kvsdir_watcher, (void *) kw, "%s", key);
     else
         rc = kvs_watch (f, key, l_kvswatcher, (void *) kw);
     if (rc < 0) {

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -92,7 +92,7 @@ static int l_kvsdir_kvsdir_new (lua_State *L)
     d = lua_get_kvsdir (L, 1);
     key = luaL_checkstring (L, 2);
 
-    if (kvsdir_get_dir (d, &new, key) < 0)
+    if (kvsdir_get_dir (d, &new, "%s", key) < 0)
         return lua_pusherror (L, "kvsdir_get_dir: %s",
                               (char *)flux_strerror (errno));
 
@@ -268,7 +268,7 @@ static int l_kvsdir_watch_dir (lua_State *L)
     dir = lua_get_kvsdir (L, 1);
     h = kvsdir_handle (dir);
 
-    return l_pushresult (L, kvs_watch_once_dir (h, &dir, kvsdir_key (dir)));
+    return l_pushresult (L, kvs_watch_once_dir (h, &dir, "%s", kvsdir_key (dir)));
 }
 
 static int l_kvsdir_index (lua_State *L)

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -64,12 +64,12 @@ _barrier_la_LIBADD = $(top_builddir)/src/modules/barrier/libflux-barrier.la $(co
 _barrier_la_DEPENDENCIES = _barrier_build.py
 
 
-_kvs_build.py: $(top_srcdir)/src/modules/kvs/kvs_deprecated.h $(MAKE_BINDING) _core_build.py
+_kvs_build.py: $(top_srcdir)/src/modules/kvs/kvs.h $(MAKE_BINDING) _core_build.py
 	$(PYTHON) $(MAKE_BINDING) --path $(top_srcdir)/src/modules/kvs \
 	  			  --package flux \
 	                          --modname _kvs \
 				  --include_ffi _core_build \
-				  kvs_deprecated.h
+				  kvs.h
 
 _kvs_la_SOURCES = _kvs.c
 _kvs_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/modules/kvs

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -48,12 +48,14 @@ libflux_kvs_la_LIBADD =  $(top_builddir)/src/common/libflux-internal.la \
 TESTS = \
 	test_waitqueue.t \
 	test_proto.t \
-	test_cache.t
+	test_cache.t \
+	test_dirent.t
 
 test_ldadd = \
         $(top_builddir)/src/modules/kvs/cache.o \
         $(top_builddir)/src/modules/kvs/waitqueue.o \
         $(top_builddir)/src/modules/kvs/proto.o \
+        $(top_builddir)/src/modules/kvs/json_dirent.o \
         $(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -81,3 +83,7 @@ test_proto_t_LDADD = $(test_ldadd)
 test_cache_t_SOURCES = test/cache.c
 test_cache_t_CPPFLAGS = $(test_cppflags)
 test_cache_t_LDADD = $(test_ldadd)
+
+test_dirent_t_SOURCES = test/dirent.c
+test_dirent_t_CPPFLAGS = $(test_cppflags)
+test_dirent_t_LDADD = $(test_ldadd)

--- a/src/modules/kvs/json_dirent.c
+++ b/src/modules/kvs/json_dirent.c
@@ -60,6 +60,17 @@ json_object *dirent_create (char *type, void *arg)
     return dirent;
 }
 
+bool dirent_match (json_object *dirent1, json_object *dirent2)
+{
+    if (!dirent1 && !dirent2)
+        return true;
+    if ((dirent1 && !dirent2) || (!dirent1 && dirent2))
+        return false;
+    if (!strcmp (Jtostr (dirent1), Jtostr (dirent2)))
+        return true;
+    return false;
+}
+
 void dirent_append (json_object **array, const char *key, json_object *dirent)
 {
     json_object *op = Jnew ();

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 
 /* Create a KVS dirent.
  * 'type' is one of { "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL" }.
@@ -13,6 +14,12 @@ json_object *dirent_create (char *type, void *arg);
  * changes/unlinks a key in KVS namespace.  This function asserts on failure.
  */
 void dirent_append (json_object **array, const char *key, json_object *dirent);
+
+/* Compare two dirents.
+ * N.B. The serialize/strcmp method used here can return false negatives,
+ * but a positive can be relied on.
+ */
+bool dirent_match (json_object *dirent1, json_object *dirent2);
 
 int dirent_validate (json_object *dirent);
 

--- a/src/modules/kvs/json_dirent.h
+++ b/src/modules/kvs/json_dirent.h
@@ -1,5 +1,39 @@
 #include <stdbool.h>
 
+/* JSON directory object:
+ * list of key-value pairs where key is a name, value is a dirent
+ *
+ * JSON dirent objects:
+ * object containing one key-value pair where key is one of
+ * "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL", and value is a SHA1
+ * hash key into ctx->store (FILEREF, DIRREF), an actual directory, file
+ * (value), or link target JSON object (FILEVAL, DIRVAL, LINKVAL).
+ *
+ * For example, consider KVS containing:
+ * a="foo"
+ * b="bar"
+ * c.d="baz"
+ * X -> c.d
+ *
+ * Root directory:
+ * {"a":{"FILEREF":"f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"},
+ *  "b":{"FILEREF","8714e0ef31edb00e33683f575274379955b3526c"},
+ *  "c":{"DIRREF","6eadd3a778e410597c85d74c287a57ad66071a45"},
+ *  "X":{"LINKVAL","c.d"}}
+ *
+ * Deep copy of root directory:
+ * {"a":{"FILEVAL":"foo"},
+ *  "b":{"FILEVAL","bar"},
+ *  "c":{"DIRVAL",{"d":{"FILEVAL":"baz"}}},
+ *  "X":{"LINKVAL","c.d"}}
+ *
+ * On LINKVAL's:
+ * - target is always fully qualified key name
+ * - links are always followed in path traversal of intermediate directories
+ * - for kvs_get, terminal links are only followed if 'readlink' flag is set
+ * - for kvs_put, terminal links are never followed
+ */
+
 /* Create a KVS dirent.
  * 'type' is one of { "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL" }.
  * 'arg' is dependent on the type.  This function asserts on failure.

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -22,40 +22,6 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-/* JSON directory object:
- * list of key-value pairs where key is a name, value is a dirent
- *
- * JSON dirent objects:
- * object containing one key-value pair where key is one of
- * "FILEREF", "DIRREF", "FILEVAL", "DIRVAL", "LINKVAL", and value is a SHA1
- * hash key into ctx->store (FILEREF, DIRREF), an actual directory, file
- * (value), or link target JSON object (FILEVAL, DIRVAL, LINKVAL).
- *
- * For example, consider KVS containing:
- * a="foo"
- * b="bar"
- * c.d="baz"
- * X -> c.d
- *
- * Root directory:
- * {"a":{"FILEREF":"f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"},
- *  "b":{"FILEREF","8714e0ef31edb00e33683f575274379955b3526c"},
- *  "c":{"DIRREF","6eadd3a778e410597c85d74c287a57ad66071a45"},
- *  "X":{"LINKVAL","c.d"}}
- *
- * Deep copy of root directory:
- * {"a":{"FILEVAL":"foo"},
- *  "b":{"FILEVAL","bar"},
- *  "c":{"DIRVAL",{"d":{"FILEVAL":"baz"}}},
- *  "X":{"LINKVAL","c.d"}}
- *
- * On LINKVAL's:
- * - target is always fully qualified key name
- * - links are always followed in path traversal of intermediate directories
- * - for kvs_get, terminal links are only followed if 'readlink' flag is set
- * - for kvs_put, terminal links are never followed
- */
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -296,12 +296,12 @@ static int content_store_request_send (ctx_t *ctx, const href_t ref,
     if (now) {
         if (content_store_get (rpc, ctx) < 0)
             goto error;
+    } else if (flux_rpc_then (rpc, content_store_completion, ctx) < 0) {
         flux_rpc_destroy (rpc);
-    } else if (flux_rpc_then (rpc, content_store_completion, ctx) < 0)
         goto error;
+    }
     return 0;
 error:
-    flux_rpc_destroy (rpc);
     return -1;
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -215,12 +215,12 @@ static int content_load_request_send (ctx_t *ctx, const href_t ref, bool now)
     flux_rpc_aux_set (rpc, xstrdup (ref), free);
     if (now) {
         content_load_completion (rpc, ctx);
+    } else if (flux_rpc_then (rpc, content_load_completion, ctx) < 0) {
         flux_rpc_destroy (rpc);
-    } else if (flux_rpc_then (rpc, content_load_completion, ctx) < 0)
         goto error;
+    }
     return 0;
 error:
-    flux_rpc_destroy (rpc);
     return -1;
 }
 

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -35,7 +35,8 @@ void kvsdir_incref (kvsdir_t *dir);
  * These functions return -1 on error (errno set), 0 on success.
  */
 int kvs_get (flux_t h, const char *key, char **json_str);
-int kvs_get_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...);
+int kvs_get_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
 int kvs_get_string (flux_t h, const char *key, char **valp);
 int kvs_get_int (flux_t h, const char *key, int *valp);
 int kvs_get_int64 (flux_t h, const char *key, int64_t *valp);
@@ -56,7 +57,8 @@ int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
  */
 int kvs_watch (flux_t h, const char *key, kvs_set_f set, void *arg);
 int kvs_watch_dir (flux_t h, kvs_set_dir_f set, void *arg,
-                   const char *fmt, ...);
+                   const char *fmt, ...)
+        __attribute__ ((format (printf, 4, 5)));
 int kvs_watch_string (flux_t h, const char *key, kvs_set_string_f set,
                       void *arg);
 int kvs_watch_int (flux_t h, const char *key, kvs_set_int_f set, void *arg);
@@ -81,7 +83,8 @@ int kvs_unwatch (flux_t h, const char *key);
  * FIXME: add more types.
  */
 int kvs_watch_once (flux_t h, const char *key, char **json_str);
-int kvs_watch_once_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...);
+int kvs_watch_once_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
 int kvs_watch_once_int (flux_t h, const char *key, int *valp);
 
 /* kvs_put() and kvs_put_string() both make copies of the value argument
@@ -212,7 +215,8 @@ int kvs_dropcache (flux_t h);
  * is resolved relative to the directory.
  */
 int kvsdir_get (kvsdir_t *dir, const char *key, char **json_str);
-int kvsdir_get_dir (kvsdir_t *dir, kvsdir_t **dirp, const char *fmt, ...);
+int kvsdir_get_dir (kvsdir_t *dir, kvsdir_t **dirp, const char *fmt, ...)
+        __attribute__ ((format (printf, 3, 4)));
 int kvsdir_get_string (kvsdir_t *dir, const char *key, char **valp);
 int kvsdir_get_int (kvsdir_t *dir, const char *key, int *valp);
 int kvsdir_get_int64 (kvsdir_t *dir, const char *key, int64_t *valp);

--- a/src/modules/kvs/test/dirent.c
+++ b/src/modules/kvs/test/dirent.c
@@ -1,0 +1,93 @@
+#include <string.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/modules/kvs/json_dirent.h"
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    JSON d1, d2;
+    JSON dir;
+    JSON array = NULL;
+
+    plan (NO_PLAN);
+
+    d1 = dirent_create ("FILEREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    d2 = dirent_create ("FILEREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    ok (d1 && d2,
+        "dirent_create FILEREF works");
+    ok (dirent_match (d1, d2),
+        "dirent_match says identical dirents match");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+
+    dirent_append (&array, "foo", d1);
+    dirent_append (&array, "bar", d2);
+    ok (array != NULL && json_object_array_length (array) == 2,
+        "dirent_append works"); 
+    /* ownership of d1, d2 transferred to array */
+
+    diag ("ops: %s", Jtostr (array));
+    
+    d1 = dirent_create ("DIRREF", "sha1-fbedb4eb241948f6f802bf47d95ec932e9d4deaf");
+    d2 = dirent_create ("DIRREF", "sha1-aaaaa4eb241948f6f802bf47d95ec932e9d4deaf");
+    ok (d1 && d2,
+        "dirent_create DIRREF works");
+    ok (!dirent_match (d1, d2),
+        "dirent_match says different dirents are different");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+
+    dirent_append (&array, "baz", d1);
+    dirent_append (&array, "urp", d2);
+    ok (array != NULL && json_object_array_length (array) == 4,
+        "dirent_append works"); 
+    /* ownership of d1, d2 transferred to array */
+
+    diag ("ops: %s", Jtostr (array));
+
+    /* ownership of new objects transferred to dirents */
+    d1 = dirent_create ("FILEVAL", json_object_new_int (42));
+    d2 = dirent_create ("FILEVAL", json_object_new_string ("hello world"));
+    ok (d1 && d2,
+        "dirent_create FILEVAL works");
+    ok (!dirent_match (d1, d2),
+        "dirent_match says different dirents are different");
+    ok (dirent_validate (d1) == 0 && dirent_validate (d2) == 0,
+        "dirent_validate says they are valid");
+    dirent_append (&array, "baz", d1);
+    dirent_append (&array, "urp", d2);
+    ok (array != NULL && json_object_array_length (array) == 6,
+        "dirent_append works"); 
+
+    diag ("ops: %s", Jtostr (array));
+   
+    dir = Jnew ();
+    json_object_object_add (dir, "foo", dirent_create ("FILEVAL", json_object_new_int(33)));
+    json_object_object_add (dir, "bar", dirent_create ("FILEVAL", json_object_new_string ("Mrrrrnn?")));
+    d1 = dirent_create ("DIRVAL", dir);
+    ok (d1 != NULL,
+        "dirent_create DIRVAL works");
+    ok (dirent_validate (d1) == 0,
+        "dirent_validate says it is valid");
+    dirent_append (&array, "mmm", d1);
+    ok (array != NULL && json_object_array_length (array) == 7,
+        "dirent_append works"); 
+
+    diag ("ops: %s", Jtostr (array));
+
+    dirent_append (&array, "xxx", NULL);
+    ok (array != NULL && json_object_array_length (array) == 8,
+        "dirent_append allowed op with NULL dirent (unlink op)");
+
+    diag ("ops: %s", Jtostr (array));
+
+    Jput (array);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/test/valgrind.sh
+++ b/src/test/valgrind.sh
@@ -16,5 +16,5 @@ ${top_srcdir}/src/cmd/flux /usr/bin/valgrind \
     --num-callers=30 \
     --leak-resolution=med \
     --suppressions=valgrind.supp \
-    ${top_srcdir}/src/broker/.libs/lt-flux-broker --boot-method=single \
+    ${top_srcdir}/src/broker/.libs/lt-flux-broker \
     ./valgrind-workload.sh ${NJOBS}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -151,6 +151,7 @@ check_PROGRAMS = \
 	loop/log.t \
 	kz/kzutil \
 	kvs/torture \
+	kvs/dtree \
 	kvs/asyncfence \
 	kvs/hashtest \
 	kvs/watch \
@@ -236,6 +237,12 @@ kz_kzutil_LDADD = \
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)
 kvs_torture_LDADD = \
+	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_dtree_SOURCES = kvs/dtree.c
+kvs_dtree_CPPFLAGS = $(test_cppflags)
+kvs_dtree_LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 

--- a/t/kvs/dtree.c
+++ b/t/kvs/dtree.c
@@ -1,0 +1,111 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* dtree.c - create HxW KVS directory tree */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <getopt.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+
+
+#define OPTIONS "p:w:h:"
+static const struct option longopts[] = {
+    {"prefix",          required_argument,  0, 'p'},
+    {"width",           required_argument,  0, 'w'},
+    {"height",          required_argument,  0, 'h'},
+    { 0, 0, 0, 0 },
+};
+
+void dtree (flux_t h, const char *prefix, int width, int height);
+
+void usage (void)
+{
+    fprintf (stderr,
+"Usage: dtree [--prefix NAME] [--width N] [--height N]\n"
+);
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    int ch;
+    int width = 1;
+    int height = 1;
+    char *prefix = "dtree";
+    flux_t h;
+
+    log_init ("dtree");
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'w': /* --width N */
+                width = strtoul (optarg, NULL, 10);
+                break;
+            case 'h': /* --height N */
+                height = strtoul (optarg, NULL, 10);
+                break;
+            case 'p': /* --prefix NAME */
+                prefix = optarg;
+                break;
+            default:
+                usage ();
+                break;
+        }
+    }
+    if (optind != argc)
+        usage ();
+    if (width < 1 || height < 1)
+        usage ();
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    dtree (h, prefix, width, height);
+    if (kvs_commit (h) < 0)
+       log_err_exit ("kvs_commit");
+    flux_close (h);
+}
+
+void dtree (flux_t h, const char *prefix, int width, int height)
+{
+    int i;
+    char *key;
+
+    for (i = 0; i < width; i++) {
+        key = xasprintf ("%s.%.4x", prefix, i);
+        if (height == 1) {
+            if (kvs_put_int (h, key, 1) < 0)
+                log_err_exit ("kvs_put %s", key);
+        } else
+            dtree (h, key, width, height - 1);
+        free (key);
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -364,6 +364,14 @@ test_expect_success 'kvs: kvsdir_get_size works' '
 	test "$OUTPUT" = "3"
 '
 
+test_expect_success 'kvs: store 16x3 directory tree' '
+	${FLUX_BUILD_DIR}/t/kvs/dtree -h3 -w16 --prefix $TEST.dtree
+'
+
+test_expect_success 'kvs: walk 16x3 directory tree' '
+	test $(flux kvs dir -r $TEST.dtree | wc -l) = 4096
+'
+
 test_expect_success 'kvs: put key of . fails' '
 	test_must_fail flux kvs put .=1
 '
@@ -457,6 +465,7 @@ test_expect_success 'kvs: store 10,000 keys in one dir' '
 test_expect_success LONGTEST 'kvs: store 1,000,000 keys in one dir' '
 	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $TEST.bigdir2 --count 1000000
 '
+
 
 # async fence
 


### PR DESCRIPTION
This PR contains some misc. hopefully non-controversial improvements culled from PR #820 which was withdrawn.  There are three batches here:
* testing: unit test for `json_dirent.[ch]`,  new `dtree` test for populating kvs namespace
* memory corruption: fix two use-after-free bugs in kvs module, protect `flux_rpc_t` with magic cookie, get valgrind test working again
* api: add format attributes on varargs kvs functions, update a few callers; drop deprecated kvs interfaces from python bindings