### PR TITLE
flux.service: Fix EXTRA_DIST and .gitignore

### DIFF
--- a/etc/.gitignore
+++ b/etc/.gitignore
@@ -1,1 +1,3 @@
 /flux
+/flux.service
+

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -34,5 +34,4 @@ pkgconfig_DATA = flux-core.pc flux-pmi.pc flux-optparse.pc
 endif
 
 EXTRA_DIST = \
-	gen-cmdhelp.pl \
-	flux.service
+	gen-cmdhelp.pl


### PR DESCRIPTION
Add flux.service to .gitignore, since it is generated from
flux.service.in at configure time.

Remove the EXTRA_DIST of flux.service. Since this is generated
at configure time from flux.service.in and flux.service.in
is already part of the dist by way of being declared in AC_CONFIG_FILES,
it does not appear that flux.service should be EXTRA_DIST.