### PR TITLE
initial flux-kvs cleanup

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -75,17 +75,19 @@ returned by *get*.
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.
 
-*watch* [count] 'key'::
+*watch* [-o] [count] 'key'::
 Watch 'key', displaying each change on a line of output.  If the key
 is not set, display "NULL".  If 'count' is specified, display at most
-'count' versions.  Otherwise, command runs forever.
+'count' changes.  Otherwise, command runs forever.  If '-o' is
+specified, output the current value before outputting changes.
 
-*watch-dir* [-r] [-d] [count] 'key'::
+*watch-dir* [-r] [-d] [-o] [count] 'key'::
 Watch directory specified at 'key', displaying changes within it and
 in subdirectories.  If '-r' is specified, recursively display keys
 under subdirectories.  If '-d' is specified, do not output key values.
-If 'count' is specified, display at most 'count' versions.  Otherwise,
-this command runs forever.
+If 'count' is specified, display at most 'count' changes.  Otherwise,
+this command runs forever.  If '-o' is specified, output the current
+value before outputting changes.
 
 *version*::
 Display the current KVS version, an integer value.  The version starts

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -67,11 +67,11 @@ Create a new name for 'target', similar to a symbolic link, and commit
 the change.  'target' does not have to exist.  If 'linkname' exists,
 it is overwritten.
 
-*readlink* 'key'::
+*readlink* 'key' ['key...']::
 Retrieve the key a link refers to rather than its value, as would be
 returned by *get*.
 
-*mkdir* 'key'::
+*mkdir* 'key' ['key...']::
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.
 

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -57,10 +57,9 @@ If 'key' is not provided, "." (root of the namespace) is assumed.  If '-R'
 is specified, recursively display keys under subdirectories.  If '-d' is
 specified, do not output key values.
 
-*unlink* 'key' ['key...']::
+*unlink* [-R] 'key' ['key...']::
 Remove 'key' from the KVS and commit the change.  If 'key' represents
-a directory, remove all keys underneath it.  If nothing has been stored
-under 'key', do nothing (it is not an error).
+a directory, specify '-R' to remove all keys underneath it.
 
 *link* 'target' 'linkname'::
 Create a new name for 'target', similar to a symbolic link, and commit

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -74,6 +74,18 @@ returned by *get*.
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.
 
+*copy* 'source' 'destination'::
+Copy 'source' key to 'destination' key.  If a directory is copied, a new
+reference is created; it is unnecessary for *copy* to recurse into 'source'.
+
+*move* 'source' 'destination'::
+Like *copy*, but 'source' is unlinked after the copy.
+
+*dropcache* [--all]::
+Tell the local KVS to drop any cache it is holding.  If '--all' is
+specified, send an event across the comms session instructing all KVS
+instances to drop their caches.
+
 *watch* [-R] [-d] [-o] [-c count] 'key'::
 Watch 'key' and output changes.  If 'key' is a single value, each
 change will be displayed on a line of output.  If 'key' is a
@@ -96,18 +108,6 @@ Block until the KVS version reaches 'version' or greater.  A simple form
 of synchronization between peers is:  node A puts a value, commits it,
 reads version, sends version to node B.  Node B waits for version, gets
 value.
-
-*dropcache* [--all]::
-Tell the local KVS to drop any cache it is holding.  If '--all' is
-specified, send an event across the comms session instructing all KVS
-instances to drop their caches.
-
-*copy* 'source' 'destination':: 
-Copy 'source' key to 'destination' key.  If a directory is copied, a new
-reference is created; it is unnecessary for *copy* to recurse into 'source'.
-
-*move* 'source' 'destination':: 
-Like *copy*, but 'source' is unlinked after the copy.
 
 
 AUTHOR

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -74,17 +74,13 @@ returned by *get*.
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.
 
-*watch* [-o] [-c count] 'key'::
-Watch 'key', displaying each change on a line of output.  If the key
-is not set, display "NULL".  If 'count' is specified, display at most
-'count' changes.  Otherwise, command runs forever.  If '-o' is
-specified, output the current value before outputting changes.
-
-*watch-dir* [-R] [-d] [-o] [-c count] 'key'::
-Watch directory specified at 'key', displaying changes within it and
-in subdirectories.  If '-R' is specified, recursively display keys
-under subdirectories.  If '-d' is specified, do not output key values.
-If 'count' is specified, display at most 'count' changes.  Otherwise,
+*watch* [-R] [-d] [-o] [-c count] 'key'::
+Watch 'key' and output changes.  If 'key' is a single value, each
+change will be displayed on a line of output.  If 'key' is a
+directory, changes within the directory and changes within it will be
+displayed.  If '-R' is specified, recursively display keys under
+subdirectories.  If '-d' is specified, do not output key values.  If
+'count' is specified, display at most 'count' changes.  Otherwise,
 this command runs forever.  If '-o' is specified, output the current
 value before outputting changes.
 

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -50,10 +50,10 @@ Retrieve the value stored under 'key'.  If nothing has been stored under
 Store 'value' under 'key' and commit it.  If it already has a value,
 overwrite it.
 
-*dir* [-r] [-d] ['key']::
+*dir* [-R] [-d] ['key']::
 Display all keys and their values under the directory 'key'.
 If 'key' does not exist or is not a directory, display an error message.
-If 'key' is not provided, "." (root of the namespace) is assumed.  If '-r'
+If 'key' is not provided, "." (root of the namespace) is assumed.  If '-R'
 is specified, recursively display keys under subdirectories.  If '-d' is
 specified, do not output key values.
 
@@ -81,9 +81,9 @@ is not set, display "NULL".  If 'count' is specified, display at most
 'count' changes.  Otherwise, command runs forever.  If '-o' is
 specified, output the current value before outputting changes.
 
-*watch-dir* [-r] [-d] [-o] [count] 'key'::
+*watch-dir* [-R] [-d] [-o] [count] 'key'::
 Watch directory specified at 'key', displaying changes within it and
-in subdirectories.  If '-r' is specified, recursively display keys
+in subdirectories.  If '-R' is specified, recursively display keys
 under subdirectories.  If '-d' is specified, do not output key values.
 If 'count' is specified, display at most 'count' changes.  Otherwise,
 this command runs forever.  If '-o' is specified, output the current

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -75,13 +75,13 @@ returned by *get*.
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.
 
-*watch* [-o] [count] 'key'::
+*watch* [-o] [-c count] 'key'::
 Watch 'key', displaying each change on a line of output.  If the key
 is not set, display "NULL".  If 'count' is specified, display at most
 'count' changes.  Otherwise, command runs forever.  If '-o' is
 specified, output the current value before outputting changes.
 
-*watch-dir* [-R] [-d] [-o] [count] 'key'::
+*watch-dir* [-R] [-d] [-o] [-c count] 'key'::
 Watch directory specified at 'key', displaying changes within it and
 in subdirectories.  If '-R' is specified, recursively display keys
 under subdirectories.  If '-d' is specified, do not output key values.

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -46,11 +46,6 @@ COMMANDS
 Retrieve the value stored under 'key'.  If nothing has been stored under
 'key', display an error message.
 
-*type* 'key' ['key...']::
-Display the JSON type of the value under key: 'null', 'boolean', 'double',
-'int', 'object', 'array', or 'string'.  If nothing has been stored under
-'key', display an error message.
-
 *put* 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  If it already has a value,
 overwrite it.
@@ -61,9 +56,6 @@ If 'key' does not exist or is not a directory, display an error message.
 If 'key' is not provided, "." (root of the namespace) is assumed.  If '-r'
 is specified, recursively display keys under subdirectories.  If '-d' is
 specified, do not output key values.
-
-*dirsize* 'key'::
-Get the number of keys in a directory.
 
 *unlink* 'key' ['key...']::
 Remove 'key' from the KVS and commit the change.  If 'key' represents
@@ -95,15 +87,6 @@ under subdirectories.  If '-d' is specified, do not output key values.
 If 'count' is specified, display at most 'count' versions.  Otherwise,
 this command runs forever.
 
-*copy-tokvs* 'key' 'file'::
-Copy data from 'file' to 'key', encoding to Z85 format and committing
-the change.  'file' may be a UNIX file name or "-" indicating standard
-input.
-
-*copy-fromkvs* 'key' 'file'::
-Copy data from 'key' to 'file', decoding from Z85 format.
-'file' may be a UNIX file name or "-" indicating standard output.
-
 *version*::
 Display the current KVS version, an integer value.  The version starts
 at zero and is incremented on each KVS commit.  Note that some commits
@@ -130,31 +113,6 @@ reference is created; it is unnecessary for *copy* to recurse into 'source'.
 
 *move* 'source' 'destination':: 
 Like *copy*, but 'source' is unlinked after the copy.
-
-*get-treeobj* 'key'::
-Retrieve the directory entry associated with 'key'.
-A treeobj should be treated as an opaque string value, which
-may contain spaces.
-
-*put-treeobj* 'key="treeobj"'::
-Associate a new treeobj with 'key', overwriting the previous treeobj,
-if any.  A treeobj should be treated as an opaque string value, which
-may contain spaces.
-
-*getat* 'treeobj' 'key'::
-Retrieve the value stored under 'key', starting the lookup at 'treeobj'.
-If nothing has been stored under 'key', display an error message.
-
-*dirat* [-r] [-d] 'treeobj' ['key']::
-Display all keys and their values under the directory 'key', starting
-lookup at 'treeobj'.  If 'key' does not exist or is not a directory,
-display an error message.  If 'key' is not provided, "." (root of the
-namespace) is assumed.  If '-r' is specified, recursively display keys
-under subdirectories.  If '-d' is specified, do not output key values.
-
-*readlinkat* 'treeobj' 'key'::
-Retrieve the key a link refers to rather than its value, as would be
-returned by *get*, starting lookup at 'treeobj'.
 
 
 AUTHOR

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -102,12 +102,10 @@ of synchronization between peers is:  node A puts a value, commits it,
 reads version, sends version to node B.  Node B waits for version, gets
 value.
 
-*dropcache*::
-Tell the local KVS to drop any cache it is holding.
-
-*dropcache-all*::
-Send an event across the comms session instructing all KVS instances
-to drop their caches.
+*dropcache* [--all]::
+Tell the local KVS to drop any cache it is holding.  If '--all' is
+specified, send an event across the comms session instructing all KVS
+instances to drop their caches.
 
 *copy* 'source' 'destination':: 
 Copy 'source' key to 'destination' key.  If a directory is copied, a new

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -25,8 +25,8 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <getopt.h>
 #include <flux/core.h>
+#include <flux/optparse.h>
 #include <unistd.h>
 #include <fcntl.h>
 
@@ -36,112 +36,223 @@
 #include "src/common/libutil/base64_json.h"
 #include "src/common/libutil/readall.h"
 
+int cmd_get (optparse_t *p, int argc, char **argv);
+int cmd_put (optparse_t *p, int argc, char **argv);
+int cmd_unlink (optparse_t *p, int argc, char **argv);
+int cmd_link (optparse_t *p, int argc, char **argv);
+int cmd_readlink (optparse_t *p, int argc, char **argv);
+int cmd_mkdir (optparse_t *p, int argc, char **argv);
+int cmd_version (optparse_t *p, int argc, char **argv);
+int cmd_wait (optparse_t *p, int argc, char **argv);
+int cmd_watch (optparse_t *p, int argc, char **argv);
+int cmd_watch_dir (optparse_t *p, int argc, char **argv);
+int cmd_dropcache (optparse_t *p, int argc, char **argv);
+int cmd_dropcache_all (optparse_t *p, int argc, char **argv);
+int cmd_copy (optparse_t *p, int argc, char **argv);
+int cmd_move (optparse_t *p, int argc, char **argv);
+int cmd_dir (optparse_t *p, int argc, char **argv);
 
-#define OPTIONS "+h"
-static const struct option longopts[] = {
-    {"help",       no_argument,  0, 'h'},
-    { 0, 0, 0, 0 },
+static struct optparse_option dir_opts[] =  {
+    { .name = "recursive", .key = 'r', .has_arg = 0,
+      .usage = "Recursively display keys under subdirectories",
+    },
+    { .name = "directory", .key = 'd', .has_arg = 0,
+      .usage = "List directory entries and not values",
+    },
+    OPTPARSE_TABLE_END
 };
 
-void cmd_get (flux_t *h, int argc, char **argv);
-void cmd_put (flux_t *h, int argc, char **argv);
-void cmd_unlink (flux_t *h, int argc, char **argv);
-void cmd_link (flux_t *h, int argc, char **argv);
-void cmd_readlink (flux_t *h, int argc, char **argv);
-void cmd_mkdir (flux_t *h, int argc, char **argv);
-void cmd_version (flux_t *h, int argc, char **argv);
-void cmd_wait (flux_t *h, int argc, char **argv);
-void cmd_watch (flux_t *h, int argc, char **argv);
-void cmd_watch_dir (flux_t *h, int argc, char **argv);
-void cmd_dropcache (flux_t *h, int argc, char **argv);
-void cmd_dropcache_all (flux_t *h, int argc, char **argv);
-void cmd_copy (flux_t *h, int argc, char **argv);
-void cmd_move (flux_t *h, int argc, char **argv);
-void cmd_dir (flux_t *h, int argc, char **argv);
+static struct optparse_option watch_opts[] =  {
+    { .name = "current", .key = 'o', .has_arg = 0,
+      .usage = "Output current value before changes",
+    },
+    OPTPARSE_TABLE_END
+};
 
-void usage (void)
+static struct optparse_option watch_dir_opts[] =  {
+    { .name = "recursive", .key = 'r', .has_arg = 0,
+      .usage = "Recursively display keys under subdirectories",
+    },
+    { .name = "directory", .key = 'd', .has_arg = 0,
+      .usage = "List directory entries and not values",
+    },
+    { .name = "current", .key = 'o', .has_arg = 0,
+      .usage = "Output current value before changes",
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_subcommand subcommands[] = {
+    { "get",
+      "key [key...]",
+      "Get value stored under key",
+      cmd_get,
+      0,
+      NULL
+    },
+    { "put",
+      "key=value [key=value...]",
+      "Store value under key",
+      cmd_put,
+      0,
+      NULL
+    },
+    { "dir",
+      "[-r] [-d] [key]",
+      "Display all keys under directory",
+      cmd_dir,
+      0,
+      dir_opts
+    },
+    { "unlink",
+      "key [key...]",
+      "Remove key",
+      cmd_unlink,
+      0,
+      NULL
+    },
+    { "link",
+      "target linkname",
+      "Create a new name for target",
+      cmd_link,
+      0,
+      NULL
+    },
+    { "readlink",
+      "key [key...]",
+      "Retrieve the key a link refers to",
+      cmd_readlink,
+      0,
+      NULL
+    },
+    { "mkdir",
+      "key [key...]",
+      "Create a directory",
+      cmd_mkdir,
+      0,
+      NULL
+    },
+    { "copy",
+      "source destination",
+      "Copy source key to destination key",
+      cmd_copy,
+      0,
+      NULL
+    },
+    { "move",
+      "source destination",
+      "Move source key to destination key",
+      cmd_move,
+      0,
+      NULL
+    },
+    { "dropcache",
+      "",
+      "Tell local KVS to drop its cache",
+      cmd_dropcache,
+      0,
+      NULL
+    },
+    { "dropcache-all",
+      "",
+      "Instruct all KVS to drop its cache",
+      cmd_dropcache_all,
+      0,
+      NULL
+    },
+    { "watch",
+      "[-o] [count] key",
+      "Watch value specified by key",
+      cmd_watch,
+      0,
+      watch_opts
+    },
+    { "watch-dir",
+      "[-r] [-d] [-o] [count] key",
+      "Watch directory specified by key",
+      cmd_watch_dir,
+      0,
+      watch_dir_opts
+    },
+    { "version",
+      "",
+      "Display curent KVS version",
+      cmd_version,
+      0,
+      NULL
+    },
+    { "wait",
+      "version",
+      "Block until the KVS reaches version",
+      cmd_wait,
+      0,
+      NULL
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+int usage (optparse_t *p, struct optparse_option *o, const char *optarg)
 {
-    fprintf (stderr,
-"Usage: flux-kvs get                 key [key...]\n"
-"       flux-kvs put                 key=val [key=val...]\n"
-"       flux-kvs unlink              key [key...]\n"
-"       flux-kvs link                target link_name\n"
-"       flux-kvs readlink            key\n"
-"       flux-kvs mkdir               key [key...]\n"
-"       flux-kvs watch               [count] key\n"
-"       flux-kvs watch-dir [-r] [-d] [count] key\n"
-"       flux-kvs copy                srckey dstkey\n"
-"       flux-kvs move                srckey dstkey\n"
-"       flux-kvs dir [-r] [-d]       [key]\n"
-"       flux-kvs version\n"
-"       flux-kvs wait                version\n"
-"       flux-kvs dropcache\n"
-"       flux-kvs dropcache-all\n"
-);
+    struct optparse_subcommand *s;
+    optparse_print_usage (p);
+    fprintf (stderr, "\n");
+    fprintf (stderr, "Common commands from flux-kvs:\n");
+    s = subcommands;
+    while (s->name) {
+        fprintf (stderr, "   %-15s %s\n", s->name, s->doc);
+        s++;
+    }
     exit (1);
 }
 
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    int ch;
-    char *cmd;
+    char *cmdusage = "[OPTIONS] COMMAND ARGS";
+    optparse_t *p;
+    int optindex;
+    int exitval;
 
     log_init ("flux-kvs");
 
-    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
-        switch (ch) {
-            case 'h': /* --help */
-                usage ();
-                break;
-            default:
-                usage ();
-                break;
-        }
+    p = optparse_create ("flux-kvs");
+
+    /* Override help option for our own */
+    if (optparse_set (p, OPTPARSE_USAGE, cmdusage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_set (USAGE)");
+
+    /* Override --help callback in favor of our own above */
+    if (optparse_set (p, OPTPARSE_OPTION_CB, "help", usage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_set() failed");
+
+    /* Don't print internal subcommands, we do it ourselves */
+    if (optparse_set (p, OPTPARSE_PRINT_SUBCMDS, 0) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_set (PRINT_SUBCMDS)");
+
+    if (optparse_reg_subcommands (p, subcommands) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_reg_subcommands");
+
+    if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
+        exit (1);
+
+    if ((argc - optindex == 0)
+        || !optparse_get_subcommand (p, argv[optind])) {
+        usage (p, NULL, NULL);
+        exit (1);
     }
-    if (optind == argc)
-        usage ();
-    cmd = argv[optind++];
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!strcmp (cmd, "get"))
-        cmd_get (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "put"))
-        cmd_put (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "unlink"))
-        cmd_unlink (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "link"))
-        cmd_link (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "readlink"))
-        cmd_readlink (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "mkdir"))
-        cmd_mkdir (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "version"))
-        cmd_version (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "wait"))
-        cmd_wait (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "watch"))
-        cmd_watch (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "watch-dir"))
-        cmd_watch_dir (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "dropcache"))
-        cmd_dropcache (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "dropcache-all"))
-        cmd_dropcache_all (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "copy"))
-        cmd_copy (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "move"))
-        cmd_move (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "dir"))
-        cmd_dir (h, argc - optind, argv + optind);
-    else
-        usage ();
+    optparse_set_data (p, "flux_handle", h);
+
+    if ((exitval = optparse_run_subcommand (p, argc, argv)) < 0)
+        exit (1);
 
     flux_close (h);
