### PR TITLE
add unit tests for cleanup functions

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -48,6 +48,8 @@ libutil_la_SOURCES = \
 	msglist.h \
 	cleanup.c \
 	cleanup.h \
+	unlink_recursive.c \
+	unlink_recursive.h \
 	sds.c \
 	sds.h \
 	sdsalloc.h \

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -97,6 +97,7 @@ TESTS = test_nodeset.t \
 	test_veb.t \
 	test_lru_cache.t \
 	test_unlink.t \
+	test_cleanup.t \
 	test_blobref.t
 
 test_ldadd = \
@@ -185,3 +186,7 @@ test_blobref_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
 test_unlink_t_SOURCES = test/unlink.c
 test_unlink_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
 test_unlink_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
+
+test_cleanup_t_SOURCES = test/cleanup.c
+test_cleanup_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
+test_cleanup_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -96,6 +96,7 @@ TESTS = test_nodeset.t \
 	test_stdlog.t \
 	test_veb.t \
 	test_lru_cache.t \
+	test_unlink.t \
 	test_blobref.t
 
 test_ldadd = \
@@ -180,3 +181,7 @@ test_lru_cache_t_LDADD = $(test_ldadd)
 test_blobref_t_SOURCES = test/blobref.c
 test_blobref_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
 test_blobref_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
+
+test_unlink_t_SOURCES = test/unlink.c
+test_unlink_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
+test_unlink_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)

--- a/src/common/libutil/cleanup.c
+++ b/src/common/libutil/cleanup.c
@@ -28,22 +28,15 @@
 
 #include "cleanup.h"
 #include "xzmalloc.h"
+#include "unlink_recursive.h"
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <fcntl.h>
-#include <dirent.h>
 #include <libgen.h>
 #include <unistd.h>
 #include <pthread.h>
 
 #include <czmq.h>
-
-#ifndef O_PATH
-#define O_PATH 0 /* O_PATH is too new for CentOS 6 - see issue #646 */
-#endif
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -51,40 +44,6 @@ struct cleaner {
     cleaner_fun_f * fun;
     void * arg;
 };
-
-static void unlinkat_recursive (int fd)
-{
-    DIR *dir;
-    struct dirent *d, entry;
-    struct stat sb;
-    int cfd;
-
-    if ((dir = fdopendir (fd))) {
-        while (readdir_r (dir, &entry, &d) == 0 && d != NULL) {
-            if (!strcmp (d->d_name, ".") || !strcmp (d->d_name, ".."))
-                continue;
-            if (fstatat (fd, d->d_name, &sb, AT_SYMLINK_NOFOLLOW) < 0)
-                continue;
-            if (S_ISDIR (sb.st_mode)) {
-                if ((cfd = openat (fd, d->d_name, O_PATH | O_DIRECTORY)) < 0)
-                    continue;
-                unlinkat_recursive (cfd);
-                (void)unlinkat (fd, d->d_name, AT_REMOVEDIR);
-            } else
-                (void)unlinkat (fd, d->d_name, 0);
-        }
-        closedir (dir);
-    }
-}
-
-static void unlink_recursive (const char *dirpath)
-{
-    DIR *dir = opendir (dirpath);
-    if (dir) {
-        unlinkat_recursive (dirfd (dir));
-        (void)rmdir (dirpath);
-    }
-}
 
 void cleanup_directory_recursive (const struct cleaner *c)
 {

--- a/src/common/libutil/cleanup.c
+++ b/src/common/libutil/cleanup.c
@@ -106,7 +106,7 @@ void cleanup_file (const struct cleaner *c)
 
 static pid_t cleaner_pid = 0;
 static zlist_t *cleanup_list = NULL;
-static void cleanup (void)
+void cleanup_run (void)
 {
     struct cleaner *c;
     pthread_mutex_lock(&mutex);
@@ -139,7 +139,7 @@ void cleanup_push (cleaner_fun_f *fun, void * arg)
         }
         cleanup_list = zlist_new();
         cleaner_pid = getpid();
-        atexit(cleanup);
+        atexit (cleanup_run);
     }
     struct cleaner * c = calloc(sizeof(struct cleaner), 1);
     c->fun = fun;

