### PR TITLE
Fix --rank issues, add NODESET documentation, and minor cleanup

### DIFF
--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -39,7 +39,7 @@ XML_FILES   = $(MAN1_FILES_PRIMARY:%.1=%.xml)
 
 if HAVE_A2X
 dist_man_MANS = $(MAN1_FILES)
-$(MAN1_FILES): COPYRIGHT.adoc
+$(MAN1_FILES): COPYRIGHT.adoc NODESET.adoc
 endif
 
 SUFFIXES = .adoc .1
@@ -58,6 +58,6 @@ stderr_devnull_0 = 2>/dev/null
 	    --destination-dir=$(builddir) \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
 
-EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
+EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc NODESET.adoc
 
 CLEANFILES = $(MAN1_FILES) $(XML_FILES)

--- a/doc/man1/NODESET.adoc
+++ b/doc/man1/NODESET.adoc
@@ -1,0 +1,14 @@
+A NODESET is a comma separated list of integer ranks.  Ranks may be
+listed individually or as a range in the form _l-k_ where l < k.
+
+Some examples of nodesets. 
+
+[horizontal]
+``1'':: rank 1
+``0-3'':: ranks 0, 1, 2, and 3 listed in a range
+``0,1,2,3'':: ranks 0, 1, 2, and 3 listed individually
+``2,5'':: ranks 2 and 5
+``2,4-5'':: ranks 2, 4, and 5
+
+As a special case, the string ``_all_'' can be specified to indicate every
+rank available in the flux instance.

--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -53,10 +53,16 @@ Set the working directory of remote 'COMMANDS' to 'DIR'. The default is to
 propagate the current working directory of flux-exec(1).
 
 *-r, --rank*'=NODESET'::
-Target specific ranks in 'NODESET'. Default is to target all ranks.
+Target specific ranks in 'NODESET'. Default is to target "all" ranks.
+See NODESET FORMAT below for more information.
 
 *-v, --verbose*::
 Run with more verbosity.
+
+
+NODESET FORMAT
+--------------
+include::NODESET.adoc[]
 
 
 AUTHOR

--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -11,7 +11,7 @@ flux-exec - Execute processes across flux ranks
 
 SYNOPSIS
 --------
