### PR TITLE
testsuite: revert travis-ci to vm builds and fix many broken &&-chains in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 
-sudo: false
+sudo: true
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,8 @@ before_install:
 script:
  # Skip build if we already ran coverity-scan
  - test "${TRAVIS_BRANCH}" != 'coverity_scan' || exit 0
+ # Force git to update the shallow clone and include tags so git-describe works
+ - git fetch --unshallow --tags
  - ulimit -c unlimited
  - export CC="ccache $CC"
  - export MAKECMDS="make -j 2 distcheck"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - compiler: clang
       env: CPPCHECK=t ARGS=--enable-sanitizer CC=clang-3.8 CXX=clang++-3.8
     - compiler: gcc
-      env: CC=gcc-4.9
+      env: CC=gcc-4.9 chain_lint=t
     - compiler: clang
       env: ARGS=--enable-caliper CC=clang-3.8 CXX=clang++-3.8
       

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -55,11 +55,11 @@ test_expect_success 'flux-start in subprocess/pmi mode works (size 2)' "
 	flux start ${BUG1006} --size=2 'flux comms info' | grep 'size=2'
 "
 test_expect_success 'flux-start with size 1 has no peers' "
-	flux start ${BUG1006} --size=1 'flux comms idle' > idle.out
+	flux start ${BUG1006} --size=1 'flux comms idle' > idle.out &&
         ! grep 'idle' idle.out
 "
 test_expect_success 'flux-start with size 2 has a peer' "
-	flux start ${BUG1006} --size=2 'flux comms idle' > idle.out
+	flux start ${BUG1006} --size=2 'flux comms idle' > idle.out &&
         grep 'idle' idle.out
 "
 test_expect_success 'flux-start --size=1 --bootstrap=selfpmi works' "
@@ -254,10 +254,14 @@ test_expect_success 'flux-help command can display manpages for api calls' '
 	EOF
 	MANPATH=${PWD}/man FLUX_IGNORE_NO_DOCS=y flux help flux_foo | grep "^FOO(3)"
 '
-test_expect_success 'flux-help returns nonzero exit code from man(1)' '
+missing_man_code()
+{
         man notacommand >/dev/null 2>&1
-        code=$?
-        test_expect_code $code eval FLUX_IGNORE_NO_DOCS=y flux help notacommand
+        echo $?
+}
+test_expect_success 'flux-help returns nonzero exit code from man(1)' '
+        test_expect_code $(missing_man_code) \
+                         eval FLUX_IGNORE_NO_DOCS=y flux help notacommand
 '
 test_expect_success 'flux appends colon to missing or unset MANPATH' '
       (unset MANPATH && flux /usr/bin/printenv | grep "MANPATH=.*:$") &&

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -109,7 +109,7 @@ test_expect_success 'test_under_flux works' '
 	chmod +x .test.t &&
 	SHARNESS_TEST_DIRECTORY=`pwd` &&
 	export SHARNESS_TEST_SRCDIR SHARNESS_TEST_DIRECTORY FLUX_BUILD_DIR debug &&
-	./.test.t --verbose --debug >out 2>err
+	run_timeout 5 ./.test.t --verbose --debug >out 2>err
 	) &&
 	grep "size=2" test-under-flux/out
 '

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -99,52 +99,52 @@ test_expect_success 'module: insmod returns initialization error' '
 '
 
 test_expect_success 'module: list fails on invalid rank' '
-	flux module list -r $(invalid_rank) 2> stderr
+	flux module list -r $(invalid_rank) 2> stderr &&
 	grep "No route to host" stderr
 '
 
 test_expect_success 'module: load fails on invalid rank' '
-	flux module load -r $(invalid_rank) \
-		${FLUX_BUILD_DIR}/t/module/.libs/parent.so 2> stderr
+	test_must_fail flux module load -r $(invalid_rank) \
+		${FLUX_BUILD_DIR}/t/module/.libs/parent.so 2> stderr &&
 	grep "No route to host" stderr
 '
 
 test_expect_success 'module: remove fails on invalid rank' '
 	flux module load \
-		${FLUX_BUILD_DIR}/t/module/.libs/parent.so
-	flux module remove -r $(invalid_rank) parent 2> stderr
-	flux module remove parent
+		${FLUX_BUILD_DIR}/t/module/.libs/parent.so &&
+	flux module remove -r $(invalid_rank) parent 2> stderr &&
+	flux module remove parent &&
 	grep "No route to host" stderr
 '
 
 test_expect_success 'module: load works on valid and invalid rank' '
-	flux module load -r 0,$(invalid_rank) \
-		${FLUX_BUILD_DIR}/t/module/.libs/parent.so 1> stdout 2> stderr
+	test_must_fail flux module load -r 0,$(invalid_rank) \
+		${FLUX_BUILD_DIR}/t/module/.libs/parent.so >stdout 2>stderr &&
 	flux module list -r 0 | grep parent &&
 	grep "No route to host" stderr
 '
 
 test_expect_success 'module: list works on valid and invalid rank' '
