### PR TITLE
broker: adjust errno response to "upstream" request on rank 0

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -256,10 +256,7 @@ int overlay_sendmsg_parent (overlay_t *ov, const flux_msg_t *msg)
     int rc = -1;
 
     if (!ep || !ep->zs) {
-        if (ov->rank == 0)
-            errno = ENOSYS;
-        else
-            errno = EHOSTUNREACH;
+        errno = EHOSTUNREACH;
         goto done;
     }
     rc = flux_msg_sendzsock (ep->zs, msg);

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -107,7 +107,7 @@ void ping_continuation (flux_rpc_t *rpc, void *arg)
                        "time.tv_nsec", &nsec,
                        "pad", &pad,
                        "route", &route) < 0) {
-        log_err ("flux_rpc_getf");
+        log_err ("%s!%s", ctx->rank, ctx->topic);
         goto done;
     }
 

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -165,7 +165,7 @@ test_expect_success 'ping output format for all ranks is correct (format 3)' '
 
 test_expect_success 'ping with "upstream" fails on rank 0' '
         run_timeout 5 flux exec --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr
-	grep -q "Function not implemented" stderr
+	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping with "upstream" works (format 1)' '


### PR DESCRIPTION
This PR simply changes an inappropriate errno response of ENOSYS to EHOSTUNREACH when a message reaches the rank 0 broker that was _from_ rank 0 and has the FLUX_MSGFLAG_UPSTREAM message flag set.

It also modifies `flux-ping` to display the `rank!service` that elicited the error.