### PR TITLE
modules/kvs: Log to flux not stderr

### DIFF
--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -1,6 +1,7 @@
 #ifndef _FLUX_KVS_COMMIT_H
 #define _FLUX_KVS_COMMIT_H
 
+#include <flux/core.h>
 #include <czmq.h>
 
 #include "cache.h"
@@ -96,8 +97,10 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp);
  * commit_mgr_t API
  */
 
+/* flux_t is optional, if NULL logging will go to stderr */
 commit_mgr_t *commit_mgr_create (struct cache *cache,
                                  const char *hash_name,
+                                 flux_t *h,
                                  void *aux);
 
 void commit_mgr_destroy (commit_mgr_t *cm);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -41,7 +41,6 @@
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/tstat.h"
-#include "src/common/libutil/log.h"
 #include "src/common/libkvs/treeobj.h"
 
 #include "waitqueue.h"
@@ -127,7 +126,7 @@ static kvs_ctx_t *getctx (flux_t *h)
         }
         ctx->cache = cache_create ();
         ctx->watchlist = wait_queue_create ();
-        ctx->cm = commit_mgr_create (ctx->cache, ctx->hash_name, ctx);
+        ctx->cm = commit_mgr_create (ctx->cache, ctx->hash_name, h, ctx);
         if (!ctx->cache || !ctx->watchlist || !ctx->cm) {
             saved_errno = ENOMEM;
             goto error;
@@ -706,6 +705,7 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
                                   ctx->rootdir,
                                   root_ref,
                                   key,
+                                  h,
                                   flags)))
             goto done;
 
@@ -811,6 +811,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
                                   ctx->rootdir,
                                   NULL,
                                   key,
+                                  h,
                                   flags)))
             goto done;
 

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -35,7 +35,6 @@
 #include <jansson.h>
 
 #include "src/common/libutil/blobref.h"
-#include "src/common/libutil/log.h"
 
 #include "types.h"
 

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -1,18 +1,21 @@
 #ifndef _FLUX_KVS_LOOKUP_H
 #define _FLUX_KVS_LOOKUP_H
 
+#include <flux/core.h>
 #include "cache.h"
 
 typedef struct lookup lookup_t;
 
 /* Initialize a lookup handle
  * - If root_ref is same as root_dir, can be set to NULL.
+ * - flux_t is optional, if NULL logging will go to stderr
  */
 lookup_t *lookup_create (struct cache *cache,
                          int current_epoch,
                          const char *root_dir,
                          const char *root_ref,
                          const char *path,
+                         flux_t *h,
                          int flags);
 
 /* Destroy a lookup handle */

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -72,7 +72,7 @@ void commit_mgr_basic_tests (void)
 
     cache = create_cache_with_empty_rootdir (rootref);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     ok (commit_mgr_get_noop_stores (cm) == 0,
@@ -216,7 +216,7 @@ void commit_mgr_merge_tests (void)
 
     cache = create_cache_with_empty_rootdir (rootref);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     /* test successful merge */
@@ -320,7 +320,7 @@ void commit_basic_tests (void)
 
     cache = create_cache_with_empty_rootdir (rootref);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "key1", "1", 0);
@@ -394,6 +394,7 @@ void verify_value (struct cache *cache,
                              root_ref,
                              root_ref,
                              key,
+                             NULL,
                              0)) != NULL,
         "lookup_create key %s", key);
 
@@ -426,7 +427,7 @@ void commit_basic_commit_process_test (void)
 
     cache = create_cache_with_empty_rootdir (rootref);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "key1", "1", 0);
@@ -471,7 +472,7 @@ void commit_basic_commit_process_test_multiple_fences (void)
 
     cache = create_cache_with_empty_rootdir (rootref);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "key1", "1", 0);
@@ -544,7 +545,7 @@ void commit_basic_commit_process_test_multiple_fences_merge (void)
 
     cache = create_cache_with_empty_rootdir (rootref);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "foo.key1", "1", 0);
