### PR TITLE
Remove JSON typedef, just use json_object *

### DIFF
--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -40,7 +40,7 @@ void forward (flux_reduce_t *r, int batchnum, void *arg)
     flux_rpc_t *rpc;
 
     while ((item = flux_reduce_pop (r))) {
-        JSON out = Jnew ();
+        json_object *out = Jnew ();
         Jadd_int (out, "batchnum", batchnum);
         Jadd_str (out, "nodeset", item);
         rpc = flux_rpc (ctx->h, "treduce.forward", Jtostr (out),
@@ -77,7 +77,7 @@ void forward_cb (flux_t h, flux_msg_handler_t *w,
 {
     struct context *ctx = arg;
     const char *json_str, *nodeset_str;
-    JSON in = NULL;
+    json_object *in = NULL;
     int batchnum;
     char *item;
 

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -5,7 +5,7 @@
 void get_rank (flux_rpc_t *rpc)
 {
     const char *json_str;
-    JSON o;
+    json_object *o;
     const char *rank;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
@@ -20,7 +20,7 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_rpc_t *rpc;
-    JSON o = Jnew();
+    json_object *o = Jnew();
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -5,7 +5,7 @@
 void get_rank (flux_rpc_t *rpc, void *arg)
 {
     const char *json_str;
-    JSON o;
+    json_object *o;
     const char *rank;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)
@@ -21,7 +21,7 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_rpc_t *rpc;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
 
     Jadd_str (o, "name", "rank");
     if (!(h = flux_open (NULL, 0)))

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -5,7 +5,7 @@
 void get_rank (flux_rpc_t *rpc, void *arg)
 {
     const char *json_str;
-    JSON o;
+    json_object *o;
     const char *rank;
     uint32_t nodeid;
 
@@ -21,7 +21,7 @@ int main (int argc, char **argv)
 {
     flux_t h;
     flux_rpc_t *rpc;
-    JSON o = Jnew();
+    json_object *o = Jnew();
 
     Jadd_str (o, "name", "rank");
     if (!(h = flux_open (NULL, 0)))

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -648,7 +648,7 @@ static void content_backing_request (flux_t h, flux_msg_handler_t *w,
     content_cache_t *cache = arg;
     const char *json_str;
     const char *name;
-    JSON in = NULL;
+    json_object *in = NULL;
     int rc = -1;
     bool backing;
 
@@ -735,7 +735,7 @@ static void content_stats_request (flux_t h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
-    JSON out = Jnew ();
+    json_object *out = Jnew ();
     int rc = -1;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -219,7 +219,7 @@ static void join_request (flux_t h, flux_msg_handler_t *w,
     hello_t *hello = arg;
     const char *json_str;
     int count, batch;
-    JSON in = NULL;
+    json_object *in = NULL;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         log_err_exit ("hello: flux_request_decode");
@@ -281,7 +281,7 @@ static void r_forward (flux_reduce_t *r, int batch, void *arg)
     flux_rpc_t *rpc;
     hello_t *hello = arg;
     int count = (uintptr_t)flux_reduce_pop (r);
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
 
     assert (batch == 0);
     assert (count > 0);

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -94,7 +94,7 @@ static void ping_cb (flux_t h, flux_msg_handler_t *w,
 {
     module_t *p = arg;
     const char *json_str;
-    JSON o = NULL;
+    json_object *o = NULL;
     char *route = NULL;
     char *route_plus_uuid = NULL;
     int rc = -1;
@@ -125,7 +125,7 @@ static void stats_get_cb (flux_t h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     flux_msgcounters_t mcs;
-    JSON out = Jnew ();
+    json_object *out = Jnew ();
 
     flux_get_msgcounters (h, &mcs);
     Jadd_int (out, "#request (tx)", mcs.request_tx);
@@ -159,7 +159,7 @@ static void stats_clear_request_cb (flux_t h, flux_msg_handler_t *w,
 static void rusage_cb (flux_t h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
-    JSON out = NULL;
+    json_object *out = NULL;
     int rc = -1;
 
     if (getrusage_json (RUSAGE_THREAD, &out) < 0)

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -183,12 +183,12 @@ void overlay_set_idle_warning (overlay_t *ov, int heartbeats)
 
 json_object *overlay_lspeer_encode (overlay_t *ov)
 {
-    JSON out = Jnew ();
+    json_object *out = Jnew ();
     const char *uuid;
     child_t *child;
 
     FOREACH_ZHASH (ov->children, uuid, child) {
-        JSON o = Jnew ();
+        json_object *o = Jnew ();
         Jadd_int (o, "idle", ov->epoch - child->lastseen);
         Jadd_obj (out, uuid, o); /* takes ref on 'o' */
         Jput (o);

--- a/src/broker/sequence.c
+++ b/src/broker/sequence.c
@@ -132,7 +132,8 @@ static int seq_cmp_and_set (seqhash_t *s, const char *name,
     return (0);
 }
 
-static int handle_seq_destroy (seqhash_t *s, JSON in, JSON *outp)
+static int handle_seq_destroy (seqhash_t *s, json_object *in,
+			       json_object **outp)
 {
     const char *name;
     if (!Jget_str (in, "name", &name)) {
@@ -147,7 +148,7 @@ static int handle_seq_destroy (seqhash_t *s, JSON in, JSON *outp)
     return (0);
 }
 
-static int handle_seq_set (seqhash_t *s, JSON in, JSON *outp)
+static int handle_seq_set (seqhash_t *s, json_object *in, json_object **outp)
 {
     const char *name;
     int64_t old, v;
@@ -168,7 +169,7 @@ static int handle_seq_set (seqhash_t *s, JSON in, JSON *outp)
     return (0);
 }
 
-static int handle_seq_fetch (seqhash_t *s, JSON in, JSON *outp)
+static int handle_seq_fetch (seqhash_t *s, json_object *in, json_object **outp)
 {
     const char *name;
     bool create = false;
@@ -202,11 +203,12 @@ static int handle_seq_fetch (seqhash_t *s, JSON in, JSON *outp)
     return (0);
 }
 
-int sequence_request_handler (seqhash_t *s, const flux_msg_t *msg, JSON *outp)
+int sequence_request_handler (seqhash_t *s, const flux_msg_t *msg,
+			      json_object **outp)
 {
     const char *json_str, *topic;
     const char *method;
-    JSON in = NULL;
+    json_object *in = NULL;
     int rc = -1;
 
     *outp = NULL;

--- a/src/broker/sequence.h
+++ b/src/broker/sequence.h
@@ -34,7 +34,8 @@ typedef struct seq_struct seqhash_t;
 seqhash_t *sequence_hash_create (void);
 void sequence_hash_destroy (seqhash_t *seq);
 
-int sequence_request_handler (seqhash_t *seq, const flux_msg_t *msg, JSON *op);
+int sequence_request_handler (seqhash_t *seq, const flux_msg_t *msg,
+			      json_object **op);
 
 #endif /* BROKER_SEQUENCE_H */
 

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -153,7 +153,7 @@ flux_msg_t *shutdown_vencode (double grace, int exitcode, int rank,
                               const char *fmt, va_list ap)
 {
     flux_msg_t *msg;
-    JSON out = Jnew ();
+    json_object *out = Jnew ();
     char reason[REASON_MAX];
 
     vsnprintf (reason, sizeof (reason), fmt, ap);
@@ -184,7 +184,7 @@ int shutdown_decode (const flux_msg_t *msg, double *grace, int *exitcode,
                      int *rank, char *reason, int reason_len)
 {
     const char *json_str, *s;
-    JSON in = NULL;
+    json_object *in = NULL;
     int rc = -1;
 
     if (flux_event_decode (msg, NULL, &json_str) < 0

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -29,7 +29,7 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
 {
     flux_t h;
     flux_rpc_t *rpc;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
 
     if (optparse_optind (p) != ac - 1) {
         optparse_print_usage (p);
@@ -70,7 +70,7 @@ static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
 {
     flux_t h;
     flux_rpc_t *rpc;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
 
     if (optparse_optind (p) != ac - 1) {
         optparse_print_usage (p);

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -234,9 +234,9 @@ static void config_hwloc_paths (flux_t h, const char *dirpath)
         log_err_exit ("kvs_commit");
 }
 
-static JSON hwloc_reload_json_create (const char *walk_topology)
+static json_object *hwloc_reload_json_create (const char *walk_topology)
 {
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     bool v = true;
 
     if (walk_topology == NULL)
@@ -255,7 +255,7 @@ static void request_hwloc_reload (flux_t h, const char *nodeset,
                                   const char *walk_topology)
 {
     flux_rpc_t *rpc;
-    JSON o = NULL;
+    json_object *o = NULL;
     const char *json_str = NULL;
 
     if ((o = hwloc_reload_json_create (walk_topology)))

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -333,7 +333,7 @@ done:
 int sub_request (client_t *c, const flux_msg_t *msg, bool subscribe)
 {
     const char *json_str, *topic;
-    JSON in = NULL;
+    json_object *in = NULL;
     int rc = -1;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -112,14 +112,14 @@ static FILE *open_test_outfile (const char *fn)
     return fp;
 }
 
-static inline void get_jobid (JSON jcb, int64_t *j)
+static inline void get_jobid (json_object *jcb, int64_t *j)
 {
     Jget_int64 (jcb, JSC_JOBID, j);
 }
 
-static inline void get_states (JSON jcb, int64_t *os, int64_t *ns)
+static inline void get_states (json_object *jcb, int64_t *os, int64_t *ns)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
     Jget_obj (jcb, JSC_STATE_PAIR, &o);
     Jget_int64 (o, JSC_STATE_PAIR_OSTATE, os);
     Jget_int64 (o, JSC_STATE_PAIR_NSTATE, ns);
@@ -139,7 +139,7 @@ static int job_status_cb (const char *jcbstr, void *arg, int errnum)
     int64_t j = 0;
     jstatctx_t *ctx = NULL;
     flux_t h = (flux_t)arg;
-    JSON jcb = NULL;
+    json_object *jcb = NULL;
 
     ctx = getctx (h);
     if (errnum > 0) {
@@ -193,7 +193,7 @@ static int handle_notify_req (flux_t h, const char *ofn)
 
 static int handle_query_req (flux_t h, int64_t j, const char *k, const char *n)
 {
-    JSON jcb = NULL;
+    json_object *jcb = NULL;
     jstatctx_t *ctx = NULL;
     char *jcbstr;
 

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -189,7 +189,7 @@ int main (int argc, char *argv[])
 void cmd_type (flux_t h, int argc, char **argv)
 {
     char *json_str;
-    JSON o;
+    json_object *o;
     int i;
 
     if (argc == 0)
@@ -232,7 +232,7 @@ void cmd_type (flux_t h, int argc, char **argv)
 void cmd_get (flux_t h, int argc, char **argv)
 {
     char *json_str;
-    JSON o;
+    json_object *o;
     int i;
 
     if (argc == 0)
@@ -435,7 +435,7 @@ void cmd_copy_tokvs (flux_t h, int argc, char **argv)
     char *file, *key;
     int fd, len;
     uint8_t *buf;
-    JSON o;
+    json_object *o;
 
     if (argc != 2)
         log_msg_exit ("copy-tokvs: specify key and filename");
@@ -466,7 +466,7 @@ void cmd_copy_fromkvs (flux_t h, int argc, char **argv)
     char *file, *key;
     int fd, len;
     uint8_t *buf;
-    JSON o;
+    json_object *o;
     char *json_str;
 
     if (argc != 2)
@@ -498,7 +498,7 @@ void cmd_copy_fromkvs (flux_t h, int argc, char **argv)
 
 static void dump_kvs_val (const char *key, const char *json_str)
 {
-    JSON o = Jfromstr (json_str);
+    json_object *o = Jfromstr (json_str);
     if (!o) {
         printf ("%s: invalid JSON", key);
         return;

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -80,7 +80,7 @@ void ping_continuation (flux_rpc_t *rpc, void *arg)
     int64_t sec, nsec;
     struct timespec t0;
     int seq;
-    JSON out = NULL;
+    json_object *out = NULL;
     tstat_t *tstat = flux_rpc_aux_get (rpc);
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0) {
@@ -128,7 +128,7 @@ done:
 void send_ping (struct ping_ctx *ctx)
 {
     struct timespec t0;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     flux_rpc_t *rpc;
     tstat_t *tstat = xzmalloc (sizeof (*tstat));
 

--- a/src/cmd/flux-up.c
+++ b/src/cmd/flux-up.c
@@ -131,7 +131,7 @@ int main (int argc, char *argv[])
     return 0;
 }
 
-static bool Jget_nodeset (JSON o, const char *name, nodeset_t **np)
+static bool Jget_nodeset (json_object *o, const char *name, nodeset_t **np)
 {
     nodeset_t *ns;
     const char *s;
@@ -145,7 +145,7 @@ static bool Jget_nodeset (JSON o, const char *name, nodeset_t **np)
 static ns_t *ns_fromjson (const char *json_str)
 {
     ns_t *ns = xzmalloc (sizeof (*ns));
-    JSON o = NULL;
+    json_object *o = NULL;
 
     if (!(o = Jfromstr (json_str))
                 || !Jget_nodeset (o, "ok", &ns->ok)

--- a/src/common/libcompat/request.c
+++ b/src/common/libcompat/request.c
@@ -36,7 +36,7 @@
 #include "compat.h"
 
 int flux_json_request (flux_t h, uint32_t nodeid, uint32_t matchtag,
-                       const char *topic, JSON in)
+                       const char *topic, json_object *in)
 {
     zmsg_t *zmsg;
     int rc = -1;
@@ -69,7 +69,7 @@ done:
     return rc;
 }
 
-int flux_json_respond (flux_t h, JSON out, zmsg_t **zmsg)
+int flux_json_respond (flux_t h, json_object *out, zmsg_t **zmsg)
 {
     int rc = -1;
 

--- a/src/common/libcompat/rpc.c
+++ b/src/common/libcompat/rpc.c
@@ -35,11 +35,11 @@
 #include "compat.h"
 
 int flux_json_rpc (flux_t h, uint32_t nodeid, const char *topic,
-                   JSON in, JSON *out)
+                   json_object *in, json_object **out)
 {
     flux_rpc_t *rpc;
     const char *json_str;
-    JSON o = NULL;
+    json_object *o = NULL;
     int rc = -1;
 
     if (!(rpc = flux_rpc (h, topic, Jtostr (in), nodeid, 0)))

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -86,8 +86,8 @@ static attr_t *attr_create (const char *val, int flags)
 static int attr_get_rpc (ctx_t *ctx, const char *name, attr_t **attrp)
 {
     flux_rpc_t *r;
-    JSON in = Jnew ();
-    JSON out = NULL;
+    json_object *in = Jnew ();
+    json_object *out = NULL;
     const char *json_str, *val;
     int flags;
     attr_t *attr;
@@ -119,7 +119,7 @@ done:
 static int attr_set_rpc (ctx_t *ctx, const char *name, const char *val)
 {
     flux_rpc_t *r;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     attr_t *attr;
     int rc = -1;
 
@@ -162,7 +162,8 @@ static int attr_list_rpc (ctx_t *ctx)
 {
     flux_rpc_t *r;
     const char *json_str;
-    JSON array, out = NULL;
+    json_object *array;
+    json_object *out = NULL;
     int len, i, rc = -1;
 
     if (!(r = flux_rpc (ctx->h, "cmb.attrlist", NULL, FLUX_NODEID_ANY, 0)))

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -173,7 +173,7 @@ void flux_log_error (flux_t h, const char *fmt, ...)
 static int dmesg_clear (flux_t h, int seq)
 {
     flux_rpc_t *rpc;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     int rc = -1;
 
     Jadd_int (o, "seq", seq);
@@ -192,7 +192,7 @@ done:
 static flux_rpc_t *dmesg_rpc (flux_t h, int seq, bool follow)
 {
     flux_rpc_t *rpc;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     Jadd_int (o, "seq", seq);
     Jadd_bool (o, "follow", follow);
     rpc = flux_rpc (h, "cmb.dmesg", Jtostr (o), FLUX_NODEID_ANY, 0);
@@ -204,7 +204,7 @@ static int dmesg_rpc_get (flux_rpc_t *rpc, int *seq, flux_log_f fun, void *arg)
 {
     const char *json_str;
     const char *buf;
-    JSON o = NULL;
+    json_object *o = NULL;
     int rc = -1;
 
     if (flux_rpc_get (rpc, NULL, &json_str) < 0)

--- a/src/common/libflux/heartbeat.c
+++ b/src/common/libflux/heartbeat.c
@@ -36,7 +36,7 @@
 flux_msg_t *flux_heartbeat_encode (int epoch)
 {
     flux_msg_t *msg;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
 
     Jadd_int (o, "epoch", epoch);
     msg = flux_event_encode ("hb", Jtostr (o));
@@ -47,7 +47,7 @@ flux_msg_t *flux_heartbeat_encode (int epoch)
 int flux_heartbeat_decode (const flux_msg_t *msg, int *epoch)
 {
     const char *json_str, *topic_str;
-    JSON out = NULL;
+    json_object *out = NULL;
     int rc = -1;
 
     if (flux_event_decode (msg, &topic_str, &json_str) < 0)

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -64,8 +64,8 @@ static char *mod_service (const char *modname)
 int flux_insmod_json_decode (const char *json_str,
                              char **path, char **argz, size_t *argz_len)
 {
-    JSON o = NULL;
-    JSON args = NULL;
+    json_object *o = NULL;
+    json_object *args = NULL;
     const char *s;
     int i, ac;
     int rc = -1;
@@ -94,8 +94,8 @@ done:
 
 char *flux_insmod_json_encode (const char *path, int argc, char **argv)
 {
-    JSON o = Jnew ();
-    JSON args = Jnew_ar ();
+    json_object *o = Jnew ();
+    json_object *args = Jnew_ar ();
     char *json_str;
     int i;
 
@@ -110,7 +110,7 @@ char *flux_insmod_json_encode (const char *path, int argc, char **argv)
 
 int flux_rmmod_json_decode (const char *json_str, char **name)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
     const char *s;
     int rc = -1;
     if (!(o = Jfromstr (json_str)) || !Jget_str (o, "name", &s)) {
@@ -126,7 +126,7 @@ done:
 
 char *flux_rmmod_json_encode (const char *name)
 {
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     char *json_str;
     Jadd_str (o, "name", name);
     json_str = xstrdup (Jtostr (o)); 
@@ -137,7 +137,8 @@ char *flux_rmmod_json_encode (const char *name)
 int flux_modlist_get (flux_modlist_t *mods, int n, const char **name, int *size,
                       const char **digest, int *idle, int *status)
 {
-    JSON o, a;
+    json_object *o;
+    json_object *a;
     int rc = -1;
 
     if (!Jget_obj (mods->o, "mods", &a) || !Jget_ar_obj (a, n, &o)
@@ -156,7 +157,7 @@ done:
 
 int flux_modlist_count (flux_modlist_t *mods)
 {
-    JSON a;
+    json_object *a;
     int len;
 
     if (!Jget_obj (mods->o, "mods", &a) || !Jget_ar_len (a, &len)) {
@@ -169,7 +170,8 @@ int flux_modlist_count (flux_modlist_t *mods)
 int flux_modlist_append (flux_modlist_t *mods, const char *name, int size,
                             const char *digest, int idle, int status)
 {
-    JSON a, o = Jnew ();
+    json_object *a;
+    json_object *o = Jnew ();
     int rc = -1;
 
     if (!Jget_obj (mods->o, "mods", &a)) {
@@ -382,7 +384,7 @@ int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
                  int argc, char **argv)
 {
     flux_rpc_t *r = NULL;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     char *name = NULL;
     char *service = NULL;
     char *topic = NULL;

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -40,7 +40,7 @@
 int flux_panic (flux_t h, int rank, const char *msg)
 {
     uint32_t nodeid = rank < 0 ? FLUX_NODEID_ANY : rank;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     flux_rpc_t *r = NULL;
     int rc = -1;
 

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -54,7 +54,7 @@ int flux_reparent (flux_t h, int rank, const char *uri)
 {
     flux_rpc_t *r = NULL;
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     int rc = -1;
 
     if (!uri) {

--- a/src/common/libutil/shortjson.h
+++ b/src/common/libutil/shortjson.h
@@ -5,14 +5,12 @@
 #include <stdbool.h>
 #include "oom.h"
 
-typedef json_object *JSON;
-
 /* Creates JSON object with refcount of 1.
  */
-static __inline__ JSON
+static __inline__ json_object *
 Jnew (void)
 {
-    JSON n = json_object_new_object ();
+    json_object *n = json_object_new_object ();
     if (!n)
         oom ();
     return n;
@@ -20,8 +18,8 @@ Jnew (void)
 
 /* Increment JSON object refcount.
  */
-static __inline__ JSON
-Jget (JSON o)
+static __inline__ json_object *
+Jget (json_object *o)
 {
     return o ? json_object_get (o) : o;
 }
@@ -29,7 +27,7 @@ Jget (JSON o)
 /* Decrement JSON object refcount and free if refcount == 0.
  */
 static __inline__ void
-Jput (JSON o)
+Jput (json_object *o)
 {
     if (o)
         json_object_put (o);
@@ -38,9 +36,9 @@ Jput (JSON o)
 /* Add bool to JSON.
  */
 static __inline__ void
-Jadd_bool (JSON o, const char *name, bool b)
+Jadd_bool (json_object *o, const char *name, bool b)
 {
-    JSON n = json_object_new_boolean (b);
+    json_object *n = json_object_new_boolean (b);
     if (!n)
         oom ();
     json_object_object_add (o, (char *)name, n);
@@ -49,9 +47,9 @@ Jadd_bool (JSON o, const char *name, bool b)
 /* Add integer to JSON.
  */
 static __inline__ void
-Jadd_int (JSON o, const char *name, int i)
+Jadd_int (json_object *o, const char *name, int i)
 {
-    JSON n = json_object_new_int (i);
+    json_object *n = json_object_new_int (i);
     if (!n)
         oom ();
     json_object_object_add (o, (char *)name, n);
@@ -60,9 +58,9 @@ Jadd_int (JSON o, const char *name, int i)
 /* Add 64bit integer to JSON.
  */
 static __inline__ void
-Jadd_int64 (JSON o, const char *name, int64_t i)
+Jadd_int64 (json_object *o, const char *name, int64_t i)
 {
-    JSON n = json_object_new_int64 (i);
+    json_object *n = json_object_new_int64 (i);
     if (!n)
         oom ();
     json_object_object_add (o, (char *)name, n);
@@ -71,9 +69,9 @@ Jadd_int64 (JSON o, const char *name, int64_t i)
 /* Add double to JSON.
  */
 static __inline__ void
-Jadd_double (JSON o, const char *name, double d)
+Jadd_double (json_object *o, const char *name, double d)
 {
-    JSON n = json_object_new_double (d);
+    json_object *n = json_object_new_double (d);
     if (!n)
         oom ();
     json_object_object_add (o, (char *)name, n);
@@ -82,18 +80,18 @@ Jadd_double (JSON o, const char *name, double d)
 /* Add string to JSON (caller retains ownership of original).
  */
 static __inline__ void
-Jadd_str (JSON o, const char *name, const char *s)
+Jadd_str (json_object *o, const char *name, const char *s)
 {
-    JSON n = json_object_new_string (s);
+    json_object *n = json_object_new_string (s);
     if (!n)
         oom ();
     json_object_object_add (o, (char *)name, n);
 }
 
 static __inline__ void
-Jadd_str_len (JSON o, const char *name, const char *s, int len)
+Jadd_str_len (json_object *o, const char *name, const char *s, int len)
 {
-    JSON n = json_object_new_string_len (s, len);
+    json_object *n = json_object_new_string_len (s, len);
     if (!n)
         oom ();
     json_object_object_add (o, (char *)name, n);
@@ -102,17 +100,17 @@ Jadd_str_len (JSON o, const char *name, const char *s, int len)
 /* Add object to JSON (caller retains ownership of original).
  */
 static __inline__ void
-Jadd_obj (JSON o, const char *name, JSON obj)
+Jadd_obj (json_object *o, const char *name, json_object *obj)
 {
     json_object_object_add (o, (char *)name, Jget (obj));
 }
 
 /* Wrapper for json_object_object_get_ex()
  */
-static __inline__ JSON
-Jobj_get (JSON o, const char *name)
+static __inline__ json_object *
+Jobj_get (json_object *o, const char *name)
 {
-    JSON n = NULL;
+    json_object *n = NULL;
     json_object_object_get_ex (o, (char *)name, &n);
     return (n);
 }
@@ -120,9 +118,9 @@ Jobj_get (JSON o, const char *name)
 /* Get integer from JSON.
  */
 static __inline__ bool
-Jget_int (JSON o, const char *name, int *ip)
+Jget_int (json_object *o, const char *name, int *ip)
 {
-    JSON n = Jobj_get (o, name);
+    json_object *n = Jobj_get (o, name);
     if (n && ip)
         *ip = json_object_get_int (n);
     return (n != NULL);
@@ -131,9 +129,9 @@ Jget_int (JSON o, const char *name, int *ip)
 /* Get double from JSON.
  */
 static __inline__ bool
-Jget_double (JSON o, const char *name, double *dp)
+Jget_double (json_object *o, const char *name, double *dp)
 {
-    JSON n = Jobj_get (o, name);
+    json_object *n = Jobj_get (o, name);
     if (n && dp)
         *dp = json_object_get_double (n);
     return (n != NULL);
@@ -142,9 +140,9 @@ Jget_double (JSON o, const char *name, double *dp)
 /* Get integer from JSON.
  */
 static __inline__ bool
-Jget_int64 (JSON o, const char *name, int64_t *ip)
+Jget_int64 (json_object *o, const char *name, int64_t *ip)
 {
-    JSON n = Jobj_get (o, name);
+    json_object *n = Jobj_get (o, name);
     if (n && ip)
         *ip = json_object_get_int64 (n);
     return (n != NULL);
@@ -153,9 +151,9 @@ Jget_int64 (JSON o, const char *name, int64_t *ip)
 /* Get string from JSON (still owned by JSON, do not free).
  */
 static __inline__ bool
-Jget_str (JSON o, const char *name, const char **sp)
+Jget_str (json_object *o, const char *name, const char **sp)
 {
-    JSON n = Jobj_get (o, name);
+    json_object *n = Jobj_get (o, name);
     if (n && sp)
         *sp = json_object_get_string (n);
     return (n != NULL);
@@ -164,9 +162,9 @@ Jget_str (JSON o, const char *name, const char **sp)
 /* Get object from JSON (still owned by JSON, do not free).
  */
 static __inline__ bool
-Jget_obj (JSON o, const char *name, JSON *op)
+Jget_obj (json_object *o, const char *name, json_object **op)
 {
-    JSON n = Jobj_get (o, name);
+    json_object *n = Jobj_get (o, name);
     if (n && op)
         *op = n;
     return (n != NULL);
@@ -175,9 +173,9 @@ Jget_obj (JSON o, const char *name, JSON *op)
 /* Get boolean from JSON.
  */
 static __inline__ bool
-Jget_bool (JSON o, const char *name, bool *bp)
+Jget_bool (json_object *o, const char *name, bool *bp)
 {
-    JSON n = Jobj_get (o, name);
+    json_object *n = Jobj_get (o, name);
     if (n && bp)
         *bp = json_object_get_boolean (n);
     return (n != NULL);
@@ -185,10 +183,10 @@ Jget_bool (JSON o, const char *name, bool *bp)
 
 /* Create new JSON array.
  */
-static __inline__ JSON
+static __inline__ json_object *
 Jnew_ar (void)
 {
-    JSON a = json_object_new_array ();
+    json_object *a = json_object_new_array ();
     if (!a)
         oom ();
     return a;
@@ -197,32 +195,32 @@ Jnew_ar (void)
 /* Add object to JSON array (caller retains ownership of original).
  */
 static __inline__ void
-Jadd_ar_obj (JSON o, JSON obj)
+Jadd_ar_obj (json_object *o, json_object *obj)
 {
     //assert (json_object_get_type (o) == json_type_array)
     json_object_array_add (o, Jget (obj));
 }
 
 static __inline__ void
-Jput_ar_obj (JSON o, int n, JSON obj)
+Jput_ar_obj (json_object *o, int n, json_object *obj)
 {
     //assert (json_object_get_type (o) == json_type_array)
     json_object_array_put_idx (o, n, Jget (obj));
 }
 
 static __inline__ void
-Jadd_ar_int (JSON o, int i)
+Jadd_ar_int (json_object *o, int i)
 {
-    JSON p = json_object_new_int (i);
+    json_object *p = json_object_new_int (i);
     if (!p)
         oom ();
     json_object_array_add (o, p);
 }
 
 static __inline__ void
-Jadd_ar_str (JSON o, const char *s)
+Jadd_ar_str (json_object *o, const char *s)
 {
-    JSON p = json_object_new_string (s);
+    json_object *p = json_object_new_string (s);
     if (!p)
         oom ();
     json_object_array_add (o, p);
@@ -231,7 +229,7 @@ Jadd_ar_str (JSON o, const char *s)
 /* Get JSON array length.
  */
 static __inline__ bool
-Jget_ar_len (JSON o, int *ip)
+Jget_ar_len (json_object *o, int *ip)
 {
     if (json_object_get_type (o) != json_type_array)
         return false;
@@ -243,7 +241,7 @@ Jget_ar_len (JSON o, int *ip)
 /* Get JSON object at index 'n' array.
  */
 static __inline__ bool
-Jget_ar_obj (JSON o, int n, JSON *op)
+Jget_ar_obj (json_object *o, int n, json_object **op)
 {
     if (json_object_get_type (o) != json_type_array)
         return false;
@@ -257,9 +255,9 @@ Jget_ar_obj (JSON o, int n, JSON *op)
 /* Get integer at index 'n' of array.
  */
 static __inline__ bool
-Jget_ar_int (JSON o, int n, int *ip)
+Jget_ar_int (json_object *o, int n, int *ip)
 {
-    JSON m;
+    json_object *m;
 
     if (json_object_get_type (o) != json_type_array)
         return false;
@@ -275,9 +273,9 @@ Jget_ar_int (JSON o, int n, int *ip)
 /* Get string at index 'n' of array.
  */
 static __inline__ bool
-Jget_ar_str (JSON o, int n, const char **sp)
+Jget_ar_str (json_object *o, int n, const char **sp)
 {
-    JSON m;
+    json_object *m;
 
     if (json_object_get_type (o) != json_type_array)
         return false;
@@ -293,21 +291,21 @@ Jget_ar_str (JSON o, int n, const char **sp)
 /* Encode JSON to string (owned by JSON, do not free)
  */
 static __inline__ const char *
-Jtostr (JSON o)
+Jtostr (json_object *o)
 {
     return o ? json_object_to_json_string (o) : NULL;
 }
 
 /* Decode string to JSON (caller is given ownership).
  */
-static __inline__ JSON
+static __inline__ json_object *
 Jfromstr (const char *s)
 {
     return json_tokener_parse (s);
 }
 
 static __inline__ void
-Jmerge (JSON dst, JSON src)
+Jmerge (json_object *dst, json_object *src)
 {
     json_object_iter iter;
 
@@ -317,8 +315,8 @@ Jmerge (JSON dst, JSON src)
     }
 }
 
-static __inline__ JSON
-Jdup (JSON o)
+static __inline__ json_object *
+Jdup (json_object *o)
 {
     return o ? Jfromstr (Jtostr (o)) : NULL;
 }

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -127,7 +127,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_rpc_t *rpc = NULL;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     int rc = 0;
 
     Jadd_str (in, "topic", topic);
@@ -146,7 +146,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_rpc_t *rpc = NULL;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     int rc = 0;
 
     Jadd_str (in, "topic", topic);

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -157,7 +157,7 @@ static int op_event_subscribe (void *impl, const char *topic)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     flux_rpc_t *rpc = NULL;
     int rc = -1;
 
@@ -178,7 +178,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
 {
     ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     flux_rpc_t *rpc = NULL;
     int rc = -1;
 

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -137,7 +137,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_rpc_t *rpc = NULL;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     int rc = 0;
 
     Jadd_str (in, "topic", topic);
@@ -156,7 +156,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_rpc_t *rpc = NULL;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     int rc = 0;
 
     Jadd_str (in, "topic", topic);

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -142,11 +142,11 @@ static int aggregate_push (struct aggregate *ag, int64_t value, const char *ids)
 
 /*  Push JSON represenation of an aggregate onto existing aggregate `ag`
  */
-static int aggregate_push_json (struct aggregate *ag, JSON o)
+static int aggregate_push_json (struct aggregate *ag, json_object *o)
 {
     json_object_iter i;
     int64_t n64;
-    JSON entries = NULL;
+    json_object *entries = NULL;
 
     if (ag->total == 0 && (Jget_int64 (o, "total", &n64)))
         ag->total = n64;
@@ -167,10 +167,11 @@ static int aggregate_push_json (struct aggregate *ag, JSON o)
     return (0);
 }
 
-static JSON aggregate_tojson (struct aggregate *ag)
+static json_object *aggregate_tojson (struct aggregate *ag)
 {
     struct aggregate_entry *ae;
-    JSON entries, o = Jnew ();
+    json_object *entries;
+    json_object *o = Jnew ();
     Jadd_str (o, "key", ag->key);
     Jadd_int (o, "count", ag->count);
     Jadd_int (o, "total", ag->total);
@@ -197,7 +198,7 @@ static int aggregate_forward (flux_t h, struct aggregate *ag)
     int rc = 0;
     flux_rpc_t *rpc;
     uint32_t nodeid = FLUX_NODEID_UPSTREAM;
-    JSON o = aggregate_tojson (ag);
+    json_object *o = aggregate_tojson (ag);
     flux_log (h, LOG_INFO, "forward: %s: count=%d total=%d\n",
                  ag->key, ag->count, ag->total);
     if (!(rpc = flux_rpc (h, "aggregator.push", Jtostr (o),
@@ -236,7 +237,7 @@ out:
 static int aggregate_sink (flux_t h, struct aggregate *ag)
 {
     int rc = 0;
-    JSON o;
+    json_object *o;
 
     flux_log (h, LOG_INFO, "sink: %s: count=%d total=%d",
                 ag->key, ag->count, ag->total);
@@ -462,7 +463,7 @@ static void push_cb (flux_t h, flux_msg_handler_t *w,
     struct aggregator *ctx = arg;
     struct aggregate *ag = NULL;
     const char *json_str;
-    JSON in = NULL;
+    json_object *in = NULL;
     const char *key;
     double timeout = ctx->default_timeout;
     int64_t fwd_count = 0;

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -280,7 +280,7 @@ static int send_enter_response (const char *key, void *item, void *arg)
 
 static int exit_event_send (flux_t h, const char *name, int errnum)
 {
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     flux_msg_t *msg = NULL;
     int rc = -1;
 

--- a/src/modules/barrier/libbarrier.c
+++ b/src/modules/barrier/libbarrier.c
@@ -57,7 +57,7 @@ static ctx_t *getctx (flux_t h)
 
 int flux_barrier (flux_t h, const char *name, int nprocs)
 {
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     char *s = NULL;
     flux_rpc_t *rpc = NULL;
     int ret = -1;

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -331,7 +331,7 @@ done:
 int sub_request (client_t *c, const flux_msg_t *msg, bool subscribe)
 {
     const char *json_str, *topic;
-    JSON in = NULL;
+    json_object *in = NULL;
     int rc = -1;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -397,7 +397,7 @@ done:
 int register_backing_store (flux_t h, bool value, const char *name)
 {
     flux_rpc_t *rpc;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     int saved_errno = 0;
     int rc = -1;
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -342,7 +342,8 @@ static int64_t next_cronid (flux_t h)
 {
     int64_t ret = (int64_t) -1;
     const char *json_str;
-    JSON req, resp;
+    json_object *req;
+    json_object *resp;
     flux_rpc_t *rpc;
 
     req = Jnew ();
@@ -420,7 +421,7 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
 {
     flux_t h = ctx->h;
     cron_entry_t *e = NULL;
-    JSON in;
+    json_object *in;
     const char *name;
     const char *command;
     const char *type;
@@ -589,9 +590,9 @@ error:
 
 /**************************************************************************/
 
-static JSON cron_stats_to_json (struct cron_stats *stats)
+static json_object *cron_stats_to_json (struct cron_stats *stats)
 {
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     Jadd_double (o, "ctime", stats->ctime);
     Jadd_double (o, "starttime", stats->starttime);
     Jadd_double (o, "lastrun", stats->lastrun);
@@ -604,12 +605,12 @@ static JSON cron_stats_to_json (struct cron_stats *stats)
     return (o);
 }
 
-static JSON cron_entry_to_json (cron_entry_t *e)
+static json_object *cron_entry_to_json (cron_entry_t *e)
 {
     cron_task_t *t;
-    JSON o = Jnew ();
-    JSON to = NULL;
-    JSON tasks = Jnew_ar ();
+    json_object *o = Jnew ();
+    json_object *to = NULL;
+    json_object *tasks = Jnew_ar ();
 
     /*
      *  Common entry contents:
@@ -663,7 +664,7 @@ static void cron_create_handler (flux_t h, flux_msg_handler_t *w,
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
     const char *json_str;
-    JSON out = NULL;
+    json_object *out = NULL;
     int saved_errno;
     int rc = -1;
 
@@ -697,8 +698,8 @@ static void cron_sync_handler (flux_t h, flux_msg_handler_t *w,
 {
     cron_ctx_t *ctx = arg;
     const char *json_str;
-    JSON in = NULL;
-    JSON out = NULL;
+    json_object *in = NULL;
+    json_object *out = NULL;
     const char *topic;
     bool disable;
     double epsilon;
@@ -753,11 +754,11 @@ static cron_entry_t *cron_ctx_find_entry (cron_ctx_t *ctx, int64_t id)
  *  [service] is name of service for logging purposes.
  */
 static cron_entry_t *entry_from_request (flux_t h, const flux_msg_t *msg,
-                                         cron_ctx_t *ctx, JSON *r,
+                                         cron_ctx_t *ctx, json_object **r,
                                          const char *service)
 {
     const char *json_str;
-    JSON in = NULL;
+    json_object *in = NULL;
     int64_t id;
 
     if ((flux_request_decode (msg, NULL, &json_str) < 0)
@@ -785,8 +786,8 @@ static void cron_delete_handler (flux_t h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    JSON in = NULL;
-    JSON out = NULL;
+    json_object *in = NULL;
+    json_object *out = NULL;
     bool kill = false;
     int saved_errno;
     int rc = -1;
@@ -818,7 +819,7 @@ static void cron_stop_handler (flux_t h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    JSON out = NULL;
+    json_object *out = NULL;
     int saved_errno = 0;
     int rc = -1;
 
@@ -842,7 +843,7 @@ static void cron_start_handler (flux_t h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    JSON out = NULL;
+    json_object *out = NULL;
     int saved_errno = 0;
     int rc = -1;
 
@@ -867,12 +868,12 @@ static void cron_ls_handler (flux_t h, flux_msg_handler_t *w,
 {
     cron_ctx_t *ctx = arg;
     cron_entry_t *e = NULL;
-    JSON out = Jnew ();
-    JSON entries = Jnew_ar ();
+    json_object *out = Jnew ();
+    json_object *entries = Jnew_ar ();
 
     e = zlist_first (ctx->entries);
     while (e) {
-        JSON entry = cron_entry_to_json (e);
+        json_object *entry = cron_entry_to_json (e);
         if (entry == NULL)
             flux_log_error (h, "cron_entry_to_json");
         else

--- a/src/modules/cron/datetime.c
+++ b/src/modules/cron/datetime.c
@@ -61,7 +61,7 @@ struct datetime_entry * datetime_entry_create ()
     return (dt);
 }
 
-static struct datetime_entry * datetime_entry_from_json (JSON o)
+static struct datetime_entry * datetime_entry_from_json (json_object *o)
 {
     int i;
     struct datetime_entry *dt = datetime_entry_create ();
@@ -117,7 +117,7 @@ static double reschedule_cb (flux_watcher_t *w, double now, void *arg)
     return (next);
 }
 
-static void *cron_datetime_create (flux_t h, cron_entry_t *e, JSON arg)
+static void *cron_datetime_create (flux_t h, cron_entry_t *e, json_object *arg)
 {
     struct datetime_entry *dt = datetime_entry_from_json (arg);
     if (dt == NULL)
@@ -135,11 +135,11 @@ static void *cron_datetime_create (flux_t h, cron_entry_t *e, JSON arg)
     return (dt);
 }
 
-static JSON cron_datetime_to_json (void *arg)
+static json_object *cron_datetime_to_json (void *arg)
 {
     int i;
     struct datetime_entry *dt = arg;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     if (dt->w)
         Jadd_double (o, "next_wakeup", flux_watcher_next_wakeup (dt->w));
     for (i = 0; i < TM_MAX_ITEM; i++)

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -37,7 +37,7 @@ typedef struct cron_entry cron_entry_t;
  */
 struct cron_entry_ops {
     // type creator from JSON request "arguments". Returns ptr to type object
-    void *(*create) (flux_t h, cron_entry_t *e, JSON arg);
+    void *(*create) (flux_t h, cron_entry_t *e, json_object *arg);
 
     // destroy type object contained in data
     void (*destroy) (void *data);
@@ -49,7 +49,7 @@ struct cron_entry_ops {
     void (*stop) (void *data);
 
     // return data for entry type as JSON
-    JSON (*tojson) (void *data);
+    json_object *(*tojson) (void *data);
 };
 
 struct cron_stats {

--- a/src/modules/cron/event.c
+++ b/src/modules/cron/event.c
@@ -97,7 +97,7 @@ static void event_handler (flux_t h, flux_msg_handler_t *w,
     cron_entry_schedule_task (e);
 }
 
-static void *cron_event_create (flux_t h, cron_entry_t *e, JSON arg)
+static void *cron_event_create (flux_t h, cron_entry_t *e, json_object *arg)
 {
     struct cron_event *ev;
     int nth;
@@ -167,10 +167,10 @@ static void cron_event_stop (void *arg)
     flux_msg_handler_stop (((struct cron_event *)arg)->mh);
 }
 
-static JSON cron_event_to_json (void *arg)
+static json_object *cron_event_to_json (void *arg)
 {
     struct cron_event *ev = arg;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     Jadd_str (o, "topic", ev->event);
     Jadd_int (o, "nth", ev->nth);
     Jadd_int (o, "after", ev->after);

--- a/src/modules/cron/interval.c
+++ b/src/modules/cron/interval.c
@@ -46,7 +46,7 @@ static void interval_handler (flux_reactor_t *r, flux_watcher_t *w,
     cron_entry_schedule_task ((cron_entry_t *)arg);
 }
 
-static void *cron_interval_create (flux_t h, cron_entry_t *e, JSON arg)
+static void *cron_interval_create (flux_t h, cron_entry_t *e, json_object *arg)
 {
     struct cron_interval *iv;
     double i;
@@ -89,10 +89,10 @@ static void cron_interval_stop (void *arg)
     flux_watcher_stop (((struct cron_interval *)arg)->w);
 }
 
-static JSON cron_interval_to_json (void *arg)
+static json_object *cron_interval_to_json (void *arg)
 {
     struct cron_interval *iv = arg;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     Jadd_double (o, "interval", iv->seconds);
     Jadd_double (o, "after",    iv->after);
     Jadd_double (o, "next_wakeup",

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -94,7 +94,7 @@ int cron_task_status (cron_task_t *t);
 
 /*  return JSON representation of cron task `t`
  */
-JSON cron_task_to_json (cron_task_t *t);
+json_object *cron_task_to_json (cron_task_t *t);
 
 #endif /* !HAVE_CRON_TASK_H */
 

--- a/src/modules/kvs/json_dirent.c
+++ b/src/modules/kvs/json_dirent.c
@@ -84,7 +84,7 @@ void dirent_append (json_object **array, const char *key, json_object *dirent)
 
 int dirent_validate (json_object *dirent)
 {
-    JSON o;
+    json_object *o;
 
     if (!dirent)
         goto error;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -868,14 +868,14 @@ static void get_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
-    JSON in = NULL;
-    JSON out = NULL;
+    json_object *in = NULL;
+    json_object *out = NULL;
     int flags;
     const char *key;
-    JSON val;
-    JSON root = NULL;
-    JSON root_dirent = NULL;
-    JSON tmp_dirent = NULL;
+    json_object *val;
+    json_object *root = NULL;
+    json_object *root_dirent = NULL;
+    json_object *tmp_dirent = NULL;
     const char *root_ref = ctx->rootdir;
     wait_t *wait = NULL;
     int lookup_errnum = 0;
@@ -941,11 +941,12 @@ static void watch_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
-    JSON in = NULL;
-    JSON in2 = NULL;
-    JSON out = NULL;
-    JSON oval, val = NULL;
-    JSON root = NULL;
+    json_object *in = NULL;
+    json_object *in2 = NULL;
+    json_object *out = NULL;
+    json_object *oval;
+    json_object *val = NULL;
+    json_object *root = NULL;
     flux_msg_t *cpy = NULL;
     const char *key;
     int flags;
@@ -1019,7 +1020,8 @@ static bool unwatch_cmp (const flux_msg_t *msg, void *arg)
 {
     unwatch_param_t *p = arg;
     char *sender = NULL;
-    JSON o = NULL, val;
+    json_object *o = NULL;
+    json_object *val;
     const char *key, *topic, *json_str;
     int flags;
     bool match = false;
@@ -1051,7 +1053,7 @@ static void unwatch_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
-    JSON in = NULL;
+    json_object *in = NULL;
     unwatch_param_t p = { NULL, NULL };
     int rc = -1;
 
@@ -1114,9 +1116,9 @@ error:
     return NULL;
 }
 
-static int fence_append_ops (fence_t *f, JSON ops)
+static int fence_append_ops (fence_t *f, json_object *ops)
 {
-    JSON op;
+    json_object *op;
     int i;
 
     if (ops) {
@@ -1209,8 +1211,8 @@ static void relayfence_request_cb (flux_t h, flux_msg_handler_t *w,
     ctx_t *ctx = arg;
     const char *json_str, *name;
     int nprocs;
-    JSON in = NULL;
-    JSON ops = NULL;
+    json_object *in = NULL;
+    json_object *ops = NULL;
     fence_t *f;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0) {
@@ -1261,8 +1263,8 @@ static void fence_request_cb (flux_t h, flux_msg_handler_t *w,
     ctx_t *ctx = arg;
     const char *json_str, *name;
     int nprocs;
-    JSON in = NULL;
-    JSON ops = NULL;
+    json_object *in = NULL;
+    json_object *ops = NULL;
     fence_t *f;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
@@ -1320,8 +1322,8 @@ static void sync_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
-    JSON in = NULL;
-    JSON out = Jnew ();
+    json_object *in = NULL;
+    json_object *out = Jnew ();
     int rootseq;
     wait_t *wait = NULL;
     int rc = -1;
@@ -1355,7 +1357,7 @@ static void getroot_request_cb (flux_t h, flux_msg_handler_t *w,
                                 const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
-    JSON out = NULL;
+    json_object *out = NULL;
     int rc = -1;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
@@ -1374,7 +1376,7 @@ static int getroot_rpc (ctx_t *ctx, int *rootseq, href_t rootdir)
 {
     flux_rpc_t *rpc;
     const char *json_str;
-    JSON out = NULL;
+    json_object *out = NULL;
     const char *ref;
     int rc = -1;
 
@@ -1406,8 +1408,8 @@ static void error_event_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
-    JSON out = NULL;
-    JSON names = NULL;
+    json_object *out = NULL;
+    json_object *names = NULL;
     int errnum;
 
     if (flux_event_decode (msg, NULL, &json_str) < 0) {
@@ -1430,7 +1432,7 @@ done:
 
 static int error_event_send (ctx_t *ctx, json_object *names, int errnum)
 {
-    JSON in = NULL;
+    json_object *in = NULL;
     flux_msg_t *msg = NULL;
     int rc = -1;
 
@@ -1453,12 +1455,12 @@ static void setroot_event_cb (flux_t h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
-    JSON out = NULL;
+    json_object *out = NULL;
     int rootseq;
     const char *json_str;
     const char *rootdir;
-    JSON root = NULL;
-    JSON names = NULL;
+    json_object *root = NULL;
+    json_object *names = NULL;
 
     if (flux_event_decode (msg, NULL, &json_str) < 0) {
         flux_log_error (ctx->h, "%s: flux_event_decode", __FUNCTION__);
@@ -1499,8 +1501,8 @@ done:
 
 static int setroot_event_send (ctx_t *ctx, json_object *names)
 {
-    JSON in = NULL;
-    JSON root = NULL;
+    json_object *in = NULL;
+    json_object *root = NULL;
     flux_msg_t *msg = NULL;
     int rc = -1;
 

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -44,9 +44,9 @@
 /* kvs.get
  */
 
-JSON kp_tget_enc (JSON rootdir, const char *key, int flags)
+json_object *kp_tget_enc (json_object *rootdir, const char *key, int flags)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
 
     if (!key) {
         errno = EINVAL;
@@ -61,7 +61,8 @@ done:
     return o;
 }
 
-int kp_tget_dec (JSON o, JSON *rootdir, const char **key, int *flags)
+int kp_tget_dec (json_object *o, json_object **rootdir, const char **key,
+		 int *flags)
 {
     int rc = -1;
 
@@ -80,9 +81,9 @@ done:
     return rc;
 }
 
-JSON kp_rget_enc (JSON rootdir, JSON val)
+json_object *kp_rget_enc (json_object *rootdir, json_object *val)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
 
     o = Jnew ();
     json_object_object_add (o, "rootdir", rootdir);
@@ -90,10 +91,10 @@ JSON kp_rget_enc (JSON rootdir, JSON val)
     return o;
 }
 
-int kp_rget_dec (JSON o, JSON *rootdir, JSON *val)
+int kp_rget_dec (json_object *o, json_object **rootdir, json_object **val)
 {
     int rc = -1;
-    JSON v;
+    json_object *v;
 
     if (!o || !(v = Jobj_get (o, "val"))) {
         errno = EINVAL;
@@ -111,9 +112,9 @@ done:
 /* kvs.watch
  */
 
-JSON kp_twatch_enc (const char *key, JSON val, int flags)
+json_object *kp_twatch_enc (const char *key, json_object *val, int flags)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
 
     if (!key) {
         errno = EINVAL;
@@ -127,7 +128,8 @@ done:
     return o;
 }
 
-int kp_twatch_dec (JSON o, const char **key, JSON *val, int *flags)
+int kp_twatch_dec (json_object *o, const char **key, json_object **val,
+		   int *flags)
 {
     int rc = -1;
 
@@ -145,16 +147,16 @@ done:
     return rc;
 }
 
-JSON kp_rwatch_enc (JSON val)
+json_object *kp_rwatch_enc (json_object *val)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
 
     o = Jnew ();
     json_object_object_add (o, "val", val);
     return o;
 }
 
-int kp_rwatch_dec (JSON o, JSON *val)
+int kp_rwatch_dec (json_object *o, json_object **val)
 {
     int rc = -1;
 
@@ -171,9 +173,9 @@ done:
 /* kvs.unwatch
  */
 
-JSON kp_tunwatch_enc (const char *key)
+json_object *kp_tunwatch_enc (const char *key)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
 
     if (!key) {
         errno = EINVAL;
@@ -185,7 +187,7 @@ done:
     return o;
 }
 
-int kp_tunwatch_dec (JSON o, const char **key)
+int kp_tunwatch_dec (json_object *o, const char **key)
 {
     int rc = -1;
 
@@ -204,10 +206,10 @@ done:
 
 /* kvs.fence
  */
-JSON kp_tfence_enc (const char *name, int nprocs, JSON ops)
+json_object *kp_tfence_enc (const char *name, int nprocs, json_object *ops)
 {
-    JSON o = Jnew ();
-    JSON empty_ops = NULL;
+    json_object *o = Jnew ();
+    json_object *empty_ops = NULL;
 
     Jadd_str (o, "name", name);
     Jadd_int (o, "nprocs", nprocs);
@@ -218,7 +220,8 @@ JSON kp_tfence_enc (const char *name, int nprocs, JSON ops)
     return o;
 }
 
-int kp_tfence_dec (JSON o, const char **name, int *nprocs, JSON *ops)
+int kp_tfence_dec (json_object *o, const char **name, int *nprocs,
+		   json_object **ops)
 {
     int rc = -1;
 
@@ -239,9 +242,9 @@ done:
 /* kvs.getroot
  */
 
-JSON kp_rgetroot_enc (int rootseq, const char *rootdir)
+json_object *kp_rgetroot_enc (int rootseq, const char *rootdir)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
 
     if (!rootdir) {
         errno = EINVAL;
@@ -254,7 +257,7 @@ done:
     return o;
 }
 
-int kp_rgetroot_dec (JSON o, int *rootseq, const char **rootdir)
+int kp_rgetroot_dec (json_object *o, int *rootseq, const char **rootdir)
 {
     int rc = -1;
 
@@ -274,10 +277,10 @@ done:
 /* kvs.setroot (event)
  */
 
-JSON kp_tsetroot_enc (int rootseq, const char *rootdir, JSON root,
-                      JSON names)
+json_object *kp_tsetroot_enc (int rootseq, const char *rootdir,
+			      json_object *root, json_object *names)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
     int n;
 
     if (!rootdir || !names || !Jget_ar_len (names, &n) || n < 1) {
@@ -294,8 +297,8 @@ done:
     return o;
 }
 
-int kp_tsetroot_dec (JSON o, int *rootseq, const char **rootdir,
-                     JSON *root, JSON *names)
+int kp_tsetroot_dec (json_object *o, int *rootseq, const char **rootdir,
+                     json_object **root, json_object **names)
 {
     int rc = -1;
 
@@ -320,7 +323,7 @@ done:
 
 json_object *kp_terror_enc (json_object *names, int errnum)
 {
-    JSON o = NULL;
+    json_object *o = NULL;
     int n;
 
     if (!names || !Jget_ar_len (names, &n) || n < 1 || errnum == 0) {
@@ -334,7 +337,7 @@ done:
     return o;
 }
 
-int kp_terror_dec (JSON o, json_object **names, int *errnum)
+int kp_terror_dec (json_object *o, json_object **names, int *errnum)
 {
     int rc = -1;
     if (!o || !names || !errnum) {

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -20,7 +20,8 @@ int main (int argc, char *argv[])
 {
     struct cache *cache;
     struct cache_entry *e1, *e2;
-    JSON o1, o2;
+    json_object *o1;
+    json_object *o2;
     wait_t *w;
     int count, i;
 

--- a/src/modules/kvs/test/dirent.c
+++ b/src/modules/kvs/test/dirent.c
@@ -6,9 +6,10 @@
 
 int main (int argc, char *argv[])
 {
-    JSON d1, d2;
-    JSON dir;
-    JSON array = NULL;
+    json_object *d1;
+    json_object *d2;
+    json_object *dir;
+    json_object *array = NULL;
 
     plan (NO_PLAN);
 

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -11,11 +11,11 @@
 
 void test_get (void)
 {
-    JSON o;
+    json_object *o;
     const char *key = NULL;
-    JSON val = NULL;
-    JSON dirent = NULL;
-    JSON dirent2 = NULL;
+    json_object *val = NULL;
+    json_object *dirent = NULL;
+    json_object *dirent2 = NULL;
     int i, flags;
 
     o = kp_tget_enc (NULL, "foo", 42);
@@ -64,11 +64,11 @@ void test_get (void)
 
 void test_watch (void)
 {
-    JSON o;
+    json_object *o;
     int flags;
     const char *key = NULL;
     const char *s = NULL;
-    JSON val;
+    json_object *val;
 
     val = Jnew ();
     Jadd_str (val, "s", "blatz");
@@ -103,7 +103,7 @@ void test_watch (void)
 
 void test_unwatch (void)
 {
-    JSON o;
+    json_object *o;
     const char *key;
 
     o = kp_tunwatch_enc ("foo");
@@ -117,8 +117,9 @@ void test_unwatch (void)
 
 void test_fence (void)
 {
-    JSON o, out;
-    JSON ops = Jnew_ar();
+    json_object *o;
+    json_object *out;
+    json_object *ops = Jnew_ar();
     int nprocs;
     const char *name;
 
@@ -140,7 +141,7 @@ void test_fence (void)
 
 void test_getroot (void)
 {
-    JSON o;
+    json_object *o;
     const char *rootdir;
     int rootseq;
 
@@ -156,10 +157,11 @@ void test_getroot (void)
 
 void test_setroot (void)
 {
-    JSON o;
+    json_object *o;
     const char *rootdir, *name;
     int rootseq;
-    JSON root, names;
+    json_object *root;
+    json_object *names;
 
     names = Jnew_ar ();
     Jadd_ar_str (names, "foo");
@@ -179,8 +181,8 @@ void test_setroot (void)
 
 void test_error (void)
 {
-    JSON o;
-    JSON names;
+    json_object *o;
+    json_object *names;
     const char *name[3];
     int errnum;
 

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -351,7 +351,7 @@ static int decode_reload_request (flux_t h, ctx_t *ctx,
                                   const flux_msg_t *msg)
 {
     const char *json_str;
-    JSON in = NULL;
+    json_object *in = NULL;
     bool walk_topology = ctx->walk_topology;
 
     if ((flux_request_decode (msg, NULL, &json_str) < 0)

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1256,7 +1256,7 @@ exitstatus_watcher (const char *key, const char *str, void *arg, int err)
     struct prog_ctx *ctx = arg;
     flux_t h = ctx->flux;
     int count;
-    JSON o;
+    json_object *o;
 
     if (err || !(o = Jfromstr (str))) {
         if (err != ENOENT)
@@ -1277,12 +1277,13 @@ exitstatus_watcher (const char *key, const char *str, void *arg, int err)
     return (0);
 }
 
-static JSON task_exit_tojson (struct task_info *t)
+static json_object *task_exit_tojson (struct task_info *t)
 {
     char *key = NULL;
     char *taskid = NULL;
     struct prog_ctx *ctx = t->ctx;
-    JSON o, e;
+    json_object *o;
+    json_object *e;
 
     if (asprintf (&key, "lwj.%ju.exit_status", ctx->id) < 0)
         return (NULL);
@@ -1333,7 +1334,7 @@ static int aggregator_push_task_exit (struct task_info *t)
     int rc = 0;
     flux_t h = t->ctx->flux;
     flux_rpc_t *rpc;
-    JSON o = task_exit_tojson (t);
+    json_object *o = task_exit_tojson (t);
 
     if (o == NULL) {
         flux_log_error (h, "task_exit_tojson");

--- a/t/build/hello_flux_internal.c
+++ b/t/build/hello_flux_internal.c
@@ -2,7 +2,7 @@
 
 int main (int argc, char **argv)
 {
-	JSON o = Jnew();
+	json_object *o = Jnew();
 	Jput (o);
 
 	return 0;

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -419,7 +419,7 @@ int get_watch_stats (flux_t h, int *count)
 {
     flux_rpc_t *rpc;
     const char *json_str;
-    JSON o = NULL;
+    json_object *o = NULL;
     int rc = -1;
 
     if (!(rpc = flux_rpc (h, "kvs.stats.get", NULL, FLUX_NODEID_ANY, 0)))

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -17,7 +17,7 @@
  */
 void send_watch_requests (flux_t h, const char *key)
 {
-    JSON in;
+    json_object *in;
     flux_rpc_t *r;
     const char *json_str;
 
@@ -37,7 +37,7 @@ void send_watch_requests (flux_t h, const char *key)
  */
 int count_watchers (flux_t h)
 {
-    JSON out;
+    json_object *out;
     const char *json_str;
     int n, count = 0;
     flux_rpc_t *r;

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -14,7 +14,7 @@ void rpctest_nodeid_cb (flux_t h, flux_msg_handler_t *w,
 {
     int errnum = 0;
     uint32_t nodeid;
-    JSON o = NULL;
+    json_object *o = NULL;
     int flags;
 
     if (flux_request_decode (msg, NULL, NULL) < 0

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -10,7 +10,7 @@ void rpctest_nodeid_cb (flux_t h, flux_msg_handler_t *w,
 {
     int errnum = 0;
     uint32_t nodeid;
-    JSON o = NULL;
+    json_object *o = NULL;
     int flags;
 
     if (flux_request_decode (msg, NULL, NULL) < 0

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -65,7 +65,7 @@ void count_request_cb (flux_t h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = getctx (h);
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
 
     Jadd_int (o, "count", zlist_size (ctx->clog_requests));
     if (flux_respond (h, msg, 0, Jtostr (o)) < 0)
@@ -111,7 +111,7 @@ void sink_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     const char *json_str;
     int saved_errno;
-    JSON o = NULL;
+    json_object *o = NULL;
     double d;
     int rc = -1;
 
@@ -136,7 +136,7 @@ done:
 void src_request_cb (flux_t h, flux_msg_handler_t *w,
                      const flux_msg_t *msg, void *arg)
 {
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
 
     Jadd_int (o, "wormz", 42);
     if (flux_respond (h, msg, 0, Jtostr (o)) < 0)
@@ -151,7 +151,7 @@ void nsrc_request_cb (flux_t h, flux_msg_handler_t *w,
 {
     const char *json_str;
     int saved_errno;
-    JSON o = Jnew ();
+    json_object *o = Jnew ();
     int i, count;
     int rc = -1;
 
@@ -220,8 +220,8 @@ void xping_request_cb (flux_t h, flux_msg_handler_t *w,
     int rank, seq = ctx->ping_seq++;
     const char *service;
     char *hashkey = NULL;
-    JSON in = Jnew ();
-    JSON o = NULL;
+    json_object *in = Jnew ();
+    json_object *o = NULL;
     flux_msg_t *cpy;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0) {
@@ -272,8 +272,8 @@ void ping_response_cb (flux_t h, flux_msg_handler_t *w,
 {
     ctx_t *ctx = arg;
     const char *json_str;
-    JSON o = NULL;
-    JSON out = Jnew ();;
+    json_object *o = NULL;
+    json_object *out = Jnew ();;
     int seq;
     const char *route;
     flux_msg_t *req = NULL;

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -148,8 +148,8 @@ void test_null (flux_t h, uint32_t nodeid)
 
 void test_echo (flux_t h, uint32_t nodeid)
 {
-    JSON in = Jnew ();
-    JSON out = NULL;
+    json_object *in = Jnew ();
+    json_object *out = NULL;
     const char *json_str;
     const char *s;
     flux_rpc_t *rpc;
@@ -183,7 +183,7 @@ void test_src (flux_t h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const char *json_str;
-    JSON out = NULL;
+    json_object *out = NULL;
     int i;
 
     if (!(rpc = flux_rpc (h, "req.src", NULL, nodeid, 0))
@@ -198,7 +198,7 @@ void test_src (flux_t h, uint32_t nodeid)
 void test_sink (flux_t h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
-    JSON in = Jnew();
+    json_object *in = Jnew();
 
     Jadd_double (in, "pi", 3.14);
     if (!(rpc = flux_rpc (h, "req.sink", Jtostr (in), nodeid, 0))
@@ -212,9 +212,9 @@ void test_nsrc (flux_t h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const int count = 10000;
-    JSON in = Jnew ();
+    json_object *in = Jnew ();
     const char *json_str;
-    JSON out = NULL;
+    json_object *out = NULL;
     int i, seq;
 
     Jadd_int (in, "count", count);
@@ -249,8 +249,8 @@ void test_putmsg (flux_t h, uint32_t nodeid)
     const int count = 10000;
     const int defer_start = 5000;
     const int defer_count = 500;
-    JSON in = Jnew ();
-    JSON out = NULL;
+    json_object *in = Jnew ();
+    json_object *out = NULL;
     int seq, myseq = 0;
     zlist_t *defer = zlist_new ();
     bool popped = false;
@@ -311,8 +311,8 @@ static void xping (flux_t h, uint32_t nodeid, uint32_t xnodeid, const char *svc)
 {
     flux_rpc_t *rpc;
     const char *json_str;
-    JSON in = Jnew ();
-    JSON out = NULL;
+    json_object *in = Jnew ();
+    json_object *out = NULL;
     const char *route;
 
     Jadd_int (in, "rank", xnodeid);
@@ -391,7 +391,7 @@ int req_count (flux_t h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const char *json_str;
-    JSON out = NULL;
+    json_object *out = NULL;
     int rc = -1;
     int count;
 


### PR DESCRIPTION
Remove the JSON typedef, and in its place use json_object * directly.
The JSON typedef proved to be more obfuscation than beneficial.