### PR TITLE
kvs: add kvs_getat() and related functions

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -132,6 +132,12 @@ may contain spaces.
 Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
 If nothing has been stored under 'key', display an error message.
 
+*dirat* 'treeobj' ['key']::
+Display all keys and their values under the directory 'key', starting
+lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
+display an error message.  If 'key' is not provided, "." (root of
+the namespace) is assumed.
+
 
 AUTHOR
 ------

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -128,6 +128,11 @@ Associate a new treeobj with 'key', overwriting the previous treeobj,
 if any.  A treeobj should be treated as an opaque string value, which
 may contain spaces.
 
+*getat* 'treeobj' 'key'::
+Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
+If nothing has been stored under 'key', display an error message.
+
+
 AUTHOR
 ------
 This page is maintained by the Flux community.

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -138,6 +138,10 @@ lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
 display an error message.  If 'key' is not provided, "." (root of
 the namespace) is assumed.
 
+*readlinkat* 'treeobj' 'key'::
+Retrieve the key a link refers to rather than its value, as would be
+returned by *get*, starting lookup at 'treeobj'.
+
 
 AUTHOR
 ------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -328,3 +328,4 @@ unlinked
 getat
 lookup
 dirat
+readlinkat

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -327,3 +327,4 @@ treeobj
 unlinked
 getat
 lookup
+dirat

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -325,3 +325,5 @@ hwm
 recurse
 treeobj
 unlinked
