### PR TITLE
cron: avoid use of json-c and xzmalloc

### DIFF
--- a/doc/man1/flux-cron.adoc
+++ b/doc/man1/flux-cron.adoc
@@ -68,6 +68,18 @@ Options:
  The '--options' option allows a comma separated list of extra options to be
  passed to the flux-cron service. See EXTRA OPTIONS below.
 
+ --preserve-env:::
+ -E:::
+ The '--preserve-env' option allows the current environment to be exported
+ and used for the command being executed as part of the cron job. Normally,
+ the broker environment is used.
+
+ --working-dir='DIR':::
+ -d 'DIR':::
+ The '--working-dir' option allows the working directory to be set for the command
+ being executed as part of the cron job. Normally, the working directory of
+ the broker is used.
+
 *event* [OPTIONS] 'topic' 'command'::
 
 Create a cron entry to execute 'command' after every event matching 'topic'.
@@ -99,6 +111,18 @@ Create a cron entry to execute 'command' after every event matching 'topic'.
  -o 'LIST':::
  Set comma separated EXTRA OPTIONS for this cron entry.
 
+ --preserve-env:::
+ -E:::
+ The '--preserve-env' option allows the current environment to be exported
+ and used for the command being executed as part of the cron job. Normally,
+ the broker environment is used.
+
+ --working-dir='DIR':::
+ -d 'DIR':::
+ The '--working-dir' option allows the working directory to be set for the command
+ being executed as part of the cron job. Normally, the working directory of
+ the broker is used.
+
 *tab* [OPTIONS] ['file'] ::
 Process one or more lines containing crontab expressions from 'file'
 (stdin by default) Each valid crontab line will result in a new cron
@@ -118,6 +142,17 @@ Run 'command' at specific date and time described by 'string'
  -o 'LIST':::
  Set comma separated EXTRA OPTIONS for all cron entries.
 
+ --preserve-env:::
+ -E:::
+ The '--preserve-env' option allows the current environment to be exported
+ and used for the command being executed as part of the cron job. Normally,
+ the broker environment is used.
+
+ --working-dir='DIR':::
+ -d 'DIR':::
+ The '--working-dir' option allows the working directory to be set for the command
+ being executed as part of the cron job. Normally, the working directory of
+ the broker is used.
 *list*::
 Display a list of current entries registered with the cron module and
 their current state, last run time, etc.

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -57,7 +57,7 @@ local function parse_time (s)
     if suffix and m [suffix]  then
         n = (n * m [suffix])
     end
-    return (n)
+    return tonumber (n)
 end
 
 local function now ()
@@ -129,14 +129,14 @@ function Command:request (type, typeargs, arg)
         args = typeargs,
         command = command,
         name = self.opt.N or command:match("%S+"),
-        ["repeat"] = self.opt.c
+        ["repeat"] = tonumber (self.opt.c)
     }
     -- Process comma-separated list of options to add undocumented
     --  members to JSON request, e.g. `-o rank=1,task-history-count=5`
     if self.opt.o then
         for opt in self.opt.o:gmatch ("[^,]+") do
             local k,v = opt:match("(.+)=(.+)")
-            req[k] = v
+            req[k] = tonumber (v)
         end
     end
     return f:rpc ("cron.create", req)
@@ -202,7 +202,9 @@ program:SubCommand {
  handler = function (self, arg)
     if #arg < 2 then self:die ("TOPIC and COMMAND args are required") end
     local topic = table.remove (arg, 1)
-    local args = { topic = topic, nth = self.opt.n, after = self.opt.a }
+    local args = { topic = topic,
+                   nth = tonumber (self.opt.n),
+                   after = tonumber (self.opt.a) }
     args.min_interval = parse_time (self.opt.i)
 
     local resp, err = self:request ("event", args, arg)

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -129,8 +129,12 @@ function Command:request (type, typeargs, arg)
         args = typeargs,
         command = command,
         name = self.opt.N or command:match("%S+"),
+        cwd = self.opt.d,
         ["repeat"] = tonumber (self.opt.c)
     }
+    if self.opt.E then
+        req.environ = require 'posix'.getenv ()
+    end
     -- Process comma-separated list of options to add undocumented
     --  members to JSON request, e.g. `-o rank=1,task-history-count=5`
     if self.opt.o then
