### PR TITLE
avoid deadlock when unloading connector-local module

### DIFF
--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -45,6 +45,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/cleanup.h"
+#include "src/common/libutil/iterators.h"
 
 enum {
     DEBUG_AUTHFAIL_ONESHOT = 1, /* force auth to fail one time */
@@ -963,6 +964,13 @@ done:
     if (ctx->listen_fd >= 0) {
         if (close (ctx->listen_fd) < 0)
             flux_log_error (h, "close listen_fd");
+    }
+    if (ctx->subscriptions) { // issue #1025
+        const char *topic;
+        subscription_t *sub;
+        FOREACH_ZHASH (ctx->subscriptions, topic, sub) {
+            sub->unsubscribe = NULL;
+        }
     }
     if (ctx->clients) {
         client_t *c;

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -267,5 +267,9 @@ test_expect_success 'scripts/waitfile works after 1s' '
 	p=$! &&
 	wait $p
 '
+# test for issue #1025
+test_expect_success 'instance can stop cleanly with subscribers (#1025)' '
+	flux start ${BUG1006} -s2 --bootstrap=selfpmi bash -c "nohup flux event sub hb &"
+'
 
 test_done

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -29,46 +29,62 @@ test_expect_success 'flux-keygen works' '
 	flux keygen --secdir $tmpkeydir --force &&
 	rm -rf $tmpkeydir
 '
+
+#
+# N.B. since we have many back to back flux-starts within this test,
+# and each instance runs out the shutdown grace period per issue #1006,
+# the net effect is a really slow test.
+#
+# Until #1006 is fixed, work around this by forcing an unnaturally
+# short shutdown grace period.  It means we're interrupting the tear
+# down process, but perhaps that's not so much relevant to verifying
+# basic functionality...
+#
+BUG1006="-o,--shutdown-grace=0.1"
+
+test_expect_success 'broker --shutdown-grace option works' '
+	flux start -o,--shutdown-grace=0.1 /bin/true
+'
 test_expect_success 'flux-start in exec mode works' "
-	flux start 'flux comms info' | grep 'size=1'
+	flux start ${BUG1006} 'flux comms info' | grep 'size=1'
 "
 test_expect_success 'flux-start in subprocess/pmi mode works (size 1)' "
-	flux start --size=1 'flux comms info' | grep 'size=1'
+	flux start ${BUG1006} --size=1 'flux comms info' | grep 'size=1'
 "
 test_expect_success 'flux-start in subprocess/pmi mode works (size 2)' "
-	flux start --size=2 'flux comms info' | grep 'size=2'
+	flux start ${BUG1006} --size=2 'flux comms info' | grep 'size=2'
 "
 test_expect_success 'flux-start with size 1 has no peers' "
-	flux start --size=1 'flux comms idle' > idle.out
+	flux start ${BUG1006} --size=1 'flux comms idle' > idle.out
         ! grep 'idle' idle.out
 "
 test_expect_success 'flux-start with size 2 has a peer' "
-	flux start --size=2 'flux comms idle' > idle.out
+	flux start ${BUG1006} --size=2 'flux comms idle' > idle.out
         grep 'idle' idle.out
 "
 test_expect_success 'flux-start --size=1 --bootstrap=selfpmi works' "
-	flux start --size=1 --bootstrap=selfpmi /bin/true
+	flux start ${BUG1006} --size=1 --bootstrap=selfpmi /bin/true
 "
 test_expect_success 'flux-start --size=1 --boostrap=pmi fails' "
-	test_must_fail flux start --size=1 --bootstrap=pmi /bin/true
+	test_must_fail flux start ${BUG1006} --size=1 --bootstrap=pmi /bin/true
 "
 test_expect_success 'flux-start in exec mode passes through errors from command' "
-	test_must_fail flux start /bin/false
+	test_must_fail flux start ${BUG1006} /bin/false
 "
 test_expect_success 'flux-start in subprocess/pmi mode passes through errors from command' "
-	test_must_fail flux start --size=1 /bin/false
+	test_must_fail flux start ${BUG1006} --size=1 /bin/false
 "
 test_expect_success 'flux-start in exec mode passes exit code due to signal' "
-	test_expect_code 130 flux start 'kill -INT \$\$'
+	test_expect_code 130 flux start ${BUG1006} 'kill -INT \$\$'
 "
 test_expect_success 'flux-start in subprocess/pmi mode passes exit code due to signal' "
-	test_expect_code 130 flux start --size=1 'kill -INT \$\$'
+	test_expect_code 130 flux start ${BUG1006} --size=1 'kill -INT \$\$'
 "
 test_expect_success 'flux-start in exec mode works as initial program' "
-	flux start --size=2 flux start flux comms info | grep size=1
+	flux start --size=2 flux start ${BUG1006} flux comms info | grep size=1
 "
 test_expect_success 'flux-start in subprocess/pmi mode works as initial program' "
-	flux start --size=2 flux start --size=1 flux comms info | grep size=1
+	flux start --size=2 flux start ${BUG1006} --size=1 flux comms info | grep size=1
 "
 
 test_expect_success 'test_under_flux works' '
@@ -94,26 +110,26 @@ test_expect_success 'test_under_flux works' '
 	grep "size=2" test-under-flux/out
 '
 test_expect_success 'flux-start -o,--setattr ATTR=VAL can set broker attributes' '
-	ATTR_VAL=`flux start -o,--setattr=foo-test=42 flux getattr foo-test` &&
+	ATTR_VAL=`flux start ${BUG1006} -o,--setattr=foo-test=42 flux getattr foo-test` &&
 	test $ATTR_VAL -eq 42
 '
 test_expect_success 'broker.rundir override works' '
 	RUNDIR=`mktemp -d` &&
-	DIR=`flux start -o,--setattr=broker.rundir=$RUNDIR flux getattr broker.rundir` &&
+	DIR=`flux start ${BUG1006} -o,--setattr=broker.rundir=$RUNDIR flux getattr broker.rundir` &&
 	test "$DIR" = "$RUNDIR" &&
 	test -d $RUNDIR &&
 	rmdir $RUNDIR
 '
 test_expect_success 'broker persist-directory works' '
 	PERSISTDIR=`mktemp -d` &&
-	flux start -o,--setattr=persist-directory=$PERSISTDIR /bin/true &&
+	flux start ${BUG1006} -o,--setattr=persist-directory=$PERSISTDIR /bin/true &&
 	test -d $PERSISTDIR &&
 	test `ls -1 $PERSISTDIR|wc -l` -gt 0 &&
 	rm -rf $PERSISTDIR
 '
 test_expect_success 'broker persist-filesystem works' '
 	PERSISTFS=`mktemp -d` &&
-	PERSISTDIR=`flux start -o,--setattr=persist-filesystem=$PERSISTFS flux getattr persist-directory` &&
+	PERSISTDIR=`flux start ${BUG1006} -o,--setattr=persist-filesystem=$PERSISTFS flux getattr persist-directory` &&
 	test -d $PERSISTDIR &&
 	test `ls -1 $PERSISTDIR|wc -l` -gt 0 &&
 	rm -rf $PERSISTDIR &&
@@ -123,7 +139,7 @@ test_expect_success 'broker persist-filesystem works' '
 test_expect_success 'broker persist-filesystem is ignored if persist-directory set' '
 	PERSISTFS=`mktemp -d` &&
 	PERSISTDIR=`mktemp -d` &&
-	DIR=`flux start -o,--setattr=persist-filesystem=$PERSISTFS,--setattr=persist-directory=$PERSISTDIR \
+	DIR=`flux start ${BUG1006} -o,--setattr=persist-filesystem=$PERSISTFS,--setattr=persist-directory=$PERSISTDIR \
 		flux getattr persist-directory` &&
 	test "$DIR" = "$PERSISTDIR" &&
 	test `ls -1 $PERSISTDIR|wc -l` -gt 0 &&
@@ -132,27 +148,24 @@ test_expect_success 'broker persist-filesystem is ignored if persist-directory s
 '
 # Use -eq hack to test that BROKERPID is a number
 test_expect_success 'broker broker.pid attribute is readable' '
-	BROKERPID=`flux start flux getattr broker.pid` &&
+	BROKERPID=`flux start ${BUG1006} flux getattr broker.pid` &&
 	test -n "$BROKERPID" &&
 	test "$BROKERPID" -eq "$BROKERPID"
 '
 test_expect_success 'broker broker.pid attribute is immutable' '
-	test_must_fail flux start -o,--setattr=broker.pid=1234 flux getattr broker.pid
+	test_must_fail flux start ${BUG1006} -o,--setattr=broker.pid=1234 flux getattr broker.pid
 '
 test_expect_success 'broker --verbose option works' '
-	flux start -o,-v /bin/true
-'
-test_expect_success 'broker --shutdown-grace option works' '
-	flux start -o,--shutdown-grace=0.1 /bin/true
+	flux start ${BUG1006} -o,-v /bin/true
 '
 test_expect_success 'broker --heartrate option works' '
-	flux start -o,--heartrate=0.1,--shutdown-grace=0.1 /bin/true
+	flux start ${BUG1006} -o,--heartrate=0.1 /bin/true
 '
 test_expect_success 'broker --k-ary option works' '
-	flux start -s4 -o,--k-ary=1,--shutdown-grace=0.1 /bin/true &&
-	flux start -s4 -o,--k-ary=2,--shutdown-grace=0.1 /bin/true &&
-	flux start -s4 -o,--k-ary=3,--shutdown-grace=0.1 /bin/true &&
-	flux start -s4 -o,--k-ary=4,--shutdown-grace=0.1 /bin/true
+	flux start ${BUG1006} -s4 -o,--k-ary=1 /bin/true &&
+	flux start ${BUG1006} -s4 -o,--k-ary=2 /bin/true &&
+	flux start ${BUG1006} -s4 -o,--k-ary=3 /bin/true &&
+	flux start ${BUG1006} -s4 -o,--k-ary=4 /bin/true
 '
 
 test_expect_success 'flux-help command list can be extended' '


### PR DESCRIPTION
This PR fixes issue #1025, in which a sched test fails due to a `flux-start` timeout during post-reactor shutdown.  It turns out there is a pretty obvious deadlock potential in the connector-local module.

The connector-local module is removed manually as a special case after reactor shutdown, thus it cannot make any RPCs as part of its shutdown path since they cannot be answered.  However, it does attempt to call `flux_event_unsubscribe()` during shutdown if any clients are still connected at this point, and have active subscriptions.

The fix is to disable these unsubscribes in the tear-down path.  Their state gets removed anyway when the module context is destroyed.

Add a regression test for this case.

Also, the back-to-back instances run in t0001-basic.t take a really long time due to #1006.  I added a workaround to speed up the test at the expense of likely short circuiting teardown.  Teardown gets plenty of coverage later on - there's no need to make ourselves suffer unduly in this one test.
