### PR TITLE
security: Remove pointer from typedef flux_sec_t

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -104,7 +104,7 @@ typedef struct {
     /* 0MQ
      */
     zctx_t *zctx;               /* zeromq context (MT-safe) */
-    flux_sec_t sec;             /* security context (MT-safe) */
+    flux_sec_t *sec;             /* security context (MT-safe) */
 
     /* Reactor
      */

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -45,7 +45,7 @@ struct endpoint {
 
 struct overlay_struct {
     zctx_t *zctx;
-    flux_sec_t sec;
+    flux_sec_t *sec;
     flux_t h;
     zhash_t *children;          /* child_t - by uuid */
     flux_msg_handler_t *heartbeat;
@@ -150,7 +150,7 @@ void overlay_set_zctx (overlay_t *ov, zctx_t *zctx)
     ov->zctx = zctx;
 }
 
-void overlay_set_sec (overlay_t *ov, flux_sec_t sec)
+void overlay_set_sec (overlay_t *ov, flux_sec_t *sec)
 {
     ov->sec = sec;
 }

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -9,7 +9,7 @@ void overlay_destroy (overlay_t *ov);
 
 /* These need to be set before connect/bind.
  */
-void overlay_set_sec (overlay_t *ov, flux_sec_t sec);
+void overlay_set_sec (overlay_t *ov, flux_sec_t *sec);
 void overlay_set_zctx (overlay_t *ov, zctx_t *zctx);
 void overlay_set_rank (overlay_t *ov, uint32_t rank);
 void overlay_set_flux (overlay_t *ov, flux_t h);

--- a/src/broker/snoop.c
+++ b/src/broker/snoop.c
@@ -38,7 +38,7 @@
 #include "snoop.h"
 
 struct snoop_struct {
-    flux_sec_t sec;
+    flux_sec_t *sec;
     zctx_t *zctx;
     char *uri;
     void *zs;
@@ -59,7 +59,7 @@ void snoop_destroy (snoop_t *sn)
     }
 }
 
-void snoop_set_sec (snoop_t *sn, flux_sec_t sec)
+void snoop_set_sec (snoop_t *sn, flux_sec_t *sec)
 {
     sn->sec = sec;
 }

--- a/src/broker/snoop.h
+++ b/src/broker/snoop.h
@@ -26,7 +26,7 @@ typedef struct snoop_struct snoop_t;
 snoop_t *snoop_create (void);
 void snoop_destroy (snoop_t *sn);
 
-void snoop_set_sec (snoop_t *sn, flux_sec_t sec);
+void snoop_set_sec (snoop_t *sn, flux_sec_t *sec);
 void snoop_set_zctx (snoop_t *sn, zctx_t *zctx);
 void snoop_set_uri (snoop_t *sn, const char *fmt, ...);
 

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -51,7 +51,7 @@ void usage (void)
 int main (int argc, char *argv[])
 {
     int ch;
-    flux_sec_t sec;
+    flux_sec_t *sec;
     bool force = false;
     bool plain = false;
     const char *secdir = getenv ("FLUX_SEC_DIRECTORY");

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -63,7 +63,7 @@ void usage (void)
     exit (1);
 }
 
-static void *connect_snoop (zctx_t *zctx, flux_sec_t sec, const char *uri);
+static void *connect_snoop (zctx_t *zctx, flux_sec_t *sec, const char *uri);
 static int snoop_cb (zloop_t *zloop, zmq_pollitem_t *item, void *arg);
 static int zmon_cb (zloop_t *zloop, zmq_pollitem_t *item, void *arg);
 
@@ -85,7 +85,7 @@ int main (int argc, char *argv[])
     void *s;
     zloop_t *zloop;
     zmq_pollitem_t zp;
-    flux_sec_t sec;
+    flux_sec_t *sec;
     const char *secdir;
 
     log_init ("flux-snoop");
@@ -201,7 +201,7 @@ int main (int argc, char *argv[])
     return 0;
 }
 