@@ -607,7 +608,7 @@ void commit_basic_root_not_dir (void)
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "val", "42", 0);
@@ -675,7 +676,7 @@ void commit_process_root_missing (void)
 
     json_decref (rootdir);
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "key1", "1", 0);
@@ -780,7 +781,7 @@ void commit_process_missing_ref (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "dir.val", "52", 0);
@@ -873,7 +874,7 @@ void commit_process_error_callbacks (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "dir.val", "52", 0);
@@ -955,7 +956,7 @@ void commit_process_error_callbacks_partway (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "dir.fileA", "52", 0);
@@ -1001,7 +1002,7 @@ void commit_process_invalid_operation (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", ".", "52", 0);
@@ -1041,7 +1042,7 @@ void commit_process_invalid_hash (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "foobar", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "foobar", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "dir.fileval", "52", 0);
@@ -1105,7 +1106,7 @@ void commit_process_follow_link (void) {
     cache_insert (cache, root_ref, cache_entry_create (root));
 
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "symlink.val", "52", 0);
@@ -1161,7 +1162,7 @@ void commit_process_dirval_test (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "dir.val", "52", 0);
@@ -1226,7 +1227,7 @@ void commit_process_delete_test (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     /* NULL value --> delete */
@@ -1272,7 +1273,7 @@ void commit_process_delete_nosubdir_test (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     /* subdir doesn't exist for this key */
@@ -1333,7 +1334,7 @@ void commit_process_delete_filevalinpath_test (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     /* val is in path */
@@ -1397,7 +1398,7 @@ void commit_process_bad_dirrefs (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     create_ready_commit (cm, "fence1", "dir.val", "52", 0);
@@ -1447,7 +1448,7 @@ void commit_process_big_fileval (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     memset (bigstr, '\0', bigstrsize);
@@ -1553,7 +1554,7 @@ void commit_process_giant_dir (void) {
 
     cache_insert (cache, root_ref, cache_entry_create (root));
 
-    ok ((cm = commit_mgr_create (cache, "sha1", &test_global)) != NULL,
+    ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
     /* make three ready commits */

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -26,6 +26,7 @@ void basic_api (void)
                              "root.foo",
                              "ref.bar",
                              "path.baz",
+                             NULL,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create works");
     ok (lookup_validate (lh) == true,
@@ -68,6 +69,7 @@ void basic_api (void)
                              "root.bar",
                              NULL,
                              "path.baz",
+                             NULL,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create works");
 
@@ -94,6 +96,7 @@ void basic_api_errors (void)
                        NULL,
                        NULL,
                        NULL,
+                       NULL,
                        0) == NULL,
         "lookup_create fails on bad input");
 
@@ -105,6 +108,7 @@ void basic_api_errors (void)
                              "root.foo",
                              "ref.bar",
                              "path.baz",
+                             NULL,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create works");
 
@@ -312,6 +316,7 @@ void lookup_root (void) {
                              root_ref,
                              root_ref,
                              ".",
+                             NULL,
                              0)) != NULL,
         "lookup_create on root, no flags, works");
     check (lh, true, EISDIR, NULL, NULL, "root no flags");
@@ -322,6 +327,7 @@ void lookup_root (void) {
                              root_ref,
                              root_ref,
                              ".",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on root w/ flag = FLUX_KVS_READDIR, works");
     check (lh, true, 0, root, NULL, "root w/ FLUX_KVS_READDIR");
@@ -332,6 +338,7 @@ void lookup_root (void) {
                              root_ref,
                              root_ref,
                              ".",
+                             NULL,
                              FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create on root w/ flag = FLUX_KVS_TREEOBJ, works");
     test = treeobj_create_dirref (root_ref);
@@ -400,6 +407,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on path dirref");
     check (lh, true, 0, dirref, NULL, "lookup dirref");
@@ -410,6 +418,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.valref",
+                             NULL,
                              0)) != NULL,
         "lookup_create on path dirref.valref");
     test = treeobj_create_val ("abcd", 4);
@@ -422,6 +431,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.val",
+                             NULL,
                              0)) != NULL,
         "lookup_create on path dirref.val");
     test = treeobj_create_val ("foo", 3);
@@ -434,6 +444,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.dir",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on path dirref.dir");
     check (lh, true, 0, dir, NULL, "lookup dirref.dir");
@@ -444,6 +455,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.symlink",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create on path dirref.symlink");
     test = treeobj_create_symlink ("baz");
@@ -456,6 +468,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref",
+                             NULL,
                              FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create on path dirref (treeobj)");
     test = treeobj_create_dirref (dirref_ref);
@@ -468,6 +481,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.valref",
+                             NULL,
                              FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create on path dirref.valref (treeobj)");
     test = treeobj_create_valref (valref_ref);
@@ -480,6 +494,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.val",
+                             NULL,
                              FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create on path dirref.val (treeobj)");
     test = treeobj_create_val ("foo", 3);
@@ -492,6 +507,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.dir",
+                             NULL,
                              FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create on path dirref.dir (treeobj)");
     check (lh, true, 0, dir, NULL, "lookup dirref.dir treeobj");
@@ -502,6 +518,7 @@ void lookup_basic (void) {
                              root_ref,
                              root_ref,
                              "dirref.symlink",
+                             NULL,
                              FLUX_KVS_TREEOBJ)) != NULL,
         "lookup_create on path dirref.symlink (treeobj)");
     test = treeobj_create_symlink ("baz");
