### PR TITLE
KVS oom() and xzmalloc() cleanup

### DIFF
--- a/src/common/libkvs/jansson_dirent.c
+++ b/src/common/libkvs/jansson_dirent.c
@@ -37,20 +37,27 @@
 
 json_t *j_dirent_create (const char *type, void *arg)
 {
-    json_t *dirent;
+    json_t *dirent = NULL;
     bool valid_type = false;
 
-    if (!(dirent = json_object ()))
-        oom ();
+    if (!(dirent = json_object ())) {
+        errno = ENOMEM;
+        goto error;
+    }
 
     if (!strcmp (type, "FILEREF") || !strcmp (type, "DIRREF")) {
         char *ref = arg;
         json_t *o;
 
-        if (!(o = json_string (ref)))
-            oom ();
-        if (json_object_set_new (dirent, type, o) < 0)
-            oom ();
+        if (!(o = json_string (ref))) {
+            errno = ENOMEM;
+            goto error;
+        }
+        if (json_object_set_new (dirent, type, o) < 0) {
+            json_decref (o);
+            errno = ENOMEM;
+            goto error;
+        }
 
         valid_type = true;
     } else if (!strcmp (type, "FILEVAL") || !strcmp (type, "DIRVAL")
@@ -60,16 +67,25 @@ json_t *j_dirent_create (const char *type, void *arg)
         if (val)
             json_incref (val);
         else {
-            if (!(val = json_object ()))
-                oom ();
+            if (!(val = json_object ())) {
+                errno = ENOMEM;
+                goto error;
+            }
         }
-        if (json_object_set_new (dirent, type, val) < 0)
-            oom ();
+        if (json_object_set_new (dirent, type, val) < 0) {
+            json_decref (val);
+            errno = ENOMEM;
+            goto error;
+        }
         valid_type = true;
     }
     assert (valid_type == true);
 
     return dirent;
+
+error:
+    json_decref (dirent);
+    return NULL;
 }
 
 int j_dirent_validate (json_t *dirent)

--- a/src/common/libkvs/jansson_dirent.c
+++ b/src/common/libkvs/jansson_dirent.c
@@ -31,7 +31,6 @@
 #include <jansson.h>
 
 #include "src/common/libutil/blobref.h"
-#include "src/common/libutil/oom.h"
 
 #include "jansson_dirent.h"
 

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -46,7 +46,6 @@
 #include "src/common/libutil/iterators.h"
 
 #include "waitqueue.h"
-#include "kvs_util.h"
 #include "cache.h"
 
 struct cache_entry {

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -153,7 +153,8 @@ int cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait)
             if (!(hp->waitlist_notdirty = wait_queue_create ()))
                 return -1;
         }
-        wait_addqueue (hp->waitlist_notdirty, wait);
+        if (wait_addqueue (hp->waitlist_notdirty, wait) < 0)
+            return -1;
     }
     return 0;
 }
@@ -165,7 +166,8 @@ int cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait)
             if (!(hp->waitlist_valid = wait_queue_create ()))
                 return -1;
         }
-        wait_addqueue (hp->waitlist_valid, wait);
+        if (wait_addqueue (hp->waitlist_valid, wait) < 0)
+            return -1;
     }
     return 0;
 }

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -304,7 +304,11 @@ done:
 
 struct cache *cache_create (void)
 {
-    struct cache *cache = xzmalloc (sizeof (*cache));
+    struct cache *cache = calloc (1, sizeof (*cache));
+    if (!cache) {
+        errno = ENOMEM;
+        return NULL;
+    }
     if (!(cache->zh = zhash_new ())) {
         free (cache);
         errno = ENOMEM;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -41,7 +41,6 @@
 #include <jansson.h>
 
 #include "src/common/libutil/blobref.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/iterators.h"
@@ -64,7 +63,11 @@ struct cache {
 
 struct cache_entry *cache_entry_create (json_t *o)
 {
-    struct cache_entry *hp = xzmalloc (sizeof (*hp));
+    struct cache_entry *hp = calloc (1, sizeof (*hp));
+    if (!hp) {
+        errno = ENOMEM;
+        return NULL;
+    }
     if (o)
         hp->o = o;
     return hp;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -144,22 +144,28 @@ void cache_entry_destroy (void *arg)
     }
 }
 
-void cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait)
+int cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait)
 {
     if (wait) {
-        if (!hp->waitlist_notdirty)
-            hp->waitlist_notdirty = wait_queue_create ();
+        if (!hp->waitlist_notdirty) {
+            if (!(hp->waitlist_notdirty = wait_queue_create ()))
+                return -1;
+        }
         wait_addqueue (hp->waitlist_notdirty, wait);
     }
+    return 0;
 }
 
