### PR TITLE
common/libutil: Fix base64 API documentation

### DIFF
--- a/src/common/libutil/base64.h
+++ b/src/common/libutil/base64.h
@@ -104,15 +104,15 @@ int base64_cleanup (base64_ctx *x);
 
 int base64_encode_block (void *dst, int *dstlen, const void *src, int srclen);
 /*
- *  Base64-encodes [srclen] bytes from the contiguous [src] into [dst].
- *    If [dstlen] is not NULL, it will be set to the number of bytes written.
+ *  Base64-encodes [srclen] bytes from the contiguous [src] into [dst] and
+ *    sets [dstlen] to the number of bytes written.
  *  Returns 0 on success, or -1 on error.
  */
 
 int base64_decode_block (void *dst, int *dstlen, const void *src, int srclen);
 /*
- *  Base64-decodes [srclen] bytes from the contiguous [src] into [dst].
- *    If [dstlen] is not NULL, it will be set to the number of bytes written.
+ *  Base64-decodes [srclen] bytes from the contiguous [src] into [dst] and
+ *    sets [dstlen] to the number of bytes written.
  *  Returns 0 on success, or -1 on error.
  */
 


### PR DESCRIPTION
base64_encode_block() and base64_decode_block() require dstlen
to be passed in, but the header files say they are optional.  Adjust
documentation appropriately.