### PR TITLE
KVS more oom() fixes

### DIFF
--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -282,10 +282,11 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
     int size = 0;
     int incomplete = 0;
     int dirty = 0;
+    int saved_errno;
     int rc = -1;
 
     if (!(keys = zhash_keys (cache->zh))) {
-        errno = ENOMEM;
+        saved_errno = ENOMEM;
         goto cleanup;
     }
     while ((ref = zlist_pop (keys))) {
@@ -295,7 +296,7 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
             char *s = json_dumps (hp->o, JSON_ENCODE_ANY);
             int obj_size;
             if (!s) {
-                errno = ENOMEM;
+                saved_errno = ENOMEM;
                 goto cleanup;
             }
             obj_size = strlen (s);
@@ -317,6 +318,8 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
     rc = 0;
 cleanup:
     zlist_destroy (&keys);
+    if (rc < 0)
+        errno = saved_errno;
     return rc;
 }
 

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -109,6 +109,16 @@ int cache_entry_clear_dirty (struct cache_entry *hp)
     return -1;
 }
 
+int cache_entry_force_clear_dirty (struct cache_entry *hp)
+{
+    if (hp && hp->o) {
+        if (hp->dirty)
+            hp->dirty = 0;
+        return hp->dirty ? 1 : 0;
+    }
+    return -1;
+}
+
 json_t *cache_entry_get_json (struct cache_entry *hp)
 {
     if (!hp || !hp->o)

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -24,9 +24,10 @@ bool cache_entry_get_valid (struct cache_entry *hp);
 /* Get/set cache entry's dirty bit.
  * The dirty bit indicates that a store RPC is in progress.
  * A true->false transitions runs the entry's wait queue, if any.
+ * cache_entry_set_dirty() returns -1 on error, 0 on success
  */
 bool cache_entry_get_dirty (struct cache_entry *hp);
-void cache_entry_set_dirty (struct cache_entry *hp, bool val);
+int cache_entry_set_dirty (struct cache_entry *hp, bool val);
 
 /* cache_entry_clear_dirty() is similar to calling
  * cache_entry_set_dirty(hp,false), but it will not set to the dirty
@@ -46,9 +47,10 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
 /* Accessors for cache entry data.
  * If non-NULL, set transfers ownership of 'o' to the cache entry.
  * An invalid->valid transition runs the entry's wait queue, if any.
+ * cache_entry_set_json() returns -1 on error, 0 on success
  */
 json_t *cache_entry_get_json (struct cache_entry *hp);
-void cache_entry_set_json (struct cache_entry *hp, json_t *o);
+int cache_entry_set_json (struct cache_entry *hp, json_t *o);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -36,8 +36,12 @@ void cache_entry_set_dirty (struct cache_entry *hp, bool val);
  * to give up on a previously marked dirty cache entry but has not yet
  * done anything with it.  Returns current value of dirty bit on
  * success, -1 on error.
+ *
+ * cache_entry_force_clear_dirty() will clear the dirty bit no matter
+ * what.  It should be only used in emergency error handling cases.
  */
 int cache_entry_clear_dirty (struct cache_entry *hp);
+int cache_entry_force_clear_dirty (struct cache_entry *hp);
 
 /* Accessors for cache entry data.
  * If non-NULL, set transfers ownership of 'o' to the cache entry.

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -155,14 +155,18 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
     if (c->state == COMMIT_STATE_STORE
         || c->state == COMMIT_STATE_PRE_FINISHED) {
         href_t ref;
+        int ret;
         assert (cache_entry_get_dirty (hp) == true);
-        assert (cache_entry_clear_dirty (hp) == 0);
+        ret = cache_entry_clear_dirty (hp);
+        assert (ret == 0);
         if (kvs_util_json_hash (c->cm->hash_name,
                                 cache_entry_get_json (hp),
                                 ref) < 0)
             log_err ("kvs_util_json_hash");
-        else
-            assert (cache_remove_entry (c->cm->cache, ref) == 1);
+        else {
+            ret = cache_remove_entry (c->cm->cache, ref);
+            assert (ret == 1);
+        }
     }
 }
 
@@ -203,12 +207,14 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         rc = 0;
     } else {
         if (cache_entry_set_json (hp, o) < 0) {
-            assert (cache_remove_entry (c->cm->cache, ref) == 1);
+            int ret = cache_remove_entry (c->cm->cache, ref);
+            assert (ret == 1);
             goto decref_done;
         }
         if (cache_entry_set_dirty (hp, true) < 0) {
             /* cache_remove_entry will decref object */
-            assert (cache_remove_entry (c->cm->cache, ref) == 1);
+            int ret = cache_remove_entry (c->cm->cache, ref);
+            assert (ret == 1);
             goto done;
         }
         rc = 1;

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -139,7 +139,11 @@ void commit_mgr_clear_noop_stores (commit_mgr_t *cm);
 /* In internally stored ready commits (moved to ready status via
  * commit_mgr_process_fence_request()), merge them if they are capable
  * of being merged.
+ * Returns -1 on error, 0 on success.  On error, it is possible that
+ * the ready commit has been modified with different fence names
+ * and operations.  The caller is responsible for sending errors to
+ * all appropriately.
  */