-void cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait)
+int cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait)
 {
     if (wait) {
-        if (!hp->waitlist_valid)
-            hp->waitlist_valid = wait_queue_create ();
+        if (!hp->waitlist_valid) {
+            if (!(hp->waitlist_valid = wait_queue_create ()))
+                return -1;
+        }
         wait_addqueue (hp->waitlist_valid, wait);
     }
+    return 0;
 }
 
 struct cache_entry *cache_lookup (struct cache *cache, const char *ref,

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -305,8 +305,11 @@ done:
 struct cache *cache_create (void)
 {
     struct cache *cache = xzmalloc (sizeof (*cache));
-    if (!(cache->zh = zhash_new ()))
-        oom ();
+    if (!(cache->zh = zhash_new ())) {
+        free (cache);
+        errno = ENOMEM;
+        return NULL;
+    }
     return cache;
 }
 

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -49,9 +49,10 @@ void cache_entry_set_json (struct cache_entry *hp, json_t *o);
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a
  * load or store RPC.
+ * Returns -1 on error, 0 on success
  */
-void cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait);
-void cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait);
+int cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait);
+int cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait);
 
 /* Create/destroy the cache container and its contents.
  */

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -45,7 +45,6 @@ int cache_entry_clear_dirty (struct cache_entry *hp);
  */
 json_t *cache_entry_get_json (struct cache_entry *hp);
 void cache_entry_set_json (struct cache_entry *hp, json_t *o);
-int cache_entry_clear_json (struct cache_entry *hp);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -92,13 +92,15 @@ int cache_count_entries (struct cache *cache);
 
 /* Expire cache entries that are not dirty, not incomplete, and last
  * used more than 'thresh' epoch's ago.
+ * Returns -1 on error, expired count on success.
  */
 int cache_expire_entries (struct cache *cache, int current_epoch, int thresh);
 
 /* Obtain statistics on the cache.
+ * Returns -1 on error, 0 on success
  */
-void cache_get_stats (struct cache *cache, tstat_t *ts, int *size,
-                      int *incomplete, int *dirty);
+int cache_get_stats (struct cache *cache, tstat_t *ts, int *size,
+                     int *incomplete, int *dirty);
 
 /* Destroy wait_t's on the waitqueue_t of any cache entry
  * if they meet match criteria.

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -192,7 +192,10 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         goto decref_done;
     }
     if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
-        hp = cache_entry_create (NULL);
+        if (!(hp = cache_entry_create (NULL))) {
+            errno = ENOMEM;
+            goto decref_done;
+        }
         cache_insert (c->cm->cache, ref, hp);
     }
     if (cache_entry_get_valid (hp)) {

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -230,7 +230,7 @@ static int fileval_big (json_t *value)
 
 /* Store DIRVAL objects, converting them to DIRREFs.
  * Store (large) FILEVAL objects, converting them to FILEREFs.
- * Return false and enqueue wait_t on cache object(s) if any are dirty.
+ * Return 0 on success, -1 on error
  */
 static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
 {

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -339,8 +339,12 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
                 json_decref (subdir);
                 goto done;
             }
-            if (json_object_set_new (dir, name, tmpdirent) < 0)
-                oom ();
+            if (json_object_set_new (dir, name, tmpdirent) < 0) {
+                json_decref (tmpdirent);
+                json_decref (subdir);
+                errno = ENOMEM;
+                goto done;
+            }
             json_decref (subdir);
         } else if ((o = json_object_get (subdirent, "DIRVAL"))) {
             subdir = o;
@@ -359,8 +363,12 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
                 json_decref (subdir);
                 goto done;
             }