-	flux module list -r 0,$(invalid_rank) 1> stdout 2> stderr
+	flux module list -r 0,$(invalid_rank) 1> stdout 2> stderr &&
 	grep "parent" stdout &&
 	grep "No route to host" stderr
 '
 
 test_expect_success 'module: remove works on valid and invalid rank' '
-	flux module load -r 0,$(invalid_rank) \
-		${FLUX_BUILD_DIR}/t/module/.libs/parent.so
-	flux module remove -r 0,$(invalid_rank) parent 2> stderr
+	! flux module load -r 0,$(invalid_rank) \
+		${FLUX_BUILD_DIR}/t/module/.libs/parent.so &&
+	flux module remove -r 0,$(invalid_rank) parent 2> stderr &&
 	! flux module list -r 0 | grep parent &&
 	grep "No route to host" stderr
 '
 
 test_expect_success 'module: load fails on invalid module' '
-	flux module load nosuchmodule 2> stderr
+	! flux module load nosuchmodule 2> stderr &&
 	grep "nosuchmodule: not found in module search path" stderr
 '
 
 test_expect_success 'module: remove fails on invalid module' '
-	flux module remove nosuchmodule 2> stderr
+	flux module remove nosuchmodule 2> stderr &&
 	grep "nosuchmodule: No such file or directory" stderr
 '
 
@@ -207,14 +207,14 @@ test_expect_success 'flux module stats --parse "#event (tx)" counts events' '
 
 test_expect_success 'flux module stats --clear works' '
 	flux event pub xyz &&
-	flux module stats --clear $TESTMOD
+	flux module stats --clear $TESTMOD &&
 	EVENT_TX2=$(flux module stats --parse "#event (tx)" $TESTMOD) &&
 	test "$EVENT_TX" = 0
 '
 
 test_expect_success 'flux module stats --clear-all works' '
 	flux event pub xyz &&
-	flux module stats --clear-all $TESTMOD
+	flux module stats --clear-all $TESTMOD &&
 	EVENT_TX2=$(flux module stats --parse "#event (tx)" $TESTMOD) &&
 	test "$EVENT_TX" = 0
 '
@@ -275,9 +275,9 @@ test_expect_success 'flux module load "noexist" fails' '
 
 test_expect_success 'flux module detects bad nodeset' '
 	! flux module load -r smurf kvs 2>badns-load.out &&
-	grep -q "target nodeset" badns-load.out
+	grep -q "target nodeset" badns-load.out &&
 	! flux module remove -r smurf kvs 2>badns-remove.out &&
-	grep -q "target nodeset" badns-remove.out
+	grep -q "target nodeset" badns-remove.out &&
 	! flux module list -r smurf 2>badns-list.out &&
 	grep -q "target nodeset" badns-list.out
 '

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -61,100 +61,100 @@ test_expect_success 'ping all works with 64K payload' '
 '
 
 test_expect_success 'ping fails on invalid rank (specified as target)' '
-	run_timeout 5 flux ping --count 1 $(invalid_rank) 2>stderr
+	run_timeout 5 flux ping --count 1 $(invalid_rank) 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping fails on invalid rank (specified in option)' '
-	run_timeout 5 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr
+	run_timeout 5 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping works on valid and invalid rank' '
-	run_timeout 5 flux ping --count 1 --rank 0,$(invalid_rank) cmb 1>stdout 2>stderr
+	run_timeout 5 flux ping --count 1 --rank 0,$(invalid_rank) cmb 1>stdout 2>stderr &&
 	grep -q "No route to host" stderr &&
 	grep -q "0,$(invalid_rank)!cmb.ping" stdout
 '
 
 test_expect_success 'ping fails on invalid target' '
-	run_timeout 5 flux ping --count 1 --rank 0 nosuchtarget 2>stderr
+	run_timeout 5 flux ping --count 1 --rank 0 nosuchtarget 2>stderr &&
 	grep -q "Function not implemented" stderr
 '
 
 test_expect_success 'ping output format for "any" single rank is correct (default)' '
-	run_timeout 5 flux ping --count 1 cmb 1>stdout
+	run_timeout 5 flux ping --count 1 cmb 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" single rank is correct (format 1)' '
-	run_timeout 5 flux ping --count 1 --rank any cmb 1>stdout
+	run_timeout 5 flux ping --count 1 --rank any cmb 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" single rank is correct (format 2)' '
-	run_timeout 5 flux ping --count 1 any!cmb 1>stdout
+	run_timeout 5 flux ping --count 1 any!cmb 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" single rank is correct (format 3)' '
-	run_timeout 5 flux ping --count 1 any 1>stdout
+	run_timeout 5 flux ping --count 1 any 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific single rank is correct (format 1)' '
-	run_timeout 5 flux ping --count 1 --rank 0 cmb 1>stdout
+	run_timeout 5 flux ping --count 1 --rank 0 cmb 1>stdout &&
         grep -q "^0!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific single rank is correct (format 2)' '
