### PR TITLE
implement flux_future_t API

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -41,7 +41,9 @@ MAN3_FILES_PRIMARY = \
 	flux_response_decode.3 \
 	flux_request_encode.3 \
 	flux_content_load.3 \
-	flux_log.3
+	flux_log.3 \
+	flux_future_then.3 \
+	flux_future_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -114,7 +116,16 @@ MAN3_FILES_SECONDARY = \
 	flux_content_store_get.3 \
 	flux_vlog.3 \
 	flux_log_set_appname.3 \
-	flux_log_set_procid.3
+	flux_log_set_procid.3 \
+	flux_future_wait_for.3 \
+	flux_future_destroy.3 \
+	flux_future_get.3 \
+	flux_future_fulfill.3 \
+	flux_future_fulfill_error.3 \
+	flux_future_aux_set.3 \
+	flux_future_aux_get.3 \
+	flux_future_set_flux.3 \
+	flux_future_get_flux.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -204,6 +215,15 @@ flux_content_store_get.3: flux_content_load.3
 flux_vlog.3: flux_log.3
 flux_log_set_appname.3: flux_log.3
 flux_log_set_procid.3: flux_log.3
+flux_future_destroy.3: flux_future_then.3
+flux_future_wait_for.3: flux_future_then.3
+flux_future_get.3: flux_future_then.3
+flux_future_fulfill.3: flux_future_create.3
+flux_future_fulfill_error.3: flux_future_create.3
+flux_future_aux_set.3: flux_future_create.3
+flux_future_aux_get.3: flux_future_create.3
+flux_future_set_flux.3: flux_future_create.3
+flux_future_get_flux.3: flux_future_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -46,6 +46,7 @@ MAN3_FILES_PRIMARY = \
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
 MAN3_FILES_SECONDARY = \
+	flux_clone.3 \
 	flux_close.3 \
 	flux_aux_get.3 \
 	flux_flags_unset.3 \
@@ -137,6 +138,7 @@ stderr_devnull_0 = 2>/dev/null
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
 
 
+flux_clone.3: flux_open.3
 flux_close.3: flux_open.3
 flux_aux_get.3: flux_aux_set.3
 flux_flags_unset.3: flux_flags_set.3

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -1,0 +1,176 @@
+flux_future_create(3)
+=====================
+:doctype: manpage
+
+
+NAME
+----
+flux_future_create, flux_future_fulfill, flux_future_fulfill_error, flux_future_aux_get, flux_future_aux_set, flux_future_set_flux, flux_future_get_flux - support methods for classes that return futures
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef void (*flux_future_init_f)(flux_future_t *f,
+                                   flux_reactor_t *r, void *arg);
+
+ flux_future_t *flux_future_create (flux_reactor_t *r,
+                                    flux_future_init_f cb, void *arg);
+
+ void flux_future_fulfill (flux_future_t *f,
+                           void *result, flux_free_f free_fn);
+
+ void flux_future_fulfill_error (flux_future_t *f, int errnum);
+
+ void *flux_future_aux_get (flux_future_t *f, const char *name);
+
+ int flux_future_aux_set (flux_future_t *f, const char *name,
+                          void *aux, flux_free_f destroy);
+
+ void flux_future_set_flux (flux_future_t *f, flux_t *h);
+
+ flux_t *flux_future_get_flux (flux_future_t *f);
+
+
+DESCRIPTION
+-----------
+
+A Flux future represents some activity that may be completed with reactor
+watchers and/or message handlers.  It is intended to be returned by other
+classes as a handle for synchronization and a container for results.
+Such a class provides two user-facing functions, one to initiate the
+activity and return a future which internally calls `flux_future_create()`,
+and one to access class-specific result(s), which internally calls
+`flux_future_get()`.  The class also provides a _flux_future_init_f_
+function that is called lazily by the future implementation to perform
+class-specific reactor setup, such as installing watchers and message
+handlers.  This page describes the future interfaces used by such classes.
+Class users and users seeking an introduction to Flux futures are referred
+to `flux_future_then(3)`.
+
+`flux_future_create()` creates a future, associates a reactor with it,
+ and registers the class-specific initialization callback _cb_, and an
+opaque argument _arg_ that will be passed to _cb_.  The callback sets
+up class-specific watchers on the reactor to handle asynchronous events.
+The watchers must eventually call `flux_future_fulfill()` or
+`flux_future_fulfill_error()` to fulfill the future.  The callback may
+occur in one or both of two contexts.  A call in the first context occurs
+when the user calls `flux_future_then()`.  A call in the second context
+occurs when the user (or `flux_future_get()`) calls `flux_future_wait_for()`.
+In the former case, the callback receives the reactor _r_ passed to
+`flux_future_create()`.  In the latter case, it receives a temporary reactor
+created within the `flux_future_wait_for()` implementation.  See REACTOR
+CONTEXTS below for more information.
+
+`flux_future_fulfill()` fulfills the future, assigning an opaque
+_result_ value with optional destructor _free_fn_ to the future.
+A NULL _result_ is valid and also fulfills the future.  The _result_
+is contained within the future and can be accessed with `flux_future_get()`
+as needed until the future is destroyed.
+
+`flux_future_fulfill_error()` fulfills the future, assigning an _errnum_
+value.  After the future is fulfilled with an error, `flux_future_get()`
+will return -1 with errno set to _errnum_.
+
+`flux_future_aux_set()` attaches an object _aux_, with optional destructor
+_destroy_, to the future under an optional _name_.  `flux_future_aux_get()`
+retrieves an object by _name_.  Destructors are called when the future is
+destroyed.  Objects may be stored anonymously under a NULL _name_ to be
+scheduled for destruction without the option of retrieval.
+
+`flux_future_set_flux()` may be used to associate a Flux broker handle
+with a future.  The handle may be retrieved from within an init callback using
+`flux_future_get_flux()` and used to set up message handlers that
+fulfill the future in the same manner as described for reactor watchers.
+
+Futures may "contain" other futures, to arbitrary depth.  That is, an
+init callback may create futures and use their continuations to fulfill
+the containing future in the same manner as reactor watchers and message
+handlers.
+
+
+REACTOR CONTEXTS
+----------------
+
+Internally, a future can operate in two reactor contexts.  The init
+callback may be called in either or both contexts, depending on which
+synchronization functions are called by the user.
+
+The main reactor context involves the reactor passed to `flux_future_create()`.
+This reactor is expected to be run or re-entered by the user, and can process
+the future's watchers in parallel with other watchers registered by the
+application.  The call to `flux_future_then()` triggers the init callback
+in this context.
+
+Alternatively, an internal reactor is created when `flux_future_wait_for()`
+is called before the future is complete.  The separate reactor allows these
+functions to wait _only_ for the future's events, without allowing unrelated
+watchers registered in the main reactor to run, which might complicate the
+application's control flow.  After the internal reactor is created, the
+init callback is made in this context.
+
+Since the init callback may be made in either reactor context (at most once
+each), and is unaware of which context that is, it should take care when
+managing any context-specific state not to overwrite the state from a prior
+call.  The ability to attach objects with destructors anonymously to the future
+with `flux_future_aux_set()` may be useful for managing the life cycle
+of reactor watchers and message handlers created by init callbacks.
+
+
+MESSAGE HANDLERS
+----------------
+
+To allow message handlers to be registered in either reactor context,
+`flux_future_get_flux()` is context sensitive.  If called in the main
+reactor context, it directly returns the broker handle registered with
+`flux_future_set_flux()`.  If called in the internal reactor context,
+it returns a clone of that handle, obtained with `flux_clone()`, and
+associated with the internal reactor.  After the internal reactor returns,
+any message unmatched by the dispatcher on the cloned handle are requeued
+in the handle with `flux_dispatch_requeue()`.
+
+
+RETURN VALUE
+------------
+
+`flux_future_create()` returns a future on success.  On error, NULL is
+returned and errno is set appropriately.
+
+`flux_future_aux_set()` returns zero on success.  On error, -1 is
+returned and errno is set appropriately.
+
+`flux_future_aux_get()` returns the requested object on success.
+If it is not found NULL.  This function does not set errno.
+
+`flux_future_get_flux()` returns a flux_t handle on success.  On error,
+NULL is returned and errno is set appropriately.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+EINVAL::
+Invalid argument.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_future_create(3), flux_clone(3)

