### PR TITLE
kvs: doc updates, consistency fixes, new convenience options

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -55,11 +55,12 @@ Display the JSON type of the value under key: 'null', 'boolean', 'double',
 Store 'value' under 'key' and commit it.  If it already has a value,
 overwrite it.
 
-*dir* [-r] ['key']::
+*dir* [-r] [-d] ['key']::
 Display all keys and their values under the directory 'key'.
 If 'key' does not exist or is not a directory, display an error message.
 If 'key' is not provided, "." (root of the namespace) is assumed.  If '-r'
-is specified, recursively display keys under subdirectories.
+is specified, recursively display keys under subdirectories.  If '-d' is
+specified, do not output key values.
 
 *dirsize* 'key'::
 Get the number of keys in a directory.
@@ -87,11 +88,12 @@ Watch 'key', displaying each change on a line of output.  If the key
 is not set, display "NULL".  If 'count' is specified, display at most
 'count' versions.  Otherwise, command runs forever.
 
-*watch-dir* [-r] [count] 'key'::
+*watch-dir* [-r] [-d] [count] 'key'::
 Watch directory specified at 'key', displaying changes within it and
 in subdirectories.  If '-r' is specified, recursively display keys
-under subdirectories.  If 'count' is specified, display at most
-'count' versions.  Otherwise, this command runs forever.
+under subdirectories.  If '-d' is specified, do not output key values.
+If 'count' is specified, display at most 'count' versions.  Otherwise,
+this command runs forever.
 
 *copy-tokvs* 'key' 'file'::
 Copy data from 'file' to 'key', encoding to Z85 format and committing
@@ -143,12 +145,12 @@ may contain spaces.
 Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
 If nothing has been stored under 'key', display an error message.
 
-*dirat* [-r] 'treeobj' ['key']::
+*dirat* [-r] [-d] 'treeobj' ['key']::
 Display all keys and their values under the directory 'key', starting
 lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
-display an error message.  If 'key' is not provided, "." (root of
-the namespace) is assumed.  If '-r' is specified, recursively display
-keys under subdirectories.
+display an error message.  If 'key' is not provided, "." (root of the
+namespace) is assumed.  If '-r' is specified, recursively display keys
+under subdirectories.  If '-d' is specified, do not output key values.
 
 *readlinkat* 'treeobj' 'key'::
 Retrieve the key a link refers to rather than its value, as would be

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -82,9 +82,10 @@ returned by *get*.
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.
 
-*watch* 'key'::
-Watch 'key', displaying each change on a line of output.
-If the key is not set, display "NULL".  This command runs forever.
+*watch* [count] 'key'::
+Watch 'key', displaying each change on a line of output.  If the key
+is not set, display "NULL".  If 'count' is specified, display at most
+'count' versions.  Otherwise, command runs forever.
 
 *watch-dir* [-r] [count] 'key'::
 Watch directory specified at 'key', displaying changes within it and

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -55,10 +55,11 @@ Display the JSON type of the value under key: 'null', 'boolean', 'double',
 Store 'value' under 'key' and commit it.  If it already has a value,
 overwrite it.
 
-*dir* ['key']::
+*dir* [-r] ['key']::
 Display all keys and their values under the directory 'key'.
 If 'key' does not exist or is not a directory, display an error message.
-If 'key' is not provided, "." (root of the namespace) is assumed.
+If 'key' is not provided, "." (root of the namespace) is assumed.  If '-r'
+is specified, recursively display keys under subdirectories.
 
 *dirsize* 'key'::
 Get the number of keys in a directory.
@@ -135,11 +136,12 @@ may contain spaces.
 Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
 If nothing has been stored under 'key', display an error message.
 
-*dirat* 'treeobj' ['key']::
+*dirat* [-r] 'treeobj' ['key']::
 Display all keys and their values under the directory 'key', starting
 lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
 display an error message.  If 'key' is not provided, "." (root of
-the namespace) is assumed.
+the namespace) is assumed.  If '-r' is specified, recursively display
+keys under subdirectories.
 
 *readlinkat* 'treeobj' 'key'::
 Retrieve the key a link refers to rather than its value, as would be

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -60,6 +60,9 @@ Display all keys and their values under the directory 'key'.
 If 'key' does not exist or is not a directory, display an error message.
 If 'key' is not provided, "." (root of the namespace) is assumed.
 
