### PR TITLE
add optional initial program timeout, for test scripts

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -572,6 +572,7 @@ int main (int argc, char *argv[])
         runlevel_set_subprocess_manager (ctx.runlevel, ctx.sm);
         runlevel_set_callback (ctx.runlevel, runlevel_cb, &ctx);
         runlevel_set_io_callback (ctx.runlevel, runlevel_io_cb, &ctx);
+        runlevel_set_flux (ctx.runlevel, ctx.h);
 
         if (runlevel_set_rc (ctx.runlevel, 1, rc1, rc1 ? strlen (rc1) + 1 : 0, uri) < 0)
             log_err_exit ("runlevel_set_rc 1");

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -21,6 +21,7 @@ int runlevel_register_attrs (runlevel_t *r, attr_t *attr);
 void runlevel_set_subprocess_manager (runlevel_t *r,
                                       struct subprocess_manager *sm);
 void runlevel_set_size (runlevel_t *r, uint32_t size);
+void runlevel_set_flux (runlevel_t *r, flux_t *h);
 void runlevel_destroy (runlevel_t *r);
 
 /* Handle run level subprocess completion.

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -87,6 +87,10 @@ test_expect_success 'flux-start in subprocess/pmi mode works as initial program'
 	flux start --size=2 flux start ${BUG1006} --size=1 flux comms info | grep size=1
 "
 
+test_expect_success 'flux-start init.rc2_timeout attribute works' "
+	test_expect_code 143 flux start ${BUG1006} -o,-Sinit.rc2_timeout=0.1 sleep 5
+"
+
 test_expect_success 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&
 	mkdir -p test-under-flux && (


### PR DESCRIPTION
Add an optional timeout on the initial program (rc2) - something @grondo and I were discussing this morning.  The idea was that sharness `test_under_flux` might use this to make travis test hangs more easy to debug.

The timeout is set as an attribute.  When the timeout expires, a SIGTERM is sent to the initial program.  For example
```
$ ./flux start -o,-Sinit.rc2_timeout=0.1 sleep 1
2017-07-26T17:53:31.306006Z broker.err[0]: runlevel 2 timeout, sending SIGTERM
2017-07-26T17:53:31.306390Z broker.err[0]: Run level 2 Terminated (rc=143) 0.1s
$ echo $?
143
```

This is mainly useful for testing, or at least I didn't have another use case in mind as I wrote this.
