### PR TITLE
kvs: refactor kvs cache to handle raw data as "primary" data

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -70,6 +70,7 @@ test_cache_t_CPPFLAGS = $(test_cppflags)
 test_cache_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)
 
 test_lookup_t_SOURCES = test/lookup.c

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -181,6 +181,7 @@ int cache_entry_set_raw (struct cache_entry *hp, void *data, int len)
         }
         return 0;
     }
+    errno = EINVAL;
     return -1;
 }
 
@@ -234,6 +235,7 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
         }
         return 0;
     }
+    errno = EINVAL;
     return -1;
 }
 

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -202,8 +202,7 @@ int cache_entry_set_raw (struct cache_entry *hp, void *data, int len)
             if ((data && hp->data) || (!data && !hp->data))
                 free (data); /* no-op, 'data' is assumed identical to hp->data */
             else {
-                /* attempt to change already valid cache entry,
-                 * cannot, must call cache_entry_clear_data() */
+                /* attempt to change already valid cache entry */
                 errno = EBADE;
                 return -1;
             }
@@ -244,8 +243,7 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
     if (hp && o) {
         if (hp->entry_valid) {
             if (!hp->data) {
-                /* attempt to change already valid cache entry,
-                 * cannot, must call cache_entry_clear_data() */
+                /* attempt to change already valid cache entry */
                 errno = EBADE;
                 return -1;
             }
@@ -277,24 +275,6 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
                 }
             }
         }
-        return 0;
-    }
-    return -1;
-}
-
-int cache_entry_clear_data (struct cache_entry *hp)
-{
-    if (hp) {
-        if (hp->data) {
-            free (hp->data);
-            hp->data = NULL;
-            hp->len = 0;
-        }
-        if (hp->o) {
-            json_decref (hp->o);
-            hp->o = NULL;
-        }
-        hp->entry_valid = false;
         return 0;
     }
     return -1;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -77,49 +77,6 @@ struct cache_entry *cache_entry_create (void)
     return hp;
 }
 
