### PR TITLE
fix possible unconstrained memory growth in modules/libjsc

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -71,7 +71,9 @@ libutil_la_SOURCES = \
 	wallclock.c \
 	stdlog.h \
 	stdlog.c \
-	oom.h
+	oom.h \
+	lru_cache.h \
+	lru_cache.c
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -89,7 +89,8 @@ TESTS = test_nodeset.t \
 	test_cronodate.t \
 	test_wallclock.t \
 	test_stdlog.t \
-	test_veb.t
+	test_veb.t \
+	test_lru_cache.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -161,3 +162,7 @@ test_stdlog_t_LDADD = $(test_ldadd)
 test_veb_t_SOURCES = test/veb.c
 test_veb_t_CPPFLAGS = $(test_cppflags)
 test_veb_t_LDADD = $(test_ldadd)
+
+test_lru_cache_t_SOURCES = test/lru_cache.c
+test_lru_cache_t_CPPFLAGS = $(test_cppflags)
+test_lru_cache_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/lru_cache.c
+++ b/src/common/libutil/lru_cache.c
@@ -1,0 +1,228 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* lru_cache.c - simple lru cache in c */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <czmq.h>
+
+#include "lru_cache.h"
+
+struct lru_entry {
+    lru_cache_t *lru;
+    char *key;
+    void *item;
+
+    struct lru_entry *prev;
+    struct lru_entry *next;
+};
+
+struct lru_cache {
+    int maxsize;
+    int count;
+
+    lru_cache_free_f freefn;
+
+    zhash_t *entries;
+    struct lru_entry *first, *last;
+};
+
+
+static struct lru_entry *
+lru_entry_create (lru_cache_t *lru, const char *key, void *item)
+{
+    struct lru_entry *l = malloc (sizeof (*l));
+    if (!l || !(l->key = strdup (key))) {
+        free (l);
+        return (NULL);
+    }
+    l->lru = lru;
+    l->item = item;
+    l->prev = l->next = NULL;
+    return (l);
+}
+
+
+static void lru_entry_destroy (struct lru_entry *l)
+{
+    if (l) {
+        if (l->lru && l->lru->freefn)
+            (*l->lru->freefn) (l->item);
+        free (l->key);
+        free (l);
+    }
+}
+
+static void lru_entry_remove (lru_cache_t *lru, struct lru_entry *l)
+{
+    /* Unlink l from queue first */
+    if (l->prev == NULL)
+        lru->first = l->next;
+    else
+        l->prev->next = l->next;
+    if (l->next == NULL)
+        lru->last = l->prev;
+    else
+        l->next->prev = l->prev;
+}
+
+static void lru_entry_push (lru_cache_t *lru, struct lru_entry *l)
+{
+    /* add to front of the LRU list */
+    l->next = lru->first;
+    if (lru->last == NULL) /* empty list */
+        lru->last = lru->first = l;
+    else { /* Update head of list */
+        lru->first->prev = l;
+        lru->first = l;
+    }
+}
+
+static void lru_entry_purge (lru_cache_t *lru, struct lru_entry *l)
+{
+    lru_entry_remove (lru, l);
+
+    /* Now remove entry from hash, this will result in memory
+     *  for `l` being freed.
+     */
+    zhash_delete (lru->entries, l->key);
+    lru->count--;
+}
+
+static void lru_purge_last (lru_cache_t *lru)
+{
+    if (lru->last == NULL)
+        return;
+    lru_entry_purge (lru, lru->last);
+}
+
+static void *
+lru_entry_enqueue (lru_cache_t *lru, const char *key, void *value)
+{
+    struct lru_entry *l = lru_entry_create (lru, key, value);
+    if (!l)
+        return (NULL);
+
+    if (lru->count == lru->maxsize)
+        lru_purge_last (lru);
+    lru_entry_push (lru, l);
+    lru->count++;
+
+    /* Place entry on hash, and add cleanup function */
+    if (zhash_insert (lru->entries, key, l) < 0)
+        abort ();
+    zhash_freefn (lru->entries, key, (zhash_free_fn *) lru_entry_destroy);
+
+    return (l->item);
+}
+
+static void *
+lru_entry_requeue (lru_cache_t *lru, struct lru_entry *l)
+{
+    lru_entry_remove (lru, l);
+    lru_entry_push (lru, l);
+    return (l->item);
+}
+
+/*
+ *  Public functions:
+ */
+
+void lru_cache_destroy (lru_cache_t *lru)
+{
+    zhash_destroy (&lru->entries);
+    free (lru);
+}
+
+lru_cache_t * lru_cache_create (int maxsize)
+{
+    lru_cache_t *lru = NULL;
+    zhash_t *zh = NULL;
+
+    if (!(zh = zhash_new ()) || !(lru = malloc (sizeof (*lru)))) {
+        free (lru);
+        free (zh);
+        return (NULL);
+    }
+
+    lru->maxsize = maxsize;
+    lru->count = 0;
+    lru->entries = zh;
+    lru->first = lru->last = NULL;
+    lru->freefn = NULL;
+
+    return (lru);
+}
+
+void lru_cache_set_free_f (lru_cache_t *lru, lru_cache_free_f fn)
+{
+    lru->freefn = fn;
+}
+
+void *lru_cache_get (lru_cache_t *lru, const char *key)
+{
+    struct lru_entry *l;
+    if ((l = zhash_lookup (lru->entries, key)))
+        return lru_entry_requeue (lru, l);
+    return (NULL);
+}
+
+bool lru_cache_check (lru_cache_t *lru, const char *key)
+{
+    if (zhash_lookup (lru->entries, key) == NULL)
+        return false;
+    return true;
+}
+
+int lru_cache_put (lru_cache_t *lru, const char *key, void *value)
+{
+    if (lru_cache_get (lru, key)) {
+        errno = EEXIST;
+        return (-1);
+    }
+    if (lru_entry_enqueue (lru, key, value) < 0)
+        return (-1);
+    return (0);
+}
+
+int lru_cache_remove (lru_cache_t *lru, const char *key)
+{
+    struct lru_entry *l;
+    if (!(l = zhash_lookup (lru->entries, key)))
+        return (-1);
+    lru_entry_purge (lru, l);
+    return (0);
+}
+
+int lru_cache_size (lru_cache_t *lru)
+{
+    return (lru->count);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/lru_cache.h
+++ b/src/common/libutil/lru_cache.h
@@ -1,0 +1,51 @@
+
+/*
+ *  lru_cache_t - simple LRU cache interface
+ */
+
+#ifndef HAVE_LRU_CACHE_H
+#define HAVE_LRU_CACHE_H
+
+#include <stdbool.h>
+
+typedef struct lru_cache lru_cache_t;
+typedef void (*lru_cache_free_f) (void *data);
+
+/*  Create a lru cache which holds at maximum `maxsize` objects
+ */
+lru_cache_t *lru_cache_create (int maxsize);
+void lru_cache_destroy (lru_cache_t *lru);
+
+/*  Set a function `fn` to free items stored in lru cache when they
+ *   purged or removed with `lru_cache_remove`.
+ */
+void lru_cache_set_free_f (lru_cache_t *lru, lru_cache_free_f fn);
+
+/*  Return current number of items stored in lru cache.
+ */
+int lru_cache_size (lru_cache_t *lru);
+
+/*  Put item `value` into cache, associated by key `key`.
+ *  Returns 0 on success, -1 on failure, with EEXIST if item already cached.
+ *
+ *  If value already existed in LRU cache, it will be moved to the front
+ *  of the LRU list.
+ */
+int lru_cache_put (lru_cache_t *lru, const char *key, void *item);
+
+/*  Get item associated with key. Returns NULL if item not found.
+ *  This will also move the item, if found, to the front of the LRU list.
+ */
+void *lru_cache_get (lru_cache_t *lru, const char *key);
+
+/*  Check if item with `key` is cached, without updating reference
+ *   of the item (i.e. do not promote it on the LRU list)
+ */
+bool lru_cache_check (lru_cache_t *lru, const char *key);
+
+/*
+ *  Force removal of item associated with `key` from the LRU cache.
+ */
+int lru_cache_remove (lru_cache_t *lru, const char *key);
+
+#endif /* !HAVE_LRU_CACHE_H */

--- a/src/common/libutil/test/lru_cache.c
+++ b/src/common/libutil/test/lru_cache.c
@@ -1,0 +1,91 @@
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/lru_cache.h"
+#include "src/common/libutil/xzmalloc.h"
+
+void test_basic ()
+{
+    int i;
+    const int size = 5;
+    const int nputs = size*2;
+    lru_cache_t *lru;
+
+    lru = lru_cache_create (size);
+    ok (lru != NULL, "lru_cache_create (%d)", size);
+    ok (lru_cache_size (lru) == 0, "lru_cache_size == 0");
+
+    lru_cache_set_free_f (lru, free);
+
+    for (i = 0; i < nputs; i++) {
+        char *key = xasprintf ("%d", i);
+        int *ip = xzmalloc (sizeof (*ip));
+        *ip = i;
+        ok (lru_cache_put (lru, key, ip) == 0, "lru_cache_put (%s)", key);
+        ok (lru_cache_check (lru, key), "lru_cache_check (%s)", key);
+        free (key);
+        if (i >= 4) /* keep entry 0 "hot" */
+            lru_cache_get (lru, "0");
+    }
+    ok (lru_cache_size (lru) == size,
+        "lru_cache_size still %d after %d puts", size, nputs);
+    ok (lru_cache_get (lru, "0") != NULL, "0 still cached");
+    ok (lru_cache_put (lru, "0", NULL) == -1 && errno == EEXIST,
+        "lru_cache_put on existing key returns -1");
+    ok (lru_cache_get (lru, "6") != NULL, "6 still cached");
+    ok (lru_cache_get (lru, "7") != NULL, "7 still cached");
+    ok (lru_cache_get (lru, "8") != NULL, "8 still cached");
+    ok (lru_cache_get (lru, "9") != NULL, "9 still cached");
+    ok (lru_cache_get (lru, "5") == NULL, "5 not cached");
+
+    ok (lru_cache_get (lru, "9") != NULL, "second get worked");
+
+    ok (lru_cache_remove (lru, "0") >= 0, "lru_cache_remove ()");
+    ok (lru_cache_get (lru, "0") == NULL, "remove worked");
+    ok (lru_cache_size (lru) == (size-1),
+        "cache size %d after remove", size - 1);
+
+    lru_cache_destroy (lru);
+}
+
+void fake_int_free (int *iptr)
+{
+    /*  Note this has been "freed" by setting to -1 */
+    *iptr = -1;
+}
+
+void test_free_fn ()
+{
+    lru_cache_t *lru;
+    int x = 1, y = 2, z = 3;
+
+    lru = lru_cache_create (2);
+    lru_cache_set_free_f (lru, (lru_cache_free_f) fake_int_free);
+
+    ok (lru_cache_put (lru, "x", &x) == 0, "lru_cache_put (x)");
+    ok (lru_cache_put (lru, "y", &y) == 0, "lru_cache_put (y)");
+    ok (lru_cache_put (lru, "z", &z) == 0, "lru_cache_put (z)");
+
+    ok (lru_cache_check (lru, "x") == false, "lru_cache_check (x) is false");
+    ok (x == -1, "x has been freed");
+    ok (y == 2,  "y is not freed");
+    ok (z == 3,  "z is not freed");
+
+    lru_cache_destroy (lru);
+
+    ok (y == -1, "y is now freed");
+    ok (z == -1, "z is now freed");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+    test_basic ();
+    test_free_fn ();
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
When libjsc was converted over to use the new hierarchical directory scheme under `lwj.`, the mapping between jobid and kvs path was memoized in an internal hash. At the time, no management of entries in this hash was also added, so the current code has the potential for unbounded memory growth when an application using libjsc is long running or managing many jobs.

This PR changes the internal hash of jobid to kvs path mappings into an LRU cache. The cache, for now, has a max size of 256. If needed, this could be made configurable or adjustable later.

The simple LRU cache implementation is added to libutil in case it can be used elsewhere.
