### PR TITLE
allow flux-logger(1) and flux_log(3) to get an EPERM error, optionally

### DIFF
--- a/doc/man1/flux-logger.adoc
+++ b/doc/man1/flux-logger.adoc
@@ -16,21 +16,19 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-flux-logger(1) creates Flux log entries.  Log entries are sent to
-the local Flux communications broker, then forwarded to the
-root of the overlay network, where they are disposed of according
-to the logging configuration of the communications session.
+flux-logger(1) appends Flux log entries to the local Flux
+broker's circular buffer.
 
 Log entries are associated with a syslog(3) style severity.
 Valid severity names are 'emerg', 'alert', 'crit', 'err',
 'warning', 'notice', 'info', 'debug'.
 
-Log entries may also have an application name (default 'logger').
+Log entries may also have a user-defined application name.
+This is different than the syslog 'facility', which is always set
+to LOG_USER in Flux log messages.
 
-Log entries are timestamped with the wall clock time, as
-reported by gettimeofday(2) at the point of origin, and with
-the rank of the communications broker originating the message.
-
+The wall clock time (UTC) and the broker rank are added to the log
+message when it is created.
 
 OPTIONS
 -------
@@ -38,7 +36,7 @@ OPTIONS
 Specify the log message severity.  The default severity is 'info'.
 
 *-n, --appname*='NAME'::
-Specify an application name to associate with the log message.
+Specify a user-defined application name to associate with the log message.
 The default appname is 'logger'.
 
 AUTHOR
@@ -58,4 +56,4 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
-syslog(3)
+flux-dmesg(1), flux_log(3), syslog(3)

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -38,7 +38,8 @@ MAN3_FILES_PRIMARY = \
 	flux_reactor_now.3 \
 	flux_request_decode.3 \
 	flux_event_decode.3 \
-	flux_content_load.3
+	flux_content_load.3 \
+	flux_log.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -102,9 +103,12 @@ MAN3_FILES_SECONDARY = \
 	flux_event_decodef.3 \
 	flux_event_encode.3 \
 	flux_event_encodef.3 \
-	flux_content_load_get.3
-	flux_content_store.3 \
-	flux_content_store_get.3
+	flux_content_load_get.3 \
+	flux_content_store.3
+	flux_content_store_get.3 \
+	flux_vlog.3 \
+	flux_log_set_appname.3 \
+	flux_log_set_procid.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -190,6 +194,9 @@ flux_event_encodef.3: flux_event_decode.3
 flux_content_load_get.3: flux_content_load.3
 flux_content_store.3: flux_content_load.3
 flux_content_store_get.3: flux_content_load.3
+flux_vlog.3: flux_log.3
+flux_log_set_appname.3: flux_log.3
+flux_log_set_procid.3: flux_log.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -93,6 +93,7 @@ MAN3_FILES_SECONDARY = \
 	flux_msg_handler_delvec.3 \
 	flux_child_watcher_get_rpid.3 \
 	flux_child_watcher_get_rstatus.3 \
+	flux_signal_watcher_get_signum.3 \
 	flux_stat_watcher_get_rstat.3 \
 	flux_rpc_get_raw.3 \
 	flux_respond_raw.3 \
@@ -104,7 +105,7 @@ MAN3_FILES_SECONDARY = \
 	flux_event_encode.3 \
 	flux_event_encodef.3 \
 	flux_content_load_get.3 \
-	flux_content_store.3
+	flux_content_store.3 \
 	flux_content_store_get.3 \
 	flux_vlog.3 \
 	flux_log_set_appname.3 \
@@ -181,6 +182,7 @@ flux_msg_handler_stop.3: flux_msg_handler_create.3
 flux_msg_handler_delvec.3: flux_msg_handler_addvec.3
 flux_child_watcher_get_rpid.3: flux_child_watcher_create.3
 flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
+flux_signal_watcher_get_signum.3: flux_signal_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_rpc_get_raw.3: flux_rpc_raw.3
 flux_respond_raw.3: flux_respond.3

