### PR TITLE
Convert to inttypes.h conversion specifiers

### DIFF
--- a/doc/man3/topen.c
+++ b/doc/man3/topen.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <flux/core.h>
 #include "src/common/libutil/log.h"
 
@@ -10,7 +11,7 @@ int main (int argc, char **argv)
         log_err_exit ("flux_open");
     if (flux_get_rank (h, &rank) < 0)
         log_err_exit ("flux_get_rank");
-    printf ("My rank is %d\n", (int)rank);
+    printf ("My rank is %"PRIu32"\n", rank);
     flux_close (h);
     return (0);
 }

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <inttypes.h>
 #include <flux/core.h>
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/nodeset.h"
@@ -130,7 +131,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     ctx.batchnum = 0;
     if (flux_get_rank (h, &rank) < 0)
         return -1;
-    snprintf (ctx.rankstr, sizeof (ctx.rankstr), "%d", rank);
+    snprintf (ctx.rankstr, sizeof (ctx.rankstr), "%"PRIu32, rank);
     ctx.h = h;
 
     if (!(ctx.r = flux_reduce_create (h, reduce_ops, timeout, &ctx, flags)))

--- a/src/bindings/lua/lua-affinity/cpuset-str.c
+++ b/src/bindings/lua/lua-affinity/cpuset-str.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h> /* ULONG_MAX */
+#include <inttypes.h>
 
 char * cpuset_to_cstr (cpu_set_t *mask, char *str)
 {
@@ -119,7 +120,7 @@ int cpuset_to_hex (cpu_set_t *mask, char *str, size_t len)
 
         for (bit = HEXCHUNKSZ - 1; bit >= 0; bit--)
             val = val << 1 | CPU_ISSET (chunk * HEXCHUNKSZ + bit, mask);
-        cnt += snprintf (str + cnt, max (len - cnt, 0), "%s%0*x",
+        cnt += snprintf (str + cnt, max (len - cnt, 0), "%s%0*"PRIx32,
                 sep, HEXCHARSIZE, val);
 
         sep = ",";

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -27,6 +27,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <inttypes.h>
 #include <czmq.h>
 #include <flux/core.h>
 #include "src/common/libutil/xzmalloc.h"
@@ -893,7 +894,7 @@ static int content_cache_getattr (const char *name, const char **val, void *arg)
     else if (!strcmp (name, "content-backing"))
         *val = cache->backing_name;
     else if (!strcmp (name, "content-acct-entries")) {
-        snprintf (s, sizeof (s), "%ld", zhash_size (cache->entries));
+        snprintf (s, sizeof (s), "%zd", zhash_size (cache->entries));
         *val = s;
     } else
         return -1;

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -349,7 +349,7 @@ static int attr_get_log (const char *name, const char **val, void *arg)
         assert (n < sizeof (s));
         *val = s;
     } else if (!strcmp (name, "log-ring-used")) {
-        n = snprintf (s, sizeof (s), "%d", (int)zlist_size (logbuf->buf));
+        n = snprintf (s, sizeof (s), "%zd", zlist_size (logbuf->buf));
         assert (n < sizeof (s));
         *val = s;
     } else if (!strcmp (name, "log-count")) {

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -38,6 +38,7 @@
 #include <sys/time.h>
 #include <stdarg.h>
 #include <dlfcn.h>
+#include <inttypes.h>
 #include <argz.h>
 #include <czmq.h>
 #include <flux/core.h>
@@ -139,7 +140,7 @@ static void *module_thread (void *arg)
                       p->zctx, sizeof (p->zctx)) < 0)
         log_err_exit ("flux_opt_set ZEROMQ_CONTEXT");
 
