### PR TITLE
libflux/rpc: add flux_rpcf_multi(), add "any" nodeset option, various refactoring

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -55,6 +55,7 @@ MAN3_FILES_SECONDARY = \
 	flux_rpc_destroy.3 \
 	flux_rpc_check.3 \
 	flux_rpc_get.3 \
+	flux_rpcf_multi.3 \
 	flux_rpc_next.3 \
 	flux_rpc_get_nodeid.3 \
 	flux_rpcf.3 \
@@ -138,6 +139,7 @@ flux_rpc_get.3: flux_rpc.3
 flux_rpc_getf.3: flux_rpc.3
 flux_rpcf.3: flux_rpc.3
 flux_rpc_check.3: flux_rpc_then.3
+flux_rpcf_multi.3: flux_rpc_multi.3
 flux_rpc_next.3: flux_rpc_multi.3
 flux_rpc_get_nodeid.3: flux_rpc_multi.3
 flux_reduce_destroy.3: flux_reduce_create.3

--- a/doc/man3/flux_rpc_multi.adoc
+++ b/doc/man3/flux_rpc_multi.adoc
@@ -5,7 +5,7 @@ flux_rpc_multi(3)
 
 NAME
 ----
-flux_rpc_multi, flux_rpc_next, flux_rpc_get_nodeid - send a remote procedure call to a Flux service on multiple ranks
+flux_rpc_multi, flux_rpcf_multi, flux_rpc_next, flux_rpc_get_nodeid - send a remote procedure call to a Flux service on multiple ranks
 
 
 SYNOPSIS
@@ -14,6 +14,9 @@ SYNOPSIS
 
 flux_rpc_t *flux_rpc_multi (flux_t *h, const char *topic, const char *json_str,
                             const char *nodeset, int flags);
+
+flux_rpc_t *flux_rpcf_multi (flux_t *h, const char *topic, const char *nodeset,
+                             int flags, const char *fmt, ...);
 
 int flux_rpc_next (flux_rpc_t *rpc);
 
@@ -68,11 +71,21 @@ a response containing an error, `flux_rpc_get_nodeid()` will succeed,
 while `flux_rpc_get()` will fail.  This allows the failing nodeid to
 be determined.
 
+`flux_rpcf_multi()` is a variant of `flux_rpc_multi()` that constructs a
+JSON payload based on the provided _fmt_ string and variable arguments.
+The _fmt_ string and variable arguments are passed internally to
+jansson's `json_pack()` function.  See below for details.
+
+
+include::JSON_PACK.adoc[]
+
+
 RETURN VALUE
 ------------
 
-`flux_rpc_multi()` returns a flux_rpc_t object on success.  On error, NULL
-is returned, and errno is set appropriately.
+`flux_rpc_multi()` and `flux_rpcf_multi()` returns a flux_rpc_t object
+on success.  On error, NULL is returned, and errno is set
+appropriately.
 
 `flux_rpc_next()` returns 0 if additional responses are expected, else -1.
 It does not set errno.

--- a/doc/man3/flux_rpc_multi.adoc
+++ b/doc/man3/flux_rpc_multi.adoc
@@ -36,9 +36,11 @@ _json_in_, if non-NULL, must be a string containing valid serialized
 JSON to be attached as payload to the request.  If NULL, the request
 will be sent without a payload.
 
-_nodeset_ is a string containing a bracketed set of ranks or "all" as a
-shorthand for all ranks in the session.  Examples of valid nodeset
-strings are "[0-255]", "[1,2.3]", and "[0,3,5-10]".
+_nodeset_ is a string containing a bracketed set of ranks, "all" as a
+shorthand for all ranks in the session, or "any" as a shorthand for a
+single RPC to FLUX_NODEID_ANY, or "upstream" as a shorthand for a
+single RPC to FLUX_NODEID_UPSTREAM.  Examples of valid nodeset strings
+are "[0-255]", "[1,2.3]", and "[0,3,5-10]".
 
 _flags_ may be zero or:
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -474,6 +474,16 @@ static flux_rpc_t *rpc_multi (flux_t *h,
         errno = EINVAL;
         goto error;
     }
