### PR TITLE
add userid, rolemask per RFC 3, 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,7 @@ AC_CONFIG_FILES( \
   src/modules/cron/Makefile \
   src/modules/aggregator/Makefile \
   src/modules/pymod/Makefile \
+  src/modules/userdb/Makefile \
   src/test/Makefile \
   src/test/kap/Makefile \
   etc/Makefile \

--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -23,7 +23,8 @@ MAN1_FILES_PRIMARY = \
 	flux-content.1 \
 	flux-hwloc.1 \
 	flux-proxy.1 \
-	flux-cron.1
+	flux-cron.1 \
+	flux-user.1
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man1/flux-ping.adoc
+++ b/doc/man1/flux-ping.adoc
@@ -59,6 +59,10 @@ responses have been received for all the requests.  Default: unlimited.
 *-b, --batch*::
 Begin processing responses after all requests are sent.  Requires --count.
 
+*-u, --userid*::
+Include userid and rolemask of original request, which are echoed back
+in ping response, in ping output.
+
 EXAMPLES
 --------
 

--- a/doc/man1/flux-user.adoc
+++ b/doc/man1/flux-user.adoc
@@ -1,0 +1,76 @@
+// flux-help-include: true
+FLUX-USER(1)
+============
+:doctype: manpage
+
+
+NAME
+----
+flux-user - Flux user database client
+
+
+SYNOPSIS
+--------
+*flux* *user* 'COMMAND' ['OPTIONS']
+
+
+DESCRIPTION
+-----------
+The Flux user database is used to authorize users to access the
+Flux instance with assigned roles, as described in Flux RFC 12.
+
+This command line client can be used to manipulate the database.
+
+If the 'userdb' module is loaded with the '--default-rolemask'
+option, then users are added to the user database when they successfully
+authenticate to a Flux connector.  Otherwise, users that are not
+already present in the database are denied access.
+
+COMMANDS
+--------
+*list*::
+List the contents of the user database.  Each entry is listed with
+fields separated by colons.  The first field is the 32-bit userid
+in decimal.  The second field is the 32-bit rolemask, represented as
+a comma-delimited list of strings.
+
+*lookup* 'USERID'::
+Look up 'USERID' in the user database and display its entry,
+as described above.  If any part of 'USERID' is non-numeric,
+an attempt is made to look up 'USERID' as a name in the password file.
+If successful, the resulting UID is used in the query.
+
+*addrole* 'USERID' 'ROLEMASK'::
+Request that the database add the roles in 'ROLEMASK' to the existing
+roles held by 'USERID'.  If 'USERID' has no entry in the database,
+one is added.  If any part of 'USERID' is non-numeric, an attempt is
+made to look up 'USERID' as a name in the password file and use the UID
+from the result. 'ROLEMASK' may be numeric (any base - use strtoul base
+prefix rules), or may be a comma-separated list of roles, e.g.
+"owner", "user", etc..
+
+*delrole* 'USERID' 'ROLEMASK'::
+Request that the database remove the roles in 'ROLEMASK' from the existing
+roles held by 'USERID'.  If after removing those roles, 'USERID' has no
+roles, the entry is removed from the database.  'USERID' and 'ROLEMASK'
+may be specified as described above.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+https://github.com/flux-framework/rfc/blob/master/spec_12.adoc[RFC 12: Flux Security Architecture]
+

--- a/etc/rc1
+++ b/etc/rc1
@@ -13,6 +13,8 @@ flux module load -r all resource-hwloc & pids="$pids $!"
 flux module load -r all job
 flux module load -r 0 cron sync=hb
 
+flux module load -r 0 userdb
+
 wait $pids
 
 core_dir=$(cd ${0%/*} && pwd -P)

--- a/etc/rc3
+++ b/etc/rc3
@@ -16,6 +16,8 @@ if PERSISTDIR=$(flux getattr persist-directory 2>/dev/null); then
     flux wreck ls >${PERSISTDIR}/joblog 2>/dev/null || :
 fi
 
+flux module remove -r 0 userdb
+
 flux module remove -r 0 cron
 flux module remove -r all job
 flux module remove -r all resource-hwloc

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -395,15 +395,20 @@ error:
 
 static struct flux_msg_handler_spec handlers[] = {
     { FLUX_MSGTYPE_REQUEST, "attr.get",    getattr_request_cb },
-    { FLUX_MSGTYPE_REQUEST, "attr.set",    setattr_request_cb },
     { FLUX_MSGTYPE_REQUEST, "attr.list",   lsattr_request_cb },
+    { FLUX_MSGTYPE_REQUEST, "attr.set",    setattr_request_cb },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
 
 int attr_register_handlers (attr_t *attrs, flux_t *h)
 {
-    return flux_msg_handler_addvec (h, handlers, attrs);
+    if (flux_msg_handler_addvec (h, handlers, attrs) < 0)
+        return -1;
+    /* allow any user to attr.get and attr.list */
+    flux_msg_handler_allow_rolemask (handlers[0].w, FLUX_ROLE_ALL);
+    flux_msg_handler_allow_rolemask (handlers[1].w, FLUX_ROLE_ALL);
+    return 0;
 }
 
 void attr_unregister_handlers (void)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -625,7 +625,7 @@ int main (int argc, char *argv[])
         log_err_exit ("sequence_hash_initialize");
     if (exec_initialize (ctx.h, ctx.sm, ctx.rank, ctx.attrs) < 0)
         log_err_exit ("exec_initialize");
-    if (ping_initialize (ctx.h) < 0)
+    if (ping_initialize (ctx.h, "cmb") < 0)
         log_err_exit ("ping_initialize");
     if (rusage_initialize (ctx.h) < 0)
         log_err_exit ("rusage_initialize");

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -662,28 +662,6 @@ done:
     return mods;
 }
 
-int module_stop_all (modhash_t *mh)
-{
-    zlist_t *uuids;
-    char *uuid;
-    int rc = -1;
-
-    if (!(uuids = zhash_keys (mh->zh_byuuid)))
-        oom ();
-    uuid = zlist_first (uuids);
-    while (uuid) {
-        module_t *p = zhash_lookup (mh->zh_byuuid, uuid);
-        assert (p != NULL);
-        if (module_stop (p) < 0)
-            goto done;
-        uuid = zlist_next (uuids);
-    }
-    rc = 0;
-done:
-    zlist_destroy (&uuids);
-    return rc;
-}
-
 int module_start_all (modhash_t *mh)
 {
     zlist_t *uuids;

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -373,19 +373,16 @@ int module_stop (module_t *p)
 {
     assert (p->magic == MODULE_MAGIC);
     char *topic = xasprintf ("%s.shutdown", p->name);
-    flux_msg_t *msg;
+    flux_rpc_t *rpc;
     int rc = -1;
 
-    if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
-        goto done;
-    if (flux_msg_set_topic (msg, topic) < 0)
-        goto done;
-    if (flux_msg_sendzsock (p->sock, msg) < 0)
+    if (!(rpc = flux_rpc (p->broker_h, topic, NULL,
+                          FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE)))
         goto done;
     rc = 0;
 done:
     free (topic);
-    flux_msg_destroy (msg);
+    flux_rpc_destroy (rpc);
     return rc;
 }
 

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -91,7 +91,6 @@ int module_start_all (modhash_t *mh);
 /* Stop module thread by sending a shutdown request.
  */
 int module_stop (module_t *p);
-int module_stop_all (modhash_t *mh);
 
 /* Prepare an 'lsmod' response payload.
  */

--- a/src/broker/ping.h
+++ b/src/broker/ping.h
@@ -3,7 +3,7 @@
 
 #include <flux/core.h>
 
-int ping_initialize (flux_t *h);
+int ping_initialize (flux_t *h, const char *service);
 
 #endif /* BROKER_PING_H */
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -41,7 +41,8 @@ flux_SOURCES = \
 	builtin/hwloc.c \
 	builtin/nodeset.c \
 	builtin/heaptrace.c \
-	builtin/proxy.c
+	builtin/proxy.c \
+	builtin/user.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/user.c
+++ b/src/cmd/builtin/user.c
@@ -1,0 +1,374 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+#include "builtin.h"
+
+#include <unistd.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <argz.h>
+
+typedef struct {
+    const char *name;
+    uint32_t value;
+} role_t;
+
+static role_t roletab[] = {
+    { "owner",    FLUX_ROLE_OWNER },
+    { "user",     FLUX_ROLE_USER },
+    { NULL, 0 },
+};
+
+const char *unknown_role_msg = "Valid roles are owner, user.";
+
+static const char *rolestr (uint32_t rolemask, char *s, size_t len)
+{
+    const char *ret = s;
+    role_t *rp = &roletab[0];
+
+    if (rolemask == 0) {
+        snprintf (s, len, "none");
+        goto done;
+    }
+    while ((rp->name != NULL)) {
+        if ((rolemask & rp->value)) {
+            snprintf (s, len, "%s%s", ret < s ? "," : "", rp->name);
+            len -= strlen (s);
+            s += strlen (s);
+        }
+        rp++;
+    }
+done:
+    return ret;
+}
+
+static int strrole (const char *s, uint32_t *rolemask)
+{
+    role_t *rp = &roletab[0];
+
+    while ((rp->name != NULL)) {
+        if (!strcmp (rp->name, s)) {
+            *rolemask |= rp->value;
+            return 0;
+        }
+        rp++;
+    }
+    return -1;
+}
+
+static int parse_rolemask_string (const char *s, uint32_t *rolemask)
+{
+    char *argz = NULL;
+    size_t argz_len;
+    int e;
+    char *entry  = NULL;
+    uint32_t mask = FLUX_ROLE_NONE;
+    int rc = -1;
+
+    if ((e = argz_create_sep (s, ',', &argz, &argz_len)) != 0) {
+        errno = e;
+        goto done;
+    }
+    while ((entry = argz_next (argz, argz_len, entry))) {
+        if (strrole (entry, &mask) < 0)
+            goto done;
+    }
+    *rolemask = mask;
+    rc = 0;
+done:
+    free (argz);
+    return rc;
+}
+
+static void delrole (flux_t *h, uint32_t userid, uint32_t rolemask)
+{
+    flux_rpc_t *r;
+    uint32_t final;
+    char s[256];
+
+    r = flux_rpcf (h, "userdb.delrole", FLUX_NODEID_ANY, 0,
+                   "{s:i s:i}", "userid", userid,
+                                "rolemask", rolemask);
+    if (!r)
+        log_err_exit ("userdb.delrole");
+    if (flux_rpc_getf (r, "{s:i s:i}", "userid", &userid,
+                                       "rolemask", &final) < 0) {
+        if (errno == ENOSYS)
+            log_msg_exit ("userdb module is not loaded");
+        if (errno == ENOENT)
+            log_msg_exit ("No such user: %" PRIu32, userid);
+        log_err_exit ("userdb.delrole");
+    }
+    printf ("%" PRIu32 ":%s\n", userid, rolestr (final, s, sizeof (s)));
+    flux_rpc_destroy (r);
+}
+
+static void addrole (flux_t *h, uint32_t userid, uint32_t rolemask)
+{
+    flux_rpc_t *r;
+    uint32_t final;
+    char s[256];
+
+    r = flux_rpcf (h, "userdb.addrole", FLUX_NODEID_ANY, 0,
+                   "{s:i s:i}", "userid", userid,
+                                    "rolemask", rolemask);
+    if (!r)
+        log_err_exit ("userdb.addrole");
+    if (flux_rpc_getf (r, "{s:i s:i}", "userid", &userid,
+                                       "rolemask", &final) < 0) {
+        if (errno == ENOSYS)
+            log_msg_exit ("userdb module is not loaded");
+        if (errno == ENOENT)
+            log_msg_exit ("No such user: %" PRIu32, userid);
+        log_err_exit ("userdb.addrole");
+    }
+    printf ("%" PRIu32 ":%s\n", userid, rolestr (final, s, sizeof (s)));
+    flux_rpc_destroy (r);
+}
+
+static uint32_t lookup_user (const char *name)
+{
+    struct passwd pwd, *result;
+    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    char *buf;
+    int e;
+    uint32_t userid = FLUX_USERID_UNKNOWN;
+
+    if (bufsize == -1)
+        bufsize = 16384;        /* Should be more than enough */
+    buf = xzmalloc (bufsize);
+    e = getpwnam_r (name, &pwd, buf, bufsize, &result);
+    if (result == NULL) {
+        if (e == 0)
+            log_msg_exit ("%s: unknown user", name);
+        else
+            log_errn_exit (e, "%s", name);
+    }
+    userid = result->pw_uid;
+    free (buf);
+    return userid;
+}
+
+static int internal_user_list (optparse_t *p, int ac, char *av[])
+{
+    int n;
+    flux_t *h;
+    flux_rpc_t *r;
+    uint32_t userid;
+    uint32_t rolemask;
+    char s[256];
+
+    n = optparse_option_index (p);
+    if (n != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    for (;;) {
+        r = flux_rpc (h, "userdb.getnext", NULL, FLUX_NODEID_ANY, 0);
+        if (!r)
+            log_err_exit ("userdb.getnext");
+        if (flux_rpc_getf (r, "{s:i s:i}", "userid", &userid,
+                                           "rolemask", &rolemask) < 0) {
+            if (errno == ENOSYS)
+                log_msg_exit ("userdb module is not loaded");
+            if (errno != ENOENT)
+                log_err_exit ("userdb.getnext");
+            flux_rpc_destroy (r);
+            break;
+        }
+        printf ("%" PRIu32 ":%s\n",
+                userid, rolestr (rolemask, s, sizeof (s)));
+
+        flux_rpc_destroy (r);
+    }
+    flux_close (h);
+    return (0);
+}
+
+static int internal_user_lookup (optparse_t *p, int ac, char *av[])
+{
+    int n;
+    flux_t *h;
+    flux_rpc_t *r;
+    uint32_t userid;
+    uint32_t rolemask;
+    char *endptr;
+    char s[256];
+
+    n = optparse_option_index (p);
+    if (n != ac - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    userid = strtoul (av[n], &endptr, 10);
+    if (*endptr != '\0')
+        userid = lookup_user (av[n]);
+    if (userid == FLUX_USERID_UNKNOWN)
+        log_msg_exit ("%s: invalid userid", av[n]);
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    r = flux_rpcf (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
+                   "{s:i}", "userid", userid);
+    if (!r)
+        log_err_exit ("userdb.lookup");
+    if (flux_rpc_getf (r, "{s:i s:i}", "userid", &userid,
+                                       "rolemask", &rolemask) < 0) {
+        if (errno == ENOSYS)
+            log_msg_exit ("userdb module is not loaded");
+        if (errno == ENOENT)
+            log_msg_exit ("No such user: %" PRIu32, userid);
+        log_err_exit ("userdb.lookup");
+    }
+    printf ("%" PRIu32 ":%s\n",
+            userid, rolestr (rolemask, s, sizeof (s)));
+    flux_rpc_destroy (r);
+    flux_close (h);
+    return (0);
+}
+
+static int internal_user_addrole (optparse_t *p, int ac, char *av[])
+{
+    int n;
+    flux_t *h;
+    uint32_t userid, rolemask;
+    char *endptr;
+
+    n = optparse_option_index (p);
+    if (n != ac - 2) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    userid = strtoul (av[n], &endptr, 10);
+    if (*endptr != '\0')
+        userid = lookup_user (av[n]);
+    if (userid == FLUX_USERID_UNKNOWN)
+        log_msg_exit ("%s: invalid userid", av[n]);
+    n++;
+    rolemask = strtoul (av[n], &endptr, 0);
+    if (*endptr != '\0') {
+        if (parse_rolemask_string (av[n], &rolemask) < 0)
+            log_err_exit ("%s: invalid rolemask", av[n]);
+    }
+    if (rolemask == FLUX_ROLE_NONE)
+        log_msg_exit ("%s: invalid rolemask", av[n]);
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    addrole (h, userid, rolemask);
+    flux_close (h);
+    return (0);
+}
+
+static int internal_user_delrole (optparse_t *p, int ac, char *av[])
+{
+    int n;
+    flux_t *h;
+    uint32_t userid, rolemask;
+    char *endptr;
+
+    n = optparse_option_index (p);
+    if (n != ac - 2) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    userid = strtoul (av[n], &endptr, 10);
+    if (*endptr != '\0')
+        userid = lookup_user (av[n]);
+    if (userid == FLUX_USERID_UNKNOWN)
+        log_msg_exit ("%s: invalid userid", av[n]);
+    n++;
+    rolemask = strtoul (av[n], &endptr, 0);
+    if (*endptr != '\0') {
+        if (parse_rolemask_string (av[n], &rolemask) < 0)
+            log_err_exit ("%s: invalid rolemask", av[n]);
+    }
+    if (rolemask == FLUX_ROLE_NONE)
+        log_msg_exit ("%s: invalid rolemask", av[n]);
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    delrole (h, userid, rolemask);
+    flux_close (h);
+    return (0);
+}
+
+
+int cmd_user (optparse_t *p, int ac, char *av[])
+{
+    log_init ("flux-user");
+
+    if (optparse_run_subcommand (p, ac, av) != OPTPARSE_SUCCESS)
+        exit (1);
+    return (0);
+}
+
+static struct optparse_subcommand user_subcmds[] = {
+    { "list",
+      "",
+      "List users and their assigned roles",
+      internal_user_list,
+      0,
+      NULL,
+    },
+    { "lookup",
+      "USERID",
+      "Lookup roles assigned to USERID",
+      internal_user_lookup,
+      0,
+      NULL,
+    },
+    { "addrole",
+      "USERID role[,role,...]",
+      "Add roles to USERID",
+      internal_user_addrole,
+      0,
+      NULL,
+    },
+    { "delrole",
+      "USERID role[,role,...]",
+      "Remove roles from USERID",
+      internal_user_delrole,
+      0,
+      NULL,
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+int subcommand_user_register (optparse_t *p)
+{
+    optparse_err_t e;
+
+    e = optparse_reg_subcommand (p,
+            "user", cmd_user, NULL, "Access user database", 0, NULL);
+    if (e != OPTPARSE_SUCCESS)
+        return (-1);
+
+    e = optparse_reg_subcommands (optparse_get_subcommand (p, "user"),
+                                  user_subcmds);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libflux/dispatch.h
+++ b/src/common/libflux/dispatch.h
@@ -18,6 +18,12 @@ void flux_msg_handler_destroy (flux_msg_handler_t *w);
 void flux_msg_handler_start (flux_msg_handler_t *w);
 void flux_msg_handler_stop (flux_msg_handler_t *w);
 
+/* By default, only messages from FLUX_ROLE_OWNER are delivered to handler.
+ * Use _allow_rolemask() add roles, _deny_rolemask() to remove them.
+ * (N.B. FLUX_ROLE_OWNER cannot be denied)
+ */
+void flux_msg_handler_allow_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
+void flux_msg_handler_deny_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
 
 struct flux_msg_handler_spec {
     int typemask;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -306,6 +306,7 @@ flux_t *flux_open (const char *uri, int flags)
     char *scheme = NULL;
     void *dso = NULL;
     connector_init_f *connector_init = NULL;
+    const char *s;
     flux_t *h = NULL;
 
     if (!uri)
@@ -337,6 +338,18 @@ flux_t *flux_open (const char *uri, int flags)
 #if HAVE_CALIPER
     profiling_context_init(&h->prof);
 #endif
+    if ((s = getenv ("FLUX_HANDLE_USERID"))) {
+        uint32_t userid = strtoul (s, NULL, 10);
+        if (flux_opt_set (h, FLUX_OPT_TESTING_USERID, &userid,
+                                                      sizeof (userid)) < 0)
+            goto done;
+    }
+    if ((s = getenv ("FLUX_HANDLE_ROLEMASK"))) {
+        uint32_t rolemask = strtoul (s, NULL, 0);
+        if (flux_opt_set (h, FLUX_OPT_TESTING_ROLEMASK, &rolemask,
+                                                        sizeof (rolemask)) < 0)
+            goto done;
+    }
 done:
     free (scheme);
     free (default_uri);

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -55,6 +55,8 @@ enum {
  * (Connectors may define custom option names)
  */
 #define FLUX_OPT_ZEROMQ_CONTEXT     "flux::zeromq_context"
+#define FLUX_OPT_TESTING_USERID     "flux::testing_userid"
+#define FLUX_OPT_TESTING_ROLEMASK   "flux::testing_rolemask"
 
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a connector to dynamically load.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -188,6 +188,7 @@ int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid);
 enum {
     FLUX_ROLE_NONE = 0,
     FLUX_ROLE_OWNER = 1,
+    FLUX_ROLE_USER = 2,
     FLUX_ROLE_ALL = 0xFFFFFFFF,
 };
 int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -175,6 +175,24 @@ enum {
 int flux_msg_set_nodeid (flux_msg_t *msg, uint32_t nodeid, int flags);
 int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeid, int *flags);
 
+/* Get/set userid
+ */
+enum {
+    FLUX_USERID_UNKNOWN = 0xFFFFFFFF
+};
+int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid);
+int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid);
+
+/* Get/set rolemask
+ */
+enum {
+    FLUX_ROLE_NONE = 0,
+    FLUX_ROLE_OWNER = 1,
+    FLUX_ROLE_ALL = 0xFFFFFFFF,
+};
+int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask);
+int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask);
+
 /* Get/set errnum (response/keepalive only)
  */
 int flux_msg_set_errnum (flux_msg_t *msg, int errnum);

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -190,6 +190,10 @@ static flux_msg_t *derive_response (flux_t *h, const flux_msg_t *request,
         goto fatal;
     if (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) < 0)
         goto fatal;
+    if (flux_msg_set_userid (msg, FLUX_USERID_UNKNOWN) < 0)
+        goto fatal;
+    if (flux_msg_set_rolemask (msg, FLUX_ROLE_NONE) < 0)
+        goto fatal;
     if (errnum && flux_msg_set_errnum (msg, errnum) < 0)
         goto fatal;
     return msg;

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -408,6 +408,30 @@ void check_matchtag (void)
     flux_msg_destroy (msg);
 }
 
+void check_security (void)
+{
+    flux_msg_t *msg;
+    uint32_t userid, rolemask;
+
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
+        "flux_msg_create works");
+    ok (flux_msg_get_userid (msg, &userid) == 0
+        && userid == FLUX_USERID_UNKNOWN,
+        "message created with userid=FLUX_USERID_UNKNOWN");
+    ok (flux_msg_get_rolemask (msg, &rolemask) == 0
+        && rolemask == FLUX_ROLE_NONE,
+        "message created with rolemask=FLUX_ROLE_NONE");
+    ok (flux_msg_set_userid (msg, 4242) == 0
+        && flux_msg_get_userid (msg, &userid) == 0
+        && userid == 4242,
+        "flux_msg_set_userid 4242 works");
+    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_ALL) == 0
+        && flux_msg_get_rolemask (msg, &rolemask) == 0
+        && rolemask == FLUX_ROLE_ALL,
+        "flux_msg_set_rolemask FLUX_ROLE_ALL works");
+    flux_msg_destroy (msg);
+}
+
 void check_cmp (void)
 {
     struct flux_match match = FLUX_MATCH_ANY;
@@ -566,6 +590,7 @@ int main (int argc, char *argv[])
     check_payload_json ();
     check_payload_json_formatted ();
     check_matchtag ();
+    check_security ();
 
     check_cmp ();
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -47,6 +47,8 @@ typedef struct {
     int fd_nonblock;
     struct flux_msg_iobuf outbuf;
     struct flux_msg_iobuf inbuf;
+    uint32_t testing_userid;
+    uint32_t testing_rolemask;
     flux_t *h;
 } local_ctx_t;
 
@@ -99,16 +101,42 @@ static int op_pollfd (void *impl)
     return c->fd;
 }
 
