### PR TITLE
fixes for minor issues detected by Coverity

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1503,7 +1503,6 @@ static int cmb_write_cb (flux_msg_t **msg, void *arg)
 {
     ctx_t *ctx = arg;
     json_object *request = NULL;
-    json_object *response = NULL;
     json_object *o = NULL;
     const char *json_str;
     int pid;
@@ -1538,13 +1537,10 @@ static int cmb_write_cb (flux_msg_t **msg, void *arg)
         free (data);
     }
 out:
-    response = Jnew ();
-    Jadd_int (response, "code", errnum);
-    flux_respond (ctx->h, *msg, 0, Jtostr (response));
+    if (flux_respondf (ctx->h, *msg, "{si}", "code", errnum) < 0)
+        flux_log_error (ctx->h, "write_cb: flux_respondf");
     flux_msg_destroy (*msg);
     *msg = NULL;
-    if (response)
-        json_object_put (response);
     if (request)
         json_object_put (request);
     return (0);
@@ -1554,7 +1550,6 @@ static int cmb_signal_cb (flux_msg_t **msg, void *arg)
 {
     ctx_t *ctx = arg;
     json_object *request = NULL;
-    json_object *response = NULL;
     const char *json_str;
     int pid;
     int errnum = EPROTO;
@@ -1578,13 +1573,10 @@ static int cmb_signal_cb (flux_msg_t **msg, void *arg)
         }
     }
 out:
-    response = Jnew ();
-    Jadd_int (response, "code", errnum);
-    flux_respond (ctx->h, *msg, 0, Jtostr (response));
+    if (flux_respondf (ctx->h, *msg, "{si}", "code", errnum) < 0)
+        flux_log_error (ctx->h, "signal_cb: flux_respondf");
     flux_msg_destroy (*msg);
     *msg = NULL;
-    if (response)
-        json_object_put (response);
     if (request)
         json_object_put (request);
     return (0);

--- a/src/common/libpmi/simple_server.c
+++ b/src/common/libpmi/simple_server.c
@@ -177,6 +177,7 @@ static int mcmd_begin (struct pmi_simple_server *pmi, void *client,
         return -1;
     }
     if (!(c->mcmd = zlist_new ())) {
+        free (c);
         errno = ENOMEM;
         return -1;
     }

--- a/src/common/libutil/base64_json.c
+++ b/src/common/libutil/base64_json.c
@@ -63,6 +63,7 @@ int base64_json_decode (json_object *o, uint8_t **datp, int *lenp)
     dst = xzmalloc (base64_decode_length (len));
     if (base64_decode_block (dst, &dlen, s, len) < 0) {
         free (dst);
+        dst = NULL;
         errno = EINVAL;
         return -1;
     }

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -446,6 +446,7 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
      */
     if ((e->id = next_cronid (h)) < 0) {
         cron_entry_destroy (e);
+        e = NULL;
         saved_errno = errno;
         goto done;
     }

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -141,6 +141,7 @@ static int io_handler (flux_t *h, cron_task_t *t,
 
     if ((len = zio_json_decode (json_str, &data, &eof)) < 0) {
         flux_log_error (h, "io decode");
+        free (data);
         return (-1);
     }
     (void) Jget_str (resp, "name", &stream);

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -1205,17 +1205,20 @@ int kvs_symlink (flux_t *h, const char *key, const char *target)
 
 int kvs_mkdir (flux_t *h, const char *key)
 {
+    int rc = -1;
     kvsctx_t *ctx = getctx (h);
     json_object *val = Jnew ();
     json_object **ops = ctx->fence_context ? &ctx->fence_context : &ctx->ops;
 
     if (!h || !key) {
         errno = EINVAL;
-        return -1;
+        goto out;
     }
+    rc = 0;
     dirent_append (ops, key, dirent_create ("DIRVAL", val));
+out:
     Jput (val);
-    return 0;
+    return rc;
 }
 
 /**

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -961,6 +961,7 @@ static void fixup_newjob_event (flux_t *h, int64_t nj)
         goto done;
     }
 done:
+    Jput (jcb);
     free (key);
     return;
 }

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -198,7 +198,7 @@ static char *escape_and_join_kvs_path (const char *base,
         suffix = escape_kvs_key (suffix);
 
         if (!ret_str || !strlen (ret_str))
-            ret_str = suffix;
+            ret_str = xstrdup (suffix);
         else
             ret_str = xasprintf ("%s.%s", ret_str, suffix);
         free (suffix);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1152,8 +1152,11 @@ int update_job_state (struct prog_ctx *ctx, const char *state)
     if (kvsdir_put_string (ctx->kvs, "state", state) < 0)
         return (-1);
 
-    if (asprintf (&key, "%s-time", state) < 0)
+    if (asprintf (&key, "%s-time", state) < 0) {
+        wlog_err (ctx, "update_job_state: asprintf: %s", strerror (errno));
+        json_object_put (to);
         return (-1);
+    }
     if (kvsdir_put (ctx->kvs, key, json_object_to_json_string (to)) < 0)
         return (-1);
     free (key);


### PR DESCRIPTION
Nothing major here, but a series of minor fixups for issues flagged by Coverity.
Most of these are in error handling so we were unlikely to hit them.

A few of these were cleaned up by moving from raw JSON handling through json-c to use of `flux_rpcf`, `flux_rpc_getf` and `flux_respondf` etc.