### PR TITLE
modules/kvs: handle root dir object caching more precisely

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1392,14 +1392,13 @@ static int setroot_event_send (kvs_ctx_t *ctx, json_t *names)
     flux_msg_t *msg = NULL;
     int saved_errno, rc = -1;
 
+    assert (ctx->rank == 0);
+
     if (event_includes_rootdir) {
-        bool stall;
-        if (load (ctx, ctx->rootdir, NULL, &root, &stall) < 0) {
-            saved_errno = errno;
-            flux_log_error (ctx->h, "%s: load", __FUNCTION__);
-            goto done;
-        }
-        FASSERT (ctx->h, stall == false);
+        struct cache_entry *hp;
+        if ((hp = cache_lookup (ctx->cache, ctx->rootdir, ctx->epoch)))
+            root = cache_entry_get_json (hp);
+        assert (root != NULL); // root entry is always in cache on rank 0
     }
     else {
         if (!(nullobj = json_null ())) {

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -688,8 +688,7 @@ static void heartbeat_cb (flux_t *h, flux_msg_handler_t *w,
         ctx->watchlist_lastrun_epoch = ctx->epoch;
     }
     /* "touch" root */
-    if (load (ctx, ctx->rootdir, NULL, NULL, NULL) < 0)
-        flux_log_error (ctx->h, "%s: load", __FUNCTION__);
+    (void)cache_lookup (ctx->cache, ctx->rootdir, ctx->epoch);
 
     if (cache_expire_entries (ctx->cache, ctx->epoch, max_lastuse_age) < 0)
         flux_log_error (ctx->h, "%s: cache_expire_entries", __FUNCTION__);


### PR DESCRIPTION
This PR fixes needless alarming error messages noted in #1174, and eliminates the last use of the (internal) KVS  `load()` function with wait == NULL.  That allows `load()` to be simplified a bit.