-	run_timeout 5 flux ping --count 1 0!cmb 1>stdout
+	run_timeout 5 flux ping --count 1 0!cmb 1>stdout &&
         grep -q "^0!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific single rank is correct (format 3)' '
-	run_timeout 5 flux ping --count 1 0 1>stdout
+	run_timeout 5 flux ping --count 1 0 1>stdout &&
         grep -q "^0!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific multiple ranks is correct (format 1)' '
-	run_timeout 5 flux ping --count 1 --rank 0-1 cmb 1>stdout
+	run_timeout 5 flux ping --count 1 --rank 0-1 cmb 1>stdout &&
         grep -q "^0-1!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
 '
 
 test_expect_success 'ping output format for specific multiple ranks is correct (format 2)' '
-	run_timeout 5 flux ping --count 1 0-1!cmb 1>stdout
+	run_timeout 5 flux ping --count 1 0-1!cmb 1>stdout &&
         grep -q "^0-1!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
 '
 
 test_expect_success 'ping output format for specific multiple ranks is correct (format 3)' '
-	run_timeout 5 flux ping --count 1 0-1 1>stdout
+	run_timeout 5 flux ping --count 1 0-1 1>stdout &&
         grep -q "^0-1!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
 '
 
 test_expect_success 'ping output format for all ranks is correct (format 1)' '
-	run_timeout 5 flux ping --count 1 --rank all cmb 1>stdout
+	run_timeout 5 flux ping --count 1 --rank all cmb 1>stdout &&
         grep -q "^all!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
 '
 
 test_expect_success 'ping output format for all ranks is correct (format 2)' '
-	run_timeout 5 flux ping --count 1 all!cmb 1>stdout
+	run_timeout 5 flux ping --count 1 all!cmb 1>stdout &&
         grep -q "^all!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
 '
 
 test_expect_success 'ping output format for all ranks is correct (format 3)' '
-	run_timeout 5 flux ping --count 1 all 1>stdout
+	run_timeout 5 flux ping --count 1 all 1>stdout &&
         grep -q "^all!cmb.ping" stdout &&
         grep -q -E "time=\([0-9]+\.[0-9]+:[0-9]+\.[0-9]+:[0-9]+\.[0-9]+\)" stdout
 '
@@ -164,24 +164,24 @@ test_expect_success 'ping output format for all ranks is correct (format 3)' '
 # rank 1 should work
 
 test_expect_success 'ping with "upstream" fails on rank 0' '
-        run_timeout 5 flux exec --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr
+        run_timeout 5 flux exec --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping with "upstream" works (format 1)' '
-        run_timeout 5 flux exec --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout
+        run_timeout 5 flux exec --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 2)' '
-        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream!cmb 1>stdout
+        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream!cmb 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 3)' '
-        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream 1>stdout
+        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -54,13 +54,13 @@ test_expect_success 'ring buffer wraps over old entries' '
 	flux logger hello_wrap1 &&
 	flux logger hello_wrap2 &&
 	flux logger hello_wrap3 &&
-	! flux dmesg | grep -q hello_wrap1
+	! flux dmesg | grep -q hello_wrap1 &&
 	flux setattr log-ring-size $OLD_RINGSIZE
 '
 
 # Try to make flux dmesg get an EPROTO error
 test_expect_success 'logged non-ascii characters handled ok' '
-	/bin/echo -n -e "\xFF\xFE\x82\x00" | flux logger
+	/bin/echo -n -e "\xFF\xFE\x82\x00" | flux logger &&
 	flux dmesg
 '
 

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -30,15 +30,18 @@ test_expect_success 'version: reports an expected string' '
 	flux version | grep -q "flux-core-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"
 '
 
+heaptrace_error_check()
+{
+	output=$(flux heaptrace "$@" 2>&1) \
+		|| echo $output | grep -q "Function not implemented"
+}
+
 # heaptrace is only enabled if configured --with-tcmalloc
 #   so ENOSYS is a valid response.  We are at least testing that code path.
 test_expect_success 'heaptrace start' '
-	output=$(flux heaptrace start heaptrace.out 2>&1) \
-		|| echo $output | grep -q "Function not implemented"
-	output=$(flux heaptrace dump "No reason" 2>&1) \
-		|| echo $output | grep -q "Function not implemented"
-	output=$(flux heaptrace stop 2>&1) \
-		|| echo $output | grep -q "Function not implemented"
+	heaptrace_error_check start heaptrace.out &&
+	heaptrace_error_check dump "No reason" &&
+	heaptrace_error_check stop
 '
 
 

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -27,9 +27,7 @@ test_expect_success 'event: can subscribe' '
 '
 
 test_expect_success 'version: reports an expected string' '
-        set -x
-	flux version | grep -q "flux-core-[0-9]+\.[0-9]+\.[0-9]"
-	set +x
+	flux version | grep -q "flux-core-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"
 '
 
 # heaptrace is only enabled if configured --with-tcmalloc

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -129,7 +129,7 @@ test_expect_success 'flux-cron event works' '
     $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
         flux event pub t.cron.trigger &&
     cron_entry_check ${id} stats.count 1 &&
