### PR TITLE
flux-{start,broker}: propagate argument quoting

### DIFF
--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -1,6 +1,12 @@
 #ifndef _BROKER_RUNLEVEL_H
 #define _BROKER_RUNLEVEL_H
 
+#include "attr.h"
+#include "src/common/libsubprocess/subprocess.h"
+
+#include <stdint.h>
+#include <stddef.h> // for size_t
+
 typedef struct runlevel runlevel_t;
 
 typedef void (*runlevel_cb_f)(runlevel_t *r, int level, int rc, double elapsed,
@@ -28,8 +34,8 @@ void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg);
 /* Associate 'command' with 'level'.  'local_uri' and 'library_path' are
  * used to set FLUX_URI and LD_LIBRARY_PATH in the subprocess environment.
  */
-int runlevel_set_rc (runlevel_t *r, int level, const char *command,
-                     const char *local_uri);
+int runlevel_set_rc (runlevel_t *r, int level, const char *cmd_argz,
+                     size_t cmd_argz_len, const char *local_uri);
 
 /* Change the runlevel.  It is assumed that the previous run level (if any)
  * has completed and this is being called from the runlevel callback.

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -431,6 +431,18 @@ int subprocess_set_args (struct subprocess *p, int argc, char **argv)
     return (init_argz (&p->argz, &p->argz_len, argv));
 }
 
+int subprocess_set_args_from_argz (struct subprocess *p, const char * argz, size_t argz_len)
+{
+    if (p->started || argz == NULL) {
+        errno = EINVAL;
+        return (-1);
+    }
+    free (p->argz);
+    p->argz_len = 0;
+    int e = argz_append (&p->argz, &p->argz_len, argz, argz_len);
+    return e ? (errno = e, -1) : 0;
+}
+
 const char * subprocess_get_arg (struct subprocess *p, int n)
 {
     int i;
@@ -482,6 +494,22 @@ int subprocess_argv_append (struct subprocess *p, const char *s)
     }
 
     if ((e = argz_add (&p->argz, &p->argz_len, s)) != 0) {
+        errno = e;
+        return -1;
+    }
+    return (0);
+}
+
+int subprocess_argv_append_argz (struct subprocess *p, const char *argz, size_t argz_len)
+{
+    int e;
+
+    if (p->started) {
+        errno = EINVAL;
+        return (-1);
+    }
+
+    if ((e = argz_append (&p->argz, &p->argz_len, argz, argz_len)) != 0) {
         errno = e;
         return -1;
     }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -22,6 +22,9 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
+#ifndef _SUBPROCESS_H
+#define _SUBPROCESS_H
+
 #include <stdbool.h>
 
 struct subprocess_manager;
@@ -142,6 +145,14 @@ void *subprocess_get_context (struct subprocess *p, const char *name);
 int subprocess_set_args (struct subprocess *p, int argc, char *argv[]);
 
 /*
+ *  Set argument vector for subprocess [p] from argz vector (argz, argz_len).
+ *   This function is only valid before subprocess_run() is called. Any existing
+ *   args associated with subprocess are discarded.
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_set_args_from_argz (struct subprocess *p, const char * argz, size_t argz_len);
+
+/*
  *  Identical subprocess_set_args(), subprocess_set_command() is a
  *   convenience function similar to system(3). That is, it will set
  *   arguments for subprocess [p] to
@@ -158,6 +169,13 @@ int subprocess_set_command (struct subprocess *p, const char *command);
  *   Returns -1 with errno set to EINVAL if subprocess has already started.
  */
 int subprocess_argv_append (struct subprocess *p, const char *arg);
+
+/*
+ *  Append a single argument to the subprocess [p] argument vector.
+ *   Returns -1 with errno set to EINVAL if subprocess has already started.
+ */
+int subprocess_argv_append_argz (struct subprocess *p, const char *argz, size_t argz_len);
+
 
 /*
  *  Get argument at index [n] from current argv array for process [p]
@@ -327,3 +345,5 @@ int subprocess_io_complete (struct subprocess *p);
  *   be scheduled for stdin one all buffered data is written.
  */
 int subprocess_write (struct subprocess *p, void *buf, size_t count, bool eof);
+
+#endif /* !_SUBPROCESS_H */


### PR DESCRIPTION
Kinda random, but after running into this setting up little one-liner tests a lot lately I thought it would be worth fixing.  I'm open to adjusting this if it doesn't behave the way others think it should, but it makes one-off testing rather more ergonomic at least for me.


Both flux-start and flux-broker have classically taken the user command
through an argz_stringify, causing all arguments to be flattened into a
single argument and requiring odd double quoting to make many commands
work.  This makes flux-start propagate all arguments as-is through to
the next stage.  The flux-broker case is a bit more complicated, because
of the shell default, but is currently set up to default to a shell with
no command, use `${shell} -c <arg>` when there is only one argument, and
directly invoke <arg1>...<argn> when there are multiple.  Basic result
is that commands like `flux start -s 2 flux wreckrun -n 4 sh -c
'./something_per_rank | grep stuff | ...'` do something sensible.  Old
behavior caused that to run sh -c 'sh -c ./something_per_rank ...' which
just set the arguments in the inner sh to the rest of the values, losing
them in the command.