### PR TITLE
liboptparse: cleanup, minor fixes, minor additions

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -81,7 +81,7 @@ void client_destroy (struct client *cli);
 char *find_broker (const char *searchpath);
 static void setup_profiling_env (struct context *ctx);
 
-const char *default_killer_timeout = "1.0";
+double default_killer_timeout = 1.0;
 
 const int default_size = 1;
 
@@ -138,8 +138,8 @@ int main (int argc, char *argv[])
         log_msg_exit ("optparse_set usage");
     if ((optind = optparse_parse_args (ctx->opts, argc, argv)) < 0)
         exit (1);
-    ctx->killer_timeout = strtod (optparse_get_str (ctx->opts, "killer-timeout",
-                                                    default_killer_timeout), NULL);
+    ctx->killer_timeout = optparse_get_double (ctx->opts, "killer-timeout",
+                                               default_killer_timeout);
     if (ctx->killer_timeout < 0.)
         log_msg_exit ("--killer-timeout argument must be >= 0");
     if (optind < argc) {

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -156,6 +156,8 @@ int main (int argc, char *argv[])
     setup_profiling_env (ctx);
 
     ctx->size = optparse_get_int (ctx->opts, "size", default_size);
+    if (ctx->size <= 0)
+        log_msg_exit ("--size argument must be >= 0");
 
     if (ctx->size == 1) {
         status = exec_broker (ctx, command);

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -818,8 +818,9 @@ int optparse_get_int (optparse_t *p, const char *name, int default_value)
         return default_value;
     if (s == NULL || strlen (s) == 0)
         goto badarg;
+    errno = 0;
     l = strtol (s, &endptr, 10);
-    if (*endptr != '\0' ||  l < 0 || l > INT_MAX)
+    if (errno || *endptr != '\0' ||  l < 0 || l > INT_MAX)
         goto badarg;
     return l;
 badarg:

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -830,6 +830,36 @@ badarg:
     return -1;
 }
 
+double optparse_get_double (optparse_t *p, const char *name,
+                            double default_value)
+{
+    int n;
+    double d;
+    const char *s;
+    char *endptr;
+
+    if ((n = optparse_getopt (p, name, &s)) < 0) {
+        optparse_fatalmsg (p, 1,
+                           "%s: optparse error: no such argument '%s'\n",
+                           p->program_name, name);
+        return -1;
+    }
+    if (n == 0)
+        return default_value;
+    if (s == NULL || strlen (s) == 0)
+        goto badarg;
+    errno = 0;
+    d = strtod (s, &endptr);
+    if (errno || *endptr != '\0')
+        goto badarg;
+    return d;
+badarg:
+    optparse_fatalmsg (p, 1,
+                       "%s: Option '%s' requires a floating point argument\n",
+                       p->program_name, name);
+    return -1;
+}
+
 const char *optparse_get_str (optparse_t *p, const char *name,
                               const char *default_value)
 {

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -820,7 +820,7 @@ int optparse_get_int (optparse_t *p, const char *name, int default_value)
         goto badarg;
     errno = 0;
     l = strtol (s, &endptr, 10);
-    if (errno || *endptr != '\0' ||  l < 0 || l > INT_MAX)
+    if (errno || *endptr != '\0' || l < INT_MIN || l > INT_MAX)
         goto badarg;
     return l;
 badarg:

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -297,6 +297,14 @@ bool optparse_hasopt (optparse_t *p, const char *name);
 int optparse_get_int (optparse_t *p, const char *name, int default_value);
 
 /*
+ *   Return the option argument as a double if 'name' was used,
+ *    'default_value' if not.  If the option is unknown, or the argument
+ *    could not be converted to a double, call the fatal error function.
+ */
+double optparse_get_double (optparse_t *p, const char *name,
+                            double default_value);
+
+/*
  *   Return the option argument as a string if 'name' was used, 'default_value'
  *    if not.  If the option is unknown, call the fatal error function.
  */

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -218,10 +218,13 @@ void test_convenience_accessors (void)
 { .name = "mnf", .key = 4, .has_arg = 1, .arginfo = "", .usage = "" },
 { .name = "oop", .key = 5, .has_arg = 1, .arginfo = "", .usage = "" },
 { .name = "neg", .key = 6, .has_arg = 1, .arginfo = "", .usage = "" },
+{ .name = "dub", .key = 7, .has_arg = 1, .arginfo = "", .usage = "" },
+{ .name = "ndb", .key = 8, .has_arg = 1, .arginfo = "", .usage = "" },
         OPTPARSE_TABLE_END,
     };
 
-    char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", "--neg=-4", NULL };
+    char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", "--neg=-4",
+                   "--dub=5.7", "--ndb=-3.2", NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
     int rc, optind;
 
@@ -254,7 +257,9 @@ void test_convenience_accessors (void)
     dies_ok ({optparse_get_int (p, "foo", 0); },
             "get_int exits on option with no argument");
     dies_ok ({optparse_get_int (p, "baz", 0); },
-            "get_int exits on option with wrong type argument");
+            "get_int exits on option with wrong type argument (string)");
+    dies_ok ({optparse_get_int (p, "dub", 0); },
+            "get_int exits on option with wrong type argument (float)");
     lives_ok ({optparse_get_int (p, "bar", 0); },
             "get_int lives on known arg");
     ok (optparse_get_int (p, "bar", 42) == 42,
@@ -263,6 +268,27 @@ void test_convenience_accessors (void)
             "get_int returns arg when present");
     ok (optparse_get_int (p, "neg", 42) == -4,
             "get_int returns negative arg when present");
