### PR TITLE
Add fixes to dirwalk tests

### DIFF
--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -182,7 +182,7 @@ static int d_unlinkat (dirwalk_t *d, void *arg)
 
 int main(int argc, char** argv)
 {
-    char *s, *tmp = NULL, *tmp2 = NULL;
+    char *s, *rpath, *tmp = NULL, *tmp2 = NULL;
     int n;
 
     plan (NO_PLAN);
@@ -293,9 +293,12 @@ int main(int argc, char** argv)
     l = dirwalk_find (tmp, flags, "*", 0, find_dir, NULL);
     ok (l && zlist_size (l) >  0, "dirwalk works with DIRWALK_REALPATH");
 
-    ok (l && check_zlist_order (l, tmp, expect_breadth),
+    /* tmp base for comparison must also be realpath-ed */
+    rpath = realpath (tmp, NULL);
+    ok (l && check_zlist_order (l, rpath, expect_breadth),
         "breadth-first visited directories with DIRWALK_REALPATH works");
     zlist_destroy (&l);
+    free (rpath);
 
     if (chdir (cwd) < 0)
         BAIL_OUT ("chdir (%s)", cwd);

--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -158,11 +158,12 @@ int check_zlist_order (zlist_t *l, const char *base, char *expected[])
             BAIL_OUT ("asprintf");
 
         result = strcmp (exp, dir);
-        free (exp);
         if (result != 0) {
-            diag ("check_zlist: %d: expected %s got %s", i, expected[i], dir);
+            diag ("check_zlist: %d: expected %s got %s", i, exp, dir);
+            free (exp);
             return 0;
         }
+        free (exp);
         i++;
         dir = zlist_next (l);
     }


### PR DESCRIPTION
Hit this on catalyst:

```
FAIL: test_dirwalk.t 20 - breadth-first visited directories with DIRWALK_REALPATH works
```

Debugged a bit, had to fix what I think is a corner case in the debug output:

```diff
@@ -158,11 +158,12 @@ int check_zlist_order (zlist_t *l, const char *base, char *expected[])
             BAIL_OUT ("asprintf");
 
         result = strcmp (exp, dir);
-        free (exp);
         if (result != 0) {
-            diag ("check_zlist: %d: expected %s got %s", i, expected[i], dir);
+            diag ("check_zlist: %d: expected %s got %s", i, exp, dir);
+            free (exp);
             return 0;
         }
+        free (exp);
         i++;
         dir = zlist_next (l);
     }
```

Result:

```
# zlist_order: 0: /tmp/achu/dirwalk_test.NdXBNK
# check_zlist: 0: expected /var/tmp/achu/dirwalk_test.NdXBNK got /tmp/achu/dirwalk_test.NdXBNK
not ok 20 - breadth-first visited directories with DIRWALK_REALPATH works
#   Failed test 'breadth-first visited directories with DIRWALK_REALPATH works'
#   at test/dirwalk.c line 297.
```

My ```TMPDIR``` happens to default to ```/var/tmp```, which is a symlink.  Changing it to ```/tmp``` resolves the error.

So looks like the base directory needs to be "REALPATH"'d too before being passed into the check zlist function.