### PR TITLE
allow hash type to be configured

### DIFF
--- a/doc/man1/flux-content.adoc
+++ b/doc/man1/flux-content.adoc
@@ -53,7 +53,7 @@ if available (see below).
 BACKING STORE
 -------------
 The rank 0 cache retains all content until a module providing
-the "content-backing" service is loaded which can offload content
+the "content.backing" service is loaded which can offload content
 to some other place.  The *content-sqlite* module provides this
 service, and is loaded by default.
 
@@ -79,21 +79,21 @@ CACHE EXPIRATION
 The parameters affecting local cache expiration may be tuned with
 flux-setattr(1):
 
-*content-purge-target-entries*::
+*content.purge-target-entries*::
 The cache is purged to bring the number of cache entries less than
 or equal to this value
 (default 1048576).
 
-*content-purge-target-size*::
+*content.purge-target-size*::
 The cache is purged to bring the sum of the size of cached blobs less
 than or equal to this value
 (default 16777216)
 
-*content-purge-old-entry*::
+*content.purge-old-entry*::
 Only entries that have not been accessed in *old-entry* heartbeat epochs
 are eligible for purge (default 5).
 
-*content-purge-large-entry*::
+*content.purge-large-entry*::
 Only entries with blob size greater than or equal to *large-entry* are
 purged to reach the size target (default 256).
 
@@ -106,16 +106,16 @@ CACHE ACCOUNTING
 ----------------
 Some accounting info for the local cache can be viewed with flux-getattr(1):
 
-*content-acct-entries*::
+*content.acct-entries*::
 The total number of cache entries.
 
-*content-acct-size*::
+*content.acct-size*::
 The sum of the size of cached blobs.
 
-*content-acct-dirty*::
+*content.acct-dirty*::
 The number of dirty cache entries.
 
-*content-acct-valid*::
+*content.acct-valid*::
 The number of valid cache entries.
 
 

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -134,50 +134,50 @@ in the ring buffer.
 
 CONTENT ATTRIBUTES
 ------------------
-content-acct-dirty::
+content.acct-dirty::
 The number of dirty cache entries on this rank.
 
-content-acct-entries::
+content.acct-entries::
 The total number of cache entries on this rank.
 
-content-acct-size::
+content.acct-size::
 The estimated total size in bytes consumed by cache entries on
 this rank, excluding overhead.
 
-content-acct-valid::
+content.acct-valid::
 The number of valid cache entries on this rank.
 
-content-backing::
+content.backing::
 The selected backing store, if any.  This attribute is only
 set on rank 0 where the content backing store is active.
 
-content-blob-size-limit::
+content.blob-size-limit::
 The maximum size of a blob, the basic unit of content storage.
 
-content-flush-batch-count::
+content.flush-batch-count::
 The current number of outstanding store requests, either to the
 backing store (rank 0) or upstream (rank > 0).
 
-content-flush-batch-limit::
+content.flush-batch-limit::
 The maximum number of outstanding store requests that will be
 initiated when handling a flush or backing store load operation.
 
-content-hash::
+content.hash::
 The selected hash algorithm, default sha1.
 
-content-purge-large-entry::
+content.purge-large-entry::
 When the cache size footprint needs to be reduced, first consider
 purging entries of this size or greater.
 
-content-purge-old-entry::
+content.purge-old-entry::
 When the cache size footprint needs to be reduced, only consider
 purging entries that are older than this number of heartbeats.
 
-content-purge-target-entries::
+content.purge-target-entries::
 If possible, the cache size purged periodically so that the total
 number of entries stays at or below this value.
 
