### PR TITLE
t/t2000-wreck.t: Fix invalid compare on 'wreckrun: --input=0 works' test

### DIFF
--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -83,7 +83,7 @@ test_expect_success 'wreckrun: --input=1 works' '
         cat >expected.1 <<-EOF &&
 	1: hello
 	EOF
-        test_cmp expected.0 output.0
+        test_cmp expected.1 output.1
 '
 test_expect_success 'wreckrun: --input=0-2 works' '
         echo hello | flux wreckrun --input=0-2 -l -n${SIZE} cat |


### PR DESCRIPTION
I don't have the test framework's code/internals fully understood yet, but this didn't look right.  Outputs are named ```output.1``` and ```expected.1```, but we're comparing ```output.0``` and ```expected.1```?