### PR TITLE
build: fix newer compiler warnings about enum passed to va_start

### DIFF
--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -995,7 +995,7 @@ optparse_err_t optparse_add_doc (optparse_t *p, const char *doc, int group)
     return optparse_add_option (p, &o);
 }
 
-optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...)
+optparse_err_t optparse_set (optparse_t *p, int item, ...)
 {
     optparse_err_t e = OPTPARSE_SUCCESS;
     va_list vargs;
@@ -1074,7 +1074,7 @@ static void * lookup_recursive (optparse_t *p, const char *key)
 }
 
 
-optparse_err_t optparse_get (optparse_t *p, optparse_item_t item, ...)
+optparse_err_t optparse_get (optparse_t *p, int item, ...)
 {
     optparse_err_t e = OPTPARSE_SUCCESS;
     va_list vargs;

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -243,9 +243,9 @@ optparse_err_t optparse_add_option_table (optparse_t *p,
  */
 optparse_err_t optparse_add_doc (optparse_t *p, const char *doc, int group);
 
-optparse_err_t optparse_set (optparse_t *p, optparse_item_t item, ...);
+optparse_err_t optparse_set (optparse_t *p, int item, ...);
 
-optparse_err_t optparse_get (optparse_t *p, optparse_item_t item, ...);
+optparse_err_t optparse_get (optparse_t *p, int item, ...);
 
 /*   Set and get arbitrary ancillary data associated with an optparse
  *    object. optparse_get_data () returns NULL if data not found.

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -1082,7 +1082,7 @@ subprocess_manager_reap_all (struct subprocess_manager *sm)
 }
 
 int
-subprocess_manager_set (struct subprocess_manager *sm, sm_item_t item, ...)
+subprocess_manager_set (struct subprocess_manager *sm, int item, ...)
 {
     va_list ap;
 

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -66,8 +66,7 @@ struct subprocess_manager * subprocess_manager_create (void);
 /*
  *  Set value for item [item] in subprocess manager [sm]
  */
-int subprocess_manager_set (struct subprocess_manager *sm,
-	sm_item_t item, ...);
+int subprocess_manager_set (struct subprocess_manager *sm, int item, ...);
 
 /*
  *  Free memory associated with a subprocess manager object:

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -31,13 +31,13 @@ https://github.com/danmar/cppcheck.git \
 https://github.com/LLNL/Caliper.git"
 
 declare -A checkout_sha1=(\
-["libfaketime"]="b68f2820c4091075fbc205965ec6976f6d241aaa" \
+["libfaketime"]="5d41d41da8f67e396f630280b180cdfb8e56abbc" \
 ["cppcheck"]="7466a49b216d4ba5e25b48381d85a8c3b2d3a228" \
 ["Caliper"]="be6b488bedb75012e60d3062f8cd2749032985fe" \
 )
 
 declare -A extra_make_opts=(\
-["libfaketime"]="LIBDIRNAME=/lib"
+["libfaketime"]="LIBDIRNAME=/lib CC=gcc"
 ["cppcheck"]="CFGDIR=/${prefix}/etc/cppcheck CXX=g++ CC=gcc"
 )
 


### PR DESCRIPTION
This PR fixes newer compiler warnings that complain about passing default type promoted objects as an argument to `va_start`. In both places this is done in the current code, an enum is passed as the last argument before the ellipsis in a variadic function, and I guess this could cause undefined behavior depending on how the enum is promoted.

The fix for now is to simply change the argument to an integer.

This should fix current failures in travis, since the warning causes  a fatal error with `-Werror`