### PR TITLE
doc/man1/flux-start.adoc: Fix example option usage

### DIFF
--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -60,7 +60,7 @@ EXAMPLES
 Launch an 8-way Flux instance with an interactive shell
 as the initial program and all logs output to stderr:
 
-  flux start -s8 -o,log-stderr-level=7
+  flux start -s8 -o,--setattr=log-stderr-level=7
 
 Launch an 8-way Flux instance within a slurm job, with an interactive
 shell as the initial program:


### PR DESCRIPTION
Noticed this didn't work:

```
$ src/cmd/flux start -s8 -o,log-stderr-level=7
log-stderr-level=7: Command not found.
2016-10-13T20:59:52.618549Z broker.err[0]: Run level 2 Exited with non-zero status (rc=1) 0.1s
flux-start: 0 (pid 53483) exited with rc=1
```

Which I got out of the manpage.  I think it should be: ```-o,--setattr=log-stderr-level=7``` now?