-static int op_send (void *impl, const flux_msg_t *msg, int flags)
+static int send_normal (local_ctx_t *c, const flux_msg_t *msg, int flags)
 {
-    local_ctx_t *c = impl;
-    assert (c->magic == CTX_MAGIC);
-
     if (set_nonblock (c, (flags & FLUX_O_NONBLOCK)) < 0)
         return -1;
     if (flux_msg_sendfd (c->fd, msg, &c->outbuf) < 0)
         return -1;
     return 0;
+}
+
+static int send_testing (local_ctx_t *c, const flux_msg_t *msg, int flags)
+{
+    flux_msg_t *cpy;
+    int rc = -1;
+
+    if (!(cpy = flux_msg_copy (msg, true)))
+        goto done;
+    if (flux_msg_set_userid (cpy, c->testing_userid) < 0)
+        goto done;
+    if (flux_msg_set_rolemask (cpy, c->testing_rolemask) < 0)
+        goto done;
+    rc = send_normal (c, cpy, flags);
+done:
+    flux_msg_destroy (cpy);
+    return rc;
+}
+
+
+static int op_send (void *impl, const flux_msg_t *msg, int flags)
+{
+    local_ctx_t *c = impl;
+    assert (c->magic == CTX_MAGIC);
+    if (c->testing_userid != FLUX_USERID_UNKNOWN
+                                || c->testing_rolemask != FLUX_ROLE_NONE)
+        return send_testing (c, msg, flags);
+    else
+        return send_normal (c, msg, flags);
 }
 
 static flux_msg_t *op_recv (void *impl, int flags)