--- a/doc/man3/flux_log.adoc
+++ b/doc/man3/flux_log.adoc
@@ -1,0 +1,132 @@
+flux_log(3)
+===========
+:doctype: manpage
+
+
+NAME
+----
+flux_log, flux_vlog, flux_log_set_appname, flux_log_set_procid - Log messages to the Flux Message Broker
+
+
+SYNOPSIS
+--------
+#include <flux/core.h>
+
+int flux_vlog (flux_t *h, int level, const char *fmt, va_list ap);
+
+int flux_log (flux_t *h, int level, const char *fmt, ...);
+
+void flux_log_set_appname (flux_t *h, const char *s);
+
+void flux_log_set_procid (flux_t *h, const char *s);
+
+DESCRIPTION
+-----------
+
+`flux_log()` creates RFC 5424 format log messages and sends them
+to the Flux message broker on 'h' for handling.
+
+The 'level' parameter should be set to one of the syslog(3) severity
+levels, which are, in order of decreasing importance:
+
+'LOG_EMERG'::      system is unusable
+'LOG_ALERT'::      action must be taken immediately
+'LOG_CRIT'::       critical conditions
+'LOG_ERR'::        error conditions
+'LOG_WARNING'::    warning conditions
+'LOG_NOTICE'::     normal, but significant, condition
+'LOG_INFO'::       informational message
+'LOG_DEBUG'::      debug-level message
+
+In addition, the flag 'FLUX_LOG_CHECK' may be logically ORed with
+the 'level' to direct `flux_log()` to wait for a response from the broker
+indicating whether the log request was accepted or not.  Otherwise, log
+requests are "fire and forget".
+
+Log messages are are added to the broker's circular buffer which
+can be accessed with flux-dmesg(3).  From there, a message's disposition
+is up to the broker's log configuration.
+
+`flux_log_set_procid()` may be used to override the default procid,
+which is initialized to the calling process's PID.
+
+`flux_log_set_appname()` may be used to override the default
+application name, which is initialized to the value of the '__progname'
+symbol (normally the argv[0] program name).
+
+MAPPING TO SYSLOG
+-----------------
+
+A Flux log message is formatted as a Flux request with a "raw" payload,
+as defined by Flux RFC 3.  The raw payload is formatted according to
+Internet RFC 5424.
+
+The following Syslog header fields are set in a Flux log messages when it is
+created within `flux_log()`:
+
+PRI::
+Set to the user-specified severity level combined with the facility,
+which is hardwired to 'LOG_USER' in Flux log messages.
+
+VERSION::
+Set to 1.
+
+TIMESTAMP::
+Set to the current UTC wallclock time.
+
+HOSTNAME::
+Set to the broker rank associated with 'h'.
+
+APP-NAME::
+Set to the user-defined application name, truncated to 48 characters,
+excluding terminating NULL.
+
+PROCID::
+Set to the PID of the calling process.
+
+MSGID::
+Set to the NIL string "-".
+
+The STRUCTURED-DATA portion of the message is empty, and reserved for
+future use by Flux.
+
+The MSG portion is post-processed to ensure it contains no NULL's or non-ASCII
+characters.  At this time non-ASCII UTF-8 is not supported by `flux_log()`.
+
+RETURN VALUE
+------------
+
+`flux_log()` normally returns 0 with no possibility of error.
+However, if the 'FLUX_LOG_CHECK' check flag is specified, it may
+return -1 with errno set on error.
+
+
+ERRORS
+------
+
+EPERM::
+The user does not have permission to log messages to this Flux instance.
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux-dmesg(1), flux-logger(1),
+https://tools.ietf.org/html/rfc5424[RFC 5424 The Syslog Protocol]

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -93,7 +93,8 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_open");
 
     flux_log_set_appname (h, appname);
-    flux_log (h, severity, "%s", message);
+    if (flux_log (h, severity | FLUX_LOG_CHECK, "%s", message) < 0)
+        log_err_exit ("flux_log");
 
     flux_close (h);
 

