### PR TITLE
travis-ci: mitigate slow builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
  - test "${TRAVIS_BRANCH}" != 'coverity_scan' || exit 0
  - ulimit -c unlimited
  - export CC="ccache $CC"
- - export MAKECMDS="make distcheck"
+ - export MAKECMDS="make -j 2 distcheck"
  # Ensure travis builds libev such that libfaketime will work:
  # (force libev to *not* use syscall interface for clock_gettime())
  - export CPPFLAGS="-DEV_USE_CLOCK_SYSCALL=0 -DEV_USE_MONOTONIC=1"
@@ -102,9 +102,9 @@ script:
 
  # Enable coverage for $CC-coverage build
  # We can't use distcheck here, it doesn't play well with coverage testing:
- - if test "$COVERAGE" = "t" ; then ARGS="$ARGS --enable-code-coverage"; MAKECMDS="make && make check-code-coverage && lcov -l flux*-coverage.info"; fi
+ - if test "$COVERAGE" = "t" ; then ARGS="$ARGS --enable-code-coverage"; MAKECMDS="make -j 2 && make -j 2 check-code-coverage && lcov -l flux*-coverage.info"; fi
  # Use make install for T_INSTALL:
- - if test "$T_INSTALL" = "t" ; then ARGS="$ARGS --prefix=/tmp/flux"; MAKECMDS="make && make install && /tmp/flux/bin/flux keygen && FLUX_TEST_INSTALLED_PATH=/tmp/flux/bin make check"; fi
+ - if test "$T_INSTALL" = "t" ; then ARGS="$ARGS --prefix=/tmp/flux"; MAKECMDS="make && make install && /tmp/flux/bin/flux keygen && FLUX_TEST_INSTALLED_PATH=/tmp/flux/bin make -j 2 check"; fi
  # Use src/test/cppcheck.sh instead of make?:
  - if test "$CPPCHECK" = "t" ; then MAKECMDS="sh -x src/test/cppcheck.sh && make"; fi
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -190,7 +190,7 @@ for url in $checkouts; do
             cmake -DCMAKE_INSTALL_PREFIX=${prefix} $cmake_opts ..
         fi
       fi
-      make PREFIX=${prefix} $make_opts &&
+      make -j2 PREFIX=${prefix} $make_opts &&
       make PREFIX=${prefix} $make_opts install
     ) || die "Failed to build and install $name"
     add_cache "$cache_name"
@@ -211,7 +211,7 @@ for pkg in $downloads; do
       test -x configure && CC=gcc ./configure --prefix=${prefix} \
                   --sysconfdir=${prefix}/etc \
                   ${extra_configure_opts[$name]} || : &&
-      make PREFIX=${prefix} &&
+      make -j 2 PREFIX=${prefix} &&
       make PREFIX=${prefix} install
     ) || die "Failed to build and install $name"
     add_cache "$name"


### PR DESCRIPTION
This PR adds `-j2` to many of the make commands during travis-ci builds (both builds of dependencies and  make distcheck for the code itself)

This helps mitigate the problem described in #1141.