-void commit_mgr_merge_ready_commits (commit_mgr_t *cm);
+int commit_mgr_merge_ready_commits (commit_mgr_t *cm);
 
 #endif /* !_FLUX_KVS_COMMIT_H */

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -41,7 +41,7 @@ int fence_add_request_copy (fence_t *f, const flux_msg_t *request);
 int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data);
 
 /* Merge src ops & names into dest ops & names
- * - return 1 on merge success, 0 on no-merge
+ * - return 1 on merge success, 0 on no-merge, -1 on error
  */
 int fence_merge (fence_t *dest, fence_t *src);
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -518,8 +518,13 @@ static void commit_check_cb (flux_reactor_t *r, flux_watcher_t *w,
     flux_watcher_stop (ctx->idle_w);
 
     if ((c = commit_mgr_get_ready_commit (ctx->cm))) {
-        if (ctx->commit_merge)
-            commit_mgr_merge_ready_commits (ctx->cm);
+        if (ctx->commit_merge) {
+            /* if merge fails, set errnum in commit_t, let
+             * commit_apply() handle error handling.
+             */
+            if (commit_mgr_merge_ready_commits (ctx->cm) < 0)
+                commit_set_aux_errnum (c, errno);
+        }
         commit_apply (c);
     }
 }

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -77,13 +77,16 @@ int kvs_util_json_encoded_size (json_t *o, size_t *size)
 
 int kvs_util_json_hash (const char *hash_name, json_t *o, href_t ref)
 {
-    char *s;
-    int rc;
+    char *s = NULL;
+    int rc = -1;
 
     if (!(s = kvs_util_json_dumps (o)))
-        return -1;
-    rc = blobref_hash (hash_name, (uint8_t *)s, strlen (s) + 1,
-                       ref, sizeof (href_t));
+        goto error;
+    if (blobref_hash (hash_name, (uint8_t *)s, strlen (s) + 1,
+                      ref, sizeof (href_t)) < 0)
+        goto error;
+    rc = 0;
+error:
     free (s);
     return rc;
 }

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -60,14 +60,16 @@ int main (int argc, char *argv[])
         "cache entry initially valid");
     ok (cache_entry_get_dirty (e1) == false,
         "cache entry initially not dirty");
-    cache_entry_set_dirty (e1, true);
+    ok (cache_entry_set_dirty (e1, true) == 0,
+        "cache_entry_set_dirty success");
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry succcessfully set dirty");
     ok (cache_entry_clear_dirty (e1) == 0,
         "cache_entry_clear_dirty returns 0, b/c no waiters");
     ok (cache_entry_get_dirty (e1) == false,
         "cache entry succcessfully now not dirty");