-    cron_entry_check ${id} task.1.state Exited
+    cron_entry_check ${id} task.1.state Exited &&
     $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.complete \
         flux event pub t.cron.trigger &&
     cron_entry_check ${id} stats.count 2 &&
@@ -160,7 +160,7 @@ test_expect_success 'flux-cron event --nth works' '
     cron_entry_check ${id} typedata.counter 3 &&
     $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
         flux event pub t.cron.trigger &&
-    cron_entry_check ${id} stats.count 1
+    cron_entry_check ${id} stats.count 1 &&
     cron_entry_check ${id} typedata.counter 4
 '
 
@@ -207,7 +207,7 @@ test_expect_success 'flux-cron can set timeout on tasks' '
     $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua t.cron t.cron.trigger \
         flux event pub t.cron.trigger &&
     sleep 0.1 &&
-    i=0
+    i=0 &&
     while test $i -lt 5; do
         cron_entry_check ${id} task.1.state Timeout
 	rc=$?
@@ -216,7 +216,7 @@ test_expect_success 'flux-cron can set timeout on tasks' '
         i=$((i+1))
 	echo "cron-${id}: $i"
     	flux cron dump ${id}
-    done
+    done &&
     test $rc -eq 0
 '
 test_expect_success 'flux-cron can set stop-on-failure' '
@@ -252,7 +252,7 @@ test_expect_success 'sync and sync_epsilon are set as expected' '
     flux cron sync | grep "cron\.sync.*epsilon=0.025"
 '
 test_expect_success 'tasks do not run until sync event' '
-    id=$(flux_cron event t.cron.trigger flux event pub t.cron.complete)
+    id=$(flux_cron event t.cron.trigger flux event pub t.cron.complete) &&
     test_when_finished "flux cron delete ${id}" &&
     cron_entry_check ${id} stopped false &&
     cron_entry_check ${id} stats.count 0 &&

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -60,7 +60,7 @@ test_expect_success 'libfaketime works' '
     flux logger "libfaketime-test" &&
     test "$(date +%s)" = $(date +%s --date="Jun 4 1991 00:00:00") &&
     date +%s &&
-    flux dmesg | grep libfaketime-test
+    flux dmesg | grep libfaketime-test &&
     echo $now > ${FAKETIME_TIMESTAMP_FILE}
 '
 test_expect_success 'load cron module' '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -98,16 +98,16 @@ test_expect_success 'kvs: object get' '
 	test_kvs_key $KEY.object "{\"a\": 42}"
 '
 test_expect_success 'kvs: dir' '
-	flux kvs dir $DIR | sort >output
-	cat >expected <<EOF
+	flux kvs dir $DIR | sort >output &&
+	cat >expected <<EOF &&
 $DIR.c.
 $DIR.d.
 EOF
 	test_cmp expected output
 '
 test_expect_success 'kvs: dir -R' '
-	flux kvs dir -R $DIR | sort >output
-	cat >expected <<EOF
+	flux kvs dir -R $DIR | sort >output &&
+	cat >expected <<EOF &&
 $KEY.array = [1, 3, 5]
 $KEY.booleanfalse = false
 $KEY.booleantrue = true
@@ -122,8 +122,8 @@ EOF
 	test_cmp expected output
 '
 test_expect_success 'kvs: dir -R -d' '
-	flux kvs dir -R -d $DIR | sort >output
-	cat >expected <<EOF
+	flux kvs dir -R -d $DIR | sort >output &&
+	cat >expected <<EOF &&
 $KEY.array
 $KEY.booleanfalse
 $KEY.booleantrue
@@ -194,8 +194,8 @@ test_expect_success 'kvs: put (multiple)' '
 	flux kvs put $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
 '
 test_expect_success 'kvs: get (multiple)' '
-	flux kvs get $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output
-	cat >expected <<EOF
+	flux kvs get $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output &&
+	cat >expected <<EOF &&
 42
 3.140000
 foo
@@ -209,8 +209,8 @@ test_expect_success 'kvs: mkdir (multiple)' '
 	flux kvs mkdir $SUBDIR1 $SUBDIR2
 '
 test_expect_success 'kvs: dir' '
-	flux kvs dir $DIR | sort >output
-	cat >expected <<EOF
+	flux kvs dir $DIR | sort >output &&
+	cat >expected <<EOF &&
 $DIR.c.
 $DIR.d.
 $DIR.e.
@@ -218,8 +218,8 @@ EOF
 	test_cmp expected output
 '
 test_expect_success 'kvs: dir -R' '
-	flux kvs dir -R $DIR | sort >output
-	cat >expected <<EOF
+	flux kvs dir -R $DIR | sort >output &&
+	cat >expected <<EOF &&
 $KEY.a = 42
 $KEY.b = 3.140000
 $KEY.c = foo
@@ -250,7 +250,7 @@ test_expect_success 'kvs: create a dir with keys and subdir' '
         flux kvs put $DIR.d=\"snerg\" &&
         flux kvs put $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
