### PR TITLE
t2000-wreck.t: fix logic in check for archive job

### DIFF
--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -373,8 +373,8 @@ test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded'
 
 check_complete_link() {
     for i in `seq 0 5`; do
-        lastdir=$(flux kvs dir lwj-complete | tail -1)
-        flux kvs get ${lastdir}${1}.state && return 0
+        lastepoch=$(flux kvs dir lwj-complete | awk -F. '{print $2}' | sort -n | tail -1)
+        flux kvs get lwj-complete.${lastepoch}.${1}.state && return 0
         sleep 0.2
     done
     return 1


### PR DESCRIPTION
The check for the last complete job via

```
flux kvs dir lwj-complete | tail -1
```

is not safe b/c there is no guarantee that the directory entries
are sorted when output.  In combination with the lastjobid, the
test may try to retrieve a kvs field that will never exist.

Sort lwj complete entries by epoch and then use ```tail -1```.  Adjust
surrounding code appropriately.