### PR TITLE
improve reliability of module unloading

### DIFF
--- a/etc/rc3
+++ b/etc/rc3
@@ -21,7 +21,7 @@ flux module remove -r 0 userdb
 flux module remove -r 0 cron
 flux module remove -r all job
 flux module remove -r all resource-hwloc
-
+flux module remove -r all aggregator
 flux module remove -r all kvs
 flux module remove -r all barrier
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -197,8 +197,6 @@ static int boot_pmi (broker_ctx_t *ctx, double *elapsed_sec);
 static int attr_get_snoop (const char *name, const char **val, void *arg);
 static int attr_get_overlay (const char *name, const char **val, void *arg);
 
-static void sigalrm_cb (int signum);
-
 static void init_attrs (broker_ctx_t *ctx);
 
 static const struct flux_handle_ops broker_handle_ops;
@@ -702,15 +700,6 @@ int main (int argc, char *argv[])
         log_err_exit ("sigaction");
     if (sigaction (SIGTERM, &old_sigact_term, NULL) < 0)
         log_err_exit ("sigaction");
-    /* Install SIGALRM handler and set timer in case we get stuck.
-     */
-    struct sigaction sigact_alrm = {
-        .sa_handler = sigalrm_cb,
-        .sa_flags = 0,
-    };
-    if (sigaction (SIGALRM, &sigact_alrm, NULL) < 0)
-        log_err_exit ("sigaction");
-    alarm (1); // 1s to tear down
 
     /* remove heartbeat timer, if any
      */
@@ -834,13 +823,6 @@ static void hello_update_cb (hello_t *hello, void *arg)
         flux_log (ctx->h, LOG_INFO, "wireup: %d/%d (incomplete) %.1fs",
                   hello_get_count (hello), ctx->size, hello_get_time (hello));
     }
-}
-
-/* Signal handler teardown timeout.
- */
-static void sigalrm_cb (int signum)
-{
-    exit (exit_rc);
 }
 
 /* Currently 'expired' is always true.

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -84,8 +84,6 @@
 #define zsocket_set_immediate   zsocket_set_delay_attach_on_connect
 #endif
 
-const char *default_modules = "connector-local";
-
 typedef enum {
     ERROR_MODE_RESPOND,
     ERROR_MODE_RETURN,
@@ -178,7 +176,11 @@ static void broker_unhandle_signals (zlist_t *sigwatchers);
 
 static void broker_add_services (broker_ctx_t *ctx);
 
-static void load_modules (broker_ctx_t *ctx, const char *default_modules);
+static int load_module_byname (broker_ctx_t *ctx, const char *name,
+                               const char *argz, size_t argz_len,
+                               const flux_msg_t *request);
+static int unload_module_byname (broker_ctx_t *ctx, const char *name,
+                                 const flux_msg_t *request, bool async);
 
 static void update_proctitle (broker_ctx_t *ctx);
 static void runlevel_cb (runlevel_t *r, int level, int rc, double elapsed,
@@ -646,15 +648,22 @@ int main (int argc, char *argv[])
 
     broker_add_services (&ctx);
 
-    /* Load default modules
+    /* Initialize comms module infrastructure.
      */
     if (ctx.verbose)
-        log_msg ("loading default modules");
+        log_msg ("initializing modules");
     modhash_set_zctx (ctx.modhash, ctx.zctx);
     modhash_set_rank (ctx.modhash, ctx.rank);
     modhash_set_flux (ctx.modhash, ctx.h);
     modhash_set_heartbeat (ctx.modhash, ctx.heartbeat);
-    load_modules (&ctx, default_modules);
+    /* Load the local connector module.
+     * Other modules will be loaded in rc1 using flux module,
+     * which uses the local connector.
+     */
+    if (ctx.verbose)
+        log_msg ("loading connector-local");
+    if (load_module_byname (&ctx, "connector-local", NULL, 0, NULL) < 0)
+        log_err_exit ("load_module connector-local");
 
     /* install heartbeat (including timer on rank 0)
      */