--- a/doc/man3/flux_future_then.adoc
+++ b/doc/man3/flux_future_then.adoc
@@ -1,0 +1,128 @@
+flux_future_then(3)
+===================
+:doctype: manpage
+
+
+NAME
+----
+flux_future_then, flux_future_wait_for, flux_future_get, flux_future_destroy - synchronize an activity
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ typedef struct flux_future flux_future_t;
+
+ typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);
+
+ int flux_future_then (flux_future_t *f, double timeout,
+                       flux_continuation_f cb, void *arg);
+
+ int bool flux_future_wait_for (flux_future_t *f, double timeout);
+
+ int flux_future_get (flux_future_t *f, void *result);
+
+ void flux_future_destroy (flux_future_t *f);
+
+
+DESCRIPTION
+-----------
+
+A Flux future represents some activity that may be completed with reactor
+watchers and/or message handlers.  It is both a handle for synchronization
+and a container for the result.  A Flux future is said to be "fulfilled"
+when a result is available in the future container, or a fatal error has
+occurred.  Flux futures were inspired by similar constructs in other
+programming environments mentioned in RESOURCES, but are not a faithful
+implementation of any particular one.
+
+Generally other Flux classes return futures, and provide a class-specific
+access function for results. The functions described in this page can be
+used to access, synchronize, and destroy futures returned from any such class.
+Authors of classes that return futures are referred to `flux_future_create(3)`.
+
+`flux_future_then()` sets up a continuation callback _cb_ that is called
+with opaque argument _arg_ once the future is fulfilled.  The continuation
+is registered on the main reactor passed in to `flux_future_create()`.
+The continuation will normally use `flux_future_get()` or a class-specific
+access function to obtain the result from the future container without
+blocking.  `flux_future_then()` may only be called once on a given future.
+It is not an error to set up a continuation on a future that has already
+been fulfilled.  If _timeout_ is non-negative, the future must be fulfilled
+within the specified amount of time or the timeout fulfills it with an error
+(errno set to ETIMEDOUT).  The reactor must be run or re-entered in order
+for the timer and the future activity to make progress.  It is safe to
+destroy the future from within the continuation callback.
+
+`flux_future_wait_for()` blocks until the future is fulfilled, or _timeout_
+(if non-negative) expires.  This function may be called multiple times,
+with different values for _timeout_.  If the timeout expires before
+the future is fulfilled, an error is returned (errno set to ETIMEDOUT)
+but the future remains unfulfilled.  The timer and the future activity can
+make progress while `flux_future_wait_for()` is executing, unless _timeout_
+is zero, in which case the function times out immediately if the future
+has not already been fulfilled.  While `flux_future_wait_for()` is executing,
+unrelated reactor watchers and message handlers are not active.
+
+`flux_future_get()` accesses the result of a fulfilled future.  If the
+future is not yet fulfilled, it calls `flux_future_wait_for()` internally
+with a negative _timeout_, causing it to block until the future is fulfilled.
+A pointer to the result is assigned to _result_ (caller must NOT free),
+or -1 is returned if the future was fulfilled with an error.  Often this
+function is wrapped with a class-specific result access function.
+
+`flux_future_destroy()` destroys a future, including any result contained
+within.
+
+
+RETURN VALUE
+------------
+
+`flux_future_then()`, `flux_future_get()`, and `flux_future_wait_for()`
+return zero on success.  On error, -1 is returned, and errno is set
+appropriately.
+
+`flux_future_check()` returns a boolean result.  If an error occurs,
+it returns true.  A subsequent call to `flux_future_get()` returns
+-1 with errno set to the error that occurred during the check.
+
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+EINVAL::
+Invalid argument.
+
+ETIMEDOUT::
+A timeout passed to `flux_future_wait_for()` expired before the future
+was fulfilled.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+C++ std::future: <http://en.cppreference.com/w/cpp/thread/future>
+
+Java util.concurrent.Future: <https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html>
+
+Python3 concurrent.futures: <https://docs.python.org/3/library/concurrent.futures.html>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_future_create (3)

--- a/doc/man3/flux_open.adoc
+++ b/doc/man3/flux_open.adoc
@@ -5,7 +5,7 @@ flux_open(3)
 
 NAME
 ----
-flux_open, flux_close - open/close connection to Flux Message Broker
+flux_open, flux_clone, flux_close - open/close connection to Flux Message Broker
 
 
 SYNOPSIS
@@ -15,6 +15,8 @@ SYNOPSIS
 flux_t *flux_open (const char *uri, int flags);
 
 void flux_close (flux_t *h);
+
+flux_t *flux_clone (flux_t *orig);
 
 
 DESCRIPTION
@@ -36,6 +38,13 @@ Dumps message trace to stderr.
 FLUX_O_NONBLOCK::
 The `flux_send()` and `flux_recv()` functions should never block.
 
+`flux_clone()` creates another reference to a `flux_t` handle that is
+identical to the original in all respects except that it does not inherit
+a copy of the original handle's "aux" hash, or its reactor and message
+dispatcher references.  By creating a clone, and calling `flux_set_reactor()`
+on it, one can create message handlers on the cloned handle that run on a
+different reactor than the one associated with the original handle.
+
 `flux_close()` destroys a `flux_t` handle, closing its connection with
 the Flux message broker.
 
