### PR TITLE
Issue#1194: delay thread cancellation during sqlite.

### DIFF
--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -254,6 +254,9 @@ void load_cb (flux_t *h, flux_msg_handler_t *w,
     int size = 0;
     int uncompressed_size;
     int rc = -1;
+    int old_state;
+    //delay cancellation to ensure lock-correctness in sqlite
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state);
 
     if (flux_request_decode_raw (msg, NULL, (void **)&blobref,
                                  &blobref_size) < 0) {
@@ -317,6 +320,7 @@ done:
     if (flux_respond_raw (h, msg, rc < 0 ? errno : 0, data, size) < 0)
         flux_log_error (h, "load: flux_respond");
     (void )sqlite3_reset (ctx->load_stmt);
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }
 
 void store_cb (flux_t *h, flux_msg_handler_t *w,
@@ -329,6 +333,9 @@ void store_cb (flux_t *h, flux_msg_handler_t *w,
     char blobref[BLOBREF_MAX_STRING_SIZE] = "-";
     int uncompressed_size = -1;
     int rc = -1;
+    int old_state;
+    //delay cancellation to ensure lock-correctness in sqlite
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state);
 
     if (flux_request_decode_raw (msg, NULL, &data, &size) < 0) {
         flux_log_error (h, "store: request decode failed");
@@ -386,6 +393,7 @@ done:
                                         blobref, strlen (blobref) + 1) < 0)
         flux_log_error (h, "store: flux_respond");
     (void) sqlite3_reset (ctx->store_stmt);
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }
 
 int register_backing_store (flux_t *h, bool value, const char *name)
@@ -430,6 +438,7 @@ void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
     sqlite_ctx_t *ctx = arg;
     flux_future_t *f;
     int count = 0;
+    int old_state;
 
     flux_log (h, LOG_DEBUG, "shutdown: begin");
     if (register_backing_store (h, false, "content-sqlite") < 0) {
@@ -440,6 +449,8 @@ void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log (h, LOG_DEBUG, "shutdown: instance is terminating, don't reload to cache");
         goto done;
     }
+    //delay cancellation to ensure lock-correctness in sqlite
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state);
     while (sqlite3_step (ctx->dump_stmt) == SQLITE_ROW) {
         const char *blobref;
         int blobref_size;
@@ -497,6 +508,7 @@ void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
     (void )sqlite3_reset (ctx->dump_stmt);
     flux_log (h, LOG_DEBUG, "shutdown: %d entries returned to cache", count);
 done:
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
     flux_reactor_stop (flux_get_reactor (h));
 }
 


### PR DESCRIPTION
If thread cancellation interrupts sqlite operation, the main thread may not be 
able to acquire lock inside sqlite calls during clean up and hangs.
