### PR TITLE
rename jansson pack/unpack-based Flux API functions

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -116,10 +116,10 @@ MAN3_FILES_SECONDARY = \
 	flux_future_aux_get.3 \
 	flux_future_set_flux.3 \
 	flux_future_get_flux.3 \
-	flux_rpcf.3 \
+	flux_rpc_pack.3 \
 	flux_rpc_raw.3 \
 	flux_rpc_get.3 \
-	flux_rpc_getf.3 \
+	flux_rpc_get_unpack.3 \
 	flux_rpc_get_raw.3 \
 	flux_kvs_lookupat.3 \
 	flux_kvs_lookup_get.3 \
@@ -216,10 +216,10 @@ flux_future_aux_set.3: flux_future_create.3
 flux_future_aux_get.3: flux_future_create.3
 flux_future_set_flux.3: flux_future_create.3
 flux_future_get_flux.3: flux_future_create.3
-flux_rpcf.3: flux_rpc.3
+flux_rpc_pack.3: flux_rpc.3
 flux_rpc_raw.3: flux_rpc.3
 flux_rpc_get.3: flux_rpc.3
-flux_rpc_getf.3: flux_rpc.3
+flux_rpc_get_unpack.3: flux_rpc.3
 flux_rpc_get_raw.3: flux_rpc.3
 flux_kvs_lookupat.3: flux_kvs_lookup.3
 flux_kvs_get.3: flux_kvs_lookup.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -123,7 +123,7 @@ MAN3_FILES_SECONDARY = \
 	flux_rpc_get_raw.3 \
 	flux_kvs_lookupat.3 \
 	flux_kvs_lookup_get.3 \
-	flux_kvs_lookup_getf.3
+	flux_kvs_lookup_get_unpack.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -92,7 +92,7 @@ MAN3_FILES_SECONDARY = \
 	flux_signal_watcher_get_signum.3 \
 	flux_stat_watcher_get_rstat.3 \
 	flux_respond_raw.3 \
-	flux_respondf.3 \
+	flux_respond_pack.3 \
 	flux_reactor_now_update.3 \
 	flux_request_unpack.3 \
 	flux_request_decode_raw.3 \
@@ -192,7 +192,7 @@ flux_child_watcher_get_rstatus.3: flux_child_watcher_create.3
 flux_signal_watcher_get_signum.3: flux_signal_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_respond_raw.3: flux_respond.3
-flux_respondf.3: flux_respond.3
+flux_respond_pack.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
 flux_request_unpack.3: flux_request_decode.3
 flux_request_decode_raw.3: flux_request_decode.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -96,9 +96,9 @@ MAN3_FILES_SECONDARY = \
 	flux_reactor_now_update.3 \
 	flux_request_decodef.3 \
 	flux_request_decode_raw.3 \
-	flux_event_decodef.3 \
+	flux_event_unpack.3 \
 	flux_event_encode.3 \
-	flux_event_encodef.3 \
+	flux_event_pack.3 \
 	flux_response_decode_raw.3 \
 	flux_request_encode_raw.3 \
 	flux_content_load_get.3 \
@@ -196,9 +196,9 @@ flux_respondf.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
 flux_request_decodef.3: flux_request_decode.3
 flux_request_decode_raw.3: flux_request_decode.3
-flux_event_decodef.3: flux_event_decode.3
+flux_event_unpack.3: flux_event_decode.3
 flux_event_encode.3: flux_event_decode.3
-flux_event_encodef.3: flux_event_decode.3
+flux_event_pack.3: flux_event_decode.3
 flux_response_decode_raw.3: flux_response_decode.3
 flux_request_encode_raw.3: flux_request_encode.3
 flux_content_load_get.3: flux_content_load.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -94,7 +94,7 @@ MAN3_FILES_SECONDARY = \
 	flux_respond_raw.3 \
 	flux_respondf.3 \
 	flux_reactor_now_update.3 \
-	flux_request_decodef.3 \
+	flux_request_unpack.3 \
 	flux_request_decode_raw.3 \
 	flux_event_unpack.3 \
 	flux_event_encode.3 \
@@ -194,7 +194,7 @@ flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_respond_raw.3: flux_respond.3
 flux_respondf.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
-flux_request_decodef.3: flux_request_decode.3
+flux_request_unpack.3: flux_request_decode.3
 flux_request_decode_raw.3: flux_request_decode.3
 flux_event_unpack.3: flux_event_decode.3
 flux_event_encode.3: flux_event_decode.3

--- a/doc/man3/flux_event_decode.adoc
+++ b/doc/man3/flux_event_decode.adoc
@@ -5,8 +5,7 @@ flux_event_decode(3)
 
 NAME
 ----
-flux_event_decode, flux_event_decodef, flux_event_encode, flux_event_encodef 
- - encode/decode a Flux event message
+flux_event_decode, flux_event_unpack, flux_event_encode, flux_event_pack - encode/decode a Flux event message
 
 
 SYNOPSIS
@@ -17,15 +16,15 @@ SYNOPSIS
                         const char **topic,
                         const char **json_str);
 
- int flux_event_decodef (const flux_msg_t *msg,
-                         const char **topic,
-                         const char *fmt, ...);
+ int flux_event_unpack (const flux_msg_t *msg,
+                        const char **topic,
+                        const char *fmt, ...);
 
  flux_msg_t *flux_event_encode (const char *topic,
                                 const char *json_str);
 
- flux_msg_t *flux_event_encodef (const char *topic,
-                                 const char *fmt, ...);
+ flux_msg_t *flux_event_pack (const char *topic,
+                              const char *fmt, ...);
 
 
 DESCRIPTION
@@ -40,7 +39,7 @@ _json_str_, if non-NULL, will be set to the message's JSON payload. If
 no payload exists, _json_str_ is set to NULL.  The storage for this
 string belongs to _msg_ and should not be freed.
 
-`flux_event_decodef()` decodes a Flux event message with a JSON payload as
+`flux_event_unpack()` decodes a Flux event message with a JSON payload as
 above, parsing the payload using variable arguments with a format string
 in the style of jansson's `json_unpack()` (used internally). Decoding fails
 if the message doesn't have a JSON payload.
@@ -49,9 +48,9 @@ if the message doesn't have a JSON payload.
 and optional JSON payload _json_str_.  The newly constructed message that
 is returned must be destroyed with `flux_msg_destroy()`.
 
-`flux_event_encodef()` encodes a Flux event message with a JSON payload as
+`flux_event_pack()` encodes a Flux event message with a JSON payload as
 above, encoding the payload using variable arguments with a format string
-in the style of jansson's `json_unpack()` (used internally). Decoding fails
+in the style of jansson's `json_pack()` (used internally). Decoding fails
 if the message doesn't have a JSON payload.
 
 Events propagated to all subscribers.  Events will not be received

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -5,7 +5,7 @@ flux_kvs_lookup(3)
 
 NAME
 ----
-flux_kvs_lookup, flux_kvs_lookupat, flux_kvs_lookup_get, flux_kvs_lookup_getf - look up KVS key
+flux_kvs_lookup, flux_kvs_lookupat, flux_kvs_lookup_get, flux_kvs_lookup_get_unpack - look up KVS key
 
 
 SYNOPSIS
@@ -19,7 +19,7 @@ SYNOPSIS
 
  int flux_kvs_lookup_get (flux_future_t *f, const char **json_str);
 
- int flux_kvs_lookup_getf (flux_future_t *f, const char *fmt, ...);
+ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 
 DESCRIPTION
@@ -44,7 +44,7 @@ response(s) if needed, parsing the result, and returning the requested
 value in _json_str_.  _buf_ is valid until `flux_future_destroy()` is called.
 _json_str_ may be a JSON object, array, or bare value.
 
-`flux_kvs_lookup_getf()` is identical to `flux_kvs_lookup_get()` except
+`flux_kvs_lookup_get_unpack()` is identical to `flux_kvs_lookup_get()` except
 the returned JSON is parsed according to variable arguments in Jansson
 `json_unpack()` format.
 

--- a/doc/man3/flux_request_decode.adoc
+++ b/doc/man3/flux_request_decode.adoc
@@ -5,7 +5,7 @@ flux_request_decode(3)
 
 NAME
 ----
-flux_request_decode, flux_request_decodef, flux_request_decode_raw - decode a Flux request message
+flux_request_decode, flux_request_unpack, flux_request_decode_raw - decode a Flux request message
 
 
 SYNOPSIS
@@ -16,9 +16,9 @@ SYNOPSIS
                           const char **topic,
                           const char **json_str);
 
- int flux_request_decodef (const flux_msg_t *msg,
-                           const char **topic,
-                           const char *fmt, ...);
+ int flux_request_unpack (const flux_msg_t *msg,
+                          const char **topic,
+                          const char *fmt, ...);
 
  int flux_request_decode_raw (const flux_msg_t *msg,
                               const char **topic,
@@ -36,7 +36,7 @@ _json_str_, if non-NULL, will be set to the message's JSON payload.
 If no payload exists, _json_str_ is set to NULL.  The storage for this
 string belongs to _msg_ and should not be freed.
 
-`flux_request_decodef()` decodes a request message with a JSON payload as
+`flux_request_unpack()` decodes a request message with a JSON payload as
 above, parsing the payload using variable arguments with a format string
 in the style of jansson's `json_unpack()` (used internally). Decoding fails
 if the message doesn't have a JSON payload.

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -5,7 +5,7 @@ flux_respond(3)
 
 NAME
 ----
-flux_respond, flux_respondf, flux_respond_raw - respond to a request
+flux_respond, flux_respond_pack, flux_respond_raw - respond to a request
 
 
 SYNOPSIS
@@ -15,8 +15,8 @@ SYNOPSIS
  int flux_respond (flux_t *h, const flux_msg_t *request,
                    int errnum, const char *json_str);
 
- int flux_respondf (flux_t *h, const flux_msg_t *request,
-                    const char *fmt, ...);
+ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
+                        const char *fmt, ...);
 
  int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                        int errnum, const void *data, int length);
@@ -25,7 +25,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-`flux_respond()`, `flux_respondf()`, and `flux_respond_raw()` encode
+`flux_respond()`, `flux_respond_pack()`, and `flux_respond_raw()` encode
 and send a response message on handle _h_, deriving topic string,
 matchtag, and route stack from the provided _request_.
 
@@ -37,7 +37,7 @@ If _json_str_ is non-NULL, `flux_respond()` will send it as the response
 payload, otherwise there will be no payload.  Similarly, if _data_ is
 non-NULL, `flux_respond_raw()` will send it as the response payload.
 
-`flux_respondf()` encodes a response message with a JSON payload,
+`flux_respond_pack()` encodes a response message with a JSON payload,
 building the payload using variable arguments with a format string in
 the style of jansson's `json_pack()` (used internally).
 

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -5,7 +5,7 @@ flux_rpc(3)
 
 NAME
 ----
-flux_rpc, flux_rpcf, flux_rpc_raw, flux_rpc_get, flux_rpc_getf, flux_rpc_get_raw - perform a remote procedure call to a Flux service
+flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw - perform a remote procedure call to a Flux service
 
 
 SYNOPSIS
@@ -16,9 +16,9 @@ SYNOPSIS
                           const char *json_str,
                           uint32_t nodeid, int flags);
 
- flux_future_t *flux_rpcf (flux_t *h, const char *topic,
-                           uint32_t nodeid, int flags,
-                           const char *fmt, ...);
+ flux_future_t *flux_rpc_pack (flux_t *h, const char *topic,
+                               uint32_t nodeid, int flags,
+                               const char *fmt, ...);
 
  flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
                               const void *data, int len,
@@ -26,7 +26,7 @@ SYNOPSIS
 
  int flux_rpc_get (flux_future_t *f, const char **json_str);
 
- int flux_rpc_getf (flux_future_t *f, const char *fmt, ...);
+ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
  int flux_rpc_get_raw (flux_future_t *f, void *data, int *len);
 
@@ -36,7 +36,7 @@ DESCRIPTION
 
 A remote procedure call (RPC) consists of a matched request and
 response message exchanged with a Flux service.  `flux_rpc()`,
-`flux_rpcf()`, and `flux_rpc_raw()` encode and send a request message
+`flux_rpc_pack()`, and `flux_rpc_raw()` encode and send a request message
 via Flux broker handle _h_ to a Flux service identified by _topic_
 and _nodeid_.  A `flux_future_t` object is returned which acts as a handle
 for synchronization and a container for the response message which in
@@ -47,7 +47,7 @@ turn contains the RPC result.
 `flux_future_wait_for(3)` may be used to block until the
 response has been received.  Both accept an optional timeout.
 
-`flux_rpc_get()`, `flux_rpc_getf()`, and `flux_rpc_get_raw()`
+`flux_rpc_get()`, `flux_rpc_get_unpack()`, and `flux_rpc_get_raw()`
 decode the RPC result.  Internally, they call `flux_future_get()`
 to access the response message stored in the future.  If the response
 message has not yet been received, these functions block until it is,
@@ -63,8 +63,8 @@ using one of the three `flux_rpc()` variants.
 `flux_rpc()` attaches _json_str_, a serialized JSON string, as request
 payload.  If NULL, the request is encoded without a payload.
 
-`flux_rpcf()` attaches a JSON payload encoded using Jansson `json_pack()`
-style arguments (see below).
+`flux_rpc_pack()` attaches a JSON payload encoded using Jansson
+`json_pack()` style arguments (see below).
 
 `flux_rpc_raw()` attaches a raw payload _data_ of length _len_, in bytes.
 If _data_ is NULL, the request is encoded without a payload.
@@ -103,9 +103,9 @@ return an error.
 payload contained in the RPC response.  If there was no payload, _json_str_
 is set to NULL.
 
-`flux_rpc_getf()` decodes the JSON payload using Jansson `json_unpack()` style
-arguments (see below).  It is an error if there is no payload, or if the
-payload is not JSON.
+`flux_rpc_get_unpack()` decodes the JSON payload using Jansson `json_unpack()`
+style arguments (see below).  It is an error if there is no payload, or if
+the payload is not JSON.
 
 `flux_rpc_get_raw()` assigns the raw payload of the RPC response message
 to _data_ and its length to _len_.  If there is no payload, this function
@@ -135,11 +135,11 @@ on that handle.
 RETURN VALUE
 ------------
 
-`flux_rpc()`, `flux_rpcf()`, and `flux_rpc_raw()` return a flux_future_t
+`flux_rpc()`, `flux_rpc_pack()`, and `flux_rpc_raw()` return a flux_future_t
 object on success.  On error, NULL is returned, and errno is set appropriately.
 
-`flux_rpc_get()`, `flux_rpc_getf()`, and `flux_rpc_get_raw()` returns zero on
-success.  On error, -1 is returned, and errno is set appropriately.
+`flux_rpc_get()`, `flux_rpc_get_unpack()`, and `flux_rpc_get_raw()` return
+zero on success.  On error, -1 is returned, and errno is set appropriately.
 
 
 ERRORS

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -10,8 +10,8 @@ int main (int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_rpcf (h, "attr.get", FLUX_NODEID_ANY, 0,
-		        "{s:s}", "name", "rank")))
+    if (!(f = flux_rpc_pack (h, "attr.get", FLUX_NODEID_ANY, 0,
+		             "{s:s}", "name", "rank")))
         log_err_exit ("flux_rpcf");
 
     if (flux_rpc_getf (f, "{s:s}", "value", &rankstr) < 0)

