### PR TITLE
[cleanup] convert KVS users to new API and jansson, drop some old API functions

### DIFF
--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -304,147 +304,165 @@ static void output_key_json_str (const char *key,
 
 int cmd_get (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
-    char *json_str;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
+    const char *key, *json_str;
+    flux_future_t *f;
     int optindex, i;
 
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
-
     optindex = optparse_option_index (p);
-
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
     for (i = optindex; i < argc; i++) {
-        if (kvs_get (h, argv[i], &json_str) < 0)
-            log_err_exit ("%s", argv[i]);
-        output_key_json_str (NULL, json_str, argv[i]);
-        free (json_str);
+        key = argv[i];
+        if (!(f = flux_kvs_lookup (h, 0, key))
+                || flux_kvs_lookup_get (f, &json_str) < 0)
+            log_err_exit ("%s", key);
+        output_key_json_str (NULL, json_str, key);
+        flux_future_destroy (f);
     }
     return (0);
 }
 
 int cmd_put (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     int optindex, i;
-
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
+    flux_future_t *f;
+    flux_kvs_txn_t *txn;
 
     optindex = optparse_option_index (p);
-
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
     for (i = optindex; i < argc; i++) {
         char *key = xstrdup (argv[i]);
         char *val = strchr (key, '=');
         if (!val)
             log_msg_exit ("put: you must specify a value as key=value");
         *val++ = '\0';
-        if (kvs_put (h, key, val) < 0) {
-            if (errno != EINVAL || kvs_put_string (h, key, val) < 0)
+
+        if (flux_kvs_txn_put (txn, 0, key, val) < 0) {
+            if (errno != EINVAL)
+                log_err_exit ("%s", key);
+            if (flux_kvs_txn_pack (txn, 0, key, "s", val) < 0)
                 log_err_exit ("%s", key);
         }
         free (key);
     }
-    if (kvs_commit (h, 0) < 0)
-        log_err_exit ("kvs_commit");
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_commit");
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
     return (0);
 }
 
-bool key_exists (flux_t *h, const char *key, bool *isdir, int *dirsize)
+/* Some checks prior to unlinking key:
+ * - fail if key does not exist (ENOENT) or other fatal lookup error
+ * - fail if key is a non-empty directory (ENOTEMPTY) and -R was not specified
+ */
+static int unlink_safety_check (flux_t *h, const char *key, bool Ropt)
 {
-    char *json_str = NULL;
+    flux_future_t *f;
     kvsdir_t *dir = NULL;
+    const char *json_str;
+    int rc = -1;
 
-    if (kvs_get (h, key, &json_str) == 0) {
-        *isdir = false;
-        free (json_str);
-        return true;
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key)))
+        goto done;
+    if (flux_kvs_lookup_get (f, &json_str) < 0) {
+        if (errno != ENOTDIR)
+            goto done;
     }
-    if (errno == EISDIR && kvs_get_dir (h, &dir, "%s", key) == 0) {
-        *dirsize = kvsdir_get_size (dir);
-        *isdir = true;
+    else if (!Ropt) {
+        if (!(dir = kvsdir_create (h, NULL, key, json_str)))
+            goto done;
+        if (kvsdir_get_size (dir) > 0) {
+            errno = ENOTEMPTY;
+            goto done;
+        }
+    }
+    rc = 0;
+done:
+    if (dir)
         kvsdir_destroy (dir);
-        return true;
-    }
-    *isdir = false;
-    return false;
+    flux_future_destroy (f);
+    return rc;
 }
 
 int cmd_unlink (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
-    int optindex, dirsize, i;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
+    int optindex, i;
+    flux_future_t *f;
+    flux_kvs_txn_t *txn;
     bool Ropt;
-    bool isdir;
-
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
 
     optindex = optparse_option_index (p);
-
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
-
     Ropt = optparse_hasopt (p, "recursive");
 
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
     for (i = optindex; i < argc; i++) {
-        if (!key_exists (h, argv[i], &isdir, &dirsize))
-            log_msg_exit ("cannot unlink '%s': %s",
-                          argv[i], strerror (ENOENT));
-        if (isdir && !Ropt && dirsize > 0)
-            log_msg_exit ("cannot unlink '%s': %s",
-                          argv[i], strerror (ENOTEMPTY));
-        if (kvs_unlink (h, argv[i]) < 0)
+        if (unlink_safety_check (h, argv[i], Ropt) < 0)
+            log_err_exit ("cannot unlink '%s'", argv[i]);
+        if (flux_kvs_txn_unlink (txn, 0, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
-    if (kvs_commit (h, 0) < 0)
-        log_err_exit ("kvs_commit");
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_commit");
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
     return (0);
 }
 
 int cmd_link (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     int optindex;
-
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
+    flux_kvs_txn_t *txn;
+    flux_future_t *f;
 
     optindex = optparse_option_index (p);
-
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
     if (optindex != (argc - 2))
         log_msg_exit ("link: specify target and link_name");
-    if (kvs_symlink (h, argv[optindex + 1], argv[optindex]) < 0)
+
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+    if (flux_kvs_txn_symlink (txn, 0, argv[optindex + 1], argv[optindex]) < 0)
         log_err_exit ("%s", argv[optindex + 1]);
-    if (kvs_commit (h, 0) < 0)
-        log_err_exit ("kvs_commit");
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_commit");
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
     return (0);
 }
 
 int cmd_readlink (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     int optindex, i;
     const char *target;
     flux_future_t *f;
 
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
-
     optindex = optparse_option_index (p);
-
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
+
     for (i = optindex; i < argc; i++) {
         if (!(f = flux_kvs_lookup (h, FLUX_KVS_READLINK, argv[i]))
                 || flux_kvs_lookup_get_unpack (f, "s", &target) < 0)
@@ -458,23 +476,27 @@ int cmd_readlink (optparse_t *p, int argc, char **argv)
 
 int cmd_mkdir (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     int optindex, i;
-
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
+    flux_kvs_txn_t *txn;
+    flux_future_t *f;
 
     optindex = optparse_option_index (p);
-
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
+
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
     for (i = optindex; i < argc; i++) {
-        if (kvs_mkdir (h, argv[i]) < 0)
+        if (flux_kvs_txn_mkdir (txn, 0, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
-    if (kvs_commit (h, 0) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
         log_err_exit ("kvs_commit");
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
     return (0);
 }
 
@@ -750,52 +772,62 @@ static void dump_kvs_dir (kvsdir_t *dir, bool Ropt, bool dopt)
 
 int cmd_dir (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     bool Ropt;
     bool dopt;
-    char *key;
+    const char *key, *json_str;
+    flux_future_t *f;
     kvsdir_t *dir;
     int optindex;
 
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
-
     optindex = optparse_option_index (p);
-
     Ropt = optparse_hasopt (p, "recursive");
     dopt = optparse_hasopt (p, "directory");
-
     if (optindex == argc)
         key = ".";
     else if (optindex == (argc - 1))
         key = argv[optindex];
     else
         log_msg_exit ("dir: specify zero or one directory");
-    if (kvs_get_dir (h, &dir, "%s", key) < 0)
+
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key))
+                || flux_kvs_lookup_get (f, &json_str) < 0)
         log_err_exit ("%s", key);
+    if (!(dir = kvsdir_create (h, NULL, key, json_str)))
+        log_err_exit ("kvsdir_create");
     dump_kvs_dir (dir, Ropt, dopt);
     kvsdir_destroy (dir);
+    flux_future_destroy (f);
     return (0);
 }
 
 int cmd_copy (optparse_t *p, int argc, char **argv)
 {
-    flux_t *h;
+    flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     int optindex;
-
-    h = (flux_t *)optparse_get_data (p, "flux_handle");
+    flux_future_t *f;
+    const char *srckey, *dstkey, *json_str;
+    flux_kvs_txn_t *txn;
 
     optindex = optparse_option_index (p);
-
-    if ((optindex - argc) == 0) {
-        optparse_print_usage (p);
-        exit (1);
-    }
     if (optindex != (argc - 2))
         log_msg_exit ("copy: specify srckey dstkey");
-    if (kvs_copy (h, argv[optindex], argv[optindex + 1]) < 0)
-        log_err_exit ("kvs_copy %s %s", argv[optindex], argv[optindex + 1]);
-    if (kvs_commit (h, 0) < 0)
-        log_err_exit ("kvs_commit");
+    srckey = argv[optindex];
+    dstkey = argv[optindex + 1];
+
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_TREEOBJ, srckey))
+            || flux_kvs_lookup_get (f, &json_str) < 0)
+        log_err_exit ("flux_kvs_lookup %s", srckey);
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+    if (flux_kvs_txn_put (txn, FLUX_KVS_TREEOBJ, dstkey, json_str) < 0)
+        log_err_exit( "flux_kvs_txn_put");
+    flux_future_destroy (f);
+
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_commit");
+    flux_kvs_txn_destroy (txn);
+    flux_future_destroy (f);
     return (0);
 }
 
@@ -803,21 +835,33 @@ int cmd_move (optparse_t *p, int argc, char **argv)
 {
     flux_t *h;
     int optindex;
+    flux_future_t *f;
+    const char *srckey, *dstkey, *json_str;
+    flux_kvs_txn_t *txn;
 
     h = (flux_t *)optparse_get_data (p, "flux_handle");
 
     optindex = optparse_option_index (p);
-
-    if ((optindex - argc) == 0) {
-        optparse_print_usage (p);
-        exit (1);
-    }
     if (optindex != (argc - 2))
         log_msg_exit ("move: specify srckey dstkey");
-    if (kvs_move (h, argv[optindex], argv[optindex + 1]) < 0)
-        log_err_exit ("kvs_move %s %s", argv[optindex], argv[optindex + 1]);
-    if (kvs_commit (h, 0) < 0)
-        log_err_exit ("kvs_commit");
+    srckey = argv[optindex];
+    dstkey = argv[optindex + 1];
+
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_TREEOBJ, srckey))
+            || flux_kvs_lookup_get (f, &json_str) < 0)
+        log_err_exit ("flux_kvs_lookup %s", srckey);
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+    if (flux_kvs_txn_put (txn, FLUX_KVS_TREEOBJ, dstkey, json_str) < 0)
+        log_err_exit( "flux_kvs_txn_put");
+    if (flux_kvs_txn_unlink (txn, 0, srckey) < 0)
+        log_err_exit( "flux_kvs_txn_unlink");
+    flux_future_destroy (f);
+
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_commit");
+    flux_kvs_txn_destroy (txn);
+    flux_future_destroy (f);
     return (0);
 }
 

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -375,17 +375,6 @@ int kvsdir_unlink (kvsdir_t *dir, const char *key)
     return rc;
 }
 
