### PR TITLE
establish single run directory and default URI for system instance

### DIFF
--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -58,6 +58,14 @@ configuration profile named 'PROFILE'. Requires a version of Flux
 built with --enable-caliper. Unless CALI_LOG_VERBOSITY is already
 set in the environment, it will default to 0 for all brokers.
 
+*--scratchdir*='DIR'::
+For selfpmi bootstrap mode, set a pre-existing directory that will
+contain the generated broker.rundir directories for the instance.
+If a DIR is not set with this option, a unique temporary directory will
+be created for the lifetime of the instance and removed when the
+instance is destroyed.
+
+
 EXAMPLES
 --------
 

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -29,12 +29,6 @@ The number of ranks in the comms session.
 session-id::
 The identity of the comms session.
 
-scratch-directory::
-A temporary directory available for scratch storage within
-the session.  This directory _may_ be shared by multiple ranks.
-Cleanup of directory contents is the responsibility of
-the creator.
-
 broker.rundir::
 A temporary directory available for scratch storage within
 the session.  This directory is unique to the local rank.
@@ -44,7 +38,7 @@ the creator.
 persist-directory::
 A persistent directory available for storage on rank 0 only.
 If persist-directory is not defined, persistence is unavailable
-and users should fall back to scratch-directory, with cleanup.
+and users should fall back to broker.rundir, with cleanup.
 
 persist-filesystem::
 If defined, and persist-directory is not defined, the rank

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -35,10 +35,9 @@ the session.  This directory _may_ be shared by multiple ranks.
 Cleanup of directory contents is the responsibility of
 the creator.
 
-scratch-directory-rank::
+broker.rundir::
 A temporary directory available for scratch storage within
-the session.  This directory is unique to the local rank,
-and is usually a sub-directory of scratch-directory.
+the session.  This directory is unique to the local rank.
 Cleanup of directory contents is the responsibility of
 the creator.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -355,4 +355,4 @@ metadata
 treeref
 valref
 ver
-
+rundir

--- a/src/bindings/python/test_commands/sideflux.py
+++ b/src/bindings/python/test_commands/sideflux.py
@@ -50,7 +50,8 @@ class SideFlux(object):
 
     def start(self):
         flux_command = [flux_exe, 'start', '--size={}'.format(self.size), '-o',
-                        '-Slog-forward-level=7,-Sscratch-directory=' + self.tmpdir , 'bash']
+                        '-Slog-forward-level=7',
+                        '--scratchdir=' + self.tmpdir, 'bash']
         # print ' '.join(flux_command)
         FNULL = open(os.devnull, 'w+')
         self.subenv = os.environ.copy()

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -187,8 +187,7 @@ static void runlevel_io_cb (runlevel_t *r, const char *name,
                             const char *msg, void *arg);
 
 static int create_persistdir (attr_t *attrs, uint32_t rank);
-static int create_scratchdir (attr_t *attrs);
-static int create_rundir (attr_t *attrs, uint32_t rank);
+static int create_rundir (attr_t *attrs);
 static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size);
 
 static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec);
@@ -446,16 +445,13 @@ int main (int argc, char *argv[])
     // Setup profiling
     setup_profiling (argv[0], ctx.rank);
 
-    /* Create directory for sockets, and a subdirectory specific
-     * to this rank that will contain the pidfile and local connector socket.
-     * (These may have already been called by boot method)
-     * If persist-filesystem or persist-directory are set, initialize those,
+    /* Create/validate runtime directory (this function is idempotent)
+     */
+    if (create_rundir (ctx.attrs) < 0)
+        log_err_exit ("create_rundir");
+    /* If persist-filesystem or persist-directory are set, initialize those,
      * but only on rank 0.
      */
-    if (create_scratchdir (ctx.attrs) < 0)
-        log_err_exit ("create_scratchdir");
-    if (create_rundir (ctx.attrs, ctx.rank) < 0)
-        log_err_exit ("create_rundir");
     if (create_persistdir (ctx.attrs, ctx.rank) < 0)
         log_err_exit ("create_persistdir");
 