-            if (json_object_set_new (dir, name, tmpdirent) < 0)
-                oom ();
+            if (json_object_set_new (dir, name, tmpdirent) < 0) {
+                json_decref (tmpdirent);
+                json_decref (subdir);
+                errno = ENOMEM;
+                goto done;
+            }
             json_decref (subdir);
         } else if ((o = json_object_get (subdirent, "LINKVAL"))) {
             assert (json_is_string (o));
@@ -391,8 +399,12 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
                 json_decref (subdir);
                 goto done;
             }
-            if (json_object_set_new (dir, name, tmpdirent) < 0)
-                oom ();
+            if (json_object_set_new (dir, name, tmpdirent) < 0) {
+                json_decref (tmpdirent);
+                json_decref (subdir);
+                errno = ENOMEM;
+                goto done;
+            }
             json_decref (subdir);
         }
         name = next;
@@ -401,8 +413,10 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
     /* This is the final path component of the key.  Add it to the directory.
      */
     if (!json_is_null (dirent)) {
-        if (json_object_set_new (dir, name, json_incref (dirent)) < 0)
-            oom ();
+        if (json_object_set_new (dir, name, json_incref (dirent)) < 0) {
+            json_decref (dirent);
+            goto done;
+        }
     }
     else
         json_object_del (dir, name);

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -85,6 +85,13 @@ int commit_iter_dirty_cache_entries (commit_t *c,
                                      commit_cache_entry_cb cb,
                                      void *data);
 
+/* convenience function for cleaning up a dirty cache entry that was
+ * returned to the user via commit_process().  Generally speaking, this
+ * should only be used for error cleanup in the callback function used in
+ * commit_iter_dirty_cache_entries().
+ */
+void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp);
+
 /*
  * commit_mgr_t API
  */

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -36,7 +36,6 @@
 #include <flux/core.h>
 #include <jansson.h>
 
