### PR TITLE
build foundation for private KVS namespaces

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -41,7 +41,8 @@ MAN3_FILES_PRIMARY = \
 	flux_content_load.3 \
 	flux_log.3 \
 	flux_future_then.3 \
-	flux_future_create.3
+	flux_future_create.3 \
+	flux_kvs_ns_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -119,7 +120,15 @@ MAN3_FILES_SECONDARY = \
 	flux_rpc_raw.3 \
 	flux_rpc_get.3 \
 	flux_rpc_getf.3 \
-	flux_rpc_get_raw.3
+	flux_rpc_get_raw.3 \
+	flux_kvs_ns_remove.3 \
+	flux_kvs_ns_lookup.3 \
+	flux_kvs_ns_lookup_get.3 \
+	flux_kvs_ns_lookup_getf.3 \
+	flux_kvs_ns_lookup_get_seq.3 \
+	flux_kvs_ns_commit.3 \
+	flux_kvs_ns_commitf.3 \
+	flux_kvs_ns_event_decode.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -217,6 +226,14 @@ flux_rpc_raw.3: flux_rpc.3
 flux_rpc_get.3: flux_rpc.3
 flux_rpc_getf.3: flux_rpc.3
 flux_rpc_get_raw.3: flux_rpc.3
+flux_kvs_ns_remove.3: flux_kvs_ns_create.3
+flux_kvs_ns_lookup.3: flux_kvs_ns_create.3
+flux_kvs_ns_lookup_get.3: flux_kvs_ns_create.3
+flux_kvs_ns_lookup_getf.3: flux_kvs_ns_create.3
+flux_kvs_ns_lookup_get_seq.3: flux_kvs_ns_create.3
+flux_kvs_ns_commit.3: flux_kvs_ns_create.3
+flux_kvs_ns_commitf.3: flux_kvs_ns_create.3
+flux_kvs_ns_event_decode.3: flux_kvs_ns_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/flux_kvs_ns_create.adoc
+++ b/doc/man3/flux_kvs_ns_create.adoc
@@ -1,0 +1,211 @@
+flux_kvs_ns_create(3)
+=====================
+:doctype: manpage
+
+
+NAME
+----
+flux_kvs_ns_create, flux_kvs_ns_remove, flux_kvs_ns_lookup, flux_kvs_ns_lookup_get, flux_kvs_ns_lookup_getf, flux_kvs_ns_lookup_get_seq, flux_kvs_ns_commit, flux_kvs_ns_commitf, flux_kvs_ns_event_decode - create, remove, lookup, update KVS namespace
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_kvs_ns_create (flux_t *h,
+                                    uint32_t nodeid,
+                                    const char *name,
+                                    uint32_t userid,
+                                    int flags);
+
+ flux_future_t *flux_kvs_ns_remove (flux_t *h,
+                                    uint32_t nodeid,
+                                    const char *name);
+
+ flux_future_t *flux_kvs_ns_lookup (flux_t *h,
+                                    uint32_t nodeid,
+                                    const char *name,
+                                    int min_seq,
+                                    int flags);
+
+ int flux_kvs_ns_lookup_get (flux_future_t *f,
+                             const char **json_str);
+
+ int flux_kvs_ns_lookup_getf (flux_future_t *f,
+                              const char *fmt, ...);
+
+ int flux_kvs_ns_lookup_get_seq (flux_future_t *f,
+                                 int *seq);
+
+ flux_future_t *flux_kvs_ns_commit (flux_t *h,
+                                    uint32_t nodeid,
+                                    const char *name,
+                                    int seq,
+                                    const char *json_str);
+
+ flux_future_t *flux_kvs_ns_commitf (flux_t *h,
+                                     uint32_t nodeid,
+                                     const char *name,
+                                     int seq,
+                                     const char *fmt, ...);
+
+ int flux_kvs_ns_event_decode (const flux_msg_t *msg,
+                               const char **name,
+                               int *seq,
+                               const char **json_str);
+
+
+
+DESCRIPTION
+-----------
+
+The flux namespace service tracks the roots of multiple KVS namespaces.
+It provides the ability to create, remove, lookup, and update namespaces
+by name. Each namespace stores a sequenced JSON object intended, but not
+required, to be a Flux RFC 11 treeref reference.
+
+Namespaces can be global for an instance or local to a broker rank.
+The broker rank that receives the create request for a namespace becomes
+the "master" for it.  All commits for a namespace must be directed to its
+master.  If the FLUX_NS_SYNCHRONIZE flag was set on creation, other broker
+ranks act as "slaves" for the namespace, and only handle lookup requests.
+The master updates slaves by broadcasting an event in an open loop manner,
+thus the slaves are "eventually consistent" with the master.
+
+The namespace API calls may be used in reactor or non-reactor
+environments.  Calls that send a request to the namespace service return
+a flux_future_t that acts as a handle for synchronization and a container
+for the result.  Futures returned by these functions must be destroyed with
+`flux_future_destroy(3)`.  See `flux_future_then(3)` for more information
+on synchronizing with futures.
+
+`flux_kvs_ns_create()` creates namespace  _name_ on broker _nodeid_,
+owned by _userid_.  If the FLUX_NS_SYNCHRONIZE flag is set, a create event
+instructs other ranks to become slaves for this namespace.
+`flux_future_get(3)` with a NULL payload argument is used to obtain the
+result of the create operation.
+
+`flux_kvs_ns_remove()` removes namespace _name_ from broker _nodeid_,
+which must be the master for the namespace.  If the namespace was created
+with the FLUX_NS_SYNCHRONIZE flag, a remove event instructs other ranks
+to remove this namespace.  `flux_future_get(3)` with a NULL payload argument
+is used to obtain the result of the remove operation.
+
+`flux_kvs_ns_lookup()` sends a lookup request for the root of
+namespace _name_ to broker _nodeid_.  _min_seq_ should be set to the
+minimum sequence number that can satisfy the lookup, or FLUX_NS_SEQ_ANY (0).
+If _flags_ includes FLUX_NS_WAIT, the future will not be fulfilled until
+the namespace is created and/or _min_seq_ is satisfied.  The JSON portion
+of the result may be accessed with `flux_kvs_ns_lookup_get()` or its cousin,
+`flux_future_lookup_getf()`.  `flux_kvs_ns_lookup_get()` sets _json_str_,
+if non-NULL, to point to a serialized JSON string representing the root
+reference.  `flux_kvs_ns_lookup_getf()` decodes the root reference according
+to the _fmt_ string and variable arguments, which are passed internally to
+jansson's `json_unpack()` function.  `flux_kvs_ns_lookup_get_seq()` sets
+_seq_, if non-NULL, to the sequence number portion of the result.
+
+`flux_kvs_ns_commit()` updates namespace _name_ on broker _nodeid_,
+which must be the master for the namespace.  _seq_ must be the the current
+sequence number plus one.  _json_str_ is the encoded JSON object representing
+the root reference.  `flux_kvs_ns_commitf()` encodes the JSON object
+according to the _fmt_ string and variable arguments, which are passed
+internally to jansson's `json_pack()` function.
+`flux_future_get(3)` with a NULL payload argument is used to obtain the
+result of the commit operation.
+
+In addition to the above API functions, applications may subscribe
+to `ns.allcommit.NAME` to receive an event message each time the `NAME`
+namespace is updated.  `flux_kvs_ns_event_decode()` decodes _msg_ and
+sets _json_str_, if non-NULL, to a serialized JSON string representing the
+root reference, and _seq_, if non-NULL to the matching sequence number.
+
+
+FLAGS
+-----
+
+FLUX_NS_SYNCHRONIZE::
+Create only:  synchronize with slaves on create/remove/update.
+If this flag is not used, the namespace will only be known on the
+broker rank it was created on.
+
+FLUX_NS_WAIT::
+Lookup only:  block until the namespace is created, or until it reaches
+a minimum sequence number specified in _min_seq_.
+
+
+SECURITY
+--------
+
+Only the instance owner can create or remove namespaces.
+
+A namespace is created with a _userid_.  Only this user or the instance
+owner are allowed to access or change the namespace.
+
+The privacy bit is set on ns.allcommit events used to synchronize masters
+and slaves.  The userid is set to the namespace owner.  This prevents a
+user other than the owner of the namespace or the instance owner from
+obtaining content references and looking up content.
+
+
+include::JSON_PACK.adoc[]
+
+
+include::JSON_UNPACK.adoc[]
+
+
+RETURN VALUE
+------------
+
+`flux_kvs_ns_create()`, `flux_kvs_ns_remove()`,
+`flux_kvs_ns_lookup()`, and `flux_kvs_ns_commit()` return a
+_flux_future_t_ on success.  On failure, NULL is returned and errno
+is set appropriately.
+
+`flux_kvs_ns_lookup_get()`, `flux_kvs_ns_lookup_getf()`,
+`flux_kvs_ns_lookup_get_seq()`, and `flux_kvs_ns_event_decode()` return 0
+on success.  On failure, -1 is returned and errno is set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+One of the arguments was invalid.
+
+ENOMEM::
+Out of memory.
+
+ENOENT::
+Lookup, commit, or remove was attempted on an unknown namespace.
+
+EEXIST::
+Create was attempted on an existing namespace.
+
+EPROTO::
+A request was malformed.
+
+EPERM::
+A commit was attempted on a namespace without appropriate rolemask
+or userid credentials.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_event_subscribe(3), flux_future_then(3)
+
+https://github.com/flux-framework/rfc/blob/master/spec_11.adoc[RFC 11: Key Value Store Tree Object Format v1]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -392,3 +392,7 @@ PUs
 ETIMEDOUT
 fn
 destructors
+allcommit
+commitf
+namespaces
+ns

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -43,7 +43,9 @@ flux_broker_SOURCES = \
 	ping.h \
 	ping.c \
 	rusage.h \
-	rusage.c
+	rusage.c \
+	namespace.h \
+	namespace.c
 
 flux_broker_LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -80,6 +80,7 @@
 #include "exec.h"
 #include "ping.h"
 #include "rusage.h"
+#include "namespace.h"
 
 /* Generally accepted max, although some go higher (IE is 2083) */
 #define ENDPOINT_MAX 2048
@@ -614,6 +615,9 @@ int main (int argc, char *argv[])
         log_err_exit ("ping_initialize");
     if (rusage_initialize (ctx.h, "cmb") < 0)
         log_err_exit ("rusage_initialize");
+    if (namespace_initialize (ctx.h) < 0)
+        log_err_exit ("namespace_initialize");
+
 
     broker_add_services (&ctx);
 
@@ -1772,6 +1776,7 @@ static struct internal_service services[] = {
     { "hello",              NULL },
     { "attr",               NULL },
     { "heaptrace",          NULL },
+    { "ns",                 NULL },
     { NULL, NULL, },
 };
 

--- a/src/broker/namespace.c
+++ b/src/broker/namespace.c
@@ -1,0 +1,536 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+#include "namespace.h"
+
+#include "src/common/libutil/iterators.h"
+
+struct namespace {
+    int flags;
+    int seq;
+    json_t *object;
+    bool slave;
+    char *name;
+    uint32_t userid;
+};
+
+struct namespace_context {
+    zhash_t *spaces;
+    zlist_t *waiters;
+};
+
+static void namespace_destroy (void *arg)
+{
+    struct namespace *ns = arg;
+    if (ns) {
+        int saved_errno = errno;
+        free (ns->name);
+        json_decref (ns->object);
+        free (ns);
+        errno = saved_errno;
+    }
+}
+
+static struct namespace *namespace_create (const char *name,
+                                           uint32_t userid, int flags)
+{
+    struct namespace *ns;
+    if (!(ns = calloc (1, sizeof (*ns))))
+        goto nomem;
+    if (!(ns->name = strdup (name)))
+        goto nomem;
+    ns->flags = flags;
+    ns->userid = userid;
+    ns->seq = -1;
+    return ns;
+nomem:
+    errno = ENOMEM;
+    namespace_destroy (ns);
+    return NULL;
+}
+
+static int request_save (zlist_t *l, const flux_msg_t *msg)
+{
+    flux_msg_t *cpy;
+
+    if (!(cpy = flux_msg_copy (msg, true)))
+        goto error;
+    if (zlist_append (l, cpy) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    flux_msg_destroy (cpy);
+    return -1;
+}
+
+static int request_restore_all (zlist_t *l, flux_t *h)
+{
+    flux_msg_t *msg;
+
+    while ((msg = zlist_head (l))) {
+        if (flux_requeue (h, msg, FLUX_RQ_TAIL) < 0)
+            return -1;
+        zlist_pop (l);
+        flux_msg_destroy (msg);
+    }
+    return 0;
+}
+
+static int request_remove_from (zlist_t *l, const char *id)
+{
+    zlist_t *tmp;
+    flux_msg_t *msg;
+    char *msg_id;
+    int rc = -1;
+
+    if (!(tmp = zlist_dup (l))) { // N.B. items are not duplicated
+        errno = ENOMEM;
+        goto done;
+    }
+    FOREACH_ZLIST (tmp, msg) {
+        if (flux_msg_get_route_first (msg, &msg_id) < 0)
+            goto done;
+        if (!strcmp (id, msg_id)) {
+            zlist_remove (l, msg);
+            flux_msg_destroy (msg);
+        }
+        free (msg_id);
+    }
+    rc = 0;
+done:
+    zlist_destroy (&tmp);
+    return rc;
+}
+
+static void stats_get_cb (flux_t *h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+
+    if (flux_respondf (h, msg, "{s:i s:i}",
+                               "waiters", zlist_size (ctx->waiters),
+                               "namespaces", zhash_size (ctx->spaces)) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+}
+
+static void disconnect_cb (flux_t *h, flux_msg_handler_t *w,
+                           const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    char *id = NULL;
+
+    if (flux_msg_get_route_first (msg, &id) < 0) {
+        flux_log_error (h, "%s: could not determine sender", __FUNCTION__);
+        goto done;
+    }
+    if (request_remove_from (ctx->waiters, id) < 0) {
+        flux_log_error (h, "%s: flux_remove_from %s", __FUNCTION__, id);
+        goto done;
+    }
+done:
+    free (id);
+}
+
+static void allcommit_cb (flux_t *h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    struct namespace *ns;
+    const char *name, *topic;
+    int seq;
+    json_t *object;
+    const int prefix_length = strlen ("ns.allcommit.");
+    uint32_t userid, rolemask;
+
+    if (flux_event_decodef (msg, &topic, "{s:i s:o}",
+                            "seq", &seq,
+                            "object", &object) < 0) {
+        flux_log_error (h, "%s: error decoding event", __FUNCTION__);
+        return;
+    }
+    if (strlen (topic) <= prefix_length) {
+        flux_log(h, LOG_ERR, "%s: %s topic too short", __FUNCTION__, topic);
+        return;
+    }
+    name = topic + prefix_length;
+    if (!(ns = zhash_lookup (ctx->spaces, name)) || !ns->slave)
+        return;
+
+    /* security check */
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        return;
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+        return;
+    if (!(rolemask & FLUX_ROLE_OWNER) && (ns->userid == FLUX_USERID_UNKNOWN
+                                       || ns->userid != userid)) {
+        flux_log (h, LOG_ERR, "%s: commit %s: permission denied",
+                  __FUNCTION__, name);
+        return;
+    }
+
+    /* sequence must not regress */
+    if (seq <= ns->seq) {
+        flux_log (h, LOG_ERR, "%s: commit %s: invalid sequence (%d->%d)",
+                  __FUNCTION__, name, ns->seq, seq);
+        return;
+    }
+    json_decref (ns->object);
+    ns->object = json_incref (object);
+    ns->seq = seq;
+    if (request_restore_all (ctx->waiters, h) < 0) {
+        flux_log_error (h, "%s: create %s: requeuing waiters",
+                        __FUNCTION__, name);
+    }
+}
+
+static void commit_cb (flux_t *h, flux_msg_handler_t *w,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    const char *name;
+    int seq;
+    json_t *object;
+    struct namespace *ns;
+    flux_msg_t *event = NULL;
+    char *topic = NULL;
+    uint32_t userid, rolemask;
+
+    if (flux_request_decodef (msg, NULL, "{s:s s:i s:o}",
+                              "name", &name,
+                              "seq", &seq,
+                              "object", &object) < 0)
+        goto error;
+    if (!(ns = zhash_lookup (ctx->spaces, name))) {
+        errno = ENOENT;
+        goto error;
+    }
+    if (ns->slave || seq != ns->seq + 1) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    /* security check */
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+    if (!(rolemask & FLUX_ROLE_OWNER) && (ns->userid == FLUX_USERID_UNKNOWN
+                                       || ns->userid != userid)) {
+        errno = EPERM;
+        goto error;
+    }
+
+    json_decref (ns->object);
+    ns->object = json_incref (object);
+    ns->seq = seq;
+    if ((ns->flags & FLUX_NS_SYNCHRONIZE)) {
+        if (asprintf (&topic, "ns.allcommit.%s", name) < 0)
+            goto nomem;
+        if (!(event = flux_event_encodef (topic, "{s:i s:i s:O}",
+                                        "flags", ns->flags,
+                                        "seq", ns->seq,
+                                        "object", ns->object)))
+            goto error;
+        if (ns->userid != FLUX_USERID_UNKNOWN) {
+            if (flux_msg_set_userid (event, ns->userid) < 0)
+                goto error;
+        }
+        if (flux_msg_set_private (event) < 0) // private to namespace owner
+            goto error;                       //  (and instance owner)
+        if (flux_send (h, event, 0) < 0)
+            goto error;
+    }
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_msg_destroy (event);
+    if (request_restore_all (ctx->waiters, h) < 0) {
+        flux_log_error (h, "%s: create %s: requeuing waiters",
+                        __FUNCTION__, name);
+    }
+    free (topic);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_msg_destroy (event);
+    free (topic);
+}
+
+static void lookup_cb (flux_t *h, flux_msg_handler_t *w,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    const char *name;
+    struct namespace *ns;
+    int flags;
+    int min_seq;
+    uint32_t userid, rolemask;
+
+    if (flux_request_decodef (msg, NULL, "{s:s s:i s:i}",
+                              "name", &name,
+                              "min_seq", &min_seq,
+                              "flags", &flags) < 0)
+        goto error;
+    if (min_seq < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(ns = zhash_lookup (ctx->spaces, name)) || ns->seq < min_seq) {
+        if ((flags & FLUX_NS_WAIT)) {
+            if (request_save (ctx->waiters, msg) < 0)
+                goto error;
+            return;
+        }
+        else {
+            errno = ENOENT;
+            goto error;
+        }
+    }
+
+    /* security check */
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+    if (!(rolemask & FLUX_ROLE_OWNER) && (ns->userid == FLUX_USERID_UNKNOWN
+                                       || ns->userid != userid)) {
+        errno = EPERM;
+        goto error;
+    }
+
+    if (flux_respondf (h, msg, "{s:i s:O}", "seq", ns->seq,
+                                            "object", ns->object) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+}
+
+static void allcreate_cb (flux_t *h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    struct namespace *ns;
+    const char *name;
+    uint32_t userid;
+    int flags;
+
+    if (flux_event_decodef (msg, NULL, "{s:s s:i s:i}",
+                            "name", &name,
+                            "userid", &userid,
+                            "flags", &flags) < 0) {
+        flux_log_error (h, "%s: error decoding event", __FUNCTION__);
+        return;
+    }
+    if ((ns = zhash_lookup (ctx->spaces, name)))
+        return;
+    if (!(ns = namespace_create (name, userid, flags))) {
+        flux_log_error (h, "%s: create %s", __FUNCTION__, name);
+        return;
+    }
+    ns->slave = true;
+    if (zhash_insert (ctx->spaces, name, ns) < 0) {
+        flux_log (h, LOG_ERR, "%s: create %s: out of memory",
+                  __FUNCTION__, name);
+        namespace_destroy (ns);
+        return;
+    }
+    zhash_freefn (ctx->spaces, name, namespace_destroy);
+    if (request_restore_all (ctx->waiters, h) < 0) {
+        flux_log_error (h, "%s: create %s: requeuing waiters",
+                        __FUNCTION__, name);
+    }
+}
+
+static void create_cb (flux_t *h, flux_msg_handler_t *w,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    struct namespace *ns = NULL;
+    int flags;
+    char *name;
+    flux_msg_t *event = NULL;
+    uint32_t userid;
+
+    if (flux_request_decodef (msg, NULL, "{s:s s:i s:i}",
+                              "name", &name,
+                              "userid", &userid,
+                              "flags", &flags) < 0)
+        goto error;
+    if (zhash_lookup (ctx->spaces, name)) {
+        errno = EEXIST;
+        goto error;
+    }
+    if (!(ns = namespace_create (name, userid, flags)))
+        goto error;
+    if (zhash_insert (ctx->spaces, ns->name, ns) < 0) {
+        namespace_destroy (ns);
+        goto nomem;
+    }
+    zhash_freefn (ctx->spaces, ns->name, namespace_destroy);
+    if ((ns->flags & FLUX_NS_SYNCHRONIZE)) {
+        if (!(event = flux_event_encodef ("ns.allcreate", "{s:s s:i s:i}",
+                                          "name", name,
+                                          "userid", userid,
+                                          "flags", flags)))
+            goto error;
+        if (flux_msg_set_private (event) < 0)
+            goto error;
+        if (flux_send (h, event, 0) < 0)
+            goto error;
+    }
+    flux_msg_destroy (event);
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_msg_destroy (event);
+}
+
+static void allremove_cb (flux_t *h, flux_msg_handler_t *w,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    struct namespace *ns;
+    const char *name;
+
+    if (flux_event_decodef (msg, NULL, "{s:s}",
+                            "name", &name) < 0) {
+        flux_log_error (h, "%s: error decoding event", __FUNCTION__);
+        return;
+    }
+    if ((ns = zhash_lookup (ctx->spaces, name)) && ns->slave)
+        zhash_delete (ctx->spaces, name);
+}
+
+static void remove_cb (flux_t *h, flux_msg_handler_t *w,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct namespace_context *ctx = arg;
+    struct namespace *ns;
+    const char *name;
+    flux_msg_t *event = NULL;
+
+    if (flux_request_decodef (msg, NULL, "{s:s}", "name", &name) < 0)
+        goto error;
+    if (!(ns = zhash_lookup (ctx->spaces, name))) {
+        errno = ENOENT;
+        goto error;
+    }
+    if ((ns->flags & FLUX_NS_SYNCHRONIZE)) {
+        if (!(event = flux_event_encodef ("ns.allremove",
+                                          "{s:s}", "name", name)))
+            goto error;
+        if (flux_msg_set_private (event) < 0)
+            goto error;
+        if (flux_send (h, event, 0) < 0)
+            goto error;
+    }
+    zhash_delete (ctx->spaces, name);
+    flux_msg_destroy (event);
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_msg_destroy (event);
+}
+
+static struct flux_msg_handler_spec handlers[] = {
+    { FLUX_MSGTYPE_REQUEST, "ns.create",    create_cb,    0, NULL },
+    { FLUX_MSGTYPE_EVENT,   "ns.allcreate", allcreate_cb, 0, NULL },
+    { FLUX_MSGTYPE_REQUEST, "ns.remove",    remove_cb,    0, NULL },
+    { FLUX_MSGTYPE_EVENT,   "ns.allremove", allremove_cb, 0, NULL },
+
+    { FLUX_MSGTYPE_REQUEST, "ns.commit",     commit_cb,  FLUX_ROLE_ALL, NULL },
+    { FLUX_MSGTYPE_EVENT, "ns.allcommit.*",  allcommit_cb,
+                                                         FLUX_ROLE_ALL, NULL },
+    { FLUX_MSGTYPE_REQUEST, "ns.lookup",     lookup_cb,  FLUX_ROLE_ALL, NULL },
+    { FLUX_MSGTYPE_REQUEST, "ns.disconnect", disconnect_cb,
+                                                         FLUX_ROLE_ALL, NULL },
+    { FLUX_MSGTYPE_REQUEST, "ns.stats.get", stats_get_cb,
+                                                         FLUX_ROLE_ALL, NULL },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void namespace_finalize (void *arg)
+{
+    struct namespace_context *ctx = arg;
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (handlers);
+        zhash_destroy (&ctx->spaces);
+        if (ctx->waiters) {
+            flux_msg_t *msg;
+            while ((msg = zlist_pop (ctx->waiters)))
+                flux_msg_destroy (msg);
+            zlist_destroy (&ctx->waiters);
+        }
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+int namespace_initialize (flux_t *h)
+{
+    struct namespace_context *ctx = calloc (1, sizeof (*ctx));
+    if (!ctx)
+        goto nomem;
+    if (!(ctx->spaces = zhash_new ()))
+        goto nomem;
+    if (!(ctx->waiters = zlist_new ()))
+        goto nomem;
+    if (flux_msg_handler_addvec (h, handlers, ctx) < 0)
+        goto error;
+    if (flux_event_subscribe (h, "ns.") < 0)
+        goto error;
+    flux_aux_set (h, "flux::namespace", ctx, namespace_finalize);
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    namespace_finalize (ctx);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/namespace.h
+++ b/src/broker/namespace.h
@@ -3,12 +3,6 @@
 
 #include <flux/core.h>
 
-/* flags */
-enum {
-    FLUX_NS_SEQUENCED = 1,      // require sequenced updates
-    FLUX_NS_SYNCHRONIZE = 2,    // publish ns.sync on create/remove/update
-};
-
 int namespace_initialize (flux_t *h);
 
 #endif /* BROKER_NAMESPACE_H */

--- a/src/broker/namespace.h
+++ b/src/broker/namespace.h
@@ -1,0 +1,18 @@
+#ifndef BROKER_NAMESPACE_H
+#define BROKER_NAMESPACE_H
+
+#include <flux/core.h>
+
+/* flags */
+enum {
+    FLUX_NS_SEQUENCED = 1,      // require sequenced updates
+    FLUX_NS_SYNCHRONIZE = 2,    // publish ns.sync on create/remove/update
+};
+
+int namespace_initialize (flux_t *h);
+
+#endif /* BROKER_NAMESPACE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -71,7 +71,8 @@ fluxcoreinclude_HEADERS = \
 	heartbeat.h \
 	content.h \
 	future.h \
-	barrier.h
+	barrier.h \
+	kvs_ns.h
 
 noinst_LTLIBRARIES = \
 	libflux.la
@@ -102,7 +103,8 @@ libflux_la_SOURCES = \
 	keepalive.c \
 	content.c \
 	future.c \
-	barrier.c
+	barrier.c \
+	kvs_ns.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -25,6 +25,7 @@
 #include "content.h"
 #include "future.h"
 #include "barrier.h"
+#include "kvs_ns.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/kvs_ns.c
+++ b/src/common/libflux/kvs_ns.c
@@ -1,0 +1,209 @@
+/*****************************************************************************\
+ *  Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "kvs_ns.h"
+
+/* This key is used to attach re-serialized "object" member of JSON payload
+ * to future (lookup_get), or event message (event_decode).
+ */
+static const char *auxkey = "flux::kvs_ns.json_str";
+
+flux_future_t *flux_kvs_ns_create (flux_t *h, uint32_t nodeid,
+                                   const char *name, uint32_t userid,
+                                   int flags)
+{
+    return flux_rpcf (h, "ns.create", nodeid, 0, "{s:s s:i s:i}",
+                                                 "name", name,
+                                                 "userid", userid,
+                                                 "flags", flags);
+}
+
+flux_future_t *flux_kvs_ns_remove (flux_t *h, uint32_t nodeid,
+                                   const char *name)
+{
+    return flux_rpcf (h, "ns.remove", nodeid, 0, "{s:s}", "name", name);
+}
+
+flux_future_t *flux_kvs_ns_lookup (flux_t *h, uint32_t nodeid,
+                                   const char *name, int min_seq, int flags)
+{
+    return flux_rpcf (h, "ns.lookup", nodeid, 0, "{s:s s:i s:i}",
+                                                 "name", name,
+                                                 "min_seq", min_seq,
+                                                 "flags", flags);
+}
+
+int flux_kvs_ns_lookup_get (flux_future_t *f, const char **json_str)
+{
+    json_t *o;
+    char *s;
+
+    if (flux_rpc_getf (f, "{s:o}", "object", &o) < 0)
+        return -1;
+    if (json_str) {
+        if (!(s = flux_future_aux_get (f, auxkey))) {
+            if (!(s = json_dumps (o, 0))) {
+                errno = EPROTO;
+                return -1;
+            }
+            if (flux_future_aux_set (f, auxkey, s, free) < 0) {
+                free (s);
+                return -1;
+            }
+        }
+        *json_str = s;
+    }
+    return 0;
+}
+
+int flux_kvs_ns_lookup_getf (flux_future_t *f, const char *fmt, ...)
+{
+    json_t *o;
+    va_list ap;
+    int rc;
+
+    if (!fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_rpc_getf (f, "{s:o}", "object", &o) < 0)
+        return -1;
+    va_start (ap, fmt);
+    rc = json_vunpack_ex (o, NULL, 0, fmt, ap);
+    va_end (ap);
+    if (rc < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+int flux_kvs_ns_lookup_get_seq (flux_future_t *f, int *seq)
+{
+    int i;
+
+    if (flux_rpc_getf (f, "{s:i}", "seq", &i) < 0)
+        return -1;
+    if (seq)
+        *seq = i;
+    return 0;
+}
+
+flux_future_t *flux_kvs_ns_commit (flux_t *h, uint32_t nodeid,
+                                   const char *name, int seq,
+                                   const char *json_str)
+{
+    json_t *o;
+    flux_future_t *f;
+
+    if (!(o = json_loads (json_str, 0, NULL))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    f = flux_rpcf (h, "ns.commit", nodeid, 0, "{s:s s:i s:o}", "name", name,
+                                                               "seq", seq,
+                                                               "object", o);
+    if (!f) {
+        json_decref (o);
+        return NULL;
+    }
+    return f;
+}
+
+flux_future_t *flux_kvs_ns_commitf (flux_t *h, uint32_t nodeid,
+                                    const char *name, int seq,
+                                    const char *fmt, ...)
+{
+    va_list ap;
+    json_t *o;
+    flux_future_t *f;
+
+    va_start (ap, fmt);
+    o = json_vpack_ex (NULL, 0, fmt, ap);
+    va_end (ap);
+    if (!o) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    f = flux_rpcf (h, "ns.commit", nodeid, 0, "{s:s s:i s:o}", "name", name,
+                                                               "seq", seq,
+                                                               "object", o);
+    if (!f) {
+        json_decref (o);
+        return NULL;
+    }
+    return f;
+}
+
+int flux_kvs_ns_event_decode (const flux_msg_t *msg, const char **namep,
+                              int *seqp, const char **json_strp)
+{
+    const char *topic;
+    int seq;
+    json_t *object;
+    const int prefix_length = strlen ("ns.allcommit.");
+    char *str;
+
+    if (flux_event_decodef (msg, &topic, "{s:i s:o}",
+                             "seq", &seq,
+                             "object", &object) < 0)
+        goto error;
+    if (strlen (topic) <= prefix_length) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (json_strp) {
+        if (!(str = flux_msg_aux_get (msg, auxkey))) {
+            if (!(str = json_dumps (object, 0))) {
+                errno = EPROTO;
+                goto error;
+            }
+            if (flux_msg_aux_set (msg, auxkey, str, free) < 0) {
+                free (str);
+                goto error;
+            }
+        }
+        *json_strp = str;
+    }
+    if (namep)
+        *namep = topic + prefix_length;
+    if (seqp)
+        *seqp = seq;
+    return 0;
+error:
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/kvs_ns.h
+++ b/src/common/libflux/kvs_ns.h
@@ -1,0 +1,67 @@
+#ifndef _FLUX_CORE_KVS_NS_H
+#define _FLUX_CORE_KVS_NS_H
+
+#include <flux/core.h>
+
+/* create flags */
+enum {
+    FLUX_NS_SYNCHRONIZE = 1,    // publish ns.sync on create/remove/update
+};
+
+/* lookup flags */
+enum {
+    FLUX_NS_WAIT = 1,           // wait until created/min_seq reached
+};
+
+enum {
+    FLUX_NS_SEQ_ANY = 0,        // min_seq "don't care" value
+};
+
+flux_future_t *flux_kvs_ns_create (flux_t *h,
+                                   uint32_t nodeid,
+                                   const char *name,
+                                   uint32_t userid,
+                                   int flags);
+
+flux_future_t *flux_kvs_ns_remove (flux_t *h,
+                                   uint32_t nodeid,
+                                   const char *name);
+
+flux_future_t *flux_kvs_ns_lookup (flux_t *h,
+                                   uint32_t nodeid,
+                                   const char *name,
+                                   int min_seq,
+                                   int flags);
+
+int flux_kvs_ns_lookup_get (flux_future_t *f,
+                            const char **json_str);
+
+int flux_kvs_ns_lookup_getf (flux_future_t *f,
+                             const char *fmt, ...);
+
+int flux_kvs_ns_lookup_get_seq (flux_future_t *f,
+                                int *seq);
+
+flux_future_t *flux_kvs_ns_commit (flux_t *h,
+                                   uint32_t nodeid,
+                                   const char *name,
+                                   int seq,
+                                   const char *json_str);
+
+flux_future_t *flux_kvs_ns_commitf (flux_t *h,
+                                    uint32_t nodeid,
+                                    const char *name,
+                                    int seq,
+                                    const char *fmt, ...);
+
+int flux_kvs_ns_event_decode (const flux_msg_t *msg,
+                              const char **name,
+                              int *seq,
+                              const char **json_str);
+
+
+#endif /* !_FLUX_CORE_KVS_NS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/proto.c
+++ b/src/modules/kvs/proto.c
@@ -242,50 +242,6 @@ done:
     return rc;
 }
 
-/* kvs.setroot (event)
- */
-
-json_object *kp_tsetroot_enc (int rootseq, const char *rootdir,
-			      json_object *root, json_object *names)
-{
-    json_object *o = NULL;
-    int n;
-
-    if (!rootdir || !names || !Jget_ar_len (names, &n) || n < 1) {
-        errno = EINVAL;
-        goto done;
-    }
-    o = Jnew ();
-    Jadd_int (o, "rootseq", rootseq);
-    Jadd_str (o, "rootdir", rootdir);
-    Jadd_obj (o, "names", names);         /* takes a ref */
-    if (root)
-        Jadd_obj (o, "rootdirval", root); /* takes a ref */
-done:
-    return o;
-}
-
-int kp_tsetroot_dec (json_object *o, int *rootseq, const char **rootdir,
-                     json_object **root, json_object **names)
-{
-    int rc = -1;
-
-    if (!o || !rootseq || !rootdir || !root || !names) {
-        errno = EINVAL;
-        goto done;
-    }
-    if (!Jget_int (o, "rootseq", rootseq) || !Jget_str (o, "rootdir", rootdir)
-                                          || !Jget_obj (o, "names", names)) {
-        errno = EPROTO;
-        goto done;
-    }
-    *root = NULL;
-    (void)Jget_obj (o, "rootdirval", root);
-    rc = 0;
-done:
-    return rc;
-}
-
 /* kvs.error (event)
  */
 

--- a/src/modules/kvs/proto.h
+++ b/src/modules/kvs/proto.h
@@ -44,13 +44,6 @@ json_object *kp_tfence_enc (const char *name, int nprocs, int flags,
 int kp_tfence_dec (json_object *o, const char **name, int *nprocs,
                    int *flags, json_object **ops);
 
-/* kvs.setroot (event)
- */
-json_object *kp_tsetroot_enc (int rootseq, const char *rootdir,
-                              json_object *root, json_object *names);
-int kp_tsetroot_dec (json_object *o, int *rootseq, const char **rootdir,
-                     json_object **root, json_object **names);
-
 /* kvs.error (event)
  */
 json_object *kp_terror_enc (json_object *names, int errnum);

--- a/src/modules/kvs/test/proto.c
+++ b/src/modules/kvs/test/proto.c
@@ -140,30 +140,6 @@ void test_fence (void)
     Jput (ops);
 }
 
-void test_setroot (void)
-{
-    json_object *o;
-    const char *rootdir, *name;
-    int rootseq;
-    json_object *root;
-    json_object *names;
-
-    names = Jnew_ar ();
-    Jadd_ar_str (names, "foo");
-    ok ((o = kp_tsetroot_enc (42, "abc", NULL, names)) != NULL,
-        "kp_tsetroot_enc works");
-    Jput (names);
-
-    diag ("setroot: %s", Jtostr (o));
-
-    ok (kp_tsetroot_dec (o, &rootseq, &rootdir, &root, &names) == 0
-        && rootseq == 42 && rootdir != NULL && !strcmp (rootdir, "abc")
-        && root == NULL && names != NULL && Jget_ar_str (names, 0, &name)
-        && !strcmp (name, "foo"),
-        "kp_tsetroot_dec works");
-    Jput (o);
-}
-
 void test_error (void)
 {
     json_object *o;
@@ -198,7 +174,6 @@ int main (int argc, char *argv[])
     test_get ();
     test_watch ();
     test_unwatch ();
-    test_setroot ();
     test_fence ();
     test_error ();
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -51,6 +51,7 @@ TESTS = \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1002-kvs-cmd.t \
+	t1003-namespace.t \
 	t1005-cmddriver.t \
 	t1006-apidisconnect.t \
 	t1007-kz.t \
@@ -122,6 +123,7 @@ check_SCRIPTS = \
 	t1000-kvs-basic.t \
 	t1001-barrier-basic.t \
 	t1002-kvs-cmd.t \
+	t1003-namespace.t \
 	t1005-cmddriver.t \
 	t1006-apidisconnect.t \
 	t1007-kz.t \
@@ -178,6 +180,7 @@ check_PROGRAMS = \
 	kvs/watch_disconnect \
 	kvs/commit \
 	kvs/commitmerge \
+	kvs/namespace \
 	kvs/basic \
 	module/basic \
 	request/treq \
@@ -313,6 +316,11 @@ kvs_commitmerge_SOURCES = kvs/commitmerge.c
 kvs_commitmerge_CPPFLAGS = $(test_cppflags)
 kvs_commitmerge_LDADD = \
 	$(top_builddir)/src/modules/kvs/libflux-kvs.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_namespace_SOURCES = kvs/namespace.c
+kvs_namespace_CPPFLAGS = $(test_cppflags)
+kvs_namespace_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 kvs_watch_disconnect_SOURCES = kvs/watch_disconnect.c

--- a/t/kvs/namespace.c
+++ b/t/kvs/namespace.c
@@ -1,0 +1,115 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include <src/common/libutil/log.h>
+
+
+const char *usage_str = "Usage: namespace {create|remove|lookup|commit} ...";
+
+void cmd_create (flux_t *h, int argc, char **argv)
+{
+    if (argc != 3)
+        log_msg_exit ("Usage: content create name userid flags");
+
+    const char *name = argv[0];
+    uint32_t userid = strtoul (argv[1], NULL, 0);
+    int flags = strtoul (argv[2], NULL, 0);
+    flux_future_t *f;
+
+    if (!(f = flux_kvs_ns_create (h, FLUX_NODEID_ANY, name, userid, flags)))
+        log_err_exit ("flux_kvs_ns_create");
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+    flux_future_destroy (f);
+}
+
+void cmd_remove (flux_t *h, int argc, char **argv)
+{
+    if (argc != 1)
+        log_msg_exit ("Usage: content remove name");
+
+    const char *name = argv[0];
+    flux_future_t *f;
+
+    if (!(f = flux_kvs_ns_remove (h, FLUX_NODEID_ANY, name)))
+        log_err_exit ("flux_kvs_ns_remove");
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+    flux_future_destroy (f);
+}
+
+void cmd_lookup (flux_t *h, int argc, char **argv)
+{
+    if (argc != 3)
+        log_msg_exit ("Usage: content lookup name min_seq flags");
+
+    const char *name = argv[0];
+    int min_seq = strtoul (argv[1], NULL, 10);
+    int flags = strtoul (argv[2], NULL, 0);
+    flux_future_t *f;
+    int seq;
+    const char *json_str;
+
+    if (!(f = flux_kvs_ns_lookup (h, FLUX_NODEID_ANY, name, min_seq, flags)))
+        log_err_exit ("flux_kvs_ns_lookup");
+    if (flux_kvs_ns_lookup_get (f, &json_str) < 0)
+        log_err_exit ("flux_kvs_ns_lookup");
+    if (flux_kvs_ns_lookup_get_seq (f, &seq) < 0)
+        log_err_exit ("flux_kvs_ns_lookup");
+    printf ("%d %s\n", seq, json_str);
+    flux_future_destroy (f);
+}
+
+void cmd_commit (flux_t *h, int argc, char **argv)
+{
+    if (argc != 3)
+        log_msg_exit ("Usage: commit name seq obj");
+    const char *name = argv[0];
+    int seq = strtoul (argv[1], NULL, 10);
+    const char *json_str = argv[2];
+    flux_future_t *f;
+
+    if (!(f = flux_kvs_ns_commit (h, FLUX_NODEID_ANY, name, seq, json_str)))
+        log_err_exit ("flux_kvs_ns_commit");
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+    printf ("%d %s\n", seq, json_str);
+    flux_future_destroy (f);
+}
+
+int main (int argc, char *argv[])
+{
+    log_init ("namespace");
+    if (argc < 2)
+        log_msg_exit ("%s\n", usage_str);
+    flux_t *h = flux_open (NULL, 0);
+    if (!h)
+        log_err_exit ("flux_open");
+
+    if (!strcmp (argv[1], "create")) {
+        cmd_create (h, argc - 2, argv + 2);
+    }
+    else if (!strcmp (argv[1], "remove")) {
+        cmd_remove (h, argc - 2, argv + 2);
+    }
+    else if (!strcmp (argv[1], "lookup")) {
+        cmd_lookup (h, argc - 2, argv + 2);
+    }
+    else if (!strcmp (argv[1], "commit")) {
+        cmd_commit (h, argc - 2, argv + 2);
+    }
+    else {
+        log_msg_exit ("%s\n", usage_str);
+    }
+
+    flux_close (h);
+    return 0;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -268,41 +268,41 @@ test_expect_success 'dispatcher suppresses guest event to same guest connection'
 	! grep -q test.a ev8.out
 '
 
-# kvs.setroot is a "private" event
+# ns.allcommit.kvs is a "private" event
 
 test_expect_success 'loaded kvs module' '
 	flux module load kvs
 '
 
-test_expect_success 'connector delivers kvs.setroot event to owner connection' '
+test_expect_success 'connector delivers ns.allcommit.kvs event to owner connection' '
 	run_timeout 5 \
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
-		kvs kvs.test.end \
-                "flux event pub kvs.test.a; \
+		ns ns.test.end \
+                "flux event pub ns.test.a; \
                  flux kvs put ev9=42; \
-                 flux event pub kvs.test.end" >ev9.out &&
-	grep -q kvs.setroot ev9.out
+                 flux event pub ns.test.end" >ev9.out &&
+	grep -q ns.allcommit.kvs ev9.out
 '
 
-test_expect_success 'dispatcher delivers kvs.setroot event to owner connection' '
+test_expect_success 'dispatcher delivers ns.allcommit.kvs event to owner connection' '
 	run_timeout 5 \
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
-		kvs kvs.test.end \
-                "flux event pub kvs.test.a; \
+		ns ns.test.end \
+                "flux event pub ns.test.a; \
                  flux kvs put ev10=42; \
-                 flux event pub kvs.test.end" >ev10.out &&
-	grep -q kvs.setroot ev10.out
+                 flux event pub ns.test.end" >ev10.out &&
+	grep -q ns.allcommit.kvs ev10.out
 '
 
-test_expect_success 'connector suppresses kvs.setroot event to guest connection' '
+test_expect_success 'connector suppresses ns.allcommit.kvs event to guest connection' '
 	flux module debug --set 4 connector-local &&
 	run_timeout 5 \
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
-		kvs kvs.test.end \
-                "flux event pub kvs.test.a; \
+		ns ns.test.end \
+                "flux event pub ns.test.a; \
                  flux kvs put ev11=42; \
-                 flux event pub kvs.test.end" >ev11.out &&
-	! grep -q kvs.setroot ev11.out
+                 flux event pub ns.test.end" >ev11.out &&
+	! grep -q ns.allcommit.kvs ev11.out
 '
 
 test_expect_success 'unloaded kvs module' '

--- a/t/t1003-namespace.t
+++ b/t/t1003-namespace.t
@@ -1,0 +1,250 @@
+#!/bin/sh
+#
+
+test_description='Test namespace service
+
+Test broker-resident namespace service
+'
+
+. `dirname $0`/sharness.sh
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE} minimal
+echo "# $0: flux session size will be ${SIZE}"
+
+# Test command usage:
+#   ${NS} create name flags seq json_str  (flags: SEQUENCED=1, SYNC=2)
+#   ${NS} remove name
+#   ${NS} lookup name min_seq flags (flags: WAIT=1)
+#   ${NS} commit name seq json_str
+CREATE_FLAGS=3 # SEQUENCED | SYNC
+LOOKUP_NONBLOCK=0
+LOOKUP_BLOCK=1
+NS=${FLUX_BUILD_DIR}/t/kvs/namespace
+USERID_UNKNOWN=0xFFFFFFFF
+
+# next connection via local connector will be as USER not OWNER role
+connect_guest_next() {
+    flux module debug --set 4 connector-local
+}
+
+test_expect_success 'namespace create works' '
+	before=$(flux module stats --parse namespaces ns) &&
+	${NS} create ns-test ${USERID_UNKNOWN} ${CREATE_FLAGS} &&
+	after=$(flux module stats --parse namespaces ns) &&
+	test ${after} -eq $((${before}+1))
+'
+
+test_expect_success 'namespace create fails if namespace exists' '
+	before=$(flux module stats --parse namespaces ns) &&
+	! ${NS} create ns-test ${USERID_UNKNOWN} ${CREATE_FLAGS} &&
+	after=$(flux module stats --parse namespaces ns) &&
+	test ${after} -eq ${before}
+'
+
+test_expect_success 'namespace lookup fails before first commit' '
+	test_must_fail ${NS} lookup ns-test 0 ${LOOKUP_NONBLOCK}
+'
+
+test_expect_success 'namespace commit works (seq=0)' '
+	${NS} commit ns-test 0 "{}" &&
+	echo "0 {}" >ns-test.0
+'
+
+test_expect_success 'namespace lookup works, expected value' '
+	${NS} lookup ns-test 0 ${LOOKUP_NONBLOCK} >lookup.0 &&
+	test_cmp ns-test.0 lookup.0
+'
+
+test_expect_success 'namespace lookup (wait=1) works rank>0, expected values' '
+	for rank in $(seq 1 $((${SIZE}-1))); do \
+          flux exec -r ${rank} \
+	      ${NS} lookup ns-test 0 ${LOOKUP_BLOCK} >lookup.0.r${rank} &&
+	          test_cmp ns-test.0 lookup.0.r${rank}
+	done
+'
+
+test_expect_success 'namespace commit works (seq=1), verified with lookup' '
+	${NS} commit ns-test 1 "{}" &&
+	echo "1 {}" >ns-test.1 &&
+	${NS} lookup ns-test 1 ${LOOKUP_NONBLOCK} >lookup.1 &&
+	test_cmp ns-test.1 lookup.1
+'
+
+test_expect_success 'namespace lookup (wait=1) works rank>0, expected values' '
+	for rank in $(seq 1 $((${SIZE}-1))); do \
+          flux exec -r ${rank} \
+	      ${NS} lookup ns-test 1 ${LOOKUP_BLOCK} >lookup.1.r${rank} &&
+	          test_cmp ns-test.1 lookup.1.r${rank}
+	done
+'
+
+test_expect_success 'namespace commit (seq=3) fails due to seq skip' '
+	test_must_fail ${NS} commit ns-test 3 "{}"
+'
+
+test_expect_success 'previous state unchanged on all ranks' '
+	for rank in $(seq 0 $((${SIZE}-1))); do \
+          flux exec -r ${rank} \
+	      ${NS} lookup ns-test 1 ${LOOKUP_BLOCK} >lookup.1.r${rank} &&
+	          test_cmp ns-test.1 lookup.1.r${rank}
+	done
+'
+
+test_expect_success 'namespace commit (seq=2) fails on slave rank' '
+	test_must_fail flux exec -r 1 ${NS} commit ns-test 2 "{}"
+'
+
+test_expect_success 'namespace event generated on commit' '
+        run_timeout 5 \
+	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
+	        ns ns.test.end \
+		"flux event pub ns.test.a; \
+		${NS} commit ns-test 2 \{\}; \
+		flux event pub ns.test.end" >ev.out &&
+	grep -q ns.allcommit.ns-test ev.out
+'
+
+test_expect_success 'guest cannot see owner namespace event' '
+	connect_guest_next &&
+        run_timeout 5 \
+	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
+	        ns ns.test.end \
+		"flux event pub ns.test.a; \
+		${NS} commit ns-test 3 \{\}; \
+		flux event pub ns.test.end" >evguest.out &&
+	! grep -q ns.allcommit.ns-test evguest.out
+'
+
+test_expect_success 'namespace remove works' '
+	before=$(flux module stats --parse namespaces ns) &&
+	${NS} remove ns-test &&
+	after=$(flux module stats --parse namespaces ns) &&
+	test ${after} -eq $((${before}-1))
+'
+
+test_expect_success 'namespace remove fails if namespace does not exist' '
+	test_must_fail ${NS} remove ns-test
+'
+
+test_expect_success 'namespace lookup fails if namespace does not exist' '
+	test_must_fail ${NS} lookup ns-test 0 ${LOOKUP_NONBLOCK}
+'
+
+test_expect_success 'namespace commit fails if namespace does not exist' '
+	test_must_fail ${NS} commit ns-test 4 "{}"
+'
+
+test_expect_success 'namespace create + first commit works' '
+	before=$(flux module stats --parse namespaces ns) &&
+	${NS} create ns-test2 ${USERID_UNKNOWN} ${CREATE_FLAGS} &&
+	after=$(flux module stats --parse namespaces ns) &&
+	test ${after} -eq $((${before}+1)) &&
+	${NS} commit ns-test2 0 "{}"
+'
+
+test_expect_success 'blocking namespace lookup works' '
+	before=$(flux module stats --parse waiters ns) &&
+	${NS} lookup ns-test2 1 ${LOOKUP_BLOCK} >lookup2.1 &
+	while test $(flux module stats --parse waiters ns) -eq ${before}; do \
+	    /bin/true; done &&
+	test $(flux module stats --parse waiters ns) -eq $((${before}+1)) &&
+	${NS} commit ns-test2 1 "{}" &&
+	echo "1 {}" >ns-test2.1 &&
+	run_timeout 5 wait &&
+	test_cmp ns-test2.1 lookup2.1 &&
+	after=$(flux module stats --parse waiters ns) &&
+       	test ${after} -eq ${before}
+'
+
+test_expect_success 'blocking namespace lookup cleans up when interrupted' '
+	before=$(flux module stats --parse waiters ns) &&
+	! run_timeout 1 ${NS} lookup ns-test2 2 ${LOOKUP_BLOCK} &&
+	after=$(flux module stats --parse waiters ns) &&
+	test ${before} -eq ${after}
+'
+
+test_expect_success 'guest cannot lookup owner namespace' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEOTHERUSER} \
+	    ${NS} lookup ns-test2 0 ${LOOKUP_NONBLOCK}
+'
+
+test_expect_success 'guest cannot commit to owner namespace' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEOTHERUSER} \
+	    ${NS} commit ns-test2 2 "{}"
+'
+
+test_expect_success 'namespace remove works' '
+	before=$(flux module stats --parse namespaces ns) &&
+	${NS} remove ns-test2 &&
+	after=$(flux module stats --parse namespaces ns) &&
+	test ${after} -eq $((${before}-1))
+'
+
+FAKEUSER=42
+FAKEOTHERUSER=43
+
+test_expect_success 'guest cannot create namespaces for themselves' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEUSER} \
+	    ${NS} create ns-test3 ${FAKEUSER} ${CREATE_FLAGS}
+'
+test_expect_success 'instance owner can create namespace for guest' '
+	${NS} create ns-test3 ${FAKEUSER} ${CREATE_FLAGS}
+'
+
+test_expect_success 'instance owner can commit to guest namespace' '
+	${NS} commit ns-test3 0 "{}"
+'
+
+test_expect_success 'instance owner can lookup guest namespace' '
+	${NS} lookup ns-test3 0 ${LOOKUP_NONBLOCK}
+'
+
+test_expect_success 'guest can commit to their namespace' '
+	FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEUSER} \
+	    ${NS} commit ns-test3 1 "{}"
+'
+
+test_expect_success 'guest can lookup their namespace' '
+	FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEUSER} \
+	    ${NS} lookup ns-test3 0 ${LOOKUP_NONBLOCK}
+'
+
+test_expect_success 'guest cannot commit to another guests namespace' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEOTHERUSER} \
+	    ${NS} commit ns-test3 2 "{}"
+'
+
+test_expect_success 'guest cannot lookup another guests namespace' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEOTHERUSER} \
+	    ${NS} lookup ns-test3 0 ${LOOKUP_NONBLOCK}
+'
+
+# here the "other guest" is FLUX_USERID_UNKNOWN
+test_expect_success 'guest cannot see another guests namespace events' '
+	connect_guest_next &&
+        run_timeout 5 \
+	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
+	        ns ns.test.end \
+		"flux event pub ns.test.a; \
+		${NS} commit ns-test3 3 \{\}; \
+		flux event pub ns.test.end" >evguest2.out &&
+	! grep -q ns.allcommit.ns-test3 evguest2.out
+'
+
+test_expect_success 'guest cannot remove another guests namespace' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEOTHERUSER} \
+	    ${NS} remove ns-test3
+'
+
+test_expect_success 'guest cannot remove their namespace' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${FAKEUSER} \
+	    ${NS} remove ns-test3
+'
+
+test_expect_success 'instance owner can remove guest namespace' '
+	${NS} remove ns-test3
+'
+
+test_done


### PR DESCRIPTION
This PR adds a broker-resident service for managing loosely-consistent KVS namespaces.

The service is simply a hash of user-provided unique names to optionally sequenced, optionally distributed JSON objects.  The JSON objects are intended to point to directory metadata in the content store (such as RFC 11 treeref or a standalone blobref), but they could also be self-contained dictionaries.

The service provides **create**, **remove**, **lookup** and **commit** operations.  It is multi-user:  only the instance owner can create and remove namespaces, but the instance owner can designate an owner for a new namespace, and that user can perform lookups and commits on it.  I was thinking of the new execution system here:  instance owner could create a namespace for each job, let the job shell have at it, then upon termination, "reap" this space possibly folding it into the main namespace.  The instance could have many jobs running updating independent namespaces without serialization of commits that way.

Namespaces can be created on any rank.  Once created, that rank is designated as the master for that namespace, and must be the only rank that accepts commit operations for it (updating the JSON object and incrementing sequence number).  If distribution is selected, an event keeps other "slave" ranks loosely in sync with the master.  It would not be a difficult thing (I think!) to allow the master to migrate to a new slave, but I didn't go that far here.

The KVS master code is modified to store its current root reference in the namespace service, and to use the built-in consistency to keep slaves up to date.   One nice thing that fell out of this, is it is now possible to reload the KVS master module without losing data. 

The lookup operation provides the current sequence number of a namespace, and can optionally take a minimum sequence number and a blocking flag to block until a particular sequence number is reached.  This allowed the KVS "get version" and "wait version" calls to be implemented directly on the namespace service.

I added some basic tests but still need to add some for security of private user namespaces.

Going forward, I would envision this as one component for private KVS namespaces.   There are several ways to go forward from here.  One good idea @grondo had was providing the ability to mount a fstype:fsname into a handle-view of a namespace and enabling this view to be accessed using the regular KVS API.  E.g. mount job-specific namespace to /job _within the job_.  Another idea is to think about synthetic file system-like applications.  For example maybe a handle's message counters could be mounted on /sys/msgcounters and read with kvs_get().

Another thought is that these namespaces could be backed by a true consensus algorithm like RAFT provided by etcd, in a manner similar to the content store pluggable back-ends. 