-    rankstr = xasprintf ("%u", p->rank);
+    rankstr = xasprintf ("%"PRIu32, p->rank);
     if (flux_attr_fake (p->h, "rank", rankstr, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
         log_err ("%s: error faking rank attribute", p->name);
         goto done;
@@ -246,7 +247,7 @@ int module_sendmsg (module_t *p, const flux_msg_t *msg)
     switch (type) {
         case FLUX_MSGTYPE_REQUEST: { /* simulate DEALER socket */
             char uuid[16];
-            snprintf (uuid, sizeof (uuid), "%u", p->rank);
+            snprintf (uuid, sizeof (uuid), "%"PRIu32, p->rank);
             if (!(cpy = flux_msg_copy (msg, true)))
                 goto done;
             if (flux_msg_push_route (cpy, uuid) < 0)

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -28,6 +28,7 @@
 #include <stdarg.h>
 #include <czmq.h>
 #include <flux/core.h>
+#include <inttypes.h>
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
@@ -158,7 +159,7 @@ void overlay_set_sec (overlay_t *ov, flux_sec_t *sec)
 void overlay_set_rank (overlay_t *ov, uint32_t rank)
 {
     ov->rank = rank;
-    snprintf (ov->rankstr, sizeof (ov->rankstr), "%u", rank);
+    snprintf (ov->rankstr, sizeof (ov->rankstr), "%"PRIu32, rank);
 }
 
 void overlay_set_flux (overlay_t *ov, flux_t *h)

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -42,6 +42,7 @@
 #include <argz.h>
 #include <glob.h>
 #include <czmq.h>
+#include <inttypes.h>
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/cleanup.h"
@@ -425,7 +426,7 @@ static int disconnect_update (client_t *c, const flux_msg_t *msg)
     svc = xstrdup (topic);
     if ((p = strchr (svc, '.')))
         *p = '\0';
-    key = xasprintf ("%s:%u:%d", svc, nodeid, flags);
+    key = xasprintf ("%s:%"PRIu32":%d", svc, nodeid, flags);
     if (!zhash_lookup (c->disconnect_notify, key)) {
         d = xzmalloc (sizeof (*d));
         d->c = c;

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <argz.h>
 #include <flux/core.h>
+#include <inttypes.h>
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/shortjson.h"
@@ -137,8 +138,8 @@ int main (int argc, char *argv[])
         if (!(s = flux_attr_get (h, "tbon.arity", NULL)))
             log_err_exit ("flux_attr_get tbon.arity");
         arity = strtoul (s, NULL, 10);
-        printf ("rank=%d\n", rank);
-        printf ("size=%d\n", size);
+        printf ("rank=%"PRIu32"\n", rank);
+        printf ("size=%"PRIu32"\n", size);
         printf ("arity=%d\n", arity);
     } else
         usage ();

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
+#include <inttypes.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 
@@ -138,7 +139,7 @@ done:
                 char s[16] = {0};
                 if (strcmp (ctx->rank, "any"))
                     snprintf (s, sizeof (s), "%s!", ctx->rank);
-                printf ("%s%s pad=%lu seq=%d time=%0.3f ms (%s)\n",
+                printf ("%s%s pad=%zu seq=%d time=%0.3f ms (%s)\n",
                         s, ctx->topic, strlen (ctx->pad), pdata->seq,
                         tstat_mean (tstat), pdata->route);
             }

--- a/src/common/libcompat/reactor.c
+++ b/src/common/libcompat/reactor.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <czmq.h>
 
 #include "src/common/libflux/handle.h"
@@ -238,7 +239,7 @@ int flux_fdhandler_add (flux_t *h, int fd, short events,
         return -1;
     }
     flux_watcher_start (c->w);
-    snprintf (hashkey, sizeof (hashkey), "fd:%d:%d", fd, events);
+    snprintf (hashkey, sizeof (hashkey), "fd:%d:%hd", fd, events);
     zhash_update (ctx->watchers, hashkey, c);
     zhash_freefn (ctx->watchers, hashkey, (zhash_free_fn *)fd_compat_free);
     return 0;
@@ -250,7 +251,7 @@ void flux_fdhandler_remove (flux_t *h, int fd, short events)
     struct fd_compat *c;
     char hashkey[HASHKEY_LEN];
 
-    snprintf (hashkey, sizeof (hashkey), "fd:%d:%d", fd, events);
+    snprintf (hashkey, sizeof (hashkey), "fd:%d:%hd", fd, events);
     if ((c = zhash_lookup (ctx->watchers, hashkey))) {
         flux_watcher_stop (c->w);
         zhash_delete (ctx->watchers, hashkey);

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -31,6 +31,7 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <fnmatch.h>
+#include <inttypes.h>
 #include <czmq.h>
 #include <jansson.h>
 
@@ -1234,7 +1235,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
     /* Topic (keepalive has none)
      */
     if (topic)
-        fprintf (f, "%s[%3.3lu] %s\n", prefix, strlen (topic), topic);
+        fprintf (f, "%s[%3.3zu] %s\n", prefix, strlen (topic), topic);
     /* Payload
      */
     if (flux_msg_has_payload (msg)) {
@@ -1242,7 +1243,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
         void *buf;
         int size, flags;
         if (flux_msg_get_json (msg, &json_str) == 0)
-            fprintf (f, "%s[%3.3lu] %s\n", prefix, strlen (json_str), json_str);
+            fprintf (f, "%s[%3.3zu] %s\n", prefix, strlen (json_str), json_str);
         else if (flux_msg_get_payload (msg, &flags, &buf, &size) == 0)
             fprintf (f, "%s[%3.3d] ...\n", prefix, size);
         else

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -31,6 +31,7 @@
 #include <sys/wait.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 #include <czmq.h>
 #include <argz.h>
 #include <envz.h>
@@ -697,7 +698,7 @@ static int sp_barrier_read_error (int fd)
     int e;
     ssize_t n = read (fd, &e, sizeof (int));
     if (n < 0) {
-        log_err ("sp_read_error: read: %m");
+        log_err ("sp_read_error: read");
         return (-1);
     }
     else if (n == sizeof (int)) {
@@ -711,7 +712,7 @@ static int sp_barrier_signal (int fd)
 {
     char c = 0;
     if (write (fd, &c, sizeof (c)) != 1) {
-        log_err ("sp_barrier_signal: write: %m");
+        log_err ("sp_barrier_signal: write");
         return (-1);
     }
     return (0);
@@ -722,7 +723,7 @@ static int sp_barrier_wait (int fd)
     char c;
     int n;
     if ((n = read (fd, &c, sizeof (c))) != 1) {
-        log_err ("sp_barrier_wait: read:fd=%d: (got %d): %m", fd, n);
+        log_err ("sp_barrier_wait: read:fd=%d: (got %d)", fd, n);
         return (-1);
     }
     return (0);
@@ -731,7 +732,7 @@ static int sp_barrier_wait (int fd)
 static void sp_barrier_write_error (int fd, int e)
 {
     if (write (fd, &e, sizeof (int)) != sizeof (int)) {
-        log_err ("sp_barrier_error: write: %m");
+        log_err ("sp_barrier_error: write");
     }
 }
 

--- a/src/common/libutil/nodeset.c
+++ b/src/common/libutil/nodeset.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #include "veb.h"
 #include "oom.h"
@@ -443,14 +444,14 @@ const char *nodeset_string (nodeset_t *n)
                 } else if (r < NS_SIZE (n) && r == hi + 1) {
                     hi++;
                 } else if (lo == hi) {
-                    snprintf (tmp, sizeof (tmp), "%s%0*u", sep,
+                    snprintf (tmp, sizeof (tmp), "%s%0*"PRIu32, sep,
                               n->conf_padding, lo);
                     catstr (&n->s, &n->s_size, &used, tmp);
                     sep = n->conf_separator;
                     inrange = false;
                     continue;
                 } else {
-                    snprintf (tmp, sizeof (tmp), "%s%0*u-%0*u", sep,
+                    snprintf (tmp, sizeof (tmp), "%s%0*"PRIu32"-%0*"PRIu32, sep,
                              n->conf_padding, lo,
                              n->conf_padding, hi);
                     catstr (&n->s, &n->s_size, &used, tmp);
@@ -459,7 +460,7 @@ const char *nodeset_string (nodeset_t *n)
                     continue;
                 }
             } else {
-                snprintf (tmp, sizeof (tmp), "%s%0*u", sep,
+                snprintf (tmp, sizeof (tmp), "%s%0*"PRIu32, sep,
                           n->conf_padding, r);
                 catstr (&n->s, &n->s_size, &used, tmp);
                 sep = n->conf_separator;

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -93,7 +93,7 @@ static void child (struct popen2_child *p, const char *path, char *const argv[])
     saved_errno = errno;
 error:
     if (write (p->ctl[SP_CHILD], &saved_errno, sizeof (saved_errno)) < 0)
-        fprintf (stderr, "child: write to ctl failed: %m\n");
+        fprintf (stderr, "child: write to ctl failed: %s\n", strerror (errno));
     (void) close (p->ctl[SP_CHILD]);
     exit (0);
 }

--- a/src/common/libutil/test/nodeset.c
+++ b/src/common/libutil/test/nodeset.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/xzmalloc.h"
@@ -274,7 +275,7 @@ int main (int argc, char *argv[])
         monotime_since (ts)/1000, nodeset_getattr (n, NODESET_ATTR_BYTES)/1024);
 
     monotime (&ts);
-    tmp = xasprintf ("0-%u", bigset - 1);
+    tmp = xasprintf ("0-%"PRIu32, bigset - 1);
     like (nodeset_string (n), tmp, "string conversion %s [%.2fs %u Mbytes]", tmp,
         monotime_since (ts)/1000, nodeset_getattr (n, NODESET_ATTR_BYTES)/1024);
     free (tmp);
@@ -352,7 +353,7 @@ int main (int argc, char *argv[])
     ok (nodeset_count (n) == 2, "nodeset count is sane");
     /* 7 */
 
-    tmp = xasprintf ("%u-%u", maxrank-1, maxrank);
+    tmp = xasprintf ("%"PRIu32"-%"PRIu32, maxrank-1, maxrank);
     monotime (&ts);
     like (nodeset_string (n), tmp, "convert to string %s [%.2fs %u Mbytes]", tmp,
         monotime_since (ts)/1000,

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -41,6 +41,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <czmq.h>
+#include <inttypes.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/xzmalloc.h"
@@ -423,7 +424,7 @@ static int disconnect_update (client_t *c, const flux_msg_t *msg)
     svc = xstrdup (topic);
     if ((p = strchr (svc, '.')))
         *p = '\0';
-    key = xasprintf ("%s:%u:%d", svc, nodeid, flags);
+    key = xasprintf ("%s:%"PRIu32":%d", svc, nodeid, flags);
     if (!zhash_lookup (c->disconnect_notify, key)) {
         d = xzmalloc (sizeof (*d));
         d->c = c;

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -40,6 +40,7 @@
 #include <sys/socket.h>
 #include <ctype.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <flux/core.h>
 #include <czmq.h>
 
@@ -571,7 +572,7 @@ static kvs_watcher_t *add_watcher (flux_t *h, const char *key, watch_type_t type
     wp->type = type;
     wp->arg = arg;
 
-    char *k = xasprintf ("%u", matchtag);
+    char *k = xasprintf ("%"PRIu32, matchtag);
     zhash_update (ctx->watchers, k, wp);
     zhash_freefn (ctx->watchers, k, destroy_watcher);
     free (k);
@@ -584,7 +585,7 @@ static kvs_watcher_t *add_watcher (flux_t *h, const char *key, watch_type_t type
 static kvs_watcher_t *lookup_watcher (flux_t *h, uint32_t matchtag)
 {
     kvsctx_t *ctx = getctx (h);
-    char *k = xasprintf ("%u", matchtag);
+    char *k = xasprintf ("%"PRIu32, matchtag);
     kvs_watcher_t *wp = zhash_lookup (ctx->watchers, k);
     free (k);
     return wp;

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -208,7 +208,7 @@ static int jscctx_add_jobid_path (jscctx_t *ctx, int64_t id, const char *path)
     char *s;
     char key [21];
     memset (key, 0, sizeof (key));
-    if (sprintf (key, "%ju", (uintmax_t) id) < 0)
+    if (sprintf (key, "%"PRId64, id) < 0)
         return (-1);
     if (!(s = strdup (path)))
         return (-1);
@@ -226,7 +226,7 @@ static const char * jscctx_jobid_path (jscctx_t *ctx, int64_t id)
     char key [21];
 
     memset (key, 0, sizeof (key));
-    if (sprintf (key, "%ju", (uintmax_t) id) < 0)
+    if (sprintf (key, "%"PRId64, id) < 0)
         return (NULL);
     if ((path = lru_cache_get (ctx->kvs_paths, key)))
         return path;
@@ -273,7 +273,7 @@ static int fetch_and_update_state (zhash_t *aj , int64_t j, int64_t ns)
     char *key = NULL;
 
     if (!aj) return J_FOR_RENT;
-    key = xasprintf ("%"PRId64"", j);
+    key = xasprintf ("%"PRId64, j);
     if ( !(t = ((int *)zhash_lookup (aj, (const char *)key)))) {
         free (key);
         return J_FOR_RENT;
@@ -498,7 +498,7 @@ static int extract_raw_pdescs (flux_t *h, int64_t j, int64_t n, json_object *jcb
 
         eix = build_name_array (eh, cmd, ens);
         /* FIXME: we need a hostname service */
-        hnm = xasprintf ("%"PRId64"", nid);
+        hnm = xasprintf ("%"PRId64, nid);
         hix = build_name_array (hh, hnm, hns);
         po = build_parray_elem (pid, eix, hix);
         json_object_array_add (pa, po);
@@ -931,7 +931,7 @@ static void fixup_newjob_event (flux_t *h, int64_t nj)
     json_object *ss = NULL;
     json_object *jcb = NULL;
     int64_t js = J_NULL;
-    char *key = xasprintf ("%"PRId64"", nj);
+    char *key = xasprintf ("%"PRId64, nj);
     jscctx_t *ctx = getctx (h);
 
     /* We fix up ordering problem only when new job
@@ -961,7 +961,7 @@ done:
 static inline void delete_jobinfo (flux_t *h, int64_t jobid)
 {
     jscctx_t *ctx = getctx (h);
-    char *key = xasprintf ("%"PRId64"", jobid);
+    char *key = xasprintf ("%"PRId64, jobid);
     zhash_delete (ctx->active_jobs, key);
     free (key);
 }

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -81,6 +81,7 @@
 #include <stdbool.h>
 #include <sys/time.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <flux/core.h>
 #include <czmq.h>
 
@@ -186,7 +187,7 @@ static ctx_t *getctx (flux_t *h)
             flux_log_error (h, "flux_get_rank");
             goto error;
         }
-        n = snprintf (ctx->rankstr, sizeof (ctx->rankstr), "%d", ctx->rank);
+        n = snprintf (ctx->rankstr, sizeof (ctx->rankstr), "%"PRIu32, ctx->rank);
         assert (n < sizeof (ctx->rankstr));
         if (!(ctx->parents = zlist_new ()) || !(ctx->children = zhash_new ())) {
             flux_log_error (h, "zlist_new/zhash_new");
@@ -713,7 +714,7 @@ static int ns_sync (ctx_t *ctx)
         if (flux_get_size (ctx->h, &size) < 0)
             goto done;
         if (size > 1)
-            if (asprintf (&unknown, "1-%d", size - 1) < 0)
+            if (asprintf (&unknown, "1-%"PRIu32, size - 1) < 0)
                 oom ();
         ctx->ns = ns_create (ok, fail, slow, unknown);
         if (size > 1)

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -100,12 +100,12 @@ static char * lwj_to_path (uint64_t id, int levels, int bits_per_dir)
     for (i = levels; i > 0; i--) {
         int b = bits_per_dir * i;
         uint64_t d = prefix64 (id, b, b + bits_per_dir);
-        if ((n = snprintf (buf+len, nleft, ".%ju", d)) < 0 || n > nleft)
+        if ((n = snprintf (buf+len, nleft, ".%"PRIu64, d)) < 0 || n > nleft)
             return NULL;
         len += n;
         nleft -= n;
     }
-    n = snprintf (buf+len, sizeof (buf) - len, ".%ju", id);
+    n = snprintf (buf+len, sizeof (buf) - len, ".%"PRIu64, id);
     if (n < 0 || n > nleft)
         return NULL;
     return (strdup (buf));
@@ -460,7 +460,7 @@ static void exec_handler (const char *exe, int64_t id, const char *kvspath)
 
     if ((av == NULL)
      || ((av [0] = strdup (exe)) == NULL)
-     || (asprintf (&av[1], "--lwj-id=%ju", (uintmax_t) id) < 0)
+     || (asprintf (&av[1], "--lwj-id=%"PRId64, id) < 0)
      || (asprintf (&av[2], "--kvs-path=%s", kvspath) < 0)) {
         fprintf (stderr, "Out of Memory trying to exec wrexecd!\n");
         exit (1);

--- a/t/kvs/commit.c
+++ b/t/kvs/commit.c
@@ -31,6 +31,7 @@
 #include <libgen.h>
 #include <pthread.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <czmq.h>
 #include <flux/core.h>
 
@@ -92,7 +93,7 @@ void *thread (void *arg)
         goto done;
     }
     for (i = 0; i < count; i++) {
-        key = xasprintf ("%s.%u.%d.%d", prefix, rank, t->n, i);
+        key = xasprintf ("%s.%"PRIu32".%d.%d", prefix, rank, t->n, i);
         if (fopt)
             fence = xasprintf ("%s-%d", prefix, i);
         if (sopt)

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -32,6 +32,7 @@
 #include <libgen.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <czmq.h>
 #include <flux/core.h>
 
@@ -116,7 +117,7 @@ int main (int argc, char *argv[])
         uint32_t rank;
         if (flux_get_rank (h, &rank) < 0)
             log_err_exit ("flux_get_rank");
-        prefix = xasprintf ("kvstorture-%u", rank);
+        prefix = xasprintf ("kvstorture-%"PRIu32, rank);
     }
 
     if (kvs_unlink (h, prefix) < 0)

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <czmq.h>
 #include <flux/core.h>
 
@@ -144,7 +145,7 @@ static void rpctest_set_size (flux_t *h, uint32_t newsize)
     fake_size = newsize;
     char s[16];
     uint32_t size = 0;
-    snprintf (s, sizeof (s), "%u", fake_size);
+    snprintf (s, sizeof (s), "%"PRIu32, fake_size);
     flux_attr_fake (h, "size", s, FLUX_ATTRFLAG_IMMUTABLE);
     flux_get_size (h, &size);
     cmp_ok (size, "==", fake_size,


### PR DESCRIPTION
Change the printf conversion specifiers to use the portable
macros from inittypes.h.  For instance, instead of guessing %lu for
a uint32_t, use the PRIu32 macro.

Also change the length modifier for size_t types to "z", which is
an explicit printf length modifier for size_t and ssize_t arguments.

Finally, any %m conversion specifiers are replaced with explicit
%s and strerror(errno).  The %m is convenient, but it is explicitly
listed as a Glibc extension and therefore less portable.

Closes #394