-struct cache_entry *cache_entry_create_raw (void *data, int len)
-{
-    struct cache_entry *hp;
-
-    if ((data && len <= 0) || (!data && len)) {
-        errno = EINVAL;
-        return NULL;
-    }
-
-    if (!(hp = cache_entry_create ()))
-        return NULL;
-
-    if (data) {
-        hp->data = data;
-        hp->len = len;
-    }
-    /* true even if data == NULL */
-    hp->entry_valid = true;
-    return hp;
-}
-
-struct cache_entry *cache_entry_create_json (json_t *o)
-{
-    struct cache_entry *hp;
-
-    if (!o) {
-        errno = EINVAL;
-        return NULL;
-    }
-
-    if (!(hp = cache_entry_create ()))
-        return NULL;
-
-    if (!(hp->data = kvs_util_json_dumps (o))) {
-        cache_entry_destroy (hp);
-        return NULL;
-    }
-    hp->len = strlen (hp->data) + 1;
-    hp->o = o;
-    hp->entry_valid = true;
-    return hp;
-}
-
 bool cache_entry_get_valid (struct cache_entry *hp)
 {
     return (hp && hp->entry_valid);

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -12,26 +12,10 @@ struct cache;
 
 /* Create/destroy cache entry.
  *
- * cache_entry_create() creates an empty cache entry.
- *
- * cache_entry_create_raw() creates an entry storing the data passed
- * in.  The create transfers ownership of 'data' to the cache entry.
- * On destroy, free() will be called on 'data'.  If 'data' is NULL,
- * 'len' must be zero.  If 'data' is non-NULL, 'len' must be > 0.
- *
- * cache_entry_create_json() is a convenience function that will take
- * a json object and extract the raw data string from it and store
- * that in the cache entry.  The json object 'o' is also cached
- * internally for later retrieval.  The create transfers ownership of
- * 'o' to the cache entry.  On destroy, json_decref() will be called
- * on 'o'.  'o' cannot be NULL.
- *
- * cache_entry_get_valid() will return true on entries when
- * cache_entry_get_raw() or cache_entry_create_json() return success.
+ * cache_entry_create() creates an empty cache entry.  Data can be set
+ * in an entry via cache_entry_set_raw() or cache_entry_set_json().
  */
 struct cache_entry *cache_entry_create (void);
-struct cache_entry *cache_entry_create_raw (void *data, int len);
-struct cache_entry *cache_entry_create_json (json_t *o);
 void cache_entry_destroy (void *arg);
 
 /* Return true if cache entry contains valid data.  False would

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -19,8 +19,10 @@ struct cache;
  * On destroy, free() will be called on 'data'.  If 'data' is NULL,
  * 'len' must be zero.  If 'data' is non-NULL, 'len' must be > 0.
  *
- * cache_entry_create_json() creates an entry storing the data
- * associated with a json object.  The create transfers ownership of
+ * cache_entry_create_json() is a convenience function that will take
+ * a json object and extract the raw data string from it and store
+ * that in the cache entry.  The json object 'o' is also cached
+ * internally for later retrieval.  The create transfers ownership of
  * 'o' to the cache entry.  On destroy, json_decref() will be called
  * on 'o'.  'o' cannot be NULL.
  *
@@ -32,8 +34,8 @@ struct cache_entry *cache_entry_create_raw (void *data, int len);
 struct cache_entry *cache_entry_create_json (json_t *o);
 void cache_entry_destroy (void *arg);
 
-/* Return true if cache entry contains valid raw or json data.
- * False would indicate that a load RPC is in progress.
+/* Return true if cache entry contains valid data.  False would
+ * indicate that a load RPC is in progress.
  */
 bool cache_entry_get_valid (struct cache_entry *hp);
 
@@ -67,10 +69,18 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * if it is non-NULL.  If 'data' is non-NULL, 'len' must be > 0.  If
  * 'data' is NULL, 'len' must be zero.
  *
- * json set accessor transfers ownership of 'o' to the cache entry.
- * 'o' must be non-NULL.
+ * json set accessor is a convenience function that will take a json
+ * object and extract the raw data string from it and store that in
+ * the cache entry.  The json object 'o' is also cached internally for
+ * later retrieval.  The create transfers ownership of 'o' to the
+ * cache entry. 'o' must be non-NULL.
  *
- * cache_entry_clear_data () will clear any data in the entry.
+ * json get accessor is a convenience function that will return the
+ * json object equivalent of the raw data stored internally.  If the
+ * internal raw data is not a valid json object (i.e. improperly
+ * formatted or zero length), an error will be result.
+ *
+ * cache_entry_clear_data () will clear all data in the entry.
  *
  * An invalid->valid transition runs the entry's wait queue, if any in
  * both set accessors.

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -80,14 +80,15 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * internal raw data is not a valid json object (i.e. improperly
  * formatted or zero length), an error will be result.
  *
- * cache_entry_clear_data () will clear all data in the entry.
- *
  * An invalid->valid transition runs the entry's wait queue, if any in
  * both set accessors.
  *
- * Generally speaking, a cache entry can only be set once.  If you
- * wish to set it again, you must run cache_entry_clear_data() before
- * doing so.
+ * Generally speaking, a cache entry can only be set once.  An attempt
+ * to set new data in a cache entry will silently succeed.  A buffer
+ * passed to cache_entry_set_raw() will be freed for a cache entry
+ * that already has data stored.  A json object passed to
+ * cache_entry_set_json() will be json_decref()'d for a cache entry
+ * that alrdady has data stored.
  *
  * cache_entry_set_raw() & cache_entry_set_json() &
  * cache_entry_clear_data() returns -1 on error, 0 on success
@@ -97,8 +98,6 @@ int cache_entry_set_raw (struct cache_entry *hp, void *data, int len);
 
 json_t *cache_entry_get_json (struct cache_entry *hp);
 int cache_entry_set_json (struct cache_entry *hp, json_t *o);
-
-int cache_entry_clear_data (struct cache_entry *hp);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -14,25 +14,25 @@ struct cache;
  *
  * cache_entry_create() creates an empty cache entry.
  *
- * cache_entry_create_json() creates an entry storing the data
- * associated with a json object.  The create transfers ownership of
- * 'o' to the cache entry.  On destroy, json_decref() will be called
- * on 'o'.  'o' cannot be NULL.
- *
  * cache_entry_create_raw() creates an entry storing the data passed
  * in.  The create transfers ownership of 'data' to the cache entry.
  * On destroy, free() will be called on 'data'.  If 'data' is NULL,
  * 'len' must be zero.  If 'data' is non-NULL, 'len' must be > 0.
  *
+ * cache_entry_create_json() creates an entry storing the data
+ * associated with a json object.  The create transfers ownership of
+ * 'o' to the cache entry.  On destroy, json_decref() will be called
+ * on 'o'.  'o' cannot be NULL.
+ *
  * cache_entry_get_valid() will return true on entries when
- * cache_entry_create_json() and cache_entry_get_raw() return success.
+ * cache_entry_get_raw() or cache_entry_create_json() return success.
  */
 struct cache_entry *cache_entry_create (void);
-struct cache_entry *cache_entry_create_json (json_t *o);
 struct cache_entry *cache_entry_create_raw (void *data, int len);
+struct cache_entry *cache_entry_create_json (json_t *o);
 void cache_entry_destroy (void *arg);
 
-/* Return true if cache entry contains valid json or raw data.
+/* Return true if cache entry contains valid raw or json data.
  * False would indicate that a load RPC is in progress.
  */
 bool cache_entry_get_valid (struct cache_entry *hp);
@@ -63,12 +63,12 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
 
 /* Accessors for cache entry data.
  *
- * json set accessor transfers ownership of 'o' to the cache entry.
- * 'o' must be non-NULL.
- *
  * raw set accessor transfers ownership of 'data' to the cache entry
  * if it is non-NULL.  If 'data' is non-NULL, 'len' must be > 0.  If
  * 'data' is NULL, 'len' must be zero.
+ *
+ * json set accessor transfers ownership of 'o' to the cache entry.
+ * 'o' must be non-NULL.
  *
  * cache_entry_clear_data () will clear any data in the entry.
  *
@@ -79,14 +79,14 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * wish to set it again, you must run cache_entry_clear_data() before
  * doing so.
  *
- * cache_entry_set_json() & cache_entry_set_raw() &
+ * cache_entry_set_raw() & cache_entry_set_json() &
  * cache_entry_clear_data() returns -1 on error, 0 on success
  */
-json_t *cache_entry_get_json (struct cache_entry *hp);
-int cache_entry_set_json (struct cache_entry *hp, json_t *o);
-
 int cache_entry_get_raw (struct cache_entry *hp, void **data, int *len);
 int cache_entry_set_raw (struct cache_entry *hp, void *data, int len);
+
+json_t *cache_entry_get_json (struct cache_entry *hp);
+int cache_entry_set_json (struct cache_entry *hp, json_t *o);
 
 int cache_entry_clear_data (struct cache_entry *hp);
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -179,6 +179,7 @@ static void content_load_completion (flux_future_t *f, void *arg)
     int size;
     const char *blobref;
     struct cache_entry *hp;
+    char *datacpy = NULL;
 
     if (flux_content_load_get (f, &data, &size) < 0) {
         flux_log_error (ctx->h, "%s: flux_content_load_get", __FUNCTION__);
@@ -195,41 +196,26 @@ static void content_load_completion (flux_future_t *f, void *arg)
         goto done;
     }
 
-    /* If cache_entry_set_json() or cache_entry_set_raw() fail, it's a
-     * pretty terrible error case, where we've loaded an object from
-     * the content store, but can't put it in the cache.
+    /* If cache_entry_set_raw() fails, it's a pretty terrible error
+     * case, where we've loaded an object from the content store, but
+     * can't put it in the cache.
      *
      * If there was a waiter on this cache entry waiting for it to be
      * valid, the load() will ultimately hang.  The caller will
      * timeout or eventually give up, so the KVS can continue along
      * its merry way.  So we just log the error.
      */
-    if (cache_entry_is_type_raw (hp)) {
-        char *datacpy = NULL;
-
-        if (size) {
-            if (!(datacpy = malloc (size))) {
-                flux_log_error (ctx->h, "%s: malloc", __FUNCTION__);
-                goto done;
-            }
-            memcpy (datacpy, data, size);
-        }
-
-        if (cache_entry_set_raw (hp, datacpy, size) < 0) {
-            flux_log_error (ctx->h, "%s: cache_entry_set_raw", __FUNCTION__);
+    if (size) {
+        if (!(datacpy = malloc (size))) {
+            flux_log_error (ctx->h, "%s: malloc", __FUNCTION__);
             goto done;
         }
+        memcpy (datacpy, data, size);
     }
-    else {
-        json_t *o;
-        if (!(o = json_loads ((char *)data, JSON_DECODE_ANY, NULL))) {
-            flux_log_error (ctx->h, "%s: json_loads", __FUNCTION__);
-            goto done;
-        }
-        if (cache_entry_set_json (hp, o) < 0) {
-            flux_log_error (ctx->h, "%s: cache_entry_set_json", __FUNCTION__);
-            goto done;
-        }
+
+    if (cache_entry_set_raw (hp, datacpy, size) < 0) {
+        flux_log_error (ctx->h, "%s: cache_entry_set_raw", __FUNCTION__);
+        goto done;
     }
 
 done:
@@ -264,12 +250,9 @@ error:
     return -1;
 }
 
-/* Return 0 on success, -1 on error.  is_raw indicates if data being
- * loaded is raw data, so we know how to place it in the cache.  Set
- * stall variable appropriately
+/* Return 0 on success, -1 on error.  Set stall variable appropriately
  */
-static int load (kvs_ctx_t *ctx, const href_t ref, bool is_raw, wait_t *wait,
-                 bool *stall)
+static int load (kvs_ctx_t *ctx, const href_t ref, wait_t *wait, bool *stall)
 {
     struct cache_entry *hp = cache_lookup (ctx->cache, ref, ctx->epoch);
     int saved_errno, ret;
@@ -279,19 +262,10 @@ static int load (kvs_ctx_t *ctx, const href_t ref, bool is_raw, wait_t *wait,
     /* Create an incomplete hash entry if none found.
      */
     if (!hp) {
-        if (is_raw) {
-            if (!(hp = cache_entry_create (CACHE_DATA_TYPE_RAW))) {
-                flux_log_error (ctx->h, "%s: cache_entry_create",
-                                __FUNCTION__);
-                return -1;
-            }
-        }
-        else {
-            if (!(hp = cache_entry_create (CACHE_DATA_TYPE_JSON))) {
-                flux_log_error (ctx->h, "%s: cache_entry_create",
-                                __FUNCTION__);
-                return -1;
-            }
+        if (!(hp = cache_entry_create ())) {
+            flux_log_error (ctx->h, "%s: cache_entry_create",
+                            __FUNCTION__);
+            return -1;
         }
         cache_insert (ctx->cache, ref, hp);
         if (content_load_request_send (ctx, ref) < 0) {
@@ -390,30 +364,13 @@ static void content_store_completion (flux_future_t *f, void *arg)
     (void)content_store_get (f, arg);
 }
 
-/* is_raw indicates if void *data is json or raw data.  'len' is
- * ignored if it is json.
- */
 static int content_store_request_send (kvs_ctx_t *ctx, void *data, int len,
-                                       bool is_raw, bool now)
+                                       bool now)
 {
     flux_future_t *f;
-    char *dataout = NULL;
-    char *dataout_cpy = NULL;
-    int size;
     int saved_errno, rc = -1;
 
-    if (is_raw) {
-        dataout = data;
-        size = len;
-    }
-    else {
-        if (!(dataout_cpy = kvs_util_json_dumps ((json_t *)data)))
-            goto error;
-        dataout = dataout_cpy;
-        size = strlen (dataout) + 1;
-    }
-
-    if (!(f = flux_content_store (ctx->h, dataout, size, 0)))
+    if (!(f = flux_content_store (ctx->h, data, len, 0)))
         goto error;
     if (now) {
         if (content_store_get (f, ctx) < 0)
@@ -427,7 +384,6 @@ static int content_store_request_send (kvs_ctx_t *ctx, void *data, int len,
 
     rc = 0;
 error:
-    free (dataout_cpy);
     return rc;
 }
 
@@ -451,10 +407,7 @@ static int commit_load_cb (commit_t *c, const char *ref, void *data)
     struct kvs_cb_data *cbd = data;
     bool stall;
 
-    /* is_raw flag is always false on commit loads, we will never
-     * load raw data from the content store, only tree objects.
-     */
-    if (load (cbd->ctx, ref, false, cbd->wait, &stall) < 0) {
+    if (load (cbd->ctx, ref, cbd->wait, &stall) < 0) {
         cbd->errnum = errno;
         flux_log_error (cbd->ctx->h, "%s: load", __FUNCTION__);
         return -1;
@@ -473,20 +426,18 @@ static int commit_cache_cb (commit_t *c, struct cache_entry *hp, void *data)
     struct kvs_cb_data *cbd = data;
     void *storedata;
     int storedatalen = 0;
-    bool is_raw;
 
     assert (cache_entry_get_dirty (hp));
 
-    is_raw = cache_entry_is_type_raw (hp);
-    if (is_raw)
-        cache_entry_get_raw (hp, &storedata, &storedatalen);
-    else
-        storedata = cache_entry_get_json (hp);
-
+    if (cache_entry_get_raw (hp, &storedata, &storedatalen) < 0) {
+        flux_log_error (cbd->ctx->h, "%s: cache_entry_get_raw",
+                        __FUNCTION__);
+        commit_cleanup_dirty_cache_entry (c, hp);
+        return -1;
+    }
     if (content_store_request_send (cbd->ctx,
                                     storedata,
                                     storedatalen,
-                                    is_raw,
                                     false) < 0) {
         cbd->errnum = errno;
         flux_log_error (cbd->ctx->h, "%s: content_store_request_send",
@@ -710,13 +661,12 @@ static void heartbeat_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (ctx->h, "%s: cache_expire_entries", __FUNCTION__);
 }
 
-static int lookup_load_cb (lookup_t *lh, const char *ref,
-                           bool raw_data, void *data)
+static int lookup_load_cb (lookup_t *lh, const char *ref, void *data)
 {
     struct kvs_cb_data *cbd = data;
     bool stall;
 
-    if (load (cbd->ctx, ref, raw_data, cbd->wait, &stall) < 0) {
+    if (load (cbd->ctx, ref, cbd->wait, &stall) < 0) {
         cbd->errnum = errno;
         flux_log_error (cbd->ctx->h, "%s: load", __FUNCTION__);
         return -1;
@@ -1674,7 +1624,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         goto decref_done;
     }
     if (!(hp = cache_lookup (ctx->cache, ref, ctx->epoch))) {
-        if (!(hp = cache_entry_create (CACHE_DATA_TYPE_JSON))) {
+        if (!(hp = cache_entry_create ())) {
             saved_errno = errno;
             flux_log_error (ctx->h, "%s: cache_entry_create",
                             __FUNCTION__);
@@ -1683,6 +1633,8 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         cache_insert (ctx->cache, ref, hp);
     }
     if (!cache_entry_get_valid (hp)) {
+        void *data;
+        int len;
         assert (o);
         if (cache_entry_set_json (hp, o) < 0) {
             saved_errno = errno;
@@ -1700,7 +1652,15 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
             assert (ret == 1);
             goto done_error;
         }
-        if (content_store_request_send (ctx, o, 0, false, true) < 0) {
+        if (cache_entry_get_raw (hp, &data, &len) < 0) {
+            /* remove entry will decref object */
+            saved_errno = errno;
+            flux_log_error (ctx->h, "%s: cache_entry_get_raw", __FUNCTION__);
+            ret = cache_remove_entry (ctx->cache, ref);
+            assert (ret == 1);
+            goto done_error;
+        }
+        if (content_store_request_send (ctx, data, len, true) < 0) {
             /* Must clean up, don't want cache entry to be assumed
              * valid.  Everything here is synchronous and w/o waiters,
              * so nothing should error here */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1402,10 +1402,15 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
              * no consistency issue by not caching.  We will still
              * set new root below via setroot().
              */
-            if (!(hp = cache_entry_create_json (json_incref (root)))) {
-                flux_log_error (ctx->h, "%s: cache_entry_create_json",
+            if (!(hp = cache_entry_create ())) {
+                flux_log_error (ctx->h, "%s: cache_entry_create",
+                                __FUNCTION__);
+            }
+            else if (cache_entry_set_json (hp, json_incref (root)) < 0) {
+                flux_log_error (ctx->h, "%s: cache_entry_set_json",
                                 __FUNCTION__);
                 json_decref (root);
+                cache_entry_destroy (hp);
             }
             else
                 cache_insert (ctx->cache, rootdir, hp);

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -551,13 +551,13 @@ int lookup_iter_missing_refs (lookup_t *lh, lookup_ref_f cb, void *data)
 
                     /* valref points to raw data, raw_data flag is always
                      * true */
-                    if (cb (lh, ref, true, data) < 0)
+                    if (cb (lh, ref, data) < 0)
                         return -1;
                 }
             }
         }
         else {
-            if (cb (lh, lh->missing_ref, false, data) < 0)
+            if (cb (lh, lh->missing_ref, data) < 0)
                 return -1;
         }
         return 0;
@@ -653,7 +653,7 @@ static int get_single_blobref_valref_value (lookup_t *lh, bool *stall)
         return 0;
     }
     if (cache_entry_get_raw (hp, &valdata, &len) < 0) {
-        flux_log (lh->h, LOG_ERR, "valref points to non-raw data");
+        flux_log (lh->h, LOG_ERR, "cache_entry_get_raw");
         lh->errnum = ENOTRECOVERABLE;
         return -1;
     }
@@ -687,7 +687,7 @@ static int get_multi_blobref_valref_length (lookup_t *lh, int refcount,
         }
 
         if (cache_entry_get_raw (hp, NULL, &len) < 0) {
-            flux_log (lh->h, LOG_ERR, "valref points to non-raw data");
+            flux_log (lh->h, LOG_ERR, "cache_entry_get_raw");
             lh->errnum = ENOTRECOVERABLE;
             return -1;
         }

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -11,7 +11,6 @@ typedef struct lookup lookup_t;
  */
 typedef int (*lookup_ref_f)(lookup_t *c,
                             const char *ref,
-                            bool raw_data,
                             void *data);
 
 /* Initialize a lookup handle

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -44,8 +44,9 @@ void cache_entry_basic_tests (void)
     char *data;
 
     /* corner case tests */
-    ok (cache_entry_set_json (NULL, NULL) < 0,
-        "cache_entry_set_json fails with bad input");
+    ok (cache_entry_set_json (NULL, NULL) < 0
+        && errno == EINVAL,
+        "cache_entry_set_json fails with EINVAL with bad input");
     cache_entry_destroy (NULL);
     diag ("cache_entry_destroy accept NULL arg");
 
@@ -54,10 +55,12 @@ void cache_entry_basic_tests (void)
 
     data = strdup ("abcd");
 
-    ok (cache_entry_set_raw (e, data, -1) < 0,
-        "cache_entry_set_raw fails with bad input");
-    ok (cache_entry_set_raw (e, NULL, 5) < 0,
-        "cache_entry_set_raw fails with bad input");
+    ok (cache_entry_set_raw (e, data, -1) < 0
+        && errno == EINVAL,
+        "cache_entry_set_raw fails with EINVAL with bad input");
+    ok (cache_entry_set_raw (e, NULL, 5) < 0
+        && errno == EINVAL,
+        "cache_entry_set_raw fails with EINVAL with bad input");
 
     free (data);
 

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -42,17 +42,12 @@ void cache_entry_basic_tests (void)
 {
     struct cache_entry *e;
     json_t *otmp;
-    cache_data_type_t t;
 
     /* corner case tests */
-    ok (cache_entry_create (447) == NULL,
-        "cache_entry_create fails with bad input");
     ok (cache_entry_create_json (NULL) == NULL,
         "cache_entry_create_json fails with bad input");
     ok (cache_entry_create_raw (NULL, 5) == NULL,
         "cache_entry_create_raw fails with bad input");
-    ok (cache_entry_type (NULL, NULL) < 0,
-        "cache_entry_type fails with bad input");
     ok (cache_entry_set_json (NULL, NULL) < 0,
         "cache_entry_set_json fails with bad input");
     ok (cache_entry_clear_data (NULL) < 0,
@@ -70,16 +65,8 @@ void cache_entry_basic_tests (void)
 
     /* test empty cache entry created by cache_entry_create() */
 
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_NONE,
-        "cache_entry_type returns NONE");
-    ok (cache_entry_is_type_json (e) == false,
-        "cache_entry_is_type_json returns false");
-    ok (cache_entry_is_type_raw (e) == false,
-        "cache_entry_is_type_raw returns false");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -98,37 +85,12 @@ void cache_entry_json_tests (void)
 {
     struct cache_entry *e;
     json_t *otmp, *o1, *o2;
-    cache_data_type_t t;
 
     /* Play with one entry.
      * N.B.: json ref is NOT incremented by create or get_json.
      */
 
-    /* test empty cache entry with json type created by
-     * cache_entry_create() */
-
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_JSON)) != NULL,
-        "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_JSON,
-        "cache_entry_type returns JSON");
-    ok (cache_entry_is_type_json (e) == true,
-        "cache_entry_is_type_json returns true");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry initially non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry initially not dirty");
-    ok (cache_entry_set_dirty (e, true) < 0,
-        "cache_entry_set_dirty fails b/c entry non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry does not set dirty, b/c no data");
-    ok ((otmp = cache_entry_get_json (e)) == NULL,
-        "cache_entry_get_json returns NULL, no json set");
-    cache_entry_destroy (e);
-    e = NULL;
-
-    /* test empty cache entry with none type, later filled with json.
+    /* test empty cache entry later filled with json.
      */
 
     o1 = json_object ();
@@ -136,14 +98,8 @@ void cache_entry_json_tests (void)
     o2 = json_object ();
     json_object_set_new (o2, "foo", json_integer (42));
 
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_NONE,
-        "cache_entry_type returns NONE");
-    ok (cache_entry_is_type_json (e) == false,
-        "cache_entry_is_type_json returns false");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -158,54 +114,10 @@ void cache_entry_json_tests (void)
         "cache_entry_set_json success");
     ok (cache_entry_set_json (e, o2) == 0,
         "cache_entry_set_json again, silent success");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_JSON,
-        "cache_entry_type returns JSON");
     ok (cache_entry_get_valid (e) == true,
         "cache entry now valid after cache_entry_set_json call");
-    ok (cache_entry_is_type_json (e) == true,
-        "cache_entry_is_type_json returns true");
     ok (cache_entry_set_raw (e, "abcd", 4) < 0,
         "cache_entry_set_raw fails on cache entry with type json");
-    cache_entry_destroy (e);   /* destroys o1 */
-    e = NULL;
-
-    /* test empty json cache entry with type json, later filled with
-     * data.
-     */
-
-    o1 = json_object ();
-    json_object_set_new (o1, "foo", json_integer (42));
-
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_JSON)) != NULL,
-        "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_JSON,
-        "cache_entry_type returns JSON");
-    ok (cache_entry_is_type_json (e) == true,
-        "cache_entry_is_type_json returns true");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry initially non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry initially not dirty");
-    ok (cache_entry_set_dirty (e, true) < 0,
-        "cache_entry_set_dirty fails b/c entry non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry does not set dirty, b/c no data");
-    ok (cache_entry_set_raw (e, "abcd", 4) < 0,
-        "cache_entry_set_raw fails on cache entry with type json");
-    ok ((otmp = cache_entry_get_json (e)) == NULL,
-        "cache_entry_get_json returns NULL, no json set");
-    ok (cache_entry_set_json (e, o1) == 0,
-        "cache_entry_set_json success");
-    ok (cache_entry_get_valid (e) == true,
-        "cache entry now valid after cache_entry_set_json call");
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry invalid after clear");
     cache_entry_destroy (e);   /* destroys o1 */
     e = NULL;
 
@@ -216,12 +128,6 @@ void cache_entry_json_tests (void)
 
     ok ((e = cache_entry_create_json (o1)) != NULL,
         "cache_entry_create_json w/ non-NULL input works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_JSON,
-        "cache_entry_type returns JSON");
-    ok (cache_entry_is_type_json (e) == true,
-        "cache_entry_is_type_json returns true");
     ok (cache_entry_get_valid (e) == true,
         "cache entry initially valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -265,49 +171,17 @@ void cache_entry_raw_tests (void)
 {
     struct cache_entry *e;
     json_t *o1;
-    cache_data_type_t t;
     char *data, *data2;
     int len;
 
-    /* test empty cache entry with raw type created by
-     * cache_entry_create() */
-
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_RAW)) != NULL,
-        "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_RAW,
-        "cache_entry_type returns RAW");
-    ok (cache_entry_is_type_raw (e) == true,
-        "cache_entry_is_type_raw returns true");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry initially non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry initially not dirty");
-    ok (cache_entry_set_dirty (e, true) < 0,
-        "cache_entry_set_dirty fails b/c entry non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry does not set dirty, b/c no data");
-    ok (cache_entry_get_raw (e, (void **)&data, NULL) < 0,
-        "cache_entry_get_raw fails, no data set");
-    cache_entry_destroy (e);
-    e = NULL;
-
-    /* test empty cache entry with none type, later filled with raw
-     * data.
+    /* test empty cache entry later filled with raw data.
      */
 
     data = strdup ("abcd");
     data2 = strdup ("abcd");
 
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_NONE,
-        "cache_entry_type returns NONE");
-    ok (cache_entry_is_type_raw (e) == false,
-        "cache_entry_is_type_raw returns false");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -324,12 +198,6 @@ void cache_entry_raw_tests (void)
         "cache_entry_set_raw again, silent success");
     ok (cache_entry_set_raw (e, NULL, 0) < 0 && errno == EBADE,
         "cache_entry_set_raw fails with EBADE, changing validity type");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_RAW,
-        "cache_entry_type returns RAW");
-    ok (cache_entry_is_type_raw (e) == true,
-        "cache_entry_is_type_raw returns true");
     ok (cache_entry_get_valid (e) == true,
         "cache entry now valid after cache_entry_set_raw call");
     o1 = json_object ();
@@ -340,20 +208,11 @@ void cache_entry_raw_tests (void)
     cache_entry_destroy (e);   /* destroys data */
     e = NULL;
 
-    /* test empty cache entry with raw type, later filled with raw
-     * data.
+    /* test empty cache entry later filled with zero-byte raw data.
      */
 
-    data = strdup ("abcd");
-
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_RAW)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_RAW,
-        "cache_entry_type returns RAW");
-    ok (cache_entry_is_type_raw (e) == true,
-        "cache_entry_is_type_raw returns true");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -362,49 +221,6 @@ void cache_entry_raw_tests (void)
         "cache_entry_set_dirty fails b/c entry non-valid");
     ok (cache_entry_get_dirty (e) == false,
         "cache entry does not set dirty, b/c no data");
-    o1 = json_object ();
-    json_object_set_new (o1, "foo", json_integer (42));
-    ok (cache_entry_set_json (e, o1) < 0,
-        "cache_entry_set_json fails on cache entry with type raw");
-    json_decref (o1);
-    ok (cache_entry_get_raw (e, NULL, NULL) < 0,
-        "cache_entry_get_raw fails, no data set");
-    ok (cache_entry_set_raw (e, data, strlen (data) + 1) == 0,
-        "cache_entry_set_raw success");
-    ok (cache_entry_get_valid (e) == true,
-        "cache entry now valid after cache_entry_set_raw call");
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry invalid after clear");
-    cache_entry_destroy (e);   /* destroys data */
-    e = NULL;
-
-    /* test empty cache entry w/ raw type, later filled with zero-byte
-     * raw data.
-     */
-
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_RAW)) != NULL,
-        "cache_entry_create works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_RAW,
-        "cache_entry_type returns RAW");
-    ok (cache_entry_is_type_raw (e) == true,
-        "cache_entry_is_type_raw returns true");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry initially non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry initially not dirty");
-    ok (cache_entry_set_dirty (e, true) < 0,
-        "cache_entry_set_dirty fails b/c entry non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry does not set dirty, b/c no data");
-    o1 = json_object ();
-    json_object_set_new (o1, "foo", json_integer (42));
-    ok (cache_entry_set_json (e, o1) < 0,
-        "cache_entry_set_json fails on cache entry with type raw");
-    json_decref (o1);
     ok (cache_entry_get_raw (e, NULL, NULL) < 0,
         "cache_entry_get_raw fails, no data set");
     ok (cache_entry_set_raw (e, NULL, 0) == 0,
@@ -424,12 +240,6 @@ void cache_entry_raw_tests (void)
 
     ok ((e = cache_entry_create_raw (data, strlen (data) + 1)) != NULL,
         "cache_entry_create_raw w/ non-NULL input works");
-    ok (cache_entry_type (e, &t) == 0,
-        "cache_entry_type success");
-    ok (t == CACHE_DATA_TYPE_RAW,
-        "cache_entry_type returns RAW");
-    ok (cache_entry_is_type_raw (e) == true,
-        "cache_entry_is_type_raw returns true");
     ok (cache_entry_get_valid (e) == true,
         "cache entry initially valid");
     ok (cache_entry_get_dirty (e) == false,
@@ -482,7 +292,7 @@ void waiter_json_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e) == false,
         "cache entry invalid, adding waiter");
