### PR TITLE
Support KVS no merge flag

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -340,7 +340,7 @@ static int l_flux_kvs_type (lua_State *L)
 int l_flux_kvs_commit (lua_State *L)
 {
     flux_t *f = lua_get_flux (L, 1);
-    if (kvs_commit (f) < 0)
+    if (kvs_commit (f, 0) < 0)
          return lua_pusherror (L, (char *)flux_strerror (errno));
     lua_pushboolean (L, true);
     return (1);

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -206,7 +206,7 @@ static int l_kvsdir_commit (lua_State *L)
 {
     kvsdir_t *d = lua_get_kvsdir (L, 1);
     if (lua_isnoneornil (L, 2)) {
-        if (kvs_commit (kvsdir_handle (d)) < 0)
+        if (kvs_commit (kvsdir_handle (d), 0) < 0)
             return lua_pusherror (L, "kvs_commit: %s",
                                   (char *)flux_strerror (errno));
     }

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -66,8 +66,8 @@ def put(flux_handle, key, value):
     RAW.put(flux_handle, key, json_str)
 
 
-def commit(flux_handle):
-    return RAW.kvs_commit(flux_handle)
+def commit(flux_handle, flags=0):
+    return RAW.kvs_commit(flux_handle, flags)
 
 
 def dropcache(flux_handle):
@@ -128,8 +128,8 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
                              "handle must be a valid kvsdir cdata pointer")
         self.pimpl = self.InnerWrapper(flux_handle, path, handle)
 
-    def commit(self):
-        commit(self.fhdl.handle)
+    def commit(self, flags=0):
+        commit(self.fhdl.handle, flags)
 
     def key_at(self, key):
         c_str = self.pimpl.key_at(key)

--- a/src/bindings/python/test/kvs.py
+++ b/src/bindings/python/test/kvs.py
@@ -70,6 +70,11 @@ class TestKVS(unittest.TestCase):
     def test_exists_false(self):
         self.assertFalse(flux.kvs.exists(self.f, 'argbah'))
 
+    def test_commit_flags(self):
+        flux.kvs.put(self.f, 'flagcheck', 42)
+        flux.kvs.commit(self.f, 1)
+        self.assertTrue(flux.kvs.exists(self.f, 'flagcheck'))
+
     def test_remove(self):
         kd = self.set_and_check_context('todel', "things to delete")
         del kd['todel']

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -230,7 +230,7 @@ static void config_hwloc_paths (flux_t *h, const char *dirpath)
         if (kvs_put_string (h, key, path) < 0)
             log_err_exit ("kvs_put_string");
     }
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -345,7 +345,7 @@ int cmd_put (optparse_t *p, int argc, char **argv)
         }
         free (key);
     }
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     return (0);
 }
