### PR TITLE
fix invalid memory read in kvs module

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -359,7 +359,8 @@ done:
 static void setroot (kvs_ctx_t *ctx, const char *rootdir, int rootseq)
 {
     if (rootseq == 0 || rootseq > ctx->rootseq) {
-        memcpy (ctx->rootdir, rootdir, sizeof (href_t));
+        assert (strlen (rootdir) < sizeof (href_t));
+        strcpy (ctx->rootdir, rootdir);
         ctx->rootseq = rootseq;
         wait_runqueue (ctx->watchlist);
         ctx->watchlist_lastrun_epoch = ctx->epoch;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1437,7 +1437,7 @@ static int getroot_rpc (kvs_ctx_t *ctx, int *rootseq, href_t rootdir)
         errno = EPROTO;
         goto done;
     }
-    memcpy (rootdir, ref, sizeof (href_t));
+    strcpy (rootdir, ref);
     rc = 0;
 done:
     flux_rpc_destroy (rpc);


### PR DESCRIPTION
This PR addresses an invalid memory read in `getroot_rpc()` noted by @grondo in #1064.
It also fixes similar problematic code in `setroot()`, although it doesn't look like that one was actually causing a problem.