-content-purge-target-size::
+content.purge-target-size::
 If possible, the cache size purged periodically so that the total
 size of the cache stays at or below this value.
 

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -72,7 +72,7 @@ struct content_cache {
     flux_t *enclosing_h;
     uint32_t rank;
     zhash_t *entries;
-    uint8_t backing:1;              /* 'content-backing' service available */
+    uint8_t backing:1;              /* 'content.backing' service available */
     char *backing_name;
     char *hash_name;
     zlist_t *flush_requests;
@@ -262,7 +262,7 @@ static void remove_entry (content_cache_t *cache, struct cache_entry *e)
  * If a cache entry is already present and valid, response is immediate.
  * Otherwise request is queued on the invalid cache entry, and a new
  * request is sent to the next level of TBON, or on rank 0, to the
- * content-backing service.  At most a single request is sent per cache entry.
+ * content.backing service.  At most a single request is sent per cache entry.
  * Once the response is received, identical responses are sent to all
  * parked requests, and cache entry is made valid or removed if there was
  * an error such as ENOENT.
@@ -410,10 +410,10 @@ done:
  * responded to at each level.
  *
  * Dirty cache is write-back for rank 0, that is;  the response is immediate
- * even though the entry may be dirty with respect to a 'content-backing'
+ * even though the entry may be dirty with respect to a 'content.backing'
  * service.  This allows the cache to be updated at memory speeds,
  * while holding the invariant that after a store RPC returns, the entry may
- * be loaded from any rank.  The optional content-backing service can
+ * be loaded from any rank.  The optional content.backing service can
  * offload rank 0 hash entries at a slower pace.
  */
 
@@ -579,12 +579,12 @@ done:
 }
 
 /* Backing store is enabled/disabled by modules that provide the
- * 'content-backing' service.  At module load time, the backing module
+ * 'content.backing' service.  At module load time, the backing module
  * informs the content service of its availability, and entries are
  * asynchronously duplicated on the backing store and made eligible for
  * dropping from the rank 0 cache.
  *
- * At module unload time, Backing store is disabled and content-backing
+ * At module unload time, Backing store is disabled and content.backing
  * synchronously transfers content back to the cache.  This allows the
  * module providing the backing store to be replaced early at runtime,
  * before the amount of content exceeds the cache's ability to hold it.
@@ -881,11 +881,11 @@ static int content_cache_getattr (const char *name, const char **val, void *arg)
     content_cache_t *cache = arg;
     static char s[32];
 
-    if (!strcmp (name, "content-hash"))
+    if (!strcmp (name, "content.hash"))
         *val = cache->hash_name;
-    else if (!strcmp (name, "content-backing"))
+    else if (!strcmp (name, "content.backing"))
         *val = cache->backing_name;
-    else if (!strcmp (name, "content-acct-entries")) {
+    else if (!strcmp (name, "content.acct-entries")) {
         snprintf (s, sizeof (s), "%zd", zhash_size (cache->entries));
         *val = s;
     } else
@@ -897,47 +897,47 @@ int content_cache_register_attrs (content_cache_t *cache, attr_t *attr)
 {
     /* Purge tunables
      */
