### PR TITLE
python: make bindings compatible with newer versions of pylint

### DIFF
--- a/src/bindings/python/.pylintrc
+++ b/src/bindings/python/.pylintrc
@@ -87,9 +87,6 @@ logging-modules=logging
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input,file
 
@@ -262,10 +259,6 @@ notes=FIXME,XXX,TODO
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -229,8 +229,7 @@ class KVSDir(WrapperPimpl, collections.MutableMapping):
             if self.pimpl.isdir(k):
                 yield k
 
-    def list_all(self, topdown=False):
-        # pylint: disable=unused-argument
+    def list_all(self):
         files = []
         dirs = []
         for k in self:

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -76,11 +76,10 @@ class RPC(WrapperPimpl):
         return json.loads(self.get_str())
 
     def then(self, callback, args):
-        # pylint: disable=unused-argument
-        def then_wrapper(trash, arg):
+        def cb_then_wrapper(trash, arg):
             rpc_handle = ffi.from_handle(arg)
             callback(rpc_handle, rpc_handle.then_args)
         # Save the callback to keep it from getting collected
-        self.then_cb = ffi.callback('flux_then_f', then_wrapper)
+        self.then_cb = ffi.callback('flux_then_f', cb_then_wrapper)
         self.then_args = args
         return self.pimpl.then(self.then_cb, ffi.new_handle(self))

--- a/src/bindings/python/make_binding.py
+++ b/src/bindings/python/make_binding.py
@@ -84,7 +84,7 @@ ffi.include({module}_ffi)
 
 
   print >>modfile, '''
-#pylint: disable-all
+#pylint: skip-file
 # This is a generated file... linting is less than useful
 from cffi import FFI
 ffi = FFI()


### PR DESCRIPTION
remove the deprecated `unused-argument`:
  - remove the unused argument in kvs walk
  - rename `then_wrapper` to `cb_then_wrapper`; pylint won't check
    functions prefixed with `cb_` for unused arguments

remove the deprecated `required-attributes` and `ignore-iface-methods`
swap the deprecated `ignore-all` for `skip-file`

Related: https://github.com/flux-framework/flux-core/issues/1046 (I don't believe this fully fixes it, but it addresses several of the issues)