### PR TITLE
flux_reactor_run() should return active watcher count

### DIFF
--- a/doc/man3/flux_reactor_create.adoc
+++ b/doc/man3/flux_reactor_create.adoc
@@ -33,8 +33,8 @@ flux_t broker handles.
 There is currently only one possible flag for reactor creation:
 
 FLUX_REACTOR_SIGCHLD::
-  The reactor will internally register a SIGCHLD handler and be capable
-  of handling flux child watchers (see flux_child_watcher_create(3)).
+The reactor will internally register a SIGCHLD handler and be capable
+of handling flux child watchers (see flux_child_watcher_create(3)).
 
 For each event source and type that is to be monitored, a flux_watcher_t
 object is created using a type-specific create function, and started
@@ -49,14 +49,13 @@ control must be transferred to the reactor event loop by calling
 The full list of flux reactor run flags is as follows:
 
 FLUX_REACTOR_NOWAIT::
-  Return after all outstanding events have been consumed.  If there are remaining
-  registered watchers, flux_reactor_run() will return an error.  See RETURN VALUE.
-FLUX_REACTOR_ONCE::
-  Return after at least on event has occurred, and all outstanding
-  events have been consumed.  If there are remaining registered watchers,
-  flux_reactor_run() will return an error.  See RETURN VALUE.
+Run one reactor loop iteration without blocking.
 
-flux_reactor_run() processes events until one of the following conditions is met:
+FLUX_REACTOR_ONCE::
+Run one reactor loop iteration, blocking until at least one event is handled.
+
+flux_reactor_run() processes events until one of the following conditions
+is met:
 
 * There are no more active watchers.
 * The `flux_reactor_stop()` or `flux_reactor_stop_error()` functions
@@ -81,11 +80,9 @@ RETURN VALUE
 `flux_reactor_create()` returns a flux_reactor_t object on success.
 On error, NULL is returned, and errno is set appropriately.
 
-`flux_reactor_run()` returns zero on normal termination.
-On failure, termination by `flux_reactor_stop_error()` -1 is returned
-with errno set.  Additionally if either FLUX_REACTOR_NOWAIT or FLUX_REACTOR_ONCE
-is set and there are still watchers registered -1 is returned and errno set
-to EWOULDBLOCK.
+`flux_reactor_run()` returns the number of active watchers on success.
+On failure, it returns -1 with errno set.  A failure return is triggered
+when the application sets errno and calls `flux_reactor_stop_error()`.
 
 
 ERRORS

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -387,7 +387,7 @@ static void test_periodic (flux_reactor_t *reactor)
                                            do_stop_reactor, reactor)) != NULL,
         "periodic: creating with resched callback works");
     flux_watcher_start (w);
-    ok (flux_reactor_run (reactor, 0) == 0,
+    ok (flux_reactor_run (reactor, 0) >= 0,
         "periodic: reactor ran to completion");
     ok (resched_called, "resched_cb was called");
     ok (do_stop_callback_ran, "stop reactor callback was run");
@@ -476,7 +476,7 @@ static void test_prepcheck (flux_reactor_t *reactor)
         "created check watcher");
     flux_watcher_start (chk);
 
-    ok (flux_reactor_run (reactor, 0) == 0,
+    ok (flux_reactor_run (reactor, 0) >= 0,
         "reactor ran successfully");
     ok (prepchecktimer_count == 8,
         "timer fired 8 times, then reactor was stopped");
@@ -522,7 +522,7 @@ static void test_signal (flux_reactor_t *reactor)
         "created idle watcher");
     flux_watcher_start (idle);
 
