### PR TITLE
KVS refactor of lookup() / walk() functions

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -23,7 +23,9 @@ kvs_la_SOURCES = \
 	proto.c \
 	proto.h \
 	json_dirent.c \
-	json_dirent.h
+	json_dirent.h \
+	json_util.h \
+	json_util.c
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -25,7 +25,9 @@ kvs_la_SOURCES = \
 	json_dirent.c \
 	json_dirent.h \
 	json_util.h \
-	json_util.c
+	json_util.c \
+	lookup.h \
+	lookup.c
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -53,13 +53,16 @@ TESTS = \
 	test_waitqueue.t \
 	test_proto.t \
 	test_cache.t \
-	test_dirent.t
+	test_dirent.t \
+	test_lookup.t
 
 test_ldadd = \
         $(top_builddir)/src/modules/kvs/cache.o \
         $(top_builddir)/src/modules/kvs/waitqueue.o \
         $(top_builddir)/src/modules/kvs/proto.o \
         $(top_builddir)/src/modules/kvs/json_dirent.o \
+        $(top_builddir)/src/modules/kvs/json_util.o \
+        $(top_builddir)/src/modules/kvs/lookup.o \
         $(top_builddir)/src/modules/kvs/libflux-kvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -91,3 +94,7 @@ test_cache_t_LDADD = $(test_ldadd)
 test_dirent_t_SOURCES = test/dirent.c
 test_dirent_t_CPPFLAGS = $(test_cppflags)
 test_dirent_t_LDADD = $(test_ldadd)
+
+test_lookup_t_SOURCES = test/lookup.c
+test_lookup_t_CPPFLAGS = $(test_cppflags)
+test_lookup_t_LDADD = $(test_ldadd)

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -158,6 +158,14 @@ struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
     return hp;
 }
 