@@ -592,6 +609,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "foo",
+                             NULL,
                              0)) != NULL,
         "lookup_create on bad path in path");
     check (lh, true, 0, NULL, NULL, "lookup bad path");
@@ -603,6 +621,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "val.foo",
+                             NULL,
                              0)) != NULL,
         "lookup_create on val in path");
     check (lh, true, 0, NULL, NULL, "lookup val in path");
@@ -614,6 +633,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "valref.foo",
+                             NULL,
                              0)) != NULL,
         "lookup_create on valref in path");
     check (lh, true, 0, NULL, NULL, "lookup valref in path");
@@ -624,6 +644,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dir.foo",
+                             NULL,
                              0)) != NULL,
         "lookup_create on dir in path");
     check (lh, true, EPERM, NULL, NULL, "lookup dir in path");
@@ -634,6 +655,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "symlink1",
+                             NULL,
                              0)) != NULL,
         "lookup_create on link loop");
     check (lh, true, ELOOP, NULL, NULL, "lookup infinite links");
@@ -644,6 +666,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dirref",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create on dirref");
     check (lh, true, EINVAL, NULL, NULL, "lookup dirref, expecting link");
@@ -654,6 +677,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dir",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create on dir");
     check (lh, true, EINVAL, NULL, NULL, "lookup dir, expecting link");
@@ -664,6 +688,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "valref",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create on valref");
     check (lh, true, EINVAL, NULL, NULL, "lookup valref, expecting link");
@@ -674,6 +699,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "val",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create on val");
     check (lh, true, EINVAL, NULL, NULL, "lookup val, expecting link");
@@ -684,6 +710,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dirref",
+                             NULL,
                              0)) != NULL,
         "lookup_create on dirref");
     check (lh, true, EISDIR, NULL, NULL, "lookup dirref, not expecting dirref");
@@ -694,6 +721,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dir",
+                             NULL,
                              0)) != NULL,
         "lookup_create on dir");
     check (lh, true, EISDIR, NULL, NULL, "lookup dir, not expecting dir");
@@ -704,6 +732,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "valref",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on valref");
     check (lh, true, ENOTDIR, NULL, NULL, "lookup valref, expecting dir");
@@ -714,6 +743,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "val",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on val");
     check (lh, true, ENOTDIR, NULL, NULL, "lookup val, expecting dir");
@@ -724,6 +754,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "symlink",
+                             NULL,
                              FLUX_KVS_READLINK | FLUX_KVS_READDIR)) != NULL,
         "lookup_create on symlink");
     check (lh, true, ENOTDIR, NULL, NULL, "lookup symlink, expecting dir");
@@ -734,6 +765,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dirref_bad",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on dirref_bad");
     check (lh, true, EPERM, NULL, NULL, "lookup dirref_bad");
@@ -744,6 +776,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "valref_bad",
+                             NULL,
                              0)) != NULL,
         "lookup_create on valref_bad");
     check (lh, true, EPERM, NULL, NULL, "lookup valref_bad");
@@ -754,6 +787,7 @@ void lookup_errors (void) {
                              root_ref,
                              valref_ref,
                              "val",
+                             NULL,
                              0)) != NULL,
         "lookup_create on bad root_ref");
     check (lh, true, EINVAL, NULL, NULL, "lookup bad root_ref");
@@ -764,6 +798,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dirref_multi",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on dirref_multi");
     check (lh, true, EPERM, NULL, NULL, "lookup dirref_multi");
@@ -775,6 +810,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "dirref_multi.foo",
+                             NULL,
                              0)) != NULL,
         "lookup_create on dirref_multi, part of path");
     check (lh, true, EPERM, NULL, NULL, "lookup dirref_multi, part of path");
@@ -785,6 +821,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "valref_multi",
+                             NULL,
                              0)) != NULL,
         "lookup_create on valref_multi");
     check (lh, true, EPERM, NULL, NULL, "lookup valref_multi");
@@ -797,6 +834,7 @@ void lookup_errors (void) {
                              root_ref,
                              root_ref,
                              "valref_multi.foo",
+                             NULL,
                              0)) != NULL,
         "lookup_create on valref_multi, part of path");
     check (lh, true, 0, NULL, NULL, "lookup valref_multi, part of path");
@@ -893,6 +931,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref.symlink",
+                             NULL,
                              0)) != NULL,
         "lookup_create link to val via two links");
     test = treeobj_create_val ("foo", 3);
@@ -905,6 +944,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref.val",
+                             NULL,
                              0)) != NULL,
         "lookup_create link to val");
     test = treeobj_create_val ("foo", 3);
@@ -917,6 +957,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref.valref",
+                             NULL,
                              0)) != NULL,
         "lookup_create link to valref");
     test = treeobj_create_val ("abcd", 4);
