### PR TITLE
KVS lua refcount fix, drop unused deprecated functions

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1023,7 +1023,7 @@ static int kvswatch_cb_common (const char *key, kvsdir_t *dir,
     assert (lua_isuserdata (L, -1));
 
     if (dir) {
-        lua_push_kvsdir (L, dir);
+        lua_push_kvsdir_external (L, dir); // take a reference
         lua_pushnil (L);
     }
     else if (val) {

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -266,14 +266,6 @@ int kvs_mkdir (flux_t *h, const char *key)
     return flux_kvs_txn_mkdir (txn, 0, key);
 }
 
-int kvs_put_treeobj (flux_t *h, const char *key, const char *treeobj)
-{
-    flux_kvs_txn_t *txn = get_default_txn (h);
-    if (!txn)
-        return -1;
-    return flux_kvs_txn_put (txn, FLUX_KVS_TREEOBJ, key, treeobj);
-}
-
 int kvs_copy (flux_t *h, const char *from, const char *to)
 {
     flux_kvs_txn_t *txn = get_default_txn (h);

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -242,14 +242,6 @@ int kvs_put_int64 (flux_t *h, const char *key, int64_t val)
     return flux_kvs_txn_pack (txn, 0, key, "I", val);
 }
 
-int kvs_put_boolean (flux_t *h, const char *key, bool val)
-{
-    flux_kvs_txn_t *txn = get_default_txn (h);
-    if (!txn)
-        return -1;
-    return flux_kvs_txn_pack (txn, 0, key, "b", (int)val);
-}
-
 int kvs_unlink (flux_t *h, const char *key)
 {
     flux_kvs_txn_t *txn = get_default_txn (h);

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -242,14 +242,6 @@ int kvs_put_int64 (flux_t *h, const char *key, int64_t val)
     return flux_kvs_txn_pack (txn, 0, key, "I", val);
 }
 
-int kvs_put_double (flux_t *h, const char *key, double val)
-{
-    flux_kvs_txn_t *txn = get_default_txn (h);
-    if (!txn)
-        return -1;
-    return flux_kvs_txn_pack (txn, 0, key, "f", val);
-}
-
 int kvs_put_boolean (flux_t *h, const char *key, bool val)
 {
     flux_kvs_txn_t *txn = get_default_txn (h);

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -11,7 +11,6 @@ int kvs_put (flux_t *h, const char *key, const char *json_str);
 int kvs_put_string (flux_t *h, const char *key, const char *val);
 int kvs_put_int (flux_t *h, const char *key, int val);
 int kvs_put_int64 (flux_t *h, const char *key, int64_t val);
-int kvs_put_boolean (flux_t *h, const char *key, bool val);
 int kvs_unlink (flux_t *h, const char *key);
 int kvs_symlink (flux_t *h, const char *key, const char *target);
 int kvs_mkdir (flux_t *h, const char *key);

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -14,7 +14,6 @@ int kvs_put_int64 (flux_t *h, const char *key, int64_t val);
 int kvs_unlink (flux_t *h, const char *key);
 int kvs_symlink (flux_t *h, const char *key, const char *target);
 int kvs_mkdir (flux_t *h, const char *key);
-int kvs_put_treeobj (flux_t *h, const char *key, const char *treeobj);
 int kvs_copy (flux_t *h, const char *from, const char *to);
 int kvs_move (flux_t *h, const char *from, const char *to);
 

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -11,7 +11,6 @@ int kvs_put (flux_t *h, const char *key, const char *json_str);
 int kvs_put_string (flux_t *h, const char *key, const char *val);
 int kvs_put_int (flux_t *h, const char *key, int val);
 int kvs_put_int64 (flux_t *h, const char *key, int64_t val);
-int kvs_put_double (flux_t *h, const char *key, double val);
 int kvs_put_boolean (flux_t *h, const char *key, bool val);
 int kvs_unlink (flux_t *h, const char *key);
 int kvs_symlink (flux_t *h, const char *key, const char *target);

--- a/t/kvs/basic.c
+++ b/t/kvs/basic.c
@@ -748,10 +748,14 @@ void cmd_put_treeobj (flux_t *h, int argc, char **argv)
     if (!val)
         log_msg_exit ("put-treeobj: you must specify a value as key=val");
     *val++ = '\0';
-    if (kvs_put_treeobj (h, key, val) < 0)
-        log_err_exit ("kvs_put_treeobj %s=%s", key, val);
-    if (kvs_commit (h, 0) < 0)
-        log_err_exit ("kvs_commit");
+    flux_kvs_txn_t *txn;
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+    if (flux_kvs_txn_put (txn, FLUX_KVS_TREEOBJ, key, val) < 0)
+        log_err_exit ("flux_kvs_txn_put %s=%s", key, val);
+    if (flux_kvs_commit (h, 0, txn) < 0)
+        log_err_exit ("flux_kvs_commit");
+    flux_kvs_txn_destroy (txn);
     free (key);
 }
 


### PR DESCRIPTION
This PR collects some odds and ends that were left out of pr #1107:

* A fix to #1112 after @grondo verified with valgrind that it's needed (I thought might fix a problem I was looking for in #1107 but that turned out to be something else).
* Drop some "classic" functions that have no users in sched or core: `kvs_put_double()` and `kvs_put_boolean()`.
* Drop `kvs_put_treeobj()` which had only one test user (test converted to `flux_kvs_txn_put()`)
