### PR TITLE
API: add const to message payload accessor functions

### DIFF
--- a/doc/man3/flux_content_load.adoc
+++ b/doc/man3/flux_content_load.adoc
@@ -17,7 +17,7 @@ SYNOPSIS
                                    int flags);
 
  int flux_content_load_get (flux_future_t *f,
-                            void **buf,
+                            const void **buf,
                             size_t *len);
 
 

--- a/doc/man3/flux_mrpc.adoc
+++ b/doc/man3/flux_mrpc.adoc
@@ -22,7 +22,7 @@ int flux_mrpc_get (flux_mrpc_t *mrpc, const char **json_str);
 
 int flux_mrpc_getf (flux_mrpc_t *mrpc, const char *fmt, ...);
 
-int flux_mrpc_get_raw (flux_mrpc_t *mrpc, void **data, int *len);
+int flux_mrpc_get_raw (flux_mrpc_t *mrpc, const void **data, int *len);
 
 int flux_mrpc_get_nodeid (flux_mrpc_t *mrpc, uint32_t *nodeid);
 

--- a/doc/man3/flux_request_decode.adoc
+++ b/doc/man3/flux_request_decode.adoc
@@ -22,7 +22,7 @@ SYNOPSIS
 
  int flux_request_decode_raw (const flux_msg_t *msg,
                               const char **topic,
-                              void **data, int *len);
+                              const void **data, int *len);
 
 DESCRIPTION
 -----------

--- a/doc/man3/flux_response_decode.adoc
+++ b/doc/man3/flux_response_decode.adoc
@@ -18,7 +18,7 @@ SYNOPSIS
 
  int flux_response_decode_raw (const flux_msg_t *msg,
                                const char **topic,
-                               void **data, int *len);
+                               const void **data, int *len);
 
 DESCRIPTION
 -----------

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -28,7 +28,8 @@ SYNOPSIS
 
  int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
