### PR TITLE
Kvs cleanup error paths

### DIFF
--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -95,6 +95,18 @@ void cache_entry_set_dirty (struct cache_entry *hp, bool val)
     }
 }
 
+int cache_entry_clear_dirty (struct cache_entry *hp)
+{
+    if (hp && hp->o) {
+        if (hp->dirty
+            && (!hp->waitlist_notdirty
+                || !wait_queue_length (hp->waitlist_notdirty)))
+            hp->dirty = 0;
+        return hp->dirty ? 1 : 0;
+    }
+    return -1;
+}
+
 json_t *cache_entry_get_json (struct cache_entry *hp)
 {
     if (!hp || !hp->o)

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -56,7 +56,6 @@ struct cache_entry {
     json_t *o;              /* value object */
     int lastuse_epoch;      /* time of last use for cache expiry */
     uint8_t dirty:1;
-    uint8_t content_store_flag:1;
 };
 
 struct cache {
@@ -94,17 +93,6 @@ void cache_entry_set_dirty (struct cache_entry *hp, bool val)
                 wait_runqueue (hp->waitlist_notdirty);
         }
     }
-}
-
-bool cache_entry_get_content_store_flag (struct cache_entry *hp)
-{
-    return (hp && hp->o && hp->content_store_flag);
-}
-
-void cache_entry_set_content_store_flag (struct cache_entry *hp, bool val)
-{
-    if (hp && hp->o)
-        hp->content_store_flag = val;
 }
 
 json_t *cache_entry_get_json (struct cache_entry *hp)

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -28,12 +28,24 @@ bool cache_entry_get_valid (struct cache_entry *hp);
 bool cache_entry_get_dirty (struct cache_entry *hp);
 void cache_entry_set_dirty (struct cache_entry *hp, bool val);
 
+/* cache_entry_clear_dirty() is similar to calling
+ * cache_entry_set_dirty(hp,false), but it will not set to the dirty
+ * bit to false if there are waiters for notdirty
+ * (i.e. cache_entry_wait_notdirty() has been called on this entry).
+ * This is typically called in an error path where the caller wishes
+ * to give up on a previously marked dirty cache entry but has not yet
+ * done anything with it.  Returns current value of dirty bit on
+ * success, -1 on error.
+ */
+int cache_entry_clear_dirty (struct cache_entry *hp);
+
 /* Accessors for cache entry data.
  * If non-NULL, set transfers ownership of 'o' to the cache entry.
  * An invalid->valid transition runs the entry's wait queue, if any.
  */
 json_t *cache_entry_get_json (struct cache_entry *hp);
 void cache_entry_set_json (struct cache_entry *hp, json_t *o);
+int cache_entry_clear_json (struct cache_entry *hp);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -28,13 +28,6 @@ bool cache_entry_get_valid (struct cache_entry *hp);
 bool cache_entry_get_dirty (struct cache_entry *hp);
 void cache_entry_set_dirty (struct cache_entry *hp, bool val);
 
-/* Get set content store flag, used to internally manage
- * whether or not content in cache entry has been
- * stored off node into content store.
- */
-bool cache_entry_get_content_store_flag (struct cache_entry *hp);
-void cache_entry_set_content_store_flag (struct cache_entry *hp, bool val);
-
 /* Accessors for cache entry data.
  * If non-NULL, set transfers ownership of 'o' to the cache entry.
  * An invalid->valid transition runs the entry's wait queue, if any.

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -81,6 +81,12 @@ json_t *cache_lookup_and_get_json (struct cache *cache,
 void cache_insert (struct cache *cache, const char *ref,
                    struct cache_entry *hp);
 
+/* Remove a cache_entry from the cache.  Will not be removed if dirty
+ * or there are any waiters of any sort.
+ * Returns 1 on removed, 0 if not
+ */
+int cache_remove_entry (struct cache *cache, const char *ref);
+
 /* Return the number of cache entries.
  */
 int cache_count_entries (struct cache *cache);

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -126,7 +126,10 @@ const char *commit_get_newroot_ref (commit_t *c)
     return NULL;
 }
 
-/* Store object 'o' under key 'ref' in local cache. */
+/* Store object 'o' under key 'ref' in local cache.
+ * Object reference is given to this function, it will either give it
+ * to the cache or decref it.
+ */
 static int store_cache (commit_t *c, int current_epoch, json_t *o,
                         href_t ref, struct cache_entry **hpp)
 {
@@ -135,7 +138,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
 
     if (kvs_util_json_hash (c->cm->hash_name, o, ref) < 0) {
         log_err ("kvs_util_json_hash");
-        goto done;
+        goto decref_done;
     }
     if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
         hp = cache_entry_create (NULL);
@@ -151,7 +154,10 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
     }
     *hpp = hp;
     rc = 0;