-*flux* *exec* [--noinput] ['--labelio] ['--dir=DIR'] ['--rank=RANKS'] ['--verbose'] COMMANDS...
+*flux* *exec* [--noinput] ['--labelio] ['--dir=DIR'] ['--rank=NODESET'] ['--verbose'] COMMANDS...
 
 
 DESCRIPTION
@@ -52,8 +52,8 @@ Redirect `stdin` from `/dev/null`.
 Set the working directory of remote 'COMMANDS' to 'DIR'. The default is to
 propagate the current working directory of flux-exec(1).
 
-*-r, --rank*'=RANKS'::
-Target specific ranks in 'RANKS'. Default is to target all ranks.
+*-r, --rank*'=NODESET'::
+Target specific ranks in 'NODESET'. Default is to target all ranks.
 
 *-v, --verbose*::
 Run with more verbosity.

--- a/doc/man1/flux-hwloc.adoc
+++ b/doc/man1/flux-hwloc.adoc
@@ -48,7 +48,8 @@ Options:
 
  --rank='NODESET':::
  -r 'NODESET':::
- Only reload XML on provided 'NODESET'.
+ Only reload XML on provided 'NODESET'.  See NODESET FORMAT below for
+ more information.
 
  --walk-topology=['yes|no']:::
  -t ['yes|no']:::
@@ -58,6 +59,11 @@ Options:
 
 *topology*::
 Dump current aggregate topology XML for the current session to stdout.
+
+
+NODESET FORMAT
+--------------
+include::NODESET.adoc[]
 
 
 AUTHOR

--- a/doc/man1/flux-hwloc.adoc
+++ b/doc/man1/flux-hwloc.adoc
@@ -46,9 +46,9 @@ Reload hwloc topology information, optionally loading hwloc XML files
 from `DIR/<rank>.xml` files.
 Options:
 
- --rank=['RANKS']:::
- -r 'RANKS':::
- Only reload XML on provided nodeset 'RANKS'.
+ --rank='NODESET':::
+ -r 'NODESET':::
+ Only reload XML on provided 'NODESET'.
 
  --walk-topology=['yes|no']:::
  -t ['yes|no']:::

--- a/doc/man1/flux-module.adoc
+++ b/doc/man1/flux-module.adoc
@@ -47,10 +47,13 @@ List modules loaded by 'service', or by flux-broker(1) if 'service' is unspecifi
 OPTIONS
 -------
 *-r, --rank*'=NODESET'::
-Specify which ranks to apply the command to.
+Specify which ranks to apply the command to.  See NODESET FORMAT below
+for more information.
 
 *-x, --exclude*'=NODESET'::
-Specify ranks to exclude the command from.
+Specify ranks to exclude the command from.  See NODESET FORMAT below
+for more information.
+
 
 
 LIST OUTPUT
@@ -92,6 +95,11 @@ If there is no prefix, the module is loaded by flux-broker(1).
 
 *int mod_main (void *context, int argc, char **argv);*::
 An entry function.
+
+
+NODESET FORMAT
+--------------
+include::NODESET.adoc[]
 
 
 AUTHOR

--- a/doc/man1/flux-module.adoc
+++ b/doc/man1/flux-module.adoc
@@ -49,6 +49,9 @@ OPTIONS
 *-r, --rank*=['all'|'nodeset']::
 Specify which ranks to apply the command to.
 
+*-x, --exclude*=['nodeset']::
+Specify ranks to exclude the command from.
+
 
 LIST OUTPUT
 -----------

--- a/doc/man1/flux-module.adoc
+++ b/doc/man1/flux-module.adoc
@@ -46,10 +46,10 @@ List modules loaded by 'service', or by flux-broker(1) if 'service' is unspecifi
 
 OPTIONS
 -------
-*-r, --rank*=['all'|'nodeset']::
+*-r, --rank*'=NODESET'::
 Specify which ranks to apply the command to.
 
-*-x, --exclude*=['nodeset']::
+*-x, --exclude*'=NODESET'::
 Specify ranks to exclude the command from.
 
 

--- a/doc/man1/flux-ping.adoc
+++ b/doc/man1/flux-ping.adoc
@@ -37,8 +37,8 @@ module, is to be pinged.  "flux ping 0-15" is equivalent to
 OPTIONS
 -------
 *-r, --rank*'=NODESET'::
-Find target on a specific broker rank(s).
-Default: send to FLUX_NODEID_ANY.
+Find target on a specific broker rank(s).  See NODESET FORMAT below
+for more information.  Default: send to FLUX_NODEID_ANY.
 
 *-p, --pad*'=N'::
 Include in the payload a string of length 'N' bytes.  The payload will be
@@ -85,6 +85,12 @@ One can direct a ping request to a nodeset, e.g.
 This tells you that the message brokers on ranks 0-7 are responsive.
 The time shows the statistical breakdown of RTT values for the set of
 responses in (min:mean:max) format.
+
+
+NODESET FORMAT
+--------------
+include::NODESET.adoc[]
+
 
 AUTHOR
 ------

--- a/doc/man1/flux-ps.adoc
+++ b/doc/man1/flux-ps.adoc
@@ -1,6 +1,6 @@
 // flux-help-description: List subprocesses managed by brokers
 FLUX-PS(1)
-============
+==========
 :doctype: manpage
 
 

--- a/doc/man1/flux-ps.adoc
+++ b/doc/man1/flux-ps.adoc
@@ -24,10 +24,16 @@ OPTIONS
 -------
 
 *-r, --rank*'=NODESET'::
-Target specific ranks in 'NODESET'. Default is to target all ranks.
+Target specific ranks in 'NODESET'. Default is to target "all" ranks.
+See NODESET FORMAT below for more information.
 
 *-v, --verbose*::
 Run with more verbosity.
+
+
+NODESET FORMAT
+--------------
+include::NODESET.adoc[]
 
 
 AUTHOR

--- a/doc/man1/flux-ps.adoc
+++ b/doc/man1/flux-ps.adoc
@@ -11,7 +11,7 @@ flux-ps - List managed subprocess of one or more flux brokers
 
 SYNOPSIS
 --------
-*flux* *ps* ['--rank=RANKS'] ['--verbose'] COMMANDS...
+*flux* *ps* ['--rank=NODESET'] ['--verbose'] COMMANDS...
 
 
 DESCRIPTION
@@ -23,8 +23,8 @@ the command being run.
 OPTIONS
 -------
 
-*-r, --rank*'=RANKS'::
-Target specific ranks in 'RANKS'. Default is to target all ranks.
+*-r, --rank*'=NODESET'::
+Target specific ranks in 'NODESET'. Default is to target all ranks.
 
 *-v, --verbose*::
 Run with more verbosity.

--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -65,7 +65,7 @@ as the initial program and all logs output to stderr:
 Launch an 8-way Flux instance within a slurm job, with an interactive
 shell as the initial program:
 
-  srun -pty -N8 flux start
+  srun --pty -N8 flux start
 
 Launch an 8-way Flux instance under Flux, with /bin/true as
 the initial program:

--- a/doc/man1/flux-submit.adoc
+++ b/doc/man1/flux-submit.adoc
@@ -1,6 +1,6 @@
 // flux-help-description: submit job requests to a scheduler
 FLUX-SUBMIT(1)
-================
+==============
 :doctype: manpage
 
 

--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -1,6 +1,6 @@
 // flux-help-description: Flux wreck convenience utilities
 FLUX-WRECK(1)
-===========
+=============
 :doctype: manpage
 
 

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -71,7 +71,7 @@ int main (int argc, char *argv[])
             case 'h': /* --help */
                 usage ();
                 break;
-            case 'r': /* --rank N */
+            case 'r': /* --rank NODESET */
                 rank = strtoul (optarg, NULL, 10);
                 break;
             default:

--- a/src/cmd/flux-exec
+++ b/src/cmd/flux-exec
@@ -148,7 +148,7 @@ local function program_state_create (f, n)
 end
 
 local function get_ranklist (f, r)
-    if not r then r = '0-'..f.size-1 end
+    if r == "all" or not r then r = '0-'..f.size-1 end
     return hostlist.new ('['..r..']')
 end
 

--- a/src/cmd/flux-ps
+++ b/src/cmd/flux-ps
@@ -80,7 +80,7 @@ local function display_usage ()
 end
 
 local function get_ranklist (f, r)
-    if not r then r = '0-'..f.size-1 end
+    if r == "all" or not r then r = '0-'..f.size-1 end
     return hostlist.new ('['..r..']')
 end
 

--- a/src/cmd/flux-ps
+++ b/src/cmd/flux-ps
@@ -44,7 +44,7 @@ List subprocesses managed by flux-broker.
 
  -h, --help           Display this message
  -v, --verbose        Be verbose.
- -r, --rank=RANKS     Target only ranks in list RANKS
+ -r, --rank=NODESET   Target only ranks in NODESET
 
 ]]
 