-#include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/oom.h"
 
 #include "fence.h"

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -75,10 +75,15 @@ fence_t *fence_create (const char *name, int nprocs, int flags)
     f->nprocs = nprocs;
     f->flags = flags;
     if (name) {
-        if (!(s = json_string (name)))
-            oom();
-        if (json_array_append_new (f->names, s) < 0)
-            oom();
+        if (!(s = json_string (name))) {
+            errno = ENOMEM;
+            goto error;
+        }
+        if (json_array_append_new (f->names, s) < 0) {
+            json_decref (s);
+            errno = ENOMEM;
+            goto error;
+        }
     }
 
     return f;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -286,7 +286,10 @@ static int content_store_request_send (kvs_ctx_t *ctx, json_t *val,
     int size;
     int rc = -1;
 
-    data = kvs_util_json_dumps (val);
+    if (!(data = kvs_util_json_dumps (val))) {
+        errno = ENOMEM;
+        goto error;
+    }
 
     size = strlen (data) + 1;
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -669,8 +669,11 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
 
     if (!root_dirent) {
-        tmp_dirent = j_dirent_create ("DIRREF",
-                                      (char *)lookup_get_root_ref (lh));
+        char *tmprootref = (char *)lookup_get_root_ref (lh);
+        if (!(tmp_dirent = j_dirent_create ("DIRREF", tmprootref))) {
+            flux_log_error (h, "%s: j_dirent_create", __FUNCTION__);
+            goto done;
+        }
         root_dirent = tmp_dirent;
     }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1349,10 +1349,10 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
             /* Must clean up, don't want cache entry to be assumed
              * valid.  Everything here is synchronous and w/o waiters,
              * so nothing should error here */
-            assert (cache_entry_clear_dirty (hp) == 0);
-            assert (cache_remove_entry (ctx->cache, ref) == 1);
             flux_log_error (ctx->h, "%s: content_store_request_send",
                             __FUNCTION__);
+            assert (cache_entry_clear_dirty (hp) == 0);
+            assert (cache_remove_entry (ctx->cache, ref) == 1);
             goto done;
         }
     } else

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -49,17 +49,10 @@ char *kvs_util_json_dumps (json_t *o)
     int flags = JSON_ENCODE_ANY | JSON_COMPACT | JSON_SORT_KEYS;
     char *s;
     if (!o) {
-        json_t *tmp;
-        if (!(tmp = json_null ())) {
+        if (!(s = strdup ("null"))) {
             errno = ENOMEM;
             return NULL;
         }
-        if (!(s = json_dumps (tmp, flags))) {
-            json_decref (tmp);
-            errno = ENOMEM;
-            return NULL;
-        }
-        json_decref (tmp);
         return s;
     }
     if (!(s = json_dumps (o, flags))) {

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -35,7 +35,6 @@
 #include <jansson.h>
 
 #include "src/common/libutil/blobref.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/oom.h"
 

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -36,25 +36,8 @@
 
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/oom.h"
 
 #include "types.h"
-
-json_t *kvs_util_json_copydir (json_t *dir)
-{
-    json_t *cpy;
-    const char *key;
-    json_t *value;
-
-    if (!(cpy = json_object ()))
-        oom ();
-
-    json_object_foreach (dir, key, value) {
-        if (json_object_set (cpy, key, value) < 0)
-            oom ();
-    }
-    return cpy;
-}
 
 char *kvs_util_json_dumps (json_t *o)
 {

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -62,6 +62,19 @@ char *kvs_util_json_dumps (json_t *o)
     return s;
 }
 
+int kvs_util_json_encoded_size (json_t *o, size_t *size)
+{
+    char *s = kvs_util_json_dumps (o);
+    if (!s) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (size)
+        *size = strlen (s);
+    free (s);
+    return 0;
+}
+
 int kvs_util_json_hash (const char *hash_name, json_t *o, href_t ref)
 {
     char *s;

--- a/src/modules/kvs/kvs_util.h
+++ b/src/modules/kvs/kvs_util.h
@@ -6,10 +6,6 @@
 #include "waitqueue.h"
 #include "types.h"
 
-/* Copy element wise a json directory object into a new json object.
- */
-json_t *kvs_util_json_copydir (json_t *dir);
-
 /* Get compact string representation of json object, or json null
  * object if o is NULL.  Use this function for consistency, especially
  * when dealing with data that may be hashed via json_hash().

--- a/src/modules/kvs/kvs_util.h
+++ b/src/modules/kvs/kvs_util.h
@@ -14,6 +14,9 @@
  */
 char *kvs_util_json_dumps (json_t *o);
 
+/* returns 0 on success, -1 on failure */
+int kvs_util_json_encoded_size (json_t *o, size_t *size);
+
 /* Calculate hash of a json object
  *
  * Returns -1 on error, 0 on success

--- a/src/modules/kvs/kvs_util.h
+++ b/src/modules/kvs/kvs_util.h
@@ -13,10 +13,14 @@ json_t *kvs_util_json_copydir (json_t *dir);
 /* Get compact string representation of json object, or json null
  * object if o is NULL.  Use this function for consistency, especially
  * when dealing with data that may be hashed via json_hash().
+ *
+ * Returns NULL on error
  */
 char *kvs_util_json_dumps (json_t *o);
 
 /* Calculate hash of a json object
+ *
+ * Returns -1 on error, 0 on success
  */
 int kvs_util_json_hash (const char *hash_name, json_t *o, href_t ref);
 

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -41,7 +41,6 @@
 #include "src/common/libkvs/jansson_dirent.h"
 
 #include "cache.h"
-#include "kvs_util.h"
 
 #include "lookup.h"
 
@@ -582,7 +581,10 @@ bool lookup (lookup_t *lh)
                     lh->missing_ref = reftmp;
                     goto stall;
                 }
-                lh->val = kvs_util_json_copydir (valtmp);
+                if (!(lh->val = json_copy (valtmp))) {
+                    lh->errnum = ENOMEM;
+                    goto done;
+                }
             } else if ((vp = json_object_get (lh->wdirent, "FILEREF"))) {
                 if ((lh->flags & FLUX_KVS_READLINK)) {
                     lh->errnum = EINVAL;
@@ -610,7 +612,10 @@ bool lookup (lookup_t *lh)
                     lh->errnum = EISDIR;
                     goto done;
                 }
-                lh->val = kvs_util_json_copydir (vp);
+                if (!(lh->val = json_copy (vp))) {
+                    lh->errnum = ENOMEM;
+                    goto done;
+                }
             } else if ((vp = json_object_get (lh->wdirent, "FILEVAL"))) {
                 if ((lh->flags & FLUX_KVS_READLINK)) {
                     lh->errnum = EINVAL;

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -89,7 +89,8 @@ int main (int argc, char *argv[])
         "cache_entry_clear_dirty returns error, b/c no object set");
     o1 = json_object ();
     json_object_set_new (o1, "foo", json_integer (42));
-    cache_entry_wait_valid (e1, w);
+    ok (cache_entry_wait_valid (e1, w) == 0,
+        "cache_entry_wait_valid success");
     cache_entry_set_json (e1, o1);
     ok (cache_entry_get_valid (e1) == true,
         "cache entry set valid with one waiter");
@@ -102,7 +103,8 @@ int main (int argc, char *argv[])
     cache_entry_set_dirty (e1, true);
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry set dirty, adding waiter");
-    cache_entry_wait_notdirty (e1, w);
+    ok (cache_entry_wait_notdirty (e1, w) == 0,
+        "cache_entry_wait_notdirty success");
     ok (cache_entry_clear_dirty (e1) == 1,
         "cache_entry_clear_dirty returns 1, b/c of a waiter");
     cache_entry_set_dirty (e1, false);
@@ -233,7 +235,8 @@ int main (int argc, char *argv[])
         "cache_lookup verify entry exists");
     ok (cache_entry_get_valid (e5) == false,
         "cache entry invalid, adding waiter");
-    cache_entry_wait_valid (e5, w);
+    ok (cache_entry_wait_valid (e5, w) == 0,
+        "cache_entry_wait_valid success");
     ok (cache_remove_entry (cache, "remove-ref") == 0,
         "cache_remove_entry failed on valid waiter");
     o4 = json_string ("foobar");
@@ -259,7 +262,8 @@ int main (int argc, char *argv[])
     cache_entry_set_dirty (e5, true);
     ok (cache_remove_entry (cache, "remove-ref") == 0,
         "cache_remove_entry not removed b/c dirty");
-    cache_entry_wait_notdirty (e5, w);
+    ok (cache_entry_wait_notdirty (e5, w) == 0,
+        "cache_entry_wait_notdirty success");
     ok (cache_remove_entry (cache, "remove-ref") == 0,
         "cache_remove_entry failed on notdirty waiter");
     cache_entry_set_dirty (e5, false);

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -73,6 +73,9 @@ int main (int argc, char *argv[])
         "json_object_get success");
     ok (json_integer_value (o) == 42,
         "expected json object found");