@@ -551,7 +361,7 @@ void waiter_raw_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e) == false,
         "cache entry invalid, adding waiter");
@@ -635,7 +445,7 @@ void cache_remove_entry_tests (void)
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
 
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
     cache_insert (cache, "remove-ref", e);
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
@@ -650,7 +460,7 @@ void cache_remove_entry_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create created empty object");
     cache_insert (cache, "remove-ref", e);
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
@@ -721,7 +531,7 @@ void cache_expiration_tests (void)
         "cache contains 0 entries");
 
     /* first test w/ entry w/o json object */
-    ok ((e1 = cache_entry_create (CACHE_DATA_TYPE_NONE)) != NULL,
+    ok ((e1 = cache_entry_create ()) != NULL,
         "cache_entry_create works");
     cache_insert (cache, "xxx1", e1);
     ok (cache_count_entries (cache) == 1,

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -41,7 +41,6 @@ void cache_tests (void)
 void cache_entry_basic_tests (void)
 {
     struct cache_entry *e;
-    json_t *otmp;
 
     /* corner case tests */
     ok (cache_entry_create_raw (NULL, 5) == NULL,
@@ -61,23 +60,6 @@ void cache_entry_basic_tests (void)
         "cache_entry_set_raw fails with bad input");
     ok (cache_entry_set_raw (e, NULL, 5) < 0,
         "cache_entry_set_raw fails with bad input");
-    cache_entry_destroy (e);
-    e = NULL;
-
-    /* test empty cache entry created by cache_entry_create() */
-
-    ok ((e = cache_entry_create ()) != NULL,
-        "cache_entry_create works");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry initially non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry initially not dirty");
-    ok (cache_entry_set_dirty (e, true) < 0,
-        "cache_entry_set_dirty fails b/c entry non-valid");
-    ok (cache_entry_get_raw (e, NULL, NULL) < 0,
-        "cache_entry_get_raw fails, no data set");
-    ok ((otmp = cache_entry_get_json (e)) == NULL,
-        "cache_entry_get_json returns NULL, no json set");
     cache_entry_destroy (e);
     e = NULL;
 }
@@ -128,16 +110,6 @@ void cache_entry_raw_tests (void)
 
     ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry initially non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry initially not dirty");
-    ok (cache_entry_set_dirty (e, true) < 0,
-        "cache_entry_set_dirty fails b/c entry non-valid");
-    ok (cache_entry_get_dirty (e) == false,
-        "cache entry does not set dirty, b/c no data");
-    ok (cache_entry_get_raw (e, NULL, NULL) < 0,
-        "cache_entry_get_raw fails, no data set");
     ok (cache_entry_set_raw (e, NULL, 0) == 0,
         "cache_entry_set_raw success");
     ok (cache_entry_get_valid (e) == true,

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -50,8 +50,6 @@ void cache_entry_basic_tests (void)
         "cache_entry_create_json fails with bad input");
     ok (cache_entry_set_json (NULL, NULL) < 0,
         "cache_entry_set_json fails with bad input");
-    ok (cache_entry_clear_data (NULL) < 0,
-        "cache_entry_clear_data fails with bad input");
     cache_entry_destroy (NULL);
     diag ("cache_entry_destroy accept NULL arg");
 
@@ -117,10 +115,6 @@ void cache_entry_raw_tests (void)
         "raw data matches expected string");
     ok (datatmp && (len == strlen (data) + 1),
         "raw data length matches expected length");
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry invalid after clear");
     cache_entry_destroy (e);   /* destroys data */
     e = NULL;
 
@@ -155,10 +149,6 @@ void cache_entry_raw_tests (void)
         "raw data is NULL");
     ok (len == 0,
         "raw data length is zero");
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry invalid after clear");
     cache_entry_destroy (e);   /* destroys data */
     e = NULL;
 