+    optparse_destroy (p);
     log_fini ();
-    return 0;
+    return (exitval);
 }
 
 static void output_key_json_object (const char *key, json_object *o)
@@ -190,28 +301,43 @@ static void output_key_json_str (const char *key,
     Jput (o);
 }
 
-void cmd_get (flux_t *h, int argc, char **argv)
+int cmd_get (optparse_t *p, int argc, char **argv)
 {
+    flux_t *h;
     char *json_str;
-    int i;
+    int optindex, i;
 
-    if (argc == 0)
-        log_msg_exit ("get: specify one or more keys");
-    for (i = 0; i < argc; i++) {
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    for (i = optindex; i < argc; i++) {
         if (kvs_get (h, argv[i], &json_str) < 0)
             log_err_exit ("%s", argv[i]);
         output_key_json_str (NULL, json_str, argv[i]);
         free (json_str);
     }
+    return (0);
 }
 
-void cmd_put (flux_t *h, int argc, char **argv)
+int cmd_put (optparse_t *p, int argc, char **argv)
 {
-    int i;
+    flux_t *h;
+    int optindex, i;
 
-    if (argc == 0)
-        log_msg_exit ("put: specify one or more key=value pairs");
-    for (i = 0; i < argc; i++) {
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    for (i = optindex; i < argc; i++) {
         char *key = xstrdup (argv[i]);
         char *val = strchr (key, '=');
         if (!val)
@@ -225,15 +351,23 @@ void cmd_put (flux_t *h, int argc, char **argv)
     }
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+    return (0);
 }
 
-void cmd_unlink (flux_t *h, int argc, char **argv)
+int cmd_unlink (optparse_t *p, int argc, char **argv)
 {
-    int i;
+    flux_t *h;
+    int optindex, i;
 
-    if (argc == 0)
-        log_msg_exit ("unlink: specify one or more keys");
-    for (i = 0; i < argc; i++) {
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    for (i = optindex; i < argc; i++) {
         /* FIXME: unlink nonexistent silently fails */
         /* FIXME: unlink directory silently succeeds */
         if (kvs_unlink (h, argv[i]) < 0)
@@ -241,123 +375,171 @@ void cmd_unlink (flux_t *h, int argc, char **argv)
     }
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+    return (0);
 }
 
-void cmd_link (flux_t *h, int argc, char **argv)
+int cmd_link (optparse_t *p, int argc, char **argv)
 {
-    if (argc != 2)
+    flux_t *h;
+    int optindex;
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (optindex != (argc - 2))
         log_msg_exit ("link: specify target and link_name");
-    if (kvs_symlink (h, argv[1], argv[0]) < 0)
-        log_err_exit ("%s", argv[1]);
+    if (kvs_symlink (h, argv[optindex + 1], argv[optindex]) < 0)
+        log_err_exit ("%s", argv[optindex + 1]);
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+    return (0);
 }
 
-void cmd_readlink (flux_t *h, int argc, char **argv)
+int cmd_readlink (optparse_t *p, int argc, char **argv)
 {
-    int i;
+    flux_t *h;
+    int optindex, i;
     char *target;
 
-    if (argc == 0)
-        log_msg_exit ("readlink: specify one or more keys"); 
-    for (i = 0; i < argc; i++) {
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    for (i = optindex; i < argc; i++) {
         if (kvs_get_symlink (h, argv[i], &target) < 0)
             log_err_exit ("%s", argv[i]);
         else
             printf ("%s\n", target);
         free (target);
     }
+    return (0);
 }
 
-void cmd_mkdir (flux_t *h, int argc, char **argv)
+int cmd_mkdir (optparse_t *p, int argc, char **argv)
 {
-    int i;
+    flux_t *h;
+    int optindex, i;
 
-    if (argc == 0)
-        log_msg_exit ("mkdir: specify one or more directories");
-    for (i = 0; i < argc; i++) {
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    for (i = optindex; i < argc; i++) {
         if (kvs_mkdir (h, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+    return (0);
 }
 
-void cmd_version (flux_t *h, int argc, char **argv)
+int cmd_version (optparse_t *p, int argc, char **argv)
 {
+    flux_t *h;
     int vers;
-    if (argc != 0)
-        log_msg_exit ("version: takes no arguments");
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
     if (kvs_get_version (h, &vers) < 0)
         log_err_exit ("kvs_get_version");
     printf ("%d\n", vers);
+    return (0);
 }
 
-void cmd_wait (flux_t *h, int argc, char **argv)
+int cmd_wait (optparse_t *p, int argc, char **argv)
 {
+    flux_t *h;
     int vers;
-    if (argc != 1)
+    int optindex;
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (optindex != (argc - 1))
         log_msg_exit ("wait: specify a version");
-    vers = strtoul (argv[0], NULL, 10);
+    vers = strtoul (argv[optindex], NULL, 10);
     if (kvs_wait_version (h, vers) < 0)
         log_err_exit ("kvs_get_version");
+    return (0);
 }
 
-void cmd_watch (flux_t *h, int argc, char **argv)
+int cmd_watch (optparse_t *p, int argc, char **argv)
 {
+    flux_t *h;
     char *json_str = NULL;
     char *key;
     int count = -1;
-    bool oopt = false;
+    bool oopt;
+    int optindex;
 
-    if (argc > 0) {
-        while (argc) {
-            if (!strcmp (argv[0], "-o")) {
-                oopt = true;
-                argc--;
-                argv++;
-            }
-            else
-                break;
-        }
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
     }
-    if (argc == 2) {
-        count = strtoul (argv[0], NULL, 10);
-        argc--;
-        argv++;
-    }
-    if (argc != 1)
+    if (optindex != (argc - 1))
         log_msg_exit ("watch: specify one key");
-    key = argv[0];
+
+    oopt = optparse_hasopt (p, "current");
+
+    key = argv[optindex];
     if (kvs_get (h, key, &json_str) < 0 && errno != ENOENT) 
         log_err_exit ("%s", key);
     if (oopt)
         output_key_json_str (NULL, json_str, key);
     while (count) {
-        if (kvs_watch_once (h, argv[0], &json_str) < 0 && errno != ENOENT)
-            log_err_exit ("%s", argv[0]);
+        if (kvs_watch_once (h, argv[optindex], &json_str) < 0 && errno != ENOENT)
+            log_err_exit ("%s", argv[optindex]);
         output_key_json_str (NULL, json_str, key);
         count--;
     }
     free (json_str);
+    return (0);
 }
 
-void cmd_dropcache (flux_t *h, int argc, char **argv)
+int cmd_dropcache (optparse_t *p, int argc, char **argv)
 {
-    if (argc != 0)
-        log_msg_exit ("dropcache: takes no arguments");
+    flux_t *h;
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
     if (kvs_dropcache (h) < 0)
         log_err_exit ("kvs_dropcache");
+    return (0);
 }
 
-void cmd_dropcache_all (flux_t *h, int argc, char **argv)
+int cmd_dropcache_all (optparse_t *p, int argc, char **argv)
 {
-    if (argc != 0)
-        log_msg_exit ("dropcache-all: takes no arguments");
+    flux_t *h;
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
     flux_msg_t *msg = flux_event_encode ("kvs.dropcache", NULL);
     if (!msg || flux_send (h, msg, 0) < 0)
         log_err_exit ("flux_send");
     flux_msg_destroy (msg);
+    return (0);
 }
 
 static void dump_kvs_val (const char *key, const char *json_str)
@@ -412,45 +594,34 @@ static void dump_kvs_dir (kvsdir_t *dir, bool ropt, bool dopt)
     kvsitr_destroy (itr);
 }
 
-void cmd_watch_dir (flux_t *h, int argc, char **argv)
+int cmd_watch_dir (optparse_t *p, int argc, char **argv)
 {
-    bool ropt = false;
-    bool dopt = false;
-    bool oopt = false;
+    flux_t *h;
+    bool ropt;
+    bool dopt;
+    bool oopt;
     char *key;
     kvsdir_t *dir = NULL;
     int rc;
     int count = -1;
+    int optindex;
 
-    if (argc > 0) {
-        while (argc) {
-            if (!strcmp (argv[0], "-r")) {
-                ropt = true;
-                argc--;
-                argv++;
-            }
-            else if (!strcmp (argv[0], "-d")) {
-                dopt = true;
-                argc--;
-                argv++;
-            }
-            else if (!strcmp (argv[0], "-o")) {
-                oopt = true;
-                argc--;
-                argv++;
-            }
-            else
-                break;
-        }
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
     }
-    if (argc == 2) {
-        count = strtoul (argv[0], NULL, 10);
-        argc--;
-        argv++;
-    }
-    if (argc != 1)
+    if (optindex != (argc - 1))
         log_msg_exit ("watchdir: specify one directory");
-    key = argv[0];
+
+    ropt = optparse_hasopt (p, "recursive");
+    dopt = optparse_hasopt (p, "directory");
+    oopt = optparse_hasopt (p, "current");
+
+    key = argv[optindex];
 
     rc = kvs_get_dir (h, &dir, "%s", key);
     if (oopt) {
@@ -476,61 +647,80 @@ void cmd_watch_dir (flux_t *h, int argc, char **argv)
     log_err_exit ("%s", key);
 done:
     kvsdir_destroy (dir);
+    return (0);
 }
 
-void cmd_dir (flux_t *h, int argc, char **argv)
+int cmd_dir (optparse_t *p, int argc, char **argv)
 {
-    bool ropt = false;
-    bool dopt = false;
+    flux_t *h;
+    bool ropt;
+    bool dopt;
     char *key;
     kvsdir_t *dir;
+    int optindex;
 
-    if (argc > 0) {
-        while (argc) {
-            if (!strcmp (argv[0], "-r")) {
-                ropt = true;
-                argc--;
-                argv++;
-            }
-            else if (!strcmp (argv[0], "-d")) {
-                dopt = true;
-                argc--;
-                argv++;
-            }
-            else
-                break;
-        }
-    }
-    if (argc == 0)
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    ropt = optparse_hasopt (p, "recursive");
+    dopt = optparse_hasopt (p, "directory");
+
+    if (optindex == argc)
         key = ".";
-    else if (argc == 1)
-        key = argv[0];
+    else if (optindex == (argc - 1))
+        key = argv[optindex];
     else
         log_msg_exit ("dir: specify zero or one directory");
     if (kvs_get_dir (h, &dir, "%s", key) < 0)
         log_err_exit ("%s", key);
     dump_kvs_dir (dir, ropt, dopt);
     kvsdir_destroy (dir);
+    return (0);
 }
 
-void cmd_copy (flux_t *h, int argc, char **argv)
+int cmd_copy (optparse_t *p, int argc, char **argv)
 {
-    if (argc != 2)
+    flux_t *h;
+    int optindex;
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (optindex != (argc - 2))
         log_msg_exit ("copy: specify srckey dstkey");
-    if (kvs_copy (h, argv[0], argv[1]) < 0)
-        log_err_exit ("kvs_copy %s %s", argv[0], argv[1]);
+    if (kvs_copy (h, argv[optindex], argv[optindex + 1]) < 0)
+        log_err_exit ("kvs_copy %s %s", argv[optindex], argv[optindex + 1]);
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+    return (0);
 }
 
-void cmd_move (flux_t *h, int argc, char **argv)
+int cmd_move (optparse_t *p, int argc, char **argv)
 {
-    if (argc != 2)
+    flux_t *h;
+    int optindex;
+
+    h = (flux_t *)optparse_get_data (p, "flux_handle");
+
+    optindex = optparse_option_index (p);
+
+    if ((optindex - argc) == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (optindex != (argc - 2))
         log_msg_exit ("move: specify srckey dstkey");
-    if (kvs_move (h, argv[0], argv[1]) < 0)
-        log_err_exit ("kvs_move %s %s", argv[0], argv[1]);
+    if (kvs_move (h, argv[optindex], argv[optindex + 1]) < 0)
+        log_err_exit ("kvs_move %s %s", argv[optindex], argv[optindex + 1]);
     if (kvs_commit (h) < 0)
         log_err_exit ("kvs_commit");
+    return (0);
 }
 
 /*

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -412,7 +412,6 @@ void cmd_wait (flux_t *h, int argc, char **argv)
     vers = strtoul (argv[0], NULL, 10);
     if (kvs_wait_version (h, vers) < 0)
         log_err_exit ("kvs_get_version");
-    //printf ("%d\n", vers);
 }
 
 void cmd_watch (flux_t *h, int argc, char **argv)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -53,7 +53,7 @@ int cmd_move (optparse_t *p, int argc, char **argv);
 int cmd_dir (optparse_t *p, int argc, char **argv);
 
 static struct optparse_option dir_opts[] =  {
-    { .name = "recursive", .key = 'r', .has_arg = 0,
+    { .name = "recursive", .key = 'R', .has_arg = 0,
       .usage = "Recursively display keys under subdirectories",
     },
     { .name = "directory", .key = 'd', .has_arg = 0,
@@ -70,7 +70,7 @@ static struct optparse_option watch_opts[] =  {
 };
 
 static struct optparse_option watch_dir_opts[] =  {
-    { .name = "recursive", .key = 'r', .has_arg = 0,
+    { .name = "recursive", .key = 'R', .has_arg = 0,
       .usage = "Recursively display keys under subdirectories",
     },
     { .name = "directory", .key = 'd', .has_arg = 0,
@@ -98,7 +98,7 @@ static struct optparse_subcommand subcommands[] = {
       NULL
     },
     { "dir",
-      "[-r] [-d] [key]",
+      "[-R] [-d] [key]",
       "Display all keys under directory",
       cmd_dir,
       0,
@@ -168,7 +168,7 @@ static struct optparse_subcommand subcommands[] = {
       watch_opts
     },
     { "watch-dir",
-      "[-r] [-d] [-o] [count] key",
+      "[-R] [-d] [-o] [count] key",
       "Watch directory specified by key",
       cmd_watch_dir,
       0,
@@ -553,7 +553,7 @@ static void dump_kvs_val (const char *key, const char *json_str)
     Jput (o);
 }
 
-static void dump_kvs_dir (kvsdir_t *dir, bool ropt, bool dopt)
+static void dump_kvs_dir (kvsdir_t *dir, bool Ropt, bool dopt)
 {
     kvsitr_t *itr;
     const char *name;
@@ -570,11 +570,11 @@ static void dump_kvs_dir (kvsdir_t *dir, bool ropt, bool dopt)
             free (link);
 
         } else if (kvsdir_isdir (dir, name)) {
-            if (ropt) {
+            if (Ropt) {
                 kvsdir_t *ndir;
                 if (kvsdir_get_dir (dir, &ndir, "%s", name) < 0)
                     log_err_exit ("%s", key);
-                dump_kvs_dir (ndir, ropt, dopt);
+                dump_kvs_dir (ndir, Ropt, dopt);
                 kvsdir_destroy (ndir);
             } else
                 printf ("%s.\n", key);
@@ -597,7 +597,7 @@ static void dump_kvs_dir (kvsdir_t *dir, bool ropt, bool dopt)
 int cmd_watch_dir (optparse_t *p, int argc, char **argv)
 {
     flux_t *h;
-    bool ropt;
+    bool Ropt;
     bool dopt;
     bool oopt;
     char *key;
@@ -617,7 +617,7 @@ int cmd_watch_dir (optparse_t *p, int argc, char **argv)
     if (optindex != (argc - 1))
         log_msg_exit ("watchdir: specify one directory");
 
-    ropt = optparse_hasopt (p, "recursive");
+    Ropt = optparse_hasopt (p, "recursive");
     dopt = optparse_hasopt (p, "directory");
     oopt = optparse_hasopt (p, "current");
 
@@ -625,7 +625,7 @@ int cmd_watch_dir (optparse_t *p, int argc, char **argv)
 
     rc = kvs_get_dir (h, &dir, "%s", key);
     if (oopt) {
-        dump_kvs_dir (dir, ropt, dopt);
+        dump_kvs_dir (dir, Ropt, dopt);
         printf ("======================\n");
         fflush (stdout);
     }
@@ -637,7 +637,7 @@ int cmd_watch_dir (optparse_t *p, int argc, char **argv)
                 kvsdir_destroy (dir);
             dir = NULL;
         } else {
-            dump_kvs_dir (dir, ropt, dopt);
+            dump_kvs_dir (dir, Ropt, dopt);
             printf ("======================\n");
             fflush (stdout);
         }
@@ -653,7 +653,7 @@ done:
 int cmd_dir (optparse_t *p, int argc, char **argv)
 {
     flux_t *h;
-    bool ropt;
+    bool Ropt;
     bool dopt;
     char *key;
     kvsdir_t *dir;
@@ -663,7 +663,7 @@ int cmd_dir (optparse_t *p, int argc, char **argv)
 
     optindex = optparse_option_index (p);
 
-    ropt = optparse_hasopt (p, "recursive");
+    Ropt = optparse_hasopt (p, "recursive");
     dopt = optparse_hasopt (p, "directory");
 
     if (optindex == argc)
@@ -674,7 +674,7 @@ int cmd_dir (optparse_t *p, int argc, char **argv)
         log_msg_exit ("dir: specify zero or one directory");
     if (kvs_get_dir (h, &dir, "%s", key) < 0)
         log_err_exit ("%s", key);
-    dump_kvs_dir (dir, ropt, dopt);
+    dump_kvs_dir (dir, Ropt, dopt);
     kvsdir_destroy (dir);
     return (0);
 }

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -66,6 +66,9 @@ static struct optparse_option watch_opts[] =  {
     { .name = "current", .key = 'o', .has_arg = 0,
       .usage = "Output current value before changes",
     },
+    { .name = "count", .key = 'c', .has_arg = 1,
+      .usage = "Display at most count changes",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -78,6 +81,9 @@ static struct optparse_option watch_dir_opts[] =  {
     },
     { .name = "current", .key = 'o', .has_arg = 0,
       .usage = "Output current value before changes",
+    },
+    { .name = "count", .key = 'c', .has_arg = 1,
+      .usage = "Display at most count changes",
     },
     OPTPARSE_TABLE_END
 };
@@ -161,14 +167,14 @@ static struct optparse_subcommand subcommands[] = {
       NULL
     },
     { "watch",
-      "[-o] [count] key",
+      "[-o] [-c count] key",
       "Watch value specified by key",
       cmd_watch,
       0,
       watch_opts
     },
     { "watch-dir",
-      "[-R] [-d] [-o] [count] key",
+      "[-R] [-d] [-o] [-c count] key",
       "Watch directory specified by key",
       cmd_watch_dir,
       0,
@@ -486,7 +492,7 @@ int cmd_watch (optparse_t *p, int argc, char **argv)
     flux_t *h;
     char *json_str = NULL;
     char *key;
-    int count = -1;
+    int count;
     bool oopt;
     int optindex;
 
@@ -502,6 +508,7 @@ int cmd_watch (optparse_t *p, int argc, char **argv)
         log_msg_exit ("watch: specify one key");
 
     oopt = optparse_hasopt (p, "current");
+    count = optparse_get_int (p, "count", -1);
 
     key = argv[optindex];
     if (kvs_get (h, key, &json_str) < 0 && errno != ENOENT) 
@@ -603,7 +610,7 @@ int cmd_watch_dir (optparse_t *p, int argc, char **argv)
     char *key;
     kvsdir_t *dir = NULL;
     int rc;
-    int count = -1;
+    int count;
     int optindex;
 
     h = (flux_t *)optparse_get_data (p, "flux_handle");
@@ -620,6 +627,7 @@ int cmd_watch_dir (optparse_t *p, int argc, char **argv)
     Ropt = optparse_hasopt (p, "recursive");
     dopt = optparse_hasopt (p, "directory");
     oopt = optparse_hasopt (p, "current");
+    count = optparse_get_int (p, "count", -1);
 
     key = argv[optindex];
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -162,6 +162,7 @@ check_PROGRAMS = \
 	kvs/watch \
 	kvs/watch_disconnect \
 	kvs/commit \
+	kvs/basic \
 	request/treq
 
 check_LTLIBRARIES = \
@@ -287,6 +288,12 @@ kvs_hashtest_SOURCES = kvs/hashtest.c
 kvs_hashtest_CPPFLAGS = $(test_cppflags) $(SQLITE_CFLAGS)
 kvs_hashtest_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL) $(LIBJUDY) $(SQLITE_LIBS)
+
+kvs_basic_SOURCES = kvs/basic.c
+kvs_basic_CPPFLAGS = $(test_cppflags)
+kvs_basic_LDADD = \
+	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 request_treq_SOURCES = request/treq.c
 request_treq_CPPFLAGS = $(test_cppflags)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -47,6 +47,7 @@ TESTS = \
 	t0017-security.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
+	t1002-kvs-cmd.t \
 	t1005-cmddriver.t \
 	t1006-apidisconnect.t \
 	t1007-kz.t \
@@ -112,6 +113,7 @@ check_SCRIPTS = \
 	t0017-security.t \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
+	t1002-kvs-cmd.t \
 	t1005-cmddriver.t \
 	t1006-apidisconnect.t \
 	t1007-kz.t \

--- a/t/kvs/basic.c
+++ b/t/kvs/basic.c
@@ -1,0 +1,792 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <getopt.h>
+#include <flux/core.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/base64_json.h"
+#include "src/common/libutil/readall.h"
+
+
+#define OPTIONS "+h"
+static const struct option longopts[] = {
+    {"help",       no_argument,  0, 'h'},
+    { 0, 0, 0, 0 },
+};
+
+void cmd_get (flux_t *h, int argc, char **argv);
+void cmd_type (flux_t *h, int argc, char **argv);
+void cmd_put (flux_t *h, int argc, char **argv);
+void cmd_unlink (flux_t *h, int argc, char **argv);
+void cmd_link (flux_t *h, int argc, char **argv);
+void cmd_readlink (flux_t *h, int argc, char **argv);
+void cmd_mkdir (flux_t *h, int argc, char **argv);
+void cmd_exists (flux_t *h, int argc, char **argv);
+void cmd_version (flux_t *h, int argc, char **argv);
+void cmd_wait (flux_t *h, int argc, char **argv);
+void cmd_watch (flux_t *h, int argc, char **argv);
+void cmd_watch_dir (flux_t *h, int argc, char **argv);
+void cmd_dropcache (flux_t *h, int argc, char **argv);
+void cmd_dropcache_all (flux_t *h, int argc, char **argv);
+void cmd_copy_tokvs (flux_t *h, int argc, char **argv);
+void cmd_copy_fromkvs (flux_t *h, int argc, char **argv);
+void cmd_copy (flux_t *h, int argc, char **argv);
+void cmd_move (flux_t *h, int argc, char **argv);
+void cmd_dir (flux_t *h, int argc, char **argv);
+void cmd_dirsize (flux_t *h, int argc, char **argv);
+void cmd_get_treeobj (flux_t *h, int argc, char **argv);
+void cmd_put_treeobj (flux_t *h, int argc, char **argv);
+void cmd_getat (flux_t *h, int argc, char **argv);
+void cmd_dirat (flux_t *h, int argc, char **argv);
+void cmd_readlinkat (flux_t *h, int argc, char **argv);
+
+
+void usage (void)
+{
+    fprintf (stderr,
+"Usage: basic get                 key [key...]\n"
+"       basic type                key [key...]\n"
+"       basic put                 key=val [key=val...]\n"
+"       basic unlink              key [key...]\n"
+"       basic link                target link_name\n"
+"       basic readlink            key\n"
+"       basic mkdir               key [key...]\n"
+"       basic exists              key\n"
+"       basic watch               [count] key\n"
+"       basic watch-dir [-r] [-d] [count] key\n"
+"       basic copy-tokvs          key file\n"
+"       basic copy-fromkvs        key file\n"
+"       basic copy                srckey dstkey\n"
+"       basic move                srckey dstkey\n"
+"       basic dir [-r] [-d]       [key]\n"
+"       basic dirsize             key\n"
+"       basic version\n"
+"       basic wait                version\n"
+"       basic dropcache\n"
+"       basic dropcache-all\n"
+"       basic get-treeobj         key\n"
+"       basic put-treeobj         key=treeobj\n"
+"       basic getat               treeobj key\n"
+"       basic dirat [-r] [-d]     treeobj [key]\n"
+"       basic readlinkat          treeobj key\n"
+);
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    int ch;
+    char *cmd;
+
+    log_init ("basic");
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'h': /* --help */
+                usage ();
+                break;
+            default:
+                usage ();
+                break;
+        }
+    }
+    if (optind == argc)
+        usage ();
+    cmd = argv[optind++];
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!strcmp (cmd, "get"))
+        cmd_get (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "type"))
+        cmd_type (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "put"))
+        cmd_put (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "unlink"))
+        cmd_unlink (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "link"))
+        cmd_link (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "readlink"))
+        cmd_readlink (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "mkdir"))
+        cmd_mkdir (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "exists"))
+        cmd_exists (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "version"))
+        cmd_version (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "wait"))
+        cmd_wait (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "watch"))
+        cmd_watch (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "watch-dir"))
+        cmd_watch_dir (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dropcache"))
+        cmd_dropcache (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dropcache-all"))
+        cmd_dropcache_all (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "copy-tokvs"))
+        cmd_copy_tokvs (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "copy-fromkvs"))
+        cmd_copy_fromkvs (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "copy"))
+        cmd_copy (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "move"))
+        cmd_move (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dir"))
+        cmd_dir (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dirsize"))
+        cmd_dirsize (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "get-treeobj"))
+        cmd_get_treeobj (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "put-treeobj"))
+        cmd_put_treeobj (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "getat"))
+        cmd_getat (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "dirat"))
+        cmd_dirat (h, argc - optind, argv + optind);
+    else if (!strcmp (cmd, "readlinkat"))
+        cmd_readlinkat (h, argc - optind, argv + optind);
+    else
+        usage ();
+
+    flux_close (h);
+    log_fini ();
+    return 0;
+}
+
+void cmd_type (flux_t *h, int argc, char **argv)
+{
+    char *json_str;
+    json_object *o;
+    int i;
+
+    if (argc == 0)
+        log_msg_exit ("get-type: specify one or more keys");
+    for (i = 0; i < argc; i++) {
+        if (kvs_get (h, argv[i], &json_str) < 0)
+            log_err_exit ("%s", argv[i]);
+        if (!(o = Jfromstr (json_str)))
+            log_msg_exit ("%s: malformed JSON", argv[i]);
+        const char *type = "unknown";
+        switch (json_object_get_type (o)) {
+            case json_type_null:
+                type = "null";
+                break;
+            case json_type_boolean:
+                type = "boolean";
+                break;
+            case json_type_double:
+                type = "double";
+                break;
+            case json_type_int:
+                type = "int";
+                break;
+            case json_type_object:
+                type = "object";
+                break;
+            case json_type_array:
+                type = "array";
+                break;
+            case json_type_string:
+                type = "string";
+                break;
+        }
+        printf ("%s\n", type);
+        Jput (o);
+        free (json_str);
+    }
+}
+
+static void output_key_json_object (const char *key, json_object *o)
+{
+    if (key)
+        printf ("%s = ", key);
+
+    switch (json_object_get_type (o)) {
+    case json_type_null:
+        printf ("nil\n");
+        break;
+    case json_type_boolean:
+        printf ("%s\n", json_object_get_boolean (o) ? "true" : "false");
+        break;
+    case json_type_double:
+        printf ("%f\n", json_object_get_double (o));
+        break;
+    case json_type_int:
+        printf ("%d\n", json_object_get_int (o));
+        break;
+    case json_type_string:
+        printf ("%s\n", json_object_get_string (o));
+        break;
+    case json_type_array:
+    case json_type_object:
+    default:
+        printf ("%s\n", Jtostr (o));
+        break;
+    }
+}
+
+static void output_key_json_str (const char *key,
+                                 const char *json_str,
+                                 const char *arg)
+{
+    json_object *o;
+
+    if (!json_str) {
+        output_key_json_object (key, NULL); 
+        return;
+    }
+
+    if (!(o = Jfromstr (json_str)))
+        log_msg_exit ("%s: malformed JSON", arg);
+    output_key_json_object (key, o);
+    Jput (o);
+}
+
+void cmd_get (flux_t *h, int argc, char **argv)
+{
+    char *json_str;
+    int i;
+
+    if (argc == 0)
+        log_msg_exit ("get: specify one or more keys");
+    for (i = 0; i < argc; i++) {
+        if (kvs_get (h, argv[i], &json_str) < 0)
+            log_err_exit ("%s", argv[i]);
+        output_key_json_str (NULL, json_str, argv[i]);
+        free (json_str);
+    }
+}
+
+void cmd_put (flux_t *h, int argc, char **argv)
+{
+    int i;
+
+    if (argc == 0)
+        log_msg_exit ("put: specify one or more key=value pairs");
+    for (i = 0; i < argc; i++) {
+        char *key = xstrdup (argv[i]);
+        char *val = strchr (key, '=');
+        if (!val)
+            log_msg_exit ("put: you must specify a value as key=value");
+        *val++ = '\0';
+        if (kvs_put (h, key, val) < 0) {
+            if (errno != EINVAL || kvs_put_string (h, key, val) < 0)
+                log_err_exit ("%s", key);
+        }
+        free (key);
+    }
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+}
+
+void cmd_unlink (flux_t *h, int argc, char **argv)
+{
+    int i;
+
+    if (argc == 0)
+        log_msg_exit ("unlink: specify one or more keys");
+    for (i = 0; i < argc; i++) {
+        /* FIXME: unlink nonexistent silently fails */
+        /* FIXME: unlink directory silently succeeds */
+        if (kvs_unlink (h, argv[i]) < 0)
+            log_err_exit ("%s", argv[i]);
+    }
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+}
+
+void cmd_link (flux_t *h, int argc, char **argv)
+{
+    if (argc != 2)
+        log_msg_exit ("link: specify target and link_name");
+    if (kvs_symlink (h, argv[1], argv[0]) < 0)
+        log_err_exit ("%s", argv[1]);
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+}
+
+void cmd_readlink (flux_t *h, int argc, char **argv)
+{
+    int i;
+    char *target;
+
+    if (argc == 0)
+        log_msg_exit ("readlink: specify one or more keys"); 
+    for (i = 0; i < argc; i++) {
+        if (kvs_get_symlink (h, argv[i], &target) < 0)
+            log_err_exit ("%s", argv[i]);
+        else
+            printf ("%s\n", target);
+        free (target);
+    }
+}
+
+void cmd_mkdir (flux_t *h, int argc, char **argv)
+{
+    int i;
+
+    if (argc == 0)
+        log_msg_exit ("mkdir: specify one or more directories");
+    for (i = 0; i < argc; i++) {
+        if (kvs_mkdir (h, argv[i]) < 0)
+            log_err_exit ("%s", argv[i]);
+    }
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+}
+
+bool key_exists (flux_t *h, const char *key)
+{
+    char *json_str = NULL;
+    kvsdir_t *dir = NULL;
+
+    if (kvs_get (h, key, &json_str) == 0) {
+        free (json_str);
+        return true;
+    }
+    if (errno == EISDIR && kvs_get_dir (h, &dir, "%s", key) == 0) {
+        kvsdir_destroy (dir);
+        return true;
+    }
+    return false;
+}
+
+void cmd_exists (flux_t *h, int argc, char **argv)
+{
+    int i;
+    if (argc == 0)
+        log_msg_exit ("exist: specify one or more keys");
+    for (i = 0; i < argc; i++) {
+        if (!key_exists (h, argv[i]))
+            exit (1);
+    }
+}
+
+void cmd_version (flux_t *h, int argc, char **argv)
+{
+    int vers;
+    if (argc != 0)
+        log_msg_exit ("version: takes no arguments");
+    if (kvs_get_version (h, &vers) < 0)
+        log_err_exit ("kvs_get_version");
+    printf ("%d\n", vers);
+}
+
+void cmd_wait (flux_t *h, int argc, char **argv)
+{
+    int vers;
+    if (argc != 1)
+        log_msg_exit ("wait: specify a version");
+    vers = strtoul (argv[0], NULL, 10);
+    if (kvs_wait_version (h, vers) < 0)
+        log_err_exit ("kvs_get_version");
+    //printf ("%d\n", vers);
+}
+
+void cmd_watch (flux_t *h, int argc, char **argv)
+{
+    char *json_str = NULL;
+    char *key;
+    int count = -1;
+
+    if (argc == 2) {
+        count = strtoul (argv[0], NULL, 10);
+        argc--;
+        argv++;
+    }
+    if (argc != 1)
+        log_msg_exit ("watch: specify one key");
+    key = argv[0];
+    if (kvs_get (h, key, &json_str) < 0 && errno != ENOENT) 
+        log_err_exit ("%s", key);
+    do {
+        output_key_json_str (NULL, json_str, key);
+        if (--count == 0)
+            break;
+        if (kvs_watch_once (h, argv[0], &json_str) < 0 && errno != ENOENT)
+            log_err_exit ("%s", argv[0]);
+    } while (true);
+    free (json_str);
+}
+
+void cmd_dropcache (flux_t *h, int argc, char **argv)
+{
+    if (argc != 0)
+        log_msg_exit ("dropcache: takes no arguments");
+    if (kvs_dropcache (h) < 0)
+        log_err_exit ("kvs_dropcache");
+}
+
+void cmd_dropcache_all (flux_t *h, int argc, char **argv)
+{
+    if (argc != 0)
+        log_msg_exit ("dropcache-all: takes no arguments");
+    flux_msg_t *msg = flux_event_encode ("kvs.dropcache", NULL);
+    if (!msg || flux_send (h, msg, 0) < 0)
+        log_err_exit ("flux_send");
+    flux_msg_destroy (msg);
+}
+
+void cmd_copy_tokvs (flux_t *h, int argc, char **argv)
+{
+    char *file, *key;
+    int fd, len;
+    uint8_t *buf;
+    json_object *o;
+
+    if (argc != 2)
+        log_msg_exit ("copy-tokvs: specify key and filename");
+    key = argv[0];
+    file = argv[1];
+    if (!strcmp (file, "-")) {
+        if ((len = read_all (STDIN_FILENO, &buf)) < 0)
+            log_err_exit ("stdin");
+    } else {
+        if ((fd = open (file, O_RDONLY)) < 0)
+            log_err_exit ("%s", file);
+        if ((len = read_all (fd, &buf)) < 0)
+            log_err_exit ("%s", file);
+        (void)close (fd);
+    }
+    o = Jnew ();
+    json_object_object_add (o, "data", base64_json_encode (buf, len));
+    if (kvs_put (h, key, Jtostr (o)) < 0)
+        log_err_exit ("%s", key);
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+    Jput (o);
+    free (buf);
+}
+
+void cmd_copy_fromkvs (flux_t *h, int argc, char **argv)
+{
+    char *file, *key;
+    int fd, len;
+    uint8_t *buf;
+    json_object *o;
+    char *json_str;
+
+    if (argc != 2)
+        log_msg_exit ("copy-fromkvs: specify key and filename");
+    key = argv[0];
+    file = argv[1];
+    if (kvs_get (h, key, &json_str) < 0)
+        log_err_exit ("%s", key);
+    if (!(o = Jfromstr (json_str)))
+        log_msg_exit ("%s: invalid JSON", key);
+    if (base64_json_decode (Jobj_get (o, "data"), &buf, &len) < 0)
+        log_err_exit ("%s: decode error", key);
+    if (!strcmp (file, "-")) {
+        if (write_all (STDOUT_FILENO, buf, len) < 0)
+            log_err_exit ("stdout");
+    } else {
+        if ((fd = creat (file, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) < 0)
+            log_err_exit ("%s", file);
+        if (write_all (fd, buf, len) < 0)
+            log_err_exit ("%s", file);
+        if (close (fd) < 0)
+            log_err_exit ("%s", file);
+    }
+    free (buf);
+    Jput (o);
+    free (json_str);
+}
+
+
+static void dump_kvs_val (const char *key, const char *json_str)
+{
+    json_object *o = Jfromstr (json_str);
+    if (!o) {
+        printf ("%s: invalid JSON", key);
+        return;
+    }
+    output_key_json_object (key, o);
+    Jput (o);
+}
+
+static void dump_kvs_dir (kvsdir_t *dir, bool ropt, bool dopt)
+{
+    kvsitr_t *itr;
+    const char *name;
+    char *key;
+
+    itr = kvsitr_create (dir);
+    while ((name = kvsitr_next (itr))) {
+        key = kvsdir_key_at (dir, name);
+        if (kvsdir_issymlink (dir, name)) {
+            char *link;
+            if (kvsdir_get_symlink (dir, name, &link) < 0)
+                log_err_exit ("%s", key);
+            printf ("%s -> %s\n", key, link);
+            free (link);
+
+        } else if (kvsdir_isdir (dir, name)) {
+            if (ropt) {
+                kvsdir_t *ndir;
+                if (kvsdir_get_dir (dir, &ndir, "%s", name) < 0)
+                    log_err_exit ("%s", key);
+                dump_kvs_dir (ndir, ropt, dopt);
+                kvsdir_destroy (ndir);
+            } else
+                printf ("%s.\n", key);
+        } else {
+            if (!dopt) {
+                char *json_str;
+                if (kvsdir_get (dir, name, &json_str) < 0)
+                    log_err_exit ("%s", key);
+                dump_kvs_val (key, json_str);
+                free (json_str);
+            }
+            else
+                printf ("%s\n", key);
+        }
+        free (key);
+    }
+    kvsitr_destroy (itr);
+}
+
+void cmd_watch_dir (flux_t *h, int argc, char **argv)
+{
+    bool ropt = false;
+    bool dopt = false;
+    char *key;
+    kvsdir_t *dir = NULL;
+    int rc;
+    int count = -1;
+
+    if (argc > 0) {
+        while (argc) {
+            if (!strcmp (argv[0], "-r")) {
+                ropt = true;
+                argc--;
+                argv++;
+            }
+            else if (!strcmp (argv[0], "-d")) {
+                dopt = true;
+                argc--;
+                argv++;
+            }
+            else
+                break;
+        }
+    }
+    if (argc == 2) {
+        count = strtoul (argv[0], NULL, 10);
+        argc--;
+        argv++;
+    }
+    if (argc != 1)
+        log_msg_exit ("watchdir: specify one directory");
+    key = argv[0];
+
+    rc = kvs_get_dir (h, &dir, "%s", key);
+    while (rc == 0 || (rc < 0 && errno == ENOENT)) {
+        if (rc < 0) {
+            printf ("%s: %s\n", key, flux_strerror (errno));
+            if (dir)
+                kvsdir_destroy (dir);
+            dir = NULL;
+        } else {
+            dump_kvs_dir (dir, ropt, dopt);
+            printf ("======================\n");
+            fflush (stdout);
+        }
+        if (--count == 0)
+            goto done;
+        rc = kvs_watch_once_dir (h, &dir, "%s", key);
+    }
+    log_err_exit ("%s", key);
+done:
+    kvsdir_destroy (dir);
+}
+
+void cmd_dir (flux_t *h, int argc, char **argv)
+{
+    bool ropt = false;
+    bool dopt = false;
+    char *key;
+    kvsdir_t *dir;
+
+    if (argc > 0) {
+        while (argc) {
+            if (!strcmp (argv[0], "-r")) {
+                ropt = true;
+                argc--;
+                argv++;
+            }
+            else if (!strcmp (argv[0], "-d")) {
+                dopt = true;
+                argc--;
+                argv++;
+            }
+            else
+                break;
+        }
+    }
+    if (argc == 0)
+        key = ".";
+    else if (argc == 1)
+        key = argv[0];
+    else
+        log_msg_exit ("dir: specify zero or one directory");
+    if (kvs_get_dir (h, &dir, "%s", key) < 0)
+        log_err_exit ("%s", key);
+    dump_kvs_dir (dir, ropt, dopt);
+    kvsdir_destroy (dir);
+}
+
+void cmd_dirat (flux_t *h, int argc, char **argv)
+{
+    bool ropt = false;
+    bool dopt = false;
+    char *key;
+    kvsdir_t *dir;
+
+    if (argc > 0) {
+        while (argc) {
+            if (!strcmp (argv[0], "-r")) {
+                ropt = true;
+                argc--;
+                argv++;
+            }
+            else if (!strcmp (argv[0], "-d")) {
+                dopt = true;
+                argc--;
+                argv++;
+            }
+            else
+                break;
+        }
+    }
+    if (argc == 1)
+        key = ".";
+    else if (argc == 2)
+        key = argv[1];
+    else
+        log_msg_exit ("dir: specify treeobj and zero or one directory");
+    if (kvs_get_dirat (h, argv[0], key, &dir) < 0)
+        log_err_exit ("%s", key);
+    dump_kvs_dir (dir, ropt, dopt);
+    kvsdir_destroy (dir);
+}
+
+void cmd_dirsize (flux_t *h, int argc, char **argv)
+{
+    kvsdir_t *dir = NULL;
+    if (argc != 1)
+        log_msg_exit ("dirsize: specify one directory");
+    if (kvs_get_dir (h, &dir, "%s", argv[0]) < 0)
+        log_err_exit ("%s", argv[0]);
+    printf ("%d\n", kvsdir_get_size (dir));
+    kvsdir_destroy (dir);
+}
+
+void cmd_copy (flux_t *h, int argc, char **argv)
+{
+    if (argc != 2)
+        log_msg_exit ("copy: specify srckey dstkey");
+    if (kvs_copy (h, argv[0], argv[1]) < 0)
+        log_err_exit ("kvs_copy %s %s", argv[0], argv[1]);
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+}
+
+void cmd_move (flux_t *h, int argc, char **argv)
+{
+    if (argc != 2)
+        log_msg_exit ("move: specify srckey dstkey");
+    if (kvs_move (h, argv[0], argv[1]) < 0)
+        log_err_exit ("kvs_move %s %s", argv[0], argv[1]);
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+}
+
+void cmd_get_treeobj (flux_t *h, int argc, char **argv)
+{
+    char *treeobj = NULL;
+    if (argc != 1)
+        log_msg_exit ("get-treeobj: specify key");
+    if (kvs_get_treeobj (h, argv[0], &treeobj) < 0)
+        log_err_exit ("kvs_get_treeobj %s", argv[0]);
+    printf ("%s\n", treeobj);
+    free (treeobj);
+}
+
+void cmd_getat (flux_t *h, int argc, char **argv)
+{
+    char *json_str;
+    if (argc != 2)
+        log_msg_exit ("getat: specify treeobj and key");
+    if (kvs_getat (h, argv[0], argv[1], &json_str) < 0)
+        log_err_exit ("kvs_getat %s %s", argv[0], argv[1]);
+    output_key_json_str (NULL, json_str, argv[1]);
+    free (json_str);
+}
+
+void cmd_put_treeobj (flux_t *h, int argc, char **argv)
+{
+    if (argc != 1)
+        log_msg_exit ("put-treeobj: specify key=val");
+    char *key = xstrdup (argv[0]);
+    char *val = strchr (key, '=');
+    if (!val)
+        log_msg_exit ("put-treeobj: you must specify a value as key=val");
+    *val++ = '\0';
+    if (kvs_put_treeobj (h, key, val) < 0)
+        log_err_exit ("kvs_put_treeobj %s=%s", key, val);
+    if (kvs_commit (h) < 0)
+        log_err_exit ("kvs_commit");
+    free (key);
+}
+
+void cmd_readlinkat (flux_t *h, int argc, char **argv)
+{
+    int i;
+    char *target;
+
+    if (argc < 2)
+        log_msg_exit ("readlink: specify treeobj and one or more keys");
+    for (i = 1; i < argc; i++) {
+        if (kvs_get_symlinkat (h, argv[0], argv[i], &target) < 0)
+            log_err_exit ("%s", argv[i]);
+        else
+            printf ("%s\n", target);
+        free (target);
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/kvs/basic.c
+++ b/t/kvs/basic.c
@@ -599,7 +599,6 @@ done:
 void cmd_dir (flux_t *h, int argc, char **argv)
 {
     bool ropt = false;
-    char *key;
     kvsdir_t *dir;
 
     if (argc > 0) {
@@ -613,14 +612,10 @@ void cmd_dir (flux_t *h, int argc, char **argv)
                 break;
         }
     }
-    if (argc == 0)
-        key = ".";
-    else if (argc == 1)
-        key = argv[0];
-    else
-        log_msg_exit ("dir: specify zero or one directory");
-    if (kvs_get_dir (h, &dir, "%s", key) < 0)
-        log_err_exit ("%s", key);
+    if (argc != 1)
+        log_msg_exit ("dir: specify directory");
+    if (kvs_get_dir (h, &dir, "%s", argv[0]) < 0)
+        log_err_exit ("%s", argv[0]);
     dump_kvs_dir (dir, ropt);
     kvsdir_destroy (dir);
 }
@@ -628,7 +623,6 @@ void cmd_dir (flux_t *h, int argc, char **argv)
 void cmd_dirat (flux_t *h, int argc, char **argv)
 {
     bool ropt = false;
-    char *key;
     kvsdir_t *dir;
 
     if (argc > 0) {
@@ -642,14 +636,10 @@ void cmd_dirat (flux_t *h, int argc, char **argv)
                 break;
         }
     }
-    if (argc == 1)
-        key = ".";
-    else if (argc == 2)
-        key = argv[1];
-    else
-        log_msg_exit ("dir: specify treeobj and zero or one directory");
-    if (kvs_get_dirat (h, argv[0], key, &dir) < 0)
-        log_err_exit ("%s", key);
+    if (argc != 2)
+        log_msg_exit ("dir: specify treeobj and directory");
+    if (kvs_get_dirat (h, argv[0], argv[1], &dir) < 0)
+        log_err_exit ("%s", argv[1]);
     dump_kvs_dir (dir, ropt);
     kvsdir_destroy (dir);
 }

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -158,7 +158,11 @@ test_expect_success 'kvs: empty directory can be created' '
 	test_empty_directory $DIR
 '
 test_expect_success 'kvs: put values in a directory then retrieve them' '
-	${KVSBASIC} put $DIR.a=69 $DIR.b=70 $DIR.c=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} put $DIR.a=69 &&
+        ${KVSBASIC} put $DIR.b=70 &&
+        ${KVSBASIC} put $DIR.c=3.14 &&
+        ${KVSBASIC} put $DIR.d=\"snerg\" &&
+        ${KVSBASIC} put $DIR.e=true &&
 	${KVSBASIC} dir $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
