### PR TITLE
sanitize log entries before they enter circular buffer

### DIFF
--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -25,6 +25,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <unistd.h>
 #include <stdio.h>
 #include <getopt.h>
 #include <argz.h>
@@ -33,6 +34,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/stdlog.h"
+#include "src/common/libutil/readall.h"
 
 
 #define OPTIONS "hs:n:"
@@ -79,12 +81,13 @@ int main (int argc, char *argv[])
                 break;
         }
     }
-    if (optind == argc)
-        usage ();
-
-    if ((e = argz_create (argv + optind, &message, &len)) != 0)
-        log_errn_exit (e, "argz_create");
-    argz_stringify (message, len, ' ');
+    if (optind == argc) {
+        len = read_all (STDIN_FILENO, (uint8_t **)&message);
+    } else {
+        if ((e = argz_create (argv + optind, &message, &len)) != 0)
+            log_errn_exit (e, "argz_create");
+        argz_stringify (message, len, ' ');
+    }
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -105,7 +105,7 @@ void flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)
     int saved_errno = errno;
     uint32_t rank;
     flux_rpc_t *rpc = NULL;
-    int n, len;
+    int len;
     char timestamp[WALLCLOCK_MAXLEN];
     char hostname[STDLOG_MAX_HOSTNAME + 1];
     struct stdlog_header hdr;
@@ -121,15 +121,10 @@ void flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)
     hdr.appname = ctx->appname;
     hdr.procid = ctx->procid;
 
-    len = stdlog_encode (ctx->buf, sizeof (ctx->buf), &hdr,
-                         STDLOG_NILVALUE, "");
-    assert (len < sizeof (ctx->buf));
-
-    n = vsnprintf (ctx->buf + len, sizeof (ctx->buf) - len, fmt, ap);
-    if (n > sizeof (ctx->buf) - len) /* ignore truncation of message */
-        n = sizeof (ctx->buf) - len;
-    len += n;
-
+    len = stdlog_vencodef (ctx->buf, sizeof (ctx->buf), &hdr,
+                           STDLOG_NILVALUE, fmt, ap);
+    if (len >= sizeof (ctx->buf))
+        len = sizeof (ctx->buf);
     if (ctx->cb) {
         ctx->cb (ctx->buf, len, ctx->cb_arg);
     } else {

--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -145,7 +145,7 @@ int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
 int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
                      const char *sd, const char *fmt, va_list ap)
 {
-    int m, n;
+    int m, n, i;
     int rc; // includes any overflow
 
     m = snprintf (buf, len, "<%d>%d %.*s %.*s %.*s %.*s %.*s %s ",
@@ -164,6 +164,8 @@ int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
     rc += n;
     if (n > len - m)
         n = len - m;
+    for (i = 0; i < n; i++)
+        buf[m + i] &= 0x7f; // ensure only ascii chars are logged
     return rc;
 }
 

--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <syslog.h>
+#include <stdarg.h>
 
 #include "stdlog.h"
 
@@ -140,17 +141,48 @@ int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
     return 0;
 }
 
+
+int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
+                     const char *sd, const char *fmt, va_list ap)
+{
+    int m, n;
+    int rc; // includes any overflow
+
+    m = snprintf (buf, len, "<%d>%d %.*s %.*s %.*s %.*s %.*s %s ",
+                  hdr->pri, hdr->version,
+                  STDLOG_MAX_TIMESTAMP, hdr->timestamp,
+                  STDLOG_MAX_HOSTNAME, hdr->hostname,
+                  STDLOG_MAX_APPNAME, hdr->appname,
+                  STDLOG_MAX_PROCID, hdr->procid,
+                  STDLOG_MAX_MSGID, hdr->msgid,
+                  sd);
+    rc = m;
+    if (m > len)
+        m = len;
+
+    n = vsnprintf (buf + m, len - m, fmt, ap);
+    rc += n;
+    if (n > len - m)
+        n = len - m;
+    return rc;
+}
+
+int stdlog_encodef (char *buf, int len, struct stdlog_header *hdr,
+                    const char *sd, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = stdlog_vencodef (buf, len, hdr, sd, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
 int stdlog_encode (char *buf, int len, struct stdlog_header *hdr,
                    const char *sd, const char *msg)
 {
-    return snprintf (buf, len, "<%d>%d %.*s %.*s %.*s %.*s %.*s %s %s",
-                     hdr->pri, hdr->version,
-                     STDLOG_MAX_TIMESTAMP, hdr->timestamp,
-                     STDLOG_MAX_HOSTNAME, hdr->hostname,
-                     STDLOG_MAX_APPNAME, hdr->appname,
-                     STDLOG_MAX_PROCID, hdr->procid,
-                     STDLOG_MAX_MSGID, hdr->msgid,
-                     sd, msg);
+    return stdlog_encodef (buf, len, hdr, sd, "%s", msg);
 }
 
 void stdlog_init (struct stdlog_header *hdr)

--- a/src/common/libutil/stdlog.h
+++ b/src/common/libutil/stdlog.h
@@ -1,6 +1,8 @@
 #ifndef _UTIL_STDLOG_H
 #define _UTIL_STDLOG_H
 
+#include <stdarg.h>
+
 /* RFC 5424 syslog wire format */
 
 #define STDLOG_MAX_PRI          5
@@ -36,6 +38,12 @@ int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
 
 int stdlog_encode (char *buf, int len, struct stdlog_header *hdr,
                    const char *sd, const char *msg);
+
+int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
+                     const char *sd, const char *fmt, va_list ap);
+
+int stdlog_encodef (char *buf, int len, struct stdlog_header *hdr,
+                    const char *sd, const char *fmt, ...);
 
 void stdlog_init (struct stdlog_header *hdr);
 

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -58,4 +58,10 @@ test_expect_success 'ring buffer wraps over old entries' '
 	flux setattr log-ring-size $OLD_RINGSIZE
 '
 
+# Try to make flux dmesg get an EPROTO error
+test_expect_success 'logged non-ascii characters handled ok' '
+	/bin/echo -n -e "\xFF\xFE\x82\x00" | flux logger
+	flux dmesg
+'
+
 test_done


### PR DESCRIPTION
Here's a fix for #939 that simply strips the eighth bit from all characters in logged messages.

I added a test that failed before and works with the fix.