@@ -197,11 +187,6 @@ void cache_entry_raw_tests (void)
         "raw data matches expected string");
     ok (datatmp && (len == strlen (data) + 1),
         "raw data length matches expected length");
-
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_raw (e, (void **)&data, &len) < 0,
-        "cache entry no longer has data object");
 
     cache_entry_destroy (e); /* destroys data */
     e = NULL;
@@ -254,10 +239,6 @@ void cache_entry_json_tests (void)
     ok (cache_entry_set_raw (e, NULL, 0) < 0
         && errno == EBADE,
         "cache_entry_set_raw fails with EBADE, changing validity type");
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_json (e) == NULL,
-        "cache entry no longer has json object");
     cache_entry_destroy (e);   /* destroys o1 */
     e = NULL;
 
@@ -297,11 +278,6 @@ void cache_entry_json_tests (void)
         "json_object_get success");
     ok (json_integer_value (otmp) == 42,
         "expected json object found");
-
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_json (e) == NULL,
-        "cache entry no longer has json object");
 
     cache_entry_destroy (e); /* destroys o1 */
     e = NULL;
@@ -394,24 +370,6 @@ void waiter_raw_tests (void)
     ok (count == 1,
         "waiter callback ran");
 
-    /* set cache entry to zero-data, should also call get valid
-     * waiter */
-    count = 0;
-    ok ((w = wait_create (wait_cb, &count)) != NULL,
-        "wait_create works");
-    ok (cache_entry_clear_data (e) == 0,
-        "cache_entry_clear_data success");
-    ok (cache_entry_get_valid (e) == false,
-        "cache entry invalid, adding waiter");
-    ok (cache_entry_wait_valid (e, w) == 0,
-        "cache_entry_wait_valid success");
-    ok (cache_entry_set_raw (e, NULL, 0) == 0,
-        "cache_entry_set_raw success");
-    ok (cache_entry_get_valid (e) == true,
-        "cache entry set valid with one waiter");
-    ok (count == 1,
-        "waiter callback ran");
-
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
@@ -446,7 +404,28 @@ void waiter_raw_tests (void)
     ok (count == 0,
         "waiter callback not called on force clear dirty");
 