@@ -171,7 +175,11 @@ EOF
 '
 test_expect_success 'kvs: create a dir with keys and subdir' '
 	${KVSBASIC} unlink $TEST &&
-	${KVSBASIC} put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} put $DIR.a=69 &&
+        ${KVSBASIC} put $DIR.b=70 &&
+        ${KVSBASIC} put $DIR.c.d.e.f.g=3.14 &&
+        ${KVSBASIC} put $DIR.d=\"snerg\" &&
+        ${KVSBASIC} put $DIR.e=true &&
 	${KVSBASIC} dir -r $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
@@ -185,7 +193,11 @@ EOF
 
 test_expect_success 'kvs: directory with multiple subdirs' '
 	${KVSBASIC} unlink $TEST &&
-	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} put $DIR.a=69 &&
+        ${KVSBASIC} put $DIR.b.c.d.e.f.g=70 &&
+        ${KVSBASIC} put $DIR.c.a.b=3.14 &&
+        ${KVSBASIC} put $DIR.d=\"snerg\" &&
+        ${KVSBASIC} put $DIR.e=true &&
 	${KVSBASIC} dir -r $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
@@ -199,7 +211,11 @@ EOF
 
 test_expect_success 'kvs: directory with multiple subdirs using dirat' '
 	${KVSBASIC} unlink $TEST &&
