### PR TITLE
optparse: test and allow adjustment of posixly-correct behavior

### DIFF
--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1110,11 +1110,10 @@ void *optparse_get_data (optparse_t *p, const char *s)
 
 static char * optstring_create ()
 {
-    char *optstring = malloc (2);
+    char *optstring = malloc (1);
     if (optstring == NULL)
         return (NULL);
-    optstring[0] = '+';
-    optstring[1] = '\0';
+    optstring[0] = '\0';
     return (optstring);
 }
 
@@ -1248,10 +1247,10 @@ static void opt_append_optarg (optparse_t *p, struct option_info *opt, const cha
  */
 static int getopt_long_r (int argc, char *const *argv, const char *options,
                 const struct option *long_options, int *opt_index,
-                struct _getopt_data *d)
+                struct _getopt_data *d, int posixly_correct)
 {
   return _getopt_internal_r (argc, argv, options, long_options, opt_index,
-                             0, d, 0);
+                             0, d, posixly_correct);
 }
 
 int optparse_parse_args (optparse_t *p, int argc, char *argv[])
@@ -1269,7 +1268,7 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
      */
     memset (&d, 0, sizeof (d));
 
-    while ((c = getopt_long_r (argc, argv, optstring, optz, &li, &d)) >= 0) {
+    while ((c = getopt_long_r (argc, argv, optstring, optz, &li, &d, 1)) >= 0) {
         struct option_info *opt;
         struct optparse_option *o;
         if (c == '?') {

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1372,5 +1372,53 @@ int optparse_option_index (optparse_t *p)
 }
 
 /*
+ *  Reset one optparse_t object -- set option_index to zero and
+ *   reset and free option arguments, etc.
+ */
+static void optparse_reset_one (optparse_t *p)
+{
+    struct option_info *o;
+    ListIterator i;
+
+    if (!p)
+        return;
+
+    p->option_index = -1;
+
+    if (!p->option_list || !list_count (p->option_list))
+        return;
+
+    i = list_iterator_create (p->option_list);
+    while ((o = list_next (i))) {
+        if (o->isdoc)
+            continue;
+        o->found = 0;
+        if (o->optargs) {
+            list_destroy (o->optargs);
+            o->optargs = NULL;
+        }
+        o->optarg = NULL;
+    }
+    list_iterator_destroy (i);
+    return;
+}
+
+void optparse_reset (optparse_t *p)
+{
+    zlist_t *cmds = subcmd_list_sorted (p);
+
+    if ((cmds = subcmd_list_sorted (p))) {
+        const char *cmd = zlist_first (cmds);
+        while (cmd) {
+            optparse_t *o = zhash_lookup (p->subcommands, cmd);
+            optparse_reset_one (o);
+            cmd = zlist_next (cmds);
+        }
+        zlist_destroy (&cmds);
+    }
+    optparse_reset_one (p);
+}
+
+/*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -68,6 +68,7 @@ struct opt_parser {
     unsigned int   skip_subcmds:1;  /* Do not Print subcommands in --help   */
     unsigned int   no_options:1;    /* Skip option processing for subcmd    */
     unsigned int   hidden:1;        /* If subcmd, skip in --help output     */
+    unsigned int   posixly_correct:1; /* Value of GNU getopt posixly correct*/
 
     zhash_t *      dhash;           /* Hash of ancillary data               */
 
@@ -698,6 +699,7 @@ optparse_t *optparse_create (const char *prog)
     p->left_margin = 2;
     p->option_width = 25;
     p->option_index = -1;
+    p->posixly_correct = 1;
 
     /*
      *  Register -h, --help
@@ -1049,6 +1051,10 @@ optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...)
         n = va_arg (vargs, int);
         p->hidden = n;
         break;
+    case OPTPARSE_POSIXLY_CORRECT:
+        n = va_arg (vargs, int);
+        p->posixly_correct = n;
+        break;
     default:
         e = OPTPARSE_BAD_ARG;
     }
@@ -1268,7 +1274,8 @@ int optparse_parse_args (optparse_t *p, int argc, char *argv[])
      */
     memset (&d, 0, sizeof (d));
 
-    while ((c = getopt_long_r (argc, argv, optstring, optz, &li, &d, 1)) >= 0) {
+    while ((c = getopt_long_r (argc, argv, optstring, optz,
+                               &li, &d, p->posixly_correct)) >= 0) {
         struct option_info *opt;
         struct optparse_option *o;
         if (c == '?') {

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -198,6 +198,13 @@ optparse_err_t optparse_reg_subcommands (optparse_t *p,
 void optparse_destroy (optparse_t *p);
 
 /*
+ *   Reset option processing for optparse object [p]. Forget all previous
+ *    options processed and their arguments. Useful to restart option
+ *    processing or parse a new argument vector.
+ */
+void optparse_reset (optparse_t *p);
+
+/*
  *   Register the option [o] with the program options object [p].
  *
  *   Returns OPTPARSE_SUCCESS if the option was successfully registered

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -56,6 +56,7 @@ typedef enum {
     OPTPARSE_PRINT_SUBCMDS,/* Print all subcommands in --help (default = T  */
     OPTPARSE_SUBCMD_NOOPTS,/* Don't parse options for this subcommand       */
     OPTPARSE_SUBCMD_HIDE,  /* Don't output this subcmd in --help output     */
+    OPTPARSE_POSIXLY_CORRECT, /* Set POSIXLY_CORRECT value                  */
 } optparse_item_t;
 
 /*

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -1055,6 +1055,20 @@ void test_non_option_arguments (void)
     ok (optparse_getopt (p, "test", NULL) == 0,
         "didn't process --test=foo (expected 0 got %d)",
         optparse_getopt (p, "test", NULL));
+
+    /* Test OPTPARSE_POSIXLY_CORRECT */
+    optparse_reset (p);
+    e = optparse_set (p, OPTPARSE_POSIXLY_CORRECT, 0);
+    ok (optparse_parse_args (p, ac, av4) != -1,
+        "!posixly_correct: optparse_parse_args");
+    optindex = optparse_option_index (p);
+    ok (optindex == 2,
+        "!posixly_correct: argv elements are permuted");
+    is (av4[1], "--test=foo",
+        "!posixly_correct: argv[1] is now --test=foo");
+    is (av4[2], "1234",
+        "!posixly_correct: argv[2] is now non-option arg (1234)");
+
     optparse_destroy (p);
 }
 
@@ -1062,7 +1076,7 @@ void test_non_option_arguments (void)
 int main (int argc, char *argv[])
 {
 
-    plan (241);
+    plan (245);
 
     test_convenience_accessors (); /* 35 tests */
     test_usage_output (); /* 42 tests */
@@ -1075,7 +1089,7 @@ int main (int argc, char *argv[])
     test_optional_argument (); /* 9 tests */
     test_corner_case (); /* 3 tests */
     test_reset (); /* 9 tests */
-    test_non_option_arguments (); /* 9 tests */
+    test_non_option_arguments (); /* 13 tests */
 
     done_testing ();
     return (0);

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -51,7 +51,7 @@ declare -A extra_cmake_opts=(\
 pips="\
 cffi==1.1 \
 coverage \
-pylint
+pylint==1.5.6
 "
 
 #


### PR DESCRIPTION
Initially started working on this because I thought POSIXLY_CORRECT behavior of optparse was broken. In order to test properly, an `optparse_reset()` function was added to allow a full reset of a parser (mostly useful in testing perhaps), then tests for this new interface as well as posixly-correct parsing behavior were added.

In the end, there wasn't a problem with POSIXLY_CORRECT functionality of optparse. Instead of throwing away all the new testing, I added an ability to disable POSIXLY_CORRECT for GNU getopt in optparse, which could come in handy in the future (?).

Additionally, I had to add a fix for #1048 here in order to get travis to pass in my branch.