+    if (!strcmp (nodeset, "any"))
+        return rpc_request (h,
+                            FLUX_NODEID_ANY,
+                            flags,
+                            msg);
+    if (!strcmp (nodeset, "upstream"))
+        return rpc_request (h,
+                            FLUX_NODEID_UPSTREAM,
+                            flags,
+                            msg);
     if (!strcmp (nodeset, "all")) {
         if (flux_get_size (h, &count) < 0)
             goto error;

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -455,6 +455,7 @@ flux_rpc_t *flux_rpc_raw (flux_t *h,
         goto error;
 #if HAVE_CALIPER
     cali_begin_string_byname ("flux.message.rpc", "single");
+    cali_begin_int_byname ("flux.message.rpc.nodeid", nodeid);
     cali_begin_int_byname ("flux.message.response_expected",
                            !(flags & FLUX_RPC_NORESPONSE));
 #endif
@@ -462,6 +463,7 @@ flux_rpc_t *flux_rpc_raw (flux_t *h,
         goto error;
 #if HAVE_CALIPER
     cali_end_byname ("flux.message.response_expected");
+    cali_end_byname ("flux.message.rpc.nodeid");
     cali_end_byname ("flux.message.rpc");
 #endif
     return rpc;

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -168,6 +168,16 @@ done:
     return rc;
 }
 
+static int rpc_request_prepare_send (flux_rpc_t *rpc, flux_msg_t *msg,
+                                     uint32_t nodeid)
+{
+    if (rpc_request_prepare (rpc, msg, nodeid) < 0)
+        return -1;
+    if (flux_send (rpc->h, msg, 0) < 0)
+        return -1;
+    return 0;
+}
+
 static int rpc_request_send (flux_rpc_t *rpc, const char *topic,
                              uint32_t nodeid, const char *json_str)
 {
@@ -176,11 +186,7 @@ static int rpc_request_send (flux_rpc_t *rpc, const char *topic,
 
     if (!(msg = flux_request_encode (topic, json_str)))
         goto done;
-    if (rpc_request_prepare (rpc, msg, nodeid) < 0)
-        goto done;
-    if (flux_send (rpc->h, msg, 0) < 0)
-        goto done;
-    rc = 0;
+    rc = rpc_request_prepare_send (rpc, msg, nodeid);
 done:
     flux_msg_destroy (msg);
     return rc;
@@ -196,11 +202,7 @@ static int rpc_request_vsendf (flux_rpc_t *rpc, const char *topic,
         goto done;
     if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
         goto done;
-    if (rpc_request_prepare (rpc, msg, nodeid) < 0)
-        goto done;
-    if (flux_send (rpc->h, msg, 0) < 0)
-        goto done;
-    rc = 0;
+    rc = rpc_request_prepare_send (rpc, msg, nodeid);
 done:
     flux_msg_destroy (msg);
     return rc;
@@ -214,11 +216,7 @@ static int rpc_request_send_raw (flux_rpc_t *rpc, const char *topic,
 
     if (!(msg = flux_request_encode_raw (topic, data, len)))
         goto done;
-    if (rpc_request_prepare (rpc, msg, nodeid) < 0)
-        goto done;
-    if (flux_send (rpc->h, msg, 0) < 0)
-        goto done;
-    rc = 0;
+    rc = rpc_request_prepare_send (rpc, msg, nodeid);
 done:
     flux_msg_destroy (msg);
     return rc;

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -553,6 +553,29 @@ done:
     return rc;
 }
 
+flux_rpc_t *flux_rpcf_multi (flux_t *h,
+                             const char *topic,
+                             const char *nodeset,
+                             int flags,
+                             const char *fmt,
+                             ...)
+{
+    flux_msg_t *msg;
+    flux_rpc_t *rc = NULL;
+    va_list ap;
+
+    va_start (ap, fmt);
+    if (!(msg = flux_request_encode (topic, NULL)))
+        goto done;
+    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+        goto done;
+    rc = rpc_multi (h, nodeset, flags, msg);
+done:
+    va_end (ap);
+    flux_msg_destroy (msg);
+    return rc;
+}
+
 const char *flux_rpc_type_get (flux_rpc_t *rpc)
 {
     return rpc->type;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -87,12 +87,14 @@ void flux_rpc_type_set (flux_rpc_t *rpc, const char *type);
 void *flux_rpc_aux_get (flux_rpc_t *rpc);
 void flux_rpc_aux_set (flux_rpc_t *rpc, void *aux, flux_free_f destroy);
 
-/* Variants of flux_rpc and flux_rpc_get that encode/decode json payloads
- * using jansson pack/unpack format strings.  Returned strings are invalidated
- * by flux_rpc_destroy().
+/* Variants of flux_rpc, flux_rpc_multi, and flux_rpc_get that
+ * encode/decode json payloads using jansson pack/unpack format
+ * strings.  Returned strings are invalidated by flux_rpc_destroy().
  */
 flux_rpc_t *flux_rpcf (flux_t *h, const char *topic, uint32_t nodeid,
                        int flags, const char *fmt, ...);
+flux_rpc_t *flux_rpcf_multi (flux_t *h, const char *topic, const char *nodeset,
+                             int flags, const char *fmt, ...);
 int flux_rpc_getf (flux_rpc_t *rpc, const char *fmt, ...);
 
 #endif /* !_FLUX_CORE_RPC_H */

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -61,9 +61,12 @@ int flux_rpc_get_raw (flux_rpc_t *rpc, void *data, int *len);
  */
 int flux_rpc_then (flux_rpc_t *rpc, flux_then_f cb, void *arg);
 
-/* Send an RPC request to 'nodeset' and return a flux_rpc_t object
- * to allow responses to be handled.  "all" is a valid shorthand for
- * all ranks in the comms session.  On failure return NULL with errno set.
+/* Send an RPC request to 'nodeset' and return a flux_rpc_t object to
+ * allow responses to be handled.  "all" is a valid shorthand for all
+ * ranks in the comms session.  "any" is a valid shorthand for a
+ * single rpc sent to FLUX_NODEID_ANY.  "upstream" is a valid
+ * shorthand for a single rpc sent to FLUX_NODEID_UPSTREAM.  On
+ * failure return NULL with errno set.
  */
 flux_rpc_t *flux_rpc_multi (flux_t *h, const char *topic, const char *json_str,
                             const char *nodeset, int flags);

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -125,6 +125,34 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
         "rpc was called once");
     flux_rpc_destroy (r);
 
+    /* working no-payload RPC for "any" */
+    old_count = hello_count;
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", NULL, "any", 0)) != NULL,
+        "flux_rpc_multi [0] with no payload when none is expected works");
+    if (!r)
+        BAIL_OUT ("can't continue without successful rpc call");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_get (r, NULL) == 0,
+        "flux_rpc_get works");
+    ok (hello_count == old_count + 1,
+        "rpc was called once");
+    flux_rpc_destroy (r);
+
+    /* working no-payload RPC for "upstream" */
+    old_count = hello_count;
+    ok ((r = flux_rpc_multi (h, "rpctest.hello", NULL, "upstream", 0)) != NULL,
+        "flux_rpc_multi [0] with no payload when none is expected works");
+    if (!r)
+        BAIL_OUT ("can't continue without successful rpc call");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_get (r, NULL) == 0,
+        "flux_rpc_get works");
+    ok (hello_count == old_count + 1,
+        "rpc was called once");
+    flux_rpc_destroy (r);
+
     /* cause remote EPROTO (unexpected payload) - picked up in _get() */
     ok ((r = flux_rpc_multi (h, "rpctest.hello", "{}", "all", 0)) != NULL,
         "flux_rpc_multi [0] with unexpected payload works, at first");

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -35,6 +35,29 @@ done:
     Jput (o);
 }
 
+void rpcftest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
+                         const flux_msg_t *msg, void *arg)
+{
+    int errnum = 0;
+    uint32_t nodeid = 0;
+    int flags = 0;
+
+    if (flux_request_decodef (msg, NULL, "{}") < 0
+            || flux_msg_get_nodeid (msg, &nodeid, &flags) < 0) {
+        errnum = errno;
+        goto done;
+    }
+    if (nodeid == nodeid_fake_error) {
+        nodeid_fake_error = -1;
+        errnum = EPERM; /* an error not likely to be seen */
+        goto done;
+    }
+
+done:
+    (void)flux_respondf (h, msg, "{ s:i s:i s:i }", "errnum", errnum,
+                         "nodeid", nodeid, "flags", flags);
+}
+
 /* request payload echoed in response */
 void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