+json_object *cache_lookup_and_get_json (struct cache *cache,
+                                        const char *ref,
+                                        int current_epoch)
+{
+    struct cache_entry *hp = cache_lookup (cache, ref, current_epoch);
+    return cache_entry_get_valid (hp) ? cache_entry_get_json (hp) : NULL;
+}
+
 void cache_insert (struct cache *cache, const char *ref, struct cache_entry *hp)
 {
     int rc = zhash_insert (cache->zh, ref, hp);

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -49,6 +49,15 @@ void cache_destroy (struct cache *cache);
 struct cache_entry *cache_lookup (struct cache *cache,
                                   const char *ref, int current_epoch);
 
+/* Look up a cache entry and get json of cache entry only if entry
+ * contains valid json.  This is a convenience function that is
+ * effectively successful if calls to cache_lookup() and
+ * cache_entry_get_json() are both successful.
+ */
+json_object *cache_lookup_and_get_json (struct cache *cache,
+                                        const char *ref,
+                                        int current_epoch);
+
 /* Insert an entry in the cache by blobref 'ref'.
  * Ownership of the cache entry is transferred to the cache.
  */

--- a/src/modules/kvs/json_util.c
+++ b/src/modules/kvs/json_util.c
@@ -1,0 +1,60 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+
+json_object *json_object_copydir (json_object *dir)
+{
+    json_object *cpy;
+    json_object_iter iter;
+
+    if (!(cpy = json_object_new_object ()))
+        oom ();
+    json_object_object_foreachC (dir, iter) {
+        json_object_get (iter.val);
+        json_object_object_add (cpy, iter.key, iter.val);
+    }
+    return cpy;
+}
+
+bool json_compare (json_object *o1, json_object *o2)
+{
+    const char *s1 = json_object_to_json_string (o1);
+    const char *s2 = json_object_to_json_string (o2);
+
+    return !strcmp (s1, s2);
+}

--- a/src/modules/kvs/json_util.h
+++ b/src/modules/kvs/json_util.h
@@ -1,0 +1,14 @@
+#include "src/common/libutil/tstat.h"
+#include "waitqueue.h"
+
+/* Copy element wise a json directory object into a new json object.
+ */
+json_object *json_object_copydir (json_object *dir);
+
+/* Compare two json objects, return true if same, false if not
+ */
+bool json_compare (json_object *o1, json_object *o2);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -756,8 +756,8 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (!load (ctx, root_ref, wait, &root))
         goto stall;
-    if (!lookup (ctx->cache, ctx->epoch, root, ctx->rootdir, key, flags,
-                 &val, &missing_ref, &lookup_errnum)) {
+    if (!lookup (ctx->cache, ctx->epoch, root, root_dirent, ctx->rootdir, key,
+                 flags, &val, &missing_ref, &lookup_errnum)) {
         assert (missing_ref);
         if (load (ctx, missing_ref, wait, NULL))
             log_msg_exit ("%s: failure in load logic", __FUNCTION__);
@@ -796,6 +796,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
     json_object *oval;
     json_object *val = NULL;
     json_object *root = NULL;
+    json_object *root_dirent = NULL;
     flux_msg_t *cpy = NULL;
     const char *key;
     int flags;
@@ -817,8 +818,9 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto done;
     if (!load (ctx, ctx->rootdir, wait, &root))
         goto stall;
-    if (!lookup (ctx->cache, ctx->epoch, root, ctx->rootdir, key, flags,
-                 &val, &missing_ref, &lookup_errnum)) {
+    root_dirent = dirent_create ("DIRREF", ctx->rootdir);
+    if (!lookup (ctx->cache, ctx->epoch, root, root_dirent, ctx->rootdir, key,
+                 flags, &val, &missing_ref, &lookup_errnum)) {
         assert (missing_ref);
         if (load (ctx, missing_ref, wait, NULL))
             log_msg_exit ("%s: failure in load logic", __FUNCTION__);
@@ -864,6 +866,7 @@ stall:
     Jput (in2);
     Jput (out);
     flux_msg_destroy (cpy);
+    Jput (root_dirent);
 }
 
 typedef struct {

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -278,7 +278,6 @@ stall:
 
 lookup_t *lookup_create (struct cache *cache,
                          int current_epoch,
-                         json_object *root_dirent,
                          const char *root_dir,
                          const char *root_ref,
                          const char *path,
@@ -286,7 +285,7 @@ lookup_t *lookup_create (struct cache *cache,
 {
     lookup_t *lh = NULL;
 
-    if (!cache || !root_dirent || !root_dir || !path) {
+    if (!cache || !root_dir || !path) {
         errno = EINVAL;
         return NULL;
     }
@@ -295,7 +294,6 @@ lookup_t *lookup_create (struct cache *cache,
 
     lh->cache = cache;
     lh->current_epoch = current_epoch;
-    lh->root_dirent = root_dirent;
     /* must duplicate these strings, user may not keep pointer
      * alive */
     lh->root_dir = xstrdup (root_dir);
@@ -314,6 +312,8 @@ lookup_t *lookup_create (struct cache *cache,
     lh->missing_ref = NULL;
     lh->errnum = 0;
 
+    lh->root_dirent = dirent_create ("DIRREF", lh->root_ref);
+
     return lh;
 }
 
@@ -323,6 +323,7 @@ void lookup_destroy (lookup_t *lh)
         free (lh->root_dir);
         free (lh->root_ref_copy);
         free (lh->path);
+        Jput (lh->root_dirent);
         free (lh);
     }
 }

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -1,0 +1,260 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/blobref.h"
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+
+#include "cache.h"
+#include "proto.h"
+#include "json_dirent.h"
+#include "json_util.h"
+
+/* Break cycles in symlink references.
+ */
+#define SYMLINK_CYCLE_LIMIT 10
+
+/* Get dirent of the requested path starting at the given root.
+ *
+ * Return true on success or error, error code is returned in ep and
+ * should be checked upon return.
+ *
+ * Return false if path cannot be resolved.  Return missing reference
+ * in load ref, which caller should then use to load missing reference
+ * into KVS cache.
+ */
+static bool walk (struct cache *cache, int current_epoch, json_object *root,
+                  const char *path, int flags, int depth,
+                  json_object **direntp, const char **missing_ref, int *ep)
+{
+    char *cpy = xstrdup (path);
+    char *next, *name = cpy;
+    const char *ref;
+    const char *link;
+    json_object *dirent = NULL;
+    json_object *dir = root;
+    int errnum = 0;
+
+    depth++;
+
+    /* walk directories */
+    while ((next = strchr (name, '.'))) {
+        *next++ = '\0';
+        if (!json_object_object_get_ex (dir, name, &dirent))
+            /* not necessarily ENOENT, let caller decide */
+            goto error;
+        if (Jget_str (dirent, "LINKVAL", &link)) {
+            if (depth == SYMLINK_CYCLE_LIMIT) {
+                errnum = ELOOP;
+                goto error;
+            }
+            if (!walk (cache, current_epoch, root, link, flags, depth,
+                       &dirent, missing_ref, ep))
+                goto stall;
+            if (*ep != 0) {
+                errnum = *ep;
+                goto error;
+            }
+            if (!dirent)
+                /* not necessarily ENOENT, let caller decide */
+                goto error;
+        }
+
+        /* Check for errors in dirent before looking up reference.
+         * Note that reference to lookup is determined in final
+         * error check.
+         */
+
+        if (json_object_object_get_ex (dirent, "DIRVAL", NULL)) {
+            /* N.B. in current code, directories are never stored by value */
+            log_msg_exit ("%s: unexpected DIRVAL: path=%s name=%s: dirent=%s ",
+                          __FUNCTION__, path, name, Jtostr (dirent));
+        } else if ((Jget_str (dirent, "FILEREF", NULL)
+                    || json_object_object_get_ex (dirent, "FILEVAL", NULL))) {
+            /* don't return ENOENT or ENOTDIR, error to be determined
+             * by caller */
+            goto error;
+        } else if (!Jget_str (dirent, "DIRREF", &ref)) {
+            log_msg_exit ("%s: unknown dirent type: path=%s name=%s: dirent=%s ",
+                          __FUNCTION__, path, name, Jtostr (dirent));
+        }
+
+        if (!(dir = cache_lookup_and_get_json (cache,
+                                               ref,
+                                               current_epoch))) {
+            *missing_ref = ref;
+            goto stall;
+        }
+
+        name = next;
+    }
+    /* now terminal path component */
+    if (json_object_object_get_ex (dir, name, &dirent) &&
+        Jget_str (dirent, "LINKVAL", &link)) {
+        if (!(flags & KVS_PROTO_READLINK) && !(flags & KVS_PROTO_TREEOBJ)) {
+            if (depth == SYMLINK_CYCLE_LIMIT) {
+                errnum = ELOOP;
+                goto error;
+            }
+            if (!walk (cache, current_epoch, root, link, flags, depth,
+                       &dirent, missing_ref, ep))
+                goto stall;
+            if (*ep != 0) {
+                errnum = *ep;
+                goto error;
+            }
+        }
+    }
+    free (cpy);
+    *direntp = dirent;
+    return true;
+error:
+    if (errnum != 0)
+        *ep = errnum;
+    free (cpy);
+    *direntp = NULL;
+    return true;
+stall:
+    free (cpy);
+    return false;
+}
+
+bool lookup (struct cache *cache, int current_epoch, json_object *root,
+             const char *rootdir, const char *path, int flags, 
+             json_object **valp, const char **missing_ref, int *ep)
+{
+    json_object *vp, *dirent, *val = NULL;
+    int walk_errnum = 0;
+    int errnum = 0;
+
+    if (!strcmp (path, ".")) { /* special case root */
+        if ((flags & KVS_PROTO_TREEOBJ)) {
+            val = dirent_create ("DIRREF", (char *)rootdir);
+        } else {
+            if (!(flags & KVS_PROTO_READDIR)) {
+                errnum = EISDIR;
+                goto done;
+            }
+            val = json_object_get (root);
+        }
+    } else {
+        if (!walk (cache, current_epoch, root, path, flags, 0,
+                   &dirent, missing_ref, &walk_errnum))
+            goto stall;
+        if (walk_errnum != 0) {
+            errnum = walk_errnum;
+            goto done;
+        }
+        if (!dirent) {
+            //errnum = ENOENT;
+            goto done; /* a NULL response is not necessarily an error */
+        }
+        if ((flags & KVS_PROTO_TREEOBJ)) {
+            val = json_object_get (dirent);
+            goto done;
+        }
+        if (json_object_object_get_ex (dirent, "DIRREF", &vp)) {
+            if ((flags & KVS_PROTO_READLINK)) {
+                errnum = EINVAL;
+                goto done;
+            }
+            if (!(flags & KVS_PROTO_READDIR)) {
+                errnum = EISDIR;
+                goto done;
+            }
+            if (!(val = cache_lookup_and_get_json (cache,
+                                                   json_object_get_string (vp),
+                                                   current_epoch))) {
+                *missing_ref = json_object_get_string (vp);
+                goto stall;
+            }
+            val = json_object_copydir (val);
+        } else if (json_object_object_get_ex (dirent, "FILEREF", &vp)) {
+            if ((flags & KVS_PROTO_READLINK)) {
+                errnum = EINVAL;
+                goto done;
+            }
+            if ((flags & KVS_PROTO_READDIR)) {
+                errnum = ENOTDIR;
+                goto done;
+            }
+            if (!(val = cache_lookup_and_get_json (cache,
+                                                   json_object_get_string (vp),
+                                                   current_epoch))) {
+                *missing_ref = json_object_get_string (vp);
+                goto stall;
+            }
+            val = json_object_get (val);
+        } else if (json_object_object_get_ex (dirent, "DIRVAL", &vp)) {
+            if ((flags & KVS_PROTO_READLINK)) {
+                errnum = EINVAL;
+                goto done;
+            }
+            if (!(flags & KVS_PROTO_READDIR)) {
+                errnum = EISDIR;
+                goto done;
+            }
+            val = json_object_copydir (vp);
+        } else if (json_object_object_get_ex (dirent, "FILEVAL", &vp)) {
+            if ((flags & KVS_PROTO_READLINK)) {
+                errnum = EINVAL;
+                goto done;
+            }
+            if ((flags & KVS_PROTO_READDIR)) {
+                errnum = ENOTDIR;
+                goto done;
+            }
+            val = json_object_get (vp);
+        } else if (json_object_object_get_ex (dirent, "LINKVAL", &vp)) {
+            if (!(flags & KVS_PROTO_READLINK) || (flags & KVS_PROTO_READDIR)) {
+                errnum = EPROTO;
+                goto done;
+            }
+            val = json_object_get (vp);
+        } else
+            log_msg_exit ("%s: corrupt dirent: %s", __FUNCTION__,
+                          Jtostr (dirent));
+    }
+    /* val now contains the requested object (copied) */
+done:
+    *valp = val;
+    if (errnum != 0)
+        *ep = errnum;
+    return true;
+stall:
+    return false;
+}

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -51,12 +51,48 @@
  */
 #define SYMLINK_CYCLE_LIMIT 10
 
+#define LOOKUP_MAGIC 0x15151515
+
 typedef struct {
     int depth;
     char *path_copy;            /* for internal parsing, do not use */
     json_object *dirent;
     zlist_t *pathcomps;
 } walk_level_t;
+
+struct lookup {
+    int magic;
+
+    /* inputs from user */
+    struct cache *cache;
+    int current_epoch;
+
+    char *root_dir;
+    char *root_ref;
+    char *root_ref_copy;
+
+    char *path;
+    int flags;
+
+    void *aux;
+
+    /* potential return values from lookup */
+    json_object *val;           /* value of lookup */
+    const char *missing_ref;    /* on stall, missing ref to load */
+    int errnum;                 /* errnum if error */
+
+    /* API internal */
+    json_object *root_dirent;
+    zlist_t *levels;
+    json_object *wdirent;       /* result after walk() */
+    enum {
+        LOOKUP_STATE_INIT,
+        LOOKUP_STATE_CHECK_ROOT,
+        LOOKUP_STATE_WALK,
+        LOOKUP_STATE_VALUE,
+        LOOKUP_STATE_FINISHED,
+    } state;
+};
 
 static bool last_pathcomp (zlist_t *pathcomps, const void *data)
 {
@@ -276,6 +312,7 @@ lookup_t *lookup_create (struct cache *cache,
 
     lh = xzmalloc (sizeof (*lh));
 
+    lh->magic = LOOKUP_MAGIC;
     lh->cache = cache;
     lh->current_epoch = current_epoch;
     /* must duplicate these strings, user may not keep pointer
@@ -291,6 +328,8 @@ lookup_t *lookup_create (struct cache *cache,
     }
     lh->path = xstrdup (path);
     lh->flags = flags;
+
+    lh->aux = NULL;
 
     lh->val = NULL;
     lh->missing_ref = NULL;
@@ -319,14 +358,123 @@ lookup_t *lookup_create (struct cache *cache,
 
 void lookup_destroy (lookup_t *lh)
 {
-    if (lh) {
+    if (lh && lh->magic == LOOKUP_MAGIC) {
         free (lh->root_dir);
         free (lh->root_ref_copy);
         free (lh->path);
+        Jput (lh->val);
         Jput (lh->root_dirent);
         zlist_destroy (&lh->levels);
+        lh->magic = ~LOOKUP_MAGIC;
         free (lh);
     }
+}
+
+bool lookup_validate (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return true;
+    return false;
+}
+
+int lookup_get_errnum (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC) {
+        if (lh->state == LOOKUP_STATE_FINISHED)
+            return lh->errnum;
+        if (lh->state == LOOKUP_STATE_CHECK_ROOT
+            || lh->state == LOOKUP_STATE_WALK
+            || lh->state == LOOKUP_STATE_VALUE)
+            return EAGAIN;
+    }
+    return EINVAL;
+}
+
+json_object *lookup_get_value (lookup_t *lh)
+{
+    if (lh
+        && lh->magic == LOOKUP_MAGIC
+        && lh->state == LOOKUP_STATE_FINISHED
+        && lh->errnum == 0)
+        return json_object_get (lh->val);
+    return NULL;
+}
+
+const char *lookup_get_missing_ref (lookup_t *lh)
+{
+    if (lh
+        && lh->magic == LOOKUP_MAGIC
+        && (lh->state == LOOKUP_STATE_CHECK_ROOT
+            || lh->state == LOOKUP_STATE_WALK
+            || lh->state == LOOKUP_STATE_VALUE))
+        return lh->missing_ref;
+    return NULL;
+}
+
+struct cache *lookup_get_cache (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->cache;
+    return NULL;
+}
+
+int lookup_get_current_epoch (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->current_epoch;
+    return -1;
+}
+
+const char *lookup_get_root_dir (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->root_dir;
+    return NULL;
+}
+
+const char *lookup_get_root_ref (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->root_ref;
+    return NULL;
+}
+
+const char *lookup_get_path (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->path;
+    return NULL;
+}
+
+int lookup_get_flags (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->flags;
+    return -1;
+}
+
+void *lookup_get_aux_data (lookup_t *lh)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC)
+        return lh->aux;
+    return NULL;
+}
+
+int lookup_set_current_epoch (lookup_t *lh, int epoch)
+{
+    if (lh && lh->magic == LOOKUP_MAGIC) {
+        lh->current_epoch = epoch;
+        return 0;
+    }
+    return -1;
+}
+
+int lookup_set_aux_data (lookup_t *lh, void *data) {
+    if (lh && lh->magic == LOOKUP_MAGIC) {
+        lh->aux = data;
+        return 0;
+    }
+    return -1;
 }
 
 bool lookup (lookup_t *lh)
@@ -334,7 +482,7 @@ bool lookup (lookup_t *lh)
     json_object *vp, *valtmp = NULL;
     const char *reftmp;
 
-    if (!lh) {
+    if (!lh || lh->magic != LOOKUP_MAGIC) {
         errno = EINVAL;
         return true;
     }

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -276,8 +276,8 @@ stall:
     return false;
 }
 
-bool lookup (struct cache *cache, int current_epoch, json_object *root,
-             json_object *root_dirent, const char *rootdir, const char *path,
+bool lookup (struct cache *cache, int current_epoch, json_object *root_dirent,
+             const char *rootdir, const char *root_ref, const char *path,
              int flags, json_object **valp, const char **missing_ref, int *ep)
 {
     json_object *vp, *dirent, *val = NULL;
@@ -292,7 +292,13 @@ bool lookup (struct cache *cache, int current_epoch, json_object *root,
                 errnum = EISDIR;
                 goto done;
             }
-            val = json_object_get (root);
+            if (!(val = cache_lookup_and_get_json (cache,
+                                                   root_ref,
+                                                   current_epoch))) {
+                *missing_ref = root_ref;
+                goto stall;
+            }
+            val = json_object_get (val);
         }
     } else {
         if (!walk (cache, current_epoch, root_dirent, path, flags,

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -10,8 +10,8 @@
  * reference into KVS cache via rpc or otherwise.
  */
 bool lookup (struct cache *cache, int current_epoch, json_object *root,
-             const char *rootdir, const char *path, int flags,
-             json_object **valp, const char **missing_ref, int *ep);
+             json_object *root_dirent, const char *rootdir, const char *path,
+             int flags, json_object **valp, const char **missing_ref, int *ep);
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -21,6 +21,13 @@ struct lookup {
     json_object *root_dirent;
     zlist_t *levels;
     json_object *wdirent;       /* result after walk() */
+    enum {
+        LOOKUP_STATE_INIT,
+        LOOKUP_STATE_CHECK_ROOT,
+        LOOKUP_STATE_WALK,
+        LOOKUP_STATE_VALUE,
+        LOOKUP_STATE_FINISHED,
+    } state;
 };
 
 typedef struct lookup lookup_t;

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -1,0 +1,18 @@
+#include "cache.h"
+
+/* Lookup the key path in the KVS cache starting at root.
+ *
+ * Return true on success or error, error code is returned in ep and
+ * should be checked upon return.
+ *
+ * Return false if key name cannot be resolved.  Return missing
+ * reference in missing_ref, which caller should then use to load missing
+ * reference into KVS cache via rpc or otherwise.
+ */
+bool lookup (struct cache *cache, int current_epoch, json_object *root,
+             const char *rootdir, const char *path, int flags,
+             json_object **valp, const char **missing_ref, int *ep);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -9,8 +9,8 @@
  * reference in missing_ref, which caller should then use to load missing
  * reference into KVS cache via rpc or otherwise.
  */
-bool lookup (struct cache *cache, int current_epoch, json_object *root,
-             json_object *root_dirent, const char *rootdir, const char *path,
+bool lookup (struct cache *cache, int current_epoch, json_object *root_dirent,
+             const char *rootdir, const char *root_ref, const char *path,
              int flags, json_object **valp, const char **missing_ref, int *ep);
 
 /*

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -19,6 +19,8 @@ struct lookup {
 
     /* API internal */
     json_object *root_dirent;
+    zlist_t *levels;
+    json_object *wdirent;       /* result after walk() */
 };
 
 typedef struct lookup lookup_t;

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -5,7 +5,6 @@ struct lookup {
     struct cache *cache;
     int current_epoch;
 
-    json_object *root_dirent;
     char *root_dir;
     char *root_ref;
     char *root_ref_copy;
@@ -17,6 +16,9 @@ struct lookup {
     json_object *val;           /* value of lookup */
     const char *missing_ref;    /* on stall, missing ref to load */
     int errnum;                 /* errnum if error */
+
+    /* API internal */
+    json_object *root_dirent;
 };
 
 typedef struct lookup lookup_t;
@@ -26,7 +28,6 @@ typedef struct lookup lookup_t;
  */
 lookup_t *lookup_create (struct cache *cache,
                          int current_epoch,
-                         json_object *root_dirent,
                          const char *root_dir,
                          const char *root_ref,
                          const char *path,

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -1,17 +1,50 @@
 #include "cache.h"
 
+struct lookup {
+    /* inputs from user */
+    struct cache *cache;
+    int current_epoch;
+
+    json_object *root_dirent;
+    char *root_dir;
+    char *root_ref;
+    char *root_ref_copy;
+
+    char *path;
+    int flags;
+
+    /* potential return values from lookup */
+    json_object *val;           /* value of lookup */
+    const char *missing_ref;    /* on stall, missing ref to load */
+    int errnum;                 /* errnum if error */
+};
+
+typedef struct lookup lookup_t;
+
+/* Initialize a lookup handle
+ * - If root_ref is same as root_dir, can be set to NULL.
+ */
+lookup_t *lookup_create (struct cache *cache,
+                         int current_epoch,
+                         json_object *root_dirent,
+                         const char *root_dir,
+                         const char *root_ref,
+                         const char *path,
+                         int flags);
+
+/* Destroy a lookup handle */
+void lookup_destroy (lookup_t *lh);
+
 /* Lookup the key path in the KVS cache starting at root.
  *
- * Return true on success or error, error code is returned in ep and
- * should be checked upon return.
+ * Return true on success or error, error code is returned in errnum
+ * and should be checked upon return.
  *
  * Return false if key name cannot be resolved.  Return missing
  * reference in missing_ref, which caller should then use to load missing
  * reference into KVS cache via rpc or otherwise.
  */
-bool lookup (struct cache *cache, int current_epoch, json_object *root_dirent,
-             const char *rootdir, const char *root_ref, const char *path,
-             int flags, json_object **valp, const char **missing_ref, int *ep);
+bool lookup (lookup_t *lh);
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -1,35 +1,5 @@
 #include "cache.h"
 
-struct lookup {
-    /* inputs from user */
-    struct cache *cache;
-    int current_epoch;
-
-    char *root_dir;
-    char *root_ref;
-    char *root_ref_copy;
-
-    char *path;
-    int flags;
-
-    /* potential return values from lookup */
-    json_object *val;           /* value of lookup */
-    const char *missing_ref;    /* on stall, missing ref to load */
-    int errnum;                 /* errnum if error */
-
-    /* API internal */
-    json_object *root_dirent;
-    zlist_t *levels;
-    json_object *wdirent;       /* result after walk() */
-    enum {
-        LOOKUP_STATE_INIT,
-        LOOKUP_STATE_CHECK_ROOT,
-        LOOKUP_STATE_WALK,
-        LOOKUP_STATE_VALUE,
-        LOOKUP_STATE_FINISHED,
-    } state;
-};
-
 typedef struct lookup lookup_t;
 
 /* Initialize a lookup handle
@@ -45,14 +15,75 @@ lookup_t *lookup_create (struct cache *cache,
 /* Destroy a lookup handle */
 void lookup_destroy (lookup_t *lh);
 
+/* Determine if lookup handle valid */
+bool lookup_validate (lookup_t *lh);
+
+/* Get errnum, should be checked after lookup() returns true to see if
+ * an error occurred or not */
+int lookup_get_errnum (lookup_t *lh);
+
+/* Get resulting value of lookup() after lookup() returns true.  The
+ * json object returned gives a reference to the caller and must be
+ * json_object_put()'ed to free memory. */
+json_object *lookup_get_value (lookup_t *lh);
+
+/* Get missing ref after a lookup stall, missing reference can then be
+ * used to load reference into the KVS cache */
+const char *lookup_get_missing_ref (lookup_t *lh);
+
+/* Convenience function to get cache from earlier instantiation.
+ * Convenient if replaying RPC and don't have it presently.
+ */
+struct cache *lookup_get_cache (lookup_t *lh);
+
+/* Convenience function to get current epoch from earlier
+ * instantiation.  Convenient if replaying RPC and don't have it
+ * presently.
+ */
+int lookup_get_current_epoch (lookup_t *lh);
+
+/* Convenience function to get root dir from earlier instantiation.
+ * Convenient if replaying RPC and don't have it presently.
+ */
+const char *lookup_get_root_dir (lookup_t *lh);
+
+/* Convenience function to get root ref from earlier instantiation.
+ * Convenient if replaying RPC and don't have it presently.
+ */
+const char *lookup_get_root_ref (lookup_t *lh);
+
+/* Convenience function to get path from earlier instantiation.
+ * Convenient if replaying RPC and don't have it presently.
+ */
+const char *lookup_get_path (lookup_t *lh);
+
+/* Convenience function to get flags from earlier instantiation.
+ * Convenient if replaying RPC and don't have it presently.
+ */
+int lookup_get_flags (lookup_t *lh);
+
+/* Get auxiliarry data set by user */
+void *lookup_get_aux_data (lookup_t *lh);
+
+/* Set a new current epoch.  Convenience on RPC replays and epoch may
+ * be new */
+int lookup_set_current_epoch (lookup_t *lh, int epoch);
+
+/* Set auxiliarry data for convenience.  User is responsible for
+ * freeing data.
+ */
+int lookup_set_aux_data (lookup_t *lh, void *data);
+
 /* Lookup the key path in the KVS cache starting at root.
  *
- * Return true on success or error, error code is returned in errnum
- * and should be checked upon return.
+ * Return true on success or error.  After return, error should be
+ * checked via lookup_get_errnum().  On success, value of resulting
+ * lookup can be retrieved via lookup_get_value().
  *
- * Return false if key name cannot be resolved.  Return missing
- * reference in missing_ref, which caller should then use to load missing
- * reference into KVS cache via rpc or otherwise.
+ * Return false if key name cannot be resolved.  Get missing reference
+ * in via lookup_get_missing_ref().  Caller should then use
+ * missing reference to load missing reference into KVS cache via rpc
+ * or otherwise.
  */
 bool lookup (lookup_t *lh);
 

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -22,6 +22,7 @@ int main (int argc, char *argv[])
     struct cache_entry *e1, *e2, *e3, *e4;
     json_object *o1;
     json_object *o2;
+    json_object *o3;
     wait_t *w;
     int count, i;
 
@@ -105,8 +106,12 @@ int main (int argc, char *argv[])
         "cache contains 1 entry after insert");
     ok (cache_lookup (cache, "yyy1", 0) == NULL,
         "cache_lookup of wrong hash fails");
+    ok (cache_lookup_and_get_json (cache, "yyy1", 0) == NULL,
+        "cache_lookup_and_get_json of wrong hash fails");
     ok ((e2 = cache_lookup (cache, "xxx1", 42)) != NULL,
         "cache_lookup of correct hash works (last use=42)");
+    ok (cache_lookup_and_get_json (cache, "xxx1", 0) == NULL,
+        "cache_lookup_and_get_json of correct hash, but non valid entry fails");
     ok (cache_entry_get_json (e2) == NULL,
         "no json object found");
     ok (cache_count_entries (cache) == 1,
@@ -135,6 +140,11 @@ int main (int argc, char *argv[])
     i = 0;
     ok ((o2 = cache_entry_get_json (e4)) != NULL
         && Jget_int (o2, "foo", &i) == true && i == 42,
+        "expected json object found");
+    ok ((o3 = cache_lookup_and_get_json (cache, "xxx2", 0)) != NULL,
+        "cache_lookup_and_get_json of correct hash and valid entry works");
+    i = 0;
+    ok (Jget_int (o3, "foo", &i) == true && i == 42,
         "expected json object found");
     ok (cache_count_entries (cache) == 2,
         "cache contains 2 entries");

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -1,0 +1,1156 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libtap/tap.h"
+#include "src/modules/kvs/waitqueue.h"
+#include "src/modules/kvs/cache.h"
+#include "src/modules/kvs/proto.h"
+#include "src/modules/kvs/lookup.h"
+#include "src/modules/kvs/json_dirent.h"
+#include "src/modules/kvs/json_util.h"
+
+void basic_api (void)
+{
+    struct cache *cache;
+    lookup_t *lh;
+    const char *tmp;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    ok ((lh = lookup_create (cache,
+                             42,
+                             "root.foo",
+                             "ref.bar",
+                             "path.baz",
+                             KVS_PROTO_READLINK | KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create works");
+    ok (lookup_validate (lh) == true,
+        "lookup_validate works");
+    ok (lookup_get_cache (lh) == cache,
+        "lookup_get_cache works");
+    ok (lookup_get_current_epoch (lh) == 42,
+        "lookup_get_current_epoch works");
+    ok ((tmp = lookup_get_root_dir (lh)) != NULL,
+        "lookup_get_root_dir works");
+    ok (!strcmp (tmp, "root.foo"),
+        "lookup_get_root_dir returns correct string");
+    ok ((tmp = lookup_get_root_ref (lh)) != NULL,
+        "lookup_get_root_ref works");
+    ok (!strcmp (tmp, "ref.bar"),
+        "lookup_get_root_ref returns correct string");
+    ok ((tmp = lookup_get_path (lh)) != NULL,
+        "lookup_get_path works");
+    ok (!strcmp (tmp, "path.baz"),
+        "lookup_get_path returns correct string");
+    ok (lookup_get_flags (lh) == (KVS_PROTO_READLINK | KVS_PROTO_TREEOBJ),
+        "lookup_get_flags works");
+    ok (lookup_set_current_epoch (lh, 43) == 0,
+        "lookup_set_current_epoch works");
+    ok (lookup_get_current_epoch (lh) == 43,
+        "lookup_get_current_epoch works");
+    ok (lookup_get_aux_data (lh) == NULL,
+        "lookup_get_aux_data returns NULL b/c nothing set");
+    ok (lookup_set_aux_data (lh, lh) == 0,
+        "lookup_set_aux_data works");
+    ok (lookup_get_aux_data (lh) == lh,
+        "lookup_get_aux_data returns works");
+
+    lookup_destroy (lh);
+
+    /* if root_ref is set to NULL, make sure both root_dir and
+     * root_ref goto root_dir */
+    ok ((lh = lookup_create (cache,
+                             42,
+                             "root.bar",
+                             NULL,
+                             "path.baz",
+                             KVS_PROTO_READLINK | KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create works");
+
+    ok ((tmp = lookup_get_root_dir (lh)) != NULL,
+        "lookup_get_root_dir works");
+    ok (!strcmp (tmp, "root.bar"),
+        "lookup_get_root_dir returns correct string");
+    ok ((tmp = lookup_get_root_ref (lh)) != NULL,
+        "lookup_get_root_ref works");
+    ok (!strcmp (tmp, "root.bar"),
+        "lookup_get_root_ref returns correct string");
+    lookup_destroy (lh);
+
+    cache_destroy (cache);
+}
+
+void basic_api_errors (void)
+{
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok (lookup_create (NULL,
+                       0,
+                       NULL,
+                       NULL,
+                       NULL,
+                       0) == NULL,
+        "lookup_create fails on bad input");
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    ok ((lh = lookup_create (cache,
+                             42,
+                             "root.foo",
+                             "ref.bar",
+                             "path.baz",
+                             KVS_PROTO_READLINK | KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create works");
+
+    ok (lookup_get_errnum (lh) == EINVAL,
+        "lookup_get_errnum returns EINVAL b/c lookup not yet started");
+    ok (lookup_get_value (lh) == NULL,
+        "lookup_get_value fails b/c lookup not yet started");
+    ok (lookup_get_missing_ref (lh) == NULL,
+        "lookup_get_missing_ref fails b/c lookup not yet started");
+
+    ok (lookup_validate (NULL) == false,
+        "lookup_validate fails on NULL pointer");
+    ok (lookup (NULL) == true,
+        "lookup does not segfault on NULL pointer");
+    ok (lookup_get_errnum (NULL) == EINVAL,
+        "lookup_get_errnum returns EINVAL on NULL pointer");
+    ok (lookup_get_value (NULL) == NULL,
+        "lookup_get_value fails on NULL pointer");
+    ok (lookup_get_missing_ref (NULL) == NULL,
+        "lookup_get_missing_ref fails on NULL pointer");
+    ok (lookup_get_cache (NULL) == NULL,
+        "lookup_get_cache fails on NULL pointer");
+    ok (lookup_get_current_epoch (NULL) < 0,
+        "lookup_get_current_epoch fails on NULL pointer");
+    ok (lookup_get_root_dir (NULL) == NULL,
+        "lookup_get_root_dir fails on NULL pointer");
+    ok (lookup_get_root_ref (NULL) == NULL,
+        "lookup_get_root_ref fails on NULL pointer");
+    ok (lookup_get_path (NULL) == NULL,
+        "lookup_get_path fails on NULL pointer");
+    ok (lookup_get_flags (NULL) < 0,
+        "lookup_get_flags fails on NULL pointer");
+    ok (lookup_get_aux_data (NULL) == NULL,
+        "lookup_get_aux_data fails on NULL pointer");
+    ok (lookup_set_current_epoch (NULL, 42) < 0,
+        "lookup_set_current_epoch fails on NULL pointer");
+    ok (lookup_set_aux_data (NULL, NULL) < 0,
+        "lookup_set_aux_data fails n NULL pointer");
+    /* lookup_destroy ok on NULL pointer */
+    lookup_destroy (NULL);
+
+    lookup_destroy (lh);
+
+    /* Now lh destroyed */
+
+    ok (lookup_validate (lh) == false,
+        "lookup_validate fails on bad pointer");
+    ok (lookup (lh) == true,
+        "lookup does not segfault on bad pointer");
+    ok (lookup_get_errnum (lh) == EINVAL,
+        "lookup_get_errnum returns EINVAL on bad pointer");
+    ok (lookup_get_value (lh) == NULL,
+        "lookup_get_value fails on bad pointer");
+    ok (lookup_get_missing_ref (lh) == NULL,
+        "lookup_get_missing_ref fails on bad pointer");
+    ok (lookup_get_cache (lh) == NULL,
+        "lookup_get_cache fails on bad pointer");
+    ok (lookup_get_current_epoch (lh) < 0,
+        "lookup_get_current_epoch fails on bad pointer");
+    ok (lookup_get_root_dir (lh) == NULL,
+        "lookup_get_root_dir fails on bad pointer");
+    ok (lookup_get_root_ref (lh) == NULL,
+        "lookup_get_root_ref fails on bad pointer");
+    ok (lookup_get_path (lh) == NULL,
+        "lookup_get_path fails on bad pointer");
+    ok (lookup_get_flags (lh) < 0,
+        "lookup_get_flags fails on bad pointer");
+    ok (lookup_get_aux_data (lh) == NULL,
+        "lookup_get_aux_data fails on bad pointer");
+    ok (lookup_set_current_epoch (lh, 42) < 0,
+        "lookup_set_current_epoch fails on bad pointer");
+    ok (lookup_set_aux_data (lh, NULL) < 0,
+        "lookup_set_aux_data fails n bad pointer");
+    /* lookup_destroy ok on bad pointer */
+    lookup_destroy (lh);
+
+    cache_destroy (cache);
+}
+
+void check_common (lookup_t *lh,
+                   bool lookup_result,
+                   int get_errnum_result,
+                   json_object *get_value_result,
+                   const char *missing_ref_result,
+                   const char *msg,
+                   bool destroy_lookup)
+{
+    json_object *val;
+
+    ok (lookup (lh) == lookup_result,
+        "%s: lookup matched result", msg);
+    ok (lookup_get_errnum (lh) == get_errnum_result,
+        "%s: lookup_get_errnum returns expected errnum", msg);
+    if (get_value_result) {
+        ok ((val = lookup_get_value (lh)) != NULL,
+            "%s: lookup_get_value returns non-NULL as expected", msg);
+        if (val) {
+            ok (json_compare (get_value_result, val) == true,
+                "%s: lookup_get_value returned matching value", msg);
+            Jput (val);
+        }
+        else {
+            ok (false, "%s: lookup_get_value returned matching value", msg);
+        }
+    }
+    else {
+        ok ((val = lookup_get_value (lh)) == NULL,
+            "%s: lookup_get_value returns NULL as expected", msg);
+        Jput (val);             /* just in case error */
+    }
+    if (missing_ref_result) {
+        const char *missing_ref;
+
+        ok ((missing_ref = lookup_get_missing_ref (lh)) != NULL,
+            "%s: lookup_get_missing_ref returns expected non-NULL result", msg);
+
+        if (missing_ref) {
+            ok (strcmp (missing_ref_result, missing_ref) == 0,
+                "%s: missing ref returned matched expectation", msg);
+        }
+        else {
+            ok (false, "%s: missing ref returned matched expectation", msg);
+        }
+    }
+    else {
+        ok (lookup_get_missing_ref (lh) == NULL,
+            "%s: lookup_get_missing_ref returns NULL as expected", msg);
+    }
+
+    if (destroy_lookup)
+        lookup_destroy (lh);
+}
+
+void check (lookup_t *lh,
+            bool lookup_result,
+            int get_errnum_result,
+            json_object *get_value_result,
+            const char *missing_ref_result,
+            const char *msg)
+{
+    check_common (lh,
+                  lookup_result,
+                  get_errnum_result,
+                  get_value_result,
+                  missing_ref_result,
+                  msg,
+                  true);
+}
+
+void check_stall (lookup_t *lh,
+                  bool lookup_result,
+                  int get_errnum_result,
+                  json_object *get_value_result,
+                  const char *missing_ref_result,
+                  const char *msg)
+{
+    check_common (lh,
+                  lookup_result,
+                  get_errnum_result,
+                  get_value_result,
+                  missing_ref_result,
+                  msg,
+                  false);
+}
+
+/* lookup tests on root dir */
+void lookup_root (void) {
+    json_object *root;
+    json_object *test;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dir" : { "DIRREF" : "dir-ref" } }
+     */
+
+    root = Jnew ();
+    json_object_object_add (root, "dir", dirent_create ("DIRREF", "dir-ref"));
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    /* flags = 0, should error EISDIR */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             ".",
+                             0)) != NULL,
+        "lookup_create on root, no flags, works");
+    check (lh, true, EISDIR, NULL, NULL, "root no flags");
+
+    /* flags = KVS_PROTO_READDIR, should succeed */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             ".",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create on root w/ flag = KVS_PROTO_READDIR, works");
+    check (lh, true, 0, root, NULL, "root w/ KVS_PROTO_READDIR");
+
+    /* flags = KVS_PROTO_TREEOBJ, should succeed */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             ".",
+                             KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create on root w/ flag = KVS_PROTO_TREEOBJ, works");
+    test = dirent_create ("DIRREF", "root-ref");
+    check (lh, true, 0, test, NULL, "root w/ KVS_PROTO_TREEOBJ");
+    Jput (test);
+
+    cache_destroy (cache);
+}
+
+/* lookup basic tests */
+void lookup_basic (void) {
+    json_object *root;
+    json_object *dirref;
+    json_object *dirval;
+    json_object *linkval;
+    json_object *test;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dir" : { "DIRREF" : "dir-ref" } }
+     *
+     * dir-ref
+     * { "fileval" : { "FILEVAL" : 42 }
+     *   "file" : { "FILEREF" : "file-ref" }
+     *   "dirval" : { "DIRVAL" : { "foo" : { "FILEVAL" : 43 } } }
+     *   "linkval" : { "LINKVAL" : "baz" } }
+     *
+     * file-ref
+     * { 44 }
+     */
+
+    root = Jnew ();
+    json_object_object_add (root, "dir", dirent_create ("DIRREF", "dir-ref"));
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    dirval = json_object_new_object ();
+    json_object_object_add (dirval, "foo", dirent_create ("FILEVAL", json_object_new_int (43)));
+
+    linkval = dirent_create ("LINKVAL", json_object_new_string ("baz"));
+
+    dirref = Jnew ();
+    json_object_object_add (dirref, "fileval", dirent_create ("FILEVAL", json_object_new_int (42)));
+    json_object_object_add (dirref, "file", dirent_create ("FILEREF", "file-ref"));
+    json_object_object_add (dirref, "dirval", dirent_create ("DIRVAL", dirval));
+    json_object_object_add (dirref, "linkval", linkval);
+
+    cache_insert (cache, "dir-ref", cache_entry_create (dirref));
+
+    cache_insert (cache, "file-ref", cache_entry_create (json_object_new_int (44)));
+
+    /* lookup dir value */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create on path dir");
+    check (lh, true, 0, dirref, NULL, "lookup dir");
+
+    /* lookup file value */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.file",
+                             0)) != NULL,
+        "lookup_create on path dir.file");
+    test = json_object_new_int (44);
+    check (lh, true, 0, test, NULL, "lookup dir.file");
+    Jput (test);
+
+    /* lookup fileval value */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.fileval",
+                             0)) != NULL,
+        "lookup_create on path dir.fileval");
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "lookup dir.fileval");
+    Jput (test);
+
+    /* lookup dirval value */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.dirval",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create on path dir.dirval");
+    check (lh, true, 0, dirval, NULL, "lookup dir.dirval");
+
+    /* lookup linkval value */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.linkval",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create on path dir.linkval");
+    test = json_object_new_string ("baz");
+    check (lh, true, 0, test, NULL, "lookup dir.linkval");
+    Jput (test);
+
+    /* lookup dir treeobj */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir",
+                             KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create on path dir (treeobj)");
+    test = dirent_create ("DIRREF", "dir-ref");
+    check (lh, true, 0, test, NULL, "lookup dir treeobj");
+    Jput (test);
+
+    /* lookup file treeobj */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.file",
+                             KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create on path dir.file (treeobj)");
+    test = dirent_create ("FILEREF", "file-ref");
+    check (lh, true, 0, test, NULL, "lookup dir.file treeobj");
+    Jput (test);
+
+    /* lookup fileval treeobj */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.fileval",
+                             KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create on path dir.fileval (treeobj)");
+    test = dirent_create ("FILEVAL", json_object_new_int (42));
+    check (lh, true, 0, test, NULL, "lookup dir.fileval treeobj");
+    Jput (test);
+
+    /* lookup dirval treeobj */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.dirval",
+                             KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create on path dir.dirval (treeobj)");
+    test = dirent_create ("DIRVAL", dirval);
+    check (lh, true, 0, test, NULL, "lookup dir.dirval treeobj");
+    Jput (test);
+
+    /* lookup linkval treeobj */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir.linkval",
+                             KVS_PROTO_TREEOBJ)) != NULL,
+        "lookup_create on path dir.linkval (treeobj)");
+    check (lh, true, 0, linkval, NULL, "lookup dir.linkval treeobj");
+
+    cache_destroy (cache);
+}
+
+/* lookup tests reach an error or "non-good" result */
+void lookup_errors (void) {
+    json_object *root;
+    json_object *dirval;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dirref" : { "DIRREF" : "dirref-ref" },
+     *   "fileref" : { "FILEREF" : "fileref-ref" }
+     *   "dirval" : { "DIRVAL" : { "foo" : { "FILEVAL" : 42 } } }
+     *   "fileval" : { "FILEVAL" : 42 }
+     *   "linkval" : { "LINKVAL" : "linkvalstr" }
+     *   "linkval1" : { "LINKVAL" : "linkval2" }
+     *   "linkval2" : { "LINKVAL" : "linkval1" } }
+     */
+
+    dirval = json_object_new_object ();
+    json_object_object_add (dirval, "foo", dirent_create ("FILEVAL", json_object_new_int (42)));
+
+    root = Jnew ();
+    json_object_object_add (root, "dirref", dirent_create ("DIRREF", "dirref-ref"));
+    json_object_object_add (root, "fileref", dirent_create ("FILEREF", "fileref-ref"));
+    json_object_object_add (root, "dirval", dirent_create ("DIRVAL", dirval));
+    json_object_object_add (root, "fileval", dirent_create ("FILEVAL", json_object_new_int (42)));
+    json_object_object_add (root, "linkval", dirent_create ("LINKVAL", json_object_new_string ("linkvalstr")));
+    json_object_object_add (root, "linkval1", dirent_create ("LINKVAL", json_object_new_string ("linkval2")));
+    json_object_object_add (root, "linkval2", dirent_create ("LINKVAL", json_object_new_string ("linkval1")));
+
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    /* Lookup non-existent field.  Not ENOENT - caller of lookup
+     * decides what to do with entry not found */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "foo",
+                             0)) != NULL,
+        "lookup_create on bad path in path");
+    check (lh, true, 0, NULL, NULL, "lookup bad path");
+
+    /* Lookup path w/ fileval in middle, Not ENOENT - caller of lookup
+     * decides what to do with entry not found */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "fileval.foo",
+                             0)) != NULL,
+        "lookup_create on fileval in path");
+    check (lh, true, 0, NULL, NULL, "lookup fileval in path");
+
+    /* Lookup path w/ fileref in middle, Not ENOENT - caller of lookup
+     * decides what to do with entry not found */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "fileref.foo",
+                             0)) != NULL,
+        "lookup_create on fileref in path");
+    check (lh, true, 0, NULL, NULL, "lookup fileref in path");
+
+    /* Lookup path w/ dirval in middle, should get EPERM */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dirval.foo",
+                             0)) != NULL,
+        "lookup_create on dirval in path");
+    check (lh, true, EPERM, NULL, NULL, "lookup dirval in path");
+
+    /* Lookup path w/ infinite link loop, should get ELOOP */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "linkval1",
+                             0)) != NULL,
+        "lookup_create on link loop");
+    check (lh, true, ELOOP, NULL, NULL, "lookup infinite links");
+
+    /* Lookup a dirref, but expecting a link, should get EINVAL. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dirref",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create on dirref");
+    check (lh, true, EINVAL, NULL, NULL, "lookup dirref, expecting link");
+
+    /* Lookup a dirval, but expecting a link, should get EINVAL. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dirval",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create on dirval");
+    check (lh, true, EINVAL, NULL, NULL, "lookup dirval, expecting link");
+
+    /* Lookup a fileref, but expecting a link, should get EINVAL. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "fileref",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create on fileref");
+    check (lh, true, EINVAL, NULL, NULL, "lookup fileref, expecting link");
+
+    /* Lookup a fileval, but expecting a link, should get EINVAL. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "fileval",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create on fileval");
+    check (lh, true, EINVAL, NULL, NULL, "lookup fileval, expecting link");
+
+    /* Lookup a dirref, but don't expect a dir, should get EISDIR. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dirref",
+                             0)) != NULL,
+        "lookup_create on dirref");
+    check (lh, true, EISDIR, NULL, NULL, "lookup dirref, not expecting dirref");
+
+    /* Lookup a dirval, but don't expect a dir, should get EISDIR. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dirval",
+                             0)) != NULL,
+        "lookup_create on dirval");
+    check (lh, true, EISDIR, NULL, NULL, "lookup dirval, not expecting dirval");
+
+    /* Lookup a fileref, but expecting a dir, should get ENOTDIR. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "fileref",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create on fileref");
+    check (lh, true, ENOTDIR, NULL, NULL, "lookup fileref, expecting dir");
+
+    /* Lookup a fileval, but expecting a dir, should get ENOTDIR. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "fileval",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create on fileval");
+    check (lh, true, ENOTDIR, NULL, NULL, "lookup fileval, expecting dir");
+
+    /* Lookup a linkval, but expecting a dir, should get ENOTDIR. */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "linkval",
+                             KVS_PROTO_READLINK | KVS_PROTO_READDIR)) != NULL,
+        "lookup_create on linkval");
+    check (lh, true, ENOTDIR, NULL, NULL, "lookup linkval, expecting dir");
+
+    cache_destroy (cache);
+}
+
+/* lookup link tests */
+void lookup_links (void) {
+    json_object *root;
+    json_object *dir1ref;
+    json_object *dir2ref;
+    json_object *dir3ref;
+    json_object *dirval;
+    json_object *linkval;
+    json_object *test;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dir1" : { "DIRREF" : "dir1-ref" }
+     *   "dir2" : { "DIRREF" : "dir2-ref" } }
+     *
+     * dir1-ref
+     * { "link2dir" : { "LINKVAL" : "dir2" }
+     *   "link2fileval" : { "LINKVAL" : "dir2.fileval" }
+     *   "link2file" : { "LINKVAL" : "dir2.file" }
+     *   "link2dirval" : { "LINKVAL" : "dir2.dirval" }
+     *   "link2linkval" : { "LINKVAL" : "dir2.linkval" } }
+     *
+     * dir2-ref
+     * { "fileval" : { "FILEVAL" : 42 }
+     *   "file" : { "FILEREF" : "file-ref" }
+     *   "dirval" : { "DIRVAL" : { "foo" : { "FILEVAL" : 43 } } }
+     *   "dir" : { "DIRREF" : "dir3-ref" }
+     *   "linkval" : { "LINKVAL" : "dir2.fileval" } }
+     *
+     * dir3-ref
+     * { "fileval" : { "FILEVAL" : 44 } }
+     *
+     * file-ref
+     * { 45 }
+     */
+
+    root = Jnew ();
+    json_object_object_add (root, "dir1", dirent_create ("DIRREF", "dir1-ref"));
+    json_object_object_add (root, "dir2", dirent_create ("DIRREF", "dir2-ref"));
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    dir1ref = Jnew ();
+    json_object_object_add (dir1ref, "link2dir", dirent_create ("LINKVAL", json_object_new_string ("dir2")));
+    json_object_object_add (dir1ref, "link2fileval", dirent_create ("LINKVAL", json_object_new_string ("dir2.fileval")));
+    json_object_object_add (dir1ref, "link2file", dirent_create ("LINKVAL", json_object_new_string ("dir2.file")));
+    json_object_object_add (dir1ref, "link2dirval", dirent_create ("LINKVAL", json_object_new_string ("dir2.dirval")));
+    json_object_object_add (dir1ref, "link2linkval", dirent_create ("LINKVAL", json_object_new_string ("dir2.linkval")));
+
+    cache_insert (cache, "dir1-ref", cache_entry_create (dir1ref));
+
+    dirval = json_object_new_object ();
+    json_object_object_add (dirval, "foo", dirent_create ("FILEVAL", json_object_new_int (43)));
+
+    linkval = dirent_create ("LINKVAL", json_object_new_string ("dir2.fileval"));
+
+    dir2ref = Jnew ();
+    json_object_object_add (dir2ref, "fileval", dirent_create ("FILEVAL", json_object_new_int (42)));
+    json_object_object_add (dir2ref, "file", dirent_create ("FILEREF", "file-ref"));
+    json_object_object_add (dir2ref, "dirval", dirent_create ("DIRVAL", dirval));
+    json_object_object_add (dir2ref, "dir", dirent_create ("DIRREF", "dir3-ref"));
+    json_object_object_add (dir2ref, "linkval", linkval);
+
+    cache_insert (cache, "dir2-ref", cache_entry_create (dir2ref));
+
+    dir3ref = Jnew ();
+    json_object_object_add (dir3ref, "fileval", dirent_create ("FILEVAL", json_object_new_int (44)));
+
+    cache_insert (cache, "dir3-ref", cache_entry_create (dir3ref));
+
+    cache_insert (cache, "file-ref", cache_entry_create (json_object_new_int (45)));
+
+    /* lookup fileval, follow two links */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir.linkval",
+                             0)) != NULL,
+        "lookup_create link to fileval via two links");
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "fileval via two links");
+    Jput (test);
+
+    /* lookup fileval, link is middle of path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir.fileval",
+                             0)) != NULL,
+        "lookup_create link to fileval");
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "dir1.link2dir.fileval");
+    Jput (test);
+
+    /* lookup file, link is middle of path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir.file",
+                             0)) != NULL,
+        "lookup_create link to file");
+    test = json_object_new_int (45);
+    check (lh, true, 0, test, NULL, "dir1.link2dir.file");
+    Jput (test);
+
+    /* lookup dirval, link is middle of path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir.dirval",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create link to dirval");
+    check (lh, true, 0, dirval, NULL, "dir1.link2dir.dirval");
+
+    /* lookup dir, link is middle of path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir.dir",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create link to dir");
+    check (lh, true, 0, dir3ref, NULL, "dir1.link2dir.dir");
+
+    /* lookup linkval, link is middle of path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir.linkval",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create link to linkval");
+    test = json_object_new_string ("dir2.fileval");
+    check (lh, true, 0, test, NULL, "dir1.link2dir.linkval");
+    Jput (test);
+
+    /* lookup fileval, link is last part in path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2fileval",
+                             0)) != NULL,
+        "lookup_create link to fileval (last part path)");
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "dir1.link2fileval");
+    Jput (test);
+
+    /* lookup file, link is last part in path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2file",
+                             0)) != NULL,
+        "lookup_create link to file (last part path)");
+    test = json_object_new_int (45);
+    check (lh, true, 0, test, NULL, "dir1.link2file");
+    Jput (test);
+
+    /* lookup dirval, link is last part in path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dirval",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create link to dirval (last part path)");
+    check (lh, true, 0, dirval, NULL, "dir1.link2dirval");
+
+    /* lookup dir, link is last part in path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2dir",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create link to dir (last part path)");
+    check (lh, true, 0, dir2ref, NULL, "dir1.link2dir");
+
+    /* lookup linkval, link is last part in path */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.link2linkval",
+                             KVS_PROTO_READLINK)) != NULL,
+        "lookup_create link to linkval (last part path)");
+    test = json_object_new_string ("dir2.linkval");
+    check (lh, true, 0, test, NULL, "dir1.link2linkval");
+    Jput (test);
+
+    cache_destroy (cache);
+}
+
+/* lookup alternate root tests */
+void lookup_alt_root (void) {
+    json_object *root;
+    json_object *dir1ref;
+    json_object *dir2ref;
+    json_object *test;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dir1" : { "DIRREF" : "dir1-ref" }
+     *   "dir2" : { "DIRREF" : "dir2-ref" } }
+     *
+     * dir1-ref
+     * { "fileval" : { "FILEVAL" : 42 } }
+     *
+     * dir2-ref
+     * { "fileval" : { "FILEVAL" : 43 } }
+     */
+
+    root = Jnew ();
+    json_object_object_add (root, "dir1", dirent_create ("DIRREF", "dir1-ref"));
+    json_object_object_add (root, "dir2", dirent_create ("DIRREF", "dir2-ref"));
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    dir1ref = Jnew ();
+    json_object_object_add (dir1ref, "fileval", dirent_create ("FILEVAL", json_object_new_int (42)));
+    cache_insert (cache, "dir1-ref", cache_entry_create (dir1ref));
+
+    dir2ref = Jnew ();
+    json_object_object_add (dir2ref, "fileval", dirent_create ("FILEVAL", json_object_new_int (43)));
+    cache_insert (cache, "dir2-ref", cache_entry_create (dir2ref));
+
+    /* lookup fileval, alt root-ref dir1-ref */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "dir1-ref",
+                             "fileval",
+                             0)) != NULL,
+        "lookup_create fileval w/ dir1ref root_ref");
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "alt root fileval");
+    Jput (test);
+
+    /* lookup fileval, alt root-ref dir2-ref */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "dir2-ref",
+                             "fileval",
+                             0)) != NULL,
+        "lookup_create fileval w/ dir2ref root_ref");
+    test = json_object_new_int (43);
+    check (lh, true, 0, test, NULL, "alt root fileval");
+    Jput (test);
+
+    cache_destroy (cache);
+}
+
+/* lookup stall tests on root */
+void lookup_stall_root (void) {
+    json_object *root;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dir" : { "DIRREF" : "dir-ref" } }
+     */
+
+    root = Jnew ();
+    json_object_object_add (root, "dir", dirent_create ("DIRREF", "dir-ref"));
+
+    /* do not insert entries into cache until later for these stall tests */
+
+    /* lookup root ".", should stall on root */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             ".",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create stalltest \".\"");
+    check_stall (lh, false, EAGAIN, NULL, "root-ref", "root \".\" stall");
+
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    /* lookup root ".", should succeed */
+    check (lh, true, 0, root, NULL, "root \".\" #1");
+
+    /* lookup root ".", now fully cached, should succeed */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             ".",
+                             KVS_PROTO_READDIR)) != NULL,
+        "lookup_create stalltest \".\"");
+    check (lh, true, 0, root, NULL, "root \".\" #2");
+
+    cache_destroy (cache);
+}
+
+/* lookup stall tests */
+void lookup_stall (void) {
+    json_object *root;
+    json_object *dir1ref;
+    json_object *dir2ref;
+    json_object *fileref;
+    json_object *test;
+    struct cache *cache;
+    lookup_t *lh;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+
+    /* This cache is
+     *
+     * root-ref
+     * { "dir1" : { "DIRREF" : "dir1-ref" }
+     *   "dir2" : { "DIRREF" : "dir2-ref" }
+     *   "linkval" : { "LINKVAL" : "dir2" } }
+     *
+     * dir1-ref
+     * { "fileval" : { "FILEVAL" : 42 }
+     *   "file" : { "FILEREF" : "file-ref" } }
+     *
+     * dir2-ref
+     * { "fileval" : { "FILEVAL" : 43 } }
+     *
+     * file-ref
+     * { 44 }
+     *
+     */
+
+    root = Jnew ();
+    json_object_object_add (root, "dir1", dirent_create ("DIRREF", "dir1-ref"));
+    json_object_object_add (root, "dir2", dirent_create ("DIRREF", "dir2-ref"));
+    json_object_object_add (root, "linkval", dirent_create ("LINKVAL", json_object_new_string ("dir2")));
+
+    dir1ref = Jnew ();
+    json_object_object_add (dir1ref, "fileval", dirent_create ("FILEVAL", json_object_new_int (42)));
+    json_object_object_add (dir1ref, "file", dirent_create ("FILEREF", "file-ref"));
+
+    dir2ref = Jnew();
+    json_object_object_add (dir2ref, "fileval", dirent_create ("FILEVAL", json_object_new_int (43)));
+
+    fileref = json_object_new_int (44);
+
+    /* do not insert entries into cache until later for these stall tests */
+
+    /* lookup dir1.fileval, should stall on root */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.fileval",
+                             0)) != NULL,
+        "lookup_create stalltest dir1.fileval");
+    check_stall (lh, false, EAGAIN, NULL, "root-ref", "dir1.fileval stall #1");
+
+    cache_insert (cache, "root-ref", cache_entry_create (root));
+
+    /* next call to lookup, should stall */
+    check_stall (lh, false, EAGAIN, NULL, "dir1-ref", "dir1.fileval stall #2");
+
+    cache_insert (cache, "dir1-ref", cache_entry_create (dir1ref));
+
+    /* final call to lookup, should succeed */
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "dir1.fileval #1");
+    Jput (test);
+
+    /* lookup dir1.fileval, now fully cached, should succeed */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.fileval",
+                             0)) != NULL,
+        "lookup_create dir1.fileval");
+    test = json_object_new_int (42);
+    check (lh, true, 0, test, NULL, "dir1.fileval #2");
+    Jput (test);
+
+    /* lookup linkval.fileval, should stall */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "linkval.fileval",
+                             0)) != NULL,
+        "lookup_create stalltest linkval.fileval");
+    check_stall (lh, false, EAGAIN, NULL, "dir2-ref", "linkval.fileval stall");
+
+    cache_insert (cache, "dir2-ref", cache_entry_create (dir2ref));
+
+    /* lookup linkval.fileval, should succeed */
+    test = json_object_new_int (43);
+    check (lh, true, 0, test, NULL, "linkval.fileval #1");
+    Jput (test);
+
+    /* lookup linkval.fileval, now fully cached, should succeed */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "linkval.fileval",
+                             0)) != NULL,
+        "lookup_create linkval.fileval");
+    test = json_object_new_int (43);
+    check (lh, true, 0, test, NULL, "linkval.fileval #2");
+    Jput (test);
+
+    /* lookup dir1.file, should stall */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.file",
+                             0)) != NULL,
+        "lookup_create stalltest dir1.file");
+    check_stall (lh, false, EAGAIN, NULL, "file-ref", "dir1.file stall");
+
+    cache_insert (cache, "file-ref", cache_entry_create (fileref));
+
+    /* lookup dir1.file, should succeed */
+    test = json_object_new_int (44);
+    check (lh, true, 0, test, NULL, "dir1.file #1");
+    Jput (test);
+
+    /* lookup dir1.file, now fully cached, should succeed */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             "root-ref",
+                             "root-ref",
+                             "dir1.file",
+                             0)) != NULL,
+        "lookup_create stalltest dir1.file");
+    test = json_object_new_int (44);
+    check (lh, true, 0, test, NULL, "dir1.file #2");
+    Jput (test);
+
+    cache_destroy (cache);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic_api ();
+    basic_api_errors ();
+
+    lookup_root ();
+    lookup_basic ();
+    lookup_errors ();
+    lookup_links ();
+    lookup_alt_root ();
+    lookup_stall_root ();
+    lookup_stall ();
+
+    done_testing ();
+    return (0);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
In this PR, we convert the KVS walk function from a recursive implementation into a non-recursive one and simplified the logic as well.  The predominant logic changes are:

A) In preparation for maintaining "state" so that RPCs aren't fully replayed, the entire path of the kvs get request is pre-parsed and stored in a list.

B) The walk() function has been made non-recursive and "depth" is maintained in a stack.  This is also in preparation for maintaining "state" for removal of RPC replay.

C) A variety of	code logic changes to make the walk() function simpler.

The predominant logic changes that may look strange in this PR are:

A) The pre-parsing of the path makes things more inefficient for the time being b/c RPCs are still completely replayed (i.e. it is fully parsed on every RPC-then continuation).

B) There are some paths (such as through get_request_cb()) in which a load() will be called twice on the same root reference.  This will be resolved when lookup() is refactored.  This PR is only sticking to walk().

I still need to run through valgrind to make sure I didn't mem-leak anything.  But wanted to throw the PR up here for a first skim.