--- a/src/cmd/flux-ps
+++ b/src/cmd/flux-ps
@@ -123,10 +123,8 @@ local mh, err = f:msghandler {
     handler = function (f, msg, mh)
         if msg.errnum ~= 0 then
             warn ("Error: %s\n", posix.errno (msg.errnum))
-            size = size - 1
         elseif not msg.data then 
             warn ("Error: empty message!\n")
-            size = size - 1
         else
             local resp = msg.data
             local rank = resp.rank

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -114,5 +114,14 @@ test_expect_success 'module: remove works on valid and invalid rank' '
 	grep "No route to host" stderr
 '
 
+test_expect_success 'module: load fails on invalid module' '
+	flux module load nosuchmodule 2> stderr
+	grep "nosuchmodule: not found in module search path" stderr
+'
+
+test_expect_success 'module: remove fails on invalid module' '
+	flux module remove nosuchmodule 2> stderr
+	grep "nosuchmodule: No such file or directory" stderr
+'
 
 test_done

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -124,4 +124,12 @@ test_expect_success 'module: remove fails on invalid module' '
 	grep "nosuchmodule: No such file or directory" stderr
 '
 
+test_expect_success 'module: info works' '
+	flux module info ${FLUX_BUILD_DIR}/t/module/.libs/parent.so
+'
+
+test_expect_success 'module: info fails on invalid module' '
+	! flux module info nosuchmodule
+'
+
 test_done

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -19,6 +19,9 @@ test_expect_success 'exec to specific rank' '
 	flux exec -r 0 /bin/true
 '
 
+test_expect_success 'exec to "all" ranks' '
+	flux exec -r all /bin/true
+'
 test_expect_success 'exec to non-existent rank is an error' '
 	test_must_fail flux exec -r 9999 /bin/true
 '
@@ -161,6 +164,17 @@ test_expect_success 'process listing works - multiple processes' '
 	test_expect_code 130 wait $q &&
 	test "$(flux ps | grep -c sleep)" = "0"
 
+'
+
+test_expect_success 'process listing works - all ranks' '
+	flux exec -r all sleep 100 </dev/null &
+	q=$! &&
+	sleep 1 &&
+	count=$(flux ps -r all | grep -c sleep) &&
+	kill -INT $q &&
+	test "$count" = "4" &&
+	test_expect_code 130 wait $q &&
+	test "$(flux ps -r all | grep -c sleep)" = "0"
 '
 
 test_expect_success 'flux-exec disconnect terminates all running processes' '

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -8,6 +8,10 @@ test_description='Stress test the local connector with flood pings
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} minimal
 