-	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} put $DIR.a=69
+        ${KVSBASIC} put $DIR.b.c.d.e.f.g=70 &&
+        ${KVSBASIC} put $DIR.c.a.b=3.14 &&
+        ${KVSBASIC} put $DIR.d=\"snerg\" &&
+        ${KVSBASIC} put $DIR.e=true &&
         DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
 	${KVSBASIC} dirat -r $DIRREF | sort >output &&
 	cat >expected <<EOF

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -217,7 +217,7 @@ test_expect_success 'kvs: directory with multiple subdirs using dirat' '
         ${KVSBASIC} put $DIR.d=\"snerg\" &&
         ${KVSBASIC} put $DIR.e=true &&
         DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
-	${KVSBASIC} dirat -r $DIRREF | sort >output &&
+	${KVSBASIC} dirat -r $DIRREF . | sort >output &&
 	cat >expected <<EOF
 a = 69
 b.c.d.e.f.g = 70
@@ -464,7 +464,7 @@ test_expect_success 'kvs: walk 16x3 directory tree' '
 test_expect_success 'kvs: unlink, walk 16x3 directory tree with dirat' '
 	DIRREF=$(${KVSBASIC} get-treeobj $TEST.dtree) &&
 	${KVSBASIC} unlink $TEST.dtree &&
