### PR TITLE
Issue 495 - jansson style rpc calls

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -712,20 +712,19 @@ static void content_stats_request (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
-    json_object *out = Jnew ();
-    int rc = -1;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
-        goto done;
-    Jadd_int (out, "count", zhash_size (cache->entries));
-    Jadd_int (out, "valid", cache->acct_valid);
-    Jadd_int (out, "dirty", cache->acct_dirty);
-    Jadd_int (out, "size", cache->acct_size);
-    rc = 0;
-done:
-    if (flux_respond (h, msg, rc < 0 ? errno : 0, Jtostr (out)) < 0)
+        goto error;
+    if (flux_respondf (h, msg, "{ s:i s:i s:i s:i}",
+                       "count", zhash_size (cache->entries),
+                       "valid", cache->acct_valid,
+                       "dirty", cache->acct_dirty,
+                       "size", cache->acct_size) < 0)
         flux_log_error (h, "content stats");
-    Jput (out);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "content stats");
 }
 
 /* Flush all dirty entries by walking the entire cache, issuing store

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -90,21 +90,19 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     flux_msgcounters_t mcs;
-    json_object *out = Jnew ();
 
     flux_get_msgcounters (h, &mcs);
-    Jadd_int (out, "#request (tx)", mcs.request_tx);
-    Jadd_int (out, "#request (rx)", mcs.request_rx);
-    Jadd_int (out, "#response (tx)", mcs.response_tx);
-    Jadd_int (out, "#response (rx)", mcs.response_rx);
-    Jadd_int (out, "#event (tx)", mcs.event_tx);
-    Jadd_int (out, "#event (rx)", mcs.event_rx);
-    Jadd_int (out, "#keepalive (tx)", mcs.keepalive_tx);
-    Jadd_int (out, "#keepalive (rx)", mcs.keepalive_rx);
 
-    if (flux_respond (h, msg, 0, Jtostr (out)) < 0)
-        FLUX_LOG_ERROR (h);
-    Jput (out);
+    if (flux_respondf (h, msg, "{ s:i s:i s:i s:i s:i s:i s:i s:i }",
+                       "#request (tx)", mcs.request_tx,
+                       "#request (rx)", mcs.request_rx,
+                       "#response (tx)", mcs.response_tx,
+                       "#response (rx)", mcs.response_rx,
+                       "#event (tx)", mcs.event_tx,
+                       "#event (rx)", mcs.event_rx,
+                       "#keepalive (tx)", mcs.keepalive_tx,
+                       "#keepalive (rx)", mcs.keepalive_rx) < 0)
+      FLUX_LOG_ERROR (h);
 }
 
 static void stats_clear_event_cb (flux_t *h, flux_msg_handler_t *w,

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -23,28 +23,23 @@
 \*****************************************************************************/
 #include "builtin.h"
 