-    ok (flux_reactor_run (reactor, 0) == 0,
+    ok (flux_reactor_run (reactor, 0) >= 0,
         "reactor ran successfully");
     ok (sigusr1_count == 8,
         "signal watcher handled correct number of SIGUSR1's");

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -207,7 +207,7 @@ local to = f:timer {
 }
 local r, err = f:reactor()
 
-is (r, 0, "reactor exited normally with "..(r and r or err))
+isnt (r, -1, "reactor exited normally with "..(r and r or err))
 to:remove()
 
 ok (kw:remove(), "Can remove kvswatcher without error")
@@ -250,7 +250,7 @@ local t, err = f:timer {
 os.execute (string.format ("sleep 0.25 && flux exec -r 3 flux kvs put %s=%s",
     data.key, data.value))
 local r, err = f:reactor()
-is (r, 0, "reactor exited normally with ".. (r and r or err))
+isnt (r, -1, "reactor exited normally with ".. (r and r or err))
 is (ncount, 2, "kvswatch callback invoked exactly twice")
 
 note ("Ensure kvs watch callback not invoked after kvswatcher removal")
@@ -263,7 +263,7 @@ local t, err = f:timer {
     handler = function (f, to) return f:reactor_stop () end
 }
 local r, err = f:reactor()
-is (r, 0, "reactor exited normally with "..(r and r or err))
+isnt (r, -1, "reactor exited normally with "..(r and r or err))
 is (ncount, 2, "kvswatch callback not invoked after kvs_unwatch")
 is (dir [data.key], "test3", "but key value has been updated")
 

--- a/t/rolemask/loop.c
+++ b/t/rolemask/loop.c
@@ -143,9 +143,7 @@ static void check_rpc_default_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "default-creds: reactor successfully handled one event");
     ok (testrpc1_called == true
         && flux_rpc_check (rpc) && flux_rpc_get (rpc, NULL) == 0,
@@ -168,9 +166,7 @@ static void check_rpc_default_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "random-creds: reactor successfully handled one event");
     errno = 0;
     ok (testrpc1_called == false
@@ -205,9 +201,7 @@ static void check_rpc_open_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "default-creds: reactor successfully handled one event");
     ok (testrpc1_called == true
         && flux_rpc_check (rpc) && flux_rpc_get (rpc, NULL) == 0,
@@ -230,9 +224,7 @@ static void check_rpc_open_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "random-creds: reactor successfully handled one event");
     ok (testrpc1_called == true
         && flux_rpc_check (rpc) == true && flux_rpc_get (rpc, NULL) == 0,
@@ -271,9 +263,7 @@ static void check_rpc_targetted_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "default-creds: reactor successfully handled one event");
     ok (testrpc1_called == true
         && flux_rpc_check (rpc) && flux_rpc_get (rpc, NULL) == 0,
@@ -293,9 +283,7 @@ static void check_rpc_targetted_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "target-creds: reactor successfully handled one event");
     ok (testrpc1_called == true
         && flux_rpc_check (rpc) == true && flux_rpc_get (rpc, NULL) == 0,
@@ -315,9 +303,7 @@ static void check_rpc_targetted_policy (flux_t *h)
     if (rpc == NULL)
         BAIL_OUT ("flux_rpc: %s", flux_strerror (errno));
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
-    if (rc < 0 && errno == EAGAIN && errno == EWOULDBLOCK)
-        rc = 0;
-    ok (rc == 0,
+    ok (rc >= 0,
         "nontarget-creds: reactor successfully handled one event");
     errno = 0;
     ok (testrpc1_called == false

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -416,7 +416,7 @@ void test_then (flux_t *h)
     ok (flux_rpc_then (r, then_cb, h) == 0,
         "flux_rpc_then works");
     /* enough of that */
-    ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
         "reactor completed normally");
     flux_rpc_destroy (r);
 
@@ -430,7 +430,7 @@ void test_then (flux_t *h)
         "flux_rpc_get works synchronously and returned expected payload");
     ok (flux_rpc_then (r, then_cb, h) == 0,
         "flux_rpc_then works");
-    ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,
+    ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0,
         "reactor completed normally");
     flux_rpc_destroy (r);
 

--- a/t/rpc/util.c
+++ b/t/rpc/util.c
@@ -31,7 +31,10 @@ static void *thread_wrapper (void *arg)
 {
     struct test_server *a = arg;
 
-    a->rc = a->cb (a->s, a->arg);
+    if (a->cb (a->s, a->arg) < 0)
+        a->rc = -1;
+    else
+        a->rc = 0;
 
     return NULL;
 }


### PR DESCRIPTION
This PR was split out of PR #1083.  It alters the return value of `flux_reactor_run()`.  On success, return the active watcher count so >= 0 indicates success, not just zero.  Drop the code that returned -1 with errno = EWOULDBLOCK if the FLUX_REACTOR_NOWAIT or FLUX_REACTOR_ONCE flag was specified as agreed in #963.