### PR TITLE
Flux object prototype

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -69,7 +69,10 @@ fluxcoreinclude_HEADERS = \
 	flog.h \
 	conf.h \
 	heartbeat.h \
-	content.h
+	content.h \
+	fop.h \
+	fop_dynamic.h \
+	fop_protected.h
 
 noinst_LTLIBRARIES = \
 	libflux.la
@@ -98,6 +101,8 @@ libflux_la_SOURCES = \
 	ev_flux.c \
 	heartbeat.c \
 	keepalive.c \
+	fop.c \
+	fop_dynamic.c \
 	content.c
 
 libflux_la_CPPFLAGS = \
@@ -113,7 +118,8 @@ TESTS = test_module.t \
 	test_event.t \
 	test_tagpool.t \
 	test_security.t \
-	test_reactor.t
+	test_reactor.t \
+	test_fop.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
@@ -142,6 +148,9 @@ test_module_t_DEPENDENCIES = $(top_builddir)/src/modules/kvs/kvs.la
 $(test_module_t_DEPENDENCIES):
 	@cd `dirname $@` && $(MAKE)
 
+test_fop_t_SOURCES = test/test_fop.c
+test_fop_t_CPPFLAGS = $(test_cppflags)
+test_fop_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_message_t_SOURCES = test/message.c
 test_message_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -72,6 +72,7 @@ fluxcoreinclude_HEADERS = \
 	content.h \
 	fop.h \
 	fop_dynamic.h \
+	arp.h \
 	fop_protected.h
 
 noinst_LTLIBRARIES = \
@@ -103,6 +104,7 @@ libflux_la_SOURCES = \
 	keepalive.c \
 	fop.c \
 	fop_dynamic.c \
+	arp.c \
 	content.c
 
 libflux_la_CPPFLAGS = \

--- a/src/common/libflux/arp.c
+++ b/src/common/libflux/arp.c
@@ -1,0 +1,92 @@
+#include "arp.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_once_t arp_stack_once = PTHREAD_ONCE_INIT;
+pthread_key_t arp_stack;
+
+static void arp_stack_drain ()
+{
+    arp_scope_pop (0);
+}
+
+static void arp_stack_init ()
+{
+    pthread_key_create (&arp_stack, arp_stack_drain);
+}
+
+struct arp_pair {
+    arp_cb_f fn;
+    void *obj;
+};
+
+struct arp_autorelease_pool {
+    struct arp_pair *stack;
+    size_t top;
+    size_t cap;
+};
+
+ssize_t arp_scope_push ()
+{
+    pthread_once (&arp_stack_once, arp_stack_init);
+    struct arp_autorelease_pool *pool = pthread_getspecific (arp_stack);
+    if (pool == NULL) {
+        pool = calloc (1, sizeof *pool);
+        pthread_setspecific (arp_stack, pool);
+    }
+    arp_auto_call ((void*)7, (void*)7);
+    return pool->top - 1;
+}
+static ssize_t arp_scope_pop_inner (ssize_t scope, int stop_at_one)
+{
+    struct arp_autorelease_pool *pool = pthread_getspecific (arp_stack);
+    assert (pool && (scope >= 0));
+    ssize_t top = 0;
+    for (top = pool->top - 1; top >= scope && top >= 0; top--) {
+        if (pool->stack[top].fn == (void*)7) {
+            if (stop_at_one)
+                break;
+            else
+                continue;
+        }
+        if (!pool->stack[top].fn)
+            fop_release (pool->stack[top].obj);
+        else
+            pool->stack[top].fn (pool->stack[top].obj);
+    }
+    pool->top = top;
+    return top;
+}
+ssize_t arp_scope_pop (ssize_t scope)
+{
+    return arp_scope_pop_inner (scope, 0);
+}
+ssize_t arp_scope_pop_one ()
+{
+    return arp_scope_pop_inner (0, 1);
+}
+
+void *arp_auto_call (void *o, arp_cb_f fn)
+{
+    struct arp_autorelease_pool *pool = pthread_getspecific (arp_stack);
+    assert (pool);
+    if (pool->top >= pool->cap) {
+        // Need more space
+        size_t new_cap = pool->cap ? pool->cap * 2 : 512;
+        void *tmp = realloc (pool->stack, new_cap);
+        assert (tmp);
+        pool->stack = tmp;
+        pool->cap = new_cap;
+    }
+    pool->stack[pool->top].obj = o;
+    pool->stack[pool->top].fn = fn;
+    pool->top++;
+    return o;
+}
+
+fop *arp_autorelease (fop *o)
+{
+    return arp_auto_call (o, NULL);
+}

--- a/src/common/libflux/arp.h
+++ b/src/common/libflux/arp.h
@@ -1,0 +1,21 @@
+#ifndef __FLUX_CORE_ARP_H
+#define __FLUX_CORE_ARP_H
+
+#include "fop.h"
+
+#define ARP_AUTORELEASE_FOR                                         \
+    for (ssize_t i = 0, __arp_for_scope = arp_scope_push (); i < 1; \
+         ++i, arp_scope_pop (__arp_for_scope))
+
+typedef struct arp_pair arp_t;
+
+ssize_t arp_scope_push ();
+ssize_t arp_scope_pop (ssize_t scope);
+ssize_t arp_scope_pop_one ();
+
+typedef void (*arp_cb_f) (void *);
+
+fop *arp_autorelease (fop *o);
+void *arp_auto_call (void *o, arp_cb_f fn);
+
+#endif /* __FLUX_CORE_ARP_H */

--- a/src/common/libflux/fop.c
+++ b/src/common/libflux/fop.c
@@ -261,40 +261,53 @@ void *class_initialize (fop *c_in, va_list *app)
     return c;
 };
 
+void *class_desc (fop *c_in, FILE *s)
+{
+    fop_class_t *c = c_in;
+    fprintf (s, "class %s(%s){\n", c->name, fop_super(c)->name);
+    fprintf (s, "    size: %zu\n", c->size);
+    fprintf (s, "    tags: %zu\n", c->inner.tags_len);
+    for (size_t i = 0; i < c->inner.tags_len; ++i) {
+        struct fop_method_record *rec = c->inner.tags_by_selector + i;
+        fprintf (s, "        %s: %p, %p, %zu\n", rec->tag, rec->selector, rec->method, rec->offset);
+    }
+    return c_in;
+};
+
 // Object and Class definition, static for this special case
 
 // DYNAMIC METHOD INFORMATION
 static struct fop_method_record object_tags[] = {
     {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
-     offsetof (fop_class_t, new)},
+        offsetof (fop_class_t, new)},
     {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
-     offsetof (fop_class_t, initialize)},
+        offsetof (fop_class_t, initialize)},
     {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
-     offsetof (fop_class_t, finalize)},
+        offsetof (fop_class_t, finalize)},
     {"describe", (fop_vv_f)fop_describe, 0,
-     offsetof (fop_class_t, describe)},  // describe
+        offsetof (fop_class_t, describe)},  // describe
     {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
-     offsetof (fop_class_t, represent)},
+        offsetof (fop_class_t, represent)},
     {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
-     offsetof (fop_class_t, retain)},
+        offsetof (fop_class_t, retain)},
     {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
-     offsetof (fop_class_t, release)}};
+        offsetof (fop_class_t, release)}};
 
 static struct fop_method_record class_tags[] = {
-        {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
-                offsetof (fop_class_t, new)},
-        {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
-                offsetof (fop_class_t, initialize)},
-        {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
-                offsetof (fop_class_t, finalize)},
-        {"describe", (fop_vv_f)fop_describe, 0,
-                offsetof (fop_class_t, describe)},  // describe
-        {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
-                offsetof (fop_class_t, represent)},
-        {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
-                offsetof (fop_class_t, retain)},
-        {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
-                offsetof (fop_class_t, release)}};
+    {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
+        offsetof (fop_class_t, new)},
+    {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
+        offsetof (fop_class_t, initialize)},
+    {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
+        offsetof (fop_class_t, finalize)},
+    {"describe", (fop_vv_f)fop_describe, 0,
+        offsetof (fop_class_t, describe)},  // describe
+    {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
+        offsetof (fop_class_t, represent)},
+    {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
+        offsetof (fop_class_t, retain)},
+    {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
+        offsetof (fop_class_t, release)}};
 // END DYNAMIC METHOD INFORMATION
 
 
@@ -310,8 +323,10 @@ static struct fclass __Object = {
     &__Object,               // superclass
     sizeof (struct object),  // size
     {sizeof (object_tags) / sizeof (struct fop_method_record),
-     sizeof (object_tags) / sizeof (struct fop_method_record), object_tags,
-     0},  // Inner
+        sizeof (object_tags) / sizeof (struct fop_method_record), object_tags,
+        0,
+        0,
+        0},  // Inner
     object_new,
     object_initialize,
     object_finalize,
@@ -332,12 +347,14 @@ static struct fclass __Class = {
     &__Object,               // superclass
     sizeof (struct fclass),  // size
     {sizeof (object_tags) / sizeof (struct fop_method_record),
-     sizeof (object_tags) / sizeof (struct fop_method_record), class_tags,
-     0},  // Inner
+        sizeof (object_tags) / sizeof (struct fop_method_record), class_tags,
+        0,
+        0,
+        0},  // Inner
     object_new,
     class_initialize,
     0,  // finalize
-    0,  // describe
+    class_desc,  // describe
     object_represent,
     0,  // retain
     0   // release

--- a/src/common/libflux/fop.c
+++ b/src/common/libflux/fop.c
@@ -75,6 +75,12 @@ const fop_class_t *fop_get_class (const void *o)
     return obj ? obj->fclass : NULL;
 }
 
