### PR TITLE
flux-ping refactor and cleanup

### DIFF
--- a/doc/man1/flux-ping.adoc
+++ b/doc/man1/flux-ping.adoc
@@ -38,7 +38,9 @@ OPTIONS
 -------
 *-r, --rank*'=NODESET'::
 Find target on a specific broker rank(s).  See NODESET FORMAT below
-for more information.  Default: send to FLUX_NODEID_ANY.
+for more information.  Special case strings ``_any_'' and
+``_upstream_'' available to ping FLUX_NODEID_ANY and
+FLUX_NODEID_UPSTREAM respectively.  Default: send to ``_any_''.
 
 *-p, --pad*'=N'::
 Include in the payload a string of length 'N' bytes.  The payload will be

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -127,22 +127,23 @@ void ping_continuation (flux_rpc_t *rpc, void *arg)
     pdata->rpc_count++;
 
 done:
-    if (flux_rpc_next (rpc) < 0 && pdata->rpc_count) {
-        if (ctx->rank != NULL) {
-            printf ("%s!%s pad=%lu seq=%d time=(%0.3f:%0.3f:%0.3f) ms stddev %0.3f\n",
-                    ctx->rank,
-                    ctx->topic, strlen (ctx->pad), pdata->seq,
-                    tstat_min (tstat), tstat_mean (tstat), tstat_max (tstat),
-                    tstat_stddev (tstat));
-        } else {
-            char s[16];
-            snprintf (s, sizeof (s), "%u", ctx->nodeid);
-            printf ("%s%s%s pad=%lu seq=%d time=%0.3f ms (%s)\n",
-                    ctx->nodeid == FLUX_NODEID_ANY ? "" : s,
-                    ctx->nodeid == FLUX_NODEID_ANY ? "" : "!",
-                    ctx->topic, strlen (ctx->pad), pdata->seq,
-                    tstat_mean (tstat),
-                    pdata->route);
+    if (flux_rpc_next (rpc) < 0) {
+        if (pdata->rpc_count) {
+            if (ctx->rank != NULL) {
+                printf ("%s!%s pad=%lu seq=%d time=(%0.3f:%0.3f:%0.3f) ms "
+                        "stddev %0.3f\n",
+                        ctx->rank, ctx->topic, strlen (ctx->pad), pdata->seq,
+                        tstat_min (tstat), tstat_mean (tstat),
+                        tstat_max (tstat), tstat_stddev (tstat));
+            } else {
+                char s[16];
+                snprintf (s, sizeof (s), "%u", ctx->nodeid);
+                printf ("%s%s%s pad=%lu seq=%d time=%0.3f ms (%s)\n",
+                        ctx->nodeid == FLUX_NODEID_ANY ? "" : s,
+                        ctx->nodeid == FLUX_NODEID_ANY ? "" : "!",
+                        ctx->topic, strlen (ctx->pad), pdata->seq,
+                        tstat_mean (tstat), pdata->route);
+            }
         }
         flux_rpc_destroy (rpc);
     }

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -81,4 +81,64 @@ test_expect_success 'ping fails on invalid target' '
 	grep -q "Function not implemented" stderr
 '
 
+test_expect_success 'ping output format for "any" single rank is correct' '
+	run_timeout 5 flux ping --count 1 cmb 1>stdout
+        grep -q "^cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for specific single rank is correct (format 1)' '
+	run_timeout 5 flux ping --count 1 --rank 0 cmb 1>stdout
+        grep -q "^0!cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for specific single rank is correct (format 2)' '
+	run_timeout 5 flux ping --count 1 0!cmb 1>stdout
+        grep -q "^0!cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for specific single rank is correct (format 3)' '
+	run_timeout 5 flux ping --count 1 0 1>stdout
+        grep -q "^0!cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for specific multiple ranks is correct (format 1)' '
+	run_timeout 5 flux ping --count 1 --rank 0-1 cmb 1>stdout
+        grep -q "^0-1!cmb.ping" stdout &&
+        grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
+test_expect_success 'ping output format for specific multiple ranks is correct (format 2)' '
+	run_timeout 5 flux ping --count 1 0-1!cmb 1>stdout
+        grep -q "^0-1!cmb.ping" stdout &&
+        grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
+test_expect_success 'ping output format for specific multiple ranks is correct (format 3)' '
+	run_timeout 5 flux ping --count 1 0-1 1>stdout
+        grep -q "^0-1!cmb.ping" stdout &&
+        grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
+test_expect_success 'ping output format for all ranks is correct (format 1)' '
+	run_timeout 5 flux ping --count 1 --rank all cmb 1>stdout
+        grep -q "^all!cmb.ping" stdout &&
+        grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
+test_expect_success 'ping output format for all ranks is correct (format 2)' '
+	run_timeout 5 flux ping --count 1 all!cmb 1>stdout
+        grep -q "^all!cmb.ping" stdout &&
+        grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
+test_expect_success 'ping output format for all ranks is correct (format 3)' '
+	run_timeout 5 flux ping --count 1 all 1>stdout
+        grep -q "^all!cmb.ping" stdout &&
+        grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
 test_done

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -81,8 +81,26 @@ test_expect_success 'ping fails on invalid target' '
 	grep -q "Function not implemented" stderr
 '
 
-test_expect_success 'ping output format for "any" single rank is correct' '
+test_expect_success 'ping output format for "any" single rank is correct (default)' '
 	run_timeout 5 flux ping --count 1 cmb 1>stdout
+        grep -q "^cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for "any" single rank is correct (format 1)' '
+	run_timeout 5 flux ping --count 1 --rank any cmb 1>stdout
+        grep -q "^cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for "any" single rank is correct (format 2)' '
+	run_timeout 5 flux ping --count 1 any!cmb 1>stdout
+        grep -q "^cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping output format for "any" single rank is correct (format 3)' '
+	run_timeout 5 flux ping --count 1 any 1>stdout
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
@@ -139,6 +157,33 @@ test_expect_success 'ping output format for all ranks is correct (format 3)' '
 	run_timeout 5 flux ping --count 1 all 1>stdout
         grep -q "^all!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
+'
+
+# test "upstream" via exec.  Ping started on rank 0 should result in
+# an error b/c there is no where to go upstream.  Ping executed on
+# rank 1 should work
+
+test_expect_success 'ping with "upstream" fails on rank 0' '
+        run_timeout 5 flux exec --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr
+	grep -q "Function not implemented" stderr
+'
+
+test_expect_success 'ping with "upstream" works (format 1)' '
+        run_timeout 5 flux exec --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout
+        grep -q "^upstream!cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping with "upstream" works (format 2)' '
+        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream!cmb 1>stdout
+        grep -q "^upstream!cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
+'
+
+test_expect_success 'ping with "upstream" works (format 3)' '
+        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream 1>stdout
+        grep -q "^upstream!cmb.ping" stdout &&
+        grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_done


### PR DESCRIPTION
Per discussion in PR #860 and some offline discussion, cleanup flux-ping to use jansson API.  I'm not 100% done as I noticed a few things, but thought I'd start w/ this PR.

Lots of mini-cleanup.  Notable changes:

For consistency to ping(8), change ```--delay``` to ```--interval``` in flux-ping.  This is an outright breakage of old command line but thought important to make it consistent and now's the time to do it.  acc62ef7337fbdbd7ed1dca527e0c99a3a21fcab

Refactor ```flux_rpc_multi``` and add a ```flux_rpcf_multi``` jansson equivalent.  Stuck typdef of callback in the middle of the file, right before usage.  It's not the style I normally use, but noticed it elsewhere.  Could cleanup usage all around if not liked.  96171838a9a299a8e6cd2044796bd8b418134830 & 7cab3c6c8679f6ba935aa7ccebb4f69183dd9357

Use jansson API in ```flux-ping```.  Not as cleaned up as I hoped. It's a complete wash when it comes to LOC.  Perhaps need to just call ```flux_rpcf_multi``` regardless if it's a single or multi-call.  Haven't quite figured out the right logic for that yet.  Perhaps a rank of ```"any"``` could be another key that can be accepted by the ```flux_rpc_multi``` functions? 87ee115f6b1a3ad475e3c2a4984e851ae105d38f

I continue to use ```int64_t``` where it would be preferable to use ```json_int_t```, but there's some header collisions between libjson-c and jansson.  Can't remove ```shortjson.h``` header, because it's needed for ```tstat.h```.  So should refactor that somehow.

Another thing I noticed is that in ```message.c``` we got this check for ```json_int_t```.  Now that ```json_int_t``` can be used multiple places, I'm thinking we should stick it in ```configure``` and just fail if longs aren't 8 bytes.

```
/* Ensure %I format for jansson pack/unpack works with int64_t
 */
#if JSON_INTEGER_IS_LONG_LONG
# if SIZEOF_LONG_LONG != 8
# error json_int_t is not 64 bits
# endif
#else
# if SIZEOF_LONG != 8
# error json_int_t is not 64 bits
# endif
#endif
```