@@ -66,6 +89,17 @@ done:
     (void)flux_respond (h, msg, errnum, NULL);
 }
 
+void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
+                        const flux_msg_t *msg, void *arg)
+{
+    if (flux_request_decodef (msg, NULL, "{}") < 0) {
+        goto done;
+    }
+    hello_count++;
+done:
+    (void)flux_respondf (h, msg, "{}");
+}
+
 /* then test - add nodeid to 'then_ns' */
 static nodeset_t *then_ns = NULL;
 static int then_count = 0;
@@ -77,6 +111,19 @@ static void then_cb (flux_rpc_t *r, void *arg)
 
     if (flux_rpc_get_nodeid (r, &nodeid) < 0
             || flux_rpc_get (r, NULL) < 0
+            || !nodeset_add_rank (then_ns, nodeid)
+            || ++then_count == 128) {
+        flux_reactor_stop (flux_get_reactor (h));
+    }
+}
+
+static void thenf_cb (flux_rpc_t *r, void *arg)
+{
+    flux_t *h = arg;
+    uint32_t nodeid;
+
+    if (flux_rpc_get_nodeid (r, &nodeid) < 0
+            || flux_rpc_getf (r, "{}") < 0
             || !nodeset_add_rank (then_ns, nodeid)
             || ++then_count == 128) {
         flux_reactor_stop (flux_get_reactor (h));
@@ -285,11 +332,199 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
      * run_multi_test() */
 }
 
+void rpcftest_begin_cb (flux_t *h, flux_msg_handler_t *w,
+                        const flux_msg_t *msg, void *arg)
+{
+    uint32_t nodeid;
+    int count;
+    int old_count;
+    flux_rpc_t *r;
+    const char *json_str;
+
+    rpctest_set_size (h, 1);
+
+    errno = 0;
+    ok (!(r = flux_rpcf_multi (h, NULL, "all", 0, "{}")) && errno == EINVAL,
+        "flux_rpcf_multi [0] with NULL topic fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpcf_multi (h, "bar", NULL, 0, "{}")) && errno == EINVAL,
+        "flux_rpcf_multi [0] with NULL nodeset fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpcf_multi (h, "bar", "xyz", 0, "{}")) && errno == EINVAL,
+        "flux_rpcf_multi [0] with bad nodeset fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpcf_multi (h, "bar", "all", 0, NULL)) && errno == EINVAL,
+        "flux_rpcf_multi [0] with NULL fmt fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpcf_multi (h, "bar", "all", 0, "")) && errno == EINVAL,
+        "flux_rpcf_multi [0] with empty string fmt fails with EINVAL");
+    errno = 0;
+    ok (!(r = flux_rpcf_multi (h, "bar", "all", 0, "{ s }", "foo")) && errno == EINVAL,
+        "flux_rpcf_multi [0] with bad string fmt fails with EINVAL");
+
+    /* working empty payload RPC */
+    old_count = hello_count;
+    ok ((r = flux_rpcf_multi (h, "rpcftest.hello", "all", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0] with empty payload when none is expected works");
+    if (!r)
+        BAIL_OUT ("can't continue without successful rpc call");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_getf (r, "{}") == 0,
+        "flux_rpc_getf works");
+    ok (hello_count == old_count + 1,
+        "rpc was called once");
+    flux_rpc_destroy (r);
+
+    /* working empty payload RPC for "any" */
+    old_count = hello_count;
+    ok ((r = flux_rpcf_multi (h, "rpcftest.hello", "any", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0] with empty payload when none is expected works");
+    if (!r)
+        BAIL_OUT ("can't continue without successful rpc call");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_getf (r, "{}") == 0,
+        "flux_rpc_getf works");
+    ok (hello_count == old_count + 1,
+        "rpc was called once");
+    flux_rpc_destroy (r);
+
+    /* working empty payload RPC for "upstream" */
+    old_count = hello_count;
+    ok ((r = flux_rpcf_multi (h, "rpcftest.hello", "upstream", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0] with empty payload when none is expected works");
+    if (!r)
+        BAIL_OUT ("can't continue without successful rpc call");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    ok (flux_rpc_getf (r, "{}") == 0,
+        "flux_rpc_getf works");
+    ok (hello_count == old_count + 1,
+        "rpc was called once");
+    flux_rpc_destroy (r);
+
+    /* fake that we have a larger session */
+    rpctest_set_size (h, 128);
+
+    /* repeat working empty-payload RPC test (now with 128 nodes) */
+    old_count = hello_count;
+    ok ((r = flux_rpcf_multi (h, "rpcftest.hello", "all", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0-%d] with empty payload when none is expected works",
+        fake_size - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    count = 0;
+    do {
+        if (flux_rpc_getf (r, "{}") < 0)
+            break;
+        count++;
+    } while (flux_rpc_next (r) == 0);
+    ok (count == fake_size,
+        "flux_rpc_get succeded %d times", fake_size);
+
+    cmp_ok (hello_count - old_count, "==", fake_size,
+        "rpc was called %d times", fake_size);
+    flux_rpc_destroy (r);
+
+    /* same with a subset */
+    old_count = hello_count;
+    ok ((r = flux_rpcf_multi (h, "rpcftest.hello", "[0-63]", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0-%d] with empty payload when none is expected works",
+        64 - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    count = 0;
+    do {
+        if (flux_rpc_get_nodeid (r, &nodeid) < 0
+                || flux_rpc_getf (r, "{}") < 0 || nodeid != count)
+            break;
+        count++;
+    } while (flux_rpc_next (r) == 0);
+    ok (count == 64,
+        "flux_rpc_get succeded %d times, with correct nodeid map", 64);
+
+    cmp_ok (hello_count - old_count, "==", 64,
+        "rpc was called %d times", 64);
+    flux_rpc_destroy (r);
+
+    /* same with echo payload */
+    ok ((r = flux_rpcf_multi (h, "rpctest.echo", "[0-63]", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0-%d] ok",
+        64 - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    count = 0;
+    do {
+        if (flux_rpc_get (r, &json_str) < 0
+                || !json_str || strcmp (json_str, "{}") != 0)
+            break;
+        count++;
+    } while (flux_rpc_next (r) == 0);
+    ok (count == 64,
+        "flux_rpc_get succeded %d times, with correct return payload", 64);
+    flux_rpc_destroy (r);
+
+    /* detect partial failure without response */
+    nodeid_fake_error = 20;
+    ok ((r = flux_rpcf_multi (h, "rpcftest.nodeid", "[0-63]", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0-%d] ok",
+        64 - 1);
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    int fail_count = 0;
+    uint32_t fail_nodeid_last = FLUX_NODEID_ANY;
+    int fail_errno_last = 0;
+    int errnum;
+    int flags;
+    do {
+        if (flux_rpc_get_nodeid (r, &nodeid) < 0
+            || flux_rpc_getf (r, "{ s:i s:i s:i !}",
+                              "errnum", &errnum,
+                              "nodeid", &nodeid,
+                              "flags", &flags) < 0
+            || errnum) {
+            fail_errno_last = errnum;
+            fail_nodeid_last = nodeid;
+            fail_count++;
+        }
+    } while (flux_rpc_next (r) == 0);
+    ok (fail_count == 1 && fail_nodeid_last == 20 && fail_errno_last == EPERM,
+        "flux_rpc_get correctly reports single error");
+    flux_rpc_destroy (r);
+
+    /* test that a fatal handle error causes flux_rpc_next () to fail */
+    flux_fatal_set (h, NULL, NULL); /* reset handler and flag */
+    ok (flux_fatality (h) == false,
+        "flux_fatality says all is well");
+    ok ((r = flux_rpcf_multi (h, "rpctest.nodeid", "[0-1]", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0-1] ok");
+    flux_fatal_error (h, __FUNCTION__, "Foo");
+    ok (flux_fatality (h) == true,
+        "flux_fatality shows simulated failure");
+    ok (flux_rpc_next (r) == -1,
+        "flux_rpc_next fails");
+    flux_fatal_set (h, fatal_err, NULL); /* reset handler and flag  */
+    flux_rpc_destroy (r);
+
+    /* test _then (still at fake session size of 128) */
+    then_count = 0;
+    ok ((then_r = flux_rpcf_multi (h, "rpcftest.hello", "[0-127]", 0, "{}")) != NULL,
+        "flux_rpcf_multi [0-127] ok");
+    ok (flux_rpc_then (then_r, thenf_cb, h) == 0,
+        "flux_rpc_then works");
+    /* thenf_cb stops reactor; results reported, then_r destroyed in
+     * run_multi_test() */
+}
+
 static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,   "rpctest.begin",          rpctest_begin_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.begin",         rpcftest_begin_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",         rpcftest_hello_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.nodeid",        rpcftest_nodeid_cb},
     FLUX_MSGHANDLER_TABLE_END,
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);
@@ -348,6 +583,8 @@ int main (int argc, char *argv[])
         "registered message handlers");
 
     run_multi_test (h, reactor, "rpctest.begin");
+
+    run_multi_test (h, reactor, "rpcftest.begin");
 
     flux_msg_handler_delvec (htab);
     flux_close (h);


### PR DESCRIPTION
Another spin-off from #898 as the patch series is long.  A fair amount of refactoring, adding support for ```flux_rpcf_multi()``` the jansson equivalent to ```flux_rpc_multi()```.  Compared to my original patch series in #898, ```flux_rpc[f]_multi``` now constructs a single flux message for all rpcs instead of a message on each iteration.  So the refactoring is now cleaner and it should shave off a few instructions for the old case.

An ```"any"``` special case option for the ```nodeset``` input was added to the ```flux_rpc[f]_multi``` functions for convenience.  Passing "FLUX_NODEID_ANY" appears to be the one case that can't be
handled by ```flux_rpc[f]_multi```.  So tools needed a special case to deal with that and call ```flux_rpc()```.  This hopefully removes that need for that special case handling.  I know it's one more string comparison in the function, but figured it was no big deal since the for loop in the middle is the big cost.

Also, fixed #905 along the way.