-int kvsdir_symlink (kvsdir_t *dir, const char *key, const char *target)
-{
-    struct dir_put dp;
-    int rc;
-    if (dir_put_init (dir, key, &dp) < 0)
-        return -1;
-    rc = flux_kvs_txn_symlink (dp.txn, 0, dp.key, target);
-    dir_put_fini (&dp);
-    return rc;
-}
-
 int kvsdir_mkdir (kvsdir_t *dir, const char *key)
 {
     struct dir_put dp;

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -287,13 +287,6 @@ done:
     return rc;
 }
 
-int kvs_move (flux_t *h, const char *from, const char *to)
-{
-    if (kvs_copy (h, from, to) < 0)
-        return -1;
-    return kvs_unlink (h, from);
-}
-
 struct dir_put {
     char *key;
     flux_kvs_txn_t *txn;

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -266,27 +266,6 @@ int kvs_mkdir (flux_t *h, const char *key)
     return flux_kvs_txn_mkdir (txn, 0, key);
 }
 
-int kvs_copy (flux_t *h, const char *from, const char *to)
-{
-    flux_kvs_txn_t *txn = get_default_txn (h);
-    flux_future_t *f;
-    const char *json_str;
-    int rc = -1;
-
-    if (!txn)
-        return -1;
-    if (!(f = flux_kvs_lookup (h, FLUX_KVS_TREEOBJ, from)))
-        goto done;
-    if (flux_kvs_lookup_get (f, &json_str) < 0)
-        goto done;
-    if (flux_kvs_txn_put (txn, FLUX_KVS_TREEOBJ, to, json_str) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
 struct dir_put {
     char *key;
     flux_kvs_txn_t *txn;

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -15,7 +15,6 @@ int kvs_unlink (flux_t *h, const char *key);
 int kvs_symlink (flux_t *h, const char *key, const char *target);
 int kvs_mkdir (flux_t *h, const char *key);
 int kvs_copy (flux_t *h, const char *from, const char *to);
-int kvs_move (flux_t *h, const char *from, const char *to);
 
 int kvs_commit (flux_t *h, int flags);
 int kvs_fence (flux_t *h, const char *name, int nprocs, int flags);

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -30,7 +30,6 @@ int kvsdir_put_double (kvsdir_t *dir, const char *key, double val);
 int kvsdir_put_boolean (kvsdir_t *dir, const char *key, bool val);
 
 int kvsdir_unlink (kvsdir_t *dir, const char *key);
-int kvsdir_symlink (kvsdir_t *dir, const char *key, const char *target);
 int kvsdir_mkdir (kvsdir_t *dir, const char *key);
 
 

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -14,7 +14,6 @@ int kvs_put_int64 (flux_t *h, const char *key, int64_t val);
 int kvs_unlink (flux_t *h, const char *key);
 int kvs_symlink (flux_t *h, const char *key, const char *target);
 int kvs_mkdir (flux_t *h, const char *key);
-int kvs_copy (flux_t *h, const char *from, const char *to);
 
 int kvs_commit (flux_t *h, int flags);
 int kvs_fence (flux_t *h, const char *name, int nprocs, int flags);

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -616,23 +616,6 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, mix
 
 # watch tests
 
-test_expect_success 'kvs: watch 5 versions of key'  '
-	${KVSBASIC} unlink $TEST.foo &&
-        ${KVSBASIC} put $TEST.foo.a=1 &&
-	${KVSBASIC} watch 5 $TEST.foo.a >watch_out &
-        for i in $(seq 2 5); do
-            ${KVSBASIC} put $TEST.foo.a=${i}
-        done
-'
-
-test_expect_success 'kvs: watch 5 versions of directory'  '
-	${KVSBASIC} unlink $TEST.foo &&
-	${KVSBASIC} watch-dir -r 5 $TEST.foo >watch_dir_out &
-	while $(grep -s '===============' watch_dir_out | wc -l) -lt 5; do
-	    ${KVSBASIC} put $TEST.foo.a=$(date +%N); \
-	done
-'
-
 test_expect_success 'kvs: watch-mt: multi-threaded kvs watch program' '
 	${FLUX_BUILD_DIR}/t/kvs/watch mt 100 100 $TEST.a &&
 	${KVSBASIC} unlink $TEST.a

--- a/t/t1000-kvs-basic.t
+++ b/t/t1000-kvs-basic.t
@@ -130,7 +130,7 @@ test_expect_success 'kvs: array type' '
 	test_kvs_type $KEY array
 '
 test_expect_success 'kvs: array get' '
-	test_kvs_key $KEY "[ 1, 3, 5, 7 ]"
+	test_kvs_key $KEY "[1, 3, 5, 7]"
 '
 test_expect_success 'kvs: object put' '
 	${KVSBASIC} put $KEY="{\"a\":42}"
@@ -139,7 +139,7 @@ test_expect_success 'kvs: object type' '
 	test_kvs_type $KEY object
 '
 test_expect_success 'kvs: object get' '
-	test_kvs_key $KEY "{ \"a\": 42 }"
+	test_kvs_key $KEY "{\"a\": 42}"
 '
 test_expect_success 'kvs: try to retrieve key as directory should fail' '
 	test_must_fail ${KVSBASIC} dir $KEY

--- a/t/t1002-kvs-cmd.t
+++ b/t/t1002-kvs-cmd.t
@@ -68,10 +68,10 @@ test_expect_success 'kvs: boolean get' '
 	test_kvs_key $KEY.boolean true
 '
 test_expect_success 'kvs: array get' '
-	test_kvs_key $KEY.array "[ 1, 3, 5 ]"
+	test_kvs_key $KEY.array "[1, 3, 5]"
 '
 test_expect_success 'kvs: object get' '
-	test_kvs_key $KEY.object "{ \"a\": 42 }"
+	test_kvs_key $KEY.object "{\"a\": 42}"
 '
 test_expect_success 'kvs: dir' '
 	flux kvs dir $DIR | sort >output
@@ -84,11 +84,11 @@ EOF
 test_expect_success 'kvs: dir -R' '
 	flux kvs dir -R $DIR | sort >output
 	cat >expected <<EOF
-$KEY.array = [ 1, 3, 5 ]
+$KEY.array = [1, 3, 5]
 $KEY.boolean = true
 $KEY.double = 3.140000
 $KEY.integer = 42
-$KEY.object = { "a": 42 }
+$KEY.object = {"a": 42}
 $KEY.string = foo
 EOF
 	test_cmp expected output
@@ -152,8 +152,8 @@ test_expect_success 'kvs: get (multiple)' '
 3.140000
 foo
 true
-[ 1, 3, 5 ]
-{ "a": 42 }
+[1, 3, 5]
+{"a": 42}
 EOF
 	test_cmp expected output
 '
@@ -176,8 +176,8 @@ $KEY.a = 42
 $KEY.b = 3.140000
 $KEY.c = foo
 $KEY.d = true
-$KEY.e = [ 1, 3, 5 ]
-$KEY.f = { "a": 42 }
+$KEY.e = [1, 3, 5]
+$KEY.f = {"a": 42}
 EOF
 	test_cmp expected output
 '


### PR DESCRIPTION
This PR converts some KVS users to new API functions and jansson, and removes several "classic" functions: `kvs_move()`, `kvs_copy()`, and `kvsdir_symlink()` from the API.

