### PR TITLE
fix several arm7l portability issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_TYPE_SIZE_T
 AX_COMPILE_CHECK_SIZEOF(int)
 AX_COMPILE_CHECK_SIZEOF(long)
 AX_COMPILE_CHECK_SIZEOF(long long)
+AX_COMPILE_CHECK_SIZEOF(uintptr_t, [#include <stdint.h>])
 AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stdint.h>])
 
 

--- a/src/bindings/lua/lua-affinity/lua-affinity.c
+++ b/src/bindings/lua/lua-affinity/lua-affinity.c
@@ -36,7 +36,7 @@
 
 #include "cpuset-str.h"
 
-#define MAX_LUAINT (0xfffffffffffff0)
+#define MAX_LUAINT ((1ULL<<(8*(sizeof(lua_Integer)-1)))-0x10)
 
 static cpu_set_t * l_cpu_set_alloc (lua_State *L)
 {

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -450,7 +450,7 @@ static void cache_store_continuation (flux_rpc_t *rpc, void *arg)
 done:
     if (respond_requests_raw (&e->store_requests, cache->h,
                                         rc < 0 ? saved_errno : 0,
-                                        e->blobref, strlen (blobref) + 1) < 0)
+                                        e->blobref, strlen (e->blobref) + 1) < 0)
         flux_log_error (cache->h, "%s: error responding to store requests",
                         __FUNCTION__);
     flux_rpc_destroy (rpc);

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -174,7 +174,7 @@ int main (int argc, char **argv)
         "attr_get on active uint32_t tracks value: %s", val);
     b = UINT_MAX - 1;
     ok (attr_get (attrs, "b", &val, NULL) == 0
-        && strtol (val, NULL, 10) == UINT_MAX - 1,
+        && strtoul (val, NULL, 10) == UINT_MAX - 1,
         "attr_get on active uint32_t tracks value: %s", val);
 
     ok (attr_set (attrs, "b", "0", false) == 0 && b == 0,

--- a/src/cmd/flux-jstat.c
+++ b/src/cmd/flux-jstat.c
@@ -203,7 +203,7 @@ static int handle_query_req (flux_t *h, int64_t j, const char *k, const char *n)
         return -1;
     }
     jcb = Jfromstr (jcbstr);