+getat
+lookup

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -229,6 +229,7 @@ static void join_request (flux_t h, flux_msg_handler_t *w,
         log_msg_exit ("hello: error decoding join request");
     if (flux_reduce_append (hello->reduce, (void *)(uintptr_t)count, batch) < 0)
         log_err_exit ("hello: flux_reduce_append");
+    Jput (in);
 }
 
 /* Reduction ops

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -66,6 +66,7 @@ void cmd_dir (flux_t h, int argc, char **argv);
 void cmd_dirsize (flux_t h, int argc, char **argv);
 void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
+void cmd_getat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -93,6 +94,7 @@ void usage (void)
 "       flux-kvs dropcache-all\n"
 "       flux-kvs get-treeobj     key\n"
 "       flux-kvs put-treeobj     key=treeobj\n"
+"       flux-kvs getat           treeobj key\n"
 );
     exit (1);
 }
@@ -166,6 +168,8 @@ int main (int argc, char *argv[])
         cmd_get_treeobj (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "put-treeobj"))
         cmd_put_treeobj (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "getat"))
+        cmd_getat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -645,6 +649,17 @@ void cmd_get_treeobj (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_get_treeobj %s", argv[0]);
     printf ("%s\n", treeobj);
     free (treeobj);
+}
+
+void cmd_getat (flux_t h, int argc, char **argv)
+{
+    char *val = NULL;
+    if (argc != 2)
+        log_msg_exit ("getat: specify treeobj and key");
+    if (kvs_getat (h, argv[0], argv[1], &val) < 0)
+        log_err_exit ("kvs_getat %s %s", argv[0], argv[1]);
+    printf ("%s\n", val);
+    free (val);
 }
 
 void cmd_put_treeobj (flux_t h, int argc, char **argv)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -67,6 +67,7 @@ void cmd_dirsize (flux_t h, int argc, char **argv);
 void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
 void cmd_getat (flux_t h, int argc, char **argv);
+void cmd_dirat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -95,6 +96,7 @@ void usage (void)
 "       flux-kvs get-treeobj     key\n"
 "       flux-kvs put-treeobj     key=treeobj\n"
 "       flux-kvs getat           treeobj key\n"
+"       flux-kvs dirat [-r]      treeobj [key]\n"
 );
     exit (1);
 }
@@ -170,6 +172,8 @@ int main (int argc, char *argv[])
         cmd_put_treeobj (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "getat"))
         cmd_getat (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dirat"))
+        cmd_dirat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -521,34 +525,34 @@ static void dump_kvs_val (const char *key, const char *json_str)
     Jput (o);
 }
 
-static void dump_kvs_dir (flux_t h, bool ropt, const char *path)
+static void dump_kvs_dir (kvsdir_t *dir, bool ropt)
 {
-    kvsdir_t *dir;
     kvsitr_t *itr;
     const char *name;
     char *key;
-
-    if (kvs_get_dir (h, &dir, "%s", path) < 0)
-        log_err_exit ("%s", path);
 
     itr = kvsitr_create (dir);
     while ((name = kvsitr_next (itr))) {
         key = kvsdir_key_at (dir, name);
         if (kvsdir_issymlink (dir, name)) {
             char *link;
-            if (kvs_get_symlink (h, key, &link) < 0)
+            if (kvsdir_get_symlink (dir, name, &link) < 0)
                 log_err_exit ("%s", key);
             printf ("%s -> %s\n", key, link);
             free (link);
 
         } else if (kvsdir_isdir (dir, name)) {
-            if (ropt)
-                dump_kvs_dir (h, ropt, key);
-            else
+            if (ropt) {
+                kvsdir_t *ndir;
+                if (kvsdir_get_dir (dir, &ndir, "%s", name) < 0)
+                    log_err_exit ("%s", key);
+                dump_kvs_dir (ndir, ropt);
+                kvsdir_destroy (ndir);
+            } else
                 printf ("%s.\n", key);
         } else {
             char *json_str;
-            if (kvs_get (h, key, &json_str) < 0)
+            if (kvsdir_get (dir, name, &json_str) < 0)
                 log_err_exit ("%s", key);
             dump_kvs_val (key, json_str);
             free (json_str);
@@ -556,7 +560,6 @@ static void dump_kvs_dir (flux_t h, bool ropt, const char *path)
         free (key);
     }
     kvsitr_destroy (itr);
-    kvsdir_destroy (dir);
 }
 
 void cmd_watch_dir (flux_t h, int argc, char **argv)
@@ -583,7 +586,8 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
                 kvsdir_destroy (dir);
             dir = NULL;
         } else {
-            dump_kvs_dir (h, ropt, key);
+            dump_kvs_dir (dir, ropt);
+            kvsdir_destroy (dir);
             printf ("======================\n");
         }
         rc = kvs_watch_once_dir (h, &dir, "%s", key);
@@ -595,6 +599,8 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
 void cmd_dir (flux_t h, int argc, char **argv)
 {
     bool ropt = false;
+    char *key;
+    kvsdir_t *dir;
 
     if (argc > 0 && !strcmp (argv[0], "-r")) {
         ropt = true;
@@ -602,11 +608,38 @@ void cmd_dir (flux_t h, int argc, char **argv)
         argv++;
     }
     if (argc == 0)
-        dump_kvs_dir (h, ropt, ".");
+        key = ".";
     else if (argc == 1)
-        dump_kvs_dir (h, ropt, argv[0]);
+        key = argv[0];
     else
         log_msg_exit ("dir: specify zero or one directory");
+    if (kvs_get_dir (h, &dir, "%s", key) < 0)
+        log_err_exit ("%s", key);
+    dump_kvs_dir (dir, ropt);
+    kvsdir_destroy (dir);
+}
+
+void cmd_dirat (flux_t h, int argc, char **argv)
+{
+    bool ropt = false;
+    char *key;
+    kvsdir_t *dir;
+
+    if (argc > 0 && !strcmp (argv[0], "-r")) {
+        ropt = true;
+        argc--;
+        argv++;
+    }
+    if (argc == 1)
+        key = ".";
+    else if (argc == 2)
+        key = argv[1];
+    else
+        log_msg_exit ("dir: specify treeobj and zero or one directory");
+    if (kvs_get_dirat (h, argv[0], key, &dir) < 0)
+        log_err_exit ("%s", key);
+    dump_kvs_dir (dir, ropt);
+    kvsdir_destroy (dir);
 }
 
 void cmd_dirsize (flux_t h, int argc, char **argv)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -68,6 +68,7 @@ void cmd_get_treeobj (flux_t h, int argc, char **argv);
 void cmd_put_treeobj (flux_t h, int argc, char **argv);
 void cmd_getat (flux_t h, int argc, char **argv);
 void cmd_dirat (flux_t h, int argc, char **argv);
+void cmd_readlinkat (flux_t h, int argc, char **argv);
 
 
 void usage (void)
@@ -97,6 +98,7 @@ void usage (void)
 "       flux-kvs put-treeobj     key=treeobj\n"
 "       flux-kvs getat           treeobj key\n"
 "       flux-kvs dirat [-r]      treeobj [key]\n"
+"       flux-kvs readlinkat      treeobj key\n"
 );
     exit (1);
 }
@@ -174,6 +176,8 @@ int main (int argc, char *argv[])
         cmd_getat (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "dirat"))
         cmd_dirat (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "readlinkat"))
+        cmd_readlinkat (h, argc - optind, argv + optind);
     else
         usage ();
 
@@ -709,6 +713,22 @@ void cmd_put_treeobj (flux_t h, int argc, char **argv)
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
 
+}
+
+void cmd_readlinkat (flux_t h, int argc, char **argv)
+{
+    int i;
+    char *target;
+
+    if (argc < 2)
+        log_msg_exit ("readlink: specify treeobj and one or more keys");
+    for (i = 1; i < argc; i++) {
+        if (kvs_get_symlinkat (h, argv[0], argv[i], &target) < 0)
+            log_err_exit ("%s", argv[i]);
+        else
+            printf ("%s\n", target);
+        free (target);
+    }
 }
 
 /*

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -83,7 +83,7 @@ void usage (void)
 "       flux-kvs mkdir           key [key...]\n"
 "       flux-kvs exists          key\n"
 "       flux-kvs watch           key\n"
-"       flux-kvs watch-dir [-r]  key\n"
+"       flux-kvs watch-dir [-r]  [count] key\n"
 "       flux-kvs copy-tokvs      key file\n"
 "       flux-kvs copy-fromkvs    key file\n"
 "       flux-kvs copy            srckey dstkey\n"
@@ -572,9 +572,15 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
     char *key;
     kvsdir_t *dir = NULL;
     int rc;
+    int count = -1;
 
     if (argc > 0 && !strcmp (argv[0], "-r")) {
         ropt = true;
+        argc--;
+        argv++;
+    }
+    if (argc == 2) {
+        count = strtoul (argv[0], NULL, 10);
         argc--;
         argv++;
     }
@@ -591,13 +597,16 @@ void cmd_watch_dir (flux_t h, int argc, char **argv)
             dir = NULL;
         } else {
             dump_kvs_dir (dir, ropt);
-            kvsdir_destroy (dir);
             printf ("======================\n");
+            fflush (stdout);
         }
+        if (--count == 0)
+            goto done;
         rc = kvs_watch_once_dir (h, &dir, "%s", key);
     }
     log_err_exit ("%s", key);
-
+done:
+    kvsdir_destroy (dir);
 }
 
 void cmd_dir (flux_t h, int argc, char **argv)

--- a/src/common/libpmi/single.c
+++ b/src/common/libpmi/single.c
@@ -79,7 +79,7 @@ int pmi_single_get_rank (struct pmi_single *pmi, int *rank)
 
 int pmi_single_get_appnum (struct pmi_single *pmi, int *appnum)
 {
-    *appnum = -1;
+    *appnum = getpid ();
     return PMI_SUCCESS;
 }
 

--- a/src/common/libpmi/test/single.c
+++ b/src/common/libpmi/test/single.c
@@ -34,8 +34,8 @@ int main (int argc, char *argv[])
         "pmi_single_get_rank works, rank == 0");
     appnum = -2;
     rc = pmi_single_get_appnum (pmi, &appnum);
-    ok (rc == PMI_SUCCESS && appnum == -1,
-        "pmi_single_get_appnum works, appnum == -1");
+    ok (rc == PMI_SUCCESS && appnum >= 0,
+        "pmi_single_get_appnum works, appnum positive number");
     size = -1;
     rc = pmi_single_get_universe_size (pmi, &size);
     ok (rc == PMI_SUCCESS && size == 1,

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1089,6 +1089,7 @@ static void fence_destroy (fence_t *f)
             /* FIXME: respond with error here? */
             zlist_destroy (&f->requests);
         }