+const fop_class_t *fop_get_class_checked (const fop_class_t *c, const void *o)
+{
+    struct object *obj = fop_cast (c, (void *)o);
+    return obj ? obj->fclass : NULL;
+}
+
 bool fop_is_a (const void *o, const fop_class_t *c)
 {
     struct object *obj = fop_cast_object ((void *)o);

--- a/src/common/libflux/fop.c
+++ b/src/common/libflux/fop.c
@@ -1,0 +1,465 @@
+#include "fop_protected.h"
+
+_Static_assert(sizeof (struct fake_object) == sizeof (struct object),
+               "object sizes must match");
+_Static_assert(sizeof (struct fake_class) == sizeof (struct fclass),
+               "class sizes must match");
+
+#include <Judy.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <search.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum fop_magic {
+    magic =  0xdeadbeef
+};
+static struct fclass __Class;
+static struct fclass __Object;
+
+static int cmp_frm (const void *l, const void *r)
+{
+    const struct fop_method_record *lhs = l, *rhs = r;
+    if (lhs && rhs && lhs->tag && rhs->tag)
+        return strcmp (lhs->tag, rhs->tag);
+    else
+        return -1;
+}
+
+static int cmp_frm_sel (const void *l, const void *r)
+{
+    const struct fop_method_record *lhs = l, *rhs = r;
+    if ((uintptr_t) lhs->selector < (uintptr_t) rhs->selector)
+        return -1;
+    if ((uintptr_t) lhs->selector == (uintptr_t) rhs->selector)
+        return 0;
+    return 1;
+}
+
+// Statically bound utility functions
+fop_object_t *fop_cast_object (void *o)
+{
+    if (!o)
+        return NULL;
+    struct object *obj = o;
+    if (obj->magic != (int)magic)
+        return NULL;
+    return o;
+}
+
+void *fop_cast (const fop_class_t *c, void *o)
+{
+    // TODO: lots of extra error checking can go here
+    struct object *obj = fop_cast_object (o);
+    if (!obj)
+        return NULL;
+    // If we've gotten this far, it has to descend from object
+    if (c == fop_object_c ())
+        return o;
+    const fop_class_t *cur = obj->fclass;
+    while (cur != c) {
+        if (cur == fop_object_c ())
+            return NULL;  // no match found
+        cur = cur->super;
+    }
+
+    return o;
+}
+
+const fop_class_t *fop_get_class (const void *o)
+{
+    struct object *obj = fop_cast_object ((void *)o);
+    return obj ? obj->fclass : NULL;
+}
+
+bool fop_is_a (const void *o, const fop_class_t *c)
+{
+    struct object *obj = fop_cast_object ((void *)o);
+    const fop_class_t *cls = fop_cast (fop_class_c (), (void *)c);
+    if (!obj || !cls)
+        return false;
+    return fop_get_class (obj) == cls;
+}
+
+bool fop_is_instance_of (const void *o, const fop_class_t *c)
+{
+    if (c == fop_object_c ())
+        return true;
+    struct object *obj = fop_cast (c, (void *)o);
+    return obj != NULL;
+}
+
+void *fop_alloc (const fop_class_t *c, size_t size)
+{
+    assert (c->size);
+    fop_object_t *o = calloc (1, size ? size : c->size);
+    if (!o) {
+        return NULL;
+    }
+    o->magic = magic;
+    o->refcount = 1;
+    o->fclass = c;
+    return o;
+}
+
+// selectors
+void *fop_new (const fop_class_t *c, ...)
+{
+    if (!c)
+        return NULL;
+    va_list ap;
+    assert (c);
+    va_start (ap, c);
+    struct object *result = c->new ? c->new (c, &ap) : NULL;
+    va_end (ap);
+    return result;
+};
+
+typedef void (*fop_vv_f) (void);
+int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method)
+{
+    struct fop_method_record matcher = {.tag = tag};
+    size_t nel = c->inner.tags_len;
+    struct fop_method_record *r =
+        bsearch (&matcher, c->inner.tags_by_selector, nel,
+               sizeof *r, cmp_frm);
+    assert (r);
+    r->method = method;
+    if (r->offset) {
+        fop_vv_f *target = (((void *)c) + r->offset);
+        *target = method;
+    }
+
+    return 0;
+}
+int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method)
+{
+    struct fop_method_record matcher = {.selector = sel};
+    size_t nel = c->inner.tags_len;
+    struct fop_method_record *r =
+        lfind (&matcher, c->inner.tags_by_selector, &nel,
+               sizeof *r, cmp_frm_sel);
+    assert (r);
+    r->method = method;
+    if (r->offset) {
+        fop_vv_f *target = (((void *)c) + r->offset);
+        *target = method;
+    }
+
+    return 0;
+}
+int fop_register_method (fop_class_t *c,
+                         fop_vv_f selector,
+                         const char *name,
+                         size_t offset,
+                         fop_vv_f fn)
+{
+    struct fop_method_record matcher = {.tag = name};
+    struct fop_method_record *r =
+        bsearch (&matcher, c->inner.tags_by_selector, c->inner.tags_len,
+                 sizeof *c->inner.tags_by_selector, cmp_frm);
+    if (r) {
+        assert (selector == r->selector);
+        assert (!strcmp (name, r->tag));
+        assert (offset == r->offset);
+        if (fn) {
+            fop_vv_f *target = (((void *)c) + r->offset);
+            *target = fn;
+            r->method = fn;
+        }
+        return 0;
+    }
+    if (c->inner.tags_cap <= c->inner.tags_len) {
+        size_t new_cap = (c->inner.tags_cap + 1) * 2;
+        new_cap = new_cap > 10 ? new_cap : 10;
+        c->inner.tags_by_selector =
+            realloc (c->inner.tags_by_selector, sizeof *r * new_cap);
+        assert (c->inner.tags_by_selector);
+        c->inner.tags_cap = new_cap;
+    }
+    r = c->inner.tags_by_selector + c->inner.tags_len;
+    assert (r);
+    r->tag = name;
+    r->offset = offset;
+    r->selector = selector;
+    r->method = fn;
+    c->inner.tags_len++;
+    qsort (c->inner.tags_by_selector, c->inner.tags_len,
+           sizeof *c->inner.tags_by_selector, cmp_frm);
+    return 0;
+}
+int fop_register_and_implement_methods (fop_class_t *c,
+                                        struct fop_method_record *records)
+{
+    if (!c || !records)
+        return -1;
+    struct fop_method_record *cur = records;
+    while (cur->selector) {
+        fop_register_method (c, cur->selector, cur->tag, cur->offset,
+                             cur->method);
+        cur++;
+    }
+    return 0;
+}
+
+void *fop_initialize (void *self, va_list *app)
+{
+    if (!self)
+        return NULL;
+    const fop_class_t *c = fop_get_class (self);
+    assert (c);
+    return c->initialize ? c->initialize (self, app) : self;
+};
+void *fop_finalize (void *o)
+{
+    if (!o)
+        return NULL;
+    const fop_class_t *c = fop_get_class (o);
+    assert (c);
+    return c->finalize ? c->finalize (o) : o;
+};
+int fop_retain (void *o)
+{
+    if (!o)
+        return -1;
+    const fop_class_t *c = fop_get_class (o);
+    assert (c);
+    return c->retain ? c->retain (o) : -1;
+};
+int fop_release (void *o)
+{
+    if (!o)
+        return -1;
+    const fop_class_t *c = fop_get_class (o);
+    assert (c);
+    return c->release ? c->release (o) : -1;
+};
+int fop_describe (void *o, FILE *s)
+{
+    if (!o)
+        return -1;
+    const fop_class_t *c = fop_get_class (o);
+    assert (c);
+    if (!c->describe) {
+        return fop_represent (o, s);
+    }
+    return c->describe (o, s);
+};
+int fop_represent (void *o, FILE *s)
+{
+    if (!o)
+        return -1;
+    const fop_class_t *c = fop_get_class (o);
+    assert (c);
+    return c->represent ? c->represent (o, s) : -1;
+};
+
+// Object methods
+
+void *object_initialize (void *o, va_list *app)
+{
+    (void)(app);  // silence unused warning...
+    if (!fop_cast_object (o)) {
+        return NULL;
+    }
+    return o;
+};
+void *object_new (const fop_class_t *c, va_list *app)
+{
+    void *buf = fop_alloc (c, 0);
+    if (!buf)
+        return NULL;
+    void *res = fop_initialize (buf, app);
+    if (!res) {
+        free (buf);
+    }
+    return res;
+};
+void *object_finalize (void *o)
+{
+    if (!fop_cast_object (o)) {
+        return NULL;
+    }
+    return o;
+};
+int object_retain (void *o)
+{
+    fop_object_t *obj = fop_cast_object (o);
+    if (!obj) {
+        return -1;
+    }
+    assert (obj->refcount < 1 << 30);
+    obj->refcount++;
+    return 0;
+};
+int object_release (void *o)
+{
+    fop_object_t *obj = fop_cast_object (o);
+    if (!obj) {
+        return -1;
+    }
+    assert (obj->refcount > 0);
+    if (--obj->refcount == 0) {
+        fprintf (stderr, "finalizing: ");
+        fop_describe (o, stderr);
+        fprintf (stderr, "\n");
+        fop_finalize (o);
+        free (o);
+    }
+    return 0;
+};
+int object_represent (void *o, FILE *s)
+{
+    fop_object_t *obj = fop_cast_object (o);
+    if (!obj) {
+        fprintf (s, "<unknown ptr@%p>", o);
+    } else {
+        const fop_class_t *c = fop_get_class (obj);
+        fprintf (s, "<%s@%p>", c->name, obj);
+    }
+    return 0;
+};
+
+// Class methods
+
+void *class_new (const fop_class_t *c, va_list *app)
+{
+    va_list local_ap;
+    va_copy (local_ap, *app);
+    const char *name = va_arg (local_ap, char *);
+    const fop_class_t *super = va_arg (local_ap, fop_class_t *);
+    size_t size = va_arg (local_ap, size_t);
+    va_end (local_ap);
+    fop_class_t *new_class = fop_alloc (c, 0);
+    assert (new_class);
+    fprintf (stderr, "new class of type %s ", c->name);
+    return fop_initialize (new_class, app);
+};
+void *class_initialize (void *c_in, va_list *app)
+{
+    fop_class_t *c = c_in;
+    const char *name = va_arg (*app, char *);
+    const fop_class_t *super = va_arg (*app, fop_class_t *);
+    size_t size = va_arg (*app, size_t);
+    size_t offset = offsetof (fop_class_t, new);
+
+    const fop_class_t *super_metaclass = fop_get_class (super);
+    fprintf (stderr, "inheriting %s(%zu) from %s(%zu), meta %s(%zu)\n", name,
+             size, super->name, super->size, super_metaclass->name,
+             super_metaclass->size);
+    if (super != NULL && super != c && super->size) {
+        if (super->inner.tags_by_selector) {
+            if (!super->inner.sorted) {
+                qsort (super->inner.tags_by_selector, super->inner.tags_len,
+                       sizeof *super->inner.tags_by_selector, cmp_frm);
+            }
+            struct fop_method_record *new_tags =
+                malloc (sizeof *new_tags * super->inner.tags_len);
+            assert (new_tags);
+            memcpy (new_tags, super->inner.tags_by_selector,
+                    sizeof *new_tags * super->inner.tags_len);
+            c->inner.tags_by_selector = new_tags;
+            c->inner.tags_len = super->inner.tags_len;
+            c->inner.tags_cap = super->inner.tags_len;
+        }
+        // inheritence...
+        memcpy (((char *)c) + offset, ((char *)super) + offset,
+                super_metaclass->size - offset);
+    }
+    c->name = name;
+    c->super = super;
+    c->size = size;
+
+    return c;
+};
+
+// Object and Class definition, static for this special case
+
+static struct fop_method_record object_tags[] = {
+    {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
+     offsetof (fop_class_t, new)},
+    {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
+     offsetof (fop_class_t, initialize)},
+    {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
+     offsetof (fop_class_t, finalize)},
+    {"describe", (fop_vv_f)fop_describe, 0,
+     offsetof (fop_class_t, describe)},  // describe
+    {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
+     offsetof (fop_class_t, represent)},
+    {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
+     offsetof (fop_class_t, retain)},
+    {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
+     offsetof (fop_class_t, release)}};
+static struct fclass __Object = {
+
+    {
+        // object _
+        magic,      // magic
+        INT32_MAX,  // refcount
+        &__Class    // class
+    },
+    "Object",                // name
+    &__Object,               // superclass
+    sizeof (struct object),  // size
+    {sizeof (object_tags) / sizeof (struct fop_method_record),
+     sizeof (object_tags) / sizeof (struct fop_method_record), object_tags,
+     0},  // Inner
+    object_new,
+    object_initialize,
+    object_finalize,
+    0,  // describe
+    object_represent,
+    object_retain,
+    object_release};
+
+static struct fop_method_record class_tags[] = {
+    {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
+     offsetof (fop_class_t, new)},
+    {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
+     offsetof (fop_class_t, initialize)},
+    {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
+     offsetof (fop_class_t, finalize)},
+    {"describe", (fop_vv_f)fop_describe, 0,
+     offsetof (fop_class_t, describe)},  // describe
+    {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
+     offsetof (fop_class_t, represent)},
+    {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
+     offsetof (fop_class_t, retain)},
+    {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
+     offsetof (fop_class_t, release)}};
+
+static struct fclass __Class = {
+
+    {
+        // object _
+        magic,      // magic
+        INT32_MAX,  // refcount
+        &__Class    // class
+    },
+    "Class",                 // name
+    &__Object,               // superclass
+    sizeof (struct fclass),  // size
+    {sizeof (object_tags) / sizeof (struct fop_method_record),
+     sizeof (object_tags) / sizeof (struct fop_method_record), object_tags,
+     0},  // Inner
+    class_new,
+    class_initialize,
+    0,  // finalize
+    0,  // describe
+    object_represent,
+    0,  // retain
+    0   // release
+};
+
+// object and class class getters
+const fop_class_t *fop_object_c ()
+{
+    return &__Object;
+}
+const fop_class_t *fop_class_c ()
+{
+    return &__Class;
+}

