### PR TITLE
call destructors in broker shutdown path

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -386,7 +386,7 @@ int main (int argc, char *argv[])
 
     /* Set up the flux reactor.
      */
-    if (!(ctx.reactor = flux_reactor_create (SIGCHLD)))
+    if (!(ctx.reactor = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
         log_err_exit ("flux_reactor_create");
 
     /* Set up flux handle.

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -685,6 +685,7 @@ int main (int argc, char *argv[])
     /* Unregister builtin services
      */
     attr_unregister_handlers ();
+    content_cache_destroy (ctx.cache);
 
     broker_unhandle_signals (sigwatchers);
     zlist_destroy (&sigwatchers);
@@ -705,7 +706,6 @@ int main (int argc, char *argv[])
     flux_close (ctx.h);
     flux_reactor_destroy (ctx.reactor);
     zlist_destroy (&ctx.subscriptions);
-    content_cache_destroy (ctx.cache);
     runlevel_destroy (ctx.runlevel);
 
     return 0;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -676,10 +676,10 @@ int main (int argc, char *argv[])
     heartbeat_stop (ctx.heartbeat);
 
     /* Unload modules.
-     * FIXME: this will hang in pthread_join unless modules have been stopped.
      */
     if (ctx.verbose)
         log_msg ("unloading modules");
+    module_stop_all (ctx.modhash);
     modhash_destroy (ctx.modhash);
 
     /* Unregister builtin services

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -195,6 +195,8 @@ static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec);
 static int attr_get_snoop (const char *name, const char **val, void *arg);
 static int attr_get_overlay (const char *name, const char **val, void *arg);
 
+static void sigalrm_cb (int signum);
+
 static void init_attrs (broker_ctx_t *ctx);
 
 static const struct flux_handle_ops broker_handle_ops;
@@ -249,7 +251,6 @@ static int setup_profiling (const char *program, int rank)
 #endif
     return (0);
 }
-
 
 int main (int argc, char *argv[])
 {
@@ -692,6 +693,15 @@ int main (int argc, char *argv[])
         log_err_exit ("sigaction");
     if (sigaction (SIGTERM, &old_sigact_term, NULL) < 0)
         log_err_exit ("sigaction");
+    /* Install SIGALRM handler and set timer in case we get stuck.
+     */
+    struct sigaction sigact_alrm = {
+        .sa_handler = sigalrm_cb,
+        .sa_flags = 0,
+    };
+    if (sigaction (SIGALRM, &sigact_alrm, NULL) < 0)
+        log_err_exit ("sigaction");
+    alarm (1); // 1s to tear down
 
     /* remove heartbeat timer, if any
      */
@@ -812,6 +822,13 @@ static void hello_update_cb (hello_t *hello, void *arg)
         flux_log (ctx->h, LOG_INFO, "wireup: %d/%d (incomplete) %.1fs",
                   hello_get_count (hello), ctx->size, hello_get_time (hello));
     }
+}
+
+/* Signal handler teardown timeout.
+ */
+static void sigalrm_cb (int signum)
+{
+    exit (exit_rc);
 }
 
 /* Currently 'expired' is always true.

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -225,7 +225,6 @@ void logbuf_destroy (logbuf_t *logbuf)
 {
     if (logbuf) {
         assert (logbuf->magic == LOGBUF_MAGIC);
-        logbuf->magic = ~LOGBUF_MAGIC;
         if (logbuf->buf) {
             logbuf_trim (logbuf, 0);
             zlist_destroy (&logbuf->buf);

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -684,6 +684,28 @@ done:
     return rc;
 }
 
+int module_stop_all (modhash_t *mh)
+{
+    zlist_t *uuids;
+    char *uuid;
+    int rc = -1;
+
+    if (!(uuids = zhash_keys (mh->zh_byuuid)))
+        oom ();
+    uuid = zlist_first (uuids);
+    while (uuid) {
+        module_t *p = zhash_lookup (mh->zh_byuuid, uuid);
+        assert (p != NULL);
+        if (module_stop (p) < 0)
+            goto done;
+        uuid = zlist_next (uuids);
+    }
+    rc = 0;
+done:
+    zlist_destroy (&uuids);
+    return rc;
+}
+
 module_t *module_lookup_byname (modhash_t *mh, const char *name)
 {
     zlist_t *uuids;

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -91,6 +91,7 @@ int module_start_all (modhash_t *mh);
 /* Stop module thread by sending a shutdown request.
  */
 int module_stop (module_t *p);
+int module_stop_all (modhash_t *mh);
 
 /* Prepare an 'lsmod' response payload.
  */

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -43,7 +43,7 @@
 #include "src/common/libpmi/dgetline.h"
 #include "src/common/libsubprocess/subprocess.h"
 
-#define DEFAULT_KILLER_TIMEOUT 1.0
+#define DEFAULT_KILLER_TIMEOUT 2.0
 
 static struct {
     double killer_timeout;


### PR DESCRIPTION
As discussed in #25, instance shutdown is far from clean.  It's a bit better than before, now that we have the rc1, rc2, and rc3 run levels  (modules loaded in rc1 are unloaded in rc3), but the "normal" path is to let the shutdown timer (started at the beginning of rc3) expire and call exit from its reactor callback.
Since the reactor never returns, we never get back to `main()` to call destructors.

Ideally we'd like to get to the point where all reactor watchers are stopped after their subsystems are torn down and the reactor would exit naturally, with the timeout acting as a fallback rather than the main path.   That will require some design work to ensure the overlay is torn down in an orderly fashion without deadlocking distributed services, and is not attempted here.  

This PR takes a step in the right direction by replacing the `exit()` call in the shutdown handler with `flux_reactor_stop()`.  The destructors in `main()` are then called - some bug fixes were needed in these.  Finally since deadlock is still possible when attempting to unload modules that failed to unload in rc3, a SIGALRM timer is set with an exit call in the handler just in case.

I think we could close #25 if this is merged and open new issues for the remaining problems.

Also this lays some groundwork for #974 (convert to latest czmq) as zsys gets sad if any sockets are open in its `atexit()` call.