### PR TITLE
tighten up PMI implementation for OpenMPI

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -540,6 +540,14 @@ int main (int argc, char *argv[])
      */
     unsetenv ("FLUX_URI");
 
+    /* If Flux was launched by Flux, now that PMI bootstrap is complete,
+     * unset Flux job environment variables since they don't leak into
+     * the jobs other children of this instance.
+     */
+    unsetenv ("FLUX_JOB_ID");
+    unsetenv ("FLUX_JOB_SIZE");
+    unsetenv ("FLUX_JOB_NNODES");
+
     /* If shutdown_grace was not provided on the command line,
      * make a guess.
      */

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -622,7 +622,7 @@ int PMI_Get_clique_ranks (int ranks[], int length)
             result = pmi_wrap_get_clique_ranks (ctx.wrap, ranks, length);
             break;
         default:
-            result = PMI_ERR_INIT;
+            result = PMI_FAIL;
             break;
     }
     if (result == PMI_FAIL)
@@ -638,7 +638,7 @@ int PMI_Get_clique_size (int *size)
             result = pmi_wrap_get_clique_size (ctx.wrap, size);
             break;
         default:
-            result = PMI_ERR_INIT;
+            result = PMI_FAIL;
             break;
     }
     if (result == PMI_FAIL)

--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -240,8 +240,6 @@ int pmi_simple_client_abort (struct pmi_simple_client *pmi,
     return PMI_FAIL;
 }
 
-#define S_(x) #x
-#define S(x) S_(x)
 int pmi_simple_client_kvs_get_my_name (struct pmi_simple_client *pmi,
                                        char *kvsname, int length)
 {

--- a/src/modules/wreck/lua.d/openmpi.lua
+++ b/src/modules/wreck/lua.d/openmpi.lua
@@ -1,31 +1,16 @@
 -- Set environment specific to openmpi
 --
--- If configured for SLURM, OpenMPI links with libpmi.so or libpmi2.so
--- (depending on options used).  Flux provides alternate versions of these
--- libraries in a non-default location, and we must set LD_LIBRARY_PATH to
--- point there.
---
--- Some versions of OpenMPI, 1.10.2 for example, set an rpath for their
--- PMI plugins that includes /usr/lib64.  That is bug and those versions
--- need to be patched patched to work with Flux.
--- 
--- If Flux supports the PMI-2 wire protocol, the SLURM libpmi.so might
--- work with Flux.  It currently doesn't, and in fact ignores the protocol
--- version handshake entirely.   (See flux-framework/flux-core#746)
-
 
 local dirname = require 'flux.posix'.dirname
 
 function rexecd_init ()
     local env = wreck.environ
     local f = wreck.flux
-    local libpmi = f:getattr ('conf.pmi_library_path')
-    local ldpath = dirname (libpmi)
+    local rankdir = f:getattr ('scratch-directory-rank')
 
-    if (env['LD_LIBRARY_PATH'] ~= nil) then
-        ldpath = ldpath..':'..env['LD_LIBRARY_PATH']
-    end
-    env['LD_LIBRARY_PATH'] = ldpath
+    -- Avoid shared memory segment name collisions
+    -- when flux instance runs >1 broker per node.
+    env['OMPI_MCA_orte_tmpdir_base'] = rankdir
 end
 
 -- vi: ts=4 sw=4 expandtab

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -2184,8 +2184,9 @@ static int wreck_pmi_kvs_get (void *arg, const char *kvsname, const char *key,
     }
 
     if (kvs_get_string (ctx->flux, kvskey, &s) < 0) {
-        wlog_err (ctx, "pmi_kvs_get: kvs_get_string(%s): %s",
-                  kvskey, strerror (errno));
+        if (errno != ENOENT)
+            wlog_err (ctx, "pmi_kvs_get: kvs_get_string(%s): %s",
+                      kvskey, strerror (errno));
         free (kvskey);
         return (-1);
     }


### PR DESCRIPTION
This PR fixes a couple more issues that came up while building openmpi support for flux.
Some general cleanup, environment cleanup as discussed in #923, implementing the clique functions, and suppressing a log for failed `PMI_KVS_Get()` since that's not necessarily a flux error.

All pretty minor.