-	test $(${KVSBASIC} dirat -r $DIRREF | wc -l) = 4096
+	test $(${KVSBASIC} dirat -r $DIRREF . | wc -l) = 4096
 '
 
 test_expect_success 'kvs: store 2x4 directory tree and walk' '

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -19,6 +19,7 @@ SIZE=$(test_size_large)
 test_under_flux ${SIZE} kvs
 echo "# $0: flux session size will be ${SIZE}"
 
+KVSBASIC=${FLUX_BUILD_DIR}/t/kvs/basic
 GETAS=${FLUX_BUILD_DIR}/t/kvs/getas
 
 TEST=$TEST_NAME
@@ -28,7 +29,7 @@ KEY=test.a.b.c
 #
 #
 test_kvs_key() {
-	flux kvs get "$1" >output
+	${KVSBASIC} get "$1" >output
 	echo "$2" >expected
 	test_cmp output expected
 	#if ! test "$OUTPUT" = "$2"; then
@@ -38,18 +39,18 @@ test_kvs_key() {
 }
 
 test_kvs_type () {
-	flux kvs type "$1" >output
+	${KVSBASIC} type "$1" >output
 	echo "$2" >expected
 	test_cmp output expected
 }
 
 test_expect_success 'kvs: get a nonexistent key' '
-	test_must_fail flux kvs get NOT.A.KEY
+	test_must_fail ${KVSBASIC} get NOT.A.KEY
 '
 
 
 test_expect_success 'kvs: integer put' '
-	flux kvs put $KEY=42 
+	${KVSBASIC} put $KEY=42 
 '
 test_expect_success 'kvs: integer type' '
 	test_kvs_type $KEY int
@@ -58,18 +59,18 @@ test_expect_success 'kvs: integer get' '
 	test_kvs_key $KEY 42
 '
 test_expect_success 'kvs: unlink works' '
-	flux kvs unlink $KEY &&
-	  test_must_fail flux kvs get $KEY
+	${KVSBASIC} unlink $KEY &&
+	  test_must_fail ${KVSBASIC} get $KEY
 '
 test_expect_success 'kvs: value can be empty' '
-	flux kvs put $KEY= &&
+	${KVSBASIC} put $KEY= &&
 	  test_kvs_key $KEY "" &&
 	  test_kvs_type $KEY string
 '
 KEY=$TEST.b.c.d
 DIR=$TEST.b.c
 test_expect_success 'kvs: string put' '
-	flux kvs put $KEY="Hello world"
+	${KVSBASIC} put $KEY="Hello world"
 '
 test_expect_success 'kvs: string type' '
 	test_kvs_type $KEY string
@@ -78,7 +79,7 @@ test_expect_success 'kvs: string get' '
 	test_kvs_key $KEY "Hello world"
 '
 test_expect_success 'kvs: boolean put (true)' '
-	flux kvs put $KEY=true
+	${KVSBASIC} put $KEY=true
 '
 test_expect_success 'kvs: boolean type' '
 	test_kvs_type $KEY boolean
@@ -87,7 +88,7 @@ test_expect_success 'kvs: boolean get (true)' '
 	test_kvs_key $KEY true
 '
 test_expect_success 'kvs: boolean put (false)' '
-	flux kvs put $KEY=false
+	${KVSBASIC} put $KEY=false
 '
 test_expect_success 'kvs: boolean type' '
 	test_kvs_type $KEY boolean
@@ -96,7 +97,7 @@ test_expect_success 'kvs: boolean get (false)' '
 	test_kvs_key $KEY false
 '
 test_expect_success 'kvs: put double' '
-	flux kvs put $KEY=3.14159
+	${KVSBASIC} put $KEY=3.14159
 '
 test_expect_success 'kvs: double type' '
 	test_kvs_type $KEY double
@@ -107,7 +108,7 @@ test_expect_success 'kvs: get double' '
 
 # issue 875
 test_expect_success 'kvs: integer can be read as int, int64, or double' '
-	flux kvs put $TEST.a=2 &&
+	${KVSBASIC} put $TEST.a=2 &&
 	test_kvs_type $TEST.a int &&
 	test $($GETAS -t int $TEST.a) = "2" &&
 	test $($GETAS -t int -d $TEST a) = "2" &&
@@ -117,7 +118,7 @@ test_expect_success 'kvs: integer can be read as int, int64, or double' '
 	test $($GETAS -t double -d $TEST a | cut -d. -f1) = "2"
 '
 test_expect_success 'kvs: array put' '
-	flux kvs put $KEY="[1,3,5,7]"
+	${KVSBASIC} put $KEY="[1,3,5,7]"
 '
 test_expect_success 'kvs: array type' '
 	test_kvs_type $KEY array
@@ -126,7 +127,7 @@ test_expect_success 'kvs: array get' '
 	test_kvs_key $KEY "[ 1, 3, 5, 7 ]"
 '
 test_expect_success 'kvs: object put' '
-	flux kvs put $KEY="{\"a\":42}"
+	${KVSBASIC} put $KEY="{\"a\":42}"
 '
 test_expect_success 'kvs: object type' '
 	test_kvs_type $KEY object
@@ -135,30 +136,30 @@ test_expect_success 'kvs: object get' '
 	test_kvs_key $KEY "{ \"a\": 42 }"
 '
 test_expect_success 'kvs: try to retrieve key as directory should fail' '
-	test_must_fail flux kvs dir $KEY
+	test_must_fail ${KVSBASIC} dir $KEY
 '
 test_expect_success 'kvs: try to retrieve a directory as key should fail' '
-	test_must_fail flux kvs get $DIR
+	test_must_fail ${KVSBASIC} get $DIR
 '
 
 test_empty_directory() {
-	OUTPUT=`flux kvs dirsize $1` &&
+	OUTPUT=`${KVSBASIC} dirsize $1` &&
 	test "x$OUTPUT" = "x0"
 }
 test_expect_success 'kvs: empty directory remains after key removed' '
-	flux kvs unlink $KEY &&
+	${KVSBASIC} unlink $KEY &&
 	test_empty_directory $DIR
 '
 test_expect_success 'kvs: remove directory' '
-	flux kvs unlink $TEST
+	${KVSBASIC} unlink $TEST
 '
 test_expect_success 'kvs: empty directory can be created' '
-	flux kvs mkdir $DIR  &&
+	${KVSBASIC} mkdir $DIR  &&
 	test_empty_directory $DIR
 '
 test_expect_success 'kvs: put values in a directory then retrieve them' '
-	flux kvs put $DIR.a=69 $DIR.b=70 $DIR.c=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir $DIR | sort >output &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b=70 $DIR.c=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} dir $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
 $DIR.b = 70
@@ -169,9 +170,9 @@ EOF
 	test_cmp expected output
 '
 test_expect_success 'kvs: create a dir with keys and subdir' '
-	flux kvs unlink $TEST &&
-	flux kvs put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir -r $DIR | sort >output &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} dir -r $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
 $DIR.b = 70
@@ -183,9 +184,9 @@ EOF
 '
 
 test_expect_success 'kvs: create a dir with keys and subdir, do not output values' '
-	flux kvs unlink $TEST &&
-	flux kvs put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir -r -d $DIR | sort >output &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} dir -r -d $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a
 $DIR.b
@@ -197,9 +198,9 @@ EOF
 '
 
 test_expect_success 'kvs: directory with multiple subdirs' '
-	flux kvs unlink $TEST &&
-	flux kvs put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir -r $DIR | sort >output &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} dir -r $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a = 69
 $DIR.b.c.d.e.f.g = 70
@@ -211,9 +212,9 @@ EOF
 '
 
 test_expect_success 'kvs: directory with multiple subdirs, do not output values' '
-	flux kvs unlink $TEST &&
-	flux kvs put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	flux kvs dir -r -d $DIR | sort >output &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+	${KVSBASIC} dir -r -d $DIR | sort >output &&
 	cat >expected <<EOF
 $DIR.a
 $DIR.b.c.d.e.f.g
@@ -225,10 +226,10 @@ EOF
 '
 
 test_expect_success 'kvs: directory with multiple subdirs using dirat' '
-	flux kvs unlink $TEST &&
-	flux kvs put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-        DIRREF=$(flux kvs get-treeobj $DIR) &&
-	flux kvs dirat -r $DIRREF | sort >output &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+        DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
+	${KVSBASIC} dirat -r $DIRREF | sort >output &&
 	cat >expected <<EOF
 a = 69
 b.c.d.e.f.g = 70
@@ -240,10 +241,10 @@ EOF
 '
 
 test_expect_success 'kvs: directory with multiple subdirs using dirat, do not output values' '
-	flux kvs unlink $TEST &&
-	flux kvs put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-        DIRREF=$(flux kvs get-treeobj $DIR) &&
-	flux kvs dirat -r -d $DIRREF | sort >output &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
+        DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
+	${KVSBASIC} dirat -r -d $DIRREF | sort >output &&
 	cat >expected <<EOF
 a
 b.c.d.e.f.g
@@ -255,227 +256,227 @@ EOF
 '
 
 test_expect_success 'kvs: cleanup' '
-	flux kvs unlink $TEST
+	${KVSBASIC} unlink $TEST
 '
 test_expect_success 'kvs: dropcache works' '
-	flux kvs dropcache
+	${KVSBASIC} dropcache
 '
 test_expect_success 'kvs: dropcache-all works' '
-	flux kvs dropcache-all
+	${KVSBASIC} dropcache-all
 '
 test_expect_success 'kvs: symlink: works' '
 	TARGET=$TEST.a.b.c &&
-	flux kvs put $TARGET=\"foo\" &&
-	flux kvs link $TARGET $TEST.Q &&
-	OUTPUT=$(flux kvs get $TEST.Q) &&
+	${KVSBASIC} put $TARGET=\"foo\" &&
+	${KVSBASIC} link $TARGET $TEST.Q &&
+	OUTPUT=$(${KVSBASIC} get $TEST.Q) &&
 	test "$OUTPUT" = "foo"
 '
 test_expect_success 'kvs: symlink: readlink fails on regular value' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
-	! flux kvs readlink $TEST.a.b.c
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c=42 &&
+	! ${KVSBASIC} readlink $TEST.a.b.c
 '
 test_expect_success 'kvs: symlink: readlink fails on directory' '
-	flux kvs unlink $TEST &&
-	flux kvs mkdir $TEST.a.b.c &&
-	! flux kvs readlink $TEST.a.b.
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} mkdir $TEST.a.b.c &&
+	! ${KVSBASIC} readlink $TEST.a.b.
 '
 test_expect_success 'kvs: symlink: path resolution when intermediate component is a symlink' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
