### PR TITLE
liboptparse: Support setting alternate usage callback function

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -86,9 +86,6 @@ void usage (optparse_t *p)
 static optparse_t * setup_optparse_parse_args (int argc, char *argv[])
 {
     optparse_err_t e;
-    struct optparse_option helpopt = {
-        .name = "help", .key = 'h', .usage = "Display this message"
-    };
     optparse_t *p = optparse_create ("flux");
     if (p == NULL)
         log_err_exit ("optparse_create");
@@ -97,13 +94,10 @@ static optparse_t * setup_optparse_parse_args (int argc, char *argv[])
     if (e != OPTPARSE_SUCCESS)
         log_msg_exit ("optparse_add_option_table() failed");
 
-    // Remove automatic `--help' in favor of our own usage() from above
-    e = optparse_remove_option (p, "help");
+    // Disable automatic `--help' in favor of our own usage() from above
+    e = optparse_set (p, OPTPARSE_OPTION_CB, "help", NULL);
     if (e != OPTPARSE_SUCCESS)
-        log_msg_exit ("optparse_remove_option (\"help\")");
-    e = optparse_add_option (p, &helpopt);
-    if (e != OPTPARSE_SUCCESS)
-        log_msg_exit ("optparse_add_option (\"help\")");
+        log_msg_exit ("optparse_set() failed");
 
     // Don't print internal subcommands in --help (we print subcommands using
     //  emit_command_help() above.

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -247,6 +247,20 @@ static optparse_err_t optparse_set_fatalerr_handle (optparse_t *p, void *handle)
     return (0);
 }
 
+static optparse_err_t optparse_set_option_cb (optparse_t *p, const char *name,
+                                              optparse_cb_f fn)
+{
+    struct option_info *o;
+
+    if (!name)
+        return (OPTPARSE_BAD_ARG);
+
+    if (!(o = find_option_info (p, name)))
+        return (OPTPARSE_BAD_ARG);
+
+    o->p_opt->cb = fn;
+    return (0);
+}
 
 /*
  *  Generic function that prints a message to stderr. Default logging function.
@@ -983,6 +997,8 @@ optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...)
 {
     optparse_err_t e = OPTPARSE_SUCCESS;
     va_list vargs;
+    optparse_cb_f cb;
+    char *str;
     int n;
 
     if (p == NULL)
@@ -1008,6 +1024,11 @@ optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...)
             e = OPTPARSE_BAD_ARG;
         else
             p->left_margin = n;
+        break;
+    case OPTPARSE_OPTION_CB:
+        str = va_arg (vargs, char *);
+        cb = va_arg (vargs, void *);
+        e = optparse_set_option_cb (p, str, cb);
         break;
     case OPTPARSE_OPTION_WIDTH:
         n = va_arg (vargs, int);
@@ -1065,6 +1086,7 @@ optparse_err_t optparse_get (optparse_t *p, optparse_item_t item, ...)
     case OPTPARSE_FATALERR_FN:
     case OPTPARSE_FATALERR_HANDLE:
     case OPTPARSE_LEFT_MARGIN:
+    case OPTPARSE_OPTION_CB:
     case OPTPARSE_OPTION_WIDTH:
         e = OPTPARSE_NOT_IMPL;
         break;

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -50,6 +50,7 @@ typedef enum {
     OPTPARSE_LOG_FN,       /* Set log function (default fprintf(stderr,..)) */
     OPTPARSE_FATALERR_FN,  /* Set fatal err function (default: exit() )     */
     OPTPARSE_FATALERR_HANDLE,  /* Set handle passed to fatalerr function    */
+    OPTPARSE_OPTION_CB,    /* Change option cb function (char *,optparse_cb_f) */
     OPTPARSE_OPTION_WIDTH, /* Width allotted to options in --help output    */
     OPTPARSE_LEFT_MARGIN,  /* Left pad for option output (default = 2)      */
     OPTPARSE_PRINT_SUBCMDS,/* Print all subcommands in --help (default = T  */

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -22,7 +22,7 @@ typedef int (*opt_fatalerr_f) (void *h, int exit_code);
 /*
  *  prototype for option callback hook
  */
-typedef int (*optparse_cb_f) (optparse_t *p, struct optparse_option *,
+typedef int (*optparse_cb_f) (optparse_t *p, struct optparse_option *o,
 			      const char *optarg);
 
 /*


### PR DESCRIPTION
I thought it was sort of inconvenient to remove the default "help" option and then re-add it back just so we can set an alternate (or no) usage callback function.  Since I was duplicating the code in ```cmd/flux``` into ```cmd/flux-kvs```, figured could refactor a bit.  So I added an option to allow the user to set an alternate usage callback function.  The callback can be disabled by setting the callback to NULL.

Also fix one nit along the way.