-    cache_entry_destroy (e); /* destroys o */
+    cache_entry_destroy (e); /* destroys data */
+    e = NULL;
+
+    /* set cache entry to zero-data, should also call get valid
+     * waiter */
+    count = 0;
+    ok ((w = wait_create (wait_cb, &count)) != NULL,
+        "wait_create works");
+    ok ((e = cache_entry_create ()) != NULL,
+        "cache_entry_create created empty object");
+    ok (cache_entry_get_valid (e) == false,
+        "cache entry invalid, adding waiter");
+    ok (cache_entry_wait_valid (e, w) == 0,
+        "cache_entry_wait_valid success");
+    ok (cache_entry_set_raw (e, NULL, 0) == 0,
+        "cache_entry_set_raw success");
+    ok (cache_entry_get_valid (e) == true,
+        "cache entry set valid with one waiter");
+    ok (count == 1,
+        "waiter callback ran");
+    cache_entry_destroy (e); /* destroys data */
+    e = NULL;
 }
 
 void waiter_json_tests (void)

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -3,6 +3,7 @@
 #endif
 #include <stdbool.h>
 #include <jansson.h>
+#include <assert.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libkvs/kvs.h"
@@ -16,6 +17,21 @@
 #include "src/modules/kvs/types.h"
 
 static int test_global = 5;
