### PR TITLE
libflux: flux_open() cleanup

### DIFF
--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -312,16 +312,14 @@ flux_t *flux_open (const char *uri, int flags)
         errno = EINVAL;
         goto done;
     }
-    if (uri) {
-        if (!(scheme = strdup (uri))) {
-            errno = ENOMEM;
-            goto done;
-        }
-        path = strstr (scheme, "://");
-        if (path) {
-            *path = '\0';
-            path = strtrim (path + 3, " \t");
-        }
+    if (!(scheme = strdup (uri))) {
+        errno = ENOMEM;
+        goto done;
+    }
+    path = strstr (scheme, "://");
+    if (path) {
+        *path = '\0';
+        path = strtrim (path + 3, " \t");
     }
     if (!(connector_init = find_connector (scheme, &dso)))
         goto done;

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -59,8 +59,8 @@ enum {
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a connector to dynamically load.
  * The rest of the URI is parsed in an connector-specific manner.
- * A NULL uri selects the "local" connector with path derived from
- * FLUX_TMPDIR.
+ * A NULL uri selects the "local" connector with path stored
+ * in the environment variable FLUX_URI.
  */
 flux_t *flux_open (const char *uri, int flags);
 void flux_close (flux_t *h);


### PR DESCRIPTION
In flux_open(), remove a redudant if-statement and fix the function
comment to list the correct environment variable.