-	flux kvs link $TEST.a.b $TEST.Z.Y &&
-	OUTPUT=$(flux kvs get $TEST.Z.Y.c) &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c=42 &&
+	${KVSBASIC} link $TEST.a.b $TEST.Z.Y &&
+	OUTPUT=$(${KVSBASIC} get $TEST.Z.Y.c) &&
 	test "$OUTPUT" = "42"
 '
 test_expect_success 'kvs: symlink: path resolution with intermediate symlink and nonexistent key' '
-	flux kvs unlink $TEST &&
-	flux kvs link $TEST.a.b $TEST.Z.Y &&
-	test_must_fail flux kvs get $TEST.Z.Y
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} link $TEST.a.b $TEST.Z.Y &&
+	test_must_fail ${KVSBASIC} get $TEST.Z.Y
 '
 test_expect_success 'kvs: symlink: intermediate symlink points to another symlink' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
-	flux kvs link $TEST.a.b $TEST.Z.Y &&
-	flux kvs link $TEST.Z.Y $TEST.X.W &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c=42 &&
+	${KVSBASIC} link $TEST.a.b $TEST.Z.Y &&
+	${KVSBASIC} link $TEST.Z.Y $TEST.X.W &&
 	test_kvs_key $TEST.X.W.c 42
 '
 test_expect_success 'kvs: symlink: intermediate symlinks are followed by put' '
-	flux kvs unlink $TEST &&
-	flux kvs mkdir $TEST.a &&
-	flux kvs link $TEST.a $TEST.link &&
-	flux kvs readlink $TEST.link >/dev/null &&
-	flux kvs put $TEST.link.X=42 &&
-	flux kvs readlink $TEST.link >/dev/null &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} mkdir $TEST.a &&
+	${KVSBASIC} link $TEST.a $TEST.link &&
+	${KVSBASIC} readlink $TEST.link >/dev/null &&
+	${KVSBASIC} put $TEST.link.X=42 &&
+	${KVSBASIC} readlink $TEST.link >/dev/null &&
 	test_kvs_key $TEST.link.X 42 &&
 	test_kvs_key $TEST.a.X 42
 '
 
 # This will fail if individual ops are applied out of order
 test_expect_success 'kvs: symlink: kvs_copy removes symlinked destination' '
-	flux kvs unlink $TEST &&
-	flux kvs mkdir $TEST.a &&
-	flux kvs link $TEST.a $TEST.link &&
-	flux kvs put $TEST.a.X=42 &&
-	flux kvs copy $TEST.a $TEST.link &&
-	! flux kvs readlink $TEST.link >/dev/null &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} mkdir $TEST.a &&
+	${KVSBASIC} link $TEST.a $TEST.link &&
+	${KVSBASIC} put $TEST.a.X=42 &&
+	${KVSBASIC} copy $TEST.a $TEST.link &&
+	! ${KVSBASIC} readlink $TEST.link >/dev/null &&
 	test_kvs_key $TEST.link.X 42
 '
 
 # This will fail if individual ops are applied out of order
 test_expect_success 'kvs: symlink: kvs_move works' '
-	flux kvs unlink $TEST &&
-	flux kvs mkdir $TEST.a &&
-	flux kvs link $TEST.a $TEST.link &&
-	flux kvs put $TEST.a.X=42 &&
-	flux kvs move $TEST.a $TEST.link &&
-	! flux kvs readlink $TEST.link >/dev/null &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} mkdir $TEST.a &&
+	${KVSBASIC} link $TEST.a $TEST.link &&
+	${KVSBASIC} put $TEST.a.X=42 &&
+	${KVSBASIC} move $TEST.a $TEST.link &&
+	! ${KVSBASIC} readlink $TEST.link >/dev/null &&
 	test_kvs_key $TEST.link.X 42 &&
-	! flux kvs dir $TEST.a >/dev/null
+	! ${KVSBASIC} dir $TEST.a >/dev/null
 '
 
 test_expect_success 'kvs: symlink: kvs_copy does not follow symlinks (top)' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.X=42 &&
-	flux kvs link $TEST.a $TEST.link &&
-	flux kvs copy $TEST.link $TEST.copy &&
-	LINKVAL=$(flux kvs readlink $TEST.copy) &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.X=42 &&
+	${KVSBASIC} link $TEST.a $TEST.link &&
+	${KVSBASIC} copy $TEST.link $TEST.copy &&
+	LINKVAL=$(${KVSBASIC} readlink $TEST.copy) &&
 	test "$LINKVAL" = "$TEST.a"
 '
 
 test_expect_success 'kvs: symlink: kvs_copy does not follow symlinks (mid)' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.X=42 &&
-	flux kvs link $TEST.a.b $TEST.a.link &&
-	flux kvs copy $TEST.a $TEST.copy &&
-	LINKVAL=$(flux kvs readlink $TEST.copy.link) &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.X=42 &&
+	${KVSBASIC} link $TEST.a.b $TEST.a.link &&
+	${KVSBASIC} copy $TEST.a $TEST.copy &&
+	LINKVAL=$(${KVSBASIC} readlink $TEST.copy.link) &&
 	test "$LINKVAL" = "$TEST.a.b"
 '
 
 test_expect_success 'kvs: symlink: kvs_copy does not follow symlinks (bottom)' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.X=42 &&
-	flux kvs link $TEST.a.b.X $TEST.a.b.link &&
-	flux kvs copy $TEST.a $TEST.copy &&
-	LINKVAL=$(flux kvs readlink $TEST.copy.b.link) &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.X=42 &&
+	${KVSBASIC} link $TEST.a.b.X $TEST.a.b.link &&
+	${KVSBASIC} copy $TEST.a $TEST.copy &&
+	LINKVAL=$(${KVSBASIC} readlink $TEST.copy.b.link) &&
 	test "$LINKVAL" = "$TEST.a.b.X"
 '
 
 test_expect_success 'kvs: get_symlinkat works after symlink unlinked' '
-	flux kvs unlink $TEST &&
-	flux kvs link $TEST.a.b.X $TEST.a.b.link &&
-	ROOTREF=$(flux kvs get-treeobj .) &&
-	flux kvs unlink $TEST &&
-	LINKVAL=$(flux kvs readlinkat $ROOTREF $TEST.a.b.link) &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} link $TEST.a.b.X $TEST.a.b.link &&
+	ROOTREF=$(${KVSBASIC} get-treeobj .) &&
+	${KVSBASIC} unlink $TEST &&
+	LINKVAL=$(${KVSBASIC} readlinkat $ROOTREF $TEST.a.b.link) &&
 	test "$LINKVAL" = "$TEST.a.b.X"
 '
 
 test_expect_success 'kvs: get-treeobj: returns directory reference for root' '
-	flux kvs unlink $TEST &&
-	flux kvs get-treeobj . | grep -q "DIRREF"
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} get-treeobj . | grep -q "DIRREF"
 '
 
 test_expect_success 'kvs: get-treeobj: returns directory reference for directory' '
-	flux kvs unlink $TEST &&
-	flux kvs mkdir $TEST.a &&
-	flux kvs get-treeobj $TEST.a | grep -q "DIRREF"
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} mkdir $TEST.a &&
+	${KVSBASIC} get-treeobj $TEST.a | grep -q "DIRREF"
 '
 
 test_expect_success 'kvs: get-treeobj: returns value for small value' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a=b &&
-	flux kvs get-treeobj $TEST.a | grep -q "FILEVAL"
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a=b &&
+	${KVSBASIC} get-treeobj $TEST.a | grep -q "FILEVAL"
 '
 
 test_expect_success 'kvs: get-treeobj: returns value ref for large value' '
-	flux kvs unlink $TEST &&
-	dd if=/dev/zero bs=4096 count=1 | flux kvs copy-tokvs $TEST.a - &&
-	flux kvs get-treeobj $TEST.a | grep -q "FILEREF"
+	${KVSBASIC} unlink $TEST &&
+	dd if=/dev/zero bs=4096 count=1 | ${KVSBASIC} copy-tokvs $TEST.a - &&
+	${KVSBASIC} get-treeobj $TEST.a | grep -q "FILEREF"
 '
 
 test_expect_success 'kvs: get-treeobj: returns link value for symlink' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.X=42 &&
-	flux kvs link $TEST.a.b.X $TEST.a.b.link &&
-	flux kvs get-treeobj $TEST.a.b.link | grep -q LINKVAL
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.X=42 &&
+	${KVSBASIC} link $TEST.a.b.X $TEST.a.b.link &&
+	${KVSBASIC} get-treeobj $TEST.a.b.link | grep -q LINKVAL
 '
 
 test_expect_success 'kvs: put-treeobj: can make root snapshot' '
-	flux kvs unlink $TEST &&
-	flux kvs get-treeobj . >snapshot &&
-	flux kvs put-treeobj $TEST.snap="`cat snapshot`" &&
-	flux kvs get-treeobj $TEST.snap >snapshot.cpy
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} get-treeobj . >snapshot &&
+	${KVSBASIC} put-treeobj $TEST.snap="`cat snapshot`" &&
+	${KVSBASIC} get-treeobj $TEST.snap >snapshot.cpy
 	test_cmp snapshot snapshot.cpy
 '
 
 test_expect_success 'kvs: put-treeobj: clobbers destination' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a=42 &&
-	flux kvs get-treeobj . >snapshot2 &&
-	flux kvs put-treeobj $TEST.a="`cat snapshot2`" &&
-	! flux kvs get $TEST.a &&
-	flux kvs dir $TEST.a
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a=42 &&
+	${KVSBASIC} get-treeobj . >snapshot2 &&
+	${KVSBASIC} put-treeobj $TEST.a="`cat snapshot2`" &&
+	! ${KVSBASIC} get $TEST.a &&
+	${KVSBASIC} dir $TEST.a
 '
 
 test_expect_success 'kvs: put-treeobj: fails bad dirent: not JSON' '
-	flux kvs unlink $TEST &&
-	test_must_fail flux kvs put-treeobj $TEST.a=xyz
+	${KVSBASIC} unlink $TEST &&
+	test_must_fail ${KVSBASIC} put-treeobj $TEST.a=xyz
 '
 
 test_expect_success 'kvs: put-treeobj: fails bad dirent: unknown type' '
-	flux kvs unlink $TEST &&
-	test_must_fail flux kvs put-treeobj $TEST.a="{\"ERSTWHILE\":\"fubar\"}"
+	${KVSBASIC} unlink $TEST &&
+	test_must_fail ${KVSBASIC} put-treeobj $TEST.a="{\"ERSTWHILE\":\"fubar\"}"
 '
 
 test_expect_success 'kvs: put-treeobj: fails bad dirent: bad link type' '
-	flux kvs unlink $TEST &&
-	test_must_fail flux kvs put-treeobj $TEST.a="{\"LINKVAL\":42}"
+	${KVSBASIC} unlink $TEST &&
+	test_must_fail ${KVSBASIC} put-treeobj $TEST.a="{\"LINKVAL\":42}"
 '
 
 test_expect_success 'kvs: put-treeobj: fails bad dirent: bad ref type' '
-	flux kvs unlink $TEST &&
-	test_must_fail flux kvs put-treeobj $TEST.a="{\"DIRREF\":{}}"
+	${KVSBASIC} unlink $TEST &&
+	test_must_fail ${KVSBASIC} put-treeobj $TEST.a="{\"DIRREF\":{}}"
 '
 
 test_expect_success 'kvs: put-treeobj: fails bad dirent: bad blobref' '
-	flux kvs unlink $TEST &&
-	test_must_fail flux kvs put-treeobj $TEST.a="{\"DIRREF\":\"sha2-aaa\"}" &&
-	test_must_fail flux kvs put-treeobj $TEST.a="{\"DIRREF\":\"sha1-bbb\"}"
+	${KVSBASIC} unlink $TEST &&
+	test_must_fail ${KVSBASIC} put-treeobj $TEST.a="{\"DIRREF\":\"sha2-aaa\"}" &&
+	test_must_fail ${KVSBASIC} put-treeobj $TEST.a="{\"DIRREF\":\"sha1-bbb\"}"
 '
 
 test_expect_success 'kvs: getat: fails bad on dirent' '
-	flux kvs unlink $TEST &&
-	test_must_fail flux kvs getat 42 $TEST.a &&
-	test_must_fail flux kvs getat "{\"DIRREF\":\"sha2-aaa\"}" $TEST.a &&
-	test_must_fail flux kvs getat "{\"DIRREF\":\"sha1-bbb\"}" $TEST.a &&
-	test_must_fail flux kvs getat "{\"DIRVAL\":{}}" $TEST.a
+	${KVSBASIC} unlink $TEST &&
+	test_must_fail ${KVSBASIC} getat 42 $TEST.a &&
+	test_must_fail ${KVSBASIC} getat "{\"DIRREF\":\"sha2-aaa\"}" $TEST.a &&
+	test_must_fail ${KVSBASIC} getat "{\"DIRREF\":\"sha1-bbb\"}" $TEST.a &&
+	test_must_fail ${KVSBASIC} getat "{\"DIRVAL\":{}}" $TEST.a
 '
 
 test_expect_success 'kvs: getat: works on root from get-treeobj' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
-	test $(flux kvs getat $(flux kvs get-treeobj .) $TEST.a.b.c) = 42
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c=42 &&
+	test $(${KVSBASIC} getat $(${KVSBASIC} get-treeobj .) $TEST.a.b.c) = 42
 '
 
 test_expect_success 'kvs: getat: works on subdir from get-treeobj' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
-	test $(flux kvs getat $(flux kvs get-treeobj $TEST.a.b) c) = 42
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c=42 &&
+	test $(${KVSBASIC} getat $(${KVSBASIC} get-treeobj $TEST.a.b) c) = 42
 '
 
 test_expect_success 'kvs: getat: works on outdated root' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
-	ROOTREF=$(flux kvs get-treeobj .) &&
-	flux kvs put $TEST.a.b.c=43 &&
-	test $(flux kvs getat $ROOTREF $TEST.a.b.c) = 42
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c=42 &&
+	ROOTREF=$(${KVSBASIC} get-treeobj .) &&
+	${KVSBASIC} put $TEST.a.b.c=43 &&
+	test $(${KVSBASIC} getat $ROOTREF $TEST.a.b.c) = 42
 '
 
 test_expect_success 'kvs: kvsdir_get_size works' '
-	flux kvs mkdir $TEST.dirsize &&
-	flux kvs put $TEST.dirsize.a=1 &&
-	flux kvs put $TEST.dirsize.b=2 &&
-	flux kvs put $TEST.dirsize.c=3 &&
-	OUTPUT=$(flux kvs dirsize $TEST.dirsize) &&
+	${KVSBASIC} mkdir $TEST.dirsize &&
+	${KVSBASIC} put $TEST.dirsize.a=1 &&
+	${KVSBASIC} put $TEST.dirsize.b=2 &&
+	${KVSBASIC} put $TEST.dirsize.c=3 &&
+	OUTPUT=$(${KVSBASIC} dirsize $TEST.dirsize) &&
 	test "$OUTPUT" = "3"
 '
 
@@ -484,67 +485,67 @@ test_expect_success 'kvs: store 16x3 directory tree' '
 '
 
 test_expect_success 'kvs: walk 16x3 directory tree' '
-	test $(flux kvs dir -r $TEST.dtree | wc -l) = 4096
+	test $(${KVSBASIC} dir -r $TEST.dtree | wc -l) = 4096
 '
 
 test_expect_success 'kvs: unlink, walk 16x3 directory tree with dirat' '
-	DIRREF=$(flux kvs get-treeobj $TEST.dtree) &&
-	flux kvs unlink $TEST.dtree &&
-	test $(flux kvs dirat -r $DIRREF | wc -l) = 4096
+	DIRREF=$(${KVSBASIC} get-treeobj $TEST.dtree) &&
+	${KVSBASIC} unlink $TEST.dtree &&
+	test $(${KVSBASIC} dirat -r $DIRREF | wc -l) = 4096
 '
 
 test_expect_success 'kvs: store 2x4 directory tree and walk' '
 	${FLUX_BUILD_DIR}/t/kvs/dtree -h4 -w2 --prefix $TEST.dtree
