### PR TITLE
Broker cleanup 3

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1114,7 +1114,7 @@ static int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k,
 
     overlay_init (overlay, (uint32_t)size, (uint32_t)rank, tbon_k);
 
-    /* Get id string.
+    /* Set session-id attribute from PMI appnum if not already set.
      */
     if (attr_get (attrs, "session-id", NULL, NULL) < 0) {
         if (attr_add_int (attrs, "session-id", appnum,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -116,7 +116,6 @@ typedef struct {
      */
     bool verbose;
     bool quiet;
-    pid_t pid;
     int event_recv_seq;
     int event_send_seq;
     bool event_active;          /* primary event source is active */
@@ -337,9 +336,7 @@ int main (int argc, char *argv[])
     if (!(ctx.runlevel = runlevel_create ()))
         oom ();
 
-    ctx.pid = getpid();
-
-    init_attrs (ctx.attrs, ctx.pid);
+    init_attrs (ctx.attrs, getpid());
 
     if (!(ctx.sm = subprocess_manager_create ()))
         oom ();

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -115,7 +115,6 @@ typedef struct {
     /* Misc
      */
     bool verbose;
-    bool quiet;
     int event_recv_seq;
     int event_send_seq;
     bool event_active;          /* primary event source is active */
@@ -242,7 +241,6 @@ void parse_command_line_arguments(int argc, char *argv[],
             ctx->verbose = true;
             break;
         case 'q':   /* --quiet */
-            ctx->quiet = true;
             break;
         case 'X':   /* --module-path PATH */
             if (attr_set (ctx->attrs, "conf.module_path", optarg, true) < 0)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -479,8 +479,6 @@ int main (int argc, char *argv[])
     if (create_dummyattrs (ctx.h, rank, size) < 0)
         log_err_exit ("creating dummy attributes");
 
-    overlay_set_rank (ctx.overlay, rank);
-
     /* Registers message handlers and obtains rank.
      */
     if (content_cache_set_flux (ctx.cache, ctx.h) < 0)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -98,7 +98,6 @@ typedef struct {
      */
     flux_t *h;
     flux_reactor_t *reactor;
-    zlist_t *sigwatchers;
 
     /* Sockets.
      */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1103,16 +1103,24 @@ done:
 static int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k,
                      double *elapsed_sec)
 {
-    int spawned, size, rank, appnum;
-    int relay_rank = -1, parent_rank;
+    int spawned;
+    int size;
+    int rank;
+    int appnum;
+    int relay_rank = -1;
+    int parent_rank;
     int clique_size;
     int *clique_ranks = NULL;
-    const char *child_uri, *relay_uri;
-    int kvsname_len, key_len, val_len;
+    const char *child_uri;
+    const char *relay_uri;
+    int kvsname_len;
+    int key_len;
+    int val_len;
     char *kvsname = NULL;
     char *key = NULL;
     char *val = NULL;
-    int e, rc = -1;
+    int e;
+    int rc = -1;
     struct timespec start_time;
     const char *attrtbonendpoint;
     char *tbonendpoint = NULL;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -185,7 +185,7 @@ static int create_persistdir (attr_t *attrs, uint32_t rank);
 static int create_rundir (attr_t *attrs);
 static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size);
 
-static char *calc_endpoint (attr_t *attrs, const char *endpoint);
+static char *format_endpoint (attr_t *attrs, const char *endpoint);
 
 static int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k,
                      double *elapsed_sec);
@@ -1036,7 +1036,7 @@ done:
  *
  * Caller is responsible for freeing memory of returned value.
  */
-static char * calc_endpoint (attr_t *attrs, const char *endpoint)
+static char * format_endpoint (attr_t *attrs, const char *endpoint)
 {
     char ipaddr[HOST_NAME_MAX + 1];
     char *ptr, *buf, *rv = NULL;
@@ -1174,8 +1174,8 @@ static int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k,
         goto done;
     }
 
-    if (!(tbonendpoint = calc_endpoint (attrs, attrtbonendpoint))) {
-        log_msg ("calc_endpoint error");
+    if (!(tbonendpoint = format_endpoint (attrs, attrtbonendpoint))) {
+        log_msg ("format_endpoint error");
         goto done;
     }
 
@@ -1191,8 +1191,8 @@ static int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k,
         goto done;
     }
 
-    if (!(mcastendpoint = calc_endpoint (attrs, attrmcastendpoint))) {
-        log_msg ("calc_endpoint error");
+    if (!(mcastendpoint = format_endpoint (attrs, attrmcastendpoint))) {
+        log_msg ("format_endpoint error");
         goto done;
     }
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -35,6 +35,7 @@
 #include "src/common/libutil/oom.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/iterators.h"
+#include "src/common/libutil/kary.h"
 
 #include "heartbeat.h"
 #include "overlay.h"
@@ -55,6 +56,10 @@ struct overlay_struct {
 
     uint32_t size;
     uint32_t rank;
+    int tbon_k;
+    int tbon_level;
+    int tbon_maxlevel;
+    int tbon_descendants;
 
     struct endpoint *parent;    /* DEALER - requests to parent */
     overlay_cb_f parent_cb;
@@ -116,14 +121,26 @@ void overlay_destroy (overlay_t *ov)
     }
 }
 
-overlay_t *overlay_create (void)
+overlay_t *overlay_create ()
 {
     overlay_t *ov = xzmalloc (sizeof (*ov));
     ov->rank = FLUX_NODEID_ANY;
     ov->parent_lastsent = -1;
+
     if (!(ov->children = zhash_new ()))
         oom ();
     return ov;
+}
+
+void overlay_init (overlay_t *overlay,
+                   uint32_t size, uint32_t rank, int tbon_k)
+{
+    overlay->size = size;
+    overlay->rank = rank;
+    overlay->tbon_k = tbon_k;
+    overlay->tbon_level = kary_levelof (tbon_k, rank);
+    overlay->tbon_maxlevel = kary_levelof (tbon_k, size - 1);
+    overlay->tbon_descendants = kary_sum_descendants (tbon_k, size, rank);
 }
 
 void overlay_set_sec (overlay_t *ov, flux_sec_t *sec)
@@ -131,19 +148,9 @@ void overlay_set_sec (overlay_t *ov, flux_sec_t *sec)
     ov->sec = sec;
 }
 
-void overlay_set_rank (overlay_t *ov, uint32_t rank)
-{
-    ov->rank = rank;
-}
-
 uint32_t overlay_get_rank (overlay_t *ov)
 {
     return ov->rank;
-}
-
-void overlay_set_size (overlay_t *ov, uint32_t size)
-{
-    ov->size = size;
 }
 
 uint32_t overlay_get_size (overlay_t *ov)
@@ -637,6 +644,25 @@ int overlay_register_attrs (overlay_t *overlay, attr_t *attrs)
                          FLUX_ATTRFLAG_IMMUTABLE,
                          overlay_attr_get_cb, NULL, overlay) < 0)
         return -1;
+    if (attr_add_uint32 (attrs, "rank", overlay->rank,
+                         FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    if (attr_add_uint32 (attrs, "size", overlay->size,
+                         FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    if (attr_add_int (attrs, "tbon.arity", overlay->tbon_k,
+                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    if (attr_add_int (attrs, "tbon.level", overlay->tbon_level,
+                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    if (attr_add_int (attrs, "tbon.maxlevel", overlay->tbon_maxlevel,
+                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+    if (attr_add_int (attrs, "tbon.descendants", overlay->tbon_descendants,
+                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        return -1;
+
     return 0;
 }
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -629,7 +629,8 @@ done:
 
 int overlay_register_attrs (overlay_t *overlay, attr_t *attrs)
 {
-    if (attr_add_active (attrs, "tbon.parent-endpoint", 0,
+    if (attr_add_active (attrs, "tbon.parent-endpoint",
+                         FLUX_ATTRFLAG_READONLY,
                          overlay_attr_get_cb, NULL, overlay) < 0)
         return -1;
     if (attr_add_active (attrs, "mcast.relay-endpoint",

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -1,6 +1,8 @@
 #ifndef _BROKER_OVERLAY_H
 #define _BROKER_OVERLAY_H
 
+#include "attr.h"
+
 typedef struct overlay_struct overlay_t;
 typedef void (*overlay_cb_f)(overlay_t *ov, void *sock, void *arg);
 
@@ -82,6 +84,16 @@ int overlay_connect (overlay_t *ov);
  * to true).  The new parent is moved to the top of the parent stack.
  */
 int overlay_reparent (overlay_t *ov, const char *uri, bool *recycled);
+
+/* Add attributes to 'attrs' that directly retrieve information from
+ * "overlay" through callbacks registered with 'attrs'.
+ * The currently added attributes keys are "tbon.parent-endpoint" and
+ * "mcast.relay-endpoint".
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int overlay_register_attrs (overlay_t *overlay, attr_t *attrs);
+
 
 #endif /* !_BROKER_OVERLAY_H */
 

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -9,12 +9,11 @@ typedef void (*overlay_cb_f)(overlay_t *ov, void *sock, void *arg);
 overlay_t *overlay_create (void);
 void overlay_destroy (overlay_t *ov);
 
-/* These need to be set before connect/bind.
+/* These need to be called before connect/bind.
  */
 void overlay_set_sec (overlay_t *ov, flux_sec_t *sec);
-void overlay_set_rank (overlay_t *ov, uint32_t rank);
-void overlay_set_size (overlay_t *ov, uint32_t size);
 void overlay_set_flux (overlay_t *ov, flux_t *h);
+void overlay_init (overlay_t *ov, uint32_t size, uint32_t rank, int tbon_k);
 void overlay_set_idle_warning (overlay_t *ov, int heartbeats);
 
 /* Accessors
@@ -85,10 +84,12 @@ int overlay_connect (overlay_t *ov);
  */
 int overlay_reparent (overlay_t *ov, const char *uri, bool *recycled);
 
-/* Add attributes to 'attrs' that directly retrieve information from
- * "overlay" through callbacks registered with 'attrs'.
- * The currently added attributes keys are "tbon.parent-endpoint" and
- * "mcast.relay-endpoint".
+/* Add attributes to 'attrs' to reveal information about the overlay
+ * network.  Two of the attributes directly retrieve information from
+ * "overlay" through callbacks registered with 'attrs': "tbon.parent-endpoint"
+ * and "mcast.relay-endpoint".  The rest are simple non-active attributes:
+ * "rank", "size", "tbon.arity", "tbon.level", "tbon.maxlevel", and
+ * "tbon.descendants".
  *
  * Returns 0 on success, -1 on error.
  */


### PR DESCRIPTION
More cleanup and refactoring of the broker in preparation for issue #1236.  The next step will likely be to break up boot_pmi() to split out the things that are really specific to PMI, and those that are not.