### PR TITLE
Improvements for cplusplus

### DIFF
--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -3,6 +3,10 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Flags can only be set by the broker.
  */
 enum {
@@ -22,6 +26,9 @@ const char *flux_attr_first (flux_t *h);
 
 const char *flux_attr_next (flux_t *h);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_ATTR_H */
 

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -1,8 +1,6 @@
 #ifndef _FLUX_CORE_ATTR_H
 #define _FLUX_CORE_ATTR_H
 
-#include <stdbool.h>
-
 #include "handle.h"
 
 /* Flags can only be set by the broker.

--- a/src/common/libflux/barrier.h
+++ b/src/common/libflux/barrier.h
@@ -3,11 +3,19 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Execute a barrier across 'nprocs' processes.
  * The 'name' must be unique across the comms session, or
  * if running in a Flux/slurm job, may be NULL.
  */
 flux_future_t *flux_barrier (flux_t *h, const char *name, int nprocs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_BARRIER_H */
 

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -1,8 +1,6 @@
 #ifndef _FLUX_CORE_CONF_H
 #define _FLUX_CORE_CONF_H
 
-#include <stdarg.h>
-
 enum {
     CONF_FLAG_INTREE=1,
 };

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -1,11 +1,19 @@
 #ifndef _FLUX_CORE_CONF_H
 #define _FLUX_CORE_CONF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     CONF_FLAG_INTREE=1,
 };
 
 const char *flux_conf_get (const char *name, int flags);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_CONF_H */
 

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -1,11 +1,6 @@
 #ifndef _FLUX_CORE_CONNECTOR_H
 #define _FLUX_CORE_CONNECTOR_H
 
-#include <stdbool.h>
-
-#include "message.h"
-#include "handle.h"
-
 /**
  ** Only handle implementation stuff below.
  ** Flux_t handle users should not use these interfaces.

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_CORE_CONNECTOR_H
 #define _FLUX_CORE_CONNECTOR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  ** Only handle implementation stuff below.
  ** Flux_t handle users should not use these interfaces.
@@ -25,6 +29,10 @@ struct flux_handle_ops {
 
 flux_t *flux_handle_create (void *impl, const struct flux_handle_ops *ops, int flags);
 void flux_handle_destroy (flux_t *hp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_CONNECTOR_H */
 

--- a/src/common/libflux/content.h
+++ b/src/common/libflux/content.h
@@ -3,6 +3,10 @@
 
 #include <flux/core.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* flags */
 enum {
     CONTENT_FLAG_CACHE_BYPASS = 1,/* request direct to backing store */
@@ -31,6 +35,10 @@ flux_future_t *flux_content_store (flux_t *h,
  * Returns 0 on success, -1 on failure with errno set.
  */
 int flux_content_store_get (flux_future_t *f, const char **blobref);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_CONTENT_H */
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -27,6 +27,7 @@
 #endif
 #include <errno.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 #include "event.h"
 #include "message.h"

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -3,6 +3,10 @@
 
 #include "message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Decode an event message.
  * If topic is non-NULL, assign the event topic string.
  * If json_str is non-NULL, assign the payload or set to NULL if none
@@ -29,6 +33,10 @@ flux_msg_t *flux_event_encode (const char *topic, const char *json_str);
  * payload directly.  Returns message or NULL on failure with errno set.
  */
 flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !FLUX_CORE_EVENT_H */
 

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -1,9 +1,6 @@
 #ifndef _FLUX_CORE_EVENT_H
 #define _FLUX_CORE_EVENT_H
 
-#include <stdbool.h>
-#include <stdarg.h>
-
 #include "message.h"
 
 /* Decode an event message.

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -8,6 +8,11 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #define FLUX_MAX_LOGBUF     2048
 
 /* May be ored with 'level' to cause log request
@@ -71,6 +76,10 @@ void flux_log_fprint (const char *buf, int len, void *arg);
  * Flux errno space includes POSIX errno + zeromq errors.
  */
 const char *flux_strerror (int errnum);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_FLOG_H */
 

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -2,7 +2,6 @@
 #define _FLUX_CORE_FLOG_H
 
 #include <stdarg.h>
-#include <stdbool.h>
 #include <syslog.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -6,6 +6,10 @@
 #include "handle.h"
 #include "msg_handler.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Interfaces useful for all classes that return futures.
  * See flux_future_then(3).
  */
@@ -43,6 +47,10 @@ flux_t *flux_future_get_flux (flux_future_t *f);
 
 void flux_future_set_reactor (flux_future_t *f, flux_reactor_t *r);
 flux_reactor_t *flux_future_get_reactor (flux_future_t *f);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_FUTURE_H */
 

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -8,6 +8,10 @@
 #include "types.h"
 #include "message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_handle_struct flux_t;
 
 typedef struct {
@@ -170,6 +174,10 @@ int flux_event_unsubscribe (flux_t *h, const char *topic);
  */
 void flux_get_msgcounters (flux_t *h, flux_msgcounters_t *mcs);
 void flux_clr_msgcounters (flux_t *h);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_HANDLE_H */
 

--- a/src/common/libflux/heartbeat.h
+++ b/src/common/libflux/heartbeat.h
@@ -3,8 +3,16 @@
 
 #include "message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 flux_msg_t *flux_heartbeat_encode (int epoch);
 int flux_heartbeat_decode (const flux_msg_t *msg, int *epoch);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_HEARTBEAT */
 

--- a/src/common/libflux/info.h
+++ b/src/common/libflux/info.h
@@ -1,8 +1,6 @@
 #ifndef _FLUX_CORE_INFO_H
 #define _FLUX_CORE_INFO_H
 
-#include <stdbool.h>
-
 #include "handle.h"
 
 int flux_get_rank (flux_t *h, uint32_t *rank);

--- a/src/common/libflux/keepalive.h
+++ b/src/common/libflux/keepalive.h
@@ -1,9 +1,17 @@
 #ifndef _FLUX_CORE_KEEPALIVE_H
 #define _FLUX_CORE_KEEPALIVE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 flux_msg_t *flux_keepalive_encode (int errnum, int status);
 
 int flux_keepalive_decode (const flux_msg_t *msg, int *errnum, int *status);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KEEPALIVE_H */
 

--- a/src/common/libflux/keepalive.h
+++ b/src/common/libflux/keepalive.h
@@ -1,5 +1,5 @@
 #ifndef _FLUX_CORE_KEEPALIVE_H
-#define _FLUX_CORE_KEEPALIVE_H 1
+#define _FLUX_CORE_KEEPALIVE_H
 
 flux_msg_t *flux_keepalive_encode (int errnum, int status);
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -8,6 +8,10 @@
 #include "types.h"
 #include "security.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_msg flux_msg_t;
 //typedef struct _zmsg_t flux_msg_t;
 
@@ -306,6 +310,10 @@ int flux_msg_get_route_count (const flux_msg_t *msg);
  * Caller must free the returned string.
  */
 char *flux_msg_get_route_string (const flux_msg_t *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_MESSAGE_H */
 

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -9,6 +9,10 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Module states, for embedding in keepalive messages (rfc 5)
  */
 enum {
@@ -109,6 +113,10 @@ int flux_rmmod_json_decode (const char *json_str, char **name);
 char *flux_insmod_json_encode (const char *path, int argc, char **argv);
 int flux_insmod_json_decode (const char *json_str, char **path,
                              char **argz, size_t *argz_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !FLUX_CORE_MODULE_H */
 

--- a/src/common/libflux/mrpc.c
+++ b/src/common/libflux/mrpc.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #if HAVE_CALIPER
 #include <caliper/cali.h>
 #include <sys/syscall.h>

--- a/src/common/libflux/mrpc.h
+++ b/src/common/libflux/mrpc.h
@@ -6,6 +6,10 @@
 #include "handle.h"
 #include "rpc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_mrpc_struct flux_mrpc_t;
 typedef void (*flux_mrpc_continuation_f)(flux_mrpc_t *mrpc, void *arg);
 
@@ -80,6 +84,10 @@ int flux_mrpc_next (flux_mrpc_t *mrpc);
 void *flux_mrpc_aux_get (flux_mrpc_t *mrpc, const char *name);
 int flux_mrpc_aux_set (flux_mrpc_t *mrpc, const char *name,
                       void *aux, flux_free_f destroy);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_MRPC_H */
 

--- a/src/common/libflux/mrpc.h
+++ b/src/common/libflux/mrpc.h
@@ -2,7 +2,6 @@
 #define _FLUX_CORE_MRPC_H
 
 #include <stdbool.h>
-#include <stdarg.h>
 
 #include "handle.h"
 #include "rpc.h"

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -565,7 +565,10 @@ int flux_msg_handler_addvec (flux_t *h, struct flux_msg_handler_spec tab[],
         if (!tab[i].typemask && !tab[i].topic_glob && !tab[i].cb)
             break; /* FLUX_MSGHANDLER_TABLE_END */
         match.typemask = tab[i].typemask;
-        match.topic_glob = tab[i].topic_glob;
+        /* flux_msg_handler_create() will make a copy of the topic_glob
+         * so it is safe to temporarily remove "const" from
+         * tab[i].topic_glob with a cast. */
+        match.topic_glob = (char *)tab[i].topic_glob;
         tab[i].w = flux_msg_handler_create (h, match, tab[i].cb, arg);
         if (!tab[i].w)
             goto error;

--- a/src/common/libflux/msg_handler.h
+++ b/src/common/libflux/msg_handler.h
@@ -4,6 +4,10 @@
 #include "message.h"
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_msg_handler flux_msg_handler_t;
 
 typedef void (*flux_msg_handler_f)(flux_t *h, flux_msg_handler_t *w,
@@ -41,6 +45,10 @@ void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
 /* Requeue any unmatched messages, if handle was cloned.
  */
 int flux_dispatch_requeue (flux_t *h);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_MSG_HANDLER_H */
 

--- a/src/common/libflux/msg_handler.h
+++ b/src/common/libflux/msg_handler.h
@@ -31,7 +31,7 @@ void flux_msg_handler_deny_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
 
 struct flux_msg_handler_spec {
     int typemask;
-    char *topic_glob;
+    const char *topic_glob;
     flux_msg_handler_f cb;
     uint32_t rolemask;
     flux_msg_handler_t *w;

--- a/src/common/libflux/panic.h
+++ b/src/common/libflux/panic.h
@@ -3,11 +3,19 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int flux_panic (flux_t *h, int rank, const char *msg);
 
 void flux_assfail (flux_t *h, char *ass, char *file, int line);
 #define FASSERT(h, exp) if ((exp)); \
                         else flux_assfail(h, #exp, __FILE__, __LINE__)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_PANIC_H */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -7,6 +7,10 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Reactor
  */
 
@@ -168,6 +172,9 @@ void * flux_watcher_impl (flux_watcher_t *w);
  */
 struct flux_watcher_ops * flux_watcher_ops (flux_watcher_t *w);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_REACTOR_H */
 

--- a/src/common/libflux/reduce.h
+++ b/src/common/libflux/reduce.h
@@ -3,6 +3,10 @@
 
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_reduce_struct flux_reduce_t;
 
 struct flux_reduce_ops {
@@ -39,6 +43,10 @@ int flux_reduce_push (flux_reduce_t *r, void *item);
 int flux_reduce_opt_get (flux_reduce_t *r, int option, void *val, size_t size);
 
 int flux_reduce_opt_set (flux_reduce_t *r, int option, void *val, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUX_CORE_REDUCE_H */
 

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -26,6 +26,7 @@
 #include "config.h"
 #endif
 #include <errno.h>
+#include <stdarg.h>
 #include "request.h"
 #include "message.h"
 #include "info.h"

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -1,9 +1,6 @@
 #ifndef _FLUX_CORE_REQUEST_H
 #define _FLUX_CORE_REQUEST_H
 
-#include <stdbool.h>
-#include <stdarg.h>
-
 #include "message.h"
 
 /* Decode a request message with optional json payload.

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -3,6 +3,10 @@
 
 #include "message.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Decode a request message with optional json payload.
  * If topic is non-NULL, assign the request topic string.
  * If json_str is non-NULL, assign the payload or set to NULL if none
@@ -38,6 +42,10 @@ flux_msg_t *flux_request_encode (const char *topic, const char *json_str);
  */
 flux_msg_t *flux_request_encode_raw (const char *topic,
                                      const void *data, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_REQUEST_H */
 

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -26,6 +26,7 @@
 #include "config.h"
 #endif
 #include <errno.h>
+#include <stdarg.h>
 
 #include "response.h"
 #include "message.h"

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -4,6 +4,10 @@
 #include "message.h"
 #include "handle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Decode a response message, with optional json payload.
  * If topic is non-NULL, assign the response topic string.
  * If json_str is non-NULL, assign the payload if one exists or set to
@@ -55,6 +59,10 @@ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
  */
 int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       int errnum, const void *data, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_RESPONSE_H */
 

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -1,9 +1,6 @@
 #ifndef _FLUX_CORE_RESPONSE_H
 #define _FLUX_CORE_RESPONSE_H
 
-#include <stdbool.h>
-#include <stdarg.h>
-
 #include "message.h"
 #include "handle.h"
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -28,6 +28,8 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
 #if HAVE_CALIPER
 #include <caliper/cali.h>
 #include <sys/syscall.h>

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -1,9 +1,6 @@
 #ifndef _FLUX_CORE_RPC_H
 #define _FLUX_CORE_RPC_H
 
-#include <stdbool.h>
-#include <stdarg.h>
-
 #include "handle.h"
 #include "future.h"
 

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -4,6 +4,10 @@
 #include "handle.h"
 #include "future.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     FLUX_RPC_NORESPONSE = 1,
 };
@@ -24,6 +28,9 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_RPC_H */
 

--- a/src/common/libflux/security.h
+++ b/src/common/libflux/security.h
@@ -3,6 +3,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_sec_struct flux_sec_t;
 
 enum {
@@ -109,6 +113,10 @@ int flux_sec_munge (flux_sec_t *c, const char *inbuf, size_t insize,
                     char **outbuf, size_t *outsize);
 int flux_sec_unmunge (flux_sec_t *c, const char *inbuf, size_t insize,
                       char **outbuf, size_t *outsize);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FLUX_CORE_SECURITY_H */
 

--- a/src/common/libflux/types.h
+++ b/src/common/libflux/types.h
@@ -1,7 +1,15 @@
 #ifndef _FLUX_CORE_TYPES_H
 #define _FLUX_CORE_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*flux_free_f)(void *arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_TYPES_H */
 

--- a/src/common/libjsc/jstatctl.h
+++ b/src/common/libjsc/jstatctl.h
@@ -27,6 +27,10 @@
 
 #include <flux/core.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Define the job states (an abstraction independent of
  * underlying task and program execution services (RFC 8)
@@ -119,6 +123,10 @@ int jsc_update_jcb (flux_t *h, int64_t jobid, const char *key, const char *jcb);
  * A convenience routine (returning the internal state name correponding to "s.")
  */
 const char *jsc_job_num2state (job_state_t s);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*! _FLUX_CORE_JSTATCTRL_H */
 

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_KVS_CLASSIC_H
 #define _FLUX_KVS_CLASSIC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* These interfaces are on their way to being deprecated */
 
 int kvs_get (flux_t *h, const char *key, char **json_str);
@@ -32,6 +36,9 @@ int kvsdir_put_boolean (kvsdir_t *dir, const char *key, bool val);
 int kvsdir_unlink (kvsdir_t *dir, const char *key);
 int kvsdir_mkdir (kvsdir_t *dir, const char *key);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_KVS_CLASSIC_H */
 

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_CORE_KVS_COMMIT_H
 #define _FLUX_CORE_KVS_COMMIT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum kvs_commit_flags {
     FLUX_KVS_NO_MERGE = 1, /* disallow commits to be mergeable with others */
 };
@@ -9,6 +13,10 @@ flux_future_t *flux_kvs_commit (flux_t *h, int flags, flux_kvs_txn_t *txn);
 
 flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
                                int nprocs, flux_kvs_txn_t *txn);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KVS_COMMIT_H */
 

--- a/src/common/libkvs/kvs_dir.h
+++ b/src/common/libkvs/kvs_dir.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_CORE_KVS_DIR_H
 #define _FLUX_CORE_KVS_DIR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct kvsdir_struct kvsdir_t;
 typedef struct kvsdir_iterator_struct kvsitr_t;
 
@@ -41,6 +45,10 @@ const char *kvsdir_rootref (kvsdir_t *dir);
 /* Get the number of keys in a directory.
  */
 int kvsdir_get_size (kvsdir_t *dir);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KVS_DIR_H */
 

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_CORE_KVS_LOOKUP_H
 #define _FLUX_CORE_KVS_LOOKUP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum kvs_lookup_flags {
     FLUX_KVS_READDIR = 1,
     FLUX_KVS_READLINK = 2,
@@ -14,6 +18,10 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
 int flux_kvs_lookup_get (flux_future_t *f, const char **json_str);
 int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
 int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KVS_LOOKUP_H */
 

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_CORE_KVS_TXN_H
 #define _FLUX_CORE_KVS_TXN_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_kvs_txn flux_kvs_txn_t;
 
 flux_kvs_txn_t *flux_kvs_txn_create (void);
@@ -23,6 +27,10 @@ int flux_kvs_txn_unlink (flux_kvs_txn_t *txn, int flags,
 
 int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
                           const char *key, const char *target);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KVS_TXN_H */
 

--- a/src/common/libkvs/kvs_watch.h
+++ b/src/common/libkvs/kvs_watch.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_CORE_KVS_WATCH_H
 #define _FLUX_CORE_KVS_WATCH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum kvs_watch_flags {
     KVS_WATCH_ONCE = 4,
     KVS_WATCH_FIRST = 8,
@@ -42,6 +46,10 @@ int kvs_unwatch (flux_t *h, const char *key);
 int kvs_watch_once (flux_t *h, const char *key, char **json_str);
 int kvs_watch_once_dir (flux_t *h, kvsdir_t **dirp, const char *fmt, ...)
         __attribute__ ((format (printf, 3, 4)));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KVS_WATCH_H */
 

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -3,6 +3,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /******************************************************************************
  *  Datatypes:
  *****************************************************************************/
@@ -369,5 +373,9 @@ const char *optparse_get_str (optparse_t *p, const char *name,
  *    not valid.
  */
 int optparse_option_index (optparse_t *p);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _UTIL_OPTPARSE_H */


### PR DESCRIPTION
Some improvements to make flux more friendly to linking with a C++ compiler: 

- fixed a const correctness issue that C++ enforces, but C does not
- Added, 'extern "c"' directives to all of the flux public headers, and hacked the python binding generation script to accomodate that change.

Also some simple header cleanups found along the way.
