### PR TITLE
build: actually disable pylint by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,7 @@ AM_CONDITIONAL([HAVE_PYTHON], [test "$enable_python" = yes])
 AC_ARG_ENABLE([pylint],
   [AS_HELP_STRING([--enable-pylint],
     [Enable pylint checks of python bindings])],,
-  [enable_pylint="yes"]
+  [enable_pylint="no"]
 )
 AS_IF([test "x$enable_pylint" = "xyes"], [
   AC_CHECK_PROG(PYLINT,[pylint],[pylint])


### PR DESCRIPTION
In commit bd4fee8dac192025a88a8fc8cf273c864f687a9b the pylint check
was accidently left enabled by default. The intent was to have the
default be *disabled* and only run pylint on --enable-pylint.

Sorry! Not sure how that slipped through (I promise I tested functionality several times) :cry: