### PR TITLE
KVS directory walk return error fixes

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -765,7 +765,7 @@ static bool walk (kvs_ctx_t *ctx, json_object *root, const char *path,
                       __FUNCTION__, path, name, Jtostr (dirent));
         } else if ((Jget_str (dirent, "FILEREF", NULL)
                  || json_object_object_get_ex (dirent, "FILEVAL", NULL))) {
-            errno = ENOTDIR;
+            /* don't return ENOENT or ENOTDIR, error to be determined by caller */
             goto error;
         } else {
             log_msg_exit ("%s: unknown dirent type: path=%s name=%s: dirent=%s ",

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -748,6 +748,7 @@ static bool walk (kvs_ctx_t *ctx, json_object *root, const char *path,
     while ((next = strchr (name, '.'))) {
         *next++ = '\0';
         if (!json_object_object_get_ex (dir, name, &dirent))
+            /* not necessarily ENOENT, let caller decide */
             goto error;
         if (Jget_str (dirent, "LINKVAL", &link)) {
             if (depth == SYMLINK_CYCLE_LIMIT) {
@@ -761,6 +762,7 @@ static bool walk (kvs_ctx_t *ctx, json_object *root, const char *path,
                 goto error;
             }
             if (!dirent)
+                /* not necessarily ENOENT, let caller decide */
                 goto error;
         }
         if (Jget_str (dirent, "DIRREF", &ref)) {

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -525,6 +525,32 @@ test_expect_success 'kvs: symlink: readlink works on non-dangling link' '
 	test "$OUTPUT" = "$TEST.a.b.c"
 '
 
+# Check for limit on link depth
+
+test_expect_success 'kvs: symlink: error on link depth' '
+	${KVSBASIC} unlink $TEST &&
+        ${KVSBASIC} put $TEST.a=1 &&
+	${KVSBASIC} link $TEST.a $TEST.b &&
+	${KVSBASIC} link $TEST.b $TEST.c &&
+	${KVSBASIC} link $TEST.c $TEST.d &&
+	${KVSBASIC} link $TEST.d $TEST.e &&
+	${KVSBASIC} link $TEST.e $TEST.f &&
+	${KVSBASIC} link $TEST.f $TEST.g &&
+	${KVSBASIC} link $TEST.g $TEST.h &&
+	${KVSBASIC} link $TEST.h $TEST.i &&
+	${KVSBASIC} link $TEST.i $TEST.j &&
+	${KVSBASIC} link $TEST.j $TEST.k &&
+	${KVSBASIC} link $TEST.k $TEST.l &&
+        test_must_fail ${KVSBASIC} get $TEST.l
+'
+
+test_expect_success 'kvs: symlink: error on link depth, loop' '
+	${KVSBASIC} unlink $TEST &&
+	${KVSBASIC} link $TEST.link1 $TEST.link2 &&
+	${KVSBASIC} link $TEST.link2 $TEST.link1 &&
+        test_must_fail ${KVSBASIC} get $TEST.link1
+'
+
 # test synchronization based on commit sequence no.
 
 test_expect_success 'kvs: put on rank 0, exists on all ranks' '


### PR DESCRIPTION
Minor changes to allow ELOOP to be returned to user when KVS links go too deep.  Add appropriate tests as well.

Remove unnecessary and potentially confusing no-op line of code.
