### PR TITLE
Update flux_t * references in man pages

### DIFF
--- a/doc/man3/flux_attr_get.adoc
+++ b/doc/man3/flux_attr_get.adoc
@@ -12,13 +12,13 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-const char *flux_attr_get (flux_t h, const char *name, int *flags);
+const char *flux_attr_get (flux_t *h, const char *name, int *flags);
 
-int flux_attr_set (flux_t h, const char *name, const char *val);
+int flux_attr_set (flux_t *h, const char *name, const char *val);
 
-const char *flux_attr_first (flux_t h);
+const char *flux_attr_first (flux_t *h);
 
-const char *flux_attr_next (flux_t h);
+const char *flux_attr_next (flux_t *h);
 
 DESCRIPTION
 -----------

--- a/doc/man3/flux_aux_set.adoc
+++ b/doc/man3/flux_aux_set.adoc
@@ -14,9 +14,9 @@ SYNOPSIS
 
 typedef void (*flux_free_f)(void *arg);
 
-void *flux_aux_get (flux_t h, const char *name);
+void *flux_aux_get (flux_t *h, const char *name);
 
-void flux_aux_set (flux_t h, const char *name, void *aux, flux_free_f destroy);
+void flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);
 
 
 DESCRIPTION

--- a/doc/man3/flux_event_subscribe.adoc
+++ b/doc/man3/flux_event_subscribe.adoc
@@ -12,9 +12,9 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-int flux_event_subscribe (flux_t h, const char *topic);
+int flux_event_subscribe (flux_t *h, const char *topic);
 
-int flux_event_unsubscribe (flux_t h, const char *topic);
+int flux_event_unsubscribe (flux_t *h, const char *topic);
 
 
 DESCRIPTION

--- a/doc/man3/flux_fatal_set.adoc
+++ b/doc/man3/flux_fatal_set.adoc
@@ -15,11 +15,11 @@ SYNOPSIS
 
 typedef void (*flux_fatal_f)(const char *msg, void *arg);
 
-void flux_fatal_set (flux_t h, flux_fatal_f fun, void *arg);
+void flux_fatal_set (flux_t *h, flux_fatal_f fun, void *arg);
 
-void flux_fatal_error (flux_t h, const char *fun, const char *msg);
+void flux_fatal_error (flux_t *h, const char *fun, const char *msg);
 
-FLUX_FATAL (flux_t h);
+FLUX_FATAL (flux_t *h);
 
 
 DESCRIPTION

--- a/doc/man3/flux_flags_set.adoc
+++ b/doc/man3/flux_flags_set.adoc
@@ -12,11 +12,11 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-void flux_flags_set (flux_t h, int flags);
+void flux_flags_set (flux_t *h, int flags);
 
-void flux_flags_unset (flux_t h, int flags);
+void flux_flags_unset (flux_t *h, int flags);
 
-int flux_flags_get (flux_t h);
+int flux_flags_get (flux_t *h);
 
 
 DESCRIPTION

--- a/doc/man3/flux_get_rank.adoc
+++ b/doc/man3/flux_get_rank.adoc
@@ -12,9 +12,9 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-int flux_get_rank (flux_t h, uint32_t *rank);
+int flux_get_rank (flux_t *h, uint32_t *rank);
 
-int flux_get_size (flux_t h, uint32_t *size);
+int flux_get_size (flux_t *h, uint32_t *size);
 
 
 DESCRIPTION

--- a/doc/man3/flux_get_reactor.adoc
+++ b/doc/man3/flux_get_reactor.adoc
@@ -12,9 +12,9 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_reactor_t *flux_get_reactor (flux_t h);
+flux_reactor_t *flux_get_reactor (flux_t *h);
 
-int flux_set_reactor (flux_t h, flux_reactor_t *r);
+int flux_set_reactor (flux_t *h, flux_reactor_t *r);
 
 
 DESCRIPTION

--- a/doc/man3/flux_handle_watcher_create.adoc
+++ b/doc/man3/flux_handle_watcher_create.adoc
@@ -17,11 +17,11 @@ SYNOPSIS
                                 int revents, void *arg);
 
  flux_watcher_t *flux_handle_watcher_create (flux_reactor_t *r,
-                                             flux_t h, int events,
+                                             flux_t *h, int events,
                                              flux_watcher_f callback,
                                              void *arg);
 
- flux_t flux_handle_watcher_get_flux (flux_watcher_t *w);
+ flux_t *flux_handle_watcher_get_flux (flux_watcher_t *w);
 
 
 DESCRIPTION

--- a/doc/man3/flux_msg_handler_addvec.adoc
+++ b/doc/man3/flux_msg_handler_addvec.adoc
@@ -19,7 +19,7 @@ SYNOPSIS
      flux_msg_handler_t *w;
  };
 