+    cache_entry_set_json (e1, NULL);
+    ok (cache_entry_get_json (e1) == NULL,
+        "cache entry no longer has json object");
     cache_entry_destroy (e1); /* destroys o1 */
 
     /* Test cache entry waiters.

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -778,6 +778,7 @@ int ref_error_cb (commit_t *c, const char *ref, void *data)
 
 int cache_error_cb (commit_t *c, struct cache_entry *hp, void *data)
 {
+    commit_cleanup_dirty_cache_entry (c, hp);
     return -1;
 }
 

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -13,7 +13,6 @@
 #include "src/modules/kvs/fence.h"
 #include "src/modules/kvs/kvs_util.h"
 #include "src/modules/kvs/types.h"
-#include "src/common/libutil/oom.h"
 
 static int test_global = 5;
 

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -8,7 +8,6 @@
 #include "src/common/libkvs/kvs.h"
 #include "src/common/libflux/message.h"
 #include "src/common/libflux/request.h"
-#include "src/modules/kvs/kvs_util.h"
 #include "src/modules/kvs/fence.h"
 
 int msg_cb (fence_t *f, const flux_msg_t *req, void *data)

--- a/src/modules/kvs/test/kvs_util.c
+++ b/src/modules/kvs/test/kvs_util.c
@@ -13,6 +13,7 @@ int main (int argc, char *argv[])
     json_t *obj;
     href_t ref;
     char *s1, *s2;
+    size_t size;
 
     plan (NO_PLAN);
 
@@ -43,6 +44,15 @@ int main (int argc, char *argv[])
     ok (!strcmp (s1, s2),
         "kvs_util_json_dumps dumps correct string");
 
+    ok (kvs_util_json_encoded_size (obj, NULL) == 0,
+        "kvs_util_json_encoded_size works w/ NULL size param");
+
+    ok (kvs_util_json_encoded_size (obj, &size) == 0,
+        "kvs_util_json_encoded_size works");
+
+    ok (size == strlen (s2),
+        "kvs_util_json_encoded_size returns correct size");
+
     free (s1);
     s1 = NULL;
     json_decref (obj);
@@ -57,6 +67,12 @@ int main (int argc, char *argv[])
     ok (!strcmp (s1, s2),
         "kvs_util_json_dumps works on null object");
 
+    ok (kvs_util_json_encoded_size (obj, &size) == 0,
+        "kvs_util_json_encoded_size works");
+
+    ok (size == strlen (s2),
+        "kvs_util_json_encoded_size returns correct size");
+
     free (s1);
     s1 = NULL;
     json_decref (obj);
@@ -69,8 +85,15 @@ int main (int argc, char *argv[])
     ok (!strcmp (s1, s2),
         "kvs_util_json_dumps works on NULL pointer");
 
+    ok (kvs_util_json_encoded_size (NULL, &size) == 0,
+        "kvs_util_json_encoded_size works on NULL pointer");
+
+    ok (size == strlen (s2),
+        "kvs_util_json_encoded_size returns correct size");
+
     free (s1);
     s1 = NULL;
+
 
     done_testing ();
     return (0);

--- a/src/modules/kvs/test/kvs_util.c
+++ b/src/modules/kvs/test/kvs_util.c
@@ -10,9 +10,8 @@
 
 int main (int argc, char *argv[])
 {
-    json_t *obj, *cpy, *o;
+    json_t *obj;
     href_t ref;
-    const char *s;
     char *s1, *s2;
 
     plan (NO_PLAN);
@@ -22,35 +21,6 @@ int main (int argc, char *argv[])
     json_object_set_new (obj, "B", json_string ("bar"));
     json_object_set_new (obj, "C", json_string ("cow"));
 
-    ok ((cpy = kvs_util_json_copydir (obj)) != NULL,
-        "kvs_util_json_copydir works");
-
-    /* first manually verify */
-    ok ((o = json_object_get (cpy, "A")) != NULL,
-        "json_object_get got object A");
-    ok ((s = json_string_value (o)) != NULL,
-        "json_string_value got string A");
-    ok (strcmp (s, "foo") == 0,
-        "string A is correct");
-
-    ok ((o = json_object_get (cpy, "B")) != NULL,
-        "json_object_get got object B");
-    ok ((s = json_string_value (o)) != NULL,
-        "json_string_value got string B");
-    ok (strcmp (s, "bar") == 0,
-        "string B is correct");
-
-    ok ((o = json_object_get (cpy, "C")) != NULL,
-        "json_object_get got object C");
-    ok ((s = json_string_value (o)) != NULL,
-        "json_string_value got string C");
-    ok (strcmp (s, "cow") == 0,
-        "string C is correct");
-
-    /* now use comparison to verify */
-    ok (json_equal (cpy, obj) == true,
-        "json_equal returns true on duplicate");
-
     ok (kvs_util_json_hash ("sha1", obj, ref) == 0,
         "kvs_util_json_hash works on sha1");
 