- int flux_rpc_get_raw (flux_future_t *f, void **data, int *len);
+ int flux_rpc_get_raw (flux_future_t *f,
+                       const void **data, int *len);
 
 
 DESCRIPTION

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -273,7 +273,7 @@ static void cache_load_continuation (flux_future_t *f, void *arg)
 {
     content_cache_t *cache = arg;
     struct cache_entry *e = flux_future_aux_get (f, "entry");
-    void *data = NULL;
+    const void *data = NULL;
     int len = 0;
     int saved_errno;
     int rc = -1;
@@ -359,7 +359,7 @@ void content_load_request (flux_t *h, flux_msg_handler_t *w,
     int saved_errno = 0;
     int rc = -1;
 
-    if (flux_request_decode_raw (msg, NULL, (void **)&blobref,
+    if (flux_request_decode_raw (msg, NULL, (const void **)&blobref,
                                  &blobref_size) < 0) {
         saved_errno = errno;
         goto done;
@@ -518,7 +518,7 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
-    void *data;
+    const void *data;
     int len;
     struct cache_entry *e = NULL;
     char blobref[BLOBREF_MAX_STRING_SIZE];

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -532,7 +532,7 @@ static void append_request_cb (flux_t *h, flux_msg_handler_t *w,
         log_msg ("%s: malformed log request", __FUNCTION__);
         return;
     }
-    if (flux_request_decode_raw (msg, NULL, (void **)&buf, &len) < 0)
+    if (flux_request_decode_raw (msg, NULL, (const void **)&buf, &len) < 0)
         goto error;
     if (logbuf_append (logbuf, buf, len) < 0)
         goto error;

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -32,7 +32,7 @@ static int internal_content_load (optparse_t *p, int ac, char *av[])
 {
     int n;
     const char *ref;
-    uint8_t *data;
+    const uint8_t *data;
     int size;
     flux_t *h;
     flux_future_t *f;
@@ -50,7 +50,7 @@ static int internal_content_load (optparse_t *p, int ac, char *av[])
         flags |= CONTENT_FLAG_CACHE_BYPASS;
     if (!(f = flux_content_load (h, ref, flags)))
         log_err_exit ("flux_content_load");
-    if (flux_content_load_get (f, (void **)&data, &size) < 0)
+    if (flux_content_load_get (f, (const void **)&data, &size) < 0)
         log_err_exit ("flux_content_load_get");
     if (write_all (STDOUT_FILENO, data, size) < 0)
         log_err_exit ("write");

--- a/src/common/libflux/content.c
+++ b/src/common/libflux/content.c
@@ -52,7 +52,7 @@ flux_future_t *flux_content_load (flux_t *h, const char *blobref, int flags)
     return flux_rpc_raw (h, topic, blobref, strlen (blobref) + 1, rank, 0);
 }
 
-int flux_content_load_get (flux_future_t *f, void **buf, int *len)
+int flux_content_load_get (flux_future_t *f, const void **buf, int *len)
 {
     return flux_rpc_get_raw (f, buf, len);
 }
@@ -76,7 +76,7 @@ int flux_content_store_get (flux_future_t *f, const char **blobref)
     int ref_size;
     const char *ref;
 
-    if (flux_rpc_get_raw (f, (void **)&ref, &ref_size) < 0)
+    if (flux_rpc_get_raw (f, (const void **)&ref, &ref_size) < 0)
         return -1;
     if (!ref || ref[ref_size - 1] != '\0' || blobref_validate (ref) < 0) {
         errno = EPROTO;

--- a/src/common/libflux/content.h
+++ b/src/common/libflux/content.h
@@ -19,7 +19,7 @@ flux_future_t *flux_content_load (flux_t *h,
  * Storage for 'buf' belongs to 'f' and is valid until 'f' is destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int flux_content_load_get (flux_future_t *f, void **buf, int *len);
+int flux_content_load_get (flux_future_t *f, const void **buf, int *len);
 
 /* Send request to store blob.
  */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1061,7 +1061,8 @@ int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...)
     return rc;
 }
 
-int flux_msg_get_payload (const flux_msg_t *msg, int *flags, void **buf, int *size)
+int flux_msg_get_payload (const flux_msg_t *msg, int *flags,
+                          const void **buf, int *size)
 {
     zframe_t *zf;
     uint8_t msgflags;
@@ -1124,7 +1125,7 @@ done:
 
 int flux_msg_get_json (const flux_msg_t *msg, const char **s)
 {
-    char *buf;
+    const char *buf;
     int size;
     int flags;
     int rc = -1;
@@ -1133,7 +1134,7 @@ int flux_msg_get_json (const flux_msg_t *msg, const char **s)
         errno = EINVAL;
         goto done;
     }
-    if (flux_msg_get_payload (msg, &flags, (void **)&buf, &size) < 0) {
+    if (flux_msg_get_payload (msg, &flags, (const void **)&buf, &size) < 0) {
         errno = 0;
         *s = NULL;
     } else {
@@ -1403,7 +1404,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
      */
     if (flux_msg_has_payload (msg)) {
         const char *json_str;
-        void *buf;
+        const void *buf;
         int size, flags;
         if (flux_msg_get_json (msg, &json_str) == 0)
             fprintf (f, "%s[%3.3zu] %s\n", prefix, strlen (json_str), json_str);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -160,7 +160,7 @@ int flux_msg_get_topic (const flux_msg_t *msg, const char **topic);
  * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
  */
 int flux_msg_get_payload (const flux_msg_t *msg, int *flags,
-                          void **buf, int *size);
+                          const void **buf, int *size);
 int flux_msg_set_payload (flux_msg_t *msg, int flags,
                           const void *buf, int size);
 bool flux_msg_has_payload (const flux_msg_t *msg);

--- a/src/common/libflux/mrpc.c
+++ b/src/common/libflux/mrpc.c
@@ -241,7 +241,7 @@ done:
     return rc;
 }
 
-int flux_mrpc_get_raw (flux_mrpc_t *mrpc, void **data, int *len)
+int flux_mrpc_get_raw (flux_mrpc_t *mrpc, const void **data, int *len)
 {
     int rc = -1;
 

--- a/src/common/libflux/mrpc.h
+++ b/src/common/libflux/mrpc.h
@@ -59,7 +59,7 @@ int flux_mrpc_get_nodeid (flux_mrpc_t *mrpc, uint32_t *nodeid);
  * or flux_mrpc_next().
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_mrpc_get_raw (flux_mrpc_t *mrpc, void **data, int *len);
+int flux_mrpc_get_raw (flux_mrpc_t *mrpc, const void **data, int *len);
 
 /* Arrange for reactor to handle response and call 'cb' continuation function
  * when a response is received.  The function should call flux_mrpc_get().

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -75,10 +75,10 @@ done:
 }
 
 int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
-                             void **data, int *len)
+                             const void **data, int *len)
 {
     const char *ts;
-    void *d = NULL;
+    const void *d = NULL;
     int l = 0;
     int rc = -1;
 

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -28,7 +28,7 @@ int flux_request_unpack (const flux_msg_t *msg, const char **topic,
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
-                             void **data, int *len);
+                             const void **data, int *len);
 
 /* Encode a request message.
  * If json_str is non-NULL, assign the json payload.

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -85,10 +85,10 @@ done:
 }
 
 int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
-                              void **data, int *len)
+                              const void **data, int *len)
 {
     const char *ts;
-    void *d = NULL;
+    const void *d = NULL;
     int l = 0;
     int flags = 0;
     int rc = -1;

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -27,7 +27,7 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
-                              void **data, int *len);
+                              const void **data, int *len);
 
 flux_msg_t *flux_response_encode (const char *topic, int errnum,
                                   const char *json_str);

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -98,7 +98,7 @@ done:
     return rc;
 }
 
-int flux_rpc_get_raw (flux_future_t *f, void **data, int *len)
+int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len)
 {
     const flux_msg_t *msg;
     int rc = -1;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -25,7 +25,7 @@ int flux_rpc_get (flux_future_t *f, const char **json_str);
 
 int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
-int flux_rpc_get_raw (flux_future_t *f, void **data, int *len);
+int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
 
 
 #endif /* !_FLUX_CORE_RPC_H */

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -230,7 +230,8 @@ void check_payload_json_formatted (void)
 void check_payload (void)
 {
     flux_msg_t *msg;
-    void *pay[1024], *buf;
+    const void *buf;
+    void *pay[1024];
     int plen = sizeof (pay), len;
     int flags;
 
@@ -610,8 +611,8 @@ void check_copy (void)
     int type;
     const char *topic;
     int cpylen, flags;
-    char buf[] = "xxxxxxxxxxxxxxxxxx";
-    void *cpybuf;
+    const char buf[] = "xxxxxxxxxxxxxxxxxx";
+    const void *cpybuf;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)) != NULL,
         "created no-payload keepalive");

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -11,8 +11,8 @@ int main (int argc, char *argv[])
     flux_msg_t *msg;
     const char *topic, *s;
     const char *json_str = "{\"a\":42}";
-    void *d;
-    char data[] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const void *d;
+    const char data[] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     int i, l, len = strlen (data);
 
     plan (NO_PLAN);

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -11,8 +11,8 @@ int main (int argc, char *argv[])
     flux_msg_t *msg;
     const char *topic, *s;
     const char *json_str = "{\"a\":42}";
-    void *d;
-    char data[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const void *d;
+    const char data[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     int l, len = strlen (data);
 
     plan (NO_PLAN);

--- a/src/common/libutil/readall.c
+++ b/src/common/libutil/readall.c
@@ -32,7 +32,7 @@
 
 #include "readall.h"
 
-int write_all (int fd, uint8_t *buf, int len)
+int write_all (int fd, const uint8_t *buf, int len)
 {
     int n;
     int count = 0;

--- a/src/common/libutil/readall.h
+++ b/src/common/libutil/readall.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-int write_all (int fd, uint8_t *buf, int len);
+int write_all (int fd, const uint8_t *buf, int len);
 int read_all (int fd, uint8_t **bufp);
 
 #endif /* !_UTIL_READ_ALL_H */

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -246,7 +246,7 @@ void load_cb (flux_t *h, flux_msg_handler_t *w,
               const flux_msg_t *msg, void *arg)
 {
     sqlite_ctx_t *ctx = arg;
-    char *blobref = "-";
+    const char *blobref = "-";
     int blobref_size;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
     int hash_len;
@@ -258,7 +258,7 @@ void load_cb (flux_t *h, flux_msg_handler_t *w,
     //delay cancellation to ensure lock-correctness in sqlite
     pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state);
 
-    if (flux_request_decode_raw (msg, NULL, (void **)&blobref,
+    if (flux_request_decode_raw (msg, NULL, (const void **)&blobref,
                                  &blobref_size) < 0) {
         flux_log_error (h, "load: request decode failed");
         goto done;
@@ -327,7 +327,7 @@ void store_cb (flux_t *h, flux_msg_handler_t *w,
                const flux_msg_t *msg, void *arg)
 {
     sqlite_ctx_t *ctx = arg;
-    void *data;
+    const void *data;
     int size, hash_len;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
     char blobref[BLOBREF_MAX_STRING_SIZE] = "-";
@@ -492,7 +492,7 @@ void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
             flux_log_error (h, "shutdown: store");
             continue;
         }
-        if (flux_rpc_get_raw (f, (void **)&blobref, &blobref_size) < 0) {
+        if (flux_rpc_get_raw (f, (const void **)&blobref, &blobref_size) < 0) {
             flux_log_error (h, "shutdown: store");
             flux_future_destroy (f);
             continue;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -169,7 +169,7 @@ static void content_load_completion (flux_future_t *f, void *arg)
 {
     kvs_ctx_t *ctx = arg;
     json_t *o;
-    void *data;
+    const void *data;
     int size;
     const char *blobref;
     struct cache_entry *hp;

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -328,7 +328,7 @@ void null_request_cb (flux_t *h, flux_msg_handler_t *w,
     t_req_ctx_t *ctx = arg;
     const char *topic;
     int type, size;
-    void *buf;
+    const void *buf;
     uint32_t nodeid;
     int flags;
 

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -63,7 +63,7 @@ void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *w,
                          const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
-    void *d = NULL;
+    const void *d = NULL;
     int l = 0;
 
     if (flux_request_decode_raw (msg, NULL, &d, &l) < 0) {
@@ -260,8 +260,8 @@ void test_encoding (flux_t *h)
     flux_future_destroy (r);
 
     /* working with-payload RPC (raw) */
-    void *d;
-    char data[] = "aaaaaaaaaaaaaaaaaaaa";
+    const void *d;
+    const char data[] = "aaaaaaaaaaaaaaaaaaaa";
     int l, len = strlen (data);
     ok ((r = flux_rpc_raw (h, "rpctest.rawecho", data, len,
                           FLUX_NODEID_ANY, 0)) != NULL,


### PR DESCRIPTION
As noted in #1211, `flux_msg_get_payload()`  and all the functions based on it should use const on the `void **data` paramter, since the payload belongs to the message (also const).

New prototypes:
```c
int flux_msg_get_payload (const flux_msg_t *msg, int *flags,
                          const void **buf, int *size);

int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
                             const void **data, int *len);

int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
                              const void **data, int *len);

int flux_content_load_get (flux_future_t *f, const void **buf, int *len);

int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);

int flux_mrpc_get_raw (flux_mrpc_t *mrpc, const void **data, int *len);
```

All the internal code that touches these functions was also updated.

Man pages were updated.