### PR TITLE
kvs: store data pointed by valref raw and unencoded in content store

### DIFF
--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -196,33 +196,6 @@ void test_val (void)
     json_decref (val2);
 }
 
-void test_val_base64 (void)
-{
-    json_t *val;
-    char *base64 = "NDI="; /* 42 w/o ending NUL byte*/
-    char *outbuf;
-    int outlen;
-
-    ok ((val = treeobj_create_val_base64 (base64)) != NULL,
-        "treeobj_create_val_base64 works");
-    diag_json (val);
-    ok (treeobj_is_val (val),
-        "treeobj_is_value returns true");
-    ok (treeobj_decode_val (val, (void **)&outbuf, &outlen) == 0,
-        "treeobj_decode_val works");
-    ok (outlen == 2,
-        "and returned correct size");
-    ok (memcmp ("42", outbuf, 2) == 0,
-        "and returned correct data");
-    free (outbuf);
-
-    errno = 0;
-    ok (treeobj_create_val_base64 (NULL) == NULL && errno == EINVAL,
-        "treeobj_create_val_base64 NULL fails ");
-
-    json_decref (val);
-}
-
 void test_dirref (void)
 {
     json_t *dirref;
@@ -563,7 +536,6 @@ int main(int argc, char** argv)
 
     test_valref ();
     test_val ();
-    test_val_base64 ();
     test_dirref ();
     test_dir ();
     test_copy_dir ();

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -380,30 +380,14 @@ json_t *treeobj_create_val (const void *data, int len)
     }
     base64_encode_block (xdata, &xlen, data, len);
 
-    if (!(obj = treeobj_create_val_base64 (xdata)))
-        goto done;
-
-done:
-    free (xdata);
-    return obj;
-}
-
-json_t *treeobj_create_val_base64 (const char *data)
-{
-    json_t *obj = NULL;
-
-    if (!data) {
-        errno = EINVAL;
-        return NULL;
-    }
-
     if (!(obj = json_pack ("{s:i s:s s:s}", "ver", treeobj_version,
                                             "type", "val",
-                                            "data", data))) {
+                                            "data", xdata))) {
         errno = ENOMEM;
         goto done;
     }
 done:
+    free (xdata);
     return obj;
 }
 

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -9,13 +9,11 @@
 /* Create a treeobj
  * valref, dirref: if blobref is NULL, treeobj_append_blobref()
  * must be called before object is valid.
- * val & val_base64: copies argument (caller retains ownership)
- * val_base64: user supplies base64 string
+ * val: copies argument (caller retains ownership)
  * Return JSON object on success, NULL on failure with errno set.
  */
 json_t *treeobj_create_symlink (const char *target);
 json_t *treeobj_create_val (const void *data, int len);
-json_t *treeobj_create_val_base64 (const char *data);
 json_t *treeobj_create_valref (const char *blobref);
 json_t *treeobj_create_dir (void);
 json_t *treeobj_create_dirref (const char *blobref);

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -60,13 +60,21 @@ struct cache {
     zhash_t *zh;
 };
 