@@ -929,6 +970,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref.dir",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create link to dir");
     check (lh, true, 0, dir, NULL, "dirref1.link2dirref.dir");
@@ -939,6 +981,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref.dirref",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create link to dirref");
     check (lh, true, 0, dirref3, NULL, "dirref1.link2dirref.dirref");
@@ -949,6 +992,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref.symlink",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create link to symlink");
     test = treeobj_create_symlink ("dirref2.val");
@@ -961,6 +1005,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2val",
+                             NULL,
                              0)) != NULL,
         "lookup_create link to val (last part path)");
     test = treeobj_create_val ("foo", 3);
@@ -973,6 +1018,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2valref",
+                             NULL,
                              0)) != NULL,
         "lookup_create link to valref (last part path)");
     test = treeobj_create_val ("abcd", 4);
@@ -985,6 +1031,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dir",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create link to dir (last part path)");
     check (lh, true, 0, dir, NULL, "dirref1.link2dir");
@@ -995,6 +1042,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2dirref",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create link to dirref (last part path)");
     check (lh, true, 0, dirref2, NULL, "dirref1.link2dirref");
@@ -1005,6 +1053,7 @@ void lookup_links (void) {
                              root_ref,
                              root_ref,
                              "dirref1.link2symlink",
+                             NULL,
                              FLUX_KVS_READLINK)) != NULL,
         "lookup_create link to symlink (last part path)");
     test = treeobj_create_symlink ("dirref2.symlink");
@@ -1063,6 +1112,7 @@ void lookup_alt_root (void) {
                              root_ref,
                              dirref1_ref,
                              "val",
+                             NULL,
                              0)) != NULL,
         "lookup_create val w/ dirref1 root_ref");
     test = treeobj_create_val ("foo", 3);
@@ -1075,6 +1125,7 @@ void lookup_alt_root (void) {
                              root_ref,
                              dirref2_ref,
                              "val",
+                             NULL,
                              0)) != NULL,
         "lookup_create val w/ dirref2 root_ref");
     test = treeobj_create_val ("bar", 3);
@@ -1112,6 +1163,7 @@ void lookup_stall_root (void) {
                              root_ref,
                              root_ref,
                              ".",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create stalltest \".\"");
     check_stall (lh, false, EAGAIN, NULL, root_ref, "root \".\" stall");
@@ -1127,6 +1179,7 @@ void lookup_stall_root (void) {
                              root_ref,
                              root_ref,
                              ".",
+                             NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create stalltest \".\"");
     check (lh, true, 0, root, NULL, "root \".\" #2");
@@ -1196,6 +1249,7 @@ void lookup_stall (void) {
                              root_ref,
                              root_ref,
                              "dirref1.val",
+                             NULL,
                              0)) != NULL,
         "lookup_create stalltest dirref1.val");
     check_stall (lh, false, EAGAIN, NULL, root_ref, "dirref1.val stall #1");
@@ -1218,6 +1272,7 @@ void lookup_stall (void) {
                              root_ref,
                              root_ref,
                              "dirref1.val",
+                             NULL,
                              0)) != NULL,
         "lookup_create dirref1.val");
     test = treeobj_create_val ("foo", 3);
@@ -1230,6 +1285,7 @@ void lookup_stall (void) {
                              root_ref,
                              root_ref,
                              "symlink.val",
+                             NULL,
                              0)) != NULL,
         "lookup_create stalltest symlink.val");
     check_stall (lh, false, EAGAIN, NULL, dirref2_ref, "symlink.val stall");
@@ -1247,6 +1303,7 @@ void lookup_stall (void) {
                              root_ref,
                              root_ref,
                              "symlink.val",
+                             NULL,
                              0)) != NULL,
         "lookup_create symlink.val");
     test = treeobj_create_val ("bar", 3);
@@ -1259,6 +1316,7 @@ void lookup_stall (void) {
                              root_ref,
                              root_ref,
                              "dirref1.valref",
+                             NULL,
                              0)) != NULL,
         "lookup_create stalltest dirref1.valref");
     check_stall (lh, false, EAGAIN, NULL, valref_ref, "dirref1.valref stall");
@@ -1276,6 +1334,7 @@ void lookup_stall (void) {
                              root_ref,
                              root_ref,
                              "dirref1.valref",
+                             NULL,
                              0)) != NULL,
         "lookup_create stalltest dirref1.valref");
     test = treeobj_create_val ("abcd", 4);


### PR DESCRIPTION
Replace lingering log calls that log to stderr with calls that
log to flux logging facility.  Requires passing optional flux_t
handle to internal lookup and commit APIs.

Remove lingering unnecessary includes of log.h throughout.

Fixes #1165