### PR TITLE
KVS: Support valref pointing to zero length blob objects

### DIFF
--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -227,13 +227,15 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
     return -1;
 }
 
-void *cache_entry_get_raw (struct cache_entry *hp, int *len)
+int cache_entry_get_raw (struct cache_entry *hp, void **data, int *len)
 {
     if (!hp || !hp->data || hp->type != CACHE_DATA_TYPE_RAW)
-        return NULL;
+        return -1;
+    if (data)
+        (*data) = hp->data;
     if (len)
         (*len) = hp->len;
-    return hp->data;
+    return 0;
 }
 
 int cache_entry_set_raw (struct cache_entry *hp, void *data, int len)

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -62,25 +62,32 @@ struct cache {
     zhash_t *zh;
 };
 
-struct cache_entry *cache_entry_create (void)
+struct cache_entry *cache_entry_create (cache_data_type_t t)
 {
-    struct cache_entry *hp = calloc (1, sizeof (*hp));
-    if (!hp) {
+    struct cache_entry *hp;
+
+    if (t != CACHE_DATA_TYPE_NONE
+        && t != CACHE_DATA_TYPE_JSON
+        && t != CACHE_DATA_TYPE_RAW) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(hp = calloc (1, sizeof (*hp)))) {
         errno = ENOMEM;
         return NULL;
     }
-    hp->type = CACHE_DATA_TYPE_NONE;
+    hp->type = t;
     return hp;
 }
 
 struct cache_entry *cache_entry_create_json (json_t *o)
 {
-    struct cache_entry *hp = cache_entry_create ();
+    struct cache_entry *hp = cache_entry_create (CACHE_DATA_TYPE_JSON);
     if (!hp)
         return NULL;
     if (o)
         hp->data = o;
-    hp->type = CACHE_DATA_TYPE_JSON;
     return hp;
 }
 
@@ -93,13 +100,13 @@ struct cache_entry *cache_entry_create_raw (void *data, int len)
         return NULL;
     }
 
-    if (!(hp = cache_entry_create ()))
+    if (!(hp = cache_entry_create (CACHE_DATA_TYPE_RAW)))
         return NULL;
+
     if (data) {
         hp->data = data;
         hp->len = len;
     }
-    hp->type = CACHE_DATA_TYPE_RAW;
     return hp;
 }
 

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -272,6 +272,22 @@ int cache_entry_set_raw (struct cache_entry *hp, void *data, int len)
     return -1;
 }
 