@@ -710,7 +719,11 @@ int main (int argc, char *argv[])
     /* Unload modules.
      */
     if (ctx.verbose)
-        log_msg ("unloading modules");
+        log_msg ("unloading connector-local");
+    if (unload_module_byname (&ctx, "connector-local", NULL, false) < 0)
+        log_err ("unload connector-local");
+    if (ctx.verbose)
+        log_msg ("finalizing modules");
     modhash_destroy (ctx.modhash);
 
     /* Unregister builtin services
@@ -1320,53 +1333,97 @@ static int mod_svc_cb (const flux_msg_t *msg, void *arg)
     return rc;
 }
 
-/* Load command line/default comms modules.  If module name contains
- * one or more '/' characters, it refers to a .so path.
- */
-static void load_modules (broker_ctx_t *ctx, const char *default_modules)
+static int load_module_bypath (broker_ctx_t *ctx, const char *path,
+                               const char *argz, size_t argz_len,
+                               const flux_msg_t *request)
 {
-    char *cpy = xstrdup (default_modules);
-    char *s, *saveptr = NULL, *a1 = cpy;
+    module_t *p = NULL;
+    char *name, *arg;
+
+    if (!(name = flux_modname (path))) {
+        errno = ENOENT;
+        goto error;
+    }
+    if (!(p = module_add (ctx->modhash, path)))
+        goto error;
+    if (!svc_add (ctx->services, module_get_name (p),
+                                 module_get_service (p), mod_svc_cb, p)) {
+        errno = EEXIST;
+        goto error;
+    }
+    arg = argz_next (argz, argz_len, NULL);
+    while (arg) {
+        module_add_arg (p, arg);
+        arg = argz_next (argz, argz_len, arg);
+    }
+    module_set_poller_cb (p, module_cb, ctx);
+    module_set_status_cb (p, module_status_cb, ctx);
+    if (request && module_push_insmod (p, request) < 0) // response deferred
+        goto error;
+    if (module_start (p) < 0)
+        goto error;
+    flux_log (ctx->h, LOG_DEBUG, "insmod %s", name);
+    free (name);
+    return 0;
+error:
+    if (p)
+        module_remove (ctx->modhash, p);
+    free (name);
+    return -1;
+}
+
+static int load_module_byname (broker_ctx_t *ctx, const char *name,
+                               const char *argz, size_t argz_len,
+                               const flux_msg_t *request)
+{
     const char *modpath;
+    char *path;
+
+    if (attr_get (ctx->attrs, "conf.module_path", &modpath, NULL) < 0) {
+        log_msg ("conf.module_path is not set");
+        return -1;
+    }
+    if (!(path = flux_modfind (modpath, name))) {
+        log_msg ("%s: not found in module search path", name);
+        return -1;
+    }
+    if (load_module_bypath (ctx, path, argz, argz_len, request) < 0) {
+        free (path);
+        return -1;
+    }
+    free (path);
+    return 0;
+}
+
+/* If 'async' is true, service de-registration and module
+ * destruction (including join) are deferred until module keepalive
+ * status indicates module main() has exited (via module_status_cb).
+ * This allows modules with distributed shutdown to talk to each
+ * other while they shut down, and also does not block the reactor
+ * from handling other events.  If 'async' is false, do all that
+ * teardown synchronously here.
+ */
+static int unload_module_byname (broker_ctx_t *ctx, const char *name,
+                                 const flux_msg_t *request, bool async)
+{
     module_t *p;
 
-    if (attr_get (ctx->attrs, "conf.module_path", &modpath, NULL) < 0)
-        log_err_exit ("conf.module_path is not set");
-
-    while ((s = strtok_r (a1, ",", &saveptr))) {
-        char *name = NULL;
-        char *path = NULL;
-        char *sp;
-        if ((sp = strchr (s, '['))) {
-            if (!nodeset_member (sp, ctx->rank))
-                goto next;
-            *sp = '\0';
-        }
-        if (strchr (s, '/')) {
-            if (!(name = flux_modname (s)))
-                log_msg_exit ("%s", dlerror ());
-            path = s;
-        } else {
-            if (!(path = flux_modfind (modpath, s)))
-                log_msg_exit ("%s: not found in module search path", s);
-            name = s;
-        }
-        if (!(p = module_add (ctx->modhash, path)))
-            log_err_exit ("%s: module_add %s", name, path);
-        if (!svc_add (ctx->services, module_get_name (p),
-                                     module_get_service (p), mod_svc_cb, p))
-            log_msg_exit ("could not register service %s", module_get_name (p));
-        module_set_poller_cb (p, module_cb, ctx);
-        module_set_status_cb (p, module_status_cb, ctx);
-next:
-        if (name != s)
-            free (name);
-        if (path != s)
-            free (path);
-        a1 = NULL;
+    if (!(p = module_lookup_byname (ctx->modhash, name))) {
+        errno = ENOENT;
+        return -1;
     }
-    module_start_all (ctx->modhash);
-    free (cpy);
+    if (module_stop (p) < 0)
+        return -1;
+    if (async) {
+        if (request && module_push_rmmod (p, request) < 0)
+            return -1;
+    } else {
+        assert (request == NULL);
+        svc_remove (ctx->services, module_get_name (p));
+        module_remove (ctx->modhash, p);
+    }
+    flux_log (ctx->h, LOG_DEBUG, "rmmod %s", name);
+    return 0;
 }
 
 static void broker_handle_signals (broker_ctx_t *ctx, zlist_t *sigwatchers)
@@ -1433,7 +1490,6 @@ static void cmb_rmmod_cb (flux_t *h, flux_msg_handler_t *w,
     broker_ctx_t *ctx = arg;
     const char *json_str;
     char *name = NULL;
-    module_t *p;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto error;
@@ -1443,18 +1499,8 @@ static void cmb_rmmod_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (flux_rmmod_json_decode (json_str, &name) < 0)
         goto error;
-    if (!(p = module_lookup_byname (ctx->modhash, name))) {
-        errno = ENOENT;
+    if (unload_module_byname (ctx, name, msg, true) < 0)
         goto error;
-    }
-    /* N.B. can't remove 'service' entry here as distributed
-     * module shutdown may require inter-rank module communication.
-     */
-    if (module_stop (p) < 0)
-        goto error;
-    if (module_push_rmmod (p, msg) < 0) // response deferred
-        goto error;
-    flux_log (h, LOG_DEBUG, "rmmod %s", name);
     free (name);
     return;
 error:
@@ -1468,11 +1514,9 @@ static void cmb_insmod_cb (flux_t *h, flux_msg_handler_t *w,
 {
     broker_ctx_t *ctx = arg;
     const char *json_str;
-    char *name = NULL;
     char *path = NULL;
     char *argz = NULL;
     size_t argz_len = 0;
-    module_t *p = NULL;
 
     if (flux_request_decode (msg, NULL, &json_str) < 0)
         goto error;
@@ -1482,39 +1526,14 @@ static void cmb_insmod_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (flux_insmod_json_decode (json_str, &path, &argz, &argz_len) < 0)
         goto error;
-    if (!(name = flux_modname (path))) {
-        errno = ENOENT;
+    if (load_module_bypath (ctx, path, argz, argz_len, msg) < 0)
         goto error;
-    }
-    if (!(p = module_add (ctx->modhash, path)))
-        goto error;
-    if (!svc_add (ctx->services, module_get_name (p),
-                                 module_get_service (p), mod_svc_cb, p)) {
-        errno = EEXIST;
-        goto error;
-    }
-    arg = argz_next (argz, argz_len, NULL);
-    while (arg) {
-        module_add_arg (p, arg);
-        arg = argz_next (argz, argz_len, arg);
-    }
-    module_set_poller_cb (p, module_cb, ctx);
-    module_set_status_cb (p, module_status_cb, ctx);
-    if (module_push_insmod (p, msg) < 0) // response deferred
-        goto error;
-    if (module_start (p) < 0)
-        goto error;
-    flux_log (h, LOG_DEBUG, "insmod %s", name);
-    free (name);
     free (path);
     free (argz);
     return;
 error:
     if (flux_respond (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-    if (p)
-        module_remove (ctx->modhash, p);
-    free (name);
     free (path);
     free (argz);
 }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -556,13 +556,13 @@ int main (int argc, char *argv[])
      */
     if (ctx.shutdown_grace == 0) {
         if (ctx.size < 16)
-            ctx.shutdown_grace = 0.5;
-        else if (ctx.size < 128)
             ctx.shutdown_grace = 1;
-        else if (ctx.size < 1024)
+        else if (ctx.size < 128)
             ctx.shutdown_grace = 2;
+        else if (ctx.size < 1024)
+            ctx.shutdown_grace = 4;
         else
-            ctx.shutdown_grace = 5;
+            ctx.shutdown_grace = 10;
     }
 
     if (ctx.verbose) {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -711,7 +711,6 @@ int main (int argc, char *argv[])
      */
     if (ctx.verbose)
         log_msg ("unloading modules");
-    module_stop_all (ctx.modhash);
     modhash_destroy (ctx.modhash);
 
     /* Unregister builtin services

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -86,12 +86,10 @@ module_t *module_lookup_byname (modhash_t *mh, const char *name);
 /* Start module thread.
  */
 int module_start (module_t *p);
-int module_start_all (modhash_t *mh);
 
 /* Stop module thread by sending a shutdown request.
  */
 int module_stop (module_t *p);
-int module_stop_all (modhash_t *mh);
 
 /* Prepare an 'lsmod' response payload.
  */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -90,7 +90,10 @@ EXTRA_DIST= \
 	$(T) \
 	rc/rc1-kvs \
 	rc/rc1-wreck \
-	rc/rc1-testenv
+	rc/rc1-testenv \
+	rc/rc3-kvs \
+	rc/rc3-wreck \
+	rc/rc3-testenv
 
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output

--- a/t/rc/rc3-kvs
+++ b/t/rc/rc3-kvs
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+flux module remove -r all -x 0 kvs
+flux module remove -r 0 kvs
+flux module remove -r 0  content-sqlite

--- a/t/rc/rc3-testenv
+++ b/t/rc/rc3-testenv
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+# t0014-runlevel.t loads rc1-testenv so we need corresponding rc3-testenv

--- a/t/rc/rc3-wreck
+++ b/t/rc/rc3-wreck
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+flux module remove -r all job
+flux module remove -r all aggregator
+flux module remove -r all barrier
+
+flux module remove -r all -x 0 kvs
+flux module remove -r 0 kvs
+flux module remove -r 0  content-sqlite

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -57,8 +57,9 @@ test_under_flux() {
         export FLUX_RC3_PATH=""
     elif test "$personality" != "full"; then
         export FLUX_RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
-        export FLUX_RC3_PATH=""
-        test -x $FLUX_RC1_PATH || error "$FLUX_RC1_PATH"
+        export FLUX_RC3_PATH=$FLUX_SOURCE_DIR/t/rc/rc3-$personality
+        test -x $FLUX_RC1_PATH || error "cannot execute $FLUX_RC1_PATH"
+        test -x $FLUX_RC3_PATH || error "cannot execute $FLUX_RC3_PATH"
     else
         unset FLUX_RC1_PATH
         unset FLUX_RC3_PATH

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -67,7 +67,7 @@ test_under_flux() {
 
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --size=${size} ${quiet} "sh $0 ${flags}"
+      exec flux start --bootstrap=selfpmi --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
 mock_bootstrap_instance() {

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -139,6 +139,22 @@ test_expect_success 'broker broker.pid attribute is readable' '
 test_expect_success 'broker broker.pid attribute is immutable' '
 	test_must_fail flux start -o,--setattr=broker.pid=1234 flux getattr broker.pid
 '
+test_expect_success 'broker --verbose option works' '
+	flux start -o,-v /bin/true
+'
+test_expect_success 'broker --shutdown-grace option works' '
+	flux start -o,--shutdown-grace=0.1 /bin/true
+'
+test_expect_success 'broker --heartrate option works' '
+	flux start -o,--heartrate=0.1,--shutdown-grace=0.1 /bin/true
+'
+test_expect_success 'broker --k-ary option works' '
+	flux start -s4 -o,--k-ary=1,--shutdown-grace=0.1 /bin/true &&
+	flux start -s4 -o,--k-ary=2,--shutdown-grace=0.1 /bin/true &&
+	flux start -s4 -o,--k-ary=3,--shutdown-grace=0.1 /bin/true &&
+	flux start -s4 -o,--k-ary=4,--shutdown-grace=0.1 /bin/true
+'
+
 test_expect_success 'flux-help command list can be extended' '
 	mkdir help.d &&
 	cat <<-EOF  > help.d/test.json &&

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -203,5 +203,9 @@ test_expect_success 'exercise batching of asynchronous flush to backing store' '
 	test $OLD_COUNT -le $NEW_COUNT
 '
 
+test_expect_success 'remove content-sqlite module on rank 0' '
+	flux module remove --rank 0 content-sqlite
+'
+
 
 test_done

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -257,4 +257,7 @@ test_expect_success 'flux cron sync can set epsilon' '
     flux cron sync --epsilon=42s cron.sync2 &&
     flux cron sync | grep 42.000s
 '
+test_expect_success 'flux module remove cron' '
+    flux module remove cron
+'
 test_done

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -152,4 +152,7 @@ test_expect_success 'relative flux-cron at works' '
     cron_entry_check ${id} stats.count 1 &&
     cron_entry_check ${id} stopped true
 '
+test_expect_success 'remove cron module' '
+    flux module remove cron
+'
 test_done

--- a/t/t1001-barrier-basic.t
+++ b/t/t1001-barrier-basic.t
@@ -49,4 +49,9 @@ test_expect_success 'barrier: succeeds with name=NULL inside SLURM step' '
 	flux exec ${tbarrier} --nprocs ${SIZE}
 '
 
+test_expect_success 'barrier: remove barrier module' '
+	flux module remove -r all barrier
+'
+
+
 test_done

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -122,4 +122,8 @@ test_expect_success 'hwloc: HostName is populated in by_rank' '
     test x"$HW_HOST" = x"$REAL_HOST"
 '
 
+test_expect_success 'hwloc: remove hwloc module' '
+    flux module remove -r all resource-hwloc
+'
+
 test_done


### PR DESCRIPTION
This PR takes another step towards cleaning up the broker shutdown path.

rc3 unloads modules that were loaded in rc1.   A reactor timer is set when rc3 is entered so that if it takes too long, the reactor is terminated and we can clean up and exit.  Due to #1006, we actually always let this timer run out to completion.

In this post-reactor cleanup path is some code that sends a "shutdown" request to any modules still loaded, and then calls `modhash_destroy()` which tries to destroy each module starting with a `pthread_join()`.  This is prone to hanging because for whatever reason, modules may not have processed the shutdown message (for example, they may be blocked in an RPC).

A SIGARLM timer was set up to break out of _this_ hang and move things along, however it's a kludge, another source of timing related behavior variability, and it caused some troubles noted in #1014 with atexit handlers being called from signal handler context. 

This PR removes the cause of the hangs in `pthread_join()` by replacing the shutdown message in the post-reactor cleanup path with a `pthread_cancel()`.  The SIGALRM handler is then dropped.

Since cancelling a thread causes it to terminate early, potentially missing some cleanup, we should try to avoid this case by making rc3 successful, if possible.  Thus when it happens, we log to stderr (though still exit 0).  The default shutdown grace period was increased somewhat (0.5s to 1.0s for <16 ranks).