### PR TITLE
hwloc: open topology request to user role, add simple "info" subcommand

### DIFF
--- a/doc/man1/flux-hwloc.adoc
+++ b/doc/man1/flux-hwloc.adoc
@@ -12,6 +12,8 @@ flux-hwloc - Control/query resource-hwloc service
 
 SYNOPSIS
 --------
+*flux* *hwloc* *info* ['OPTIONS']
+
 *flux* *hwloc* *lstopo* ['lstopo-OPTIONS']
 
 *flux* *hwloc* *reload* ['OPTIONS'] ['DIR']
@@ -33,6 +35,11 @@ COMMANDS
 
 *flux hwloc* requires a 'COMMAND' argument. The supported commands
 are
+
+*info*::
+Dump a short-form summary of the total number of Machines, Cores,
+and Processing Units (PUs) available across all flux-brokers
+in the current instance.
 
 *lstopo*::
 Run `lstopo(1)` against the full hardware hierarchy configured in the

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -390,3 +390,4 @@ FFFFFFFFF
 rootdir
 IP
 mcast
+PUs

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -14,7 +14,7 @@ fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
-	$(ZMQ_LIBS) $(LIBMUNGE) $(LIBPTHREAD) $(LIBDL)
+	$(ZMQ_LIBS) $(LIBMUNGE) $(LIBPTHREAD) $(LIBDL) $(HWLOC_LIBS)
 
 LDADD = $(fluxcmd_ldadd)
 

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -180,8 +180,12 @@ static int cmd_lstopo (optparse_t *p, int ac, char *av[])
 
     status = exec_lstopo (p, ac, av, hwloc_topo_topology (t));
     if (status) {
-        if (WIFEXITED (status) && WEXITSTATUS (status) != ENOENT)
-            log_msg_exit ("lstopo: Exited with %d", WEXITSTATUS (status));
+        if (WIFEXITED (status)) {
+            if (WEXITSTATUS (status) == ENOENT)
+                log_msg_exit ("Unable to find an lstopo variant to execute.");
+            else
+                log_msg_exit ("lstopo: Exited with %d", WEXITSTATUS (status));
+        }
         if (WIFSIGNALED (status) && WTERMSIG (status) != SIGPIPE)
             log_msg_exit ("lstopo: %s%s", strsignal (WTERMSIG (status)),
                       WCOREDUMP (status) ? " (core dumped)" : "");

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -526,9 +526,14 @@ static void process_args (flux_t *h, resource_ctx_t *ctx, int argc, char **argv)
 }
 
 static struct flux_msg_handler_spec htab[] = {
-    {FLUX_MSGTYPE_REQUEST, "resource-hwloc.reload", reload_request_cb, 0, NULL},
-    {FLUX_MSGTYPE_REQUEST, "resource-hwloc.topo", topo_request_cb, 0, NULL},
-    FLUX_MSGHANDLER_TABLE_END};
+    { FLUX_MSGTYPE_REQUEST, "resource-hwloc.reload", reload_request_cb,
+       0, NULL
+    },
+    { FLUX_MSGTYPE_REQUEST, "resource-hwloc.topo", topo_request_cb,
+       FLUX_ROLE_USER, NULL
+    },
+    FLUX_MSGHANDLER_TABLE_END
+};
 
 int mod_main (flux_t *h, int argc, char **argv)
 {

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -55,8 +55,24 @@ test_expect_success 'hwloc: each rank reloads a non-overlapping set of a node ' 
     flux hwloc reload $exclu2
 '
 
+#  Keep this test after 'reload exclu2' above so we're processing
+#   know topology xml from reload.
+#
+test_expect_success 'hwloc: flux-hwloc info reports expected resources' '
+    cat <<-EOF > hwloc-info.expected1 &&
+	2 Machines, 16 Cores, 16 PUs
+	EOF
+    flux hwloc info > hwloc-info.out1 &&
+    test_cmp hwloc-info.expected1 hwloc-info.out1
+'
+
 test_expect_success 'hwloc: every rank reloads the same xml of a node' '
-    flux hwloc reload $shared2
+    flux hwloc reload $shared2 &&
+    cat <<-EOF > hwloc-info.expected2 &&
+	2 Machines, 32 Cores, 32 PUs
+	EOF
+    flux hwloc info > hwloc-info.out2 &&
+    test_cmp hwloc-info.expected2 hwloc-info.out2
 '
 
 test_expect_success 'hwloc: only one rank reloads an xml file' '


### PR DESCRIPTION
A bit of a diversion here. While playing with system instance of flux, I found it handy for FLUX_ROLE_USER to be able to query hwloc topology. No other `resource-hwloc` service is exposed further than the owner role.

Additionally, for a terse view of resources across the instance, I added a `flux hwloc info` subcommand, which gives the simplest possible view of Machines, Cores, and PUs available from the instance. This should be viewed as a stand-in for a better replacement down the road (it should use a separate service in `resource-hwloc` to calculate counts at each broker, reduce and forward results for scalability, and other resources like Memory should be added), however, this simple approach has proved useful for now.

```
$ srun --pty -N24 --mpi=none src/cmd/flux start
(flux-923ktt) $ flux hwloc info
24 Machines, 384 Cores, 384 PUs
```

Tests were added for this new subcommand, and its output is used to sanity check the expected results from `flux hwloc reload` testing in the testsuite.

One drawback is that the `flux` command driver now needs to be linked with `libhwloc`, so I'll understand if the subcommand is a pass for now.