### PR TITLE
resource-hwloc: put HostName in by_rank directory

### DIFF
--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -116,4 +116,10 @@ test_expect_success 'hwloc: reload fails on invalid rank' '
     grep "No route to host" stderr
 '
 
+test_expect_success 'hwloc: HostName is populated in by_rank' '
+    HW_HOST=$(flux kvs get resource.hwloc.by_rank.0.HostName) &&
+    REAL_HOST=$(hostname) &&
+    test x"$HW_HOST" = x"$REAL_HOST"
+'
+
 test_done


### PR DESCRIPTION
Had this commit sitting on a branch for a while, getting stale. It might be useful so I'm proposing it as a PR for discussion.

Adds a resource.hwloc.by_rank.<id>.HostName key containing the hwloc-provided hostname for the current rank.