-struct cache_entry *cache_entry_create (json_t *o)
+struct cache_entry *cache_entry_create (void)
 {
     struct cache_entry *hp = calloc (1, sizeof (*hp));
     if (!hp) {
         errno = ENOMEM;
         return NULL;
     }
+    return hp;
+}
+
+struct cache_entry *cache_entry_create_json (json_t *o)
+{
+    struct cache_entry *hp = cache_entry_create ();
+    if (!hp)
+        return NULL;
     if (o)
         hp->data = o;
     return hp;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -52,6 +52,7 @@ struct cache_entry {
     waitqueue_t *waitlist_notdirty;
     waitqueue_t *waitlist_valid;
     void *data;             /* value object/data */
+    int len;
     cache_data_type_t type; /* what does data point to */
     int lastuse_epoch;      /* time of last use for cache expiry */
     uint8_t dirty:1;
@@ -83,6 +84,25 @@ struct cache_entry *cache_entry_create_json (json_t *o)
     return hp;
 }
 
+struct cache_entry *cache_entry_create_raw (void *data, int len)
+{
+    struct cache_entry *hp;
+
+    if ((data && len <= 0) || (!data && len)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(hp = cache_entry_create ()))
+        return NULL;
+    if (data) {
+        hp->data = data;
+        hp->len = len;
+    }
+    hp->type = CACHE_DATA_TYPE_RAW;
+    return hp;
+}
+
 int cache_entry_type (struct cache_entry *hp, cache_data_type_t *t)
 {
     if (hp) {
@@ -96,6 +116,11 @@ int cache_entry_type (struct cache_entry *hp, cache_data_type_t *t)
 bool cache_entry_is_type_json (struct cache_entry *hp)
 {
     return (hp && hp->type == CACHE_DATA_TYPE_JSON);
+}
+
+bool cache_entry_is_type_raw (struct cache_entry *hp)
+{
+    return (hp && hp->type == CACHE_DATA_TYPE_RAW);
 }
 
 bool cache_entry_get_valid (struct cache_entry *hp)
@@ -190,6 +215,49 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
     return -1;
 }
 
+void *cache_entry_get_raw (struct cache_entry *hp, int *len)
+{
+    if (!hp || !hp->data || hp->type != CACHE_DATA_TYPE_RAW)
+        return NULL;
+    if (len)
+        (*len) = hp->len;
+    return hp->data;
+}
+
+int cache_entry_set_raw (struct cache_entry *hp, void *data, int len)
+{
+    if ((data && len <= 0) || (!data && len)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (hp
+        && (hp->type == CACHE_DATA_TYPE_NONE
+            || hp->type == CACHE_DATA_TYPE_RAW)) {
+        if ((data && hp->data) || (!data && !hp->data)) {
+            free (data); /* no-op, 'data' is assumed identical to hp->data */
+        } else if (data && !hp->data) {
+            hp->data = data;
+            hp->len = len;
+            if (hp->waitlist_valid) {
+                if (wait_runqueue (hp->waitlist_valid) < 0) {
+                    /* set back to orig */
+                    hp->data = NULL;
+                    hp->len = 0;
+                    return -1;
+                }
+            }
+        } else if (!data && hp->data) {
+            free (hp->data);
+            hp->data = NULL;
+            hp->len = 0;
+        }
+        hp->type = CACHE_DATA_TYPE_RAW;
+        return 0;
+    }
+    return -1;
+}
+
 void cache_entry_destroy (void *arg)
 {
     struct cache_entry *hp = arg;
@@ -197,6 +265,8 @@ void cache_entry_destroy (void *arg)
         if (hp->data) {
             if (hp->type == CACHE_DATA_TYPE_JSON)
                 json_decref (hp->data);
+            else if (hp->type == CACHE_DATA_TYPE_RAW)
+                free (hp->data);
         }
         if (hp->waitlist_notdirty)
             wait_queue_destroy (hp->waitlist_notdirty);
@@ -330,15 +400,20 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
     while ((ref = zlist_pop (keys))) {
         hp = zhash_lookup (cache->zh, ref);
         if (cache_entry_get_valid (hp)) {
-            /* must pass JSON_ENCODE_ANY, object could be anything */
-            char *s = json_dumps (hp->data, JSON_ENCODE_ANY);
-            int obj_size;
-            if (!s) {
-                saved_errno = ENOMEM;
-                goto cleanup;
+            int obj_size = 0;
+
+            if (hp->type == CACHE_DATA_TYPE_JSON) {
+                /* must pass JSON_ENCODE_ANY, object could be anything */
+                char *s = json_dumps (hp->data, JSON_ENCODE_ANY);
+                if (!s) {
+                    saved_errno = ENOMEM;
+                    goto cleanup;
+                }
+                obj_size = strlen (s);
+                free (s);
             }
-            obj_size = strlen (s);
-            free (s);
+            else if (hp->type == CACHE_DATA_TYPE_RAW)
+                obj_size = hp->len;
             size += obj_size;
             tstat_push (ts, obj_size);
         } else

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -11,9 +11,11 @@ struct cache;
 
 
 /* Create/destroy cache entry.
- * If non-NULL, create transfers ownership of 'o' to the cache entry.
+ * In cache_entry_create_json(), create transfers ownership of 'o' to
+ * the cache entry.  If 'o' is NULL, calls cache_entry_create().
  */
-struct cache_entry *cache_entry_create (json_t *o);
+struct cache_entry *cache_entry_create (void);
+struct cache_entry *cache_entry_create_json (json_t *o);
 void cache_entry_destroy (void *arg);
 
 /* Return true if cache entry contains valid json.

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -197,7 +197,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         goto done;
     }
     if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
-        if (!(hp = cache_entry_create (NULL))) {
+        if (!(hp = cache_entry_create ())) {
             saved_errno = ENOMEM;
             goto done;
         }

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -36,6 +36,7 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "src/common/libutil/base64.h"
 #include "src/common/libkvs/treeobj.h"
 
 #include "commit.h"
@@ -182,19 +183,43 @@ static void cleanup_dirty_cache_list (commit_t *c)
 
 /* Store object 'o' under key 'ref' in local cache.
  * Object reference is still owned by the caller.
+ * 'is_raw' indicates this data is a json string w/ base64 value and
+ * should be flushed to the content store as raw data.
  * Returns -1 on error, 0 on success entry already there, 1 on success
  * entry needs to be flushed to content store
  */
 static int store_cache (commit_t *c, int current_epoch, json_t *o,
-                        href_t ref, struct cache_entry **hpp)
+                        bool is_raw, href_t ref, struct cache_entry **hpp)
 {
     struct cache_entry *hp;
     int saved_errno, rc = -1;
+    const char *xdata;
+    char *data = NULL;
+    int xlen, len;
 
-    if (kvs_util_json_hash (c->cm->hash_name, o, ref) < 0) {
-        saved_errno = errno;
-        flux_log_error (c->cm->h, "kvs_util_json_hash");
-        goto done;
+    if (is_raw) {
+        xdata = json_string_value (o);
+        xlen = strlen (xdata);
+        len = base64_decode_length (xlen);
+        if (!(data = malloc (len))) {
+            saved_errno = errno;
+            flux_log_error (c->cm->h, "malloc");
+            goto done;
+        }
+        if (base64_decode_block (data, &len, xdata, xlen) < 0) {
+            free (data);
+            saved_errno = errno;
+            flux_log_error (c->cm->h, "base64_decode_block");
+            goto done;
+        }
+        blobref_hash (c->cm->hash_name, data, len, ref, sizeof (href_t));
+    }
+    else {
+        if (kvs_util_json_hash (c->cm->hash_name, o, ref) < 0) {
+            saved_errno = errno;
+            flux_log_error (c->cm->h, "kvs_util_json_hash");
+            goto done;
+        }
     }
     if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
         if (!(hp = cache_entry_create ())) {
@@ -205,20 +230,34 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
     }
     if (cache_entry_get_valid (hp)) {
         c->cm->noop_stores++;
+        if (is_raw)
+            free (data);
         rc = 0;
     } else {
-        json_incref (o);
-        if (cache_entry_set_json (hp, o) < 0) {
-            int ret;
-            saved_errno = errno;
-            json_decref (o);
-            ret = cache_remove_entry (c->cm->cache, ref);
-            assert (ret == 1);
-            goto done;
+        if (is_raw) {
+            if (cache_entry_set_raw (hp, data, len) < 0) {
+                int ret;
+                saved_errno = errno;
+                free (data);
+                ret = cache_remove_entry (c->cm->cache, ref);
+                assert (ret == 1);
+                goto done;
+            }
+        }
+        else {
+            json_incref (o);
+            if (cache_entry_set_json (hp, o) < 0) {
+                int ret;
+                saved_errno = errno;
+                json_decref (o);
+                ret = cache_remove_entry (c->cm->cache, ref);
+                assert (ret == 1);
+                goto done;
+            }
         }
         if (cache_entry_set_dirty (hp, true) < 0) {
-            /* cache entry now owns a reference, cache_remove_entry
-             * will decref object */
+            /* cache entry now owns data, cache_remove_entry
+             * will decref/free object/data */
             int ret;
             saved_errno = errno;
             ret = cache_remove_entry (c->cm->cache, ref);
@@ -264,7 +303,8 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
         if (treeobj_is_dir (dir_entry)) {
             if (commit_unroll (c, current_epoch, dir_entry) < 0) /* depth first */
                 return -1;
-            if ((ret = store_cache (c, current_epoch, dir_entry, ref, &hp)) < 0)
+            if ((ret = store_cache (c, current_epoch, dir_entry,
+                                    false, ref, &hp)) < 0)
                 return -1;
             if (ret) {
                 if (zlist_push (c->item_callback_list, hp) < 0) {
@@ -291,7 +331,7 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
                 return -1;
             if (size > BLOBREF_MAX_STRING_SIZE) {
                 if ((ret = store_cache (c, current_epoch, val_data,
-                                        ref, &hp)) < 0)
+                                        true, ref, &hp)) < 0)
                     return -1;
                 if (ret) {
                     if (zlist_push (c->item_callback_list, hp) < 0) {
@@ -592,6 +632,7 @@ commit_process_t commit_process (commit_t *c,
             else if ((sret = store_cache (c,
                                           current_epoch,
                                           c->rootcpy,
+                                          false,
                                           c->newroot,
                                           &hp)) < 0)
                      c->errnum = errno;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -252,7 +252,7 @@ static int load (kvs_ctx_t *ctx, const href_t ref, wait_t *wait, bool *stall)
     /* Create an incomplete hash entry if none found.
      */
     if (!hp) {
-        if (!(hp = cache_entry_create (NULL))) {
+        if (!(hp = cache_entry_create ())) {
             flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
             return -1;
         }
@@ -1349,8 +1349,9 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
              * no consistency issue by not caching.  We will still
              * set new root below via setroot().
              */
-            if (!(hp = cache_entry_create (json_incref (root)))) {
-                flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
+            if (!(hp = cache_entry_create_json (json_incref (root)))) {
+                flux_log_error (ctx->h, "%s: cache_entry_create_json",
+                                __FUNCTION__);
                 json_decref (root);
                 return;
             }
@@ -1570,7 +1571,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         goto decref_done;
     }
     if (!(hp = cache_lookup (ctx->cache, ref, ctx->epoch))) {
-        if (!(hp = cache_entry_create (NULL))) {
+        if (!(hp = cache_entry_create ())) {
             saved_errno = errno;
             flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
             goto decref_done;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -38,6 +38,7 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "src/common/libutil/base64.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/tstat.h"
@@ -168,7 +169,6 @@ error:
 static void content_load_completion (flux_future_t *f, void *arg)
 {
     kvs_ctx_t *ctx = arg;
-    json_t *o;
     const void *data;
     int size;
     const char *blobref;
@@ -179,10 +179,6 @@ static void content_load_completion (flux_future_t *f, void *arg)
         goto done;
     }
     blobref = flux_future_aux_get (f, "ref");
-    if (!(o = json_loads ((char *)data, JSON_DECODE_ANY, NULL))) {
-        flux_log_error (ctx->h, "%s: json_loads", __FUNCTION__);
-        goto done;
-    }
     /* should be impossible for lookup to fail, cache entry created
      * earlier, and cache_expire_entries() could not have removed it
      * b/c it is not yet valid.  But check and log incase there is
@@ -193,22 +189,45 @@ static void content_load_completion (flux_future_t *f, void *arg)
         goto done;
     }
 
-    /* This is a pretty terrible error case, where we've loaded an
-     * object from the content store, but can't put it in the cache.
+    /* If cache_entry_set_json() or cache_entry_set_raw() fail, it's a
+     * pretty terrible error case, where we've loaded an object from
+     * the content store, but can't put it in the cache.
      *
      * If there was a waiter on this cache entry waiting for it to be
      * valid, the load() will ultimately hang.  The caller will
      * timeout or eventually give up, so the KVS can continue along
-     * its merry way.  So we just log this error.
+     * its merry way.  So we just log the error.
      *
      * If this is the result of a synchronous call to load(), there
      * should be no waiters on this cache entry.  load() will handle
      * this error scenario appropriately.
      */
-    if (cache_entry_set_json (hp, o) < 0) {
-        flux_log_error (ctx->h, "%s: cache_entry_set_json", __FUNCTION__);
-        goto done;
+    if (cache_entry_is_type_raw (hp)) {
+        char *datacpy;
+
+        if (!(datacpy = malloc (size))) {
+            flux_log_error (ctx->h, "%s: malloc", __FUNCTION__);
+            goto done;
+        }
+        memcpy (datacpy, data, size);
+
+        if (cache_entry_set_raw (hp, datacpy, size) < 0) {
+            flux_log_error (ctx->h, "%s: cache_entry_set_raw", __FUNCTION__);
+            goto done;
+        }
     }
+    else {
+        json_t *o;
+        if (!(o = json_loads ((char *)data, JSON_DECODE_ANY, NULL))) {
+            flux_log_error (ctx->h, "%s: json_loads", __FUNCTION__);
+            goto done;
+        }
+        if (cache_entry_set_json (hp, o) < 0) {
+            flux_log_error (ctx->h, "%s: cache_entry_set_json", __FUNCTION__);
+            goto done;
+        }
+    }
+
 done:
     flux_future_destroy (f);
 }
@@ -241,8 +260,12 @@ error:
     return -1;
 }
 
-/* Return 0 on success, -1 on error.  Set stall variable appropriately */
-static int load (kvs_ctx_t *ctx, const href_t ref, wait_t *wait, bool *stall)
+/* Return 0 on success, -1 on error.  is_raw indicates if data being
+ * loaded is raw data, so we know how to place it in the cache.  Set
+ * stall variable appropriately
+ */
+static int load (kvs_ctx_t *ctx, const href_t ref, bool is_raw, wait_t *wait,
+                 bool *stall)
 {
     struct cache_entry *hp = cache_lookup (ctx->cache, ref, ctx->epoch);
     int saved_errno, ret;
@@ -252,9 +275,19 @@ static int load (kvs_ctx_t *ctx, const href_t ref, wait_t *wait, bool *stall)
     /* Create an incomplete hash entry if none found.
      */
     if (!hp) {
-        if (!(hp = cache_entry_create ())) {
-            flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
-            return -1;
+        if (is_raw) {
+            if (!(hp = cache_entry_create_raw (NULL, 0))) {
+                flux_log_error (ctx->h, "%s: cache_entry_create_raw",
+                                __FUNCTION__);
+                return -1;
+            }
+        }
+        else {
+            if (!(hp = cache_entry_create_json (NULL))) {
+                flux_log_error (ctx->h, "%s: cache_entry_create_json",
+                                __FUNCTION__);
+                return -1;
+            }
         }
         cache_insert (ctx->cache, ref, hp);
         if (content_load_request_send (ctx, ref) < 0) {
@@ -353,20 +386,30 @@ static void content_store_completion (flux_future_t *f, void *arg)
     (void)content_store_get (f, arg);
 }
 
-static int content_store_request_send (kvs_ctx_t *ctx, json_t *val,
-                                       bool now)
+/* is_raw indicates if void *data is json or raw data.  'len' is
+ * ignored if it is json.
+ */
+static int content_store_request_send (kvs_ctx_t *ctx, void *data, int len,
+                                       bool is_raw, bool now)
 {
     flux_future_t *f;
-    char *data = NULL;
+    char *dataout = NULL;
+    char *dataout_cpy = NULL;
     int size;
     int saved_errno, rc = -1;
 
-    if (!(data = kvs_util_json_dumps (val)))
-        goto error;
+    if (is_raw) {
+        dataout = data;
+        size = len;
+    }
+    else {
+        if (!(dataout_cpy = kvs_util_json_dumps ((json_t *)data)))
+            goto error;
+        dataout = dataout_cpy;
+        size = strlen (dataout) + 1;
+    }
 
-    size = strlen (data) + 1;
-
-    if (!(f = flux_content_store (ctx->h, data, size, 0)))
+    if (!(f = flux_content_store (ctx->h, dataout, size, 0)))
         goto error;
     if (now) {
         if (content_store_get (f, ctx) < 0)
@@ -380,7 +423,7 @@ static int content_store_request_send (kvs_ctx_t *ctx, json_t *val,
 
     rc = 0;
 error:
-    free (data);
+    free (dataout_cpy);
     return rc;
 }
 
@@ -410,7 +453,10 @@ static int commit_load_cb (commit_t *c, const char *ref, void *data)
     struct commit_cb_data *cbd = data;
     bool stall;
 
-    if (load (cbd->ctx, ref, cbd->wait, &stall) < 0) {
+    /* is_raw flag is always false on commit loads, we will never
+     * load raw data from the content store, only tree objects.
+     */
+    if (load (cbd->ctx, ref, false, cbd->wait, &stall) < 0) {
         cbd->errnum = errno;
         flux_log_error (cbd->ctx->h, "%s: load", __FUNCTION__);
         return -1;
@@ -427,11 +473,22 @@ static int commit_load_cb (commit_t *c, const char *ref, void *data)
 static int commit_cache_cb (commit_t *c, struct cache_entry *hp, void *data)
 {
     struct commit_cb_data *cbd = data;
+    void *storedata;
+    int storedatalen = 0;
+    bool is_raw;
 
     assert (cache_entry_get_dirty (hp));
 
+    is_raw = cache_entry_is_type_raw (hp);
+    if (is_raw)
+        storedata = cache_entry_get_raw (hp, &storedatalen);
+    else
+        storedata = cache_entry_get_json (hp);
+
     if (content_store_request_send (cbd->ctx,
-                                    cache_entry_get_json (hp),
+                                    storedata,
+                                    storedatalen,
+                                    is_raw,
                                     false) < 0) {
         cbd->errnum = errno;
         flux_log_error (cbd->ctx->h, "%s: content_store_request_send",
@@ -721,14 +778,14 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (!lookup (lh)) {
         const char *missing_ref;
-        bool stall;
+        bool ref_raw, stall;
 
-        missing_ref = lookup_get_missing_ref (lh);
+        missing_ref = lookup_get_missing_ref (lh, &ref_raw);
         assert (missing_ref);
 
         if (!(wait = wait_create_msg_handler (h, w, msg, get_request_cb, lh)))
             goto done;
-        if (load (ctx, missing_ref, wait, &stall) < 0) {
+        if (load (ctx, missing_ref, ref_raw, wait, &stall) < 0) {
             flux_log_error (h, "%s: load", __FUNCTION__);
             goto done;
         }
@@ -829,14 +886,14 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (!lookup (lh)) {
         const char *missing_ref;
-        bool stall;
+        bool ref_raw, stall;
 
-        missing_ref = lookup_get_missing_ref (lh);
+        missing_ref = lookup_get_missing_ref (lh, &ref_raw);
         assert (missing_ref);
 
         if (!(wait = wait_create_msg_handler (h, w, msg, watch_request_cb, lh)))
             goto done;
-        if (load (ctx, missing_ref, wait, &stall) < 0) {
+        if (load (ctx, missing_ref, ref_raw, wait, &stall) < 0) {
             flux_log_error (h, "%s: load", __FUNCTION__);
             goto done;
         }
@@ -1595,7 +1652,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
             assert (ret == 1);
             goto done_error;
         }
-        if (content_store_request_send (ctx, o, true) < 0) {
+        if (content_store_request_send (ctx, o, 0, false, true) < 0) {
             /* Must clean up, don't want cache entry to be assumed
              * valid.  Everything here is synchronous and w/o waiters,
              * so nothing should error here */

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -34,8 +34,12 @@ int lookup_get_errnum (lookup_t *lh);
 json_t *lookup_get_value (lookup_t *lh);
 
 /* Get missing ref after a lookup stall, missing reference can then be
- * used to load reference into the KVS cache */
-const char *lookup_get_missing_ref (lookup_t *lh);
+ * used to load reference into the KVS cache
+ *
+ * If the missing references points to raw data, 'ref_raw' will be set
+ * to true, otherwise false.
+ */
+const char *lookup_get_missing_ref (lookup_t *lh, bool *ref_raw);
 
 /* Convenience function to get cache from earlier instantiation.
  * Convenient if replaying RPC and don't have it presently.

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -42,8 +42,11 @@ void cache_entry_tests (void)
 {
     struct cache_entry *e;
     json_t *otmp, *o1, *o2;
+    cache_data_type_t t;
 
     /* corner case tests */
+    ok (cache_entry_type (NULL, NULL) < 0,
+        "cache_entry_type fails with bad input");
     ok (cache_entry_set_json (NULL, NULL) < 0,
         "cache_entry_set_json fails with bad input");
     cache_entry_destroy (NULL);
@@ -57,6 +60,12 @@ void cache_entry_tests (void)
 
     ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_NONE,
+        "cache_entry_type returns NONE");
+    ok (cache_entry_is_type_json (e) == false,
+        "cache_entry_is_type_json returns false");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -72,6 +81,12 @@ void cache_entry_tests (void)
 
     ok ((e = cache_entry_create_json (NULL)) != NULL,
         "cache_entry_create_json w/ NULL input works");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_JSON,
+        "cache_entry_type returns JSON");
+    ok (cache_entry_is_type_json (e) == true,
+        "cache_entry_is_type_json returns true");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -85,15 +100,20 @@ void cache_entry_tests (void)
     cache_entry_destroy (e);
     e = NULL;
 
-    /* test empty cache entry created by cache_entry_create_json(),
-     * later filled with data.
+    /* test empty cache entry created, later filled with data.
      */
 
     o1 = json_object ();
     json_object_set_new (o1, "foo", json_integer (42));
 
-    ok ((e = cache_entry_create_json (NULL)) != NULL,
-        "cache_entry_create_json w/ NULL input works");
+    ok ((e = cache_entry_create ()) != NULL,
+        "cache_entry_create works");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_NONE,
+        "cache_entry_type returns NONE");
+    ok (cache_entry_is_type_json (e) == false,
+        "cache_entry_is_type_json returns false");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -106,8 +126,14 @@ void cache_entry_tests (void)
         "cache_entry_get_json returns NULL, no json set");
     ok (cache_entry_set_json (e, o1) == 0,
         "cache_entry_set_json success");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_JSON,
+        "cache_entry_type returns JSON");
     ok (cache_entry_get_valid (e) == true,
         "cache entry now valid after cache_entry_set_json call");
+    ok (cache_entry_is_type_json (e) == true,
+        "cache_entry_is_type_json returns true");
     cache_entry_destroy (e);   /* destroys o1 */
     e = NULL;
 
@@ -118,6 +144,12 @@ void cache_entry_tests (void)
 
     ok ((e = cache_entry_create_json (o1)) != NULL,
         "cache_entry_create_json w/ non-NULL input works");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_JSON,
+        "cache_entry_type returns JSON");
+    ok (cache_entry_is_type_json (e) == true,
+        "cache_entry_is_type_json returns true");
     ok (cache_entry_get_valid (e) == true,
         "cache entry initially valid");
     ok (cache_entry_get_dirty (e) == false,

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -55,8 +55,8 @@ struct cache *create_cache_with_empty_rootdir (href_t ref)
         "cache_create works");
     ok (kvs_util_json_hash ("sha1", rootdir, ref) == 0,
         "kvs_util_json_hash worked");
-    ok ((hp = cache_entry_create (rootdir)) != NULL,
-        "cache_entry_create works");
+    ok ((hp = cache_entry_create_json (rootdir)) != NULL,
+        "cache_entry_create_json works");
     cache_insert (cache, ref, hp);
     return cache;
 }
@@ -606,7 +606,7 @@ void commit_basic_root_not_dir (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -647,8 +647,8 @@ int rootref_cb (commit_t *c, const char *ref, void *data)
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
 
-    ok ((hp = cache_entry_create (rootdir)) != NULL,
-        "cache_entry_create works");
+    ok ((hp = cache_entry_create_json (rootdir)) != NULL,
+        "cache_entry_create_json works");
 
     cache_insert (rd->cache, ref, hp);
 
@@ -733,8 +733,8 @@ int missingref_cb (commit_t *c, const char *ref, void *data)
     ok (strcmp (ref, md->dir_ref) == 0,
         "missing reference is what we expect it to be");
 
-    ok ((hp = cache_entry_create (md->dir)) != NULL,
-        "cache_entry_create works");
+    ok ((hp = cache_entry_create_json (md->dir)) != NULL,
+        "cache_entry_create_json works");
 
     cache_insert (md->cache, ref, hp);
 
@@ -779,7 +779,7 @@ void commit_process_missing_ref (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -872,7 +872,7 @@ void commit_process_error_callbacks (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -890,7 +890,7 @@ void commit_process_error_callbacks (void) {
 
     /* insert cache entry now, want don't want missing refs on next
      * commit_process call */
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -946,7 +946,7 @@ void commit_process_error_callbacks_partway (void) {
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -954,7 +954,7 @@ void commit_process_error_callbacks_partway (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1000,7 +1000,7 @@ void commit_process_invalid_operation (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1040,7 +1040,7 @@ void commit_process_invalid_hash (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "foobar", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1094,7 +1094,7 @@ void commit_process_follow_link (void) {
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1103,7 +1103,7 @@ void commit_process_follow_link (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
@@ -1160,7 +1160,7 @@ void commit_process_dirval_test (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1217,7 +1217,7 @@ void commit_process_delete_test (void) {
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1225,7 +1225,7 @@ void commit_process_delete_test (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1271,7 +1271,7 @@ void commit_process_delete_nosubdir_test (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1324,7 +1324,7 @@ void commit_process_delete_filevalinpath_test (void) {
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1332,7 +1332,7 @@ void commit_process_delete_filevalinpath_test (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1385,7 +1385,7 @@ void commit_process_bad_dirrefs (void) {
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     dirref = treeobj_create_dirref (dir_ref);
     treeobj_append_blobref (dirref, dir_ref);
@@ -1396,7 +1396,7 @@ void commit_process_bad_dirrefs (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1446,7 +1446,7 @@ void commit_process_big_fileval (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1544,7 +1544,7 @@ void commit_process_giant_dir (void) {
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create (dir));
+    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (dir, "dir", treeobj_create_dirref (dir_ref));
@@ -1552,7 +1552,7 @@ void commit_process_giant_dir (void) {
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -371,7 +371,7 @@ void commit_basic_tests (void)
     cache_destroy (cache);
 }
 
-int cache_count_cb (commit_t *c, struct cache_entry *hp, void *data)
+int cache_count_dirty_cb (commit_t *c, struct cache_entry *hp, void *data)
 {
     int *count = data;
     if (cache_entry_get_dirty (hp)) {
@@ -438,7 +438,7 @@ void commit_basic_commit_process_test (void)
     ok (commit_process (c, 1, rootref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
 
-    ok (commit_iter_dirty_cache_entries (c, cache_count_cb, &count) == 0,
+    ok (commit_iter_dirty_cache_entries (c, cache_count_dirty_cb, &count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
     ok (count == 1,
@@ -484,7 +484,7 @@ void commit_basic_commit_process_test_multiple_fences (void)
     ok (commit_process (c, 1, rootref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
 
-    ok (commit_iter_dirty_cache_entries (c, cache_count_cb, &count) == 0,
+    ok (commit_iter_dirty_cache_entries (c, cache_count_dirty_cb, &count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
     ok (count == 1,
@@ -509,7 +509,7 @@ void commit_basic_commit_process_test_multiple_fences (void)
 
     count = 0;
 
-    ok (commit_iter_dirty_cache_entries (c, cache_count_cb, &count) == 0,
+    ok (commit_iter_dirty_cache_entries (c, cache_count_dirty_cb, &count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
     /* why two? 1 for root (new dir added), 1 for dir.key2 (a new dir) */
@@ -561,7 +561,7 @@ void commit_basic_commit_process_test_multiple_fences_merge (void)
     ok (commit_process (c, 1, rootref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
 
-    ok (commit_iter_dirty_cache_entries (c, cache_count_cb, &count) == 0,
+    ok (commit_iter_dirty_cache_entries (c, cache_count_dirty_cb, &count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
     /* why three? 1 for root, 1 for foo.key1 (a new dir), and 1 for
@@ -1420,6 +1420,16 @@ void commit_process_bad_dirrefs (void) {
     cache_destroy (cache);
 }
 
+int cache_count_raw_cb (commit_t *c, struct cache_entry *hp, void *data)
+{
+    int *count = data;
+    if (cache_entry_is_type_raw (hp)) {
+        if (count)
+            (*count)++;
+    }
+    return 0;
+}
+
 void commit_process_big_fileval (void) {
     struct cache *cache;
     commit_mgr_t *cm;
@@ -1429,6 +1439,7 @@ void commit_process_big_fileval (void) {
     const char *newroot;
     int bigstrsize = BLOBREF_MAX_STRING_SIZE * 2;
     char bigstr[bigstrsize];
+    int count;
     int i;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1451,11 +1462,10 @@ void commit_process_big_fileval (void) {
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
 
-    memset (bigstr, '\0', bigstrsize);
-    for (i = 0; i < bigstrsize - 1; i++)
-        bigstr[i] = 'a';
+    /* first commit a small value, to make sure it isn't type raw in
+     * the cache */
 
-    create_ready_commit (cm, "fence1", "val", bigstr, 0);
+    create_ready_commit (cm, "fence1", "val", "smallstr", 0);
 
     ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
         "commit_mgr_get_ready_commit returns ready commit");
@@ -1463,8 +1473,45 @@ void commit_process_big_fileval (void) {
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
 
-    ok (commit_iter_dirty_cache_entries (c, cache_noop_cb, NULL) == 0,
+    count = 0;
+    ok (commit_iter_dirty_cache_entries (c, cache_count_raw_cb, &count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
+
+    ok (count == 0,
+        "correct number of cache entries were raw");
+
+    ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_FINISHED,
+        "commit_process returns COMMIT_PROCESS_FINISHED");
+
+    ok ((newroot = commit_get_newroot_ref (c)) != NULL,
+        "commit_get_newroot_ref returns != NULL when processing complete");
+
+    verify_value (cache, newroot, "val", "smallstr");
+
+    commit_mgr_remove_commit (cm, c);
+
+    /* next commit a big value, to make sure it is flagged raw in the
+     * cache */
+
+    memset (bigstr, '\0', bigstrsize);
+    for (i = 0; i < bigstrsize - 1; i++)
+        bigstr[i] = 'a';
+
+    create_ready_commit (cm, "fence2", "val", bigstr, 0);
+
+    ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
+        "commit_mgr_get_ready_commit returns ready commit");
+
+    ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
+        "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
+
+    count = 0;
+    ok (commit_iter_dirty_cache_entries (c, cache_count_raw_cb, &count) == 0,
+        "commit_iter_dirty_cache_entries works for dirty cache entries");
+
+    /* this entry should be raw, b/c large val converted into valref */
+    ok (count == 1,
+        "correct number of cache entries were raw");
 
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_FINISHED,
         "commit_process returns COMMIT_PROCESS_FINISHED");

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -309,11 +309,11 @@ void lookup_root (void) {
 
     opaque_data = get_json_base64_string ("abcd");
     kvs_util_json_hash ("sha1", opaque_data, valref_ref);
-    cache_insert (cache, valref_ref, cache_entry_create (opaque_data));
+    cache_insert (cache, valref_ref, cache_entry_create_json (opaque_data));
 
     root = treeobj_create_dir ();
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* flags = 0, should error EISDIR */
     ok ((lh = lookup_create (cache,
@@ -397,7 +397,7 @@ void lookup_basic (void) {
 
     opaque_data = get_json_base64_string ("abcd");
     kvs_util_json_hash ("sha1", opaque_data, valref_ref);
-    cache_insert (cache, valref_ref, cache_entry_create (opaque_data));
+    cache_insert (cache, valref_ref, cache_entry_create_json (opaque_data));
 
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("bar", 3));
@@ -409,13 +409,13 @@ void lookup_basic (void) {
     treeobj_insert_entry (dirref, "symlink", treeobj_create_symlink ("baz"));
 
     kvs_util_json_hash ("sha1", dirref, dirref_ref);
-    cache_insert (cache, dirref_ref, cache_entry_create (dirref));
+    cache_insert (cache, dirref_ref, cache_entry_create_json (dirref));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref", treeobj_create_dirref (dirref_ref));
 
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* lookup dir via dirref */
     ok ((lh = lookup_create (cache,
@@ -585,12 +585,12 @@ void lookup_errors (void) {
 
     opaque_data = get_json_base64_string ("abcd");
     kvs_util_json_hash ("sha1", opaque_data, valref_ref);
-    cache_insert (cache, valref_ref, cache_entry_create (opaque_data));
+    cache_insert (cache, valref_ref, cache_entry_create_json (opaque_data));
 
     dirref = treeobj_create_dir ();
     treeobj_insert_entry (dirref, "val", treeobj_create_val ("bar", 3));
     kvs_util_json_hash ("sha1", dirref, dirref_ref);
-    cache_insert (cache, dirref_ref, cache_entry_create (dirref));
+    cache_insert (cache, dirref_ref, cache_entry_create_json (dirref));
 
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("baz", 3));
@@ -616,7 +616,7 @@ void lookup_errors (void) {
     treeobj_insert_entry (root, "valref_multi", valref_multi);
 
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* Lookup non-existent field.  Not ENOENT - caller of lookup
      * decides what to do with entry not found */
@@ -918,12 +918,12 @@ void lookup_links (void) {
 
     opaque_data = get_json_base64_string ("abcd");
     kvs_util_json_hash ("sha1", opaque_data, valref_ref);
-    cache_insert (cache, valref_ref, cache_entry_create (opaque_data));
+    cache_insert (cache, valref_ref, cache_entry_create_json (opaque_data));
 
     dirref3 = treeobj_create_dir ();
     treeobj_insert_entry (dirref3, "val", treeobj_create_val ("baz", 3));
     kvs_util_json_hash ("sha1", dirref3, dirref3_ref);
-    cache_insert (cache, dirref3_ref, cache_entry_create (dirref3));
+    cache_insert (cache, dirref3_ref, cache_entry_create_json (dirref3));
 
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("bar", 3));
@@ -935,7 +935,7 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref2, "dirref", treeobj_create_dirref (dirref3_ref));
     treeobj_insert_entry (dirref2, "symlink", treeobj_create_symlink ("dirref2.val"));
     kvs_util_json_hash ("sha1", dirref2, dirref2_ref);
-    cache_insert (cache, dirref2_ref, cache_entry_create (dirref2));
+    cache_insert (cache, dirref2_ref, cache_entry_create_json (dirref2));
 
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "link2dirref", treeobj_create_symlink ("dirref2"));
@@ -944,13 +944,13 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref1, "link2dir", treeobj_create_symlink ("dirref2.dir"));
     treeobj_insert_entry (dirref1, "link2symlink", treeobj_create_symlink ("dirref2.symlink"));
     kvs_util_json_hash ("sha1", dirref1, dirref1_ref);
-    cache_insert (cache, dirref1_ref, cache_entry_create (dirref1));
+    cache_insert (cache, dirref1_ref, cache_entry_create_json (dirref1));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* lookup val, follow two links */
     ok ((lh = lookup_create (cache,
@@ -1120,18 +1120,18 @@ void lookup_alt_root (void) {
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "val", treeobj_create_val ("foo", 3));
     kvs_util_json_hash ("sha1", dirref1, dirref1_ref);
-    cache_insert (cache, dirref1_ref, cache_entry_create (dirref1));
+    cache_insert (cache, dirref1_ref, cache_entry_create_json (dirref1));
 
     dirref2 = treeobj_create_dir ();
     treeobj_insert_entry (dirref2, "val", treeobj_create_val ("bar", 3));
     kvs_util_json_hash ("sha1", dirref2, dirref2_ref);
-    cache_insert (cache, dirref2_ref, cache_entry_create (dirref2));
+    cache_insert (cache, dirref2_ref, cache_entry_create_json (dirref2));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* lookup val, alt root-ref dirref1_ref */
     ok ((lh = lookup_create (cache,
@@ -1195,7 +1195,7 @@ void lookup_stall_root (void) {
         "lookup_create stalltest \".\"");
     check_stall (lh, EAGAIN, root_ref, "root \".\" stall");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* lookup root ".", should succeed */
     check (lh, 0, root, "root \".\" #1");
@@ -1281,12 +1281,12 @@ void lookup_stall (void) {
         "lookup_create stalltest dirref1.val");
     check_stall (lh, EAGAIN, root_ref, "dirref1.val stall #1");
 
-    cache_insert (cache, root_ref, cache_entry_create (root));
+    cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* next call to lookup, should stall */
     check_stall (lh, EAGAIN, dirref1_ref, "dirref1.val stall #2");
 
-    cache_insert (cache, dirref1_ref, cache_entry_create (dirref1));
+    cache_insert (cache, dirref1_ref, cache_entry_create_json (dirref1));
 
     /* final call to lookup, should succeed */
     test = treeobj_create_val ("foo", 3);
@@ -1317,7 +1317,7 @@ void lookup_stall (void) {
         "lookup_create stalltest symlink.val");
     check_stall (lh, EAGAIN, dirref2_ref, "symlink.val stall");
 
-    cache_insert (cache, dirref2_ref, cache_entry_create (dirref2));
+    cache_insert (cache, dirref2_ref, cache_entry_create_json (dirref2));
 
     /* lookup symlink.val, should succeed */
     test = treeobj_create_val ("bar", 3);
@@ -1348,7 +1348,7 @@ void lookup_stall (void) {
         "lookup_create stalltest dirref1.valref");
     check_stall (lh, EAGAIN, valref_ref, "dirref1.valref stall");
 
-    cache_insert (cache, valref_ref, cache_entry_create (opaque_data));
+    cache_insert (cache, valref_ref, cache_entry_create_json (opaque_data));
 
     /* lookup dirref1.valref, should succeed */
     test = treeobj_create_val ("abcd", 4);


### PR DESCRIPTION
This series of patches updates the KVS so that treeobj valref objects will read/write data to the content store in raw/unencoded form.

The key work was to ensure the internal KVS cache could handle storing raw data instead of only json.  After this work, the remaining work sort of "fell out" of this.  On lookup, create cache entries that contain raw data and handle them appropriately for valref objects.  On commits, cache entries with raw data will be written out as raw data (instead of everything being assumed json).