### PR TITLE
Issue 495 - misc cleanup

### DIFF
--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -162,6 +162,7 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
         }
         free (data);
     }
+    errnum = 0;
 out:
     if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
         flux_log_error (h, "write_request_cb: flux_respondf");

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -161,7 +161,7 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
         free (data);
     }
 out:
-    if (flux_respondf (h, msg, "{si}", "code", errnum) < 0)
+    if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
         flux_log_error (h, "write_cb: flux_respondf");
     if (request)
         json_object_put (request);
@@ -195,7 +195,7 @@ static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
         }
     }
 out:
-    if (flux_respondf (h, msg, "{si}", "code", errnum) < 0)
+    if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
         flux_log_error (h, "signal_cb: flux_respondf");
     if (request)
         json_object_put (request);

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -132,8 +132,10 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
     int pid;
     int errnum = EPROTO;
 
-    if (flux_request_decode (msg, NULL, &json_str) < 0)
+    if (flux_request_decode (msg, NULL, &json_str) < 0) {
+        errnum = errno;
         goto out;
+    }
 
     if ((request = Jfromstr (json_str)) && Jget_int (request, "pid", &pid) &&
         Jget_obj (request, "stdin", &o)) {
@@ -176,8 +178,10 @@ static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
     int pid;
     int errnum = EPROTO;
 
-    if (flux_request_decode (msg, NULL, &json_str) < 0)
+    if (flux_request_decode (msg, NULL, &json_str) < 0) {
+        errnum = errno;
         goto out;
+    }
     if ((request = Jfromstr (json_str)) && Jget_int (request, "pid", &pid)) {
         int signum;
         struct subprocess *p;

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -162,7 +162,7 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
 out:
     if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
-        flux_log_error (h, "write_cb: flux_respondf");
+        flux_log_error (h, "write_request_cb: flux_respondf");
     if (request)
         json_object_put (request);
 }
@@ -196,7 +196,7 @@ static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
 out:
     if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
-        flux_log_error (h, "signal_cb: flux_respondf");
+        flux_log_error (h, "signal_request_cb: flux_respondf");
     if (request)
         json_object_put (request);
 }

--- a/src/broker/sequence.c
+++ b/src/broker/sequence.c
@@ -157,10 +157,12 @@ static int handle_seq_set (seqhash_t *s, json_object *in, json_object **outp)
         errno = EPROTO;
         return (-1);
     }
-    if ((Jget_int64 (in, "oldvalue", &old)
-        && (seq_cmp_and_set (s, name, old, v) < 0))
-        || (seq_set (s, name, v) < 0))
-            return (-1);
+
+    if (Jget_int64 (in, "oldvalue", &old)
+        && seq_cmp_and_set (s, name, old, v) < 0)
+        return (-1);
+    else if (seq_set (s, name, v) < 0)
+        return (-1);
 
     *outp = Jnew ();
     Jadd_str (*outp, "name", name);

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -44,6 +44,7 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
         log_err_exit ("heaptrace.start");
     flux_rpc_destroy (rpc);
     flux_close (h);
+    Jput (in);
     return (0);
 }
 
@@ -85,6 +86,7 @@ static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
         log_err_exit ("heaptrace.dump");
     flux_rpc_destroy (rpc);
     flux_close (h);
+    Jput (in);
     return (0);
 }
 

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -264,9 +264,9 @@ static void request_hwloc_reload (flux_t *h, const char *nodeset,
                                                         nodeset, 0)))
         log_err_exit ("flux_rpc_multi");
     do {
-        const char *json_str;
+        const char *tmp_str;
         uint32_t nodeid = FLUX_NODEID_ANY;
-        if (flux_rpc_get (rpc, &json_str) < 0
+        if (flux_rpc_get (rpc, &tmp_str) < 0
                         || flux_rpc_get_nodeid (rpc, &nodeid)) {
             if (nodeid == FLUX_NODEID_ANY)
                 log_err ("flux_rpc_get");

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -264,9 +264,8 @@ static void request_hwloc_reload (flux_t *h, const char *nodeset,
                                                         nodeset, 0)))
         log_err_exit ("flux_rpc_multi");
     do {
-        const char *tmp_str;
         uint32_t nodeid = FLUX_NODEID_ANY;
-        if (flux_rpc_get (rpc, &tmp_str) < 0
+        if (flux_rpc_get (rpc, NULL) < 0
                         || flux_rpc_get_nodeid (rpc, &nodeid)) {
             if (nodeid == FLUX_NODEID_ANY)
                 log_err ("flux_rpc_get");

--- a/src/modules/live/live.c
+++ b/src/modules/live/live.c
@@ -970,12 +970,12 @@ static void push_request_cb (flux_t *h, flux_msg_handler_t *w,
     json_object *in = NULL;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0) {
-        flux_log_error (ctx->h, "%s: reuqest decode", __FUNCTION__);
+        flux_log_error (ctx->h, "%s: request decode", __FUNCTION__);
         goto done;
     }
     if (!(in = Jfromstr (json_str))) {
         errno = EPROTO;
-        flux_log_error (ctx->h, "%s: reuqest decode", __FUNCTION__);
+        flux_log_error (ctx->h, "%s: request decode", __FUNCTION__);
         goto done;
     }
     flux_reduce_append (ctx->r, Jget (in), 0);

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -397,7 +397,7 @@ static void reload_request_cb (flux_t *h,
         || (ctx_hwloc_init (h, ctx) < 0)
         || (load_hwloc (h, ctx) < 0))
         errnum = errno;
-    if (flux_respond (h, msg, errnum, "{}") < 0)
+    if (flux_respond (h, msg, errnum, NULL) < 0)
         flux_log_error (h, "flux_respond");
 }
 


### PR DESCRIPTION
While doing a lot of conversion to jansson-style functions in #495, fixed of variety of cleanup things along the way.  Decided to split them all off onto another pull request, before sending over the beefier changes.

Most fixes are obvious, the notable exception may be 57a29a9ead64740acd4f3534f271dc914ab6f6d2.  It was necessary b/c jansson is pickier on types.  (i.e. ```"1"``` is a string while ```1``` is an int).  My lua is weak, would appreciate look to make sure ```toboolean``` local function is a smart solution?


