### PR TITLE
Refactor how data is loaded in KVS walk/lookup

### DIFF
--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -158,6 +158,14 @@ struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
     return hp;
 }
 
+json_object *cache_lookup_and_get_json (struct cache *cache,
+                                        const char *ref,
+                                        int current_epoch)
+{
+    struct cache_entry *hp = cache_lookup (cache, ref, current_epoch);
+    return cache_entry_get_valid (hp) ? cache_entry_get_json (hp) : NULL;
+}
+
 void cache_insert (struct cache *cache, const char *ref, struct cache_entry *hp)
 {
     int rc = zhash_insert (cache->zh, ref, hp);

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -46,6 +46,15 @@ void cache_destroy (struct cache *cache);
 struct cache_entry *cache_lookup (struct cache *cache,
                                   const char *ref, int current_epoch);
 
+/* Look up a cache entry and get json of cache entry only if entry
+ * contains valid json.  This is a convenience function that is
+ * effectively successful if calls to cache_lookup() and
+ * cache_entry_get_json() are both successful.
+ */
+json_object *cache_lookup_and_get_json (struct cache *cache,
+                                        const char *ref,
+                                        int current_epoch);
+
 /* Insert an entry in the cache by blobref 'ref'.
  * Ownership of the cache entry is transferred to the cache.
  */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -230,10 +230,10 @@ error:
     return -1;
 }
 
+/* Return true if load successful, false if stalling */
 static bool load (kvs_ctx_t *ctx, const href_t ref, wait_t *wait, json_object **op)
 {
     struct cache_entry *hp = cache_lookup (ctx->cache, ref, ctx->epoch);
-    bool stall = false;
 
     /* Create an incomplete hash entry if none found.
      */
@@ -249,12 +249,12 @@ static bool load (kvs_ctx_t *ctx, const href_t ref, wait_t *wait, json_object **
      */
     if (!cache_entry_get_valid (hp)) {
         cache_entry_wait_valid (hp, wait);
-        stall = true;
+        return false;
     }
 
-    if (!stall && op)
+    if (op)
         *op = cache_entry_get_json (hp);
-    return !stall;
+    return true;
 }
 
 static int content_store_get (flux_rpc_t *rpc, void *arg)

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -22,6 +22,7 @@ int main (int argc, char *argv[])
     struct cache_entry *e1, *e2, *e3, *e4;
     json_object *o1;
     json_object *o2;
+    json_object *o3;
     wait_t *w;
     int count, i;
 
@@ -105,8 +106,12 @@ int main (int argc, char *argv[])
         "cache contains 1 entry after insert");
     ok (cache_lookup (cache, "yyy1", 0) == NULL,
         "cache_lookup of wrong hash fails");
+    ok (cache_lookup_and_get_json (cache, "yyy1", 0) == NULL,
+        "cache_lookup_and_get_json of wrong hash fails");
     ok ((e2 = cache_lookup (cache, "xxx1", 42)) != NULL,
         "cache_lookup of correct hash works (last use=42)");
+    ok (cache_lookup_and_get_json (cache, "xxx1", 0) == NULL,
+        "cache_lookup_and_get_json of correct hash, but non valid entry fails");
     ok (cache_entry_get_json (e2) == NULL,
         "no json object found");
     ok (cache_count_entries (cache) == 1,
@@ -135,6 +140,11 @@ int main (int argc, char *argv[])
     i = 0;
     ok ((o2 = cache_entry_get_json (e4)) != NULL
         && Jget_int (o2, "foo", &i) == true && i == 42,
+        "expected json object found");
+    ok ((o3 = cache_lookup_and_get_json (cache, "xxx2", 0)) != NULL,
+        "cache_lookup_and_get_json of correct hash and valid entry works");
+    i = 0;
+    ok (Jget_int (o3, "foo", &i) == true && i == 42,
         "expected json object found");
     ok (cache_count_entries (cache) == 2,
         "cache contains 2 entries");


### PR DESCRIPTION
Per discussion in #1066, it is difficult to splice out some of the KVS functions into separate files/APIs b/c of dependencies in certain libraries/calls.  One of the major dependencies was functions calling the ```load()``` function, which may load data from the KVS cache, or issue a RPC to the content cache and stall.

This patch refactors the ```walk()``` and ```lookup()``` functions to not load data from the content cache or stall.  Instead, it only checks the KVS cache.  If the KVS cache does not have the data that it desires, the missing reference is passed all the way back to the caller.  It is then the caller's responsibility to call ```load()``` which will issue a RPC to the content cache.

This decoupling will eventually allow us to splice off some functions like ```walk()``` into other convenience APIs/files.