### PR TITLE
convert broker from json-c to jansson (cleanup)

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1618,11 +1618,16 @@ static void cmb_lspeer_cb (flux_t *h, flux_msg_handler_t *w,
                            const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
+    char *out;
 
-    json_object *out = overlay_lspeer_encode (ctx->overlay);
-    if (flux_respond (h, msg, 0, Jtostr (out)) < 0)
+    if (!(out = overlay_lspeer_encode (ctx->overlay))) {
+        if (flux_respond (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+        return;
+    }
+    if (flux_respond (h, msg, 0, out) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-    Jput (out);
+    free (out);
 }
 
 static void cmb_reparent_cb (flux_t *h, flux_msg_handler_t *w,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -50,11 +50,11 @@
 #endif
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/cleanup.h"
 #include "src/common/libutil/nodeset.h"
 #include "src/common/libutil/ipaddr.h"
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/kary.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libpmi/pmi.h"

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -235,15 +235,15 @@ static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
     exec_t *x = arg;
     int pid;
     int errnum = EPROTO;
-    int signum;
+    int signum = SIGTERM;
     struct subprocess *p;
 
-    if (flux_request_decodef (msg, NULL, "{ s:i }", "pid", &pid) < 0) {
+    if (flux_request_decodef (msg, NULL, "{s:i s?:i}",
+                              "pid", &pid,
+                              "signum", &signum) < 0) {
         errnum = errno;
         goto out;
     }
-    if (flux_request_decodef (msg, NULL, "{ s:i }", "signum", &signum) < 0)
-        signum = SIGTERM;
     p = subprocess_manager_first (x->sm);
     while (p) {
         if (pid == subprocess_pid (p)) {

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -31,7 +31,6 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
 
 #include "heartbeat.h"
 

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -43,7 +43,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 
 #include "module.h"

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -49,7 +49,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
-#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/oom.h"
 #include "src/common/libutil/iterators.h"
 
 #include "heartbeat.h"

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -47,7 +47,7 @@ void overlay_checkin_child (overlay_t *ov, const char *uuid);
 
 /* Encode cmb.lspeer response payload.
  */
-json_object *overlay_lspeer_encode (overlay_t *ov);
+char *overlay_lspeer_encode (overlay_t *ov);
 
 /* The event socket is SUB for ranks > 0, and PUB for rank 0.
  * Internally, all events are routed to rank 0 before being published.

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -30,7 +30,7 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/oom.h"
 
 #include "service.h"
 


### PR DESCRIPTION
This PR is more cleanup.  It converts the remaining broker C modules that use json-c to jansson.

@grondo it may be good for you to have a quick look over the exec.c commit proposed here.   It's passing tests on my c9 image, but I did need to change it more than I wanted to make the error paths more clear (to me) as I worked through it.  If this causes grief in your imp test branch, we can always skip this commit here and try again later.