### PR TITLE
doc/man1/flux-module.adoc: Fix environment variable error

### DIFF
--- a/doc/man1/flux-module.adoc
+++ b/doc/man1/flux-module.adoc
@@ -27,7 +27,7 @@ COMMANDS
 Display information about module 'name'.
 If 'name' includes a slash '/' character, it is interpreted as a
 file path, and the module name is then determined by reading the
-*mod_name* symbol.  Otherwise, FLUX_MODPATH is searched for a module
+*mod_name* symbol.  Otherwise, FLUX_MODULE_PATH is searched for a module
 with *mod_name* equal to 'name'.
 
 *load* ['OPTIONS'] 'name' ['module-arguments' ...]::


### PR DESCRIPTION
Environment variable for searching modules is FLUX_MODULE_PATH,
not FLUX_MODPATH.