--- a/src/common/libflux/fop.c
+++ b/src/common/libflux/fop.c
@@ -1,7 +1,8 @@
 #include "fop_protected.h"
+
 #include "fop_dynamic.h"
 
-#include <assert.h>
+#include "src/common/libutil/sds.h"
 
 #include <Judy.h>
 
@@ -11,27 +12,25 @@
 #include <stdlib.h>
 #include <string.h>
 
-enum fop_magic {
-    magic =  0xdeadbeef
-};
-static struct fclass __Class;
-static struct fclass __Object;
+enum fop_magic { magic = 0xdeadbeef };
+static fop_class_t __Class;
+static fop_class_t __Object;
 
 // Statically bound utility functions
 fop_object_t *fop_cast_object (const void *o)
 {
     if (!o)
         return NULL;
-    const struct object *obj = o;
+    const fop_object_t *obj = o;
     if (obj->magic != (int)magic)
         return NULL;
-    return (struct object *)o;
+    return (fop_object_t *)o;
 }
 
 void *fop_cast (const fop_class_t *c, const void *o)
 {
     // TODO: lots of extra error checking can go here
-    struct object *obj = fop_cast_object (o);
+    fop_object_t *obj = fop_cast_object (o);
     if (!obj)
         return NULL;
     // If we've gotten this far, it has to descend from object
@@ -49,26 +48,26 @@ void *fop_cast (const fop_class_t *c, const void *o)
 
 const void *fop_get_class (const void *o)
 {
-    struct object *obj = fop_cast_object ((void *)o);
+    fop_object_t *obj = fop_cast_object ((void *)o);
     return obj ? obj->fclass : NULL;
 }
 
 const void *fop_get_class_checked (const void *o, const fop_class_t *c)
 {
-    struct object *obj = fop_cast (c, (void *)o);
+    fop_object_t *obj = fop_cast (c, (void *)o);
     return obj ? obj->fclass : NULL;
 }
 
 const fop_class_t *fop_super (const fop_class_t *c)
 {
     c = fop_cast (fop_class_c (), c);
-    assert(c && c->super);
+    assert (c && c->super);
     return c->super;
 }
 
 bool fop_is_a (const void *o, const fop_class_t *c)
 {
-    struct object *obj = fop_cast_object ((void *)o);
+    fop_object_t *obj = fop_cast_object ((void *)o);
     const fop_class_t *cls = fop_cast (fop_class_c (), (void *)c);
     if (!obj || !cls)
         return false;
@@ -79,8 +78,15 @@ bool fop_is_instance_of (const void *o, const fop_class_t *c)
 {
     if (c == fop_object_c ())
         return true;
-    struct object *obj = fop_cast (c, (void *)o);
+    fop_object_t *obj = fop_cast (c, (void *)o);
     return obj != NULL;
+}
+
+void fop_tag_object (fop_object_t *o, const fop_class_t *c)
+{
+    o->magic = magic;
+    o->refcount = 1;
+    o->fclass = c;
 }
 
 void *fop_alloc (const fop_class_t *c, size_t size)
@@ -90,9 +96,7 @@ void *fop_alloc (const fop_class_t *c, size_t size)
     if (!o) {
         return NULL;
     }
-    o->magic = magic;
-    o->refcount = 1;
-    o->fclass = c;
+    fop_tag_object (o, c);
     return o;
 }
 
@@ -104,7 +108,7 @@ void *fop_new (const fop_class_t *c, ...)
     va_list ap;
     assert (c);
     va_start (ap, c);
-    struct object *result = c->new ? c->new (c, &ap) : NULL;
+    fop_object_t *result = c->new ? c->new (c, &ap) : NULL;
     va_end (ap);
     return result;
 };
@@ -127,33 +131,37 @@ void *fop_initialize_super (const fop_class_t *c, void *self, va_list *app)
 };
 void fop_finalize (void *o)
 {
-    if (!o) return;
+    if (!o)
+        return;
     const fop_class_t *c = fop_get_class (o);
-    if (c && c->finalize )
+    if (c && c->finalize)
         c->finalize (o);
 };
 void fop_finalize_super (const fop_class_t *c, void *o)
 {
-    if (!o) return;
+    if (!o)
+        return;
     const fop_class_t *superclass = fop_super (c);
-    if (superclass && superclass->finalize )
+    if (superclass && superclass->finalize)
         superclass->finalize (o);
 };
 void fop_retain (void *o)
 {
-    if (!o) return;
+    if (!o)
+        return;
     const fop_class_t *c = fop_get_class (o);
-    if (c && c->retain )
+    if (c && c->retain)
         c->retain (o);
 };
 void fop_release (void *o)
 {
-    if (!o) return;
+    if (!o)
+        return;
     const fop_class_t *c = fop_get_class (o);
-    if (c && c->release )
+    if (c && c->release)
         c->release (o);
 };
-fop * fop_describe (void *o, FILE *s)
+fop *fop_describe (void *o, FILE *s)
 {
     const fop_class_t *c = fop_get_class (o);
     if (!c)
@@ -163,13 +171,79 @@ fop * fop_describe (void *o, FILE *s)
     }
     return c->describe (o, s);
 };
-fop * fop_represent (void *o, FILE *s)
+fop *fop_represent (void *o, FILE *s)
 {
     const fop_class_t *c = fop_get_class (o);
     if (!c)
         return NULL;
     return c->represent ? c->represent (o, s) : NULL;
 };
+
+// Class construction routines
+
+fop_class_t *fop_class_set_new (fop *_c, fop_new_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->new = fn;
+    return c;
+}
+fop_class_t *fop_class_set_init (fop *_c, fop_init_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->initialize = fn;
+    return c;
+}
+fop_class_t *fop_class_set_fini (fop *_c, fop_fini_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->finalize = fn;
+    return c;
+}
+fop_class_t *fop_class_set_describe (fop *_c, fop_putter_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->describe = fn;
+    return c;
+}
+fop_class_t *fop_class_set_represent (fop *_c, fop_putter_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->represent = fn;
+    return c;
+}
+fop_class_t *fop_class_set_retain (fop *_c, fop_retain_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->retain = fn;
+    return c;
+}
+fop_class_t *fop_class_set_release (fop *_c, fop_release_f fn)
+{
+    fop_class_t * c = fop_cast (fop_class_c (), _c);
+    if (!c) {
+        return NULL;
+    }
+    c->release = fn;
+    return c;
+}
 
 // Object methods
 
@@ -197,8 +271,7 @@ void *object_new (const fop_class_t *c, va_list *app)
     }
     return res;
 };
-void object_finalize (void *o)
-{
+void object_finalize (void *o){
     // Nothing to do, release does the free
 };
 void object_retain (void *o)
@@ -222,7 +295,7 @@ void object_release (void *o)
         free (o);
     }
 };
