### PR TITLE
travis-ci: minor updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ addons:
       - gcc-4.9
       - g++-4.9
       - libjansson-dev
+      - libmunge-dev
       - lua5.1
       - liblua5.1-0-dev
       - luarocks

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ env:
    - secure: "T06LmG6hAwmRculQGfmV06A0f2i9rPoc8itDwyWkmg2CbtCqDyYV93V53jsVknqKA1LA9+Yo7Q3bJnnEAWI7kWAptTcL5ipRycYkl5FqoYawkwRdQW3giZwbs9zRchrwFmZ03N0hRfl31IntXhDmj5EkHOZoduMpkQFFGo0XDC4="
 
 before_install:
+  # Do not run coverity-scan on every build in matrix
+  - test "${TRAVIS_BRANCH}" != 'coverity_scan' -o "${TRAVIS_JOB_NUMBER##*.}" = '1' || exit 0
+  #
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
   - eval $(./src/test/travis-dep-builder.sh --printenv)
@@ -80,6 +83,8 @@ before_install:
   - echo '#error Non-build-tree flux/core.h!' > $HOME/local/include/flux/core.h
 
 script:
+ # Skip build if we already ran coverity-scan
+ - test "${TRAVIS_BRANCH}" != 'coverity_scan' || exit 0
  - ulimit -c unlimited
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"

--- a/src/test/backtrace-all.sh
+++ b/src/test/backtrace-all.sh
@@ -6,13 +6,14 @@
 say () { printf "\033[91m%s\033[39m\n" "$@" >&2; }
 die () { say "$@"; exit 1; }
 
-find . -name *.core -o -name core | while read -r line; do
+find . -name '*.core' -o -name core -type f | while read -r line; do
     d=$(dirname $line)
     f=$(basename $line)
     exe=$(file $line | sed "s/.*from '\([^ \t]*\).*'.*/\1/")
     ( cd $d &&
-      test -x $exe || die "Failed to find executable at $exe" &&
+      exe=$(which $exe || echo $exe)
       say "Found corefile for $exe" &&
+      test -x $exe || die "Failed to find executable at $exe" &&
       gdb --batch --quiet -ex "thread apply all bt full" $exe $f
     )
 done

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -10,11 +10,9 @@ cachedir=$HOME/local/.cache
 #  NOTE: Code currently assumes .tar.gz suffix...
 #
 downloads="\
-https://github.com/dun/munge/archive/munge-0.5.11.tar.gz \
 https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz \
 https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz \
 https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz \
-https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz \
 http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz \
 http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.0.tar.gz \
 http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz"


### PR DESCRIPTION
Some minor cleanup and fixes for Travis:

 - Fix a few bugs in `backtrace-all.sh` to clean up spurious errors and allow backtrace of executables in `$PATH` (e.g. `/usr/bin/lua`)
 - Remove `libjson-c` build, it is built-in to flux-core now
 - Pull in `munge` as a package since it is now whitelisted
 - Do not perform multiple builds on `coverity_scan` branch