@@ -160,6 +164,12 @@ program:SubCommand {
     { name = "options", char = "o", arg = "OPTS",
       usage = "Comma separated list of key=value options to set in request"
     },
+    { name = "preserve-env", char = "E",
+      usage = "Use current environment for cron command"
+    },
+    { name = "working-dir", char = "d", arg = "DIR",
+      usage = "Set working director for cron command"
+    }
  },
  handler = function (self, arg)
     if #arg <  2 then self:die ("INTERVAL and COMMAND required") end
@@ -197,6 +207,12 @@ program:SubCommand {
     },
     { name = "name", char = "N", arg = "S",
       usage = "Name cron job string S instead of default"
+    },
+    { name = "preserve-env", char = "E",
+      usage = "Use current environment for cron command"
+    },
+    { name = "working-dir", char = "d", arg = "DIR",
+      usage = "Set working director for cron command"
     }
  },
  handler = function (self, arg)
@@ -221,6 +237,12 @@ program:SubCommand {
     { name = "options", char = "o", arg = "OPTS",
       usage = "Comma separated list of key=value options to set in request"
     },
+    { name = "preserve-env", char = "E",
+      usage = "Use current environment for cron command"
+    },
+    { name = "working-dir", char = "d", arg = "DIR",
+      usage = "Set working director for cron command"
+    }
  },
  handler = function (self, arg)
     local fp = io.stdin
@@ -273,6 +295,12 @@ program:SubCommand {
     { name = "options", char = "o", arg = "OPTS",
       usage = "Comma separated list of key=value options to set in request"
     },
+    { name = "preserve-env", char = "E",
+      usage = "Use current environment for cron command"
+    },
+    { name = "working-dir", char = "d", arg = "DIR",
+      usage = "Set working director for cron command"
+    }
  },
  handler = function (self, arg)
     if #arg < 2 then self:die ("TIME and COMMAND args are required") end

--- a/src/common/libutil/cronodate.c
+++ b/src/common/libutil/cronodate.c
@@ -297,6 +297,20 @@ int cronodate_set (cronodate_t *d, tm_unit_t item, const char *range)
     return range_parse (n, item, range);
 }
 
+int cronodate_set_integer (cronodate_t *d, tm_unit_t item, int value)
+{
+    nodeset_t *n = d->item [item];
+    assert (n != NULL);
+    if (value > tm_unit_max (item) || value < tm_unit_min (item)) {
+        errno = ERANGE;
+        return -1;
+    }
+    /*  Clear all members before setting the new value */
+    nodeset_delete_range (n, tm_unit_min (item), tm_unit_max (item));
+    nodeset_add_rank (n, value);
+    return 0;
+}
+
 const char *cronodate_get (cronodate_t *d, tm_unit_t u)
 {
     return (nodeset_string (d->item [u]));

--- a/src/common/libutil/cronodate.h
+++ b/src/common/libutil/cronodate.h
@@ -62,6 +62,12 @@ void cronodate_emptyset (cronodate_t *);
  */
 int cronodate_set (cronodate_t *d, tm_unit_t u, const char *range);
 
+/*  Set cronodate field for time unit u to a single value
+ *  Returns EINVAL if value is outside of [min, max] for time unit u.
+ *  Returns 0 on success.
+ */
+int cronodate_set_integer (cronodate_t *d, tm_unit_t u, int value);
+
 /*  Get the current set/range for time unit `u` in cronodate object `d`
  *   in the form of a nodeset range string.
  */
@@ -73,7 +79,7 @@ const char *cronodate_get (cronodate_t *d, tm_unit_t u);
  */
 bool cronodate_match (cronodate_t *d, struct tm *tm);
 
-/* 
+/*
  *  Advance `now` to the next date/time that will match `m`.
  */
 int cronodate_next (cronodate_t *d, struct tm *now);

--- a/src/common/libutil/shortjson.h
+++ b/src/common/libutil/shortjson.h
@@ -33,17 +33,6 @@ Jput (json_object *o)
         json_object_put (o);
 }
 
-/* Add bool to JSON.
- */
-static __inline__ void
-Jadd_bool (json_object *o, const char *name, bool b)
-{
-    json_object *n = json_object_new_boolean (b);
-    if (!n)
-        oom ();
-    json_object_object_add (o, (char *)name, n);
-}
-
 /* Add integer to JSON.
  */
 static __inline__ void

--- a/src/common/libutil/test/cronodate.c
+++ b/src/common/libutil/test/cronodate.c
@@ -214,6 +214,47 @@ int main (int argc, char *argv[])
     ok (cronodate_check_next (d, "2016-06-06 08:00:00", "2016-06-13 08:00:00"),
         "cronodate_next returns next matching date when current matches ");
 