@@ -148,6 +176,37 @@ static int op_event_subscribe (void *impl, const char *topic)
 static int op_event_unsubscribe (void *impl, const char *topic)
 {
     return op_event (impl, topic, "local.unsub");
+}
+
+static int op_setopt (void *impl, const char *option,
+                      const void *val, size_t size)
+{
+    local_ctx_t *ctx = impl;
+    assert (ctx->magic == CTX_MAGIC);
+    size_t val_size;
+    int rc = -1;
+
+    if (option && !strcmp (option, FLUX_OPT_TESTING_USERID)) {
+        val_size = sizeof (ctx->testing_userid);
+        if (size != val_size) {
+            errno = EINVAL;
+            goto done;
+        }
+        memcpy (&ctx->testing_userid, val, val_size);
+    } else if (option && !strcmp (option, FLUX_OPT_TESTING_ROLEMASK)) {
+        val_size = sizeof (ctx->testing_rolemask);
+        if (size != val_size) {
+            errno = EINVAL;
+            goto done;
+        }
+        memcpy (&ctx->testing_rolemask, val, val_size);
+    } else {
+        errno = EINVAL;
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
 }
 
 static void op_fini (void *impl)
@@ -193,6 +252,9 @@ flux_t *connector_init (const char *path, int flags)
     }
     memset (c, 0, sizeof (*c));
     c->magic = CTX_MAGIC;
