### PR TITLE
make flux_msg_t a bonafide type, add jansson payload accessors

### DIFF
--- a/doc/man1/flux-snoop.adoc
+++ b/doc/man1/flux-snoop.adoc
@@ -66,10 +66,6 @@ OPTIONS
 *-a, --all*::
 Do not suppress 'cmb.info', 'cmb.log', and 'cmb.pub' messages.
 
-*-l, --long*::
-Display long format of message dumps.  Do not truncate at 80 columns.
-Do not compress DEALER - ROUTER routing frames into a single line.
-
 AUTHOR
 ------
 This page is maintained by the Flux community.

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -35,7 +35,8 @@ MAN3_FILES_PRIMARY = \
 	flux_stat_watcher_create.3 \
 	flux_rpc_raw.3 \
 	flux_respond.3 \
-	flux_reactor_now.3
+	flux_reactor_now.3 \
+	flux_request_decode.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -91,7 +92,9 @@ MAN3_FILES_SECONDARY = \
 	flux_stat_watcher_get_rstat.3 \
 	flux_rpc_get_raw.3 \
 	flux_respond_raw.3 \
-	flux_reactor_now_update.3
+	flux_reactor_now_update.3 \
+	flux_request_decodef.3 \
+	flux_request_decode_raw.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -166,6 +169,8 @@ flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_rpc_get_raw.3: flux_rpc_raw.3
 flux_respond_raw.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
+flux_request_decodef.3: flux_request_decode.3
+flux_request_decode_raw.3: flux_request_decode.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -92,6 +92,7 @@ MAN3_FILES_SECONDARY = \
 	flux_stat_watcher_get_rstat.3 \
 	flux_rpc_get_raw.3 \
 	flux_respond_raw.3 \
+	flux_respondf.3 \
 	flux_reactor_now_update.3 \
 	flux_request_decodef.3 \
 	flux_request_decode_raw.3
@@ -168,6 +169,7 @@ flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_rpc_get_raw.3: flux_rpc_raw.3
 flux_respond_raw.3: flux_respond.3
+flux_respondf.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
 flux_request_decodef.3: flux_request_decode.3
 flux_request_decode_raw.3: flux_request_decode.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -36,7 +36,8 @@ MAN3_FILES_PRIMARY = \
 	flux_rpc_raw.3 \
 	flux_respond.3 \
 	flux_reactor_now.3 \
-	flux_request_decode.3
+	flux_request_decode.3 \
+	flux_event_decode.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -95,7 +96,10 @@ MAN3_FILES_SECONDARY = \
 	flux_respondf.3 \
 	flux_reactor_now_update.3 \
 	flux_request_decodef.3 \
-	flux_request_decode_raw.3
+	flux_request_decode_raw.3 \
+	flux_event_decodef.3 \
+	flux_event_encode.3 \
+	flux_event_encodef.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -173,6 +177,9 @@ flux_respondf.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
 flux_request_decodef.3: flux_request_decode.3
 flux_request_decode_raw.3: flux_request_decode.3
+flux_event_decodef.3: flux_event_decode.3
+flux_event_encode.3: flux_event_decode.3
+flux_event_encodef.3: flux_event_decode.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_event_decode.adoc
+++ b/doc/man3/flux_event_decode.adoc
@@ -1,0 +1,108 @@
+flux_event_decode(3)
+====================
+:doctype: manpage
+
+
+NAME
+----
+flux_event_decode, flux_event_decodef, flux_event_encode, flux_event_encodef 
+ - encode/decode a Flux event message
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ int flux_event_decode (const flux_msg_t *msg,
+                        const char **topic,
+                        const char **json_str);
+
+ int flux_event_decodef (const flux_msg_t *msg,
+                         const char **topic,
+                         const char *fmt, ...);
+
+ flux_msg_t *flux_event_encode (const char *topic,
+                                const char *json_str);
+
+ flux_msg_t *flux_event_encodef (const char *topic,
+                                 const char *fmt, ...);
+
+
+DESCRIPTION
+-----------
+
+`flux_event_decode()` decodes a Flux event message _msg_.
+
+_topic_, if non-NULL, will be set the message's topic string. The storage
+for this string belongs to _msg_ and should not be freed.
+
+_json_str_, if non-NULL, will be set to the message's JSON payload. The
+storage for this string belongs to _msg_ and should not be freed.
+If non-NULL, decoding fails if the message doesn't have a JSON payload.
+If NULL, decoding fails if the message does have a JSON payload.
+
+`flux_event_decodef()` decodes a Flux event message with a JSON payload as
+above, parsing the payload using variable arguments with a format string
+in the style of jansson's `json_unpack()` (used internally). Decoding fails
+if the message doesn't have a JSON payload.
+
+`flux_event_encode()` encodes a Flux event message with topic string _topic_
+and optional JSON payload _json_str_.  The newly constructed message that
+is returned must be destroyed with `flux_msg_destroy()`.
+
+`flux_event_decodef()` decodes a Flux event message with a JSON payload as
+above, parsing the payload using variable arguments with a format string
+in the style of jansson's `json_unpack()` (used internally). Decoding fails
+if the message doesn't have a JSON payload.
+
+Events propagated to all subscribers.  Events will not be received
+without a matching subscription established using `flux_event_subscribe()`.
+
+
+RETURN VALUE
+------------
+
+Decoding functions return 0 on success.  On error, -1 is returned, and
+errno is set appropriately.
+
+Encoding functions return a message on success.  On error, NULL is returned,
+and errno is set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+The _msg_ argument was NULL or there was a problem encoding.
+
+ENOMEM::
+Memory was unavailable.
+
+EPROTO::
+Message decoding failed, such as due to missing or unexpected payload,
+incorrect message type, missing topic string, etc..
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_event_subscribe(3)
+
+http://jansson.readthedocs.io/en/2.7/apiref.html#parsing-and-validating-values[Jansson API: Parsing and Validating Values]
+
+http://jansson.readthedocs.io/en/2.7/apiref.html#building-values[Jansson API: Building Values]
+

--- a/doc/man3/flux_request_decode.adoc
+++ b/doc/man3/flux_request_decode.adoc
@@ -1,0 +1,87 @@
+flux_request_decode(3)
+======================
+:doctype: manpage
+
+
+NAME
+----
+flux_request_decode, flux_request_decodef, flux_request_decode_raw - decode a Flux request message
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ int flux_request_decode (const flux_msg_t *msg,
+                          const char **topic,
+                          const char **json_str);
+
+ int flux_request_decodef (const flux_msg_t *msg,
+                           const char **topic,
+                           const char *fmt, ...);
+
+ int flux_request_decode_raw (const flux_msg_t *msg,
+                              const char **topic,
+                              void *data, int *len);
+
+DESCRIPTION
+-----------
+
+`flux_request_decode()` decodes a request message _msg_.
+
+_topic_, if non-NULL, will be set the message's topic string. The storage
+for this string belongs to _msg_ and should not be freed.
+
+_json_str_, if non-NULL, will be set to the message's JSON payload. The
+storage for this string belongs to _msg_ and should not be freed.
+If non-NULL, decoding fails if the message doesn't have a JSON payload.
+If NULL, decoding fails if the message does have a JSON payload.
+
+`flux_request_decodef()` decodes a request message with a JSON payload as
+above, parsing the payload using variable arguments with a format string
+in the style of jansson's `json_unpack()` (used internally). Decoding fails
+if the message doesn't have a JSON payload.
+
+`flux_request_decode_raw()` decodes a request message with a raw payload,
+setting _data_ and _len_ to the payload data and length. The storage for
+the raw payload belongs to _msg_ and should not be freed.
+
+
+RETURN VALUE
+------------
+
+These functions return 0 on success.  On error, -1 is returned, and
+errno is set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+The _msg_ argument was NULL.
+
+EPROTO::
+Message decoding failed, such as due to missing or unexpected payload,
+incorrect message type, missing topic string, etc..
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_respond(3), flux_rpc(3)
+
+http://jansson.readthedocs.io/en/2.7/apiref.html#parsing-and-validating-values[Jansson API: Parsing and Validating Values]

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -5,7 +5,7 @@ flux_respond(3)
 
 NAME
 ----
-flux_respond, flux_respond_raw - respond to a request
+flux_respond, flux_respondf, flux_respond_raw - respond to a request
 
 
 SYNOPSIS
@@ -15,15 +15,19 @@ SYNOPSIS
  int flux_respond (flux_t *h, const flux_msg_t *request,
                    int errnum, const char *json_str);
 
+ int flux_respondf (flux_t *h, const flux_msg_t *request,
+                    const char *fmt, ...);
+
  int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                        int errnum, const void *data, int length);
+
 
 DESCRIPTION
 -----------
 
-`flux_respond()` and `flux_respond_raw()` encode and send a response
-message on handle _h_, deriving topic string, matchtag, and route stack
-from the provided _request_.
+`flux_respond()`, `flux_respondf()`, and `flux_respond_raw()` encode
+and send a response message on handle _h_, deriving topic string,
+matchtag, and route stack from the provided _request_.
 
 If _errnum_ is non-zero, an error is returned to the sender such that
 `flux_rpc_get(3)` or `flux_rpc_get_raw(3)` will fail, with the system
@@ -32,6 +36,10 @@ errno set to _errnum_.  Any payload arguments are ignored in this case.
 If _json_str_ is non-NULL, `flux_respond()` will send it as the response
 payload, otherwise there will be no payload.  Similarly, if _data_ is
 non-NULL, `flux_respond_raw()` will send it as the response payload.
+
+`flux_respondf()` encodes a response message with a JSON payload,
+building the payload using variable arguments with a format string in
+the style of jansson's `json_pack()` (used internally).
 
 
 RETURN VALUE
@@ -77,3 +85,5 @@ https://github.com/flux-framework/rfc/blob/master/spec_6.adoc[RFC 6: Flux
 Remote Procedure Call Protocol]
 
 https://github.com/flux-framework/rfc/blob/master/spec_3.adoc[RFC 3: CMB1 - Flux Comms Message Broker Protocol]
+
+http://jansson.readthedocs.io/en/2.7/apiref.html#building-values[Jansson API: Building Values]

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -80,14 +80,14 @@ an RPC before completion renders the matchtag associated with the RPC
 unusable; it is effectively leaked from the matchtag pool.
 
 `flux_rpcf()` is a variant of `flux_rpc()` that constructs a JSON
-payload based on the provided `fmt` string and variable arguments.
-The `fmt` string and variable arguments are passed internally to
+payload based on the provided _fmt_ string and variable arguments.
+The _fmt_ string and variable arguments are passed internally to
 jansson's `json_pack()` function.  See jansson documentation for
 details.
 
 `flux_rpc_getf()` is a variant of `flux_rpc_get()` that parses a JSON