-	test $(flux kvs dir -r $TEST.dtree | wc -l) = 16
+	test $(${KVSBASIC} dir -r $TEST.dtree | wc -l) = 16
 '
 
 # exercise kvsdir_get_symlink, _double, _boolean, 
 test_expect_success 'kvs: add other types to 2x4 directory and walk' '
-	flux kvs link $TEST.dtree $TEST.dtree.link &&
-	flux kvs put $TEST.dtree.double=3.14 &&
-	flux kvs put $TEST.dtree.booelan=true &&
-	test $(flux kvs dir -r $TEST.dtree | wc -l) = 19
+	${KVSBASIC} link $TEST.dtree $TEST.dtree.link &&
+	${KVSBASIC} put $TEST.dtree.double=3.14 &&
+	${KVSBASIC} put $TEST.dtree.booelan=true &&
+	test $(${KVSBASIC} dir -r $TEST.dtree | wc -l) = 19
 '
 
 test_expect_success 'kvs: store 3x4 directory tree using kvsdir_put functions' '
-	flux kvs unlink $TEST.dtree &&
+	${KVSBASIC} unlink $TEST.dtree &&
 	${FLUX_BUILD_DIR}/t/kvs/dtree --mkdir -h4 -w3 --prefix $TEST.dtree &&
-	test $(flux kvs dir -r $TEST.dtree | wc -l) = 81
+	test $(${KVSBASIC} dir -r $TEST.dtree | wc -l) = 81
 '
 
 test_expect_success 'kvs: put key of . fails' '
-	test_must_fail flux kvs put .=1
+	test_must_fail ${KVSBASIC} put .=1
 '
 
 # Keep the next two tests in order
 test_expect_success 'kvs: symlink: dangling link' '
-	flux kvs unlink $TEST &&
-	flux kvs link $TEST.dangle $TEST.a.b.c
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} link $TEST.dangle $TEST.a.b.c
 '
 test_expect_success 'kvs: symlink: readlink on dangling link' '
-	OUTPUT=$(flux kvs readlink $TEST.a.b.c) &&
+	OUTPUT=$(${KVSBASIC} readlink $TEST.a.b.c) &&
 	test "$OUTPUT" = "$TEST.dangle"
 '
 test_expect_success 'kvs: symlink: readlink works on non-dangling link' '
-	flux kvs unlink $TEST &&
-	flux kvs put $TEST.a.b.c="foo" &&
-	flux kvs link $TEST.a.b.c $TEST.link &&
-	OUTPUT=$(flux kvs readlink $TEST.link) &&
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put $TEST.a.b.c="foo" &&
+	${KVSBASIC} link $TEST.a.b.c $TEST.link &&
+	OUTPUT=$(${KVSBASIC} readlink $TEST.link) &&
 	test "$OUTPUT" = "$TEST.a.b.c"
 '
 
 # test synchronization based on commit sequence no.
 
 test_expect_success 'kvs: put on rank 0, exists on all ranks' '
-	flux kvs put $TEST.xxx=99 &&
-	VERS=$(flux kvs version) &&
-	flux exec sh -c "flux kvs wait ${VERS} && flux kvs exists $TEST.xxx"
+	${KVSBASIC} put $TEST.xxx=99 &&
+	VERS=$(${KVSBASIC} version) &&
+	flux exec sh -c "${KVSBASIC} wait ${VERS} && ${KVSBASIC} exists $TEST.xxx"
 '
 
 test_expect_success 'kvs: unlink on rank 0, does not exist all ranks' '
-	flux kvs unlink $TEST.xxx &&
-	VERS=$(flux kvs version) &&
-	flux exec sh -c "flux kvs wait ${VERS} && ! flux kvs exists $TEST.xxx"
+	${KVSBASIC} unlink $TEST.xxx &&
+	VERS=$(${KVSBASIC} version) &&
+	flux exec sh -c "${KVSBASIC} wait ${VERS} && ! ${KVSBASIC} exists $TEST.xxx"
 '
 
 # commit test
@@ -567,53 +568,53 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 # watch tests
 
 test_expect_success 'kvs: watch 5 versions of key'  '
-	flux kvs unlink $TEST.foo &&
-        flux kvs put $TEST.a.b.c=1 &&
-	flux kvs watch 5 $TEST.foo.a >watch_out &
+	${KVSBASIC} unlink $TEST.foo &&
+        ${KVSBASIC} put $TEST.a.b.c=1 &&
+	${KVSBASIC} watch 5 $TEST.foo.a >watch_out &
         for i in $(seq 2 5); do
-            flux kvs put $TEST.foo.a=${i}
+            ${KVSBASIC} put $TEST.foo.a=${i}
         done
 '
 
 test_expect_success 'kvs: watch 5 versions of directory'  '
-	flux kvs unlink $TEST.foo &&
-	flux kvs watch-dir -r 5 $TEST.foo >watch_dir_out &
+	${KVSBASIC} unlink $TEST.foo &&
+	${KVSBASIC} watch-dir -r 5 $TEST.foo >watch_dir_out &
 	while $(grep -s '===============' watch_dir_out | wc -l) -lt 5; do
-	    flux kvs put $TEST.foo.a=$(date +%N); \
+	    ${KVSBASIC} put $TEST.foo.a=$(date +%N); \
 	done
 '
 
 test_expect_success 'kvs: watch 5 versions of directory, do not output values'  '
-	flux kvs unlink $TEST.foo &&
-	flux kvs watch-dir -r -d 5 $TEST.foo >watch_dir_out &
+	${KVSBASIC} unlink $TEST.foo &&
+	${KVSBASIC} watch-dir -r -d 5 $TEST.foo >watch_dir_out &
 	while $(grep -s '===============' watch_dir_out | wc -l) -lt 5; do
-	    flux kvs put $TEST.foo.a=$(date +%N); \
+	    ${KVSBASIC} put $TEST.foo.a=$(date +%N); \
 	done
 '
 
 test_expect_success 'kvs: watch-mt: multi-threaded kvs watch program' '
 	${FLUX_BUILD_DIR}/t/kvs/watch mt 100 100 $TEST.a &&
-	flux kvs unlink $TEST.a
+	${KVSBASIC} unlink $TEST.a
 '
 
 test_expect_success 'kvs: watch-selfmod: watch callback modifies watched key' '
 	${FLUX_BUILD_DIR}/t/kvs/watch selfmod $TEST.a &&
-	flux kvs unlink $TEST.a
+	${KVSBASIC} unlink $TEST.a
 '
 
 test_expect_success 'kvs: watch-unwatch unwatch works' '
 	${FLUX_BUILD_DIR}/t/kvs/watch unwatch $TEST.a &&
-	flux kvs unlink $TEST.a
+	${KVSBASIC} unlink $TEST.a
 '
 
 test_expect_success 'kvs: watch-unwatchloop 1000 watch/unwatch ok' '
 	${FLUX_BUILD_DIR}/t/kvs/watch unwatchloop $TEST.a &&
-	flux kvs unlink $TEST.a
+	${KVSBASIC} unlink $TEST.a
 '
 
 test_expect_success 'kvs: 8192 simultaneous watches works' '
 	${FLUX_BUILD_DIR}/t/kvs/watch simulwatch $TEST.a 8192 &&
-	flux kvs unlink $TEST.a
+	${KVSBASIC} unlink $TEST.a
 '
 
 
@@ -640,10 +641,10 @@ test_expect_success 'kvs: async kvs_fence allows puts with fence in progress' '
 
 # base64 data
 test_expect_success 'kvs: copy-tokvs and copy-fromkvs work' '
-	flux kvs unlink $TEST &&
+	${KVSBASIC} unlink $TEST &&
 	dd if=/dev/urandom bs=4096 count=1 >random.data &&
-	flux kvs copy-tokvs $TEST.data random.data &&
-	flux kvs copy-fromkvs $TEST.data reread.data &&
+	${KVSBASIC} copy-tokvs $TEST.data random.data &&
+	${KVSBASIC} copy-fromkvs $TEST.data reread.data &&
 	test_cmp random.data reread.data
 '
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -542,7 +542,7 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 
 test_expect_success 'kvs: watch 5 versions of key'  '
 	${KVSBASIC} unlink $TEST.foo &&
-        ${KVSBASIC} put $TEST.a.b.c=1 &&
+        ${KVSBASIC} put $TEST.foo.a=1 &&
 	${KVSBASIC} watch 5 $TEST.foo.a >watch_out &
         for i in $(seq 2 5); do
             ${KVSBASIC} put $TEST.foo.a=${i}

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -183,20 +183,6 @@ EOF
 	test_cmp expected output
 '
 
-test_expect_success 'kvs: create a dir with keys and subdir, do not output values' '
-	${KVSBASIC} unlink $TEST &&
-	${KVSBASIC} put $DIR.a=69 $DIR.b=70 $DIR.c.d.e.f.g=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	${KVSBASIC} dir -r -d $DIR | sort >output &&
-	cat >expected <<EOF
-$DIR.a
-$DIR.b
-$DIR.c.d.e.f.g
-$DIR.d
-$DIR.e
-EOF
-	test_cmp expected output
-'
-
 test_expect_success 'kvs: directory with multiple subdirs' '
 	${KVSBASIC} unlink $TEST &&
 	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
@@ -207,20 +193,6 @@ $DIR.b.c.d.e.f.g = 70
 $DIR.c.a.b = 3.140000
 $DIR.d = snerg
 $DIR.e = true
-EOF
-	test_cmp expected output
-'
-
-test_expect_success 'kvs: directory with multiple subdirs, do not output values' '
-	${KVSBASIC} unlink $TEST &&
-	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-	${KVSBASIC} dir -r -d $DIR | sort >output &&
-	cat >expected <<EOF
-$DIR.a
-$DIR.b.c.d.e.f.g
-$DIR.c.a.b
-$DIR.d
-$DIR.e
 EOF
 	test_cmp expected output
 '
@@ -236,21 +208,6 @@ b.c.d.e.f.g = 70
 c.a.b = 3.140000
 d = snerg
 e = true
-EOF
-	test_cmp expected output
-'
-
-test_expect_success 'kvs: directory with multiple subdirs using dirat, do not output values' '
-	${KVSBASIC} unlink $TEST &&
-	${KVSBASIC} put $DIR.a=69 $DIR.b.c.d.e.f.g=70 $DIR.c.a.b=3.14 $DIR.d=\"snerg\" $DIR.e=true &&
-        DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
-	${KVSBASIC} dirat -r -d $DIRREF | sort >output &&
-	cat >expected <<EOF
-a
-b.c.d.e.f.g
-c.a.b
-d
-e
 EOF
 	test_cmp expected output
 '
@@ -579,14 +536,6 @@ test_expect_success 'kvs: watch 5 versions of key'  '
 test_expect_success 'kvs: watch 5 versions of directory'  '
 	${KVSBASIC} unlink $TEST.foo &&
 	${KVSBASIC} watch-dir -r 5 $TEST.foo >watch_dir_out &
-	while $(grep -s '===============' watch_dir_out | wc -l) -lt 5; do
-	    ${KVSBASIC} put $TEST.foo.a=$(date +%N); \
-	done
-'
-
-test_expect_success 'kvs: watch 5 versions of directory, do not output values'  '
-	${KVSBASIC} unlink $TEST.foo &&
-	${KVSBASIC} watch-dir -r -d 5 $TEST.foo >watch_dir_out &
 	while $(grep -s '===============' watch_dir_out | wc -l) -lt 5; do
 	    ${KVSBASIC} put $TEST.foo.a=$(date +%N); \
 	done