+
+    c->testing_userid = FLUX_USERID_UNKNOWN;
+    c->testing_rolemask = FLUX_ROLE_NONE;
 
     c->fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (c->fd < 0)
@@ -244,6 +306,8 @@ static const struct flux_handle_ops handle_ops = {
     .recv = op_recv,
     .event_subscribe = op_event_subscribe,
     .event_unsubscribe = op_event_unsubscribe,
+    .setopt = op_setopt,
+    .getopt = NULL,
     .impl_destroy = op_fini,
 };
 

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -122,6 +122,64 @@ static flux_msg_t *op_recv (void *impl, int flags)
     return msg;
 }
 
+static int op_getopt (void *impl, const char *option, void *val, size_t size)
+{
+    loop_ctx_t *ctx = impl;
+    assert (ctx->magic == CTX_MAGIC);
+    int rc = -1;
+
+    if (option && !strcmp (option, FLUX_OPT_TESTING_USERID)) {
+        if (size != sizeof (ctx->userid)) {
+            errno = EINVAL;
+            goto done;
+        }
+        memcpy (val, &ctx->userid, size);
+    } else if (option && !strcmp (option, FLUX_OPT_TESTING_ROLEMASK)) {
+        if (size != sizeof (ctx->rolemask)) {
+            errno = EINVAL;
+            goto done;
+        }
+        memcpy (val, &ctx->rolemask, size);
+    } else {
+        errno = EINVAL;
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+static int op_setopt (void *impl, const char *option,
+                      const void *val, size_t size)
+{
+    loop_ctx_t *ctx = impl;
+    assert (ctx->magic == CTX_MAGIC);
+    size_t val_size;
+    int rc = -1;
+
+    if (option && !strcmp (option, FLUX_OPT_TESTING_USERID)) {
+        val_size = sizeof (ctx->userid);
+        if (size != val_size) {
+            errno = EINVAL;
+            goto done;
+        }
+        memcpy (&ctx->userid, val, val_size);
+    } else if (option && !strcmp (option, FLUX_OPT_TESTING_ROLEMASK)) {
+        val_size = sizeof (ctx->rolemask);
+        if (size != val_size) {
+            errno = EINVAL;
+            goto done;
+        }
+        memcpy (&ctx->rolemask, val, val_size);
+    } else {
+        errno = EINVAL;
+        goto done;
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
 static void op_fini (void *impl)
 {
     loop_ctx_t *c = impl;
@@ -172,6 +230,8 @@ static const struct flux_handle_ops handle_ops = {
     .pollevents = op_pollevents,
     .send = op_send,
     .recv = op_recv,
+    .getopt = op_getopt,
+    .setopt = op_setopt,
     .impl_destroy = op_fini,
 };
 

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -10,7 +10,8 @@ SUBDIRS = \
  libjsc \
  resource-hwloc \
  cron \
- aggregator
+ aggregator \
+ userdb
 
 if HAVE_PYTHON
 SUBDIRS += pymod

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -46,6 +46,10 @@
 
 #include "src/common/libutil/cleanup.h"
 
+enum {
+    DEBUG_AUTHFAIL_ONESHOT = 1,
+};
+
 
 #define LISTEN_BACKLOG      5
 
@@ -187,10 +191,10 @@ static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
         goto error;
     }
     int *debug_flags = flux_aux_get (h, "flux::debug_flags");
-    if (debug_flags && (*debug_flags & 1)) {
+    if (debug_flags && (*debug_flags & DEBUG_AUTHFAIL_ONESHOT)) {
         flux_log (h, LOG_ERR, "connect by uid=%d pid=%d denied by debug flag",
                   ucred.uid, (int)ucred.pid);
-        *debug_flags &= ~1; // one shot
+        *debug_flags &= ~DEBUG_AUTHFAIL_ONESHOT;
         errno = EPERM;
         goto error;
     }

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -210,6 +210,7 @@ static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
     if (lookup_userdb (h, ucred.uid, &lookup_rolemask) < 0) {
         flux_log_error (h, "%s: userdb lookup uid=%d pid=%d",
                         __FUNCTION__, ucred.uid, ucred.pid);
+        errno = EPERM;
         goto error;
     }
     if (lookup_rolemask == FLUX_ROLE_NONE) {

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -196,7 +196,7 @@ static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
     }
     if (ucred.uid == instance_owner) {
         lookup_rolemask = FLUX_ROLE_OWNER;
-        goto success;
+        goto success_nolog;
     }
     if (lookup_userdb (h, ucred.uid, &lookup_rolemask) < 0) {
         flux_log_error (h, "%s: userdb lookup uid=%d pid=%d",
@@ -209,11 +209,11 @@ static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
         errno = EPERM;
         goto error;
     }
-success:
-    *userid = ucred.uid;
-    *rolemask = lookup_rolemask;
     flux_log (h, LOG_INFO, "%s: uid=%d pid=%d allowed rolemask=0x%x",
               __FUNCTION__, ucred.uid, ucred.pid, lookup_rolemask);
+success_nolog:
+    *userid = ucred.uid;
+    *rolemask = lookup_rolemask;
     return 0;
 error:
     return -1;

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -154,13 +154,28 @@ static int send_auth_response (int fd, unsigned char e)
     return write (fd, &e, 1);
 }
 
-/* Deny connections by user other than instance owner for now.
- */
+static int lookup_userdb (flux_t *h, uint32_t userid, uint32_t *rolemask)
+{
+    flux_rpc_t *rpc;
+    int rc = -1;
+
+    if (!(rpc = flux_rpcf (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
+                           "{s:i}", "userid", userid)))
+        goto done;
+    if (flux_rpc_getf (rpc, "{s:i}", "rolemask", rolemask) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_rpc_destroy (rpc);
+    return rc;
+}
+
 static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
                                 uint32_t *userid, uint32_t *rolemask)
 {
     struct ucred ucred;
     socklen_t crlen = sizeof (ucred);
+    uint32_t lookup_rolemask;
 
     if (getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &ucred, &crlen) < 0) {
         flux_log_error (h, "%s: getsockopt SO_PEERCRED", __FUNCTION__);
@@ -177,18 +192,31 @@ static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
                   ucred.uid, (int)ucred.pid);
         *debug_flags &= ~1; // one shot
         errno = EPERM;
+        goto error;
     }
-    if (ucred.uid != instance_owner) {
-        flux_log (h, LOG_ERR, "connect by uid=%d pid=%d denied",
-                  ucred.uid, (int)ucred.pid);
+    if (ucred.uid == instance_owner) {
+        lookup_rolemask = FLUX_ROLE_OWNER;
+        goto success;
+    }
+    if (lookup_userdb (h, ucred.uid, &lookup_rolemask) < 0) {
+        flux_log_error (h, "%s: userdb lookup uid=%d pid=%d",
+                        __FUNCTION__, ucred.uid, ucred.pid);
+        goto error;
+    }
+    if (lookup_rolemask == FLUX_ROLE_NONE) {
+        flux_log (h, LOG_ERR, "%s: uid=%d pid=%d no assigned roles",
+                  __FUNCTION__, ucred.uid, ucred.pid);
         errno = EPERM;
         goto error;
     }
+success:
     *userid = ucred.uid;
-    *rolemask = FLUX_ROLE_OWNER;
+    *rolemask = lookup_rolemask;
+    flux_log (h, LOG_INFO, "%s: uid=%d pid=%d allowed rolemask=0x%x",
+              __FUNCTION__, ucred.uid, ucred.pid, lookup_rolemask);
     return 0;
 error:
-   return -1;
+    return -1;
 }
 
 static client_t * client_create (mod_local_ctx_t *ctx, int fd)

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -55,7 +55,7 @@ typedef struct {
     zlist_t *clients;
     flux_t *h;
     flux_reactor_t *reactor;
-    uid_t session_owner;
+    uid_t instance_owner;
     zhash_t *subscriptions;
 } mod_local_ctx_t;
 
@@ -79,7 +79,8 @@ typedef struct {
     zhash_t *disconnect_notify;
     zhash_t *subscriptions;
     zuuid_t *uuid;
-    struct ucred ucred;
+    uint32_t userid;
+    uint32_t rolemask;
 } client_t;
 
 struct disconnect_notify {
@@ -125,7 +126,7 @@ static mod_local_ctx_t *getctx (flux_t *h)
             errno = ENOMEM;
             goto error;
         }
-        ctx->session_owner = geteuid ();
+        ctx->instance_owner = geteuid ();
         flux_aux_set (h, "flux::local_connector", ctx, freectx);
     }
     return ctx;
@@ -153,10 +154,46 @@ static int send_auth_response (int fd, unsigned char e)
     return write (fd, &e, 1);
 }
 
+/* Deny connections by user other than instance owner for now.
+ */
+static int client_authenticate (int fd, flux_t *h, uint32_t instance_owner,
+                                uint32_t *userid, uint32_t *rolemask)
+{
+    struct ucred ucred;
+    socklen_t crlen = sizeof (ucred);
+
+    if (getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &ucred, &crlen) < 0) {
+        flux_log_error (h, "%s: getsockopt SO_PEERCRED", __FUNCTION__);
+        goto error;
+    }
+    if (crlen != sizeof (ucred)) {
+        errno = EPERM;
+        flux_log_error (h, "%s: ucred is wrong size", __FUNCTION__);
+        goto error;
+    }
+    int *debug_flags = flux_aux_get (h, "flux::debug_flags");
+    if (debug_flags && (*debug_flags & 1)) {
+        flux_log (h, LOG_ERR, "connect by uid=%d pid=%d denied by debug flag",
+                  ucred.uid, (int)ucred.pid);
+        *debug_flags &= ~1; // one shot
+        errno = EPERM;
+    }
+    if (ucred.uid != instance_owner) {
+        flux_log (h, LOG_ERR, "connect by uid=%d pid=%d denied",
+                  ucred.uid, (int)ucred.pid);
+        errno = EPERM;
+        goto error;
+    }
+    *userid = ucred.uid;
+    *rolemask = FLUX_ROLE_OWNER;
+    return 0;
+error:
+   return -1;
+}
+
 static client_t * client_create (mod_local_ctx_t *ctx, int fd)
 {
     client_t *c;
-    socklen_t crlen = sizeof (c->ucred);
     flux_t *h = ctx->h;
 
     if (!(c = calloc (1, sizeof (*c)))) {
@@ -174,24 +211,9 @@ static client_t * client_create (mod_local_ctx_t *ctx, int fd)
         errno = ENOMEM;
         goto error;
     }
-    if (getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &c->ucred, &crlen) < 0)
+    if (client_authenticate (fd, h, ctx->instance_owner, &c->userid,
+                                                         &c->rolemask) < 0)
         goto error;
-    /* Deny connections by uid other than session owner for now.
-     */
-    if (c->ucred.uid != ctx->session_owner) {
-        flux_log (h, LOG_ERR, "connect by uid=%d pid=%d denied",
-                  c->ucred.uid, (int)c->ucred.pid);
-        errno = EPERM;
-        goto error;
-    }
-    int *debug_flags = flux_aux_get (h, "flux::debug_flags");
-    if (debug_flags && (*debug_flags & 1)) {
-        flux_log (h, LOG_ERR, "connect by uid=%d pid=%d denied by debug flag",
-                  c->ucred.uid, (int)c->ucred.pid);
-        *debug_flags &= ~1; // one shot
-        errno = EPERM;
-        goto error;
-    }
     if (!(c->inw = flux_fd_watcher_create (ctx->reactor, fd, FLUX_POLLIN,
                                            client_read_cb, c)) != 0)
         goto error;
@@ -208,8 +230,7 @@ static client_t * client_create (mod_local_ctx_t *ctx, int fd)
     c->fd = fd;
     return (c);
 error:
-    if (send_auth_response (fd, errno) < 0)
-        goto error_noresponse;
+    send_auth_response (fd, errno);
 error_noresponse:
     client_destroy (c);
     return NULL;
@@ -592,6 +613,7 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
     flux_t *h = c->ctx->h;
     flux_msg_t *msg = NULL;
     int type;
+    uint32_t userid, rolemask;
 
     if (revents & FLUX_POLLERR)
         goto error_disconnect;
@@ -614,13 +636,46 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
         flux_log_error (h, "flux_msg_get_type");
         goto error;
     }
