### PR TITLE
Issue 495 - re-architect behavior of numerous rpc/msg functions

### DIFF
--- a/doc/man3/flux_event_decode.adoc
+++ b/doc/man3/flux_event_decode.adoc
@@ -36,10 +36,9 @@ DESCRIPTION
 _topic_, if non-NULL, will be set the message's topic string. The storage
 for this string belongs to _msg_ and should not be freed.
 
-_json_str_, if non-NULL, will be set to the message's JSON payload. The
-storage for this string belongs to _msg_ and should not be freed.
-If non-NULL, decoding fails if the message doesn't have a JSON payload.
-If NULL, decoding fails if the message does have a JSON payload.
+_json_str_, if non-NULL, will be set to the message's JSON payload. If
+no payload exists, _json_str_ is set to NULL.  The storage for this
+string belongs to _msg_ and should not be freed.
 
 `flux_event_decodef()` decodes a Flux event message with a JSON payload as
 above, parsing the payload using variable arguments with a format string

--- a/doc/man3/flux_request_decode.adoc
+++ b/doc/man3/flux_request_decode.adoc
@@ -32,10 +32,9 @@ DESCRIPTION
 _topic_, if non-NULL, will be set the message's topic string. The storage
 for this string belongs to _msg_ and should not be freed.
 
-_json_str_, if non-NULL, will be set to the message's JSON payload. The
-storage for this string belongs to _msg_ and should not be freed.
-If non-NULL, decoding fails if the message doesn't have a JSON payload.
-If NULL, decoding fails if the message does have a JSON payload.
+_json_str_, if non-NULL, will be set to the message's JSON payload.
+If no payload exists, _json_str_ is set to NULL.  The storage for this
+string belongs to _msg_ and should not be freed.
 
 `flux_request_decodef()` decodes a request message with a JSON payload as
 above, parsing the payload using variable arguments with a format string

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -66,13 +66,11 @@ and the flux_rpc_t returned by `flux_rpc()` may be immediately destroyed.
 `flux_rpc_get()` blocks until a matching response is received, then
 decodes the result.  For asynchronous response handling, see flux_rpc_then(3).
 
-_json_out_, if non-NULL, is assigned a string containing valid serialized
-JSON from the response payload.  It is a protocol error if a payload that is
-expected (signified by a non-NULL _json_out_) does not arrive;
-similarly, it is a protocol error if an unexpected payload (signified
-by a NULL _json_out_) arrives.  The storage associated with _json_out_
-belongs to the flux_rpc_t object and is invalidated when that object is
-destroyed.
+_json_out_, if non-NULL, is assigned a string containing valid
+serialized JSON from the response payload.  If no payload exists,
+_json_out_ is set to NULL.  The storage associated with _json_out_
+belongs to the flux_rpc_t object and is invalidated when that object
+is destroyed.
 
 `flux_rpc_destroy()` destroys a completed `flux_rpc_t`, invalidating 
 payload as described above, and freeing the RPC matchtag.  Destroying

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -83,6 +83,7 @@ void forward_cb (flux_t *h, flux_msg_handler_t *w,
     char *item;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0
+            || !json_str
             || !(in = Jfromstr (json_str))
             || !Jget_int (in, "batchnum", &batchnum)
             || !Jget_str (in, "nodeset", &nodeset_str))

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -10,7 +10,9 @@ void get_rank (flux_rpc_t *rpc)
 
     if (flux_rpc_get (rpc, &json_str) < 0)
         log_err_exit ("flux_rpc_get");
-    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_str (o, "value", &rank))
         log_msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
     Jput (o);

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -10,7 +10,9 @@ void get_rank (flux_rpc_t *rpc, void *arg)
 
     if (flux_rpc_get (rpc, &json_str) < 0)
         log_err_exit ("flux_rpc_get");
-    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_str (o, "value", &rank))
         log_msg_exit ("response protocol error");
     printf ("rank is %s\n", rank);
     Jput (o);

--- a/doc/man3/trpc_then_multi.c
+++ b/doc/man3/trpc_then_multi.c
@@ -13,7 +13,9 @@ void get_rank (flux_rpc_t *rpc, void *arg)
         log_err_exit ("flux_rpc_get_nodeid");
     if (flux_rpc_get (rpc, &json_str) < 0)
         log_err_exit ("flux_rpc_get");
-    if (!(o = Jfromstr (json_str)) || !Jget_str (o, "value", &rank))
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_str (o, "value", &rank))
         log_msg_exit ("response protocol error");
     printf ("[%" PRIu32 "] rank is %s\n", nodeid, rank);
     Jput (o);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1438,6 +1438,10 @@ static void cmb_rmmod_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto error;