-payload based on the provided `fmt` string and variable arguments.
-The `fmt` string and variable arguments are passed internally to
+payload based on the provided _fmt_ string and variable arguments.
+The _fmt_ string and variable arguments are passed internally to
 jansson's `json_unpack()` function.  Any strings or objects returned
 are invalidated when `flux_rpc_destroy()` is called.  See jansson
 documentation for details.
@@ -162,3 +162,7 @@ flux_rpc_then(3), flux_rpc_multi(3)
 
 https://github.com/flux-framework/rfc/blob/master/spec_6.adoc[RFC 6: Flux
 Remote Procedure Call Protocol]
+
+http://jansson.readthedocs.io/en/2.7/apiref.html#parsing-and-validating-values[Jansson API: Parsing and Validating Values]
+
+http://jansson.readthedocs.io/en/2.7/apiref.html#building-values[Jansson API: Building Values]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -336,3 +336,4 @@ jansson's
 rpcf
 decodef
 len
+respondf

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -337,3 +337,4 @@ rpcf
 decodef
 len
 respondf
+encodef

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -334,3 +334,5 @@ getf
 jansson
 jansson's
 rpcf
+decodef
+len

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -505,7 +505,7 @@ static int l_flux_recv (lua_State *L)
         goto error;
 
     if (errnum == 0 && (flux_msg_get_topic (msg, &topic) < 0
-                     || flux_msg_get_payload_json (msg, &json_str) < 0))
+                     || flux_msg_get_json (msg, &json_str) < 0))
         goto error;
 
     if (json_str && !(o = json_tokener_parse (json_str)))
