### PR TITLE
address build problem under cffi-1.1

### DIFF
--- a/src/modules/kvs/kvs.h
+++ b/src/modules/kvs/kvs.h
@@ -7,7 +7,7 @@
 
 /* Flags for commit and fence operations
  */
-enum {
+enum flux_kvs_flags {
     KVS_NO_MERGE = 1,  /* disallow commits to be mergeable with others */
 };
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -46,7 +46,7 @@ declare -A extra_cmake_opts=(\
 #  Python pip packages
 #
 pips="\
-cffi>=1.1,<1.4 \
+cffi==1.1 \
 coverage \
 pylint
 "


### PR DESCRIPTION
As discussed in #984, this PR de-anonymizes the enum in kvs.h containing KVS_NO_MERGE, as this was causing build problems under python-cffi 1.1.  Later versions such as 1.5 worked OK but since configure checks that cffi is >= 1.1, flux-core is supposed to build with that version.

cffi in travis-ci is rolled back to 1.1 so that we catch problems like this in the future.

Note: I initially submitted just the travis-ci change and verified that it failed, then added the kvs.h fix.  Those commits are in the reverse order in this PR so that git bisect won't break.