--- a/t/t1002-kvs-cmd.t
+++ b/t/t1002-kvs-cmd.t
@@ -1,0 +1,594 @@
+#!/bin/sh
+#
+
+test_description='Test flux-kvs usage in flux session
+
+This differs from basic KVS tests as it tests the flux-kvs command
+line interface to KVS and not necessarily the KVS functionality.  Some
+tests may be identical.
+'
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE} kvs
+echo "# $0: flux session size will be ${SIZE}"
+
+DIR=test.a.b
+KEY=test.a.b.c
+SUBDIR1=test.a.b.d
+SUBDIR2=test.a.b.e
+
+test_kvs_key() {
+	flux kvs get "$1" >output
+	echo "$2" >expected
+	test_cmp output expected
+}
+
+#
+# Basic put, get, mkdir, dir, unlink tests
+#
+
+test_expect_success 'kvs: integer put' '
+	flux kvs put $KEY.integer=42
+'
+test_expect_success 'kvs: double put' '
+	flux kvs put $KEY.double=3.14
+'
+test_expect_success 'kvs: string put' '
+	flux kvs put $KEY.string=foo
+'
+test_expect_success 'kvs: boolean put' '
+	flux kvs put $KEY.boolean=true
+'
+test_expect_success 'kvs: array put' '
+	flux kvs put $KEY.array="[1,3,5]"
+'
+test_expect_success 'kvs: object put' '
+	flux kvs put $KEY.object="{\"a\":42}"
+'
+test_expect_success 'kvs: mkdir' '
+	flux kvs mkdir $SUBDIR1
+'
+test_expect_success 'kvs: integer get' '
+	test_kvs_key $KEY.integer 42
+'
+test_expect_success 'kvs: double get' '
+	test_kvs_key $KEY.double 3.140000
+'
+test_expect_success 'kvs: string get' '
+	test_kvs_key $KEY.string foo
+'
+test_expect_success 'kvs: boolean get' '
+	test_kvs_key $KEY.boolean true
+'
+test_expect_success 'kvs: array get' '
+	test_kvs_key $KEY.array "[ 1, 3, 5 ]"
+'
+test_expect_success 'kvs: object get' '
+	test_kvs_key $KEY.object "{ \"a\": 42 }"
+'
+test_expect_success 'kvs: dir' '
+	flux kvs dir $DIR | sort >output
+	cat >expected <<EOF
+$DIR.c.
+$DIR.d.
+EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: dir -R' '
+	flux kvs dir -R $DIR | sort >output
+	cat >expected <<EOF
+$KEY.array = [ 1, 3, 5 ]
+$KEY.boolean = true
+$KEY.double = 3.140000
+$KEY.integer = 42
+$KEY.object = { "a": 42 }
+$KEY.string = foo
+EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: dir -R -d' '
+	flux kvs dir -R -d $DIR | sort >output
+	cat >expected <<EOF
+$KEY.array
+$KEY.boolean
+$KEY.double
+$KEY.integer
+$KEY.object
+$KEY.string
+EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: unlink works' '
+	flux kvs unlink $KEY.integer &&
+	  test_must_fail flux kvs get $KEY.integer
+'
+test_expect_success 'kvs: unlink works' '
+	flux kvs unlink $KEY.double &&
+	  test_must_fail flux kvs get $KEY.double
+'
+test_expect_success 'kvs: unlink works' '
+	flux kvs unlink $KEY.string &&
+	  test_must_fail flux kvs get $KEY.string
+'
+test_expect_success 'kvs: unlink works' '
+	flux kvs unlink $KEY.boolean &&
+	  test_must_fail flux kvs get $KEY.boolean
+'
+test_expect_success 'kvs: unlink works' '
+	flux kvs unlink $KEY.array &&
+	  test_must_fail flux kvs get $KEY.array
+'
+test_expect_success 'kvs: unlink works' '
+	flux kvs unlink $KEY.object &&
+	  test_must_fail flux kvs get $KEY.object
+'
+test_expect_success 'kvs: unlink dir works' '
+        flux kvs unlink $SUBDIR1 &&
+          test_must_fail flux kvs dir $SUBDIR1
+'
+test_expect_success 'kvs: unlink -R works' '
+        flux kvs unlink -R $DIR &&
+          test_must_fail flux kvs dir $DIR
+'
+
+#
+# Basic put, get, mkdir, dir, unlink tests w/ multiple key inputs
+#
+
+test_expect_success 'kvs: put (multiple)' '
+	flux kvs put $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
+'
+test_expect_success 'kvs: get (multiple)' '
+	flux kvs get $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output
+	cat >expected <<EOF
+42
+3.140000
+foo
+true
+[ 1, 3, 5 ]
+{ "a": 42 }
+EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: mkdir (multiple)' '
+	flux kvs mkdir $SUBDIR1 $SUBDIR2
+'
+test_expect_success 'kvs: dir' '
+	flux kvs dir $DIR | sort >output
+	cat >expected <<EOF
+$DIR.c.
+$DIR.d.
+$DIR.e.
+EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: dir -R' '
+	flux kvs dir -R $DIR | sort >output
+	cat >expected <<EOF
+$KEY.a = 42
+$KEY.b = 3.140000
+$KEY.c = foo
+$KEY.d = true
+$KEY.e = [ 1, 3, 5 ]
+$KEY.f = { "a": 42 }
+EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: unlink (multiple)' '
+	flux kvs unlink $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f &&
+          test_must_fail flux kvs get $KEY.a &&
+          test_must_fail flux kvs get $KEY.b &&
+          test_must_fail flux kvs get $KEY.c &&
+          test_must_fail flux kvs get $KEY.d &&
+          test_must_fail flux kvs get $KEY.e &&
+          test_must_fail flux kvs get $KEY.f
+'
+test_expect_success 'kvs: unlink -R works' '
+        flux kvs unlink -R $DIR &&
+          test_must_fail flux kvs dir $DIR
+'
+
+#
+# get corner case tests
+#
+
+test_expect_success 'kvs: get a nonexistent key' '
+	test_must_fail flux kvs get NOT.A.KEY
+'
+test_expect_success 'kvs: try to retrieve a directory as key should fail' '
+        flux kvs mkdir $DIR.a.b.c
+	test_must_fail flux kvs get $DIR
+'
+
+#
+# put corner case tests
+#
+
+test_expect_success 'kvs: put with invalid input' '
+	test_must_fail flux kvs put NOVALUE
+'
+
+#
+# dir corner case tests
+#
+
+test_expect_success 'kvs: try to retrieve key as directory should fail' '
+        flux kvs put $DIR.a.b.c.d=42
+	test_must_fail flux kvs dir $DIR.a.b.c.d
+'
+
+#
+# unlink corner case tests
+#
+
+test_expect_success 'kvs: unlink nonexistent key fails' '
+        test_must_fail flux kvs unlink NOT.A.KEY
+'
+test_expect_success 'kvs: unlink non-empty dir fails' '
+        flux kvs mkdir $SUBDIR1 $SUBDIR2
+	test_must_fail flux kvs unlink $DIR
+'
+test_expect_success 'kvs: unlink -R works' '
+        flux kvs unlink -R $DIR &&
+          test_must_fail flux kvs dir $SUBDIR1 &&
+          test_must_fail flux kvs dir $SUBDIR2 &&
+          test_must_fail flux kvs dir $DIR
+'
+
+#
+# link/readlink tests
+#
+
+test_expect_success 'kvs: link works' '
+	TARGET=$DIR.target &&
+	flux kvs put $TARGET=\"foo\" &&
+	flux kvs link $TARGET $DIR.link &&
+	OUTPUT=$(flux kvs get $DIR.link) &&
+	test "$OUTPUT" = "foo"
+'
+test_expect_success 'kvs: readlink works' '
+	TARGET=$DIR.target &&
+	flux kvs put $TARGET=\"foo\" &&
+	flux kvs link $TARGET $DIR.link &&
+	OUTPUT=$(flux kvs readlink $DIR.link) &&
+	test "$OUTPUT" = "$TARGET"
+'
+test_expect_success 'kvs: readlink works (multiple inputs)' '
+	TARGET1=$DIR.target1 &&
+	TARGET2=$DIR.target2 &&
+	flux kvs put $TARGET1=\"foo1\" &&
+	flux kvs put $TARGET2=\"foo2\" &&
+	flux kvs link $TARGET1 $DIR.link1 &&
+	flux kvs link $TARGET2 $DIR.link2 &&
+	flux kvs readlink $DIR.link1 $DIR.link2 >output
+	cat >expected <<EOF
+$TARGET1
+$TARGET2
+EOF
+	test_cmp output expected
+'
+test_expect_success 'kvs: readlink fails on regular value' '
+        flux kvs unlink -R $DIR &&
+	flux kvs put $DIR.target=42 &&
+	! flux kvs readlink $DIR.target
+'
+test_expect_success 'kvs: readlink fails on directory' '
+        flux kvs unlink -R $DIR &&
+	flux kvs mkdir $DIR.a.b.c &&
+	! flux kvs readlink $DIR.a.b.
+'
+
+#
+# copy/move tests
+#
+test_expect_success 'kvs: copy works' '
+        flux kvs unlink -R $DIR &&
+	flux kvs put $DIR.src=\"foo\" &&
+        flux kvs copy $DIR.src $DIR.dest &&
+	OUTPUT1=$(flux kvs get $DIR.src) &&
+	OUTPUT2=$(flux kvs get $DIR.dest) &&
+	test "$OUTPUT1" = "foo"
+	test "$OUTPUT2" = "foo"
+'
+
+test_expect_success 'kvs: move works' '
+        flux kvs unlink -R $DIR &&
+	flux kvs put $DIR.src=\"foo\" &&
+        flux kvs move $DIR.src $DIR.dest &&
+	test_must_fail flux kvs get $DIR.src &&
+	OUTPUT=$(flux kvs get $DIR.dest) &&
+	test "$OUTPUT" = "foo"
+'
+
+#
+# dropcache tests
+#
+
+test_expect_success 'kvs: dropcache works' '
+	flux kvs dropcache
+'
+test_expect_success 'kvs: dropcache --all works' '
+	flux kvs dropcache --all
+'
+
+#
+# version/wait tests
+#
+
+test_expect_success 'kvs: version and wait' '
+	VERS=$(flux kvs version)
+        VERS=$((VERS + 1))
+        flux kvs wait $VERS &
+        kvswaitpid=$! &&
+        flux kvs put $DIR.xxx=99 &&
+        test_expect_code 0 wait $kvswaitpid
+'
+
+#
+# watch tests
+#
+
+# Various loops to wait for conditions before moving on.  Have
+# observed racing between backgrounding watch process and foreground
+# activities.
+#
+# Loop count is just to make sure we don't spin forever on error, 50
+# loops/5 seconds seems like a decent maximum.
+
+wait_watch_put() {
+        i=0
+        while [ "$(flux kvs get $1 2> /dev/null)" != "$2" ] && [ $i -lt "50" ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ $i == "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+wait_watch_empty() {
+        i=0
+        while flux kvs get $1 2> /dev/null && [ $i -lt "50" ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ $i == "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+wait_watch_current() {
+        i=0
+        while [ "$(tail -n 1 watch_out 2> /dev/null)" != "$1" ] && [ $i -lt "50" ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ $i == "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+# Note that we do not && after the final call to wait_watch_put or
+# wait_watch_empty.  We want that as a barrier before launching our
+# background watch process.
+
+test_expect_success 'kvs: watch a key'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.foo=0 &&
+        wait_watch_put "$DIR.foo" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+        watchpid=$! &&
+        wait_watch_current "0"
+        flux kvs put $DIR.foo=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+0
+1
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a key that at first doesnt exist'  '
+	flux kvs unlink -R $DIR &&
+        wait_watch_empty "$DIR.foo"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+        watchpid=$! &&
+        wait_watch_current "nil" &&
+        flux kvs put $DIR.foo=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+nil
+1
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a key that gets removed'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.foo=0 &&
+        wait_watch_put "$DIR.foo" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+        watchpid=$!
+        wait_watch_current "0" &&
+        flux kvs unlink $DIR.foo &&
+        wait $watchpid
+	cat >expected <<EOF
+0
+nil
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a key that becomes a dir'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.foo=0 &&
+        wait_watch_put "$DIR.foo" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+        watchpid=$! &&
+        wait_watch_current "0" &&
+        flux kvs put $DIR.foo.bar.baz=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+0
+======================
+$DIR.foo.bar.
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a dir'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
+        wait_watch_put "$DIR.a.a" "0" &&
+        wait_watch_put "$DIR.a.b" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
+        watchpid=$! &&
+        wait_watch_current "======================" &&
+        flux kvs put $DIR.a.a=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+$DIR.a.
+======================
+$DIR.a.
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a dir that at first doesnt exist'  '
+	flux kvs unlink -R $DIR &&
+        wait_watch_empty "$DIR"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
+        watchpid=$! &&
+        wait_watch_current "nil" &&
+        flux kvs put $DIR.a.a=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+nil
+======================
+$DIR.a.
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a dir that gets removed'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
+        wait_watch_put "$DIR.a.a.a" "0" &&
+        wait_watch_put "$DIR.a.a.b" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
+        watchpid=$! &&
+        wait_watch_current "======================" &&
+        flux kvs unlink -R $DIR.a &&
+        wait $watchpid
+	cat >expected <<EOF
+$DIR.a.a.
+======================
+nil
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a dir, converted into a key'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
+        wait_watch_put "$DIR.a.a.a" "0" &&
+        wait_watch_put "$DIR.a.a.b" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
+        watchpid=$! &&
+        wait_watch_current "======================" &&
+        flux kvs put $DIR.a=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+$DIR.a.a.
+======================
+1
+EOF
+        test_cmp watch_out expected
+'
+
+# Difference between this test and prior one is we are converting $DIR
+# to a key instead of $DIR.a to a key.  Since we are watching $DIR.a,
+# prior test should see conversion of a $DIR.a to a key.  This time,
+# $DIR.a is no longer valid and we should see 'nil' as a result.
+test_expect_success 'kvs: watch a dir, prefix path converted into a key'  '
+        flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
+        wait_watch_put "$DIR.a.a.a" "0" &&
+        wait_watch_put "$DIR.a.a.b" "0"
+	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
+        watchpid=$! &&
+        wait_watch_current "======================" &&
+        flux kvs put $DIR=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+$DIR.a.a.
+======================
+nil
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a dir with -R'  '
+        flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
+        wait_watch_put "$DIR.a.a" "0" &&
+        wait_watch_put "$DIR.a.b" "0"
+	stdbuf -oL flux kvs watch -R -o -c 1 $DIR >watch_out &
+        watchpid=$! &&
+        wait_watch_current "======================" &&
+        flux kvs put $DIR.a.a=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+$DIR.a.a = 0
+$DIR.a.b = 0
+======================
+$DIR.a.a = 1
+$DIR.a.b = 0
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch a dir with -R and -d'  '
+	flux kvs unlink -R $DIR &&
+        flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
+        wait_watch_put "$DIR.a.a" "0" &&
+        wait_watch_put "$DIR.a.b" "0"
+	stdbuf -oL flux kvs watch -R -d -o -c 1 $DIR >watch_out &
+        watchpid=$! &&
+        wait_watch_current "======================" &&
+        flux kvs put $DIR.a.a=1 &&
+        wait $watchpid
+	cat >expected <<EOF
+$DIR.a.a
+$DIR.a.b
+======================
+$DIR.a.a
+$DIR.a.b
+======================
+EOF
+        test_cmp watch_out expected
+'
+
+test_done

--- a/t/t1007-kz.t
+++ b/t/t1007-kz.t
@@ -10,7 +10,7 @@ test_under_flux ${SIZE} kvs
 test_expect_success 'kz: hello world copy in, copy out' '
 	echo "hello world" >kztest.1.in &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil --b 4096 -c - kztest.1 <kztest.1.in &&
-	test $(flux kvs dirsize kztest.1) -eq 2 &&
+	test $(flux kvs dir kztest.1 | wc -l) -eq 2 &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil -c kztest.1 - >kztest.1.out &&
 	test_cmp kztest.1.in kztest.1.out 
 '
@@ -18,7 +18,7 @@ test_expect_success 'kz: hello world copy in, copy out' '
 test_expect_success 'kz: 128K urandom copy in, copy out' '
 	dd if=/dev/urandom bs=4096 count=32 2>/dev/null >kztest.2.in &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil -b 4096 -c - kztest.2 <kztest.2.in &&
-	test $(flux kvs dirsize kztest.2) -eq 33 &&
+	test $(flux kvs dir kztest.2 | wc -l) -eq 33 &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil -c kztest.2 - >kztest.2.out &&
 	test_cmp kztest.2.in kztest.2.out
 '

--- a/t/t1008-proxy.t
+++ b/t/t1008-proxy.t
@@ -83,7 +83,7 @@ test_expect_success 'ssh:// with jobid works' '
 
 test_expect_success 'ssh:// can handle nontrivial message load' '
 	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=$TEST_SSH \
-	  flux kvs dir -r >dir.out
+	  flux kvs dir -R >dir.out
 '
 
 test_expect_success 'ssh:// with bad query option fails in flux_open()' '


### PR DESCRIPTION
Per #897 , cleaned up a bunch of flux-kvs command, trying to make it a more "user facing" tool instead of the unit-testing tool it was before.  Refactor w/ liboptparse along the way.  Copied the old tool into ```t/kvs/basic``` for unit testing.

Ended up axeing ```get-treeobj```, ```put-treeobj```, ```getat```, ```dirat```, ```readlinkat```, ```type```, ```dirsize```, and ```exists``` as I felt they were more for testing the KVS api & implementation than really something users need.  Casual users will just use ```wc -l``` or ```-n $str``` in scripts with ```dir``` and ```get```.

Other minor fixes along the way:

- make ```watch``` command logic more in line with user thinking that it means "N changes" occured.  Add ```-o``` option to output current value.
- Rename ```-r``` to ```-R``` for consistency to ```ls```
- merge ```dropcache``` and ```dropcache-all``` into one command
- ```count``` turned into an option

There's still a few more things that I think could be cleaned up, but they will probably be for a future PR.

- ```dropcache --all```, could be a KVS lib function or an option in ```kvs_dropcache()``` or perhaps could be per rank if tweaked appropriately.  Sending an event message doesn't seen necessary.
- merging ```watch``` and ```watch-dir``` into one.  Maybe can be done right now, but not enough details in ```kvs.h``` about what functions can return EISDIR to program at the moment.  Need to dig into ```libkvs``` deeper.
- various lingering FIXMEs in flux-kvs and kvs

The help output from ```flux-kvs``` via ```liboptparse``` is IMO a little ugly

```
Usage: flux-kvs copy source destination
   or: flux-kvs copy-fromkvs key file
   or: flux-kvs copy-tokvs key file
   or: flux-kvs dir [-R] [-d] [key]
   or: flux-kvs dropcache [--all]
   or: flux-kvs get key [key...]
   or: flux-kvs link target linkname
   or: flux-kvs mkdir key [key...]
   or: flux-kvs move source destination
   or: flux-kvs put key=value [key=value...]
   or: flux-kvs readlink key [key...]
   or: flux-kvs unlink key [key...]
   or: flux-kvs version 
   or: flux-kvs wait version
   or: flux-kvs watch [-o] [-c count] key
   or: flux-kvs watch-dir [-R] [-d] [-o] [-c count] key
  -h, --help             Display this message.
```

I think some tweeks to the liboptparse library could make this nicer (and possibly could be taken advantage by ```flux.c```).  Perhaps it could be something more like:

```
Usage: flux-kvs [OPTIONS] <command> [<args>]
  -h, --help             Display this message.

flux-kvs commands
  copy           do something
  copy-fromkvs   do something else
  ... 
```

Still need to add basic tests for the new command (edit: and update old tests that used flux kvs), so don't hit merge yet.  Or perhaps I should work on the liboptparse help output first.