@@ -603,11 +599,11 @@ int main (int argc, char *argv[])
     snoop_set_zctx (ctx.snoop, ctx.zctx);
     snoop_set_sec (ctx.snoop, ctx.sec);
     {
-        const char *scratch_dir;
-        if (attr_get (ctx.attrs, "scratch-directory", &scratch_dir, NULL) < 0) {
-            log_msg_exit ("scratch-directory attribute is not set");
+        const char *rundir;
+        if (attr_get (ctx.attrs, "broker.rundir", &rundir, NULL) < 0) {
+            log_msg_exit ("broker.rundir attribute is not set");
         }
-        snoop_set_uri (ctx.snoop, "ipc://%s/%d/snoop", scratch_dir, ctx.rank);
+        snoop_set_uri (ctx.snoop, "ipc://%s/snoop", rundir, ctx.rank);
     }
 
     shutdown_set_handle (ctx.shutdown, ctx.h);
@@ -894,13 +890,12 @@ static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size)
 
 /* If user set the 'broker.rundir' attribute on the command line,
  * validate the directory and its permissions, and set the immutable flag
- * on the attribute.  If unset, create it within 'scratch-directory'.
- * If we created the directory, arrange to remove it on exit.
- * This function is idempotent.
+ * on the attribute.  If unset, a unique directory and arrange to remove
+ * it on exit.  This function is idempotent.
  */
