### PR TITLE
Change flux_handle_destroy prototype to avoid potential memory corruption, fix small leak in flux cmd help

### DIFF
--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -154,6 +154,7 @@ static int command_list_read (zhash_t *h, const char *path)
             //zlist_set_destructor (zl, (czmq_destructor *) cmdhelp_destroy);
             zhash_insert (h, s, (void *) zl);
             zhash_freefn (h, s, (zhash_free_fn *) cmd_list_destroy);
+            free (s);
         }
         zlist_append (zl, cmdhelp_create (command, description));
     }

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -29,7 +29,7 @@ struct flux_handle_ops {
 };
 
 flux_t *flux_handle_create (void *impl, const struct flux_handle_ops *ops, int flags);
-void flux_handle_destroy (flux_t **hp);
+void flux_handle_destroy (flux_t *hp);
 
 #endif /* !_FLUX_CORE_CONNECTOR_H */
 

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -407,7 +407,7 @@ error:
     if (c) {
         int saved_errno = errno;
         if (c->h)
-            flux_handle_destroy (&c->h); /* calls op_fini */
+            flux_handle_destroy (c->h); /* calls op_fini */
         else
             op_fini (c);
         errno = saved_errno;


### PR DESCRIPTION
As discussed in #1062, we were seeing memory corruption from an error path in ssh connector because of the order of destruction of connector implementation object and flux handle object. Since `flux_handle_destroy` wanted to nullify its argument, but called the implementation's destroy method first, this could result in writing to freed memory if the handle was stored *within* the implementation (as in ssh connector).

Long story short - it is probably simplest to avoid the "destroy nullifies its argument" idiom in this case, as it is rarely used in the rest of flux API, and we can thereby avoid other accidental cases of memory corruption like this in the future.

I also found a small memory leak in cmd/cmdhelp.c that I threw in here (after some valgrind runs)