-	cat >expected <<EOF
+	cat >expected <<EOF &&
 $DIR.a = 69
 $DIR.b = 70
 $DIR.c.d.e.f.g = 3.140000
@@ -268,7 +268,7 @@ test_expect_success 'kvs: directory with multiple subdirs' '
         flux kvs put $DIR.d=\"snerg\" &&
         flux kvs put $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
-	cat >expected <<EOF
+	cat >expected <<EOF &&
 $DIR.a = 69
 $DIR.b.c.d.e.f.g = 70
 $DIR.c.a.b = 3.140000
@@ -286,7 +286,7 @@ test_expect_success 'kvs: get a nonexistent key' '
 	test_must_fail flux kvs get NOT.A.KEY
 '
 test_expect_success 'kvs: try to retrieve a directory as key should fail' '
-        flux kvs mkdir $DIR.a.b.c
+        flux kvs mkdir $DIR.a.b.c &&
 	test_must_fail flux kvs get $DIR
 '
 
@@ -311,7 +311,7 @@ test_empty_directory() {
 }
 
 test_expect_success 'kvs: try to retrieve key as directory should fail' '
-        flux kvs put $DIR.a.b.c.d=42
+        flux kvs put $DIR.a.b.c.d=42 &&
 	test_must_fail flux kvs dir $DIR.a.b.c.d
 '
 test_expect_success 'kvs: empty directory can be created' '
@@ -334,7 +334,7 @@ test_expect_success 'kvs: unlink nonexistent dir with -f does not fail' '
         flux kvs unlink -Rf NOT.A.KEY
 '
 test_expect_success 'kvs: unlink non-empty dir fails' '
-        flux kvs mkdir $SUBDIR1 $SUBDIR2
+        flux kvs mkdir $SUBDIR1 $SUBDIR2 &&
 	test_must_fail flux kvs unlink $DIR
 '
 test_expect_success 'kvs: unlink -R works' '
@@ -376,8 +376,8 @@ test_expect_success 'kvs: readlink works (multiple inputs)' '
 	flux kvs put $TARGET2=\"foo2\" &&
 	flux kvs link $TARGET1 $DIR.link1 &&
 	flux kvs link $TARGET2 $DIR.link2 &&
-	flux kvs readlink $DIR.link1 $DIR.link2 >output
-	cat >expected <<EOF
+	flux kvs readlink $DIR.link1 $DIR.link2 >output &&
+	cat >expected <<EOF &&
 $TARGET1
 $TARGET2
 EOF
@@ -525,7 +525,7 @@ test_expect_success 'kvs: copy works' '
         flux kvs copy $DIR.src $DIR.dest &&
 	OUTPUT1=$(flux kvs get $DIR.src) &&
 	OUTPUT2=$(flux kvs get $DIR.dest) &&
-	test "$OUTPUT1" = "foo"
+	test "$OUTPUT1" = "foo" &&
 	test "$OUTPUT2" = "foo"
 '
 
@@ -553,7 +553,7 @@ test_expect_success 'kvs: dropcache --all works' '
 # version/wait tests
 #
 
-test_expect_success 'kvs: version and wait' '
+test_expect_success NO_CHAIN_LINT 'kvs: version and wait' '
 	VERS=$(flux kvs version)
         VERS=$((VERS + 1))
         flux kvs wait $VERS &
