### PR TITLE
Remove pointer from typedef flux_t

### DIFF
--- a/doc/man3/tevent.c
+++ b/doc/man3/tevent.c
@@ -3,7 +3,7 @@
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_msg_t *msg;
     const char *topic;
 

--- a/doc/man3/tinfo.c
+++ b/doc/man3/tinfo.c
@@ -5,7 +5,7 @@
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     uint32_t rank, n;
 
     if (!(h = flux_open (NULL, 0)))

--- a/doc/man3/topen.c
+++ b/doc/man3/topen.c
@@ -3,7 +3,7 @@
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     uint32_t rank;
 
     if (!(h = flux_open (NULL, 0)))

--- a/doc/man3/trecv.c
+++ b/doc/man3/trecv.c
@@ -3,7 +3,7 @@
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_msg_t *msg;
     const char *topic;
 

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -8,7 +8,7 @@ struct context {
     int batchnum;
     flux_reduce_t *r;
     char rankstr[16];
-    flux_t h;
+    flux_t *h;
 };
 
 int itemweight (void *item)
@@ -72,7 +72,7 @@ void reduce (flux_reduce_t *r, int batchnum, void *arg)
     }
 }
 
-void forward_cb (flux_t h, flux_msg_handler_t *w,
+void forward_cb (flux_t *h, flux_msg_handler_t *w,
                  const flux_msg_t *msg, void *arg)
 {
     struct context *ctx = arg;
@@ -92,7 +92,7 @@ void forward_cb (flux_t h, flux_msg_handler_t *w,
     Jput (in);
 }
 
-void heartbeat_cb (flux_t h, flux_msg_handler_t *w,
+void heartbeat_cb (flux_t *h, flux_msg_handler_t *w,
                    const flux_msg_t *msg, void *arg)
 {
     struct context *ctx = arg;
@@ -115,7 +115,7 @@ struct flux_reduce_ops reduce_ops = {
     .sink = sink,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     struct context ctx;
     uint32_t rank;

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -18,7 +18,7 @@ void get_rank (flux_rpc_t *rpc)
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     json_object *o = Jnew();
 

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -19,7 +19,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     json_object *o = Jnew ();
 

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -19,7 +19,7 @@ void get_rank (flux_rpc_t *rpc, void *arg)
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     json_object *o = Jnew();
 

--- a/doc/man3/tsend.c
+++ b/doc/man3/tsend.c
@@ -3,7 +3,7 @@
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_msg_t *msg;
 
     if (!(h = flux_open (NULL, 0)))

--- a/src/bindings/lua/flux-lua.h
+++ b/src/bindings/lua/flux-lua.h
@@ -5,10 +5,10 @@
 
 /*
  *  Push a flux_t object onto Lua stack for state [L]. Increases the
- *   refcount for [f] since the flux_t object was created outside of
+ *   refcount for [f] since the flux_t *object was created outside of
  *   Lua.
  */
-int lua_push_flux_handle_external (lua_State *L, flux_t f);
+int lua_push_flux_handle_external (lua_State *L, flux_t *f);
 
 int luaopen_flux (lua_State *L);
 #endif /* !HAVE_FLUX_LUA_H */

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -262,7 +262,7 @@ err:
 
 static int l_kvsdir_watch_dir (lua_State *L)
 {
-    flux_t h;
+    flux_t *h;
     kvsdir_t *dir;
 
     dir = lua_get_kvsdir (L, 1);
@@ -274,7 +274,7 @@ static int l_kvsdir_watch_dir (lua_State *L)
 static int l_kvsdir_index (lua_State *L)
 {
     int rc;
-    flux_t f;
+    flux_t *f;
     kvsdir_t *d;
     const char *key = lua_tostring (L, 2);
     char *fullkey = NULL;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -108,7 +108,7 @@ typedef struct {
 
     /* Reactor
      */
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
     zlist_t *sigwatchers;
 
@@ -149,7 +149,7 @@ typedef struct {
     bool enable_epgm;
     bool shared_ipc_namespace;
     hello_t *hello;
-    flux_t enclosing_h;
+    flux_t *enclosing_h;
     runlevel_t *runlevel;
 
     /* Subprocess management

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -69,8 +69,8 @@ struct cache_entry {
 };
 
 struct content_cache {
-    flux_t h;
-    flux_t enclosing_h;
+    flux_t *h;
+    flux_t *enclosing_h;
     uint32_t rank;
     zhash_t *entries;
     uint8_t backing:1;              /* 'content-backing' service available */
@@ -110,7 +110,7 @@ static void message_list_destroy (zlist_t **l)
  * The list is always run to completion, then destroyed.
  * Returns 0 on succes, -1 on failure with errno set.
  */
-static int respond_requests_raw (zlist_t **l, flux_t h, int errnum,
+static int respond_requests_raw (zlist_t **l, flux_t *h, int errnum,
                                  const void *data, int len)
 {
     flux_msg_t *msg;
@@ -349,7 +349,7 @@ done:
     return rc;
 }
 
-void content_load_request (flux_t h, flux_msg_handler_t *w,
+void content_load_request (flux_t *h, flux_msg_handler_t *w,
                            const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -520,7 +520,7 @@ done:
     return rc;
 }
 
-static void content_store_request (flux_t h, flux_msg_handler_t *w,
+static void content_store_request (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -642,7 +642,7 @@ static int cache_flush (content_cache_t *cache)
     return rc;
 }
 
-static void content_backing_request (flux_t h, flux_msg_handler_t *w,
+static void content_backing_request (flux_t *h, flux_msg_handler_t *w,
                                      const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -688,7 +688,7 @@ done:
  * N.B. this walks the entire cache in one go.
  */
 
-static void content_dropcache_request (flux_t h, flux_msg_handler_t *w,
+static void content_dropcache_request (flux_t *h, flux_msg_handler_t *w,
                                        const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -731,7 +731,7 @@ done:
 /* Return stats about the cache.
  */
 
-static void content_stats_request (flux_t h, flux_msg_handler_t *w,
+static void content_stats_request (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -775,7 +775,7 @@ static void flush_respond (content_cache_t *cache)
                         __FUNCTION__);
 }
 
-static void content_flush_request (flux_t h, flux_msg_handler_t *w,
+static void content_flush_request (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -858,7 +858,7 @@ done:
     return rc;
 }
 
-static void heartbeat_event (flux_t h, flux_msg_handler_t *w,
+static void heartbeat_event (flux_t *h, flux_msg_handler_t *w,
                              const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -882,7 +882,7 @@ static struct flux_msg_handler_spec handlers[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int content_cache_set_flux (content_cache_t *cache, flux_t h)
+int content_cache_set_flux (content_cache_t *cache, flux_t *h)
 {
     cache->h = h;
 
@@ -894,7 +894,7 @@ int content_cache_set_flux (content_cache_t *cache, flux_t h)
     return 0;
 }
 
-void content_cache_set_enclosing_flux (content_cache_t *cache, flux_t h)
+void content_cache_set_enclosing_flux (content_cache_t *cache, flux_t *h)
 {
     cache->enclosing_h = h;
 }

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -1,7 +1,7 @@
 typedef struct content_cache content_cache_t;
 
-int content_cache_set_flux (content_cache_t *cache, flux_t h);
-void content_cache_set_enclosing_flux (content_cache_t *cache, flux_t h);
+int content_cache_set_flux (content_cache_t *cache, flux_t *h);
+void content_cache_set_enclosing_flux (content_cache_t *cache, flux_t *h);
 
 content_cache_t *content_cache_create (void);
 void content_cache_destroy (content_cache_t *cache);

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -36,7 +36,7 @@
 #include "heartbeat.h"
 
 struct heartbeat_struct {
-    flux_t h;
+    flux_t *h;
     double rate;
     flux_watcher_t *timer;
     flux_msg_handler_t *handler;
@@ -63,7 +63,7 @@ heartbeat_t *heartbeat_create (void)
     return hb;
 }
 
-void heartbeat_set_flux (heartbeat_t *hb, flux_t h)
+void heartbeat_set_flux (heartbeat_t *hb, flux_t *h)
 {
     hb->h = h;
 }
@@ -115,7 +115,7 @@ int heartbeat_get_epoch (heartbeat_t *hb)
     return hb->epoch;
 }
 
-static void event_cb (flux_t h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     heartbeat_t *hb = arg;

--- a/src/broker/heartbeat.h
+++ b/src/broker/heartbeat.h
@@ -29,7 +29,7 @@ int heartbeat_set_ratestr (heartbeat_t *hb, const char *s);
 int heartbeat_set_rate (heartbeat_t *hb, double rate);
 double heartbeat_get_rate (heartbeat_t *hb);
 
-void heartbeat_set_flux (heartbeat_t *hb, flux_t h);
+void heartbeat_set_flux (heartbeat_t *hb, flux_t *h);
 int heartbeat_set_attrs (heartbeat_t *hb, attr_t *attrs);
 
 void heartbeat_set_epoch (heartbeat_t *hb, int epoch);

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -41,7 +41,7 @@
 static double default_reduction_timeout = 10.;
 
 struct hello_struct {
-    flux_t h;
+    flux_t *h;
     attr_t *attrs;
     uint32_t rank;
     uint32_t size;
@@ -55,7 +55,7 @@ struct hello_struct {
     flux_reduce_t *reduce;
 };
 
-static void join_request (flux_t h, flux_msg_handler_t *w,
+static void join_request (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg);
 
 static void r_reduce (flux_reduce_t *r, int batch, void *arg);
@@ -129,7 +129,7 @@ static struct flux_msg_handler_spec handlers[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-void hello_set_flux (hello_t *hello, flux_t h)
+void hello_set_flux (hello_t *hello, flux_t *h)
 {
     hello->h = h;
 }
@@ -213,7 +213,7 @@ done:
 
 /* handle a message sent from downstream via downstream's r_forward op.
  */
-static void join_request (flux_t h, flux_msg_handler_t *w,
+static void join_request (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     hello_t *hello = arg;

--- a/src/broker/hello.h
+++ b/src/broker/hello.h
@@ -16,7 +16,7 @@ void hello_destroy (hello_t *hello);
 
 /* Register handle
  */
-void hello_set_flux (hello_t *hello, flux_t h);
+void hello_set_flux (hello_t *hello, flux_t *h);
 
 /* Set up broker attributes
  */

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -45,7 +45,7 @@ static const int default_level = LOG_DEBUG;
 #define LOGBUF_MAGIC 0xe1e2e3e4
 struct logbuf_struct {
     int magic;
-    flux_t h;
+    flux_t *h;
     uint32_t rank;
     char *filename;
     FILE *f;
@@ -243,7 +243,7 @@ void logbuf_destroy (logbuf_t *logbuf)
     }
 }
 
-void logbuf_set_flux (logbuf_t *logbuf, flux_t h)
+void logbuf_set_flux (logbuf_t *logbuf, flux_t *h)
 {
     assert (logbuf->magic == LOGBUF_MAGIC);
     logbuf->h = h;

--- a/src/broker/log.h
+++ b/src/broker/log.h
@@ -11,7 +11,7 @@ typedef struct logbuf_struct logbuf_t;
 logbuf_t *logbuf_create (void);
 void logbuf_destroy (logbuf_t *logbuf);
 
-void logbuf_set_flux (logbuf_t *logbuf, flux_t h);
+void logbuf_set_flux (logbuf_t *logbuf, flux_t *h);
 void logbuf_set_rank (logbuf_t *logbuf, uint32_t rank);
 
 int logbuf_register_attrs (logbuf_t *logbuf, attr_t *attrs);

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -52,7 +52,7 @@
 #include "modservice.h"
 
 typedef struct {
-    flux_t h;
+    flux_t *h;
     module_t *p;
     zlist_t *handlers;
     flux_watcher_t *w_prepare;
@@ -71,7 +71,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t h, module_t *p)
+static ctx_t *getctx (flux_t *h, module_t *p)
 {
     ctx_t *ctx = flux_aux_get (h, "flux::modservice");
 
@@ -89,7 +89,7 @@ static ctx_t *getctx (flux_t h, module_t *p)
 
 /* Route string will not include the endpoints.
  */
-static void ping_cb (flux_t h, flux_msg_handler_t *w,
+static void ping_cb (flux_t *h, flux_msg_handler_t *w,
                      const flux_msg_t *msg, void *arg)
 {
     module_t *p = arg;
@@ -121,7 +121,7 @@ done:
         free (route);
 }
 
-static void stats_get_cb (flux_t h, flux_msg_handler_t *w,
+static void stats_get_cb (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     flux_msgcounters_t mcs;
@@ -142,13 +142,13 @@ static void stats_get_cb (flux_t h, flux_msg_handler_t *w,
     Jput (out);
 }
 
-static void stats_clear_event_cb (flux_t h, flux_msg_handler_t *w,
+static void stats_clear_event_cb (flux_t *h, flux_msg_handler_t *w,
                                   const flux_msg_t *msg, void *arg)
 {
     flux_clr_msgcounters (h);
 }
 
-static void stats_clear_request_cb (flux_t h, flux_msg_handler_t *w,
+static void stats_clear_request_cb (flux_t *h, flux_msg_handler_t *w,
                                     const flux_msg_t *msg, void *arg)
 {
     flux_clr_msgcounters (h);
@@ -156,7 +156,7 @@ static void stats_clear_request_cb (flux_t h, flux_msg_handler_t *w,
         FLUX_LOG_ERROR (h);
 }
 
-static void rusage_cb (flux_t h, flux_msg_handler_t *w,
+static void rusage_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     json_object *out = NULL;
@@ -172,7 +172,7 @@ done:
     Jput (out);
 }
 
-static void shutdown_cb (flux_t h, flux_msg_handler_t *w,
+static void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
                          const flux_msg_t *msg, void *arg)
 {
     flux_reactor_stop (flux_get_reactor (h));
@@ -235,7 +235,7 @@ static void register_request (ctx_t *ctx, const char *name,
     free (match.topic_glob);
 }
 
-void modservice_register (flux_t h, module_t *p)
+void modservice_register (flux_t *h, module_t *p)
 {
     ctx_t *ctx = getctx (h, p);
     flux_reactor_t *r = flux_get_reactor (h);

--- a/src/broker/modservice.h
+++ b/src/broker/modservice.h
@@ -3,7 +3,7 @@
 
 #include "module.h"
 
-void modservice_register (flux_t h, module_t *p);
+void modservice_register (flux_t *h, module_t *p);
 
 #endif /* !_BROKER_MODSERVICE_H */
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -62,7 +62,7 @@ struct module_struct {
 
     zctx_t *zctx;
     uint32_t rank;
-    flux_t broker_h;
+    flux_t *broker_h;
     flux_watcher_t *broker_w;
 
     int lastseen;
@@ -91,7 +91,7 @@ struct module_struct {
     zlist_t *rmmod;
     flux_msg_t *insmod;
 
-    flux_t h;               /* module's handle */
+    flux_t *h;               /* module's handle */
 
     zlist_t *subs;          /* subscription strings */
 };
@@ -100,7 +100,7 @@ struct modhash_struct {
     zhash_t *zh_byuuid;
     zctx_t *zctx;
     uint32_t rank;
-    flux_t broker_h;
+    flux_t *broker_h;
     heartbeat_t *heartbeat;
 };
 
@@ -597,7 +597,7 @@ void modhash_set_rank (modhash_t *mh, uint32_t rank)
     mh->rank = rank;
 }
 
-void modhash_set_flux (modhash_t *mh, flux_t h)
+void modhash_set_flux (modhash_t *mh, flux_t *h)
 {
     mh->broker_h = h;
 }

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -15,7 +15,7 @@ void modhash_destroy (modhash_t *mh);
 
 void modhash_set_zctx (modhash_t *mh, zctx_t *zctx);
 void modhash_set_rank (modhash_t *mh, uint32_t rank);
-void modhash_set_flux (modhash_t *mh, flux_t h);
+void modhash_set_flux (modhash_t *mh, flux_t *h);
 void modhash_set_heartbeat (modhash_t *mh, heartbeat_t *hb);
 
 /* Prepare module at 'path' for starting.

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -46,7 +46,7 @@ struct endpoint {
 struct overlay_struct {
     zctx_t *zctx;
     flux_sec_t *sec;
-    flux_t h;
+    flux_t *h;
     zhash_t *children;          /* child_t - by uuid */
     flux_msg_handler_t *heartbeat;
     int epoch;
@@ -79,7 +79,7 @@ typedef struct {
     bool mute;
 } child_t;
 
-static void heartbeat_handler (flux_t h, flux_msg_handler_t *w,
+static void heartbeat_handler (flux_t *h, flux_msg_handler_t *w,
                                const flux_msg_t *msg, void *arg);
 
 static void endpoint_destroy (struct endpoint *ep)
@@ -161,7 +161,7 @@ void overlay_set_rank (overlay_t *ov, uint32_t rank)
     snprintf (ov->rankstr, sizeof (ov->rankstr), "%u", rank);
 }
 
-void overlay_set_flux (overlay_t *ov, flux_t h)
+void overlay_set_flux (overlay_t *ov, flux_t *h)
 {
     struct flux_match match = FLUX_MATCH_EVENT;
 
@@ -288,7 +288,7 @@ done:
     return rc;
 }
 
-static void heartbeat_handler (flux_t h, flux_msg_handler_t *w,
+static void heartbeat_handler (flux_t *h, flux_msg_handler_t *w,
                                const flux_msg_t *msg, void *arg)
 {
     overlay_t *ov = arg;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -12,7 +12,7 @@ void overlay_destroy (overlay_t *ov);
 void overlay_set_sec (overlay_t *ov, flux_sec_t *sec);
 void overlay_set_zctx (overlay_t *ov, zctx_t *zctx);
 void overlay_set_rank (overlay_t *ov, uint32_t rank);
-void overlay_set_flux (overlay_t *ov, flux_t h);
+void overlay_set_flux (overlay_t *ov, flux_t *h);
 void overlay_set_idle_warning (overlay_t *ov, int heartbeats);
 
 /* All ranks but rank 0 connect to a parent to form the main TBON.

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -38,7 +38,7 @@
 #define REASON_MAX 256
 
 struct shutdown_struct {
-    flux_t h;
+    flux_t *h;
     flux_watcher_t *timer;
     flux_msg_handler_t *shutdown;
     uint32_t myrank;
@@ -87,7 +87,7 @@ static void timer_handler (flux_reactor_t *r, flux_watcher_t *w,
 /* On receipt of the shutdown event message, begin the grace timer,
  * and log the "shutdown in..." message on rank 0.
  */
-void shutdown_handler (flux_t h, flux_msg_handler_t *w,
+void shutdown_handler (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     shutdown_t *s = arg;
@@ -111,7 +111,7 @@ void shutdown_handler (flux_t h, flux_msg_handler_t *w,
     }
 }
 
-void shutdown_set_handle (shutdown_t *s, flux_t h)
+void shutdown_set_handle (shutdown_t *s, flux_t *h)
 {
     struct flux_match match = FLUX_MATCH_EVENT;
 

--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -23,10 +23,10 @@ typedef void (*shutdown_cb_f)(shutdown_t *s, bool expired, void *arg);
 shutdown_t *shutdown_create (void);
 void shutdown_destroy (shutdown_t *s);
 
-/* Set the flux_t handle to be used to configure the event message
+/* Set the flux_t *handle to be used to configure the event message
  * handler, grace timer watcher, and log the shutdown message.
  */
-void shutdown_set_handle (shutdown_t *s, flux_t h);
+void shutdown_set_handle (shutdown_t *s, flux_t *h);
 
 /* Reigster a shutdown callback to be called
  * 1) when the grace timeout is armed, and

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -11,7 +11,7 @@ void fatal_err (const char *message, void *arg)
     BAIL_OUT ("fatal error: %s", message);
 }
 
-void heartbeat_event_cb (flux_t h, flux_msg_handler_t *w,
+void heartbeat_event_cb (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     heartbeat_t *hb = arg;
@@ -40,7 +40,7 @@ void check_codec (void)
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     heartbeat_t *hb;
     flux_msg_handler_t *w;
 

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -6,7 +6,7 @@
 
 #include "src/common/libtap/tap.h"
 
-static flux_t h;
+static flux_t *h;
 
 void fatal_err (const char *message, void *arg)
 {

--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -19,7 +19,7 @@ void shutdown_cb (shutdown_t *s, bool expired, void *arg)
         "shutowon callback retrieved exitcode");
 }
 
-void log_request_cb (flux_t h, flux_msg_handler_t *w,
+void log_request_cb (flux_t *h, flux_msg_handler_t *w,
                      const flux_msg_t *msg, void *arg)
 {
     ok (msg != NULL,
@@ -44,7 +44,7 @@ void check_codec (void)
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     shutdown_t *sh;
     flux_msg_handler_t *log_w;
     struct flux_match matchlog = FLUX_MATCH_REQUEST;

--- a/src/cmd/builtin.h
+++ b/src/cmd/builtin.h
@@ -35,4 +35,4 @@ struct builtin_cmd {
 };
 
 void usage (optparse_t *p);
-flux_t builtin_get_flux_handle (optparse_t *p);
+flux_t *builtin_get_flux_handle (optparse_t *p);

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -34,7 +34,7 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
 {
     int n;
     const char *name = NULL, *val = NULL;
-    flux_t h;
+    flux_t *h;
 
     log_init ("flux-setattr");
 
@@ -66,7 +66,7 @@ static struct optparse_option lsattr_opts[] = {
 static int cmd_lsattr (optparse_t *p, int ac, char *av[])
 {
     const char *name, *val;
-    flux_t h;
+    flux_t *h;
 
     log_init ("flux-lsatrr");
 
@@ -89,7 +89,7 @@ static int cmd_lsattr (optparse_t *p, int ac, char *av[])
 
 static int cmd_getattr (optparse_t *p, int ac, char *av[])
 {
-    flux_t h = NULL;
+    flux_t *h = NULL;
     const char *val;
     int n, flags;
 

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -35,7 +35,7 @@ static int internal_content_load (optparse_t *p, int ac, char *av[])
     const char *blobref;
     uint8_t *data;
     int size;
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     const char *topic;
 
@@ -67,7 +67,7 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
     const uint32_t blob_size_limit = 1048576; /* RFC 10 */
     uint8_t *data;
     int size;
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     const char *topic;
 
@@ -122,7 +122,7 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
 
 static int internal_content_flush (optparse_t *p, int ac, char *av[])
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc = NULL;
     const char *topic = "content.flush";
 
@@ -143,7 +143,7 @@ static int internal_content_flush (optparse_t *p, int ac, char *av[])
 
 static int internal_content_dropcache (optparse_t *p, int ac, char *av[])
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc = NULL;
     const char *topic = "content.dropcache";
 
@@ -185,7 +185,7 @@ static int internal_content_spam (optparse_t *p, int ac, char *av[])
 {
     int i, count;
     flux_rpc_t *rpc;
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *r;
     char data[256];
     int size = 256;

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -37,7 +37,7 @@ static struct optparse_option dmesg_opts[] = {
 static int cmd_dmesg (optparse_t *p, int ac, char *av[])
 {
     int n;
-    flux_t h;
+    flux_t *h;
     int flags = 0;
     flux_log_f print_cb = flux_log_fprint;
 

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -27,7 +27,7 @@
 
 static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     json_object *in = Jnew ();
 
@@ -49,7 +49,7 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
 
 static int internal_heaptrace_stop (optparse_t *p, int ac, char *av[])
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
 
     if (optparse_optind (p) != ac) {
@@ -68,7 +68,7 @@ static int internal_heaptrace_stop (optparse_t *p, int ac, char *av[])
 
 static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     json_object *in = Jnew ();
 

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -36,7 +36,7 @@
 #include "src/common/libutil/sds.h"
 
 struct hwloc_topo {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
     json_object *o;
     const char *topo;
@@ -204,7 +204,7 @@ static int cmd_topology (optparse_t *p, int ac, char *av[])
     return (0);
 }
 
-static void config_hwloc_paths (flux_t h, const char *dirpath)
+static void config_hwloc_paths (flux_t *h, const char *dirpath)
 {
     uint32_t size, rank;
     const char *key_prefix = "config.resource.hwloc.xml";
@@ -251,7 +251,7 @@ static json_object *hwloc_reload_json_create (const char *walk_topology)
 }
 
 
-static void request_hwloc_reload (flux_t h, const char *nodeset,
+static void request_hwloc_reload (flux_t *h, const char *nodeset,
                                   const char *walk_topology)
 {
     flux_rpc_t *rpc;
@@ -284,7 +284,7 @@ static int internal_hwloc_reload (optparse_t *p, int ac, char *av[])
     const char *nodeset = optparse_get_str (p, "rank", default_nodeset);
     const char *walk_topology = optparse_get_str (p, "walk-topology", NULL);
     char *dirpath = NULL;
-    flux_t h;
+    flux_t *h;
 
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -54,7 +54,7 @@ typedef struct {
     int listen_fd;
     flux_watcher_t *listen_w;
     zlist_t *clients;
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
     uid_t session_owner;
     zhash_t *subscriptions;
@@ -113,7 +113,7 @@ static void ctx_destroy (ctx_t *ctx)
     }
 }
 
-static ctx_t *ctx_create (flux_t h)
+static ctx_t *ctx_create (flux_t *h)
 {
     ctx_t *ctx = xzmalloc (sizeof (*ctx));
     ctx->h = h;
@@ -152,7 +152,7 @@ static int set_nonblock (int fd, bool nonblock)
 static client_t * client_create (ctx_t *ctx, int rfd, int wfd)
 {
     client_t *c;
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
 
     c = xzmalloc (sizeof (*c));
     c->rfd = rfd;
@@ -529,7 +529,7 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
 {
     client_t *c = arg;
     ctx_t *ctx = c->ctx;
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
     flux_msg_t *msg = NULL;
     int type;
 
@@ -591,7 +591,7 @@ disconnect:
  * Look up the sender uuid in clients hash and deliver.
  * Responses for disconnected clients are silently discarded.
  */
-static void response_cb (flux_t h, flux_msg_handler_t *w,
+static void response_cb (flux_t *h, flux_msg_handler_t *w,
                          const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -636,7 +636,7 @@ done:
 /* Received an event message from broker.
  * Find all subscribers and deliver.
  */
-static void event_cb (flux_t h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -696,7 +696,7 @@ static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
 {
     int fd = flux_fd_watcher_get_fd (w);
     ctx_t *ctx = arg;
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
 
     if (revents & FLUX_POLLIN) {
         client_t *c;
@@ -887,7 +887,7 @@ static struct optparse_option proxy_opts[] = {
 
 static int cmd_proxy (optparse_t *p, int ac, char *av[])
 {
-    flux_t h = NULL;
+    flux_t *h = NULL;
     int n;
     ctx_t *ctx;
     const char *tmpdir = getenv ("TMPDIR");

--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -65,7 +65,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     uint32_t nodeid = FLUX_NODEID_ANY;
     char *target;

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -58,7 +58,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     uint32_t rank = FLUX_NODEID_ANY; /* local */
     char *cmd;

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -45,7 +45,7 @@ int main (int argc, char *argv[])
 {
     int n;
     optparse_t *p;
-    flux_t h;
+    flux_t *h;
 
     log_init ("flux-event");
     if (!(p = optparse_create ("flux-event")))
@@ -84,7 +84,7 @@ static void event_pub_register (optparse_t *parent)
 
 static int event_pub (optparse_t *p, int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     char *topic = argv[1];  /* "pub" should be argv0 */
     flux_msg_t *msg = NULL;
     char *json_str = NULL;
@@ -118,7 +118,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
     return (0);
 }
 
-static void subscribe_all (flux_t h, int tc, char **tv)
+static void subscribe_all (flux_t *h, int tc, char **tv)
 {
     int i;
     for (i = 0; i < tc; i++) {
@@ -127,7 +127,7 @@ static void subscribe_all (flux_t h, int tc, char **tv)
     }
 }
 
-static void unsubscribe_all (flux_t h, int tc, char **tv)
+static void unsubscribe_all (flux_t *h, int tc, char **tv)
 {
     int i;
     for (i = 0; i < tc; i++) {
@@ -165,7 +165,7 @@ void event_sub_register (optparse_t *op)
 
 static int event_sub (optparse_t *p, int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     flux_msg_t *msg;
     int n, count;
     bool raw = false;

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -45,12 +45,12 @@
  *                                                                            * 
  ******************************************************************************/
 typedef struct {
-    flux_t h;
+    flux_t *h;
     FILE *op;
 } jstatctx_t;
 
 /* Note: Should only be used for signal handling */
-static flux_t sig_flux_h;
+static flux_t *sig_flux_h;
 
 #define OPTIONS "o:h"
 static const struct option longopts[] = {
@@ -82,7 +82,7 @@ static void freectx (void *arg)
         fclose (ctx->op);
 }
 
-static jstatctx_t *getctx (flux_t h)
+static jstatctx_t *getctx (flux_t *h)
 {
     jstatctx_t *ctx = (jstatctx_t *)flux_aux_get (h, "jstat");
     if (!ctx) {
@@ -138,7 +138,7 @@ static int job_status_cb (const char *jcbstr, void *arg, int errnum)
     int64_t ns = 0;
     int64_t j = 0;
     jstatctx_t *ctx = NULL;
-    flux_t h = (flux_t)arg;
+    flux_t *h = (flux_t *)arg;
     json_object *jcb = NULL;
 
     ctx = getctx (h);
@@ -170,7 +170,7 @@ static int job_status_cb (const char *jcbstr, void *arg, int errnum)
  *                                                                            *
  ******************************************************************************/
 
-static int handle_notify_req (flux_t h, const char *ofn)
+static int handle_notify_req (flux_t *h, const char *ofn)
 {
     jstatctx_t *ctx = NULL;
 
@@ -191,7 +191,7 @@ static int handle_notify_req (flux_t h, const char *ofn)
     return 0;
 }
 
-static int handle_query_req (flux_t h, int64_t j, const char *k, const char *n)
+static int handle_query_req (flux_t *h, int64_t j, const char *k, const char *n)
 {
     json_object *jcb = NULL;
     jstatctx_t *ctx = NULL;
@@ -212,7 +212,7 @@ static int handle_query_req (flux_t h, int64_t j, const char *k, const char *n)
     return 0;
 }
 
-static int handle_update_req (flux_t h, int64_t j, const char *k, 
+static int handle_update_req (flux_t *h, int64_t j, const char *k, 
                               const char *jcbstr, const char *n)
 {
     jstatctx_t *ctx = NULL;
@@ -231,7 +231,7 @@ static int handle_update_req (flux_t h, int64_t j, const char *k,
 
 int main (int argc, char *argv[])
 {
-    flux_t h; 
+    flux_t *h; 
     int ch = 0;
     int rc = 0;
     char *cmd = NULL;

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -44,31 +44,31 @@ static const struct option longopts[] = {
     { 0, 0, 0, 0 },
 };
 
-void cmd_get (flux_t h, int argc, char **argv);
-void cmd_type (flux_t h, int argc, char **argv);
-void cmd_put (flux_t h, int argc, char **argv);
-void cmd_unlink (flux_t h, int argc, char **argv);
-void cmd_link (flux_t h, int argc, char **argv);
-void cmd_readlink (flux_t h, int argc, char **argv);
-void cmd_mkdir (flux_t h, int argc, char **argv);
-void cmd_exists (flux_t h, int argc, char **argv);
-void cmd_version (flux_t h, int argc, char **argv);
-void cmd_wait (flux_t h, int argc, char **argv);
-void cmd_watch (flux_t h, int argc, char **argv);
-void cmd_watch_dir (flux_t h, int argc, char **argv);
-void cmd_dropcache (flux_t h, int argc, char **argv);
-void cmd_dropcache_all (flux_t h, int argc, char **argv);
-void cmd_copy_tokvs (flux_t h, int argc, char **argv);
-void cmd_copy_fromkvs (flux_t h, int argc, char **argv);
-void cmd_copy (flux_t h, int argc, char **argv);
-void cmd_move (flux_t h, int argc, char **argv);
-void cmd_dir (flux_t h, int argc, char **argv);
-void cmd_dirsize (flux_t h, int argc, char **argv);
-void cmd_get_treeobj (flux_t h, int argc, char **argv);
-void cmd_put_treeobj (flux_t h, int argc, char **argv);
-void cmd_getat (flux_t h, int argc, char **argv);
-void cmd_dirat (flux_t h, int argc, char **argv);
-void cmd_readlinkat (flux_t h, int argc, char **argv);
+void cmd_get (flux_t *h, int argc, char **argv);
+void cmd_type (flux_t *h, int argc, char **argv);
+void cmd_put (flux_t *h, int argc, char **argv);
+void cmd_unlink (flux_t *h, int argc, char **argv);
+void cmd_link (flux_t *h, int argc, char **argv);
+void cmd_readlink (flux_t *h, int argc, char **argv);
+void cmd_mkdir (flux_t *h, int argc, char **argv);
+void cmd_exists (flux_t *h, int argc, char **argv);
+void cmd_version (flux_t *h, int argc, char **argv);
+void cmd_wait (flux_t *h, int argc, char **argv);
+void cmd_watch (flux_t *h, int argc, char **argv);
+void cmd_watch_dir (flux_t *h, int argc, char **argv);
+void cmd_dropcache (flux_t *h, int argc, char **argv);
+void cmd_dropcache_all (flux_t *h, int argc, char **argv);
+void cmd_copy_tokvs (flux_t *h, int argc, char **argv);
+void cmd_copy_fromkvs (flux_t *h, int argc, char **argv);
+void cmd_copy (flux_t *h, int argc, char **argv);
+void cmd_move (flux_t *h, int argc, char **argv);
+void cmd_dir (flux_t *h, int argc, char **argv);
+void cmd_dirsize (flux_t *h, int argc, char **argv);
+void cmd_get_treeobj (flux_t *h, int argc, char **argv);
+void cmd_put_treeobj (flux_t *h, int argc, char **argv);
+void cmd_getat (flux_t *h, int argc, char **argv);
+void cmd_dirat (flux_t *h, int argc, char **argv);
+void cmd_readlinkat (flux_t *h, int argc, char **argv);
 
 
 void usage (void)
@@ -105,7 +105,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     char *cmd;
 
@@ -186,7 +186,7 @@ int main (int argc, char *argv[])
     return 0;
 }
 
-void cmd_type (flux_t h, int argc, char **argv)
+void cmd_type (flux_t *h, int argc, char **argv)
 {
     char *json_str;
     json_object *o;
@@ -229,7 +229,7 @@ void cmd_type (flux_t h, int argc, char **argv)
     }
 }
 
-void cmd_get (flux_t h, int argc, char **argv)
+void cmd_get (flux_t *h, int argc, char **argv)
 {
     char *json_str;
     json_object *o;
@@ -269,7 +269,7 @@ void cmd_get (flux_t h, int argc, char **argv)
     }
 }
 
-void cmd_put (flux_t h, int argc, char **argv)
+void cmd_put (flux_t *h, int argc, char **argv)
 {
     int i;
 
@@ -291,7 +291,7 @@ void cmd_put (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_commit");
 }
 
-void cmd_unlink (flux_t h, int argc, char **argv)
+void cmd_unlink (flux_t *h, int argc, char **argv)
 {
     int i;
 
@@ -307,7 +307,7 @@ void cmd_unlink (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_commit");
 }
 
-void cmd_link (flux_t h, int argc, char **argv)
+void cmd_link (flux_t *h, int argc, char **argv)
 {
     if (argc != 2)
         log_msg_exit ("link: specify target and link_name");
@@ -317,7 +317,7 @@ void cmd_link (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_commit");
 }
 
-void cmd_readlink (flux_t h, int argc, char **argv)
+void cmd_readlink (flux_t *h, int argc, char **argv)
 {
     int i;
     char *target;
@@ -333,7 +333,7 @@ void cmd_readlink (flux_t h, int argc, char **argv)
     }
 }
 
-void cmd_mkdir (flux_t h, int argc, char **argv)
+void cmd_mkdir (flux_t *h, int argc, char **argv)
 {
     int i;
 
@@ -347,7 +347,7 @@ void cmd_mkdir (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_commit");
 }
 
-bool key_exists (flux_t h, const char *key)
+bool key_exists (flux_t *h, const char *key)
 {
     char *json_str = NULL;
     kvsdir_t *dir = NULL;
@@ -363,7 +363,7 @@ bool key_exists (flux_t h, const char *key)
     return false;
 }
 
-void cmd_exists (flux_t h, int argc, char **argv)
+void cmd_exists (flux_t *h, int argc, char **argv)
 {
     int i;
     if (argc == 0)
@@ -374,7 +374,7 @@ void cmd_exists (flux_t h, int argc, char **argv)
     }
 }
 
-void cmd_version (flux_t h, int argc, char **argv)
+void cmd_version (flux_t *h, int argc, char **argv)
 {
     int vers;
     if (argc != 0)
@@ -384,7 +384,7 @@ void cmd_version (flux_t h, int argc, char **argv)
     printf ("%d\n", vers);
 }
 
-void cmd_wait (flux_t h, int argc, char **argv)
+void cmd_wait (flux_t *h, int argc, char **argv)
 {
     int vers;
     if (argc != 1)
@@ -395,7 +395,7 @@ void cmd_wait (flux_t h, int argc, char **argv)
     //printf ("%d\n", vers);
 }
 
-void cmd_watch (flux_t h, int argc, char **argv)
+void cmd_watch (flux_t *h, int argc, char **argv)
 {
     char *json_str = NULL;
     char *key;
@@ -412,7 +412,7 @@ void cmd_watch (flux_t h, int argc, char **argv)
     } while (true);
 }
 
-void cmd_dropcache (flux_t h, int argc, char **argv)
+void cmd_dropcache (flux_t *h, int argc, char **argv)
 {
     if (argc != 0)
         log_msg_exit ("dropcache: takes no arguments");
@@ -420,7 +420,7 @@ void cmd_dropcache (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_dropcache");
 }
 
-void cmd_dropcache_all (flux_t h, int argc, char **argv)
+void cmd_dropcache_all (flux_t *h, int argc, char **argv)
 {
     if (argc != 0)
         log_msg_exit ("dropcache-all: takes no arguments");
@@ -430,7 +430,7 @@ void cmd_dropcache_all (flux_t h, int argc, char **argv)
     flux_msg_destroy (msg);
 }
 
-void cmd_copy_tokvs (flux_t h, int argc, char **argv)
+void cmd_copy_tokvs (flux_t *h, int argc, char **argv)
 {
     char *file, *key;
     int fd, len;
@@ -461,7 +461,7 @@ void cmd_copy_tokvs (flux_t h, int argc, char **argv)
     free (buf);
 }
 
-void cmd_copy_fromkvs (flux_t h, int argc, char **argv)
+void cmd_copy_fromkvs (flux_t *h, int argc, char **argv)
 {
     char *file, *key;
     int fd, len;
@@ -566,7 +566,7 @@ static void dump_kvs_dir (kvsdir_t *dir, bool ropt)
     kvsitr_destroy (itr);
 }
 
-void cmd_watch_dir (flux_t h, int argc, char **argv)
+void cmd_watch_dir (flux_t *h, int argc, char **argv)
 {
     bool ropt = false;
     char *key;
@@ -609,7 +609,7 @@ done:
     kvsdir_destroy (dir);
 }
 
-void cmd_dir (flux_t h, int argc, char **argv)
+void cmd_dir (flux_t *h, int argc, char **argv)
 {
     bool ropt = false;
     char *key;
@@ -632,7 +632,7 @@ void cmd_dir (flux_t h, int argc, char **argv)
     kvsdir_destroy (dir);
 }
 
-void cmd_dirat (flux_t h, int argc, char **argv)
+void cmd_dirat (flux_t *h, int argc, char **argv)
 {
     bool ropt = false;
     char *key;
@@ -655,7 +655,7 @@ void cmd_dirat (flux_t h, int argc, char **argv)
     kvsdir_destroy (dir);
 }
 
-void cmd_dirsize (flux_t h, int argc, char **argv)
+void cmd_dirsize (flux_t *h, int argc, char **argv)
 {
     kvsdir_t *dir = NULL;
     if (argc != 1)
@@ -666,7 +666,7 @@ void cmd_dirsize (flux_t h, int argc, char **argv)
     kvsdir_destroy (dir);
 }
 
-void cmd_copy (flux_t h, int argc, char **argv)
+void cmd_copy (flux_t *h, int argc, char **argv)
 {
     if (argc != 2)
         log_msg_exit ("copy: specify srckey dstkey");
@@ -676,7 +676,7 @@ void cmd_copy (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_commit");
 }
 
-void cmd_move (flux_t h, int argc, char **argv)
+void cmd_move (flux_t *h, int argc, char **argv)
 {
     if (argc != 2)
         log_msg_exit ("move: specify srckey dstkey");
@@ -686,7 +686,7 @@ void cmd_move (flux_t h, int argc, char **argv)
         log_err_exit ("kvs_commit");
 }
 
-void cmd_get_treeobj (flux_t h, int argc, char **argv)
+void cmd_get_treeobj (flux_t *h, int argc, char **argv)
 {
     char *treeobj = NULL;
     if (argc != 1)
@@ -697,7 +697,7 @@ void cmd_get_treeobj (flux_t h, int argc, char **argv)
     free (treeobj);
 }
 
-void cmd_getat (flux_t h, int argc, char **argv)
+void cmd_getat (flux_t *h, int argc, char **argv)
 {
     char *val = NULL;
     if (argc != 2)
@@ -708,7 +708,7 @@ void cmd_getat (flux_t h, int argc, char **argv)
     free (val);
 }
 
-void cmd_put_treeobj (flux_t h, int argc, char **argv)
+void cmd_put_treeobj (flux_t *h, int argc, char **argv)
 {
     if (argc != 1)
         log_msg_exit ("put-treeobj: specify key=val");
@@ -724,7 +724,7 @@ void cmd_put_treeobj (flux_t h, int argc, char **argv)
 
 }
 
-void cmd_readlinkat (flux_t h, int argc, char **argv)
+void cmd_readlinkat (flux_t *h, int argc, char **argv)
 {
     int i;
     char *target;

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -52,7 +52,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     char *message = NULL;
     size_t len = 0;

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -56,14 +56,14 @@ static const struct option longopts[] = {
     { 0, 0, 0, 0 },
 };
 
-void mod_lsmod (flux_t h, opt_t opt);
-void mod_rmmod (flux_t h, opt_t opt);
-void mod_insmod (flux_t h, opt_t opt);
-void mod_info (flux_t h, opt_t opt);
+void mod_lsmod (flux_t *h, opt_t opt);
+void mod_rmmod (flux_t *h, opt_t opt);
+void mod_insmod (flux_t *h, opt_t opt);
+void mod_info (flux_t *h, opt_t opt);
 
 typedef struct {
     const char *name;
-    void (*fun)(flux_t h, opt_t opt);
+    void (*fun)(flux_t *h, opt_t opt);
 } func_t;
 
 static func_t funcs[] = {
@@ -98,7 +98,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h = NULL;
+    flux_t *h = NULL;
     int ch;
     char *cmd;
     func_t *f;
@@ -195,7 +195,7 @@ void parse_modarg (const char *arg, char **name, char **path)
     *path = modpath;
 }
 
-void mod_info (flux_t h, opt_t opt)
+void mod_info (flux_t *h, opt_t opt)
 {
     char *modpath = NULL;
     char *modname = NULL;
@@ -229,7 +229,7 @@ char *getservice (const char *modname)
     return service;
 }
 
-void mod_insmod (flux_t h, opt_t opt)
+void mod_insmod (flux_t *h, opt_t opt)
 {
     char *modname;
     char *modpath;
@@ -271,7 +271,7 @@ void mod_insmod (flux_t h, opt_t opt)
         exit (1);
 }
 
-void mod_rmmod (flux_t h, opt_t opt)
+void mod_rmmod (flux_t *h, opt_t opt)
 {
     char *modname = NULL;
 
@@ -425,7 +425,7 @@ done:
     return rc;
 }
 
-void mod_lsmod (flux_t h, opt_t opt)
+void mod_lsmod (flux_t *h, opt_t opt)
 {
     char *service = "cmb";
 

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -48,7 +48,7 @@ struct ping_ctx {
     int count;          /* number of pings to send */
     int send_count;     /* sending count */
     bool batch;         /* begin receiving only after count sent */
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
 };
 

--- a/src/cmd/flux-snoop.c
+++ b/src/cmd/flux-snoop.c
@@ -75,7 +75,7 @@ zlist_t *subscriptions = NULL;
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     const char *uri = NULL;
     bool vopt = false;

--- a/src/cmd/flux-up.c
+++ b/src/cmd/flux-up.c
@@ -73,8 +73,8 @@ typedef struct {
     nodeset_t *unknown;
 } ns_t;
 
-static ns_t *ns_guess (flux_t h);
-static ns_t *ns_fromkvs (flux_t h);
+static ns_t *ns_guess (flux_t *h);
+static ns_t *ns_fromkvs (flux_t *h);
 static void ns_destroy (ns_t *ns);
 static void ns_print_down (ns_t *ns, fmt_t fmt);
 static void ns_print_up (ns_t *ns, fmt_t fmt);
@@ -82,7 +82,7 @@ static void ns_print_all (ns_t *ns, fmt_t fmt);
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     bool uopt = false;
     bool dopt = false;
@@ -159,7 +159,7 @@ static ns_t *ns_fromjson (const char *json_str)
     return ns;
 }
 
-static ns_t *ns_fromkvs (flux_t h)
+static ns_t *ns_fromkvs (flux_t *h)
 {
     char *json_str = NULL;
     ns_t *ns = NULL;
@@ -173,7 +173,7 @@ done:
     return ns;
 }
 
-static ns_t *ns_guess (flux_t h)
+static ns_t *ns_guess (flux_t *h)
 {
     ns_t *ns = xzmalloc (sizeof (*ns));
     uint32_t size, rank;

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -359,9 +359,9 @@ static void print_environment (struct environment *env)
     fflush(stdout);
 }
 
-flux_t builtin_get_flux_handle (optparse_t *p)
+flux_t *builtin_get_flux_handle (optparse_t *p)
 {
-    flux_t h = NULL;
+    flux_t *h = NULL;
     if ((h = optparse_get_data (p, "flux_t")))
         flux_incref (h);
     else if ((h = flux_open (NULL, 0)) == NULL)

--- a/src/common/libcompat/handle.c
+++ b/src/common/libcompat/handle.c
@@ -33,7 +33,7 @@
 
 #include "compat.h"
 
-int flux_sendmsg (flux_t h, zmsg_t **zmsg)
+int flux_sendmsg (flux_t *h, zmsg_t **zmsg)
 {
     if (flux_send (h, *zmsg, 0) < 0)
         return -1;
@@ -41,12 +41,12 @@ int flux_sendmsg (flux_t h, zmsg_t **zmsg)
     return 0;
 }
 
-flux_msg_t *flux_recvmsg (flux_t h, bool nonblock)
+flux_msg_t *flux_recvmsg (flux_t *h, bool nonblock)
 {
     return flux_recv (h, FLUX_MATCH_ANY, nonblock ? FLUX_O_NONBLOCK : 0);
 }
 
-flux_msg_t *flux_recvmsg_match (flux_t h, struct flux_match match,
+flux_msg_t *flux_recvmsg_match (flux_t *h, struct flux_match match,
                                 bool nonblock)
 {
     return flux_recv (h, match, nonblock ? FLUX_O_NONBLOCK : 0);

--- a/src/common/libcompat/handle.h
+++ b/src/common/libcompat/handle.h
@@ -6,13 +6,13 @@
 
 #include "src/common/libflux/message.h"
 
-int flux_sendmsg (flux_t h, flux_msg_t **msg)
+int flux_sendmsg (flux_t *h, flux_msg_t **msg)
                   __attribute__ ((deprecated));
 
-flux_msg_t *flux_recvmsg (flux_t h, bool nonblock)
+flux_msg_t *flux_recvmsg (flux_t *h, bool nonblock)
                           __attribute__ ((deprecated));
 
-flux_msg_t *flux_recvmsg_match (flux_t h, struct flux_match match,
+flux_msg_t *flux_recvmsg_match (flux_t *h, struct flux_match match,
                                 bool nonblock)
                                 __attribute__ ((deprecated));
 

--- a/src/common/libcompat/info.c
+++ b/src/common/libcompat/info.c
@@ -37,7 +37,7 @@
 #include "info.h"
 #include "compat.h"
 
-int flux_rank (flux_t h)
+int flux_rank (flux_t *h)
 {
     uint32_t rank;
     if (flux_get_rank (h, &rank) < 0)
@@ -49,7 +49,7 @@ int flux_rank (flux_t h)
     return rank;
 }
 
-int flux_size (flux_t h)
+int flux_size (flux_t *h)
 {
     uint32_t size;
     if (flux_get_size (h, &size) < 0)

--- a/src/common/libcompat/info.h
+++ b/src/common/libcompat/info.h
@@ -5,9 +5,9 @@
 
 #include "src/common/libflux/handle.h"
 
-int flux_rank (flux_t h)
+int flux_rank (flux_t *h)
                     __attribute__ ((deprecated));
-int flux_size (flux_t h)
+int flux_size (flux_t *h)
                     __attribute__ ((deprecated));
 
 #endif /* !_FLUX_COMPAT_INFO_H */

--- a/src/common/libcompat/reactor.c
+++ b/src/common/libcompat/reactor.c
@@ -56,14 +56,14 @@ struct msg_compat {
 };
 
 struct fd_compat {
-    flux_t h;
+    flux_t *h;
     flux_watcher_t *w;
     FluxFdHandler fn;
     void *arg;
 };
 
 struct timer_compat {
-    flux_t h;
+    flux_t *h;
     flux_watcher_t *w;
     FluxTmoutHandler fn;
     void *arg;
@@ -80,7 +80,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static struct ctx *getctx (flux_t h)
+static struct ctx *getctx (flux_t *h)
 {
     struct ctx *ctx = flux_aux_get (h, "reactor_compat");
 
@@ -120,7 +120,7 @@ static int libzmq_to_events (int events)
 
 /* message
  */
-void msg_compat_cb (flux_t h, flux_msg_handler_t *w,
+void msg_compat_cb (flux_t *h, flux_msg_handler_t *w,
                     const flux_msg_t *msg, void *arg)
 {
     struct msg_compat *compat = arg;
@@ -145,7 +145,7 @@ static void msg_compat_free (struct msg_compat *c)
     }
 }
 
-static int msghandler_add (flux_t h, int typemask, const char *pattern,
+static int msghandler_add (flux_t *h, int typemask, const char *pattern,
                          FluxMsgHandler cb, void *arg)
 {
     struct ctx *ctx = getctx (h);
@@ -170,13 +170,13 @@ static int msghandler_add (flux_t h, int typemask, const char *pattern,
     return 0;
 }
 
-int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
+int flux_msghandler_add (flux_t *h, int typemask, const char *pattern,
                          FluxMsgHandler cb, void *arg)
 {
     return msghandler_add (h, typemask, pattern, cb, arg);
 }
 
-int flux_msghandler_addvec (flux_t h, msghandler_t *hv, int len, void *arg)
+int flux_msghandler_addvec (flux_t *h, msghandler_t *hv, int len, void *arg)
 {
     int i;
 
@@ -187,7 +187,7 @@ int flux_msghandler_addvec (flux_t h, msghandler_t *hv, int len, void *arg)
     return 0;
 }
 
-void flux_msghandler_remove (flux_t h, int typemask, const char *pattern)
+void flux_msghandler_remove (flux_t *h, int typemask, const char *pattern)
 {
     struct ctx *ctx = getctx (h);
     struct msg_compat *c;
@@ -221,7 +221,7 @@ static void fd_compat_cb (flux_reactor_t *r, flux_watcher_t *w, int revents,
 }
 
 
-int flux_fdhandler_add (flux_t h, int fd, short events,
+int flux_fdhandler_add (flux_t *h, int fd, short events,
                         FluxFdHandler cb, void *arg)
 {
     struct ctx *ctx = getctx (h);
@@ -244,7 +244,7 @@ int flux_fdhandler_add (flux_t h, int fd, short events,
     return 0;
 }
 
-void flux_fdhandler_remove (flux_t h, int fd, short events)
+void flux_fdhandler_remove (flux_t *h, int fd, short events)
 {
     struct ctx *ctx = getctx (h);
     struct fd_compat *c;
@@ -276,7 +276,7 @@ static void timer_compat_cb (flux_reactor_t *r, flux_watcher_t *w,
         flux_reactor_stop_error (r);
 }
 
-int flux_tmouthandler_add (flux_t h, unsigned long msec, bool oneshot,
+int flux_tmouthandler_add (flux_t *h, unsigned long msec, bool oneshot,
                            FluxTmoutHandler cb, void *arg)
 {
     struct ctx *ctx = getctx (h);
@@ -303,7 +303,7 @@ int flux_tmouthandler_add (flux_t h, unsigned long msec, bool oneshot,
     return c->id;
 }
 
-void flux_tmouthandler_remove (flux_t h, int timer_id)
+void flux_tmouthandler_remove (flux_t *h, int timer_id)
 {
     struct ctx *ctx = getctx (h);
     struct timer_compat *c;
@@ -319,7 +319,7 @@ void flux_tmouthandler_remove (flux_t h, int timer_id)
 /* Newly deprecated message stuff
  */
 
-int flux_reactor_start (flux_t h)
+int flux_reactor_start (flux_t *h)
 {
     return flux_reactor_run (flux_get_reactor (h), 0);
 }

--- a/src/common/libcompat/reactor.h
+++ b/src/common/libcompat/reactor.h
@@ -10,10 +10,10 @@
  * Callbacks return 0 on success, -1 on error and set errno.
  * Error terminates reactor, and flux_reactor_start() returns -1.
  */
-typedef int (*FluxMsgHandler)(flux_t h, int typemask, flux_msg_t **msg,
+typedef int (*FluxMsgHandler)(flux_t *h, int typemask, flux_msg_t **msg,
                               void *arg);
-typedef int (*FluxFdHandler)(flux_t h, int fd, short revents, void *arg);
-typedef int (*FluxTmoutHandler)(flux_t h, void *arg);
+typedef int (*FluxFdHandler)(flux_t *h, int fd, short revents, void *arg);
+typedef int (*FluxTmoutHandler)(flux_t *h, void *arg);
 
 typedef struct {
     int typemask;
@@ -25,52 +25,52 @@ typedef struct {
  * matching typemask and pattern (glob) is received.  The callback is
  * added to the beginning of the msghandler list.
  */
-int flux_msghandler_add (flux_t h, int typemask, const char *pattern,
+int flux_msghandler_add (flux_t *h, int typemask, const char *pattern,
                          FluxMsgHandler cb, void *arg)
                          __attribute__ ((deprecated));
 
 /* Register a batch of FluxMsgHandler's
  */
-int flux_msghandler_addvec (flux_t h, msghandler_t *handlers, int len,
+int flux_msghandler_addvec (flux_t *h, msghandler_t *handlers, int len,
                             void *arg)
                             __attribute__ ((deprecated));
 
 /* Unregister a FluxMsgHandler callback.  Only the first callback with
  * identical typemask and pattern is removed.
  */
-void flux_msghandler_remove (flux_t h, int typemask, const char *pattern)
+void flux_msghandler_remove (flux_t *h, int typemask, const char *pattern)
                              __attribute__ ((deprecated));
 
 
 /* Register a FluxFdHandler callback to be called whenever an event
  * in the 'events' mask occurs on the given file descriptor 'fd'.
  */
-int flux_fdhandler_add (flux_t h, int fd, short events,
+int flux_fdhandler_add (flux_t *h, int fd, short events,
                         FluxFdHandler cb, void *arg)
                         __attribute__ ((deprecated));
 
 /* Unregister a FluxFdHandler callback.  Only the first callback with
  * identical fd and events is removed.
  */
-void flux_fdhandler_remove (flux_t h, int fd, short events)
+void flux_fdhandler_remove (flux_t *h, int fd, short events)
                             __attribute__ ((deprecated));
 
 
 /* Register a FluxTmoutHandler callback.  Returns timer_id or -1 on error.
  */
-int flux_tmouthandler_add (flux_t h, unsigned long msec, bool oneshot,
+int flux_tmouthandler_add (flux_t *h, unsigned long msec, bool oneshot,
                            FluxTmoutHandler cb, void *arg)
                            __attribute__ ((deprecated));
 
 /* Unregister a FluxTmoutHandler callback.
  */
-void flux_tmouthandler_remove (flux_t h, int timer_id)
+void flux_tmouthandler_remove (flux_t *h, int timer_id)
                                __attribute__ ((deprecated));
 
 
 /* Start the reactor.
  */
-int flux_reactor_start (flux_t h)
+int flux_reactor_start (flux_t *h)
                         __attribute__ ((deprecated));
 
 #endif /* !_FLUX_COMPAT_REACTOR_H */

--- a/src/common/libcompat/request.c
+++ b/src/common/libcompat/request.c
@@ -35,7 +35,7 @@
 
 #include "compat.h"
 
-int flux_json_request (flux_t h, uint32_t nodeid, uint32_t matchtag,
+int flux_json_request (flux_t *h, uint32_t nodeid, uint32_t matchtag,
                        const char *topic, json_object *in)
 {
     zmsg_t *zmsg;
@@ -69,7 +69,7 @@ done:
     return rc;
 }
 
-int flux_json_respond (flux_t h, json_object *out, zmsg_t **zmsg)
+int flux_json_respond (flux_t *h, json_object *out, zmsg_t **zmsg)
 {
     int rc = -1;
 

--- a/src/common/libcompat/request.h
+++ b/src/common/libcompat/request.h
@@ -17,7 +17,7 @@
  * This function does not wait for a response message.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_json_request (flux_t h, uint32_t nodeid, uint32_t matchtag,
+int flux_json_request (flux_t *h, uint32_t nodeid, uint32_t matchtag,
                        const char *topic, json_object *in)
                        __attribute__ ((deprecated));
 
@@ -26,7 +26,7 @@ int flux_json_request (flux_t h, uint32_t nodeid, uint32_t matchtag,
  * The original payload in the request, if any, is destroyed.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_json_respond (flux_t h, json_object *out, zmsg_t **zmsg)
+int flux_json_respond (flux_t *h, json_object *out, zmsg_t **zmsg)
                        __attribute__ ((deprecated));
 
 #endif /* !_FLUX_JSONC_REQUEST_H */

--- a/src/common/libcompat/rpc.c
+++ b/src/common/libcompat/rpc.c
@@ -34,7 +34,7 @@
 
 #include "compat.h"
 
-int flux_json_rpc (flux_t h, uint32_t nodeid, const char *topic,
+int flux_json_rpc (flux_t *h, uint32_t nodeid, const char *topic,
                    json_object *in, json_object **out)
 {
     flux_rpc_t *rpc;

--- a/src/common/libcompat/rpc.h
+++ b/src/common/libcompat/rpc.h
@@ -13,7 +13,7 @@
  * set and there is no JSON payload, or 'out' is not set and there is.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_json_rpc (flux_t h, uint32_t nodeid, const char *topic,
+int flux_json_rpc (flux_t *h, uint32_t nodeid, const char *topic,
                    json_object *in, json_object **out)
                    __attribute__ ((deprecated));
 

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -38,7 +38,7 @@
 typedef struct {
     zhash_t *hash;
     zlist_t *names;
-    flux_t h;
+    flux_t *h;
 } ctx_t;
 
 typedef struct {
@@ -54,7 +54,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     ctx_t *ctx = flux_aux_get (h, "flux::attr");
 
@@ -195,7 +195,7 @@ done:
     return rc;
 }
 
-const char *flux_attr_get (flux_t h, const char *name, int *flags)
+const char *flux_attr_get (flux_t *h, const char *name, int *flags)
 {
     ctx_t *ctx = getctx (h);
     attr_t *attr;
@@ -209,7 +209,7 @@ const char *flux_attr_get (flux_t h, const char *name, int *flags)
     return attr ? attr->val : NULL;
 }
 
-int flux_attr_set (flux_t h, const char *name, const char *val)
+int flux_attr_set (flux_t *h, const char *name, const char *val)
 {
     ctx_t *ctx = getctx (h);
 
@@ -218,7 +218,7 @@ int flux_attr_set (flux_t h, const char *name, const char *val)
     return 0;
 }
 
-int flux_attr_fake (flux_t h, const char *name, const char *val, int flags)
+int flux_attr_fake (flux_t *h, const char *name, const char *val, int flags)
 {
     ctx_t *ctx = getctx (h);
     attr_t *attr = attr_create (val, flags);
@@ -227,7 +227,7 @@ int flux_attr_fake (flux_t h, const char *name, const char *val, int flags)
     return 0;
 }
 
-const char *flux_attr_first (flux_t h)
+const char *flux_attr_first (flux_t *h)
 {
     ctx_t *ctx = getctx (h);
 
@@ -236,7 +236,7 @@ const char *flux_attr_first (flux_t h)
     return ctx->names ? zlist_first (ctx->names) : NULL;
 }
 
-const char *flux_attr_next (flux_t h)
+const char *flux_attr_next (flux_t *h)
 {
     ctx_t *ctx = flux_aux_get (h, "flux::attr");
 

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -14,15 +14,15 @@ enum {
     FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
 };
 
-const char *flux_attr_get (flux_t h, const char *name, int *flags);
+const char *flux_attr_get (flux_t *h, const char *name, int *flags);
 
-int flux_attr_set (flux_t h, const char *name, const char *val);
+int flux_attr_set (flux_t *h, const char *name, const char *val);
 
-int flux_attr_fake (flux_t h, const char *name, const char *val, int flags);
+int flux_attr_fake (flux_t *h, const char *name, const char *val, int flags);
 
-const char *flux_attr_first (flux_t h);
+const char *flux_attr_first (flux_t *h);
 
-const char *flux_attr_next (flux_t h);
+const char *flux_attr_next (flux_t *h);
 
 
 #endif /* !_FLUX_CORE_ATTR_H */

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -10,7 +10,7 @@
  ** Only handle implementation stuff below.
  ** Flux_t handle users should not use these interfaces.
  */
-typedef flux_t (connector_init_f)(const char *uri, int flags);
+typedef flux_t *(connector_init_f)(const char *uri, int flags);
 
 struct flux_handle_ops {
     int         (*setopt)(void *impl, const char *option,
@@ -28,8 +28,8 @@ struct flux_handle_ops {
     void        (*impl_destroy)(void *impl);
 };
 
-flux_t flux_handle_create (void *impl, const struct flux_handle_ops *ops, int flags);
-void flux_handle_destroy (flux_t *hp);
+flux_t *flux_handle_create (void *impl, const struct flux_handle_ops *ops, int flags);
+void flux_handle_destroy (flux_t **hp);
 
 #endif /* !_FLUX_CORE_CONNECTOR_H */
 

--- a/src/common/libflux/dispatch.c
+++ b/src/common/libflux/dispatch.c
@@ -57,7 +57,7 @@ struct fastpath {
 
 
 struct dispatch {
-    flux_t h;
+    flux_t *h;
     zlist_t *handlers;
     zlist_t *handlers_new;
     struct fastpath norm;
@@ -135,7 +135,7 @@ static void dispatch_destroy (void *arg)
     dispatch_usecount_decr (d);
 }
 
-static struct dispatch *dispatch_get (flux_t h)
+static struct dispatch *dispatch_get (flux_t *h)
 {
     struct dispatch *d = flux_aux_get (h, "flux::dispatch");
     if (!d) {
@@ -328,7 +328,7 @@ static int backlog_flush (flux_msg_handler_t *w)
     return rc;
 }
 
-int flux_sleep_on (flux_t h, struct flux_match match)
+int flux_sleep_on (flux_t *h, struct flux_match match)
 {
     struct dispatch *d = dispatch_get (h);
     int rc = -1;
@@ -718,7 +718,7 @@ void flux_msg_handler_destroy (flux_msg_handler_t *w)
     }
 }
 
-flux_msg_handler_t *flux_msg_handler_create (flux_t h,
+flux_msg_handler_t *flux_msg_handler_create (flux_t *h,
                                              const struct flux_match match,
                                              flux_msg_handler_f cb, void *arg)
 {
@@ -758,7 +758,7 @@ error:
     return NULL;
 }
 
-int flux_msg_handler_addvec (flux_t h, struct flux_msg_handler_spec tab[],
+int flux_msg_handler_addvec (flux_t *h, struct flux_msg_handler_spec tab[],
                              void *arg)
 {
     int i;

--- a/src/common/libflux/dispatch.h
+++ b/src/common/libflux/dispatch.h
@@ -6,10 +6,10 @@
 
 typedef struct flux_msg_handler flux_msg_handler_t;
 
-typedef void (*flux_msg_handler_f)(flux_t h, flux_msg_handler_t *w,
+typedef void (*flux_msg_handler_f)(flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg);
 
-flux_msg_handler_t *flux_msg_handler_create (flux_t h,
+flux_msg_handler_t *flux_msg_handler_create (flux_t *h,
                                              const struct flux_match match,
                                              flux_msg_handler_f cb, void *arg);
 
@@ -27,7 +27,7 @@ struct flux_msg_handler_spec {
 };
 #define FLUX_MSGHANDLER_TABLE_END { 0, NULL, NULL }
 
-int flux_msg_handler_addvec (flux_t h, struct flux_msg_handler_spec tab[],
+int flux_msg_handler_addvec (flux_t *h, struct flux_msg_handler_spec tab[],
                              void *arg);
 void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
 
@@ -38,7 +38,7 @@ void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
  * Currently only message handlers are started as coprocesses, if the
  * handle has FLUX_O_COPROC set.  This is used internally by flux_recv().
  */
-int flux_sleep_on (flux_t h, struct flux_match match);
+int flux_sleep_on (flux_t *h, struct flux_match match);
 
 #endif /* !_FLUX_CORE_DISPATCH_H */
 

--- a/src/common/libflux/ev_flux.c
+++ b/src/common/libflux/ev_flux.c
@@ -34,7 +34,7 @@
 
 /* Get flux poll events, converted to libev
  */
-static int get_pollevents (flux_t h)
+static int get_pollevents (flux_t *h)
 {
     int e = flux_pollevents (h);
     int events = 0;
@@ -72,7 +72,7 @@ static void check_cb (struct ev_loop *loop, ev_check *w, int revents)
         fw->cb (loop, fw, events);
 }
 
-int ev_flux_init (struct ev_flux *w, ev_flux_f cb, flux_t h, int events)
+int ev_flux_init (struct ev_flux *w, ev_flux_f cb, flux_t *h, int events)
 {
     w->cb = cb;
     w->h = h;

--- a/src/common/libflux/ev_flux.h
+++ b/src/common/libflux/ev_flux.h
@@ -12,14 +12,14 @@ struct ev_flux {
     ev_prepare  prepare_w;
     ev_idle     idle_w;
     ev_check    check_w;
-    flux_t      h;
+    flux_t      *h;
     int         pollfd;
     int         events;
     ev_flux_f   cb;
     void        *data;
 };
 
-int ev_flux_init (struct ev_flux *w, ev_flux_f cb, flux_t h, int events);
+int ev_flux_init (struct ev_flux *w, ev_flux_f cb, flux_t *h, int events);
 void ev_flux_start (struct ev_loop *loop, struct ev_flux *w);
 void ev_flux_stop (struct ev_loop *loop, struct ev_flux *w);
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -59,7 +59,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static logctx_t *getctx (flux_t h)
+static logctx_t *getctx (flux_t *h)
 {
     logctx_t *ctx = (logctx_t *)flux_aux_get (h, "flux::log");
     extern char *__progname;
@@ -74,20 +74,20 @@ static logctx_t *getctx (flux_t h)
     return ctx;
 }
 
-void flux_log_set_appname (flux_t h, const char *s)
+void flux_log_set_appname (flux_t *h, const char *s)
 {
     logctx_t *ctx = getctx (h);
     snprintf (ctx->appname, sizeof (ctx->appname), "%s", s);
 }
 
-void flux_log_set_procid (flux_t h, const char *s)
+void flux_log_set_procid (flux_t *h, const char *s)
 {
     logctx_t *ctx = getctx (h);
     snprintf (ctx->procid, sizeof (ctx->procid), "%s", s);
 }
 
 
-void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg)
+void flux_log_set_redirect (flux_t *h, flux_log_f fun, void *arg)
 {
     logctx_t *ctx = getctx (h);
     ctx->cb = fun;
@@ -99,7 +99,7 @@ const char *flux_strerror (int errnum)
     return zmq_strerror (errnum);
 }
 
-void flux_vlog (flux_t h, int level, const char *fmt, va_list ap)
+void flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)
 {
     logctx_t *ctx = getctx (h);
     int saved_errno = errno;
@@ -142,7 +142,7 @@ done:
     errno = saved_errno;
 }
 
-void flux_log (flux_t h, int lev, const char *fmt, ...)
+void flux_log (flux_t *h, int lev, const char *fmt, ...)
 {
     va_list ap;
 
@@ -151,7 +151,7 @@ void flux_log (flux_t h, int lev, const char *fmt, ...)
     va_end (ap);
 }
 
-void flux_log_verror (flux_t h, const char *fmt, va_list ap)
+void flux_log_verror (flux_t *h, const char *fmt, va_list ap)
 {
     int saved_errno = errno;
     char *s = xvasprintf (fmt, ap);
@@ -161,7 +161,7 @@ void flux_log_verror (flux_t h, const char *fmt, va_list ap)
     errno = saved_errno;
 }
 
-void flux_log_error (flux_t h, const char *fmt, ...)
+void flux_log_error (flux_t *h, const char *fmt, ...)
 {
     va_list ap;
 
@@ -170,7 +170,7 @@ void flux_log_error (flux_t h, const char *fmt, ...)
     va_end (ap);
 }
 
-static int dmesg_clear (flux_t h, int seq)
+static int dmesg_clear (flux_t *h, int seq)
 {
     flux_rpc_t *rpc;
     json_object *o = Jnew ();
@@ -189,7 +189,7 @@ done:
     return rc;
 }
 
-static flux_rpc_t *dmesg_rpc (flux_t h, int seq, bool follow)
+static flux_rpc_t *dmesg_rpc (flux_t *h, int seq, bool follow)
 {
     flux_rpc_t *rpc;
     json_object *o = Jnew ();
@@ -221,7 +221,7 @@ done:
     return rc;
 }
 
-int flux_dmesg (flux_t h, int flags, flux_log_f fun, void *arg)
+int flux_dmesg (flux_t *h, int flags, flux_log_f fun, void *arg)
 {
     int rc = -1;
     int seq = -1;

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -16,25 +16,25 @@ typedef void (*flux_log_f)(const char *buf, int len, void *arg);
 /* Set log appname for handle instance.
  * Value will be truncated after FLUX_MAX_APPNAME bytes.
  */
-void flux_log_set_appname (flux_t h, const char *s);
+void flux_log_set_appname (flux_t *h, const char *s);
 
 /* Set log procid for handle instance.
  * Value will be truncated after FLUX_MAX_PROCID bytes.
  */
-void flux_log_set_procid (flux_t h, const char *s);
+void flux_log_set_procid (flux_t *h, const char *s);
 
 /* Log a message at the specified level, as defined for syslog(3).
  */
-void flux_vlog (flux_t h, int level, const char *fmt, va_list ap);
-void flux_log (flux_t h, int level, const char *fmt, ...)
+void flux_vlog (flux_t *h, int level, const char *fmt, va_list ap);
+void flux_log (flux_t *h, int level, const char *fmt, ...)
               __attribute__ ((format (printf, 3, 4)));
 
 /* Log a message at LOG_ERR level, appending a colon, space, and error string.
  * The system 'errno' is assumed to be valid and contain an error code
  * that can be decoded with zmq_strerror(3).
  */
-void flux_log_verror (flux_t h, const char *fmt, va_list ap);
-void flux_log_error (flux_t h, const char *fmt, ...)
+void flux_log_verror (flux_t *h, const char *fmt, va_list ap);
+void flux_log_error (flux_t *h, const char *fmt, ...)
                  __attribute__ ((format (printf, 2, 3)));
 
 #define FLUX_LOG_ERROR(h) \
@@ -42,7 +42,7 @@ void flux_log_error (flux_t h, const char *fmt, ...)
 
 /* Redirect log messages to flux_log_f in this handle instance.
  */
-void flux_log_set_redirect (flux_t h, flux_log_f fun, void *arg);
+void flux_log_set_redirect (flux_t *h, flux_log_f fun, void *arg);
 
 
 /* Manipulate the broker's ring buffer.
@@ -52,7 +52,7 @@ enum {
     FLUX_DMESG_FOLLOW = 2,
 };
 
-int flux_dmesg (flux_t h, int flags, flux_log_f fun, void *arg);
+int flux_dmesg (flux_t *h, int flags, flux_log_f fun, void *arg);
 
 /* flux_log_f callback that prints a log message to a FILE stream
  * passed in as 'arg'.

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -7,7 +7,7 @@
 
 #include "message.h"
 
-typedef struct flux_handle_struct *flux_t;
+typedef struct flux_handle_struct flux_t;
 
 typedef struct {
     int request_tx;
@@ -62,36 +62,36 @@ enum {
  * A NULL uri selects the "local" connector with path derived from
  * FLUX_TMPDIR.
  */
-flux_t flux_open (const char *uri, int flags);
-void flux_close (flux_t h);
+flux_t *flux_open (const char *uri, int flags);
+void flux_close (flux_t *h);
 
 /* Increment internal reference count on 'h'.
  */
-void flux_incref (flux_t h);
+void flux_incref (flux_t *h);
 
 /* Get/set handle options.  Options are interpreted by connectors.
  * Returns 0 on success, or -1 on failure with errno set (e.g. EINVAL).
  */
-int flux_opt_set (flux_t h, const char *option, const void *val, size_t len);
-int flux_opt_get (flux_t h, const char *option, void *val, size_t len);
+int flux_opt_set (flux_t *h, const char *option, const void *val, size_t len);
+int flux_opt_get (flux_t *h, const char *option, void *val, size_t len);
 
 /* Register a handler for fatal handle errors.
  * A fatal error is ENOMEM or a handle send/recv error after which
  * it is inadvisable to continue using the handle.
  */
-void flux_fatal_set (flux_t h, flux_fatal_f fun, void *arg);
+void flux_fatal_set (flux_t *h, flux_fatal_f fun, void *arg);
 
 /* Set the fatality bit and call the user's fatal error handler, if any.
  * The fatal error handler will only be called once.
  */
-void flux_fatal_error (flux_t h, const char *fun, const char *msg);
+void flux_fatal_error (flux_t *h, const char *fun, const char *msg);
 #define FLUX_FATAL(h) do { \
     flux_fatal_error((h),__FUNCTION__,(strerror (errno))); \
 } while (0)
 
 /* Return true if the handle 'h' has encountered a fatal error.
  */
-bool flux_fatality (flux_t h);
+bool flux_fatality (flux_t *h);
 
 /* A mechanism is provide for users to attach auxiliary state to the flux_t
  * handle by name.  The flux_free_f, if non-NULL, will be called
@@ -99,27 +99,27 @@ bool flux_fatality (flux_t h);
  * Key names used internally by flux-core are prefixed with "flux::".
  */
 typedef void (*flux_free_f)(void *arg);
-void *flux_aux_get (flux_t h, const char *name);
-void flux_aux_set (flux_t h, const char *name, void *aux, flux_free_f destroy);
+void *flux_aux_get (flux_t *h, const char *name);
+void flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);
 
 /* Set/clear FLUX_O_* on a flux_t handle.
  */
-void flux_flags_set (flux_t h, int flags);
-void flux_flags_unset (flux_t h, int flags);
-int flux_flags_get (flux_t h);
+void flux_flags_set (flux_t *h, int flags);
+void flux_flags_unset (flux_t *h, int flags);
+int flux_flags_get (flux_t *h);
 
 /* Alloc/free matchtag for matched request/response.
  * This is mainly used internally by the rpc code.
  */
-uint32_t flux_matchtag_alloc (flux_t h, int flags);
-void flux_matchtag_free (flux_t h, uint32_t matchtag);
-uint32_t flux_matchtag_avail (flux_t h, int flags);
+uint32_t flux_matchtag_alloc (flux_t *h, int flags);
+void flux_matchtag_free (flux_t *h, uint32_t matchtag);
+uint32_t flux_matchtag_avail (flux_t *h, int flags);
 
 /* Send a message
  * flags may be 0 or FLUX_O_TRACE or FLUX_O_NONBLOCK (FLUX_O_COPROC is ignored)
  * Returns 0 on success, -1 on failure with errno set.
  */
-int flux_send (flux_t h, const flux_msg_t *msg, int flags);
+int flux_send (flux_t *h, const flux_msg_t *msg, int flags);
 
 /* Receive a message
  * flags may be 0 or FLUX_O_TRACE or FLUX_O_NONBLOCK (FLUX_O_COPROC is ignored)
@@ -128,20 +128,20 @@ int flux_send (flux_t h, const flux_msg_t *msg, int flags);
  * Returns message on success, NULL on failure.
  * The message must be destroyed with flux_msg_destroy().
  */
-flux_msg_t *flux_recv (flux_t h, struct flux_match match, int flags);
+flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags);
 
 /* Requeue a message
  * flags must be either FLUX_RQ_HEAD or FLUX_RQ_TAIL.
  * A message that is requeued will be seen again by flux_recv() and will
  * cause FLUX_POLLIN to be raised in flux_pollevents().
  */
-int flux_requeue (flux_t h, const flux_msg_t *msg, int flags);
+int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
 
 /* Obtain a bitmask of FLUX_POLL* bits for the flux handle.
  * Returns bitmask on success, -1 on error with errno set.
  * See flux_pollfd() comment below.
  */
-int flux_pollevents (flux_t h);
+int flux_pollevents (flux_t *h);
 
 /* Obtain a file descriptor that can be used to integrate a flux_t handle
  * into an external event loop.  When one of FLUX_POLLIN, FLUX_POLLOUT, or
@@ -152,17 +152,17 @@ int flux_pollevents (flux_t h);
  * that is used internally by the flux reactor.
  * Returns fd on sucess, -1 on failure with errno set.
  */
-int flux_pollfd (flux_t h);
+int flux_pollfd (flux_t *h);
 
 /* Event subscribe/unsubscribe.
  */
-int flux_event_subscribe (flux_t h, const char *topic);
-int flux_event_unsubscribe (flux_t h, const char *topic);
+int flux_event_subscribe (flux_t *h, const char *topic);
+int flux_event_unsubscribe (flux_t *h, const char *topic);
 
 /* Get/clear handle message counters.
  */
-void flux_get_msgcounters (flux_t h, flux_msgcounters_t *mcs);
-void flux_clr_msgcounters (flux_t h);
+void flux_get_msgcounters (flux_t *h, flux_msgcounters_t *mcs);
+void flux_clr_msgcounters (flux_t *h);
 
 #endif /* !_FLUX_CORE_HANDLE_H */
 

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -35,7 +35,7 @@
 
 #include "src/common/libutil/nodeset.h"
 
-int flux_get_size (flux_t h, uint32_t *size)
+int flux_get_size (flux_t *h, uint32_t *size)
 {
     const char *val;
 
@@ -45,7 +45,7 @@ int flux_get_size (flux_t h, uint32_t *size)
     return 0;
 }
 
-int flux_get_rank (flux_t h, uint32_t *rank)
+int flux_get_rank (flux_t *h, uint32_t *rank)
 {
     const char *val;
 
@@ -96,7 +96,7 @@ static int ns_subtract (nodeset_t *ns1, nodeset_t *ns2)
     return 0;
 }
 
-static nodeset_t *ns_special (flux_t h, const char *arg)
+static nodeset_t *ns_special (flux_t *h, const char *arg)
 {
     nodeset_t *ns = NULL;
     uint32_t rank, size;
@@ -142,7 +142,7 @@ error:
     return NULL;
 }
 
-const char *flux_get_nodeset (flux_t h, const char *nodeset,
+const char *flux_get_nodeset (flux_t *h, const char *nodeset,
                               const char *exclude)
 {
     char *mask = getenv ("FLUX_NODESET_MASK");

--- a/src/common/libflux/info.h
+++ b/src/common/libflux/info.h
@@ -5,11 +5,11 @@
 
 #include "handle.h"
 
-int flux_get_rank (flux_t h, uint32_t *rank);
+int flux_get_rank (flux_t *h, uint32_t *rank);
 
-int flux_get_size (flux_t h, uint32_t *size);
+int flux_get_size (flux_t *h, uint32_t *size);
 
-const char *flux_get_nodeset (flux_t h, const char *nodeset,
+const char *flux_get_nodeset (flux_t *h, const char *nodeset,
                               const char *exclude);
 
 #endif /* !_FLUX_CORE_INFO_H */

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -318,7 +318,7 @@ char *flux_modfind (const char *searchpath, const char *modname)
     return modpath;
 }
 
-int flux_rmmod (flux_t h, uint32_t nodeid, const char *name)
+int flux_rmmod (flux_t *h, uint32_t nodeid, const char *name)
 {
     flux_rpc_t *r = NULL;
     char *service = mod_service (name);
@@ -343,7 +343,7 @@ done:
     return rc;
 }
 
-int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
+int flux_lsmod (flux_t *h, uint32_t nodeid, const char *service,
                 flux_lsmod_f cb, void *arg)
 {
     flux_rpc_t *r = NULL;
@@ -380,7 +380,7 @@ done:
     return rc;
 }
 
-int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
+int flux_insmod (flux_t *h, uint32_t nodeid, const char *path,
                  int argc, char **argv)
 {
     flux_rpc_t *r = NULL;

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -35,14 +35,14 @@ typedef int (flux_lsmod_f)(const char *name, int size, const char *digest,
  * On success, the 'cb' function is called for each module with 'arg'.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_lsmod (flux_t h, uint32_t nodeid, const char *service,
+int flux_lsmod (flux_t *h, uint32_t nodeid, const char *service,
                 flux_lsmod_f cb, void *arg);
 
 /* Send a request to remove a module 'name'.
  * The request is sent to a service determined by parsing 'name'.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_rmmod (flux_t h, uint32_t nodeid, const char *name);
+int flux_rmmod (flux_t *h, uint32_t nodeid, const char *name);
 
 /* Send a request to insert a module 'path'.
  * The request is sent to a service determined by parsing the module's name,
@@ -50,7 +50,7 @@ int flux_rmmod (flux_t h, uint32_t nodeid, const char *name);
  * described by 'argc' and 'argv' to the module's 'mod_main' function.
  * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
+int flux_insmod (flux_t *h, uint32_t nodeid, const char *path,
                 int argc, char **argv);
 
 
@@ -60,7 +60,7 @@ int flux_insmod (flux_t h, uint32_t nodeid, const char *path,
 
 #define MOD_NAME(x) const char *mod_name = x
 #define MOD_SERVICE(x) const char *mod_service = x
-typedef int (mod_main_f)(flux_t h, int argc, char *argv[]);
+typedef int (mod_main_f)(flux_t *h, int argc, char *argv[]);
 
 
 /**

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -37,7 +37,7 @@
 #include "src/common/libutil/shortjson.h"
 
 
-int flux_panic (flux_t h, int rank, const char *msg)
+int flux_panic (flux_t *h, int rank, const char *msg)
 {
     uint32_t nodeid = rank < 0 ? FLUX_NODEID_ANY : rank;
     json_object *in = Jnew ();
@@ -56,7 +56,7 @@ done:
     return rc;
 }
 
-void flux_assfail (flux_t h, char *ass, char *file, int line)
+void flux_assfail (flux_t *h, char *ass, char *file, int line)
 {
     flux_log (h, LOG_CRIT, "assertion failure: %s:%d: %s", file, line, ass);
     sleep (5);

--- a/src/common/libflux/panic.h
+++ b/src/common/libflux/panic.h
@@ -3,9 +3,9 @@
 
 #include "handle.h"
 
-int flux_panic (flux_t h, int rank, const char *msg);
+int flux_panic (flux_t *h, int rank, const char *msg);
 
-void flux_assfail (flux_t h, char *ass, char *file, int line);
+void flux_assfail (flux_t *h, char *ass, char *file, int line);
 #define FASSERT(h, exp) if ((exp)); \
                         else flux_assfail(h, #exp, __FILE__, __LINE__)
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -101,7 +101,7 @@ flux_reactor_t *flux_reactor_create (int flags)
     return r;
 }
 
-int flux_set_reactor (flux_t h, flux_reactor_t *r)
+int flux_set_reactor (flux_t *h, flux_reactor_t *r)
 {
     if (flux_aux_get (h, "flux::reactor")) {
         errno = EEXIST;
@@ -111,7 +111,7 @@ int flux_set_reactor (flux_t h, flux_reactor_t *r)
     return 0;
 }
 
-flux_reactor_t *flux_get_reactor (flux_t h)
+flux_reactor_t *flux_get_reactor (flux_t *h)
 {
     flux_reactor_t *r = flux_aux_get (h, "flux::reactor");
     if (!r) {
@@ -296,7 +296,7 @@ static void handle_cb (struct ev_loop *loop, ev_flux *fw, int revents)
 }
 
 flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
-                                            flux_t h, int events,
+                                            flux_t *h, int events,
                                             flux_watcher_f cb, void *arg)
 {
     struct watcher_ops ops = {
@@ -314,7 +314,7 @@ flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
     return w;
 }
 
-flux_t flux_handle_watcher_get_flux (flux_watcher_t *w)
+flux_t *flux_handle_watcher_get_flux (flux_watcher_t *w)
 {
     assert (w->signature == HANDLE_SIG);
     ev_flux *fw = w->impl;

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -31,8 +31,8 @@ enum {
 flux_reactor_t *flux_reactor_create (int flags);
 void flux_reactor_destroy (flux_reactor_t *r);
 
-flux_reactor_t *flux_get_reactor (flux_t h);
-int flux_set_reactor (flux_t h, flux_reactor_t *r);
+flux_reactor_t *flux_get_reactor (flux_t *h);
+int flux_set_reactor (flux_t *h, flux_reactor_t *r);
 
 int flux_reactor_run (flux_reactor_t *r, int flags);
 
@@ -60,9 +60,9 @@ double flux_watcher_next_wakeup (flux_watcher_t *w);
  */
 
 flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
-                                            flux_t h, int events,
+                                            flux_t *h, int events,
                                             flux_watcher_f cb, void *arg);
-flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
+flux_t *flux_handle_watcher_get_flux (flux_watcher_t *w);
 
 /* file descriptor
  */

--- a/src/common/libflux/reduce.c
+++ b/src/common/libflux/reduce.c
@@ -47,7 +47,7 @@ struct flux_reduce_struct {
     bool old_flag;
 
     uint32_t rank;
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
     int flags;
 
@@ -74,7 +74,7 @@ static void timer_cb (flux_reactor_t *reactor, flux_watcher_t *w,
     flush_current (r);
 }
 
-flux_reduce_t *flux_reduce_create (flux_t h, struct flux_reduce_ops ops,
+flux_reduce_t *flux_reduce_create (flux_t *h, struct flux_reduce_ops ops,
                                    double timeout, void *arg, int flags)
 {
     if (!h || ((flags & FLUX_REDUCE_HWMFLUSH) && !ops.itemweight)

--- a/src/common/libflux/reduce.h
+++ b/src/common/libflux/reduce.h
@@ -25,7 +25,7 @@ enum {
     FLUX_REDUCE_OPT_WCOUNT = 4,
 };
 
-flux_reduce_t *flux_reduce_create (flux_t h, struct flux_reduce_ops ops,
+flux_reduce_t *flux_reduce_create (flux_t *h, struct flux_reduce_ops ops,
                                    double timeout, void *arg, int flags);
 
 void flux_reduce_destroy (flux_reduce_t *r);

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -33,7 +33,7 @@
 #include "src/common/libutil/xzmalloc.h"
 
 
-char *flux_lspeer (flux_t h, int rank)
+char *flux_lspeer (flux_t *h, int rank)
 {
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);
     flux_rpc_t *r = NULL;
@@ -50,7 +50,7 @@ done:
     return ret;
 }
 
-int flux_reparent (flux_t h, int rank, const char *uri)
+int flux_reparent (flux_t *h, int rank, const char *uri)
 {
     flux_rpc_t *r = NULL;
     uint32_t nodeid = (rank == -1 ? FLUX_NODEID_ANY : rank);

--- a/src/common/libflux/reparent.h
+++ b/src/common/libflux/reparent.h
@@ -3,9 +3,9 @@
 
 #include "handle.h"
 
-char *flux_lspeer (flux_t h, int rank);
+char *flux_lspeer (flux_t *h, int rank);
 
-int flux_reparent (flux_t h, int rank, const char *uri);
+int flux_reparent (flux_t *h, int rank, const char *uri);
 
 #endif /* !_FLUX_CORE_REPARENT_H */
 

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -177,7 +177,7 @@ error:
     return NULL;
 }
 
-static flux_msg_t *derive_response (flux_t h, const flux_msg_t *request,
+static flux_msg_t *derive_response (flux_t *h, const flux_msg_t *request,
                                     int errnum)
 {
     flux_msg_t *msg = NULL;
@@ -199,7 +199,7 @@ fatal:
     return NULL;
 }
 
-int flux_respond (flux_t h, const flux_msg_t *request,
+int flux_respond (flux_t *h, const flux_msg_t *request,
                   int errnum, const char *json_str)
 {
     flux_msg_t *msg = derive_response (h, request, errnum);
@@ -217,7 +217,7 @@ fatal:
     return -1;
 }
 
-int flux_respond_raw (flux_t h, const flux_msg_t *request,
+int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       int errnum, const void *data, int len)
 {
     flux_msg_t *msg = derive_response (h, request, errnum);

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -39,14 +39,14 @@ flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
  * If errnum is nonzero, payload argument is ignored.
  * All errors in this function are fatal - see flux_fatal_set().
  */
-int flux_respond (flux_t h, const flux_msg_t *request,
+int flux_respond (flux_t *h, const flux_msg_t *request,
                   int errnum, const char *json_str);
 
 /* Create a response to the provided request message with optional raw payload.
  * If errnum is nonzero, payload argument is ignored.
  * All errors in this function are fatal - see flux_fatal_set().
  */
-int flux_respond_raw (flux_t h, const flux_msg_t *request,
+int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       int errnum, const void *data, int len);
 
 #endif /* !_FLUX_CORE_RESPONSE_H */

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -48,7 +48,7 @@
 struct flux_rpc_struct {
     int magic;
     struct flux_match m;
-    flux_t h;
+    flux_t *h;
     flux_then_f then_cb;
     void *then_arg;
     flux_msg_handler_t *w;
@@ -102,7 +102,7 @@ void flux_rpc_destroy (flux_rpc_t *rpc)
     errno = saved_errno;
 }
 
-static flux_rpc_t *rpc_create (flux_t h, int rx_expected)
+static flux_rpc_t *rpc_create (flux_t *h, int rx_expected)
 {
     flux_rpc_t *rpc;
     int flags = 0;
@@ -291,7 +291,7 @@ done:
  * The reactor will repeatedly call the continuation (level-triggered)
  * until all received responses are consumed.
  */
-static void rpc_cb (flux_t h, flux_msg_handler_t *w,
+static void rpc_cb (flux_t *h, flux_msg_handler_t *w,
                     const flux_msg_t *msg, void *arg)
 {
     flux_rpc_t *rpc = arg;
@@ -358,7 +358,7 @@ bool flux_rpc_completed (flux_rpc_t *rpc)
     return false;
 }
 
-flux_rpc_t *flux_rpc (flux_t h,
+flux_rpc_t *flux_rpc (flux_t *h,
                       const char *topic,
                       const char *json_str,
                       uint32_t nodeid,
@@ -390,7 +390,7 @@ error:
     return NULL;
 }
 
-flux_rpc_t *flux_rpc_raw (flux_t h,
+flux_rpc_t *flux_rpc_raw (flux_t *h,
                           const char *topic,
                           const void *data,
                           int len,
@@ -421,7 +421,7 @@ error:
     return NULL;
 }
 
-flux_rpc_t *flux_rpc_multi (flux_t h,
+flux_rpc_t *flux_rpc_multi (flux_t *h,
                             const char *topic,
                             const char *json_str,
                             const char *nodeset,

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -16,14 +16,14 @@ typedef void (*flux_then_f)(flux_rpc_t *rpc, void *arg);
  * and return a flux_rpc_t object to allow the response to be handled.
  * On failure return NULL with errno set.
  */
-flux_rpc_t *flux_rpc (flux_t h, const char *topic, const char *json_str,
+flux_rpc_t *flux_rpc (flux_t *h, const char *topic, const char *json_str,
                       uint32_t nodeid, int flags);
 
 /* Send an RPC request to 'nodeid' with optional raw paylaod,
  * and return a flux_rpc_t object to allow the response to be handled.
  * On failure return NULL with errno set.
  */
-flux_rpc_t *flux_rpc_raw (flux_t h, const char *topic,
+flux_rpc_t *flux_rpc_raw (flux_t *h, const char *topic,
                           const void *data, int len,
                           uint32_t nodeid, int flags);
 
@@ -61,7 +61,7 @@ int flux_rpc_then (flux_rpc_t *rpc, flux_then_f cb, void *arg);
  * to allow responses to be handled.  "all" is a valid shorthand for
  * all ranks in the comms session.  On failure return NULL with errno set.
  */
-flux_rpc_t *flux_rpc_multi (flux_t h, const char *topic, const char *json_str,
+flux_rpc_t *flux_rpc_multi (flux_t *h, const char *topic, const char *json_str,
                             const char *nodeset, int flags);
 
 /* Returns true when all responses to an RPC have been received and consumed.

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -1066,7 +1066,7 @@ subprocess_manager_set (struct subprocess_manager *sm, sm_item_t item, ...)
             sm->wait_flags = va_arg (ap, int);
             break;
         case SM_FLUX:
-            sm->reactor = flux_get_reactor ((flux_t) va_arg (ap, void *));
+            sm->reactor = flux_get_reactor ((flux_t *) va_arg (ap, void *));
             break;
         case SM_REACTOR:
             sm->reactor = (flux_reactor_t *) va_arg (ap, void *);

--- a/src/common/libsubprocess/zio.c
+++ b/src/common/libsubprocess/zio.c
@@ -888,7 +888,7 @@ int zio_reactor_attach (zio_t *zio, flux_reactor_t *r)
     return (zio_bootstrap (zio));
 }
 
-int zio_flux_attach (zio_t *zio, flux_t h)
+int zio_flux_attach (zio_t *zio, flux_t *h)
 {
     return zio_reactor_attach (zio, flux_get_reactor (h));
 }

--- a/src/common/libsubprocess/zio.h
+++ b/src/common/libsubprocess/zio.h
@@ -104,9 +104,9 @@ int zio_write_json (zio_t *z, const char *json_str);
 int zio_reactor_attach (zio_t *z, flux_reactor_t *reactor);
 
 /*
- *   Same as above but use reactor associated with flux_t handle.
+ *   Same as above but use reactor associated with flux_t *handle.
  */
-int zio_flux_attach (zio_t *z, flux_t h);
+int zio_flux_attach (zio_t *z, flux_t *h);
 
 /*
  *  ZIO buffering options:

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -48,7 +48,7 @@ typedef struct {
     int fd_nonblock;
     struct flux_msg_iobuf outbuf;
     struct flux_msg_iobuf inbuf;
-    flux_t h;
+    flux_t *h;
 } ctx_t;
 
 static const struct flux_handle_ops handle_ops;
@@ -199,7 +199,7 @@ static int env_getint (char *name, int dflt)
 /* Path is interpreted as the directory containing the unix domain socket
  * and broker pid.
  */
-flux_t connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags)
 {
     ctx_t *c = NULL;
     struct sockaddr_un addr;

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -39,7 +39,7 @@
 #define CTX_MAGIC   0xf434aaa0
 typedef struct {
     int magic;
-    flux_t h;
+    flux_t *h;
 
     int pollfd;
     int pollevents;
@@ -118,7 +118,7 @@ static void op_fini (void *impl)
     free (c);
 }
 
-flux_t connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags)
 {
     ctx_t *c = malloc (sizeof (*c));
     if (!c) {

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -42,7 +42,7 @@ typedef struct {
     void *sock;
     char *uuid;
     char *uri;
-    flux_t h;
+    flux_t *h;
     zctx_t *zctx;
 } ctx_t;
 
@@ -278,7 +278,7 @@ static int connect_socket (ctx_t *ctx)
     return 0;
 }
 
-flux_t connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags)
 {
 #if HAVE_CALIPER
     cali_id_t uuid   = cali_create_attribute ("flux.uuid",

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -58,7 +58,7 @@ typedef struct {
     char **ssh_argv;
     int ssh_argc;
     struct popen2_child *p;
-    flux_t h;
+    flux_t *h;
 } ctx_t;
 
 static const struct flux_handle_ops handle_ops;
@@ -371,7 +371,7 @@ done:
 /* Path is interpreted as
  *   [user@]hostname[:port][/unix-path][?key=val[&key=val]...]
  */
-flux_t connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags)
 {
     ctx_t *c = NULL;
 

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -42,7 +42,7 @@ const double barrier_reduction_timeout_sec = 0.001;
 
 typedef struct {
     zhash_t *barriers;
-    flux_t h;
+    flux_t *h;
     bool timer_armed;
     flux_watcher_t *timer;
     uint32_t rank;
@@ -57,7 +57,7 @@ typedef struct _barrier_struct {
     int errnum;
 } barrier_t;
 
-static int exit_event_send (flux_t h, const char *name, int errnum);
+static int exit_event_send (flux_t *h, const char *name, int errnum);
 static void timeout_cb (flux_reactor_t *r, flux_watcher_t *w,
                         int revents, void *arg);
 
@@ -72,7 +72,7 @@ static void freectx (void *arg)
     }
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "flux::barrier");
 
@@ -178,7 +178,7 @@ static int timeout_reduction (const char *key, void *item, void *arg)
  * notification upon barrier termination.
  */
 
-static void enter_request_cb (flux_t h, flux_msg_handler_t *w,
+static void enter_request_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -257,7 +257,7 @@ static int disconnect (const char *key, void *item, void *arg)
     return 0;
 }
 
-static void disconnect_request_cb (flux_t h, flux_msg_handler_t *w,
+static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -278,7 +278,7 @@ static int send_enter_response (const char *key, void *item, void *arg)
     return 0;
 }
 
-static int exit_event_send (flux_t h, const char *name, int errnum)
+static int exit_event_send (flux_t *h, const char *name, int errnum)
 {
     json_object *o = Jnew ();
     flux_msg_t *msg = NULL;
@@ -297,7 +297,7 @@ done:
     return rc;
 }
 
-static void exit_event_cb (flux_t h, flux_msg_handler_t *w,
+static void exit_event_cb (flux_t *h, flux_msg_handler_t *w,
                            const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -345,7 +345,7 @@ static struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
     ctx_t *ctx = getctx (h);

--- a/src/modules/barrier/barrier.h
+++ b/src/modules/barrier/barrier.h
@@ -7,7 +7,7 @@
  * The 'name' must be unique across the comms session, or
  * if running in a Flux LWJ, may be NULL.
  */
-int flux_barrier (flux_t h, const char *name, int nprocs);
+int flux_barrier (flux_t *h, const char *name, int nprocs);
 
 #endif /* !_FLUX_BARRIER_H */
 

--- a/src/modules/barrier/libbarrier.c
+++ b/src/modules/barrier/libbarrier.c
@@ -41,7 +41,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     ctx_t *ctx = flux_aux_get (h, "barriercli");
     if (!ctx) {
@@ -55,7 +55,7 @@ static ctx_t *getctx (flux_t h)
     return ctx;
 }
 
-int flux_barrier (flux_t h, const char *name, int nprocs)
+int flux_barrier (flux_t *h, const char *name, int nprocs)
 {
     json_object *in = Jnew ();
     char *s = NULL;

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -55,7 +55,7 @@ typedef struct {
     int listen_fd;
     flux_watcher_t *listen_w;
     zlist_t *clients;
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
     uid_t session_owner;
     zhash_t *subscriptions;
@@ -105,7 +105,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "flux::local_connector");
 
@@ -143,7 +143,7 @@ static client_t * client_create (ctx_t *ctx, int fd)
 {
     client_t *c;
     socklen_t crlen = sizeof (c->ucred);
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
 
     c = xzmalloc (sizeof (*c));
     c->fd = fd;
@@ -521,7 +521,7 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
                             int revents, void *arg)
 {
     client_t *c = arg;
-    flux_t h = c->ctx->h;
+    flux_t *h = c->ctx->h;
     flux_msg_t *msg = NULL;
     int type;
 
@@ -581,7 +581,7 @@ disconnect:
  * Look up the sender uuid in clients hash and deliver.
  * Responses for disconnected clients are silently discarded.
  */
-static void response_cb (flux_t h, flux_msg_handler_t *w,
+static void response_cb (flux_t *h, flux_msg_handler_t *w,
                          const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -626,7 +626,7 @@ done:
 /* Received an event message from broker.
  * Find all subscribers and deliver.
  */
-static void event_cb (flux_t h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -665,7 +665,7 @@ static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
 {
     int fd = flux_fd_watcher_get_fd (w);
     ctx_t *ctx = arg;
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
 
     if (revents & FLUX_POLLIN) {
         client_t *c;
@@ -730,7 +730,7 @@ static struct flux_msg_handler_spec htab[] = {
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     ctx_t *ctx = getctx (h);
     char sockpath[PATH_MAX + 1];

--- a/src/modules/cron/datetime.c
+++ b/src/modules/cron/datetime.c
@@ -39,7 +39,7 @@
 #include "entry.h"
 
 struct datetime_entry {
-    flux_t h;
+    flux_t *h;
     flux_watcher_t *w;
     cronodate_t *d;
 };
@@ -117,7 +117,7 @@ static double reschedule_cb (flux_watcher_t *w, double now, void *arg)
     return (next);
 }
 
-static void *cron_datetime_create (flux_t h, cron_entry_t *e, json_object *arg)
+static void *cron_datetime_create (flux_t *h, cron_entry_t *e, json_object *arg)
 {
     struct datetime_entry *dt = datetime_entry_from_json (arg);
     if (dt == NULL)

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -37,7 +37,7 @@ typedef struct cron_entry cron_entry_t;
  */
 struct cron_entry_ops {
     // type creator from JSON request "arguments". Returns ptr to type object
-    void *(*create) (flux_t h, cron_entry_t *e, json_object *arg);
+    void *(*create) (flux_t *h, cron_entry_t *e, json_object *arg);
 
     // destroy type object contained in data
     void (*destroy) (void *data);

--- a/src/modules/cron/event.c
+++ b/src/modules/cron/event.c
@@ -31,7 +31,7 @@
 /* event handler
  */
 struct cron_event {
-    flux_t h;
+    flux_t *h;
     flux_msg_handler_t *mh;
     int paused;
     double min_interval;
@@ -52,7 +52,7 @@ static void ev_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     ev->paused = 0;
 }
 
-static void event_handler (flux_t h, flux_msg_handler_t *w,
+static void event_handler (flux_t *h, flux_msg_handler_t *w,
                            const flux_msg_t *msg, void *arg)
 {
     cron_entry_t *e = arg;
@@ -97,7 +97,7 @@ static void event_handler (flux_t h, flux_msg_handler_t *w,
     cron_entry_schedule_task (e);
 }
 
-static void *cron_event_create (flux_t h, cron_entry_t *e, json_object *arg)
+static void *cron_event_create (flux_t *h, cron_entry_t *e, json_object *arg)
 {
     struct cron_event *ev;
     int nth;

--- a/src/modules/cron/interval.c
+++ b/src/modules/cron/interval.c
@@ -46,7 +46,7 @@ static void interval_handler (flux_reactor_t *r, flux_watcher_t *w,
     cron_entry_schedule_task ((cron_entry_t *)arg);
 }
 
-static void *cron_interval_create (flux_t h, cron_entry_t *e, json_object *arg)
+static void *cron_interval_create (flux_t *h, cron_entry_t *e, json_object *arg)
 {
     struct cron_interval *iv;
     double i;

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -39,7 +39,7 @@
 #include "task.h"
 
 struct cron_task {
-    flux_t                h;      /* flux handle used to create this task   */
+    flux_t *              h;      /* flux handle used to create this task   */
     struct flux_match     match;  /* match object for message handler       */
     flux_msg_handler_t *  mh;     /* msg handler specific to this task      */
 
@@ -86,7 +86,7 @@ void cron_task_destroy (cron_task_t *t)
     free (t);
 }
 
-cron_task_t *cron_task_new (flux_t h, cron_task_complete_f cb, void *arg)
+cron_task_t *cron_task_new (flux_t *h, cron_task_complete_f cb, void *arg)
 {
     cron_task_t *t = xzmalloc (sizeof (*t));
     memset (t, 0, sizeof (*t));
@@ -130,7 +130,7 @@ static void cron_task_state_update (cron_task_t *t, const char *fmt, ...)
     va_end (ap);
 }
 
-static int io_handler (flux_t h, cron_task_t *t,
+static int io_handler (flux_t *h, cron_task_t *t,
     const char *json_str, json_object *resp)
 {
     const char *stream = "stdout";
@@ -161,7 +161,7 @@ static int io_handler (flux_t h, cron_task_t *t,
     return (0);
 }
 
-static int state_handler (flux_t h, cron_task_t *t, json_object *resp)
+static int state_handler (flux_t *h, cron_task_t *t, json_object *resp)
 {
     const char *state;
 
@@ -224,7 +224,7 @@ static void cron_task_handle_completion (cron_task_t *t)
         (*t->completion_cb) (t->h, t, t->arg);
 }
 
-static void exec_handler (flux_t h, flux_msg_handler_t *w,
+static void exec_handler (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     struct cron_task *t = arg;
@@ -271,7 +271,7 @@ static flux_msg_t *kill_request_create (cron_task_t *t, int sig)
 
 int cron_task_kill (cron_task_t *t, int sig)
 {
-    flux_t h = t->h;
+    flux_t *h = t->h;
     flux_msg_t *msg;
 
     if (!t->started || t->exited) {
@@ -350,7 +350,7 @@ int cron_task_run (cron_task_t *t,
     int rank, const char *cmd, const char *cwd,
     char *const env[])
 {
-    flux_t h = t->h;
+    flux_t *h = t->h;
     json_object *req = NULL;
     flux_msg_t *msg = NULL;
     int rc = -1;

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -33,25 +33,25 @@ typedef struct cron_task cron_task_t;
 
 /*  io callback fn for cron task
  */
-typedef void (*cron_task_io_f) (flux_t h, cron_task_t *t, void *arg,
+typedef void (*cron_task_io_f) (flux_t *h, cron_task_t *t, void *arg,
                                 bool is_stderr, void *data, int datalen,
                                 bool eof);
 
 /*  task state change handler for cron task, check state with
  *   cron_task_state().
  */
-typedef void (*cron_task_state_f) (flux_t h, cron_task_t *t, void *arg);
+typedef void (*cron_task_state_f) (flux_t *h, cron_task_t *t, void *arg);
 
 /*  task completion handler, the only required handler for cron task,
  *   called when task and its I/O have completed.
  */
-typedef void (*cron_task_complete_f) (flux_t h, cron_task_t *t, void *arg);
+typedef void (*cron_task_complete_f) (flux_t *h, cron_task_t *t, void *arg);
 
 /*  create a new cron task using flux handle `h`. Completion handler
  *   `cb` will be called when cron task has fully completed. All callbacks
  *   will be passed context `arg`.
  */
-cron_task_t *cron_task_new (flux_t h, cron_task_complete_f cb, void *arg);
+cron_task_t *cron_task_new (flux_t *h, cron_task_complete_f cb, void *arg);
 
 /*  destroy cron task `t`
  */

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -34,27 +34,27 @@ void kvsdir_incref (kvsdir_t *dir);
  * kvsdir_destroy(), and free() respectively.
  * These functions return -1 on error (errno set), 0 on success.
  */
-int kvs_get (flux_t h, const char *key, char **json_str);
-int kvs_get_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...)
+int kvs_get (flux_t *h, const char *key, char **json_str);
+int kvs_get_dir (flux_t *h, kvsdir_t **dirp, const char *fmt, ...)
         __attribute__ ((format (printf, 3, 4)));
-int kvs_get_string (flux_t h, const char *key, char **valp);
-int kvs_get_int (flux_t h, const char *key, int *valp);
-int kvs_get_int64 (flux_t h, const char *key, int64_t *valp);
-int kvs_get_double (flux_t h, const char *key, double *valp);
-int kvs_get_boolean (flux_t h, const char *key, bool *valp);
-int kvs_get_symlink (flux_t h, const char *key, char **valp);
+int kvs_get_string (flux_t *h, const char *key, char **valp);
+int kvs_get_int (flux_t *h, const char *key, int *valp);
+int kvs_get_int64 (flux_t *h, const char *key, int64_t *valp);
+int kvs_get_double (flux_t *h, const char *key, double *valp);
+int kvs_get_boolean (flux_t *h, const char *key, bool *valp);
+int kvs_get_symlink (flux_t *h, const char *key, char **valp);
 
 /* Get treeobj associated with a key.  Caller must free.
  */
-int kvs_get_treeobj (flux_t h, const char *key, char **treeobj);
+int kvs_get_treeobj (flux_t *h, const char *key, char **treeobj);
 
 /* Like kvs_get() but lookup is relative to 'treeobj'.
  */
-int kvs_getat (flux_t h, const char *treeobj,
+int kvs_getat (flux_t *h, const char *treeobj,
                const char *key, char **json_str);
-int kvs_get_dirat (flux_t h, const char *treeobj,
+int kvs_get_dirat (flux_t *h, const char *treeobj,
                    const char *key, kvsdir_t **dirp);
-int kvs_get_symlinkat (flux_t h, const char *treeobj,
+int kvs_get_symlinkat (flux_t *h, const char *treeobj,
                                const char *key, char **val);
 
 
@@ -65,23 +65,23 @@ int kvs_get_symlinkat (flux_t h, const char *treeobj,
  * callback is freed when the callback returns.  If a value is unset, the
  * callback gets errnum = ENOENT.
  */
-int kvs_watch (flux_t h, const char *key, kvs_set_f set, void *arg);
-int kvs_watch_dir (flux_t h, kvs_set_dir_f set, void *arg,
+int kvs_watch (flux_t *h, const char *key, kvs_set_f set, void *arg);
+int kvs_watch_dir (flux_t *h, kvs_set_dir_f set, void *arg,
                    const char *fmt, ...)
         __attribute__ ((format (printf, 4, 5)));
-int kvs_watch_string (flux_t h, const char *key, kvs_set_string_f set,
+int kvs_watch_string (flux_t *h, const char *key, kvs_set_string_f set,
                       void *arg);
-int kvs_watch_int (flux_t h, const char *key, kvs_set_int_f set, void *arg);
-int kvs_watch_int64 (flux_t h, const char *key, kvs_set_int64_f set, void *arg);
-int kvs_watch_double (flux_t h, const char *key, kvs_set_double_f set,
+int kvs_watch_int (flux_t *h, const char *key, kvs_set_int_f set, void *arg);
+int kvs_watch_int64 (flux_t *h, const char *key, kvs_set_int64_f set, void *arg);
+int kvs_watch_double (flux_t *h, const char *key, kvs_set_double_f set,
                       void *arg);
-int kvs_watch_boolean (flux_t h, const char *key, kvs_set_boolean_f set,
+int kvs_watch_boolean (flux_t *h, const char *key, kvs_set_boolean_f set,
                        void *arg);
 
 /* Cancel a kvs_watch, freeing server-side state, and unregistering any
  * callback.  Returns 0 on success, or -1 with errno set on error.
  */
-int kvs_unwatch (flux_t h, const char *key);
+int kvs_unwatch (flux_t *h, const char *key);
 
 /* While the above callback interface makes sense in plugin context,
  * the following is better for API context.  'valp' is an IN/OUT parameter.
@@ -92,25 +92,25 @@ int kvs_unwatch (flux_t h, const char *key);
  * If the key is not set, ENOENT is returned without affecting *valp.
  * FIXME: add more types.
  */
-int kvs_watch_once (flux_t h, const char *key, char **json_str);
-int kvs_watch_once_dir (flux_t h, kvsdir_t **dirp, const char *fmt, ...)
+int kvs_watch_once (flux_t *h, const char *key, char **json_str);
+int kvs_watch_once_dir (flux_t *h, kvsdir_t **dirp, const char *fmt, ...)
         __attribute__ ((format (printf, 3, 4)));
-int kvs_watch_once_int (flux_t h, const char *key, int *valp);
+int kvs_watch_once_int (flux_t *h, const char *key, int *valp);
 
 /* kvs_put() and kvs_put_string() both make copies of the value argument
  * The caller retains ownership of the original.
  * These functions return -1 on error (errno set), 0 on success.
  */
-int kvs_put (flux_t h, const char *key, const char *json_str);
-int kvs_put_string (flux_t h, const char *key, const char *val);
-int kvs_put_int (flux_t h, const char *key, int val);
-int kvs_put_int64 (flux_t h, const char *key, int64_t val);
-int kvs_put_double (flux_t h, const char *key, double val);
-int kvs_put_boolean (flux_t h, const char *key, bool val);
+int kvs_put (flux_t *h, const char *key, const char *json_str);
+int kvs_put_string (flux_t *h, const char *key, const char *val);
+int kvs_put_int (flux_t *h, const char *key, int val);
+int kvs_put_int64 (flux_t *h, const char *key, int64_t val);
+int kvs_put_double (flux_t *h, const char *key, double val);
+int kvs_put_boolean (flux_t *h, const char *key, bool val);
 
 /* As above but associate a preconstructed treeobj with key.
  */
-int kvs_put_treeobj (flux_t h, const char *key, const char *treeobj);
+int kvs_put_treeobj (flux_t *h, const char *key, const char *treeobj);
 
 /* An iterator interface for walking the list of names in a kvsdir_t
  * returned by kvs_get_dir().  kvsitr_create() always succeeds.
@@ -148,12 +148,12 @@ int kvsdir_get_size (kvsdir_t *dir);
  * the idiom: "unlink a; put a.a; put a.b; commit" should be avoided.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_unlink (flux_t h, const char *key);
+int kvs_unlink (flux_t *h, const char *key);
 
 /* Create symlink.  kvsdir_symlink creates it relatived to 'dir'.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_symlink (flux_t h, const char *key, const char *target);
+int kvs_symlink (flux_t *h, const char *key, const char *target);
 
 /* Create an empty directory.  kvsdir_mkdir creates it relative to 'dir'.
  * Usually this is not necessary, as kvs_put() will create directories
@@ -164,20 +164,20 @@ int kvs_symlink (flux_t h, const char *key, const char *target);
  * the idiom: "mkdir a; put a.a; put a.b; commit" should be avoided.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_mkdir (flux_t h, const char *key);
+int kvs_mkdir (flux_t *h, const char *key);
 
 /* kvs_commit() must be called after kvs_put*, kvs_unlink, and kvs_mkdir
  * to finalize the update.  The new data is immediately available on
  * the calling node when the commit returns.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_commit (flux_t h);
+int kvs_commit (flux_t *h);
 
 /* kvs_commit_begin() sends the commit request and returns immediately.
  * kvs_commit_finish() blocks until the response is received, then returns.
  * Use flux_rpc_then() to arrange for the commit to complete asynchronously.
  */
-flux_rpc_t *kvs_commit_begin (flux_t h);
+flux_rpc_t *kvs_commit_begin (flux_t *h);
 int kvs_commit_finish (flux_rpc_t *rpc);
 
 /* kvs_fence() is a collective commit operation.  nprocs tasks make the
@@ -190,35 +190,35 @@ int kvs_commit_finish (flux_rpc_t *rpc);
  * queued in the handle become part of the fence.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_fence (flux_t h, const char *name, int nprocs);
+int kvs_fence (flux_t *h, const char *name, int nprocs);
 
 /* kvs_fence_begin() sends the fence request and returns immediately.
  * kvs_fence_finish() blocks until the response is received, then returns.
  * Use flux_rpc_then() to arrange for the fence to complete asynchronously.
  */
-flux_rpc_t *kvs_fence_begin (flux_t h, const char *name, int nprocs);
+flux_rpc_t *kvs_fence_begin (flux_t *h, const char *name, int nprocs);
 int kvs_fence_finish (flux_rpc_t *rpc);
 
 /* Operations (put, unlink, symlink, mkdir) may be associated with a named
  * fence by setting the fence context to that name before issuing them.
  * When the fence context is clear (the default), operations are anonymous.
  */
-void kvs_fence_set_context (flux_t h, const char *name);
-void kvs_fence_clear_context (flux_t h);
+void kvs_fence_set_context (flux_t *h, const char *name);
+void kvs_fence_clear_context (flux_t *h);
 
 /* Synchronization:
  * Process A commits data, then gets the store version V and sends it to B.
  * Process B waits for the store version to be >= V, then reads data.
  */
-int kvs_get_version (flux_t h, int *versionp);
-int kvs_wait_version (flux_t h, int version);
+int kvs_get_version (flux_t *h, int *versionp);
+int kvs_wait_version (flux_t *h, int version);
 
 /* Garbage collect the cache.  On the root node, drop all data that
  * doesn't have a reference in the namespace.  On other nodes, the entire
  * cache is dropped and will be reloaded on demand.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_dropcache (flux_t h);
+int kvs_dropcache (flux_t *h);
 
 /* kvsdir_ convenience functions
  * They behave exactly like their kvs_ counterparts, except the 'key' path
@@ -247,8 +247,8 @@ int kvsdir_mkdir (kvsdir_t *dir, const char *key);
 
 /* Copy/move a key to a new name.  If 'from' is a directory, copy recursively.
  */
-int kvs_copy (flux_t h, const char *from, const char *to);
-int kvs_move (flux_t h, const char *from, const char *to);
+int kvs_copy (flux_t *h, const char *from, const char *to);
+int kvs_move (flux_t *h, const char *from, const char *to);
 
 #endif /* !_FLUX_CORE_KVS_H */
 

--- a/src/modules/kvs/kvs_deprecated.h
+++ b/src/modules/kvs/kvs_deprecated.h
@@ -11,16 +11,16 @@
 typedef int (*kvs_set_obj_f)(const char *key, json_object *val, void *arg,
                              int errnum);
 
-int kvs_get_obj (flux_t h, const char *key, json_object **valp)
+int kvs_get_obj (flux_t *h, const char *key, json_object **valp)
                  __attribute__ ((deprecated));
 
-int kvs_watch_obj (flux_t h, const char *key, kvs_set_obj_f set, void *arg)
+int kvs_watch_obj (flux_t *h, const char *key, kvs_set_obj_f set, void *arg)
                    __attribute__ ((deprecated));
 
-int kvs_watch_once_obj (flux_t h, const char *key, json_object **valp)
+int kvs_watch_once_obj (flux_t *h, const char *key, json_object **valp)
                         __attribute__ ((deprecated));
 
-int kvs_put_obj (flux_t h, const char *key, json_object *val)
+int kvs_put_obj (flux_t *h, const char *key, json_object *val)
                  __attribute__ ((deprecated));
 
 int kvsdir_get_obj (kvsdir_t *dir, const char *key, json_object **valp)

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -9,7 +9,7 @@ void wait_cb (void *arg)
     (*count)++;
 }
 
-void msghand (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg, void *arg)
+void msghand (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, void *arg)
 {
     int *count = arg;
     (*count)++;

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -35,7 +35,7 @@
 
 struct handler {
     flux_msg_handler_f cb;
-    flux_t h;
+    flux_t *h;
     flux_msg_handler_t *w;
     flux_msg_t *msg;
     void *arg;
@@ -74,7 +74,7 @@ wait_t *wait_create (wait_cb_f cb, void *arg)
     return w;
 }
 
-wait_t *wait_create_msg_handler (flux_t h, flux_msg_handler_t *wh,
+wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *wh,
                                  const flux_msg_t *msg,
                                  flux_msg_handler_f cb, void *arg)
 {

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -52,7 +52,7 @@ void wait_runqueue (waitqueue_t *q);
  * The message handler will be reinvoked once the wait_t usecount reaches zero.
  * Message will be copied and destroyed with the wait_t.
  */
-wait_t *wait_create_msg_handler (flux_t h, flux_msg_handler_t *w,
+wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *w,
                                  const flux_msg_t *msg,
                                  flux_msg_handler_f cb, void *arg);
 

--- a/src/modules/libjsc/jstatctl.h
+++ b/src/modules/libjsc/jstatctl.h
@@ -94,7 +94,7 @@ typedef int (*jsc_handler_f)(const char *base_jcb, void *arg, int errnum);
  * multiple times. The callbacks will be invoked in the order
  * they are registered. Returns 0 on success; otherwise -1.
  */
-int jsc_notify_status (flux_t h, jsc_handler_f callback, void *d);
+int jsc_notify_status (flux_t *h, jsc_handler_f callback, void *d);
 
 /**
  * Query the "key" attribute of JCB of "jobid." The JCB info on this attribute
@@ -103,7 +103,7 @@ int jsc_notify_status (flux_t h, jsc_handler_f callback, void *d);
  * are trasferred to "jcb," so that json_object_put (*jcb) will free this hierarchy
  * in its entirety.  Returns 0 on success; otherwise -1.
  */
-int jsc_query_jcb (flux_t h, int64_t jobid, const char *key, char **jcb);
+int jsc_query_jcb (flux_t *h, int64_t jobid, const char *key, char **jcb);
 
 
 /**
@@ -112,7 +112,7 @@ int jsc_query_jcb (flux_t h, int64_t jobid, const char *key, char **jcb);
  * This will not release "jcb," so it is the caller's responsibility to
  * free "jcb."
  */
-int jsc_update_jcb (flux_t h, int64_t jobid, const char *key, const char *jcb);
+int jsc_update_jcb (flux_t *h, int64_t jobid, const char *key, const char *jcb);
 
 
 /**

--- a/src/modules/libjsc/jstatctl_deprecated.h
+++ b/src/modules/libjsc/jstatctl_deprecated.h
@@ -30,12 +30,12 @@
 
 typedef int (*jsc_handler_obj_f)(json_object *base_jcb, void *arg, int errnum);
 
-int jsc_notify_status_obj (flux_t h, jsc_handler_obj_f callback, void *d)
+int jsc_notify_status_obj (flux_t *h, jsc_handler_obj_f callback, void *d)
                            __attribute__ ((deprecated));
-int jsc_query_jcb_obj (flux_t h, int64_t jobid, const char *key,
+int jsc_query_jcb_obj (flux_t *h, int64_t jobid, const char *key,
                        json_object **jcb)
                        __attribute__ ((deprecated));
-int jsc_update_jcb_obj (flux_t h, int64_t jobid, const char *key,
+int jsc_update_jcb_obj (flux_t *h, int64_t jobid, const char *key,
                         json_object *jcb)
                        __attribute__ ((deprecated));
 

--- a/src/modules/libkz/kz.c
+++ b/src/modules/libkz/kz.c
@@ -71,7 +71,7 @@ struct kz_struct {
     int flags;
     char *name;
     char *stream;
-    flux_t h;
+    flux_t *h;
     int seq;
     kvsdir_t *dir;
     kz_ready_f ready_cb;
@@ -94,7 +94,7 @@ static void kz_destroy (kz_t *kz)
     free (kz);
 }
 
-static bool key_exists (flux_t h, const char *key)
+static bool key_exists (flux_t *h, const char *key)
 {
     char *json_str = NULL;
     bool ret = false;
@@ -106,7 +106,7 @@ static bool key_exists (flux_t h, const char *key)
     return ret;
 }
 
-kz_t *kz_open (flux_t h, const char *name, int flags)
+kz_t *kz_open (flux_t *h, const char *name, int flags)
 {
     kz_t *kz = xzmalloc (sizeof (*kz));
 
@@ -155,7 +155,7 @@ static int kz_fence (kz_t *kz)
     return rc;
 }
 
-kz_t *kz_gopen (flux_t h, const char *grpname, int nprocs,
+kz_t *kz_gopen (flux_t *h, const char *grpname, int nprocs,
                const char *name, int flags)
 {
     kz_t *kz;

--- a/src/modules/libkz/kz.h
+++ b/src/modules/libkz/kz.h
@@ -28,13 +28,13 @@ enum kz_flags {
 
 /* Prepare to read or write a KVS stream.
  */
-kz_t *kz_open (flux_t h, const char *name, int flags);
+kz_t *kz_open (flux_t *h, const char *name, int flags);
 
 /* Prepare to write to one KVS stream that is a part of a group.
  * The kvs_commit()s normally issued at open and close are replaced with
  * a kvs_fence().
  */
-kz_t *kz_gopen (flux_t h, const char *grpname, int nprocs,
+kz_t *kz_gopen (flux_t *h, const char *grpname, int nprocs,
                const char *name, int flags);
 
 /* Write one block of data to a KVS stream.  Unless kz was opened with

--- a/src/modules/live/liblive.c
+++ b/src/modules/live/liblive.c
@@ -29,7 +29,7 @@
 
 #include "src/common/libutil/shortjson.h"
 
-int flux_failover (flux_t h, uint32_t rank)
+int flux_failover (flux_t *h, uint32_t rank)
 {
     flux_rpc_t *rpc;
     int rc = -1;
@@ -44,7 +44,7 @@ done:
     return rc;
 }
 
-int flux_recover (flux_t h, uint32_t rank)
+int flux_recover (flux_t *h, uint32_t rank)
 {
     flux_rpc_t *rpc;
     int rc = -1;
@@ -59,7 +59,7 @@ done:
     return rc;
 }
 
-int flux_recover_all (flux_t h)
+int flux_recover_all (flux_t *h)
 {
     int rc = -1;
     flux_msg_t *msg;

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -126,7 +126,7 @@ typedef struct {
     flux_reduce_t *r;
     ns_t *ns;           /* master only */
     json_object *topo;          /* master only */
-    flux_t h;
+    flux_t *h;
     optparse_t *opts;
 } ctx_t;
 
@@ -177,7 +177,7 @@ static void freectx (void *arg)
     }
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     ctx_t *ctx = flux_aux_get (h, "flux::live");
     int n;
@@ -391,7 +391,7 @@ static int recover (ctx_t *ctx)
     return reparent (ctx, oldrank, newp);
 }
 
-static void cstate_cb (flux_t h, flux_msg_handler_t *w,
+static void cstate_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -471,7 +471,7 @@ static void cstate_change (ctx_t *ctx, child_t *c, cstate_t newstate)
  * which is indexed by peer socket id.
  * The socket id is the stringified rank for cmbds.
  */
-static void hb_cb (flux_t h, flux_msg_handler_t *w,
+static void hb_cb (flux_t *h, flux_msg_handler_t *w,
                    const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -574,7 +574,7 @@ static int slow_idle_cb (const char *key, int val, void *arg, int errnum)
 
 /* Goodbye request is fire and forget.
  */
-static void goodbye_request_cb (flux_t h, flux_msg_handler_t *w,
+static void goodbye_request_cb (flux_t *h, flux_msg_handler_t *w,
                                 const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -969,7 +969,7 @@ static void hello_source (ctx_t *ctx, const char *prank, int crank)
 
 /* push request is fire and forget.
  */
-static void push_request_cb (flux_t h, flux_msg_handler_t *w,
+static void push_request_cb (flux_t *h, flux_msg_handler_t *w,
                              const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -993,7 +993,7 @@ done:
 /* hello: parents discover their children, and children discover their
  * grandparents which are potential failover candidates.
  */
-static void hello_request_cb (flux_t h, flux_msg_handler_t *w,
+static void hello_request_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -1079,7 +1079,7 @@ done:
     return rc;
 }
 
-static void failover_request_cb (flux_t h, flux_msg_handler_t *w,
+static void failover_request_cb (flux_t *h, flux_msg_handler_t *w,
                                  const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -1097,7 +1097,7 @@ done:
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static void recover_request_cb (flux_t h, flux_msg_handler_t *w,
+static void recover_request_cb (flux_t *h, flux_msg_handler_t *w,
                                 const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -1115,7 +1115,7 @@ done:
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static void recover_event_cb (flux_t h, flux_msg_handler_t *w,
+static void recover_event_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -1148,7 +1148,7 @@ static struct optparse_option opts[] = {
     OPTPARSE_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
     ctx_t *ctx = getctx (h);

--- a/src/modules/live/live.h
+++ b/src/modules/live/live.h
@@ -3,9 +3,9 @@
 
 #include <flux/core.h>
 
-int flux_failover (flux_t h, uint32_t rank);
-int flux_recover (flux_t h, uint32_t rank);
-int flux_recover_all (flux_t h);
+int flux_failover (flux_t *h, uint32_t rank);
+int flux_recover (flux_t *h, uint32_t rank);
+int flux_recover_all (flux_t *h);
 
 #endif /* !_FLUX_CORE_LIVE_H */
 

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -88,7 +88,7 @@ static struct optparse_option opts[] = {
     OPTPARSE_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     optparse_t *p = optparse_create ("pymod");
     if (optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS)

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -47,7 +47,7 @@ typedef struct
     bool walk_topology;
 } ctx_t;
 
-static int ctx_hwloc_init (flux_t h, ctx_t *ctx)
+static int ctx_hwloc_init (flux_t *h, ctx_t *ctx)
 {
     int ret = -1;
     char *key, *path = NULL;
@@ -130,7 +130,7 @@ static void resource_hwloc_ctx_destroy (ctx_t *ctx)
     }
 }
 
-static ctx_t *resource_hwloc_ctx_create (flux_t h)
+static ctx_t *resource_hwloc_ctx_create (flux_t *h)
 {
     ctx_t *ctx = xzmalloc (sizeof(ctx_t));
     if (flux_get_rank (h, &ctx->rank) < 0) {
@@ -147,7 +147,7 @@ error:
     return NULL;
 }
 
-static int load_xml_to_kvs (flux_t h, ctx_t *ctx)
+static int load_xml_to_kvs (flux_t *h, ctx_t *ctx)
 {
     char *xml_path = NULL;
     char *buffer = NULL;
@@ -208,7 +208,7 @@ static char *escape_and_join_kvs_path (const char *base,
     return ret_str;
 }
 
-static int walk_topology (flux_t h,
+static int walk_topology (flux_t *h,
                           hwloc_topology_t topology,
                           hwloc_obj_t obj,
                           const char *path)
@@ -266,7 +266,7 @@ done:
     return ret;
 }
 
-static int load_info_to_kvs (flux_t h, ctx_t *ctx)
+static int load_info_to_kvs (flux_t *h, ctx_t *ctx)
 {
     char *base_path = NULL;
     int ret = -1, i;
@@ -315,7 +315,7 @@ done:
     return ret;
 }
 
-static int load_hwloc (flux_t h, ctx_t *ctx)
+static int load_hwloc (flux_t *h, ctx_t *ctx)
 {
     uint32_t size;
     char *completion_path = NULL;
@@ -347,7 +347,7 @@ done:
     return rc;
 }
 
-static int decode_reload_request (flux_t h, ctx_t *ctx,
+static int decode_reload_request (flux_t *h, ctx_t *ctx,
                                   const flux_msg_t *msg)
 {
     const char *json_str;
@@ -370,7 +370,7 @@ static int decode_reload_request (flux_t h, ctx_t *ctx,
     return (0);
 }
 
-static void reload_request_cb (flux_t h,
+static void reload_request_cb (flux_t *h,
                                flux_msg_handler_t *watcher,
                                const flux_msg_t *msg,
                                void *arg)
@@ -386,7 +386,7 @@ static void reload_request_cb (flux_t h,
         flux_log_error (h, "flux_respond");
 }
 
-static void topo_request_cb (flux_t h,
+static void topo_request_cb (flux_t *h,
                              flux_msg_handler_t *watcher,
                              const flux_msg_t *msg,
                              void *arg)
@@ -477,7 +477,7 @@ done:
     Jput (out);
 }
 
-static void process_args (flux_t h, ctx_t *ctx, int argc, char **argv)
+static void process_args (flux_t *h, ctx_t *ctx, int argc, char **argv)
 {
     int i;
     for (i = 0; i < argc; i++) {
@@ -493,7 +493,7 @@ static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_REQUEST, "resource-hwloc.topo", topo_request_cb, NULL},
     FLUX_MSGHANDLER_TABLE_END};
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
     ctx_t *ctx;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -36,7 +36,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
 
-static int kvs_job_set_state (flux_t h, unsigned long jobid, const char *state)
+static int kvs_job_set_state (flux_t *h, unsigned long jobid, const char *state)
 {
     int rc;
     char *key = NULL;
@@ -76,12 +76,12 @@ out:
     return rc;
 }
 
-static int kvs_job_new (flux_t h, unsigned long jobid)
+static int kvs_job_new (flux_t *h, unsigned long jobid)
 {
     return kvs_job_set_state (h, jobid, "reserved");
 }
 
-static int64_t next_jobid (flux_t h)
+static int64_t next_jobid (flux_t *h)
 {
     int64_t ret = (int64_t) -1;
     const char *json_str;
@@ -119,7 +119,7 @@ static char * realtime_string (char *buf, size_t sz)
     return (buf);
 }
 
-static void wait_for_event (flux_t h, int64_t id, char *topic)
+static void wait_for_event (flux_t *h, int64_t id, char *topic)
 {
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_EVENT,
@@ -131,7 +131,7 @@ static void wait_for_event (flux_t h, int64_t id, char *topic)
     return;
 }
 
-static void send_create_event (flux_t h, int64_t id, char *topic)
+static void send_create_event (flux_t *h, int64_t id, char *topic)
 {
     flux_msg_t *msg;
     char *json = NULL;
@@ -157,7 +157,7 @@ out:
     free (json);
 }
 
-static int add_jobinfo (flux_t h, int64_t id, json_object *req)
+static int add_jobinfo (flux_t *h, int64_t id, json_object *req)
 {
     int rc = 0;
     char buf [64];
@@ -189,7 +189,7 @@ out:
     return (rc);
 }
 
-static bool ping_sched (flux_t h)
+static bool ping_sched (flux_t *h)
 {
     bool retval = false;
     const char *s;
@@ -206,7 +206,7 @@ static bool ping_sched (flux_t h)
     return (retval);
 }
 
-static bool sched_loaded (flux_t h)
+static bool sched_loaded (flux_t *h)
 {
     static bool v = false;
     if (!v && ping_sched (h))
@@ -214,7 +214,7 @@ static bool sched_loaded (flux_t h)
     return (v);
 }
 
-static int do_submit_job (flux_t h, unsigned long id)
+static int do_submit_job (flux_t *h, unsigned long id)
 {
     if (kvs_job_set_state (h, id, "submitted") < 0) {
         flux_log_error (h, "kvs_job_set_state");
@@ -224,7 +224,7 @@ static int do_submit_job (flux_t h, unsigned long id)
     return (0);
 }
 
-static void job_request_cb (flux_t h, flux_msg_handler_t *w,
+static void job_request_cb (flux_t *h, flux_msg_handler_t *w,
                            const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -298,7 +298,7 @@ struct flux_msg_handler_spec mtab[] = {
     FLUX_MSGHANDLER_TABLE_END
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     if (flux_msg_handler_addvec (h, mtab, NULL) < 0) {
         flux_log_error (h, "flux_msg_handler_addvec");

--- a/src/modules/wreck/wrexec.c
+++ b/src/modules/wreck/wrexec.c
@@ -48,7 +48,7 @@
 
 struct rexec_ctx {
     uint32_t nodeid;
-    flux_t h;
+    flux_t *h;
     const char *wrexecd_path;
     const char *local_uri;
 };
@@ -68,7 +68,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static struct rexec_ctx *getctx (flux_t h)
+static struct rexec_ctx *getctx (flux_t *h)
 {
     struct rexec_ctx *ctx = (struct rexec_ctx *)flux_aux_get (h, "wrexec");
 
@@ -270,7 +270,7 @@ int lwj_targets_this_node (struct rexec_ctx *ctx, int64_t id)
     return (1);
 }
 
-static void event_cb (flux_t h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
 {
@@ -289,7 +289,7 @@ static void event_cb (flux_t h, flux_msg_handler_t *w,
     }
 }
 
-static void request_cb (flux_t h,
+static void request_cb (flux_t *h,
 			flux_msg_handler_t *w,
 			const flux_msg_t *msg,
 			void *arg)
@@ -309,7 +309,7 @@ struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     struct rexec_ctx *ctx = getctx (h);
     if (ctx == NULL)

--- a/src/test/kap/kap_personality.c
+++ b/src/test/kap/kap_personality.c
@@ -39,7 +39,7 @@ typedef struct _VAC_t {
  *********************************************************/
 static int _tester_rank = -1;
 static int _tester_size = -1;
-static flux_t _hndl = NULL;
+static flux_t *_hndl = NULL;
 
 
 /*********************************************************

--- a/src/test/kap/kap_personality.h
+++ b/src/test/kap/kap_personality.h
@@ -24,7 +24,7 @@ typedef struct _kap_personality_t {
     int size;
     int iter_count;
     kap_role_e role;
-    flux_t handle; 
+    flux_t *handle; 
 } kap_personality_t;
 
 //!

--- a/src/test/tbarrier.c
+++ b/src/test/tbarrier.c
@@ -56,7 +56,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     struct timespec t0;
     char *name = NULL;

--- a/t/kvs/asyncfence.c
+++ b/t/kvs/asyncfence.c
@@ -5,7 +5,7 @@
 
 #include "src/common/libutil/log.h"
 
-void kput (flux_t h, const char *s, int val)
+void kput (flux_t *h, const char *s, int val)
 {
     char key[128];
     snprintf (key, sizeof (key), "test.asyncfence.%s", s);
@@ -14,14 +14,14 @@ void kput (flux_t h, const char *s, int val)
     log_msg ("kvs_put_int %s=%d", key, val);
 }
 
-void kcommit (flux_t h)
+void kcommit (flux_t *h)
 {
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
     log_msg ("kvs_commit");
 }
 
-void kfencectx (flux_t h, const char *s)
+void kfencectx (flux_t *h, const char *s)
 {
     if (s) {
         char name[128];
@@ -34,7 +34,7 @@ void kfencectx (flux_t h, const char *s)
     }
 }
 
-void kfence (flux_t h, const char *s)
+void kfence (flux_t *h, const char *s)
 {
     char name[128];
     snprintf (name, sizeof (name), "test.asyncfence.%s", s);
@@ -43,7 +43,7 @@ void kfence (flux_t h, const char *s)
     log_msg ("kvs_fence %s", name);
 }
 
-void kget_xfail (flux_t h, const char *s)
+void kget_xfail (flux_t *h, const char *s)
 {
     char key[128];
     int val;
@@ -53,7 +53,7 @@ void kget_xfail (flux_t h, const char *s)
     log_msg ("kvs_get_int %s failed (expected)", key);
 }
 
-void kget (flux_t h, const char *s, int expected)
+void kget (flux_t *h, const char *s, int expected)
 {
     char key[128];
     int val;
@@ -65,7 +65,7 @@ void kget (flux_t h, const char *s, int expected)
     log_msg ("kvs_get_int %s=%d", key, val);
 }
 
-void kunlink (flux_t h, const char *s)
+void kunlink (flux_t *h, const char *s)
 {
     char key[128];
     snprintf (key, sizeof (key), "test.asyncfence.%s", s);
@@ -76,7 +76,7 @@ void kunlink (flux_t h, const char *s)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     flux_rpc_t *rpc;
 
     log_init ("asynfence");

--- a/t/kvs/commit.c
+++ b/t/kvs/commit.c
@@ -45,7 +45,7 @@ typedef struct {
     pthread_t t;
     pthread_attr_t attr;
     int n;
-    flux_t h;
+    flux_t *h;
     zlist_t *perf;
 } thd_t;
 

--- a/t/kvs/dtree.c
+++ b/t/kvs/dtree.c
@@ -43,8 +43,8 @@ static const struct option longopts[] = {
     { 0, 0, 0, 0 },
 };
 
-void dtree (flux_t h, const char *prefix, int width, int height);
-void dtree_mkdir (flux_t h, kvsdir_t *dir, int width, int height);
+void dtree (flux_t *h, const char *prefix, int width, int height);
+void dtree_mkdir (flux_t *h, kvsdir_t *dir, int width, int height);
 
 void usage (void)
 {
@@ -61,7 +61,7 @@ int main (int argc, char *argv[])
     int height = 1;
     char *prefix = "dtree";
     int Dopt = 0;
-    flux_t h;
+    flux_t *h;
 
     log_init ("dtree");
 
@@ -111,7 +111,7 @@ int main (int argc, char *argv[])
 /* This version simply puts keys and values, creating intermediate
  * directories as a side effect.
  */
-void dtree (flux_t h, const char *prefix, int width, int height)
+void dtree (flux_t *h, const char *prefix, int width, int height)
 {
     int i;
     char *key;
@@ -131,7 +131,7 @@ void dtree (flux_t h, const char *prefix, int width, int height)
  * using kvsdir_t objects.  This is a less efficient method but provides
  * alternate code coverage.
  */
-void dtree_mkdir (flux_t h, kvsdir_t *dir, int width, int height)
+void dtree_mkdir (flux_t *h, kvsdir_t *dir, int width, int height)
 {
     int i;
     char key[16];

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -65,7 +65,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     int i, count = 20;
     int size = 20;

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -57,7 +57,7 @@ typedef struct {
     pthread_t tid;
     pthread_attr_t attr;
     int n;
-    flux_t h;
+    flux_t *h;
     int change_count;
     int nil_count;
     int stable_count;
@@ -194,7 +194,7 @@ void test_mt (int argc, char **argv)
 {
     thd_t *thd;
     int i, rc;
-    flux_t h;
+    flux_t *h;
     int errors = 0;
 
     if (argc != 3) {
@@ -275,7 +275,7 @@ static int selfmod_watch_cb (const char *key, int val, void *arg, int errnum)
 {
     log_msg ("%s: value = %d errnum = %d", __FUNCTION__, val, errnum);
 
-    flux_t h = arg;
+    flux_t *h = arg;
     if (kvs_put_int (h, key, val + 1) < 0)
         log_err_exit ("%s: kvs_put_int", __FUNCTION__);
     if (kvs_commit (h) < 0)
@@ -285,7 +285,7 @@ static int selfmod_watch_cb (const char *key, int val, void *arg, int errnum)
 
 void test_selfmod (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     char *key;
 
     if (argc != 1) {
@@ -318,7 +318,7 @@ static int unwatch_watch_cb (const char *key, int val, void *arg, int errnum)
 }
 
 struct timer_ctx {
-    flux_t h;
+    flux_t *h;
     char *key;
 };
 
@@ -384,7 +384,7 @@ static int unwatchloop_cb (const char *key, int val, void *arg, int errnum)
 void test_unwatchloop (int argc, char **argv)
 {
     int i;
-    flux_t h;
+    flux_t *h;
     char *key;
 
     if (argc != 1) {
@@ -415,7 +415,7 @@ static int simulwatch_cb (const char *key, int val, void *arg, int errnum)
     return 0;
 }
 
-int get_watch_stats (flux_t h, int *count)
+int get_watch_stats (flux_t *h, int *count)
 {
     flux_rpc_t *rpc;
     const char *json_str;
@@ -441,7 +441,7 @@ void test_simulwatch (int argc, char **argv)
 {
     int i, max;
     const char *key;
-    flux_t h;
+    flux_t *h;
     int start, fin, count = 0;
     int exit_rc = 0;
 

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -15,7 +15,7 @@
  * changes then we are screwed here because we will have recycled the
  * matchtags but more responses will be coming.
  */
-void send_watch_requests (flux_t h, const char *key)
+void send_watch_requests (flux_t *h, const char *key)
 {
     json_object *in;
     flux_rpc_t *r;
@@ -35,7 +35,7 @@ void send_watch_requests (flux_t h, const char *key)
 
 /* Sum #watchers over all ranks.
  */
-int count_watchers (flux_t h)
+int count_watchers (flux_t *h)
 {
     json_object *out;
     const char *json_str;
@@ -58,7 +58,7 @@ int count_watchers (flux_t h)
 
 int main (int argc, char **argv)
 {
-    flux_t h;
+    flux_t *h;
     int w0, w1, w2;
 
     /* Install watchers on every rank, then disconnect.

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -41,16 +41,16 @@
 
 
 typedef struct {
-    flux_t h;
+    flux_t *h;
     void *zs;
     kz_t *kz[3];
     int readers;
     int blocksize;
 } ctx_t;
 
-static void copy (flux_t h, const char *src, const char *dst, int kzoutflags,
+static void copy (flux_t *h, const char *src, const char *dst, int kzoutflags,
                   int blocksize);
-static void attach (flux_t h, const char *key, bool raw, int kzoutflags,
+static void attach (flux_t *h, const char *key, bool raw, int kzoutflags,
                    int blocksize);
 
 #define OPTIONS "ha:crk:tb:d"
@@ -89,7 +89,7 @@ int main (int argc, char *argv[])
     char *key = NULL;
     int blocksize = 4096;
     int kzoutflags = KZ_FLAGS_WRITE;
-    flux_t h;
+    flux_t *h;
     uint32_t rank;
     bool rawtty = false;
 
@@ -269,7 +269,7 @@ static void attach_stdin_ready_cb (flux_reactor_t *r, flux_watcher_t *w,
     free (buf);
 }
 
-static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
+static void attach (flux_t *h, const char *key, bool rawtty, int kzoutflags,
                     int blocksize)
 {
     ctx_t *ctx = xzmalloc (sizeof (*ctx));
@@ -352,7 +352,7 @@ static void attach (flux_t h, const char *key, bool rawtty, int kzoutflags,
     free (ctx);
 }
 
-static void copy_k2k (flux_t h, const char *src, const char *dst,
+static void copy_k2k (flux_t *h, const char *src, const char *dst,
                       int kzoutflags)
 {
     kz_t *kzin, *kzout;
@@ -377,7 +377,7 @@ static void copy_k2k (flux_t h, const char *src, const char *dst,
         log_err_exit ("kz_close %s", dst);
 }
 
-static void copy_f2k (flux_t h, const char *src, const char *dst,
+static void copy_f2k (flux_t *h, const char *src, const char *dst,
                       int kzoutflags, int blocksize)
 {
     int srcfd = STDIN_FILENO;
@@ -403,7 +403,7 @@ static void copy_f2k (flux_t h, const char *src, const char *dst,
         log_err_exit ("kz_close %s", dst);
 }
 
-static void copy_k2f (flux_t h, const char *src, const char *dst)
+static void copy_k2f (flux_t *h, const char *src, const char *dst)
 {
     kz_t *kzin;
     int dstfd = STDOUT_FILENO;
@@ -436,7 +436,7 @@ static bool isfile (const char *name)
     return (!strcmp (name, "-") || strchr (name, '/'));
 }
 
-static void copy (flux_t h, const char *src, const char *dst, int kzoutflags,
+static void copy (flux_t *h, const char *src, const char *dst, int kzoutflags,
                   int blocksize)
 {
     if (!isfile (src) && !isfile (dst)) {

--- a/t/loop/handle.c
+++ b/t/loop/handle.c
@@ -38,7 +38,7 @@ static void fatal_err (const char *message, void *arg)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     char *s;
     flux_msg_t *msg;
     const char *topic;

--- a/t/loop/log.c
+++ b/t/loop/log.c
@@ -7,7 +7,7 @@
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
 
     plan (NO_PLAN);
 

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -9,7 +9,7 @@ static uint32_t fake_size = 1;
 
 /* request nodeid and flags returned in response */
 static int nodeid_fake_error = -1;
-void rpctest_nodeid_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
                         const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -36,7 +36,7 @@ done:
 }
 
 /* request payload echoed in response */
-void rpctest_echo_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -52,7 +52,7 @@ done:
 
 /* no-payload response */
 static int hello_count = 0;
-void rpctest_hello_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -72,7 +72,7 @@ static int then_count = 0;
 static flux_rpc_t *then_r;
 static void then_cb (flux_rpc_t *r, void *arg)
 {
-    flux_t h = arg;
+    flux_t *h = arg;
     uint32_t nodeid;
 
     if (flux_rpc_get (r, &nodeid, NULL) < 0
@@ -91,7 +91,7 @@ static void fatal_err (const char *message, void *arg)
         fatal_tested = true;
 }
 
-void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     uint32_t nodeid;
@@ -263,7 +263,7 @@ const int htablen = sizeof (htab) / sizeof (htab[0]);
 int main (int argc, char *argv[])
 {
     flux_msg_t *msg;
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
 
     plan (NO_PLAN);

--- a/t/loop/reactor.c
+++ b/t/loop/reactor.c
@@ -8,7 +8,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libtap/tap.h"
 
-static int send_request (flux_t h, const char *topic)
+static int send_request (flux_t *h, const char *topic)
 {
     int rc = -1;
     flux_msg_t *msg = flux_request_encode (topic, NULL);
@@ -24,7 +24,7 @@ done:
 }
 
 static int multmatch_count = 0;
-static void multmatch1 (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
+static void multmatch1 (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg,
                         void *arg)
 {
     const char *topic;
@@ -34,7 +34,7 @@ static void multmatch1 (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
     multmatch_count++;
 }
 
-static void multmatch2 (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
+static void multmatch2 (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg,
                         void *arg)
 {
     const char *topic;
@@ -44,7 +44,7 @@ static void multmatch2 (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
     multmatch_count++;
 }
 
-static void test_multmatch (flux_t h)
+static void test_multmatch (flux_t *h)
 {
     flux_msg_handler_t *w1, *w2;
     struct flux_match m1 = FLUX_MATCH_ANY;
@@ -73,7 +73,7 @@ static void test_multmatch (flux_t h)
 }
 
 static int msgwatcher_count = 100;
-static void msgreader (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
+static void msgreader (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg,
                        void *arg)
 {
     static int count = 0;
@@ -82,7 +82,7 @@ static void msgreader (flux_t h, flux_msg_handler_t *w, const flux_msg_t *msg,
         flux_msg_handler_stop (w);
 }
 
-static void test_msg (flux_t h)
+static void test_msg (flux_t *h)
 {
     flux_msg_handler_t *w;
     int i;
@@ -103,14 +103,14 @@ static void test_msg (flux_t h)
     flux_msg_handler_destroy (w);
 }
 
-static void dummy (flux_t h, flux_msg_handler_t *w,
+static void dummy (flux_t *h, flux_msg_handler_t *w,
                    const flux_msg_t *msg, void *arg)
 {
 }
 
 static void leak_msg_handler (void)
 {
-    flux_t h;
+    flux_t *h;
     flux_msg_handler_t *w;
 
     if (!(h = flux_open ("loop://", 0)))
@@ -128,7 +128,7 @@ static void fatal_err (const char *message, void *arg)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
 
     plan (NO_PLAN);

--- a/t/loop/reduce.c
+++ b/t/loop/reduce.c
@@ -73,7 +73,7 @@ static struct flux_reduce_ops reduce_ops =  {
     .itemweight = itemweight,
 };
 
-void test_hwm (flux_t h)
+void test_hwm (flux_t *h)
 {
     flux_reduce_t *r;
     int i, errors;
@@ -224,7 +224,7 @@ void test_hwm (flux_t h)
     flux_reduce_destroy (r);
 }
 
-void test_nopolicy (flux_t h)
+void test_nopolicy (flux_t *h)
 {
     flux_reduce_t *r;
     int i, errors;
@@ -253,7 +253,7 @@ void test_nopolicy (flux_t h)
     flux_reduce_destroy (r);
 }
 
-void test_timed (flux_t h)
+void test_timed (flux_t *h)
 {
     flux_reduce_t *r;
     int i, errors;
@@ -342,7 +342,7 @@ void test_timed (flux_t h)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
 
     plan (1+6+37+18);
 

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -5,7 +5,7 @@
 #include "src/common/libtap/tap.h"
 
 /* request nodeid and flags returned in response */
-void rpctest_nodeid_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
                         const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -27,7 +27,7 @@ done:
 }
 
 /* request payload echoed in response */
-void rpctest_echo_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -42,7 +42,7 @@ done:
 }
 
 /* raw request payload echoed in response */
-void rpctest_rawecho_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *w,
                          const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -58,7 +58,7 @@ done:
 }
 
 /* no-payload response */
-void rpctest_hello_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -71,7 +71,7 @@ done:
     (void)flux_respond (h, msg, errnum, NULL);
 }
 
-void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -144,7 +144,7 @@ void rpctest_begin_cb (flux_t h, flux_msg_handler_t *w,
 
 static void then_cb (flux_rpc_t *r, void *arg)
 {
-    flux_t h = arg;
+    flux_t *h = arg;
     const char *json_str;
 
     ok (flux_rpc_check (r) == true,
@@ -157,7 +157,7 @@ static void then_cb (flux_rpc_t *r, void *arg)
 }
 
 static flux_rpc_t *thenbug_r = NULL;
-void rpctest_thenbug_cb (flux_t h, flux_msg_handler_t *w,
+void rpctest_thenbug_cb (flux_t *h, flux_msg_handler_t *w,
                          const flux_msg_t *msg, void *arg)
 {
     (void)flux_rpc_check (thenbug_r);
@@ -182,7 +182,7 @@ static struct flux_msg_handler_spec htab[] = {
 int main (int argc, char *argv[])
 {
     flux_msg_t *msg;
-    flux_t h;
+    flux_t *h;
     flux_reactor_t *reactor;
 
     plan (37);

--- a/t/module/parent.c
+++ b/t/module/parent.c
@@ -112,7 +112,7 @@ static flux_modlist_t *module_list (void)
     return mods;
 }
 
-static void insmod_request_cb (flux_t h, flux_msg_handler_t *w,
+static void insmod_request_cb (flux_t *h, flux_msg_handler_t *w,
                                const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -145,7 +145,7 @@ done:
         free (argz);
 }
 
-static void rmmod_request_cb (flux_t h, flux_msg_handler_t *w,
+static void rmmod_request_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -174,7 +174,7 @@ done:
         free (name);
 }
 
-static void lsmod_request_cb (flux_t h, flux_msg_handler_t *w,
+static void lsmod_request_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     flux_modlist_t *mods = NULL;
@@ -211,7 +211,7 @@ struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     int saved_errno;
 

--- a/t/request/coproc.c
+++ b/t/request/coproc.c
@@ -10,7 +10,7 @@
 
 /* The req.clog request will not be answered until req.flush is called.
  */
-void stuck_request_cb (flux_t h, flux_msg_handler_t *w,
+void stuck_request_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     flux_rpc_t *rpc;
@@ -33,7 +33,7 @@ done:
     flux_rpc_destroy (rpc);
 }
 
-void hi_request_cb (flux_t h, flux_msg_handler_t *w,
+void hi_request_cb (flux_t *h, flux_msg_handler_t *w,
                     const flux_msg_t *msg, void *arg)
 {
     if (flux_respond (h, msg, 0, NULL) < 0)
@@ -48,7 +48,7 @@ struct flux_msg_handler_spec htab[] = {
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     int saved_errno;
     flux_flags_set (h, FLUX_O_COPROC);

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -9,7 +9,7 @@
 #include "src/common/libutil/shortjson.h"
 
 typedef struct {
-    flux_t h;
+    flux_t *h;
     zhash_t *ping_requests;
     int ping_seq;
     zlist_t *clog_requests;
@@ -32,7 +32,7 @@ static void freectx (void *arg)
     }
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     int saved_errno;
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "req");
@@ -61,7 +61,7 @@ error:
 
 /* Return number of queued clog requests
  */
-void count_request_cb (flux_t h, flux_msg_handler_t *w,
+void count_request_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = getctx (h);
@@ -75,7 +75,7 @@ void count_request_cb (flux_t h, flux_msg_handler_t *w,
 
 /* Don't reply to request - just queue it for later.
  */
-void clog_request_cb (flux_t h, flux_msg_handler_t *w,
+void clog_request_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = getctx (h);
@@ -87,7 +87,7 @@ void clog_request_cb (flux_t h, flux_msg_handler_t *w,
 
 /* Reply to all queued requests.
  */
-void flush_request_cb (flux_t h, flux_msg_handler_t *w,
+void flush_request_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = getctx (h);
@@ -106,7 +106,7 @@ void flush_request_cb (flux_t h, flux_msg_handler_t *w,
 /* Accept a json payload, verify it and return error if it doesn't
  * match expected.
  */
-void sink_request_cb (flux_t h, flux_msg_handler_t *w,
+void sink_request_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -133,7 +133,7 @@ done:
 
 /* Return a fixed json payload
  */
-void src_request_cb (flux_t h, flux_msg_handler_t *w,
+void src_request_cb (flux_t *h, flux_msg_handler_t *w,
                      const flux_msg_t *msg, void *arg)
 {
     json_object *o = Jnew ();
@@ -146,7 +146,7 @@ void src_request_cb (flux_t h, flux_msg_handler_t *w,
 
 /* Return 'n' sequenced responses.
  */
-void nsrc_request_cb (flux_t h, flux_msg_handler_t *w,
+void nsrc_request_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -182,7 +182,7 @@ done:
 
 /* Always return an error 42
  */
-void err_request_cb (flux_t h, flux_msg_handler_t *w,
+void err_request_cb (flux_t *h, flux_msg_handler_t *w,
                      const flux_msg_t *msg, void *arg)
 {
     if (flux_respond (h, msg, 42, NULL) < 0)
@@ -191,7 +191,7 @@ void err_request_cb (flux_t h, flux_msg_handler_t *w,
 
 /* Echo a json payload back to requestor.
  */
-void echo_request_cb (flux_t h, flux_msg_handler_t *w,
+void echo_request_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -211,7 +211,7 @@ done:
 
 /* Proxy ping.
  */
-void xping_request_cb (flux_t h, flux_msg_handler_t *w,
+void xping_request_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -267,7 +267,7 @@ error:
 /* Handle ping response for proxy ping.
  * Match it with a request and respond to that request.
  */
-void ping_response_cb (flux_t h, flux_msg_handler_t *w,
+void ping_response_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -310,7 +310,7 @@ done:
 /* Handle the simplest possible request.
  * Verify that everything is as expected; log it and stop the reactor if not.
  */
-void null_request_cb (flux_t h, flux_msg_handler_t *w,
+void null_request_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     ctx_t *ctx = arg;
@@ -385,7 +385,7 @@ struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     int saved_errno;
     ctx_t *ctx = getctx (h);

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -39,23 +39,23 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/shortjson.h"
 
-void test_null (flux_t h, uint32_t nodeid);
-void test_echo (flux_t h, uint32_t nodeid);
-void test_err (flux_t h, uint32_t nodeid);
-void test_src (flux_t h, uint32_t nodeid);
-void test_sink (flux_t h, uint32_t nodeid);
-void test_nsrc (flux_t h, uint32_t nodeid);
-void test_putmsg (flux_t h, uint32_t nodeid);
-void test_pingzero (flux_t h, uint32_t nodeid);
-void test_pingself (flux_t h, uint32_t nodeid);
-void test_pingupstream (flux_t h, uint32_t nodeid);
-void test_flush (flux_t h, uint32_t nodeid);
-void test_clog (flux_t h, uint32_t nodeid);
-void test_coproc (flux_t h, uint32_t nodeid);
+void test_null (flux_t *h, uint32_t nodeid);
+void test_echo (flux_t *h, uint32_t nodeid);
+void test_err (flux_t *h, uint32_t nodeid);
+void test_src (flux_t *h, uint32_t nodeid);
+void test_sink (flux_t *h, uint32_t nodeid);
+void test_nsrc (flux_t *h, uint32_t nodeid);
+void test_putmsg (flux_t *h, uint32_t nodeid);
+void test_pingzero (flux_t *h, uint32_t nodeid);
+void test_pingself (flux_t *h, uint32_t nodeid);
+void test_pingupstream (flux_t *h, uint32_t nodeid);
+void test_flush (flux_t *h, uint32_t nodeid);
+void test_clog (flux_t *h, uint32_t nodeid);
+void test_coproc (flux_t *h, uint32_t nodeid);
 
 typedef struct {
     const char *name;
-    void (*fun)(flux_t h, uint32_t nodeid);
+    void (*fun)(flux_t *h, uint32_t nodeid);
 } test_t;
 
 static test_t tests[] = {
@@ -100,7 +100,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch;
     uint32_t nodeid = FLUX_NODEID_ANY;
     test_t *t;
@@ -136,7 +136,7 @@ int main (int argc, char *argv[])
     return 0;
 }
 
-void test_null (flux_t h, uint32_t nodeid)
+void test_null (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
 
@@ -146,7 +146,7 @@ void test_null (flux_t h, uint32_t nodeid)
     flux_rpc_destroy (rpc);
 }
 
-void test_echo (flux_t h, uint32_t nodeid)
+void test_echo (flux_t *h, uint32_t nodeid)
 {
     json_object *in = Jnew ();
     json_object *out = NULL;
@@ -166,7 +166,7 @@ void test_echo (flux_t h, uint32_t nodeid)
     flux_rpc_destroy (rpc);
 }
 
-void test_err (flux_t h, uint32_t nodeid)
+void test_err (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
 
@@ -179,7 +179,7 @@ void test_err (flux_t h, uint32_t nodeid)
     flux_rpc_destroy (rpc);
 }
 
-void test_src (flux_t h, uint32_t nodeid)
+void test_src (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const char *json_str;
@@ -195,7 +195,7 @@ void test_src (flux_t h, uint32_t nodeid)
     flux_rpc_destroy (rpc);
 }
 
-void test_sink (flux_t h, uint32_t nodeid)
+void test_sink (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     json_object *in = Jnew();
@@ -208,7 +208,7 @@ void test_sink (flux_t h, uint32_t nodeid)
     flux_rpc_destroy (rpc);
 }
 
-void test_nsrc (flux_t h, uint32_t nodeid)
+void test_nsrc (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const int count = 10000;
@@ -242,7 +242,7 @@ void test_nsrc (flux_t h, uint32_t nodeid)
  * are "put back" on the handle using flux_putmsg().  We ensure that
  * the 10K messages are nonetheless received in order.
  */
-void test_putmsg (flux_t h, uint32_t nodeid)
+void test_putmsg (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const char *json_str;
@@ -307,7 +307,7 @@ static int count_hops (const char *s)
     return count;
 }
 
-static void xping (flux_t h, uint32_t nodeid, uint32_t xnodeid, const char *svc)
+static void xping (flux_t *h, uint32_t nodeid, uint32_t xnodeid, const char *svc)
 {
     flux_rpc_t *rpc;
     const char *json_str;
@@ -328,22 +328,22 @@ static void xping (flux_t h, uint32_t nodeid, uint32_t xnodeid, const char *svc)
     flux_rpc_destroy (rpc);
 }
 
-void test_pingzero (flux_t h, uint32_t nodeid)
+void test_pingzero (flux_t *h, uint32_t nodeid)
 {
     xping (h, nodeid, 0, "req.ping");
 }
 
-void test_pingupstream (flux_t h, uint32_t nodeid)
+void test_pingupstream (flux_t *h, uint32_t nodeid)
 {
     xping (h, nodeid, FLUX_NODEID_UPSTREAM, "req.ping");
 }
 
-void test_pingself (flux_t h, uint32_t nodeid)
+void test_pingself (flux_t *h, uint32_t nodeid)
 {
     xping (h, nodeid, nodeid, "req.ping");
 }
 
-void test_flush (flux_t h, uint32_t nodeid)
+void test_flush (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     if (!(rpc = flux_rpc (h, "req.flush", NULL, nodeid, 0))
@@ -352,7 +352,7 @@ void test_flush (flux_t h, uint32_t nodeid)
     flux_rpc_destroy (rpc);
 }
 
-void test_clog (flux_t h, uint32_t nodeid)
+void test_clog (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     if (!(rpc = flux_rpc (h, "req.clog", NULL, nodeid, 0))
@@ -373,7 +373,7 @@ void *thd (void *arg)
 {
     flux_rpc_t *rpc;
     uint32_t *nodeid = arg;
-    flux_t h;
+    flux_t *h;
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
@@ -387,7 +387,7 @@ void *thd (void *arg)
     return NULL;
 }
 
-int req_count (flux_t h, uint32_t nodeid)
+int req_count (flux_t *h, uint32_t nodeid)
 {
     flux_rpc_t *rpc;
     const char *json_str;
@@ -409,7 +409,7 @@ done:
     return rc;
 }
 
-void test_coproc (flux_t h, uint32_t nodeid)
+void test_coproc (flux_t *h, uint32_t nodeid)
 {
     pthread_t t;
     int rc;


### PR DESCRIPTION
Remove the pointer from the definition of the typedef
flux_t to comply with the Coding Style Guide.

Fixes #840