-fop * object_represent (fop *o, FILE *s)
+fop *object_represent (fop *o, FILE *s)
 {
     fop_object_t *obj = fop_cast_object (o);
     if (!obj) {
@@ -245,7 +318,8 @@ void *class_initialize (fop *c_in, va_list *app)
     size_t offset = offsetof (fop_class_t, new);
 
     const fop_class_t *super_metaclass = fop_get_class (super);
-    /* fprintf (stderr, "inheriting %s(%zu) from %s(%zu), meta %s(%zu)\n", name, */
+    /* fprintf (stderr, "inheriting %s(%zu) from %s(%zu), meta %s(%zu)\n", name,
+     */
     /*          size, super->name, super->size, super_metaclass->name, */
     /*          super_metaclass->size); */
     if (super != NULL && super != c && super->size) {
@@ -264,54 +338,48 @@ void *class_initialize (fop *c_in, va_list *app)
 void *class_desc (fop *c_in, FILE *s)
 {
     fop_class_t *c = c_in;
-    fprintf (s, "class %s(%s){\n", c->name, fop_super(c)->name);
+    fprintf (s, "class %s(%s)\n", c->name, fop_super (c)->name);
     fprintf (s, "    size: %zu\n", c->size);
-    fprintf (s, "    tags: %zu\n", c->inner.tags_len);
-    for (size_t i = 0; i < c->inner.tags_len; ++i) {
-        struct fop_method_record *rec = c->inner.tags_by_selector + i;
-        fprintf (s, "        %s: %p, %p, %zu\n", rec->tag, rec->selector, rec->method, rec->offset);
+    size_t nif =
+        c->inner.interfaces
+            ? sdslen ((void *)c->inner.interfaces) / sizeof (struct iface_pair)
+            : 0;
+    fprintf (s, "    interfaces: %zu\n", nif);
+
+    for (size_t i = 0; i < nif; ++i) {
+        struct iface_pair *rec = c->inner.interfaces + i;
+        fprintf (s, "        %s: %zu\n", rec->iface->name, rec->offset);
     }
+    fprintf (s, "    default methods:\n");
+    fprintf (s, "        new: %s\n",
+             c->new ? (c->new == object_new ? "default" : "custom") : "unimplem"
+                                                                      "ented");
+    fprintf (s, "        initialize: %s\n",
+             c->initialize
+                 ? (c->initialize == object_initialize ? "default" : "custom")
+                 : "unimplemented");
+    fprintf (s, "        finalize: %s\n",
+             c->finalize
+                 ? (c->finalize == object_finalize ? "default" : "custom")
+                 : "unimplemented");
+    fprintf (s, "        describe: %s\n", c->describe ? "custom" : "unimplement"
+                                                                   "ed");
+    fprintf (s, "        represent: %s\n",
+             c->represent
+                 ? (c->represent == object_represent ? "default" : "custom")
+                 : "unimplemented");
+    fprintf (s, "        retain: %s\n",
+             c->retain ? (c->retain == object_retain ? "default" : "custom")
+                       : "unimplemented");
+    fprintf (s, "        release: %s\n",
+             c->release ? (c->release == object_release ? "default" : "custom")
+                        : "unimplemented");
     return c_in;
 };
 
 // Object and Class definition, static for this special case
 
-// DYNAMIC METHOD INFORMATION
-static struct fop_method_record object_tags[] = {
-    {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
-        offsetof (fop_class_t, new)},
-    {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
-        offsetof (fop_class_t, initialize)},
-    {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
-        offsetof (fop_class_t, finalize)},
-    {"describe", (fop_vv_f)fop_describe, 0,
-        offsetof (fop_class_t, describe)},  // describe
-    {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
-        offsetof (fop_class_t, represent)},
-    {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
-        offsetof (fop_class_t, retain)},
-    {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
-        offsetof (fop_class_t, release)}};
-
-static struct fop_method_record class_tags[] = {
-    {"new", (fop_vv_f)fop_new, (fop_vv_f)object_new,
-        offsetof (fop_class_t, new)},
-    {"initialize", (fop_vv_f)fop_initialize, (fop_vv_f)object_initialize,
-        offsetof (fop_class_t, initialize)},
-    {"finalize", (fop_vv_f)fop_finalize, (fop_vv_f)object_finalize,
-        offsetof (fop_class_t, finalize)},
-    {"describe", (fop_vv_f)fop_describe, 0,
-        offsetof (fop_class_t, describe)},  // describe
-    {"represent", (fop_vv_f)fop_represent, (fop_vv_f)object_represent,
-        offsetof (fop_class_t, represent)},
-    {"retain", (fop_vv_f)fop_retain, (fop_vv_f)object_retain,
-        offsetof (fop_class_t, retain)},
-    {"release", (fop_vv_f)fop_release, (fop_vv_f)object_release,
-        offsetof (fop_class_t, release)}};
-// END DYNAMIC METHOD INFORMATION
-
-
-static struct fclass __Object = {
+static fop_class_t __Object = {
 
     {
         // object _
@@ -321,12 +389,8 @@ static struct fclass __Object = {
     },
     "Object",                // name
     &__Object,               // superclass
-    sizeof (struct object),  // size
-    {sizeof (object_tags) / sizeof (struct fop_method_record),
-        sizeof (object_tags) / sizeof (struct fop_method_record), object_tags,
-        0,
-        0,
-        0},  // Inner
+    sizeof (fop_object_t),  // size
+    {0},                     // Inner
     object_new,
     object_initialize,
     object_finalize,
@@ -335,7 +399,7 @@ static struct fclass __Object = {
     object_retain,
     object_release};
 
-static struct fclass __Class = {
+static fop_class_t __Class = {
 
     {
         // object _
@@ -345,15 +409,11 @@ static struct fclass __Class = {
     },
     "Class",                 // name
     &__Object,               // superclass
-    sizeof (struct fclass),  // size
-    {sizeof (object_tags) / sizeof (struct fop_method_record),
-        sizeof (object_tags) / sizeof (struct fop_method_record), class_tags,
-        0,
-        0,
-        0},  // Inner
+    sizeof (fop_class_t),  // size
+    {0},                     // Inner
     object_new,
     class_initialize,
-    0,  // finalize
+    0,           // finalize
     class_desc,  // describe
     object_represent,
     0,  // retain

--- a/src/common/libflux/fop.h
+++ b/src/common/libflux/fop.h
@@ -39,7 +39,8 @@ const fop_class_t *fop_class_c ();
 // utility functions
 fop_object_t *fop_cast_object (void *o);
 void *fop_cast (const fop_class_t *c, void *o);
-const fop_class_t *fop_get_class (const void *o);
+const void *fop_get_class (const void *o);
+const void *fop_get_class_checked (const fop_class_t *c, const void *o);
 bool fop_is_a (const void *o, const fop_class_t *c);
 bool fop_is_instance_of (const void *o, const fop_class_t *c);
 

--- a/src/common/libflux/fop.h
+++ b/src/common/libflux/fop.h
@@ -17,10 +17,11 @@ const fop_class_t *fop_object_c ();
 const fop_class_t *fop_class_c ();
 
 // utility functions
-fop_object_t *fop_cast_object (fop *o);
-void *fop_cast (const fop_class_t *c, fop *o);
+fop_object_t *fop_cast_object (const fop *o);
+void *fop_cast (const fop_class_t *c, const fop *o);
 const void *fop_get_class (const fop *o);
 const void *fop_get_class_checked (const fop *o, const fop_class_t *c);
+const fop_class_t *fop_super (const fop_class_t *c);
 
 bool fop_is_a (const fop *o, const fop_class_t *c);
 bool fop_is_instance_of (const fop *o, const fop_class_t *c);
@@ -34,5 +35,9 @@ void fop_retain (fop *o);
 void fop_release (fop *o);
 fop * fop_describe (fop *o, FILE *s);
 fop * fop_represent (fop *o, FILE *s);
+
+// super helpers
+void *fop_initialize_super (const fop_class_t *c, void *self, va_list *app);
+void fop_finalize_super (const fop_class_t *c, void *o);
 
 #endif /* __FLUX_CORE_FOP_H */

--- a/src/common/libflux/fop.h
+++ b/src/common/libflux/fop.h
@@ -49,7 +49,7 @@ fop *fop_describe (fop *o, FILE *s);
 fop *fop_represent (fop *o, FILE *s);
 uintptr_t fop_hash (fop *);
 bool fop_equal (const fop *, const fop *);
-fop *fop_copy (const fop *);
+fop *fop_copy (fop *self, const fop *from);
 
 // fop class construction routines
 
@@ -68,7 +68,7 @@ typedef void (*fop_release_f) (void *);
 typedef fop *(*fop_putter_f) (fop *, FILE *);
 typedef uintptr_t (*fop_hash_f) (fop *);
 typedef bool (*fop_equal_f) (const fop *, const fop *);
-typedef fop *(*fop_copy_f) (const fop *);
+typedef fop *(*fop_copy_f) (fop *self, const fop *from);
 
 fop_class_t *fop_class_set_new (fop *c, fop_new_f fn);
 fop_class_t *fop_class_set_init (fop *c, fop_init_f fn);

--- a/src/common/libflux/fop.h
+++ b/src/common/libflux/fop.h
@@ -6,8 +6,19 @@
 #include <stdint.h>
 #include <stdio.h>
 
-typedef struct object fop_object_t;
-typedef struct fclass fop_class_t;
+struct fop_object_fake {
+    void *fake[2];
+};
+struct fop_class_fake {
+    void *fake[32];
+};
+#ifndef FOP_PROT
+typedef struct fop_object_fake fop_object_t;
+typedef struct fop_class_fake fop_class_t;
+#else
+typedef struct fop_object fop_object_t;
+typedef struct fop_class fop_class_t;
+#endif
 
 // Flux object pointer
 typedef void fop;
@@ -28,13 +39,30 @@ bool fop_is_instance_of (const fop *o, const fop_class_t *c);
 
 // fop_object_c selectors
 // Every class is a subclass of fop_object_c, so these are pretty universal
+fop *fop_alloc (const fop_class_t *c, size_t size);
 fop *fop_new (const fop_class_t *c, ...);
 fop *fop_initialize (fop *self, va_list *app);
 void fop_finalize (fop *o);
 void fop_retain (fop *o);
 void fop_release (fop *o);
-fop * fop_describe (fop *o, FILE *s);
-fop * fop_represent (fop *o, FILE *s);
+fop *fop_describe (fop *o, FILE *s);
+fop *fop_represent (fop *o, FILE *s);
+
+// fop class construction routines
+typedef fop *(*fop_new_f) (const fop_class_t *, va_list *);
+typedef fop *(*fop_init_f) (fop *, va_list *);
+typedef void (*fop_fini_f) (void *);
+typedef void (*fop_retain_f) (void *);
+typedef void (*fop_release_f) (void *);
+typedef fop *(*fop_putter_f) (fop *, FILE *);
+
+fop_class_t *fop_class_set_new (fop *c, fop_new_f fn);
+fop_class_t *fop_class_set_init (fop *c, fop_init_f fn);
+fop_class_t *fop_class_set_fini (fop *c, fop_fini_f fn);
+fop_class_t *fop_class_set_describe (fop *c, fop_putter_f fn);
+fop_class_t *fop_class_set_represent (fop *c, fop_putter_f fn);
+fop_class_t *fop_class_set_retain (fop *c, fop_retain_f fn);
+fop_class_t *fop_class_set_release (fop *c, fop_release_f fn);
 
 // super helpers
 void *fop_initialize_super (const fop_class_t *c, void *self, va_list *app);

--- a/src/common/libflux/fop.h
+++ b/src/common/libflux/fop.h
@@ -6,68 +6,33 @@
 #include <stdint.h>
 #include <stdio.h>
 
-struct fake_object {
-    int64_t fake[2];
-};
-typedef void (*fop_vv_f) (void);
-struct fake_class {
-    struct fake_object fake1;
-    void *fake2[2];
-    size_t fake3[1];
-    struct {
-        size_t meh1[2];
-        void *meh2;
-        bool bah;
-    } fake5;
-    fop_vv_f fake4[7];
-};
-#ifndef FOP_PROT
-typedef struct fake_object fop_object_t;
-#else
 typedef struct object fop_object_t;
-#endif
-#ifndef FOP_PROT
-typedef struct fake_class fop_class_t;
-#else
 typedef struct fclass fop_class_t;
-#endif
+
+// Flux object pointer
+typedef void fop;
 
 // class getters
 const fop_class_t *fop_object_c ();
 const fop_class_t *fop_class_c ();
 
 // utility functions
-fop_object_t *fop_cast_object (void *o);
-void *fop_cast (const fop_class_t *c, void *o);
-const void *fop_get_class (const void *o);
-const void *fop_get_class_checked (const fop_class_t *c, const void *o);
-bool fop_is_a (const void *o, const fop_class_t *c);
-bool fop_is_instance_of (const void *o, const fop_class_t *c);
+fop_object_t *fop_cast_object (fop *o);
+void *fop_cast (const fop_class_t *c, fop *o);
+const void *fop_get_class (const fop *o);
+const void *fop_get_class_checked (const fop *o, const fop_class_t *c);
 
-int fop_register_method (fop_class_t *c,
-                         fop_vv_f selector,
-                         const char *name,
-                         size_t offset,
-                         fop_vv_f fn);
-int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method);
-int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method);
-struct fop_method_record {
-    const char *tag;
-    fop_vv_f selector;
-    fop_vv_f method;
-    size_t offset;
-};
-int fop_register_and_implement_methods (fop_class_t *c,
-                                        struct fop_method_record *records);
+bool fop_is_a (const fop *o, const fop_class_t *c);
+bool fop_is_instance_of (const fop *o, const fop_class_t *c);
 
 // fop_object_c selectors
 // Every class is a subclass of fop_object_c, so these are pretty universal
-void *fop_new (const fop_class_t *c, ...);
-void *fop_initialize (void *self, va_list *app);
-void *fop_finalize (void *o);
-int fop_retain (void *o);
-int fop_release (void *o);
-int fop_describe (void *o, FILE *s);
-int fop_represent (void *o, FILE *s);
+fop *fop_new (const fop_class_t *c, ...);
+fop *fop_initialize (fop *self, va_list *app);
+void fop_finalize (fop *o);
+void fop_retain (fop *o);
+void fop_release (fop *o);
+fop * fop_describe (fop *o, FILE *s);
+fop * fop_represent (fop *o, FILE *s);
 
 #endif /* __FLUX_CORE_FOP_H */

--- a/src/common/libflux/fop.h
+++ b/src/common/libflux/fop.h
@@ -1,0 +1,72 @@
+#ifndef __FLUX_CORE_FOP_H
+#define __FLUX_CORE_FOP_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+struct fake_object {
+    int64_t fake[2];
+};
+typedef void (*fop_vv_f) (void);
+struct fake_class {
+    struct fake_object fake1;
+    void *fake2[2];
+    size_t fake3[1];
+    struct {
+        size_t meh1[2];
+        void *meh2;
+        bool bah;
+    } fake5;
+    fop_vv_f fake4[7];
+};
+#ifndef FOP_PROT
+typedef struct fake_object fop_object_t;
+#else
+typedef struct object fop_object_t;
+#endif
+#ifndef FOP_PROT
+typedef struct fake_class fop_class_t;
+#else
+typedef struct fclass fop_class_t;
+#endif
+
+// class getters
+const fop_class_t *fop_object_c ();
+const fop_class_t *fop_class_c ();
+
+// utility functions
+fop_object_t *fop_cast_object (void *o);
+void *fop_cast (const fop_class_t *c, void *o);
+const fop_class_t *fop_get_class (const void *o);
+bool fop_is_a (const void *o, const fop_class_t *c);
+bool fop_is_instance_of (const void *o, const fop_class_t *c);
+
+int fop_register_method (fop_class_t *c,
+                         fop_vv_f selector,
+                         const char *name,
+                         size_t offset,
+                         fop_vv_f fn);
+int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method);
+int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method);
+struct fop_method_record {
+    const char *tag;
+    fop_vv_f selector;
+    fop_vv_f method;
+    size_t offset;
+};
+int fop_register_and_implement_methods (fop_class_t *c,
+                                        struct fop_method_record *records);
+
+// fop_object_c selectors
+// Every class is a subclass of fop_object_c, so these are pretty universal
+void *fop_new (const fop_class_t *c, ...);
+void *fop_initialize (void *self, va_list *app);
+void *fop_finalize (void *o);
+int fop_retain (void *o);
+int fop_release (void *o);
+int fop_describe (void *o, FILE *s);
+int fop_represent (void *o, FILE *s);
+
+#endif /* __FLUX_CORE_FOP_H */

--- a/src/common/libflux/fop_dynamic.c
+++ b/src/common/libflux/fop_dynamic.c
@@ -26,11 +26,18 @@ const fop_class_t *fop_interface_c ()
 {
     // TODO: make un-allocatable
     static fop_class_t *cls = NULL;
-    if (!cls) {
-        cls = fop_new (fop_class_c (), "interface_class", fop_class_c (),
-                       sizeof (fop_class_t));
+    if (fop_class_needs_init (&cls)) {
+        cls = fop_new_metaclass ("interface_class", fop_class_c (),
+                                 sizeof (fop_class_t));
     }
     return (void *)cls;
+}
+
+fop_class_t *fop_new_interface_class (const char *name,
+                                      const fop_class_t *parent,
+                                      size_t size)
+{
+    return fop_new (fop_interface_c (), name, parent, size);
 }
 
 static void add_interface (fop_class_t *c, struct iface_pair *p)
@@ -82,7 +89,7 @@ const void *fop_get_interface (const fop *o, const fop_class_t *interface)
     interface = fop_cast (fop_class_c (), interface);
     if (!c || !interface || !c->inner.interfaces)
         return NULL;
-    struct iface_pair p = {interface, 0};
+    struct iface_pair p = {interface, 0, 0};
     size_t nel = sdslen ((void *)c->inner.interfaces) / sizeof p;
     const struct iface_pair *ret =
         lfind (&p, c->inner.interfaces, &nel, sizeof p, cmp_interface_pair);

--- a/src/common/libflux/fop_dynamic.c
+++ b/src/common/libflux/fop_dynamic.c
@@ -9,19 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef void (*fop_vv_f) (void);
-
-// method record comparators
-
-static int cmp_interface_pair (const void *key, const void *member)
-{
-    const struct iface_pair *k = key;
-    const struct iface_pair *p = member;
-    if (k->iface == p->iface)
-        return 0;
-    return fop_cast (k->iface, p->iface) ? 0 : 1;
-}
-
 const fop_class_t *fop_interface_c ()
 {
     // TODO: make un-allocatable
@@ -66,33 +53,23 @@ void fop_implement_interface (fop_class_t *c,
     add_interface (c, &p);
 }
 
-void fop_implement_dynamic_interface (fop_class_t *c,
-                                      const fop_class_t *interface,
-                                      fop_interface_t *impl)
-{
-    c = fop_cast (fop_class_c (), c);
-    interface = fop_cast (fop_interface_c (), interface);
-    assert (c && interface);
-
-    struct iface_pair p = {(fop_class_t *)interface, impl, 0};
-    add_interface (c, &p);
-}
-
 const void *fop_get_interface (const fop *o, const fop_class_t *interface)
 {
     // TODO: Make interfaces un-allocatable, not really classes, just
     // interfaces
     const fop_class_t *c = fop_get_class (o);
-    fop_describe ((void *)c, stderr);
-    fop_describe ((void *)interface, stderr);
 
-    interface = fop_cast (fop_class_c (), interface);
+    interface = fop_cast (fop_interface_c (), interface);
     if (!c || !interface || !c->inner.interfaces)
         return NULL;
-    struct iface_pair p = {interface, 0, 0};
-    size_t nel = sdslen ((void *)c->inner.interfaces) / sizeof p;
-    const struct iface_pair *ret =
-        lfind (&p, c->inner.interfaces, &nel, sizeof p, cmp_interface_pair);
+    const struct iface_pair *ret = NULL;
+    for (size_t i = 0; i < sdslen((void *)c->inner.interfaces); ++i) {
+        const struct iface_pair *cur = &c->inner.interfaces[i];
+        if (interface == cur->iface || fop_cast (interface, cur->iface)) {
+            ret = cur;
+            break;
+        }
+    }
     if (!ret || !(ret->impl || ret->offset))
         return NULL;
     return ret->impl ? ret->impl : ((void *)c) + ret->offset;

--- a/src/common/libflux/fop_dynamic.c
+++ b/src/common/libflux/fop_dynamic.c
@@ -1,47 +1,74 @@
+#include "fop_protected.h"
+
 #include "fop_dynamic.h"
+
+#include "src/common/libutil/sds.h"
 
 #include <assert.h>
 #include <search.h>
 #include <stdlib.h>
 #include <string.h>
 
+typedef void (*fop_vv_f) (void);
+
 // method record comparators
-static int cmp_frm (const void *l, const void *r)
-{
-    const struct fop_method_record *lhs = l, *rhs = r;
-    if (lhs && rhs && lhs->tag && rhs->tag)
-        return strcmp (lhs->tag, rhs->tag);
-    else
-        return -1;
-}
 
-static int cmp_frm_sel (const void *l, const void *r)
+static int cmp_interface_pair (const void *key, const void *member)
 {
-    const struct fop_method_record *lhs = l, *rhs = r;
-    if ((uintptr_t) lhs->selector < (uintptr_t) rhs->selector)
-        return -1;
-    if ((uintptr_t) lhs->selector == (uintptr_t) rhs->selector)
+    const struct iface_pair *k = key;
+    const struct iface_pair *p = member;
+    if (k->iface == p->iface)
         return 0;
-    return 1;
-}
-
-static int cmp_interface (const void *key, const void *member)
-{
-    const fop_class_t *k = key;
-    return fop_cast (k, member) == 0;
+    return fop_cast (k->iface, p->iface) ? 0 : 1;
 }
 
 const fop_class_t *fop_interface_c ()
 {
+    // TODO: make un-allocatable
     static fop_class_t *cls = NULL;
     if (!cls) {
-        cls = fop_new (fop_class_c (), "Interface", fop_class_c (),
-                sizeof (fop_class_t));
-        free (cls->inner.tags_by_selector);
-        cls->inner.tags_by_selector = NULL;
-        cls->inner.tags_len = 0;
+        cls = fop_new (fop_class_c (), "interface_class", fop_class_c (),
+                       sizeof (fop_class_t));
     }
-    return cls;
+    return (void *)cls;
+}
+
+static void add_interface (fop_class_t *c, struct iface_pair *p)
+{
+    if (!c->inner.interfaces) {
+        c->inner.interfaces = (void *)sdsempty ();
+    }
+
+    c->inner.interfaces =
+        (void *)sdscatlen ((void *)c->inner.interfaces, p, sizeof *p);
+}
+
+void fop_implement_interface (fop_class_t *c,
+                              const fop_class_t *interface,
+                              size_t offset)
+{
+    c = fop_cast (fop_class_c (), c);
+    interface = fop_cast (fop_interface_c (), interface);
+    assert (c && interface);
+
+    // Turn embedded interface into a valid object
+    fop_object_t *embedded_if = ((void *)c) + offset;
+    fop_tag_object (embedded_if, interface);
+
+    struct iface_pair p = {(fop_class_t *)interface, NULL, offset};
+    add_interface (c, &p);
+}
+
+void fop_implement_dynamic_interface (fop_class_t *c,
+                                      const fop_class_t *interface,
+                                      fop_interface_t *impl)
+{
+    c = fop_cast (fop_class_c (), c);
+    interface = fop_cast (fop_interface_c (), interface);
+    assert (c && interface);
+
+    struct iface_pair p = {(fop_class_t *)interface, impl, 0};
+    add_interface (c, &p);
 }
 
 const void *fop_get_interface (const fop *o, const fop_class_t *interface)
@@ -49,156 +76,24 @@ const void *fop_get_interface (const fop *o, const fop_class_t *interface)
     // TODO: Make interfaces un-allocatable, not really classes, just
     // interfaces
     const fop_class_t *c = fop_get_class (o);
-    fop_describe ((void*)c, stderr);
-    fop_describe ((void*)interface, stderr);
+    fop_describe ((void *)c, stderr);
+    fop_describe ((void *)interface, stderr);
 
     interface = fop_cast (fop_class_c (), interface);
-    if (!c || !interface)
+    if (!c || !interface || !c->inner.interfaces)
         return NULL;
-    size_t nel = c->inner.interfaces_len;
-    const fop_class_t *ret =
-            bsearch (&interface, c->inner.interfaces, nel,
-                     sizeof (void *), cmp_interface);
-    if (ret)
-        return ret;
-
-    ret = fop_new (interface, c->name, interface, 0);
-
-    for (size_t i = 0; i < interface->inner.tags_len; ++i) {
-        fop_vv_f fn = fop_get_method (c, interface->inner.tags_by_selector[i].tag);
-        assert (fn);
-
-        fop_vv_f *target = (((void *)ret) + interface->inner.tags_by_selector[i].offset);
-        *target = fn;
-    }
-
-    return ret;
-}
-
-// method registration and implementation functions
-
-fop_vv_f fop_get_method (const fop_class_t *c, const char *name)
-{
-    struct fop_method_record matcher = {.tag = name};
-    size_t nel = c->inner.tags_len;
-    struct fop_method_record *r =
-            bsearch (&matcher, c->inner.tags_by_selector, nel,
-                   sizeof *r, cmp_frm);
-    if (!r)
+    struct iface_pair p = {interface, 0};
+    size_t nel = sdslen ((void *)c->inner.interfaces) / sizeof p;
+    const struct iface_pair *ret =
+        lfind (&p, c->inner.interfaces, &nel, sizeof p, cmp_interface_pair);
+    if (!ret || !(ret->impl || ret->offset))
         return NULL;
-    return r->method;
-}
-fop_vv_f fop_get_method_by_sel (const fop_class_t *c, fop_vv_f sel)
-{
-    struct fop_method_record matcher = {.selector = sel};
-    size_t nel = c->inner.tags_len;
-    struct fop_method_record *r =
-            lfind (&matcher, c->inner.tags_by_selector, &nel,
-                   sizeof *r, cmp_frm_sel);
-    if (!r)
-        return NULL;
-    return r->method;
-}
-int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method)
-{
-    struct fop_method_record matcher = {.tag = tag};
-    size_t nel = c->inner.tags_len;
-    struct fop_method_record *r =
-            bsearch (&matcher, c->inner.tags_by_selector, nel,
-                     sizeof *r, cmp_frm);
-    assert (r);
-    r->method = method;
-    if (r->offset) {
-        fop_vv_f *target = (((void *)c) + r->offset);
-        *target = method;
-    }
-
-    return 0;
-}
-int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method)
-{
-    struct fop_method_record matcher = {.selector = sel};
-    size_t nel = c->inner.tags_len;
-    struct fop_method_record *r =
-            lfind (&matcher, c->inner.tags_by_selector, &nel,
-                   sizeof *r, cmp_frm_sel);
-    assert (r);
-    r->method = method;
-    if (r->offset) {
-        fop_vv_f *target = (((void *)c) + r->offset);
-        *target = method;
-    }
-
-    return 0;
-}
-int fop_register_method (fop_class_t *c,
-                         fop_vv_f selector,
-                         const char *name,
-                         size_t offset,
-                         fop_vv_f fn)
-{
-    struct fop_method_record matcher = {.tag = name};
-    struct fop_method_record *r =
-            bsearch (&matcher, c->inner.tags_by_selector, c->inner.tags_len,
-                     sizeof *c->inner.tags_by_selector, cmp_frm);
-    if (r) {
-        assert (selector == r->selector);
-        assert (!strcmp (name, r->tag));
-        assert (offset == r->offset);
-        if (fn) {
-            fop_vv_f *target = (((void *)c) + r->offset);
-            *target = fn;
-            r->method = fn;
-        }
-        return 0;
-    }
-    if (c->inner.tags_cap <= c->inner.tags_len) {
-        size_t new_cap = (c->inner.tags_cap + 1) * 2;
-        new_cap = new_cap > 10 ? new_cap : 10;
-        c->inner.tags_by_selector =
-                realloc (c->inner.tags_by_selector, sizeof *r * new_cap);
-        assert (c->inner.tags_by_selector);
-        c->inner.tags_cap = new_cap;
-    }
-    r = c->inner.tags_by_selector + c->inner.tags_len;
-    assert (r);
-    r->tag = name;
-    r->offset = offset;
-    r->selector = selector;
-    r->method = fn;
-    c->inner.tags_len++;
-    qsort (c->inner.tags_by_selector, c->inner.tags_len,
-           sizeof *c->inner.tags_by_selector, cmp_frm);
-    return 0;
-}
-int fop_register_and_implement_methods (fop_class_t *c,
-                                        struct fop_method_record *records)
-{
-    if (!c || !records)
-        return -1;
-    struct fop_method_record *cur = records;
-    while (cur->selector) {
-        fop_register_method (c, cur->selector, cur->tag, cur->offset,
-                             cur->method);
-        cur++;
-    }
-    return 0;
+    return ret->impl ? ret->impl : ((void *)c) + ret->offset;
 }
 
 void fop_dynamic_class_init (fop_class_t *c, const fop_class_t *super)
 {
-    if (super->inner.tags_by_selector) {
-        if (!super->inner.sorted) {
-            qsort (super->inner.tags_by_selector, super->inner.tags_len,
-                   sizeof *super->inner.tags_by_selector, cmp_frm);
-        }
-        struct fop_method_record *new_tags =
-                malloc (sizeof *new_tags * super->inner.tags_len);
-        assert (new_tags);
-        memcpy (new_tags, super->inner.tags_by_selector,
-                sizeof *new_tags * super->inner.tags_len);
-        c->inner.tags_by_selector = new_tags;
-        c->inner.tags_len = super->inner.tags_len;
-        c->inner.tags_cap = super->inner.tags_len;
+    if (super->inner.interfaces) {
+        c->inner.interfaces = (void *)sdsdup ((void *)super->inner.interfaces);
     }
 }

--- a/src/common/libflux/fop_dynamic.c
+++ b/src/common/libflux/fop_dynamic.c
@@ -1,0 +1,132 @@
+#include "fop_dynamic.h"
+
+#include <assert.h>
+#include <search.h>
+#include <stdlib.h>
+#include <string.h>
+
+// method record comparators
+static int cmp_frm (const void *l, const void *r)
+{
+    const struct fop_method_record *lhs = l, *rhs = r;
+    if (lhs && rhs && lhs->tag && rhs->tag)
+        return strcmp (lhs->tag, rhs->tag);
+    else
+        return -1;
+}
+
+static int cmp_frm_sel (const void *l, const void *r)
+{
+    const struct fop_method_record *lhs = l, *rhs = r;
+    if ((uintptr_t) lhs->selector < (uintptr_t) rhs->selector)
+        return -1;
+    if ((uintptr_t) lhs->selector == (uintptr_t) rhs->selector)
+        return 0;
+    return 1;
+}
+
+// method registration and implementation functions
+
+int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method)
+{
+    struct fop_method_record matcher = {.tag = tag};
+    size_t nel = c->inner.tags_len;
+    struct fop_method_record *r =
+            bsearch (&matcher, c->inner.tags_by_selector, nel,
+                     sizeof *r, cmp_frm);
+    assert (r);
+    r->method = method;
+    if (r->offset) {
+        fop_vv_f *target = (((void *)c) + r->offset);
+        *target = method;
+    }
+
+    return 0;
+}
+int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method)
+{
+    struct fop_method_record matcher = {.selector = sel};
+    size_t nel = c->inner.tags_len;
+    struct fop_method_record *r =
+            lfind (&matcher, c->inner.tags_by_selector, &nel,
+                   sizeof *r, cmp_frm_sel);
+    assert (r);
+    r->method = method;
+    if (r->offset) {
+        fop_vv_f *target = (((void *)c) + r->offset);
+        *target = method;
+    }
+
+    return 0;
+}
+int fop_register_method (fop_class_t *c,
+                         fop_vv_f selector,
+                         const char *name,
+                         size_t offset,
+                         fop_vv_f fn)
+{
+    struct fop_method_record matcher = {.tag = name};
+    struct fop_method_record *r =
+            bsearch (&matcher, c->inner.tags_by_selector, c->inner.tags_len,
+                     sizeof *c->inner.tags_by_selector, cmp_frm);
+    if (r) {
+        assert (selector == r->selector);
+        assert (!strcmp (name, r->tag));
+        assert (offset == r->offset);
+        if (fn) {
+            fop_vv_f *target = (((void *)c) + r->offset);
+            *target = fn;
+            r->method = fn;
+        }
+        return 0;
+    }
+    if (c->inner.tags_cap <= c->inner.tags_len) {
+        size_t new_cap = (c->inner.tags_cap + 1) * 2;
+        new_cap = new_cap > 10 ? new_cap : 10;
+        c->inner.tags_by_selector =
+                realloc (c->inner.tags_by_selector, sizeof *r * new_cap);
+        assert (c->inner.tags_by_selector);
+        c->inner.tags_cap = new_cap;
+    }
+    r = c->inner.tags_by_selector + c->inner.tags_len;
+    assert (r);
+    r->tag = name;
+    r->offset = offset;
+    r->selector = selector;
+    r->method = fn;
+    c->inner.tags_len++;
+    qsort (c->inner.tags_by_selector, c->inner.tags_len,
+           sizeof *c->inner.tags_by_selector, cmp_frm);
+    return 0;
+}
+int fop_register_and_implement_methods (fop_class_t *c,
+                                        struct fop_method_record *records)
+{
+    if (!c || !records)
+        return -1;
+    struct fop_method_record *cur = records;
+    while (cur->selector) {
+        fop_register_method (c, cur->selector, cur->tag, cur->offset,
+                             cur->method);
+        cur++;
+    }
+    return 0;
+}
+
+void fop_dynamic_class_init (fop_class_t *c, const fop_class_t *super)
+{
+    if (super->inner.tags_by_selector) {
+        if (!super->inner.sorted) {
+            qsort (super->inner.tags_by_selector, super->inner.tags_len,
+                   sizeof *super->inner.tags_by_selector, cmp_frm);
+        }
+        struct fop_method_record *new_tags =
+                malloc (sizeof *new_tags * super->inner.tags_len);
+        assert (new_tags);
+        memcpy (new_tags, super->inner.tags_by_selector,
+                sizeof *new_tags * super->inner.tags_len);
+        c->inner.tags_by_selector = new_tags;
+        c->inner.tags_len = super->inner.tags_len;
+        c->inner.tags_cap = super->inner.tags_len;
+    }
+}

--- a/src/common/libflux/fop_dynamic.h
+++ b/src/common/libflux/fop_dynamic.h
@@ -3,6 +3,10 @@
 
 #include "fop_protected.h"
 typedef void (*fop_vv_f) (void);
+const fop_class_t *fop_interface_c ();
+const void *fop_get_interface (const fop *o, const fop_class_t *interface);
+fop_vv_f fop_get_method (const fop_class_t *c, const char *name);
+fop_vv_f fop_get_method_by_sel (const fop_class_t *c, fop_vv_f sel);
 int fop_register_method (fop_class_t *c,
                          fop_vv_f selector,
                          const char *name,

--- a/src/common/libflux/fop_dynamic.h
+++ b/src/common/libflux/fop_dynamic.h
@@ -13,10 +13,6 @@ fop_class_t *fop_new_interface_class (const char *name,
 void fop_implement_interface (fop_class_t *c,
                               const fop_class_t *interface,
                               size_t offset);
-void fop_implement_dynamic_interface (fop_class_t *c,
-                                      const fop_class_t *interface,
-                                      fop_interface_t *impl);
-
 void fop_dynamic_class_init (fop_class_t *c, const fop_class_t *super);
 
 #endif /* __FLUX_CORE_FOP_DYNAMIC_H */

--- a/src/common/libflux/fop_dynamic.h
+++ b/src/common/libflux/fop_dynamic.h
@@ -1,29 +1,19 @@
 #ifndef __FLUX_CORE_FOP_DYNAMIC_H
 #define __FLUX_CORE_FOP_DYNAMIC_H
 
-#include "fop_protected.h"
-typedef void (*fop_vv_f) (void);
+#include "fop.h"
+typedef struct fop_interface {
+    fop_object_t _;
+} fop_interface_t;
 const fop_class_t *fop_interface_c ();
 const void *fop_get_interface (const fop *o, const fop_class_t *interface);
-fop_vv_f fop_get_method (const fop_class_t *c, const char *name);
-fop_vv_f fop_get_method_by_sel (const fop_class_t *c, fop_vv_f sel);
-int fop_register_method (fop_class_t *c,
-                         fop_vv_f selector,
-                         const char *name,
-                         size_t offset,
-                         fop_vv_f fn);
-int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method);
-int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method);
-struct fop_method_record {
-    const char *tag;
-    fop_vv_f selector;
-    fop_vv_f method;
-    size_t offset;
-};
-int fop_register_and_implement_methods (fop_class_t *c,
-                                        struct fop_method_record *records);
+void fop_implement_interface (fop_class_t *c,
+                              const fop_class_t *interface,
+                              size_t offset);
+void fop_implement_dynamic_interface (fop_class_t *c,
+                                      const fop_class_t *interface,
+                                      fop_interface_t *impl);
 
 void fop_dynamic_class_init (fop_class_t *c, const fop_class_t *super);
-
 
 #endif /* __FLUX_CORE_FOP_DYNAMIC_H */

--- a/src/common/libflux/fop_dynamic.h
+++ b/src/common/libflux/fop_dynamic.h
@@ -1,0 +1,25 @@
+#ifndef __FLUX_CORE_FOP_DYNAMIC_H
+#define __FLUX_CORE_FOP_DYNAMIC_H
+
+#include "fop_protected.h"
+typedef void (*fop_vv_f) (void);
+int fop_register_method (fop_class_t *c,
+                         fop_vv_f selector,
+                         const char *name,
+                         size_t offset,
+                         fop_vv_f fn);
+int fop_implement_method (fop_class_t *c, const char *tag, fop_vv_f method);
+int fop_implement_method_by_sel (fop_class_t *c, fop_vv_f sel, fop_vv_f method);
+struct fop_method_record {
+    const char *tag;
+    fop_vv_f selector;
+    fop_vv_f method;
+    size_t offset;
+};
+int fop_register_and_implement_methods (fop_class_t *c,
+                                        struct fop_method_record *records);
+
+void fop_dynamic_class_init (fop_class_t *c, const fop_class_t *super);
+
+
+#endif /* __FLUX_CORE_FOP_DYNAMIC_H */

--- a/src/common/libflux/fop_dynamic.h
+++ b/src/common/libflux/fop_dynamic.h
@@ -7,6 +7,9 @@ typedef struct fop_interface {
 } fop_interface_t;
 const fop_class_t *fop_interface_c ();
 const void *fop_get_interface (const fop *o, const fop_class_t *interface);
+fop_class_t *fop_new_interface_class (const char *name,
+                                      const fop_class_t *parent,
+                                      size_t size);
 void fop_implement_interface (fop_class_t *c,
                               const fop_class_t *interface,
                               size_t offset);

--- a/src/common/libflux/fop_protected.h
+++ b/src/common/libflux/fop_protected.h
@@ -19,10 +19,14 @@ typedef fop *(*new_f) (const fop_class_t *, va_list *);
 typedef fop *(*init_f) (fop *, va_list *);
 typedef fop *(*putter_f) (fop *, FILE *);
 
+struct fclass;
+
 struct fclass_inner {
     size_t tags_len;
     size_t tags_cap;
     struct fop_method_record * tags_by_selector;
+    size_t interfaces_len;
+    fop_class_t **interfaces;
     bool sorted;
 };
 

--- a/src/common/libflux/fop_protected.h
+++ b/src/common/libflux/fop_protected.h
@@ -38,7 +38,7 @@ struct fop_class {
     size_t size;
     struct fclass_inner inner;
 
-    fop_new_f new;
+    fop_new_f new_fn;
     fop_init_f initialize;
     fop_fini_f finalize;
     fop_putter_f describe;

--- a/src/common/libflux/fop_protected.h
+++ b/src/common/libflux/fop_protected.h
@@ -45,10 +45,9 @@ struct fop_class {
     fop_putter_f represent;
     fop_retain_f retain;
     fop_release_f release;
-    uintptr_t (*hash) (fop *);
-    bool (*equal) (fop *, fop *);
-    int (*compare) (fop *, fop *);
-    fop *(*copy) (fop *);
+    fop_hash_f hash;
+    fop_equal_f equal;
+    fop_copy_f copy;
 };
 
 #endif /* __FLUX_CORE_FOP_PROT_H */

--- a/src/common/libflux/fop_protected.h
+++ b/src/common/libflux/fop_protected.h
@@ -1,8 +1,6 @@
 #ifndef __FLUX_CORE_FOP_PROT_H
 #define __FLUX_CORE_FOP_PROT_H
-#define FOP_PROT
 #include "fop.h"
-#undef FOP_PROT
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -14,11 +12,12 @@ struct object {
     const fop_class_t *fclass;
 };
 
+typedef void (*self_only_v_f) (void *);
 typedef int (*self_only_i_f) (void *);
-typedef void *(*self_only_p_f) (void *);
-typedef void *(*new_f) (const fop_class_t *, va_list *);
-typedef void *(*init_f) (void *, va_list *);
-typedef int (*putter_f) (void *, FILE *);
+typedef fop *(*self_only_p_f) (fop *);
+typedef fop *(*new_f) (const fop_class_t *, va_list *);
+typedef fop *(*init_f) (fop *, va_list *);
+typedef fop *(*putter_f) (fop *, FILE *);
 
 struct fclass_inner {
     size_t tags_len;
@@ -36,11 +35,11 @@ struct fclass {
 
     new_f new;
     init_f initialize;
-    self_only_p_f finalize;
+    self_only_v_f finalize;
     putter_f describe;
     putter_f represent;
-    self_only_i_f retain;
-    self_only_i_f release;
+    self_only_v_f retain;
+    self_only_v_f release;
 };
 
 #endif /* __FLUX_CORE_FOP_PROT_H */

--- a/src/common/libflux/fop_protected.h
+++ b/src/common/libflux/fop_protected.h
@@ -1,0 +1,46 @@
+#ifndef __FLUX_CORE_FOP_PROT_H
+#define __FLUX_CORE_FOP_PROT_H
+#define FOP_PROT
+#include "fop.h"
+#undef FOP_PROT
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+struct object {
+    int32_t magic;
+    int32_t refcount;
+    const fop_class_t *fclass;
+};
+
+typedef int (*self_only_i_f) (void *);
+typedef void *(*self_only_p_f) (void *);
+typedef void *(*new_f) (const fop_class_t *, va_list *);
+typedef void *(*init_f) (void *, va_list *);
+typedef int (*putter_f) (void *, FILE *);
+
+struct fclass_inner {
+    size_t tags_len;
+    size_t tags_cap;
+    struct fop_method_record * tags_by_selector;
+    bool sorted;
+};
+
+struct fclass {
+    struct object _;  // A class is also an object
+    const char *name;
+    const fop_class_t *super;
+    size_t size;
+    struct fclass_inner inner;
+
+    new_f new;
+    init_f initialize;
+    self_only_p_f finalize;
+    putter_f describe;
+    putter_f represent;
+    self_only_i_f retain;
+    self_only_i_f release;
+};
+
+#endif /* __FLUX_CORE_FOP_PROT_H */

--- a/src/common/libflux/test/test_fop.c
+++ b/src/common/libflux/test/test_fop.c
@@ -1,4 +1,4 @@
-#include "fop_dynamic.h"
+#include "src/common/libflux/fop_dynamic.h"
 
 #include "src/common/libtap/tap.h"
 
@@ -26,9 +26,10 @@ json_t *jsonable_to_json (fop *o)
 const fop_class_t *jsonable_interface_c ()
 {
     static fop_class_t *cls = NULL;
-    if (!cls) {
-        cls = fop_new (fop_interface_c (), "jsonable_interface_c",
-                       fop_interface_c (), sizeof (struct jsonableInterface));
+    if (fop_class_needs_init (&cls)) {
+        cls =
+            fop_new_interface_class ("jsonable_interface_c", fop_interface_c (),
+                                     sizeof (struct jsonableInterface));
     }
     return cls;
 }
@@ -52,9 +53,9 @@ struct geomClass {
 const fop_class_t *geom_class_c ()
 {
     static fop_class_t *cls = NULL;
-    if (!cls) {
-        cls = fop_new (fop_class_c (), "geom_class_c", fop_class_c (),
-                       sizeof (struct geomClass));
+    if (fop_class_needs_init (&cls) ) {
+        cls = fop_new_metaclass ("geom_class_c", fop_class_c (),
+                                 sizeof (struct geomClass));
     }
     return cls;
 }
@@ -83,9 +84,9 @@ void geom_fini (void *_c)
 const fop_class_t *geom_c ()
 {
     static struct geomClass *cls = NULL;
-    if (!cls) {
-        cls = fop_new (geom_class_c (), "geom_c", fop_object_c (),
-                       sizeof (struct geom));
+    if (fop_class_needs_init (&cls)) {
+        cls = fop_new_class (geom_class_c (), "geom_c", fop_object_c (),
+                             sizeof (struct geom));
         fop_class_set_init (cls, geom_init);
         fop_class_set_fini (cls, geom_fini);
         cls->jsonable.to_json = geom_to_json;
@@ -141,7 +142,7 @@ double rect_perim (struct geom *_r)
 const fop_class_t *rect_c ()
 {
     static struct geomClass *cls = NULL;
-    if (!cls) {
+    if (fop_class_needs_init (&cls)) {
         cls = fop_new (geom_class_c (), "rect_c", geom_c (),
                        sizeof (struct rect));
         fop_class_set_init (cls, rect_init);
@@ -184,7 +185,7 @@ void *circle_desc (void *_c, FILE *s)
 const fop_class_t *circle_c ()
 {
     static struct geomClass *cls = NULL;
-    if (!cls) {
+    if (fop_class_needs_init (&cls)) {
         cls = fop_new (geom_class_c (), "circle_c", geom_c (),
                        sizeof (struct circle));
         fop_class_set_fini (cls, circle_fini);

--- a/src/common/libflux/test/test_fop.c
+++ b/src/common/libflux/test/test_fop.c
@@ -7,26 +7,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct geom {
-    fop_object_t _;
-};
-
+struct geom;
+// geom_class metaclass
 struct geomClass {
     fop_class_t _;
     double (*area) (struct geom *);
     double (*perim) (struct geom *);
 };
-
-struct rect {
-    struct geom _;
-    double w, h;
-};
-struct circle {
-    struct geom _;
-    double r;
-};
-
-// geom_class metaclass
 const fop_class_t *geom_class_c ()
 {
     static fop_class_t *cls = NULL;
@@ -39,6 +26,9 @@ const fop_class_t *geom_class_c ()
 }
 
 // abstract class geom, instance of metaclass geom_class
+struct geom {
+    fop_object_t _;
+};
 double geom_area (struct geom *self);
 double geom_perim (struct geom *self);
 fop_class_t *geom_c ()
@@ -66,6 +56,10 @@ double geom_perim (struct geom *o)
 }
 
 // class rect, instance of metaclass geom_class, child of geom
+struct rect {
+    struct geom _;
+    double w, h;
+};
 const fop_class_t *rect_c ();
 void *rect_init (void *_self, va_list *app)
 {
@@ -100,6 +94,10 @@ const fop_class_t *rect_c ()
 }
 
 // class rect, instance of metaclass geom_class, child of geom
+struct circle {
+    struct geom _;
+    double r;
+};
 const fop_class_t *circle_c ();
 double circle_area (struct geom *_c)
 {

--- a/src/common/libflux/test/test_fop.c
+++ b/src/common/libflux/test/test_fop.c
@@ -1,0 +1,148 @@
+#include "fop_protected.h"
+
+#include "src/common/libtap/tap.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct geom {
+    fop_object_t _;
+};
+
+struct geomClass {
+    fop_class_t _;
+    double (*area) (struct geom *);
+    double (*perim) (struct geom *);
+};
+
+struct rect {
+    struct geom _;
+    double w, h;
+};
+struct circle {
+    struct geom _;
+    double r;
+};
+
+// geom_class metaclass
+const fop_class_t *geom_class_c ()
+{
+    static fop_class_t *cls = NULL;
+    if (!cls) {
+        cls = fop_new (fop_class_c (), "geom_class_c", fop_class_c (),
+                       sizeof (struct geomClass));
+    }
+    fprintf(stderr, "passed init %p\n", cls);
+    return cls;
+}
+
+// abstract class geom, instance of metaclass geom_class
+double geom_area (struct geom *self);
+double geom_perim (struct geom *self);
+fop_class_t *geom_c ()
+{
+    static fop_class_t *cls = NULL;
+    if (!cls) {
+        cls = fop_new (geom_class_c (), "geom_c", fop_object_c (),
+                       sizeof (struct geom));
+    }
+    return cls;
+}
+
+// selectors
+double geom_area (struct geom *o)
+{
+    const struct geomClass *c = (void *)fop_get_class_checked (o, geom_c());
+    assert (c->area);
+    return c->area (o);
+}
+double geom_perim (struct geom *o)
+{
+    const struct geomClass *c = (void *)fop_get_class_checked (o, geom_c());
+    assert (c->perim);
+    return c->perim (o);
+}
+
+// class rect, instance of metaclass geom_class, child of geom
+const fop_class_t *rect_c ();
+void *rect_init (void *_self, va_list *app)
+{
+    struct rect *self = fop_cast (rect_c (), _self);
+    self->w = va_arg (*app, double);
+    self->h = va_arg (*app, double);
+    fprintf (stderr, "INITIALIZING RECT!\n");
+    return self;
+}
+double rect_area (struct geom *_r)
+{
+    struct rect *r = fop_cast (rect_c(), _r);
+    return r->w * r->h;
+}
+
+double rect_perim (struct geom *_r)
+{
+    struct rect *r = fop_cast (rect_c(), _r);
+    return r->w * 2 + 2 * r->h;
+}
+const fop_class_t *rect_c ()
+{
+    static struct geomClass *cls = NULL;
+    if (!cls) {
+        cls = fop_new (geom_class_c (), "rect_c", geom_c (),
+                       sizeof (struct rect));
+        cls->_.initialize = rect_init;
+        cls->area = rect_area;
+        cls->perim = rect_perim;
+    }
+    return &cls->_;
+}
+
+// class rect, instance of metaclass geom_class, child of geom
+const fop_class_t *circle_c ();
+double circle_area (struct geom *_c)
+{
+    struct circle *c = fop_cast (circle_c(), _c);
+    return c->r * c->r * 3.14159;
+}
+
+double circle_perim (struct geom *_c)
+{
+    struct circle *c = fop_cast (circle_c(), _c);
+    return 3.14159 * c->r * 2;
+}
+const fop_class_t *circle_c ()
+{
+    static struct geomClass *cls = NULL;
+    if (!cls) {
+        cls = fop_new (geom_class_c (), "circle_c", geom_c (),
+                       sizeof (struct circle));
+        cls->perim = circle_perim;
+        cls->area = circle_area;
+    }
+    return &cls->_;
+}
+
+void measure (struct geom *g)
+{
+    printf ("a %lf\n", geom_area (g));
+    printf ("p %lf\n", geom_perim (g));
+}
+
+int main (int argc, char *argv[])
+{
+    plan (2);
+    struct rect *r = fop_new (rect_c (), 3.0, 4.0);
+    ok (r != NULL);
+    struct circle *c = fop_new (circle_c ());
+    ok (c != NULL);
+    c->r = 5;
+    measure (&r->_);
+    measure (&c->_);
+    fop_describe (r, stderr);
+    fop_describe (c, stderr);
+    fop_release (r);
+    fop_release (c);
+    return 0;
+}

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -19,7 +19,8 @@ http://www.digip.org/jansson/releases/jansson-2.9.tar.gz \
 http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz \
 https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
 https://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz \
-https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
+https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz \
+http://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz "
 
 declare -A extra_configure_opts=(\
 ["mpich-3.1.4"]="--disable-fortran --disable-cxx --disable-maintainer-mode --disable-dependency-tracking --enable-shared --disable-wrapper-rpath" \


### PR DESCRIPTION
This is meant to address #363.

I thought it might be easier to have this as a pull request for discussion purposes.  Some of the ABI related concerns should be addressed here, and the original prototype has been reworked to remove dynamic method lookup in favor of a (much simpler) explicit interface implementation option that still gives many of the same benefits.  This version also includes an autorelease-pool implementation, to make dealing with interfaces that need to return something they currently own to a caller that may not want it significantly easier.

The remaining issue, from @grondo and @garlick's comments on #363, would seem to be the question of ABI pollution.  This will actually be no worse than we have now, in that any structure directly exposed will become part of the ABI.  That said, part of the question was how to use fop to implement a conforming object defined by our external API. This motivated the switch to an interface-based mechanism, which would allow us to expose something of the form:

```c
struct flux_module_loader_interface {
    flux_interface_t _;
    int (*init) (flux_module_t *p, const char *path, int flags);
    int (*load) (flux_module_t *p);
    int (*unload) (flux_module_t *p);
    void (*destroy) (flux_module_t *p);
    void * (*lookup) (flux_module_t *p, const char *symbol);
    const char * (*get_name) (flux_module_t *p);
    const char * (*strerror) (flux_module_t *p);
};
```

Then a metaclass and an object, from anywhere with any structure of its own, can be made to implement that interface:

```c
struct my_loader;
struct my_loader_class {
    fop_class_t _;
    void (*random_stuff) (struct my_loader *);
    int (*things_mod_doesnt_care_about) (struct my_loader *);
    struct module_loader_interface loader;
};
const fop_class_t *my_loader_class_c ()
{
    static fop_class_t *cls = NULL;
    if (fop_class_needs_init ((fop_class_t **)&cls)) {
        cls = fop_new_metaclass ("my_loader_class_c", fop_class_c (),
                                 sizeof (struct my_loader));
    }
    return cls;
}
struct my_loader {
    fop_object_t _;
    int something;
};
const fop_class_t *my_loader_c ()
{
    static struct my_loader_class *cls = NULL;
    if (fop_class_needs_init ((fop_class_t **)&cls)) {
        cls = fop_new_class (my_loader_class_c (), "my_loader_c", fop_object_c (),
                             sizeof (struct my_loader));
        cls->random_stuff = my_loader_random_stuff;
        cls->things_mod_doesnt_care_about = my_loader_something_else;
        cls->loader.init = my_loader_mod_init;
        ...
        cls->loader.strerror = my_loader_strerror;

        fop_implement_interface ((void *)cls, module_loader_interface_c (),
                                 offsetof (struct my_loader_class, loader));
    }
    return (void *)cls;
}
```

At this point I'm going to do my best to stay hands-off on this until I hear back whether folks think this, or something we can make from it, is something we want to use.