### PR TITLE
disable pylint check of python bindings by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ compiler:
 matrix:
   include:
     - compiler: gcc
-      env: COVERAGE=t ARGS=--enable-caliper
+      env: COVERAGE=t ARGS="--enable-caliper --enable-pylint"
     - compiler: gcc
       env: T_INSTALL=t
     - compiler: clang

--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,17 @@ if test "$enable_python" = "yes"; then
 fi
 AM_CONDITIONAL([HAVE_PYTHON], [test "$enable_python" = yes])
 
+AC_ARG_ENABLE([pylint],
+  [AS_HELP_STRING([--enable-pylint],
+    [Enable pylint checks of python bindings])],,
+  [enable_pylint="yes"]
+)
+AS_IF([test "x$enable_pylint" = "xyes"], [
+  AC_CHECK_PROG(PYLINT,[pylint],[pylint])
+  AS_IF([test "x$PYLINT" != "xpylint"], [AC_MSG_ERROR([No pylint found in PATH])])
+])
+AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
+
 AX_PROG_LUA([5.1],[5.3])
 AX_LUA_HEADERS
 AX_LUA_LIBS

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -98,10 +98,12 @@ lib-copy: ${fluxpy_PYTHON} ${fluxpy_LTLIBRARIES}
 	done
 	[ "$(top_srcdir)" != "$(top_builddir)" ] && cp $(top_srcdir)/src/bindings/python/flux/*.py ./ || true
 
+if ENABLE_PYLINT
 #TODO: there must be a better way to do this
 # scan flux bindings with pylint, currently fails on any exit but 0
 check-local: lib-copy
 	if [ -x "$$( which pylint )" ] ; then  pylint --rcfile=$(top_srcdir)/src/bindings/python/.pylintrc ../flux ; fi
+endif
 
 all-local: lib-copy
 


### PR DESCRIPTION
This PR disables the pylint check for the python bindings by default, and adds a new configure option `configure --enable-pylint` to get them back. That option is enabled on one of the travis-ci builders so that we still get pylint run on every PR submission and push to the repo.

The pylint implementation seems to be rather brittle, extremely version dependent, etc. as described in #1250, so this will hopefully make those problems invisible for most users (while still enabling those working on the python bindings to enable the check as they need it)