### PR TITLE
build: Add dependency on "all" to top-level make check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 .NOTPARALLEL:
 
-SUBDIRS = src doc etc t
+SUBDIRS = . src doc etc t
 
 EXTRA_DIST = \
 	config/tap-driver.sh \
@@ -29,3 +29,14 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
+
+# Many of flux-core's tests live down in subdirectories with
+# the core that that it is testing.  However, some of those tests
+# also have dependencies on other subdirectories higher up the
+# source tree.  With the recursive Makefiles approach, there is
+# no easy way to express that build dependency in a way that will
+# actually trigger the build of the that dependency.  The following
+# check-local rule, in conjunction with putting "." _first_ in this
+# file's SUBDIRS, ensures that "all" is built before any of the
+# recursive checks.
+check-local: all

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 .NOTPARALLEL:
 
-#This order is *important*, common must preceed modules, 
-#		            modules must preceed lib 
+#This order is *important*, common must precede modules,
+#		            modules must precede lib
 SUBDIRS = common modules broker connectors bindings cmd test
 
 check-local: all


### PR DESCRIPTION
Many of flux-core's tests live down in subdirectories with
the core that that it is testing.  However, some of those tests
also have dependencies on other subdirectories higher up the
source tree.  With the recursive Makefiles approach, there is
no easy way to express that build dependency in a way that will
actually trigger the build of the that dependency.  The following
check-local rule, in conjunction with putting "." _first_ in this
file's SUBDIRS, ensures that "all" is built before any of the
recursive checks.

"check-local" is the only way that was found to add a dependency to
the "check" target.  But "make check" is a recursive operation by
default, so the this dependency can only happen first if we also
make "." the first subdirectory in the SUBDIRS list.

Note that this approach will _only_ work at the top level of the
source tree.  However, it seems likely that this is not the only
place in the flux-core source tree when a make target needs to be
run at a higher level of the tree in order to be successful.  This
is probably an inevitable consequence of the using recursive makefiles
and the design of the ordering dependencies in flux-core.

This was tested to work with "make -j 32 check" as well.