### PR TITLE
improve reactor documentation

### DIFF
--- a/doc/man3/flux_reactor_create.adoc
+++ b/doc/man3/flux_reactor_create.adoc
@@ -60,10 +60,10 @@ is met:
 * There are no more active watchers.
 * The `flux_reactor_stop()` or `flux_reactor_stop_error()` functions
   are called by one of the watchers.
-* Flags include FLUX_REACTOR_NOWAIT and all outstanding events have
-  been consumed
-* Flags include FLUX_REACTOR_ONCE, at least one event has occurred,
-  and all outstanding events have been consumed.
+* Flags include FLUX_REACTOR_NOWAIT and one reactor loop iteration
+  has been completed.
+* Flags include FLUX_REACTOR_ONCE, at least one event has been handled,
+  and one reactor loop iteration has been completed.
 
 If `flux_reactor_stop_error()` is called, this will cause
 `flux_reactor_run()` to return -1 indicating that an error has occurred.

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -15,8 +15,7 @@ typedef struct flux_reactor flux_reactor_t;
 /* Flags for flux_reactor_run()
  */
 enum {
-    FLUX_REACTOR_NOWAIT = 1,  /* return after all new and outstanding */
-                              /*     events have been handled */
+    FLUX_REACTOR_NOWAIT = 1,  /* run loop once without blocking */
     FLUX_REACTOR_ONCE = 2,    /* same as above but block until at least */
                               /*     one event occurs */
 };


### PR DESCRIPTION
Fix a comment in reactor.h for FLUX_REACTOR_NOWAIT that was out of date, as noted by @grondo in #1085.

Also, fix an out of date flag description in flux_reactor_create(3).