### PR TITLE
modules/kvs: Fix forced dirty bit clear error

### DIFF
--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -118,8 +118,13 @@ int cache_entry_clear_dirty (struct cache_entry *hp)
 int cache_entry_force_clear_dirty (struct cache_entry *hp)
 {
     if (hp && hp->o) {
-        if (hp->dirty)
+        if (hp->dirty) {
+            if (hp->waitlist_notdirty) {
+                wait_queue_destroy (hp->waitlist_notdirty);
+                hp->waitlist_notdirty = NULL;
+            }
             hp->dirty = 0;
+        }
         return hp->dirty ? 1 : 0;
     }
     return -1;

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -39,7 +39,8 @@ int cache_entry_set_dirty (struct cache_entry *hp, bool val);
  * success, -1 on error.
  *
  * cache_entry_force_clear_dirty() will clear the dirty bit no matter
- * what.  It should be only used in emergency error handling cases.
+ * what and destroy internal wait queue of dirty bit waiters.  It
+ * should be only used in emergency error handling cases.
  */
 int cache_entry_clear_dirty (struct cache_entry *hp);
 int cache_entry_force_clear_dirty (struct cache_entry *hp);

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -127,6 +127,22 @@ int main (int argc, char *argv[])
         "cache entry set not dirty with one waiter");
     ok (count == 1,
         "waiter callback ran");
+
+    count = 0;
+    ok ((w = wait_create (wait_cb, &count)) != NULL,
+        "wait_create works");
+    ok (cache_entry_set_dirty (e1, true) == 0,
+        "cache_entry_set_dirty success");
+    ok (cache_entry_get_dirty (e1) == true,
+        "cache entry set dirty, adding waiter");
+    ok (cache_entry_wait_notdirty (e1, w) == 0,
+        "cache_entry_wait_notdirty success");
+    ok (cache_entry_force_clear_dirty (e1) == 0,
+        "cache_entry_clear_dirty returns 0 w/ waiter");
+    ok (cache_entry_get_dirty (e1) == false,
+        "cache entry set not dirty with one waiter");
+    ok (count == 0,
+        "waiter callback not called on force clear dirty");
     cache_entry_destroy (e1); /* destroys o1 */
 
     /* Put entry in cache and test lookup, expire


### PR DESCRIPTION
The function cache_entry_force_clear_dirty() should also destroy the
dirty waitqueue, as the entries in the waitqueue no longer matter
and it would prevent the cache entry from ever being reclaimed.