### PR TITLE
Misc Cleanup/Minor Fixes from KVS TreeObject Work

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -368,7 +368,7 @@ int l_flux_kvs_put (lua_State *L)
         json_object_put (o);
     }
     if (rc < 0)
-        return lua_pusherror (L, "kvsdir_put (%s): %s",
+        return lua_pusherror (L, "kvs_put (%s): %s",
                                 key, (char *)flux_strerror (errno));
 
     lua_pushboolean (L, true);

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -1,3 +1,27 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -481,9 +481,6 @@ commit_process_t commit_process (commit_t *c,
             }
 
             if (!(c->rootcpy = json_copy (rootdir))) {
-                const char *tmpref;
-                /* empty item_callback_list to prevent mistakes later */
-                while ((tmpref = zlist_pop (c->item_callback_list)));
                 c->errnum = ENOMEM;
                 return COMMIT_PROCESS_ERROR;
             }

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -125,7 +125,6 @@ int fence_add_request_data (fence_t *f, json_t *ops)
         for (i = 0; i < json_array_size (ops); i++) {
             if ((op = json_array_get (ops, i)))
                 if (json_array_append (f->ops, op) < 0) {
-                    json_decref (op);
                     errno = ENOMEM;
                     return -1;
                 }

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -1608,6 +1608,7 @@ int main (int argc, char *argv[])
      * "normal" situation and is tested throughout
      */
     commit_process_error_callbacks ();
+    commit_process_error_callbacks_partway ();
     commit_process_invalid_operation ();
     commit_process_invalid_hash ();
     commit_process_follow_link ();

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -106,7 +106,7 @@ void commit_mgr_basic_tests (void)
 
     ops = json_array ();
     ops_append (ops, "key1", "1");
- 
+
     ok (fence_add_request_data (f, ops) == 0,
         "fence_add_request_data add works");
 

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -472,7 +472,7 @@ void commit_basic_commit_process_test_multiple_fences (void)
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "key1", "1", 0);
-    create_ready_commit (cm, "fence2", "key2", "2", 0);
+    create_ready_commit (cm, "fence2", "dir.key2", "2", 0);
 
     ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
         "commit_mgr_get_ready_commit returns ready commit");
@@ -508,7 +508,8 @@ void commit_basic_commit_process_test_multiple_fences (void)
     ok (commit_iter_dirty_cache_entries (c, cache_count_cb, &count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (count == 1,
+    /* why two? 1 for root (new dir added), 1 for dir.key2 (a new dir) */
+    ok (count == 2,
         "correct number of cache entries were dirty");
 
     ok (commit_process (c, 1, rootref) == COMMIT_PROCESS_FINISHED,
@@ -518,7 +519,7 @@ void commit_basic_commit_process_test_multiple_fences (void)
         "commit_get_newroot_ref returns != NULL when processing complete");
 
     verify_value (cache, newroot, "key1", "1");
-    verify_value (cache, newroot, "key2", "2");
+    verify_value (cache, newroot, "dir.key2", "2");
 
     commit_mgr_remove_commit (cm, c);
 

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -147,8 +147,8 @@ void ops_tests (void)
         "initial fence_get_json_ops call works");
 
     ops = json_array ();
-                           json_array_append_new (ops, json_string ("A"));
-                           json_array_append_new (ops, json_string ("B"));
+    json_array_append_new (ops, json_string ("A"));
+    json_array_append_new (ops, json_string ("B"));
 
     ok (json_equal (ops, o) == true,
         "fence_get_json_ops match");


### PR DESCRIPTION
Spliced out set of cleanup patches or minor bug fixes from TreeObject work both @garlick and I have been working on.

Note that @garlick has one patch in this PR, but it's only addition of a copyright header.  Dunno if its safe for him to hit the button.  But copyright header probably counts as "non-source documentation" (https://github.com/flux-framework/rfc/blob/master/spec_1.adoc).