--- a/src/common/libutil/cleanup.h
+++ b/src/common/libutil/cleanup.h
@@ -31,3 +31,5 @@ void cleanup_file (const struct cleaner *c);
 
 void cleanup_push (cleaner_fun_f *fun, void * arg);
 void cleanup_push_string (cleaner_fun_f *fun, const char * path);
+
+void cleanup_run (void);

--- a/src/common/libutil/test/cleanup.c
+++ b/src/common/libutil/test/cleanup.c
@@ -1,0 +1,132 @@
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/unlink_recursive.h"
+#include "src/common/libutil/cleanup.h"
+
+int main(int argc, char** argv)
+{
+    const char *tmp = getenv ("TMPDIR");
+    char file[PATH_MAX];
+    char dir[PATH_MAX];
+    char dir2[PATH_MAX];
+    struct stat sb;
+    int fd;
+
+    plan (NO_PLAN);
+
+    /* Independent file and dir
+     */
+    snprintf (file, sizeof (file), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!(fd = mkstemp (file)))
+        BAIL_OUT ("could not create tmp file");
+    close (fd);
+
+    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (dir))
+        BAIL_OUT ("could not create tmp directory");
+
+    cleanup_push_string (cleanup_file, file);
+    cleanup_push_string (cleanup_directory, dir);
+    cleanup_run ();
+    ok (stat (file, &sb) < 0 && errno == ENOENT,
+        "cleanup removed independent file");
+    ok (stat (dir, &sb) < 0 && errno == ENOENT,
+        "cleanup removed independent dir");
+
+    /* This time put file inside directory
+     */
+    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (dir))
+        BAIL_OUT ("could not create tmp directory");
+
+    snprintf (file, sizeof (file), "%s/file", dir);
+    if (!(fd = open (file, O_CREAT, 0644)))
+        BAIL_OUT ("could not create tmp file");
+    close (fd);
+
+    cleanup_push_string (cleanup_directory, dir);
+    cleanup_push_string (cleanup_file, file);
+    cleanup_run ();
+    ok (stat (file, &sb) < 0 && errno == ENOENT,
+        "cleanup removed file pushed second");
+    ok (stat (dir, &sb) < 0 && errno == ENOENT,
+        "cleanup removed dir pushed first");
+
+    /* Same but reverse push order
+     */
+    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (dir))
+        BAIL_OUT ("could not create tmp directory");
+
+    snprintf (file, sizeof (file), "%s/file", dir);
+    if (!(fd = open (file, O_CREAT, 0644)))
+        BAIL_OUT ("could not create tmp file");
+    close (fd);
+
+    cleanup_push_string (cleanup_file, file);
+    cleanup_push_string (cleanup_directory, dir);
+    cleanup_run ();
+    ok (stat (dir, &sb) == 0,
+        "cleanup failed to remove dir pushed first");
+    ok (stat (file, &sb) < 0 && errno == ENOENT,
+        "cleanup removed file pushed second (1 deep)");
+
+    (void)unlink (dir);
+
+    /* Same but recursive removal
+     */
+    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (dir))
+        BAIL_OUT ("could not create tmp directory");
+
+    snprintf (file, sizeof (file), "%s/file", dir);
+    if (!(fd = open (file, O_CREAT, 0644)))
+        BAIL_OUT ("could not create tmp file");
+    close (fd);
+
+    cleanup_push_string (cleanup_directory_recursive, dir);
+    cleanup_run ();
+
+    ok (stat (file, &sb) < 0 && errno == ENOENT,
+        "cleanup removed file not pushed (1 deep)");
+    ok (stat (dir, &sb) < 0 && errno == ENOENT,
+        "cleanup removed pushed dir recursively");
+
+    /* Try couple levels deep
+     */
+    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (dir))
+        BAIL_OUT ("could not create tmp directory");
+    snprintf (dir2, sizeof (dir), "%s/dir", dir);
+    if (mkdir (dir2, 0755) < 0)
+        BAIL_OUT ("mkdir failed");
+
+    snprintf (file, sizeof (file), "%s/file", dir2);
+    if (!(fd = open (file, O_CREAT, 0644)))
+        BAIL_OUT ("could not create tmp file");
+    close (fd);
+
+    cleanup_push_string (cleanup_directory_recursive, dir);
+    cleanup_run ();
+
+    ok (stat (file, &sb) < 0 && errno == ENOENT,
+        "cleanup removed file not pushed (2 deep)");
+    ok (stat (dir2, &sb) < 0 && errno == ENOENT,
+        "cleanup removed dir not pushed (1 deep)");
+    ok (stat (dir, &sb) < 0 && errno == ENOENT,
+        "cleanup removed pushed dir recursively");
+
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/unlink.c
+++ b/src/common/libutil/test/unlink.c
@@ -1,0 +1,82 @@
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/unlink_recursive.h"
+
+int main(int argc, char** argv)
+{
+    const char *tmp = getenv ("TMPDIR");
+    char path[PATH_MAX];
+    char path2[PATH_MAX];
+    int n;
+    struct stat sb;
+    int fd;
+
+    plan (NO_PLAN);
+
+    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (path))
+        BAIL_OUT ("could not create tmp directory");
+
+    n = unlink_recursive (path);
+    errno = 0;
+    ok (n == 1 && stat (path, &sb) < 0 && errno == ENOENT,
+        "cleaned up directory containing nothing");
+
+
+    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (path))
+        BAIL_OUT ("could not create tmp directory");
+    snprintf (path2, sizeof (path2), "%s/a", path);
+    if (mkdir (path2, 0777) < 0)
+        BAIL_OUT ("could not create subdirectory");
+    n = unlink_recursive (path);
+    errno = 0;
+    ok (n == 2 && stat (path, &sb) < 0 && errno == ENOENT,
+        "cleaned up directory containing 1 dir");
+
+
+    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (path))
+        BAIL_OUT ("could not create tmp directory");
+    snprintf (path2, sizeof (path2), "%s/a", path);
+    if (mkdir (path2, 0777) < 0)
+        BAIL_OUT ("could not create subdirectory");
+    snprintf (path2, sizeof (path2), "%s/b", path);
+    if ((fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
+        BAIL_OUT ("could not create subdirectory");
+    n = unlink_recursive (path);
+    errno = 0;
+    ok (n == 3 && stat (path, &sb) < 0 && errno == ENOENT,
+        "cleaned up directory containing 1 dir (empty) + 1 file ");
+
+    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if (!mkdtemp (path))
+        BAIL_OUT ("could not create tmp directory");
+    snprintf (path2, sizeof (path2), "%s/a", path);
+    if (mkdir (path2, 0777) < 0)
+        BAIL_OUT ("could not create subdirectory");
+    snprintf (path2, sizeof (path2), "%s/b", path);
+    if ((fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
+        BAIL_OUT ("could not create subdirectory");
+    snprintf (path2, sizeof (path2), "%s/a/a", path);
+    if ((fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
+        BAIL_OUT ("could not create file in subdirectory");
+    n = unlink_recursive (path);
+    errno = 0;
+    ok (n == 4 && stat (path, &sb) < 0 && errno == ENOENT,
+        "cleaned up directory containing 1 dir (with 1 file) + 1 file ");
+
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/unlink_recursive.c
+++ b/src/common/libutil/unlink_recursive.c
@@ -1,0 +1,81 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <unistd.h>
+
+#include <czmq.h>
+#include "unlink_recursive.h"
+
+#ifndef O_PATH
+#define O_PATH 0 /* O_PATH is too new for CentOS 6 - see issue #646 */
+#endif
+
+static void unlinkat_recursive (int fd)
+{
+    DIR *dir;
+    struct dirent *d, entry;
+    struct stat sb;
+    int cfd;
+
+    if ((dir = fdopendir (fd))) {
+        while (readdir_r (dir, &entry, &d) == 0 && d != NULL) {
+            if (!strcmp (d->d_name, ".") || !strcmp (d->d_name, ".."))
+                continue;
+            if (fstatat (fd, d->d_name, &sb, AT_SYMLINK_NOFOLLOW) < 0)
+                continue;
+            if (S_ISDIR (sb.st_mode)) {
+                if ((cfd = openat (fd, d->d_name, O_PATH | O_DIRECTORY)) < 0)
+                    continue;
+                unlinkat_recursive (cfd);
+                (void)unlinkat (fd, d->d_name, AT_REMOVEDIR);
+            } else
+                (void)unlinkat (fd, d->d_name, 0);
+        }
+        closedir (dir);
+    }
+}
+
+void unlink_recursive (const char *dirpath)
+{
+    DIR *dir = opendir (dirpath);
+    if (dir) {
+        unlinkat_recursive (dirfd (dir));
+        (void)rmdir (dirpath);
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/unlink_recursive.c
+++ b/src/common/libutil/unlink_recursive.c
@@ -38,10 +38,6 @@
 #include <czmq.h>
 #include "unlink_recursive.h"
 
-#ifndef O_PATH
-#define O_PATH 0 /* O_PATH is too new for CentOS 6 - see issue #646 */
-#endif
-
 static int unlinkat_recursive (int fd)
 {
     DIR *dir;
@@ -57,7 +53,7 @@ static int unlinkat_recursive (int fd)
             if (fstatat (fd, d->d_name, &sb, AT_SYMLINK_NOFOLLOW) < 0)
                 continue;
             if (S_ISDIR (sb.st_mode)) {
-                if ((cfd = openat (fd, d->d_name, O_PATH | O_DIRECTORY)) < 0)
+                if ((cfd = openat (fd, d->d_name, O_DIRECTORY)) < 0)
                     continue;
                 count += unlinkat_recursive (cfd);
                 if (unlinkat (fd, d->d_name, AT_REMOVEDIR) == 0)

--- a/src/common/libutil/unlink_recursive.h
+++ b/src/common/libutil/unlink_recursive.h
@@ -1,4 +1,6 @@
-void unlink_recursive (const char *dirpath);
+/* Return number of files/directories unlinked or -1 on error.
+ */
+int unlink_recursive (const char *dirpath);
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/unlink_recursive.h
+++ b/src/common/libutil/unlink_recursive.h
@@ -1,0 +1,6 @@
+void unlink_recursive (const char *dirpath);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This PR was originally in #1013 but wasn't quite on topic there, hence was broken out.

After the reactor exits, the broker sets up a SIGALRM handler in case its last ditch attempts to unload modules hangs.  This signal handler calls `exit()` which causes any registered `atexit()` functions to run, including one to clean up temporary files and `zsys_shutdown()` to close dangling zeromq sockets.  This latter one is installed automatically through the use of various libczmq classes.

`zsys_shutdown()`  has an internal mutex that would appear to only protect against concurrent calls to itself, not against calls to other socket operations.  Since zeromq sockets are not thread safe, this can lead to segfaults.  This became evident in PR #1013 when converting from zsocket to zsock classes.

To avoid calling this function from the SIGALARM handler where comms modules may still be shutting down, replace the call to `exit()` with `_exit()`.  We _do_ however still want to clean up temporary files, so expose `cleanup_run()` and call it manually from the signal handler.

The `unlink_recursive()` function called by `cleanup_run()` is generally useful and has no tests, so break it out to its own libutil source module and add a test.  Fix a bug discovered by the test.