@@ -43,8 +52,8 @@ the Flux message broker.
 RETURN VALUE
 ------------
 
-`flux_open()` returns an open `flux_t` handle on success.  On error,
-NULL is returned, and errno is set appropriately.
+`flux_open()` and `flux_clone()` return a `flux_t` handle on success.
+On error, NULL is returned, and errno is set appropriately.
 
 
 ERRORS

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -389,3 +389,6 @@ rootdir
 IP
 mcast
 PUs
+ETIMEDOUT
+fn
+destructors

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -115,6 +115,7 @@ TESTS = test_module.t \
 	test_event.t \
 	test_tagpool.t \
 	test_security.t \
+	test_future.t \
 	test_reactor.t
 
 test_ldadd = \
@@ -172,3 +173,7 @@ test_reactor_t_LDADD = $(test_ldadd) $(LIBDL)
 test_security_t_SOURCES = test/security.c
 test_security_t_CPPFLAGS = $(test_cppflags)
 test_security_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_future_t_SOURCES = test/future.c
+test_future_t_CPPFLAGS = $(test_cppflags)
+test_future_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -69,7 +69,8 @@ fluxcoreinclude_HEADERS = \
 	flog.h \
 	conf.h \
 	heartbeat.h \
-	content.h
+	content.h \
+	future.h
 
 noinst_LTLIBRARIES = \
 	libflux.la
@@ -98,7 +99,8 @@ libflux_la_SOURCES = \
 	ev_flux.c \
 	heartbeat.c \
 	keepalive.c \
-	content.c
+	content.c \
+	future.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \

--- a/src/common/libflux/dispatch.c
+++ b/src/common/libflux/dispatch.c
@@ -310,7 +310,8 @@ static bool dispatch_message (struct dispatch *d,
 
     /* fastpath */
     if (type == FLUX_MSGTYPE_RESPONSE) {
-        if (fastpath_response_lookup (d, msg, &w) == 0 && w->running) {
+        if (fastpath_response_lookup (d, msg, &w) == 0 && w->running
+                                            && flux_msg_cmp (msg, w->match)) {
             call_handler (w, msg);
             match = true;
         }

--- a/src/common/libflux/dispatch.h
+++ b/src/common/libflux/dispatch.h
@@ -38,6 +38,10 @@ int flux_msg_handler_addvec (flux_t *h, struct flux_msg_handler_spec tab[],
                              void *arg);
 void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
 
+/* Requeue any unmatched messages, if handle was cloned.
+ */
+int flux_dispatch_requeue (flux_t *h);
+
 #endif /* !_FLUX_CORE_DISPATCH_H */
 
 /*

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -23,6 +23,7 @@
 #include "conf.h"
 #include "heartbeat.h"
 #include "content.h"
+#include "future.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -1,0 +1,482 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <czmq.h>
+
+#include "future.h"
+
+struct now_context {
+    flux_t *h;              // (optional) cloned flux_t handle
+    flux_reactor_t *r;      // reactor created for this get/check
+    flux_watcher_t *timer;  // timer watcher (if timeout set)
+    bool init_called;       // other watchers configured (if init set)
+    bool running;
+};
+
+struct then_context {
+    flux_reactor_t *r;      // external reactor for then
+    flux_watcher_t *timer;  // timer watcher (if timeout set)
+    flux_watcher_t *prepare;// doorbell for fulfill
+    flux_watcher_t *check;
+    flux_watcher_t *idle;
+    flux_continuation_f continuation;
+    void *continuation_arg;
+};
+
+struct flux_future {
+    flux_reactor_t *r;
+    flux_t *h;
+    zhash_t *aux;
+    int aux_anon_ctr;
+    void *result;
+    flux_free_f result_free;
+    int result_errnum;
+    flux_future_init_f init;
+    void *init_arg;
+    struct now_context *now;
+    struct then_context *then;
+    bool result_valid;
+    bool result_errnum_valid;
+};
+
+static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
+                        int revents, void *arg);
+static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
+                      int revents, void *arg);
+static void now_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                          int revents, void *arg);
+static void then_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                           int revents, void *arg);
+
+/* "now" reactor context - used for flux_future_wait_on()
+ * This is set up lazily; wait until the user calls flux_future_wait_on().
+ * N.B. _wait_on() can be called multiple times (with different timeouts).
+ */
+
+static void now_context_destroy (struct now_context *now)
+{
+    if (now) {
+        flux_watcher_destroy (now->timer);
+        flux_reactor_destroy (now->r);
+        flux_close (now->h);
+        free (now);
+    }
+}
+
+static struct now_context *now_context_create (void)
+{
+    struct now_context *now = calloc (1, sizeof (*now));
+    if (!now) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (!(now->r = flux_reactor_create (0)))
+        goto error;
+    return now;
+error:
+    now_context_destroy (now);
+    return NULL;
+}
+
+static int now_context_set_timeout (struct now_context *now,
+                                    double timeout, void *arg)
+{
+    if (now) {
+        if (timeout < 0.)       // disable
+            flux_watcher_stop (now->timer);
+        else {
+            if (!now->timer) {  // set
+                now->timer = flux_timer_watcher_create (now->r, timeout, 0.,
+                                                        now_timer_cb, arg);
+                if (!now->timer)
+                    return -1;
+            }
+            else {              // reset
+                flux_timer_watcher_reset (now->timer, timeout, 0.);
+            }
+            flux_watcher_start (now->timer);
+        }
+    }
+    return 0;
+}
+
+static void now_context_clear_timer (struct now_context *now)
+{
+    if (now)
+        flux_watcher_stop (now->timer);
+}
+
+/* "then" reactor context - used for continuation
+ * This is set up lazily; wait until the user calls flux_future_then().
+ * N.B. then() can only be called once.
+ */
+
+static void then_context_destroy (struct then_context *then)
+{
+    if (then) {
+        flux_watcher_destroy (then->timer);
+        flux_watcher_destroy (then->prepare);
+        flux_watcher_destroy (then->check);
+        flux_watcher_destroy (then->idle);
+        free (then);
+    }
+}
+
+static struct then_context *then_context_create (flux_reactor_t *r, void *arg)
+{
+    struct then_context *then = calloc (1, sizeof (*then));
+    if (!then) {
+        errno = ENOMEM;
+        goto error;
+    }
+    then->r = r;
+    if (!(then->prepare = flux_prepare_watcher_create (r, prepare_cb, arg)))
+        goto error;
+    if (!(then->check = flux_check_watcher_create (r, check_cb, arg)))
+        goto error;
+    if (!(then->idle = flux_idle_watcher_create (r, NULL, NULL)))
+        goto error;
+    flux_watcher_start (then->prepare);
+    flux_watcher_start (then->check);
+    return then;
+error:
+    then_context_destroy (then);
+    return NULL;
+}
+
+static int then_context_set_timeout (struct then_context *then,
+                                     double timeout, void *arg)
+{
+    assert (then != NULL);
+    assert (then->timer == NULL);
+    assert (timeout >= 0.);
+    if (!(then->timer = flux_timer_watcher_create (then->r, timeout, 0.,
+                                                   then_timer_cb, arg)))
+        return -1;
+    flux_watcher_start (then->timer);
+    return 0;
+}
+
+static void then_context_clear_timer (struct then_context *then)
+{
+    if (then)
+        flux_watcher_stop (then->timer);
+}
+
+/* Destroy a future.
+ */
+void flux_future_destroy (flux_future_t *f)
+{
+    int saved_errno = errno;
+    if (f) {
+        zhash_destroy (&f->aux);
+        if (f->result) {
+            if (f->result_free)
+                f->result_free (f->result);
+        }
+        now_context_destroy (f->now);
+        then_context_destroy (f->then);
+        free (f);
+    }
+    errno = saved_errno;
+}
+
+/* Create a future.
+ */
+flux_future_t *flux_future_create (flux_reactor_t *r,
+                                   flux_future_init_f cb, void *arg)
+{
+    flux_future_t *f = calloc (1, sizeof (*f));
+    if (!f) {
+        errno = ENOMEM;
+        goto error;
+    }
+    f->init = cb;
+    f->init_arg = arg;
+    f->r = r;
+    return f;
+error:
+    flux_future_destroy (f);
+    return NULL;
+}
+
+/* Set flux handle
+ */
+void flux_future_set_flux (flux_future_t *f, flux_t *h)
+{
+    f->h = h;
+}
+
+/* Context dependent get of flux handle.
+ * If "now" context, a one-off message dispatcher needs to be created to
+ * go with the one-off reactor, hence flux_clone()
+ */
+flux_t *flux_future_get_flux (flux_future_t *f)
+{
+    flux_t *h = NULL;
+
+    if (!f->h) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!f->now || !f->now->running) {
+        h = f->h;
+    }
+    else {
+        if (!f->now->h) {
+            if (!(f->now->h = flux_clone (f->h)))
+                goto done;
+            if (flux_set_reactor (f->now->h, f->now->r) < 0)
+                goto done;
+        }
+        h = f->now->h;
+    }
+done:
+    return h;
+}
+
+/* Block until future is fulfilled or timeout expires.
+ * This function can be called multiple times, with different timeouts.
+ * If timeout <= 0., there is no timeout.
+ * If timeout == 0., time out immediately if future has not been fulfilled.
+ * If timeout > 0., lazily set up the "now" reactor context (first call)
+ * and un that reactor until fulfilled or error.  If timer expires,
+ * don't fulfill the future; user might want to defer to continuation.
+ * If flux_t handle is used, any messages not "consumed" by the future
+ * have to go back to the parent handle with flux_dispatch_requeue().
+ */
+int flux_future_wait_for (flux_future_t *f, double timeout)
+{
+    if (!f->result_valid && !f->result_errnum_valid) {
+        if (timeout == 0.) { // don't setup 'now' context in this case
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        if (!f->now) {
+            if (!(f->now = now_context_create ()))
+                return -1;
+        }
+        if (timeout >= 0.) {
+            if (now_context_set_timeout (f->now, timeout, f) < 0)
+                return -1;
+        }
+        f->now->running = true;
+        if (f->init && !f->now->init_called) {
+            f->init (f, f->now->r, f->init_arg); // might set error
+            f->now->init_called = true;
+        }
+        if (!f->result_valid && !f->result_errnum_valid) {
+            if (flux_reactor_run (f->now->r, 0) < 0)
+                return -1; // errno set by now_timer_cb or other watcher
+        }
+        if (f->now->h)
+            flux_dispatch_requeue (f->now->h);
+        f->now->running = false;
+    }
+    if (!f->result_valid && !f->result_errnum_valid)
+        return -1;
+    return 0;
+}
+
+/* Block until future is fulfilled if not already.
+ * Then return either result or error depending on how it was fulfilled.
+ */
+int flux_future_get (flux_future_t *f, void *result)
+{
+    if (flux_future_wait_for (f, -1.0) < 0) // no timeout
+        return -1;
+    if (f->result_errnum_valid) {
+        errno = f->result_errnum;
+        return -1;
+    }
+    if (result)
+        *(void **)result = f->result;
+    return 0;
+}
+
+/* Set up continuation to run once future is fulfilled.
+ * Lazily set up the "then" reactor context.
+ * If timer expires, fulfill the future with ETIMEDOUT error.
+ * This function can only be called once.
+ */
+int flux_future_then (flux_future_t *f, double timeout,
+                      flux_continuation_f cb, void *arg)
+{
+    if (!f->r || !cb || f->then != NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f->then = then_context_create (f->r, f)))
+        return -1;
+    if (timeout >= 0. && then_context_set_timeout (f->then, timeout, f) < 0)
+        return -1;
+    f->then->continuation = cb;
+    f->then->continuation_arg = arg;
+    if (f->init)
+        f->init (f, f->then->r, f->init_arg); // might set error
+    if (f->result_errnum_valid) {
+        errno = f->result_errnum;
+        return -1;
+    }
+    return 0;
+}
+
+/* Retrieve 'aux' object by name.  Name cannot be NULL.
+ */
+void *flux_future_aux_get (flux_future_t *f, const char *name)
+{
+    if (!f->aux)
+        return NULL;
+    return zhash_lookup (f->aux, name);
+}
+
+/* Store 'aux' object by name.  Allow "aononymous" (name=NULL) objects to
+ * be set - useful for adding destructors for watchers created in init
+ * function, which may be called in both "now" and "then" contexts without
+ * knowing which it is.
+ */
+int flux_future_aux_set (flux_future_t *f, const char *name,
+                         void *aux, flux_free_f destroy)
+{
+    char name_buf[32];
+
+    if (!name && !destroy) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!f->aux)
+        f->aux = zhash_new ();
+    if (!f->aux) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (!name) {
+        snprintf (name_buf, sizeof (name_buf), "anon.%d", f->aux_anon_ctr++);
+        name = name_buf;
+    }
+    zhash_delete (f->aux, name);
+    if (zhash_insert (f->aux, name, aux) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    zhash_freefn (f->aux, name, destroy);
+    return 0;
+}
+
+void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn)
+{
+    if (f->result) {
+        if (f->result_free)
+            f->result_free (f->result);
+    }
+    f->result = result;
+    f->result_free = free_fn;
+    f->result_valid = true;
+    now_context_clear_timer (f->now);
+    then_context_clear_timer (f->then);
+    if (f->now)
+        flux_reactor_stop (f->now->r);
+    /* in "then" context, the main reactor prepare/check/idle watchers
+     * will run continuation in the next reactor loop for fairness.
+     */
+}
+
+void flux_future_fulfill_error (flux_future_t *f, int errnum)
+{
+    f->result_errnum = errnum;
+    f->result_errnum_valid = true;
+    now_context_clear_timer (f->now);
+    then_context_clear_timer (f->then);
+    if (f->now)
+        flux_reactor_stop (f->now->r);
+    /* in "then" context, the main reactor prepare/check/idle watchers
+     * will run continuation in the next reactor loop for fairness.
+     */
+}
+
+/* timer - for flux_future_then() timeout
+ * fulfill the future with an error
+ */
+static void then_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                           int revents, void *arg)
+{
+    flux_future_t *f = arg;
+    flux_future_fulfill_error (f, ETIMEDOUT);
+}
+
+/* timer - for flux_future_wait_for() timeout
+ * stop the reactor but don't fulfill the future
+ */
+static void now_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                          int revents, void *arg)
+{
+    errno = ETIMEDOUT;
+    flux_reactor_stop_error (r);
+}
+
+/* prepare - if results are ready, ensure loop doesn't block
+ * so check can call continuation on next loop iteration
+ */
+static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
+                        int revents, void *arg)
+{
+    flux_future_t *f = arg;
+
+    assert (f->then != NULL);
+
+    if (f->result_valid || f->result_errnum_valid)
+        flux_watcher_start (f->then->idle); // prevent reactor from blocking
+}
+
+/* check - if results are ready, call the continuation
+ */
+static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    flux_future_t *f = arg;
+
+    assert (f->then != NULL);
+
+    flux_watcher_stop (f->then->idle);
+    if (f->result_valid || f->result_errnum_valid) {
+        flux_watcher_stop (f->then->timer);
+        flux_watcher_stop (f->then->prepare);
+        flux_watcher_stop (f->then->check);
+        if (f->then->continuation)
+            f->then->continuation (f, f->then->continuation_arg);
+        // N.B. callback might destroy future
+    }
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -1,0 +1,44 @@
+#ifndef _FLUX_CORE_FUTURE_H
+#define _FLUX_CORE_FUTURE_H
+
+#include "reactor.h"
+#include "types.h"
+#include "handle.h"
+#include "dispatch.h"
+
+typedef struct flux_future flux_future_t;
+
+typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);
+
+int flux_future_then (flux_future_t *f, double timeout,
+                      flux_continuation_f cb, void *arg);
+
+int flux_future_wait_for (flux_future_t *f, double timeout);
+
+void flux_future_destroy (flux_future_t *f);
+
+void *flux_future_aux_get (flux_future_t *f, const char *name);
+int flux_future_aux_set (flux_future_t *f, const char *name,
+                         void *aux, flux_free_f destroy);
+
+
+typedef void (*flux_future_init_f)(flux_future_t *f,
+                                   flux_reactor_t *r, void *arg);
+
+flux_future_t *flux_future_create (flux_reactor_t *r,
+                                   flux_future_init_f cb, void *arg);
+
+int flux_future_get (flux_future_t *f, void *result);
+
+void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn);
+void flux_future_fulfill_error (flux_future_t *f, int errnum);
+
+void flux_future_set_flux (flux_future_t *f, flux_t *h);
+flux_t *flux_future_get_flux (flux_future_t *f);
+
+
+#endif /* !_FLUX_CORE_FUTURE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -27,6 +27,7 @@ typedef void (*flux_fatal_f)(const char *msg, void *arg);
  */
 enum {
     FLUX_O_TRACE = 1,   /* send message trace to stderr */
+    FLUX_O_CLONE = 2,   /* handle was created with flux_clone() */
     FLUX_O_NONBLOCK = 4,/* handle should not block on send/recv */
 };
 