@@ -58,7 +28,6 @@ int main (int argc, char *argv[])
         "kvs_util_json_hash error on bad hash name");
 
     json_decref (obj);
-    json_decref (cpy);
 
     obj = json_object ();
     json_object_set_new (obj, "A", json_string ("a"));

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -8,7 +8,6 @@
 #include "src/common/libkvs/jansson_dirent.h"
 #include "src/modules/kvs/cache.h"
 #include "src/modules/kvs/lookup.h"
-#include "src/modules/kvs/kvs_util.h"
 
 void basic_api (void)
 {

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -62,7 +62,8 @@ int main (int argc, char *argv[])
        "wait_create works");
     ok ((q = wait_queue_create ()) != NULL,
        "wait_queue_create works");
-    wait_addqueue (q, w);
+    ok (wait_addqueue (q, w) == 0,
+        "wait_addqueue works");
     ok (wait_get_usecount (w) == 1,
        "wait_get_usecount 1 after wait_addqueue");
     ok (count == 0,
@@ -99,10 +100,12 @@ int main (int argc, char *argv[])
 
     ok (wait_get_usecount (w) == 0,
         "wait_usecount 0 initially");
-    wait_addqueue (q, w);
+    ok (wait_addqueue (q, w) == 0,
+        "wait_addqueue works");
     ok (wait_get_usecount (w) == 1,
         "wait_usecount 1 after adding to one queue");
-    wait_addqueue (q2, w);
+    ok (wait_addqueue (q2, w) == 0,
+        "wait_addqueue works");
     ok (wait_get_usecount (w) == 2,
         "wait_usecount 2 after adding to second queue");
     ok (wait_queue_length (q) == 1 && wait_queue_length (q2) == 1,
@@ -136,7 +139,8 @@ int main (int argc, char *argv[])
         if (!(w = wait_create_msg_handler (NULL, NULL, msg, msghand, &count)))
             break;
         flux_msg_destroy (msg); /* msg was copied into wait_t */
-        wait_addqueue (q, w);
+        if (wait_addqueue (q, w) < 0)
+            break;
     }
     ok (wait_queue_length (q) == 20,
         "wait_queue_length 20 after 20 wait_addqueues");

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -1,6 +1,5 @@
 #include "src/modules/kvs/waitqueue.h"
 #include "src/common/libflux/message.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "src/common/libtap/tap.h"
 
 void wait_cb (void *arg)

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -140,13 +140,16 @@ int wait_queue_length (waitqueue_t *q)
     return zlist_size (q->q);
 }
 