@@ -398,7 +398,7 @@ int cmd_unlink (optparse_t *p, int argc, char **argv)
         if (kvs_unlink (h, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     return (0);
 }
@@ -420,7 +420,7 @@ int cmd_link (optparse_t *p, int argc, char **argv)
         log_msg_exit ("link: specify target and link_name");
     if (kvs_symlink (h, argv[optindex + 1], argv[optindex]) < 0)
         log_err_exit ("%s", argv[optindex + 1]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     return (0);
 }
@@ -466,7 +466,7 @@ int cmd_mkdir (optparse_t *p, int argc, char **argv)
         if (kvs_mkdir (h, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     return (0);
 }
@@ -778,7 +778,7 @@ int cmd_copy (optparse_t *p, int argc, char **argv)
         log_msg_exit ("copy: specify srckey dstkey");
     if (kvs_copy (h, argv[optindex], argv[optindex + 1]) < 0)
         log_err_exit ("kvs_copy %s %s", argv[optindex], argv[optindex + 1]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     return (0);
 }
@@ -800,7 +800,7 @@ int cmd_move (optparse_t *p, int argc, char **argv)
         log_msg_exit ("move: specify srckey dstkey");
     if (kvs_move (h, argv[optindex], argv[optindex + 1]) < 0)
         log_err_exit ("kvs_move %s %s", argv[optindex], argv[optindex + 1]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     return (0);
 }

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -256,7 +256,7 @@ static int aggregate_sink (flux_t *h, struct aggregate *ag)
         flux_log_error (h, "sink: kvs_put");
         goto out;
     }
-    if ((rc = kvs_commit (h)) < 0)
+    if ((rc = kvs_commit (h, 0)) < 0)
         flux_log_error (h, "sink: kvs_commit");
 out:
     Jput (o);

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -173,13 +173,13 @@ int kvs_mkdir (flux_t *h, const char *key);
  * the calling node when the commit returns.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_commit (flux_t *h);
+int kvs_commit (flux_t *h, int flags);
 
 /* kvs_commit_begin() sends the commit request and returns immediately.
  * kvs_commit_finish() blocks until the response is received, then returns.
  * Use flux_rpc_then() to arrange for the commit to complete asynchronously.
  */
-flux_rpc_t *kvs_commit_begin (flux_t *h);
+flux_rpc_t *kvs_commit_begin (flux_t *h, int flags);
 int kvs_commit_finish (flux_rpc_t *rpc);
 
 /* kvs_fence() is a collective commit operation.  nprocs tasks make the
@@ -192,13 +192,13 @@ int kvs_commit_finish (flux_rpc_t *rpc);
  * queued in the handle become part of the fence.
  * Returns -1 on error (errno set), 0 on success.
  */
-int kvs_fence (flux_t *h, const char *name, int nprocs);
+int kvs_fence (flux_t *h, const char *name, int nprocs, int flags);
 
 /* kvs_fence_begin() sends the fence request and returns immediately.
  * kvs_fence_finish() blocks until the response is received, then returns.
  * Use flux_rpc_then() to arrange for the fence to complete asynchronously.
  */
-flux_rpc_t *kvs_fence_begin (flux_t *h, const char *name, int nprocs);
+flux_rpc_t *kvs_fence_begin (flux_t *h, const char *name, int nprocs, int flags);
 int kvs_fence_finish (flux_rpc_t *rpc);
 
 /* Operations (put, unlink, symlink, mkdir) may be associated with a named

--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -5,6 +5,12 @@
 #include <stdint.h>
 #include <flux/core.h>
 
+/* Flags for commit and fence operations
+ */
+enum {
+    KVS_NO_MERGE = 1,  /* disallow commits to be mergeable with others */
+};
+
 typedef struct kvsdir_struct kvsdir_t;
 
 typedef int (*kvs_set_f)(const char *key, const char *json_str, void *arg,

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -1226,7 +1226,7 @@ out:
  ** Commit/synchronization
  **/
 
-flux_rpc_t *kvs_commit_begin (flux_t *h)
+flux_rpc_t *kvs_commit_begin (flux_t *h, int flags)
 {
     zuuid_t *uuid = NULL;
     flux_rpc_t *rpc = NULL;
@@ -1236,7 +1236,7 @@ flux_rpc_t *kvs_commit_begin (flux_t *h)
         errno = ENOMEM;
         goto done;
     }
-    if (!(rpc = kvs_fence_begin (h, zuuid_str (uuid), 1)))
+    if (!(rpc = kvs_fence_begin (h, zuuid_str (uuid), 1, flags)))
         goto done;
 done:
     saved_errno = errno;
@@ -1250,12 +1250,12 @@ int kvs_commit_finish (flux_rpc_t *rpc)
     return flux_rpc_get (rpc, NULL);
 }
 
-int kvs_commit (flux_t *h)
+int kvs_commit (flux_t *h, int flags)
 {
     flux_rpc_t *rpc = NULL;
     int rc = -1;
 
-    if (!(rpc = kvs_commit_begin (h)))
+    if (!(rpc = kvs_commit_begin (h, flags)))
         goto done;
     if (kvs_commit_finish (rpc) < 0)
         goto done;
@@ -1265,7 +1265,7 @@ done:
     return rc;
 }
 
-flux_rpc_t *kvs_fence_begin (flux_t *h, const char *name, int nprocs)
+flux_rpc_t *kvs_fence_begin (flux_t *h, const char *name, int nprocs, int flags)
 {
     kvsctx_t *ctx = getctx (h);
     json_object *in = NULL;
@@ -1321,12 +1321,12 @@ void kvs_fence_clear_context (flux_t *h)
     kvs_fence_set_context (h, NULL);
 }
 
-int kvs_fence (flux_t *h, const char *name, int nprocs)
+int kvs_fence (flux_t *h, const char *name, int nprocs, int flags)
 {
     flux_rpc_t *rpc = NULL;
     int rc = -1;
 
-    if (!(rpc = kvs_fence_begin (h, name, nprocs)))
+    if (!(rpc = kvs_fence_begin (h, name, nprocs, flags)))
         goto done;
     if (kvs_fence_finish (rpc) < 0)
         goto done;

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -1276,11 +1276,11 @@ flux_rpc_t *kvs_fence_begin (flux_t *h, const char *name, int nprocs, int flags)
     if (ctx->fence_ops)
         fence_ops = zhash_lookup (ctx->fence_ops, name);
     if (fence_ops) {
-        if (!(in = kp_tfence_enc (name, nprocs, fence_ops)))
+        if (!(in = kp_tfence_enc (name, nprocs, flags, fence_ops)))
             goto done;
         zhash_delete (ctx->fence_ops, name);
     } else {
-        if (!(in = kp_tfence_enc (name, nprocs, ctx->ops)))
+        if (!(in = kp_tfence_enc (name, nprocs, flags, ctx->ops)))
             goto done;
         Jput (ctx->ops);
         ctx->ops = NULL;

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -206,13 +206,15 @@ done:
 
 /* kvs.fence
  */
-json_object *kp_tfence_enc (const char *name, int nprocs, json_object *ops)
+json_object *kp_tfence_enc (const char *name, int nprocs, int flags,
+                            json_object *ops)
 {
     json_object *o = Jnew ();
     json_object *empty_ops = NULL;
 
     Jadd_str (o, "name", name);
     Jadd_int (o, "nprocs", nprocs);
+    Jadd_int (o, "flags", flags);
     if (!ops)
         ops = empty_ops = Jnew_ar();
     Jadd_obj (o, "ops", ops); /* takes a ref on ops */
@@ -221,15 +223,16 @@ json_object *kp_tfence_enc (const char *name, int nprocs, json_object *ops)
 }
 
 int kp_tfence_dec (json_object *o, const char **name, int *nprocs,
-		   json_object **ops)
+                   int *flags, json_object **ops)
 {
     int rc = -1;
 
-    if (!name || !nprocs || !ops) {
+    if (!name || !nprocs || !flags || !ops ) {
         errno = EINVAL;
         goto done;
     }
     if (!Jget_obj (o, "ops", ops) || !Jget_str (o, "name", name)
+                                  || !Jget_int (o, "flags", flags)
                                   || !Jget_int (o, "nprocs", nprocs)) {
         errno = EPROTO;
         goto done;

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -39,9 +39,10 @@ int kp_tunwatch_dec (json_object *o, const char **key);
 /* kvs.fence
  * kvs.relayfence
  */
-json_object *kp_tfence_enc (const char *name, int nprocs, json_object *ops);
+json_object *kp_tfence_enc (const char *name, int nprocs, int flags,
+                            json_object *ops);
 int kp_tfence_dec (json_object *o, const char **name, int *nprocs,
-                   json_object **ops);
+                   int *flags, json_object **ops);
 
 /* kvs.getroot (request)
  */

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -120,18 +120,19 @@ void test_fence (void)
     json_object *o;
     json_object *out;
     json_object *ops = Jnew_ar();
-    int nprocs;
+    int nprocs, flags;
     const char *name;
 
-    ok ((o = kp_tfence_enc ("foo", 42, ops)) != NULL,
+    ok ((o = kp_tfence_enc ("foo", 42, 55, ops)) != NULL,
         "kp_tfence_enc works");
     name = NULL;
     nprocs = 0;
+    flags = 0;
     out = NULL;
     diag ("fence: %s", Jtostr (o));
-    ok (kp_tfence_dec (o, &name, &nprocs, &out) == 0
+    ok (kp_tfence_dec (o, &name, &nprocs, &flags, &out) == 0
         && name != NULL && !strcmp (name, "foo")
-        && nprocs == 42 && out != NULL,
+        && nprocs == 42 && flags == 55 && out != NULL,
         "kp_tfence_dec works");
     Jput (out);
     Jput (o);

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -668,7 +668,7 @@ static int update_state (flux_t *h, int64_t j, json_object *o)
     key = lwj_key (h, j, ".state");
     if (kvs_put_string (h, key, jsc_job_num2state ((job_state_t)st)) < 0)
         flux_log_error (h, "update %s", key);
-    else if (kvs_commit (h) < 0)
+    else if (kvs_commit (h, 0) < 0)
         flux_log_error (h, "commit %s", key);
     else {
         flux_log (h, LOG_DEBUG, "job (%"PRId64") assigned new state: %s", j,
@@ -708,7 +708,7 @@ static int update_rdesc (flux_t *h, int64_t j, json_object *o)
         flux_log_error (h, "update %s", key2);
     else if (kvs_put_int64 (h, key3, walltime) < 0)
         flux_log_error (h, "update %s", key3);
-    else if (kvs_commit (h) < 0)
+    else if (kvs_commit (h, 0) < 0)
         flux_log_error (h, "commit failed");
     else {
         flux_log (h, LOG_DEBUG, "job (%"PRId64") assigned new resources.", j);
@@ -726,7 +726,7 @@ static int update_rdl (flux_t *h, int64_t j, const char *rs)
     char *key = lwj_key (h, j, ".rdl");
     if (kvs_put_string (h, key, rs) < 0)
         flux_log_error (h, "update %s", key);
-    else if (kvs_commit (h) < 0)
+    else if (kvs_commit (h, 0) < 0)
         flux_log_error (h, "commit failed");
     else {
         flux_log (h, LOG_DEBUG, "job (%"PRId64") assigned new rdl.", j);
@@ -795,7 +795,7 @@ static int update_rdl_alloc (flux_t *h, int64_t j, json_object *o)
             goto done;
         }
     }
-    if (kvs_commit (h) < 0) {
+    if (kvs_commit (h, 0) < 0) {
         flux_log (h, LOG_ERR, "update_pdesc commit failed");
         goto done;
     }
@@ -873,7 +873,7 @@ static int update_pdesc (flux_t *h, int64_t j, json_object *o)
         if ( (rc = update_1pdesc (h, i, j, pde, h_arr, e_arr)) < 0)
             goto done;
     }
-    if (kvs_commit (h) < 0) {
+    if (kvs_commit (h, 0) < 0) {
         flux_log (h, LOG_ERR, "update_pdesc commit failed");
         goto done;
     }

--- a/src/modules/libkz/kz.c
+++ b/src/modules/libkz/kz.c
@@ -128,7 +128,7 @@ kz_t *kz_open (flux_t *h, const char *name, int flags)
         if (kvs_mkdir (h, name) < 0) /* N.B. does not catch EEXIST */
             goto error;
         if (!(flags & KZ_FLAGS_NOCOMMIT_OPEN)) {
-            if (kvs_commit (h) < 0)
+            if (kvs_commit (h, 0) < 0)
                 goto error;
         }
     } else if ((flags & KZ_FLAGS_READ)) {
@@ -149,7 +149,7 @@ static int kz_fence (kz_t *kz)
     int rc;
     if (asprintf (&name, "%s.%d", kz->grpname, kz->fencecount++) < 0)
         oom ();
-    rc = kvs_fence (kz->h, name, kz->nprocs);
+    rc = kvs_fence (kz->h, name, kz->nprocs, 0);
     free (name);
     return rc;
 }
@@ -191,7 +191,7 @@ static int putnext (kz_t *kz, const char *json_str)
     if (kvs_put (kz->h, key, json_str) < 0)
         goto done;
     if (!(kz->flags & KZ_FLAGS_NOCOMMIT_PUT)) {
-        if (kvs_commit (kz->h) < 0)
+        if (kvs_commit (kz->h, 0) < 0)
             goto done;
     }
     rc = 0;
@@ -323,7 +323,7 @@ int kz_flush (kz_t *kz)
 {
     int rc = 0;
     if ((kz->flags & KZ_FLAGS_WRITE))
-        rc = kvs_commit (kz->h);
+        rc = kvs_commit (kz->h, 0);
     return rc;
 }
 
@@ -345,7 +345,7 @@ int kz_close (kz_t *kz)
                 goto done;
         }
         if (!(kz->flags & KZ_FLAGS_NOCOMMIT_CLOSE)) {
-            if (kvs_commit (kz->h) < 0)
+            if (kvs_commit (kz->h, 0) < 0)
                 goto done;
         }
         if (kz->nprocs > 0 && kz->grpname) {

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -673,7 +673,7 @@ static int ns_tokvs (live_ctx_t *ctx)
 
     if (kvs_put (ctx->h, "conf.live.status", Jtostr (o)) < 0)
         goto done;
-    if (kvs_commit (ctx->h) < 0)
+    if (kvs_commit (ctx->h, 0) < 0)
         goto done;
     rc = 0;
 done:
@@ -826,7 +826,7 @@ static int topo_tokvs (live_ctx_t *ctx)
     }
     if (kvs_put (ctx->h, "conf.live.topology", Jtostr (ar)) < 0)
         goto done;
-    if (kvs_commit (ctx->h) < 0)
+    if (kvs_commit (ctx->h, 0) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -349,7 +349,7 @@ static int load_hwloc (flux_t *h, resource_ctx_t *ctx)
         flux_log_error (h, "%s: kvs_put_int", __FUNCTION__);
         goto done;
     }
-    if (kvs_commit (h) < 0) {
+    if (kvs_commit (h, 0) < 0) {
         flux_log_error (h, "%s: kvs_commit", __FUNCTION__);
         goto done;
     }

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -138,7 +138,7 @@ static int kvs_job_set_state (flux_t *h, unsigned long jobid, const char *state)
         goto out;
     }
 
-    if ((rc = kvs_commit (h)) < 0)
+    if ((rc = kvs_commit (h, 0)) < 0)
         flux_log_error (h, "kvs_job_set_state: kvs_commit");
 
 out:
@@ -304,7 +304,7 @@ static void handle_job_create (flux_t *h, const flux_msg_t *msg,
         goto out;
     }
 
-    if (kvs_commit (h) < 0) {
+    if (kvs_commit (h, 0) < 0) {
         flux_log_error (h, "job_request: kvs_commit");
         goto out;
     }

--- a/src/test/kap/kap_roles.c
+++ b/src/test/kap/kap_roles.c
@@ -222,7 +222,8 @@ commit_kv_cache (kap_params_t *param)
             Begin = now ();
             if ( kvs_fence (param->pers.handle,
                             fence_n,
-                            param->config.nproducers) < 0) {
+                            param->config.nproducers,
+                            0) < 0) {
                 fprintf (stderr, "kvs_commit failed.\n\n");
                     goto error;
                 }
@@ -234,7 +235,7 @@ commit_kv_cache (kap_params_t *param)
              *        MEASURE Commit_bn_Puts LATENCY       *
              **********************************************/
             Begin = now ();
-            if ( kvs_commit (param->pers.handle) < 0) {
+            if ( kvs_commit (param->pers.handle, 0) < 0) {
                 fprintf (stderr, "kvs_commit failed.\n\n");
                 goto error;
             }
@@ -320,8 +321,9 @@ run_fence_sync (kap_params_t *param)
                   "pr-co-fen-%d",
                   (int) param->config.instance_num);   
         if ( kvs_fence (param->pers.handle, 
-                       fn, 
-                       fence_count)  < 0) {
+                        fn, 
+                        fence_count,
+                        0)  < 0) {
             fprintf (stderr,
                 "kvs_fence failed.\n");
             goto error;
@@ -415,8 +417,9 @@ run_causal_sync (kap_params_t *param)
                   "pr-causal-fen-%d",
                   (int) param->config.instance_num);
         if ( kvs_fence (param->pers.handle, 
-                       fn, 
-                       param->config.nproducers) < 0) {
+                        fn, 
+                        param->config.nproducers,
+                        0) < 0) {
             fprintf (stderr,
                 "kvs_fence failed.\n");
             goto error;
@@ -480,7 +483,7 @@ run_producer (kap_params_t *param)
         "prod-st-fen-%d",
         (int) param->config.instance_num);
     if ( kvs_fence (param->pers.handle, fn, 
-                     param->config.nproducers) < 0) {
+                    param->config.nproducers, 0) < 0) {
         fprintf (stderr, 
             "flux_fence (%s) failed.\n", fn);       
         goto error;

--- a/t/kvs/asyncfence.c
+++ b/t/kvs/asyncfence.c
@@ -16,7 +16,7 @@ void kput (flux_t *h, const char *s, int val)
 
 void kcommit (flux_t *h)
 {
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     log_msg ("kvs_commit");
 }
@@ -38,7 +38,7 @@ void kfence (flux_t *h, const char *s)
 {
     char name[128];
     snprintf (name, sizeof (name), "test.asyncfence.%s", s);
-    if (kvs_fence (h, name, 1) < 0)
+    if (kvs_fence (h, name, 1, 0) < 0)
         log_err_exit ("kvs_fence %s", name);
     log_msg ("kvs_fence %s", name);
 }
@@ -93,7 +93,7 @@ int main (int argc, char *argv[])
      * get a,b (should be 42,43)
      */
     kput (h, "a", 42);
-    if (!(rpc = kvs_fence_begin (h, "test.asyncfence.1", 1)))
+    if (!(rpc = kvs_fence_begin (h, "test.asyncfence.1", 1, 0)))
         log_err_exit ("kvs_fence_begin 1");
     log_msg ("kvs_fence_begin 1");
     kput (h, "b", 43);

--- a/t/kvs/basic.c
+++ b/t/kvs/basic.c
@@ -297,7 +297,7 @@ void cmd_put (flux_t *h, int argc, char **argv)
             log_err_exit ("%s", key);
     }
     free (key);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 
@@ -307,7 +307,7 @@ void cmd_unlink (flux_t *h, int argc, char **argv)
         log_msg_exit ("unlink: specify key");
     if (kvs_unlink (h, argv[0]) < 0)
         log_err_exit ("%s", argv[0]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 
@@ -317,7 +317,7 @@ void cmd_link (flux_t *h, int argc, char **argv)
         log_msg_exit ("link: specify target and link_name");
     if (kvs_symlink (h, argv[1], argv[0]) < 0)
         log_err_exit ("%s", argv[1]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 
@@ -340,7 +340,7 @@ void cmd_mkdir (flux_t *h, int argc, char **argv)
         log_msg_exit ("mkdir: specify directory");
     if (kvs_mkdir (h, argv[0]) < 0)
         log_err_exit ("%s", argv[0]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 
@@ -458,7 +458,7 @@ void cmd_copy_tokvs (flux_t *h, int argc, char **argv)
     json_object_object_add (o, "data", base64_json_encode (buf, len));
     if (kvs_put (h, key, Jtostr (o)) < 0)
         log_err_exit ("%s", key);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     Jput (o);
     free (buf);
@@ -661,7 +661,7 @@ void cmd_copy (flux_t *h, int argc, char **argv)
         log_msg_exit ("copy: specify srckey dstkey");
     if (kvs_copy (h, argv[0], argv[1]) < 0)
         log_err_exit ("kvs_copy %s %s", argv[0], argv[1]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 
@@ -671,7 +671,7 @@ void cmd_move (flux_t *h, int argc, char **argv)
         log_msg_exit ("move: specify srckey dstkey");
     if (kvs_move (h, argv[0], argv[1]) < 0)
         log_err_exit ("kvs_move %s %s", argv[0], argv[1]);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 }
 
@@ -708,7 +708,7 @@ void cmd_put_treeobj (flux_t *h, int argc, char **argv)
     *val++ = '\0';
     if (kvs_put_treeobj (h, key, val) < 0)
         log_err_exit ("kvs_put_treeobj %s=%s", key, val);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     free (key);
 }

--- a/t/kvs/commit.c
+++ b/t/kvs/commit.c
@@ -101,10 +101,10 @@ void *thread (void *arg)
         if (kvs_put_int (t->h, key, 42) < 0)
             log_err_exit ("%s", key);
         if (fopt) {
-            if (kvs_fence (t->h, fence, fence_nprocs) < 0)
+            if (kvs_fence (t->h, fence, fence_nprocs, 0) < 0)
                 log_err_exit ("kvs_fence");
         } else {
-            if (kvs_commit (t->h) < 0)
+            if (kvs_commit (t->h, 0) < 0)
                 log_err_exit ("kvs_commit");
         }
         if (sopt && zlist_append (t->perf, ddup (monotime_since (t0))) < 0)

--- a/t/kvs/commitmerge.c
+++ b/t/kvs/commitmerge.c
@@ -148,7 +148,7 @@ void *watchthread (void *arg)
     if (!rc) {
         if (kvs_unlink (t->h, key) < 0)
             log_err_exit ("kvs_unlink");
-        if (kvs_commit (t->h) < 0)
+        if (kvs_commit (t->h, 0) < 0)
             log_err_exit ("kvs_commit");
     }
 
@@ -193,7 +193,7 @@ void *committhread (void *arg)
     if (kvs_put_int (t->h, key, t->n) < 0)
         log_err_exit ("%s", key);
 
-    if (kvs_commit (t->h) < 0)
+    if (kvs_commit (t->h, 0) < 0)
         log_err_exit ("kvs_commit");
 
     flux_close (t->h);

--- a/t/kvs/dtree.c
+++ b/t/kvs/dtree.c
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
         kvsdir_t *dir;
         if (kvs_mkdir (h, prefix) < 0)
             log_err_exit ("kvs_mkdir %s", prefix);
-        if (kvs_commit (h) < 0)
+        if (kvs_commit (h, 0) < 0)
             log_err_exit ("kvs_commit");
         if (kvs_get_dir (h, &dir, "%s", prefix) < 0)
             log_err_exit ("kvs_get_dir %s", prefix);
@@ -103,7 +103,7 @@ int main (int argc, char *argv[])
     } else {
         dtree (h, prefix, width, height);
     }
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
        log_err_exit ("kvs_commit");
     flux_close (h);
 }
@@ -145,7 +145,7 @@ void dtree_mkdir (flux_t *h, kvsdir_t *dir, int width, int height)
         } else {
             if (kvsdir_mkdir (dir, key) < 0)
                 log_err_exit ("kvsdir_mkdir %s", key);
-            if (kvs_commit (h) < 0)
+            if (kvs_commit (h, 0) < 0)
                 log_err_exit ("kvs_commit");
             if (kvsdir_get_dir (dir, &ndir, "%s", key) < 0)
                 log_err_exit ("kvsdir_get_dir");

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -122,7 +122,7 @@ int main (int argc, char *argv[])
 
     if (kvs_unlink (h, prefix) < 0)
         log_err_exit ("kvs_unlink %s", prefix);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 
     val = xzmalloc (size);
@@ -146,7 +146,7 @@ int main (int argc, char *argv[])
              monotime_since (t0)/1000, count, size);
 
     monotime (&t0);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     if (!quiet)
         log_msg ("kvs_commit: time=%0.3f s", monotime_since (t0)/1000);

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -216,7 +216,7 @@ void test_mt (int argc, char **argv)
     if (kvs_put_int (h, key_stable, 0) < 0)
         log_err_exit ("kvs_put_int %s", key);
 
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
 
     for (i = 0; i < nthreads; i++) {
@@ -232,7 +232,7 @@ void test_mt (int argc, char **argv)
     for (i = 0; i < changes; i++) {
         if (kvs_put_int (h, key, i) < 0)
             log_err_exit ("kvs_put_int %s", key);
-        if (kvs_commit (h) < 0)
+        if (kvs_commit (h, 0) < 0)
             log_err_exit ("kvs_commit");
     }
 
@@ -277,7 +277,7 @@ static int selfmod_watch_cb (const char *key, int val, void *arg, int errnum)
     flux_t *h = arg;
     if (kvs_put_int (h, key, val + 1) < 0)
         log_err_exit ("%s: kvs_put_int", __FUNCTION__);
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("%s: kvs_commit", __FUNCTION__);
     return (val == 0 ? -1 : 0);
 }
@@ -297,7 +297,7 @@ void test_selfmod (int argc, char **argv)
 
     if (kvs_put_int (h, key, -1) < 0)
         log_err_exit ("kvs_put_int");
-    if (kvs_commit (h) < 0)
+    if (kvs_commit (h, 0) < 0)
         log_err_exit ("kvs_commit");
     if (kvs_watch_int (h, key, selfmod_watch_cb, h) < 0)
         log_err_exit ("kvs_watch_int");
@@ -329,7 +329,7 @@ static void unwatch_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     log_msg ("%s", __FUNCTION__);
     if (kvs_put_int (ctx->h, ctx->key, count++) < 0)
         log_err_exit ("%s: kvs_put_int", __FUNCTION__);
-    if (kvs_commit (ctx->h) < 0)
+    if (kvs_commit (ctx->h, 0) < 0)
         log_err_exit ("%s: kvs_commit", __FUNCTION__);
     if (count == 10) {
         if (kvs_unwatch (ctx->h, ctx->key) < 0)

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -547,12 +547,25 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop' '
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
+test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop, no merging' '
+	THREADS=8 &&
+	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge ${THREADS} 100 \
+		$(basename ${SHARNESS_TEST_FILE})
+'
+
 # fence test
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 	THREADS=8 &&
 	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
 		--fence $((${SIZE}*${THREADS})) ${THREADS} 100 \
+		$(basename ${SHARNESS_TEST_FILE})
+'
+
+test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, no merging' '
+	THREADS=8 &&
+	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
+		--fence $((${SIZE}*${THREADS})) --nomerge ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -209,6 +209,24 @@ EOF
 	test_cmp expected output
 '
 
+test_expect_success 'kvs: put using no-merge flag' '
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} put-no-merge $DIR.a=69 &&
+        ${KVSBASIC} put-no-merge $DIR.b.c.d.e.f.g=70 &&
+        ${KVSBASIC} put-no-merge $DIR.c.a.b=3.14 &&
+        ${KVSBASIC} put-no-merge $DIR.d=\"snerg\" &&
+        ${KVSBASIC} put-no-merge $DIR.e=true &&
+	${KVSBASIC} dir -r $DIR | sort >output &&
+	cat >expected <<EOF
+$DIR.a = 69
+$DIR.b.c.d.e.f.g = 70
+$DIR.c.a.b = 3.140000
+$DIR.d = snerg
+$DIR.e = true
+EOF
+	test_cmp expected output
+'
+
 test_expect_success 'kvs: directory with multiple subdirs using dirat' '
 	${KVSBASIC} unlink $TEST &&
 	${KVSBASIC} put $DIR.a=69

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -549,7 +549,13 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop' '
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop, no merging' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge ${THREADS} 100 \
+	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge 1 ${THREADS} 100 \
+		$(basename ${SHARNESS_TEST_FILE})
+'
+
+test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop, mixed no merging' '
+	THREADS=8 &&
+	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge 2 ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
@@ -565,7 +571,14 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, no merging' '
 	THREADS=8 &&
 	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
-		--fence $((${SIZE}*${THREADS})) --nomerge ${THREADS} 100 \
+		--fence $((${SIZE}*${THREADS})) --nomerge 1 ${THREADS} 100 \
+		$(basename ${SHARNESS_TEST_FILE})
+'
+
+test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, mixed no merging' '
+	THREADS=8 &&
+	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
+		--fence $((${SIZE}*${THREADS})) --nomerge 2 ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -631,6 +631,18 @@ test_expect_success 'kvs: copy-tokvs and copy-fromkvs work' '
 	test_cmp random.data reread.data
 '
 
+# kvs merging tests
+
+# If commit-merge=1 and we set KVS_NO_MERGE on all commits, this test
+# should behave similarly to commit-merge=0 and OUTPUT should equal
+# THREADS.
+test_expect_success 'kvs: test that KVS_NO_MERGE works with kvs_commit()' '
+        THREADS=64 &&
+        OUTPUT=`${FLUX_BUILD_DIR}/t/kvs/commitmerge --nomerge ${THREADS} \
+                $(basename ${SHARNESS_TEST_FILE})`
+	test "$OUTPUT" = "${THREADS}"
+'
+
 # All tests below assume commit-merge=0
 
 # commit-merge option test


### PR DESCRIPTION
Here's an initial try at issue #813.  Note that I duplicated a bunch of functions by appending ```_flags``` to the name (e.g. ```kvs_commit_flags()```).  I didn't want to break ABI for the time being.  Will convert appropriately later on.  In hindsight, I think I should have two commits, one introducing a "flags", then another introducing the flag ```KVS_NO_MERGE```.  Will redo that when I cleanup.

I elected to the make the "mergeable" boolean in each fence wire packet optional.  I can sort of go either way on this.  It could be made a mandatory boolean in each packet?

Probably need some additional tests too, minimally to test flags on the fence functions.

Wasn't sure how to go about the ABI breakage.  Obviously I can fix everything in flux-core, but should I just send PR to flux-sched as well at the appropriate time?