- done:
+    return rc;
+
+ decref_done:
+    json_decref (o);
     return rc;
 }
 

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -55,6 +55,7 @@ struct commit_mgr {
 
 struct commit {
     int errnum;
+    int aux_errnum;
     fence_t *f;
     int blocked:1;
     json_t *rootcpy;   /* working copy of root dir */
@@ -107,6 +108,17 @@ error:
 int commit_get_errnum (commit_t *c)
 {
     return c->errnum;
+}
+
+int commit_get_aux_errnum (commit_t *c)
+{
+    return c->aux_errnum;
+}
+
+int commit_set_aux_errnum (commit_t *c, int errnum)
+{
+    c->aux_errnum = errnum;
+    return c->aux_errnum;
 }
 
 fence_t *commit_get_fence (commit_t *c)

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -442,8 +442,11 @@ commit_process_t commit_process (commit_t *c,
                     }
                 }
 
-                if (c->errnum != 0)
+                if (c->errnum != 0) {
+                    /* empty item_callback_list to prevent mistakes later */
+                    while ((missing_ref = zlist_pop (c->item_callback_list)));
                     return COMMIT_PROCESS_ERROR;
+                }
 
                 if (zlist_first (c->item_callback_list))
                     goto stall_load;

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -65,6 +65,8 @@ commit_process_t commit_process (commit_t *c,
 
 /* on commit stall, iterate through all missing refs that the caller
  * should load into the cache
+ *
+ * return -1 in callback to break iteration
  */
 int commit_iter_missing_refs (commit_t *c, commit_ref_cb cb, void *data);
 
@@ -75,6 +77,8 @@ int commit_iter_missing_refs (commit_t *c, commit_ref_cb cb, void *data);
  * cache_entry_get_content_store_flag() can be used to indicate if it
  * should be sent to the content store or not (be sure to clear the
  * flag appropriately.)
+ *
+ * return -1 in callback to break iteration
  */
 int commit_iter_dirty_cache_entries (commit_t *c,
                                      commit_cache_entry_cb cb,

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -29,6 +29,12 @@ typedef int (*commit_cache_entry_cb)(commit_t *c,
 
 int commit_get_errnum (commit_t *c);
 
+/* if user wishes to stall, but needs future knowledge to fail and
+ * what error caused the failure.
+ */
+int commit_get_aux_errnum (commit_t *c);
+int commit_set_aux_errnum (commit_t *c, int errnum);
+
 fence_t *commit_get_fence (commit_t *c);
 
 /* returns aux data passed into commit_mgr_create() */

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -77,12 +77,7 @@ commit_process_t commit_process (commit_t *c,
 int commit_iter_missing_refs (commit_t *c, commit_ref_cb cb, void *data);
 
 /* on commit stall, iterate through all dirty cache entries that need
- * to be pushed to the content store or wait to be finished being sent
- * to content store.
- *
- * cache_entry_get_content_store_flag() can be used to indicate if it
- * should be sent to the content store or not (be sure to clear the
- * flag appropriately.)
+ * to be pushed to the content store.
  *
  * return -1 in callback to break iteration
  */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1269,6 +1269,8 @@ static void process_args (kvs_ctx_t *ctx, int ac, char **av)
 
 /* Store initial rootdir in local cache, and flush to content
  * cache synchronously.
+ * Object reference is given to this function, it will either give it
+ * to the cache or decref it.
  */
 static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
 {
@@ -1277,7 +1279,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
 
     if (kvs_util_json_hash (ctx->hash_name, o, ref) < 0) {
         flux_log_error (ctx->h, "kvs_util_json_hash");
-        goto done;
+        goto decref_done;
     }
     if (!(hp = cache_lookup (ctx->cache, ref, ctx->epoch))) {
         hp = cache_entry_create (NULL);
@@ -1294,6 +1296,10 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         json_decref (o);
     rc = 0;
 done:
+    return rc;
+
+decref_done:
+    json_decref (o);
     return rc;
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -191,8 +191,10 @@ static int content_load_request_send (kvs_ctx_t *ctx, const href_t ref, bool now
     if (!(f = flux_rpc_raw (ctx->h, "content.load",
                     ref, strlen (ref) + 1, FLUX_NODEID_ANY, 0)))
         goto error;
-    if (flux_future_aux_set (f, "ref", xstrdup (ref), free) < 0)
+    if (flux_future_aux_set (f, "ref", xstrdup (ref), free) < 0) {
+        flux_future_destroy (f);
         goto error;
+    }
     if (now) {
         content_load_completion (f, ctx);
     } else if (flux_future_then (f, -1., content_load_completion, ctx) < 0) {

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -326,15 +326,14 @@ static int commit_cache_cb (commit_t *c, struct cache_entry *hp, void *data)
 {
     struct commit_cb_data *cbd = data;
 
-    if (cache_entry_get_content_store_flag (hp)) {
-        if (content_store_request_send (cbd->ctx,
-                                        cache_entry_get_json (hp),
-                                        false) < 0) {
-            cbd->errnum = errno;
-            flux_log_error (cbd->ctx->h, "content_store");
-            return -1;
-        }
-        cache_entry_set_content_store_flag (hp, false);
+    assert (cache_entry_get_dirty (hp));
+
+    if (content_store_request_send (cbd->ctx,
+                                    cache_entry_get_json (hp),
+                                    false) < 0) {
+        cbd->errnum = errno;
+        flux_log_error (cbd->ctx->h, "content_store");
+        return -1;
     }
     cache_entry_wait_notdirty (hp, cbd->wait);
     return 0;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1309,6 +1309,11 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         cache_entry_set_json (hp, o);
         cache_entry_set_dirty (hp, true);
         if (content_store_request_send (ctx, o, true) < 0) {
+            /* Must clean up, don't want cache entry to be assumed
+             * valid.  Everything here is synchronous and w/o waiters,
+             * so nothing should error here */
+            assert (cache_entry_clear_dirty (hp) == 0);
+            assert (cache_remove_entry (ctx->cache, ref) == 1);
             flux_log_error (ctx->h, "content_store");
             goto done;
         }

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -53,6 +53,10 @@ int main (int argc, char *argv[])
     cache_entry_set_dirty (e1, true);
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry succcessfully set dirty");
+    ok (cache_entry_clear_dirty (e1) == 0,
+        "cache_entry_clear_dirty returns 0, b/c no waiters");
+    ok (cache_entry_get_dirty (e1) == false,
+        "cache entry succcessfully now not dirty");
     ok ((o2 = cache_entry_get_json (e1)) != NULL,
         "json retrieved from cache entry");
     ok ((o = json_object_get (o2, "foo")) != NULL,
@@ -71,6 +75,8 @@ int main (int argc, char *argv[])
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e1) == false,
         "cache entry invalid, adding waiter");
+    ok (cache_entry_clear_dirty (e1) < 0,
+        "cache_entry_clear_dirty returns error, b/c no object set");
     o1 = json_object ();
     json_object_set_new (o1, "foo", json_integer (42));
     cache_entry_wait_valid (e1, w);
@@ -87,6 +93,8 @@ int main (int argc, char *argv[])
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry set dirty, adding waiter");
     cache_entry_wait_notdirty (e1, w);
+    ok (cache_entry_clear_dirty (e1) == 1,
+        "cache_entry_clear_dirty returns 1, b/c of a waiter");
     cache_entry_set_dirty (e1, false);
     ok (cache_entry_get_dirty (e1) == false,
         "cache entry set not dirty with one waiter");

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -19,10 +19,11 @@ void wait_cb (void *arg)
 int main (int argc, char *argv[])
 {
     struct cache *cache;
-    struct cache_entry *e1, *e2, *e3, *e4;
+    struct cache_entry *e1, *e2, *e3, *e4, *e5;
     json_t *o1;
     json_t *o2;
     json_t *o3;
+    json_t *o4;
     json_t *o;
     wait_t *w;
     int count;
@@ -170,6 +171,67 @@ int main (int argc, char *argv[])
         "cache_expire_entries now=44 thresh=1 expired 1");
     ok (cache_count_entries (cache) == 1,
         "cache contains 1 entry");
+
+    /* cache_remove_entry tests */
+
+    ok ((e5 = cache_entry_create (NULL)) != NULL,
+        "cache_entry_create works");
+    cache_insert (cache, "remove-ref", e5);
+    ok (cache_lookup (cache, "remove-ref", 0) != NULL,
+        "cache_lookup verify entry exists");
+    ok (cache_remove_entry (cache, "blalalala") == 0,
+        "cache_remove_entry failed on bad reference");
+    ok (cache_remove_entry (cache, "remove-ref") == 1,
+        "cache_remove_entry removed cache entry w/o object");
+    ok (cache_lookup (cache, "remove-ref", 0) == NULL,
+        "cache_lookup verify entry gone");
+
+    count = 0;
+    ok ((w = wait_create (wait_cb, &count)) != NULL,
+        "wait_create works");
+    ok ((e5 = cache_entry_create (NULL)) != NULL,
+        "cache_entry_create created empty object");
+    cache_insert (cache, "remove-ref", e5);
+    ok (cache_lookup (cache, "remove-ref", 0) != NULL,
+        "cache_lookup verify entry exists");
+    ok (cache_entry_get_valid (e5) == false,
+        "cache entry invalid, adding waiter");
+    cache_entry_wait_valid (e5, w);
+    ok (cache_remove_entry (cache, "remove-ref") == 0,
+        "cache_remove_entry failed on valid waiter");
+    o4 = json_string ("foobar");
+    cache_entry_set_json (e5, o4);
+    ok (cache_entry_get_valid (e5) == true,
+        "cache entry set valid with one waiter");
+    ok (count == 1,
+        "waiter callback ran");
+    ok (cache_remove_entry (cache, "remove-ref") == 1,
+        "cache_remove_entry removed cache entry after valid waiter gone");
+    ok (cache_lookup (cache, "remove-ref", 0) == NULL,
+        "cache_lookup verify entry gone");
+
+    count = 0;
+    ok ((w = wait_create (wait_cb, &count)) != NULL,
+        "wait_create works");
+    o4 = json_string ("foobar");
+    ok ((e5 = cache_entry_create (o4)) != NULL,
+        "cache_entry_create created empty object");
+    cache_insert (cache, "remove-ref", e5);
+    ok (cache_lookup (cache, "remove-ref", 0) != NULL,
+        "cache_lookup verify entry exists");
+    cache_entry_set_dirty (e5, true);
+    ok (cache_remove_entry (cache, "remove-ref") == 0,
+        "cache_remove_entry not removed b/c dirty");
+    cache_entry_wait_notdirty (e5, w);
+    ok (cache_remove_entry (cache, "remove-ref") == 0,
+        "cache_remove_entry failed on notdirty waiter");
+    cache_entry_set_dirty (e5, false);
+    ok (count == 1,
+        "waiter callback ran");
+    ok (cache_remove_entry (cache, "remove-ref") == 1,
+        "cache_remove_entry removed cache entry after notdirty waiter gone");
+    ok (cache_lookup (cache, "remove-ref", 0) == NULL,
+        "cache_lookup verify entry gone");
 
     cache_destroy (cache);
 

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -53,14 +53,6 @@ int main (int argc, char *argv[])
     cache_entry_set_dirty (e1, true);
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry succcessfully set dirty");
-    ok (cache_entry_get_content_store_flag (e1) == false,
-        "cache entry content_store_flag initially false");
-    cache_entry_set_content_store_flag (e1, true);
-    ok (cache_entry_get_content_store_flag (e1) == true,
-        "cache entry succcessfully set content_store_flag to true");
-    cache_entry_set_content_store_flag (e1, false);
-    ok (cache_entry_get_content_store_flag (e1) == false,
-        "cache entry succcessfully set content_store_flag to false");
     ok ((o2 = cache_entry_get_json (e1)) != NULL,
         "json retrieved from cache entry");
     ok ((o = json_object_get (o2, "foo")) != NULL,

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -343,6 +343,18 @@ void commit_basic_tests (void)
     ok (commit_get_errnum (c) == 0,
         "commit_get_errnum returns no error");
 
+    ok (commit_get_aux_errnum (c) == 0,
+        "commit_get_aux_errnum returns no error");
+
+    ok (commit_set_aux_errnum (c, EINVAL) == EINVAL,
+        "commit_set_aux_errnum works");
+
+    ok (commit_get_aux_errnum (c) == EINVAL,
+        "commit_get_aux_errnum gets EINVAL");
+
+    ok (commit_get_errnum (c) == 0,
+        "commit_get_errnum still works");
+
     ok (commit_get_aux (c) == &test_global,
         "commit_get_aux returns correct pointer");
 


### PR DESCRIPTION
I was in the process of doing a lot of random cleanup (remove oom() calls, remove use of xzmalloc(), etc.) and found a number of circumstances where there were cleanup errors along error/cleanup
paths.  Here are descriptions of some of the bigger ones:

17d1764947d23e6ccef34875205f44ad9578e39a - if RPCs are already in flight when an error occurs, stall and let them finish, before returning error to user.  This was in older KVS code and I broke it while refactoring.

a41bfed76c04ca4f7f616262660bc2b2e6d6e217 - Way back in commit 0cbeacc09aba444f2c972cd7cd83846d721922f7, there was a relatively harmless logic error (i.e. had no effect except for possibly a tad less optimal).  But with the commit API refactoring, it actually mattered a bit more b/c it complicated some logic.  This logic has been corrected.  The key is that it is not necessary to wait twice for a dirty cache entry to become flushed.  Once is sufficient.

7fb6a412c3c387845289fcb79d9c4bfb00ebf7a3 - This was actually a pretty bad mistake on my part while refactoring.  If an error occurred while flushing a list of dirty cache entries, then what do you do with the dirty cache entries that were not flushed?  They should be removed from the cache, otherwise they will sit there being dirty forever and un-expireable.  It may seem strange that I create both a ```cache_entry_clear_dirty()``` function and a ```cache_remove_entry()``` function to deal with this cleanup.  But I felt it was important that the latter only work on non-dirty entries (and could be used elsewhere in the future).  So it obviated the need for a "clear dirty" function as well.