@@ -622,7 +622,7 @@ wait_watch_current() {
 # We rm -f watch_out to remove any potential race with backgrounding
 # of kvs watch process and a previous test's watch_out file.
 
-test_expect_success 'kvs: watch a key'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.foo=0 &&
         wait_watch_put "$DIR.foo" "0"
@@ -632,14 +632,14 @@ test_expect_success 'kvs: watch a key'  '
         wait_watch_current "0"
         flux kvs put $DIR.foo=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	0
 	1
 	EOF
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a key that at first doesnt exist'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist'  '
 	flux kvs unlink -Rf $DIR &&
         wait_watch_empty "$DIR.foo"
         rm -f watch_out
@@ -648,14 +648,14 @@ test_expect_success 'kvs: watch a key that at first doesnt exist'  '
         wait_watch_current "nil" &&
         flux kvs put $DIR.foo=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	nil
 	1
 	EOF
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a key that gets removed'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.foo=0 &&
         wait_watch_put "$DIR.foo" "0"
@@ -665,14 +665,14 @@ test_expect_success 'kvs: watch a key that gets removed'  '
         wait_watch_current "0" &&
         flux kvs unlink $DIR.foo &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	0
 	nil
 	EOF
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a key that becomes a dir'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.foo=0 &&
         wait_watch_put "$DIR.foo" "0"
@@ -682,7 +682,7 @@ test_expect_success 'kvs: watch a key that becomes a dir'  '
         wait_watch_current "0" &&
         flux kvs put $DIR.foo.bar.baz=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	0
 	======================
 	$DIR.foo.bar.
@@ -691,7 +691,7 @@ test_expect_success 'kvs: watch a key that becomes a dir'  '
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a dir'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
         wait_watch_put "$DIR.a.a" "0" &&
@@ -702,7 +702,7 @@ test_expect_success 'kvs: watch a dir'  '
         wait_watch_current "======================" &&
         flux kvs put $DIR.a.a=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	$DIR.a.
 	======================
 	$DIR.a.
@@ -711,7 +711,7 @@ test_expect_success 'kvs: watch a dir'  '
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a dir that at first doesnt exist'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist'  '
 	flux kvs unlink -Rf $DIR &&
         wait_watch_empty "$DIR"
         rm -f watch_out
@@ -720,7 +720,7 @@ test_expect_success 'kvs: watch a dir that at first doesnt exist'  '
         wait_watch_current "nil" &&
         flux kvs put $DIR.a.a=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	nil
 	======================
 	$DIR.a.
@@ -729,7 +729,7 @@ test_expect_success 'kvs: watch a dir that at first doesnt exist'  '
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a dir that gets removed'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         wait_watch_put "$DIR.a.a.a" "0" &&
@@ -740,7 +740,7 @@ test_expect_success 'kvs: watch a dir that gets removed'  '
         wait_watch_current "======================" &&
         flux kvs unlink -R $DIR.a &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	$DIR.a.a.
 	======================
 	nil
@@ -749,7 +749,7 @@ test_expect_success 'kvs: watch a dir that gets removed'  '
         test_cmp watch_out expected
 '
 
-test_expect_success 'kvs: watch a dir, converted into a key'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         wait_watch_put "$DIR.a.a.a" "0" &&
@@ -760,7 +760,7 @@ test_expect_success 'kvs: watch a dir, converted into a key'  '
         wait_watch_current "======================" &&
         flux kvs put $DIR.a=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	$DIR.a.a.
 	======================
 	1
@@ -772,7 +772,7 @@ test_expect_success 'kvs: watch a dir, converted into a key'  '
 # to a key instead of $DIR.a to a key.  Since we are watching $DIR.a,
 # prior test should see conversion of a $DIR.a to a key.  This time,
 # $DIR.a is no longer valid and we should see 'nil' as a result.
-test_expect_success 'kvs: watch a dir, prefix path converted into a key'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, prefix path converted into a key'  '
         flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         wait_watch_put "$DIR.a.a.a" "0" &&
@@ -783,7 +783,7 @@ test_expect_success 'kvs: watch a dir, prefix path converted into a key'  '
         wait_watch_current "======================" &&
         flux kvs put $DIR=1 &&
         wait $watchpid
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	$DIR.a.a.
 	======================
 	nil
@@ -812,7 +812,7 @@ sort_watch_output() {
         return 0
 }
 
-test_expect_success 'kvs: watch a dir with -R'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
         flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
         wait_watch_put "$DIR.a.a" "0" &&
@@ -824,7 +824,7 @@ test_expect_success 'kvs: watch a dir with -R'  '
         flux kvs put $DIR.a.a=1 &&
         wait $watchpid
         sort_watch_output
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	$DIR.a.a = 0
 	$DIR.a.b = 0
 	======================
@@ -835,7 +835,7 @@ test_expect_success 'kvs: watch a dir with -R'  '
         test_cmp watch_out_sorted expected
 '
 
-test_expect_success 'kvs: watch a dir with -R and -d'  '
+test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R and -d'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
         wait_watch_put "$DIR.a.a" "0" &&
@@ -847,7 +847,7 @@ test_expect_success 'kvs: watch a dir with -R and -d'  '
         flux kvs put $DIR.a.a=1 &&
         wait $watchpid
         sort_watch_output
-	cat >expected <<-EOF
+	cat >expected <<-EOF &&
 	$DIR.a.a
 	$DIR.a.b
 	======================

--- a/t/t1001-barrier-basic.t
+++ b/t/t1001-barrier-basic.t
@@ -32,20 +32,20 @@ test_expect_success 'barrier: blocks while incomplete' '
 '
 
 test_expect_success 'barrier: fails with name=NULL outside of LWJ' '
-	unset FLUX_JOB_ID
-	unset SLURM_STEPID
+	unset FLUX_JOB_ID &&
+	unset SLURM_STEPID &&
 	test_expect_code 1 ${tbarrier} --nprocs 1
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside LWJ' '
-	unset SLURM_STEPID
-        FLUX_JOB_ID=1; export FLUX_JOB_ID
+	unset SLURM_STEPID &&
+        FLUX_JOB_ID=1 && export FLUX_JOB_ID &&
 	flux exec ${tbarrier} --nprocs ${SIZE}
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside SLURM step' '
-	unset FLUX_LWJ_ID
-        SLURM_STEPID=1; export SLURM_STEPID
+	unset FLUX_LWJ_ID &&
+        SLURM_STEPID=1 && export SLURM_STEPID &&
 	flux exec ${tbarrier} --nprocs ${SIZE}
 '
 

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -120,7 +120,7 @@ test_expect_success 'kvs: put using no-merge flag' '
         ${KVSBASIC} put-no-merge $DIR.d=\"snerg\" &&
         ${KVSBASIC} put-no-merge $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
-	cat >expected <<EOF
+	cat >expected <<EOF &&
 $DIR.a = 69
 $DIR.b.c.d.e.f.g = 70
 $DIR.c.a.b = 3.140000
@@ -132,14 +132,14 @@ EOF
 
 test_expect_success 'kvs: directory with multiple subdirs using dirat' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $DIR.a=69
+	flux kvs put $DIR.a=69 &&
         flux kvs put $DIR.b.c.d.e.f.g=70 &&
         flux kvs put $DIR.c.a.b=3.14 &&
         flux kvs put $DIR.d=\"snerg\" &&
         flux kvs put $DIR.e=true &&
         DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
 	${KVSBASIC} dirat -r $DIRREF . | sort >output &&
-	cat >expected <<EOF
+	cat >expected <<EOF &&
 a = 69
 b.c.d.e.f.g = 70
 c.a.b = 3.140000
@@ -192,7 +192,7 @@ test_expect_success 'kvs: put-treeobj: can make root snapshot' '
 	flux kvs unlink -Rf $TEST &&
 	${KVSBASIC} get-treeobj . >snapshot &&
 	${KVSBASIC} put-treeobj $TEST.snap="`cat snapshot`" &&
-	${KVSBASIC} get-treeobj $TEST.snap >snapshot.cpy
+	${KVSBASIC} get-treeobj $TEST.snap >snapshot.cpy &&
 	test_cmp snapshot snapshot.cpy
 '
 
@@ -285,7 +285,7 @@ test_expect_success 'kvs: unlink, walk 16x3 directory tree with dirat' '
 '
 
 test_expect_success 'kvs: store 2x4 directory tree and walk' '
-	${FLUX_BUILD_DIR}/t/kvs/dtree -h4 -w2 --prefix $TEST.dtree
+	${FLUX_BUILD_DIR}/t/kvs/dtree -h4 -w2 --prefix $TEST.dtree &&
 	test $(flux kvs dir -R $TEST.dtree | wc -l) = 16
 '
 
@@ -426,7 +426,7 @@ test_expect_success 'kvs: copy-tokvs and copy-fromkvs work' '
 test_expect_success 'kvs: test that KVS_NO_MERGE works with kvs_commit()' '
         THREADS=64 &&
         OUTPUT=`${FLUX_BUILD_DIR}/t/kvs/commitmerge --nomerge ${THREADS} \
-                $(basename ${SHARNESS_TEST_FILE})`
+                $(basename ${SHARNESS_TEST_FILE})` &&
 	test "$OUTPUT" = "${THREADS}"
 '
 
@@ -437,7 +437,7 @@ test_expect_success 'kvs: commit-merge disabling works' '
         THREADS=64 &&
         flux module remove -r 0 kvs &&
         flux module load -r 0 kvs commit-merge=0 &&
-        OUTPUT=`${FLUX_BUILD_DIR}/t/kvs/commitmerge ${THREADS} $(basename ${SHARNESS_TEST_FILE})`
+        OUTPUT=`${FLUX_BUILD_DIR}/t/kvs/commitmerge ${THREADS} $(basename ${SHARNESS_TEST_FILE})` &&
 	test "$OUTPUT" = "${THREADS}"
 '
 

--- a/t/t1008-proxy.t
+++ b/t/t1008-proxy.t
@@ -93,25 +93,25 @@ test_expect_success 'ssh:// can work with events' '
 
 test_expect_success 'ssh:// with bad query option fails in flux_open()' '
 	FLUX_URI=ssh://localhost/$TEST_JOBID?badarg=bar FLUX_SSH=$TEST_SSH \
-	  flux getattr size 2>badarg.out; test $? -ne 0 &&
+	  test_must_fail flux getattr size 2>badarg.out &&
 	grep -q "flux_open:" badarg.out
 '
 
 test_expect_success 'ssh:// with bad FLUX_SSH value fails in flux_open()' '
 	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=/noexist \
-	  flux getattr size 2>noexist.out; test $? -ne 0 &&
+	  test_must_fail flux getattr size 2>noexist.out &&
 	grep -q "flux_open:" noexist.out
 '
 
 test_expect_success 'ssh:// with bad FLUX_SSH_RCMD value fails in flux_open()' '
 	FLUX_URI=ssh://localhost/$TEST_JOBID FLUX_SSH=$TEST_SSH \
-	  FLUX_SSH_RCMD=/nocmd flux getattr size 2>nocmd.out; test $? -ne 0 &&
+	  FLUX_SSH_RCMD=/nocmd test_must_fail flux getattr size 2>nocmd.out &&
 	grep -q "flux_open:" nocmd.out
 '
 
 test_expect_success 'ssh:// with missing path component fails in flux_open()' '
 	FLUX_URI=ssh://localhost FLUX_SSH=$TEST_SSH \
-	  flux getattr size 2>nopath.out; test $? -ne 0 &&
+	  test_must_fail flux getattr size 2>nopath.out &&
 	grep -q "flux_open:" nopath.out
 '
 

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -138,7 +138,7 @@ test_expect_success 'wreck: job state events emitted' '
 	EOF
 	test_cmp expected_states output_states
 '
-test_expect_success 'wreck: signaling wreckrun works' '
+test_expect_success NO_CHAIN_LINT 'wreck: signaling wreckrun works' '
         flux wreckrun -n${SIZE} sleep 15 </dev/null &
 	q=$! &&
 	$SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
@@ -164,7 +164,7 @@ test_expect_success 'wreckrun: -n1 runs one task on rank 0' '
 '
 test_expect_success 'wreckrun: -n divides tasks among ranks' '
 	flux wreckrun -l -n$((${SIZE}*2)) printenv FLUX_NODE_ID | sort >output_nx2 &&
-        i=0
+        i=0 &&
 	for n in $(seq 0 $((${SIZE}-1))); do
 		echo "$i: $n"; echo "$((i+1)): $n";
 		i=$((i+2));
@@ -246,14 +246,14 @@ test_expect_success 'wreckrun: top level environment' '
 	test_cmp expected_top_env2 output_top_env2
 '
 test_expect_success 'wreck plugins can use wreck:log_msg()' '
-	saved_pattern=$(flux getattr wrexec.lua_pattern)
+	saved_pattern=$(flux getattr wrexec.lua_pattern) &&
 	if test $? = 0; then
 	  test_when_finished \
 	    "flux setattr wrexec.lua_pattern \"$saved_pattern\""
 	else
 	  test_when_finished \
 	     "flux setattr --expunge wrexec.lua_pattern"
-	fi
+	fi &&
 	cat <<-EOF >test.lua &&
 	function rexecd_init ()
 	    local rc, err = wreck:log_msg ("lwj.%d: plugin test successful", wreck.id)
@@ -262,7 +262,7 @@ test_expect_success 'wreck plugins can use wreck:log_msg()' '
 	EOF
 	flux setattr wrexec.lua_pattern "$(pwd)/*.lua" &&
 	flux wreckrun /bin/true &&
-	flux dmesg | grep "plugin test successful" || (flux dmesg | grep lwj\.$(last_job_id) && false)
+	(flux dmesg | grep "plugin test successful" || (flux dmesg | grep lwj\.$(last_job_id) && false))
 '
 test_expect_success 'wreckrun: --detach supported' '
 	flux wreckrun --detach /bin/true | grep "^[0-9]"

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -216,7 +216,7 @@ EOF
 "
 
 test_expect_success 'jstat 10: update procdescs' "
-    flux kvs get $(flux wreck kvs-path 1).0.procdesc > output.10.1
+    flux kvs get $(flux wreck kvs-path 1).0.procdesc > output.10.1 &&
     flux jstat update 1 pdesc '{\"pdesc\": {\"procsize\":1, \"hostnames\":[\"0\"], \"executables\":[\"fake\"], \"pdarray\":[{\"pid\":8482,\"eindx\":0,\"hindx\":0}]}}' &&
     flux kvs get $(flux wreck kvs-path 1).0.procdesc > output.10.2 &&
     test_expect_code 1 diff output.10.1 output.10.2 

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -128,7 +128,7 @@ test_expect_success 'hwloc: reload --walk-topology=no removes broken down topo' 
 '
 
 test_expect_success 'hwloc: reload fails on invalid rank' '
-    flux hwloc reload -r $(invalid_rank) 2> stderr
+    flux hwloc reload -r $(invalid_rank) 2> stderr &&
     grep "No route to host" stderr
 '
 

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -38,7 +38,7 @@ for OPTS in "stdio-delay-commit"; do
   '
 
   test_expect_success "mpi hello oversubscribed with $OPTS" '
-	NTASKS=$((${SIZE}*4)); \
+	NTASKS=$((${SIZE}*4)) && \
 	run_program 5 ${NTASKS} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
 		| tee oversub.$OPTS \
 		&& grep -q "There are ${NTASKS} tasks" oversub.$OPTS


### PR DESCRIPTION
This PR reverts Travis-CI to use the vm builder instead of container builders by replacing `sudo: false` with `sudo: true` in `.travis.yml`. In my testing, this change completely resolves the intermittent (but high frequency) failures under travis such as hangs the `write error` problem, and really slow builds (#1145, #1141, etc.)

WIth that change in place, I was able to rebase many (minor) testsuite fixes I had on a branch, which fix up all the broken `&&`-chains in the testsuite, as well as add timeouts to some tests which have the potential to hang.

I think because many people have moved to the container build infrastructure, the VM build queue is not quite as long as it was getting before, so I don't think this change will slow down the turnaround time on Travis reporting.

This PR also uses one of the builders (currently the `gcc-4.9` build) to run the suite with `--chain-lint` so we catch any broken `&&`-chains that might creep back in. (Many of these are harmless, however some broken `&&` chains could cause a false positive in a test, so best to keep the testsuite suite in this regard)