- int flux_msg_handler_addvec (flux_t h,
+ int flux_msg_handler_addvec (flux_t *h,
                               struct flux_msg_handler_spec tab[],
                               void *arg);
 

--- a/doc/man3/flux_msg_handler_create.adoc
+++ b/doc/man3/flux_msg_handler_create.adoc
@@ -13,13 +13,13 @@ SYNOPSIS
 --------
  #include <flux/core.h>
 
- typedef void (*flux_msg_handler_f)(flux_t h,
+ typedef void (*flux_msg_handler_f)(flux_t *h,
                                     flux_msg_handler_t *w,
                                     const flux_msg_t *msg,
                                     void *arg);
 
  flux_msg_handler_t *
- flux_msg_handler_create (flux_t h,
+ flux_msg_handler_create (flux_t *h,
                           const struct flux_match match,
                           flux_msg_handler_f callback,
                           void *arg);

--- a/doc/man3/flux_open.adoc
+++ b/doc/man3/flux_open.adoc
@@ -12,9 +12,9 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_t flux_open (const char *uri, int flags);
+flux_t *flux_open (const char *uri, int flags);
 
-void flux_close (flux_t h);
+void flux_close (flux_t *h);
 
 
 DESCRIPTION

--- a/doc/man3/flux_pollevents.adoc
+++ b/doc/man3/flux_pollevents.adoc
@@ -12,9 +12,9 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-int flux_pollevents (flux_t h);
+int flux_pollevents (flux_t *h);
 
-int flux_pollfd (flux_t h);
+int flux_pollfd (flux_t *h);
 
 
 DESCRIPTION
@@ -103,7 +103,7 @@ struct ev_flux {
     ev_prepare  prepare_w;
     ev_idle     idle_w;
     ev_check    check_w;
-    flux_t      h;
+    flux_t      *h;
     int         pollfd;
     int         events;
     ev_flux_f   cb;
@@ -114,7 +114,7 @@ struct ev_flux {
 
 ....
 // ev_flux.c
-static int get_pollevents (flux_t h)
+static int get_pollevents (flux_t *h)
 {
     int e = flux_pollevents (h);
     int events = 0;
@@ -155,7 +155,7 @@ static void check_cb (struct ev_loop *loop, ev_check *w,
 }
 
 int ev_flux_init (struct ev_flux *w, ev_flux_f cb,
-                  flux_t h, int events)
+                  flux_t *h, int events)
 {
     w->cb = cb;
     w->h = h;

--- a/doc/man3/flux_recv.adoc
+++ b/doc/man3/flux_recv.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_msg_t *flux_recv (flux_t h, struct flux_match match, int flags);
+flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags);
 
 
 DESCRIPTION

--- a/doc/man3/flux_reduce_create.adoc
+++ b/doc/man3/flux_reduce_create.adoc
@@ -21,7 +21,7 @@ SYNOPSIS
      int          (*itemweight)(void *item);
  };
 
- flux_reduce_t *flux_reduce_create (flux_t h, flux_reduce_ops ops,
+ flux_reduce_t *flux_reduce_create (flux_t *h, flux_reduce_ops ops,
                                     double timeout, void *arg, int flags);
 
  void flux_reduce_destroy (flux_reduce_t *r);

--- a/doc/man3/flux_requeue.adoc
+++ b/doc/man3/flux_requeue.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-int flux_requeue (flux_t h, const flux_msg_t *msg, int flags);
+int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
 
 
 DESCRIPTION

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -12,10 +12,10 @@ SYNOPSIS
 --------
  #include <flux/core.h>
 
- int flux_respond (flux_t h, const flux_msg_t *request,
+ int flux_respond (flux_t *h, const flux_msg_t *request,
                    int errnum, const char *json_str);
 
- int flux_respond_raw (flux_t h, const flux_msg_t *request,
+ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                        int errnum, const void *data, int length);
 
 DESCRIPTION

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
  #include <flux/core.h>
 
- flux_rpc_t *flux_rpc (flux_t h, const char *topic,
+ flux_rpc_t *flux_rpc (flux_t *h, const char *topic,
                        const char *json_in,
                        uint32_t nodeid_in, int flags);
 

--- a/doc/man3/flux_rpc_multi.adoc
+++ b/doc/man3/flux_rpc_multi.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_rpc_t *flux_rpc_multi (flux_t h, const char *topic, const char *json_str,
+flux_rpc_t *flux_rpc_multi (flux_t *h, const char *topic, const char *json_str,
                             const char *nodeset, int flags);
 
 bool flux_rpc_completed (flux_rpc_t *rpc);

--- a/doc/man3/flux_rpc_raw.adoc
+++ b/doc/man3/flux_rpc_raw.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
  #include <flux/core.h>
 
- flux_rpc_t *flux_rpc_raw (flux_t h, const char *topic,
+ flux_rpc_t *flux_rpc_raw (flux_t *h, const char *topic,
                            const void *data_in, int length_in,
                            uint32_t nodeid_in, int flags);
 

--- a/doc/man3/flux_send.adoc
+++ b/doc/man3/flux_send.adoc
@@ -12,7 +12,7 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-int flux_send (flux_t h, const flux_msg_t *msg, int flags);
+int flux_send (flux_t *h, const flux_msg_t *msg, int flags);
 
 
 DESCRIPTION


### PR DESCRIPTION
Update the man pages to also reflect the recent change of the flux_t
typedef no longer containing a pointer.

Fixes #843