### PR TITLE
only run valgrind tests if valgrind/valgrind.h was found

### DIFF
--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -11,6 +11,18 @@ if ! which valgrind >/dev/null; then
     test_done
 fi
 
+# Do not run test by default unless valgrind/valgrind.h was found, since
+#  this has been known to introduce false positives (#1097). However, allow
+#  run to be forced on the cmdline with -d, --debug.
+#
+have_valgrind_h() {
+    grep -q "^#define HAVE_VALGRIND_VALGRIND_H" ${FLUX_BUILD_DIR}/config/config.h
+}
+if ! have_valgrind_h && test "$debug" = ""; then
+    skip_all='skipping valgrind tests b/c valgrind.h not found. Use -d, --debug to force'
+    test_done
+fi
+
 export FLUX_PMI_SINGLETON=1 # avoid finding leaks in slurm libpmi.so
 
 VALGRIND=`which valgrind`


### PR DESCRIPTION
Quick attempt at w/a for false positive valgrind results observed in #1097.

Even if `valgrind/valgrind.h` is not found, the test can be forced if the `-d` or `--debug` option is used on the cmdline, e.g.:

```
 grondo@hype2:~/git/flux-core.git/t$ ./t5000-valgrind.t 
1..0 # SKIP skipping valgrind tests b/c valgrind.h not found. Use -d, --debug to force
 grondo@hype2:~/git/flux-core.git/t$ ./t5000-valgrind.t -d    
sharness: loading extensions from /g/g0/grondo/git/flux-core.git/t/sharness.d/01-setup.sh
sharness: loading extensions from /g/g0/grondo/git/flux-core.git/t/sharness.d/flux-sharness.sh
not ok 1 - valgrind reports no new errors on single broker run
#	
#		flux ${VALGRIND} \
#			--tool=memcheck \
#			--leak-check=full \
#			--gen-suppressions=all \
#			--trace-children=no \
#			--child-silent-after-fork=yes \
#			--num-callers=30 \
#			--leak-resolution=med \
#			--error-exitcode=1 \
#			--suppressions=$VALGRIND_SUPPRESSIONS \
#			${BROKER} --shutdown-grace=4 ${VALGRIND_WORKLOAD} 10
#	
# failed 1 among 1 test(s)
1..1

```