+
+    /* get_double
+     */
+    dies_ok ({optparse_get_double (p, "no-exist", 0); },
+            "get_double exits on unknown arg");
+    dies_ok ({optparse_get_double (p, "foo", 0); },
+            "get_double exits on option with no argument");
+    dies_ok ({optparse_get_double (p, "baz", 0); },
+            "get_int exits on option with wrong type argument (string)");
+    lives_ok ({optparse_get_double (p, "bar", 0); },
+            "get_double lives on known arg");
+    ok (optparse_get_double (p, "bar", 42.0) == 42.0,
+            "get_double returns default argument when arg not present");
+    ok (optparse_get_double (p, "mnf", 42) == 7.0,
+            "get_double returns arg when present");
+    ok (optparse_get_double (p, "neg", 42) == -4.0,
+            "get_double returns negative arg when present");
+    ok (optparse_get_double (p, "dub", 42) == 5.7,
+            "get_double returns arg when present");
+    ok (optparse_get_double (p, "ndb", 42) == -3.2,
+            "get_double returns negative arg when present");
 
     /* get_str
      */
@@ -729,9 +755,9 @@ Usage: test one [OPTIONS]\n\
 int main (int argc, char *argv[])
 {
 
-    plan (168);
+    plan (178);
 
-    test_convenience_accessors (); /* 25 tests */
+    test_convenience_accessors (); /* 35 tests */
     test_usage_output (); /* 36 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -217,10 +217,11 @@ void test_convenience_accessors (void)
 { .name = "baz", .key = 3, .has_arg = 1, .arginfo = "", .usage = "" },
 { .name = "mnf", .key = 4, .has_arg = 1, .arginfo = "", .usage = "" },
 { .name = "oop", .key = 5, .has_arg = 1, .arginfo = "", .usage = "" },
+{ .name = "neg", .key = 6, .has_arg = 1, .arginfo = "", .usage = "" },
         OPTPARSE_TABLE_END,
     };
 
-    char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", NULL };
+    char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", "--neg=-4", NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
     int rc, optind;
 
@@ -260,6 +261,8 @@ void test_convenience_accessors (void)
             "get_int returns default argument when arg not present");
     ok (optparse_get_int (p, "mnf", 42) == 7,
             "get_int returns arg when present");
+    ok (optparse_get_int (p, "neg", 42) == -4,
+            "get_int returns negative arg when present");
 
     /* get_str
      */
@@ -726,9 +729,9 @@ Usage: test one [OPTIONS]\n\
 int main (int argc, char *argv[])
 {
 
-    plan (167);
+    plan (168);
 
-    test_convenience_accessors (); /* 24 tests */
+    test_convenience_accessors (); /* 25 tests */
     test_usage_output (); /* 36 tests */
     test_errors (); /* 9 tests */
     test_multiret (); /* 19 tests */


### PR DESCRIPTION
Another spinoff from #898.  WIth the minor exception of the test count in ```test/optparse.c```, I don't believe anything here will conflict with PR #910 .

Most notable fix is ```optparse_get_int``` can return negative values, so it's up the caller to check for correctness of the inputted value.

Most notable addition is ```optparse_get_double``` convenience function.