### PR TITLE
cmd/flux-start: Add input error check

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -208,6 +208,8 @@ int main (int argc, char *argv[])
         status = exec_broker (command, len, broker_path);
         break;
     case BOOTSTRAP_SELFPMI:
+        if (!optparse_hasopt (ctx.opts, "size"))
+            log_msg_exit ("--size must be specified for --bootstrap=selfpmi");
         status = start_session (command, len, broker_path);
         break;
     default:

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -69,6 +69,9 @@ test_expect_success 'flux-start with size 2 has a peer' "
 test_expect_success 'flux-start --size=1 --bootstrap=selfpmi works' "
 	flux start ${ARGS} --size=1 --bootstrap=selfpmi /bin/true
 "
+test_expect_success 'flux-start --bootstrap=selfpmi fails (no size specified)' "
+	test_must_fail flux start ${ARGS} --bootstrap=selfpmi /bin/true
+"
 test_expect_success 'flux-start --size=1 --boostrap=pmi fails' "
 	test_must_fail flux start ${ARGS} --size=1 --bootstrap=pmi /bin/true
 "


### PR DESCRIPTION
If user specifies --bootstrap=selfpmi but does not specify --size,
output error message indicating it is needed.

Add unit test to test for this particular failure.

Fixes #1026