### PR TITLE
tweak watcher structure, add external watcher construction interface

### DIFF
--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -224,7 +224,7 @@ void flux_watcher_start (flux_watcher_t *w)
 {
     if (w) {
         if (w->ops->start)
-            w->ops->start (w->impl, w);
+            w->ops->start (w);
     }
 }
 
@@ -232,7 +232,7 @@ void flux_watcher_stop (flux_watcher_t *w)
 {
     if (w) {
         if (w->ops->stop)
-            w->ops->stop (w->impl, w);
+            w->ops->stop (w);
     }
 }
 
@@ -240,9 +240,9 @@ void flux_watcher_destroy (flux_watcher_t *w)
 {
     if (w) {
         if (w->ops->stop)
-            w->ops->stop (w->impl, w);
+            w->ops->stop (w);
         if (w->ops->destroy)
-            w->ops->destroy (w->impl, w);
+            w->ops->destroy (w);
         if (w->r)
             reactor_usecount_decr (w->r);
         free (w);
@@ -277,14 +277,14 @@ static void watcher_stop_safe (flux_watcher_t *w)
 /* flux_t handle
  */
 
-static void handle_start (void *impl, flux_watcher_t *w)
+static void handle_start (flux_watcher_t *w)
 {
-    ev_flux_start (w->r->loop, (ev_flux *)impl);
+    ev_flux_start (w->r->loop, (ev_flux *)w->impl);
 }
 
-static void handle_stop (void *impl, flux_watcher_t *w)
+static void handle_stop (flux_watcher_t *w)
 {
-    ev_flux_stop (w->r->loop, (ev_flux *)impl);
+    ev_flux_stop (w->r->loop, (ev_flux *)w->impl);
 }
 
 static void handle_cb (struct ev_loop *loop, ev_flux *fw, int revents)
@@ -325,14 +325,14 @@ flux_t *flux_handle_watcher_get_flux (flux_watcher_t *w)
 /* file descriptors
  */
 
-static void fd_start (void *impl, flux_watcher_t *w)
+static void fd_start (flux_watcher_t *w)
 {
-    ev_io_start (w->r->loop, (ev_io *)impl);
+    ev_io_start (w->r->loop, (ev_io *)w->impl);
 }
 
-static void fd_stop (void *impl, flux_watcher_t *w)
+static void fd_stop (flux_watcher_t *w)
 {
-    ev_io_stop (w->r->loop, (ev_io *)impl);
+    ev_io_stop (w->r->loop, (ev_io *)w->impl);
 }
 
 static void fd_cb (struct ev_loop *loop, ev_io *iow, int revents)
@@ -373,14 +373,14 @@ int flux_fd_watcher_get_fd (flux_watcher_t *w)
 /* 0MQ sockets
  */
 
-static void zmq_start (void *impl, flux_watcher_t *w)
+static void zmq_start (flux_watcher_t *w)
 {
-    ev_zmq_start (w->r->loop, (ev_zmq *)impl);
+    ev_zmq_start (w->r->loop, (ev_zmq *)w->impl);
 }
 
-static void zmq_stop (void *impl, flux_watcher_t *w)
+static void zmq_stop (flux_watcher_t *w)
 {
-    ev_zmq_stop (w->r->loop, (ev_zmq *)impl);
+    ev_zmq_stop (w->r->loop, (ev_zmq *)w->impl);
 }
 
 static void zmq_cb (struct ev_loop *loop, ev_zmq *pw, int revents)
@@ -425,14 +425,14 @@ void *flux_zmq_watcher_get_zsock (flux_watcher_t *w)
 /* Timer
  */
 
-static void timer_start (void *impl, flux_watcher_t *w)
+static void timer_start (flux_watcher_t *w)
 {
-    ev_timer_start (w->r->loop, (ev_timer *)impl);
+    ev_timer_start (w->r->loop, (ev_timer *)w->impl);
 }
 
-static void timer_stop (void *impl, flux_watcher_t *w)
+static void timer_stop (flux_watcher_t *w)
 {
-    ev_timer_stop (w->r->loop, (ev_timer *)impl);
+    ev_timer_stop (w->r->loop, (ev_timer *)w->impl);
 }
 
 static void timer_cb (struct ev_loop *loop, ev_timer *tw, int revents)
@@ -482,13 +482,13 @@ struct f_periodic {
     flux_reschedule_f    reschedule_cb;
 };
 
-static void periodic_start (void *impl, flux_watcher_t *w)
+static void periodic_start (flux_watcher_t *w)
 {
     struct f_periodic *fp = w->impl;
     ev_periodic_start (w->r->loop, &fp->evp);
 }
 
-static void periodic_stop (void *impl, flux_watcher_t *w)
+static void periodic_stop (flux_watcher_t *w)
 {
     struct f_periodic *fp = w->impl;
     ev_periodic_stop (w->r->loop, &fp->evp);
@@ -582,14 +582,14 @@ double flux_watcher_next_wakeup (flux_watcher_t *w)
 
 /* Prepare
  */
-static void prepare_start (void *impl, flux_watcher_t *w)
+static void prepare_start (flux_watcher_t *w)
 {
-    ev_prepare_start (w->r->loop, (ev_prepare *)impl);
+    ev_prepare_start (w->r->loop, (ev_prepare *)w->impl);
 }
 
-static void prepare_stop (void *impl, flux_watcher_t *w)
+static void prepare_stop (flux_watcher_t *w)
 {
-    ev_prepare_stop (w->r->loop, (ev_prepare *)impl);
+    ev_prepare_stop (w->r->loop, (ev_prepare *)w->impl);
 }
 
 static void prepare_cb (struct ev_loop *loop, ev_prepare *pw, int revents)
@@ -623,14 +623,14 @@ flux_watcher_t *flux_prepare_watcher_create (flux_reactor_t *r,
 /* Check
  */
 
-static void check_start (void *impl, flux_watcher_t *w)
+static void check_start (flux_watcher_t *w)
 {
-    ev_check_start (w->r->loop, (ev_check *)impl);
+    ev_check_start (w->r->loop, (ev_check *)w->impl);
 }
 
-static void check_stop (void *impl, flux_watcher_t *w)
+static void check_stop (flux_watcher_t *w)
 {
-    ev_check_stop (w->r->loop, (ev_check *)impl);
+    ev_check_stop (w->r->loop, (ev_check *)w->impl);
 }
 
 static void check_cb (struct ev_loop *loop, ev_check *cw, int revents)
@@ -664,14 +664,14 @@ flux_watcher_t *flux_check_watcher_create (flux_reactor_t *r,
 /* Idle
  */
 
-static void idle_start (void *impl, flux_watcher_t *w)
+static void idle_start (flux_watcher_t *w)
 {
-    ev_idle_start (w->r->loop, (ev_idle *)impl);
+    ev_idle_start (w->r->loop, (ev_idle *)w->impl);
 }
 
-static void idle_stop (void *impl, flux_watcher_t *w)
+static void idle_stop (flux_watcher_t *w)
 {
-    ev_idle_stop (w->r->loop, (ev_idle *)impl);
+    ev_idle_stop (w->r->loop, (ev_idle *)w->impl);
 }
 
 static void idle_cb (struct ev_loop *loop, ev_idle *iw, int revents)
@@ -705,14 +705,14 @@ flux_watcher_t *flux_idle_watcher_create (flux_reactor_t *r,
 /* Child
  */
 
-static void child_start (void *impl, flux_watcher_t *w)
+static void child_start (flux_watcher_t *w)
 {
-    ev_child_start (w->r->loop, (ev_child *)impl);
+    ev_child_start (w->r->loop, (ev_child *)w->impl);
 }
 
-static void child_stop (void *impl, flux_watcher_t *w)
+static void child_stop (flux_watcher_t *w)
 {
-    ev_child_stop (w->r->loop, (ev_child *)impl);
+    ev_child_stop (w->r->loop, (ev_child *)w->impl);
 }
 
 static void child_cb (struct ev_loop *loop, ev_child *cw, int revents)
@@ -772,14 +772,14 @@ int flux_child_watcher_get_rstatus (flux_watcher_t *w)
 /* Signal
  */
 
-static void signal_start (void *impl, flux_watcher_t *w)
+static void signal_start (flux_watcher_t *w)
 {
-    ev_signal_start (w->r->loop, (ev_signal *)impl);
+    ev_signal_start (w->r->loop, (ev_signal *)w->impl);
 }
 
-static void signal_stop (void *impl, flux_watcher_t *w)
+static void signal_stop (flux_watcher_t *w)
 {
-    ev_signal_stop (w->r->loop, (ev_signal *)impl);
+    ev_signal_stop (w->r->loop, (ev_signal *)w->impl);
 }
 
 static void signal_cb (struct ev_loop *loop, ev_signal *sw, int revents)
@@ -823,14 +823,14 @@ int flux_signal_watcher_get_signum (flux_watcher_t *w)
 /* Stat
  */
 
-static void stat_start (void *impl, flux_watcher_t *w)
+static void stat_start (flux_watcher_t *w)
 {
-    ev_stat_start (w->r->loop, (ev_stat *)impl);
+    ev_stat_start (w->r->loop, (ev_stat *)w->impl);
 }
 
-static void stat_stop (void *impl, flux_watcher_t *w)
+static void stat_stop (flux_watcher_t *w)
 {
-    ev_stat_stop (w->r->loop, (ev_stat *)impl);
+    ev_stat_stop (w->r->loop, (ev_stat *)w->impl);
 }
 
 static void stat_cb (struct ev_loop *loop, ev_stat *sw, int revents)

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -145,9 +145,9 @@ void flux_stat_watcher_get_rstat (flux_watcher_t *w,
  */
 
 struct flux_watcher_ops {
-    void (*start)(void *impl, flux_watcher_t *w);
-    void (*stop)(void *impl, flux_watcher_t *w);
-    void (*destroy)(void *impl, flux_watcher_t *w);
+    void (*start) (flux_watcher_t *w);
+    void (*stop) (flux_watcher_t *w);
+    void (*destroy) (flux_watcher_t *w);
 };
 
 /*  Create a custom watcher on reactor 'r' with 'impl_size' bytes reserved
@@ -168,7 +168,6 @@ void * flux_watcher_impl (flux_watcher_t *w);
 /*  Return pointer to flux_watcher_ops structure for this watcher.
  */
 struct flux_watcher_ops * flux_watcher_ops (flux_watcher_t *w);
-
 
 
 #endif /* !_FLUX_CORE_REACTOR_H */

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -141,6 +141,36 @@ flux_watcher_t *flux_stat_watcher_create (flux_reactor_t *r,
 void flux_stat_watcher_get_rstat (flux_watcher_t *w,
                                   struct stat *stat, struct stat *prev);
 
+/* Custom watcher construction functions:
+ */
+
+struct flux_watcher_ops {
+    void (*start)(void *impl, flux_watcher_t *w);
+    void (*stop)(void *impl, flux_watcher_t *w);
+    void (*destroy)(void *impl, flux_watcher_t *w);
+};
+
+/*  Create a custom watcher on reactor 'r' with 'impl_size' bytes reserved
+ *   for the implementor, implementation operations in 'ops' and user
+ *   watcher callback and data 'fn' and 'arg'.
+ *
+ *  Caller retrieves pointer to allocated implementation data with
+ *   flux_watcher_impl (w).
+ */
+flux_watcher_t * flux_watcher_create (flux_reactor_t *r, size_t impl_size,
+                                      struct flux_watcher_ops *ops,
+                                      flux_watcher_f fn, void *arg);
+
+/*  Return pointer to implementation data reserved by watcher object 'w'.
+ */
+void * flux_watcher_impl (flux_watcher_t *w);
+
+/*  Return pointer to flux_watcher_ops structure for this watcher.
+ */
+struct flux_watcher_ops * flux_watcher_ops (flux_watcher_t *w);
+
+
+
 #endif /* !_FLUX_CORE_REACTOR_H */
 
 /*


### PR DESCRIPTION
This PR is not intended to be merged, but just to get feedback.

Following up on @garlick's similar changes to allow creation of custom watchers outside of `reactor.c`, these changes slightly modify watcher internals and expose `flux_watcher_create` and some accessors for the opaque watcher type.

However, I'm not sure if the approach goes too far, or not far enough, or if we should try something else.

The changes are pretty simple, however, highlights are:

 * The integer per-class `signature` was dropped because it didn't seem like there was a feasible way to guarantee uniqueness for new and/or custom watchers.
 * The watcher operations structure was replaced with a pointer to a global per-class `flux_watcher_ops` structure, since there should just be one global/static operations structure per "class" not per watcher. (If there is a good reason to copy in the `ops` structure to the watcher, I'm sorry I didn't know it)
 * The ops pointer can now be used to check for the class of watcher, replacing the previous use case for the watcher signatures.
 * Accessors were added to return the `void *impl` implementation data as well as the address of the operations structure
 * Since there's now an accessor for `impl`,  both the return by reference argument to`flux_watcher_create` and the explicit `void * impl`  argument to the watcher `start`,`stop`,`destroy` methods were dropped.