+*dirsize* 'key'::
+Get the number of keys in a directory.
+
 *unlink* 'key' ['key...']::
 Remove 'key' from the KVS and commit the change.  If 'key' represents
 a directory, remove all keys underneath it.  If nothing has been stored

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -86,6 +86,12 @@ it is overwritten.
 Watch 'key', displaying each change on a line of output.
 If the key is not set, display "NULL".  This command runs forever.
 
+*watch-dir* [-r] [count] 'key'::
+Watch directory specified at 'key', displaying changes within it and
+in subdirectories.  If '-r' is specified, recursively display keys
+under subdirectories.  If 'count' is specified, display at most
+'count' versions.  Otherwise, this command runs forever.
+
 *copy-tokvs* 'key' 'file'::
 Copy data from 'file' to 'key', encoding to Z85 format and committing
 the change.  'file' may be a UNIX file name or "-" indicating standard

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -340,3 +340,5 @@ respondf
 encodef
 UTF
 whitespace
+dirsize
+subdirectories

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -81,7 +81,7 @@ void usage (void)
 "       flux-kvs readlink        key\n"
 "       flux-kvs mkdir           key [key...]\n"
 "       flux-kvs exists          key\n"
-"       flux-kvs watch           key\n"
+"       flux-kvs watch           [count] key\n"
 "       flux-kvs watch-dir [-r]  [count] key\n"
 "       flux-kvs copy-tokvs      key file\n"
 "       flux-kvs copy-fromkvs    key file\n"
@@ -398,7 +398,13 @@ void cmd_watch (flux_t *h, int argc, char **argv)
 {
     char *json_str = NULL;
     char *key;
+    int count = -1;
 
+    if (argc == 2) {
+        count = strtoul (argv[0], NULL, 10);
+        argc--;
+        argv++;
+    }
     if (argc != 1)
         log_msg_exit ("watch: specify one key");
     key = argv[0];
@@ -406,6 +412,8 @@ void cmd_watch (flux_t *h, int argc, char **argv)
         log_err_exit ("%s", key);
     do {
         printf ("%s\n", json_str ? json_str : "NULL");
+        if (--count == 0)
+            break;
         if (kvs_watch_once (h, argv[0], &json_str) < 0 && errno != ENOENT)
             log_err_exit ("%s", argv[0]);
     } while (true);

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -502,10 +502,19 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 
 # watch tests
 
+test_expect_success 'kvs: watch 5 versions of key'  '
+	flux kvs unlink $TEST.foo &&
+        flux kvs put $TEST.a.b.c=1 &&
+	flux kvs watch 5 $TEST.foo.a >watch_out &
+        for i in $(seq 2 5); do
+            flux kvs put $TEST.foo.a=${i}
+        done
+'
+
 test_expect_success 'kvs: watch 5 versions of directory'  '
 	flux kvs unlink $TEST.foo &&
-	flux kvs watch-dir -r 5 $TEST.foo >watch_out &
-	while $(grep -s '===============' watch_out | wc -l) -lt 5; do
+	flux kvs watch-dir -r 5 $TEST.foo >watch_dir_out &
+	while $(grep -s '===============' watch_dir_out | wc -l) -lt 5; do
 	    flux kvs put $TEST.foo.a=$(date +%N); \
 	done
 '


### PR DESCRIPTION
Wanted to add a simple option to list kvs entries without the values since some entries are gigantic and flood stdout.  Sometimes just want to know what entries were there.  Lead to a lot of cleanup along the way.

The new ```-d``` option I added to several subcommands was chosen b/c I likened the option to the ```-d``` option of ```ls```.  I know that may just be my weird way of thinking about it and maybe most won't think of it that way.

The subcommand option parsing could be cleaned up, but I decided to leave it be, let the code have one more "strike" before cleanup.