### PR TITLE
kvs: add flux kvs ls subcommand

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -50,6 +50,14 @@ Retrieve the value stored under 'key'.  If nothing has been stored under
 Store 'value' under 'key' and commit it.  If it already has a value,
 overwrite it.
 
+*ls* [-R] [-d] [-F] [-w COLS] [-1] ['key' ...]::
+Display directory referred to by _key_, or "." (root) if unspecified.
+Options are roughly equivalent to a subset of ls(1) options.
+'-R' lists directory recursively.  '-d' displays directory not its contents.
+'-F' classifies files with one character suffix (. is directory, @ is symlink).
+'-w COLS' sets the terminal width in characters.  '-1' causes output to be
+displayed in one column.
+
 *dir* [-R] [-d] ['key']::
 Display all keys and their values under the directory 'key'.
 If 'key' does not exist or is not a directory, display an error message.

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS = \
 	$(ZMQ_CFLAGS)
 
 fluxcmd_ldadd = \
+	$(top_builddir)/src/common/libkvs/libkvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -25,7 +25,6 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/ioctl.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <unistd.h>

--- a/src/common/libkvs/test/kvs_dir.c
+++ b/src/common/libkvs/test/kvs_dir.c
@@ -87,6 +87,16 @@ void test_empty (void)
     ok (kvsdir_get_size (dir) == 0,
         "kvsdir_get_size returns zero");
 
+    errno = 0;
+    ok (kvsitr_create (NULL) == NULL && errno == EINVAL,
+        "kvsitr_create with NULL dir fails with EINVAL");
+    ok (kvsitr_next (NULL) == NULL,
+        "kvsitr_next on NULL iterator returns NULL");
+    lives_ok ({kvsitr_rewind (NULL);},
+        "kvsitr_rewind on NULL iterator doesn't crash");
+    lives_ok ({kvsitr_destroy (NULL);},
+        "kvsitr_destroy on NULL iterator doesn't crash");
+
     itr = kvsitr_create (dir);
     ok (itr != NULL,
         "kvsitr_create works");


### PR DESCRIPTION
This adds a `flux kvs ls` subcommand that behaves similar to ls(1), as discussed in #1158.

```
Usage: flux-kvs ls [-R] [-d] [-w COLS] [-1] [-W] [-C] [key...]
List directory
  -1, --1                Force one entry per line
  -C, --columns          List entries by columns
  -F, --classify         Append indicator (one of .@) to entries
  -R, --recursive        List directory recursively
  -d, --directory        List directory instead of contents
  -h, --help             Display this message.
  -w, --width            Set output width to COLS.  0 means no limit
```