+    if (flux_msg_get_userid (msg, &userid) < 0) {
+        flux_log_error (h, "flux_msg_get_userid");
+        goto error;
+    }
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0) {
+        flux_log_error (h, "flux_msg_get_rolemask");
+        goto error;
+    }
+    if (rolemask == FLUX_ROLE_NONE)
+        rolemask = c->rolemask;
+    if (userid == FLUX_USERID_UNKNOWN)
+        userid = c->userid;
+    /* Allow message to set userid/rolemask only if connection is
+     * authenticated with FLUX_ROLE_OWNER.
+     */
+    if (userid != c->userid || rolemask != c->rolemask) {
+        if (!(c->rolemask & FLUX_ROLE_OWNER)) {
+            flux_log (h, LOG_ERR, "message has inappropriate userid/rolemask");
+            if (type == FLUX_MSGTYPE_REQUEST) {
+                if (flux_respond (h, msg, EPERM, NULL) < 0)
+                    flux_log_error (h, "error sending EPERM response");
+            } /* else drop */
+            goto done;
+        }
+    }
+    if (flux_msg_set_userid (msg, userid) < 0) {
+        flux_log_error (h, "flux_msg_set_userid");
+        goto error_disconnect;
+    }
+    if (flux_msg_set_rolemask (msg, rolemask) < 0) {
+        flux_log_error (h, "flux_msg_set_rolemask");
+        goto error_disconnect;
+    }
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
             if (!internal_request (c, msg)) {
                 /* insert disconnect notifier before forwarding request */
                 if (c->disconnect_notify && disconnect_update (c, msg) < 0) {
                     flux_log_error (h, "disconnect_update");
-                    goto error_disconnect;
+                    goto error;
                 }
                 if (flux_msg_push_route (msg, zuuid_str (c->uuid)) < 0) {
                     flux_log_error (h, "flux_msg_push_route");
@@ -643,6 +698,7 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
                       flux_msg_typestr (type));
             goto error;
     }
+done:
     flux_msg_destroy (msg);
     return;
 error_disconnect:

