### PR TITLE
Fix intermittent failure of t2000-wreck.t

### DIFF
--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -372,8 +372,8 @@ test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded'
 '
 
 check_complete_link() {
-    lastdir=$(flux kvs dir lwj-complete | tail -1)
     for i in `seq 0 5`; do
+        lastdir=$(flux kvs dir lwj-complete | tail -1)
         flux kvs get ${lastdir}${1}.state && return 0
         sleep 0.2
     done


### PR DESCRIPTION
Fix failure:

 not ok 49 - wreck job is linked in lwj-complete after failure

which may occur if lwj-complete.<epoch> directory has not appeared
in kvs by the time of the *first* pass in the check_complete_link()
function.

Instead of checking for the last epoch dir once in the function,
check it on every loop.

Fixes #1101