### PR TITLE
KVS modify commit protocol in preparation for append

### DIFF
--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -14,6 +14,12 @@
 extern "C" {
 #endif
 
+enum {
+    FLUX_KVS_READDIR = 1,
+    FLUX_KVS_READLINK = 2,
+    FLUX_KVS_TREEOBJ = 16,
+};
+
 /* Synchronization:
  * Process A commits data, then gets the store version V and sends it to B.
  * Process B waits for the store version to be >= V, then reads data.

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -37,8 +37,10 @@ flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
 {
     if (txn) {
         json_t *ops;
-        if (txn_get (txn, TXN_GET_ALL, &ops) < 0)
+        if (!(ops = txn_get_ops (txn))) {
+            errno = EINVAL;
             return NULL;
+        }
         return flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
                                  "{s:s s:i s:i s:O}",
                                  "name", name,

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -5,12 +5,6 @@
 extern "C" {
 #endif
 
-enum kvs_lookup_flags {
-    FLUX_KVS_READDIR = 1,
-    FLUX_KVS_READLINK = 2,
-    FLUX_KVS_TREEOBJ = 16,
-};
-
 flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key);
 flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
                                   const char *treeobj);

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -350,6 +350,7 @@ int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
         goto error;
     if (flux_kvs_txn_put_treeobj (txn, flags, key, dirent) < 0)
         goto error;
+    json_decref (dirent);
     return 0;
 error:
     saved_errno = errno;

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -58,7 +58,6 @@
  */
 struct flux_kvs_txn {
     json_t *ops;
-    int cursor;
 };
 
 void flux_kvs_txn_destroy (flux_kvs_txn_t *txn)
@@ -364,30 +363,27 @@ error:
     return -1;
 }
 