+
+/* convenience function */
+static struct cache_entry *create_cache_entry_json (json_t *o)
+{
+    struct cache_entry *hp;
+    int ret;
+
+    assert (o);
+
+    hp = cache_entry_create ();
+    assert (hp);
+    ret = cache_entry_set_json (hp, o);
+    assert (ret == 0);
+    return hp;
+}
 
 /* Append a json object containing
  *     { "key" : key, "dirent" : <treeobj> } }
@@ -51,8 +67,8 @@ struct cache *create_cache_with_empty_rootdir (href_t ref)
         "cache_create works");
     ok (kvs_util_json_hash ("sha1", rootdir, ref) == 0,
         "kvs_util_json_hash worked");
-    ok ((hp = cache_entry_create_json (rootdir)) != NULL,
-        "cache_entry_create_json works");
+    ok ((hp = create_cache_entry_json (rootdir)) != NULL,
+        "create_cache_entry_json works");
     cache_insert (cache, ref, hp);
     return cache;
 }
@@ -602,7 +618,7 @@ void commit_basic_root_not_dir (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -643,8 +659,8 @@ int rootref_cb (commit_t *c, const char *ref, void *data)
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
 
-    ok ((hp = cache_entry_create_json (rootdir)) != NULL,
-        "cache_entry_create_json works");
+    ok ((hp = create_cache_entry_json (rootdir)) != NULL,
+        "create_cache_entry_json works");
 
     cache_insert (rd->cache, ref, hp);
 
@@ -729,8 +745,8 @@ int missingref_cb (commit_t *c, const char *ref, void *data)
     ok (strcmp (ref, md->dir_ref) == 0,
         "missing reference is what we expect it to be");
 
-    ok ((hp = cache_entry_create_json (md->dir)) != NULL,
-        "cache_entry_create_json works");
+    ok ((hp = create_cache_entry_json (md->dir)) != NULL,
+        "create_cache_entry_json works");
 
     cache_insert (md->cache, ref, hp);
 
@@ -776,7 +792,7 @@ void commit_process_missing_ref (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -875,7 +891,7 @@ void commit_process_error_callbacks (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -895,7 +911,7 @@ void commit_process_error_callbacks (void)
 
     /* insert cache entry now, want don't want missing refs on next
      * commit_process call */
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -956,7 +972,7 @@ void commit_process_error_callbacks_partway (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -964,7 +980,7 @@ void commit_process_error_callbacks_partway (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1013,7 +1029,7 @@ void commit_process_invalid_operation (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1108,7 +1124,7 @@ void commit_process_invalid_hash (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "foobar", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1163,7 +1179,7 @@ void commit_process_follow_link (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1172,7 +1188,7 @@ void commit_process_follow_link (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
@@ -1230,7 +1246,7 @@ void commit_process_dirval_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1288,7 +1304,7 @@ void commit_process_delete_test (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1296,7 +1312,7 @@ void commit_process_delete_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1343,7 +1359,7 @@ void commit_process_delete_nosubdir_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1397,7 +1413,7 @@ void commit_process_delete_filevalinpath_test (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1405,7 +1421,7 @@ void commit_process_delete_filevalinpath_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1459,7 +1475,7 @@ void commit_process_bad_dirrefs (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     dirref = treeobj_create_dirref (dir_ref);
     treeobj_append_blobref (dirref, dir_ref);
@@ -1470,7 +1486,7 @@ void commit_process_bad_dirrefs (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1541,7 +1557,7 @@ void commit_process_big_fileval (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1686,7 +1702,7 @@ void commit_process_giant_dir (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, cache_entry_create_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (dir, "dir", treeobj_create_dirref (dir_ref));
@@ -1694,7 +1710,7 @@ void commit_process_giant_dir (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, cache_entry_create_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_json (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -16,19 +16,16 @@
 struct lookup_ref_data
 {
     const char *ref;
-    bool raw_data;
     int count;
 };
 
 int lookup_ref (lookup_t *c,
                 const char *ref,
-                bool raw_data,
                 void *data)
 {
     struct lookup_ref_data *ld = data;
     if (ld) {
         ld->ref = ref;
-        ld->raw_data = raw_data;
         ld->count++;
     }
     return 0;
@@ -36,7 +33,6 @@ int lookup_ref (lookup_t *c,
 
 int lookup_ref_error (lookup_t *c,
                       const char *ref,
-                      bool raw_data,
                       void *data)
 {
     /* pick a weird errno */
@@ -229,36 +225,50 @@ void basic_api_errors (void)
 void check_common (lookup_t *lh,
                    bool lookup_result,
                    int get_errnum_result,
+                   bool check_is_val_treeobj,
                    json_t *get_value_result,
                    int missing_ref_count,
                    const char *missing_ref_result,
-                   bool missing_ref_raw,
                    const char *msg,
                    bool destroy_lookup)
 {
     json_t *val;
-    struct lookup_ref_data ld = { .ref = NULL, .raw_data = false, .count = 0 };
+    struct lookup_ref_data ld = { .ref = NULL, .count = 0 };
 
     ok (lookup (lh) == lookup_result,
         "%s: lookup matched result", msg);
     ok (lookup_get_errnum (lh) == get_errnum_result,
         "%s: lookup_get_errnum returns expected errnum %d", msg, lookup_get_errnum (lh));
-    if (get_value_result) {
+    if (check_is_val_treeobj) {
         ok ((val = lookup_get_value (lh)) != NULL,
             "%s: lookup_get_value returns non-NULL as expected", msg);
         if (val) {
-            ok (json_equal (get_value_result, val) == true,
-                "%s: lookup_get_value returned matching value", msg);
+            ok (treeobj_is_val (val) == true,
+                "%s: lookup_get_value returned treeobj val as expected", msg);
             json_decref (val);
         }
         else {
-            ok (false, "%s: lookup_get_value returned matching value", msg);
+            ok (false, "%s: lookup_get_value returned treeobj val as expected", msg);
         }
     }
     else {
-        ok ((val = lookup_get_value (lh)) == NULL,
-            "%s: lookup_get_value returns NULL as expected", msg);
-        json_decref (val);             /* just in case error */
+        if (get_value_result) {
+            ok ((val = lookup_get_value (lh)) != NULL,
+                "%s: lookup_get_value returns non-NULL as expected", msg);
+            if (val) {
+                ok (json_equal (get_value_result, val) == true,
+                    "%s: lookup_get_value returned matching value", msg);
+                json_decref (val);
+            }
+            else {
+                ok (false, "%s: lookup_get_value returned matching value", msg);
+            }
+        }
+        else {
+            ok ((val = lookup_get_value (lh)) == NULL,
+                "%s: lookup_get_value returns NULL as expected", msg);
+            json_decref (val);             /* just in case error */
+        }
     }
     if (missing_ref_count == 1) {
         if (missing_ref_result) {
@@ -275,9 +285,6 @@ void check_common (lookup_t *lh,
             else {
                 ok (false, "%s: missing ref returned matched expectation", msg);
             }
-
-            ok (ld.raw_data == missing_ref_raw,
-                "%s: missing ref raw_data bool returned expected value", msg);
         }
         else {
             ok (lookup_iter_missing_refs (lh, lookup_ref, &ld) < 0,
@@ -308,10 +315,25 @@ void check (lookup_t *lh,
     check_common (lh,
                   true,
                   get_errnum_result,
+                  false,
                   get_value_result,
                   1,
                   NULL,
-                  false,        /* doesn't matter */
+                  msg,
+                  true);
+}
+
+void check_treeobj_val_result (lookup_t *lh,
+                               int get_errnum_result,
+                               const char *msg)
+{
+    check_common (lh,
+                  true,
+                  get_errnum_result,
+                  true,
+                  NULL,         /* doesn't matter */
+                  1,
+                  NULL,
                   msg,
                   true);
 }
@@ -320,16 +342,15 @@ void check_stall (lookup_t *lh,
                   int get_errnum_result,
                   int missing_ref_count,
                   const char *missing_ref_result,
-                  bool missing_ref_raw,
                   const char *msg)
 {
     check_common (lh,
                   false,
                   get_errnum_result,
+                  false,
                   NULL,
                   missing_ref_count,
                   missing_ref_result,
-                  missing_ref_raw,
                   msg,
                   false);
 }
@@ -415,14 +436,17 @@ void lookup_root (void) {
 void lookup_basic (void) {
     json_t *root;
     json_t *dirref;
+    json_t *dirref_test;
     json_t *dir;
     json_t *valref_multi;
+    json_t *valref_multi_with_dirref;
     json_t *test;
     struct cache *cache;
     lookup_t *lh;
     href_t valref_ref;
     href_t valref2_ref;
     href_t dirref_ref;
+    href_t dirref_test_ref;
     href_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
@@ -436,9 +460,14 @@ void lookup_basic (void) {
      * valref2_ref
      * "efgh"
      *
+     * dirref_test_ref
+     * "dummy" : val to "dummy"
+     *
      * dirref_ref
      * "valref" : valref to valref_ref
+     * "valref_with_dirref" : valref to dirref_ref
      * "valref_multi" : valref to [ valref_ref, valref2_ref ]
+     * "valref_multi_with_dirref" : valref to [ valref_ref, dirref_test_ref ]
      * "val" : val to "foo"
      * "dir" : dir w/ "val" : val to "bar"
      * "symlink" : symlink to "baz"
@@ -453,11 +482,18 @@ void lookup_basic (void) {
     blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (href_t));
     cache_insert (cache, valref2_ref, cache_entry_create_raw (strdup ("efgh"), 4));
 
+    dirref_test = treeobj_create_dir ();
+    treeobj_insert_entry (dirref_test, "dummy", treeobj_create_val ("dummy", 5));
+
+    kvs_util_json_hash ("sha1", dirref_test, dirref_test_ref);
+    cache_insert (cache, dirref_test_ref, cache_entry_create_json (dirref_test));
+
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("bar", 3));
 
     dirref = treeobj_create_dir ();
     treeobj_insert_entry (dirref, "valref", treeobj_create_valref (valref_ref));
+    treeobj_insert_entry (dirref, "valref_with_dirref", treeobj_create_valref (dirref_test_ref));
     treeobj_insert_entry (dirref, "val", treeobj_create_val ("foo", 3));
     treeobj_insert_entry (dirref, "dir", dir);
     treeobj_insert_entry (dirref, "symlink", treeobj_create_symlink ("baz"));
@@ -466,6 +502,11 @@ void lookup_basic (void) {
     treeobj_append_blobref (valref_multi, valref2_ref);
 
     treeobj_insert_entry (dirref, "valref_multi", valref_multi);
+
+    valref_multi_with_dirref = treeobj_create_valref (valref_ref);
+    treeobj_append_blobref (valref_multi_with_dirref, dirref_test_ref);
+
+    treeobj_insert_entry (dirref, "valref_multi_with_dirref", valref_multi_with_dirref);
 
     kvs_util_json_hash ("sha1", dirref, dirref_ref);
     cache_insert (cache, dirref_ref, cache_entry_create_json (dirref));
@@ -500,6 +541,21 @@ void lookup_basic (void) {
     check (lh, 0, test, "lookup dirref.valref");
     json_decref (test);
 
+    /* lookup value via valref_with_dirref
+     * - in this case user accidentally put a dirref in a valref
+     *    object.  It succeeds, but we get the junk raw data of the
+     *    treeobj of whatever the dirref was pointing to.
+     */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             root_ref,
+                             root_ref,
+                             "dirref.valref_with_dirref",
+                             NULL,
+                             0)) != NULL,
+        "lookup_create on dirref.valref_with_dirref");
+    check_treeobj_val_result (lh, 0, "lookup dirref.valref_with_dirref");
+
     /* Lookup value via valref with multiple blobrefs */
     ok ((lh = lookup_create (cache,
                              1,
@@ -512,6 +568,21 @@ void lookup_basic (void) {
     test = treeobj_create_val ("abcdefgh", 8);
     check (lh, 0, test, "lookup valref_multi");
     json_decref (test);
+
+    /* lookup value via valref_multi_with_dirref
+     * - in this case user accidentally put a dirref in a valref
+     *    object.  It succeeds, but we get the junk raw data of the
+     *    treeobj of whatever the dirref was pointing to.
+     */
+    ok ((lh = lookup_create (cache,
+                             1,
+                             root_ref,
+                             root_ref,
+                             "dirref.valref_multi_with_dirref",
+                             NULL,
+                             0)) != NULL,
+        "lookup_create on dirref.valref_multi_with_dirref");
+    check_treeobj_val_result (lh, 0, "lookup dirref.valref_multi_with_dirref");
 
     /* lookup value via val */
     ok ((lh = lookup_create (cache,
@@ -622,7 +693,6 @@ void lookup_errors (void) {
     json_t *dirref;
     json_t *dir;
     json_t *dirref_multi;
-    json_t *valref_multi_bad;
     json_t *valref_multi_overflow;
     struct cache *cache;
     lookup_t *lh;
@@ -654,8 +724,6 @@ void lookup_errors (void) {
      * "dirref" : dirref to dirref_ref
      * "dir" : dir w/ "val" : val to "baz"
      * "dirref_bad" : dirref to valref_ref
-     * "valref_bad" : valref to dirref_ref
-     * "valref_multi_bad" : [ valref_ref, dirref_ref ]
      * "valref_multi_overflow" : [ valref_long_ref, valref_long_ref ]
      * "dirref_multi" : dirref to [ dirref_ref, dirref_ref ]
      */
@@ -689,11 +757,6 @@ void lookup_errors (void) {
     treeobj_insert_entry (root, "dirref", treeobj_create_dirref (dirref_ref));
     treeobj_insert_entry (root, "dir", dir);
     treeobj_insert_entry (root, "dirref_bad", treeobj_create_dirref (valref_ref));
-    treeobj_insert_entry (root, "valref_bad", treeobj_create_valref (dirref_ref));
-
-    valref_multi_bad = treeobj_create_valref (valref_ref);
-    treeobj_append_blobref (valref_multi_bad, dirref_ref);
-    treeobj_insert_entry (root, "valref_multi_bad", valref_multi_bad);
 
     valref_multi_overflow = treeobj_create_valref (valref_long_ref);
     treeobj_append_blobref (valref_multi_overflow, valref_long_ref);
@@ -886,30 +949,6 @@ void lookup_errors (void) {
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create on dirref_bad, in middle of path");
     check (lh, ENOTRECOVERABLE, NULL, "lookup dirref_bad, in middle of path");
-
-    /* Lookup a valref that doesn't point to raw data, should get
-     * ENOTRECOVERABLE */
-    ok ((lh = lookup_create (cache,
-                             1,
-                             root_ref,
-                             root_ref,
-                             "valref_bad",
-                             NULL,
-                             0)) != NULL,
-        "lookup_create on valref_bad");
-    check (lh, ENOTRECOVERABLE, NULL, "lookup valref_bad");
-
-    /* Lookup a valref multiple blobref that doesn't point to raw
-     * data, should get ENOTRECOVERABLE */
-    ok ((lh = lookup_create (cache,
-                             1,
-                             root_ref,
-                             root_ref,
-                             "valref_multi_bad",
-                             NULL,
-                             0)) != NULL,
-        "lookup_create on valref_multi_bad");
-    check (lh, ENOTRECOVERABLE, NULL, "lookup valref_multi_bad");
 
     /* Lookup a valref multiple blobref that points to buffers that will
      * over int, should get EOVERFLOW.
@@ -1283,7 +1322,7 @@ void lookup_stall_root (void) {
                              NULL,
                              FLUX_KVS_READDIR)) != NULL,
         "lookup_create stalltest \".\"");
-    check_stall (lh, EAGAIN, 1, root_ref, false, "root \".\" stall");
+    check_stall (lh, EAGAIN, 1, root_ref, "root \".\" stall");
 
     cache_insert (cache, root_ref, cache_entry_create_json (root));
 
@@ -1406,12 +1445,12 @@ void lookup_stall (void) {
                              NULL,
                              0)) != NULL,
         "lookup_create stalltest dirref1.val");
-    check_stall (lh, EAGAIN, 1, root_ref, false, "dirref1.val stall #1");
+    check_stall (lh, EAGAIN, 1, root_ref, "dirref1.val stall #1");
 
     cache_insert (cache, root_ref, cache_entry_create_json (root));
 
     /* next call to lookup, should stall */
-    check_stall (lh, EAGAIN, 1, dirref1_ref, false, "dirref1.val stall #2");
+    check_stall (lh, EAGAIN, 1, dirref1_ref, "dirref1.val stall #2");
 
     cache_insert (cache, dirref1_ref, cache_entry_create_json (dirref1));
 
@@ -1442,7 +1481,7 @@ void lookup_stall (void) {
                              NULL,
                              0)) != NULL,
         "lookup_create stalltest symlink.val");
-    check_stall (lh, EAGAIN, 1, dirref2_ref, false, "symlink.val stall");
+    check_stall (lh, EAGAIN, 1, dirref2_ref, "symlink.val stall");
 
     cache_insert (cache, dirref2_ref, cache_entry_create_json (dirref2));
 
@@ -1473,7 +1512,7 @@ void lookup_stall (void) {
                              NULL,
                              0)) != NULL,
         "lookup_create stalltest dirref1.valref");
-    check_stall (lh, EAGAIN, 1, valref1_ref, true, "dirref1.valref stall");
+    check_stall (lh, EAGAIN, 1, valref1_ref, "dirref1.valref stall");
 
     cache_insert (cache, valref1_ref, cache_entry_create_raw (strdup ("abcd"), 4));
 
@@ -1506,7 +1545,7 @@ void lookup_stall (void) {
         "lookup_create stalltest dirref1.valref_multi");
     /* should only be one missing ref, as we loaded one of the refs in
      * the 'valref' above */
-    check_stall (lh, EAGAIN, 1, valref2_ref, true, "dirref1.valref_multi stall");
+    check_stall (lh, EAGAIN, 1, valref2_ref, "dirref1.valref_multi stall");
 
     cache_insert (cache, valref2_ref, cache_entry_create_raw (strdup ("efgh"), 4));
 
@@ -1538,7 +1577,7 @@ void lookup_stall (void) {
                              0)) != NULL,
         "lookup_create stalltest dirref1.valref_multi2");
     /* should two missing refs, as we have not loaded either here */
-    check_stall (lh, EAGAIN, 2, NULL, true, "dirref1.valref_multi2 stall");
+    check_stall (lh, EAGAIN, 2, NULL, "dirref1.valref_multi2 stall");
 
     cache_insert (cache, valref3_ref, cache_entry_create_raw (strdup ("ijkl"), 4));
     cache_insert (cache, valref4_ref, cache_entry_create_raw (strdup ("mnop"), 4));
@@ -1616,7 +1655,6 @@ int main (int argc, char *argv[])
     lookup_alt_root ();
     lookup_stall_root ();
     lookup_stall ();
-
     done_testing ();
     return (0);
 }

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -304,12 +304,12 @@ test_expect_success 'kvs: valref that points to zero size content store data can
 	test $(${KVSBASIC} copy-fromkvs $TEST.empty -|wc -c) -eq 0
 '
 
-test_expect_success 'kvs: valref that doesnt point to raw data fails' '
+test_expect_success 'kvs: valref can point to other treeobjs' '
 	flux kvs unlink -Rf $TEST &&
         flux kvs mkdir $TEST.a.b.c &&
         dirhash=`${KVSBASIC} get-treeobj $TEST.a.b.c | grep -P "sha1-[A-Za-z0-9]+" -o` &&
 	${KVSBASIC} put-treeobj $TEST.value="{\"data\":[\"${dirhash}\"],\"type\":\"valref\",\"ver\":1}" &&
-        test_must_fail ${KVSBASIC} copy-fromkvs $TEST.value -
+        ${KVSBASIC} copy-fromkvs $TEST.value - | grep dir
 '
 
 # multi-blobref valrefs
@@ -351,13 +351,13 @@ test_expect_success 'kvs: multi blob-ref valref with an empty blobref in middle,
         test $(${KVSBASIC} copy-fromkvs $TEST.multival -|wc -c) -eq 8
 '
 
-test_expect_success 'kvs: multi blob-ref valref with a blobref that doesnt point to raw data fails' '
+test_expect_success 'kvs: multi blob-ref valref with a blobref pointing to a treeobj' '
         flux kvs unlink -Rf $TEST &&
 	hashval1=`echo -n "abcd" | flux content store` &&
         flux kvs mkdir $TEST.a.b.c &&
         dirhash=`${KVSBASIC} get-treeobj $TEST.a.b.c | grep -P "sha1-[A-Za-z0-9]+" -o` &&
 	${KVSBASIC} put-treeobj $TEST.multival="{\"data\":[\"${hashval1}\", \"${dirhash}\"],\"type\":\"valref\",\"ver\":1}" &&
-        test_must_fail ${KVSBASIC} copy-fromkvs $TEST.multival -
+        ${KVSBASIC} copy-fromkvs $TEST.multival - | grep dir
 '
 
 # dtree tests


### PR DESCRIPTION
This PR refactors the KVS cache to favor the storage of raw data over json objects.  This accomplishes several goals.

1) before this PR, KVS cache entries had a data "type" associated with it.  This can lead to a "race" in which how the data was loaded into the KVS cache the first time and could lead to errors/bugs later.  For example, if data was incorrectly loaded into the KVS cache as type json, a later attempt to read the data out of the KVS cache as raw data would fail, leading to an error.

2) This should clean up the code and hopefully make it less confusing.  Many unit tests were removed in this PR, so I feel the less confusing part was accomplished.

The primary idea behind this refactor to remove the "type" system with KVS cache entries and make the KVS cache primarily for storing raw data.

Users can set get/set json objects in the KVS cache, but the API is simply a set of convenience functions converting those json objects to/from their raw string form.

As an aside, I am sometimes anal when it comes to code "ordering".  In commit https://github.com/chu11/flux-core/commit/368f8588bb3b4255914774260e569c3c3f2c43f7  I literally just move "json" code below "raw data" code, b/c I want "raw data" code to be listed first as it is now the "primary" way the KVS cache works.  I know its more code change than may be necessary.