### PR TITLE
create a pkg-config package for Flux PMI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,7 @@ AC_CONFIG_FILES( \
   src/test/kap/Makefile \
   etc/Makefile \
   etc/flux-core.pc \
+  etc/flux-pmi.pc \
   doc/Makefile \
   doc/man1/Makefile \
   doc/man3/Makefile \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -26,7 +26,7 @@ clean-local:
 	-rm -rf flux
 
 if WITH_PKG_CONFIG
-pkgconfig_DATA = flux-core.pc
+pkgconfig_DATA = flux-core.pc flux-pmi.pc
 endif
 
 EXTRA_DIST = \

--- a/etc/flux-pmi.pc.in
+++ b/etc/flux-pmi.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: flux-pmi
+Description: Flux Core PMI Library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir}/flux -lpmi
+Cflags: -I${includedir}/flux

--- a/src/common/libpmi/test/kvstest.c
+++ b/src/common/libpmi/test/kvstest.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     if (e != PMI_SUCCESS)
         log_msg_exit ("%d: PMI_Barrier: %s", rank, pmi_strerror (e));
     if (rank == 0)
-        printf ("%d: put phase: %.3f sec\n", rank, monotime_since (t));
+        printf ("%d: put phase: %.3f msec\n", rank, monotime_since (t));
 
     /* Get phase
      * no options:    (keycount * GET) + BARRIER
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     if (e != PMI_SUCCESS)
         log_msg_exit ("%d: PMI_Barrier: %s", rank, pmi_strerror (e));
     if (rank == 0)
-        printf ("%d: get phase: %.3f sec\n", rank, monotime_since (t));
+        printf ("%d: get phase: %.3f msec\n", rank, monotime_since (t));
 
     e = PMI_Finalize ();
     if (e != PMI_SUCCESS)


### PR DESCRIPTION
This PR adds a pkg-config package for Flux's libpmi.so in support of an OpenMPI "flux" component under discussion in rhc54/ompi#1.

libpmi.so is purposefully excluded from flux-core's pkg-config package because in general we want the selection of a PMI library to be a runtime decision.  The new component will normally try to dlopen our library at `$FLUX_PMI_LIBRARY_PATH`.  However in cases where OpenMPI builds all its modules statically (apparently common on big systems), dlopen is not permitted and it needs to find our libpmi.so at build time.  Using pkg-config for this avoids hard wiring a search heuristic in the configuration m4sh for the flux component.

Unrelated fix to a silly output typo in a PMI test program is tacked on here as well.