--- a/src/modules/userdb/Makefile.am
+++ b/src/modules/userdb/Makefile.am
@@ -1,0 +1,20 @@
+AM_CFLAGS = \
+	@GCCWARN@ \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(ZMQ_CFLAGS)
+
+fluxmod_LTLIBRARIES = userdb.la
+
+userdb_la_SOURCES = userdb.c
+userdb_la_LDFLAGS = $(fluxmod_ldflags) -module
+userdb_la_LIBADD = $(fluxmod_libadd) \
+		    $(top_builddir)/src/common/libflux-internal.la \
+		    $(top_builddir)/src/common/libflux-core.la \
+		    $(top_builddir)/src/common/libflux-optparse.la \
+		    $(ZMQ_LIBS)

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -1,0 +1,394 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* userdb.c - map userid to rolemask
+ *
+ * The instance owner is automatically added with the FLUX_ROLE_OWNER role.
+ *
+ * If the module is loaded with --default-rolemask=ROLE[,ROLE,...]
+ * then new userids are automatically added upon lookup, with the
+ * specified roles.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/liboptparse/optparse.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
+#include "src/common/libutil/xzmalloc.h"
+
+#define USERDB_CTX_MAGIC 0x2134aaaa
+typedef struct {
+    int magic;
+    optparse_t *opt;
+    uint32_t default_rolemask;
+    zhash_t *db;
+    zhash_t *iterators;
+} userdb_ctx_t;
+
+struct user {
+    uint32_t userid;
+    uint32_t rolemask;
+};
+
+static struct optparse_option opts[] = {
+    { .name = "default-rolemask",
+      .has_arg = 1,
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .arginfo = "ROLE[,ROLE,...]",
+      .usage = "Assign specified roles to all users",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+static void freelist (zlist_t *l)
+{
+    zlist_destroy (&l);
+}
+
+static void freectx (void *arg)
+{
+    userdb_ctx_t *ctx = arg;
+    if (ctx) {
+        ctx->magic = ~USERDB_CTX_MAGIC;
+        optparse_destroy (ctx->opt);
+        zhash_destroy (&ctx->db);
+        zhash_destroy (&ctx->iterators);
+        free (ctx);
+    }
+}
+
+static userdb_ctx_t *getctx (flux_t *h, int argc, char **argv)
+{
+    userdb_ctx_t *ctx = (userdb_ctx_t *)flux_aux_get (h, "flux::userdb");
+    const char *arg;
+    optparse_err_t e;
+
+    if (!ctx) {
+        if (!(ctx = calloc (1, sizeof (*ctx)))) {
+            errno = ENOMEM;
+            goto error;
+        }
+        ctx->magic = USERDB_CTX_MAGIC;
+        ctx->default_rolemask = FLUX_ROLE_NONE;
+        if (!(ctx->opt = optparse_create ("userdb"))) {
+            errno = ENOMEM;
+            goto error;
+        }
+        e = optparse_add_option_table (ctx->opt, opts);
+        if (e != OPTPARSE_SUCCESS) {
+            if (e == OPTPARSE_NOMEM)
+                errno = ENOMEM;
+            else
+                errno = EINVAL;
+            goto error;
+        }
+        if (optparse_parse_args (ctx->opt, argc + 1,
+                                           argv - 1) < 0) {
+            errno = EINVAL;
+            goto error;
+        }
+        optparse_getopt_iterator_reset (ctx->opt, "default-rolemask");
+        while ((arg = optparse_getopt_next (ctx->opt, "default-rolemask"))) {
+            if (!strcmp (arg, "user"))
+                ctx->default_rolemask |= FLUX_ROLE_USER;
+            else if (!strcmp (arg, "owner"))
+                ctx->default_rolemask |= FLUX_ROLE_OWNER;
+            else {
+                flux_log (h, LOG_ERR, "unknown role: %s", arg);
+                errno = EINVAL;
+                goto error;
+            }
+        }
+        if (optparse_hasopt (ctx->opt, "default-rolemask"))
+            flux_log (h, LOG_INFO, "default rolemask override=0x%" PRIx32,
+                      ctx->default_rolemask);
+        if (!(ctx->db = zhash_new ()) || !(ctx->iterators = zhash_new ())) {
+            errno = ENOMEM;
+            goto error;
+        }
+        flux_aux_set (h, "flux::userdb", ctx, freectx);
+    }
+    return ctx;
+error:
+    freectx (ctx);
+    return NULL;
+}
+
+struct user *user_create (uint32_t userid, uint32_t rolemask)
+{
+    struct user *up;
+
+    if (!(up = calloc (1, sizeof (*up)))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    up->userid = userid;
+    up->rolemask = rolemask;
+    return up;
+error:
+    free (up);
+    return NULL;
+}
+
+static struct user *user_add (userdb_ctx_t *ctx, uint32_t userid,
+                                                 uint32_t rolemask)
+{
+    struct user *up = NULL;
+    char key[16];
+
+    snprintf (key, sizeof (key), "%" PRIu32, userid);
+    if (!(up = user_create (userid, rolemask))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (zhash_insert (ctx->db, key, up) < 0) {
+        errno = EEXIST;
+        goto error;
+    }
+    zhash_freefn (ctx->db, key, (zhash_free_fn *)free);
+    return up;
+error:
+    free (up);
+    return NULL;
+}
+
+static struct user *user_lookup (userdb_ctx_t *ctx, uint32_t userid)
+{
+    struct user *up = NULL;
+    char key[16];
+
+    snprintf (key, sizeof (key), "%" PRIu32, userid);
+    if (!(up = zhash_lookup (ctx->db, key))) {
+        errno = ENOENT;
+        goto error;
+    }
+    return up;
+error:
+    free (up);
+    return NULL;
+}
+
+static void user_delete (userdb_ctx_t *ctx, uint32_t userid)
+{
+    char key[16];
+
+    snprintf (key, sizeof (key), "%" PRIu32, userid);
+    zhash_delete (ctx->db, key);
+}
+
+static void lookup (flux_t *h, flux_msg_handler_t *w,
+                    const flux_msg_t *msg, void *arg)
+{
+    userdb_ctx_t *ctx = arg;
+    uint32_t userid;
+    struct user *up;
+
+    if (flux_request_decodef (msg, NULL, "{s:i}", "userid", &userid) < 0)
+        goto error;
+    if (!(up = user_lookup (ctx, userid))) {
+        if (ctx->default_rolemask != FLUX_ROLE_NONE) {
+            if (!(up = user_add (ctx, userid, ctx->default_rolemask)))
+                goto error;
+        } else
+            goto error;
+    }
+    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
+                                            "rolemask", up->rolemask) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void addrole (flux_t *h, flux_msg_handler_t *w,
+                     const flux_msg_t *msg, void *arg)
+{
+    userdb_ctx_t *ctx = arg;
+    uint32_t userid, rolemask;
+    struct user *up;
+
+    if (flux_request_decodef (msg, NULL, "{s:i s:i}",
+                              "userid", &userid,
+                              "rolemask", &rolemask) < 0)
+        goto error;
+    if (!(up = user_lookup (ctx, userid))) {
+        if (rolemask == FLUX_ROLE_NONE)
+            rolemask = ctx->default_rolemask;
+        if (rolemask == FLUX_ROLE_NONE) {
+            errno = EINVAL;
+            goto error;
+        }
+        if (!(up = user_add (ctx, userid, rolemask)))
+            goto error;
+    } else
+        up->rolemask |= rolemask;
+    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
+                                            "rolemask", up->rolemask) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void delrole (flux_t *h, flux_msg_handler_t *w,
+                     const flux_msg_t *msg, void *arg)
+{
+    userdb_ctx_t *ctx = arg;
+    uint32_t userid, rolemask;
+    struct user *up;
+
+    if (flux_request_decodef (msg, NULL, "{s:i s:i}",
+                              "userid", &userid,
+                              "rolemask", &rolemask) < 0)
+        goto error;
+    if (!(up = user_lookup (ctx, userid)))
+        goto error;
+    up->rolemask &= ~rolemask;
+    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
+                                            "rolemask", up->rolemask) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    if (up->rolemask == FLUX_ROLE_NONE)
+        user_delete (ctx, userid);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static int compare_keys (const char *s1, const char *s2)
+{
+    uint32_t u1 = strtoul (s1, NULL, 10);
+    uint32_t u2 = strtoul (s2, NULL, 10);
+    if (u1 < u2)
+        return -1;
+    if (u1 > u2)
+        return 1;
+    return 0;
+}
+
+static void getnext (flux_t *h, flux_msg_handler_t *w,
+                     const flux_msg_t *msg, void *arg)
+{
+    userdb_ctx_t *ctx = arg;
+    char *key;
+    struct user *up = NULL;
+    char *uuid = NULL;
+    zlist_t *itr;
+
+    if (flux_msg_get_route_first (msg, &uuid) < 0)
+        goto error;
+    if (!(itr = zhash_lookup (ctx->iterators, uuid))) {
+        if (!(itr = zhash_keys (ctx->db))) {
+            errno = ENOMEM;
+            goto error;
+        }
+        zlist_sort (itr, (zlist_compare_fn *)compare_keys);
+        zhash_update (ctx->iterators, uuid, itr);
+        zhash_freefn (ctx->iterators, uuid, (zhash_free_fn *)freelist);
+        key = zlist_first (itr);
+    } else {
+        key = zlist_next (itr);
+    }
+    if (!key || !(up = zhash_lookup (ctx->db, key))) {
+        zhash_delete (ctx->iterators, uuid);
+        errno = ENOENT;
+        goto error;
+    }
+
+    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
+                                            "rolemask", up->rolemask) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    free (uuid);
+}
+
+static void disconnect (flux_t *h, flux_msg_handler_t *w,
+                        const flux_msg_t *msg, void *arg)
+{
+    userdb_ctx_t *ctx = arg;
+    char *uuid;
+    if (flux_msg_get_route_first (msg, &uuid) == 0) {
+        zhash_delete (ctx->iterators, uuid);
+        free (uuid);
+    }
+}
+
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "userdb.lookup", lookup},
+    { FLUX_MSGTYPE_REQUEST,  "userdb.addrole", addrole },
+    { FLUX_MSGTYPE_REQUEST,  "userdb.delrole", delrole },
+    { FLUX_MSGTYPE_REQUEST,  "userdb.getnext", getnext},
+    { FLUX_MSGTYPE_REQUEST,  "userdb.disconnect", disconnect},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    int rc = -1;
+    userdb_ctx_t *ctx;
+    struct user *up;
+
+    if (!(ctx = getctx (h, argc, argv))) {
+        goto done;
+    }
+    if (!(up = user_add (ctx, geteuid (), FLUX_ROLE_OWNER))) {
+        flux_log_error (h, "failed to add owner to userdb");
+        goto done;
+    }
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log_error (h, "flux_msghandler_add");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done_unreg;
+    }
+    rc = 0;
+done_unreg:
+    flux_msg_handler_delvec (htab);
+done:
+    return rc;
+}
+
+MOD_NAME ("userdb");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -29,6 +29,7 @@ TESTS = \
 	loop/multrpc.t \
 	loop/reduce.t \
 	loop/log.t \
+	rolemask/loop.t \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -154,6 +155,7 @@ check_PROGRAMS = \
 	loop/multrpc.t \
 	loop/reduce.t \
 	loop/log.t \
+	rolemask/loop.t \
 	kz/kzutil \
 	kvs/torture \
 	kvs/dtree \
@@ -227,6 +229,10 @@ loop_multrpc_t_LDADD = $(test_ldadd) $(LIBDL)
 loop_reduce_t_SOURCES = loop/reduce.c
 loop_reduce_t_CPPFLAGS = $(test_cppflags)
 loop_reduce_t_LDADD = $(test_ldadd) $(LIBDL)
+
+rolemask_loop_t_SOURCES = rolemask/loop.c
+rolemask_loop_t_CPPFLAGS = $(test_cppflags)
+rolemask_loop_t_LDADD = $(test_ldadd) $(LIBDL)
 
 mpi_hello_SOURCES = mpi/hello.c
 mpi_hello_CPPFLAGS = $(MPI_CFLAGS)