@@ -69,6 +70,12 @@ void flux_close (flux_t *h);
 /* Increment internal reference count on 'h'.
  */
 void flux_incref (flux_t *h);
+
+/* Create a new handle that is an alias for 'orig' in all respects
+ * except it adds FLUX_O_CLONE to flags and has its own 'aux' hash
+ * (which means it has its own reactor and dispatcher).
+ */
+flux_t *flux_clone (flux_t *orig);
 
 /* Get/set handle options.  Options are interpreted by connectors.
  * Returns 0 on success, or -1 on failure with errno set (e.g. EINVAL).

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -1,0 +1,294 @@
+#include <errno.h>
+#include <string.h>
+
+#include "future.h"
+#include "reactor.h"
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libtap/tap.h"
+
+int aux_destroy_called;
+void *aux_destroy_arg;
+void aux_destroy (void *arg)
+{
+    aux_destroy_called++;
+    aux_destroy_arg = arg;
+}
+
+int result_destroy_called;
+void *result_destroy_arg;
+void result_destroy (void *arg)
+{
+    result_destroy_called = 1;
+    result_destroy_arg = arg;
+}
+
+int contin_called;
+void *contin_arg;
+int contin_get_rc;
+void *contin_get_result;
+void contin (flux_future_t *f, void *arg)
+{
+    contin_called = 1;
+    contin_arg = arg;
+    contin_get_rc = flux_future_get (f, &contin_get_result);
+}
+
+void test_simple (void)
+{
+    flux_future_t *f;
+    flux_reactor_t *r;
+
+    r = flux_reactor_create (0);
+    if (!r)
+        BAIL_OUT ("flux_reactor_create failed");
+
+    /* create */
+    f = flux_future_create (r, NULL, NULL);
+    ok (f != NULL,
+        "flux_future_create works");
+    if (!f)
+        BAIL_OUT ("flux_future_create failed");
+
+    /* aux */
+    errno = 0;
+    ok (flux_future_aux_set (f, NULL, "bar", NULL) < 0
+         && errno == EINVAL,
+        "flux_future_aux_set anon w/o destructor is EINVAL");
+    aux_destroy_called = 0;
+    aux_destroy_arg = NULL;
+    ok (flux_future_aux_set (f, "foo", "bar", aux_destroy) == 0,
+        "flux_future_aux_set works");
+    char *p = flux_future_aux_get (f, "baz");
+    ok (p == NULL,
+        "flux_future_aux_get of wrong value returns NULL");
+    p = flux_future_aux_get (f, "foo");
+    ok (p != NULL && !strcmp (p, "bar"),
+        "flux_future_aux_get of known returns it");
+    // same value as "foo" key to not muck up destructor arg test
+    ok (flux_future_aux_set (f, NULL, "bar", aux_destroy) == 0,
+        "flux_future_aux_set with NULL key works");
+
+    /* wait_for/get - no future_init; artificially call fulfill */
+    errno = 0;
+    ok (flux_future_wait_for (f, 0.) < 0 && errno == ETIMEDOUT,
+        "flux_future_wait_for initially times out");
+    errno = 0;
+    void *result = NULL;
+    result_destroy_called = 0;
+    result_destroy_arg = NULL;
+    flux_future_fulfill (f, "Hello", result_destroy);
+    ok (flux_future_wait_for (f, 0.) == 0,
+        "flux_future_wait_for succedes after result is set");
+    ok (flux_future_get (f, &result) == 0
+        && result != NULL && !strcmp (result, "Hello"),
+        "flux_future_get returns correct result");
+    ok (flux_future_get (f, NULL) == 0,
+        "flux_future_get with NULL results argument also works");
+
+    /* continuation (result already ready) */
+    contin_called = 0;
+    contin_arg = NULL;
+    contin_get_rc = -42;
+    contin_get_result = NULL;
+    ok (flux_future_then (f, -1., contin, "nerp") == 0,
+        "flux_future_then registered continuation");
+    ok (flux_reactor_run (r, 0) == 0,
+        "reactor ran successfully");
+    ok (contin_called && contin_arg != NULL && !strcmp (contin_arg, "nerp"),
+        "continuation was called with correct argument");
+    ok (contin_get_rc == 0 && contin_get_result != NULL
+        && !strcmp (contin_get_result, "Hello"),
+        "continuation obtained correct result with flux_future_get");
+
+    /* destructors */
+    flux_future_destroy (f);
+    ok (aux_destroy_called == 2 && aux_destroy_arg != NULL
+        && !strcmp (aux_destroy_arg, "bar"),
+        "flux_future_destroy called aux destructor correctly");
+    ok (result_destroy_called && result_destroy_arg != NULL
+        && !strcmp (result_destroy_arg, "Hello"),
+        "flux_future_destroy called result destructor correctly");
+
+    diag ("%s: simple tests completed", __FUNCTION__);
+}
+
+void test_timeout_now (void)
+{
+    flux_future_t *f;
+
+    f = flux_future_create (NULL, NULL, NULL);
+    ok (f != NULL,
+        "flux_future_create works");
+    if (!f)
+        BAIL_OUT ("flux_future_create failed");
+    errno = 0;
+    ok (flux_future_wait_for (f, 0.1) < 0 && errno == ETIMEDOUT,
+        "flux_future_wait_for timed out");
+    flux_future_destroy (f);
+
+    diag ("%s: timeout works in synchronous context", __FUNCTION__);
+}
+
+void timeout_contin (flux_future_t *f, void *arg)
+{
+    int *errnum = arg;
+    if (flux_future_get (f, NULL) < 0)
+        *errnum = errno;
+}
+
+void test_timeout_then (void)
+{
+    flux_future_t *f;
+    flux_reactor_t *r;
+    int errnum;
+
+    r = flux_reactor_create (0);
+    if (!r)
+        BAIL_OUT ("flux_reactor_create failed");
+
+    f = flux_future_create (r, NULL, NULL);
+    ok (f != NULL,
+        "flux_future_create works");
+    if (!f)
+        BAIL_OUT ("flux_future_create failed");
+
+    ok (flux_future_then (f, 0.1, timeout_contin, &errnum) == 0,
+        "flux_future_then registered continuation with timeout");
+    errnum = 0;
+    ok (flux_reactor_run (r, 0) == 0,
+        "reactor ran successfully");
+    ok (errnum == ETIMEDOUT,
+        "continuation called flux_future_get and got ETIMEDOUT");
+
+    flux_future_destroy (f);
+    flux_reactor_destroy (r);
+
+    diag ("%s: timeout works in reactor context", __FUNCTION__);
+}
+
+void simple_init_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                              int revents, void *arg)
+{
+    flux_future_t *f = arg;
+    flux_future_fulfill (f, "Result!", NULL);
+}
+
+int simple_init_called;
+void *simple_init_arg;
+void simple_init (flux_future_t *f, flux_reactor_t *r, void *arg)
+{
+    flux_watcher_t *w;
+
+    simple_init_called++;
+    simple_init_arg = arg;
+
+    w = flux_timer_watcher_create (r, 0.1, 0., simple_init_timer_cb, f);
+    if (!w)
+        goto error;
+    if (flux_future_aux_set (f, NULL, w,
+                             (flux_free_f)flux_watcher_destroy) < 0) {
+        flux_watcher_destroy (w);
+        goto error;
+    }
+    flux_watcher_start (w);
+    return;
+error:
+   flux_future_fulfill_error (f, errno);
+}
+
+void test_init_now (void)
+{
+    flux_future_t *f;
+    char *result;
+
+    f = flux_future_create (NULL, simple_init, "testarg");
+    ok (f != NULL,
+        "flux_future_create works");
+    if (!f)
+        BAIL_OUT ("flux_future_create failed");
+    simple_init_called = 0;
+    simple_init_arg = NULL;
+    result = NULL;
+    ok (flux_future_get (f, &result) == 0,
+        "flux_future_get worked");
+    ok (result != NULL && !strcmp (result, "Result!"),
+        "and correct result was returned");
+    ok (simple_init_called == 1 && simple_init_arg != NULL
+        && !strcmp (simple_init_arg, "testarg"),
+        "init was called once with correct arg");
+
+    flux_future_destroy (f);
+
+    diag ("%s: init works in synchronous context", __FUNCTION__);
+}
+
+char *simple_contin_result;
+int simple_contin_called;
+int simple_contin_rc;
+void simple_contin (flux_future_t *f, void *arg)
+{
+    simple_contin_called++;
+    simple_contin_rc = flux_future_get (f, &simple_contin_result);
+}
+
+void test_init_then (void)
+{
+    flux_future_t *f;
+    flux_reactor_t *r;
+
+    r = flux_reactor_create (0);
+    if (!r)
+        BAIL_OUT ("flux_reactor_create failed");
+
+    f = flux_future_create (r, simple_init, "testarg");
+    ok (f != NULL,
+        "flux_future_create works");
+    if (!f)
+        BAIL_OUT ("flux_future_create failed");
+    simple_init_called = 0;
+    simple_init_arg = &f;
+    simple_contin_result = NULL;
+    simple_contin_called = 0;
+    simple_contin_rc = -42;
+    ok (flux_future_then (f, -1., simple_contin, NULL) == 0,
+        "flux_future_then registered continuation");
+    ok (simple_init_called == 1 && simple_init_arg != NULL
+        && !strcmp (simple_init_arg, "testarg"),
+        "init was called once with correct arg");
+    ok (flux_reactor_run (r, 0) == 0,
+        "reactor successfully run");
+    ok (simple_contin_called == 1,
+        "continuation was called once");
+    ok (simple_contin_rc == 0,
+        "continuation get succeeded");
+    ok (simple_contin_result != NULL
+        && !strcmp (simple_contin_result, "Result!"),
+        "continuation get returned correct result");
+
+    flux_future_destroy (f);
+    flux_reactor_destroy (r);
+
+    diag ("%s: init works in reactor context", __FUNCTION__);
+}
+
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_simple ();
+    test_timeout_now ();
+    test_timeout_then ();
+
+    test_init_now ();
+    test_init_then ();
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -25,6 +25,7 @@ uninstall-local:
 TESTS = \
 	shmem/backtoback.t \
 	loop/handle.t \
