### PR TITLE
Add dirwalk interface to libutil, update readdir callers

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -73,7 +73,9 @@ libutil_la_SOURCES = \
 	stdlog.c \
 	oom.h \
 	lru_cache.h \
-	lru_cache.c
+	lru_cache.c \
+	dirwalk.h \
+	dirwalk.c
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -95,7 +95,8 @@ TESTS = test_nodeset.t \
 	test_lru_cache.t \
 	test_unlink.t \
 	test_cleanup.t \
-	test_blobref.t
+	test_blobref.t \
+	test_dirwalk.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -183,3 +184,7 @@ test_unlink_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
 test_cleanup_t_SOURCES = test/cleanup.c
 test_cleanup_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
 test_cleanup_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
+
+test_dirwalk_t_SOURCES = test/dirwalk.c
+test_dirwalk_t_CPPFLAGS = $(test_cppflags)
+test_dirwalk_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/dirwalk.c
+++ b/src/common/libutil/dirwalk.c
@@ -1,0 +1,378 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* dirwalk.c - simple interface to recurse a directory tree */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <fnmatch.h>
+
+#include <czmq.h>
+
+#include "dirwalk.h"
+
+struct direntry {
+    int close_dirfd;
+    int dirfd;
+    char *path;
+    const char *basename;
+    struct stat sb;
+};
+
+struct dirwalk {
+    int flags;
+    int count;
+    zlist_t *dirstack;
+    struct direntry *current;
+
+    zlist_t *results;
+
+    unsigned int stopped:1;
+    int errnum;
+};
+
+void direntry_destroy (struct direntry *e)
+{
+    if (e) {
+        if (e->close_dirfd)
+            close (e->dirfd);
+        e->dirfd = -1;
+        e->basename = NULL;
+        free (e->path);
+        free (e);
+    }
+}
+
+/*
+ *  Create a direntry under parent dirfd `fd` and path `dir`, from
+ *   directory entry `dent`.
+ */
+struct direntry *direntry_create (int fd, const char *dir, struct dirent *dent)
+{
+    struct direntry *e = calloc (1, sizeof (*e));
+    if (!e)
+        return NULL;
+    if (asprintf (&e->path, "%s/%s", dir, dent->d_name) < 0)
+        goto out_err;
+    if (fstatat (fd, dent->d_name, &e->sb, AT_SYMLINK_NOFOLLOW) < 0)
+        goto out_err;
+    e->dirfd = fd;
+    return (e);
+out_err:
+    direntry_destroy (e);
+    return NULL;
+}
+
+/*
+ *  Create a direntry for an initial dirpath. Force open the parent dirfd
+ *   from `dir/..` for this special object.
+ */
+static struct direntry *direntry_create_dir (const char *dirpath)
+{
+    char *parent;
+    struct direntry *e = calloc (1, sizeof (*e));
+    if (!e)
+        return NULL;
+    e->path = strdup (dirpath);
+    if (asprintf (&parent, "%s/..", dirpath) < 0)
+        goto out_err;
+    if ((e->dirfd = open (parent, O_DIRECTORY|O_RDONLY)) < 0)
+        goto out_err;
+    e->close_dirfd = 1;
+
+    /*
+     *  No need to use fstatat(2) here. This function is never called after
+     *   a check, so there should be no TOU-TOC issues here.
+     */
+    if (stat (dirpath, &e->sb) < 0)
+        goto out_err;
+
+    free (parent);
+    return e;
+out_err:
+    free (parent);
+    direntry_destroy (e);
+    return NULL;
+}
+
+void dirwalk_destroy (dirwalk_t *d)
+{
+    if (d) {
+        if (d->current)
+            direntry_destroy (d->current);
+        if (d->dirstack) {
+            struct direntry *e;
+            while ((e = zlist_pop (d->dirstack)))
+                direntry_destroy (e);
+            zlist_destroy (&d->dirstack);
+        }
+        free (d);
+    }
+}
+
+
+dirwalk_t *dirwalk_create ()
+{
+    dirwalk_t *d = calloc (1, sizeof (*d));
+    if (!d || !(d->dirstack = zlist_new ())) {
+        dirwalk_destroy (d);
+        return NULL;
+    }
+    return (d);
+}
+
+int dirwalk_set_flags (dirwalk_t *d, int flags)
+{
+    int old = d->flags;
+    d->flags = flags;
+    return old;
+}
+
+const char * dirwalk_name (dirwalk_t *d)
+{
+    if (!d->current)
+        return NULL;
+    if (!d->current->basename)
+        d->current->basename = basename (d->current->path);
+    return d->current->basename;
+}
+
+const char * dirwalk_path (dirwalk_t *d)
+{
+    if (!d->current)
+        return NULL;
+    return d->current->path;
+}
+
+const struct stat * dirwalk_stat (dirwalk_t *d)
+{
+    if (!d->current)
+        return NULL;
+    return &d->current->sb;
+}
+
+int dirwalk_dirfd (dirwalk_t *d)
+{
+    if (!d->current)
+        return -1;
+    return d->current->dirfd;
+}
+
+int dirwalk_isdir (dirwalk_t *d)
+{
+    if (!d->current)
+        return 0;
+    return S_ISDIR (d->current->sb.st_mode);
+}
+
+static int is_dotted_dir (struct dirent *dent)
+{
+    if (!strcmp (dent->d_name, ".") || !strcmp (dent->d_name, ".."))
+        return 1;
+    return 0;
+}
+
+static void dirwalk_visit (dirwalk_t *d, dirwalk_filter_f fn, void *arg)
+{
+    if (fn)
+        (*fn) (d, arg);
+    d->count++;
+}
+
+/*
+ *  Continue traversal of d->current, which must be a directory
+ */
+int dirwalk_traverse (dirwalk_t *d, dirwalk_filter_f fn, void *arg)
+{
+    int fd;
+    const char *path;
+    struct dirent *dent;
+    DIR *dirp = NULL;
+
+    assert (dirwalk_isdir (d));
+    path = d->current->path;
+
+    if (!(dirp = opendir (path)))
+        return -1;
+
+    if ((fd = dirfd (dirp)) < 0)
+        goto done;
+
+    /*
+     * Visit this directory if not depth-first
+     */
+    if (!(d->flags & DIRWALK_DEPTH))
+        dirwalk_visit (d, fn, arg);
+
+    zlist_push (d->dirstack, d->current);
+    while ((dent = readdir (dirp)) && !d->stopped) {
+        if (is_dotted_dir (dent))
+            continue;
+        if (!(d->current = direntry_create (fd, path, dent))) {
+            if (errno == ENOMEM)
+                dirwalk_stop (d, errno);
+            continue;
+        }
+        if (S_ISDIR (d->current->sb.st_mode)) {
+            /*
+             *  Save current direntry onto stack and call traverse()
+             */
+            zlist_push (d->dirstack, d->current);
+            (void) dirwalk_traverse (d, fn, arg);
+            d->current = zlist_pop (d->dirstack);
+        }
+        else /* Not A directory, simply visit this file */
+            dirwalk_visit (d, fn, arg);
+        direntry_destroy (d->current);
+        d->current = NULL;
+    }
+    d->current = zlist_pop (d->dirstack);
+
+    /*
+     *  Visit directory if !stopped and not depth-first
+     */
+    if (!d->stopped && (d->flags & DIRWALK_DEPTH))
+        dirwalk_visit (d, fn, arg);
+
+done:
+    closedir (dirp);
+    if (d->errnum) {
+        errno = d->errnum;
+        return -1;
+    }
+    return 0;
+}
+
+void dirwalk_stop (dirwalk_t *d, int errnum)
+{
+    d->stopped = 1;
+    d->errnum = errnum;
+}
+
+int dirwalk (const char *path, int flags,
+             dirwalk_filter_f fn, void *arg)
+{
+    char *dirpath = NULL;
+    int count = -1;
+    dirwalk_t *d = dirwalk_create ();
+    if (!d)
+        return -1;
+    /*
+     *  If user requested realpaths then resolve path argument
+     *   using realpath(3) here. This should result in *all*
+     *   following paths being absolute realpaths as well.
+     */
+    if ((flags & DIRWALK_REALPATH)) {
+        if (!(dirpath = realpath (path, NULL)))
+            goto out;
+        path = dirpath;
+    }
+    /*
+     *  Bootstrap traversal by pushing flags into dirwalk object,
+     *   then force "current" dir to the path at which we want to
+     *   start traversal.
+     */
+    if ((dirwalk_set_flags (d, flags) < 0)
+     || !(d->current = direntry_create_dir (path))
+     || (dirwalk_traverse (d, fn, arg) < 0))
+        goto out;
+    count = d->count;
+out:
+    free (dirpath);
+    dirwalk_destroy (d);
+    return count;
+}
+
+struct find_arg {
+    int count;
+    const char *pattern;
+    zlist_t *results;
+    dirwalk_filter_f fn;
+    void *arg;
+};
+
+static int find_f (dirwalk_t *d, void *arg)
+{
+    struct find_arg *a = arg;
+    /* Skip directories unless DIRWALK_FIND_DIR was provided */
+    if (!(d->flags & DIRWALK_FIND_DIR) && dirwalk_isdir (d))
+        return 0;
+
+    if (fnmatch (a->pattern, dirwalk_name (d), 0) == 0) {
+        if (a->fn && ((*a->fn) (d, a->arg) <= 0))
+            return 0;
+        zlist_append (a->results, (char *) dirwalk_path (d));
+        if (a->count && zlist_size (a->results) == a->count)
+            dirwalk_stop (d, 0);
+    }
+    return 0;
+}
+
+zlist_t *dirwalk_find (const char *searchpath, int flags,
+                       const char *pattern, int count,
+                       dirwalk_filter_f fn, void *uarg)
+{
+    int saved_errno;
+    char *copy = NULL;
+    char *s, *dirpath, *sptr = NULL;
+    struct find_arg arg = { .count = count, .pattern = pattern,
+                            .fn = fn, .arg = uarg };
+
+    if (!(arg.results = zlist_new ()))
+        return NULL;
+    zlist_autofree (arg.results);
+
+    if (!(copy = strdup (searchpath)))
+        goto err;
+
+    s = copy;
+    while ((dirpath = strtok_r (s, ":", &sptr))) {
+        if ((dirwalk (dirpath, flags, find_f, &arg) < 0)) {
+            /* Ignore missing and inaccessible paths */
+            if ((errno != ENOENT) && (errno != EACCES))
+                goto err;
+        }
+        else if (count && zlist_size (arg.results) == count)
+            break;
+        s = NULL;
+    }
+    free (copy);
+    return arg.results;
+err:
+    saved_errno = errno;
+    if (arg.results)
+        zlist_destroy (&arg.results);
+    free (copy);
+    errno = saved_errno;
+    return NULL;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/dirwalk.h
+++ b/src/common/libutil/dirwalk.h
@@ -1,0 +1,104 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef HAVE_UTIL_DIRWALK_H
+#define HAVE_UTIL_DIRWALK_H
+
+#include <czmq.h> /* zlist_t */
+
+typedef struct dirwalk dirwalk_t;
+
+enum {
+    DIRWALK_DEPTH =    1<<0,  /* Traverse in depth-first order             */
+    DIRWALK_REALPATH = 1<<1,  /* Resolve all paths with realpath(3)        */
+    DIRWALK_FIND_DIR = 1<<2,  /* Do not skip directories in dirwalk_find() */
+};
+
+/*
+ *  Dirwalk visitor function.
+ *  dirwalk_t handle can be used with various accessors below
+ *   to return current path, dirfd, stat buffer, etc.
+ *  Function can signal error or request to stop traversal with
+ *   dirwalk_stop (d, errnum);
+ */
+typedef int (*dirwalk_filter_f) (dirwalk_t *d, void *arg);
+
+/*
+ *  One-shot directory tree walk.
+ *
+ *  Starting at directory `path` apply `fn` visitor function at each
+ *   path, passing user context `arg` to each invocation of the filter.
+ *
+ *  Returns the number of entries successfully visited, or -1 on
+ *   error, e.g. fatal error in traversal or dirwalk_stop() with nonzero
+ *   errnum.
+ *
+ *  Return value from dirwalk_filter_f is ignored, use dirwalk_stop() to
+ *   halt traversal.
+ */
+int dirwalk (const char *path, int flags, dirwalk_filter_f fn, void *arg);
+
+/*
+ *  Stop in-progress traversal immediately. If errnum != 0, then dirwalk
+ *   traversal will return -1 with errno set to errnum.
+ */
+void dirwalk_stop (dirwalk_t *d, int errnum);
+
+/*  Return current path visited during a dirwalk. May be a relative
+ *   path unless DIRWALK_REALPATH flag was used.
+ */
+const char * dirwalk_path (dirwalk_t *d);
+
+/*  Return the current file name (as in dirent.d_name) during a dirwalk.
+ */
+const char * dirwalk_name (dirwalk_t *d);
+
+/*  Return a pointer to the struct stat structure for the current file
+ *   being visited during a dirwalk.
+ */
+const struct stat * dirwalk_stat (dirwalk_t *d);
+
+/*  Return fd for current directory in dirwalk.
+ */
+int dirwalk_dirfd (dirwalk_t *d);
+
+/*  Return 1 if current path is a directory, 0 if not.
+ */
+int dirwalk_isdir (dirwalk_t *d);
+
+/*
+ *  Search a (possibly colon-separated) path `path` with flags `flags`
+ *   and accumulate filenames matching `pattern` returning zlist of results.
+ *   Stops traversal after `count` matches are found if count > 0.
+ *
+ *  If `fn` is non-NULL then function is called for each match and results
+ *   are only accumulated if function returns > 0.
+ *
+ *  zlist must be freed by caller (results are set to autofree).
+ */
+zlist_t * dirwalk_find (const char *path, int flags,
+                        const char *pattern, int count,
+                        dirwalk_filter_f fn, void *arg);
+
+#endif /* !HAVE_UTIL_DIRWALK_H */

--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -1,0 +1,332 @@
+#define _GNU_SOURCE
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <dirent.h>
+
+#include <czmq.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/dirwalk.h"
+
+static int makepath (const char *fmt, ...)
+{
+    int rc;
+    int errnum = 0;
+    char *pp;
+    char *sp;
+    char *path = NULL;
+    va_list ap;
+
+    va_start (ap, fmt);
+    rc = vasprintf (&path, fmt, ap);
+    va_end (ap);
+    if (rc < 0)
+        return -1;
+
+    // If mkdir works on path, we can skip attempted mkdir of all parents
+    if (mkdir (path, 0700) == 0)
+        goto out;
+
+    pp = path;
+    while ((sp = strchr(pp, '/'))) {
+        if (sp > pp) {
+            *sp = '\0';
+            if ((mkdir (path, 0777) < 0) && (errno != EEXIST)) {
+                errnum = errno;
+                goto out;
+            }
+            *sp = '/';
+        }
+        pp = sp + 1;
+    }
+    if (errnum == 0 && (mkdir (path, 0777) < 0))
+        errnum = errno;
+out:
+    free (path);
+    errno = errnum;
+    return errnum == 0 ? 0 : -1;
+}
+
+static int vcreat (const char *fmt, ...)
+{
+    int rc;
+    char *path = NULL;
+    va_list ap;
+    va_start (ap, fmt);
+    rc = vasprintf (&path, fmt, ap);
+    va_end (ap);
+    if (rc < 0)
+        return (-1);
+
+    if ((rc = creat (path, 0700)) >= 0)
+        close (rc);
+
+    free (path);
+    return (rc);
+}
+
+static char * create_test_dir ()
+{
+    const char *tmpdir = getenv ("TMPDIR");
+    const char *tmp = tmpdir ? tmpdir : "/tmp";
+    char path [PATH_MAX];
+    int n;
+
+    n = snprintf (path, sizeof (path), "%s/dirwalk_test.XXXXXX", tmp);
+    if ((n <= 0) || (n >= sizeof (path)))
+        BAIL_OUT ("Unable to create temporary directory string");
+
+    if (!mkdtemp (path))
+        BAIL_OUT ("mkdtemp failure");
+
+    return strdup (path);
+}
+
+static int find_dir (dirwalk_t *d, void *arg)
+{
+    return (dirwalk_isdir (d) ? 1 : 0); 
+}
+
+static int return_err (dirwalk_t *d, void *arg)
+{
+    if (!dirwalk_isdir (d))
+        dirwalk_stop (d, 42);
+    return 0;
+}
+
+static int check_stat (dirwalk_t *d, void *arg)
+{
+    const struct stat *sb = dirwalk_stat (d);
+    if (sb == NULL) {
+        dirwalk_stop (d, 1);
+        diag ("dirwalk_stat for %s failed\n",
+              dirwalk_path (d));
+    }
+    else if (dirwalk_isdir (d)) {
+        if (!S_ISDIR (sb->st_mode)) {
+            diag ("dirwalk_isdir() but sb->st_mode = 0x%08x\n", sb->st_mode);
+            dirwalk_stop (d, 1);
+        }
+    }
+    else if (sb->st_size < 0) {
+        diag ("sb->st_size = %ju", (uintmax_t) sb->st_size);
+        dirwalk_stop (d, 1);
+    }
+    return 0;
+}
+
+static int check_dirfd (dirwalk_t *d, void *arg)
+{
+    struct stat st;
+    const struct stat *sb = dirwalk_stat (d);
+    int dirfd = dirwalk_dirfd (d);
+    /*  Compare stat by fstatat() with internal dirwalk stat() to ensure
+     *   dirfd points to this entry's parent directory.
+     */
+    if (fstatat (dirfd, dirwalk_name (d), &st, 0) < 0) {
+        dirwalk_stop (d, errno);
+    }
+    else if (sb->st_dev != st.st_dev || sb->st_ino != st.st_ino) {
+        diag ("check_dirfd: st_dev or st_ino do not match");
+        dirwalk_stop (d, 1);
+    }
+    return 0;
+}
+
+int check_zlist_order (zlist_t *l, const char *base, char *expected[])
+{
+    int i = 0;
+    char *dir;
+    dir = zlist_first (l);
+    while (dir) {
+        diag ("zlist_order: %d: %s", i, dir);
+        int result;
+        char *exp;
+        if (expected[i] == NULL) {
+            diag ("check_zlist: more results than expected=%d\n", i-1);
+            return 0;
+        }
+        if (asprintf (&exp, "%s%s", base, expected [i]) < 0)
+            BAIL_OUT ("asprintf");
+
+        result = strcmp (exp, dir);
+        free (exp);
+        if (result != 0) {
+            diag ("check_zlist: %d: expected %s got %s", i, expected[i], dir);
+            return 0;
+        }
+        i++;
+        dir = zlist_next (l);
+    }
+    return 1;
+}
+
+static int d_unlinkat (dirwalk_t *d, void *arg)
+{
+    int rc = unlinkat (dirwalk_dirfd (d),
+                       dirwalk_name (d),
+                       dirwalk_isdir (d) ? AT_REMOVEDIR : 0);
+    if (rc < 0)
+        dirwalk_stop (d, errno);
+    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    char *s, *tmp = NULL, *tmp2 = NULL;
+    int n;
+
+    plan (NO_PLAN);
+
+    if (!(tmp = create_test_dir ()) || !(tmp2 = create_test_dir()))
+        BAIL_OUT ("unable to create test directory");
+
+    n = dirwalk (tmp, 0, NULL, NULL);
+    ok (n == 1, "dirwalk of empty directory visits one directory");
+    n = dirwalk (tmp, DIRWALK_DEPTH, NULL, NULL);
+    ok (n == 1, "dirwalk of empty directory with DIRWALK_DEPTH works");
+
+    if (makepath ("%s/a", tmp) < 0)
+        BAIL_OUT ("makepath failed");
+
+    n = dirwalk (tmp, 0, NULL, NULL);
+    ok (n == 2, "dirwalk of directory with 1 entry returns 2");
+    n = dirwalk (tmp, DIRWALK_DEPTH, NULL, NULL);
+    ok (n == 2, "dirwalk of directory with 1 entry DIRWALK_DEPTH returns 2");
+
+    if (makepath ("%s/a/b/c", tmp) < 0)
+        BAIL_OUT ("makepath failed");
+
+    n = dirwalk (tmp, 0, NULL, NULL);
+    ok (n == 4, "dirwalk of deeper dirtree");
+
+    if (makepath ("%s/a/b/c/d", tmp) < 0)
+        BAIL_OUT ("makepath failed");
+
+    if (vcreat ("%s/a/foo", tmp) < 0 || vcreat ("%s/a/b/c/foo", tmp) < 0)
+        BAIL_OUT ("vcreat");
+
+    if (makepath ("%s/bar", tmp2) < 0)
+        BAIL_OUT ("makepath failed");
+
+    if (vcreat ("%s/bar/foo", tmp2) < 0)
+        BAIL_OUT ("vcreat");
+
+    /*  dirwalk_find tests:
+     */
+
+    /* Find first file matching "foo" */
+    zlist_t *l = dirwalk_find (tmp, 0, "foo", 1, NULL, 0);
+    ok (l != NULL, "dirwalk_find");
+    ok (l && zlist_size (l) == 1, "dirwalk_find stopped at 1 result");
+    ok (strcmp (basename (zlist_first (l)), "foo") == 0,
+        "breadth-first search got expected match");
+    zlist_destroy (&l);
+
+    /* Find all files matching "foo" */
+    l = dirwalk_find (tmp, 0, "foo", 0, NULL, 0);
+    ok (l != NULL, "dirwalk with find callback");
+    ok (l && zlist_size (l) == 2, "breadth-first find found all matches");
+    zlist_destroy (&l);
+
+    /* Find all files matching "foo" with search path */
+    if (asprintf (&s, "%s:%s", tmp, tmp2) < 0)
+        BAIL_OUT ("asprintf");
+    l = dirwalk_find (s, 0, "foo", 0, NULL, 0);
+    ok (l != NULL, "dirwalk_find with search path");
+    ok (l && zlist_size (l) == 3, "find with search path found all matches");
+    zlist_destroy (&l);
+    free (s);
+ 
+    /* depth-first find */
+    l = dirwalk_find (tmp, DIRWALK_DEPTH, "foo", 0, NULL, 0);
+    ok (l != NULL, "dirwalk with find callback");
+    ok (l && zlist_size (l) == 2, "depth-first find found all results");
+    zlist_destroy (&l);
+
+    /* Special directory walk tests.
+     */
+    int flags = DIRWALK_DEPTH | DIRWALK_FIND_DIR;
+    l = dirwalk_find (tmp, flags, "*", 0, find_dir, NULL);
+    ok (l && zlist_size (l) >  0, "dirwalk to find all dirs works");
+
+    char *expect_depth[] = {
+        "/a/b/c/d",
+        "/a/b/c",
+        "/a/b",
+        "/a",
+        ""
+    };
+    ok (l && check_zlist_order (l, tmp, expect_depth),
+        "depth-first visited directories in correct order");
+    zlist_destroy (&l);
+
+    flags = DIRWALK_FIND_DIR;
+    l = dirwalk_find (tmp, flags, "*", 0, find_dir, NULL);
+    ok (l && zlist_size (l) >  0, "dirwalk to find all dirs works");
+
+    char *expect_breadth[] = {
+        "",
+        "/a",
+        "/a/b",
+        "/a/b/c",
+        "/a/b/c/d",
+    };
+    ok (l && check_zlist_order (l, tmp, expect_breadth),
+        "breadth-first visited directories in correct order");
+    zlist_destroy (&l);
+
+    char *cwd = get_current_dir_name ();
+    if (!cwd || (chdir (tmp) < 0))
+        BAIL_OUT ("chdir %s", tmp);
+
+    flags |= DIRWALK_REALPATH;
+    l = dirwalk_find (tmp, flags, "*", 0, find_dir, NULL);
+    ok (l && zlist_size (l) >  0, "dirwalk works with DIRWALK_REALPATH");
+
+    ok (l && check_zlist_order (l, tmp, expect_breadth),
+        "breadth-first visited directories with DIRWALK_REALPATH works");
+    zlist_destroy (&l);
+
+    if (chdir (cwd) < 0)
+        BAIL_OUT ("chdir (%s)", cwd);
+    free (cwd);
+
+    n = dirwalk (tmp, 0, return_err, NULL);
+    int errnum = errno;
+    ok (n == -1, "Error from callback passed to caller");
+    ok (errnum == 42, "Error from dirwalk_stop() passed back as errno");
+
+    n = dirwalk (tmp, 0, check_stat, NULL);
+    ok (n > 0, "dirwalk_stat works");
+
+    n = dirwalk (tmp, 0, check_dirfd, NULL);
+    ok (n > 0, "dirwalk_dirfd works");
+
+    /* Cleanup */
+    n = dirwalk (tmp, DIRWALK_DEPTH, d_unlinkat, NULL);
+    ok (n == 7, "dirwalk recursive unlink works");
+
+   /* Cleanup */
+    n = dirwalk (tmp2, DIRWALK_DEPTH, d_unlinkat, NULL);
+    ok (n == 3, "dirwalk recursive unlink works");
+
+    ok (access (tmp, F_OK) < 0 && errno == ENOENT, "tmp working dir removed");
+    ok (access (tmp2, F_OK) < 0 && errno == ENOENT, "tmp2 working dir removed");
+
+    free (tmp);
+    free (tmp2);
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR adds a new "dirwalk" class to libutil, encapsulating a common case of recursively walking a directory tree. `dirwalk` is like a simplified `ftw(3)`, however it allows the passing of a user context so results can be collected without the use of globals.

Since recursive directory search of a colon-separated path may be a common case, a `dirwalk_find` wrapper around `dirwalk` is also provided, which passes all entries that match a glob pattern to the user callback, and collects marked paths in a zlist_t on behalf of the user.

This may be a bit of overkill, but it was hard to stop once I started collecting common code together.

Current users of readdir were also updated to the new interface.

Fixes #1054