### PR TITLE
kvs: add flux_kvs_lookup_get_raw()

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -239,6 +239,7 @@ flux_kvs_txn_put.3: flux_kvs_txn_create.3
 flux_kvs_txn_pack.3: flux_kvs_txn_create.3
 flux_kvs_txn_mkdir.3: flux_kvs_txn_create.3
 flux_kvs_txn_unlink.3: flux_kvs_txn_create.3
+flux_kvs_txn_symlink.3: flux_kvs_txn_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -132,7 +132,8 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_txn_pack.3 \
 	flux_kvs_txn_mkdir.3 \
 	flux_kvs_txn_unlink.3 \
-	flux_kvs_txn_symlink.3
+	flux_kvs_txn_symlink.3 \
+	flux_kvs_txn_put_raw.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -240,6 +241,7 @@ flux_kvs_txn_pack.3: flux_kvs_txn_create.3
 flux_kvs_txn_mkdir.3: flux_kvs_txn_create.3
 flux_kvs_txn_unlink.3: flux_kvs_txn_create.3
 flux_kvs_txn_symlink.3: flux_kvs_txn_create.3
+flux_kvs_txn_put_raw.3: flux_kvs_txn_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -231,8 +231,8 @@ flux_rpc_get.3: flux_rpc.3
 flux_rpc_get_unpack.3: flux_rpc.3
 flux_rpc_get_raw.3: flux_rpc.3
 flux_kvs_lookupat.3: flux_kvs_lookup.3
-flux_kvs_get.3: flux_kvs_lookup.3
-flux_kvs_getf.3: flux_kvs_lookup.3
+flux_kvs_lookup_get.3: flux_kvs_lookup.3
+flux_kvs_lookup_get_unpack.3: flux_kvs_lookup.3
 flux_kvs_fence.3: flux_kvs_commit.3
 flux_kvs_txn_destroy.3: flux_kvs_txn_create.3
 flux_kvs_txn_put.3: flux_kvs_txn_create.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -126,6 +126,7 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_lookupat.3 \
 	flux_kvs_lookup_get.3 \
 	flux_kvs_lookup_get_unpack.3 \
+	flux_kvs_lookup_get_raw.3 \
 	flux_kvs_fence.3 \
 	flux_kvs_txn_destroy.3 \
 	flux_kvs_txn_put.3 \
@@ -234,6 +235,7 @@ flux_rpc_get_raw.3: flux_rpc.3
 flux_kvs_lookupat.3: flux_kvs_lookup.3
 flux_kvs_lookup_get.3: flux_kvs_lookup.3
 flux_kvs_lookup_get_unpack.3: flux_kvs_lookup.3
+flux_kvs_lookup_get_raw.3: flux_kvs_lookup.3
 flux_kvs_fence.3: flux_kvs_commit.3
 flux_kvs_txn_destroy.3: flux_kvs_txn_create.3
 flux_kvs_txn_put.3: flux_kvs_txn_create.3

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -5,7 +5,7 @@ flux_kvs_lookup(3)
 
 NAME
 ----
-flux_kvs_lookup, flux_kvs_lookupat, flux_kvs_lookup_get, flux_kvs_lookup_get_unpack - look up KVS key
+flux_kvs_lookup, flux_kvs_lookupat, flux_kvs_lookup_get, flux_kvs_lookup_get_unpack, flux_kvs_lookup_get_raw - look up KVS key
 
 
 SYNOPSIS
@@ -20,6 +20,8 @@ SYNOPSIS
  int flux_kvs_lookup_get (flux_future_t *f, const char **json_str);
 
  int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
+
+ int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len);
 
 
 DESCRIPTION
@@ -48,6 +50,9 @@ _json_str_ may be a JSON object, array, or bare value.
 the returned JSON is parsed according to variable arguments in Jansson
 `json_unpack()` format.
 
+`flux_kvs_lookup_get_raw()` is identical to `flux_kvs_lookup_get()` except
+the raw value is returned without decoding.
+
 These functions may be used asynchronously.
 See `flux_future_then(3)` for details.
 
@@ -75,8 +80,9 @@ RETURN VALUE
 `flux_kvs_lookup()` and `flux_kvs_lookupat()` return a
 `flux_future_t` on success, or NULL on failure with errno set appropriately.
 
-`flux_kvs_lookup_get()` and `flux_kvs_lookup_getat()`
-return 0 on success, or -1 on failure with errno set appropriately.
+`flux_kvs_lookup_get()`, `flux_kvs_lookup_get_unpack()`, and
+`flux_kvs_lookup_get_raw()` return 0 on success, or -1 on failure with
+errno set appropriately.
 
 
 ERRORS

--- a/doc/man3/flux_kvs_txn_create.adoc
+++ b/doc/man3/flux_kvs_txn_create.adoc
@@ -5,7 +5,7 @@ flux_kvs_txn_create(3)
 
 NAME
 ----
-flux_kvs_txn_create, flux_kvs_txn_destroy, flux_kvs_txn_put, flux_kvs_txn_pack, flux_kvs_txn_mkdir, flux_kvs_txn_unlink, flux_kvs_txn_symlink - operate on a KVS transaction object
+flux_kvs_txn_create, flux_kvs_txn_destroy, flux_kvs_txn_put, flux_kvs_txn_pack, flux_kvs_txn_mkdir, flux_kvs_txn_unlink, flux_kvs_txn_symlink, flux_kvs_txn_put_raw - operate on a KVS transaction object
 
 
 SYNOPSIS