+	loop/dispatch.t \
 	loop/reactor.t \
 	loop/reduce.t \
 	loop/log.t \
@@ -159,6 +160,7 @@ check_SCRIPTS = \
 check_PROGRAMS = \
 	shmem/backtoback.t \
 	loop/handle.t \
+	loop/dispatch.t \
 	loop/reactor.t \
 	loop/reduce.t \
 	loop/log.t \
@@ -225,6 +227,10 @@ shmem_backtoback_t_LDADD = $(test_ldadd) $(LIBDL)
 loop_handle_t_SOURCES = loop/handle.c
 loop_handle_t_CPPFLAGS = $(test_cppflags)
 loop_handle_t_LDADD = $(test_ldadd) $(LIBDL)
+
+loop_dispatch_t_SOURCES = loop/dispatch.c
+loop_dispatch_t_CPPFLAGS = $(test_cppflags)
+loop_dispatch_t_LDADD = $(test_ldadd) $(LIBDL)
 
 loop_log_t_SOURCES = loop/log.c
 loop_log_t_CPPFLAGS = $(test_cppflags)

--- a/t/loop/dispatch.c
+++ b/t/loop/dispatch.c
@@ -1,0 +1,274 @@
+#include <errno.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libtap/tap.h"
+
+int cb_called;
+flux_t *cb_h;
+flux_msg_handler_t *cb_w;
+const flux_msg_t *cb_msg;
+void *cb_arg;
+void cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, void *arg)
+{
+    cb_called++;
+    cb_h = h;
+    cb_w = w;
+    cb_msg = msg;
+    cb_arg = arg;
+}
+
+/* Simple test:
+ * create message handler for all events
+ * send an event on the loop handler
+ * run reactor - handler not called (not started)
+ * start message handler
+ * run reactor - handler called once with appropriate args
+ */
+void test_simple_msg_handler (flux_t *h)
+{
+    flux_msg_handler_t *w;
+    flux_msg_t *msg;
+    int rc;
+
+    ok ((w = flux_msg_handler_create (h, FLUX_MATCH_EVENT, cb, &w)) != NULL,
+        "handle created dispatcher on demand");
+    ok ((msg = flux_event_encode ("test", NULL)) != NULL,
+        "encoded event message");
+    ok (flux_send (h, msg, 0) == 0,
+        "sent event message on loop connector");
+    cb_called = 0;
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 0,
+        "message handler that was not started did not run");
+    cb_called = 0;
+    cb_h = NULL;
+    cb_w = NULL;
+    cb_arg = NULL;
+    flux_msg_handler_start (w);
+    diag ("started message handler");
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 1,
+        "message handler was called after being started");
+    ok (cb_h == h && cb_w == w && cb_arg == &w && cb_msg != NULL,
+        "message handler was called with appropriate args");
+    flux_msg_destroy (msg);
+    flux_msg_handler_destroy (w);
+    diag ("destroyed message and message handler");
+}
+
+/* Check fastpath response matching
+ */
+void test_fastpath (flux_t *h)
+{
+    struct flux_match m = FLUX_MATCH_RESPONSE;
+    flux_msg_handler_t *w;
+    flux_msg_t *msg;
+    int rc;
+
+    ok ((m.matchtag = flux_matchtag_alloc (h, 0)) != FLUX_MATCHTAG_NONE,
+        "allocated matchtag");
+    ok ((w = flux_msg_handler_create (h, m, cb, NULL)) != NULL,
+        "created handler for response");
+    ok ((msg = flux_response_encode ("foo", 0, NULL)) != NULL,
+        "encoded response message");
+    ok (flux_msg_set_matchtag (msg, m.matchtag) == 0,
+        "set matchtag in response");
+    ok (flux_send (h, msg, 0) == 0,
+        "sent response message on loop connector");
+    cb_called = 0;
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 0,
+        "message handler that was not started did not run");
+    flux_msg_handler_start (w);
+    diag ("started message handler");
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 1,
+        "message handler was called after being started");
+
+    ok (flux_msg_enable_route (msg) == 0
+        && flux_msg_push_route (msg, "myuuid") == 0,
+        "added route to message");
+    ok (flux_send (h, msg, 0) == 0,
+        "sent response message on loop connector");
+    cb_called = 0;
+    rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 0,
+        "dispatch did not match response in wrong matchtag domain");
+    ok (flux_recv (h, FLUX_MATCH_ANY, 0) == NULL,
+        "unmatched message was discarded by dispatcher");
+
+    flux_matchtag_free (h, m.matchtag);
+    flux_msg_destroy (msg);
+    flux_msg_handler_destroy (w);
+    diag ("freed matchtag, destroyed message and message handler");
+}
+
+void test_cloned_dispatch (flux_t *orig)
+{
+    flux_t *h;
+    flux_reactor_t *r;
+    flux_msg_t *msg;
+    flux_msg_handler_t *w, *w2;
+    struct flux_match m = FLUX_MATCH_RESPONSE;
+    struct flux_match m2 = FLUX_MATCH_RESPONSE;
+    int rc;
+    int type;
+    uint32_t matchtag;
+
+    ok (flux_recv (orig, FLUX_MATCH_ANY, 0) == NULL,
+        "nothing up my sleve");
+
+    h = flux_clone (orig);
+    ok (h != NULL,
+        "cloned handle");
+    r = flux_reactor_create (0);
+    ok (r != NULL,
+        "created reactor");
+    ok (flux_set_reactor (h, r) == 0,
+        "set reactor in cloned handle");
+
+    /* event */
+    ok ((w = flux_msg_handler_create (h, FLUX_MATCH_EVENT, cb, NULL)) != NULL,
+        "handle created dispatcher on demand");
+    flux_msg_handler_start (w);
+    ok ((msg = flux_event_encode ("test", NULL)) != NULL,
+        "encoded event message");
+    ok (flux_send (h, msg, 0) == 0,
+        "sent event message on cloned connector");
+    flux_msg_destroy (msg);
+    diag ("started event handler");
+
+    /* response (matched) */
+    m.matchtag = flux_matchtag_alloc (h, 0);
+    ok (m.matchtag != FLUX_MATCHTAG_NONE,
+        "allocated matchtag (%d)", m.matchtag); // 1
+    ok ((w2 = flux_msg_handler_create (h, m, cb, NULL)) != NULL,
+        "created handler for response");
+    flux_msg_handler_start (w2);
+    ok ((msg = flux_response_encode ("foo", 0, NULL)) != NULL,
+        "encoded response message");
+    ok (flux_msg_set_matchtag (msg, m.matchtag) == 0,
+        "set matchtag in response");
+    ok (flux_send (h, msg, 0) == 0,
+        "sent response message on cloned connector");
+    flux_msg_destroy (msg);
+    diag ("started response handler");
+
+    /* response (unmatched) */
+    m2.matchtag = flux_matchtag_alloc (h, 0);
+    ok (m2.matchtag != FLUX_MATCHTAG_NONE,
+        "allocated matchtag (%d)", m2.matchtag); // 2
+    ok ((msg = flux_response_encode ("bar", 0, NULL)) != NULL,
+        "encoded response message");
+    ok (flux_msg_set_matchtag (msg, m2.matchtag) == 0,
+        "set matchtag in response");
+    ok (flux_send (h, msg, 0) == 0,
+        "sent response message on cloned connector");
+    flux_msg_destroy (msg);
+
+    /* N.B. libev NOWAIT semantics don't guarantee that all pending
+     * events are handled as only one loop is run.  The flux_t handle
+     * ensures that only one message is handled per loop, so we need to
+     * call it twice to handle the expected two messages.
+     */
+    cb_called = 0;
+    /* 1 */
+    rc = flux_reactor_run (r, FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 1,
+        "one message handled on first reactor loop");
+    /* 2 */
+    rc = flux_reactor_run (r, FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 2,
+        "another message handled on second reactor loop");
+    /* 3 (should get nothing) */
+    rc = flux_reactor_run (r, FLUX_REACTOR_NOWAIT);
+    ok (rc >= 0,
+        "flux_reactor_run ran");
+    ok (cb_called == 2,
+        "no messages handled on third reactor loop");
+
+    /* requeue event and unmatched responses */
+    ok (flux_dispatch_requeue (h) == 0,
+        "requeued unconsumed messages in clone");
+
+    msg = flux_recv (orig, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "received first message on orig handle");
+    skip (msg == NULL, 2);
+    rc = flux_msg_get_type (msg, &type);
+    ok (rc == 0 && type == FLUX_MSGTYPE_EVENT,
+        "and its the event");
+    flux_msg_destroy (msg);
+    end_skip;
+
+    msg = flux_recv (orig, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "received second message on orig handle");
+    skip (msg == NULL, 2);
+    rc = flux_msg_get_type (msg, &type);
+    ok (rc == 0 && type == FLUX_MSGTYPE_RESPONSE,
+        "and its a response");
+    rc = flux_msg_get_matchtag (msg, &matchtag);
+    ok (rc == 0 && matchtag == 2,
+        "and matchtag=2 (%d)", matchtag);
+    flux_msg_destroy (msg);
+    end_skip;
+
+    ok (flux_recv (orig, FLUX_MATCH_ANY, 0) == NULL,
+        "there are no more messages");
+
+    /* close the clone */
+    flux_msg_handler_destroy (w);
+    flux_msg_handler_destroy (w2);
+    flux_matchtag_free (h, m.matchtag);
+    flux_matchtag_free (h, m2.matchtag);
+    flux_close (h);
+    flux_reactor_destroy (r);
+    diag ("destroyed reactor, closed clone");
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_reactor_t *r;
+
+    plan (NO_PLAN);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH",
+                  flux_conf_get ("connector_path", CONF_FLAG_INTREE), 0);
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "opened loop connector");
+    if (!h)
+        BAIL_OUT ("can't continue without loop handle");
+    ok ((r = flux_get_reactor (h)) != NULL,
+        "handle created reactor on demand");
+
+    test_simple_msg_handler (h);
+    test_fastpath (h);
+    test_cloned_dispatch (h);
+
+    flux_close (h);
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This is a preliminary PR not for merging yet.