+    cronodate_fillset (d);
+    // Same as above, but use cronodate_set_integer()
+    ok (cronodate_set_integer (d, TM_SEC, 0) >= 0, "set integer, sec = 0");
+    ok (cronodate_set_integer (d, TM_MIN, 0) >= 0, "set integer, min = 0");
+    ok (cronodate_set_integer (d, TM_HOUR, 8) >= 0, "set integer, hour = 0");
+    ok (cronodate_set_integer (d, TM_WDAY, 1) >= 0, "set integer, wday = 1 (Mon)");
+    ok (cronodate_check_next (d, "2016-06-01 10:45:00", "2016-06-06 08:00:00"),
+        "cronodate_next worked for next monday");
+    ok (cronodate_check_next (d, "2016-06-06 08:00:00", "2016-06-13 08:00:00"),
+        "cronodate_next returns next matching date when current matches ");
+
+    // ERANGE test for cronodate_set_integer
+    ok (cronodate_set_integer (d, TM_SEC, -1) < 0 && errno == ERANGE,
+        "TM_SEC == -1 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_SEC, 61) < 0 && errno == ERANGE,
+        "TM_SEC == 61 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_MIN, -1) < 0 && errno == ERANGE,
+        "TM_MIN == -1 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_MIN, 60) < 0 && errno == ERANGE,
+        "TM_MIN == 60 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_HOUR, -1) < 0 && errno == ERANGE,
+        "TM_HOUR == 0 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_HOUR, 24) < 0 && errno == ERANGE,
+        "TM_HOUR == 24 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_WDAY, -1) < 0 && errno == ERANGE,
+        "TM_WDAY == -1 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_WDAY, 7) < 0 && errno == ERANGE,
+        "TM_WDAY == 24 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_MON, -1) < 0 && errno == ERANGE,
+        "TM_MON == -1 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_MON, 12) < 0 && errno == ERANGE,
+        "TM_MON == 12 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_MDAY, 0) < 0 && errno == ERANGE,
+        "TM_MDAY == 0 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_MDAY, 32) < 0 && errno == ERANGE,
+        "TM_MDAY == 32 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_YEAR, -1) < 0 && errno == ERANGE,
+        "TM_YEAR == -1 returns ERANGE");
+    ok (cronodate_set_integer (d, TM_YEAR, 3001-1900) < 0 && errno == ERANGE,
+        "TM_YEAR == %d returns ERANGE", 3001-1900);
+
     ok (cronodate_set (d, TM_MON, "6") >= 0, "date glob set, mon = 6");
     ok (cronodate_set (d, TM_MDAY, "6") >= 0, "date glob set, mday = 6");
     ok (cronodate_set (d, TM_YEAR, "*") >= 0, "date glob set, year = *");

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -85,18 +85,11 @@ void *cron_entry_type_data (cron_entry_t *e)
     return e->data;
 }
 
-static double timespec_to_double (struct timespec *tm)
-{
-    double s = tm->tv_sec;
-    double ns = tm->tv_nsec/1.0e9 + .5e-9; // round 1/2 epsilon
-    return (s + ns);
-}
-
 double get_timestamp (void)
 {
     struct timespec tm;
     clock_gettime (CLOCK_REALTIME, &tm);
-    return timespec_to_double (&tm);
+    return ((double) tm.tv_sec + (tm.tv_nsec/1.0e9));
 }
 
 static void timeout_cb (flux_t *h, cron_task_t *t, void *arg)

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -322,6 +322,7 @@ static void cron_entry_destroy (cron_entry_t *e)
 
     free (e->name);
     free (e->command);