@@ -676,7 +676,7 @@ static int l_flux_recv_event (lua_State *L)
         return lua_pusherror (L, (char *)flux_strerror (errno));
 
     if (flux_msg_get_topic (msg, &topic) < 0
-            || flux_msg_get_payload_json (msg, &json_str) < 0
+            || flux_msg_get_json (msg, &json_str) < 0
             || (json_str && !(o = json_tokener_parse (json_str)))) {
         flux_msg_destroy (msg);
         return lua_pusherror (L, (char *)flux_strerror (errno));

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -488,7 +488,7 @@ static int l_flux_recv (lua_State *L)
     const char *json_str = NULL;
     json_object *o = NULL;
     int errnum;
-    zmsg_t *zmsg;
+    flux_msg_t *msg;
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
         .matchtag = FLUX_MATCHTAG_NONE,
@@ -498,14 +498,14 @@ static int l_flux_recv (lua_State *L)
     if (lua_gettop (L) > 1)
         match.matchtag = lua_tointeger (L, 2);
 
-    if (!(zmsg = flux_recvmsg_match (f, match, false)))
+    if (!(msg = flux_recvmsg_match (f, match, false)))
         goto error;
 
-    if (flux_msg_get_errnum (zmsg, &errnum) < 0)
+    if (flux_msg_get_errnum (msg, &errnum) < 0)
         goto error;
 
-    if (errnum == 0 && (flux_msg_get_topic (zmsg, &topic) < 0
-                     || flux_msg_get_payload_json (zmsg, &json_str) < 0))
+    if (errnum == 0 && (flux_msg_get_topic (msg, &topic) < 0
+                     || flux_msg_get_payload_json (msg, &json_str) < 0))
         goto error;
 
     if (json_str && !(o = json_tokener_parse (json_str)))
@@ -533,9 +533,9 @@ static int l_flux_recv (lua_State *L)
         lua_pushnil (L);
     return (2);
 error:
-    if (zmsg) {
+    if (msg) {
         int saved_errno = errno;
-        zmsg_destroy (&zmsg);
+        flux_msg_destroy (msg);
         errno = saved_errno;
     }
     return lua_pusherror (L, (char *)flux_strerror (errno));
@@ -631,7 +631,7 @@ static int l_flux_send_event (lua_State *L)
     json_object *o = NULL;
     const char *json_str = NULL;
     int eventidx = 2;
-    zmsg_t *zmsg;
+    flux_msg_t *msg;
     int rc = 0;
 
     /*
@@ -649,12 +649,12 @@ static int l_flux_send_event (lua_State *L)
 
     event = luaL_checkstring (L, -1);
 
-    zmsg = flux_event_encode (event, json_str);
-    if (!zmsg || flux_sendmsg (f, &zmsg) < 0)
+    msg = flux_event_encode (event, json_str);
+    if (!msg || flux_sendmsg (f, &msg) < 0)
         rc = -1;
     if (o)
         json_object_put (o);
-    zmsg_destroy (&zmsg);
+    flux_msg_destroy (msg);
 
     return l_pushresult (L, rc);
 }
@@ -670,15 +670,15 @@ static int l_flux_recv_event (lua_State *L)
         .matchtag = FLUX_MATCHTAG_NONE,
         .topic_glob = NULL,
     };
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = NULL;
 
-    if (!(zmsg = flux_recvmsg_match (f, match, 0)))
+    if (!(msg = flux_recvmsg_match (f, match, 0)))
         return lua_pusherror (L, (char *)flux_strerror (errno));
 
-    if (flux_msg_get_topic (zmsg, &topic) < 0
-            || flux_msg_get_payload_json (zmsg, &json_str) < 0
+    if (flux_msg_get_topic (msg, &topic) < 0
+            || flux_msg_get_payload_json (msg, &json_str) < 0
             || (json_str && !(o = json_tokener_parse (json_str)))) {
-        zmsg_destroy (&zmsg);
+        flux_msg_destroy (msg);
         return lua_pusherror (L, (char *)flux_strerror (errno));
     }
 
@@ -823,9 +823,9 @@ static int l_f_zi_resp_cb (lua_State *L,
 }
 
 static int create_and_push_zmsg_info (lua_State *L,
-        flux_t *f, int typemask, zmsg_t **zmsg)
+        flux_t *f, int typemask, flux_msg_t **msg)
 {
-    struct zmsg_info * zi = zmsg_info_create (zmsg, typemask);
+    struct zmsg_info * zi = zmsg_info_create (msg, typemask);
     zmsg_info_register_resp_cb (zi, (zi_resp_f) l_f_zi_resp_cb, (void *) f);
     return lua_push_zmsg_info (L, zi);
 }
@@ -833,7 +833,7 @@ static int create_and_push_zmsg_info (lua_State *L,
 static int l_flux_recvmsg (lua_State *L)
 {
     flux_t *f = lua_get_flux (L, 1);
-    zmsg_t *zmsg;
+    flux_msg_t *msg;
     int type;
     struct flux_match match = {
         .typemask = FLUX_MSGTYPE_RESPONSE,
@@ -844,18 +844,18 @@ static int l_flux_recvmsg (lua_State *L)
     if (lua_gettop (L) > 1)
         match.matchtag = lua_tointeger (L, 2);
 
-    if (!(zmsg = flux_recvmsg_match (f, match, false)))
+    if (!(msg = flux_recvmsg_match (f, match, false)))
         return lua_pusherror (L, (char *)flux_strerror (errno));
 
-    if (flux_msg_get_type (zmsg, &type) < 0)
+    if (flux_msg_get_type (msg, &type) < 0)
         type = FLUX_MSGTYPE_ANY;
 
-    create_and_push_zmsg_info (L, f, type, &zmsg);
-    zmsg_destroy (&zmsg);
+    create_and_push_zmsg_info (L, f, type, &msg);
+    flux_msg_destroy (msg);
     return (1);
 }
 
-static int msghandler (flux_t *f, int typemask, zmsg_t **zmsg, void *arg)
+static int msghandler (flux_t *f, int typemask, flux_msg_t **msg, void *arg)
 {
     int rc;
     int t;
@@ -873,7 +873,7 @@ static int msghandler (flux_t *f, int typemask, zmsg_t **zmsg, void *arg)
     lua_push_flux_handle (L, f);
     assert (lua_isuserdata (L, -1));
 
-    create_and_push_zmsg_info (L, f, typemask, zmsg);
+    create_and_push_zmsg_info (L, f, typemask, msg);
     assert (lua_isuserdata (L, -1));
 
     lua_getfield (L, t, "userdata");

--- a/src/bindings/lua/tests/zmsg-test.c
+++ b/src/bindings/lua/tests/zmsg-test.c
@@ -50,7 +50,7 @@ flux_msg_t *l_cmb_zmsg_encode (lua_State *L)
     flux_msg_t *msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
     const char *json_str = json_object_to_json_string (o);
     if (!msg || flux_msg_set_topic (msg, tag) < 0
-              || flux_msg_set_payload_json (msg, json_str) < 0) {
+              || flux_msg_set_json (msg, json_str) < 0) {
         flux_msg_destroy (msg);
         return NULL;
     }
@@ -67,10 +67,10 @@ static int l_zi_resp_cb (lua_State *L,
     const char *json_str = NULL;
     if (resp)
         json_str = json_object_to_json_string (resp);
-    if (flux_msg_set_payload_json (*msg, json_str) < 0) {
+    if (flux_msg_set_json (*msg, json_str) < 0) {
         flux_msg_destroy (*msg);
         free (msg);
-        return lua_pusherror (L, "flux_msg_set_payload_json: %s", strerror (errno));
+        return lua_pusherror (L, "flux_msg_set_json: %s", strerror (errno));
     }
 
     return lua_push_zmsg_info (L, zmsg_info_create (msg, FLUX_MSGTYPE_RESPONSE));

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -64,7 +64,7 @@ struct zmsg_info * zmsg_info_create (flux_msg_t **msg, int typemask)
         return (NULL);
     }
     zi->o = NULL;
-    if (flux_msg_get_payload_json (*msg, &json_str) < 0
+    if (flux_msg_get_json (*msg, &json_str) < 0
                 || (json_str && !(zi->o = json_tokener_parse (json_str)))) {
         free (zi->tag);
         free (zi);

--- a/src/bindings/lua/zmsg-lua.h
+++ b/src/bindings/lua/zmsg-lua.h
@@ -12,11 +12,11 @@ struct zmsg_info;
 typedef int (*zi_resp_f) (lua_State *L,
 	struct zmsg_info *zi, json_object *resp, void *arg);
 
-struct zmsg_info *zmsg_info_create (zmsg_t **zmsg, int type);
+struct zmsg_info *zmsg_info_create (flux_msg_t **msg, int type);
 
 int zmsg_info_register_resp_cb (struct zmsg_info *zi, zi_resp_f f, void *arg);
 
-zmsg_t **zmsg_info_zmsg (struct zmsg_info *zi);
+flux_msg_t **zmsg_info_zmsg (struct zmsg_info *zi);
 
 const json_object *zmsg_info_json (struct zmsg_info *zi);
 

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -63,14 +63,14 @@ class Message(WrapperPimpl):
     def payload_str(self):
         s = ffi.new('char *[1]')
         if self.pimpl.has_payload():
-            self.pimpl.get_payload_json(ffi.cast('char**', s))
+            self.pimpl.get_json(ffi.cast('char**', s))
             return ffi.string(s[0])
         else:
             return None
 
     @payload_str.setter
     def payload_str(self, value):
-        self.pimpl.set_payload_json(value)
+        self.pimpl.set_json(value)
 
     @property
     def payload(self):

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -113,16 +113,16 @@ svc_t *svc_add (svchash_t *sh, const char *name, const char *alias,
     return svc;
 }
 
-int svc_sendmsg (svchash_t *sh, zmsg_t **zmsg)
+int svc_sendmsg (svchash_t *sh, flux_msg_t **msg)
 {
     const char *topic;
     int type;
     svc_t *svc;
     int rc = -1;
 
-    if (flux_msg_get_type (*zmsg, &type) < 0)
+    if (flux_msg_get_type (*msg, &type) < 0)
         goto done;
-    if (flux_msg_get_topic (*zmsg, &topic) < 0)
+    if (flux_msg_get_topic (*msg, &topic) < 0)
         goto done;
     if (!(svc = zhash_lookup (sh->services, topic)))
         svc = zhash_lookup (sh->aliases, topic);
@@ -138,7 +138,7 @@ int svc_sendmsg (svchash_t *sh, zmsg_t **zmsg)
         errno = ENOSYS;
         goto done;
     }
-    rc = svc->cb (zmsg, svc->cb_arg);
+    rc = svc->cb (msg, svc->cb_arg);
 done:
     return rc;
 }

--- a/src/broker/service.h
+++ b/src/broker/service.h
@@ -3,7 +3,7 @@
 
 typedef struct svc_struct svc_t;
 typedef struct svchash_struct svchash_t;
-typedef int (*svc_cb_f)(zmsg_t **zmsg, void *arg);
+typedef int (*svc_cb_f)(flux_msg_t **msg, void *arg);
 
 svchash_t *svchash_create (void);
 void svchash_destroy (svchash_t *sh);
@@ -12,7 +12,7 @@ svc_t *svc_add (svchash_t *sh, const char *name, const char *alias,
                 svc_cb_f cb, void *arg);
 void svc_remove (svchash_t *sh, const char *name);
 
-int svc_sendmsg (svchash_t *sh, zmsg_t **zmsg);
+int svc_sendmsg (svchash_t *sh, flux_msg_t **msg);
 
 #endif /* !_BROKER_SERVICE_H */
 

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -195,7 +195,7 @@ static int event_sub (optparse_t *p, int argc, char **argv)
             const char *topic;
             const char *json_str;
             if (flux_msg_get_topic (msg, &topic) < 0
-                    || flux_msg_get_payload_json (msg, &json_str) < 0) {
+                    || flux_msg_get_json (msg, &json_str) < 0) {
                 printf ("malformed message ignored\n");
             } else {
                 printf ("%s\t%s\n", topic, json_str ? json_str : "");

--- a/src/common/libcompat/handle.c
+++ b/src/common/libcompat/handle.c
@@ -33,11 +33,12 @@
 
 #include "compat.h"
 
-int flux_sendmsg (flux_t *h, zmsg_t **zmsg)
+int flux_sendmsg (flux_t *h, flux_msg_t **msg)
 {
-    if (flux_send (h, *zmsg, 0) < 0)
+    if (flux_send (h, *msg, 0) < 0)
         return -1;
-    zmsg_destroy (zmsg);
+    flux_msg_destroy (*msg);
+    *msg = NULL;
     return 0;
 }
 

--- a/src/common/libcompat/request.c
+++ b/src/common/libcompat/request.c
@@ -59,7 +59,7 @@ int flux_json_request (flux_t *h, uint32_t nodeid, uint32_t matchtag,
         goto done;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto done;
-    if (flux_msg_set_payload_json (msg, in ? Jtostr (in) : NULL) < 0)
+    if (flux_msg_set_json (msg, in ? Jtostr (in) : NULL) < 0)
         goto done;
     if (flux_msg_enable_route (msg) < 0)
         goto done;
@@ -75,7 +75,7 @@ int flux_json_respond (flux_t *h, json_object *out, flux_msg_t **msg)
 
     if (flux_msg_set_type (*msg, FLUX_MSGTYPE_RESPONSE) < 0)
         goto done;
-    if (flux_msg_set_payload_json (*msg, out ? Jtostr (out) : NULL) < 0)
+    if (flux_msg_set_json (*msg, out ? Jtostr (out) : NULL) < 0)
         goto done;
     if (flux_send (h, *msg, 0) < 0)
         goto done;

--- a/src/common/libcompat/request.h
+++ b/src/common/libcompat/request.h
@@ -21,12 +21,12 @@ int flux_json_request (flux_t *h, uint32_t nodeid, uint32_t matchtag,
                        const char *topic, json_object *in)
                        __attribute__ ((deprecated));
 
-/* Convert 'zmsg' request into a response and send it.  'zmsg' is destroyed
+/* Convert 'msg' request into a response and send it.  'zmsg' is destroyed
  * on success.  Attach JSON payload 'out' (caller retains owenrship).
  * The original payload in the request, if any, is destroyed.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_json_respond (flux_t *h, json_object *out, zmsg_t **zmsg)
+int flux_json_respond (flux_t *h, json_object *out, flux_msg_t **msg)
                        __attribute__ ((deprecated));
 
 #endif /* !_FLUX_JSONC_REQUEST_H */

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -115,7 +115,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libev/libev.la \
-	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD)
+	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBMUNGE)
 
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -49,7 +49,7 @@ int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **j
     }
     if (flux_msg_get_topic (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload_json (msg, &js) < 0)
+    if (flux_msg_get_json (msg, &js) < 0)
         goto done;
     if ((json_str && !js) || (!json_str && js)) {
         errno = EPROTO;
@@ -78,7 +78,7 @@ flux_msg_t *flux_event_encode (const char *topic, const char *json_str)
         goto error;
     if (flux_msg_enable_route (msg) < 0)
         goto error;
-    if (json_str && flux_msg_set_payload_json (msg, json_str) < 0)
+    if (json_str && flux_msg_set_json (msg, json_str) < 0)
         goto error;
     return msg;
 error:

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -31,10 +31,10 @@
 #include "event.h"
 #include "message.h"
 
-int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **json_str)
+static int event_decode (const flux_msg_t *msg, const char **topic)
 {
     int type;
-    const char *ts, *js;
+    const char *ts;
     int rc = -1;
 
     if (msg == NULL) {
@@ -48,6 +48,21 @@ int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **j
         goto done;
     }
     if (flux_msg_get_topic (msg, &ts) < 0)
+        goto done;
+    if (topic)
+        *topic = ts;
+    rc = 0;
+done:
+    return rc;
+}
+
+
+int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **json_str)
+{
+    const char *ts, *js;
+    int rc = -1;
+
+    if (event_decode (msg, &ts) < 0)
         goto done;
     if (flux_msg_get_json (msg, &js) < 0)
         goto done;
@@ -64,7 +79,36 @@ done:
     return rc;
 }
 
-flux_msg_t *flux_event_encode (const char *topic, const char *json_str)
+static int flux_event_vdecodef (const flux_msg_t *msg, const char **topic,
+                                const char *fmt, va_list ap)
+{
+    const char *ts;
+    int rc = -1;
+
+    if (event_decode (msg, &ts) < 0)
+        goto done;
+    if (flux_msg_vget_jsonf (msg, fmt, ap) < 0)
+        goto done;
+    if (topic)
+        *topic = ts;
+    rc = 0;
+done:
+    return rc;
+}
+
+int flux_event_decodef (const flux_msg_t *msg, const char **topic,
+                        const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = flux_event_vdecodef (msg, topic, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+static flux_msg_t *flux_event_create (const char *topic)
 {
     flux_msg_t *msg = NULL;
 
@@ -78,12 +122,48 @@ flux_msg_t *flux_event_encode (const char *topic, const char *json_str)
         goto error;
     if (flux_msg_enable_route (msg) < 0)
         goto error;
+    return msg;
+error:
+    flux_msg_destroy (msg);
+    return NULL;
+}
+
+flux_msg_t *flux_event_encode (const char *topic, const char *json_str)
+{
+    flux_msg_t *msg = flux_event_create (topic);
+    if (!msg)
+        goto error;
     if (json_str && flux_msg_set_json (msg, json_str) < 0)
         goto error;
     return msg;
 error:
     flux_msg_destroy (msg);
     return NULL;
+}
+
+static flux_msg_t *flux_event_vencodef (const char *topic,
+                                        const char *fmt, va_list ap)
+{
+    flux_msg_t *msg = flux_event_create (topic);
+    if (!msg)
+        goto error;
+    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+        goto error;
+    return msg;
+error:
+    flux_msg_destroy (msg);
+    return NULL;
+}
+
+flux_msg_t *flux_event_encodef (const char *topic, const char *fmt, ...)
+{
+    flux_msg_t *msg;
+    va_list ap;
+
+    va_start (ap, fmt);
+    msg = flux_event_vencodef (topic, fmt, ap);
+    va_end (ap);
+    return msg;
 }
 
 /*

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -15,11 +15,24 @@
 int flux_event_decode (const flux_msg_t *msg, const char **topic,
                        const char **json_str);
 
+/* Decode an event message with json payload.  These functions use
+ * jansson unpack style variable arguments for decoding the JSON object
+ * payload directly.  Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_event_decodef (const flux_msg_t *msg, const char **topic,
+                        const char *fmt, ...);
+
 /* Encode an event message.
  * If json_str is non-NULL, it is copied to the message payload.
  * Returns message or NULL on failure with errno set.
  */
 flux_msg_t *flux_event_encode (const char *topic, const char *json_str);
+
+/* Encode an event message with json payload.  These functions use
+ * jansson pack style variable arguments for encoding the JSON object
+ * payload directly.  Returns message or NULL on failure with errno set.
+ */
+flux_msg_t *flux_event_encodef (const char *topic, const char *fmt, ...);
 
 #endif /* !FLUX_CORE_EVENT_H */
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1383,6 +1383,12 @@ done:
     return msg;
 }
 
+int flux_msg_frames (const flux_msg_t *msg)
+{
+    return zmsg_size (msg);
+}
+
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -927,7 +927,7 @@ bool flux_msg_has_payload (const flux_msg_t *msg)
     return ((flags & FLUX_MSGFLAG_PAYLOAD));
 }
 
-int flux_msg_set_payload_json (flux_msg_t *msg, const char *s)
+int flux_msg_set_json (flux_msg_t *msg, const char *s)
 {
     int rc = -1;
     if (s) {
@@ -943,7 +943,7 @@ done:
     return rc;
 }
 
-int flux_msg_get_payload_json (const flux_msg_t *msg, const char **s)
+int flux_msg_get_json (const flux_msg_t *msg, const char **s)
 {
     char *buf;
     int size;
@@ -1157,7 +1157,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
         const char *json_str;
         void *buf;
         int size, flags;
-        if (flux_msg_get_payload_json (msg, &json_str) == 0)
+        if (flux_msg_get_json (msg, &json_str) == 0)
             fprintf (f, "%s[%3.3lu] %s\n", prefix, strlen (json_str), json_str);
         else if (flux_msg_get_payload (msg, &flags, &buf, &size) == 0)
             fprintf (f, "%s[%3.3d] ...\n", prefix, size);

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -47,6 +47,10 @@
 #define PROTO_OFF_BIGINT    4 /* 4 bytes */
 #define PROTO_OFF_BIGINT2   8 /* 4 bytes */
 
+struct flux_msg {
+    zmsg_t *zmsg;
+};
+
 static int proto_set_bigint (uint8_t *data, int len, uint32_t bigint);
 static int proto_set_bigint2 (uint8_t *data, int len, uint32_t bigint);
 
@@ -172,43 +176,48 @@ static void proto_init (uint8_t *data, int len, uint8_t flags)
 /* End manual codec
  */
 
-zmsg_t *flux_msg_create (int type)
+flux_msg_t *flux_msg_create (int type)
 {
     uint8_t proto[PROTO_SIZE];
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = calloc (1, sizeof (*msg));
 
+    if (!msg) {
+        errno = ENOMEM;
+        goto error;
+    }
     proto_init (proto, PROTO_SIZE, 0);
     if (proto_set_type (proto, PROTO_SIZE, type) < 0) {
         errno = EINVAL;
-        goto done;
+        goto error;
     }
-    if (!(zmsg = zmsg_new ())) {
+    if (!(msg->zmsg = zmsg_new ())) {
         errno = ENOMEM;
-        goto done;
+        goto error;
     }
-    if (zmsg_addmem (zmsg, proto, PROTO_SIZE) < 0) {
-        zmsg_destroy (&zmsg);
-        goto done;
-    }
-done:
-    return zmsg;
+    if (zmsg_addmem (msg->zmsg, proto, PROTO_SIZE) < 0)
+        goto error;
+    return msg;
+error:
+    flux_msg_destroy (msg);
+    return NULL;
 }
 
 void flux_msg_destroy (flux_msg_t *msg)
 {
-    int saved_errno = errno;
-    if (msg)
-        zmsg_destroy (&msg);
-    errno = saved_errno;
+    if (msg) {
+        int saved_errno = errno;
+        zmsg_destroy (&msg->zmsg);
+        free (msg);
+        errno = saved_errno;
+    }
 }
 
 size_t flux_msg_encode_size (const flux_msg_t *msg)
 {
-    zmsg_t *zmsg = (zmsg_t *)msg;
     zframe_t *zf;
     size_t size = 0;
 
-    zf = zmsg_first (zmsg);
+    zf = zmsg_first (msg->zmsg);
     while (zf) {
         size_t n = zframe_size (zf);
         if (n < 255)
@@ -216,7 +225,7 @@ size_t flux_msg_encode_size (const flux_msg_t *msg)
         else
             size += 1 + 4;
         size += n;
-        zf = zmsg_next (zmsg);
+        zf = zmsg_next (msg->zmsg);
     }
     return size;
 }
@@ -224,11 +233,10 @@ size_t flux_msg_encode_size (const flux_msg_t *msg)
 
 int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t size)
 {
-    zmsg_t *zmsg = (zmsg_t *)msg;
     uint8_t *p = buf;
     zframe_t *zf;
 
-    zf = zmsg_first (zmsg);
+    zf = zmsg_first (msg->zmsg);
     while (zf) {
         size_t n = zframe_size (zf);
         if (n < 0xff) {
@@ -244,7 +252,7 @@ int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t size)
         }
         memcpy (p, zframe_data (zf), n);
         p += n;
-        zf = zmsg_next (zmsg);
+        zf = zmsg_next (msg->zmsg);
     }
     return 0;
 nospace:
@@ -254,12 +262,12 @@ nospace:
 
 flux_msg_t *flux_msg_decode (const void *buf, size_t size)
 {
-    zmsg_t *zmsg = NULL;
+    flux_msg_t *msg = calloc (1, sizeof (*msg));
     uint8_t const *p = buf;
     zframe_t *zf;
     int saved_errno;
 
-    if (!(zmsg = zmsg_new ()))
+    if (!msg || !(msg->zmsg = zmsg_new ()))
         goto nomem;
     while (p - (uint8_t *)buf < size) {
         size_t n = *p++;
@@ -277,22 +285,22 @@ flux_msg_t *flux_msg_decode (const void *buf, size_t size)
         }
         if (!(zf = zframe_new (p, n)))
             goto nomem;
-        if (zmsg_append (zmsg, &zf) < 0)
+        if (zmsg_append (msg->zmsg, &zf) < 0)
             goto nomem;
         p += n;
     }
-    return (flux_msg_t *)zmsg;
+    return msg;
 nomem:
     saved_errno = EINVAL;
 error:
-    zmsg_destroy (&zmsg);
+    flux_msg_destroy (msg);
     errno = saved_errno;
     return NULL;
 }
 
-int flux_msg_set_type (zmsg_t *zmsg, int type)
+int flux_msg_set_type (flux_msg_t *msg, int type)
 {
-    zframe_t *zf = zmsg_last (zmsg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     if (!zf || proto_set_type (zframe_data (zf), zframe_size (zf), type) < 0) {
         errno = EINVAL;
         return -1;
@@ -302,7 +310,7 @@ int flux_msg_set_type (zmsg_t *zmsg, int type)
 
 int flux_msg_get_type (const flux_msg_t *msg, int *type)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), type) < 0) {
         errno = EPROTO;
         return -1;
@@ -314,9 +322,9 @@ int flux_msg_get_type (const flux_msg_t *msg, int *type)
  * outside of this module for now.
  */
 
-static int flux_msg_set_flags (zmsg_t *zmsg, uint8_t fl)
+static int flux_msg_set_flags (flux_msg_t *msg, uint8_t fl)
 {
-    zframe_t *zf = zmsg_last (zmsg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     if (!zf || proto_set_flags (zframe_data (zf), zframe_size (zf), fl) < 0) {
         errno = EINVAL;
         return -1;
@@ -326,7 +334,7 @@ static int flux_msg_set_flags (zmsg_t *zmsg, uint8_t fl)
 
 static int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *fl)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     if (!zf || proto_get_flags (zframe_data (zf), zframe_size (zf), fl) < 0) {
         errno = EPROTO;
         return -1;
@@ -334,7 +342,7 @@ static int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *fl)
     return 0;
 }
 
-int flux_msg_set_nodeid (zmsg_t *zmsg, uint32_t nodeid, int flags)
+int flux_msg_set_nodeid (flux_msg_t *msg, uint32_t nodeid, int flags)
 {
     zframe_t *zf;
     int type;
@@ -345,7 +353,7 @@ int flux_msg_set_nodeid (zmsg_t *zmsg, uint32_t nodeid, int flags)
         goto error;
     if (flags == FLUX_MSGFLAG_UPSTREAM && nodeid == FLUX_NODEID_ANY)
         goto error;
-    if (!(zf = zmsg_last (zmsg)))
+    if (!(zf = zmsg_last (msg->zmsg)))
         goto error;
     if (proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0)
         goto error;
@@ -363,7 +371,7 @@ error:
 
 int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeid, int *flags)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
     uint8_t fl;
     uint32_t nid;
@@ -382,9 +390,9 @@ int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeid, int *flags)
     return 0;
 }
 
-int flux_msg_set_errnum (zmsg_t *zmsg, int e)
+int flux_msg_set_errnum (flux_msg_t *msg, int e)
 {
-    zframe_t *zf = zmsg_last (zmsg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
 
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0
@@ -398,7 +406,7 @@ int flux_msg_set_errnum (zmsg_t *zmsg, int e)
 
 int flux_msg_get_errnum (const flux_msg_t *msg, int *e)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
     uint32_t xe;
 
@@ -412,9 +420,9 @@ int flux_msg_get_errnum (const flux_msg_t *msg, int *e)
     return 0;
 }
 
-int flux_msg_set_seq (zmsg_t *zmsg, uint32_t seq)
+int flux_msg_set_seq (flux_msg_t *msg, uint32_t seq)
 {
-    zframe_t *zf = zmsg_last (zmsg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
 
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0
@@ -428,7 +436,7 @@ int flux_msg_set_seq (zmsg_t *zmsg, uint32_t seq)
 
 int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
 
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0
@@ -440,9 +448,9 @@ int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
     return 0;
 }
 
-int flux_msg_set_matchtag (zmsg_t *zmsg, uint32_t t)
+int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t t)
 {
-    zframe_t *zf = zmsg_last (zmsg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
 
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0
@@ -456,7 +464,7 @@ int flux_msg_set_matchtag (zmsg_t *zmsg, uint32_t t)
 
 int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
 
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0
@@ -468,9 +476,9 @@ int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
     return 0;
 }
 
-int flux_msg_set_status (zmsg_t *zmsg, int s)
+int flux_msg_set_status (flux_msg_t *msg, int s)
 {
-    zframe_t *zf = zmsg_last (zmsg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
 
     if (!zf || proto_get_type (zframe_data (zf), zframe_size (zf), &type) < 0
@@ -484,7 +492,7 @@ int flux_msg_set_status (zmsg_t *zmsg, int s)
 
 int flux_msg_get_status (const flux_msg_t *msg, int *s)
 {
-    zframe_t *zf = zmsg_last ((zmsg_t *)msg);
+    zframe_t *zf = zmsg_last (msg->zmsg);
     int type;
     uint32_t u;
 
@@ -550,71 +558,71 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
     return true;
 }
 
-int flux_msg_enable_route (zmsg_t *zmsg)
+int flux_msg_enable_route (flux_msg_t *msg)
 {
     uint8_t flags;
 
-    if (flux_msg_get_flags (zmsg, &flags) < 0)
+    if (flux_msg_get_flags (msg, &flags) < 0)
         return -1;
     if ((flags & FLUX_MSGFLAG_ROUTE))
         return 0;
-    if (zmsg_pushmem (zmsg, NULL, 0) < 0) {
+    if (zmsg_pushmem (msg->zmsg, NULL, 0) < 0) {
         errno = ENOMEM;
         return -1;
     }
     flags |= FLUX_MSGFLAG_ROUTE;
-    return flux_msg_set_flags (zmsg, flags);
+    return flux_msg_set_flags (msg, flags);
 }
 
-int flux_msg_clear_route (zmsg_t *zmsg)
+int flux_msg_clear_route (flux_msg_t *msg)
 {
     uint8_t flags;
     zframe_t *zf;
     int size;
 
-    if (flux_msg_get_flags (zmsg, &flags) < 0)
+    if (flux_msg_get_flags (msg, &flags) < 0)
         return -1;
     if (!(flags & FLUX_MSGFLAG_ROUTE))
         return 0;
-    while ((zf = zmsg_pop (zmsg))) {
+    while ((zf = zmsg_pop (msg->zmsg))) {
         size = zframe_size (zf);
         zframe_destroy (&zf);
         if (size == 0)
             break;
     }
     flags &= ~(uint8_t)FLUX_MSGFLAG_ROUTE;
-    return flux_msg_set_flags (zmsg, flags);
+    return flux_msg_set_flags (msg, flags);
 }
 
-int flux_msg_push_route (zmsg_t *zmsg, const char *id)
+int flux_msg_push_route (flux_msg_t *msg, const char *id)
 {
     uint8_t flags;
 
-    if (flux_msg_get_flags (zmsg, &flags) < 0)
+    if (flux_msg_get_flags (msg, &flags) < 0)
         return -1;
     if (!(flags & FLUX_MSGFLAG_ROUTE)) {
         errno = EPROTO;
         return -1;
     }
-    if (zmsg_pushstr (zmsg, id) < 0) {
+    if (zmsg_pushstr (msg->zmsg, id) < 0) {
         errno = ENOMEM;
         return -1;
     }
     return 0;
 }
 
-int flux_msg_pop_route (zmsg_t *zmsg, char **id)
+int flux_msg_pop_route (flux_msg_t *msg, char **id)
 {
     uint8_t flags;
     zframe_t *zf;
 
-    if (flux_msg_get_flags (zmsg, &flags) < 0)
+    if (flux_msg_get_flags (msg, &flags) < 0)
         return -1;
-    if (!(flags & FLUX_MSGFLAG_ROUTE) || !(zf = zmsg_first (zmsg))) {
+    if (!(flags & FLUX_MSGFLAG_ROUTE) || !(zf = zmsg_first (msg->zmsg))) {
         errno = EPROTO;
         return -1;
     }
-    if (zframe_size (zf) > 0 && (zf = zmsg_pop (zmsg))) {
+    if (zframe_size (zf) > 0 && (zf = zmsg_pop (msg->zmsg))) {
         if (id) {
             char *s = zframe_strdup (zf);
             if (!s) {
@@ -641,7 +649,7 @@ int flux_msg_get_route_last (const flux_msg_t *msg, char **id)
 
     if (flux_msg_get_flags (msg, &flags) < 0)
         return -1;
-    if (!(flags & FLUX_MSGFLAG_ROUTE) || !(zf = zmsg_first ((zmsg_t *)msg))) {
+    if (!(flags & FLUX_MSGFLAG_ROUTE) || !(zf = zmsg_first (msg->zmsg))) {
         errno = EPROTO;
         return -1;
     }
@@ -666,9 +674,9 @@ int flux_msg_get_route_first (const flux_msg_t *msg, char **id)
         errno = EPROTO;
         return -1;
     }
-    zf = zmsg_first ((zmsg_t *)msg);
+    zf = zmsg_first (msg->zmsg);
     while (zf && zframe_size (zf) > 0) {
-        zf_next = zmsg_next ((zmsg_t *)msg);
+        zf_next = zmsg_next (msg->zmsg);
         if (zf_next && zframe_size (zf_next) == 0)
             break;
         zf = zf_next;
@@ -697,9 +705,9 @@ int flux_msg_get_route_count (const flux_msg_t *msg)
         errno = EPROTO;
         return -1;
     }
-    zf = zmsg_first ((zmsg_t *)msg);
+    zf = zmsg_first (msg->zmsg);
     while (zf && zframe_size (zf) > 0) {
-        zf = zmsg_next ((zmsg_t *)msg);
+        zf = zmsg_next (msg->zmsg);
         count++;
     }
     return count;
@@ -707,14 +715,13 @@ int flux_msg_get_route_count (const flux_msg_t *msg)
 
 bool flux_msg_has_route (const flux_msg_t *msg, const char *s)
 {
-    zmsg_t *zmsg = (zmsg_t *)msg; /* drop const qualifier */
     zframe_t *zf;
 
-    zf = zmsg_first (zmsg);
+    zf = zmsg_first (msg->zmsg);
     while (zf && zframe_size (zf) > 0) {
         if (zframe_streq (zf, s))
             return true;
-        zf = zmsg_next (zmsg);
+        zf = zmsg_next (msg->zmsg);
     }
     return false;
 }
@@ -733,10 +740,10 @@ static int flux_msg_get_route_size (const flux_msg_t *msg)
         errno = EPROTO;
         return -1;
     }
-    zf = zmsg_first ((zmsg_t *)msg);
+    zf = zmsg_first (msg->zmsg);
     while (zf && zframe_size (zf) > 0) {
         size += zframe_size (zf);
-        zf = zmsg_next ((zmsg_t *)msg);
+        zf = zmsg_next (msg->zmsg);
     }
     return size;
 }
@@ -753,11 +760,11 @@ static zframe_t *flux_msg_get_route_nth (const flux_msg_t *msg, int n)
         errno = EPROTO;
         return NULL;
     }
-    zf = zmsg_first ((zmsg_t *)msg);
+    zf = zmsg_first (msg->zmsg);
     while (zf && zframe_size (zf) > 0) {
         if (count == n)
             return zf;
-        zf = zmsg_next ((zmsg_t *)msg);
+        zf = zmsg_next (msg->zmsg);
         count++;
     }
     errno = ENOENT;
@@ -807,7 +814,7 @@ static bool payload_overlap (const void *b, zframe_t *zf)
          && (char *)b <  (char *)zframe_data (zf) + zframe_size (zf));
 }
 
-int flux_msg_set_payload (zmsg_t *zmsg, int flags, const void *buf, int size)
+int flux_msg_set_payload (flux_msg_t *msg, int flags, const void *buf, int size)
 {
     zframe_t *zf;
     uint8_t msgflags;
@@ -817,22 +824,22 @@ int flux_msg_set_payload (zmsg_t *zmsg, int flags, const void *buf, int size)
         errno = EINVAL;
         goto done;
     }
-    if (flux_msg_get_flags (zmsg, &msgflags) < 0)
+    if (flux_msg_get_flags (msg, &msgflags) < 0)
         goto done;
     if (!(msgflags & FLUX_MSGFLAG_PAYLOAD) && (buf == NULL || size == 0)) {
         rc = 0;
         goto done;
     }
-    zf = zmsg_first (zmsg);
+    zf = zmsg_first (msg->zmsg);
     if ((msgflags & FLUX_MSGFLAG_ROUTE)) {
         while (zf && zframe_size (zf) > 0)
-            zf = zmsg_next (zmsg);      /* skip route frame */
+            zf = zmsg_next (msg->zmsg);      /* skip route frame */
         if (zf)
-            zf = zmsg_next (zmsg);      /* skip route delim */
+            zf = zmsg_next (msg->zmsg);      /* skip route delim */
     }
     if ((msgflags & FLUX_MSGFLAG_TOPIC)) {
         if (zf)
-            zf = zmsg_next (zmsg);      /* skip topic frame */
+            zf = zmsg_next (msg->zmsg);      /* skip topic frame */
     }
     if (!zf) {                          /* must at least have proto frame */
         errno = EPROTO;
@@ -853,8 +860,9 @@ int flux_msg_set_payload (zmsg_t *zmsg, int flags, const void *buf, int size)
     /* Case #2: add payload.
      */
     } else if (!(msgflags & FLUX_MSGFLAG_PAYLOAD) && (buf != NULL && size > 0)){
-        zmsg_remove (zmsg, zf);
-        if (zmsg_addmem (zmsg, buf, size) < 0 || zmsg_append (zmsg, &zf) < 0) {
+        zmsg_remove (msg->zmsg, zf);
+        if (zmsg_addmem (msg->zmsg, buf, size) < 0
+                                        || zmsg_append (msg->zmsg, &zf) < 0) {
             errno = ENOMEM;
             goto done;
         }
@@ -863,11 +871,11 @@ int flux_msg_set_payload (zmsg_t *zmsg, int flags, const void *buf, int size)
     /* Case #3: remove payload.
      */
     } else if ((msgflags & FLUX_MSGFLAG_PAYLOAD) && (buf == NULL || size == 0)){
-        zmsg_remove (zmsg, zf);
+        zmsg_remove (msg->zmsg, zf);
         zframe_destroy (&zf);
         msgflags &= ~(uint8_t)(FLUX_MSGFLAG_PAYLOAD | FLUX_MSGFLAG_JSON);
     }
-    if (flux_msg_set_flags (zmsg, msgflags) < 0)
+    if (flux_msg_set_flags (msg, msgflags) < 0)
         goto done;
     rc = 0;
 done:
@@ -885,16 +893,16 @@ int flux_msg_get_payload (const flux_msg_t *msg, int *flags, void *buf, int *siz
         errno = EPROTO;
         return -1;
     }
-    zf = zmsg_first ((zmsg_t *)msg);
+    zf = zmsg_first (msg->zmsg);
     if ((msgflags & FLUX_MSGFLAG_ROUTE)) {
         while (zf && zframe_size (zf) > 0)
-            zf = zmsg_next ((zmsg_t *)msg);
+            zf = zmsg_next (msg->zmsg);
         if (zf)
-            zf = zmsg_next ((zmsg_t *)msg);
+            zf = zmsg_next (msg->zmsg);
     }
     if ((msgflags & FLUX_MSGFLAG_TOPIC)) {
         if (zf)
-            zf = zmsg_next ((zmsg_t *)msg);
+            zf = zmsg_next (msg->zmsg);
     }
     if (!zf) {
         errno = EPROTO;
@@ -919,7 +927,7 @@ bool flux_msg_has_payload (const flux_msg_t *msg)
     return ((flags & FLUX_MSGFLAG_PAYLOAD));
 }
 
-int flux_msg_set_payload_json (zmsg_t *zmsg, const char *s)
+int flux_msg_set_payload_json (flux_msg_t *msg, const char *s)
 {
     int rc = -1;
     if (s) {
@@ -928,9 +936,9 @@ int flux_msg_set_payload_json (zmsg_t *zmsg, const char *s)
             errno = EINVAL;
             goto done;
         }
-        rc = flux_msg_set_payload (zmsg, FLUX_MSGFLAG_JSON, (char *)s, len + 1);
+        rc = flux_msg_set_payload (msg, FLUX_MSGFLAG_JSON, (char *)s, len + 1);
     } else
-        rc = flux_msg_set_payload (zmsg, 0, NULL, 0);
+        rc = flux_msg_set_payload (msg, 0, NULL, 0);
 done:
     return rc;
 }
@@ -963,20 +971,20 @@ done:
     return rc;
 }
 
-int flux_msg_set_topic (zmsg_t *zmsg, const char *topic)
+int flux_msg_set_topic (flux_msg_t *msg, const char *topic)
 {
     zframe_t *zf, *zf2 = NULL;
     uint8_t flags;
     int rc = -1;
 
-    if (flux_msg_get_flags (zmsg, &flags) < 0)
+    if (flux_msg_get_flags (msg, &flags) < 0)
         goto done;
-    zf = zmsg_first (zmsg);
+    zf = zmsg_first (msg->zmsg);
     if ((flags & FLUX_MSGFLAG_ROUTE)) {   /* skip over routing frames, if any */
         while (zf && zframe_size (zf) > 0)
-            zf = zmsg_next (zmsg);
+            zf = zmsg_next (msg->zmsg);
         if (zf)
-            zf = zmsg_next (zmsg);
+            zf = zmsg_next (msg->zmsg);
     }
     if (!zf) {                          /* must at least have proto frame */
         errno = EPROTO;
@@ -985,22 +993,22 @@ int flux_msg_set_topic (zmsg_t *zmsg, const char *topic)
     if ((flags & FLUX_MSGFLAG_TOPIC) && topic) {        /* case 1: repl topic */
         zframe_reset (zf, topic, strlen (topic) + 1);
     } else if (!(flags & FLUX_MSGFLAG_TOPIC) && topic) {/* case 2: add topic */
-        zmsg_remove (zmsg, zf);
-        if ((flags & FLUX_MSGFLAG_PAYLOAD) && (zf2 = zmsg_next (zmsg)))
-            zmsg_remove (zmsg, zf2);
-        if (zmsg_addmem (zmsg, topic, strlen (topic) + 1) < 0
-                                    || zmsg_append (zmsg, &zf) < 0
-                                    || (zf2 && zmsg_append (zmsg, &zf2) < 0)) {
+        zmsg_remove (msg->zmsg, zf);
+        if ((flags & FLUX_MSGFLAG_PAYLOAD) && (zf2 = zmsg_next (msg->zmsg)))
+            zmsg_remove (msg->zmsg, zf2);
+        if (zmsg_addmem (msg->zmsg, topic, strlen (topic) + 1) < 0
+                                    || zmsg_append (msg->zmsg, &zf) < 0
+                                    || (zf2 && zmsg_append (msg->zmsg, &zf2) < 0)) {
             errno = ENOMEM;
             goto done;
         }
         flags |= FLUX_MSGFLAG_TOPIC;
-        if (flux_msg_set_flags (zmsg, flags) < 0)
+        if (flux_msg_set_flags (msg, flags) < 0)
             goto done;
     } else if ((flags & FLUX_MSGFLAG_TOPIC) && !topic) { /* case 3: del topic */
-        zmsg_remove (zmsg, zf);
+        zmsg_remove (msg->zmsg, zf);
         flags &= ~(uint8_t)FLUX_MSGFLAG_TOPIC;
-        if (flux_msg_set_flags (zmsg, flags) < 0)
+        if (flux_msg_set_flags (msg, flags) < 0)
             goto done;
     }
     rc = 0;
@@ -1020,12 +1028,12 @@ static int zf_topic (const flux_msg_t *msg, zframe_t **zfp)
         errno = EPROTO;
         goto done;
     }
-    zf = zmsg_first ((zmsg_t *)msg);
+    zf = zmsg_first (msg->zmsg);
     if ((flags & FLUX_MSGFLAG_ROUTE)) {
         while (zf && zframe_size (zf) > 0)
-            zf = zmsg_next ((zmsg_t *)msg);
+            zf = zmsg_next (msg->zmsg);
         if (zf)
-            zf = zmsg_next ((zmsg_t *)msg);
+            zf = zmsg_next (msg->zmsg);
     }
     if (!zf) {
         errno = EPROTO;
@@ -1062,16 +1070,17 @@ done:
  */
 flux_msg_t *flux_msg_copy (const flux_msg_t *msg, bool payload)
 {
-    zmsg_t *cpy = zmsg_dup ((zmsg_t *)msg);
-    if (!cpy) {
+    flux_msg_t *cpy = calloc (1, sizeof (*cpy));
+    if (!cpy || !(cpy->zmsg = zmsg_dup (msg->zmsg))) {
         errno = ENOMEM;
-        return NULL;
+        goto error;
     }
-    if (!payload && flux_msg_set_payload (cpy, 0, NULL, 0) < 0) {
-        zmsg_destroy (&cpy);
-        return NULL;
-    }
+    if (!payload && flux_msg_set_payload (cpy, 0, NULL, 0) < 0)
+        goto error;
     return cpy;
+error:
+    flux_msg_destroy (cpy);
+    return NULL;
 }
 
 struct map_struct {
@@ -1122,7 +1131,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
         return;
     }
     if (flux_msg_get_type (msg, &type) < 0
-            || (!(proto = zmsg_last ((zmsg_t *)msg)))) {
+            || (!(proto = zmsg_last (msg->zmsg)))) {
         fprintf (f, "malformed message");
         return;
     }
@@ -1290,24 +1299,23 @@ done:
 int flux_msg_sendzsock (void *sock, const flux_msg_t *msg)
 {
     int rc = -1;
-    zmsg_t *zmsg = (zmsg_t *)msg; /* discard const qualifier */
 
-    if (!sock || !msg || !zmsg_is (zmsg)) {
+    if (!sock || !msg || !zmsg_is (msg->zmsg)) {
         errno = EINVAL;
         goto done;
     }
 
     void *handle = zsock_resolve (sock);
     int flags = ZFRAME_REUSE | ZFRAME_MORE;
-    zframe_t *zf = zmsg_first (zmsg);
+    zframe_t *zf = zmsg_first (msg->zmsg);
     size_t count = 0;
 
     while (zf) {
-        if (++count == zmsg_size (zmsg))
+        if (++count == zmsg_size (msg->zmsg))
             flags &= ~ZFRAME_MORE;
         if (zframe_send (&zf, handle, flags) < 0)
             goto done;
-        zf = zmsg_next (zmsg);
+        zf = zmsg_next (msg->zmsg);
     }
     rc = 0;
 done:
@@ -1316,7 +1324,18 @@ done:
 
 flux_msg_t *flux_msg_recvzsock (void *sock)
 {
-    return zmsg_recv (sock);
+    zmsg_t *zmsg;
+    flux_msg_t *msg;
+
+    if (!(zmsg = zmsg_recv (sock)))
+        return NULL;
+    if (!(msg = calloc (1, sizeof (*msg)))) {
+        zmsg_destroy (&zmsg);
+        errno = ENOMEM;
+        return NULL;
+    }
+    msg->zmsg = zmsg;
+    return msg;
 }
 
 int flux_msg_sendzsock_munge (void *sock, const flux_msg_t *msg,
@@ -1385,7 +1404,7 @@ done:
 
 int flux_msg_frames (const flux_msg_t *msg)
 {
-    return zmsg_size (msg);
+    return zmsg_size (msg->zmsg);
 }
 
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -151,8 +151,8 @@ bool flux_msg_has_payload (const flux_msg_t *msg);
  * set allows json_str to be NULL
  * get will set *json_str to NULL and return success if there is no payload.
  */
-int flux_msg_set_payload_json (flux_msg_t *msg, const char *json_str);
-int flux_msg_get_payload_json (const flux_msg_t *msg, const char **json_str);
+int flux_msg_set_json (flux_msg_t *msg, const char *json_str);
+int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);
 
 /* Get/set nodeid (request only)
  * If flags includes FLUX_MSGFLAG_UPSTREAM, nodeid is the sending rank.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include "security.h"
 
@@ -139,20 +140,28 @@ int flux_msg_get_topic (const flux_msg_t *msg, const char **topic);
  * Set function adds/deletes/replaces payload frame as needed.
  * The new payload will be copied (caller retains ownership).
  * Any old payload is deleted.
- * Get_payload returns pointer to msg-owned buf.
+ * flux_msg_get_payload returns pointer to msg-owned buf.
  * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
  */
+int flux_msg_get_payload (const flux_msg_t *msg, int *flags,
+                          void *buf, int *size);
 int flux_msg_set_payload (flux_msg_t *msg, int flags,
                           const void *buf, int size);
-int flux_msg_get_payload (const flux_msg_t *msg, int *flags, void *buf, int *size);
 bool flux_msg_has_payload (const flux_msg_t *msg);
 
-/* Get/set json string payload.
- * set allows json_str to be NULL
- * get will set *json_str to NULL and return success if there is no payload.
+/* Get/set JSON payload.
+ * flux_msg_set_json() accepts a NULL json_str (no payload).
+ * flux_msg_get_json() will set json_str to NULL if there is no payload
+ * jsonf functions use jansson pack/unpack style arguments for
+ * encoding/decoding the JSON object payload directly from/to its members.
  */
 int flux_msg_set_json (flux_msg_t *msg, const char *json_str);
+int flux_msg_set_jsonf (flux_msg_t *msg, const char *fmt, ...);
+int flux_msg_vset_jsonf (flux_msg_t *msg, const char *fmt, va_list ap);
+
 int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);
+int flux_msg_get_jsonf (const flux_msg_t *msg, const char *fmt, ...);
+int flux_msg_vget_jsonf (const flux_msg_t *msg, const char *fmt, va_list ap);
 
 /* Get/set nodeid (request only)
  * If flags includes FLUX_MSGFLAG_UPSTREAM, nodeid is the sending rank.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -76,6 +76,10 @@ flux_msg_t *flux_msg_copy (const flux_msg_t *msg, bool payload);
 size_t flux_msg_encode_size (const flux_msg_t *msg);
 int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t size);
 
+/* Get the number of message frames in 'msg'.
+ */
+int flux_msg_frames (const flux_msg_t *msg);
+
 /* Decode a flux_msg_t from buffer.
  * Returns message on success, NULL on failure with errno set.
  * Caller must destroy message with flux_msg_destroy().

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "security.h"
 
 typedef struct _zmsg_t flux_msg_t;
 
@@ -98,11 +99,14 @@ flux_msg_t *flux_msg_recvfd (int fd, struct flux_msg_iobuf *iobuf);
  * Returns 0 on success, -1 on failure with errno set.
  */
 int flux_msg_sendzsock (void *dest, const flux_msg_t *msg);
+int flux_msg_sendzsock_munge (void *sock, const flux_msg_t *msg,
+                              flux_sec_t *sec);
 
 /* Receive a message from zeromq socket.
  * Returns message on success, NULL on failure with errno set.
  */
 flux_msg_t *flux_msg_recvzsock (void *dest);
+flux_msg_t *flux_msg_recvzsock_munge (void *sock, flux_sec_t *sec);
 
 /* Initialize iobuf members.
  */
@@ -257,6 +261,7 @@ char *flux_msg_get_route_string (const flux_msg_t *msg);
 /* Return true if route stack contains a frame matching 's'
  */
 bool flux_msg_has_route (const flux_msg_t *msg, const char *s);
+
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -6,7 +6,8 @@
 #include <stdio.h>
 #include "security.h"
 
-typedef struct _zmsg_t flux_msg_t;
+typedef struct flux_msg flux_msg_t;
+//typedef struct _zmsg_t flux_msg_t;
 
 enum {
     FLUX_MSGTYPE_REQUEST    = 0x01,

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -63,7 +63,7 @@ int flux_request_decode (const flux_msg_t *msg, const char **topic,
 
     if (request_decode (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload_json (msg, &js) < 0)
+    if (flux_msg_get_json (msg, &js) < 0)
         goto done;
     if ((json_str && !js) || (!json_str && js)) {
         errno = EPROTO;
@@ -132,7 +132,7 @@ flux_msg_t *flux_request_encode (const char *topic, const char *json_str)
 
     if (!msg)
         goto error;
-    if (json_str && flux_msg_set_payload_json (msg, json_str) < 0)
+    if (json_str && flux_msg_set_json (msg, json_str) < 0)
         goto error;
     return msg;
 error:

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -106,6 +106,39 @@ done:
     return rc;
 }
 
+static int flux_request_vdecodef (const flux_msg_t *msg, const char **topic,
+                                  const char *fmt, va_list ap)
+{
+    const char *ts;
+    int rc = -1;
+
+    if (!fmt) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (request_decode (msg, &ts) < 0)
+        goto done;
+    if (flux_msg_vget_jsonf (msg, fmt, ap) < 0)
+        goto done;
+    if (topic)
+        *topic = ts;
+    rc = 0;
+done:
+    return rc;
+}
+
+int flux_request_decodef (const flux_msg_t *msg, const char **topic,
+                          const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = flux_request_vdecodef (msg, topic, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
 static flux_msg_t *request_encode (const char *topic)
 {
     flux_msg_t *msg = NULL;

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -15,6 +15,13 @@
 int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **json_str);
 
+/* Decode a request message with json payload.  These functions use
+ * jansson unpack style variable arguments for decoding the JSON object
+ * payload directly.  Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_request_decodef (const flux_msg_t *msg, const char **topic,
+                          const char *fmt, ...);
+
 /* Decode a request message with optional raw payload.
  * If topic is non-NULL, assign the request topic string.
  * Data and len must be non-NULL, and will be assigned the payload.

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -217,6 +217,36 @@ fatal:
     return -1;
 }
 
+static int flux_vrespondf (flux_t *h, const flux_msg_t *request,
+                    const char *fmt, va_list ap)
+{
+    flux_msg_t *msg = derive_response (h, request, 0);
+    if (!msg)
+        goto fatal;
+    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+        goto fatal;
+    if (flux_send (h, msg, 0) < 0)
+        goto fatal;
+    flux_msg_destroy (msg);
+    return 0;
+fatal:
+    flux_msg_destroy (msg);
+    FLUX_FATAL (h);
+    return -1;
+}
+
+int flux_respondf (flux_t *h, const flux_msg_t *request,
+                   const char *fmt, ...)
+{
+    int rc;
+    va_list ap;
+
+    va_start (ap, fmt);
+    rc = flux_vrespondf (h, request, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
 int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       int errnum, const void *data, int len)
 {

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -73,7 +73,7 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
 
     if (response_decode (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload_json (msg, &js) < 0)
+    if (flux_msg_get_json (msg, &js) < 0)
         goto done;
     if ((json_str && !js) || (!json_str && js)) {
         errno = EPROTO;
@@ -150,7 +150,7 @@ flux_msg_t *flux_response_encode (const char *topic, int errnum,
         errno = EINVAL;
         goto error;
     }
-    if (json_str && flux_msg_set_payload_json (msg, json_str) < 0)
+    if (json_str && flux_msg_set_json (msg, json_str) < 0)
         goto error;
     return msg;
 error:
@@ -205,7 +205,7 @@ int flux_respond (flux_t *h, const flux_msg_t *request,
     flux_msg_t *msg = derive_response (h, request, errnum);
     if (!msg)
         goto fatal;
-    if (!errnum && json_str && flux_msg_set_payload_json (msg, json_str) < 0)
+    if (!errnum && json_str && flux_msg_set_json (msg, json_str) < 0)
         goto fatal;
     if (flux_send (h, msg, 0) < 0)
         goto fatal;

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -31,7 +31,8 @@ int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
 
 flux_msg_t *flux_response_encode (const char *topic, int errnum,
                                   const char *json_str);
-
+/* Encode a response message with optional raw payload.
+ */
 flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
                                       const void *data, int len);
 
@@ -41,6 +42,15 @@ flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
  */
 int flux_respond (flux_t *h, const flux_msg_t *request,
                   int errnum, const char *json_str);
+
+/* Create a response to the provided request message with json payload, using
+ * jansson pack style variable arguments for encoding the JSON object
+ * payload directly.
+ * All errors in this function are fatal - see flux_fatal_set().
+ */
+int flux_respondf (flux_t *h, const flux_msg_t *request,
+                   const char *fmt, ...);
+
 
 /* Create a response to the provided request message with optional raw payload.
  * If errnum is nonzero, payload argument is ignored.

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -2,6 +2,7 @@
 #define _FLUX_CORE_RPC_H
 
 #include <stdbool.h>
+#include <stdarg.h>
 
 #include "handle.h"
 

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -2,7 +2,6 @@
 #define _FLUX_CORE_SECURITY_H
 
 #include <stdbool.h>
-#include "message.h"
 
 #define DEFAULT_ZAP_DOMAIN      "flux"
 
@@ -28,6 +27,7 @@ void flux_sec_destroy (flux_sec_t *c);
  */
 int flux_sec_enable (flux_sec_t *c, int type);
 int flux_sec_disable (flux_sec_t *c, int type);
+bool flux_sec_type_enabled (flux_sec_t *c, int tm);
 
 /* Get/set config directory used by security context.
  */
@@ -50,15 +50,6 @@ int flux_sec_munge_init (flux_sec_t *c);
 int flux_sec_csockinit (flux_sec_t *c, void *sock);
 int flux_sec_ssockinit (flux_sec_t *c, void *sock);
 
-/* Munge/unmunge a msg.  The munged message is a single part
- * containing a munge credential, with the original message encoded
- * inside.  MUNGE_OPT_UID_RESTRICTION is used to obtain privacy.
- * Be aware that SUB subscriptions will no longer match the message's
- * encoded topic string (you should subscribe to all).
- */
-int flux_sec_munge_zmsg (flux_sec_t *c, flux_msg_t **msg);
-int flux_sec_unmunge_zmsg (flux_sec_t *c, flux_msg_t **msg);
-
 /* Retrieve a string describing the last error.
  * This value is valid after one of the above calls returns -1.
  * The caller should not free this string.
@@ -69,6 +60,15 @@ const char *flux_sec_errstr (flux_sec_t *c);
  * The caller should not free this string.
  */
 const char *flux_sec_confstr (flux_sec_t *c);
+
+/* Convert a buffer to/from a Munge credential.
+ * Privacy is ensured through the use of MUNGE_OPT_UID_RESTRICTION
+ * Caller must free resulting string.
+ */
+int flux_sec_munge (flux_sec_t *c, const char *inbuf, size_t insize,
+                    char **outbuf, size_t *outsize);
+int flux_sec_unmunge (flux_sec_t *c, const char *inbuf, size_t insize,
+                      char **outbuf, size_t *outsize);
 
 #endif /* _FLUX_CORE_SECURITY_H */
 

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -8,8 +8,9 @@ int main (int argc, char *argv[])
     flux_msg_t *msg;
     const char *topic, *s;
     const char *json_str = "{\"a\":42}";
+    int i;
 
-    plan (8);
+    plan (NO_PLAN);
 
     /* no topic is an error */
     errno = 0;
@@ -42,6 +43,16 @@ int main (int argc, char *argv[])
     errno = 0;
     ok (flux_event_decode (msg, NULL, NULL) < 0 && errno == EPROTO,
         "flux_event_decode returns EPROTO when payload is unexpected");
+    flux_msg_destroy (msg);
+
+    /* formatted payload */
+    ok ((msg = flux_event_encodef ("foo.bar", "{s:i}", "foo", 42)) != NULL,
+        "flux_event_encodef packed payload object");
+    i = 0;
+    ok (flux_event_decodef (msg, &topic, "{s:i}", "foo", &i) == 0,
+        "flux_event_decodef unpacked payload object");
+    ok (i == 42 && topic != NULL && !strcmp (topic, "foo.bar"),
+        "unpacked payload matched packed");
     flux_msg_destroy (msg);
 
     done_testing();

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -5,7 +5,7 @@
 
 int main (int argc, char *argv[])
 {
-    zmsg_t *zmsg;
+    flux_msg_t *msg;
     const char *topic, *s;
     const char *json_str = "{\"a\":42}";
 
@@ -13,36 +13,36 @@ int main (int argc, char *argv[])
 
     /* no topic is an error */
     errno = 0;
-    ok ((zmsg = flux_event_encode (NULL, json_str)) == NULL && errno == EINVAL,
+    ok ((msg = flux_event_encode (NULL, json_str)) == NULL && errno == EINVAL,
         "flux_event_encode returns EINVAL with no topic string");
 
     /* without payload */
-    ok ((zmsg = flux_event_encode ("foo.bar", NULL)) != NULL,
+    ok ((msg = flux_event_encode ("foo.bar", NULL)) != NULL,
         "flux_event_encode works with NULL payload");
 
     topic = NULL;
-    ok (flux_event_decode (zmsg, &topic, NULL) == 0
+    ok (flux_event_decode (msg, &topic, NULL) == 0
         && topic != NULL && !strcmp (topic, "foo.bar"),
         "flux_event_decode returns encoded topic");
-    ok (flux_event_decode (zmsg, NULL, NULL) == 0,
+    ok (flux_event_decode (msg, NULL, NULL) == 0,
         "flux_event_decode topic is optional");
     errno = 0;
-    ok (flux_event_decode (zmsg, NULL, &s) < 0 && errno == EPROTO,
+    ok (flux_event_decode (msg, NULL, &s) < 0 && errno == EPROTO,
         "flux_event_decode returns EPROTO when expected payload is missing");
-    zmsg_destroy(&zmsg);
+    flux_msg_destroy(msg);
 
     /* with payload */
-    ok ((zmsg = flux_event_encode ("foo.bar", json_str)) != NULL,
+    ok ((msg = flux_event_encode ("foo.bar", json_str)) != NULL,
         "flux_event_encode works with payload");
 
     s = NULL;
-    ok (flux_event_decode (zmsg, NULL, &s) == 0
+    ok (flux_event_decode (msg, NULL, &s) == 0
         && s != NULL && !strcmp (s, json_str),
         "flux_event_decode returns encoded payload");
     errno = 0;
-    ok (flux_event_decode (zmsg, NULL, NULL) < 0 && errno == EPROTO,
+    ok (flux_event_decode (msg, NULL, NULL) < 0 && errno == EPROTO,
         "flux_event_decode returns EPROTO when payload is unexpected");
-    zmsg_destroy (&zmsg);
+    flux_msg_destroy (msg);
 
     done_testing();
     return (0);

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -129,36 +129,36 @@ void check_payload_json (void)
        "flux_msg_create works");
 
     s = (char *)msg;
-    ok (flux_msg_get_payload_json (msg, &s) == 0 && s == NULL,
-       "flux_msg_get_payload_json returns success with no payload");
+    ok (flux_msg_get_json (msg, &s) == 0 && s == NULL,
+       "flux_msg_get_json returns success with no payload");
 
     /* RFC 3 - json payload must be an object
      * Encoding should return EINVAL.
      */
     errno = 0;
-    ok (flux_msg_set_payload_json (msg, "[1,2,3]") < 0 && errno == EINVAL,
-       "flux_msg_set_payload_json array fails with EINVAL");
+    ok (flux_msg_set_json (msg, "[1,2,3]") < 0 && errno == EINVAL,
+       "flux_msg_set_json array fails with EINVAL");
     errno = 0;
-    ok (flux_msg_set_payload_json (msg, "3.14") < 0 && errno == EINVAL,
-       "flux_msg_set_payload_json scalar fails with EINVAL");
+    ok (flux_msg_set_json (msg, "3.14") < 0 && errno == EINVAL,
+       "flux_msg_set_json scalar fails with EINVAL");
 
     /* Using the lower level flux_msg_set_payload with FLUX_MSGFLAG_JSON
      * we can sneak in a malformed JSON paylaod and test decoding.
      */
     errno = 0;
     ok (flux_msg_set_payload (msg, FLUX_MSGFLAG_JSON, "[1,2,3]", 8) == 0
-            && flux_msg_get_payload_json (msg, &s) < 0 && errno == EPROTO,
-        "flux_msg_get_payload_json array fails with EPROTO");
+            && flux_msg_get_json (msg, &s) < 0 && errno == EPROTO,
+        "flux_msg_get_json array fails with EPROTO");
     errno = 0;
     ok (flux_msg_set_payload (msg, FLUX_MSGFLAG_JSON, "3.14", 5) == 0
-            && flux_msg_get_payload_json (msg, &s) < 0 && errno == EPROTO,
-        "flux_msg_get_payload_json scalar fails with EPROTO");
+            && flux_msg_get_json (msg, &s) < 0 && errno == EPROTO,
+        "flux_msg_get_json scalar fails with EPROTO");
 
-    ok (flux_msg_set_payload_json (msg, json_str) == 0,
-       "flux_msg_set_payload_json works");
-    ok (flux_msg_get_payload_json (msg, &s) == 0 && s != NULL
+    ok (flux_msg_set_json (msg, json_str) == 0,
+       "flux_msg_set_json works");
+    ok (flux_msg_get_json (msg, &s) == 0 && s != NULL
         && !strcmp (s, json_str),
-       "flux_msg_get_payload_json returns payload intact");
+       "flux_msg_get_json returns payload intact");
 
     flux_msg_destroy (msg);
 }

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -12,7 +12,7 @@ int main (int argc, char *argv[])
     const char *topic, *s;
     const char *json_str = "{\"a\":42}";
     char *d, data[] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    int l, len = strlen (data);
+    int i, l, len = strlen (data);
 
     plan (NO_PLAN);
 
@@ -47,6 +47,12 @@ int main (int argc, char *argv[])
     ok (flux_request_decode (msg, NULL, &s) == 0
         && s != NULL && !strcmp (s, json_str),
         "flux_request_decode returns encoded payload");
+    topic = NULL;
+    i = 0;
+    ok (flux_request_decodef (msg, &topic, "{s:i}", "a", &i) == 0
+        && i == 42 && topic != NULL && !strcmp (topic, "foo.bar"),
+        "flux_request_decodef returns encoded payload");
+
     errno = 0;
     ok (flux_request_decode (msg, NULL, NULL) < 0 && errno == EPROTO,
         "flux_request_decode returns EPROTO when payload is unexpected");

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -48,7 +48,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libev/libev.la \
-	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) $(LIBDL)
+	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) $(LIBDL) $(LIBMUNGE)
 
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -148,7 +148,7 @@ static flux_msg_t *op_recv (void *impl, int flags)
             goto done;
         }
     }
-    msg = zmsg_recv (ctx->sock);
+    msg = flux_msg_recvzsock (ctx->sock);
 done:
     return msg;
 }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -988,7 +988,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
             goto done;
         if (!(in2 = kp_twatch_enc (key, Jget (val), flags & ~KVS_PROTO_FIRST)))
             goto done;
-        if (flux_msg_set_payload_json (cpy, Jtostr (in2)) < 0)
+        if (flux_msg_set_json (cpy, Jtostr (in2)) < 0)
             goto done;
         if (!(watcher = wait_create_msg_handler (h, w, cpy,
                                                  watch_request_cb, arg)))

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -350,7 +350,7 @@ static void job_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_msg_get_topic (msg, &topic) < 0)
         goto out;
     flux_log (h, LOG_DEBUG, "got request %s", topic);
-    if (flux_msg_get_payload_json (msg, &json_str) < 0)
+    if (flux_msg_get_json (msg, &json_str) < 0)
         goto out;
     if (json_str && !(o = json_tokener_parse (json_str)))
         goto out;
@@ -385,7 +385,7 @@ static void job_kvspath_cb (flux_t *h, flux_msg_handler_t *w,
     json_object *ar = NULL;
     json_object *id_list = NULL;
 
-    if (flux_msg_get_payload_json (msg, &json_str) < 0)
+    if (flux_msg_get_json (msg, &json_str) < 0)
         goto out;
 
     if (!(in = Jfromstr (json_str))) {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -2070,8 +2070,8 @@ void ev_cb (flux_t *f, flux_msg_handler_t *mw,
         flux_heartbeat_decode (msg, &ctx->epoch);
         return;
     }
-    if (flux_msg_get_payload_json (msg, &json_str) < 0) {
-        wlog_err (ctx, "flux_msg_get_payload_json");
+    if (flux_msg_get_json (msg, &json_str) < 0) {
+        wlog_err (ctx, "flux_msg_get_json");
         return;
     }
     if (json_str && !(o = json_tokener_parse (json_str))) {

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -350,7 +350,7 @@ send_causal_event (kap_params_t *param)
     o = json_object_new_object (); 
     Jadd_int (o, KAP_KVSVER_NAME, v);
 
-    zmsg_t * msg = flux_event_encode(KAP_CAUSAL_CONS_EV, Jtostr(o));
+    flux_msg_t * msg = flux_event_encode(KAP_CAUSAL_CONS_EV, Jtostr(o));
     if (flux_sendmsg (param->pers.handle, &msg) < 0) {
         fprintf (stderr,
             "flux_event_send failed.\n");
@@ -371,7 +371,7 @@ enforce_c_consistency (kap_params_t *param)
     int v = 0;
     json_object *o = NULL;
 
-    zmsg_t * msg = flux_recv (param->pers.handle, FLUX_MATCH_EVENT, 0);
+    flux_msg_t * msg = flux_recv (param->pers.handle, FLUX_MATCH_EVENT, 0);
     if ( ! msg ) {
         fprintf (stderr,
             "event recv failed: %s\n", flux_strerror (errno));

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -384,7 +384,7 @@ enforce_c_consistency (kap_params_t *param)
         goto error;
     }
     const char *json_str;
-    flux_msg_get_payload_json (msg, &json_str);
+    flux_msg_get_json (msg, &json_str);
     o = json_tokener_parse (json_str);
     if ( !Jget_int (o, KAP_KVSVER_NAME, &v)) {
         fprintf (stderr,

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -117,13 +117,9 @@ test_expect_success 'event: can subscribe' '
 # for now we just ensure snoop basically works
 test_expect_success 'snoop: produces output (XXX needs fixing)' '
 	flux snoop -c 1 --verbose >output_snoop 2>&1 &
-        flux snoop -c 1 --verbose --long >output_snoop_long 2>&1 &
-	test_expect_code 0 wait &&
 	test_expect_code 0 wait &&
 	test -s output_snoop &&
-	test -s output_snoop_long &&
-	head output_snoop | grep "^flux-snoop: connecting to" &&
-	head output_snoop_long | grep "^flux-snoop: connecting to"
+	head output_snoop | grep "^flux-snoop: connecting to"
 '
 
 test_expect_success 'version: reports an expected string' '


### PR DESCRIPTION
Posted early to get any feedback.  There are still tests to write and docs to update.

`flux_msg_t` was an alias for `zmsg_t` during transition to a "real" native flux message type.  This PR finally converts remaining `zmsg_t` users to native flux message functions.  Only the minimum work was done to achieve this goal, i.e. the old czmq "destroy on send" idiom is still used in the broker and the lua bindings; however that can be cleaned up in another PR.

Freeing `flux_msg_t` to define its own opaque type allowed it to internally grow a `json_t` member for caching decoded JSON state, which in turn allowed accessors in the style of jansson pack/unpack to be implemented, where returned data is "owned" by the `flux_msg_t`.

Additional wrappers were added in the request, response, and event encoding/decoding functions that leverage this capability.  The new `flux_rpcf()` and `flux_rpc_getf()` functions were simplified to use these rather than their own `json_t` member in `flux_rpc_t`.

Here are the new interfaces.  (Honestly I may have gone slightly overboard adding interfaces that are not likely to be used much!)

**message.h**
```C
int flux_msg_set_payload_vjsonf (flux_msg_t *msg, const char *fmt, va_list ap);
int flux_msg_set_payload_jsonf (flux_msg_t *msg, const char *fmt, ...);
int flux_msg_get_payload_vjsonf (flux_msg_t *msg, const char *fmt, va_list ap);
int flux_msg_get_payload_jsonf (flux_msg_t *msg, const char *fmt, ...);
```

**request.h**
```C
int flux_request_vdecodef (flux_msg_t *msg, const char **topic,
                           const char *fmt, va_list ap);
int flux_request_decodef (flux_msg_t *msg, const char **topic,
                          const char *fmt, ...);
flux_msg_t *flux_request_vencodef (const char *topic,
                                   const char *fmt, va_list ap);
flux_msg_t *flux_request_encodef (const char *topic, const char *fmt, ...);
```

**response.h**
```C
int flux_response_vdecodef (flux_msg_t *msg, const char **topic,
                            const char *fmt, va_list ap);
int flux_response_decodef (flux_msg_t *msg, const char **topic,
                           const char *fmt, ...);
flux_msg_t *flux_response_vencodef (const char *topic,
                                    const char *fmt, va_list ap);
flux_msg_t *flux_response_encodef (const char *topic, const char *fmt, ...);
int flux_vrespondf (flux_t *h, const flux_msg_t *request,
                    const char *fmt, va_list ap);
int flux_respondf (flux_t *h, const flux_msg_t *request,
                   const char *fmt, ...);
```

**event.h**
```C
int flux_event_vdecodef (flux_msg_t *msg, const char **topic,
                         const char *fmt, va_list ap);
int flux_event_decodef (flux_msg_t *msg, const char **topic,
                         const char *fmt, ...);
flux_msg_t *flux_event_vencodef (const char *topic, const char *fmt, va_list ap);
flux_msg_t *flux_event_encodef (const char *topic, const char *fmt, ...);
```