### PR TITLE
Nitpick cleanup of liboptparse usage

### DIFF
--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -38,7 +38,7 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
 
     log_init ("flux-setattr");
 
-    n = optparse_optind (p);
+    n = optparse_option_index (p);
     if (optparse_hasopt (p, "expunge") && n == ac - 1) {
         name = av[n];
     } else if (!optparse_hasopt (p, "expunge") && n == ac - 2) {
@@ -70,7 +70,7 @@ static int cmd_lsattr (optparse_t *p, int ac, char *av[])
 
     log_init ("flux-lsatrr");
 
-    if (optparse_optind (p) != ac)
+    if (optparse_option_index (p) != ac)
         optparse_fatal_usage (p, 1, NULL);
     h = builtin_get_flux_handle (p);
     name = flux_attr_first (h);
@@ -95,7 +95,7 @@ static int cmd_getattr (optparse_t *p, int ac, char *av[])
 
     log_init ("flux-getattr");
 
-    n = optparse_optind (p);
+    n = optparse_option_index (p);
     if (n != ac - 1)
         optparse_fatal_usage (p, 1, NULL);
 

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -38,7 +38,7 @@ static int internal_content_load (optparse_t *p, int ac, char *av[])
     flux_rpc_t *r;
     int flags = 0;
 
-    n = optparse_optind (p);
+    n = optparse_option_index (p);
     if (n != ac - 1) {
         optparse_print_usage (p);
         exit (1);
@@ -68,7 +68,7 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
     const char *blobref;
     int flags = 0;
 
-    if (optparse_optind (p)  != ac) {
+    if (optparse_option_index (p)  != ac) {
         optparse_print_usage (p);
         exit (1);
     }
@@ -94,7 +94,7 @@ static int internal_content_flush (optparse_t *p, int ac, char *av[])
     flux_t *h;
     flux_rpc_t *rpc = NULL;
 
-    if (optparse_optind (p) != ac) {
+    if (optparse_option_index (p) != ac) {
         optparse_print_usage (p);
         exit (1);
     }
@@ -114,7 +114,7 @@ static int internal_content_dropcache (optparse_t *p, int ac, char *av[])
     flux_t *h;
     flux_rpc_t *rpc = NULL;
 
-    if (optparse_optind (p) != ac) {
+    if (optparse_option_index (p) != ac) {
         optparse_print_usage (p);
         exit (1);
     }

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -41,7 +41,7 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
     int flags = 0;
     flux_log_f print_cb = flux_log_fprint;
 
-    if ((n = optparse_optind (p)) != ac)
+    if ((n = optparse_option_index (p)) != ac)
         log_msg_exit ("flux-dmesg accepts no free arguments");
 
     if (!(h = builtin_get_flux_handle (p)))

--- a/src/cmd/builtin/env.c
+++ b/src/cmd/builtin/env.c
@@ -36,7 +36,7 @@ static void print_environment (struct environment *env)
 
 static int cmd_env (optparse_t *p, int ac, char *av[])
 {
-    int n = optparse_optind (p);
+    int n = optparse_option_index (p);
     if (av && av[n]) {
         execvp (av[n], av+n); /* no return if sucessful */
         log_err_exit ("execvp (%s)", av[n]);

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -31,7 +31,7 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
     flux_rpc_t *rpc;
     json_object *in = Jnew ();
 
-    if (optparse_optind (p) != ac - 1) {
+    if (optparse_option_index (p) != ac - 1) {
         optparse_print_usage (p);
         exit (1);
     }
@@ -52,7 +52,7 @@ static int internal_heaptrace_stop (optparse_t *p, int ac, char *av[])
     flux_t *h;
     flux_rpc_t *rpc;
 
-    if (optparse_optind (p) != ac) {
+    if (optparse_option_index (p) != ac) {
         optparse_print_usage (p);
         exit (1);
     }
@@ -72,7 +72,7 @@ static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
     flux_rpc_t *rpc;
     json_object *in = Jnew ();
 
-    if (optparse_optind (p) != ac - 1) {
+    if (optparse_option_index (p) != ac - 1) {
         optparse_print_usage (p);
         exit (1);
     }

--- a/src/cmd/builtin/help.c
+++ b/src/cmd/builtin/help.c
@@ -41,7 +41,7 @@ static int no_docs_set (optparse_t *p)
 
 static int cmd_help (optparse_t *p, int ac, char *av[])
 {
-    int n = optparse_optind (p);
+    int n = optparse_option_index (p);
     char *cmd;
 
     if (n < ac) {

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -280,7 +280,7 @@ static void request_hwloc_reload (flux_t *h, const char *nodeset,
 
 static int internal_hwloc_reload (optparse_t *p, int ac, char *av[])
 {
-    int n = optparse_optind (p);
+    int n = optparse_option_index (p);
     const char *default_nodeset = "all";
     const char *nodeset = optparse_get_str (p, "rank", default_nodeset);
     const char *walk_topology = optparse_get_str (p, "walk-topology", NULL);

--- a/src/cmd/builtin/nodeset.c
+++ b/src/cmd/builtin/nodeset.c
@@ -110,7 +110,7 @@ static void ns_subtract (nodeset_t *ns1, nodeset_t *ns2)
 
 static int cmd_nodeset (optparse_t *p, int ac, char *av[])
 {
-    int ix = optparse_optind (p);
+    int ix = optparse_option_index (p);
     int nsc = ac - ix;
     nodeset_t *nsp, **nsv = nsc > 0 ? xzmalloc (sizeof (nsv[0]) * nsc) : NULL;
     int i;

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -896,16 +896,16 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
     char pidfile[PATH_MAX + 1];
     const char *job;
     const char *optarg;
-    int optind;
+    int optindex;
 
     log_init ("flux-proxy");
 
-    optind = optparse_optind (p);
-    if (optind == ac)
+    optindex = optparse_optind (p);
+    if (optindex == ac)
         optparse_fatal_usage (p, 1, "JOB argument is required\n");
-    job = av[optind++];
+    job = av[optindex++];
 
-    if (optparse_hasopt (p, "stdio") && optind != ac)
+    if (optparse_hasopt (p, "stdio") && optindex != ac)
         optparse_fatal_usage (p, 1, "there can be no COMMAND with --stdio\n");
 
     while ((optarg = optparse_getopt_next (p, "setenv"))) {
@@ -979,7 +979,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
 
         /* Create child
          */
-        if (child_create (ctx, ac - optind, av + optind, workpath) < 0)
+        if (child_create (ctx, ac - optindex, av + optindex, workpath) < 0)
             log_err_exit ("child_create");
    }
 

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -900,7 +900,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
 
     log_init ("flux-proxy");
 
-    optindex = optparse_optind (p);
+    optindex = optparse_option_index (p);
     if (optindex == ac)
         optparse_fatal_usage (p, 1, "JOB argument is required\n");
     job = av[optindex++];

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -98,7 +98,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
     if (!(h = optparse_get_data (p, "handle")))
         log_err_exit ("failed to get handle");
 
-    n = optparse_optind (p);
+    n = optparse_option_index (p);
     if (n < argc - 1) {
         size_t len = 0;
         json_object *o;
@@ -179,7 +179,7 @@ static int event_sub (optparse_t *p, int argc, char **argv)
      */
     setlinebuf (stdout);
 
-    n = optparse_optind (p);
+    n = optparse_option_index (p);
     if (n < argc)
         subscribe_all (h, argc - n, argv + n);
     else if (flux_event_subscribe (h, "") < 0)

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -26,7 +26,6 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#include <getopt.h>
 #include <unistd.h>
 #include <string.h>
 #include <flux/core.h>
@@ -200,13 +199,14 @@ int main (int argc, char *argv[])
     nodeset_t *ns = NULL;
     optparse_t *opts;
     struct ping_ctx ctx = {0};
+    int optindex;
 
     log_init ("flux-ping");
 
     opts = optparse_create ("flux-ping");
     if (optparse_add_option_table (opts, cmdopts) != OPTPARSE_SUCCESS)
         log_msg_exit ("optparse_add_option_table");
-    if ((optind = optparse_parse_args (opts, argc, argv)) < 0)
+    if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)
         exit (1);
 
     pad_bytes = optparse_get_int (opts, "pad", 0);
@@ -228,12 +228,12 @@ int main (int argc, char *argv[])
     if (ctx.batch && ctx.count == 0)
         log_msg_exit ("--batch should only be used with --count");
 
-    if (optind != argc - 1) {
+    if (optindex != argc - 1) {
         optparse_print_usage (opts);
         exit (1);
     }
 
-    target = argv[optind++];
+    target = argv[optindex++];
 
     /* Create null terminated pad string for reuse in each message.
      * By default it's the empty string.

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -129,6 +129,7 @@ int main (int argc, char *argv[])
     size_t len = 0;
     struct context *ctx = xzmalloc (sizeof (*ctx));
     const char *searchpath;
+    int optindex;
 
     log_init ("flux-start");
 
@@ -137,14 +138,14 @@ int main (int argc, char *argv[])
         log_msg_exit ("optparse_add_option_table");
     if (optparse_set (ctx->opts, OPTPARSE_USAGE, usage_msg) != OPTPARSE_SUCCESS)
         log_msg_exit ("optparse_set usage");
-    if ((optind = optparse_parse_args (ctx->opts, argc, argv)) < 0)
+    if ((optindex = optparse_parse_args (ctx->opts, argc, argv)) < 0)
         exit (1);
     ctx->killer_timeout = optparse_get_double (ctx->opts, "killer-timeout",
                                                default_killer_timeout);
     if (ctx->killer_timeout < 0.)
         log_msg_exit ("--killer-timeout argument must be >= 0");
-    if (optind < argc) {
-        if ((e = argz_create (argv + optind, &command, &len)) != 0)
+    if (optindex < argc) {
+        if ((e = argz_create (argv + optindex, &command, &len)) != 0)
             log_errn_exit (e, "argz_creawte");
         argz_stringify (command, len, ' ');
     }

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -142,7 +142,7 @@ int main (int argc, char *argv[])
         usage (p); // N.B. accesses "conf_flags"
         exit (0);
     }
-    optindex = optparse_optind (p);
+    optindex = optparse_option_index (p);
     if (argc - optindex == 0) {
         usage (p);
         exit (1);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -27,7 +27,6 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
-#include <getopt.h>
 #include <unistd.h>
 #include <string.h>
 #include <libgen.h>
@@ -129,6 +128,7 @@ int main (int argc, char *argv[])
     const char *searchpath, *s;
     const char *argv0 = argv[0];
     int flags = 0;
+    int optindex;
 
     log_init ("flux");
 
@@ -142,8 +142,8 @@ int main (int argc, char *argv[])
         usage (p); // N.B. accesses "conf_flags"
         exit (0);
     }
-    optind = optparse_optind (p);
-    if (argc - optind == 0) {
+    optindex = optparse_optind (p);
+    if (argc - optindex == 0) {
         usage (p);
         exit (1);
     }
@@ -224,14 +224,14 @@ int main (int argc, char *argv[])
 
     if (vopt)
         print_environment (env);
-    if (optparse_get_subcommand (p, argv [optind])) {
+    if (optparse_get_subcommand (p, argv [optindex])) {
         if (optparse_run_subcommand (p, argc, argv) < 0)
             exit (1);
     } else {
         searchpath = environment_get (env, "FLUX_EXEC_PATH");
         if (vopt)
             printf ("sub-command search path: %s\n", searchpath);
-        exec_subcommand (searchpath, vopt, argv + optind);
+        exec_subcommand (searchpath, vopt, argv + optindex);
     }
 
     environment_destroy (env);

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -58,7 +58,7 @@ struct opt_parser {
     opt_fatalerr_f fatalerr_fn;
     void *         fatalerr_handle;
 
-    int            optind;
+    int            option_index;
 
     int            left_margin;     /* Size of --help output left margin    */
     int            option_width;    /* Width of --help output for optiion   */
@@ -683,7 +683,7 @@ optparse_t *optparse_create (const char *prog)
     p->fatalerr_handle = NULL;
     p->left_margin = 2;
     p->option_width = 25;
-    p->optind = -1;
+    p->option_index = -1;
 
     /*
      *  Register -h, --help
@@ -1280,8 +1280,8 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
 
     free (optz);
     free (optstring);
-    p->optind = d.optind;
-    return (p->optind);
+    p->option_index = d.optind;
+    return (p->option_index);
 }
 
 int optparse_run_subcommand (optparse_t *p, int argc, char *argv[])
@@ -1291,13 +1291,13 @@ int optparse_run_subcommand (optparse_t *p, int argc, char *argv[])
     optparse_subcmd_f cb;
     optparse_t *sp;
 
-    if (p->optind == -1) {
+    if (p->option_index == -1) {
         if (optparse_parse_args (p, argc, argv) < 0)
             return optparse_fatalerr (p, 1);
     }
 
-    ac = argc - p->optind;
-    av = argv + p->optind;
+    ac = argc - p->option_index;
+    av = argv + p->option_index;
 
     if (ac <= 0)
         return optparse_fatal_usage (p, 1, "missing subcommand\n");
@@ -1335,9 +1335,9 @@ int optparse_fatal_usage (optparse_t *p, int code, const char *fmt, ...)
 }
 
 
-int optparse_optind (optparse_t *p)
+int optparse_option_index (optparse_t *p)
 {
-    return (p->optind);
+    return (p->option_index);
 }
 
 /*

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -355,10 +355,10 @@ const char *optparse_get_str (optparse_t *p, const char *name,
                               const char *default_value);
 
 /*
- *   Return optind from previous call to optparse_parse_args ().
- *    Returns -1 if  args have not yet been parsed, and thus optind is
+ *   Return option index from previous call to optparse_parse_args ().
+ *    Returns -1 if args have not yet been parsed, and thus option index is
  *    not valid.
  */
-int optparse_optind (optparse_t *p);
+int optparse_option_index (optparse_t *p);
 
 #endif /* _UTIL_OPTPARSE_H */

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -268,7 +268,7 @@ void test_convenience_accessors (void)
     char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", "--neg=-4",
                    "--dub=5.7", "--ndb=-3.2", NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
-    int rc, optind;
+    int rc, optindex;
 
     optparse_t *p = optparse_create ("test");
     ok (p != NULL, "create object");
@@ -277,10 +277,10 @@ void test_convenience_accessors (void)
     ok (rc == OPTPARSE_SUCCESS, "register options");
 
     ok (optparse_optind (p) == -1, "optparse_optind returns -1 before parse");
-    optind = optparse_parse_args (p, ac, av);
-    ok (optind == ac, "parse options, verify optind");
+    optindex = optparse_parse_args (p, ac, av);
+    ok (optindex == ac, "parse options, verify optindex");
 
-    ok (optparse_optind (p) == optind, "optparse_optind works after parse");
+    ok (optparse_optind (p) == optindex, "optparse_optind works after parse");
 
     /* hasopt
      */
@@ -420,14 +420,15 @@ void test_multiret (void)
                    "-o", "-rtwo", "--multi-ret=a,b,c",
                    NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int optindex;
 
     ok (p != NULL, "optparse_create");
 
     e = optparse_add_option_table (p, opts);
     ok (e == OPTPARSE_SUCCESS, "register options");
 
-    optind = optparse_parse_args (p, ac, av);
-    ok (optind == ac, "parse options, verify optind");
+    optindex = optparse_parse_args (p, ac, av);
+    ok (optindex == ac, "parse options, verify optindex");
 
     rc = optparse_getopt (p, "required-arg", &optarg);
     ok (rc == 2, "-r used twice");
@@ -490,14 +491,15 @@ void test_long_only (void)
                    "-b", "one", "--again-long-only",
                    NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int optindex;
 
     ok (p != NULL, "optparse_create");
 
     e = optparse_add_option_table (p, opts);
     ok (e == OPTPARSE_SUCCESS, "register options");
 
-    optind = optparse_parse_args (p, ac, av);
-    ok (optind == ac, "parse options, verify optind");
+    optindex = optparse_parse_args (p, ac, av);
+    ok (optindex == ac, "parse options, verify optindex");
 
     rc = optparse_getopt (p, "basic", &optarg);
     ok (rc == 1, "got -b");
@@ -512,8 +514,8 @@ void test_long_only (void)
                     "--long-only=foo", NULL };
     ac = sizeof (av2) / sizeof(av2[0]) - 1;
 
-    optind = optparse_parse_args (p, ac, av2);
-    ok (optind == ac, "parse options, verify optind");
+    optindex = optparse_parse_args (p, ac, av2);
+    ok (optindex == ac, "parse options, verify optindex");
 
     optarg = NULL;
     rc = optparse_getopt (p, "basic", &optarg);
@@ -547,12 +549,13 @@ void test_optional_argument (void)
                    "--optional-arg", "extra-args",
                    NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int optindex;
 
     e = optparse_add_option_table (p, opts);
     ok (e == OPTPARSE_SUCCESS, "register options");
 
-    optind = optparse_parse_args (p, ac, av);
-    ok (optind == (ac - 1), "parse options, verify optind");
+    optindex = optparse_parse_args (p, ac, av);
+    ok (optindex == (ac - 1), "parse options, verify optindex");
 
     ok (optparse_hasopt (p, "optional-arg"),
         "found optional-arg option with no args");
@@ -566,8 +569,8 @@ void test_optional_argument (void)
                    NULL };
     ac = sizeof (av2) / sizeof (av2[0]) - 1;
 
-    optind = optparse_parse_args (p, ac, av2);
-    ok (optind == (ac - 1), "parse options, verify optind");
+    optindex = optparse_parse_args (p, ac, av2);
+    ok (optindex == (ac - 1), "parse options, verify optindex");
     ok (optparse_hasopt (p, "optional-arg"),
         "found optional-arg option with args");
 

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -276,11 +276,11 @@ void test_convenience_accessors (void)
     rc = optparse_add_option_table (p, opts);
     ok (rc == OPTPARSE_SUCCESS, "register options");
 
-    ok (optparse_optind (p) == -1, "optparse_optind returns -1 before parse");
+    ok (optparse_option_index (p) == -1, "optparse_option_index returns -1 before parse");
     optindex = optparse_parse_args (p, ac, av);
     ok (optindex == ac, "parse options, verify optindex");
 
-    ok (optparse_optind (p) == optindex, "optparse_optind works after parse");
+    ok (optparse_option_index (p) == optindex, "optparse_option_index works after parse");
 
     /* hasopt
      */
@@ -833,7 +833,7 @@ Usage: test one [OPTIONS]\n\
     n = optparse_run_subcommand (a, ac, av6);
     ok (n == 0, "optparse_run_subcommand with OPTPARSE_SUBCMD_NOOPTS");
     ok (value == 2, "optparse_run_subcommand() run with argc = %d (expected 2)", value);
-    ok (optparse_optind (d) == -1, "optparse_run_subcommand: skipped parse_args");
+    ok (optparse_option_index (d) == -1, "optparse_run_subcommand: skipped parse_args");
 
     optparse_destroy (a);
 }


### PR DESCRIPTION
This is a nitpick patch.  I'm not going to fight too hard over it if it's disliked.

I noticed in a number of places ```optind``` was used as a variable name when parsing args with ```liboptparse```.  ```optind``` is a global variable used by ```getopt(3)```.  Sometimes the variable was used without declaration, as code just used the global one from ```getopt```.

To try and disentangle the two parsing libraries I renamed variable usage everywhere, and declared variables when appropriate.

I then (perhaps going too far) renamed ```optparse_optind()``` to ```optparse_option_index()```.  I felt the function name invited people to use ```optind``` as a variable name.
