### PR TITLE
Fix testsuite --chain-lint option, add timeout to some tests, and other testing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,8 @@ after_failure:
  - find . -name *.broker.log | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - src/test/backtrace-all.sh
  - cat config.log
+ # Issue #997 debugging
+ - cat src/common/libflux/test_reactor.log
 
 before_deploy:
   # Get anchor (formatted properly) and base URI for latest tag in NEWS file

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
  round: down
  range: "50...100"
  ignore:
- - ".*/t/.*"
+ - "t/.*"
  - ".*/test/.*"
  - ".*/tests/.*"
  - ".*/man3/*.c"

--- a/src/common/libflux/test/security.c
+++ b/src/common/libflux/test/security.c
@@ -469,9 +469,18 @@ void test_curve (void)
     unlink_recursive (path);
 }
 
+void alarm_callback (int arg)
+{
+    diag ("test timed out");
+    exit (1);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
+
+    signal (SIGALRM, alarm_callback);
+    alarm (30);
 
     test_ctor_dtor ();
     test_keygen ();

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -107,4 +107,7 @@ if ! lua -e 'require "posix"'; then
     error "failed to find lua posix module in path"
 fi
 
+#  Some tests in flux don't work with --chain-lint, add a prereq for
+#   --no-chain-lint:
+test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
 # vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -45,6 +45,9 @@ test_under_flux() {
     if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --debug"
     fi
+    if test "$chain_lint" = "t"; then
+        flags="${flags} --chain-lint"
+    fi
     if test -n "$logfile" -o -n "$FLUX_TESTS_LOGFILE" ; then
         flags="${flags} --logfile"
     fi

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -51,6 +51,10 @@ test_under_flux() {
     if test -n "$SHARNESS_TEST_DIRECTORY"; then
         cd $SHARNESS_TEST_DIRECTORY
     fi
+    timeout="-o -Sinit.rc2_timeout=300"
+    if test -n "$FLUX_TEST_DISABLE_TIMEOUT"; then
+        timeout=""
+    fi
 
     if test "$personality" = "minimal"; then
         export FLUX_RC1_PATH=""
@@ -67,7 +71,8 @@ test_under_flux() {
 
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --bootstrap=selfpmi --size=${size} ${quiet} "sh $0 ${flags}"
+      exec flux start --bootstrap=selfpmi --size=${size} ${quiet} ${timeout} \
+                     "sh $0 ${flags}"
 }
 
 mock_bootstrap_instance() {

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -12,6 +12,7 @@ if test "$t" != "123456789" ; then
 fi
 
 SIZE=1
+export FLUX_TEST_DISABLE_TIMEOUT=t
 export LD_PRELOAD=libfaketimeMT.so.1
 export FAKETIME_NO_CACHE=1
 export FAKETIME_TIMESTAMP_FILE=$(pwd)/faketimerc


### PR DESCRIPTION
This branch started out as a small fix to propagate sharness' `--chain-lint` option to `test_under_flux` so that broken `&&`-chains can be detected for tests that run under a flux instance.

After that, I went through all the tests and fixed broken `&&`-chains so that `--chain-lint` ran clean.
In most cases the broken `&&` chain wasn't an actual problem, but I fixed the test anyway. In other cases it wasn't possible to make `--chain-lint` happy (e.g. test that use `&` to run a process in the background). For these cases I added a `NO_CHAIN_LINT` prereq that can be explicitly added to a tests so that test is skipped during a run with `--chain-lint`.

Finally, the `flux version` check (once it was fixed) didn't work in travis (at least on my personal branch) because travis uses a shallow clone of the repo. A workaround was added to `.travis.yml` to fetch tags and "unshallow" the clone so that hopefully `git describe` can create a valid version.