### PR TITLE
Small improvements for systemd unit file and install paths

### DIFF
--- a/config/systemd.m4
+++ b/config/systemd.m4
@@ -33,7 +33,7 @@ AC_DEFUN([RRA_WITH_SYSTEMD_UNITDIR],
     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
         [Directory for systemd service files])],
     [],
-    [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+    [with_systemdsystemunitdir=\${prefix}$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
  AS_IF([test x"$with_systemdsystemunitdir" != xno],
     [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
  AM_CONDITIONAL([HAVE_SYSTEMD],

--- a/config/x_ac_expand_install_dirs.m4
+++ b/config/x_ac_expand_install_dirs.m4
@@ -64,6 +64,11 @@ AC_DEFUN([X_AC_EXPAND_INSTALL_DIRS], [
     [Expansion of the "localstatedir" installation directory.])
   AC_SUBST([X_LOCALSTATEDIR])
 
+  adl_RECURSIVE_EVAL(["$runstatedir"], [X_RUNSTATEDIR])
+  AC_DEFINE_UNQUOTED([X_RUNSTATEDIR], ["$X_RUNSTATEDIR"],
+    [Expansion of the "runstatedir" installation directory.])
+  AC_SUBST([X_RUNSTATEDIR])
+
   adl_RECURSIVE_EVAL(["$libdir"], [X_LIBDIR])
   AC_DEFINE_UNQUOTED([X_LIBDIR], ["$X_LIBDIR"],
     [Expansion of the "libdir" installation directory.])

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,12 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS])
 AC_CANONICAL_SYSTEM
+##
+# If runstatedir not explicitly set on command line, use '/run' as default
+##
+if test "$runstatedir" = '${localstatedir}/run'; then
+   AC_SUBST([runstatedir],[/run])
+fi
 X_AC_EXPAND_INSTALL_DIRS
 
 ##
@@ -78,7 +84,6 @@ AX_COMPILE_CHECK_SIZEOF(long)
 AX_COMPILE_CHECK_SIZEOF(long long)
 AX_COMPILE_CHECK_SIZEOF(uintptr_t, [#include <stdint.h>])
 AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stdint.h>])
-
 
 ##
 # Checks for library functions

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,5 +1,5 @@
 #if HAVE_SYSTEMD
-systemdsystemunit_SCRIPTS = flux.service
+systemdsystemunit_DATA = flux.service
 #endif
 
 noinst_DATA = \

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -2,6 +2,7 @@
 Description=Flux message broker
 
 [Service]
+Environment=FLUX_USERDB_OPTIONS=--default-rolemask=user
 ExecStart=@X_BINDIR@/flux start -o,-Sbroker.rundir=@X_RUNSTATEDIR@/flux,-Ssession-id=%H sleep inf
 User=flux
 Group=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -2,7 +2,7 @@
 Description=Flux message broker
 
 [Service]
-ExecStart=@X_BINDIR@/flux start -o,-Sbroker.rundir=%t/flux,-Ssession-id=%H sleep inf
+ExecStart=@X_BINDIR@/flux start -o,-Sbroker.rundir=@X_RUNSTATEDIR@/flux,-Ssession-id=%H sleep inf
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -7,6 +7,12 @@ User=flux
 Group=flux
 RuntimeDirectory=flux
 RuntimeDirectoryMode=0755
+#
+# Delegate cgroup control to user flux, so that systemd doesn't reset
+#  cgroups for flux initiated processes, and to allow (some) cgroup
+#  manipulation as user flux.
+#
+Delegate=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/rc1
+++ b/etc/rc1
@@ -12,7 +12,7 @@ flux module load -r all resource-hwloc & pids="$pids $!"
 flux module load -r all job
 flux module load -r 0 cron sync=hb
 
-flux module load -r 0 userdb
+flux module load -r 0 userdb ${FLUX_USERDB_OPTIONS}
 
 wait $pids
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -25,7 +25,7 @@ installed_conf_cppflags = \
 	-DINSTALLED_WREXECD_PATH=\"$(fluxlibexecdir)/wrexecd\" \
 	-DINSTALLED_CMDHELP_PATTERN=\"${datadir}/flux/help.d/*.json\" \
 	-DINSTALLED_NO_DOCS_PATH=\"${datadir}/flux/.nodocs\" \
-	-DINSTALLED_RUNDIR=\"${localstatedir}/run/flux\"
+	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\"
 
 intree_conf_cppflags = \
 	-DINTREE_MODULE_PATH=\"$(abs_top_builddir)/src/modules\" \


### PR DESCRIPTION
A few small tweaks here to improve the default systemd service unit file included with flux.

 * Use AC variable "runstatedir" instead of $localstatedir/run for *both* "default" (i.e. system) FLUX_URI and the `broker.rundir` passed to the systemd initiated flux broker.
 * If `--with-systemdsystemunitdir=` is not explicitly used, always prepend `${prefix}` to this PATH, so that the unit file is not installed outside of the chosen `$prefix`. This could get us into trouble if systemd pkg-config file already has `$prefix` in the systemdsystemunitdir variable, but I don't think this is an issue in practice.
 * Don't install systemd unit file with executable bits
 * Add `Delegate=yes` to systemd unit to delegate cgroup for flux.service to flux user.

When installing flux-core to `/usr/local` on your desktop for example, the service unit file will not be found by systemd by default. Make a link from /etc/systemd/systemd/flux.service -> /usr/local/lib/systemd/system/flux.service and that should activate the service.

Someone should give this a try and make sure nothing breaks on at least one other system.

Fixes #1024 
Fixes #1033