-/* accessors for KVS internals and unit tests
- */
-int txn_get (flux_kvs_txn_t *txn, int request, void *arg)
+/* kvs_txn_private.h */
+
+int txn_get_op_count (flux_kvs_txn_t *txn)
 {
-    switch (request) {
-        case TXN_GET_FIRST:
-            txn->cursor = 0;
-            if (arg)
-                *(json_t **)arg = json_array_get (txn->ops, txn->cursor);
-            txn->cursor++;
-            break;
-        case TXN_GET_NEXT:
-            if (arg)
-                *(json_t **)arg = json_array_get (txn->ops, txn->cursor);
-            txn->cursor++;
-            break;
-        case TXN_GET_ALL:
-            if (arg)
-                *(json_t **)arg = txn->ops;
-            break;
-        default:
-            errno = EINVAL;
-            return -1;
+    return json_array_size (txn->ops);
+}
+
+json_t *txn_get_ops (flux_kvs_txn_t *txn)
+{
+    return txn->ops;
+}
+
+int txn_get_op (flux_kvs_txn_t *txn, int index, json_t **op)
+{
+    json_t *entry = json_array_get (txn->ops, index);
+    if (!entry) {
+        errno = EINVAL;
+        return -1;
     }
+    if (op)
+        *op = entry;
     return 0;
 }
 

--- a/src/common/libkvs/kvs_txn_private.h
+++ b/src/common/libkvs/kvs_txn_private.h
@@ -1,12 +1,11 @@
 #ifndef _KVS_TXN_PRIVATE_H
 #define _KVS_TXN_PRIVATE_H
 
-enum {
-    TXN_GET_FIRST,
-    TXN_GET_NEXT,
-    TXN_GET_ALL
-};
-int txn_get (flux_kvs_txn_t *txn, int request, void *arg);
+int txn_get_op_count (flux_kvs_txn_t *txn);
+
+json_t *txn_get_ops (flux_kvs_txn_t *txn);
+
+int txn_get_op (flux_kvs_txn_t *txn, int index, json_t **op);
 
 #endif /* !_KVS_TXN_PRIVATE_H */
 

--- a/src/common/libkvs/kvs_txn_private.h
+++ b/src/common/libkvs/kvs_txn_private.h
@@ -7,6 +7,10 @@ json_t *txn_get_ops (flux_kvs_txn_t *txn);
 
 int txn_get_op (flux_kvs_txn_t *txn, int index, json_t **op);
 
+int txn_decode_op (json_t *op, const char **key, int *flags, json_t **dirent);
+
+int txn_encode_op (const char *key, int flags, json_t *dirent, json_t **op);
+
 #endif /* !_KVS_TXN_PRIVATE_H */
 
 /*

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -149,7 +149,9 @@ void basic (void)
 
     /* Verify transaction contents
      */
-    ok (txn_get (txn, TXN_GET_FIRST, &entry) == 0
+    ok (txn_get_op_count (txn) == 7,
+        "txn contains 7 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
         && entry != NULL,
         "1: retrieved");
     ok (json_unpack (entry, "{s:s s:o}", "key", &key,
@@ -159,7 +161,7 @@ void basic (void)
         && check_int_value (dirent, 42) == 0,
         "1: put foo.bar.baz = 42");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0,
+    ok (txn_get_op (txn, 1, &entry) == 0,
         "2: retrieved");
     jdiag (entry);
     ok (json_unpack (entry, "{s:s s:o}", "key", &key,
@@ -169,7 +171,7 @@ void basic (void)
         && check_string_value (dirent, "foo") == 0,
         "2: put foo.bar.baz = \"foo\"");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry != NULL,
+    ok (txn_get_op (txn, 2, &entry) == 0 && entry != NULL,
         "3: retrieved");
     jdiag (entry);
     rc = json_unpack (entry, "{s:s s:n}", "key", &key,
@@ -177,7 +179,7 @@ void basic (void)
     ok (rc == 0 && !strcmp (key, "a"),
         "3: unlink a");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry != NULL,
+    ok (txn_get_op (txn, 3, &entry) == 0 && entry != NULL,
         "4: retrieved");
     jdiag (entry);
     rc = json_unpack (entry, "{s:s s:o}", "key", &key,
@@ -186,7 +188,7 @@ void basic (void)
         && treeobj_is_dir (dirent) && treeobj_get_count (dirent) == 0,
         "4: mkdir b.b.b");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry != NULL,
+    ok (txn_get_op (txn, 4, &entry) == 0 && entry != NULL,
         "5: retrieved");
     jdiag (entry);
     rc = json_unpack (entry, "{s:s s:o}", "key", &key,
@@ -195,7 +197,7 @@ void basic (void)
         && !strcmp (json_string_value (treeobj_get_data (dirent)), "b.b.b"),
         "5: symlink c.c.c b.b.b");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry != NULL,
+    ok (txn_get_op (txn, 5, &entry) == 0 && entry != NULL,
         "6: retrieved");
     ok (json_unpack (entry, "{s:s s:o}", "key", &key,
                                          "dirent", &dirent) == 0,
@@ -204,7 +206,7 @@ void basic (void)
         && check_int_value (dirent, 43) == 0,
         "6: put foo.bar.baz = 43");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry != NULL,
+    ok (txn_get_op (txn, 6, &entry) == 0 && entry != NULL,
         "7: retrieved");
     jdiag (entry);
     rc = json_unpack (entry, "{s:s s:n}", "key", &key,
@@ -212,7 +214,8 @@ void basic (void)
     ok (rc == 0 && !strcmp (key, "e"),
         "7: unlink e");
 
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry == NULL,
+    errno = 0;
+    ok (txn_get_op (txn, 7, &entry) < 0 && errno == EINVAL,
         "8: NULL - end of transaction");
 
     flux_kvs_txn_destroy (txn);
@@ -254,7 +257,9 @@ void test_raw_values (void)
         "flux_kvs_txn_put_raw works with data");
     /* Get first.
      */
-    ok (txn_get (txn, TXN_GET_FIRST, &entry) == 0 && entry != NULL,
+    ok (txn_get_op_count (txn) == 2,
+        "txn contains two ops");
+    ok (txn_get_op (txn, 0, &entry) == 0 && entry != NULL,
         "retreived 1st op from txn");
     jdiag (entry);
     ok (json_unpack (entry, "{s:s s:o}", "key", &key,
@@ -271,7 +276,7 @@ void test_raw_values (void)
 
     /* Get 2nd
      */
-    ok (txn_get (txn, TXN_GET_NEXT, &entry) == 0 && entry != NULL,
+    ok (txn_get_op (txn, 1, &entry) == 0 && entry != NULL,
         "retreived 2nd op from txn");
     jdiag (entry);
     ok (json_unpack (entry, "{s:s s:o}", "key", &key,

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -103,6 +103,7 @@ void basic (void)
     int rc;
     const char *key;
     json_t *entry, *dirent;
+    int flags;
 
     /* Create a transaction
      */
@@ -154,69 +155,77 @@ void basic (void)
     ok (txn_get_op (txn, 0, &entry) == 0
         && entry != NULL,
         "1: retrieved");
-    ok (json_unpack (entry, "{s:s s:o}", "key", &key,
-                                         "dirent", &dirent) == 0,
-        "1: unpacked operation");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
     ok (!strcmp (key, "foo.bar.baz")
+        && flags == 0
         && check_int_value (dirent, 42) == 0,
         "1: put foo.bar.baz = 42");
 
     ok (txn_get_op (txn, 1, &entry) == 0,
         "2: retrieved");
     jdiag (entry);
-    ok (json_unpack (entry, "{s:s s:o}", "key", &key,
-                                         "dirent", &dirent) == 0,
-        "2: unpacked operation");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "2: txn_decode_op works");
     ok (!strcmp (key, "foo.bar.bleep")
+        && flags == 0
         && check_string_value (dirent, "foo") == 0,
         "2: put foo.bar.baz = \"foo\"");
 
     ok (txn_get_op (txn, 2, &entry) == 0 && entry != NULL,
         "3: retrieved");
     jdiag (entry);
-    rc = json_unpack (entry, "{s:s s:n}", "key", &key,
-                                          "dirent");
-    ok (rc == 0 && !strcmp (key, "a"),
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "3: txn_decode_op works");
+    ok (!strcmp (key, "a")
+        && flags == 0
+        && json_is_null (dirent),
         "3: unlink a");
 
     ok (txn_get_op (txn, 3, &entry) == 0 && entry != NULL,
         "4: retrieved");
     jdiag (entry);
-    rc = json_unpack (entry, "{s:s s:o}", "key", &key,
-                                          "dirent", &dirent);
-    ok (rc == 0 && !strcmp (key, "b.b.b")
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "4: txn_decode_op works");
+    ok (!strcmp (key, "b.b.b")
+        && flags == 0
         && treeobj_is_dir (dirent) && treeobj_get_count (dirent) == 0,
         "4: mkdir b.b.b");
 
     ok (txn_get_op (txn, 4, &entry) == 0 && entry != NULL,
         "5: retrieved");
     jdiag (entry);
-    rc = json_unpack (entry, "{s:s s:o}", "key", &key,
-                                          "dirent", &dirent);
-    ok (rc == 0 && !strcmp (key, "c.c.c") && treeobj_is_symlink (dirent)
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "5: txn_decode_op works");
+    ok (!strcmp (key, "c.c.c")
+        && flags == 0
+        && treeobj_is_symlink (dirent)
         && !strcmp (json_string_value (treeobj_get_data (dirent)), "b.b.b"),
         "5: symlink c.c.c b.b.b");
 
     ok (txn_get_op (txn, 5, &entry) == 0 && entry != NULL,
         "6: retrieved");
-    ok (json_unpack (entry, "{s:s s:o}", "key", &key,
-                                         "dirent", &dirent) == 0,
-        "6: unpacked operation");
+    jdiag (entry);
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "6: txn_decode_op works");
     ok (!strcmp (key, "d.d.d")
+        && flags == 0
         && check_int_value (dirent, 43) == 0,
         "6: put foo.bar.baz = 43");
 
     ok (txn_get_op (txn, 6, &entry) == 0 && entry != NULL,
         "7: retrieved");
     jdiag (entry);
-    rc = json_unpack (entry, "{s:s s:n}", "key", &key,
-                                          "dirent");
-    ok (rc == 0 && !strcmp (key, "e"),
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "6: txn_decode_op works");
+    ok (!strcmp (key, "e")
+        && flags == 0
+        && json_is_null (dirent),
         "7: unlink e");
 
     errno = 0;
     ok (txn_get_op (txn, 7, &entry) < 0 && errno == EINVAL,
-        "8: NULL - end of transaction");
+        "8: invalid (end of transaction)");
 
     flux_kvs_txn_destroy (txn);
 }
@@ -227,7 +236,7 @@ void test_raw_values (void)
     char buf[13], *nbuf;
     json_t *entry, *dirent;
     const char *key;
-    int nlen;
+    int flags, nlen;
 
     memset (buf, 'c', sizeof (buf));
 
@@ -262,9 +271,8 @@ void test_raw_values (void)
     ok (txn_get_op (txn, 0, &entry) == 0 && entry != NULL,
         "retreived 1st op from txn");
     jdiag (entry);
-    ok (json_unpack (entry, "{s:s s:o}", "key", &key,
-                                         "dirent", &dirent) == 0,
-        "decoded op to get dirent");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "txn_decode_op works");
     nbuf = buf;
     nlen = sizeof (buf);
     ok (treeobj_decode_val (dirent, (void **)&nbuf, &nlen) == 0,
@@ -279,9 +287,8 @@ void test_raw_values (void)
     ok (txn_get_op (txn, 1, &entry) == 0 && entry != NULL,
         "retreived 2nd op from txn");
     jdiag (entry);
-    ok (json_unpack (entry, "{s:s s:o}", "key", &key,
-                                         "dirent", &dirent) == 0,
-        "decoded op to get dirent");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "txn_decode_op works");
     ok (treeobj_decode_val (dirent, (void **)&nbuf, &nlen) == 0,
         "retrieved buffer from dirent");
     ok (nlen == sizeof (buf),

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -907,3 +907,7 @@ int commit_mgr_merge_ready_commits (commit_mgr_t *cm)
     }
     return 0;
 }
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -583,8 +583,9 @@ commit_process_t commit_process (commit_t *c,
 
                 for (i = 0; i < len; i++) {
                     missing_ref = NULL;
-                    if (!(op = json_array_get (ops, i))
-                        || txn_decode_op (op, &key, &flags, &dirent) < 0)
+                    op = json_array_get (ops, i);
+                    assert (op != NULL);
+                    if (txn_decode_op (op, &key, &flags, &dirent) < 0)
                         continue;
                     if (commit_link_dirent (c,
                                             current_epoch,

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -585,8 +585,10 @@ commit_process_t commit_process (commit_t *c,
                     missing_ref = NULL;
                     op = json_array_get (ops, i);
                     assert (op != NULL);
-                    if (txn_decode_op (op, &key, &flags, &dirent) < 0)
-                        continue;
+                    if (txn_decode_op (op, &key, &flags, &dirent) < 0) {
+                        c->errnum = errno;
+                        break;
+                    }
                     if (commit_link_dirent (c,
                                             current_epoch,
                                             c->rootcpy,

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -38,6 +38,7 @@
 
 #include "src/common/libutil/base64.h"
 #include "src/common/libkvs/treeobj.h"
+#include "src/common/libkvs/kvs_txn_private.h"
 
 #include "commit.h"
 #include "kvs_util.h"
@@ -569,10 +570,12 @@ commit_process_t commit_process (commit_t *c,
              * is unrolled later on.
              */
             if (fence_get_json_ops (c->f)) {
-                json_t *op, *key, *dirent;
+                json_t *op, *dirent;
                 const char *missing_ref = NULL;
                 json_t *ops = fence_get_json_ops (c->f);
                 int i, len = json_array_size (ops);
+                const char *key;
+                int flags;
 
                 /* Caller didn't call commit_iter_missing_refs() */
                 if (zlist_first (c->item_callback_list))
@@ -581,13 +584,12 @@ commit_process_t commit_process (commit_t *c,
                 for (i = 0; i < len; i++) {
                     missing_ref = NULL;
                     if (!(op = json_array_get (ops, i))
-                        || !(key = json_object_get (op, "key"))
-                        || !(dirent = json_object_get (op, "dirent")))
+                        || txn_decode_op (op, &key, &flags, &dirent) < 0)
                         continue;
                     if (commit_link_dirent (c,
                                             current_epoch,
                                             c->rootcpy,
-                                            json_string_value (key),
+                                            key,
                                             dirent,
                                             &missing_ref) < 0) {
                         c->errnum = errno;

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -150,3 +150,7 @@ void commit_mgr_clear_noop_stores (commit_mgr_t *cm);
 int commit_mgr_merge_ready_commits (commit_mgr_t *cm);
 
 #endif /* !_FLUX_KVS_COMMIT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -217,3 +217,7 @@ error:
     errno = saved_errno;
     return -1;
 }
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -46,3 +46,8 @@ int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data);
 int fence_merge (fence_t *dest, fence_t *src);
 
 #endif /* !_FLUX_KVS_FENCE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -977,3 +977,7 @@ done:
 stall:
     return false;
 }
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -737,7 +737,8 @@ int missingref_cb (commit_t *c, const char *ref, void *data)
     return 0;
 }
 
-void commit_process_missing_ref (void) {
+void commit_process_missing_ref (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -837,7 +838,8 @@ int cache_error_cb (commit_t *c, struct cache_entry *hp, void *data)
     return -1;
 }
 
-void commit_process_error_callbacks (void) {
+void commit_process_error_callbacks (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -924,7 +926,8 @@ int cache_error_partway_cb (commit_t *c, struct cache_entry *hp, void *data)
     return 0;
 }
 
-void commit_process_error_callbacks_partway (void) {
+void commit_process_error_callbacks_partway (void)
+{
     struct cache *cache;
     struct error_partway_data epd = { .total_calls = 0, .success_returns = 0};
     commit_mgr_t *cm;
@@ -993,7 +996,8 @@ void commit_process_error_callbacks_partway (void) {
     cache_destroy (cache);
 }
 
-void commit_process_invalid_operation (void) {
+void commit_process_invalid_operation (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1033,7 +1037,8 @@ void commit_process_invalid_operation (void) {
     cache_destroy (cache);
 }
 
-void commit_process_invalid_hash (void) {
+void commit_process_invalid_hash (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1073,7 +1078,8 @@ void commit_process_invalid_hash (void) {
     cache_destroy (cache);
 }
 
-void commit_process_follow_link (void) {
+void commit_process_follow_link (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1141,7 +1147,8 @@ void commit_process_follow_link (void) {
     cache_destroy (cache);
 }
 
-void commit_process_dirval_test (void) {
+void commit_process_dirval_test (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1197,7 +1204,8 @@ void commit_process_dirval_test (void) {
     cache_destroy (cache);
 }
 
-void commit_process_delete_test (void) {
+void commit_process_delete_test (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1263,7 +1271,8 @@ void commit_process_delete_test (void) {
     cache_destroy (cache);
 }
 
-void commit_process_delete_nosubdir_test (void) {
+void commit_process_delete_nosubdir_test (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1304,7 +1313,8 @@ void commit_process_delete_nosubdir_test (void) {
     cache_destroy (cache);
 }
 
-void commit_process_delete_filevalinpath_test (void) {
+void commit_process_delete_filevalinpath_test (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1365,7 +1375,8 @@ void commit_process_delete_filevalinpath_test (void) {
     cache_destroy (cache);
 }
 
-void commit_process_bad_dirrefs (void) {
+void commit_process_bad_dirrefs (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1439,7 +1450,8 @@ int cache_count_raw_cb (commit_t *c, struct cache_entry *hp, void *data)
     return 0;
 }
 
-void commit_process_big_fileval (void) {
+void commit_process_big_fileval (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
@@ -1537,7 +1549,8 @@ void commit_process_big_fileval (void) {
 /* Test giant directory entry, as large json objects will iterate through
  * their entries randomly based on the internal hash data structure.
  */
-void commit_process_giant_dir (void) {
+void commit_process_giant_dir (void)
+{
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -7,6 +7,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libkvs/kvs.h"
 #include "src/common/libkvs/treeobj.h"
+#include "src/common/libkvs/kvs_txn_private.h"
 #include "src/modules/kvs/cache.h"
 #include "src/modules/kvs/commit.h"
 #include "src/modules/kvs/lookup.h"
@@ -25,21 +26,16 @@ static int test_global = 5;
 void ops_append (json_t *array, const char *key, const char *value)
 {
     json_t *op;
-    json_t *o;
+    json_t *dirent;
+    int flags = 0; // not used for now
 
-    op = json_object ();
-    o = json_string (key);
-    json_object_set_new (op, "key", o);
+    if (value)
+        dirent = treeobj_create_val ((void *)value, strlen (value));
+    else
+        dirent = json_null ();
 
-    if (value) {
-        json_t *dirent = treeobj_create_val ((void *)value, strlen (value));
-        json_object_set_new (op, "dirent", dirent);
-    }
-    else {
-        json_t *null;
-        null = json_null ();
-        json_object_set_new (op, "dirent", null);
-    }
+    txn_encode_op (key, flags, dirent, &op);
+    json_decref (dirent);
     json_array_append (array, op);
 }
 

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -36,7 +36,7 @@ void ops_append (json_t *array, const char *key, const char *value)
 
     txn_encode_op (key, flags, dirent, &op);
     json_decref (dirent);
-    json_array_append (array, op);
+    json_array_append_new (array, op);
 }
 
 struct cache *create_cache_with_empty_rootdir (href_t ref)

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -49,7 +49,7 @@ declare -A extra_cmake_opts=(\
 #  Python pip packages
 #
 pips="\
-cffi==1.1 \
+cffi==1.5 \
 coverage \
 pylint==1.5.6
 "


### PR DESCRIPTION
This PR changes the request message format for KVS commit/fence to incorporate a `flags` parameter in each of the operation objects in the "ops" array.  This prepares for a KVS append operation, as discussed in #1193.

Since operations were encoded/decoded in several places, I added new (internal to KVS client and server) functions `txn_encode_op()` and `txn_decode_op()`, and used them in the client transaction code, and server commit code.  The decoding function uses the JSON_STRICT `!` flag to tighten things up a bit.

While adding this to the commit code, I fixed an error handling oversight that would allow a commit request to silently ignore a malformed operation and return success to the caller.

Finally, the KVS flags definitions were moved to kvs.h from kvs_lookup.h.  They are not lookup specific.  I didn't add an append flag yet though - we can do that when we have support on the server end for it.