--- a/t/rolemask/loop.c
+++ b/t/rolemask/loop.c
@@ -1,0 +1,367 @@
+#include <errno.h>
+#include <flux/core.h>
+#include <inttypes.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libtap/tap.h"
+
+struct creds {
+    uint32_t userid;
+    uint32_t rolemask;
+};
+
+static int cred_get (flux_t *h, struct creds *cr)
+{
+    if (flux_opt_get (h, FLUX_OPT_TESTING_USERID,
+                       &cr->userid, sizeof (cr->userid)) < 0)
+        return -1;
+    if (flux_opt_get (h, FLUX_OPT_TESTING_ROLEMASK,
+                       &cr->rolemask, sizeof (cr->rolemask)) < 0)
+        return -1;
+    return 0;
+}
+
+static int cred_set (flux_t *h, struct creds *cr)
+{
+    if (flux_opt_set (h, FLUX_OPT_TESTING_USERID,
+                       &cr->userid, sizeof (cr->userid)) < 0)
+        return -1;
+    if (flux_opt_set (h, FLUX_OPT_TESTING_ROLEMASK,
+                       &cr->rolemask, sizeof (cr->rolemask)) < 0)
+        return -1;
+    return 0;
+}
+
+static void check_rpc_oneway (flux_t *h)
+{
+    flux_rpc_t *rpc = NULL;
+    flux_msg_t *msg = NULL;
+    struct creds cr;
+
+    rpc = flux_rpc (h, "testrpc0", NULL, FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE);
+    ok (rpc != NULL,
+        "sent request");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    flux_rpc_destroy (rpc);
+
+    msg = flux_recv (h, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "received looped back request");
+    ok (flux_msg_get_userid (msg, &cr.userid) == 0
+        && cr.userid == geteuid (),
+        "request contains userid belonging to instance owner");
+    ok (flux_msg_get_rolemask (msg, &cr.rolemask) == 0
+        && cr.rolemask == FLUX_ROLE_OWNER,
+        "request contains rolemask set to FLUX_ROLE_OWNER");
+    flux_msg_destroy (msg);
+}
+
+static void check_rpc_oneway_faked (flux_t *h)
+{
+    flux_rpc_t *rpc = NULL;
+    flux_msg_t *msg = NULL;
+    struct creds saved, new, cr;
+
+    ok (cred_get (h, &saved) == 0
+        && saved.userid == geteuid() && saved.rolemask == FLUX_ROLE_OWNER,
+        "saved connector creds, with expected values");
+
+    new.userid = 9999;
+    new.rolemask = 0x80000000;
+    ok (cred_set (h, &new) == 0 && cred_get (h, &cr) == 0
+        && cr.userid == new.userid && cr.rolemask == new.rolemask,
+       "set userid/rolemaks to test values");
+
+    rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE);
+    ok (rpc != NULL,
+        "sent request");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    flux_rpc_destroy (rpc);
+
+    msg = flux_recv (h, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "received looped back request");
+    ok (flux_msg_get_userid (msg, &cr.userid) == 0
+        && cr.userid == new.userid,
+        "request contains test userid");
+    ok (flux_msg_get_rolemask (msg, &cr.rolemask) == 0
+        && cr.rolemask == new.rolemask,
+        "request contains test rolemask");
+    flux_msg_destroy (msg);
+
+    ok (cred_set (h, &saved) == 0,
+        "restored connector creds");
+}
+
+static bool testrpc1_called;
+static void testrpc1 (flux_t *h, flux_msg_handler_t *w,
+                      const flux_msg_t *msg, void *arg)
+{
+    diag ("testrpc1 handler invoked");
+    testrpc1_called = true;
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        diag ("flux_respond: %s", flux_strerror (errno));
+}
+
+flux_msg_handler_t *testrpc1_handler_create (flux_t *h)
+{
+    struct flux_match match = FLUX_MATCH_REQUEST;
+    flux_msg_handler_t *w;
+    match.topic_glob = "testrpc1";
+
+    if (!(w = flux_msg_handler_create (h, match, testrpc1, NULL)))
+        return NULL;
+    flux_msg_handler_start (w);
+    return w;
+}
+
+static void check_rpc_default_policy (flux_t *h)
+{
+    flux_rpc_t *rpc;
+    flux_msg_handler_t *w;
+    struct creds saved, new, cr;
+    int rc;
+
+    ok ((w = testrpc1_handler_create (h)) != NULL,
+        "created message handler with default policy");
+    if (w == NULL)
+        BAIL_OUT ("flux_msg_handler_create: %s", flux_strerror (errno));
+
+    /* This should be a no-op since "deny all" can't deny FLUX_ROLE_OWNER,
+     * and the default policy is to require FLUX_ROLE_OWNER.
+     */
+    flux_msg_handler_deny_rolemask (w, FLUX_ROLE_ALL);
+
+
+    /* Attempt with default creds.
+     */
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "default-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "default-creds: reactor successfully handled one event");
+    ok (testrpc1_called == true
+        && flux_rpc_check (rpc) && flux_rpc_get (rpc, NULL) == 0,
+        "default-creds: handler was called and returned success response");
+    flux_rpc_destroy (rpc);
+
+    /* Attempt with non-owner creds
+     */
+    ok (cred_get (h, &saved) == 0
+        && saved.userid == geteuid() && saved.rolemask == FLUX_ROLE_OWNER,
+        "saved connector creds, with expected values");
+    new.userid = 9999;
+    new.rolemask = 0x80000000;
+    ok (cred_set (h, &new) == 0 && cred_get (h, &cr) == 0
+        && cr.userid == new.userid && cr.rolemask == new.rolemask,
+       "set userid/rolemaks to non-owner test values");
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "random-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "random-creds: reactor successfully handled one event");
+    errno = 0;
+    ok (testrpc1_called == false
+        && flux_rpc_check (rpc) == true
+        && flux_rpc_get (rpc, NULL) == -1 && errno == EPERM,
+        "random-creds: handler was NOT called and dispatcher returned EPERM response");
+    flux_rpc_destroy (rpc);
+    ok (cred_set (h, &saved) == 0,
+        "restored connector creds");
+
+    flux_msg_handler_destroy (w);
+}
+
+static void check_rpc_open_policy (flux_t *h)
+{
+    flux_rpc_t *rpc;
+    flux_msg_handler_t *w;
+    struct creds saved, new, cr;
+    int rc;
+
+    ok ((w = testrpc1_handler_create (h)) != NULL,
+        "created message handler with open policy");
+    if (w == NULL)
+        BAIL_OUT ("flux_msg_handler_create: %s", flux_strerror (errno));
+    flux_msg_handler_allow_rolemask (w, FLUX_ROLE_ALL);
+
+    /* Attempt with default creds.
+     */
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "default-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "default-creds: reactor successfully handled one event");
+    ok (testrpc1_called == true
+        && flux_rpc_check (rpc) && flux_rpc_get (rpc, NULL) == 0,
+        "default-creds: handler was called and returned success response");
+    flux_rpc_destroy (rpc);
+
+    /* Attempt with non-owner creds
+     */
+    ok (cred_get (h, &saved) == 0
+        && saved.userid == geteuid() && saved.rolemask == FLUX_ROLE_OWNER,
+        "saved connector creds, with expected values");
+    new.userid = 9999;
+    new.rolemask = 0x80000000;
+    ok (cred_set (h, &new) == 0 && cred_get (h, &cr) == 0
+        && cr.userid == new.userid && cr.rolemask == new.rolemask,
+       "set userid/rolemaks to non-owner test values");
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "random-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "random-creds: reactor successfully handled one event");
+    ok (testrpc1_called == true
+        && flux_rpc_check (rpc) == true && flux_rpc_get (rpc, NULL) == 0,
+        "random-creds: handler was called and returned success response");
+    flux_rpc_destroy (rpc);
+    ok (cred_set (h, &saved) == 0,
+        "restored connector creds");
+
+    flux_msg_handler_destroy (w);
+}
+
+static void check_rpc_targetted_policy (flux_t *h)
+{
+    flux_rpc_t *rpc;
+    flux_msg_handler_t *w;
+    struct creds saved, new, cr;
+    uint32_t allow = 0x1000;
+    int rc;
+
+    ok ((w = testrpc1_handler_create (h)) != NULL,
+        "created message handler with targetted policy");
+    if (w == NULL)
+        BAIL_OUT ("flux_msg_handler_create: %s", flux_strerror (errno));
+    flux_msg_handler_deny_rolemask (w, FLUX_ROLE_ALL);
+    flux_msg_handler_allow_rolemask (w, allow);
+
+    ok (cred_get (h, &saved) == 0
+        && saved.userid == geteuid() && saved.rolemask == FLUX_ROLE_OWNER,
+        "saved connector creds, with expected values");
+
+    /* Attempt with default creds.
+     */
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "default-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "default-creds: reactor successfully handled one event");
+    ok (testrpc1_called == true
+        && flux_rpc_check (rpc) && flux_rpc_get (rpc, NULL) == 0,
+        "default-creds: handler was called and returned success response");
+    flux_rpc_destroy (rpc);
+
+    /* Attempt with target creds
+     */
+    new.userid = 9999;
+    new.rolemask = allow;
+    ok (cred_set (h, &new) == 0 && cred_get (h, &cr) == 0
+        && cr.userid == new.userid && cr.rolemask == new.rolemask,
+       "set userid/rolemaks to random/target test values");
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "target-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "target-creds: reactor successfully handled one event");
+    ok (testrpc1_called == true
+        && flux_rpc_check (rpc) == true && flux_rpc_get (rpc, NULL) == 0,
+        "target-creds: handler was called and returned success response");
+    flux_rpc_destroy (rpc);
+
+    /* attempt with non-target creds
+     */
+    new.userid = 9999;
+    new.rolemask = 0x80000000;
+    ok (cred_set (h, &new) == 0 && cred_get (h, &cr) == 0
+        && cr.userid == new.userid && cr.rolemask == new.rolemask,
+       "set userid/rollmask to random/non-target test values");
+    testrpc1_called = false;
+    ok ((rpc = flux_rpc (h, "testrpc1", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "nontarget-creds: sent request to message handler");
+    if (rpc == NULL)
+        BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
+        rc = 0;
+    ok (rc == 0,
+        "nontarget-creds: reactor successfully handled one event");
+    errno = 0;
+    ok (testrpc1_called == false
+        && flux_rpc_check (rpc) == true
+        && flux_rpc_get (rpc, NULL) == -1 && errno == EPERM,
+        "nontarget-creds: handler was NOT called and dispatcher returned EPERM response");
+    flux_rpc_destroy (rpc);
+
+    ok (cred_set (h, &saved) == 0,
+        "restored connector creds");
+    flux_msg_handler_destroy (w);
+}
+
+static void fatal_err (const char *message, void *arg)
+{
+    BAIL_OUT ("fatal error: %s", message);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+
+    plan (NO_PLAN);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH",
+                  flux_conf_get ("connector_path", CONF_FLAG_INTREE), 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("flux_open: %s", flux_strerror (errno));
+    flux_fatal_set (h, fatal_err, NULL);
+
+    check_rpc_oneway (h);
+    check_rpc_oneway_faked (h);
+    check_rpc_default_policy (h);
+    check_rpc_open_policy (h);
+    check_rpc_targetted_policy (h);
+
+    flux_close (h);
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -17,4 +17,129 @@ test_expect_success 'simulated local connector auth failure returns EPERM' '
 	grep -q "Operation not permitted" authfail.out
 '
 
+test_expect_success 'flux user list fails with reasonable error when userdb is not loaded' '
+	test_must_fail flux user list 2>userlistfail.out &&
+	grep -q "userdb module is not loaded" userlistfail.out
+'
+
+test_expect_success 'flux userdb includes only instance owner by default' '
+	flux module load userdb &&
+	flux user list >userdb.list &&
+	grep -q $(id -u):owner userdb.list &&
+	test $(wc -l <userdb.list) -eq 1 &&
+	flux module remove userdb
+'
+
+test_expect_success '(forced) userdb lookup fails with EPERM when userdb not loaded' '
+	flux module debug --set 2 connector-local &&
+	test_must_fail flux comms info 2>authfail2.out &&
+	grep -q "Operation not permitted" authfail2.out
+'
+
+test_expect_success '(forced) userdb lookup succeeds when userdb is loaded' '
+	flux module load userdb &&
+	flux module debug --set 2 connector-local &&
+	flux comms info &&
+	flux module remove userdb
+'
+
+test_expect_success '(forced) userdb lookup fails when instance owner is removed' '
+	flux module load userdb &&
+	flux user delrole $(id -u) owner &&
+	! flux user lookup $(id -u) &&
+	flux module debug --set 2 connector-local &&
+	test_must_fail flux comms info 2>authfail3.out &&
+	grep -q "Operation not permitted" authfail3.out &&
+	flux module remove userdb
+'
+
+test_expect_success 'flux user addrole adds users' '
+	flux module load userdb &&
+	flux user addrole 1234 user &&
+	flux user list >userdb2.list &&
+	grep -q 1234:user userdb2.list &&
+	test $(wc -l <userdb2.list) -eq 2 &&
+	flux module remove userdb
+'
+
+test_expect_success 'flux user delrole removes users with no roles' '
+	flux module load userdb &&
+	flux user addrole 1234 user &&
+	flux user delrole 1234 user &&
+	flux user list >userdb2.list &&
+	! grep -q 1234:user userdb2.list &&
+	test $(wc -l <userdb2.list) -eq 1 &&
+	flux module remove userdb
+'
+
+test_expect_success 'userdb --default-rolemask works' '
+	flux module load userdb --default-rolemask=owner,user &&
+	flux user delrole $(id -u) owner &&
+	flux user list >userdb3.list &&
+	test $(wc -l <userdb3.list) -eq 0 &&
+	flux module debug --set 2 connector-local &&
+	flux comms info &&
+	flux user list >userdb4.list &&
+	grep -q $(id -u):owner,user userdb4.list &&
+	flux module remove userdb
+'
+
+test_expect_success 'flux user cannot add FLUX_USERID_UNKNOWN' '
+	flux module load userdb &&
+	! flux user addrole 4294967295 user 2>inval.out &&
+	grep -q "invalid userid" inval.out &&
+	flux module remove userdb
+'
+
+test_expect_success 'flux user can add/lookup bin user by name' '
+	flux module load userdb &&
+	flux user addrole bin user &&
+	flux user list >userdb5.list &&
+	grep -q $(id -u bin):user userdb5.list &&
+	flux user lookup bin >getbin.out &&
+	grep -q $(id -u bin):user getbin.out &&
+	flux module remove userdb
+'
+
+test_expect_success 'flux user cannot add user with no roles' '
+	flux module load userdb &&
+	! flux user addrole 1234 0 &&
+	flux module remove userdb
+'
+
+test_expect_success 'flux ping --userid displays userid' '
+	flux ping --count=1 --userid cmb >ping.out &&
+	grep -q "userid=$(id -u) rolemask=0x1" ping.out
+'
+
+test_expect_success 'FLUX_HANDLE_USERID can spoof userid in message' '
+	FLUX_HANDLE_USERID=9999 flux ping --count=1 --userid cmb >ping2.out &&
+	grep -q "userid=9999 rolemask=0x1" ping2.out
+'
+
+test_expect_success 'FLUX_HANDLE_ROLEMASK can spoof rolemask in message' '
+	FLUX_HANDLE_ROLEMASK=0xf flux ping --count=1 --userid cmb >ping3.out &&
+	grep -q "userid=$(id -u) rolemask=0xf" ping3.out
+'
+
+test_expect_success 'flux ping allowed for non-owner' '
+	FLUX_HANDLE_ROLEMASK=0x2 flux ping --count=1 --userid cmb >ping4.out &&
+	grep -q "userid=$(id -u) rolemask=0x2" ping4.out
+'
+
+test_expect_success 'flux getattr allowed for non-owner' '
+	FLUX_HANDLE_ROLEMASK=0x2 flux getattr rank >rank.out &&
+	grep -q "0" rank.out
+'
+
+test_expect_success 'flux setattr allowed for owner' '
+	flux setattr log-stderr-level 7 &&
+	test $(flux getattr log-stderr-level) -eq 7
+'
+
+test_expect_success 'flux setattr NOT allowed for non-owner' '
+	! FLUX_HANDLE_ROLEMASK=0x2 flux setattr log-stderr-level 6 &&
+	test $(flux getattr log-stderr-level) -eq 7
+'
+
 test_done


### PR DESCRIPTION
This PR implements the userid, rolemask message fields from RFC 3 and 12.  These fields are set by connectors on message ingress, and checked by message handlers.

Basic getter/setters for the message fields:
```C
/* Get/set userid
 */
enum {
    FLUX_USERID_UNKNOWN = 0xFFFFFFFF
};
int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid);
int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid);

/* Get/set rolemask
 */
enum {
    FLUX_ROLE_ANY = 0,
    FLUX_ROLE_OWNER = 1,
};
int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask);
int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask);
```

Logic is added to flux_msg_handler_t to automatically drop (or in the case of request, reply with EPERM) messages that don't match a rolemask embedded in the watcher. 
```C
/* By default, only messages from FLUX_ROLE_OWNER are delivered to handler.
 * Use allow() to allow more roles (use FLUX_ROLE_ANY to disable the role check).
 * Use deny() to deny roles (FLUX_ROLE_OWNER cannot be denied).
 */
void flux_msg_handler_allow_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
void flux_msg_handler_deny_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
```

Tests are coming soon and thus this isn't ready to merge, but I wanted to get a checkpoint out here for review if anyone is so inclined.