+    free (e->typename);
 
     if (e->completed_tasks) {
         t = zlist_first (e->completed_tasks);

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -44,9 +44,9 @@
 #include <ctype.h>
 #include <flux/core.h>
 #include <czmq.h>
+#include <jansson.h>
 
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
 
 #include "task.h"
 #include "entry.h"
@@ -67,8 +67,7 @@ struct cron_ctx {
 /**************************************************************************
  * Forward declarations
  */
-static cron_entry_t *cron_entry_create (cron_ctx_t *ctx,
-    const char *json);
+static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg);
 static void cron_entry_destroy (cron_entry_t *e);
 static int cron_entry_stop (cron_entry_t *e);
 static void cron_entry_completion_handler (flux_t *h, cron_task_t *t,
@@ -313,7 +312,8 @@ static void cron_entry_destroy (cron_entry_t *e)
     /*
      *  Before destroying entry, remove it from entries list:
      */
-    zlist_remove (e->ctx->entries, e);
+    if (e->ctx && e->ctx->entries)
+        zlist_remove (e->ctx->entries, e);
 
     if (e->data) {
         e->ops.destroy (e->data);
@@ -323,12 +323,14 @@ static void cron_entry_destroy (cron_entry_t *e)
     free (e->name);
     free (e->command);
 
-    t = zlist_first (e->completed_tasks);
-    while (t) {
-        cron_task_destroy (t);
-        t = zlist_next (e->completed_tasks);
+    if (e->completed_tasks) {
+        t = zlist_first (e->completed_tasks);
+        while (t) {
+            cron_task_destroy (t);
+            t = zlist_next (e->completed_tasks);
+        }
+        zlist_destroy (&e->completed_tasks);
     }
-    zlist_destroy (&e->completed_tasks);
 
     free (e);
 }
@@ -408,25 +410,23 @@ static void cron_stats_init (struct cron_stats *s)
 /*
  *  Create a new cron entry from JSON blob
  */
-static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
+static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg)
 {
     flux_t *h = ctx->h;
     cron_entry_t *e = NULL;
-    json_object *in;
+    json_t *args = NULL;
     const char *name;
     const char *command;
     const char *type;
     int saved_errno = EPROTO;
 
-    if (!(in = Jfromstr (json))) {
-        flux_log_error (h, "cron request decode");
-        goto done;
-    }
-
-    /* Get required fields "name" and "command" */
-    if (!Jget_str (in, "name", &name) ||
-        !Jget_str (in, "command", &command)) {
-        flux_log_error (h, "cron.create: Failed to get name/command");
+    /* Get required fields "type", "name" and "command" */
+    if (flux_msg_unpack (msg, "{ s:s, s:s, s:s, s:O }",
+            "type", &type,
+            "name", &name,
+            "command", &command,
+            "args", &args) < 0) {
+        flux_log_error (h, "cron.create: Failed to get name/command/args");
         goto done;
     }
 
@@ -453,24 +453,25 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
     }
     cron_stats_init (&e->stats);
 
-    /* Get optional fields
-     *  "repeat" -- the max number of times we'll run the target command
-     *  "rank"   -- run target command on this rank (default 0)
+    /*
+     *  Set defaults for optional fields:
      */
-    (void) Jget_int (in, "repeat", &e->repeat);
-    (void) Jget_int (in, "rank", &e->rank);
+    e->repeat = 0; /* Max number of times we'll run target command (0 = inf) */
+    e->rank = 0;   /* Rank on which to run commands (default = 0)            */
+    e->task_history_count = 1; /* Default number of entries in history list  */
+    e->stop_on_failure = 0;    /* Whether the cron job is stopped on failure */
+    e->timeout = -1.0;         /* Task timeout (default -1, no timeout)      */
 
-    /* Check to see if we want to keep more than just the status of
-     *  previous run for this cron entry.
-     */
-    if (!Jget_int (in, "task-history-count", &e->task_history_count))
-        e->task_history_count = 1;
-
-    if (!Jget_int (in, "stop-on-failure", &e->stop_on_failure))
-        e->stop_on_failure = 0;
-
-    if (!Jget_double (in, "timeout", &e->timeout))
-        e->timeout = -1.0;
+    if (flux_msg_unpack (msg, "{ s?i, s?i, s?i, s?i, s?F }",
+            "repeat",             &e->repeat,
+            "rank",               &e->rank,
+            "task-history-count", &e->task_history_count,
+            "stop-on-failure",    &e->stop_on_failure,
+            "timeout",            &e->timeout) < 0) {
+        saved_errno = EPROTO;
+        flux_log_error (h, "cron.create: flux_msg_unpack");
+        goto out_err;
+    }
 
     /* List for all completed tasks up to task-history-count
      */
@@ -484,8 +485,7 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
      *  Now, create type-specific data for this entry from type
      *   name and type-specific data in "args" key:
      */
-    if (!Jget_str (in, "type", &type)
-        || (cron_type_operations_lookup (type, &e->ops) < 0)) {
+    if (cron_type_operations_lookup (type, &e->ops) < 0) {
         saved_errno = ENOSYS; /* year,month,day,etc. not supported */
         goto out_err;
     }
@@ -493,18 +493,17 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const char *json)
         saved_errno = errno;
         goto out_err;
     }
-
-    if (!(e->data = e->ops.create (h, e, Jobj_get (in, "args")))) {
+    if (!(e->data = e->ops.create (h, e, args))) {
+        flux_log_error (h, "ops.create");
         saved_errno = errno;
         goto out_err;
     }
+    json_decref (args);
 
     // Start the entry watcher for this type:
     cron_entry_start (e);
 
 done:
-    if (in)
-        Jput (in);
     return (e);
 out_err:
     cron_entry_destroy (e);
@@ -597,66 +596,72 @@ error:
 
 /**************************************************************************/
 
-static json_object *cron_stats_to_json (struct cron_stats *stats)
+static json_t *cron_stats_to_json (struct cron_stats *stats)
 {
-    json_object *o = Jnew ();
-    Jadd_double (o, "ctime", stats->ctime);
-    Jadd_double (o, "starttime", stats->starttime);
-    Jadd_double (o, "lastrun", stats->lastrun);
-    Jadd_int (o, "count", stats->count);
-    Jadd_int (o, "failcount", stats->failcount);
-    Jadd_int (o, "total", stats->total);
-    Jadd_int (o, "success", stats->success);
-    Jadd_int (o, "failure", stats->failure);
-    Jadd_int (o, "deferred", stats->deferred);
-    return (o);
+    return json_pack ("{ s:f, s:f, s:f, s:i, s:i, s:i, s:i, s:i, s:i }",
+                      "ctime", stats->ctime,
+                      "starttime", stats->starttime,
+                      "lastrun", stats->lastrun,
+                      "count", stats->count,
+                      "failcount", stats->failcount,
+                      "total", stats->total,
+                      "success", stats->success,
+                      "failure", stats->failure,
+                      "deferred", stats->deferred);
 }
 
-static json_object *cron_entry_to_json (cron_entry_t *e)
+static json_t *cron_entry_to_json (cron_entry_t *e)
 {
     cron_task_t *t;
-    json_object *o = Jnew ();
-    json_object *to = NULL;
-    json_object *tasks = Jnew_ar ();
+    json_t *o, *to;
+    json_t *tasks;
 
     /*
      *  Common entry contents:
      */
-    Jadd_int64 (o, "id", e->id);
-    Jadd_int   (o, "rank", e->rank);
-    Jadd_str   (o, "name", e->name);
-    Jadd_str   (o, "command", e->command);
-    Jadd_int   (o, "repeat", e->repeat);
-    Jadd_bool  (o, "stopped", e->stopped);
-    Jadd_str   (o, "type", e->typename);
+    if (!(o = json_pack ("{ s:I, s:i, s:s, s:s, s:i, s:b, s:s }",
+                   "id", (json_int_t) e->id,
+                   "rank", e->rank,
+                   "name", e->name,
+                   "command", e->command,
+                   "repeat", e->repeat,
+                   "stopped", e->stopped,
+                   "type", e->typename)))
+        return NULL;
+
     if (e->timeout >= 0.0)
-        Jadd_double (o, "timeout", e->timeout);
+        json_object_set_new (o, "timeout", json_real (e->timeout));
 
     if ((to = cron_stats_to_json (&e->stats)))
-        json_object_object_add (o, "stats", to);
+        json_object_set_new (o, "stats", to);
 
     /*
      *  Add type specific json blob, under typedata key:
      */
     if ((to = e->ops.tojson (e->data)))
-        json_object_object_add (o, "typedata", to);
+        json_object_set_new (o, "typedata", to);
 
     /*
      *  Add all task information, starting with any current task:
      */
+    if (!(tasks = json_array ()))
+        goto fail;
     if (e->task && (to = cron_task_to_json (e->task)))
-        json_object_array_add (tasks, to);
+        json_array_append_new (tasks, to);
 
     t = zlist_first (e->completed_tasks);
     while (t) {
         if ((to = cron_task_to_json (t)))
-            json_object_array_add (tasks, to);
+            json_array_append_new (tasks, to);
         t = zlist_next (e->completed_tasks);
     }
 
-    json_object_object_add (o, "tasks", tasks);
+    json_object_set_new (o, "tasks", tasks);
 
     return (o);
+fail:
+    json_decref (o);
+    return NULL;
 }
 
 
@@ -670,23 +675,12 @@ static void cron_create_handler (flux_t *h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    const char *json_str;
-    json_object *out = NULL;
+    json_t *out = NULL;
+    char *json_str = NULL;
     int saved_errno = EPROTO;
     int rc = -1;
 
-    if (flux_request_decode (msg, NULL, &json_str) < 0) {
-        flux_log_error (h, "cron request decode");
-        saved_errno = errno;
-        goto done;
-    }
-
-    if (!json_str) {
-        saved_errno = EPROTO;
-        goto done;
-    }
-
-    if (!(e = cron_entry_create (ctx, json_str))) {
+    if (!(e = cron_entry_create (ctx, msg))) {
         saved_errno = errno;
         goto done;
     }
@@ -697,12 +691,14 @@ static void cron_create_handler (flux_t *h, flux_msg_handler_t *w,
     }
 
     rc = 0;
-    out = cron_entry_to_json (e);
+    if ((out = cron_entry_to_json (e))) {
+        json_str = json_dumps (out, JSON_COMPACT);
+        json_decref (out);
+    }
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
-                              rc < 0 ? NULL : Jtostr (out)) < 0)
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
         flux_log_error (h, "cron.request: flux_respond");
-    Jput (out);
+    free (json_str);
 }
 
 static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
@@ -780,7 +776,8 @@ static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    json_object *out = NULL;
+    json_t *out = NULL;
+    char *json_str = NULL;
     int kill = false;
     int saved_errno;
     int rc = -1;
@@ -799,10 +796,12 @@ static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
     cron_entry_destroy (e);
 
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
-                              rc < 0 ? NULL : Jtostr (out)) < 0)
+    if (out && rc >= 0)
+        json_str = json_dumps (out, JSON_COMPACT);
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
         flux_log_error (h, "cron.delete: flux_respond");
