### PR TITLE
Rename all ctx_t structs to make them unique.

### DIFF
--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -45,7 +45,7 @@ typedef struct {
     int pollevents;
 
     msglist_t *queue;
-} ctx_t;
+} loop_ctx_t;
 
 
 static const struct flux_handle_ops handle_ops;
@@ -54,7 +54,7 @@ const char *fake_uuid = "12345678123456781234567812345678";
 
 static int op_pollevents (void *impl)
 {
-    ctx_t *c = impl;
+    loop_ctx_t *c = impl;
     int e, revents = 0;
 
     if ((e = msglist_pollevents (c->queue)) < 0)
@@ -70,13 +70,13 @@ static int op_pollevents (void *impl)
 
 static int op_pollfd (void *impl)
 {
-    ctx_t *c = impl;
+    loop_ctx_t *c = impl;
     return msglist_pollfd (c->queue);
 }
 
 static int op_send (void *impl, const flux_msg_t *msg, int flags)
 {
-    ctx_t *c = impl;
+    loop_ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     int type;
     flux_msg_t *cpy = NULL;
@@ -98,7 +98,7 @@ done:
 
 static flux_msg_t *op_recv (void *impl, int flags)
 {
-    ctx_t *c = impl;
+    loop_ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_msg_t *msg = msglist_pop (c->queue);
     if (!msg)
@@ -108,7 +108,7 @@ static flux_msg_t *op_recv (void *impl, int flags)
 
 static void op_fini (void *impl)
 {
-    ctx_t *c = impl;
+    loop_ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
 
     if (c->pollfd >= 0)
@@ -120,7 +120,7 @@ static void op_fini (void *impl)
 
 flux_t *connector_init (const char *path, int flags)
 {
-    ctx_t *c = malloc (sizeof (*c));
+    loop_ctx_t *c = malloc (sizeof (*c));
     if (!c) {
         errno = ENOMEM;
         goto error;

--- a/src/modules/barrier/libbarrier.c
+++ b/src/modules/barrier/libbarrier.c
@@ -33,17 +33,17 @@
 typedef struct {
     const char *id;
     int seq;
-} ctx_t;
+} libbarrier_ctx_t;
 
 static void freectx (void *arg)
 {
-    ctx_t *ctx = arg;
+    libbarrier_ctx_t *ctx = arg;
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t *h)
+static libbarrier_ctx_t *getctx (flux_t *h)
 {
-    ctx_t *ctx = flux_aux_get (h, "flux::barrier_client");
+    libbarrier_ctx_t *ctx = flux_aux_get (h, "flux::barrier_client");
     if (!ctx) {
         const char *id = getenv ("FLUX_JOB_ID");
         if (!id && !(id = getenv ("SLURM_STEPID")))
@@ -62,7 +62,7 @@ int flux_barrier (flux_t *h, const char *name, int nprocs)
     int ret = -1;
 
     if (!name) {
-        ctx_t *ctx = getctx (h);
+        libbarrier_ctx_t *ctx = getctx (h);
         if (!ctx) {
             errno = EINVAL;
             goto done;

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -45,9 +45,9 @@ typedef struct
     hwloc_topology_t topology;
     bool loaded;
     bool walk_topology;
-} ctx_t;
+} resource_ctx_t;
 
-static int ctx_hwloc_init (flux_t *h, ctx_t *ctx)
+static int ctx_hwloc_init (flux_t *h, resource_ctx_t *ctx)
 {
     int ret = -1;
     char *key, *path = NULL;
@@ -121,7 +121,7 @@ done:
     return ret;
 }
 
-static void resource_hwloc_ctx_destroy (ctx_t *ctx)
+static void resource_hwloc_ctx_destroy (resource_ctx_t *ctx)
 {
     if (ctx) {
         if (ctx->topology)
@@ -130,9 +130,9 @@ static void resource_hwloc_ctx_destroy (ctx_t *ctx)
     }
 }
 
-static ctx_t *resource_hwloc_ctx_create (flux_t *h)
+static resource_ctx_t *resource_hwloc_ctx_create (flux_t *h)
 {
-    ctx_t *ctx = xzmalloc (sizeof(ctx_t));
+    resource_ctx_t *ctx = xzmalloc (sizeof(resource_ctx_t));
     if (flux_get_rank (h, &ctx->rank) < 0) {
         flux_log_error (h, "flux_get_rank");
         goto error;
@@ -147,7 +147,7 @@ error:
     return NULL;
 }
 
-static int load_xml_to_kvs (flux_t *h, ctx_t *ctx)
+static int load_xml_to_kvs (flux_t *h, resource_ctx_t *ctx)
 {
     char *xml_path = NULL;
     char *buffer = NULL;
@@ -277,7 +277,7 @@ static int put_hostname (flux_t *h, const char *base, const char *hostname)
     return (rc);
 }
 
-static int load_info_to_kvs (flux_t *h, ctx_t *ctx)
+static int load_info_to_kvs (flux_t *h, resource_ctx_t *ctx)
 {
     char *base_path = NULL;
     int ret = -1, i;
@@ -330,7 +330,7 @@ done:
     return ret;
 }
 
-static int load_hwloc (flux_t *h, ctx_t *ctx)
+static int load_hwloc (flux_t *h, resource_ctx_t *ctx)
 {
     uint32_t size;
     char *completion_path = NULL;
@@ -362,7 +362,7 @@ done:
     return rc;
 }
 
-static int decode_reload_request (flux_t *h, ctx_t *ctx,
+static int decode_reload_request (flux_t *h, resource_ctx_t *ctx,
                                   const flux_msg_t *msg)
 {
     const char *json_str;
@@ -390,7 +390,7 @@ static void reload_request_cb (flux_t *h,
                                const flux_msg_t *msg,
                                void *arg)
 {
-    ctx_t *ctx = arg;
+    resource_ctx_t *ctx = arg;
     int errnum = 0;
 
     if ((decode_reload_request (h, ctx, msg) < 0)
@@ -406,7 +406,7 @@ static void topo_request_cb (flux_t *h,
                              const flux_msg_t *msg,
                              void *arg)
 {
-    ctx_t *ctx = (ctx_t *)arg;
+    resource_ctx_t *ctx = (resource_ctx_t *)arg;
     kvsdir_t *kd = NULL;
     json_object *out = NULL;
     char *buffer;
@@ -492,7 +492,7 @@ done:
     Jput (out);
 }
 
-static void process_args (flux_t *h, ctx_t *ctx, int argc, char **argv)
+static void process_args (flux_t *h, resource_ctx_t *ctx, int argc, char **argv)
 {
     int i;
     for (i = 0; i < argc; i++) {
@@ -511,7 +511,7 @@ static struct flux_msg_handler_spec htab[] = {
 int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
-    ctx_t *ctx;
+    resource_ctx_t *ctx;
 
     if (!(ctx = resource_hwloc_ctx_create (h)))
         goto done;

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -46,7 +46,7 @@ typedef struct {
     kz_t *kz[3];
     int readers;
     int blocksize;
-} ctx_t;
+} t_kzutil_ctx_t;
 
 static void copy (flux_t *h, const char *src, const char *dst, int kzoutflags,
                   int blocksize);
@@ -203,7 +203,7 @@ static int write_all (int fd, char *buf, int len)
 
 static void attach_stdout_ready_cb (kz_t *kz, void *arg)
 {
-    ctx_t *ctx = arg;
+    t_kzutil_ctx_t *ctx = arg;
     char *data;
     int len;
 
@@ -225,7 +225,7 @@ static void attach_stdout_ready_cb (kz_t *kz, void *arg)
 
 static void attach_stderr_ready_cb (kz_t *kz, void *arg)
 {
-    ctx_t *ctx = arg;
+    t_kzutil_ctx_t *ctx = arg;
     int len;
     char *data;
 
@@ -249,7 +249,7 @@ static void attach_stdin_ready_cb (flux_reactor_t *r, flux_watcher_t *w,
                                    int revents, void *arg)
 {
     int fd = flux_fd_watcher_get_fd (w);
-    ctx_t *ctx = arg;
+    t_kzutil_ctx_t *ctx = arg;
     char *buf = xzmalloc (ctx->blocksize);
     int len;
 
@@ -272,7 +272,7 @@ static void attach_stdin_ready_cb (flux_reactor_t *r, flux_watcher_t *w,
 static void attach (flux_t *h, const char *key, bool rawtty, int kzoutflags,
                     int blocksize)
 {
-    ctx_t *ctx = xzmalloc (sizeof (*ctx));
+    t_kzutil_ctx_t *ctx = xzmalloc (sizeof (*ctx));
     char *name;
     int fdin = dup (STDIN_FILENO);
     struct termios saved_tio;


### PR DESCRIPTION
Rename all ctx_t structs to give them a unique name.   While they are
ll used in ways that avoid conflict (usually local to a single file),
it makes it more difficult for the new developer to navigate through
the code when many different structs share the same name (because
ools like cscope and ctags will show many definition locations for
the struct rather than showing the one correct location).

Fixes #972