It's an implementation of futures, as discussed in #1053.  The core API is:
```C
typedef struct flux_future_struct flux_future_t;

typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);

flux_future_t *flux_future_create (flux_reactor_t *r);
void flux_future_destroy (flux_future_t *f);

int flux_future_set_timeout (flux_future_t *f, double timeout);

int flux_future_get (flux_future_t *f, void *result);

bool flux_future_check (flux_future_t *f);

int flux_future_then (flux_future_t *f, flux_continuation_f cb, void *arg);

void flux_future_set_result (flux_future_t *f,
                             void *result, flux_free_f free_fn);
void flux_future_set_error (flux_future_t *f, int errnum);
```
The basic idea is that a future is completed by calling `set_result()` or `set_error()`.   It can also optionally be completed by a timeout.  The `get()`, `check()`, and `then()` functions work like our current RPC API.

 Internally, `get()` and `check()` create a temporary reactor and run it until the result is available, or until it would block (respectively).  `then()` registers the continuation to be called when the result is available using the main reactor passed to the create call.  The continuation is expected to call `get()`, which will not block in that context.

Next we have some utility functions intended to make creating  complex futures easy:
```C
typedef void (*flux_future_init_f)(flux_future_t *f, flux_reactor_t *r, void *arg);

void flux_future_set_init (flux_future_t *f, flux_future_init_f cb, void *arg);
```
The init is a callback that sets up reactor watchers in the context passed to it, which may be either the main reactor or the temporary reactor.  It will be called at most twice for the two different contexts, which are created on demand depending on how the functions above are called.  (For example, a synchronous operation may consist of `create()` and `get()` and in that case, only the temporary reactor context would be used, and the promise would be called only once). 

