### PR TITLE
Fix racey behavior in job log test + minor cleanups

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -594,7 +594,7 @@ int main (int argc, char *argv[])
             log_err_exit ("runlevel_set_rc 1");
         if (runlevel_set_rc (ctx.runlevel, 2, rc2, rc2_len, uri) < 0)
             log_err_exit ("runlevel_set_rc 2");
-        if (runlevel_set_rc (ctx.runlevel, 3, rc3, rc1 ? strlen (rc3) + 1 : 0, uri) < 0)
+        if (runlevel_set_rc (ctx.runlevel, 3, rc3, rc3 ? strlen (rc3) + 1 : 0, uri) < 0)
             log_err_exit ("runlevel_set_rc 3");
     }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -262,7 +262,7 @@ int main (int argc, char *argv[])
     int security_clr = 0;
     int security_set = 0;
     int e;
-
+    char *endptr;
 
     memset (&ctx, 0, sizeof (ctx));
     log_init (argv[0]);
@@ -323,7 +323,10 @@ int main (int argc, char *argv[])
                     log_err_exit ("setting conf.module_path attribute");
                 break;
             case 'k':   /* --k-ary k */
-                ctx.tbon.k = strtoul (optarg, NULL, 10);
+                errno = 0;
+                ctx.tbon.k = strtoul (optarg, &endptr, 10);
+                if (errno || *endptr != '\0')
+                    log_err_exit ("k-ary '%s'", optarg);
                 if (ctx.tbon.k < 1)
                     usage ();
                 break;
@@ -332,7 +335,12 @@ int main (int argc, char *argv[])
                     log_err_exit ("heartrate `%s'", optarg);
                 break;
             case 'g':   /* --shutdown-grace SECS */
-                ctx.shutdown_grace = strtod (optarg, NULL);
+                errno = 0;
+                ctx.shutdown_grace = strtod (optarg, &endptr);
+                if (errno || *endptr != '\0')
+                    log_err_exit ("shutdown-grace '%s'", optarg);
+                if (ctx.shutdown_grace < 0)
+                    usage ();
                 break;
             case 'E': /* --enable-epgm */
                 ctx.enable_epgm = true;

--- a/src/cmd/flux-comms-stats.c
+++ b/src/cmd/flux-comms-stats.c
@@ -29,6 +29,7 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <stdbool.h>
+#include <errno.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/xzmalloc.h"
@@ -75,6 +76,7 @@ int main (int argc, char *argv[])
     bool Ropt = false;
     double scale = 1.0;
     json_type type = json_type_object;
+    char *endptr;
 
     log_init ("flux-stats");
 
@@ -84,7 +86,10 @@ int main (int argc, char *argv[])
                 usage ();
                 break;
             case 'r': /* --rank */
-                nodeid = strtoul (optarg, NULL, 10);
+                errno = 0;
+                nodeid = strtoul (optarg, &endptr, 10);
+                if (errno || *endptr != '\0')
+                    usage();
                 break;
             case 'c': /* --clear */
                 copt = true;
@@ -99,7 +104,10 @@ int main (int argc, char *argv[])
                 objname = optarg;
                 break;
             case 's': /* --scale N */
-                scale = strtod (optarg, NULL);
+                errno = 0;
+                scale = strtod (optarg, &endptr);
+                if (errno || *endptr != '\0')
+                    usage();
                 break;
             case 't': /* --type TYPE */
                 if (!strcasecmp (optarg, "int"))

--- a/t/t2006-joblog.t
+++ b/t/t2006-joblog.t
@@ -14,9 +14,12 @@ test_expect_success 'created persistdir' '
 	PERSISTDIR=`mktemp -d`
 '
 
+# Test can be a tad "racey" at times if grace period is too low, up to
+# 5 seconds to ensure joblog can be generated properly.
+
 test_expect_success 'joblog exists, non-empty if job(s) run' '
 	rm -rf $PERSISTDIR/* &&
-	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	flux start -o,--shutdown-grace=5 -o,--setattr=persist-directory=$PERSISTDIR \
 	    flux wreckrun /bin/true &&
 	test -f $PERSISTDIR/joblog &&
 	test -s $PERSISTDIR/joblog
@@ -24,7 +27,7 @@ test_expect_success 'joblog exists, non-empty if job(s) run' '
 
 test_expect_success 'joblog exists, empty if no jobs run' '
 	rm -rf $PERSISTDIR/* &&
-	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	flux start -o,--shutdown-grace=5 -o,--setattr=persist-directory=$PERSISTDIR \
 	    /bin/true &&
 	test -f $PERSISTDIR/joblog &&
 	! test -s $PERSISTDIR/joblog


### PR DESCRIPTION
Minor cleanups mostly to check for errors on strtoul() and strtod() calls, plus a typo error I found in the broker.