+int cache_entry_clear_data (struct cache_entry *hp)
+{
+    if (hp) {
+        if (hp->data) {
+            if (hp->type == CACHE_DATA_TYPE_JSON)
+                json_decref (hp->data);
+            else if (hp->type == CACHE_DATA_TYPE_RAW)
+                free (hp->data);
+        }
+        hp->data = NULL;
+        hp->len = 0;
+        return 0;
+    }
+    return -1;
+}
+
 void cache_entry_destroy (void *arg)
 {
     struct cache_entry *hp = arg;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -83,11 +83,16 @@ struct cache_entry *cache_entry_create (cache_data_type_t t)
 
 struct cache_entry *cache_entry_create_json (json_t *o)
 {
-    struct cache_entry *hp = cache_entry_create (CACHE_DATA_TYPE_JSON);
-    if (!hp)
+    struct cache_entry *hp;
+
+    if (!o) {
+        errno = EINVAL;
         return NULL;
-    if (o)
-        hp->data = o;
+    }
+
+    if (!(hp = cache_entry_create (CACHE_DATA_TYPE_JSON)))
+        return NULL;
+    hp->data = o;
     return hp;
 }
 

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -204,11 +204,12 @@ json_t *cache_entry_get_json (struct cache_entry *hp)
 int cache_entry_set_json (struct cache_entry *hp, json_t *o)
 {
     if (hp
+        && o
         && (hp->type == CACHE_DATA_TYPE_NONE
             || hp->type == CACHE_DATA_TYPE_JSON)) {
-        if ((o && hp->data) || (!o && !hp->data)) {
+        if (hp->data) {
             json_decref (o); /* no-op, 'o' is assumed identical to hp->data */
-        } else if (o && !hp->data) {
+        } else { /* !hp->data */
             hp->data = o;
             if (hp->waitlist_valid) {
                 if (wait_runqueue (hp->waitlist_valid) < 0) {
@@ -217,9 +218,6 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
                     return -1;
                 }
             }
-        } else if (!o && hp->data) {
-            json_decref (hp->data);
-            hp->data = NULL;
         }
         hp->type = CACHE_DATA_TYPE_JSON;
         return 0;

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -19,7 +19,9 @@ struct cache;
 /* Create/destroy cache entry.
  *
  * cache_entry_create() creates an entry, setting the cache entry type
- * to CACHE_DATA_TYPE_NONE.
+ * to specified type.  CACHE_DATA_TYPE_NONE indicates user is not yet
+ * sure of the type of data to be stored, and it will be determined later
+ * when cache_entry_set_X() function is called.
  *
  * cache_entry_create_json() creates an entry, setting the cache entry
  * type to CACHE_DATA_TYPE_JSON.  The create transfers ownership of
@@ -30,10 +32,10 @@ struct cache;
  * cache_entry_create_raw() creates an entry, setting the cache entry
  * type to CACHE_DATA_TYPE_RAW.  The create transfers ownership of
  * 'data' to the cache entry.  On destroy, free() will be called on
- * 'data'.  If 'data' is NULL, no data is set, but the type is still
- * set to CACHE_DATA_TYPE_RAW and only raw can be used for the entry.
+ * 'data'.  If 'data' is NULL, 'len' must be zero.  If 'data' is
+ * non-NULL, 'len' must be > 0.
  */
-struct cache_entry *cache_entry_create (void);
+struct cache_entry *cache_entry_create (cache_data_type_t t);
 struct cache_entry *cache_entry_create_json (json_t *o);
 struct cache_entry *cache_entry_create_raw (void *data, int len);
 void cache_entry_destroy (void *arg);

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -98,17 +98,21 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * converted to CACHE_DATA_TYPE_RAW.  If non-NULL, set transfers
  * ownership of 'data' to the cache entry.
  *
+ * cache_entry_clear_data () will clear any data in the entry.
+ *
  * An invalid->valid transition runs the entry's wait queue, if any in
  * both set accessors.
  *
- * cache_entry_set_json() & cache_entry_set_raw() returns -1 on error,
- * 0 on success
+ * cache_entry_set_json() & cache_entry_set_raw() &
+ * cache_entry_clear_data() returns -1 on error, 0 on success
  */
 json_t *cache_entry_get_json (struct cache_entry *hp);
 int cache_entry_set_json (struct cache_entry *hp, json_t *o);
 
 int cache_entry_get_raw (struct cache_entry *hp, void **data, int *len);
 int cache_entry_set_raw (struct cache_entry *hp, void *data, int len);
+
+int cache_entry_clear_data (struct cache_entry *hp);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -26,8 +26,7 @@ struct cache;
  * cache_entry_create_json() creates an entry, setting the cache entry
  * type to CACHE_DATA_TYPE_JSON.  The create transfers ownership of
  * 'o' to the cache entry.  On destroy, json_decref() will be called
- * on 'o'.  If 'o' is NULL, no data is set, but the type is still set
- * to CACHE_DATA_TYPE_JSON and only json can be used for the entry.
+ * on 'o'.  'o' cannot be NULL.
  *
  * cache_entry_create_raw() creates an entry, setting the cache entry
  * type to CACHE_DATA_TYPE_RAW.  The create transfers ownership of

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -20,8 +20,11 @@ struct cache;
  *
  * cache_entry_create() creates an entry, setting the cache entry type
  * to specified type.  CACHE_DATA_TYPE_NONE indicates user is not yet
- * sure of the type of data to be stored, and it will be determined later
- * when cache_entry_set_X() function is called.
+ * sure of the type of data to be stored, and it will be determined
+ * later when cache_entry_set_X() function is called.
+ * cache_entry_get_valid() will return false after
+ * cache_entry_create() is initially called, regardless of the type
+ * passed in.
  *
  * cache_entry_create_json() creates an entry, setting the cache entry
  * type to CACHE_DATA_TYPE_JSON.  The create transfers ownership of
@@ -33,6 +36,9 @@ struct cache;
  * 'data' to the cache entry.  On destroy, free() will be called on
  * 'data'.  If 'data' is NULL, 'len' must be zero.  If 'data' is
  * non-NULL, 'len' must be > 0.
+ *
+ * cache_entry_get_valid() will return true on entries when
+ * cache_entry_create_json() and cache_entry_get_raw() return success.
  */
 struct cache_entry *cache_entry_create (cache_data_type_t t);
 struct cache_entry *cache_entry_create_json (json_t *o);
@@ -103,6 +109,10 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  *
  * An invalid->valid transition runs the entry's wait queue, if any in
  * both set accessors.
+ *
+ * Generally speaking, a cache entry can only bet set once.  If you
+ * wish to set it again, you must run cache_entry_clear_data() before
+ * doing so.
  *
  * cache_entry_set_json() & cache_entry_set_raw() &
  * cache_entry_clear_data() returns -1 on error, 0 on success

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -90,13 +90,14 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  *
  * json set accessor must have type of CACHE_DATA_TYPE_NONE or
  * CACHE_DATA_TYPE_JSON to set json object.  After setting, the type
- * is converted to CACHE_DATA_TYPE_JSON.  If non-NULL, set transfers
- * ownership of 'o' to the cache entry.
+ * is converted to CACHE_DATA_TYPE_JSON.  'o' must be non-NULL.  Set
+ * transfers ownership of 'o' to the cache entry.
  *
  * raw set accessor must have type of CACHE_DATA_TYPE_NONE or
  * CACHE_DATA_TYPE_RAW to set raw data.  After setting, the type is
- * converted to CACHE_DATA_TYPE_RAW.  If non-NULL, set transfers
- * ownership of 'data' to the cache entry.
+ * converted to CACHE_DATA_TYPE_RAW.  If 'data' is NULL, 'len' must be
+ * zero.  If 'data' is non-NULL, 'len' must be > 0.  If non-NULL, set
+ * transfers ownership of 'data' to the cache entry.
  *
  * cache_entry_clear_data () will clear any data in the entry.
  *

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -107,7 +107,7 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
 json_t *cache_entry_get_json (struct cache_entry *hp);
 int cache_entry_set_json (struct cache_entry *hp, json_t *o);
 
-void *cache_entry_get_raw (struct cache_entry *hp, int *len);
+int cache_entry_get_raw (struct cache_entry *hp, void **data, int *len);
 int cache_entry_set_raw (struct cache_entry *hp, void *data, int len);
 
 /* Arrange for message handler represented by 'wait' to be restarted

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -222,7 +222,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         }
     }
     if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
-        if (!(hp = cache_entry_create ())) {
+        if (!(hp = cache_entry_create (CACHE_DATA_TYPE_NONE))) {
             saved_errno = ENOMEM;
             goto done;
         }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1637,6 +1637,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         cache_insert (ctx->cache, ref, hp);
     }
     if (!cache_entry_get_valid (hp)) {
+        assert (o);
         if (cache_entry_set_json (hp, o) < 0) {
             saved_errno = errno;
             flux_log_error (ctx->h, "%s: cache_entry_set_json",

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -203,13 +203,15 @@ static void content_load_completion (flux_future_t *f, void *arg)
      * this error scenario appropriately.
      */
     if (cache_entry_is_type_raw (hp)) {
-        char *datacpy;
+        char *datacpy = NULL;
 
-        if (!(datacpy = malloc (size))) {
-            flux_log_error (ctx->h, "%s: malloc", __FUNCTION__);
-            goto done;
+        if (size) {
+            if (!(datacpy = malloc (size))) {
+                flux_log_error (ctx->h, "%s: malloc", __FUNCTION__);
+                goto done;
+            }
+            memcpy (datacpy, data, size);
         }
-        memcpy (datacpy, data, size);
 
         if (cache_entry_set_raw (hp, datacpy, size) < 0) {
             flux_log_error (ctx->h, "%s: cache_entry_set_raw", __FUNCTION__);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -276,15 +276,15 @@ static int load (kvs_ctx_t *ctx, const href_t ref, bool is_raw, wait_t *wait,
      */
     if (!hp) {
         if (is_raw) {
-            if (!(hp = cache_entry_create_raw (NULL, 0))) {
-                flux_log_error (ctx->h, "%s: cache_entry_create_raw",
+            if (!(hp = cache_entry_create (CACHE_DATA_TYPE_RAW))) {
+                flux_log_error (ctx->h, "%s: cache_entry_create",
                                 __FUNCTION__);
                 return -1;
             }
         }
         else {
-            if (!(hp = cache_entry_create_json (NULL))) {
-                flux_log_error (ctx->h, "%s: cache_entry_create_json",
+            if (!(hp = cache_entry_create (CACHE_DATA_TYPE_JSON))) {
+                flux_log_error (ctx->h, "%s: cache_entry_create",
                                 __FUNCTION__);
                 return -1;
             }
@@ -1628,7 +1628,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         goto decref_done;
     }
     if (!(hp = cache_lookup (ctx->cache, ref, ctx->epoch))) {
-        if (!(hp = cache_entry_create ())) {
+        if (!(hp = cache_entry_create (CACHE_DATA_TYPE_JSON))) {
             saved_errno = errno;
             flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
             goto decref_done;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1630,7 +1630,8 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
     if (!(hp = cache_lookup (ctx->cache, ref, ctx->epoch))) {
         if (!(hp = cache_entry_create (CACHE_DATA_TYPE_JSON))) {
             saved_errno = errno;
-            flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
+            flux_log_error (ctx->h, "%s: cache_entry_create_json_empty",
+                            __FUNCTION__);
             goto decref_done;
         }
         cache_insert (ctx->cache, ref, hp);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -481,7 +481,7 @@ static int commit_cache_cb (commit_t *c, struct cache_entry *hp, void *data)
 
     is_raw = cache_entry_is_type_raw (hp);
     if (is_raw)
-        storedata = cache_entry_get_raw (hp, &storedatalen);
+        cache_entry_get_raw (hp, &storedata, &storedatalen);
     else
         storedata = cache_entry_get_json (hp);
 

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -724,7 +724,7 @@ bool lookup (lookup_t *lh)
                     lh->missing_ref_raw = true;
                     goto stall;
                 }
-                if (!(valdata = cache_entry_get_raw (hp, &len))) {
+                if (cache_entry_get_raw (hp, &valdata, &len) < 0) {
                     flux_log (lh->h, LOG_ERR, "valref points to non-raw data");
                     lh->errnum = EPERM;
                     goto done;

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -84,8 +84,8 @@ void cache_entry_basic_tests (void)
         "cache_entry_set_dirty fails b/c entry non-valid");
     ok ((otmp = cache_entry_get_json (e)) == NULL,
         "cache_entry_get_json returns NULL, no json set");
-    ok (cache_entry_get_raw (e, NULL) == NULL,
-        "cache_entry_get_raw returns NULL, no data set");
+    ok (cache_entry_get_raw (e, NULL, NULL) < 0,
+        "cache_entry_get_raw fails, no data set");
     cache_entry_destroy (e);
     e = NULL;
 }
@@ -276,8 +276,8 @@ void cache_entry_raw_tests (void)
         "cache_entry_set_dirty fails b/c entry non-valid");
     ok (cache_entry_get_dirty (e) == false,
         "cache entry does not set dirty, b/c no data");
-    ok ((data = cache_entry_get_raw (e, NULL)) == NULL,
-        "cache_entry_get_raw returns NULL, no data set");
+    ok (cache_entry_get_raw (e, (void **)&data, NULL) < 0,
+        "cache_entry_get_raw fails, no data set");
     cache_entry_destroy (e);
     e = NULL;
 
@@ -303,8 +303,8 @@ void cache_entry_raw_tests (void)
         "cache_entry_set_dirty fails b/c entry non-valid");
     ok (cache_entry_get_dirty (e) == false,
         "cache entry does not set dirty, b/c no data");
-    ok (cache_entry_get_raw (e, NULL) == NULL,
-        "cache_entry_get_raw returns NULL, no data set");
+    ok (cache_entry_get_raw (e, NULL, NULL) < 0,
+        "cache_entry_get_raw fails, no data set");
     ok (cache_entry_set_raw (e, data, strlen (data) + 1) == 0,
         "cache_entry_set_raw success");
     ok (cache_entry_type (e, &t) == 0,
@@ -350,8 +350,8 @@ void cache_entry_raw_tests (void)
     ok (cache_entry_set_json (e, o1) < 0,
         "cache_entry_set_json fails on cache entry with type raw");
     json_decref (o1);
-    ok (cache_entry_get_raw (e, NULL) == NULL,
-        "cache_entry_get_raw returns NULL, no data set");
+    ok (cache_entry_get_raw (e, NULL, NULL) < 0,
+        "cache_entry_get_raw fails, no data set");
     ok (cache_entry_set_raw (e, data, strlen (data) + 1) == 0,
         "cache_entry_set_raw success");
     ok (cache_entry_get_valid (e) == true,
@@ -394,15 +394,15 @@ void cache_entry_raw_tests (void)
     ok (cache_entry_get_dirty (e) == false,
         "cache entry succcessfully now not dirty");
 
-    ok ((data = cache_entry_get_raw (e, &len)) != NULL,
+    ok (cache_entry_get_raw (e, (void **)&data, &len) == 0,
         "raw data retrieved from cache entry");
-    ok (strcmp (data, "abcd") == 0,
+    ok (data && strcmp (data, "abcd") == 0,
         "raw data matches expected string");
-    ok (len == strlen (data) + 1,
+    ok (data && (len == strlen (data) + 1),
         "raw data length matches expected length");
     ok (cache_entry_set_raw (e, NULL, 0) == 0,
         "cache_entry_set_raw success");
-    ok (cache_entry_get_raw (e, NULL) == NULL,
+    ok (cache_entry_get_raw (e, (void **)&data, &len) < 0,
         "cache entry no longer has data object");
 
     cache_entry_destroy (e); /* destroys data */

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -246,8 +246,8 @@ void cache_entry_json_tests (void)
     ok (json_integer_value (otmp) == 42,
         "expected json object found");
 
-    ok (cache_entry_set_json (e, NULL) == 0,
-        "cache_entry_set_json success");
+    ok (cache_entry_clear_data (e) == 0,
+        "cache_entry_clear_data success");
     ok (cache_entry_get_json (e) == NULL,
         "cache entry no longer has json object");
 

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -45,6 +45,8 @@ void cache_entry_basic_tests (void)
     cache_data_type_t t;
 
     /* corner case tests */
+    ok (cache_entry_create (447) == NULL,
+        "cache_entry_create fails with bad input");
     ok (cache_entry_create_raw (NULL, 5) == NULL,
         "cache_entry_create_raw fails with bad input");
     ok (cache_entry_type (NULL, NULL) < 0,
@@ -62,7 +64,7 @@ void cache_entry_basic_tests (void)
 
     /* test empty cache entry created by cache_entry_create() */
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create works");
     ok (cache_entry_type (e, &t) == 0,
         "cache_entry_type success");
@@ -96,10 +98,11 @@ void cache_entry_json_tests (void)
      * N.B.: json ref is NOT incremented by create or get_json.
      */
 
-    /* test empty cache entry created by cache_entry_create_json() */
+    /* test empty cache entry with json type created by
+     * cache_entry_create() */
 
-    ok ((e = cache_entry_create_json (NULL)) != NULL,
-        "cache_entry_create_json w/ NULL input works");
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_JSON)) != NULL,
+        "cache_entry_create works");
     ok (cache_entry_type (e, &t) == 0,
         "cache_entry_type success");
     ok (t == CACHE_DATA_TYPE_JSON,
@@ -119,13 +122,13 @@ void cache_entry_json_tests (void)
     cache_entry_destroy (e);
     e = NULL;
 
-    /* test empty cache entry, later filled with json.
+    /* test empty cache entry with none type, later filled with json.
      */
 
     o1 = json_object ();
     json_object_set_new (o1, "foo", json_integer (42));
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create works");
     ok (cache_entry_type (e, &t) == 0,
         "cache_entry_type success");
@@ -218,10 +221,11 @@ void cache_entry_raw_tests (void)
     char *data;
     int len;
 
-    /* test empty cache entry created by cache_entry_create_raw() */
+    /* test empty cache entry with raw type created by
+     * cache_entry_create() */
 
-    ok ((e = cache_entry_create_raw (NULL, 0)) != NULL,
-        "cache_entry_create_raw w/ NULL input works");
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_RAW)) != NULL,
+        "cache_entry_create works");
     ok (cache_entry_type (e, &t) == 0,
         "cache_entry_type success");
     ok (t == CACHE_DATA_TYPE_RAW,
@@ -241,12 +245,13 @@ void cache_entry_raw_tests (void)
     cache_entry_destroy (e);
     e = NULL;
 
-    /* test empty cache entry, later filled with raw data.
+    /* test empty cache entry with none type, later filled with raw
+     * data.
      */
 
     data = strdup ("abcd");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create works");
     ok (cache_entry_type (e, &t) == 0,
         "cache_entry_type success");
@@ -287,7 +292,7 @@ void cache_entry_raw_tests (void)
     data = strdup ("abcd");
 
     ok ((e = cache_entry_create_raw (data, strlen (data) + 1)) != NULL,
-        "cache_entry_create_json w/ non-NULL input works");
+        "cache_entry_create_raw w/ non-NULL input works");
     ok (cache_entry_type (e, &t) == 0,
         "cache_entry_type success");
     ok (t == CACHE_DATA_TYPE_RAW,
@@ -345,7 +350,7 @@ void waiter_json_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e) == false,
         "cache entry invalid, adding waiter");
@@ -414,7 +419,7 @@ void waiter_raw_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e) == false,
         "cache entry invalid, adding waiter");
@@ -480,7 +485,7 @@ void cache_remove_entry_tests (void)
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create works");
     cache_insert (cache, "remove-ref", e);
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
@@ -495,7 +500,7 @@ void cache_remove_entry_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create created empty object");
     cache_insert (cache, "remove-ref", e);
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
@@ -566,7 +571,7 @@ void cache_expiration_tests (void)
         "cache contains 0 entries");
 
     /* first test w/ entry w/o json object */
-    ok ((e1 = cache_entry_create ()) != NULL,
+    ok ((e1 = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
         "cache_entry_create works");
     cache_insert (cache, "xxx1", e1);
     ok (cache_count_entries (cache) == 1,

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -55,6 +55,8 @@ void cache_entry_basic_tests (void)
         "cache_entry_type fails with bad input");
     ok (cache_entry_set_json (NULL, NULL) < 0,
         "cache_entry_set_json fails with bad input");
+    ok (cache_entry_clear_data (NULL) < 0,
+        "cache_entry_clear_data fails with bad input");
     cache_entry_destroy (NULL);
     diag ("cache_entry_destroy accept NULL arg");
     ok ((e = cache_entry_create_raw (NULL, 0)) != NULL,
@@ -194,6 +196,10 @@ void cache_entry_json_tests (void)
         "cache_entry_set_json success");
     ok (cache_entry_get_valid (e) == true,
         "cache entry now valid after cache_entry_set_json call");
+    ok (cache_entry_clear_data (e) == 0,
+        "cache_entry_clear_data success");
+    ok (cache_entry_get_valid (e) == false,
+        "cache entry invalid after clear");
     cache_entry_destroy (e);   /* destroys o1 */
     e = NULL;
 
@@ -356,6 +362,10 @@ void cache_entry_raw_tests (void)
         "cache_entry_set_raw success");
     ok (cache_entry_get_valid (e) == true,
         "cache entry now valid after cache_entry_set_raw call");
+    ok (cache_entry_clear_data (e) == 0,
+        "cache_entry_clear_data success");
+    ok (cache_entry_get_valid (e) == false,
+        "cache entry invalid after clear");
     cache_entry_destroy (e);   /* destroys data */
     e = NULL;
 

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -47,6 +47,8 @@ void cache_entry_basic_tests (void)
     /* corner case tests */
     ok (cache_entry_create (447) == NULL,
         "cache_entry_create fails with bad input");
+    ok (cache_entry_create_json (NULL) == NULL,
+        "cache_entry_create_json fails with bad input");
     ok (cache_entry_create_raw (NULL, 5) == NULL,
         "cache_entry_create_raw fails with bad input");
     ok (cache_entry_type (NULL, NULL) < 0,
@@ -158,6 +160,40 @@ void cache_entry_json_tests (void)
         "cache_entry_is_type_json returns true");
     ok (cache_entry_set_raw (e, "abcd", 4) < 0,
         "cache_entry_set_raw fails on cache entry with type json");
+    cache_entry_destroy (e);   /* destroys o1 */
+    e = NULL;
+
+    /* test empty json cache entry with type json, later filled with
+     * data.
+     */
+
+    o1 = json_object ();
+    json_object_set_new (o1, "foo", json_integer (42));
+
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_JSON)) != NULL,
+        "cache_entry_create works");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_JSON,
+        "cache_entry_type returns JSON");
+    ok (cache_entry_is_type_json (e) == true,
+        "cache_entry_is_type_json returns true");
+    ok (cache_entry_get_valid (e) == false,
+        "cache entry initially non-valid");
+    ok (cache_entry_get_dirty (e) == false,
+        "cache entry initially not dirty");
+    ok (cache_entry_set_dirty (e, true) < 0,
+        "cache_entry_set_dirty fails b/c entry non-valid");
+    ok (cache_entry_get_dirty (e) == false,
+        "cache entry does not set dirty, b/c no data");
+    ok (cache_entry_set_raw (e, "abcd", 4) < 0,
+        "cache_entry_set_raw fails on cache entry with type json");
+    ok ((otmp = cache_entry_get_json (e)) == NULL,
+        "cache_entry_get_json returns NULL, no json set");
+    ok (cache_entry_set_json (e, o1) == 0,
+        "cache_entry_set_json success");
+    ok (cache_entry_get_valid (e) == true,
+        "cache entry now valid after cache_entry_set_json call");
     cache_entry_destroy (e);   /* destroys o1 */
     e = NULL;
 
@@ -284,6 +320,42 @@ void cache_entry_raw_tests (void)
     ok (cache_entry_set_json (e, o1) < 0,
         "cache_entry_set_json fails on cache entry with type raw");
     json_decref (o1);
+    cache_entry_destroy (e);   /* destroys data */
+    e = NULL;
+
+    /* test empty cache entry with raw type, later filled with raw
+     * data.
+     */
+
+    data = strdup ("abcd");
+
+    ok ((e = cache_entry_create (CACHE_DATA_TYPE_RAW)) != NULL,
+        "cache_entry_create works");
+    ok (cache_entry_type (e, &t) == 0,
+        "cache_entry_type success");
+    ok (t == CACHE_DATA_TYPE_RAW,
+        "cache_entry_type returns RAW");
+    ok (cache_entry_is_type_raw (e) == true,
+        "cache_entry_is_type_raw returns true");
+    ok (cache_entry_get_valid (e) == false,
+        "cache entry initially non-valid");
+    ok (cache_entry_get_dirty (e) == false,
+        "cache entry initially not dirty");
+    ok (cache_entry_set_dirty (e, true) < 0,
+        "cache_entry_set_dirty fails b/c entry non-valid");
+    ok (cache_entry_get_dirty (e) == false,
+        "cache entry does not set dirty, b/c no data");
+    o1 = json_object ();
+    json_object_set_new (o1, "foo", json_integer (42));
+    ok (cache_entry_set_json (e, o1) < 0,
+        "cache_entry_set_json fails on cache entry with type raw");
+    json_decref (o1);
+    ok (cache_entry_get_raw (e, NULL) == NULL,
+        "cache_entry_get_raw returns NULL, no data set");
+    ok (cache_entry_set_raw (e, data, strlen (data) + 1) == 0,
+        "cache_entry_set_raw success");
+    ok (cache_entry_get_valid (e) == true,
+        "cache entry now valid after cache_entry_set_raw call");
     cache_entry_destroy (e);   /* destroys data */
     e = NULL;
 

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -297,6 +297,13 @@ test_expect_success 'kvs: valref that points to content store data can be read' 
         flux kvs get $TEST.largeval2 | grep $largeval
 '
 
+test_expect_success 'kvs: valref that points to zero size content store data can be read' '
+	flux kvs unlink -Rf $TEST &&
+        hashval=`flux content store </dev/null` &&
+	${KVSBASIC} put-treeobj $TEST.empty="{\"data\":[\"${hashval}\"],\"type\":\"valref\",\"ver\":1}" &&
+	test $(${KVSBASIC} copy-fromkvs $TEST.empty -|wc -c) -eq 0
+'
+
 # dtree tests
 
 test_expect_success 'kvs: store 16x3 directory tree' '


### PR DESCRIPTION
This series of patches is to support valref treeobjects pointing to zero-length blobref data.

This seems like a lot of code for a pretty dumb corner case, but it came down to updating the KVS cache API to not assume non-NULL data pointer means valid and NULL data pointer is invalid.  A flag was placed into the KVS cache entry to handle this, but it beget a number of API style changes.

For starters, ```cache_entry_get_raw ()``` had to be modified so that a NULL data buffer returned wasn't automatically assumed to be error.  This is an obvious refactoring that was needed.  The rest are more subtle.

Under the old API:

```cache_entry_create_json (NULL)``` - creates an empty/invalid cache entry
```cache_entry_create_raw (NULL, 0)``` - creates a valid cache entry???

```cache_entry_set_json (hp, NULL)``` - clears json from the cache entry
```cache_entry_set_raw (hp, NULL, 0)``` - should do ...???

So for consistency, ```cache_entry_create_json()``` and ```cache_entry_set_json()``` now only take valid input (i.e. non-NULL json objects).  The raw equivalents can take NULL & 0, b/c that's just
a zero length blobref.

New functions ```cache_entry_create_json_empty()``` and ```cache_entry_create_raw_empty()``` were created to create "empty" entries.

In order to clear data from an entry, ```cache_entry_clear_data()``` was added.  The ```cache_entry_set_json()``` and ```cache_entry_set_raw()``` functions can no longer clear data from an entry by passing in NULL.

As a consequence, it's worth noting that ```cache_entry_set_raw()``` will also call ```wait_runqueue()``` when a zero-byte length buffer is set into the entry.  This was not done before.

Debate on implementation:

Tiny part of me dislikes the function name "empty".  Can discuss alternates.  I considered using a flag type variable to say "I have data", but that seemed even uglier and more confusing.

I also considered removing the "empty" functions and supporting a ```cache_entry_set_type()``` function, to say these cache entries only support json or raw (i.e. user would call ```cache_entry_create()```, then ```cache_entry_set_type()```).  But that's two function calls instead of one.  I nixed that idea.

Also, for one error case I choose errno EBADE.  Right one??