Edit: renamed "promise" to "init" per discussion with @trws 5 Jun 2017

Because it's handy to attach objects to the future so they can be destroyed when the future is destroyed,  we have
```C
void *flux_future_aux_get (flux_future_t *f, const char *name);
int flux_future_aux_set (flux_future_t *f, const char *name,
                         void *aux, flux_free_f destroy);
```
exactly like those found elsewhere in the API except these allow a NULL `name` parameter.  I found that to be useful when creating watchers from promises in the two contexts that I wanted to be destroyed when the future was destroyed.  It was inconvenient to choose a unique name for them as the promise function isn't really supposed to be aware of which context it's being called in.

Finally, message handlers, which look a lot like reactor watchers, but are not quite, were a bit of a problem.  I wanted them to work in the context of promises as described above but to do that the temporary reactor context would need to have a separate message dispatcher and `flux_t` watcher from that of the main reactor/handle.  Eventually I came up with `flux_clone()`, which creates a new handle that's identical to the original except it has a different `aux` hash, which means it can have a different reactor/dispatcher associated with it.

If a future is to be used with message handlers, one can set the main handle (presumably the one associated with the reactor passed to `create()`) with a `set_flux()` call, and from a promise obtain one that works with the appropriate reactor context with a `get_flux()`call
```C
void flux_future_set_flux (flux_future_t *f, flux_t *h);
flux_t *flux_future_get_flux (flux_future_t *f);
```
The clone is created on demand, if needed.

The PR then goes on to reimplement RPCs in terms of futures, but internally as an experiment, so its API doesn't change.  The basics work but I'm working through the corner cases now.