+    if (!json_str) {
+        errno = EPROTO;
+        goto error;
+    }
     if (flux_rmmod_json_decode (json_str, &name) < 0)
         goto error;
     if (!(p = module_lookup_byname (ctx->modhash, name))) {
@@ -1473,6 +1477,10 @@ static void cmb_insmod_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto error;
+    if (!json_str) {
+        errno = EPROTO;
+        goto error;
+    }
     if (flux_insmod_json_decode (json_str, &path, &argz, &argz_len) < 0)
         goto error;
     if (!(name = flux_modname (path))) {

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -137,8 +137,10 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto out;
     }
 
-    if ((request = Jfromstr (json_str)) && Jget_int (request, "pid", &pid) &&
-        Jget_obj (request, "stdin", &o)) {
+    if (json_str
+        && (request = Jfromstr (json_str))
+        && Jget_int (request, "pid", &pid)
+        && Jget_obj (request, "stdin", &o)) {
         int len;
         void *data = NULL;
         bool eof;
@@ -229,7 +231,8 @@ static void exec_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto out_free;
 
-    if (!(request = Jfromstr (json_str))
+    if (!json_str
+        || !(request = Jfromstr (json_str))
         || !json_object_object_get_ex (request, "cmdline", &o)
         || o == NULL
         || (json_object_get_type (o) != json_type_array)) {

--- a/src/broker/ping.c
+++ b/src/broker/ping.c
@@ -49,7 +49,7 @@ static void ping_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto error;
     if (flux_msg_get_userid (msg, &userid) < 0)
         goto error;
-    if (!(inout = Jfromstr (json_str))) {
+    if (!json_str || !(inout = Jfromstr (json_str))) {
         errno = EPROTO;
         goto error;
     }

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -486,7 +486,7 @@ void lsmod_map_hash (zhash_t *mods, flux_lsmod_f cb, void *arg)
 
 int lsmod_merge_result (uint32_t nodeid, const char *json_str, zhash_t *mods)
 {
-    flux_modlist_t *modlist;
+    flux_modlist_t *modlist = NULL;
     mod_t *m;
     int i, len;
     const char *name, *digest;
@@ -494,6 +494,10 @@ int lsmod_merge_result (uint32_t nodeid, const char *json_str, zhash_t *mods)
     int status;
     int rc = -1;
 
+    if (!json_str) {
+        errno = EPROTO;
+        goto done;
+    }
     if (!(modlist = flux_lsmod_json_decode (json_str)))
         goto done;
     if ((len = flux_modlist_count (modlist)) == -1)
@@ -655,6 +659,8 @@ int cmd_stats (optparse_t *p, int argc, char **argv)
             log_err_exit ("%s", topic);
         if (flux_rpc_get (r, &json_str) < 0)
             log_err_exit ("%s", topic);
+        if (!json_str)
+            log_errn_exit (EPROTO, "%s", topic);
         parse_json (p, json_str);
     } else {
         topic = xasprintf ("%s.stats.get", service);
@@ -662,6 +668,8 @@ int cmd_stats (optparse_t *p, int argc, char **argv)
             log_err_exit ("%s", topic);
         if (flux_rpc_get (r, &json_str) < 0)
             log_err_exit ("%s", topic);
+        if (!json_str)
+            log_errn_exit (EPROTO, "%s", topic);
         parse_json (p, json_str);
     }
     free (topic);

--- a/src/common/libcompat/rpc.c
+++ b/src/common/libcompat/rpc.c
@@ -44,10 +44,10 @@ int flux_json_rpc (flux_t *h, uint32_t nodeid, const char *topic,
 
     if (!(rpc = flux_rpc (h, topic, Jtostr (in), nodeid, 0)))
         goto done;
-    if (flux_rpc_get (rpc, out ? &json_str : NULL) < 0)
+    if (flux_rpc_get (rpc, &json_str) < 0)
         goto done;
     if (out) {
-        if (!(o = Jfromstr (json_str))) {
+        if (!json_str || !(o = Jfromstr (json_str))) {
             errno = EPROTO;
             goto done;
         }

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -66,10 +66,6 @@ int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **j
         goto done;
     if (flux_msg_get_json (msg, &js) < 0)
         goto done;
-    if ((json_str && !js) || (!json_str && js)) {
-        errno = EPROTO;
-        goto done;
-    }
     if (topic)
         *topic = ts;
     if (json_str)

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -8,9 +8,8 @@
 
 /* Decode an event message.
  * If topic is non-NULL, assign the event topic string.
- * If json_str is non-NULL, assign the payload.  json_str indicates whether
- * payload is expected and it is an EPROTO error if they don't match.
- * Returns 0 on success, or -1 on failure with errno set.
+ * If json_str is non-NULL, assign the payload or set to NULL if none
+ * exists.  Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_event_decode (const flux_msg_t *msg, const char **topic,
                        const char **json_str);

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -389,6 +389,10 @@ int flux_lsmod (flux_t *h, uint32_t nodeid, const char *service,
         goto done;
     if (flux_rpc_get (r, &json_str) < 0)
         goto done;
+    if (!json_str) {
+        errno = EPROTO;
+        goto done;
+    }
     if (!(mods = flux_lsmod_json_decode (json_str)))
         goto done;
     if ((len = flux_modlist_count (mods)) == -1)

--- a/src/common/libflux/reparent.c
+++ b/src/common/libflux/reparent.c
@@ -43,6 +43,10 @@ char *flux_lspeer (flux_t *h, int rank)
         goto done;
     if (flux_rpc_get (r, &json_str) < 0)
         goto done;
+    if (!json_str) {
+        errno = EPROTO;
+        goto done;
+    }
     ret = xstrdup (json_str);
 done:
     flux_rpc_destroy (r);

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -65,10 +65,6 @@ int flux_request_decode (const flux_msg_t *msg, const char **topic,
         goto done;
     if (flux_msg_get_json (msg, &js) < 0)
         goto done;
-    if ((json_str && !js) || (!json_str && js)) {
-        errno = EPROTO;
-        goto done;
-    }
     if (topic)
         *topic = ts;
     if (json_str)

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -8,9 +8,8 @@
 
 /* Decode a request message with optional json payload.
  * If topic is non-NULL, assign the request topic string.
- * If json_str is non-NULL, assign the payload.  This argument indicates whether
- * payload is expected and it is an EPROTO error if expectations are not met.
- * Returns 0 on success, or -1 on failure with errno set.
+ * If json_str is non-NULL, assign the payload or set to NULL if none
+ * exists.  Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_request_decode (const flux_msg_t *msg, const char **topic,
                          const char **json_str);

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -75,10 +75,6 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
         goto done;
     if (flux_msg_get_json (msg, &js) < 0)
         goto done;
-    if ((json_str && !js) || (!json_str && js)) {
-        errno = EPROTO;
-        goto done;
-    }
     if (topic)
         *topic = ts;
     if (json_str)

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -9,11 +9,11 @@
 
 /* Decode a response message, with optional json payload.
  * If topic is non-NULL, assign the response topic string.
- * If json_str is non-NULL, assign the payload.  This argument indicates whether
- * payload is expected and it is an EPROTO error if expectations are not met.
- * If response includes a nonzero errnum, errno is set to the errnum value
- * and -1 is returned with no assignments to topic or json_str.
- * Returns 0 on success, or -1 on failure with errno set.
+ * If json_str is non-NULL, assign the payload if one exists or set to
+ * NULL is none exists.  If response includes a nonzero errnum, errno
+ * is set to the errnum value and -1 is returned with no assignments
+ * to topic or json_str.  Returns 0 on success, or -1 on failure with
+ * errno set.
  */
 int flux_response_decode (const flux_msg_t *msg, const char **topic,
                           const char **json_str);

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -266,6 +266,10 @@ static int flux_rpc_vgetf (flux_rpc_t *rpc, const char *fmt, va_list ap)
         goto done;
     if (flux_response_decode (rpc->rx_msg, NULL, &json_str) < 0)
         goto done;
+    if (!json_str) {
+        errno = EPROTO;
+        goto done;
+    }
     if (flux_msg_vget_jsonf (rpc->rx_msg, fmt, ap) < 0)
         goto done;
     rc = 0;

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -28,8 +28,8 @@ int main (int argc, char *argv[])
     ok (flux_event_decode (msg, NULL, NULL) == 0,
         "flux_event_decode topic is optional");
     errno = 0;
-    ok (flux_event_decode (msg, NULL, &s) < 0 && errno == EPROTO,
-        "flux_event_decode returns EPROTO when expected payload is missing");
+    ok (flux_event_decode (msg, NULL, &s) == 0 && s == NULL,
+        "flux_event_decode returns s = NULL when expected payload is missing");
     flux_msg_destroy(msg);
 
     /* with payload */
@@ -41,8 +41,8 @@ int main (int argc, char *argv[])
         && s != NULL && !strcmp (s, json_str),
         "flux_event_decode returns encoded payload");
     errno = 0;
-    ok (flux_event_decode (msg, NULL, NULL) < 0 && errno == EPROTO,
-        "flux_event_decode returns EPROTO when payload is unexpected");
+    ok (flux_event_decode (msg, NULL, NULL) == 0,
+        "flux_event_decode works with payload but don't want the payload");
     flux_msg_destroy (msg);
 
     /* formatted payload */

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -35,8 +35,8 @@ int main (int argc, char *argv[])
     ok (flux_request_decode (msg, NULL, NULL) == 0,
         "flux_request_decode topic is optional");
     errno = 0;
-    ok (flux_request_decode (msg, NULL, &s) < 0 && errno == EPROTO,
-        "flux_request_decode returns EPROTO when expected payload is missing");
+    ok (flux_request_decode (msg, NULL, &s) == 0 && s == NULL,
+        "flux_request_decode returns s = NULL when expected payload is missing");
     flux_msg_destroy(msg);
 
     /* with JSON payload */
@@ -54,8 +54,8 @@ int main (int argc, char *argv[])
         "flux_request_decodef returns encoded payload");
 
     errno = 0;
-    ok (flux_request_decode (msg, NULL, NULL) < 0 && errno == EPROTO,
-        "flux_request_decode returns EPROTO when payload is unexpected");
+    ok (flux_request_decode (msg, NULL, NULL) == 0,
+        "flux_request_decode works with payload but don't want the payload");
     flux_msg_destroy(msg);
 
     /* without payload (raw) */

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -47,8 +47,8 @@ int main (int argc, char *argv[])
     ok (flux_response_decode (msg, NULL, NULL) == 0,
         "flux_response_decode topic is optional");
     errno = 0;
-    ok (flux_response_decode (msg, NULL, &s) < 0 && errno == EPROTO,
-        "flux_response_decode returns EPROTO when expected payload is missing");
+    ok (flux_response_decode (msg, NULL, &s) == 0 && s == NULL,
+        "flux_response_decode returns s = NULL when expected payload is missing");
     flux_msg_destroy (msg);
 
     /* without payload (raw) */
@@ -76,8 +76,8 @@ int main (int argc, char *argv[])
         && s != NULL && !strcmp (s, json_str),
         "flux_response_decode returns encoded payload");
     errno = 0;
-    ok (flux_response_decode (msg, NULL, NULL) < 0 && errno == EPROTO,
-        "flux_response_decode returns EPROTO when payload is unexpected");
+    ok (flux_response_decode (msg, NULL, NULL) == 0,
+        "flux_response_decode works with payload but don't want the payload");
     flux_msg_destroy (msg);
 
     /* with raw payload */

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -344,7 +344,6 @@ static int test_broker_connection (ssh_ctx_t *c)
     flux_msg_t *in = NULL;
     flux_msg_t *out = NULL;
     struct flux_match match = FLUX_MATCH_RESPONSE;
-    const char *json_str;
     int rc = -1;
 
     if (!(in = flux_request_encode ("cmb.ping", "{}")))
@@ -354,7 +353,7 @@ static int test_broker_connection (ssh_ctx_t *c)
     match.topic_glob = "cmb.ping";
     if (!(out = flux_recv (c->h, match, 0)))
         goto done;
-    if (flux_response_decode (out, NULL, &json_str) < 0)
+    if (flux_response_decode (out, NULL, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -475,7 +475,7 @@ static void push_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (h, "push: request decode");
         goto done;
     }
-    if (!(in = Jfromstr (json_str))) {
+    if (!json_str || !(in = Jfromstr (json_str))) {
         saved_errno = EPROTO;
         flux_log_error (h, "push: json decode");
         goto done;

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -667,6 +667,11 @@ static void cron_create_handler (flux_t *h, flux_msg_handler_t *w,
         goto done;
     }
 
+    if (!json_str) {
+        saved_errno = EPROTO;
+        goto done;
+    }
+
     if (!(e = cron_entry_create (ctx, json_str))) {
         saved_errno = errno;
         goto done;

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -234,8 +234,12 @@ static void exec_handler (flux_t *h, flux_msg_handler_t *w,
     const char *type;
     json_object *resp = NULL;
 
-    if ((flux_response_decode (msg, &topic, &json_str) < 0)
-        || !(resp = Jfromstr (json_str))) {
+    if (flux_response_decode (msg, &topic, &json_str) < 0) {
+        cron_task_rexec_failed (t, errno);
+        flux_log_error (h, "cron_task: exec_handler");
+    }
+    else if (!json_str || !(resp = Jfromstr (json_str))) {
+        errno = EPROTO;
         cron_task_rexec_failed (t, errno);
         flux_log_error (h, "cron_task: exec_handler");
     }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -905,7 +905,7 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto done;
-    if (!(in = Jfromstr (json_str))) {
+    if (!json_str || !(in = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }
@@ -979,7 +979,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto done;
-    if (!(in = Jfromstr (json_str))) {
+    if (!json_str || !(in = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }
@@ -1056,7 +1056,7 @@ static bool unwatch_cmp (const flux_msg_t *msg, void *arg)
         goto done;
     if (strcmp (sender, p->sender) != 0)
         goto done;
-    if (!(o = Jfromstr (json_str)))
+    if (!json_str || !(o = Jfromstr (json_str)))
         goto done;
     if (kp_twatch_dec (o, &key, &val, &flags) <  0)
         goto done;
@@ -1081,7 +1081,7 @@ static void unwatch_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto done;
-    if (!(in = Jfromstr (json_str))) {
+    if (!json_str || !(in = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }
@@ -1243,8 +1243,9 @@ static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (h, "%s request decode", __FUNCTION__);
         goto done;
     }
-    if (!(in = Jfromstr (json_str))
-                    || kp_tfence_dec (in, &name, &nprocs, &flags, &ops) < 0) {
+    if (!json_str
+        || !(in = Jfromstr (json_str))
+        || kp_tfence_dec (in, &name, &nprocs, &flags, &ops) < 0) {
         errno = EPROTO;
         flux_log_error (h, "%s payload decode", __FUNCTION__);
         goto done;
@@ -1296,7 +1297,7 @@ static void fence_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto error;
-    if (!(in = Jfromstr (json_str))) {
+    if (!json_str || !(in = Jfromstr (json_str))) {
         errno = EPROTO;
         goto error;
     }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1430,7 +1430,7 @@ static void error_event_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (ctx->h, "%s: flux_event_decode", __FUNCTION__);
         goto done;
     }
-    if (!(out = Jfromstr (json_str))) {
+    if (!json_str || !(out = Jfromstr (json_str))) {
         errno = EPROTO;
         flux_log_error (ctx->h, "%s: json_decode", __FUNCTION__);
         goto done;
@@ -1480,7 +1480,7 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (ctx->h, "%s: flux_event_decode", __FUNCTION__);
         goto done;
     }
-    if (!(out = Jfromstr (json_str))) {
+    if (!json_str || !(out = Jfromstr (json_str))) {
         errno = EPROTO;
         flux_log_error (ctx->h, "%s: json decode", __FUNCTION__);
         goto done;

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -695,7 +695,7 @@ static void watch_response_cb (flux_t *h, flux_msg_handler_t *w,
         goto done;
     if (flux_msg_get_matchtag (msg, &matchtag) < 0)
         goto done;
-    if (!(out = Jfromstr (json_str))) {
+    if (!json_str || !(out = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }
@@ -750,7 +750,7 @@ static int watch_rpc (flux_t *h, const char *key, json_object **val,
         goto done;
     if (flux_response_decode (response_msg, NULL, &json_str) < 0)
         goto done;
-    if (!(out = Jfromstr (json_str))) {
+    if (!json_str || !(out = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }

--- a/src/modules/kvs/libkvs.c
+++ b/src/modules/kvs/libkvs.c
@@ -274,7 +274,7 @@ static int getobj (flux_t *h, json_object *rootdir, const char *key,
         goto done;
     if (flux_rpc_get (rpc, &json_str) < 0)
         goto done;
-    if (!(out = Jfromstr (json_str))) {
+    if (!json_str || !(out = Jfromstr (json_str))) {
         errno = EPROTO;
         goto done;
     }
@@ -1357,16 +1357,15 @@ done:
 int kvs_wait_version (flux_t *h, int version)
 {
     flux_rpc_t *rpc;
-    const char *json_str;
     int ret = -1;
 
     if (!(rpc = flux_rpcf (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i }",
                            "rootseq", version)))
         goto done;
-    if (flux_rpc_get (rpc, &json_str) < 0)
-        goto done;
-    /* N.B. response contains (rootseq, rootdir) but we don't use it.
+    /* N.B. response contains (rootseq, rootdir) but we don't need it.
      */
+    if (flux_rpc_get (rpc, NULL) < 0)
+        goto done;
     ret = 0;
 done:
     flux_rpc_destroy (rpc);

--- a/src/modules/libjsc/jstatctl.c
+++ b/src/modules/libjsc/jstatctl.c
@@ -184,6 +184,10 @@ static int lwj_kvs_path (flux_t *h, int64_t id, char **pathp)
     }
     Jput (o);
     o = NULL;
+    if (!json_str) {
+        flux_log (h, LOG_ERR, "flux_rpc (job.kvspath): empty payload");
+        goto out;
+    }
     if (!(o = Jfromstr (json_str))) {
         flux_log_error (h, "flux_rpc (job.kvspath): failed to parse json");
         goto out;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -251,13 +251,12 @@ out:
 static bool ping_sched (flux_t *h)
 {
     bool retval = false;
-    const char *s;
     flux_rpc_t *rpc;
     if (!(rpc = flux_rpcf (h, "sched.ping", 0, 0, "{s:i}", "seq", 0))) {
         flux_log_error (h, "ping_sched");
         goto out;
     }
-    if (flux_rpc_get (rpc, &s) >= 0)
+    if (flux_rpc_get (rpc, NULL) >= 0)
         retval = true;
 out:
     flux_rpc_destroy (rpc);

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -305,7 +305,7 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
     int fail_errno_last = 0;
     do {
         if (flux_rpc_get_nodeid (r, &nodeid) < 0
-                || flux_rpc_get (r, &json_str) < 0) {
+                || flux_rpc_get (r, NULL) < 0) {
             fail_errno_last = errno;
             fail_nodeid_last = nodeid;
             fail_count++;

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -70,6 +70,10 @@ void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
         errnum = errno;
         goto done;
     }
+    if (!json_str) {
+        errnum = EPROTO;
+        goto done;
+    }
 done:
     (void)flux_respond (h, msg, errnum, json_str);
 }
@@ -80,9 +84,14 @@ void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
+    const char *json_str;
 
-    if (flux_request_decode (msg, NULL, NULL) < 0) {
+    if (flux_request_decode (msg, NULL, &json_str) < 0) {
         errnum = errno;
+        goto done;
+    }
+    if (json_str) {
+        errnum = EPROTO;
         goto done;
     }
     hello_count++;

--- a/t/loop/multrpc.c
+++ b/t/loop/multrpc.c
@@ -93,12 +93,18 @@ done:
 void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
                         const flux_msg_t *msg, void *arg)
 {
-    if (flux_request_decodef (msg, NULL, "{}") < 0) {
+    int errnum = 0;
+
+    if (flux_request_decodef (msg, NULL, "{ ! }") < 0) {
+        errnum = errno;
         goto done;
     }
     hello_count++;
 done:
-    (void)flux_respondf (h, msg, "{}");
+    if (errnum)
+        (void)flux_respond (h, msg, errnum, NULL);
+    else
+        (void)flux_respondf (h, msg, "{}");
 }
 
 /* then test - add nodeid to 'then_ns' */
@@ -403,6 +409,18 @@ void rpcftest_begin_cb (flux_t *h, flux_msg_handler_t *w,
         "flux_rpc_getf works");
     ok (hello_count == old_count + 1,
         "rpc was called once");
+    flux_rpc_destroy (r);
+
+    /* cause remote EPROTO (unexpected payload) - picked up in _getf() */
+    ok ((r = flux_rpcf_multi (h, "rpcftest.hello", "all", 0,
+                              "{ s:i }", "foo", 42)) != NULL,
+        "flux_rpcf_multi [0] with unexpected payload works, at first");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_getf (r, "{}") < 0
+        && errno == EPROTO,
+        "flux_rpc_getf fails with EPROTO");
     flux_rpc_destroy (r);
 
     /* fake that we have a larger session */

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -83,6 +83,22 @@ done:
     (void)flux_respond (h, msg, errnum, NULL);
 }
 
+void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
+                        const flux_msg_t *msg, void *arg)
+{
+    int errnum = 0;
+
+    if (flux_request_decodef (msg, NULL, "{ ! }") < 0) {
+        errnum = errno;
+        goto done;
+    }
+ done:
+    if (errnum)
+        (void)flux_respond (h, msg, errnum, NULL);
+    else
+        (void)flux_respondf (h, msg, "{}");
+}
+
 void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
@@ -165,6 +181,18 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
         "and service returned incremented value");
     flux_rpc_destroy (r);
 
+    /* cause remote EPROTO (unexpected payload) - will be picked up in _getf() */
+    ok ((r = flux_rpcf (h, "rpcftest.hello", FLUX_NODEID_ANY, 0,
+                        "{ s:i }", "foo", 42)) != NULL,
+        "flux_rpcf with payload when none is expected works, at first");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_getf (r, "{}") < 0
+        && errno == EPROTO,
+        "flux_rpc_getf fails with EPROTO");
+    flux_rpc_destroy (r);
+
     flux_reactor_stop (flux_get_reactor (h));
 }
 
@@ -199,6 +227,7 @@ static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,   "rpctest.incr",           rpctest_incr_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.begin",          rpctest_begin_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb},
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",         rpcftest_hello_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.rawecho",        rpctest_rawecho_cb},
     { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb},

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -49,6 +49,10 @@ void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
         errnum = errno;
         goto done;
     }
+    if (!json_str) {
+        errnum = EPROTO;
+        goto done;
+    }
 done:
     (void)flux_respond (h, msg, errnum, json_str);
 }
@@ -74,9 +78,14 @@ void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
+    const char *json_str;
 
-    if (flux_request_decode (msg, NULL, NULL) < 0) {
+    if (flux_request_decode (msg, NULL, &json_str) < 0) {
         errnum = errno;
+        goto done;
+    }
+    if (json_str) {
+        errnum = EPROTO;
         goto done;
     }
 done:

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -102,6 +102,7 @@ void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
 void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
+    json_object *o;
     const char *json_str;
     flux_rpc_t *r;
 
@@ -141,6 +142,33 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
         && errno == EPROTO,
         "flux_rpc_get fails with EPROTO");
     flux_rpc_destroy (r);
+
+    /* cause local EPROTO (user incorrectly expects payload) */
+    ok ((r = flux_rpc (h, "rpctest.hello", NULL, FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with empty payload works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_get (r, &json_str) < 0
+        && errno == EPROTO,
+        "flux_rpc_get fails with EPROTO");
+    flux_rpc_destroy (r);
+
+    /* cause local EPROTO (user incorrectly expects empty payload) */
+    errno = 0;
+    o = Jnew ();
+    Jadd_int (o, "foo", 42);
+    json_str = Jtostr (o);
+    ok ((r = flux_rpc (h, "rpctest.echo", json_str, FLUX_NODEID_ANY, 0)) != NULL,
+        "flux_rpc with payload works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_get (r, NULL) < 0
+        && errno == EPROTO,
+        "flux_rpc_get fails with EPROTO");
+    flux_rpc_destroy (r);
+    Jput (o);
 
     /* working with-payload RPC */
     ok ((r = flux_rpc (h, "rpctest.echo", "{}", FLUX_NODEID_ANY, 0)) != NULL,
@@ -189,6 +217,29 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
         "flux_rpc_check says get would block");
     errno = 0;
     ok (flux_rpc_getf (r, "{}") < 0
+        && errno == EPROTO,
+        "flux_rpc_getf fails with EPROTO");
+    flux_rpc_destroy (r);
+
+    /* cause local EPROTO (user incorrectly expects payload) */
+    ok ((r = flux_rpcf (h, "rpcftest.hello", FLUX_NODEID_ANY, 0, "{}")) != NULL,
+        "flux_rpcf with empty payload works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_getf (r, "{ s:i }", "foo", &i) < 0
+        && errno == EPROTO,
+        "flux_rpc_getf fails with EPROTO");
+    flux_rpc_destroy (r);
+
+    /* cause local EPROTO (user incorrectly expects empty payload) */
+    errno = 0;
+    ok ((r = flux_rpcf (h, "rpctest.echo", FLUX_NODEID_ANY, 0, "{ s:i }", "foo", 42)) != NULL,
+        "flux_rpcf with payload works");
+    ok (flux_rpc_check (r) == false,
+        "flux_rpc_check says get would block");
+    errno = 0;
+    ok (flux_rpc_getf (r, "{ ! }") < 0
         && errno == EPROTO,
         "flux_rpc_getf fails with EPROTO");
     flux_rpc_destroy (r);

--- a/t/loop/rpc.c
+++ b/t/loop/rpc.c
@@ -143,18 +143,18 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
         "flux_rpc_get fails with EPROTO");
     flux_rpc_destroy (r);
 
-    /* cause local EPROTO (user incorrectly expects payload) */
+    /* receive NULL payload on empty response */
     ok ((r = flux_rpc (h, "rpctest.hello", NULL, FLUX_NODEID_ANY, 0)) != NULL,
         "flux_rpc with empty payload works");
     ok (flux_rpc_check (r) == false,
         "flux_rpc_check says get would block");
     errno = 0;
-    ok (flux_rpc_get (r, &json_str) < 0
-        && errno == EPROTO,
-        "flux_rpc_get fails with EPROTO");
+    ok (flux_rpc_get (r, &json_str) == 0
+        && json_str == NULL,
+        "flux_rpc_get gets NULL payload on empty response");
     flux_rpc_destroy (r);
 
-    /* cause local EPROTO (user incorrectly expects empty payload) */
+    /* flux_rpc_get is ok if user doesn't desire response payload */
     errno = 0;
     o = Jnew ();
     Jadd_int (o, "foo", 42);
@@ -164,9 +164,8 @@ void rpctest_begin_cb (flux_t *h, flux_msg_handler_t *w,
     ok (flux_rpc_check (r) == false,
         "flux_rpc_check says get would block");
     errno = 0;
-    ok (flux_rpc_get (r, NULL) < 0
-        && errno == EPROTO,
-        "flux_rpc_get fails with EPROTO");
+    ok (flux_rpc_get (r, NULL) == 0,
+        "flux_rpc_get is ok if user doesn't desire response payload");
     flux_rpc_destroy (r);
     Jput (o);
 

--- a/t/module/parent.c
+++ b/t/module/parent.c
@@ -126,6 +126,10 @@ static void insmod_request_cb (flux_t *h, flux_msg_handler_t *w,
         saved_errno = errno;
         goto done;
     }
+    if (!json_str) {
+        saved_errno = EPROTO;
+        goto done;
+    }
     if (flux_insmod_json_decode (json_str, &path, &argz, &argz_len) < 0) {
         saved_errno = errno;
         goto done;
@@ -154,6 +158,10 @@ static void rmmod_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, &json_str) < 0) {
         saved_errno = errno;
+        goto done;
+    }
+    if (!json_str) {
+        saved_errno = EPROTO;
         goto done;
     }
     if (flux_rmmod_json_decode (json_str, &name) < 0) {

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -283,8 +283,10 @@ void ping_response_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (h, "%s: flux_response_decode", __FUNCTION__);
         goto done;
     }
-    if (!(o = Jfromstr (json_str)) || !Jget_int (o, "seq", &seq)
-                                   || !Jget_str (o, "route", &route)) {
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_int (o, "seq", &seq)
+        || !Jget_str (o, "route", &route)) {
         errno = EPROTO;
         flux_log_error (h, "%s: payload", __FUNCTION__);
         goto done;

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -119,8 +119,10 @@ void sink_request_cb (flux_t *h, flux_msg_handler_t *w,
         saved_errno = errno;
         goto done;
     }
-    if (!(o = Jfromstr (json_str)) || !Jget_double (o, "pi", &d)
-                                   || d != 3.14) {
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_double (o, "pi", &d)
+        || d != 3.14) {
         saved_errno = errno = EPROTO;
         goto done;
     }
@@ -159,7 +161,9 @@ void nsrc_request_cb (flux_t *h, flux_msg_handler_t *w,
         saved_errno = errno;
         goto done;
     }
-    if (!(o = Jfromstr (json_str)) || !Jget_int (o, "count", &count)) {
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_int (o, "count", &count)) {
         saved_errno = errno = EPROTO;
         goto done;
     }
@@ -202,6 +206,10 @@ void echo_request_cb (flux_t *h, flux_msg_handler_t *w,
         saved_errno = errno;
         goto done;
     }
+    if (!json_str) {
+        saved_errno = EPROTO;
+        goto done;
+    }
     rc = 0;
 done:
     if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
@@ -228,8 +236,10 @@ void xping_request_cb (flux_t *h, flux_msg_handler_t *w,
         saved_errno = errno;
         goto error;
     }
-    if (!(o = Jfromstr (json_str)) || !Jget_int (o, "rank", &rank)
-                                   || !Jget_str (o, "service", &service)) {
+    if (!json_str
+        || !(o = Jfromstr (json_str))
+        || !Jget_int (o, "rank", &rank)
+        || !Jget_str (o, "service", &service)) {
         saved_errno = errno = EPROTO;
         goto error;
     }

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -157,8 +157,10 @@ void test_echo (flux_t *h, uint32_t nodeid)
     if (!(rpc = flux_rpc (h, "req.echo", Jtostr (in), nodeid, 0))
              || flux_rpc_get (rpc, &json_str) < 0)
         log_err_exit ("%s", __FUNCTION__);
-    if (!(out = Jfromstr (json_str)) || !Jget_str (out, "mumble", &s)
-                                     || strcmp (s, "burble") != 0)
+    if (!json_str
+        || !(out = Jfromstr (json_str))
+        || !Jget_str (out, "mumble", &s)
+        || strcmp (s, "burble") != 0)
         log_msg_exit ("%s: returned payload wasn't an echo", __FUNCTION__);
     Jput (in);
     Jput (out);
@@ -188,7 +190,10 @@ void test_src (flux_t *h, uint32_t nodeid)
     if (!(rpc = flux_rpc (h, "req.src", NULL, nodeid, 0))
              || flux_rpc_get (rpc, &json_str) < 0)
         log_err_exit ("%s", __FUNCTION__);
-    if (!(out = Jfromstr (json_str)) || !Jget_int (out, "wormz", &i) || i != 42)
+    if (!json_str
+        || !(out = Jfromstr (json_str))
+        || !Jget_int (out, "wormz", &i)
+        || i != 42)
         log_msg_exit ("%s: didn't get expected payload", __FUNCTION__);
     Jput (out);
     flux_rpc_destroy (rpc);
@@ -325,7 +330,9 @@ static void xping (flux_t *h, uint32_t nodeid, uint32_t xnodeid, const char *svc
     if (!(rpc = flux_rpc (h, "req.xping", Jtostr (in), nodeid, 0))
             || flux_rpc_get (rpc, &json_str) < 0)
         log_err_exit ("req.xping");
-    if (!(out = Jfromstr (json_str)) || !Jget_str (out, "route", &route))
+    if (!json_str
+        || !(out = Jfromstr (json_str))
+        || !Jget_str (out, "route", &route))
         log_errn_exit (EPROTO, "req.xping");
     printf ("hops=%d\n", count_hops (route));
     Jput (out);
@@ -403,7 +410,9 @@ int req_count (flux_t *h, uint32_t nodeid)
     if (!(rpc = flux_rpc (h, "req.count", NULL, nodeid, 0))
              || flux_rpc_get (rpc, &json_str) < 0)
         goto done;
-    if (!(out = Jfromstr (json_str)) || !Jget_int (out, "count", &count)) {
+    if (!json_str
+        || !(out = Jfromstr (json_str))
+        || !Jget_int (out, "count", &count)) {
         errno = EPROTO;
         goto done;
     }

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -227,7 +227,9 @@ void test_nsrc (flux_t *h, uint32_t nodeid)
             log_err_exit ("%s", __FUNCTION__);
         if (flux_response_decode (msg, NULL, &json_str) < 0)
             log_msg_exit ("%s: decode %d", __FUNCTION__, i);
-        if (!(out = Jfromstr (json_str)) || !Jget_int (out, "seq", &seq))
+        if (!json_str
+            || !(out = Jfromstr (json_str))
+            || !Jget_int (out, "seq", &seq))
             log_msg_exit ("%s: decode %d payload", __FUNCTION__, i);
         if (seq != i)
             log_msg_exit ("%s: decode %d - seq mismatch %d", __FUNCTION__, i, seq);
@@ -270,7 +272,9 @@ void test_putmsg (flux_t *h, uint32_t nodeid)
             log_err_exit ("%s", __FUNCTION__);
         if (flux_response_decode (msg, NULL, &json_str) < 0)
             log_msg_exit ("%s: decode", __FUNCTION__);
-        if (!(out = Jfromstr (json_str)) || !Jget_int (out, "seq", &seq))
+        if (!json_str
+            || !(out = Jfromstr (json_str))
+            || !Jget_int (out, "seq", &seq))
             log_msg_exit ("%s: decode - payload", __FUNCTION__);
         Jput (out);
         if (seq >= defer_start && seq < defer_start + defer_count && !popped) {


### PR DESCRIPTION
Re-architect the API style of ```flux_response_decode()```, ```flux_rpc_get()```, ```flux_request_decode()```, and ```flux_event_decode()```.  Previously, user was required to pass in a payload pointer that matched the message payload existence (i.e. non-NULL pointer if payload is in the message, NULL pointer if a payload is not available).  Mismatched pointer + payload existence lead to EPROTO errors.

Now, the user can safely pass in a pointer or not, regardless if a payload is available.  For example, if a payload is sent, but the caller does not care about it, the caller can now safely pass in a NULL pointer indicating they do not care about the payload.  If the user was expecting a payload, they should check the payload pointer for != NULL to ensure payload data was received.
