### PR TITLE
add FLUX_PMI_SINGLETON env variable to avoid SLURM's libpmi in valgrind test

### DIFF
--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -136,7 +136,7 @@ int PMI_Init (int *spawned)
      * Try to dlopen another PMI library, e.g. SLURM's.
      * If that fails, fall through to singleton.
      */
-    if ((ctx.wrap = pmi_wrap_create (NULL))) {
+    if (!getenv ("FLUX_PMI_SINGLETON") && (ctx.wrap = pmi_wrap_create (NULL))) {
         result = pmi_wrap_init (ctx.wrap, spawned);
         if (result != PMI_SUCCESS) {
             pmi_wrap_destroy (ctx.wrap);

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -11,6 +11,8 @@ if ! which valgrind >/dev/null; then
     test_done
 fi
 
+export FLUX_PMI_SINGLETON=1 # avoid finding leaks in slurm libpmi.so
+
 VALGRIND=`which valgrind`
 VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
 VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh


### PR DESCRIPTION
Problem: Valgrind test reports leaks in slurm's libpmi.so
on TOSS 2 systems.

The broker, or rather our internal PMI library, will try
hard to use an external PMI environment if available.
On systems where slurm's libpmi.so is installed, the
broker, when run without flux-start, will use that, and
our valgrind test reports leaks in it.

Add environment variable FLUX_PMI_SINGLETON which can be used
to force (internal) singleton bootstrap if no other
environment variables are set to influence PMI bootstrap.

Fixes #1090