### PR TITLE
kvs.h add extern "C" wrapper

### DIFF
--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -10,6 +10,10 @@
 #include "kvs_txn.h"
 #include "kvs_commit.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Synchronization:
  * Process A commits data, then gets the store version V and sends it to B.
  * Process B waits for the store version to be >= V, then reads data.
@@ -23,6 +27,10 @@ int kvs_wait_version (flux_t *h, int version);
  * Returns -1 on error (errno set), 0 on success.
  */
 int kvs_dropcache (flux_t *h);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_KVS_H */
 

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -1,8 +1,6 @@
 #ifndef _FLUX_CORE_KVS_H
 #define _FLUX_CORE_KVS_H
 
-#include <stdbool.h>
-#include <stdint.h>
 #include <flux/core.h>
 
 #include "kvs_lookup.h"


### PR DESCRIPTION
Fix missing extern "C" wrapper in kvs.h from issue #1223 PR, as mentioned in issue #1224.