-static void *connect_snoop (zctx_t *zctx, flux_sec_t sec, const char *uri)
+static void *connect_snoop (zctx_t *zctx, flux_sec_t *sec, const char *uri)
 {
     void *s;
 

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -6,7 +6,7 @@
 
 #define DEFAULT_ZAP_DOMAIN      "flux"
 
-typedef struct flux_sec_struct *flux_sec_t;
+typedef struct flux_sec_struct flux_sec_t;
 
 struct _zctx_t;
 
@@ -21,34 +21,34 @@ enum {
 /* Create a security context.
  * The default mode depends on compilation options.
  */
-flux_sec_t flux_sec_create (void);
-void flux_sec_destroy (flux_sec_t c);
+flux_sec_t *flux_sec_create (void);
+void flux_sec_destroy (flux_sec_t *c);
 
 /* Enable/disable/test security modes.
  */
-int flux_sec_enable (flux_sec_t c, int type);
-int flux_sec_disable (flux_sec_t c, int type);
+int flux_sec_enable (flux_sec_t *c, int type);
+int flux_sec_disable (flux_sec_t *c, int type);
 
 /* Get/set config directory used by security context.
  */
-void flux_sec_set_directory (flux_sec_t c, const char *confdir);
-const char *flux_sec_get_directory (flux_sec_t c);
+void flux_sec_set_directory (flux_sec_t *c, const char *confdir);
+const char *flux_sec_get_directory (flux_sec_t *c);
 
 /* Generate key material for configured security modes, if applicable.
  */
-int flux_sec_keygen (flux_sec_t c, bool force, bool verbose);
+int flux_sec_keygen (flux_sec_t *c, bool force, bool verbose);
 
 /* Initialize ZAUTH (PLAIN or CURVE) and MUNGE security.
  * Calling these when relevant security modes are disabled is a no-op.
  */
-int flux_sec_zauth_init (flux_sec_t c, struct _zctx_t *zctx, const char *domain);
-int flux_sec_munge_init (flux_sec_t c);
+int flux_sec_zauth_init (flux_sec_t *c, struct _zctx_t *zctx, const char *domain);
+int flux_sec_munge_init (flux_sec_t *c);
 
 /* Enable client or server mode ZAUTH security on a zmq socket.
  * Calling these when relevant security modes are disabled is a no-op.
  */
-int flux_sec_csockinit (flux_sec_t c, void *sock);
-int flux_sec_ssockinit (flux_sec_t c, void *sock);
+int flux_sec_csockinit (flux_sec_t *c, void *sock);
+int flux_sec_ssockinit (flux_sec_t *c, void *sock);
 
 /* Munge/unmunge a msg.  The munged message is a single part
  * containing a munge credential, with the original message encoded
@@ -56,19 +56,19 @@ int flux_sec_ssockinit (flux_sec_t c, void *sock);
  * Be aware that SUB subscriptions will no longer match the message's
  * encoded topic string (you should subscribe to all).
  */
-int flux_sec_munge_zmsg (flux_sec_t c, flux_msg_t **msg);
-int flux_sec_unmunge_zmsg (flux_sec_t c, flux_msg_t **msg);
+int flux_sec_munge_zmsg (flux_sec_t *c, flux_msg_t **msg);
+int flux_sec_unmunge_zmsg (flux_sec_t *c, flux_msg_t **msg);
 
 /* Retrieve a string describing the last error.
  * This value is valid after one of the above calls returns -1.
  * The caller should not free this string.
  */
-const char *flux_sec_errstr (flux_sec_t c);
+const char *flux_sec_errstr (flux_sec_t *c);
 
 /* Retrieve a string describing the security modes selected.
  * The caller should not free this string.
  */
-const char *flux_sec_confstr (flux_sec_t c);
+const char *flux_sec_confstr (flux_sec_t *c);
 
 #endif /* _FLUX_CORE_SECURITY_H */
 

--- a/src/test/tmunge.c
+++ b/src/test/tmunge.c
@@ -58,7 +58,7 @@ static void *cs;
 void *thread (void *arg)
 {
     zmsg_t *zmsg;
-    flux_sec_t sec;
+    flux_sec_t *sec;
     int i;
 
     if (!(sec = flux_sec_create ()))
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
     pthread_t tid;
     pthread_attr_t attr;
     zmsg_t *zmsg;
-    flux_sec_t sec;
+    flux_sec_t *sec;
     int n;
     zctx_t *zctx;
 


### PR DESCRIPTION
Remove the pointer from the definition of the typedef
flux_sec_t to comply with the Coding Style Guide and
to make it easier to use.