### PR TITLE
build: Exit on error in autogen.sh plus other cleanup

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,11 +5,9 @@
 # macros are not in default aclocal search path.
 #
 echo "Running libtoolize --automake --copy ... "
-libtoolize --automake --copy 
-echo "Running autoreconf --verbose --install -I config"
-autoreconf --verbose --install -I config
-echo "Cleaning up ..."
-mv aclocal.m4 config/
-rm -rf autom4te.cache
+libtoolize --automake --copy || exit
+echo "Running autoreconf --verbose --install"
+autoreconf --verbose --install || exit
+echo "Moving aclocal.m4 to config/ ..."
+mv aclocal.m4 config/ || exit
 echo "Now run ./configure."
-


### PR DESCRIPTION
Make autogen.sh exit after any of the commands fail.

Remove the "-I config" option from the autoreconf command
which appears to be redundant with either AC_CONFIG_AUX_DIR([config])
or AC_CONFIG_MACRO_DIR([config]) in the configure.ac file.

Stop removing autom4te.cache.  We can't remember why we did that.

Resolves #1162