-    cache_entry_set_dirty (e1, true);
+    ok (cache_entry_set_dirty (e1, true) == 0,
+        "cache_entry_set_dirty success");
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry succcessfully set dirty");
     ok (cache_entry_force_clear_dirty (e1) == 0,
@@ -101,7 +103,8 @@ int main (int argc, char *argv[])
     json_object_set_new (o1, "foo", json_integer (42));
     ok (cache_entry_wait_valid (e1, w) == 0,
         "cache_entry_wait_valid success");
-    cache_entry_set_json (e1, o1);
+    ok (cache_entry_set_json (e1, o1) == 0,
+        "cache_entry_set_json success");
     ok (cache_entry_get_valid (e1) == true,
         "cache entry set valid with one waiter");
     ok (count == 1,
@@ -110,14 +113,16 @@ int main (int argc, char *argv[])
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    cache_entry_set_dirty (e1, true);
+    ok (cache_entry_set_dirty (e1, true) == 0,
+        "cache_entry_set_dirty success");
     ok (cache_entry_get_dirty (e1) == true,
         "cache entry set dirty, adding waiter");
     ok (cache_entry_wait_notdirty (e1, w) == 0,
         "cache_entry_wait_notdirty success");
     ok (cache_entry_clear_dirty (e1) == 1,
         "cache_entry_clear_dirty returns 1, b/c of a waiter");
-    cache_entry_set_dirty (e1, false);
+    ok (cache_entry_set_dirty (e1, false) == 0,
+        "cache_entry_set_dirty success");
     ok (cache_entry_get_dirty (e1) == false,
         "cache entry set not dirty with one waiter");
     ok (count == 1,
@@ -200,7 +205,8 @@ int main (int argc, char *argv[])
     ok (incomplete == 1, "cache w/ entry w/ json, incomplete == 1");
     ok (dirty == 0, "cache w/ entry w/ json, dirty == 0");
 
-    cache_entry_set_dirty (e4, true);
+    ok (cache_entry_set_dirty (e4, true)  == 0,
+        "cache_entry_set_dirty success");
 
     memset (&ts, 0, sizeof (ts));
     ok (cache_get_stats (cache, &ts, &size, &incomplete, &dirty) == 0,
@@ -210,7 +216,8 @@ int main (int argc, char *argv[])
     ok (incomplete == 1, "cache w/ entry w/ dirty json, incomplete == 1");
     ok (dirty == 1, "cache w/ entry w/ dirty json, dirty == 1");
 
-    cache_entry_set_dirty (e4, false);
+    ok (cache_entry_set_dirty (e4, false) == 0,
+        "cache_entry_set_dirty success");
 
     ok (cache_expire_entries (cache, 43, 1) == 0,
         "cache_expire_entries now=43 thresh=1 expired 0");
@@ -250,7 +257,8 @@ int main (int argc, char *argv[])
     ok (cache_remove_entry (cache, "remove-ref") == 0,
         "cache_remove_entry failed on valid waiter");
     o4 = json_string ("foobar");
-    cache_entry_set_json (e5, o4);
+    ok (cache_entry_set_json (e5, o4) == 0,
+        "cache_entry_set_json success");
     ok (cache_entry_get_valid (e5) == true,
         "cache entry set valid with one waiter");
     ok (count == 1,
@@ -269,14 +277,16 @@ int main (int argc, char *argv[])
     cache_insert (cache, "remove-ref", e5);
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
-    cache_entry_set_dirty (e5, true);
+    ok (cache_entry_set_dirty (e5, true) == 0,
+        "cache_entry_set_dirty success");
     ok (cache_remove_entry (cache, "remove-ref") == 0,
         "cache_remove_entry not removed b/c dirty");
     ok (cache_entry_wait_notdirty (e5, w) == 0,
         "cache_entry_wait_notdirty success");
     ok (cache_remove_entry (cache, "remove-ref") == 0,
         "cache_remove_entry failed on notdirty waiter");
-    cache_entry_set_dirty (e5, false);
+    ok (cache_entry_set_dirty (e5, false) == 0,
+        "cache_entry_set_dirty success");
     ok (count == 1,
         "waiter callback ran");
     ok (cache_remove_entry (cache, "remove-ref") == 1,

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -67,6 +67,13 @@ int main (int argc, char *argv[])
         "cache_entry_clear_dirty returns 0, b/c no waiters");
     ok (cache_entry_get_dirty (e1) == false,
         "cache entry succcessfully now not dirty");
+    cache_entry_set_dirty (e1, true);
+    ok (cache_entry_get_dirty (e1) == true,
+        "cache entry succcessfully set dirty");
+    ok (cache_entry_force_clear_dirty (e1) == 0,
+        "cache_entry_force_clear_dirty returns 0");
+    ok (cache_entry_get_dirty (e1) == false,
+        "cache entry succcessfully now not dirty");
     ok ((o2 = cache_entry_get_json (e1)) != NULL,
         "json retrieved from cache entry");
     ok ((o = json_object_get (o2, "foo")) != NULL,

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -221,7 +221,8 @@ void commit_mgr_merge_tests (void)
     create_ready_commit (cm, "fence1", "key1", "1", 0);
     create_ready_commit (cm, "fence2", "key2", "2", 0);
 
-    commit_mgr_merge_ready_commits (cm);
+    ok (commit_mgr_merge_ready_commits (cm) == 0,
+        "commit_mgr_merge_ready_commits success");
 
     names = json_array ();
     json_array_append (names, json_string ("fence1"));
@@ -247,7 +248,8 @@ void commit_mgr_merge_tests (void)
     create_ready_commit (cm, "fence1", "key1", "1", FLUX_KVS_NO_MERGE);
     create_ready_commit (cm, "fence2", "key2", "2", 0);
 
-    commit_mgr_merge_ready_commits (cm);
+    ok (commit_mgr_merge_ready_commits (cm) == 0,
+        "commit_mgr_merge_ready_commits success");
 
     names = json_array ();
     json_array_append (names, json_string ("fence1"));
@@ -271,7 +273,8 @@ void commit_mgr_merge_tests (void)
     create_ready_commit (cm, "fence1", "key1", "1", 0);
     create_ready_commit (cm, "fence2", "key2", "2", FLUX_KVS_NO_MERGE);
 
-    commit_mgr_merge_ready_commits (cm);
+    ok (commit_mgr_merge_ready_commits (cm) == 0,
+        "commit_mgr_merge_ready_commits success");
 
     names = json_array ();
     json_array_append (names, json_string ("fence1"));
@@ -544,7 +547,8 @@ void commit_basic_commit_process_test_multiple_fences_merge (void)
     create_ready_commit (cm, "fence2", "bar.key2", "2", 0);
 
     /* merge ready commits */
-    commit_mgr_merge_ready_commits (cm);
+    ok (commit_mgr_merge_ready_commits (cm) == 0,
+        "commit_mgr_merge_ready_commits success");
 
     ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
         "commit_mgr_get_ready_commit returns ready commit");
@@ -913,7 +917,8 @@ void commit_process_error_callbacks_partway (void) {
     create_ready_commit (cm, "fence2", "dir.fileB", "53", 0);
 
     /* merge these commits */
-    commit_mgr_merge_ready_commits (cm);
+    ok (commit_mgr_merge_ready_commits (cm) == 0,
+        "commit_mgr_merge_ready_commits success");
 
     ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
         "commit_mgr_get_ready_commit returns ready commit");
@@ -1555,7 +1560,8 @@ void commit_process_giant_dir (void) {
     create_ready_commit (cm, "fence3", "dir.fileval00D0", NULL, 0);
 
     /* merge these three commits */
-    commit_mgr_merge_ready_commits (cm);
+    ok (commit_mgr_merge_ready_commits (cm) == 0,
+        "commit_mgr_merge_ready_commits success");
 
     ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
         "commit_mgr_get_ready_commit returns ready commit");

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -68,7 +68,8 @@ int main (int argc, char *argv[])
        "wait_get_usecount 1 after wait_addqueue");
     ok (count == 0,
        "wait_t callback not run");
-    wait_runqueue (q);
+    ok (wait_runqueue (q) == 0,
+        "wait_runqueue success");
     ok (count == 1,
        "wait_runqueue ran callback");
     ok (wait_get_usecount (w) == 0,
@@ -111,7 +112,8 @@ int main (int argc, char *argv[])
     ok (wait_queue_length (q) == 1 && wait_queue_length (q2) == 1,
         "wait_queue_length of each queue is 1");
 
-    wait_runqueue (q);
+    ok (wait_runqueue (q) == 0,
+        "wait_runqueue success");
     ok (wait_queue_length (q) == 0 && wait_queue_length (q2) == 1,
         "wait_runqueue dequeued wait_t from first queue");
     ok (wait_get_usecount (w) == 1,
@@ -119,7 +121,8 @@ int main (int argc, char *argv[])
     ok (count == 0,
         "wait_t callback has not run");
 
-    wait_runqueue (q2);
+    ok (wait_runqueue (q2) == 0,
+        "wait_runqueue success");
     ok (wait_queue_length (q) == 0 && wait_queue_length (q2) == 0,
         "wait_runqueue dequeued wait_t from second queue");
     ok (count == 1,

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -46,8 +46,10 @@ int wait_addqueue (waitqueue_t *q, wait_t *wait);
  * Note: wait_runqueue() empties the waitqueue_t before invoking wait_t
  * callbacks for waiters that have a usecount of zero, hence it is safe
  * to manipulate the waitqueue_t from the callback.
+ * Returns -1 on error, 0 on success.  On error, all wait_t's on the
+ * specified queue remain there.
  */
-void wait_runqueue (waitqueue_t *q);
+int wait_runqueue (waitqueue_t *q);
 
 /* Specialized wait_t for restarting message handlers (must be idempotent!).
  * The message handler will be reinvoked once the wait_t usecount reaches zero.


### PR DESCRIPTION
These are fixups for two remaining ```oom()``` paths left in the KVS.  These were trickier and required some additional logical changes, so I wanted to put them in another PR.

In ```wait_runqueue()```, the primary change that had to occur to return an error to the user is that either all of the elements would be copied off of the queue, or none of them.  We can't have an error occurring in the middle while we remove elements off one queue and put them on another.  There's no way to get back to what you had before.  Performance wise, this is effectively a change from 2 loops to 3 loops.

There are several catastrophic-like scenarios in the main KVS code if ```wait_runqueue()``` fails.  I chose not to ```assert()``` them.  But maybe I should have.  I went back and forth on it.  Dunno what others might think.

In ```fence_merge()``` there was a similar issue of how to deal with an error in the middle.  In ```fence_merge()```, originally fence names & operations were modified while iterating through fences.  So if an error occurred at some point, how do you get back to what was there before?  The function has been modified to make copies, modify those copies, and if everything succeeds, then store the result.  So there are some extra allocations now.

In ```commit_mgr_merge_ready_commits()```, there was an issue of how to deal with a commit entry on a queue that was popped off, but what if you can't push it back on due to ENOMEM.  Through use of the ```zlist``` iterators, I can just remove the pop & push altogether, which removes any chance of an ```oom()```.  I think using the iterators and removing elements on the zlist was not allowed before (which is probably why the function was written that way), but in newer zlists it is.

I ran this through ```soak.sh -j 1000``` on master and the branch on hype2, and the performance was actually faster on the branch.  So I think we can consider it basically a wash.  The numbers are comparable to what was in PR #1105.

And with that, no more ```oom()``` in the KVS.