-static int create_rundir (attr_t *attrs, uint32_t rank)
+static int create_rundir (attr_t *attrs)
 {
-    const char *run_dir, *scratch_dir, *local_uri;
+    const char *run_dir, *local_uri;
     char *dir = NULL;
     char *uri = NULL;
     int rc = -1;
@@ -920,21 +915,13 @@ static int create_rundir (attr_t *attrs, uint32_t rank)
         if (attr_set_flags (attrs, "broker.rundir", FLUX_ATTRFLAG_IMMUTABLE) < 0)
             goto done;
     } else {
-        if (attr_get (attrs, "scratch-directory",
-                                                &scratch_dir, NULL) < 0) {
-            errno = EINVAL;
-            goto done;
-        }
-        if (rank == FLUX_NODEID_ANY) {
-            errno = EINVAL;
-            goto done;
-        }
-        dir = xasprintf ("%s/%"PRIu32, scratch_dir, rank);
-        if (mkdir (dir, 0700) < 0)
-            goto done;
-        if (attr_add (attrs, "broker.rundir", dir, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        const char *tmpdir = getenv ("TMPDIR");
+        dir = xasprintf ("%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp");
+        if (!mkdtemp (dir))
             goto done;
         cleanup_push_string (cleanup_directory, dir);
+        if (attr_add (attrs, "broker.rundir", dir, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+            goto done;
         run_dir = dir;
     }
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0) {
@@ -945,66 +932,15 @@ static int create_rundir (attr_t *attrs, uint32_t rank)
     }
     rc = 0;
 done:
-    if (dir)
-        free (dir);
-    if (uri)
-        free (uri);
-    return rc;
-}
-
-/* If user set the 'scratch-directory' attribute on the command line,
- * validate the directory and its permissions, and set the immutable flag
- * on the attribute.  If unset, create it in TMPDIR such that it will
- * be unique in the enclosing instance, and in a hierarchy of instances.
- * If we created the directory, arrange to remove it on exit.
- * This function is idempotent.
- */
-static int create_scratchdir (attr_t *attrs)
-{
-    const char *attr = "scratch-directory";
-    const char *sid, *scratch_dir;
-    const char *tmpdir = getenv ("TMPDIR");
-    char *dir, *tmpl = NULL;
-    int rc = -1;
-
-    if (attr_get (attrs, attr, &scratch_dir, NULL) == 0) {
-        struct stat sb;
-        if (stat (scratch_dir, &sb) < 0)
-            goto done;
-        if (!S_ISDIR (sb.st_mode)) {
-            errno = ENOTDIR;
-            goto done;
-        }
-        if ((sb.st_mode & S_IRWXU) != S_IRWXU) {
-            errno = EPERM;
-            goto done;
-        }
-        if (attr_set_flags (attrs, attr, FLUX_ATTRFLAG_IMMUTABLE) < 0)
-            goto done;
-    } else {
-        if (attr_get (attrs, "session-id", &sid, NULL) < 0) {
-            errno = EINVAL;
-            goto done;
-        }
-        tmpl = xasprintf ("%s/flux-%s-XXXXXX", tmpdir ? tmpdir : "/tmp", sid);
-        if (!(dir = mkdtemp (tmpl)))
-            goto done;
-        if (attr_add (attrs, attr, dir, FLUX_ATTRFLAG_IMMUTABLE) < 0)
-            goto done;
-        cleanup_push_string (cleanup_directory, dir);
-    }
-    rc = 0;
-done:
-    if (tmpl)
-        free (tmpl);
+    free (dir);
+    free (uri);
     return rc;
 }
 
 /* If 'persist-directory' set, validate it, make it immutable, done.
  * If 'persist-filesystem' set, validate it, make it immutable, then:
- * Create 'persist-directory' beneath it such that it is both unique and
- * a different basename than 'scratch-directory' (in case persist-filesystem
- * is set to TMPDIR).
+ * Avoid name collisions with other flux tmpdirs used in testing
+ * e.g. "flux-<sid>-XXXXXX"
  */
 static int create_persistdir (attr_t *attrs, uint32_t rank)
 {
@@ -1079,7 +1015,7 @@ done:
 
 static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec)
 {
-    const char *scratch_dir;
+    const char *rundir;
     int spawned, size, rank, appnum;
     int relay_rank = -1, parent_rank;
     int clique_size;
@@ -1131,25 +1067,21 @@ static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec)
             goto done;
     }
 
-    /* Initialize scratch-directory/rundir
+    /* Initialize rundir
      */
-    if (create_scratchdir (ctx->attrs) < 0) {
-        log_err ("pmi: could not initialize scratch-directory");
-        goto done;
-    }
-    if (attr_get (ctx->attrs, "scratch-directory", &scratch_dir, NULL) < 0) {
-        log_msg ("scratch-directory attribute is not set");
-        goto done;
-    }
-    if (create_rundir (ctx->attrs, ctx->rank) < 0) {
+    if (create_rundir (ctx->attrs) < 0) {
         log_err ("could not initialize rundir");
+        goto done;
+    }
+    if (attr_get (ctx->attrs, "broker.rundir", &rundir, NULL) < 0) {
+        log_msg ("broker.rundir attribute is not set");
         goto done;
     }
 
     /* Set TBON request addr.  We will need any wildcards expanded below.
      */
     if (ctx->shared_ipc_namespace) {
-        char *reqfile = xasprintf ("%s/%"PRIu32"/req", scratch_dir, ctx->rank);
+        char *reqfile = xasprintf ("%s/req", rundir);
         overlay_set_child (ctx->overlay, "ipc://%s", reqfile);
         cleanup_push_string (cleanup_file, reqfile);
         free (reqfile);
@@ -1179,7 +1111,7 @@ static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec)
                 if (relay_rank == -1 || clique_ranks[i] < relay_rank)
                     relay_rank = clique_ranks[i];
             if (relay_rank >= 0 && ctx->rank == relay_rank) {
-                char *relayfile = xasprintf ("%s/%d/relay", scratch_dir, rank);
+                char *relayfile = xasprintf ("%s/relay", rundir);
                 overlay_set_relay (ctx->overlay, "ipc://%s", relayfile);
                 cleanup_push_string (cleanup_file, relayfile);
                 free (relayfile);
@@ -1309,7 +1241,7 @@ static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec)
                                ipaddr, port);
         }
     } else if (ctx->shared_ipc_namespace) {
-        char *eventfile = xasprintf ("%s/event", scratch_dir);
+        char *eventfile = xasprintf ("%s/event", rundir);
         overlay_set_event (ctx->overlay, "ipc://%s", eventfile);
         if (ctx->rank == 0)
             cleanup_push_string (cleanup_file, eventfile);

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -24,7 +24,8 @@ installed_conf_cppflags = \
 	-DINSTALLED_WRECK_LUA_PATTERN=\"$(sysconfdir)/wreck/lua.d/*.lua\" \
 	-DINSTALLED_WREXECD_PATH=\"$(fluxlibexecdir)/wrexecd\" \
 	-DINSTALLED_CMDHELP_PATTERN=\"${datadir}/flux/help.d/*.json\" \
-	-DINSTALLED_NO_DOCS_PATH=\"${datadir}/flux/.nodocs\"
+	-DINSTALLED_NO_DOCS_PATH=\"${datadir}/flux/.nodocs\" \
+	-DINSTALLED_RUNDIR=\"${localstatedir}/run/flux\"
 
 intree_conf_cppflags = \
 	-DINTREE_MODULE_PATH=\"$(abs_top_builddir)/src/modules\" \

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -54,6 +54,7 @@ static struct config default_config[] = {
                                                     INTREE_WRECK_LUA_PATTERN },
     { "keydir",         NULL,                       INTREE_KEYDIR },
     { "no_docs_path",   INSTALLED_NO_DOCS_PATH,     INTREE_NO_DOCS_PATH },
+    { "rundir",         INSTALLED_RUNDIR,           NULL },
     { NULL, NULL, NULL },
 };
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -161,23 +161,6 @@ static void op_fini (void *impl)
     free (c);
 }
 
