### PR TITLE
wreck: check for invalid tasks to run on node and issue fatal error

### DIFF
--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -964,6 +964,11 @@ int prog_ctx_load_lwj_info (struct prog_ctx *ctx)
     else if (kvsdir_get_int (ctx->kvs, "tasks-per-node", &ctx->nprocs) < 0)
             ctx->nprocs = 1;
 
+    if (ctx->nprocs <= 0) {
+        wlog_fatal (ctx, 0,
+            "Invalid spec on node%d: ncores = %d", ctx->nodeid, ctx->nprocs);
+    }
+
     ctx->task = xzmalloc (ctx->nprocs * sizeof (struct task_info *));
     for (i = 0; i < ctx->nprocs; i++)
         ctx->task[i] = task_info_create (ctx, i);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -254,7 +254,7 @@ static void wlog_fatal (struct prog_ctx *ctx, int code, const char *format, ...)
      */
     if (c == ctx->flux && ctx->kz_err) {
         va_start (ap, format);
-        vlog_error_kvs (ctx, code, format, ap);
+        vlog_error_kvs (ctx, 1, format, ap);
         va_end (ap);
 
         if (archive_lwj (ctx) < 0)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -130,6 +130,7 @@ check_SCRIPTS = \
         issues/t0441-kvs-put-get.sh \
         issues/t0505-msg-handler-reg.lua \
         issues/t0821-kvs-segfault.sh \
+        issues/t0900-wreck-invalid-cores.sh \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/issues/t0900-wreck-invalid-cores.sh
+++ b/t/issues/t0900-wreck-invalid-cores.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+run_timeout() {
+    perl -e 'alarm shift @ARGV; exec @ARGV' "$@"
+}
+# set one of the rank.X.cores to 0, invalid specification:
+run_timeout 1 flux wreckrun -N2 -P 'lwj["rank.1.cores"] = 0' hostname
+test $? = 1 && exit 0
+
+exit 1


### PR DESCRIPTION
This should resolve the specific issue from #900. A reproducer was added under `t/issues` and I've verified it fails before and passes after this PR is applied.

There may be other cases where unexpected values cause hangs during wreck job launch, but those are not tackled here.