-    Jput (out);
+    free (json_str);
+    json_decref (out);
 }
 
 /*
@@ -813,7 +812,8 @@ static void cron_stop_handler (flux_t *h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    json_object *out = NULL;
+    json_t *out = NULL;
+    char *json_str = NULL;
     int saved_errno = 0;
     int rc = -1;
 
@@ -822,11 +822,14 @@ static void cron_stop_handler (flux_t *h, flux_msg_handler_t *w,
         goto done;
     }
     rc = cron_entry_stop (e);
-    out = cron_entry_to_json (e);
+    if ((out = cron_entry_to_json (e))) {
+        json_str = json_dumps (out, JSON_COMPACT);
+        json_decref (out);
+    }
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
-                              out ? Jtostr (out) : NULL) < 0)
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
         flux_log_error (h, "cron.stop: flux_respond");
+    free (json_str);
 }
 
 /*
@@ -837,7 +840,8 @@ static void cron_start_handler (flux_t *h, flux_msg_handler_t *w,
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
-    json_object *out = NULL;
+    json_t *out = NULL;
+    char *json_str = NULL;
     int saved_errno = 0;
     int rc = -1;
 
@@ -846,11 +850,14 @@ static void cron_start_handler (flux_t *h, flux_msg_handler_t *w,
         goto done;
     }
     rc = cron_entry_start (e);
-    out = cron_entry_to_json (e);
+    if ((out = cron_entry_to_json (e))) {
+        json_str = json_dumps (out, JSON_COMPACT);
+        json_decref (out);
+    }
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0,
-                      out ? Jtostr (out) : NULL) < 0)
+    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
         flux_log_error (h, "cron.start: flux_respond");
+    free (json_str);
 }
 
 
@@ -862,23 +869,33 @@ static void cron_ls_handler (flux_t *h, flux_msg_handler_t *w,
 {
     cron_ctx_t *ctx = arg;
     cron_entry_t *e = NULL;
-    json_object *out = Jnew ();
-    json_object *entries = Jnew_ar ();
+    char *json_str = NULL;
+    json_t *out = json_object ();
+    json_t *entries = json_array ();
+
+    if (out == NULL || entries == NULL) {
+        flux_respond (h, msg, ENOMEM, NULL);
+        flux_log_error (h, "cron.list: Out of memory");
+        return;
+    }
 
     e = zlist_first (ctx->entries);
     while (e) {
-        json_object *entry = cron_entry_to_json (e);
+        json_t *entry = cron_entry_to_json (e);
         if (entry == NULL)
             flux_log_error (h, "cron_entry_to_json");
         else
-            json_object_array_add (entries, entry);
+            json_array_append_new (entries, entry);
         e = zlist_next (ctx->entries);
     }
-    json_object_object_add (out, "entries", entries);
+    json_object_set_new (out, "entries", entries);
 
-    if (flux_respond (h, msg, 0, Jtostr (out)) < 0)
+    if (!(json_str = json_dumps (out, JSON_COMPACT)))
+        flux_log_error (h, "cron.list: json_dumps");
+    else if (flux_respond (h, msg, 0, json_str) < 0)
         flux_log_error (h, "cron.list: flux_respond");
-    Jput (out);
+    json_decref (out);
+    free (json_str);
 }
 
 /**************************************************************************/

