### PR TITLE
dirwalk: add tests for a couple corner cases, fix symbol leakage

### DIFF
--- a/src/common/libutil/dirwalk.c
+++ b/src/common/libutil/dirwalk.c
@@ -57,7 +57,7 @@ struct dirwalk {
     int errnum;
 };
 
-void direntry_destroy (struct direntry *e)
+static void direntry_destroy (struct direntry *e)
 {
     if (e) {
         if (e->close_dirfd)
@@ -73,7 +73,8 @@ void direntry_destroy (struct direntry *e)
  *  Create a direntry under parent dirfd `fd` and path `dir`, from
  *   directory entry `dent`.
  */
-struct direntry *direntry_create (int fd, const char *dir, struct dirent *dent)
+static struct direntry *direntry_create (int fd, const char *dir,
+                                         struct dirent *dent)
 {
     struct direntry *e = calloc (1, sizeof (*e));
     if (!e)
@@ -121,7 +122,7 @@ out_err:
     return NULL;
 }
 
-void dirwalk_destroy (dirwalk_t *d)
+static void dirwalk_destroy (dirwalk_t *d)
 {
     if (d) {
         if (d->current)
@@ -137,7 +138,7 @@ void dirwalk_destroy (dirwalk_t *d)
 }
 
 
-dirwalk_t *dirwalk_create ()
+static dirwalk_t *dirwalk_create ()
 {
     dirwalk_t *d = calloc (1, sizeof (*d));
     if (!d || !(d->dirstack = zlist_new ())) {
@@ -147,7 +148,7 @@ dirwalk_t *dirwalk_create ()
     return (d);
 }
 
-int dirwalk_set_flags (dirwalk_t *d, int flags)
+static int dirwalk_set_flags (dirwalk_t *d, int flags)
 {
     int old = d->flags;
     d->flags = flags;
@@ -208,7 +209,7 @@ static void dirwalk_visit (dirwalk_t *d, dirwalk_filter_f fn, void *arg)
 /*
  *  Continue traversal of d->current, which must be a directory
  */
-int dirwalk_traverse (dirwalk_t *d, dirwalk_filter_f fn, void *arg)
+static int dirwalk_traverse (dirwalk_t *d, dirwalk_filter_f fn, void *arg)
 {
     int fd;
     const char *path;

--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -180,6 +180,19 @@ static int d_unlinkat (dirwalk_t *d, void *arg)
     return 0;
 }
 
+static int make_a_link (const char *targetbase, const char *target,
+                        const char *linkbase, const char *linkname)
+{
+    int rc = -1;
+    char *l = NULL, *t = NULL;
+    if ((asprintf (&l, "%s/%s", linkbase, linkname) >= 0)
+     && (asprintf (&t, "%s/%s", targetbase, target) >= 0))
+        rc = symlink (t, l);
+    free (l);
+    free (t);
+    return rc;
+}
+
 int main(int argc, char** argv)
 {
     char *s, *rpath, *tmp = NULL, *tmp2 = NULL;
@@ -220,6 +233,9 @@ int main(int argc, char** argv)
 
     if (vcreat ("%s/bar/foo", tmp2) < 0)
         BAIL_OUT ("vcreat");
+
+    if (make_a_link (tmp, "a/b", tmp2, "link") < 0)
+        BAIL_OUT ("make_a_link");
 
     /*  dirwalk_find tests:
      */
@@ -319,9 +335,9 @@ int main(int argc, char** argv)
     n = dirwalk (tmp, DIRWALK_DEPTH, d_unlinkat, NULL);
     ok (n == 7, "dirwalk recursive unlink works");
 
-   /* Cleanup */
+    /* Cleanup */
     n = dirwalk (tmp2, DIRWALK_DEPTH, d_unlinkat, NULL);
-    ok (n == 3, "dirwalk recursive unlink works");
+    ok (n == 4, "dirwalk recursive unlink works");
 
     ok (access (tmp, F_OK) < 0 && errno == ENOENT, "tmp working dir removed");
     ok (access (tmp2, F_OK) < 0 && errno == ENOENT, "tmp2 working dir removed");

--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -240,8 +240,16 @@ int main(int argc, char** argv)
     /*  dirwalk_find tests:
      */
 
+    /* Not a directory returns an error */
+    zlist_t *l = dirwalk_find ("/etc/passwd", 0, "*", 1, NULL, 0);
+    ok (l == NULL && errno == ENOTDIR, "dirwalk_find on file returns ENOTDIR");
+
+    l = dirwalk_find ("/blah:/bloop", 0, "*", 1, NULL, 0);
+    ok (l && zlist_size (l) == 0, "dirwalk_find on nonexistent dirs works");
+    zlist_destroy (&l);
+
     /* Find first file matching "foo" */
-    zlist_t *l = dirwalk_find (tmp, 0, "foo", 1, NULL, 0);
+    l = dirwalk_find (tmp, 0, "foo", 1, NULL, 0);
     ok (l != NULL, "dirwalk_find");
     ok (l && zlist_size (l) == 1, "dirwalk_find stopped at 1 result");
     ok (strcmp (basename (zlist_first (l)), "foo") == 0,


### PR DESCRIPTION
Oops, I noticed that some functions in dirwalk.c needed to be marked `static`.

Along the way I added a couple basic tests for symlinks, and dirwalk_find() on non-directories.