-static bool pidcheck (const char *pidfile)
-{
-    pid_t pid;
-    FILE *f = NULL;
-    bool running = false;
-
-    if (!(f = fopen (pidfile, "r")))
-        goto done;
-    if (fscanf (f, "%u", &pid) != 1 || kill (pid, 0) < 0)
-        goto done;
-    running = true;
-done:
-    if (f)
-        (void)fclose (f);
-    return running;
-}
-
 static int env_getint (char *name, int dflt)
 {
     char *s = getenv (name);
@@ -222,7 +205,7 @@ flux_t *connector_init (const char *path, int flags)
         goto error;
     c->fd_nonblock = -1;
     for (count=0;;count++) {
-        if (count >= env_getint("FLUX_RETRY_COUNT", 5) || !pidcheck (pidfile))
+        if (count >= env_getint("FLUX_RETRY_COUNT", 5))
             goto error;
         memset (&addr, 0, sizeof (struct sockaddr_un));
         addr.sun_family = AF_UNIX;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -163,9 +163,9 @@ static sqlite_ctx_t *getctx (flux_t *h)
         ctx->blob_size_limit = strtoul (tmp, NULL, 10);
 
         if (!(dir = flux_attr_get (h, "persist-directory", NULL))) {
-            if (!(dir = flux_attr_get (h, "scratch-directory", NULL))) {
+            if (!(dir = flux_attr_get (h, "broker.rundir", NULL))) {
                 saved_errno = errno;
-                flux_log_error (h, "scratch-directory");
+                flux_log_error (h, "broker.rundir");
                 goto error;
             }
             cleanup = true;

--- a/src/modules/wreck/lua.d/openmpi.lua
+++ b/src/modules/wreck/lua.d/openmpi.lua
@@ -6,11 +6,11 @@ local dirname = require 'flux.posix'.dirname
 function rexecd_init ()
     local env = wreck.environ
     local f = wreck.flux
-    local rankdir = f:getattr ('scratch-directory-rank')
+    local rundir = f:getattr ('broker.rundir')
 
     -- Avoid shared memory segment name collisions
     -- when flux instance runs >1 broker per node.
-    env['OMPI_MCA_orte_tmpdir_base'] = rankdir
+    env['OMPI_MCA_orte_tmpdir_base'] = rundir
 end
 
 -- vi: ts=4 sw=4 expandtab

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -89,13 +89,6 @@ test_expect_success 'flux-start -o,--setattr ATTR=VAL can set broker attributes'
 	ATTR_VAL=`flux start -o,--setattr=foo-test=42 flux getattr foo-test` &&
 	test $ATTR_VAL -eq 42
 '
-test_expect_success 'broker scratch-directory override works' '
-	SCRATCHDIR=`mktemp -d` &&
-	DIR=`flux start -o,--setattr=scratch-directory=$SCRATCHDIR flux getattr scratch-directory` &&
-	test "$DIR" = "$SCRATCHDIR" &&
-	test -d $SCRATCHDIR &&
-	rmdir $SCRATCHDIR
-'
 test_expect_success 'broker.rundir override works' '
 	RUNDIR=`mktemp -d` &&
 	DIR=`flux start -o,--setattr=broker.rundir=$RUNDIR flux getattr broker.rundir` &&

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -96,12 +96,12 @@ test_expect_success 'broker scratch-directory override works' '
 	test -d $SCRATCHDIR &&
 	rmdir $SCRATCHDIR
 '
-test_expect_success 'broker scratch-directory-rank override works' '
-	RANKDIR=`mktemp -d` &&
-	DIR=`flux start -o,--setattr=scratch-directory-rank=$RANKDIR flux getattr scratch-directory-rank` &&
-	test "$DIR" = "$RANKDIR" &&
-	test -d $RANKDIR &&
-	rmdir $RANKDIR
+test_expect_success 'broker.rundir override works' '
+	RUNDIR=`mktemp -d` &&
+	DIR=`flux start -o,--setattr=broker.rundir=$RUNDIR flux getattr broker.rundir` &&
+	test "$DIR" = "$RUNDIR" &&
+	test -d $RUNDIR &&
+	rmdir $RUNDIR
 '
 test_expect_success 'broker persist-directory works' '
 	PERSISTDIR=`mktemp -d` &&


### PR DESCRIPTION
This PR adds a new broker attribute `broker.rundir` which replaces both `scratch-directory` and `scratch-directory-rank`.  The intent is to allow systemd to manage a single `/run` directory for a flux broker started as part of the system instance.

`flux-start` and `sideflux.py` were updated to match the simplified directory scheme.

In addition, the local connector was changed so that it no longer tries to send a signal to the broker as discussed in #987.

Finally, `flux_open()` was modified so that if a URI is not specified, and FLUX_URI is not set, it will try the local connector of the system instance (using $localstatedir/flux as the path).

This PR was split off of #980, which is focused on message security credentials.