--- a/src/common/libflux/dispatch.c
+++ b/src/common/libflux/dispatch.c
@@ -353,13 +353,16 @@ done:
 
 static void call_handler (flux_msg_handler_t *w, const flux_msg_t *msg)
 {
-    uint32_t rolemask;
+    uint32_t rolemask, matchtag;
 
     if (flux_msg_get_rolemask (msg, &rolemask) < 0)
         return;
     if (!(rolemask & w->rolemask)) {
-        if (flux_msg_cmp (msg, FLUX_MATCH_REQUEST))
-            (void)flux_respond (w->d->h, msg, EPERM, NULL);
+        if (flux_msg_cmp (msg, FLUX_MATCH_REQUEST)
+                        && flux_msg_get_matchtag (msg, &matchtag) == 0
+                        && matchtag != FLUX_MATCHTAG_NONE) {
+                (void)flux_respond (w->d->h, msg, EPERM, NULL);
+        }
         return;
     }
     w->fn (w->d->h, w, msg, w->arg);

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -11,6 +11,11 @@
 
 #define FLUX_MAX_LOGBUF     2048
 
+/* May be ored with 'level' to cause log request
+ * to wait for a success/fail response.
+ */
+#define FLUX_LOG_CHECK      0x1000
+
 typedef void (*flux_log_f)(const char *buf, int len, void *arg);
 
 /* Set log appname for handle instance.
@@ -25,8 +30,8 @@ void flux_log_set_procid (flux_t *h, const char *s);
 
 /* Log a message at the specified level, as defined for syslog(3).
  */
-void flux_vlog (flux_t *h, int level, const char *fmt, va_list ap);
-void flux_log (flux_t *h, int level, const char *fmt, ...)
+int flux_vlog (flux_t *h, int level, const char *fmt, va_list ap);
+int flux_log (flux_t *h, int level, const char *fmt, ...)
               __attribute__ ((format (printf, 3, 4)));
 
 /* Log a message at LOG_ERR level, appending a colon, space, and error string.

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -341,20 +341,25 @@ flux_t *flux_open (const char *uri, int flags)
     if ((s = getenv ("FLUX_HANDLE_USERID"))) {
         uint32_t userid = strtoul (s, NULL, 10);
         if (flux_opt_set (h, FLUX_OPT_TESTING_USERID, &userid,
-                                                      sizeof (userid)) < 0)
+                                                      sizeof (userid)) < 0) {
+            flux_handle_destroy (&h);
             goto done;
+        }
     }
     if ((s = getenv ("FLUX_HANDLE_ROLEMASK"))) {
         uint32_t rolemask = strtoul (s, NULL, 0);
         if (flux_opt_set (h, FLUX_OPT_TESTING_ROLEMASK, &rolemask,
-                                                        sizeof (rolemask)) < 0)
+                                                    sizeof (rolemask)) < 0) {
+            flux_handle_destroy (&h);
             goto done;
+        }
     }
 done:
     free (scheme);
     free (default_uri);
     return h;
 }
+
 void flux_close (flux_t *h)
 {
     int saved_errno = errno;

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -142,4 +142,16 @@ test_expect_success 'flux setattr NOT allowed for non-owner' '
 	test $(flux getattr log-stderr-level) -eq 7
 '
 
+test_expect_success 'flux logger not allowed for non-owner' '
+	MSG="hello world $$" &&
+	! FLUX_HANDLE_ROLEMASK=0x2 flux logger $MSG 2>logger.err &&
+	grep -q "Operation not permitted" logger.err
+'
+
+test_expect_success 'flux dmesg not allowed for non-owner' '
+	MSG="hello world $$" &&
+	! FLUX_HANDLE_ROLEMASK=0x2 flux dmesg 2>dmesg.err &&
+	grep -q "Operation not permitted" dmesg.err
+'
+
 test_done


### PR DESCRIPTION
This PR changes the return value of `flux_log()` and `flux_vlog()` from void to int, and adds a flag FLUX_LOG_CHECK (ored with "severity")  which enables these functions to return an error.

If that flag is set, switch `flux_log()` from "fire and forget" mode to a synchronous RPC with the possibility of an error response.  Issue the optional response in the broker "log.append" RPC handler.  Then use the flag in `flux-logger` where attempting to log to an instance without appropriate permission really should be reported as an error.

Also: fix a mem leak in the `flux_open()` error path, and change the EPERM response logic to NOT send a response to fire and forget RPC's (based on the matchtag value).

Add a couple tests.