--- a/doc/man3/trpc.c
+++ b/doc/man3/trpc.c
@@ -12,10 +12,10 @@ int main (int argc, char **argv)
 
     if (!(f = flux_rpc_pack (h, "attr.get", FLUX_NODEID_ANY, 0,
 		             "{s:s}", "name", "rank")))
-        log_err_exit ("flux_rpcf");
+        log_err_exit ("flux_rpc_pack");
 
-    if (flux_rpc_getf (f, "{s:s}", "value", &rankstr) < 0)
-        log_err_exit ("flux_rpc_getf");
+    if (flux_rpc_get_unpack (f, "{s:s}", "value", &rankstr) < 0)
+        log_err_exit ("flux_rpc_get_unpack");
 
     printf ("rank is %s\n", rankstr);
     flux_future_destroy (f);

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -5,8 +5,8 @@ void continuation (flux_future_t *f, void *arg)
 {
     const char *rankstr;
 
-    if (flux_rpc_getf (f, "{s:s}", "value", &rankstr) < 0)
-        log_err_exit ("flux_rpc_getf");
+    if (flux_rpc_get_unpack (f, "{s:s}", "value", &rankstr) < 0)
+        log_err_exit ("flux_rpc_get_unpack");
 
     printf ("rank is %s\n", rankstr);
     flux_future_destroy (f);

--- a/doc/man3/trpc_then.c
+++ b/doc/man3/trpc_then.c
@@ -20,9 +20,9 @@ int main (int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_rpcf (h, "attr.get", FLUX_NODEID_ANY, 0,
-		        "{s:s}", "name", "rank")))
-        log_err_exit ("flux_rpcf");
+    if (!(f = flux_rpc_pack (h, "attr.get", FLUX_NODEID_ANY, 0,
+		             "{s:s}", "name", "rank")))
+        log_err_exit ("flux_rpc_pack");
 
     if (flux_future_then (f, -1., continuation, NULL) < 0)
         log_err_exit ("flux_future_then");

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -315,7 +315,7 @@ static int l_flux_kvs_type (lua_State *L)
         return lua_pusherror (L, "key expected in arg #2");
 
     if ((future = flux_kvs_lookup (f, FLUX_KVS_READLINK, key))
-            && flux_kvs_lookup_getf (future, "s", &target) == 0) {
+            && flux_kvs_lookup_get_unpack (future, "s", &target) == 0) {
         lua_pushstring (L, "symlink");
         lua_pushstring (L, target);
         flux_future_destroy (future);

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -312,7 +312,9 @@ void getattr_request_cb (flux_t *h, flux_msg_handler_t *w,
         errno = ENOENT;
         goto error;
     }
-    if (flux_respondf (h, msg, "{s:s s:i}", "value", val, "flags", flags) < 0)
+    if (flux_respond_pack (h, msg, "{s:s s:i}",
+                                   "value", val,
+                                   "flags", flags) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
@@ -379,7 +381,7 @@ void lsattr_request_cb (flux_t *h, flux_msg_handler_t *w,
         }
         name = attr_next (attrs);
     }
-    if (flux_respondf (h, msg, "{s:O}", "names", names) < 0)
+    if (flux_respond_pack (h, msg, "{s:O}", "names", names) < 0)
         FLUX_LOG_ERROR (h);
     json_decref (names);
     return;

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -304,7 +304,7 @@ void getattr_request_cb (flux_t *h, flux_msg_handler_t *w,
     const char *val;
     int flags;
 
-    if (flux_request_decodef (msg, NULL, "{s:s}", "name", &name) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
         goto error;
     if (attr_get (attrs, name, &val, &flags) < 0)
         goto error;
@@ -327,9 +327,9 @@ void setattr_request_cb (flux_t *h, flux_msg_handler_t *w,
     const char *name;
     const char *val;
 
-    if (flux_request_decodef (msg, NULL, "{s:s s:s}",       /* SET */
-                              "name", &name,
-                              "value", &val) == 0) {
+    if (flux_request_unpack (msg, NULL, "{s:s s:s}",       /* SET */
+                             "name", &name,
+                             "value", &val) == 0) {
         if (attr_set (attrs, name, val, false) < 0) {
             if (errno != ENOENT)
                 goto error;
@@ -337,9 +337,9 @@ void setattr_request_cb (flux_t *h, flux_msg_handler_t *w,
                 goto error;
         }
     }
-    else if (flux_request_decodef (msg, NULL, "{s:s s:n}",  /* DELETE */
-                                   "name", &name,
-                                   "value") == 0) {
+    else if (flux_request_unpack (msg, NULL, "{s:s s:n}",  /* DELETE */
+                                  "name", &name,
+                                  "value") == 0) {
         if (attr_delete (attrs, name, false) < 0)
             goto error;
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1643,9 +1643,9 @@ static void cmb_panic_cb (flux_t *h, flux_msg_handler_t *w,
 {
     const char *s = NULL;
 
-    if (flux_request_decodef (msg, NULL, "{}") < 0)
+    if (flux_request_unpack (msg, NULL, "{}") < 0)
         goto error;
-    if (flux_request_decodef (msg, NULL, "{ s:s }", "msg", &s) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s }", "msg", &s) < 0)
         s = "no reason";
     log_msg_exit ("PANIC: %s", s ? s : "no reason");
     /*NOTREACHED*/
@@ -1686,7 +1686,7 @@ static void cmb_sub_cb (flux_t *h, flux_msg_handler_t *w,
     char *uuid = NULL;
     const char *topic;
 
-    if (flux_request_decodef (msg, NULL, "{ s:s }", "topic", &topic) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         goto error;
     if (flux_msg_get_route_first (msg, &uuid) < 0)
         goto error;
@@ -1713,7 +1713,7 @@ static void cmb_unsub_cb (flux_t *h, flux_msg_handler_t *w,
     char *uuid = NULL;
     const char *topic;
 
-    if (flux_request_decodef (msg, NULL, "{ s:s }", "topic", &topic) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         goto error;
     if (flux_msg_get_route_first (msg, &uuid) < 0)
         goto error;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -640,9 +640,9 @@ static void content_backing_request (flux_t *h, flux_msg_handler_t *w,
     int rc = -1;
     int backing;
 
-    if (flux_request_decodef (msg, NULL, "{ s:b s:s }",
-                              "backing", &backing,
-                              "name", &name) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:b s:s }",
+                             "backing", &backing,
+                             "name", &name) < 0)
         goto done;
     if (cache->rank != 0) {
         errno = EINVAL;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -722,11 +722,11 @@ static void content_stats_request (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
-    if (flux_respondf (h, msg, "{ s:i s:i s:i s:i}",
-                       "count", zhash_size (cache->entries),
-                       "valid", cache->acct_valid,
-                       "dirty", cache->acct_dirty,
-                       "size", cache->acct_size) < 0)
+    if (flux_respond_pack (h, msg, "{ s:i s:i s:i s:i}",
+                           "count", zhash_size (cache->entries),
+                           "valid", cache->acct_valid,
+                           "dirty", cache->acct_dirty,
+                           "size", cache->acct_size) < 0)
         flux_log_error (h, "content stats");
     return;
 error:

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -212,8 +212,8 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
     int errnum = 0;
     struct subprocess *p;
 
-    if (flux_request_decodef (msg, NULL, "{s:i s:o}", "pid", &pid,
-                                                      "stdin", &o) < 0) {
+    if (flux_request_unpack (msg, NULL, "{s:i s:o}", "pid", &pid,
+                                                     "stdin", &o) < 0) {
         errnum = errno;
         goto out;
     }
@@ -244,9 +244,9 @@ static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
     int signum = SIGTERM;
     struct subprocess *p;
 
-    if (flux_request_decodef (msg, NULL, "{s:i s?:i}",
-                              "pid", &pid,
-                              "signum", &signum) < 0) {
+    if (flux_request_unpack (msg, NULL, "{s:i s?:i}",
+                             "pid", &pid,
+                             "signum", &signum) < 0) {
         errnum = errno;
         goto out;
     }
@@ -355,10 +355,10 @@ static void exec_request_cb (flux_t *h, flux_msg_handler_t *w,
     const char *cwd = NULL;
     struct subprocess *p;
 
-    if (flux_request_decodef (msg, NULL, "{s:o s?:o s?:s}",
-                              "cmdline", &args,
-                              "env", &env,
-                              "cwd", &cwd) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:o s?:o s?:s}",
+                             "cmdline", &args,
+                             "env", &env,
+                             "cwd", &cwd) < 0)
         goto error;
     if (prepare_subprocess (x, args, env, cwd, msg, &p) < 0)
         goto error;

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -231,8 +231,8 @@ static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
 out:
     free (s);
-    if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
-        flux_log_error (h, "write_request_cb: flux_respondf");
+    if (flux_respond_pack (h, msg, "{ s:i }", "code", errnum) < 0)
+        flux_log_error (h, "write_request_cb: flux_respond_pack");
 }
 
 static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
@@ -261,8 +261,8 @@ static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
         p = subprocess_manager_next (x->sm);
     }
 out:
-    if (flux_respondf (h, msg, "{ s:i }", "code", errnum) < 0)
-        flux_log_error (h, "signal_request_cb: flux_respondf");
+    if (flux_respond_pack (h, msg, "{ s:i }", "code", errnum) < 0)
+        flux_log_error (h, "signal_request_cb: flux_respond_pack");
 }
 
 static int do_setpgrp (struct subprocess *p)
@@ -378,10 +378,10 @@ static void exec_request_cb (flux_t *h, flux_msg_handler_t *w,
          *   to caller on completion handler (which will be called
          *   immediately)
          */
-        if (flux_respondf (h, msg, "{s:i s:i s:s}",
-                           "rank", x->rank,
-                           "pid", subprocess_pid (p),
-                           "state", subprocess_state_string (p)) < 0)
+        if (flux_respond_pack (h, msg, "{s:i s:i s:s}",
+                               "rank", x->rank,
+                               "pid", subprocess_pid (p),
+                               "state", subprocess_state_string (p)) < 0)
             flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     }
     return;
@@ -497,9 +497,9 @@ static void ps_request_cb (flux_t *h, flux_msg_handler_t *w,
         }
         p = subprocess_manager_next (x->sm);
     }
-    if (flux_respondf (h, msg, "{s:i s:o}", "rank", x->rank,
-                                            "procs", procs) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_pack (h, msg, "{s:i s:o}", "rank", x->rank,
+                                                "procs", procs) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     return;
 error:
     if (flux_respond (h, msg, errno, NULL) < 0)

--- a/src/broker/heaptrace.c
+++ b/src/broker/heaptrace.c
@@ -43,7 +43,7 @@ static void start_cb (flux_t *h, flux_msg_handler_t *w,
 {
     const char *filename;
 
-    if (flux_request_decodef (msg, NULL, "{s:s}", "filename", &filename) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "filename", &filename) < 0)
         goto error;
 #if WITH_TCMALLOC
     if (IsHeapProfilerRunning ()) {
@@ -68,7 +68,7 @@ static void dump_cb (flux_t *h, flux_msg_handler_t *w,
 {
     const char *reason;
 
-    if (flux_request_decodef (msg, NULL, "{s:s}", "reason", &reason) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "reason", &reason) < 0)
         goto error;
 #if WITH_TCMALLOC
     if (!IsHeapProfilerRunning ()) {

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -218,10 +218,10 @@ static void join_request (flux_t *h, flux_msg_handler_t *w,
     hello_t *hello = arg;
     int count, batch;
 
-    if (flux_request_decodef (msg, NULL, "{ s:i s:i }",
-                              "count", &count,
-                              "batch", &batch) < 0)
-        log_err_exit ("hello: flux_request_decodef");
+    if (flux_request_unpack (msg, NULL, "{ s:i s:i }",
+                             "count", &count,
+                             "batch", &batch) < 0)
+        log_err_exit ("hello: flux_request_unpack");
     if (batch != 0 || count <= 0)
         log_msg_exit ("hello: error decoding join request");
     if (flux_reduce_append (hello->reduce, (void *)(uintptr_t)count, batch) < 0)

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -281,11 +281,11 @@ static void r_forward (flux_reduce_t *r, int batch, void *arg)
     assert (batch == 0);
     assert (count > 0);
 
-    if (!(f = flux_rpcf (hello->h, "hello.join", FLUX_NODEID_UPSTREAM,
-                           FLUX_RPC_NORESPONSE, "{ s:i s:i }",
-                           "count", count,
-                           "batch", batch)))
-        log_err_exit ("hello: flux_rpcf");
+    if (!(f = flux_rpc_pack (hello->h, "hello.join", FLUX_NODEID_UPSTREAM,
+                             FLUX_RPC_NORESPONSE, "{ s:i s:i }",
+                             "count", count,
+                             "batch", batch)))
+        log_err_exit ("hello: flux_rpc_pack");
     flux_future_destroy (f);
 }
 

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -555,7 +555,7 @@ static void clear_request_cb (flux_t *h, flux_msg_handler_t *w,
     int seq;
     int rc = -1;
 
-    if (flux_request_decodef (msg, NULL, "{ s:i }", "seq", &seq) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:i }", "seq", &seq) < 0)
         goto done;
     logbuf_clear (logbuf, seq);
     rc = 0;
@@ -571,9 +571,9 @@ static void dmesg_request_cb (flux_t *h, flux_msg_handler_t *w,
     int len;
     int seq, follow;
 
-    if (flux_request_decodef (msg, NULL, "{ s:i s:b }",
-                              "seq", &seq,
-                              "follow", &follow) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:i s:b }",
+                             "seq", &seq,
+                             "follow", &follow) < 0)
         goto error;
     if (logbuf_get (logbuf, seq, &seq, &buf, &len) < 0) {
         if (follow && errno == ENOENT) {

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -583,9 +583,9 @@ static void dmesg_request_cb (flux_t *h, flux_msg_handler_t *w,
         }
         goto error;
     }
-    if (flux_respondf (h, msg, "{ s:i s:s# }",
-                       "seq", seq,
-                       "buf", buf, len) < 0)
+    if (flux_respond_pack (h, msg, "{ s:i s:s# }",
+                                   "seq", seq,
+                                   "buf", buf, len) < 0)
         goto error;
     return;
 

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -93,15 +93,15 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *w,
 
     flux_get_msgcounters (h, &mcs);
 
-    if (flux_respondf (h, msg, "{ s:i s:i s:i s:i s:i s:i s:i s:i }",
-                       "#request (tx)", mcs.request_tx,
-                       "#request (rx)", mcs.request_rx,
-                       "#response (tx)", mcs.response_tx,
-                       "#response (rx)", mcs.response_rx,
-                       "#event (tx)", mcs.event_tx,
-                       "#event (rx)", mcs.event_rx,
-                       "#keepalive (tx)", mcs.keepalive_tx,
-                       "#keepalive (rx)", mcs.keepalive_rx) < 0)
+    if (flux_respond_pack (h, msg, "{ s:i s:i s:i s:i s:i s:i s:i s:i }",
+                           "#request (tx)", mcs.request_tx,
+                           "#request (rx)", mcs.request_rx,
+                           "#response (tx)", mcs.response_tx,
+                           "#response (rx)", mcs.response_rx,
+                           "#event (tx)", mcs.event_tx,
+                           "#event (rx)", mcs.event_rx,
+                           "#keepalive (tx)", mcs.keepalive_tx,
+                           "#keepalive (rx)", mcs.keepalive_rx) < 0)
       FLUX_LOG_ERROR (h);
 }
 
@@ -154,7 +154,7 @@ static void debug_cb (flux_t *h, flux_msg_handler_t *w,
         errno = EPROTO;
         goto error;
     }
-    if (flux_respondf (h, msg, "{s:i}", "flags", *debug_flags) < 0)
+    if (flux_respond_pack (h, msg, "{s:i}", "flags", *debug_flags) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -132,8 +132,8 @@ static void debug_cb (flux_t *h, flux_msg_handler_t *w,
     int *debug_flags;
     const char *op;
 
-    if (flux_request_decodef (msg, NULL, "{s:s s:i}", "op", &op,
-                                                    "flags", &flags) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s s:i}", "op", &op,
+                                                     "flags", &flags) < 0)
         goto error;
     if (!(debug_flags = flux_aux_get (h, "flux::debug_flags"))) {
         if (!(debug_flags = calloc (1, sizeof (*debug_flags)))) {

--- a/src/broker/rusage.c
+++ b/src/broker/rusage.c
@@ -45,7 +45,7 @@ static void rusage_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (getrusage (RUSAGE_THREAD, &ru) < 0)
         goto error;
-    if (flux_respondf (h, msg,
+    if (flux_respond_pack (h, msg,
             "{s:f s:f s:i s:i s:i s:i s:i s:i s:i s:i s:i s:i s:i s:i s:i s:i}",
             "utime", (double)ru.ru_utime.tv_sec + 1E-6 * ru.ru_utime.tv_usec,
             "stime", (double)ru.ru_stime.tv_sec + 1E-6 * ru.ru_stime.tv_usec,

--- a/src/broker/sequence.c
+++ b/src/broker/sequence.c
@@ -135,7 +135,7 @@ static int handle_seq_destroy (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
 {
     const char *name;
 
-    if (flux_request_decodef (msg, NULL, "{ s:s }", "name", &name) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s }", "name", &name) < 0)
         return (-1);
     if (seq_destroy (s, name) < 0)
         return (-1);
@@ -149,12 +149,12 @@ static int handle_seq_set (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
     const char *name;
     int64_t old, v;
 
-    if (flux_request_decodef (msg, NULL, "{ s:s s:I }",
-                              "name", &name,
-                              "value", &v) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s s:I }",
+                             "name", &name,
+                             "value", &v) < 0)
         return (-1);
 
-    if (!flux_request_decodef (msg, NULL, "{ s:I }", "oldvalue", &old)
+    if (!flux_request_unpack (msg, NULL, "{ s:I }", "oldvalue", &old)
         && seq_cmp_and_set (s, name, old, v) < 0)
         return (-1);
     else if (seq_set (s, name, v) < 0)
@@ -176,11 +176,11 @@ static int handle_seq_fetch (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
     bool created = false;
     int64_t v, pre, post, *valp;
 
-    if (flux_request_decodef (msg, NULL, "{ s:s s:b s:I s:I }",
-                              "name", &name,
-                              "create", &create,
-                              "preincrement", &pre,
-                              "postincrement", &post) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s s:b s:I s:I }",
+                             "name", &name,
+                             "create", &create,
+                             "preincrement", &pre,
+                             "postincrement", &post) < 0)
         return (-1);
 
     if (seq_fetch_and_add (s, name, pre, post, &v) < 0) {

--- a/src/broker/sequence.c
+++ b/src/broker/sequence.c
@@ -139,9 +139,9 @@ static int handle_seq_destroy (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
         return (-1);
     if (seq_destroy (s, name) < 0)
         return (-1);
-    return flux_respondf (h, msg, "{ s:s s:b }",
-                          "name", name,
-                          "destroyed", true);
+    return flux_respond_pack (h, msg, "{ s:s s:b }",
+                              "name", name,
+                              "destroyed", true);
 }
 
 static int handle_seq_set (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
@@ -160,10 +160,10 @@ static int handle_seq_set (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
     else if (seq_set (s, name, v) < 0)
         return (-1);
 
-    if (flux_respondf (h, msg, "{ s:s s:b s:I }",
-                       "name", name,
-                       "set", true,
-                       "value", v) < 0)
+    if (flux_respond_pack (h, msg, "{ s:s s:b s:I }",
+                           "name", name,
+                           "set", true,
+                           "value", v) < 0)
         return (-1);
 
     return (0);
@@ -196,14 +196,14 @@ static int handle_seq_fetch (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
     }
 
     if (create && created)
-        return flux_respondf (h, msg, "{ s:s s:I s:b }",
-                              "name", name,
-                              "value", v,
-                              "created", true);
+        return flux_respond_pack (h, msg, "{ s:s s:I s:b }",
+                                  "name", name,
+                                  "value", v,
+                                  "created", true);
 
-    return flux_respondf (h, msg, "{ s:s s:I }",
-                          "name", name,
-                          "value", v);
+    return flux_respond_pack (h, msg, "{ s:s s:I }",
+                              "name", name,
+                              "value", v);
 }
 
 static void sequence_request_cb (flux_t *h, flux_msg_handler_t *w,

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -181,11 +181,11 @@ int shutdown_decode (const flux_msg_t *msg, double *grace, int *exitcode,
     const char *s;
     int rc = -1;
 
-    if (flux_event_decodef (msg, NULL, "{ s:s s:F s:i s:i}",
-                            "reason", &s,
-                            "grace", grace,
-                            "rank", rank,
-                            "exitcode", exitcode) < 0)
+    if (flux_event_unpack (msg, NULL, "{ s:s s:F s:i s:i}",
+                           "reason", &s,
+                           "grace", grace,
+                           "rank", rank,
+                           "exitcode", exitcode) < 0)
         goto done;
     snprintf (reason, reason_len, "%s", s);
     rc = 0;

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -155,11 +155,11 @@ flux_msg_t *shutdown_vencode (double grace, int exitcode, int rank,
 
     vsnprintf (reason, sizeof (reason), fmt, ap);
 
-    return flux_event_encodef ("shutdown", "{ s:s s:f s:i s:i }",
-                               "reason", reason,
-                               "grace", grace,
-                               "rank", rank,
-                               "exitcode", exitcode);
+    return flux_event_pack ("shutdown", "{ s:s s:f s:i s:i }",
+                            "reason", reason,
+                            "grace", grace,
+                            "rank", rank,
+                            "exitcode", exitcode);
 }
 
 flux_msg_t *shutdown_encode (double grace, int exitcode, int rank,

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -34,8 +34,8 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
     }
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    if (!(f = flux_rpcf (h, "heaptrace.start", FLUX_NODEID_ANY, 0,
-                           "{ s:s }", "filename", av[ac - 1]))
+    if (!(f = flux_rpc_pack (h, "heaptrace.start", FLUX_NODEID_ANY, 0,
+                             "{ s:s }", "filename", av[ac - 1]))
             || flux_future_get (f, NULL) < 0)
         log_err_exit ("heaptrace.start");
     flux_future_destroy (f);
@@ -73,8 +73,8 @@ static int internal_heaptrace_dump (optparse_t *p, int ac, char *av[])
     }
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    if (!(f = flux_rpcf (h, "heaptrace.dump", FLUX_NODEID_ANY, 0,
-                           "{ s:s }", "reason", av[ac - 1]))
+    if (!(f = flux_rpc_pack (h, "heaptrace.dump", FLUX_NODEID_ANY, 0,
+                             "{ s:s }", "reason", av[ac - 1]))
             || flux_rpc_get (f , NULL) < 0)
         log_err_exit ("heaptrace.dump");
     flux_future_destroy (f);

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -57,8 +57,8 @@ static struct hwloc_topo * hwloc_topo_create (optparse_t *p)
     if (!(t->f = flux_rpc (t->h, "resource-hwloc.topo", NULL, 0, 0)))
         log_err_exit ("flux_rpc");
 
-    if (flux_rpc_getf (t->f, "{ s:s }", "topology", &t->topo) < 0)
-        log_err_exit ("flux_rpc_getf");
+    if (flux_rpc_get_unpack (t->f, "{ s:s }", "topology", &t->topo) < 0)
+        log_err_exit ("flux_rpc_get_unpack");
 
     return (t);
 }

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -336,7 +336,7 @@ int sub_request (client_t *c, const flux_msg_t *msg, bool subscribe)
     const char *topic;
     int rc = -1;
 
-    if (flux_request_decodef (msg, NULL, "{ s:s }", "topic", &topic) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         goto done;
     if (subscribe)
         rc = client_subscribe (c, topic);

--- a/src/cmd/builtin/user.c
+++ b/src/cmd/builtin/user.c
@@ -112,8 +112,8 @@ static void delrole (flux_t *h, uint32_t userid, uint32_t rolemask)
                                 "rolemask", rolemask);
     if (!f)
         log_err_exit ("userdb.delrole");
-    if (flux_rpc_getf (f, "{s:i s:i}", "userid", &userid,
-                                       "rolemask", &final) < 0) {
+    if (flux_rpc_get_unpack (f, "{s:i s:i}", "userid", &userid,
+                             "rolemask", &final) < 0) {
         if (errno == ENOSYS)
             log_msg_exit ("userdb module is not loaded");
         if (errno == ENOENT)
@@ -132,11 +132,12 @@ static void addrole (flux_t *h, uint32_t userid, uint32_t rolemask)
 
     f = flux_rpc_pack (h, "userdb.addrole", FLUX_NODEID_ANY, 0,
                        "{s:i s:i}", "userid", userid,
-                                    "rolemask", rolemask);
+                       "rolemask", rolemask);
     if (!f)
         log_err_exit ("userdb.addrole");
-    if (flux_rpc_getf (f, "{s:i s:i}", "userid", &userid,
-                                       "rolemask", &final) < 0) {
+    if (flux_rpc_get_unpack (f, "{s:i s:i}",
+                                "userid", &userid,
+                                "rolemask", &final) < 0) {
         if (errno == ENOSYS)
             log_msg_exit ("userdb module is not loaded");
         if (errno == ENOENT)
@@ -190,8 +191,8 @@ static int internal_user_list (optparse_t *p, int ac, char *av[])
         f = flux_rpc (h, "userdb.getnext", NULL, FLUX_NODEID_ANY, 0);
         if (!f)
             log_err_exit ("userdb.getnext");
-        if (flux_rpc_getf (f, "{s:i s:i}", "userid", &userid,
-                                           "rolemask", &rolemask) < 0) {
+        if (flux_rpc_get_unpack (f, "{s:i s:i}", "userid", &userid,
+                                                 "rolemask", &rolemask) < 0) {
             if (errno == ENOSYS)
                 log_msg_exit ("userdb module is not loaded");
             if (errno != ENOENT)
@@ -234,8 +235,8 @@ static int internal_user_lookup (optparse_t *p, int ac, char *av[])
                        "{s:i}", "userid", userid);
     if (!f)
         log_err_exit ("userdb.lookup");
-    if (flux_rpc_getf (f, "{s:i s:i}", "userid", &userid,
-                                       "rolemask", &rolemask) < 0) {
+    if (flux_rpc_get_unpack (f, "{s:i s:i}", "userid", &userid,
+                                             "rolemask", &rolemask) < 0) {
         if (errno == ENOSYS)
             log_msg_exit ("userdb module is not loaded");
         if (errno == ENOENT)

--- a/src/cmd/builtin/user.c
+++ b/src/cmd/builtin/user.c
@@ -107,8 +107,8 @@ static void delrole (flux_t *h, uint32_t userid, uint32_t rolemask)
     uint32_t final;
     char s[256];
 
-    f = flux_rpcf (h, "userdb.delrole", FLUX_NODEID_ANY, 0,
-                   "{s:i s:i}", "userid", userid,
+    f = flux_rpc_pack (h, "userdb.delrole", FLUX_NODEID_ANY, 0,
+                       "{s:i s:i}", "userid", userid,
                                 "rolemask", rolemask);
     if (!f)
         log_err_exit ("userdb.delrole");
@@ -130,8 +130,8 @@ static void addrole (flux_t *h, uint32_t userid, uint32_t rolemask)
     uint32_t final;
     char s[256];
 
-    f = flux_rpcf (h, "userdb.addrole", FLUX_NODEID_ANY, 0,
-                   "{s:i s:i}", "userid", userid,
+    f = flux_rpc_pack (h, "userdb.addrole", FLUX_NODEID_ANY, 0,
+                       "{s:i s:i}", "userid", userid,
                                     "rolemask", rolemask);
     if (!f)
         log_err_exit ("userdb.addrole");
@@ -230,8 +230,8 @@ static int internal_user_lookup (optparse_t *p, int ac, char *av[])
         log_msg_exit ("%s: invalid userid", av[n]);
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    f = flux_rpcf (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
-                   "{s:i}", "userid", userid);
+    f = flux_rpc_pack (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
+                       "{s:i}", "userid", userid);
     if (!f)
         log_err_exit ("userdb.lookup");
     if (flux_rpc_getf (f, "{s:i s:i}", "userid", &userid,

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -441,7 +441,7 @@ int cmd_readlink (optparse_t *p, int argc, char **argv)
     }
     for (i = optindex; i < argc; i++) {
         if (!(f = flux_kvs_lookup (h, FLUX_KVS_READLINK, argv[i]))
-                || flux_kvs_lookup_getf (f, "s", &target) < 0)
+                || flux_kvs_lookup_get_unpack (f, "s", &target) < 0)
             log_err_exit ("%s", argv[i]);
         else
             printf ("%s\n", target);
@@ -707,7 +707,7 @@ static void dump_kvs_dir (kvsdir_t *dir, bool Ropt, bool dopt)
         if (kvsdir_issymlink (dir, name)) {
             const char *link;
             if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READLINK, key, rootref))
-                    || flux_kvs_lookup_getf (f, "s", &link) < 0)
+                    || flux_kvs_lookup_get_unpack (f, "s", &link) < 0)
                 log_err_exit ("%s", key);
             printf ("%s -> %s\n", key, link);
             flux_future_destroy (f);

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -711,7 +711,7 @@ int cmd_debug (optparse_t *p, int argc, char **argv)
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0, "{s:s s:i}",
                              "op", op, "flags", flags)))
         log_err_exit ("%s", topic);
-    if (flux_rpc_getf (f, "{s:i}", "flags", &flags) < 0)
+    if (flux_rpc_get_unpack (f, "{s:i}", "flags", &flags) < 0)
         log_err_exit ("%s", topic);
     printf ("0x%x\n", flags);
     flux_future_destroy (f);

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -708,8 +708,8 @@ int cmd_debug (optparse_t *p, int argc, char **argv)
         op = "setbit";
         flags = strtoul (optparse_get_str (p, "setbit", NULL), NULL, 0);
     }
-    if (!(f = flux_rpcf (h, topic, FLUX_NODEID_ANY, 0, "{s:s s:i}",
-                           "op", op, "flags", flags)))
+    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0, "{s:s s:i}",
+                             "op", op, "flags", flags)))
         log_err_exit ("%s", topic);
     if (flux_rpc_getf (f, "{s:i}", "flags", &flags) < 0)
         log_err_exit ("%s", topic);

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -104,7 +104,8 @@ static int attr_get_rpc (attr_ctx_t *ctx, const char *name, attr_t **attrp)
     if (!(f = flux_rpc_pack (ctx->h, "attr.get", FLUX_NODEID_ANY, 0,
                              "{s:s}", "name", name)))
         goto done;
-    if (flux_rpc_getf (f, "{s:s, s:i}", "value", &val, "flags", &flags) < 0)
+    if (flux_rpc_get_unpack (f, "{s:s, s:i}",
+                             "value", &val, "flags", &flags) < 0)
         goto done;
     if (!(attr = attr_create (val, flags)))
         goto done;
@@ -170,7 +171,7 @@ static int attr_list_rpc (attr_ctx_t *ctx)
 
     if (!(f = flux_rpc (ctx->h, "attr.list", NULL, FLUX_NODEID_ANY, 0)))
         goto done;
-    if (flux_rpc_getf (f, "{s:o}", "names", &array) < 0)
+    if (flux_rpc_get_unpack (f, "{s:o}", "names", &array) < 0)
         goto done;
     zlist_destroy (&ctx->names);
     if (!(ctx->names = zlist_new ()))

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -101,8 +101,8 @@ static int attr_get_rpc (attr_ctx_t *ctx, const char *name, attr_t **attrp)
     attr_t *attr;
     int rc = -1;
 
-    if (!(f = flux_rpcf (ctx->h, "attr.get", FLUX_NODEID_ANY, 0,
-                         "{s:s}", "name", name)))
+    if (!(f = flux_rpc_pack (ctx->h, "attr.get", FLUX_NODEID_ANY, 0,
+                             "{s:s}", "name", name)))
         goto done;
     if (flux_rpc_getf (f, "{s:s, s:i}", "value", &val, "flags", &flags) < 0)
         goto done;
@@ -125,12 +125,12 @@ static int attr_set_rpc (attr_ctx_t *ctx, const char *name, const char *val)
 
 #if JANSSON_VERSION_HEX >= 0x020800
     /* $? format specifier was introduced in jansson 2.8 */
-    f = flux_rpcf (ctx->h, "attr.set", FLUX_NODEID_ANY, 0,
-                   "{s:s, s:s?}", "name", name, "value", val);
+    f = flux_rpc_pack (ctx->h, "attr.set", FLUX_NODEID_ANY, 0,
+                       "{s:s, s:s?}", "name", name, "value", val);
 #else
-    f = flux_rpcf (ctx->h, "attr.set", FLUX_NODEID_ANY, 0,
-                   val ? "{s:s, s:s}" : "{s:s, s:n}",
-                   "name", name, "value", val);
+    f = flux_rpc_pack (ctx->h, "attr.set", FLUX_NODEID_ANY, 0,
+                       val ? "{s:s, s:s}" : "{s:s, s:n}",
+                       "name", name, "value", val);
 #endif
     if (!f)
         goto done;

--- a/src/common/libflux/barrier.c
+++ b/src/common/libflux/barrier.c
@@ -91,8 +91,8 @@ flux_future_t *flux_barrier (flux_t *h, const char *name, int nprocs)
     if (!name && !(name = generate_unique_name (h)))
         return NULL;
 
-    return flux_rpcf (h, "barrier.enter", FLUX_NODEID_ANY, 0,
-                           "{s:s s:i s:i s:b}",
+    return flux_rpc_pack (h, "barrier.enter", FLUX_NODEID_ANY, 0,
+                          "{s:s s:i s:i s:b}",
                            "name", name,
                            "count", 1,
                            "nprocs", nprocs,

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -83,7 +83,7 @@ static int flux_event_vdecodef (const flux_msg_t *msg, const char **topic,
 
     if (event_decode (msg, &ts) < 0)
         goto done;
-    if (flux_msg_vget_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vunpack (msg, fmt, ap) < 0)
         goto done;
     if (topic)
         *topic = ts;

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -137,8 +137,8 @@ error:
     return NULL;
 }
 
-static flux_msg_t *flux_event_vencodef (const char *topic,
-                                        const char *fmt, va_list ap)
+static flux_msg_t *flux_event_vpack (const char *topic,
+                                     const char *fmt, va_list ap)
 {
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
@@ -151,13 +151,13 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_event_encodef (const char *topic, const char *fmt, ...)
+flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...)
 {
     flux_msg_t *msg;
     va_list ap;
 
     va_start (ap, fmt);
-    msg = flux_event_vencodef (topic, fmt, ap);
+    msg = flux_event_vpack (topic, fmt, ap);
     va_end (ap);
     return msg;
 }

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -143,7 +143,7 @@ static flux_msg_t *flux_event_vencodef (const char *topic,
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
         goto error;
-    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vpack (msg, fmt, ap) < 0)
         goto error;
     return msg;
 error:

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -75,8 +75,8 @@ done:
     return rc;
 }
 
-static int flux_event_vdecodef (const flux_msg_t *msg, const char **topic,
-                                const char *fmt, va_list ap)
+static int flux_event_vunpack (const flux_msg_t *msg, const char **topic,
+                               const char *fmt, va_list ap)
 {
     const char *ts;
     int rc = -1;
@@ -92,14 +92,14 @@ done:
     return rc;
 }
 
-int flux_event_decodef (const flux_msg_t *msg, const char **topic,
-                        const char *fmt, ...)
+int flux_event_unpack (const flux_msg_t *msg, const char **topic,
+                       const char *fmt, ...)
 {
     va_list ap;
     int rc;
 
     va_start (ap, fmt);
-    rc = flux_event_vdecodef (msg, topic, fmt, ap);
+    rc = flux_event_vunpack (msg, topic, fmt, ap);
     va_end (ap);
     return rc;
 }

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -18,8 +18,8 @@ int flux_event_decode (const flux_msg_t *msg, const char **topic,
  * jansson unpack style variable arguments for decoding the JSON object
  * payload directly.  Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_event_decodef (const flux_msg_t *msg, const char **topic,
-                        const char *fmt, ...);
+int flux_event_unpack (const flux_msg_t *msg, const char **topic,
+                       const char *fmt, ...);
 
 /* Encode an event message.
  * If json_str is non-NULL, it is copied to the message payload.

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -31,7 +31,7 @@ flux_msg_t *flux_event_encode (const char *topic, const char *json_str);
  * jansson pack style variable arguments for encoding the JSON object
  * payload directly.  Returns message or NULL on failure with errno set.
  */
-flux_msg_t *flux_event_encodef (const char *topic, const char *fmt, ...);
+flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...);
 
 #endif /* !FLUX_CORE_EVENT_H */
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -238,7 +238,7 @@ static int dmesg_rpc_get (flux_future_t *f, int *seq, flux_log_f fun, void *arg)
     const char *buf;
     int rc = -1;
 
-    if (flux_rpc_getf (f, "{s:i s:s}", "seq", seq, "buf", &buf) < 0)
+    if (flux_rpc_get_unpack (f, "{s:i s:s}", "seq", seq, "buf", &buf) < 0)
         goto done;
     fun (buf, strlen (buf), arg);
     rc = 0;

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -216,8 +216,8 @@ static int dmesg_clear (flux_t *h, int seq)
     flux_future_t *f;
     int rc = -1;
 
-    if (!(f = flux_rpcf (h, "log.clear", FLUX_NODEID_ANY, 0,
-                           "{s:i}", "seq", seq)))
+    if (!(f = flux_rpc_pack (h, "log.clear", FLUX_NODEID_ANY, 0,
+                             "{s:i}", "seq", seq)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;
@@ -229,8 +229,8 @@ done:
 
 static flux_future_t *dmesg_rpc (flux_t *h, int seq, bool follow)
 {
-    return flux_rpcf (h, "log.dmesg", FLUX_NODEID_ANY, 0,
-                      "{s:i s:b}", "seq", seq, "follow", follow);
+    return flux_rpc_pack (h, "log.dmesg", FLUX_NODEID_ANY, 0,
+                          "{s:i s:b}", "seq", seq, "follow", follow);
 }
 
 static int dmesg_rpc_get (flux_future_t *f, int *seq, flux_log_f fun, void *arg)

--- a/src/common/libflux/heartbeat.c
+++ b/src/common/libflux/heartbeat.c
@@ -36,7 +36,7 @@ flux_msg_t *flux_heartbeat_encode (int epoch)
 {
     flux_msg_t *msg = NULL;
 
-    if (!(msg = flux_event_encodef ("hb", "{ s:i }", "epoch", epoch)))
+    if (!(msg = flux_event_pack ("hb", "{ s:i }", "epoch", epoch)))
         return NULL;
     return msg;
 }

--- a/src/common/libflux/heartbeat.c
+++ b/src/common/libflux/heartbeat.c
@@ -46,7 +46,7 @@ int flux_heartbeat_decode (const flux_msg_t *msg, int *epoch)
     const char *topic_str;
     int rc = -1;
 
-    if (flux_event_decodef (msg, &topic_str, "{ s:i }", "epoch", epoch) < 0)
+    if (flux_event_unpack (msg, &topic_str, "{ s:i }", "epoch", epoch) < 0)
         goto done;
     if (strcmp (topic_str, "hb") != 0) {
         errno = EPROTO;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1050,7 +1050,7 @@ done:
     return rc;
 }
 
-int flux_msg_set_jsonf (flux_msg_t *msg, const char *fmt, ...)
+int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...)
 {
     va_list ap;
     int rc;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1025,7 +1025,7 @@ done:
     return rc;
 }
 
-int flux_msg_vset_jsonf (flux_msg_t *msg, const char *fmt, va_list ap)
+int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap)
 {
     json_error_t error;
     char *json_str = NULL;
@@ -1056,7 +1056,7 @@ int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...)
     int rc;
 
     va_start (ap, fmt);
-    rc = flux_msg_vset_jsonf (msg, fmt, ap);
+    rc = flux_msg_vpack (msg, fmt, ap);
     va_end (ap);
     return rc;
 }

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1154,7 +1154,7 @@ done:
  * allow msg to be "annotated" with parsed json object for convenience.
  * The message content is otherwise unchanged.
  */
-int flux_msg_vget_jsonf (const flux_msg_t *cmsg, const char *fmt, va_list ap)
+int flux_msg_vunpack (const flux_msg_t *cmsg, const char *fmt, va_list ap)
 {
     int rc = -1;
     const char *json_str;
@@ -1188,7 +1188,7 @@ int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...)
     int rc;
 
     va_start (ap, fmt);
-    rc = flux_msg_vget_jsonf (msg, fmt, ap);
+    rc = flux_msg_vunpack (msg, fmt, ap);
     va_end (ap);
     return rc;
 }

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1182,7 +1182,7 @@ done:
     return rc;
 }
 
-int flux_msg_get_jsonf (const flux_msg_t *msg, const char *fmt, ...)
+int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...)
 {
     va_list ap;
     int rc;

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -168,7 +168,7 @@ bool flux_msg_has_payload (const flux_msg_t *msg);
 /* Get/set JSON payload.
  * flux_msg_set_json() accepts a NULL json_str (no payload).
  * flux_msg_get_json() will set json_str to NULL if there is no payload
- * jsonf functions use jansson pack/unpack style arguments for
+ * pack/unpack functions use jansson pack/unpack style arguments for
  * encoding/decoding the JSON object payload directly from/to its members.
  */
 int flux_msg_set_json (flux_msg_t *msg, const char *json_str);
@@ -176,7 +176,7 @@ int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap);
 
 int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);
-int flux_msg_get_jsonf (const flux_msg_t *msg, const char *fmt, ...);
+int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vget_jsonf (const flux_msg_t *msg, const char *fmt, va_list ap);
 
 /* Get/set nodeid (request only)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -172,7 +172,7 @@ bool flux_msg_has_payload (const flux_msg_t *msg);
  * encoding/decoding the JSON object payload directly from/to its members.
  */
 int flux_msg_set_json (flux_msg_t *msg, const char *json_str);
-int flux_msg_set_jsonf (flux_msg_t *msg, const char *fmt, ...);
+int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vset_jsonf (flux_msg_t *msg, const char *fmt, va_list ap);
 
 int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -177,7 +177,7 @@ int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap);
 
 int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);
 int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...);
-int flux_msg_vget_jsonf (const flux_msg_t *msg, const char *fmt, va_list ap);
+int flux_msg_vunpack (const flux_msg_t *msg, const char *fmt, va_list ap);
 
 /* Get/set nodeid (request only)
  * If flags includes FLUX_MSGFLAG_UPSTREAM, nodeid is the sending rank.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -173,7 +173,7 @@ bool flux_msg_has_payload (const flux_msg_t *msg);
  */
 int flux_msg_set_json (flux_msg_t *msg, const char *json_str);
 int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...);
-int flux_msg_vset_jsonf (flux_msg_t *msg, const char *fmt, va_list ap);
+int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap);
 
 int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);
 int flux_msg_get_jsonf (const flux_msg_t *msg, const char *fmt, ...);

--- a/src/common/libflux/mrpc.c
+++ b/src/common/libflux/mrpc.c
@@ -518,7 +518,7 @@ flux_mrpc_t *flux_mrpcf (flux_t *h,
     va_start (ap, fmt);
     if (!(msg = flux_request_encode (topic, NULL)))
         goto done;
-    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vpack (msg, fmt, ap) < 0)
         goto done;
     rc = mrpc (h, nodeset, flags, msg);
 done:

--- a/src/common/libflux/mrpc.c
+++ b/src/common/libflux/mrpc.c
@@ -269,7 +269,7 @@ static int flux_mrpc_vgetf (flux_mrpc_t *mrpc, const char *fmt, va_list ap)
         errno = EPROTO;
         goto done;
     }
-    if (flux_msg_vget_jsonf (mrpc->rx_msg, fmt, ap) < 0)
+    if (flux_msg_vunpack (mrpc->rx_msg, fmt, ap) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libflux/panic.c
+++ b/src/common/libflux/panic.c
@@ -42,8 +42,8 @@ int flux_panic (flux_t *h, int rank, const char *msg)
     flux_future_t *f = NULL;
     int rc = -1;
 
-    f = flux_rpcf (h, "cmb.panic", nodeid, FLUX_RPC_NORESPONSE,
-                   "{s:s}", "msg", msg ? msg : "");
+    f = flux_rpc_pack (h, "cmb.panic", nodeid, FLUX_RPC_NORESPONSE,
+                       "{s:s}", "msg", msg ? msg : "");
     if (!f)
         goto done;
     /* No reply */

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -114,7 +114,7 @@ static int flux_request_vdecodef (const flux_msg_t *msg, const char **topic,
     }
     if (request_decode (msg, &ts) < 0)
         goto done;
-    if (flux_msg_vget_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vunpack (msg, fmt, ap) < 0)
         goto done;
     if (topic)
         *topic = ts;

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -102,8 +102,8 @@ done:
     return rc;
 }
 
-static int flux_request_vdecodef (const flux_msg_t *msg, const char **topic,
-                                  const char *fmt, va_list ap)
+static int flux_request_vunpack (const flux_msg_t *msg, const char **topic,
+                                 const char *fmt, va_list ap)
 {
     const char *ts;
     int rc = -1;
@@ -123,14 +123,14 @@ done:
     return rc;
 }
 
-int flux_request_decodef (const flux_msg_t *msg, const char **topic,
-                          const char *fmt, ...)
+int flux_request_unpack (const flux_msg_t *msg, const char **topic,
+                         const char *fmt, ...)
 {
     va_list ap;
     int rc;
 
     va_start (ap, fmt);
-    rc = flux_request_vdecodef (msg, topic, fmt, ap);
+    rc = flux_request_vunpack (msg, topic, fmt, ap);
     va_end (ap);
     return rc;
 }

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -18,8 +18,8 @@ int flux_request_decode (const flux_msg_t *msg, const char **topic,
  * jansson unpack style variable arguments for decoding the JSON object
  * payload directly.  Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_request_decodef (const flux_msg_t *msg, const char **topic,
-                          const char *fmt, ...);
+int flux_request_unpack (const flux_msg_t *msg, const char **topic,
+                         const char *fmt, ...);
 
 /* Decode a request message with optional raw payload.
  * If topic is non-NULL, assign the request topic string.

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -217,8 +217,8 @@ fatal:
     return -1;
 }
 
-static int flux_vrespondf (flux_t *h, const flux_msg_t *request,
-                    const char *fmt, va_list ap)
+static int flux_respond_vpack (flux_t *h, const flux_msg_t *request,
+                               const char *fmt, va_list ap)
 {
     flux_msg_t *msg = derive_response (h, request, 0);
     if (!msg)
@@ -235,14 +235,14 @@ fatal:
     return -1;
 }
 
-int flux_respondf (flux_t *h, const flux_msg_t *request,
-                   const char *fmt, ...)
+int flux_respond_pack (flux_t *h, const flux_msg_t *request,
+                       const char *fmt, ...)
 {
     int rc;
     va_list ap;
 
     va_start (ap, fmt);
-    rc = flux_vrespondf (h, request, fmt, ap);
+    rc = flux_respond_vpack (h, request, fmt, ap);
     va_end (ap);
     return rc;
 }

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -223,7 +223,7 @@ static int flux_vrespondf (flux_t *h, const flux_msg_t *request,
     flux_msg_t *msg = derive_response (h, request, 0);
     if (!msg)
         goto fatal;
-    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vpack (msg, fmt, ap) < 0)
         goto fatal;
     if (flux_send (h, msg, 0) < 0)
         goto fatal;

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -48,8 +48,8 @@ int flux_respond (flux_t *h, const flux_msg_t *request,
  * payload directly.
  * All errors in this function are fatal - see flux_fatal_set().
  */
-int flux_respondf (flux_t *h, const flux_msg_t *request,
-                   const char *fmt, ...);
+int flux_respond_pack (flux_t *h, const flux_msg_t *request,
+                       const char *fmt, ...);
 
 
 /* Create a response to the provided request message with optional raw payload.

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -112,7 +112,7 @@ done:
     return rc;
 }
 
-static int flux_rpc_vgetf (flux_future_t *f, const char *fmt, va_list ap)
+static int flux_rpc_get_vunpack (flux_future_t *f, const char *fmt, va_list ap)
 {
     const flux_msg_t *msg;
     int rc = -1;
@@ -126,13 +126,13 @@ done:
     return rc;
 }
 
-int flux_rpc_getf (flux_future_t *f, const char *fmt, ...)
+int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...)
 {
     va_list ap;
     int rc;
 
     va_start (ap, fmt);
-    rc = flux_rpc_vgetf (f, fmt, ap);
+    rc = flux_rpc_get_vunpack (f, fmt, ap);
     va_end (ap);
 
     return rc;

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -119,7 +119,7 @@ static int flux_rpc_vgetf (flux_future_t *f, const char *fmt, va_list ap)
 
     if (flux_future_get (f, &msg) < 0)
         goto done;
-    if (flux_msg_vget_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vunpack (msg, fmt, ap) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -295,7 +295,7 @@ static flux_future_t *flux_vrpcf (flux_t *h,
 
     if (!(msg = flux_request_encode (topic, NULL)))
         goto done;
-    if (flux_msg_vset_jsonf (msg, fmt, ap) < 0)
+    if (flux_msg_vpack (msg, fmt, ap) < 0)
         goto done;
     f = flux_rpc_msg (h, nodeid, flags, msg);
 done:

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -284,11 +284,11 @@ done:
     return f;
 }
 
-static flux_future_t *flux_vrpcf (flux_t *h,
-                                  const char *topic,
-                                  uint32_t nodeid,
-                                  int flags,
-                                  const char *fmt, va_list ap)
+static flux_future_t *flux_rpc_vpack (flux_t *h,
+                                      const char *topic,
+                                      uint32_t nodeid,
+                                      int flags,
+                                      const char *fmt, va_list ap)
 {
     flux_msg_t *msg;
     flux_future_t *f = NULL;
@@ -303,14 +303,14 @@ done:
     return f;
 }
 
-flux_future_t *flux_rpcf (flux_t *h, const char *topic, uint32_t nodeid,
-                          int flags, const char *fmt, ...)
+flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
+                              int flags, const char *fmt, ...)
 {
     va_list ap;
     flux_future_t *f;
 
     va_start (ap, fmt);
-    f = flux_vrpcf (h, topic, nodeid, flags, fmt, ap);
+    f = flux_rpc_vpack (h, topic, nodeid, flags, fmt, ap);
     va_end (ap);
     return f;
 }

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -14,8 +14,8 @@ enum {
 flux_future_t *flux_rpc (flux_t *h, const char *topic, const char *json_str,
                          uint32_t nodeid, int flags);
 
-flux_future_t *flux_rpcf (flux_t *h, const char *topic, uint32_t nodeid,
-                          int flags, const char *fmt, ...);
+flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
+                              int flags, const char *fmt, ...);
 
 flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
                              const void *data, int len,

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -23,7 +23,7 @@ flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
 
 int flux_rpc_get (flux_future_t *f, const char **json_str);
 
-int flux_rpc_getf (flux_future_t *f, const char *fmt, ...);
+int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 int flux_rpc_get_raw (flux_future_t *f, void *data, int *len);
 

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -46,8 +46,8 @@ int main (int argc, char *argv[])
     flux_msg_destroy (msg);
 
     /* formatted payload */
-    ok ((msg = flux_event_encodef ("foo.bar", "{s:i}", "foo", 42)) != NULL,
-        "flux_event_encodef packed payload object");
+    ok ((msg = flux_event_pack ("foo.bar", "{s:i}", "foo", 42)) != NULL,
+        "flux_event_pack packed payload object");
     i = 0;
     ok (flux_event_unpack (msg, &topic, "{s:i}", "foo", &i) == 0,
         "flux_event_unpack unpacked payload object");

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -49,8 +49,8 @@ int main (int argc, char *argv[])
     ok ((msg = flux_event_encodef ("foo.bar", "{s:i}", "foo", 42)) != NULL,
         "flux_event_encodef packed payload object");
     i = 0;
-    ok (flux_event_decodef (msg, &topic, "{s:i}", "foo", &i) == 0,
-        "flux_event_decodef unpacked payload object");
+    ok (flux_event_unpack (msg, &topic, "{s:i}", "foo", &i) == 0,
+        "flux_event_unpack unpacked payload object");
     ok (i == 42 && topic != NULL && !strcmp (topic, "foo.bar"),
         "unpacked payload matched packed");
     flux_msg_destroy (msg);

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -178,13 +178,13 @@ void check_payload_json_formatted (void)
         "flux_msg_get_jsonf fails with EPROTO with no payload");
 
     errno = 0;
-    ok (flux_msg_set_jsonf (msg, "[i,i,i]", 1,2,3) < 0 && errno == EINVAL,
-        "flux_msg_set_jsonf array fails with EINVAL");
+    ok (flux_msg_pack (msg, "[i,i,i]", 1,2,3) < 0 && errno == EINVAL,
+        "flux_msg_pack array fails with EINVAL");
     errno = 0;
-    ok (flux_msg_set_jsonf (msg, "i", 3.14) < 0 && errno == EINVAL,
-       "flux_msg_set_jsonf scalar fails with EINVAL");
-    ok (flux_msg_set_jsonf (msg, "{s:i, s:s}", "foo", 42, "bar", "baz") == 0,
-       "flux_msg_set_jsonf object works");
+    ok (flux_msg_pack (msg, "i", 3.14) < 0 && errno == EINVAL,
+       "flux_msg_pack scalar fails with EINVAL");
+    ok (flux_msg_pack (msg, "{s:i, s:s}", "foo", 42, "bar", "baz") == 0,
+       "flux_msg_pack object works");
     i = 0;
     s = NULL;
     ok (flux_msg_get_jsonf (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
@@ -193,8 +193,8 @@ void check_payload_json_formatted (void)
         "decoded content matches encoded content");
 
     /* reset payload */
-    ok (flux_msg_set_jsonf (msg, "{s:i, s:s}", "foo", 43, "bar", "smurf") == 0,
-       "flux_msg_set_jsonf can replace JSON object payload");
+    ok (flux_msg_pack (msg, "{s:i, s:s}", "foo", 43, "bar", "smurf") == 0,
+       "flux_msg_pack can replace JSON object payload");
     i = 0;
     s = NULL;
     ok (flux_msg_get_jsonf (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -174,8 +174,8 @@ void check_payload_json_formatted (void)
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
        "flux_msg_create works");
     errno = 0;
-    ok (flux_msg_get_jsonf (msg, "{}") < 0 && errno == EPROTO,
-        "flux_msg_get_jsonf fails with EPROTO with no payload");
+    ok (flux_msg_unpack (msg, "{}") < 0 && errno == EPROTO,
+        "flux_msg_unpack fails with EPROTO with no payload");
 
     errno = 0;
     ok (flux_msg_pack (msg, "[i,i,i]", 1,2,3) < 0 && errno == EINVAL,
@@ -187,8 +187,8 @@ void check_payload_json_formatted (void)
        "flux_msg_pack object works");
     i = 0;
     s = NULL;
-    ok (flux_msg_get_jsonf (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
-       "flux_msg_get_jsonf object works");
+    ok (flux_msg_unpack (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
+       "flux_msg_unpack object works");
     ok (i == 42 && s != NULL && !strcmp (s, "baz"),
         "decoded content matches encoded content");
 
@@ -197,29 +197,29 @@ void check_payload_json_formatted (void)
        "flux_msg_pack can replace JSON object payload");
     i = 0;
     s = NULL;
-    ok (flux_msg_get_jsonf (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
-       "flux_msg_get_jsonf object works");
+    ok (flux_msg_unpack (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
+       "flux_msg_unpack object works");
     ok (i == 43 && s != NULL && !strcmp (s, "smurf"),
         "decoded content matches new encoded content");
 
     i = 0;
     s = NULL;
-    ok (flux_msg_get_jsonf (msg, "{s:s, s:i}", "bar", &s, "foo", &i) == 0,
-       "flux_msg_get_jsonf object works out of order");
+    ok (flux_msg_unpack (msg, "{s:s, s:i}", "bar", &s, "foo", &i) == 0,
+       "flux_msg_unpack object works out of order");
     ok (i == 43 && s != NULL && !strcmp (s, "smurf"),
         "decoded content matches new encoded content");
 
     errno = 0;
-    ok (flux_msg_get_jsonf (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_jsonf fails with EINVAL with NULL format");
+    ok (flux_msg_unpack (msg, NULL) < 0 && errno == EINVAL,
+        "flux_msg_unpack fails with EINVAL with NULL format");
 
     errno = 0;
-    ok (flux_msg_get_jsonf (msg, "") < 0 && errno == EINVAL,
-        "flux_msg_get_jsonf fails with EINVAL with \"\" format");
+    ok (flux_msg_unpack (msg, "") < 0 && errno == EINVAL,
+        "flux_msg_unpack fails with EINVAL with \"\" format");
 
     errno = 0;
-    ok (flux_msg_get_jsonf (msg, "{s:s}", "nope", &s) < 0 && errno == EPROTO,
-        "flux_msg_get_jsonf fails with EPROTO with nonexistent key");
+    ok (flux_msg_unpack (msg, "{s:s}", "nope", &s) < 0 && errno == EPROTO,
+        "flux_msg_unpack fails with EPROTO with nonexistent key");
 
     flux_msg_destroy (msg);
 }

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -49,9 +49,9 @@ int main (int argc, char *argv[])
         "flux_request_decode returns encoded payload");
     topic = NULL;
     i = 0;
-    ok (flux_request_decodef (msg, &topic, "{s:i}", "a", &i) == 0
+    ok (flux_request_unpack (msg, &topic, "{s:i}", "a", &i) == 0
         && i == 42 && topic != NULL && !strcmp (topic, "foo.bar"),
-        "flux_request_decodef returns encoded payload");
+        "flux_request_unpack returns encoded payload");
 
     errno = 0;
     ok (flux_request_decode (msg, NULL, NULL) == 0,

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -669,8 +669,8 @@ static int send_state_event (flux_t *h, job_state_t st, int64_t j)
                         jsc_job_num2state (st));
         goto done;
     }
-    if ((msg = flux_event_encodef (topic, "{ s:I }", "lwj", j)) == NULL) {
-        flux_log_error (h, "flux_event_encodef");
+    if ((msg = flux_event_pack (topic, "{ s:I }", "lwj", j)) == NULL) {
+        flux_log_error (h, "flux_event_pack");
         goto done;
     }
     if (flux_send (h, msg, 0) < 0)

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -1013,12 +1013,12 @@ static void job_state_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_msg_get_topic (msg, &topic) < 0)
         goto done;
 
-    if (flux_event_decodef (msg, NULL, "{ s:I }", "lwj", &jobid) < 0) {
+    if (flux_event_unpack (msg, NULL, "{ s:I }", "lwj", &jobid) < 0) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         goto done;
     }
 
-    if (!flux_event_decodef (msg, NULL, "{ s:s }", "kvs_path", &kvs_path)) {
+    if (!flux_event_unpack (msg, NULL, "{ s:s }", "kvs_path", &kvs_path)) {
         if (jscctx_add_jobid_path (getctx (h), jobid, kvs_path) < 0)
             flux_log_error (h, "jscctx_add_jobid_path");
     }

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -369,7 +369,7 @@ static int extract_raw_nnodes (flux_t *h, int64_t j, int64_t *nnodes)
     flux_future_t *f = NULL;
 
     if (!key || !(f = flux_kvs_lookup (h, 0, key))
-             || flux_kvs_lookup_getf (f, "I", nnodes) < 0) {
+             || flux_kvs_lookup_get_unpack (f, "I", nnodes) < 0) {
         flux_log_error (h, "extract %s", key);
         rc = -1;
     }
@@ -387,7 +387,7 @@ static int extract_raw_ntasks (flux_t *h, int64_t j, int64_t *ntasks)
     flux_future_t *f = NULL;
 
     if (!key || !(f = flux_kvs_lookup (h, 0, key))
-             || flux_kvs_lookup_getf (f, "I", ntasks) < 0) {
+             || flux_kvs_lookup_get_unpack (f, "I", ntasks) < 0) {
         flux_log_error (h, "extract %s", key);
         rc = -1;
     }
@@ -405,7 +405,7 @@ static int extract_raw_walltime (flux_t *h, int64_t j, int64_t *walltime)
     flux_future_t *f = NULL;
 
     if (!key || !(f = flux_kvs_lookup (h, 0, key))
-             || flux_kvs_lookup_getf (f, "I", walltime) < 0) {
+             || flux_kvs_lookup_get_unpack (f, "I", walltime) < 0) {
         flux_log_error (h, "extract %s", key);
         rc = -1;
     }
@@ -424,7 +424,7 @@ static int extract_raw_rdl (flux_t *h, int64_t j, char **rdlstr)
     flux_future_t *f = NULL;
 
     if (!key || !(f = flux_kvs_lookup (h, 0, key))
-             || flux_kvs_lookup_getf (f, "s", &s) < 0) {
+             || flux_kvs_lookup_get_unpack (f, "s", &s) < 0) {
         flux_log_error (h, "extract %s", key);
         rc = -1;
     }
@@ -445,7 +445,7 @@ static int extract_raw_state (flux_t *h, int64_t j, int64_t *s)
     flux_future_t *f = NULL;
 
     if (!key || !(f = flux_kvs_lookup (h, 0, key))
-             || flux_kvs_lookup_getf (f, "s", &state) < 0) {
+             || flux_kvs_lookup_get_unpack (f, "s", &state) < 0) {
         flux_log_error (h, "extract %s", key);
         rc = -1;
     }
@@ -558,7 +558,7 @@ static int extract_raw_rdl_alloc (flux_t *h, int64_t j, json_object *jcb)
         flux_future_t *f = NULL;
         int64_t cores = 0;
         if (!key || !(f = flux_kvs_lookup (h, 0, key))
-                 || flux_kvs_lookup_getf (f, "I", &cores) < 0) {
+                 || flux_kvs_lookup_get_unpack (f, "I", &cores) < 0) {
             if (errno != EINVAL)
                 flux_log_error (h, "extract %s", key);
             processing = false;

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -397,8 +397,8 @@ int kvs_wait_version (flux_t *h, int version)
     flux_future_t *f;
     int ret = -1;
 
-    if (!(f = flux_rpcf (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i }",
-                           "rootseq", version)))
+    if (!(f = flux_rpc_pack (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i }",
+                             "rootseq", version)))
         goto done;
     /* N.B. response contains (rootseq, rootdir) but we don't need it.
      */

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -382,7 +382,7 @@ int kvs_get_version (flux_t *h, int *versionp)
 
     if (!(f = flux_rpc (h, "kvs.getroot", NULL, FLUX_NODEID_ANY, 0)))
         goto done;
-    if (flux_rpc_getf (f, "{ s:i }", "rootseq", &version) < 0)
+    if (flux_rpc_get_unpack (f, "{ s:i }", "rootseq", &version) < 0)
         goto done;
     if (versionp)
         *versionp = version;

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -71,7 +71,7 @@ int flux_kvs_lookup_get (flux_future_t *f, const char **json_str)
     char *s;
 
     if (!(s = flux_future_aux_get (f, auxkey))) {
-        if (flux_rpc_getf (f, "{s:o}", "val", &obj) < 0)
+        if (flux_rpc_get_unpack (f, "{s:o}", "val", &obj) < 0)
             return -1;
         if (!(s = json_dumps (obj, JSON_COMPACT|JSON_ENCODE_ANY))) {
             errno = EINVAL;
@@ -94,7 +94,7 @@ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...)
     json_t *obj;
     int rc;
 
-    if (flux_rpc_getf (f, "{s:o}", "val", &obj) < 0)
+    if (flux_rpc_get_unpack (f, "{s:o}", "val", &obj) < 0)
         return -1;
     va_start (ap, fmt);
     if ((rc = json_vunpack_ex (obj, NULL, 0, fmt, ap) < 0))

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -88,7 +88,7 @@ int flux_kvs_lookup_get (flux_future_t *f, const char **json_str)
     return 0;
 }
 
-int flux_kvs_lookup_getf (flux_future_t *f, const char *fmt, ...)
+int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...)
 {
     va_list ap;
     json_t *obj;

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -36,9 +36,9 @@
 
 flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key)
 {
-    return flux_rpcf (h, "kvs.get", FLUX_NODEID_ANY, 0, "{s:s s:i}",
-                                                        "key", key,
-                                                        "flags", flags);
+    return flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0, "{s:s s:i}",
+                                                            "key", key,
+                                                            "flags", flags);
 }
 
 flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
@@ -55,10 +55,10 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
             errno = EINVAL;
             return NULL;
         }
-        f = flux_rpcf (h, "kvs.get", FLUX_NODEID_ANY, 0, "{s:s s:i s:O}",
-                                                         "key", key,
-                                                         "flags", flags,
-                                                         "rootdir", obj);
+        f = flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0, "{s:s s:i s:O}",
+                                                             "key", key,
+                                                             "flags", flags,
+                                                             "rootdir", obj);
     }
     json_decref (obj);
     return f;

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -12,7 +12,7 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
                                   const char *treeobj);
 
 int flux_kvs_lookup_get (flux_future_t *f, const char **json_str);
-int flux_kvs_lookup_getf (flux_future_t *f, const char *fmt, ...);
+int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 #endif /* !_FLUX_CORE_KVS_LOOKUP_H */
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -157,8 +157,8 @@ static int op_event (void *impl, const char *topic, const char *msg_topic)
 
     assert (c->magic == CTX_MAGIC);
 
-    if (!(f = flux_rpcf (c->h, msg_topic, FLUX_NODEID_ANY, 0,
-                           "{s:s}", "topic", topic)))
+    if (!(f = flux_rpc_pack (c->h, msg_topic, FLUX_NODEID_ANY, 0,
+                             "{s:s}", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -139,8 +139,8 @@ static int op_event_subscribe (void *impl, const char *topic)
     flux_future_t *f;
     int rc = -1;
 
-    if (!(f = flux_rpcf (ctx->h, "cmb.sub", FLUX_NODEID_ANY, 0,
-                           "{ s:s }", "topic", topic)))
+    if (!(f = flux_rpc_pack (ctx->h, "cmb.sub", FLUX_NODEID_ANY, 0,
+                             "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;
@@ -157,8 +157,8 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     flux_future_t *f = NULL;
     int rc = -1;
 
-    if (!(f = flux_rpcf (ctx->h, "cmb.unsub", FLUX_NODEID_ANY, 0,
-                           "{ s:s }", "topic", topic)))
+    if (!(f = flux_rpc_pack (ctx->h, "cmb.unsub", FLUX_NODEID_ANY, 0,
+                             "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -138,8 +138,8 @@ static int op_event_subscribe (void *impl, const char *topic)
     flux_future_t *f;
     int rc = 0;
 
-    if (!(f = flux_rpcf (c->h, "local.sub", FLUX_NODEID_ANY, 0,
-                           "{ s:s }", "topic", topic)))
+    if (!(f = flux_rpc_pack (c->h, "local.sub", FLUX_NODEID_ANY, 0,
+                             "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;
@@ -156,8 +156,8 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     flux_future_t *f;
     int rc = 0;
 
-    if (!(f = flux_rpcf (c->h, "local.unsub", FLUX_NODEID_ANY, 0,
-                           "{ s:s }", "topic", topic)))
+    if (!(f = flux_rpc_pack (c->h, "local.unsub", FLUX_NODEID_ANY, 0,
+                             "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -197,11 +197,11 @@ static void enter_request_cb (flux_t *h, flux_msg_handler_t *w,
     const char *name;
     int count, nprocs, internal;
 
-    if (flux_request_decodef (msg, NULL, "{s:s s:i s:i s:b !}",
-                              "name", &name,
-                              "count", &count,
-                              "nprocs", &nprocs,
-                              "internal", &internal) < 0
+    if (flux_request_unpack (msg, NULL, "{s:s s:i s:i s:b !}",
+                             "name", &name,
+                             "count", &count,
+                             "nprocs", &nprocs,
+                             "internal", &internal) < 0
                 || flux_msg_get_route_first (msg, &sender) < 0) {
         flux_log_error (ctx->h, "%s: decoding request", __FUNCTION__);
         goto done;

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -270,9 +270,9 @@ static int exit_event_send (flux_t *h, const char *name, int errnum)
     flux_msg_t *msg = NULL;
     int rc = -1;
 
-    if (!(msg = flux_event_encodef ("barrier.exit", "{s:s s:i}",
-                                    "name", name,
-                                    "errnum", errnum)))
+    if (!(msg = flux_event_pack ("barrier.exit", "{s:s s:i}",
+                                 "name", name,
+                                 "errnum", errnum)))
         goto done;
     if (flux_send (h, msg, 0) < 0)
         goto done;

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -168,12 +168,12 @@ static void send_enter_request (barrier_ctx_t *ctx, barrier_t *b)
 {
     flux_future_t *f;
 
-    if (!(f = flux_rpcf (ctx->h, "barrier.enter", FLUX_NODEID_UPSTREAM,
-                           FLUX_RPC_NORESPONSE, "{s:s s:i s:i s:b}",
-                           "name", b->name,
-                           "count", b->count,
-                           "nprocs", b->nprocs,
-                           "internal", true))) {
+    if (!(f = flux_rpc_pack (ctx->h, "barrier.enter", FLUX_NODEID_UPSTREAM,
+                             FLUX_RPC_NORESPONSE, "{s:s s:i s:i s:b}",
+                             "name", b->name,
+                             "count", b->count,
+                             "nprocs", b->nprocs,
+                             "internal", true))) {
         flux_log_error (ctx->h, "sending barrier.enter request");
         goto done;
     }

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -292,9 +292,9 @@ static void exit_event_cb (flux_t *h, flux_msg_handler_t *w,
     const char *key;
     flux_msg_t *req;
 
-    if (flux_event_decodef (msg, NULL, "{s:s s:i !}",
-                            "name", &name,
-                            "errnum", &errnum) < 0) {
+    if (flux_event_unpack (msg, NULL, "{s:s s:i !}",
+                           "name", &name,
+                           "errnum", &errnum) < 0) {
         flux_log_error (h, "%s: decoding event", __FUNCTION__);
         return;
     }

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -449,7 +449,7 @@ int sub_request (client_t *c, const flux_msg_t *msg, bool subscribe)
     const char *topic;
     int rc = -1;
 
-    if (flux_request_decodef (msg, NULL, "{s:s}", "topic", &topic) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "topic", &topic) < 0)
         goto done;
     if (subscribe)
         rc = client_subscribe (c, topic);

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -169,7 +169,7 @@ static int lookup_userdb (flux_t *h, uint32_t userid, uint32_t *rolemask)
     if (!(f = flux_rpc_pack (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
                              "{s:i}", "userid", userid)))
         goto done;
-    if (flux_rpc_getf (f, "{s:i}", "rolemask", rolemask) < 0)
+    if (flux_rpc_get_unpack (f, "{s:i}", "rolemask", rolemask) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -166,8 +166,8 @@ static int lookup_userdb (flux_t *h, uint32_t userid, uint32_t *rolemask)
     flux_future_t *f;
     int rc = -1;
 
-    if (!(f = flux_rpcf (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
-                           "{s:i}", "userid", userid)))
+    if (!(f = flux_rpc_pack (h, "userdb.lookup", FLUX_NODEID_ANY, 0,
+                             "{s:i}", "userid", userid)))
         goto done;
     if (flux_rpc_getf (f, "{s:i}", "rolemask", rolemask) < 0)
         goto done;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -393,10 +393,10 @@ int register_backing_store (flux_t *h, bool value, const char *name)
     int saved_errno = 0;
     int rc = -1;
 
-    if (!(f = flux_rpcf (h, "content.backing", FLUX_NODEID_ANY, 0,
-                           "{ s:b s:s }",
-                           "backing", value,
-                           "name", name)))
+    if (!(f = flux_rpc_pack (h, "content.backing", FLUX_NODEID_ANY, 0,
+                             "{ s:b s:s }",
+                             "backing", value,
+                             "name", name)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -717,13 +717,13 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
         ctx->sync_epsilon = epsilon;
 
     if (ctx->sync_event) {
-        if (flux_respondf (h, msg, "{ s:s s:f }",
-                           "sync_event", ctx->sync_event,
-                           "sync_epsilon", ctx->sync_epsilon) < 0)
-            flux_log_error (h, "cron.request: flux_respondf");
+        if (flux_respond_pack (h, msg, "{ s:s s:f }",
+                               "sync_event", ctx->sync_event,
+                               "sync_epsilon", ctx->sync_epsilon) < 0)
+            flux_log_error (h, "cron.request: flux_respond_pack");
     } else {
-        if (flux_respondf (h, msg, "{ s:b }", "sync_disabled", true) < 0)
-            flux_log_error (h, "cron.request: flux_respondf");
+        if (flux_respond_pack (h, msg, "{ s:b }", "sync_disabled", true) < 0)
+            flux_log_error (h, "cron.request: flux_respond_pack");
     }
     return;
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -343,13 +343,13 @@ static int64_t next_cronid (flux_t *h)
     int64_t ret = (int64_t) -1;
     flux_future_t *f;
 
-    if (!(f = flux_rpcf (h, "seq.fetch", 0, 0,
-                           "{ s:s s:i s:i s:b }",
-                           "name", "cron",
-                           "preincrement", 1,
-                           "postincrement", 0,
-                           "create", true))) {
-        flux_log_error (h, "flux_rpcf");
+    if (!(f = flux_rpc_pack (h, "seq.fetch", 0, 0,
+                             "{ s:s s:i s:i s:b }",
+                             "name", "cron",
+                             "preincrement", 1,
+                             "postincrement", 0,
+                             "create", true))) {
+        flux_log_error (h, "flux_rpc_pack");
         goto out;
     }
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -700,11 +700,11 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
     double epsilon;
     int rc = -1;
 
-    if (flux_request_decodef (msg, NULL, "{}") < 0)
+    if (flux_request_unpack (msg, NULL, "{}") < 0)
         goto error;
-    if (flux_request_decodef (msg, NULL, "{ s:s }", "topic", &topic) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         topic = NULL; /* Disable sync-event */
-    if (flux_request_decodef (msg, NULL, "{ s:b }", "disable", &disable) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:b }", "disable", &disable) < 0)
         disable = false;
 
     if (topic || disable)
@@ -713,7 +713,7 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
     if (rc < 0)
         goto error;
 
-    if (!flux_request_decodef (msg, NULL, "{ s:F }", "sync_epsilon", &epsilon))
+    if (!flux_request_unpack (msg, NULL, "{ s:F }", "sync_epsilon", &epsilon))
         ctx->sync_epsilon = epsilon;
 
     if (ctx->sync_event) {
@@ -749,7 +749,7 @@ static cron_entry_t *entry_from_request (flux_t *h, const flux_msg_t *msg,
 {
     int64_t id;
 
-    if (flux_request_decodef (msg, NULL, "{ s:I }", "id", &id) < 0) {
+    if (flux_request_unpack (msg, NULL, "{ s:I }", "id", &id) < 0) {
         flux_log_error (h, "%s: request decodef", service);
         return NULL;
     }
@@ -779,7 +779,7 @@ static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
     rc = 0;
     out = cron_entry_to_json (e);
     if (e->task
-        && !flux_request_decodef (msg, NULL, "{ s:b }", "kill", &kill)
+        && !flux_request_unpack (msg, NULL, "{ s:b }", "kill", &kill)
         && kill == true)
         cron_task_kill (e->task, SIGTERM);
     cron_entry_destroy (e);

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -353,8 +353,8 @@ static int64_t next_cronid (flux_t *h)
         goto out;
     }
 
-    if (flux_rpc_getf (f, "{ s:I }", "value", &ret) < 0) {
-        flux_log_error (h, "next_cronid: rpc_getf");
+    if (flux_rpc_get_unpack (f, "{ s:I }", "value", &ret) < 0) {
+        flux_log_error (h, "next_cronid: rpc_get_unpack");
         goto out;
     }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -997,9 +997,9 @@ static int getroot_rpc (kvs_ctx_t *ctx, int *rootseq, href_t rootdir)
 
     if (!(f = flux_rpc (ctx->h, "kvs.getroot", NULL, FLUX_NODEID_UPSTREAM, 0)))
         goto done;
-    if (flux_rpc_getf (f, "{ s:i s:s }",
-                       "rootseq", rootseq,
-                       "rootdir", &ref) < 0)
+    if (flux_rpc_get_unpack (f, "{ s:i s:s }",
+                             "rootseq", rootseq,
+                             "rootdir", &ref) < 0)
         goto done;
     if (strlen (ref) > sizeof (href_t) - 1) {
         errno = EPROTO;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -960,9 +960,9 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
         wait_addqueue (ctx->watchlist, wait);
         return; /* stall */
     }
-    if (flux_respondf (h, msg, "{ s:i s:s }",
-                       "rootseq", ctx->rootseq,
-                       "rootdir", ctx->rootdir) < 0)
+    if (flux_respond_pack (h, msg, "{ s:i s:s }",
+                           "rootseq", ctx->rootseq,
+                           "rootdir", ctx->rootdir) < 0)
         goto error;
     return;
 
@@ -978,9 +978,9 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
-    if (flux_respondf (h, msg, "{ s:i s:s }",
-                       "rootseq", ctx->rootseq,
-                       "rootdir", ctx->rootdir) < 0)
+    if (flux_respond_pack (h, msg, "{ s:i s:s }",
+                           "rootseq", ctx->rootseq,
+                           "rootdir", ctx->rootdir) < 0)
         goto error;
     return;
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -951,8 +951,8 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
     int rootseq;
     wait_t *wait = NULL;
 
-    if (flux_request_decodef (msg, NULL, "{ s:i }",
-                              "rootseq", &rootseq) < 0)
+    if (flux_request_unpack (msg, NULL, "{ s:i }",
+                             "rootseq", &rootseq) < 0)
         goto error;
     if (ctx->rootseq < rootseq) {
         if (!(wait = wait_create_msg_handler (h, w, msg, sync_request_cb, arg)))

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -81,13 +81,13 @@ static int ctx_hwloc_init (flux_t *h, resource_ctx_t *ctx)
         flux_log_error (h, "flux_kvs_lookup");
         goto done;
     }
-    if (flux_kvs_lookup_getf (f, "s", &path) < 0) {
+    if (flux_kvs_lookup_get_unpack (f, "s", &path) < 0) {
         flux_future_destroy (f);
         if (!(f = flux_kvs_lookup (h, 0, "config.resource.hwloc.default_xml"))) {
             flux_log_error (h, "flux_kvs_lookup");
             goto done;
         }
-        if (flux_kvs_lookup_getf (f, "s", &path) < 0)
+        if (flux_kvs_lookup_get_unpack (f, "s", &path) < 0)
             path = NULL;
     }
 
@@ -454,7 +454,7 @@ static void topo_request_cb (flux_t *h,
         flux_future_t *f;
 
         if (!(f = flux_kvs_lookup (h, 0, key))
-                || flux_kvs_lookup_getf (f, "s", &xml) < 0) {
+                || flux_kvs_lookup_get_unpack (f, "s", &xml) < 0) {
             flux_log_error (h, "%s", base_key);
             flux_future_destroy (f);
             free (key);

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -518,8 +518,9 @@ static void topo_request_cb (flux_t *h,
         errno = EAGAIN;
         goto done;
     } else {
-        if (flux_respondf (h, msg, "{ s:s# }", "topology", buffer, buflen) < 0) {
-            flux_log_error (h, "%s: flux_respondf", __FUNCTION__);
+        if (flux_respond_pack (h, msg, "{ s:s# }",
+                               "topology", buffer, buflen) < 0) {
+            flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
             goto done;
         }
     }

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -377,16 +377,16 @@ static int decode_reload_request (flux_t *h, resource_ctx_t *ctx,
 {
     int walk_topology = ctx->walk_topology;
 
-    if (flux_request_decodef (msg, NULL, "{}") < 0) {
-        flux_log_error (h, "%s: flux_request_decodef", __FUNCTION__);
+    if (flux_request_unpack (msg, NULL, "{}") < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return (-1);
     }
 
     /*
      *  Set ctx->walk_topology to value in payload, if given.
      */
-    if (!flux_request_decodef (msg, NULL, "{ s:b }",
-                               "walk_topology", &walk_topology))
+    if (!flux_request_unpack (msg, NULL, "{ s:b }",
+                              "walk_topology", &walk_topology))
         ctx->walk_topology = walk_topology;
 
     return (0);

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -215,7 +215,7 @@ static void lookup (flux_t *h, flux_msg_handler_t *w,
     uint32_t userid;
     struct user *up;
 
-    if (flux_request_decodef (msg, NULL, "{s:i}", "userid", &userid) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:i}", "userid", &userid) < 0)
         goto error;
     if (!(up = user_lookup (ctx, userid))) {
         if (ctx->default_rolemask != FLUX_ROLE_NONE) {
@@ -240,9 +240,9 @@ static void addrole (flux_t *h, flux_msg_handler_t *w,
     uint32_t userid, rolemask;
     struct user *up;
 
-    if (flux_request_decodef (msg, NULL, "{s:i s:i}",
-                              "userid", &userid,
-                              "rolemask", &rolemask) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:i s:i}",
+                             "userid", &userid,
+                             "rolemask", &rolemask) < 0)
         goto error;
     if (!(up = user_lookup (ctx, userid))) {
         if (rolemask == FLUX_ROLE_NONE)
@@ -271,9 +271,9 @@ static void delrole (flux_t *h, flux_msg_handler_t *w,
     uint32_t userid, rolemask;
     struct user *up;
 
-    if (flux_request_decodef (msg, NULL, "{s:i s:i}",
-                              "userid", &userid,
-                              "rolemask", &rolemask) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:i s:i}",
+                             "userid", &userid,
+                             "rolemask", &rolemask) < 0)
         goto error;
     if (!(up = user_lookup (ctx, userid)))
         goto error;

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -224,8 +224,8 @@ static void lookup (flux_t *h, flux_msg_handler_t *w,
         } else
             goto error;
     }
-    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
-                                            "rolemask", up->rolemask) < 0)
+    if (flux_respond_pack (h, msg, "{s:i s:i}", "userid", up->userid,
+                                                "rolemask", up->rolemask) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
     return;
 error:
@@ -255,8 +255,8 @@ static void addrole (flux_t *h, flux_msg_handler_t *w,
             goto error;
     } else
         up->rolemask |= rolemask;
-    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
-                                            "rolemask", up->rolemask) < 0)
+    if (flux_respond_pack (h, msg, "{s:i s:i}", "userid", up->userid,
+                                                "rolemask", up->rolemask) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
     return;
 error:
@@ -278,8 +278,8 @@ static void delrole (flux_t *h, flux_msg_handler_t *w,
     if (!(up = user_lookup (ctx, userid)))
         goto error;
     up->rolemask &= ~rolemask;
-    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
-                                            "rolemask", up->rolemask) < 0)
+    if (flux_respond_pack (h, msg, "{s:i s:i}", "userid", up->userid,
+                                                "rolemask", up->rolemask) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
     if (up->rolemask == FLUX_ROLE_NONE)
         user_delete (ctx, userid);
@@ -329,8 +329,8 @@ static void getnext (flux_t *h, flux_msg_handler_t *w,
         goto error;
     }
 
-    if (flux_respondf (h, msg, "{s:i s:i}", "userid", up->userid,
-                                            "rolemask", up->rolemask) < 0)
+    if (flux_respond_pack (h, msg, "{s:i s:i}", "userid", up->userid,
+                                                "rolemask", up->rolemask) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
     return;
 error:

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -317,9 +317,10 @@ static void handle_job_create (flux_t *h, const flux_msg_t *msg,
 
 
     /* Generate reply with new jobid */
-    if (flux_respondf (h, msg, "{s:I,s:s,s:s}",
-                "jobid", id, "state", state, "kvs_path", kvs_path) < 0)
-        flux_log_error (h, "flux_respondf");
+    if (flux_respond_pack (h, msg, "{s:I,s:s,s:s}", "jobid", id,
+                                                    "state", state,
+                                                    "kvs_path", kvs_path) < 0)
+        flux_log_error (h, "flux_respond_pack");
 out:
     free (kvs_path);
 }

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -166,8 +166,8 @@ static int64_t next_jobid (flux_t *h)
         flux_log_error (h, "next_jobid: flux_rpc");
         goto out;
     }
-    if ((flux_rpc_getf (f, "{s:I}", "value", &ret)) < 0) {
-        flux_log_error (h, "rpc_getf");
+    if ((flux_rpc_get_unpack (f, "{s:I}", "value", &ret)) < 0) {
+        flux_log_error (h, "rpc_get_unpack");
         goto out;
     }
 out:

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -200,8 +200,8 @@ static void send_create_event (flux_t *h, int64_t id,
                                const char *path, char *topic)
 {
     flux_msg_t *msg;
-    msg = flux_event_encodef (topic, "{s:I,s:s}",
-                              "lwj", id, "kvs_path", path);
+    msg = flux_event_pack (topic, "{s:I,s:s}",
+                          "lwj", id, "kvs_path", path);
     if (msg == NULL) {
         flux_log_error (h, "failed to create state change event");
         return;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -157,11 +157,11 @@ static int64_t next_jobid (flux_t *h)
     int64_t ret = (int64_t) -1;
     flux_future_t *f;
 
-    f = flux_rpcf (h, "seq.fetch", 0, 0, "{s:s,s:i,s:i,s:b}",
-                        "name", "lwj",
-                        "preincrement", 1,
-                        "postincrement", 0,
-                        "create", true);
+    f = flux_rpc_pack (h, "seq.fetch", 0, 0, "{s:s,s:i,s:i,s:b}",
+                       "name", "lwj",
+                       "preincrement", 1,
+                       "postincrement", 0,
+                       "create", true);
     if (f == NULL) {
         flux_log_error (h, "next_jobid: flux_rpc");
         goto out;
@@ -252,7 +252,7 @@ static bool ping_sched (flux_t *h)
 {
     bool retval = false;
     flux_future_t *f;
-    if (!(f = flux_rpcf (h, "sched.ping", 0, 0, "{s:i}", "seq", 0))) {
+    if (!(f = flux_rpc_pack (h, "sched.ping", 0, 0, "{s:i}", "seq", 0))) {
         flux_log_error (h, "ping_sched");
         goto out;
     }

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1158,10 +1158,10 @@ void send_job_state_event (struct prog_ctx *ctx, const char *state)
         goto out;
     }
 
-    if ((msg = flux_event_encodef (topic, "{ s:I, s:s }",
-                                   "lwj", ctx->id,
-                                   "kvs_path", ctx->kvspath)) == NULL) {
-        wlog_err (ctx, "flux_event_encodef: %s", flux_strerror (errno));
+    if ((msg = flux_event_pack (topic, "{ s:I, s:s }",
+                                "lwj", ctx->id,
+                                "kvs_path", ctx->kvspath)) == NULL) {
+        wlog_err (ctx, "flux_event_pack: %s", flux_strerror (errno));
         goto out;
     }
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -804,7 +804,7 @@ int cores_on_node (struct prog_ctx *ctx, int nodeid)
         wlog_fatal (ctx, 1, "cores_on_node: out of memory");
     if (!(f = flux_kvs_lookup (ctx->flux, 0, key)))
         wlog_fatal (ctx, 1, "flux_kvs_lookup");
-    rc = flux_kvs_lookup_getf (f, "i", &ncores);
+    rc = flux_kvs_lookup_get_unpack (f, "i", &ncores);
     free (key);
     flux_future_destroy (f);
     return (rc < 0 ? -1 : ncores);
@@ -970,7 +970,7 @@ int prog_ctx_load_lwj_info (struct prog_ctx *ctx)
 
     key = kvsdir_key_at (ctx->kvs, "ntasks");
     if (!key || !(f = flux_kvs_lookup (ctx->flux, 0, key))
-             || flux_kvs_lookup_getf (f, "i", &ctx->total_ntasks) < 0)
+             || flux_kvs_lookup_get_unpack (f, "i", &ctx->total_ntasks) < 0)
         wlog_fatal (ctx, 1, "Failed to get ntasks from kvs");
     flux_future_destroy (f);
     free (key);
@@ -982,7 +982,7 @@ int prog_ctx_load_lwj_info (struct prog_ctx *ctx)
         f = NULL;
         key = kvsdir_key_at (ctx->resources, "cores");
         if (!key || !(f = flux_kvs_lookup (ctx->flux, 0, key))
-                 || flux_kvs_lookup_getf (f, "i", &ctx->nprocs) < 0)
+                 || flux_kvs_lookup_get_unpack (f, "i", &ctx->nprocs) < 0)
             wlog_fatal (ctx, 1, "Failed to get resources for this node");
         flux_future_destroy (f);
         free (key);
@@ -991,7 +991,7 @@ int prog_ctx_load_lwj_info (struct prog_ctx *ctx)
         f = NULL;
         key = kvsdir_key_at (ctx->kvs, "tasks-per-node");
         if (!key || !(f = flux_kvs_lookup (ctx->flux, 0, key))
-                 || flux_kvs_lookup_getf (f, "i", &ctx->nprocs) < 0)
+                 || flux_kvs_lookup_get_unpack (f, "i", &ctx->nprocs) < 0)
             ctx->nprocs = 1;
         flux_future_destroy (f);
         free (key);
@@ -1959,7 +1959,7 @@ int rexecd_init (struct prog_ctx *ctx)
      */
     key = kvsdir_key_at (ctx->kvs, "fatalerror");
     if (!key || !(f = flux_kvs_lookup (ctx->flux, 0, key))
-             || (flux_kvs_lookup_getf (f, "i", &errnum) < 0 && errno != ENOENT)) {
+             || (flux_kvs_lookup_get_unpack (f, "i", &errnum) < 0 && errno != ENOENT)) {
         errnum = 1;
         wlog_msg (ctx, "Error: kvsdir_get (fatalerror): %s\n", flux_strerror (errno));
     }
@@ -2225,9 +2225,9 @@ static int wreck_pmi_kvs_get (void *arg, const char *kvsname, const char *key,
         free (kvskey);
         return (-1);
     }
-    if (flux_kvs_lookup_getf (f, "s", &s) < 0) {
+    if (flux_kvs_lookup_get_unpack (f, "s", &s) < 0) {
         if (errno != ENOENT)
-            wlog_err (ctx, "pmi_kvs_get: flux_kvs_lookup_getf (s,%s): %s",
+            wlog_err (ctx, "pmi_kvs_get: flux_kvs_lookup_get_unpack (s,%s): %s",
                       kvskey, strerror (errno));
         free (kvskey);
         flux_future_destroy (f);

--- a/t/kvs/asyncfence.c
+++ b/t/kvs/asyncfence.c
@@ -52,9 +52,9 @@ void kget_xfail (flux_t *h, const char *s)
     snprintf (key, sizeof (key), "test.asyncfence.%s", s);
     if (!(f = flux_kvs_lookup (h, 0, key)))
         log_err_exit ("flux_kvs_lookup");
-    if (flux_kvs_lookup_getf (f, "i", &val) == 0)
-        log_msg_exit ("flux_kvs_lookup_getf(i) %s=%d (expected failure)", key, val);
-    log_msg ("flux_kvs_lookup_getf(i) %s failed (expected)", key);
+    if (flux_kvs_lookup_get_unpack (f, "i", &val) == 0)
+        log_msg_exit ("flux_kvs_lookup_get_unpack(i) %s=%d (expected failure)", key, val);
+    log_msg ("flux_kvs_lookup_get_unpack(i) %s failed (expected)", key);
     flux_future_destroy (f);
 }
 
@@ -67,12 +67,12 @@ void kget (flux_t *h, const char *s, int expected)
     snprintf (key, sizeof (key), "test.asyncfence.%s", s);
     if (!(f = flux_kvs_lookup (h, 0, key)))
         log_err_exit ("flux_kvs_lookup");
-    if (flux_kvs_lookup_getf (f, "i", &val) < 0)
-        log_msg_exit ("flux_kvs_lookup_getf(i) %s", key);
+    if (flux_kvs_lookup_get_unpack (f, "i", &val) < 0)
+        log_msg_exit ("flux_kvs_lookup_get_unpack(i) %s", key);
     if (expected != val)
-        log_msg_exit ("flux_kvs_lookup_getf(i) %s=%d (expected %d)",
+        log_msg_exit ("flux_kvs_lookup_get_unpack(i) %s=%d (expected %d)",
                       key, val, expected);
-    log_msg ("flux_kvs_lookup_getf(i) %s=%d", key, val);
+    log_msg ("flux_kvs_lookup_get_unpack(i) %s=%d", key, val);
     flux_future_destroy (f);
 }
 

--- a/t/kvs/basic.c
+++ b/t/kvs/basic.c
@@ -343,7 +343,7 @@ void cmd_readlink (flux_t *h, int argc, char **argv)
     if (argc != 1)
         log_msg_exit ("readlink: specify key"); 
     if (!(f = flux_kvs_lookup (h, FLUX_KVS_READLINK, argv[0]))
-            || flux_kvs_lookup_getf (f, "s", &target) < 0)
+            || flux_kvs_lookup_get_unpack (f, "s", &target) < 0)
         log_err_exit ("%s", argv[0]);
     else
         printf ("%s\n", target);
@@ -552,7 +552,7 @@ static void dump_kvs_dir (kvsdir_t *dir, bool ropt)
         if (kvsdir_issymlink (dir, name)) {
             const char *link;
             if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READLINK, key, rootref))
-                    || flux_kvs_lookup_getf (f, "s", &link) < 0)
+                    || flux_kvs_lookup_get_unpack (f, "s", &link) < 0)
                 log_err_exit ("%s", key);
             printf ("%s -> %s\n", key, link);
             flux_future_destroy (f);
@@ -763,7 +763,7 @@ void cmd_readlinkat (flux_t *h, int argc, char **argv)
     if (argc != 2)
         log_msg_exit ("readlink: specify treeobj and key");
     if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READLINK, argv[1], argv[0]))
-            || flux_kvs_lookup_getf (f, "s", &target) < 0)
+            || flux_kvs_lookup_get_unpack (f, "s", &target) < 0)
         log_err_exit ("%s", argv[1]);
     else
         printf ("%s\n", target);

--- a/t/kvs/getas.c
+++ b/t/kvs/getas.c
@@ -125,26 +125,26 @@ void getas (flux_t *h, const char *key, const char *type)
     }
     else if (!strcmp (type, "int")) {
         int value;
-        if (flux_kvs_lookup_getf (f, "i", &value) < 0)
-            log_err_exit ("flux_kvs_lookup_getf(i) %s", key);
+        if (flux_kvs_lookup_get_unpack (f, "i", &value) < 0)
+            log_err_exit ("flux_kvs_lookup_get_unpack(i) %s", key);
         printf ("%d\n", value);
     }
     else if (!strcmp (type, "int64")) {
         int64_t value;
-        if (flux_kvs_lookup_getf (f, "I", &value) < 0)
-            log_err_exit ("flux_kvs_lookup_getf(I) %s", key);
+        if (flux_kvs_lookup_get_unpack (f, "I", &value) < 0)
+            log_err_exit ("flux_kvs_lookup_get_unpack(I) %s", key);
         printf ("%" PRIi64 "\n", value);
     }
     else if (!strcmp (type, "double")) {
         double value;
-        if (flux_kvs_lookup_getf (f, "F", &value) < 0)
-            log_err_exit ("flux_kvs_lookup_getf(F) %s", key);
+        if (flux_kvs_lookup_get_unpack (f, "F", &value) < 0)
+            log_err_exit ("flux_kvs_lookup_get_unpack(F) %s", key);
         printf ("%f\n", value);
     }
     else if (!strcmp (type, "string")) {
         const char *value;
-        if (flux_kvs_lookup_getf (f, "s", &value) < 0)
-            log_err_exit ("flux_kvs_lookup_getf(s) %s", key);
+        if (flux_kvs_lookup_get_unpack (f, "s", &value) < 0)
+            log_err_exit ("flux_kvs_lookup_get_unpack(s) %s", key);
         printf ("%s\n", value);
     }
     else {

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -437,7 +437,7 @@ int get_watch_stats (flux_t *h, int *count)
 
     if (!(f = flux_rpc (h, "kvs.stats.get", NULL, FLUX_NODEID_ANY, 0)))
         goto done;
-    if (flux_rpc_getf (f, "{ s:i }", "#watchers", count) < 0)
+    if (flux_rpc_get_unpack (f, "{ s:i }", "#watchers", count) < 0)
         goto done;
     rc = 0;
 done:

--- a/t/rpc/mrpc.c
+++ b/t/rpc/mrpc.c
@@ -58,8 +58,8 @@ void rpcftest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
     }
 
 done:
-    (void)flux_respondf (h, msg, "{ s:i s:i s:i }", "errnum", errnum,
-                         "nodeid", nodeid, "flags", flags);
+    (void)flux_respond_pack (h, msg, "{ s:i s:i s:i }", "errnum", errnum,
+                             "nodeid", nodeid, "flags", flags);
 }
 
 /* request payload echoed in response */
@@ -116,7 +116,7 @@ done:
     if (errnum)
         (void)flux_respond (h, msg, errnum, NULL);
     else
-        (void)flux_respondf (h, msg, "{}");
+        (void)flux_respond_pack (h, msg, "{}");
 }
 
 static struct flux_msg_handler_spec htab[] = {

--- a/t/rpc/mrpc.c
+++ b/t/rpc/mrpc.c
@@ -46,7 +46,7 @@ void rpcftest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
     uint32_t nodeid = 0;
     int flags = 0;
 
-    if (flux_request_decodef (msg, NULL, "{}") < 0
+    if (flux_request_unpack (msg, NULL, "{}") < 0
             || flux_msg_get_nodeid (msg, &nodeid, &flags) < 0) {
         errnum = errno;
         goto done;
@@ -107,7 +107,7 @@ void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
 {
     int errnum = 0;
 
-    if (flux_request_decodef (msg, NULL, "{ ! }") < 0) {
+    if (flux_request_unpack (msg, NULL, "{ ! }") < 0) {
         errnum = errno;
         goto done;
     }

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -275,9 +275,9 @@ void test_encoding (flux_t *h)
 
     /* use newish pack/unpack payload interfaces */
     int i = 0;
-    ok ((r = flux_rpcf (h, "rpctest.incr", FLUX_NODEID_ANY, 0,
-                        "{s:i}", "n", 107)) != NULL,
-        "flux_rpcf works");
+    ok ((r = flux_rpc_pack (h, "rpctest.incr", FLUX_NODEID_ANY, 0,
+                            "{s:i}", "n", 107)) != NULL,
+        "flux_rpc_pack works");
     ok (flux_rpc_getf (r, NULL) < 0
         && errno == EINVAL,
         "flux_rpc_getf fails with EINVAL");
@@ -288,9 +288,9 @@ void test_encoding (flux_t *h)
     flux_future_destroy (r);
 
     /* cause remote EPROTO (unexpected payload) - will be picked up in _getf() */
-    ok ((r = flux_rpcf (h, "rpcftest.hello", FLUX_NODEID_ANY, 0,
-                        "{ s:i }", "foo", 42)) != NULL,
-        "flux_rpcf with payload when none is expected works, at first");
+    ok ((r = flux_rpc_pack (h, "rpcftest.hello", FLUX_NODEID_ANY, 0,
+                            "{ s:i }", "foo", 42)) != NULL,
+        "flux_rpc_pack with payload when none is expected works, at first");
     errno = 0;
     ok (flux_rpc_getf (r, "{}") < 0
         && errno == EPROTO,
@@ -298,8 +298,8 @@ void test_encoding (flux_t *h)
     flux_future_destroy (r);
 
     /* cause local EPROTO (user incorrectly expects payload) */
-    ok ((r = flux_rpcf (h, "rpcftest.hello", FLUX_NODEID_ANY, 0, "{}")) != NULL,
-        "flux_rpcf with empty payload works");
+    ok ((r = flux_rpc_pack (h, "rpcftest.hello", FLUX_NODEID_ANY, 0, "{}")) != NULL,
+        "flux_rpc_pack with empty payload works");
     errno = 0;
     ok (flux_rpc_getf (r, "{ s:i }", "foo", &i) < 0
         && errno == EPROTO,
@@ -308,8 +308,8 @@ void test_encoding (flux_t *h)
 
     /* cause local EPROTO (user incorrectly expects empty payload) */
     errno = 0;
-    ok ((r = flux_rpcf (h, "rpctest.echo", FLUX_NODEID_ANY, 0, "{ s:i }", "foo", 42)) != NULL,
-        "flux_rpcf with payload works");
+    ok ((r = flux_rpc_pack (h, "rpctest.echo", FLUX_NODEID_ANY, 0, "{ s:i }", "foo", 42)) != NULL,
+        "flux_rpc_pack with payload works");
     errno = 0;
     ok (flux_rpc_getf (r, "{ ! }") < 0
         && errno == EPROTO,

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -11,7 +11,7 @@ void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *w,
 {
     int i;
 
-    if (flux_request_decodef (msg, NULL, "{s:i}", "n", &i) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:i}", "n", &i) < 0)
         flux_respond (h, msg, errno, NULL);
     else
         flux_respondf (h, msg, "{s:i}", "n", i + 1);
@@ -99,7 +99,7 @@ void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
 {
     int errnum = 0;
 
-    if (flux_request_decodef (msg, NULL, "{ ! }") < 0) {
+    if (flux_request_unpack (msg, NULL, "{ ! }") < 0) {
         errnum = errno;
         goto done;
     }

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -14,7 +14,7 @@ void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_request_unpack (msg, NULL, "{s:i}", "n", &i) < 0)
         flux_respond (h, msg, errno, NULL);
     else
-        flux_respondf (h, msg, "{s:i}", "n", i + 1);
+        flux_respond_pack (h, msg, "{s:i}", "n", i + 1);
 }
 
 /* request nodeid and flags returned in response */
@@ -107,7 +107,7 @@ void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
     if (errnum)
         (void)flux_respond (h, msg, errnum, NULL);
     else
-        (void)flux_respondf (h, msg, "{}");
+        (void)flux_respond_pack (h, msg, "{}");
 }
 
 static struct flux_msg_handler_spec htab[] = {

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -278,11 +278,11 @@ void test_encoding (flux_t *h)
     ok ((r = flux_rpc_pack (h, "rpctest.incr", FLUX_NODEID_ANY, 0,
                             "{s:i}", "n", 107)) != NULL,
         "flux_rpc_pack works");
-    ok (flux_rpc_getf (r, NULL) < 0
+    ok (flux_rpc_get_unpack (r, NULL) < 0
         && errno == EINVAL,
-        "flux_rpc_getf fails with EINVAL");
-    ok (flux_rpc_getf (r, "{s:i}", "n", &i) == 0,
-        "flux_rpc_getf works");
+        "flux_rpc_get_unpack fails with EINVAL");
+    ok (flux_rpc_get_unpack (r, "{s:i}", "n", &i) == 0,
+        "flux_rpc_get_unpack works");
     ok (i == 108,
         "and service returned incremented value");
     flux_future_destroy (r);
@@ -292,18 +292,18 @@ void test_encoding (flux_t *h)
                             "{ s:i }", "foo", 42)) != NULL,
         "flux_rpc_pack with payload when none is expected works, at first");
     errno = 0;
-    ok (flux_rpc_getf (r, "{}") < 0
+    ok (flux_rpc_get_unpack (r, "{}") < 0
         && errno == EPROTO,
-        "flux_rpc_getf fails with EPROTO");
+        "flux_rpc_get_unpack fails with EPROTO");
     flux_future_destroy (r);
 
     /* cause local EPROTO (user incorrectly expects payload) */
     ok ((r = flux_rpc_pack (h, "rpcftest.hello", FLUX_NODEID_ANY, 0, "{}")) != NULL,
         "flux_rpc_pack with empty payload works");
     errno = 0;
-    ok (flux_rpc_getf (r, "{ s:i }", "foo", &i) < 0
+    ok (flux_rpc_get_unpack (r, "{ s:i }", "foo", &i) < 0
         && errno == EPROTO,
-        "flux_rpc_getf fails with EPROTO");
+        "flux_rpc_get_unpack fails with EPROTO");
     flux_future_destroy (r);
 
     /* cause local EPROTO (user incorrectly expects empty payload) */
@@ -311,9 +311,9 @@ void test_encoding (flux_t *h)
     ok ((r = flux_rpc_pack (h, "rpctest.echo", FLUX_NODEID_ANY, 0, "{ s:i }", "foo", 42)) != NULL,
         "flux_rpc_pack with payload works");
     errno = 0;
-    ok (flux_rpc_getf (r, "{ ! }") < 0
+    ok (flux_rpc_get_unpack (r, "{ ! }") < 0
         && errno == EPROTO,
-        "flux_rpc_getf fails with EPROTO");
+        "flux_rpc_get_unpack fails with EPROTO");
     flux_future_destroy (r);
 
     diag ("completed encoding/api test");


### PR DESCRIPTION
This PR renames the following functions, as discussed in #1094

| Old    | New       |
|---------|-------------|
| flux_kvs_lookup_getf() | flux_kvs_lookup_get_unpack()   |
| flux_msg_set_jsonf() | flux_msg_pack() |
| flux_msg_vset_jsonf() | flux_msg_vpack() |
| flux_msg_get_jsonf() | flux_msg_unpack() |
| flux_msg_vget_jsonf() | flux_msg_vunpack() |
| flux_rpcf() | flux_rpc_pack() |
| flux_rpc_getf() | flux_rpc_get_unpack() |
| flux_event_decodef() | flux_event_unpack() |
| flux_event_encodef() | flux_event_pack() |
| flux_request_decodef() | flux_request_unpack() |
| flux_respondf() | flux_respond_pack() |

There will need to be a sched patch queued up before this should be merged, but wanted to get feedback first.