-    if (attr_add_active_uint32 (attr, "content-purge-target-entries",
+    if (attr_add_active_uint32 (attr, "content.purge-target-entries",
                 &cache->purge_target_entries, 0) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-purge-target-size",
+    if (attr_add_active_uint32 (attr, "content.purge-target-size",
                 &cache->purge_target_size, 0) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-purge-old-entry",
+    if (attr_add_active_uint32 (attr, "content.purge-old-entry",
                 &cache->purge_old_entry, 0) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-purge-large-entry",
+    if (attr_add_active_uint32 (attr, "content.purge-large-entry",
                 &cache->purge_large_entry, 0) < 0)
         return -1;
     /* Accounting numbers
      */
-    if (attr_add_active_uint32 (attr, "content-acct-size",
+    if (attr_add_active_uint32 (attr, "content.acct-size",
                 &cache->acct_size, FLUX_ATTRFLAG_READONLY) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-acct-dirty",
+    if (attr_add_active_uint32 (attr, "content.acct-dirty",
                 &cache->acct_dirty, FLUX_ATTRFLAG_READONLY) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-acct-valid",
+    if (attr_add_active_uint32 (attr, "content.acct-valid",
                 &cache->acct_valid, FLUX_ATTRFLAG_READONLY) < 0)
         return -1;
-    if (attr_add_active (attr, "content-acct-entries", FLUX_ATTRFLAG_READONLY,
+    if (attr_add_active (attr, "content.acct-entries", FLUX_ATTRFLAG_READONLY,
                 content_cache_getattr, NULL, cache) < 0)
         return -1;
     /* Misc
      */
-    if (attr_add_active_uint32 (attr, "content-flush-batch-limit",
+    if (attr_add_active_uint32 (attr, "content.flush-batch-limit",
                 &cache->flush_batch_limit, 0) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-blob-size-limit",
+    if (attr_add_active_uint32 (attr, "content.blob-size-limit",
                 &cache->blob_size_limit, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
-    if (attr_add_active (attr, "content-hash", FLUX_ATTRFLAG_IMMUTABLE,
+    if (attr_add_active (attr, "content.hash", FLUX_ATTRFLAG_IMMUTABLE,
                 content_cache_getattr, NULL, cache) < 0)
         return -1;
-    if (attr_add_active (attr, "content-backing",FLUX_ATTRFLAG_READONLY,
+    if (attr_add_active (attr, "content.backing",FLUX_ATTRFLAG_READONLY,
                  content_cache_getattr, NULL, cache) < 0)
         return -1;
-    if (attr_add_active_uint32 (attr, "content-flush-batch-count",
+    if (attr_add_active_uint32 (attr, "content.flush-batch-count",
                 &cache->flush_batch_count, 0) < 0)
         return -1;
     return 0;

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -234,6 +234,13 @@ int blobref_validate (const char *blobref)
     return 0;
 }
 
+int blobref_validate_hashtype (const char *name)
+{
+    if (name == NULL || !lookup_blobhash (name))
+        return -1;
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -32,6 +32,11 @@ int blobref_hash (const char *hashtype,
  */
 int blobref_validate (const char *blobref);
 
+/* Check the validity of hash type (by name)
+ */
+int blobref_validate_hashtype (const char *name);
+
+
 #endif /* _UTIL_BLOBREF_H */
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -123,6 +123,16 @@ int main(int argc, char** argv)
         pp++;
     }
 
+    /* blobref_validate_hashtype */
+    ok (blobref_validate_hashtype ("sha1") == 0,
+        "blobref_validate_hashtype sha1 is valid");
+    ok (blobref_validate_hashtype ("sha256") == 0,
+        "blobref_validate_hashtype sha256 is valid");
+    ok (blobref_validate_hashtype ("nerf") == -1,
+        "blobref_validate_hashtype nerf is invalid");
+    ok (blobref_validate_hashtype (NULL) == -1,
+        "blobref_validate_hashtype NULL is invalid");
+
     done_testing();
 }
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -149,14 +149,14 @@ static sqlite_ctx_t *getctx (flux_t *h)
         ctx->lzo_buf = xzmalloc (lzo_buf_chunksize);
         ctx->lzo_bufsize = lzo_buf_chunksize;
         ctx->h = h;
-        if (!(ctx->hashfun = flux_attr_get (h, "content-hash", &flags))) {
+        if (!(ctx->hashfun = flux_attr_get (h, "content.hash", &flags))) {
             saved_errno = errno;
-            flux_log_error (h, "content-hash");
+            flux_log_error (h, "content.hash");
             goto error;
         }
-        if (!(tmp = flux_attr_get (h, "content-blob-size-limit", NULL))) {
+        if (!(tmp = flux_attr_get (h, "content.blob-size-limit", NULL))) {
             saved_errno = errno;
-            flux_log_error (h, "content-blob-size-limit");
+            flux_log_error (h, "content.blob-size-limit");
             goto error;
         }
         ctx->blob_size_limit = strtoul (tmp, NULL, 10);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -87,7 +87,7 @@ typedef struct {
     flux_watcher_t *idle_w;
     flux_watcher_t *check_w;
     int commit_merge;
-    char *hash_name;
+    const char *hash_name;
 } kvs_ctx_t;
 
 typedef struct {
@@ -164,7 +164,10 @@ static kvs_ctx_t *getctx (flux_t *h)
             flux_watcher_start (ctx->check_w);
         }
         ctx->commit_merge = 1;
-        ctx->hash_name = "sha1";
+        if (!(ctx->hash_name = flux_attr_get (h, "content.hash", NULL))) {
+            flux_log_error (h, "content.hash");
+            goto error;
+        }
         flux_aux_set (h, "kvssrv", ctx, freectx);
     }
     return ctx;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -61,6 +61,7 @@ TESTS = \
 	t2005-hwloc-basic.t \
 	t2006-joblog.t \
 	t2007-caliper.t \
+	t2008-althash.t \
 	t2100-aggregate.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
@@ -130,6 +131,7 @@ check_SCRIPTS = \
 	t2005-hwloc-basic.t \
 	t2006-joblog.t \
 	t2007-caliper.t \
+	t2008-althash.t \
 	t2100-aggregate.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -15,8 +15,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
 
-MAXBLOB=`flux getattr content-blob-size-limit`
-HASHFUN=`flux getattr content-hash`
+MAXBLOB=`flux getattr content.blob-size-limit`
+HASHFUN=`flux getattr content.hash`
 
 test_expect_success 'store 100 blobs on rank 0' '
         for i in `seq 0 99`; do echo test$i | \

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -15,8 +15,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
 
-MAXBLOB=`flux getattr content-blob-size-limit`
-HASHFUN=`flux getattr content-hash`
+MAXBLOB=`flux getattr content.blob-size-limit`
+HASHFUN=`flux getattr content.hash`
 
 
 store_junk() {
@@ -82,7 +82,7 @@ test_expect_success 'load 1m blob bypassing cache' '
 '
 
 # Verify same blobs on all ranks
-# forcing content to fault in from the content-backing service
+# forcing content to fault in from the content.backing service
 
 test_expect_success 'load and verify 64b blob on all ranks' '
         HASHSTR=`cat 64.0.hash` &&
@@ -184,7 +184,7 @@ test_expect_success 'load 1m blob bypassing cache' '
 '
 
 test_expect_success 'exercise batching of synchronous flush to backing store' '
-	flux setattr content-flush-batch-limit 5 &&
+	flux setattr content.flush-batch-limit 5 &&
         store_junk loadunload 200 &&
     	flux content flush &&
 	NDIRTY=`flux module stats --type int --parse dirty content` &&

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+
+test_description='Test alternate hash config 
+
+Start a session with a non-default hash type for content/kvs.'
+
+BUG1006="-o,--shutdown-grace=0.1"
+
+nil1="sha1-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+nil256="sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+test_expect_success 'Started instance with content.hash=sha1' '
+    OUT=$(flux start ${BUG1006} -o,-Scontent.hash=sha1 \
+          flux getattr content.hash) && test "$OUT" = "sha1"
+'
+
+test_expect_success 'Started instance with content.hash=sha256' '
+    OUT=$(flux start ${BUG1006} -o,-Scontent.hash=sha256 \
+          flux getattr content.hash) && test "$OUT" = "sha256"
+'
+
+test_expect_success 'Content store nil returns correct hash for sha256' '
+    OUT=$(flux start ${BUG1006} -o,-Scontent.hash=sha256 \
+          flux content store </dev/null) &&
+        test "$OUT" = "$nil256"
+'
+
+test_expect_success 'Content store nil returns correct hash for sha1' '
+    OUT=$(flux start ${BUG1006} -o,-Scontent.hash=sha1 \
+          flux content store </dev/null) &&
+        test "$OUT" = "$nil1"
+'
+
+test_expect_success 'Attempt to start instance with invalid hash fails hard' '
+    test_must_fail flux start -o,-Scontent.hash=wronghash /bin/true
+'
+
+test_done


### PR DESCRIPTION
Although the content cache was written so the hash type could be configured to use an algorithm other than the default sha1, there are a few obstacles to overcome to make that work.

First is to allow the hash type to be configured on the broker command line, e.g.
```
$ flux start -o,-Scontent.hash=sha256
```

Next is to have the KVS pick up the configured hash type and use it, since it pre-generates blobrefs to use as hash keys in its internal cache when content store requests are sent off (they can't wait for the response to get the hash key).

Finally, add a test that makes sure this works.

Along the way I updated the names of all the attributes used by the content store to be namespaced in the more modern way:  `content.name-of-attr` rather than `content-name-of-attr`, and updated users and docs.