-void wait_addqueue (waitqueue_t *q, wait_t *w)
+int wait_addqueue (waitqueue_t *q, wait_t *w)
 {
     assert (q->magic == WAITQUEUE_MAGIC);
     assert (w->magic == WAIT_MAGIC);
-    if (zlist_append (q->q, w) < 0)
-        oom ();
+    if (zlist_append (q->q, w) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
     w->usecount++;
+    return 0;
 }
 
 static void wait_runone (wait_t *w)

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -29,7 +29,6 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/oom.h"
-#include "src/common/libutil/xzmalloc.h"
 
 #include "waitqueue.h"
 
@@ -106,9 +105,16 @@ void wait_destroy (wait_t *w)
 
 waitqueue_t *wait_queue_create (void)
 {
-    waitqueue_t *q = xzmalloc (sizeof (*q));
-    if (!(q->q = zlist_new ()))
-        oom ();
+    waitqueue_t *q = calloc (1, sizeof (*q));
+    if (!q) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (!(q->q = zlist_new ())) {
+        free (q);
+        errno = ENOMEM;
+        return NULL;
+    }
     q->magic = WAITQUEUE_MAGIC;
     return q;
 }

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -59,6 +59,7 @@ wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *w,
 
 /* Destroy all wait_t's fitting message match critieria, tested with
  * wait_test_msg_f callback.
+ * On error, the waitqueue is unaltered.
  */
 typedef bool (*wait_test_msg_f)(const flux_msg_t *msg, void *arg);
 int wait_destroy_msg (waitqueue_t *q, wait_test_msg_f cb, void *arg);

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -38,8 +38,9 @@ void wait_queue_destroy (waitqueue_t *q);
 int wait_queue_length (waitqueue_t *q);
 
 /* Add a wait_t to a queue.
+ * Returns -1 on error, 0 on success
  */
-void wait_addqueue (waitqueue_t *q, wait_t *wait);
+int wait_addqueue (waitqueue_t *q, wait_t *wait);
 
 /* Remove all wait_t's from the specified queue.
  * Note: wait_runqueue() empties the waitqueue_t before invoking wait_t


### PR DESCRIPTION
Like other refactorings that have been going on in flux-core, this one removes a large number of ```oom()``` calls and functions that call ```oom()``` (notably ```xzmalloc()``` and ```xstrdup()```).  Instead
ENOMEM is detected, properly return as an error, check for error, log error, etc.

A few ```oom()```s remain (```wait_runqueue()``` and the merging ops functions).  Those will require a tad more re-architecture and logic updates so I will put those in another PR.  The changes in this PR are relatively more grunted out fixes without much thought except for cleanup path handling.

I suspect the coverage on this diff will be bad.  I'd be surprised if it was even greater than 50% coverage, as almost the entirety of it is handling ENOMEM errors and the cascading checks for functions that can now return an ENOMEM error.
