### PR TITLE
t/t0005-exec.t: Fix corner case in test for file not found

### DIFF
--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -77,7 +77,7 @@ EOF
 '
 
 test_expect_success 'flux exec exits with code 127 for file not found' '
-	test_expect_code 127 run_timeout 2 flux exec nosuchprocess
+	test_expect_code 127 run_timeout 2 flux exec ./nosuchprocess
 '
 
 test_expect_success 'flux exec exits with code 126 for non executable' '
@@ -85,7 +85,7 @@ test_expect_success 'flux exec exits with code 126 for non executable' '
 '
 
 test_expect_success 'flux exec exits with code 68 (EX_NOHOST) for rank not found' '
-	test_expect_code 68 run_timeout 2 flux exec -r 1000 nosuchprocess
+	test_expect_code 68 run_timeout 2 flux exec -r 1000 ./nosuchprocess
 '
 test_expect_success 'flux exec passes non-zero exit status' '
 	test_expect_code 2 flux exec sh -c "exit 2" &&


### PR DESCRIPTION
The fake file 'nosuchprocess' does not have a relative or absolute path specified.  So the file will be searched for in all directories in the users PATH.  If the user does not have access to one of the directories in their PATH, an EACCES error can occur instead of ENOENT, leading to a failed test.  So put "./" in front of 'nosuchprocess' to ensure it is not searched for in PATH.