+invalid_rank() {
+	echo $((${SIZE} + 1))
+}
+
 test_expect_success 'ping: 10K 1K byte echo requests' '
 	run_timeout 5 flux ping --pad 1024 --count 10240 --delay 0 0
 '
@@ -54,6 +58,22 @@ test_expect_success 'ping all works' '
 
 test_expect_success 'ping all works with 64K payload' '
 	run_timeout 5 flux ping --pad 65536 --count 10 --delay 0 all
+'
+
+test_expect_success 'ping fails on invalid rank (specified as target)' '
+	run_timeout 5 flux ping --count 1 $(invalid_rank) 2>stderr
+	grep -q "No route to host" stderr
+'
+
+test_expect_success 'ping fails on invalid rank (specified in option)' '
+	run_timeout 5 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr
+	grep -q "No route to host" stderr
+'
+
+test_expect_success 'ping works on valid and invalid rank' '
+	run_timeout 5 flux ping --count 1 --rank 0,$(invalid_rank) cmb 1>stdout 2>stderr
+	grep -q "No route to host" stderr &&
+	grep -q "0,$(invalid_rank)!cmb.ping" stdout
 '
 
 test_done

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -76,4 +76,9 @@ test_expect_success 'ping works on valid and invalid rank' '
 	grep -q "0,$(invalid_rank)!cmb.ping" stdout
 '
 
+test_expect_success 'ping fails on invalid target' '
+	run_timeout 5 flux ping --count 1 --rank 0 nosuchtarget 2>stderr
+	grep -q "Function not implemented" stderr
+'
+
 test_done


### PR DESCRIPTION
Well, what began as noticing a doc error in the ping manpage lead to a lot more.  I should maybe split this up into multiple PRs, but I'll leave it all in as it is generally a large batch of small things.  LMK if it'd be better to split up.  

- Per discussion in #854 , support --rank="all" across all tools and add tests appropriately.  Nothing too fancy here.

- Support tests for invalid ranks in tools.  Found bugs in flux-ps and flux-ping as a result.  I'd appreciate review on the bug fixes commits 31b6c2697d815b1c6b702b17686e59e19658bfa4 and
1bd8f9393f17e76bfa8c6da81fb394d179164c57, particularly the latter.  Perhaps there is something nifty that can be done in the flux api that I don't see at the moment.

- Added misc tests I thought should be there, invalid ping targets, invalid modules, module info tests.

- Per discussion in #854, made ```--rank=NODESET``` the consistent documentation across all tools and manpages and added ```NODESET FORMAT``` section to all appropriate manpages.  Would appreciate review on the text to see if I'm missing anything.  Commit 0205fb496d1438c009038cf11eb829009f74f481.