-#include "src/common/libutil/shortjson.h"
-
 static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
 {
     flux_t *h;
     flux_rpc_t *rpc;
-    json_object *in = Jnew ();
 
     if (optparse_option_index (p) != ac - 1) {
         optparse_print_usage (p);
         exit (1);
     }
-    Jadd_str (in, "filename", av[ac - 1]);
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    if (!(rpc = flux_rpc (h, "heaptrace.start", Jtostr (in),
-                          FLUX_NODEID_ANY, 0))
+    if (!(rpc = flux_rpcf (h, "heaptrace.start", FLUX_NODEID_ANY, 0,
+                           "{ s:s }", "filename", av[ac - 1]))
             || flux_rpc_get (rpc, NULL) < 0)
         log_err_exit ("heaptrace.start");
     flux_rpc_destroy (rpc);
     flux_close (h);
-    Jput (in);
     return (0);
 }
 
@@ -71,22 +66,19 @@ static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
 {
     flux_t *h;
     flux_rpc_t *rpc;
-    json_object *in = Jnew ();
 
     if (optparse_option_index (p) != ac - 1) {
         optparse_print_usage (p);
         exit (1);
     }
-    Jadd_str (in, "reason", av[ac - 1]);
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    if (!(rpc = flux_rpc (h, "heaptrace.dump", Jtostr (in),
-                          FLUX_NODEID_ANY, 0))
+    if (!(rpc = flux_rpcf (h, "heaptrace.dump", FLUX_NODEID_ANY, 0,
+                           "{ s:s }", "reason", av[ac - 1]))
             || flux_rpc_get (rpc, NULL) < 0)
         log_err_exit ("heaptrace.dump");
     flux_rpc_destroy (rpc);
     flux_close (h);
-    Jput (in);
     return (0);
 }
 

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -45,8 +45,8 @@
 #include <inttypes.h>
 
 #include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/cleanup.h"
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libsubprocess/subprocess.h"
 
 #define LISTEN_BACKLOG      5
@@ -333,22 +333,16 @@ done:
 
 int sub_request (client_t *c, const flux_msg_t *msg, bool subscribe)
 {
-    const char *json_str, *topic;
-    json_object *in = NULL;
+    const char *topic;
     int rc = -1;
 
-    if (flux_request_decode (msg, NULL, &json_str) < 0)
+    if (flux_request_decodef (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         goto done;
-    if (!(in = Jfromstr (json_str)) || !Jget_str (in, "topic", &topic)) {
-        errno = EPROTO;
-        goto done;
-    }
     if (subscribe)
         rc = client_subscribe (c, topic);
     else
         rc = client_unsubscribe (c, topic);
 done:
-    Jput (in);
     return rc;
 }
 

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -460,8 +460,13 @@ program:SubCommand {
         os.exit (1)
     end
 
+    -- opt.k is always nil or 1, so this is safe to perform
+    local function toboolean(X)
+         return not not X
+    end
+
     for _,id in ipairs (arg) do
-        local resp, err = f:rpc ("cron.delete", { id = id, kill = self.opt.k })
+        local resp, err = f:rpc ("cron.delete", { id = tonumber (id), kill = toboolean (self.opt.k) })
         if not resp then self:die (err) end
 
         local t = resp.tasks [1]
@@ -492,7 +497,7 @@ program:SubCommand {
     end
 
     for _,id in ipairs (arg) do
-        local resp, err = f:rpc ("cron.stop", { id = id })
+        local resp, err = f:rpc ("cron.stop", { id = tonumber (id) })
         if not resp then self:die (err) end
         printf ("Stopped cron-%d\n", arg[1])
     end
@@ -510,7 +515,7 @@ program:SubCommand {
     end
 
     for _,id in ipairs (arg) do
-        local resp, err = f:rpc ("cron.start", { id = id })
+        local resp, err = f:rpc ("cron.start", { id = tonumber (id) })
         if not resp then self:die (err) end
         printf ("Started cron-%d\n", arg[1])
     end

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -34,7 +34,6 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
 
 #define MODHANDLE_MAGIC    0xfeefbe02
 typedef struct {
@@ -157,19 +156,17 @@ static int op_event_subscribe (void *impl, const char *topic)
 {
     shmem_ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    json_object *in = Jnew ();
     flux_rpc_t *rpc = NULL;
     int rc = -1;
 
     if (connect_socket (ctx) < 0)
         goto done;
-    Jadd_str (in, "topic", topic);
-    if (!(rpc = flux_rpc (ctx->h, "cmb.sub", Jtostr (in), FLUX_NODEID_ANY, 0))
+    if (!(rpc = flux_rpcf (ctx->h, "cmb.sub", FLUX_NODEID_ANY, 0,
+                           "{ s:s }", "topic", topic))
                 || flux_rpc_get (rpc, NULL) < 0)
         goto done;
     rc = 0;
 done:
-    Jput (in);
     flux_rpc_destroy (rpc);
     return rc;
 }
@@ -178,19 +175,17 @@ static int op_event_unsubscribe (void *impl, const char *topic)
 {
     shmem_ctx_t *ctx = impl;
     assert (ctx->magic == MODHANDLE_MAGIC);
-    json_object *in = Jnew ();
     flux_rpc_t *rpc = NULL;
     int rc = -1;
 
     if (connect_socket (ctx) < 0)
         goto done;
-    Jadd_str (in, "topic", topic);
-    if (!(rpc = flux_rpc (ctx->h, "cmb.unsub", Jtostr (in), FLUX_NODEID_ANY, 0))
+    if (!(rpc = flux_rpcf (ctx->h, "cmb.unsub", FLUX_NODEID_ANY, 0,
+                           "{ s:s }", "topic", topic))
                 || flux_rpc_get (rpc, NULL) < 0)
         goto done;
     rc = 0;
 done:
-    Jput (in);
     flux_rpc_destroy (rpc);
     return rc;
 }

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -40,7 +40,6 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/popen2.h"
 
 static const char *default_ssh_cmd = "/usr/bin/rsh";
@@ -137,17 +136,15 @@ static int op_event_subscribe (void *impl, const char *topic)
     ssh_ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_rpc_t *rpc = NULL;
-    json_object *in = Jnew ();
     int rc = 0;
 
-    Jadd_str (in, "topic", topic);
-    if (!(rpc = flux_rpc (c->h, "local.sub", Jtostr (in), FLUX_NODEID_ANY, 0))
+    if (!(rpc = flux_rpcf (c->h, "local.sub", FLUX_NODEID_ANY, 0,
+                           "{ s:s }", "topic", topic))
                 || flux_rpc_get (rpc, NULL) < 0)
         goto done;
     rc = 0;
 done:
     flux_rpc_destroy (rpc);
-    Jput (in);
     return rc;
 }
 
@@ -156,17 +153,15 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     ssh_ctx_t *c = impl;
     assert (c->magic == CTX_MAGIC);
     flux_rpc_t *rpc = NULL;
-    json_object *in = Jnew ();
     int rc = 0;
 
-    Jadd_str (in, "topic", topic);
-    if (!(rpc = flux_rpc (c->h, "local.unsub", Jtostr (in), FLUX_NODEID_ANY, 0))
+    if (!(rpc = flux_rpcf (c->h, "local.unsub", FLUX_NODEID_ANY, 0,
+                           "{ s:s }", "topic", topic))
                 || flux_rpc_get (rpc, NULL) < 0)
         goto done;
     rc = 0;
 done:
     flux_rpc_destroy (rpc);
-    Jput (in);
     return rc;
 }
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -33,7 +33,6 @@
 
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/cleanup.h"
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libminilzo/minilzo.h"
@@ -391,21 +390,19 @@ done:
 int register_backing_store (flux_t *h, bool value, const char *name)
 {
     flux_rpc_t *rpc;
-    json_object *in = Jnew ();
     int saved_errno = 0;
     int rc = -1;
 
-    Jadd_bool (in, "backing", value);
-    Jadd_str (in, "name", name);
-    if (!(rpc = flux_rpc (h, "content.backing", Jtostr (in),
-                            FLUX_NODEID_ANY, 0)))
+    if (!(rpc = flux_rpcf (h, "content.backing", FLUX_NODEID_ANY, 0,
+                           "{ s:b s:s }",
+                           "backing", value,
+                           "name", name)))
         goto done;
     if (flux_rpc_get (rpc, NULL) < 0)
         goto done;
     rc = 0;
 done:
     saved_errno = errno;
-    Jput (in);
     flux_rpc_destroy (rpc);
     errno = saved_errno;
     return rc;

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -242,41 +242,6 @@ done:
     return rc;
 }
 
-/* kvs.getroot
- */
-
-json_object *kp_rgetroot_enc (int rootseq, const char *rootdir)
-{
-    json_object *o = NULL;
-
-    if (!rootdir) {
-        errno = EINVAL;
-        goto done;
-    }
-    o = Jnew ();
-    Jadd_int (o, "rootseq", rootseq);
-    Jadd_str (o, "rootdir", rootdir);
-done:
-    return o;
-}
-
-int kp_rgetroot_dec (json_object *o, int *rootseq, const char **rootdir)
-{
-    int rc = -1;
-
-    if (!rootseq || !rootdir) {
-        errno = EINVAL;
-        goto done;
-    }
-    if (!Jget_int (o, "rootseq", rootseq) || !Jget_str (o, "rootdir", rootdir)){
-        errno = EPROTO;
-        goto done;
-    }
-    rc = 0;
-done:
-    return rc;
-}
-
 /* kvs.setroot (event)
  */
 

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -44,12 +44,6 @@ json_object *kp_tfence_enc (const char *name, int nprocs, int flags,
 int kp_tfence_dec (json_object *o, const char **name, int *nprocs,
                    int *flags, json_object **ops);
 
-/* kvs.getroot (request)
- */
-/* empty request payload */
-json_object *kp_rgetroot_enc (int rootseq, const char *rootdir);
-int kp_rgetroot_dec (json_object *o, int *rootseq, const char **rootdir);
-
 /* kvs.setroot (event)
  */
 json_object *kp_tsetroot_enc (int rootseq, const char *rootdir,

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -140,22 +140,6 @@ void test_fence (void)
     Jput (ops);
 }
 
-void test_getroot (void)
-{
-    json_object *o;
-    const char *rootdir;
-    int rootseq;
-
-    ok ((o = kp_rgetroot_enc (42, "blah")) != NULL,
-        "kp_rgetroot_enc works");
-    diag ("getroot: %s", Jtostr (o));
-    diag ("getroot: %s", Jtostr (o));
-    ok (kp_rgetroot_dec (o, &rootseq, &rootdir) == 0
-        && rootseq == 42 && rootdir != NULL && !strcmp (rootdir, "blah"),
-        "kp_rgetroot_dec works");
-    Jput (o);
-}
-
 void test_setroot (void)
 {
     json_object *o;
@@ -214,7 +198,6 @@ int main (int argc, char *argv[])
     test_get ();
     test_watch ();
     test_unwatch ();
-    test_getroot ();
     test_setroot ();
     test_fence ();
     test_error ();


### PR DESCRIPTION
Various refactoring to update rpc calls from json-c to jansson style.  Such as calling ```flux_rpcf()``` over ```flux_rpc()```.

There are more that can be done, but I limited this PR to only those rpcs that dealt with simple int, string, etc. types.  Dealing with more complex objects/arrays require using the jansson library to create/manipulate said objects/arrays instead of the json-c library, and that's refactoring/cleanup for another day.

Most fixes should be self explanatory hopefully.  The noteable exception is https://github.com/flux-framework/flux-core/pull/1002/commits/37be05995855e21573b983422f58fd875655665d.  The jansson style functions are pickier on typing.  So a ```"1"``` (in quotes) is a string and not an integer, so I updated ```flux-cron``` to send the right type.