-    fprintf (ctx->op, "Job Control Block: attribute %s for job %ld\n", k, j);
+    fprintf (ctx->op, "Job Control Block: attribute %s for job %"PRIi64"\n", k, j);
     fprintf (ctx->op, "%s\n", jcb == NULL ? jcbstr :
         json_object_to_json_string_ext (jcb, JSON_C_TO_STRING_PRETTY));
     Jput (jcb);

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -176,8 +176,8 @@ void send_ping (struct ping_ctx *ctx)
     rpc = flux_rpcf_multi (ctx->h, ctx->topic, ctx->rank, 0,
                            "{s:i s:I s:I s:s}",
                            "seq", ctx->send_count,
-                           "time.tv_sec", t0.tv_sec,
-                           "time.tv_nsec", t0.tv_nsec,
+                           "time.tv_sec", (uint64_t)t0.tv_sec,
+                           "time.tv_nsec", (uint64_t)t0.tv_nsec,
                            "pad", ctx->pad);
     if (!rpc)
         log_err_exit ("flux_rpcf_multi");

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -137,7 +137,7 @@ done:
     if (flux_rpc_next (rpc) < 0) {
         if (pdata->rpc_count) {
             if (ctx->rank_count > 1) {
-                printf ("%s!%s pad=%lu seq=%d time=(%0.3f:%0.3f:%0.3f) ms "
+                printf ("%s!%s pad=%zu seq=%d time=(%0.3f:%0.3f:%0.3f) ms "
                         "stddev %0.3f\n",
                         ctx->rank, ctx->topic, strlen (ctx->pad), pdata->seq,
                         tstat_min (tstat), tstat_mean (tstat),

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -96,6 +96,12 @@ void flux_log_set_redirect (flux_t *h, flux_log_f fun, void *arg)
 
 const char *flux_strerror (int errnum)
 {
+    /* zeromq-4.2.1 reports EHOSTUNREACH as "Host unreachable",
+     * but "No route to host" is canonical on Linux and we have some
+     * tests that depend on it, so remap here.
+     */
+    if (errnum == EHOSTUNREACH)
+        return "No route to host";
     return zmq_strerror (errnum);
 }
 

--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -62,7 +62,16 @@ _verr (int errnum, const char *fmt, va_list ap)
 {
     char *msg = NULL;
     char buf[128];
-    const char *s = zmq_strerror (errnum);
+    const char *s;
+
+    /* zeromq-4.2.1 reports EHOSTUNREACH as "Host unreachable",
+     * but "No route to host" is canonical on Linux and we have some
+     * tests that depend on it, so remap here.
+     */
+    if (errnum == EHOSTUNREACH)
+        s = "No route to host";
+    else
+        s = zmq_strerror (errnum);
 
     if (!prog)
         log_init (NULL);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -247,8 +247,10 @@ static void wlog_fatal (struct prog_ctx *ctx, int code, const char *format, ...)
     va_start (ap, format);
     if ((ctx != NULL) && ((c = prog_ctx_flux_handle (ctx)) != NULL))
         flux_vlog (c, LOG_EMERG, format, ap);
-    else
+    else {
         vfprintf (stderr, format, ap);
+        putc ('\n', stderr);
+    }
     va_end (ap);
 
     /* Copy error to kvs if we're not in task context:
@@ -390,7 +392,7 @@ static void wreck_pmi_line (struct task_info *t, const char *line)
     struct prog_ctx *ctx = t->ctx;
     int rc;
     if ((rc = pmi_simple_server_request (ctx->pmi, line, t)) < 0)
-        wlog_fatal (ctx, 1, "pmi_simple_server_request: %s\n",
+        wlog_fatal (ctx, 1, "pmi_simple_server_request: %s",
                     strerror (errno));
     if (rc == 1)
         wreck_pmi_close (t);
@@ -2303,7 +2305,7 @@ int prog_ctx_get_id (struct prog_ctx *ctx, optparse_t *p)
     char *end;
 
     if (!optparse_getopt (p, "kvs-path", &kvspath))
-        wlog_fatal (ctx, 1, "Required arg --kvs-path missing\n");
+        wlog_fatal (ctx, 1, "Required arg --kvs-path missing");
     ctx->kvspath = strdup (kvspath);
 
     if (!optparse_getopt (p, "lwj-id", &id)) {

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -13,7 +13,7 @@ invalid_rank() {
 }
 
 test_expect_success 'ping: 10K 1K byte echo requests' '
-	run_timeout 5 flux ping --pad 1024 --count 10240 --interval 0 0
+	run_timeout 10 flux ping --pad 1024 --count 10240 --interval 0 0
 '
 
 test_expect_success 'ping: 1K 10K byte echo requests' '
@@ -33,7 +33,7 @@ test_expect_success 'ping: 10 1M byte echo requests (batched)' '
 '
 
 test_expect_success 'ping: 1K 10K byte echo requests (batched)' '
-	run_timeout 5 flux ping --pad 10240 --count 1024 --batch --interval 0 0
+	run_timeout 20 flux ping --pad 10240 --count 1024 --batch --interval 0 0
 '
 
 test_expect_success 'ping --rank 1 works' '


### PR DESCRIPTION
This PR gets flux-core working on the 32-bit arm7l architecture used in the Raspberry PI and other embedded platforms, e.g.
* fix 64 bit values used as printf-style arguments with ambiguous format specifier (e.g. `%lu`)
* relax some arbitrary test timeouts
* fix 64-bit pointer assumption in `makecontext()`  usage
* reduce VM footprint of test that tried to malloc 20gb of memory

There are a few unrelated minor bug fixes here as well:
* fix NULL deref in content-cache error path
* fix missing newlines in log output
* get working with the latest zeromq (4.2.1)