### PR TITLE
modules/kvs: normalize keys before use

### DIFF
--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -321,16 +321,17 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
                                json_t *rootdir, const char *key,
                                json_t *dirent, const char **missing_ref)
 {
-    char *cpy = strdup (key);
-    char *next, *name = cpy;
+    char *cpy = NULL;
+    char *next, *name;
     json_t *dir = rootdir;
     json_t *subdir = NULL, *dir_entry;
     int saved_errno, rc = -1;
 
-    if (!cpy) {
-        saved_errno = ENOMEM;
+    if (!(cpy = kvs_util_normalize_key (key, NULL))) {
+        saved_errno = errno;
         goto done;
     }
+    name = cpy;
 
     /* Special case root
      */

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -90,3 +90,46 @@ error:
     free (s);
     return rc;
 }
+
+char *kvs_util_normalize_key (const char *key, bool *want_directory)
+{
+    const char sep = '.';
+    char *cpy = strdup (key);
+    int i, len = strlen (key) + 1;
+    bool has_sep_suffix = false;
+
+    if (cpy) {
+        /* Transform duplicate path separators into a single one.
+         */
+        for (i = 0; i < len; ) {
+            if (cpy[i] == sep && cpy[i + 1] == sep) {
+                memmove (&cpy[i], &cpy[i + 1], len - i - 1);
+                len--;
+            }
+            else
+                i++;
+        }
+        /* Eliminate leading path separator
+         */
+        if (len > 2 && cpy[0] == sep) {
+            memmove (&cpy[0], &cpy[1], len - 1);
+            len--;
+        }
+        /* Eliminate trailing path separator
+         */
+        if (len > 2 && cpy[len - 2] == sep) {
+            cpy[len - 2] = '\0';
+            len--;
+            has_sep_suffix = true;
+        }
+        if (cpy[0] == '.')
+            has_sep_suffix = true;
+        if (want_directory)
+            *want_directory = has_sep_suffix;
+    }
+    return cpy;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvs_util.h
+++ b/src/modules/kvs/kvs_util.h
@@ -23,6 +23,13 @@ int kvs_util_json_encoded_size (json_t *o, size_t *size);
  */
 int kvs_util_json_hash (const char *hash_name, json_t *o, href_t ref);
 
+/* Normalize a KVS key
+ * Returns new key string (caller must free), or NULL with errno set.
+ * On success, 'want_directory' is set to true if key had a trailing
+ * path separator.
+ */
+char *kvs_util_normalize_key (const char *key, bool *want_directory);
+
 #endif  /* !_FLUX_KVS_JSON_UTIL_H */
 
 /*

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -41,6 +41,7 @@
 #include "src/common/libkvs/treeobj.h"
 
 #include "cache.h"
+#include "kvs_util.h"
 
 #include "lookup.h"
 
@@ -387,7 +388,7 @@ lookup_t *lookup_create (struct cache *cache,
         lh->root_ref_copy = NULL;
         lh->root_ref = lh->root_dir;
     }
-    if (!(lh->path = strdup (path))) {
+    if (!(lh->path = kvs_util_normalize_key (path, NULL))) {
         saved_errno = ENOMEM;
         goto cleanup;
     }

--- a/src/modules/kvs/test/kvs_util.c
+++ b/src/modules/kvs/test/kvs_util.c
@@ -8,6 +8,58 @@
 #include "src/modules/kvs/kvs_util.h"
 #include "src/modules/kvs/types.h"
 
+void test_norm (void)
+{
+    char *s;
+    bool dirflag;
+
+    s = kvs_util_normalize_key ("a.b.c.d.e", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+        "kvs_util_normalize_key works on normal key");
+    free (s);
+
+    s = kvs_util_normalize_key ("a.b.c..d.e", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+        "kvs_util_normalize_key transforms consecutive path separators to one");
+    free (s);
+
+    s = kvs_util_normalize_key (".a.b.c.d.e", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+        "kvs_util_normalize_key drops one leading path separator");
+    free (s);
+
+    s = kvs_util_normalize_key ("....a.b.c.d.e", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+        "kvs_util_normalize_key drops several leading path separators");
+    free (s);
+
+    s = kvs_util_normalize_key ("a.b.c.d.e.", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == true,
+        "kvs_util_normalize_key drops one trailing path separator");
+    free (s);
+
+    s = kvs_util_normalize_key ("a.b.c.d.e.....", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == true,
+        "kvs_util_normalize_key drops several trailing path separators");
+    free (s);
+
+    s = kvs_util_normalize_key (".a....b.c.....d..e.....", &dirflag);
+    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == true,
+        "kvs_util_normalize_key fixes a big mess");
+    free (s);
+
+    s = kvs_util_normalize_key (".", &dirflag);
+    ok (s != NULL && !strcmp (s, "."),
+        "kvs_util_normalize_key leaves one standalone separator as is");
+    free (s);
+
+    s = kvs_util_normalize_key ("....", &dirflag);
+    ok (s != NULL && !strcmp (s, "."),
+        "kvs_util_normalize_key transforms several standalone separators to one");
+    free (s);
+}
+
+
 int main (int argc, char *argv[])
 {
     json_t *obj;
@@ -94,6 +146,7 @@ int main (int argc, char *argv[])
     free (s1);
     s1 = NULL;
 
+    test_norm ();
 
     done_testing ();
     return (0);

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -469,6 +469,40 @@ test_expect_success 'kvs: empty directory remains after key removed' '
 '
 
 #
+# test key normalization
+#
+test_expect_success 'kvs: put with leading path separators works' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put ......$DIR.a.b.c=42 &&
+	test_kvs_key $DIR.a.b.c 42
+'
+test_expect_success 'kvs: put with trailing path separators works' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a.b.c........=43 &&
+	test_kvs_key $DIR.a.b.c 43
+'
+test_expect_success 'kvs: put with extra embedded path separators works' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.....a....b...c=44 &&
+	test_kvs_key $DIR.a.b.c 44
+'
+test_expect_success 'kvs: get with leading path separators works' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a.b.c=42 &&
+	test_kvs_key ......$DIR.a.b.c 42
+'
+test_expect_success 'kvs: get with trailing path separators works' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a.b.c=43 &&
+	test_kvs_key $DIR.a.b.c........ 43
+'
+test_expect_success 'kvs: get with extra embedded path separators works' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a.b.c=44 &&
+	test_kvs_key $DIR.....a....b...c 44
+'
+
+#
 # link/readlink tests
 #
 


### PR DESCRIPTION
This PR adds code to deal with extra path separators in keys.

Duplicate,  leading, and trailing separators are removed, which addresses #1180 and #1173.

Sharness and unit tests are added.