### PR TITLE
module: Remove pointer from typedef flux_modlist_t

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -2006,7 +2006,7 @@ done:
 static int cmb_lsmod_cb (zmsg_t **zmsg, void *arg)
 {
     ctx_t *ctx = arg;
-    flux_modlist_t mods = NULL;
+    flux_modlist_t *mods = NULL;
     char *json_str = NULL;
     int rc = -1;
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -607,9 +607,9 @@ void modhash_set_heartbeat (modhash_t *mh, heartbeat_t *hb)
     mh->heartbeat = hb;
 }
 
-flux_modlist_t module_get_modlist (modhash_t *mh)
+flux_modlist_t *module_get_modlist (modhash_t *mh)
 {
-    flux_modlist_t mods;
+    flux_modlist_t *mods;
     zlist_t *uuids;
     char *uuid;
     module_t *p;

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -95,7 +95,7 @@ int module_stop_all (modhash_t *mh);
 
 /* Prepare an 'lsmod' response payload.
  */
-flux_modlist_t module_get_modlist (modhash_t *mh);
+flux_modlist_t *module_get_modlist (modhash_t *mh);
 
 #endif /* !_BROKER_MODULE_H */
 

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -390,7 +390,7 @@ void lsmod_map_hash (zhash_t *mods, flux_lsmod_f cb, void *arg)
 
 int lsmod_merge_result (uint32_t nodeid, const char *json_str, zhash_t *mods)
 {
-    flux_modlist_t modlist;
+    flux_modlist_t *modlist;
     mod_t *m;
     int i, len;
     const char *name, *digest;

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -134,7 +134,7 @@ char *flux_rmmod_json_encode (const char *name)
     return json_str;
 }
 
-int flux_modlist_get (flux_modlist_t mods, int n, const char **name, int *size,
+int flux_modlist_get (flux_modlist_t *mods, int n, const char **name, int *size,
                       const char **digest, int *idle, int *status)
 {
     JSON o, a;
@@ -154,7 +154,7 @@ done:
     return rc;
 }
 
-int flux_modlist_count (flux_modlist_t mods)
+int flux_modlist_count (flux_modlist_t *mods)
 {
     JSON a;
     int len;
@@ -166,7 +166,7 @@ int flux_modlist_count (flux_modlist_t mods)
     return len;
 }
 
-int flux_modlist_append (flux_modlist_t mods, const char *name, int size,
+int flux_modlist_append (flux_modlist_t *mods, const char *name, int size,
                             const char *digest, int idle, int status)
 {
     JSON a, o = Jnew ();
@@ -188,7 +188,7 @@ done:
     return rc;
 }
 
-void flux_modlist_destroy (flux_modlist_t mods)
+void flux_modlist_destroy (flux_modlist_t *mods)
 {
     if (mods) {
         Jput (mods->o);
@@ -196,22 +196,22 @@ void flux_modlist_destroy (flux_modlist_t mods)
     }
 }
 
-flux_modlist_t flux_modlist_create (void)
+flux_modlist_t *flux_modlist_create (void)
 {
-    flux_modlist_t mods = xzmalloc (sizeof (*mods));
+    flux_modlist_t *mods = xzmalloc (sizeof (*mods));
     mods->o = Jnew ();
     json_object_object_add (mods->o, "mods", Jnew_ar ());
     return mods;
 }
 
-char *flux_lsmod_json_encode (flux_modlist_t mods)
+char *flux_lsmod_json_encode (flux_modlist_t *mods)
 {
     return xstrdup (Jtostr (mods->o));
 }
 
-flux_modlist_t flux_lsmod_json_decode (const char *json_str)
+flux_modlist_t *flux_lsmod_json_decode (const char *json_str)
 {
-    flux_modlist_t mods = xzmalloc (sizeof (*mods));
+    flux_modlist_t *mods = xzmalloc (sizeof (*mods));
     if (!(mods->o = Jfromstr (json_str))) {
         free (mods);
         errno = EPROTO;
@@ -346,7 +346,7 @@ int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
 {
     flux_rpc_t *r = NULL;
     char *topic = xasprintf ("%s.lsmod", service ? service : "cmb");
-    flux_modlist_t mods = NULL;
+    flux_modlist_t *mods = NULL;
     const char *json_str;
     int rc = -1;
     int i, len;

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -82,19 +82,19 @@ char *flux_modfind (const char *searchpath, const char *modname);
  * 'flux_modlist_t' is an intermediate object that can encode/decode
  * to/from a JSON string, and provides accessors for module list entries.
  */
-typedef struct flux_modlist_struct *flux_modlist_t;
+typedef struct flux_modlist_struct flux_modlist_t;
 
-flux_modlist_t flux_modlist_create (void);
-void flux_modlist_destroy (flux_modlist_t mods);
-int flux_modlist_append (flux_modlist_t mods, const char *name, int size,
+flux_modlist_t *flux_modlist_create (void);
+void flux_modlist_destroy (flux_modlist_t *mods);
+int flux_modlist_append (flux_modlist_t *mods, const char *name, int size,
                             const char *digest, int idle, int status);
-int flux_modlist_count (flux_modlist_t mods);
-int flux_modlist_get (flux_modlist_t mods, int idx, const char **name,
+int flux_modlist_count (flux_modlist_t *mods);
+int flux_modlist_get (flux_modlist_t *mods, int idx, const char **name,
                                 int *size, const char **digest, int *idle,
                                 int *status);
 
-char *flux_lsmod_json_encode (flux_modlist_t mods);
-flux_modlist_t flux_lsmod_json_decode (const char *json_str);
+char *flux_lsmod_json_encode (flux_modlist_t *mods);
+flux_modlist_t *flux_lsmod_json_decode (const char *json_str);
 
 
 /* Encode/decode rmmod payload.

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -57,7 +57,7 @@ void test_helpers (void)
 
 void test_lsmod_codec (void)
 {
-    flux_modlist_t mods;
+    flux_modlist_t *mods;
     int idle, size;
     const char *name, *digest;
     char *json_str;

--- a/t/module/parent.c
+++ b/t/module/parent.c
@@ -88,9 +88,9 @@ static module_t *module_create (const char *path, char *argz, size_t argz_len)
     return m;
 }
 
-static flux_modlist_t module_list (void)
+static flux_modlist_t *module_list (void)
 {
-    flux_modlist_t mods = flux_modlist_create ();
+    flux_modlist_t *mods = flux_modlist_create ();
     zlist_t *keys = zhash_keys (modules);
     module_t *m;
     char *name;
@@ -177,7 +177,7 @@ done:
 static void lsmod_request_cb (flux_t h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
-    flux_modlist_t mods = NULL;
+    flux_modlist_t *mods = NULL;
     char *json_str = NULL;
     int rc = -1, saved_errno;
 


### PR DESCRIPTION
Remove the pointer from the definition of the typedef
flux_modlist_t to comply with the Coding Style Guide and
to make it easier to use.

flux-sched will need a one-line change to accommodate
this change.