@@ -30,6 +30,10 @@ SYNOPSIS
 
  int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
                            const char *key, const char *target);
+
+ int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn, int flags,
+                           const char *key, const void *data, int len);
+
 
 
 DESCRIPTION
@@ -65,6 +69,9 @@ all its contents are removed as well.
 `flux_kvs_txn_symlink()` sets _key_ to a symbolic link pointing to _target_,
 another key.  _target_ need not exist.
 
+`flux_kvs_txn_put_raw()` sets _key_ to a value containing raw data
+referred to by _data_ of length _len_.
+
 
 FLAGS
 -----
@@ -90,8 +97,8 @@ RETURN VALUE
 or NULL on failure with errno set appropriately.
 
 `flux_kvs_txn_put()`, `flux_kvs_txn_pack()`, `flux_kvs_txn_mkdir()`,
-`flux_kvs_txn_unlink()`, and `flux_kvs_txn_symlink()` returns 0 on success,
-or -1 on failure with errno set appropriately.
+`flux_kvs_txn_unlink()`, `flux_kvs_txn_symlink()`, and `flux_kvs_txn_put_raw()`
+returns 0 on success, or -1 on failure with errno set appropriately.
 
 ERRORS
 ------

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -244,6 +244,32 @@ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...)
     return rc;
 }
 
+int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len)
+{
+    struct lookup_ctx *ctx;
+
+    if (!(ctx = flux_future_aux_get (f, auxkey))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(ctx->treeobj)) {
+        if (flux_rpc_get_unpack (f, "{s:o}", "val", &ctx->treeobj) < 0) {
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    if (!ctx->val_valid) {
+        if (treeobj_decode_val (ctx->treeobj, &ctx->val_data,
+                                              &ctx->val_len) < 0)
+            return -1;
+        ctx->val_valid = true;
+    }
+    if (data)
+        *data = ctx->val_data;
+    if (len)
+        *len = ctx->val_len;
+    return 0;
+}
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -13,6 +13,7 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
 
 int flux_kvs_lookup_get (flux_future_t *f, const char **json_str);
 int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
+int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len);
 
 #endif /* !_FLUX_CORE_KVS_LOOKUP_H */
 

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -148,7 +148,7 @@ error:
 }
 
 int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn, int flags,
-                          const char *key, void *data, int len)
+                          const char *key, const void *data, int len)
 {
     json_t *dirent = NULL;
     int saved_errno;

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -13,7 +13,7 @@ int flux_kvs_txn_pack (flux_kvs_txn_t *txn, int flags,
                        const char *key, const char *fmt, ...);
 
 int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn, int flags,
-                          const char *key, void *data, int len);
+                          const char *key, const void *data, int len);
 
 int flux_kvs_txn_mkdir (flux_kvs_txn_t *txn, int flags,
                         const char *key);

--- a/src/common/libkvs/test/kvs_lookup.c
+++ b/src/common/libkvs/test/kvs_lookup.c
@@ -28,6 +28,10 @@ void errors (void)
     errno = 0;
     ok (flux_kvs_lookup_get_unpack (NULL, NULL) < 0 && errno == EINVAL,
         "flux_kvs_lookup_get_unpack fails on bad input");
+
+    errno = 0;
+    ok (flux_kvs_lookup_get_raw (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_lookup_get_raw fails on bad input");
 }
 
 int main (int argc, char *argv[])

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -261,6 +261,12 @@ test_expect_success 'kvs: getat: works on outdated root' '
 	test $(${KVSBASIC} getat $ROOTREF $TEST.a.b.c) = 42
 '
 
+test_expect_success 'kvs: zero size raw value can be stored and retrieved' '
+	flux kvs unlink -Rf $TEST &&
+	${KVSBASIC} copy-tokvs $TEST.empty -  </dev/null &&
+	test $(${KVSBASIC} copy-fromkvs $TEST.empty -|wc -c) -eq 0
+'
+
 test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs mkdir $TEST.dirsize &&
 	flux kvs put $TEST.dirsize.a=1 &&

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -284,10 +284,9 @@ test_expect_success 'kvs: large put stores raw data into content store' '
         flux content load ${largevalhash} | grep $largeval
 '
 
-# TODO - convert to using "flux content store", see issue1216
 test_expect_success 'kvs: valref that points to content store data can be read' '
         flux kvs unlink -Rf $TEST &&
- 	flux kvs put $TEST.largeval=$largeval &&
+	echo "$largeval" | flux content store &&
 	${KVSBASIC} put-treeobj $TEST.largeval2="{\"data\":[\"${largevalhash}\"],\"type\":\"valref\",\"ver\":1}" &&
         flux kvs get $TEST.largeval2 | grep $largeval
 '


### PR DESCRIPTION
This PR adds `flux_kvs_lookup_get_raw()` to the KVS API, to go with `flux_kvs_txn_put_raw()`, then modifies `t/kvs/basic` to use them instead of an extra base64 encoding layer for `copy-tokvs` and `copy-fromkvs` subcommands.  Finally add a couple of sharness tests  to fill test gaps identified in #1214 (lookup unencoded content)  and #1215 (zero length value).

This is based on top of #1214