### PR TITLE
modules/cron: fix segfault on 32 bit systems

### DIFF
--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -605,7 +605,7 @@ error:
 
 static json_t *cron_stats_to_json (struct cron_stats *stats)
 {
-    return json_pack ("{ s:f, s:f, s:f, s:i, s:i, s:i, s:i, s:i, s:i }",
+    return json_pack ("{ s:f, s:f, s:f, s:I, s:I, s:I, s:I, s:I, s:I }",
                       "ctime", stats->ctime,
                       "starttime", stats->starttime,
                       "lastrun", stats->lastrun,


### PR DESCRIPTION
Problem: cron module segfaults during travis testing on arm7l.

Change a json_pack() format string to use "I" not "i" to
refer to uint64_t values.

Fixes #1176