--- a/src/modules/cron/datetime.c
+++ b/src/modules/cron/datetime.c
@@ -33,7 +33,6 @@
 
 #include "src/common/libutil/nodeset.h"
 #include "src/common/libutil/shortjson.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/cronodate.h"
 
 #include "entry.h"
@@ -54,10 +53,10 @@ void datetime_entry_destroy (struct datetime_entry *dt)
 
 struct datetime_entry * datetime_entry_create ()
 {
-    struct datetime_entry *dt = xzmalloc (sizeof (*dt));
-    dt->h = NULL;
-    dt->w = NULL;
-    dt->d = cronodate_create ();
+    struct datetime_entry *dt = calloc (1, sizeof (*dt));
+    if (dt) {
+        dt->d = cronodate_create ();
+    }
     return (dt);
 }
 

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -75,6 +75,9 @@ struct cron_entry {
     int                 rank;               /* Optional rank on which to run */
     char *              name;               /* Entry name, if given          */
     char *              command;            /* Command to execute            */
+    char *              cwd;                /* Change working directory      */
+    json_t *            env;                /* Optional environment for cmd,
+                                               (encoded as json array)       */
 
     int                 repeat;             /* Total number of times to run  */
 

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -80,7 +80,7 @@ struct cron_entry {
 
     unsigned int        stopped:1;          /* This entry is inactive        */
 
-    const char *           typename;        /* Name of this type             */
+    char *                 typename;        /* Name of this type             */
     struct cron_entry_ops  ops;             /* Type-specific operations      */
     void *                 data;            /* Entry type specific data      */
 

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -26,8 +26,8 @@
 # define HAVE_CRON_ENTRY_H
 
 #include <czmq.h>
+#include <jansson.h>
 #include <flux/core.h>
-#include "src/common/libutil/shortjson.h"
 
 typedef struct cron_ctx cron_ctx_t;
 typedef struct cron_entry cron_entry_t;
@@ -37,7 +37,7 @@ typedef struct cron_entry cron_entry_t;
  */
 struct cron_entry_ops {
     // type creator from JSON request "arguments". Returns ptr to type object
-    void *(*create) (flux_t *h, cron_entry_t *e, json_object *arg);
+    void *(*create) (flux_t *h, cron_entry_t *e, json_t *arg);
 
     // destroy type object contained in data
     void (*destroy) (void *data);
@@ -49,7 +49,7 @@ struct cron_entry_ops {
     void (*stop) (void *data);
 
     // return data for entry type as JSON
-    json_object *(*tojson) (void *data);
+    json_t *(*tojson) (void *data);
 };
 
 struct cron_stats {

--- a/src/modules/cron/interval.c
+++ b/src/modules/cron/interval.c
@@ -30,7 +30,6 @@
 
 #include <flux/core.h>
 
-#include "src/common/libutil/xzmalloc.h"
 #include "entry.h"
 
 struct cron_interval {
@@ -57,7 +56,10 @@ static void *cron_interval_create (flux_t *h, cron_entry_t *e, json_object *arg)
     if (!(Jget_double (arg, "after", &after)))
         after = i;
 
-    iv = xzmalloc (sizeof (*iv));
+    if ((iv = calloc (1, sizeof (*iv))) == NULL) {
+        flux_log_error (h, "cron interval");
+        return NULL;
+    }
     iv->seconds = i;
     iv->after = after;
     iv->w = flux_timer_watcher_create (flux_get_reactor (h),

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -348,7 +348,7 @@ void cron_task_set_timeout (cron_task_t *t, double to, cron_task_state_f cb)
 static json_t *exec_request_create (struct cron_task *t,
     const char *command,
     const char *cwd,
-    char *const env[])
+    json_t *env)
 {
     json_t *o;
     json_t *cmdline = NULL;
@@ -370,16 +370,8 @@ static json_t *exec_request_create (struct cron_task *t,
         }
     }
 
-    if (env) {
-        json_t *enva = json_array ();
-        const char *e = env[0];
-        while (e != NULL)
-            json_array_append_new (enva, json_string (e));
-        if (json_object_set_new (o, "environ", enva) < 0) {
-            json_decref (enva);
+    if (env && json_object_set (o, "env", env) < 0)
             goto fail;
-        }
-    }
     return (o);
 fail:
     json_decref (o);
@@ -388,7 +380,7 @@ fail:
 
 int cron_task_run (cron_task_t *t,
     int rank, const char *cmd, const char *cwd,
-    char *const env[])
+    json_t *env)
 {
     flux_t *h = t->h;
     json_t *req = NULL;

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -73,12 +73,13 @@ void cron_task_on_state_change (cron_task_t *t, cron_task_state_f cb);
 void cron_task_set_timeout (cron_task_t *t, double to, cron_task_state_f cb);
 
 /*  run cron task `t` as command `cmd`, optional working directory `cwd`
- *   and optional alternate environment `env`.
+ *   and optional alternate environment `env` (encoded as json object for
+ *   efficiency).
  */
 int cron_task_run (cron_task_t *t,
                    int rank, const char *cmd,
                    const char *cwd,
-                   char *const env []);
+                   json_t *env);
 
 /*
  *  Send signal `sig` to cron task t

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -25,6 +25,7 @@
 #ifndef HAVE_CRON_TASK_H
 #define HAVE_CRON_TASK_H
 
+#include <jansson.h>
 #include <flux/core.h>
 
 /*  cron_task_t: async task handling for cron
@@ -94,7 +95,7 @@ int cron_task_status (cron_task_t *t);
 
 /*  return JSON representation of cron task `t`
  */
-json_object *cron_task_to_json (cron_task_t *t);
+json_t *cron_task_to_json (cron_task_t *t);
 
 #endif /* !HAVE_CRON_TASK_H */
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -22,7 +22,7 @@ https://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz \
 https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
 
 declare -A extra_configure_opts=(\
-["mpich-3.1.4"]="--disable-fortran --disable-cxx --disable-maintainer-mode --disable-dependency-tracking --enable-shared --disable-wrapper-rpath" \
+["mpich-3.1.4"]="--disable-fortran --disable-romio --disable-cxx --disable-maintainer-mode --disable-dependency-tracking --enable-shared --disable-wrapper-rpath" \
 )
 
 checkouts="\

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -90,6 +90,21 @@ test_expect_success 'rank option works' '
     cron_entry_check ${id} rank 1 &&
     flux dmesg | grep "cron-${id}.*command=\"flux getattr rank\": \"1\""
 '
+test_expect_success '--preserve-env option works' '
+    export FOO=bar &&
+    id=$(flux_cron interval --preserve-env -c1 -o rank=1 .01s printenv FOO) &&
+    unset FOO &&
+    sleep .1 &&
+    cron_entry_check ${id} stopped true &&
+    flux dmesg | grep "cron-${id}.*command=\"printenv FOO\": \"bar\""
+'
+test_expect_success '--working-dir option works' '
+    id=$(flux_cron interval -c1 -d /tmp .01s pwd) &&
+    sleep .1 &&
+    cron_entry_check ${id} stopped true &&
+    flux dmesg | grep "cron-${id}.*command=\"pwd\": \"/tmp\""
+'
+
 test_expect_success 'cron entry exec failure is recorded' '
     id=$(flux_cron interval -c1 0.01s notaprogram) &&
     sleep 0.1 &&

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -246,7 +246,10 @@ test_expect_success 'flux module remove cron' '
     flux module remove cron
 '
 test_expect_success 'module load with sync' '
-    flux module load cron sync=cron.sync
+    flux module load cron sync=cron.sync sync_epsilon=0.025
+'
+test_expect_success 'sync and sync_epsilon are set as expected' '
+    flux cron sync | grep "cron\.sync.*epsilon=0.025"
 '
 test_expect_success 'tasks do not run until sync event' '
     id=$(flux_cron event t.cron.trigger flux event pub t.cron.complete)


### PR DESCRIPTION
This PR updates the cron module to use jansson instead of json-c, removes other uses of xzmalloc that would result in calls to `oom()` and friends, and fixes some other leaks and issues found along the way.

A new function for was added to the cronodate interface to allow adding non-range integers to a cronodate object, for cases where arguments to cron "datetime" entries are encoded by the caller as numbers and not strings (as is done for ranges, e.g. "0-3" or glob "*"). The datetime argument parser was then updated to check for whether individual arguments were encoded as strings or numbers, and uses the appropriate function `cronodate_set` or `cronodate_set_integer`. This is required because unlike json-c, jansson doesn't allow decoding a number value as a string.

This PR is based on top of #1142, becuase otherwise I couldn't get successful builds in my own branch. I'll rebase if that PR gets merged.