+        free (f);
     }
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -506,7 +506,7 @@ static void commit_apply_fence (fence_t *f)
 
     /* Make a copy of the root directory.
      */
-    if (!f->rootcpy) {
+    if (!f->rootcpy_stored && !f->rootcpy) {
         json_object *rootdir;
         if (!load (ctx, ctx->rootdir, wait, &rootdir))
             goto stall;
@@ -552,6 +552,7 @@ static void commit_apply_fence (fence_t *f)
         else if (store (ctx, f->rootcpy, f->newroot, wait) < 0)
             f->errnum = errno;
         f->rootcpy_stored = true; /* cache takes ownership of rootcpy */
+        f->rootcpy = NULL;
         if (wait_get_usecount (wait) > 0)
             goto stall;
     }
@@ -1082,6 +1083,7 @@ static void fence_destroy (fence_t *f)
     if (f) {
         Jput (f->names);
         Jput (f->ops);
+        Jput (f->rootcpy);
         if (f->requests) {
             flux_msg_t *msg;
             while ((msg = zlist_pop (f->requests)))

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -775,10 +775,8 @@ static bool lookup (ctx_t *ctx, json_object *root, wait_t *wait,
     json_object *vp, *dirent, *val = NULL;
     int errnum = 0;
 
-    if (root == NULL) {
-        if (!load (ctx, ctx->rootdir, wait, &root))
-            goto stall;
-    }
+    assert (root != NULL);
+
     if (!strcmp (name, ".")) { /* special case root */
         if ((flags & KVS_PROTO_TREEOBJ)) {
             val = dirent_create ("DIRREF", ctx->rootdir);
@@ -874,6 +872,10 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
     int flags;
     const char *key;
     JSON val;
+    JSON root = NULL;
+    JSON root_dirent = NULL;
+    JSON tmp_dirent = NULL;
+    const char *root_ref = ctx->rootdir;
     wait_t *wait = NULL;
     int lookup_errnum = 0;
     int rc = -1;
@@ -884,11 +886,24 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
         errno = EPROTO;
         goto done;
     }
-    if (kp_tget_dec (in, NULL, &key, &flags) < 0)
+    if (kp_tget_dec (in, &root_dirent, &key, &flags) < 0)
         goto done;
     if (!(wait = wait_create_msg_handler (h, w, msg, get_request_cb, arg)))
         goto done;
-    if (!lookup (ctx, NULL, wait, flags, key, &val, &lookup_errnum))
+    /* If root dirent was specified, lookup corresponding 'root' directory.
+     * Otherwise, use the current root.
+     */
+    if (root_dirent) {
+        if (!Jget_str (root_dirent, "DIRREF", &root_ref)) {
+            errno = EINVAL;
+            goto done;
+        }
+    } else {
+        root_dirent = tmp_dirent = dirent_create ("DIRREF", ctx->rootdir);
+    }
+    if (!load (ctx, root_ref, wait, &root))
+        goto stall;
+    if (!lookup (ctx, root, wait, flags, key, &val, &lookup_errnum))
         goto stall;
     if (lookup_errnum != 0) {
         errno = lookup_errnum;
@@ -898,7 +913,7 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
         errno = ENOENT;
         goto done;
     }
-    if (!(out = kp_rget_enc (NULL, val)))
+    if (!(out = kp_rget_enc (Jget (root_dirent), val)))
         goto done;
     rc = 0;
 done:
@@ -909,6 +924,7 @@ done:
 stall:
     Jput (in);
     Jput (out);
+    Jput (tmp_dirent);
 }
 
 static bool compare_json (json_object *o1, json_object *o2)
@@ -928,6 +944,7 @@ static void watch_request_cb (flux_t h, flux_msg_handler_t *w,
     JSON in2 = NULL;
     JSON out = NULL;
     JSON oval, val = NULL;
+    JSON root = NULL;
     flux_msg_t *cpy = NULL;
     const char *key;
     int flags;
@@ -946,7 +963,9 @@ static void watch_request_cb (flux_t h, flux_msg_handler_t *w,
         goto done;
     if (!(wait = wait_create_msg_handler (h, w, msg, watch_request_cb, arg)))
         goto done;
-    if (!lookup (ctx, NULL, wait, flags, key, &val, &lookup_errnum))
+    if (!load (ctx, ctx->rootdir, wait, &root))
+        goto stall;
+    if (!lookup (ctx, root, wait, flags, key, &val, &lookup_errnum))
         goto stall;
     if (lookup_errnum) {
         errno = lookup_errnum;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -884,7 +884,7 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
         errno = EPROTO;
         goto done;
     }
-    if (kp_tget_dec (in, &key, &flags) < 0)
+    if (kp_tget_dec (in, NULL, &key, &flags) < 0)
         goto done;
     if (!(wait = wait_create_msg_handler (h, w, msg, get_request_cb, arg)))
         goto done;
@@ -898,7 +898,7 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
         errno = ENOENT;
         goto done;
     }
-    if (!(out = kp_rget_enc (val)))
+    if (!(out = kp_rget_enc (NULL, val)))
         goto done;
     rc = 0;
 done:

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -626,7 +626,7 @@ void commit_merge_all (ctx_t *ctx)
                 for (i = 0; i < len; i++) {
                     json_object *op;
                     if (Jget_ar_obj (nf->ops, i, &op))
-                        Jadd_ar_obj (f->ops, Jget (op));
+                        Jadd_ar_obj (f->ops, op);
                 }
             }
         }

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -52,6 +52,9 @@ int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
  */
 int kvs_getat (flux_t h, const char *treeobj,
                const char *key, char **json_str);
+int kvs_get_dirat (flux_t h, const char *treeobj,
+                   const char *key, kvsdir_t **dirp);
+
 
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -54,6 +54,8 @@ int kvs_getat (flux_t h, const char *treeobj,
                const char *key, char **json_str);
 int kvs_get_dirat (flux_t h, const char *treeobj,
                    const char *key, kvsdir_t **dirp);
+int kvs_get_symlinkat (flux_t h, const char *treeobj,
+                               const char *key, char **val);
 
 
 /* kvs_watch* is like kvs_get* except the registered callback is called

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -48,6 +48,11 @@ int kvs_get_symlink (flux_t h, const char *key, char **valp);
  */
 int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
 
+/* Like kvs_get() but lookup is relative to 'treeobj'.
+ */
+int kvs_getat (flux_t h, const char *treeobj,
+               const char *key, char **json_str);
+
 /* kvs_watch* is like kvs_get* except the registered callback is called
  * to set the value.  It will be called immediately to set the initial
  * value and again each time the value changes.

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -341,7 +341,7 @@ static int getobj (flux_t h, const char *key, int flags, json_object **val)
         goto done;
     }
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (k, flags)))
+    if (!(in = kp_tget_enc (NULL, k, flags)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -351,7 +351,7 @@ static int getobj (flux_t h, const char *key, int flags, json_object **val)
         errno = EPROTO;
         goto done;
     }
-    if (kp_rget_dec (out, &v) < 0)
+    if (kp_rget_dec (out, NULL, &v) < 0)
         goto done;
     if (val)
         *val = Jget (v);
@@ -405,7 +405,7 @@ int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
     key = xvasprintf (fmt, ap);
     va_end (ap);
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (k, KVS_PROTO_READDIR)))
+    if (!(in = kp_tget_enc (NULL, k, KVS_PROTO_READDIR)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -415,7 +415,7 @@ int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
         errno = EPROTO;
         goto done;
     }
-    if (kp_rget_dec (out, &v) < 0)
+    if (kp_rget_dec (out, NULL, &v) < 0)
         goto done;
     *dir = kvsdir_alloc (h, k, v);
     rc = 0;

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -352,6 +352,33 @@ done:
     return rc;
 }
 
+int kvs_get_symlinkat (flux_t h, const char *treeobj,
+                       const char *key, char **val)
+{
+    JSON v = NULL;
+    JSON dirent = NULL;
+    int rc = -1;
+
+    if (!treeobj || !key || !(dirent = Jfromstr (treeobj))
+                         || dirent_validate (dirent) < 0) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (getobj (h, dirent, key, KVS_PROTO_READLINK, &v) < 0)
+        goto done;
+    if (json_object_get_type (v) != json_type_string) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (val)
+        *val = xstrdup (json_object_get_string (v));
+    rc = 0;
+done:
+    Jput (v);
+    Jput (dirent);
+    return rc;
+}
+
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -1539,6 +1539,10 @@ int kvsdir_put_obj (kvsdir_t *dir, const char *name, json_object *val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put (dir->handle, key, Jtostr (val));
     free (key);
@@ -1551,6 +1555,10 @@ int kvsdir_put (kvsdir_t *dir, const char *name, const char *val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put (dir->handle, key, val);
     free (key);
@@ -1563,6 +1571,10 @@ int kvsdir_put_string (kvsdir_t *dir, const char *name, const char *val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put_string (dir->handle, key, val);
     free (key);
@@ -1575,6 +1587,10 @@ int kvsdir_put_int (kvsdir_t *dir, const char *name, int val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put_int (dir->handle, key, val);
     free (key);
@@ -1587,6 +1603,10 @@ int kvsdir_put_int64 (kvsdir_t *dir, const char *name, int64_t val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put_int64 (dir->handle, key, val);
     free (key);
@@ -1599,6 +1619,10 @@ int kvsdir_put_double (kvsdir_t *dir, const char *name, double val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put_double (dir->handle, key, val);
     free (key);
@@ -1611,6 +1635,10 @@ int kvsdir_put_boolean (kvsdir_t *dir, const char *name, bool val)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_put_boolean (dir->handle, key, val);
     free (key);
@@ -1623,6 +1651,10 @@ int kvsdir_mkdir (kvsdir_t *dir, const char *name)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_mkdir (dir->handle, key);
     free (key);
@@ -1635,6 +1667,10 @@ int kvsdir_symlink (kvsdir_t *dir, const char *name, const char *target)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_symlink (dir->handle, key, target);
     free (key);
@@ -1647,6 +1683,10 @@ int kvsdir_unlink (kvsdir_t *dir, const char *name)
     int rc;
     char *key;
 
+    if (dir->rootref) {
+        errno = EROFS;
+        return -1;
+    }
     key = kvsdir_key_at (dir, name);
     rc = kvs_unlink (dir->handle, key);
     free (key);

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -325,7 +325,8 @@ char *kvsdir_key_at (kvsdir_t *dir, const char *name)
  ** GET
  **/
 
-static int getobj (flux_t h, const char *key, int flags, json_object **val)
+static int getobj (flux_t h, json_object *rootdir, const char *key,
+                   int flags, json_object **val)
 {
     flux_rpc_t *rpc = NULL;
     const char *json_str;
@@ -341,7 +342,7 @@ static int getobj (flux_t h, const char *key, int flags, json_object **val)
         goto done;
     }
     k = pathcat (kvs_getcwd (h), key);
-    if (!(in = kp_tget_enc (NULL, k, flags)))
+    if (!(in = kp_tget_enc (rootdir, k, flags)))
         goto done;
     if (!(rpc = flux_rpc (h, "kvs.get", Jtostr (in), FLUX_NODEID_ANY, 0)))
         goto done;
@@ -371,7 +372,7 @@ int kvs_get (flux_t h, const char *key, char **val)
 {
     JSON v;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         return -1;
     if (val)
         *val = xstrdup (Jtostr (v));
@@ -382,7 +383,7 @@ int kvs_get (flux_t h, const char *key, char **val)
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {
-    return getobj (h, key, 0, val);
+    return getobj (h, NULL, key, 0, val);
 }
 
 int kvs_get_dir (flux_t h, kvsdir_t **dir, const char *fmt, ...)
@@ -435,7 +436,7 @@ int kvs_get_symlink (flux_t h, const char *key, char **val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, KVS_PROTO_READLINK, &v) < 0)
+    if (getobj (h, NULL, key, KVS_PROTO_READLINK, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_string) {
         errno = EPROTO;
@@ -455,7 +456,7 @@ int kvs_get_treeobj (flux_t h, const char *key, char **val)
     const char *s;
     int rc = -1;
 
-    if (getobj (h, key, KVS_PROTO_TREEOBJ, &v) < 0)
+    if (getobj (h, NULL, key, KVS_PROTO_TREEOBJ, &v) < 0)
         goto done;
     if (val) {
         s = json_object_to_json_string_ext (v, JSON_C_TO_STRING_PLAIN);
@@ -472,7 +473,7 @@ int kvs_get_string (flux_t h, const char *key, char **val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_string) {
         errno = EPROTO;
@@ -491,7 +492,7 @@ int kvs_get_int (flux_t h, const char *key, int *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_int) {
         errno = EPROTO;
@@ -510,7 +511,7 @@ int kvs_get_int64 (flux_t h, const char *key, int64_t *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_int) {
         errno = EPROTO;
@@ -529,7 +530,7 @@ int kvs_get_double (flux_t h, const char *key, double *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_double) {
         errno = EPROTO;
@@ -548,7 +549,7 @@ int kvs_get_boolean (flux_t h, const char *key, bool *val)
     JSON v = NULL;
     int rc = -1;
 
-    if (getobj (h, key, 0, &v) < 0)
+    if (getobj (h, NULL, key, 0, &v) < 0)
         goto done;
     if (json_object_get_type (v) != json_type_boolean) {
         errno = EPROTO;
@@ -1651,7 +1652,7 @@ int kvsdir_unlink (kvsdir_t *dir, const char *name)
 int kvs_copy (flux_t h, const char *from, const char *to)
 {
     JSON dirent;
-    if (getobj (h, from, KVS_PROTO_TREEOBJ, &dirent) < 0)
+    if (getobj (h, NULL, from, KVS_PROTO_TREEOBJ, &dirent) < 0)
         return -1;
     if (kvs_put_dirent (h, to, dirent) < 0) {
         Jput (dirent);

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -380,6 +380,29 @@ int kvs_get (flux_t h, const char *key, char **val)
     return 0;
 }
 
+int kvs_getat (flux_t h, const char *treeobj,
+               const char *key, char **val)
+{
+    JSON v = NULL;
+    JSON dirent = NULL;
+
+    if (!treeobj || !key || !(dirent = Jfromstr (treeobj))
+                         || dirent_validate (dirent) < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (getobj (h, dirent, key, 0, &v) < 0)
+        goto error;
+    if (val)
+        *val = xstrdup (Jtostr (v));
+    Jput (dirent);
+    return 0;
+error:
+    Jput (v);
+    Jput (dirent);
+    return -1;
+}
+
 /* deprecated */
 int kvs_get_obj (flux_t h, const char *key, JSON *val)
 {

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -12,11 +12,13 @@ enum {
 
 /* kvs.get
  */
-json_object *kp_tget_enc (const char *key, int flags);
-int kp_tget_dec (json_object *o, const char **key, int *flags);
+json_object *kp_tget_enc (json_object *rootdir,
+                          const char *key, int flags);
+int kp_tget_dec (json_object *o, json_object **rootdir,
+                 const char **key, int *flags);
 
-json_object *kp_rget_enc (json_object *val);
-int kp_rget_dec (json_object *o, json_object **val);
+json_object *kp_rget_enc (json_object *rootdir, json_object *val);
+int kp_rget_dec (json_object *o, json_object **rootdir, json_object **val);
 
 
 /* kvs.watch

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -1,43 +1,64 @@
 #include <string.h>
 
 #include "src/common/libutil/shortjson.h"
-#include "src/modules/kvs/proto.h"
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
+
+#include "src/modules/kvs/proto.h"
+#include "src/modules/kvs/json_dirent.h"
 
 void test_get (void)
 {
     JSON o;
     const char *key = NULL;
     JSON val = NULL;
+    JSON dirent = NULL;
+    JSON dirent2 = NULL;
     int i, flags;
 
-    o = kp_tget_enc ("foo", 42);
+    o = kp_tget_enc (NULL, "foo", 42);
     ok (o != NULL,
         "kp_tget_enc works");
     diag ("get request: %s", Jtostr (o));
     flags = 0;
-    ok (kp_tget_dec (o, &key, &flags) == 0 && flags == 42,
+    ok (kp_tget_dec (o, NULL, &key, &flags) == 0 && flags == 42,
         "kp_tget_dec works");
     like (key, "^foo$",
         "kp_tget_dec returned encoded key");
     Jput (o);
 
+    dirent = dirent_create ("DIRREF", "sha1-abcdefabcdef00000");
+    o = kp_tget_enc (dirent, "foo", 42);
+    ok (o != NULL,
+        "kp_tget_enc with optional dirent arg works");
+    diag ("get request: %s", Jtostr (o));
+    flags = 0;
+    ok (kp_tget_dec (o, &dirent2, &key, &flags) == 0 && flags == 42,
+        "kp_tget_dec works");
+    ok (dirent_validate (dirent2) && dirent_match (dirent, dirent2),
+        "kp_tget_dec returned dirent");
+    Jput (dirent);
+    Jput (o);
+
+
     val = Jnew ();
     Jadd_int (val, "i", 42);
-    o = kp_rget_enc (val);
+    dirent = dirent_create ("DIRREF", "sha1-abcdefabcdef00000");
+    o = kp_rget_enc (dirent, val);
     val = NULL; /* val now owned by o */
     ok (o != NULL,
         "kp_rget_enc works");
     diag ("get response: %s", Jtostr (o));
-    ok (kp_rget_dec (o, &val) == 0,
+    ok (kp_rget_dec (o, &dirent2, &val) == 0,
         "kp_rget_dec works");
     // get response: { "val": { "i": 42 } }
     i = 0;
     ok (val && Jget_int (val, "i", &i) && i == 42,
         "kp_rget_dec returned encoded object");
+    ok (dirent_validate (dirent2) && dirent_match (dirent, dirent2),
+        "kp_rget_dec returned rootref");
     Jput (o); /* owns val */
 }
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -488,6 +488,14 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 
 # watch tests
 
+test_expect_success 'kvs: watch 5 versions of directory'  '
+	flux kvs unlink $TEST.foo &&
+	flux kvs watch-dir -r 5 $TEST.foo >watch_out &
+	while $(grep -s '===============' watch_out | wc -l) -lt 5; do
+	    flux kvs put $TEST.foo.a=$(date +%N); \
+	done
+'
+
 test_expect_success 'kvs: watch-mt: multi-threaded kvs watch program' '
 	${FLUX_BUILD_DIR}/t/kvs/watch mt 100 100 $TEST.a &&
 	flux kvs unlink $TEST.a

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -409,6 +409,12 @@ test_expect_success 'kvs: walk 16x3 directory tree' '
 	test $(flux kvs dir -r $TEST.dtree | wc -l) = 4096
 '
 
+test_expect_success 'kvs: unlink, walk 16x3 directory tree with dirat' '
+	DIRREF=$(flux kvs get-treeobj $TEST.dtree) &&
+	flux kvs unlink $TEST.dtree &&
+	test $(flux kvs dirat -r $DIRREF | wc -l) = 4096
+'
+
 test_expect_success 'kvs: put key of . fails' '
 	test_must_fail flux kvs put .=1
 '

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -428,6 +428,12 @@ test_expect_success 'kvs: add other types to 2x4 directory and walk' '
 	test $(flux kvs dir -r $TEST.dtree | wc -l) = 19
 '
 
+test_expect_success 'kvs: store 3x4 directory tree using kvsdir_put functions' '
+	flux kvs unlink $TEST.dtree &&
+	${FLUX_BUILD_DIR}/t/kvs/dtree --mkdir -h4 -w3 --prefix $TEST.dtree &&
+	test $(flux kvs dir -r $TEST.dtree | wc -l) = 81
+'
+
 test_expect_success 'kvs: put key of . fails' '
 	test_must_fail flux kvs put .=1
 '

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -415,6 +415,19 @@ test_expect_success 'kvs: unlink, walk 16x3 directory tree with dirat' '
 	test $(flux kvs dirat -r $DIRREF | wc -l) = 4096
 '
 
+test_expect_success 'kvs: store 2x4 directory tree and walk' '
+	${FLUX_BUILD_DIR}/t/kvs/dtree -h4 -w2 --prefix $TEST.dtree
+	test $(flux kvs dir -r $TEST.dtree | wc -l) = 16
+'
+
+# exercise kvsdir_get_symlink, _double, _boolean, 
+test_expect_success 'kvs: add other types to 2x4 directory and walk' '
+	flux kvs link $TEST.dtree $TEST.dtree.link &&
+	flux kvs put $TEST.dtree.double=3.14 &&
+	flux kvs put $TEST.dtree.booelan=true &&
+	test $(flux kvs dir -r $TEST.dtree | wc -l) = 19
+'
+
 test_expect_success 'kvs: put key of . fails' '
 	test_must_fail flux kvs put .=1
 '

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -282,6 +282,15 @@ test_expect_success 'kvs: symlink: kvs_copy does not follow symlinks (bottom)' '
 	test "$LINKVAL" = "$TEST.a.b.X"
 '
 
+test_expect_success 'kvs: get_symlinkat works after symlink unlinked' '
+	flux kvs unlink $TEST &&
+	flux kvs link $TEST.a.b.X $TEST.a.b.link &&
+	ROOTREF=$(flux kvs get-treeobj .) &&
+	flux kvs unlink $TEST &&
+	LINKVAL=$(flux kvs readlinkat $ROOTREF $TEST.a.b.link) &&
+	test "$LINKVAL" = "$TEST.a.b.X"
+'
+
 test_expect_success 'kvs: get-treeobj: returns directory reference for root' '
 	flux kvs unlink $TEST &&
 	flux kvs get-treeobj . | grep -q "DIRREF"

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -355,6 +355,34 @@ test_expect_success 'kvs: put-treeobj: fails bad dirent: bad blobref' '
 	test_must_fail flux kvs put-treeobj $TEST.a="{\"DIRREF\":\"sha1-bbb\"}"
 '
 
+test_expect_success 'kvs: getat: fails bad on dirent' '
+	flux kvs unlink $TEST &&
+	test_must_fail flux kvs getat 42 $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRREF\":\"sha2-aaa\"}" $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRREF\":\"sha1-bbb\"}" $TEST.a &&
+	test_must_fail flux kvs getat "{\"DIRVAL\":{}}" $TEST.a
+'
+
+test_expect_success 'kvs: getat: works on root from get-treeobj' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	test $(flux kvs getat $(flux kvs get-treeobj .) $TEST.a.b.c) = 42
+'
+
+test_expect_success 'kvs: getat: works on subdir from get-treeobj' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	test $(flux kvs getat $(flux kvs get-treeobj $TEST.a.b) c) = 42
+'
+
+test_expect_success 'kvs: getat: works on outdated root' '
+	flux kvs unlink $TEST &&
+	flux kvs put $TEST.a.b.c=42 &&
+	ROOTREF=$(flux kvs get-treeobj .) &&
+	flux kvs put $TEST.a.b.c=43 &&
+	test $(flux kvs getat $ROOTREF $TEST.a.b.c) = 42
+'
+
 test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs mkdir $TEST.dirsize &&
 	flux kvs put $TEST.dirsize.a=1 &&


### PR DESCRIPTION
Resubmitting work from the withdrawn PR #820, cleaned up:

This PR adds the following new KVS interfaces:
```C
/* Like kvs_get() but lookup is relative to 'treeobj'.
 */
int kvs_getat (flux_t h, const char *treeobj,
               const char *key, char **json_str);
int kvs_get_dirat (flux_t h, const char *treeobj,
                   const char *key, kvsdir_t **dirp);
int kvs_get_symlinkat (flux_t h, const char *treeobj,
                               const char *key, char **val);
```
and modifies the `kvsdir_get_*()` implementations so that a `kvsdir_t` created by `kvs_get_dirat()` can be walked recursively relative to the original treeobj, regardless of what is changing in the KVS, which finally addresses #64.

I also implemented @grondo's suggestion of making `kvsdir_put_*()` fail on a "snapshot" `kvsdir_t`.

The `flux-kvs` command has a couple of new sub-commands (getat, dirat, readlinkat), and the kvs sharness test was modified to exercise them.

I spent a long time agonizing over the API here, and came to the conclusion (again) that a sweeping KVS API overhaul is necessary and that these additions should stick to the original theme for the time being.