### PR TITLE
kvs: handle non-JSON values in flux kvs get, put, dir

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -42,13 +42,22 @@ arguments are described below.
 
 COMMANDS
 --------
-*get* 'key' ['key...']::
+*get* [-j|-r|-t] [-a treeobj] 'key' ['key...']::
 Retrieve the value stored under 'key'.  If nothing has been stored under
-'key', display an error message.
+'key', display an error message.  If no options, value is interpreted
+as a NULL-terminated string.  If '-j', it is interpreted as encoded JSON.
+If '-r', it is interpreted as raw data and is output without formatting.
+If '-t', the RFC 11 object is displayed.  '-a treeobj' causes the lookup
+to be relative to an RFC 11 snapshot reference.
 
-*put* 'key=value' ['key=value...']::
+*put* [-j|-r|-t] [-n] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  If it already has a value,
-overwrite it.
+overwrite it.  If no options, value is stored as a NULL-terminated string.
+If '-j', it is first encoded as JSON, then stored as a NULL-terminated string.
+If '-r', it is stored as raw data with no termination.  For raw mode only,
+a value of "-" indicates that the value should be read from standard input.
+If '-t', value is stored as a RFC 11 object.  '-n' prevents the commit
+from being merged with with other contemporaneous commits.
 
 *ls* [-R] [-d] [-F] [-w COLS] [-1] ['key' ...]::
 Display directory referred to by _key_, or "." (root) if unspecified.
@@ -58,12 +67,14 @@ Options are roughly equivalent to a subset of ls(1) options.
 '-w COLS' sets the terminal width in characters.  '-1' causes output to be
 displayed in one column.
 
-*dir* [-R] [-d] ['key']::
+*dir* [-R] [-d] [-w COLS] [-a treeobj] ['key']::
 Display all keys and their values under the directory 'key'.
 If 'key' does not exist or is not a directory, display an error message.
 If 'key' is not provided, "." (root of the namespace) is assumed.  If '-R'
 is specified, recursively display keys under subdirectories.  If '-d' is
-specified, do not output key values.
+specified, do not output key values.  Output is truncated to fit the
+terminal width.  '-w COLS' sets the terminal width (0=unlimited).
+'-a treeobj' causes the lookup to be relative to an RFC 11 snapshot reference.
 
 *unlink* [-R] [-f] 'key' ['key...']::
 Remove 'key' from the KVS and commit the change.  If 'key' represents
@@ -75,9 +86,10 @@ Create a new name for 'target', similar to a symbolic link, and commit
 the change.  'target' does not have to exist.  If 'linkname' exists,
 it is overwritten.
 
-*readlink* 'key' ['key...']::
+*readlink* [-a treeobj] 'key' ['key...']::
 Retrieve the key a link refers to rather than its value, as would be
-returned by *get*.
+returned by *get*.  '-a treeobj' causes the lookup to be relative to
+an RFC 11 snapshot reference.
 
 *mkdir* 'key' ['key...']::
 Create an empty directory and commit the change.  If 'key' exists,

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -444,6 +444,8 @@ int cmd_get (optparse_t *p, int argc, char **argv)
             const char *json_str;
             if (flux_kvs_lookup_get (f, &json_str) < 0)
                 log_err_exit ("%s", key);
+            if (!json_str)
+                log_msg_exit ("%s: zero-length value", key);
             output_key_json_str (NULL, json_str, key);
         }
         else if (optparse_hasopt (p, "raw")) {

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -78,6 +78,9 @@ static struct optparse_option put_opts[] =  {
     { .name = "raw", .key = 'r', .has_arg = 0,
       .usage = "Store value(s) as-is without adding NULL termination",
     },
+    { .name = "treeobj", .key = 't', .has_arg = 0,
+      .usage = "Store RFC 11 object",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -155,7 +158,7 @@ static struct optparse_subcommand subcommands[] = {
       get_opts
     },
     { "put",
-      "[-j|-r] key=value [key=value...]",
+      "[-j|-r|-t] key=value [key=value...]",
       "Store value under key",
       cmd_put,
       0,
@@ -483,7 +486,11 @@ int cmd_put (optparse_t *p, int argc, char **argv)
             log_msg_exit ("put: you must specify a value as key=value");
         *val++ = '\0';
 
-        if (optparse_hasopt (p, "json")) {
+        if (optparse_hasopt (p, "treeobj")) {
+            if (flux_kvs_txn_put_treeobj (txn, 0, key, val) < 0)
+                log_err_exit ("%s", key);
+        }
+        else if (optparse_hasopt (p, "json")) {
             json_t *obj;
             if ((obj = json_loads (val, JSON_DECODE_ANY, NULL))) {
                 if (flux_kvs_txn_put (txn, 0, key, val) < 0)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -458,7 +458,8 @@ int cmd_get (optparse_t *p, int argc, char **argv)
             const char *value;
             if (flux_kvs_lookup_get (f, &value) < 0)
                 log_err_exit ("%s", key);
-            printf ("%s\n", value);
+            if (value)
+                printf ("%s\n", value);
         }
         flux_future_destroy (f);
     }

--- a/t/issues/t0441-kvs-put-get.sh
+++ b/t/issues/t0441-kvs-put-get.sh
@@ -5,6 +5,6 @@ TEST=issue441
 
 flux kvs put --json ${TEST}.x=foo
 
-flux kvs get ${TEST}.x.y && test $? -eq 1
+flux kvs get --json ${TEST}.x.y && test $? -eq 1
 
-flux kvs get ${TEST}.x   # fails if broker died
+flux kvs get --json ${TEST}.x   # fails if broker died

--- a/t/issues/t0441-kvs-put-get.sh
+++ b/t/issues/t0441-kvs-put-get.sh
@@ -3,7 +3,7 @@
 
 TEST=issue441
 
-flux kvs put ${TEST}.x=foo
+flux kvs put --json ${TEST}.x=foo
 
 flux kvs get ${TEST}.x.y && test $? -eq 1
 

--- a/t/issues/t0821-kvs-segfault.sh
+++ b/t/issues/t0821-kvs-segfault.sh
@@ -2,6 +2,6 @@
 # kvs put test="large string", get test.x fails without panic
 
 TEST=issue0821
-flux kvs put ${TEST}="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+flux kvs put --json ${TEST}="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 flux kvs get ${TEST}.x && test $? -eq 1
 flux kvs get ${TEST}   # fails if broker died

--- a/t/issues/t0821-kvs-segfault.sh
+++ b/t/issues/t0821-kvs-segfault.sh
@@ -3,5 +3,5 @@
 
 TEST=issue0821
 flux kvs put --json ${TEST}="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-flux kvs get ${TEST}.x && test $? -eq 1
-flux kvs get ${TEST}   # fails if broker died
+flux kvs get --json ${TEST}.x && test $? -eq 1
+flux kvs get --json ${TEST}   # fails if broker died

--- a/t/kvs/basic.c
+++ b/t/kvs/basic.c
@@ -47,7 +47,6 @@ void cmd_type (flux_t *h, int argc, char **argv);
 void cmd_put_no_merge (flux_t *h, int argc, char **argv);
 void cmd_copy_tokvs (flux_t *h, int argc, char **argv);
 void cmd_copy_fromkvs (flux_t *h, int argc, char **argv);
-void cmd_dirsize (flux_t *h, int argc, char **argv);
 void cmd_getat (flux_t *h, int argc, char **argv);
 void cmd_dirat (flux_t *h, int argc, char **argv);
 void cmd_readlinkat (flux_t *h, int argc, char **argv);
@@ -60,7 +59,6 @@ void usage (void)
 "       basic put-no-merge        key=val\n"
 "       basic copy-tokvs          key file\n"
 "       basic copy-fromkvs        key file\n"
-"       basic dirsize             key\n"
 "       basic getat               treeobj key\n"
 "       basic dirat [-r]          treeobj [key]\n"
 "       basic readlinkat          treeobj key\n"
@@ -101,8 +99,6 @@ int main (int argc, char *argv[])
         cmd_copy_tokvs (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "copy-fromkvs"))
         cmd_copy_fromkvs (h, argc - optind, argv + optind);
-    else if (!strcmp (cmd, "dirsize"))
-        cmd_dirsize (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "getat"))
         cmd_getat (h, argc - optind, argv + optind);
     else if (!strcmp (cmd, "dirat"))
@@ -386,21 +382,6 @@ void cmd_dirat (flux_t *h, int argc, char **argv)
             || flux_kvs_lookup_get_dir (f, &dir) < 0)
         log_err_exit ("%s", argv[1]);
     dump_kvs_dir (dir, ropt);
-    flux_future_destroy (f);
-}
-
-void cmd_dirsize (flux_t *h, int argc, char **argv)
-{
-    flux_future_t *f;
-    const flux_kvsdir_t *dir = NULL;
-
-    if (argc != 1)
-        log_msg_exit ("dirsize: specify one directory");
-    if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, argv[0])))
-        log_err_exit ("flux_kvs_lookup");
-    if (flux_kvs_lookup_get_dir (f, &dir) < 0)
-        log_err_exit ("%s", argv[0]);
-    printf ("%d\n", flux_kvsdir_get_size (dir));
     flux_future_destroy (f);
 }
 

--- a/t/lua/t1002-kvs.t
+++ b/t/lua/t1002-kvs.t
@@ -196,7 +196,7 @@ type_ok (kw, 'userdata', "f:kvswatcher returns kvswatcher object")
 kw.testkey = "foo"
 is (kw.testkey, 'foo', "Can set arbitrary members of kvswatcher object")
 
-os.execute (string.format ("flux kvs put %s=%s", data.key, data.value))
+os.execute (string.format ("flux kvs put --json %s=%s", data.key, data.value))
 
 local to = f:timer {
     timeout = 1500,
@@ -247,7 +247,7 @@ local t, err = f:timer {
 }
 
 -- Excute on rank 3 via flux-exec:
-os.execute (string.format ("sleep 0.25 && flux exec -r 3 flux kvs put %s=%s",
+os.execute (string.format ("sleep 0.25 && flux exec -r 3 flux kvs put --json %s=%s",
     data.key, data.value))
 local r, err = f:reactor()
 isnt (r, -1, "reactor exited normally with ".. (r and r or err))
@@ -255,7 +255,7 @@ is (ncount, 2, "kvswatch callback invoked exactly twice")
 
 note ("Ensure kvs watch callback not invoked after kvswatcher removal")
 ok (kw:remove(), "Can remove kvswatcher without error")
-os.execute (string.format ("sleep 0.25 && flux exec -r 3 flux kvs put %s=%s",
+os.execute (string.format ("sleep 0.25 && flux exec -r 3 flux kvs put --json %s=%s",
     data.key, 'test3'))
 
 local t, err = f:timer {

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -279,7 +279,7 @@ test_expect_success 'connector delivers kvs.setroot event to owner connection' '
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
-                 flux kvs put ev9=42; \
+                 flux kvs put --json ev9=42; \
                  flux event pub kvs.test.end" >ev9.out &&
 	grep -q kvs.setroot ev9.out
 '
@@ -289,7 +289,7 @@ test_expect_success 'dispatcher delivers kvs.setroot event to owner connection' 
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
-                 flux kvs put ev10=42; \
+                 flux kvs put --json ev10=42; \
                  flux event pub kvs.test.end" >ev10.out &&
 	grep -q kvs.setroot ev10.out
 '
@@ -300,7 +300,7 @@ test_expect_success 'connector suppresses kvs.setroot event to guest connection'
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
-                 flux kvs put ev11=42; \
+                 flux kvs put --json ev11=42; \
                  flux event pub kvs.test.end" >ev11.out &&
 	! grep -q kvs.setroot ev11.out
 '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -25,7 +25,7 @@ SUBDIR1=test.a.b.d
 SUBDIR2=test.a.b.e
 
 test_kvs_key() {
-	flux kvs get "$1" >output
+	flux kvs get --json "$1" >output
 	echo "$2" >expected
 	test_cmp expected output
 }
@@ -139,43 +139,43 @@ EOF
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.integer &&
-	  test_must_fail flux kvs get $KEY.integer
+	  test_must_fail flux kvs get --json $KEY.integer
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.double &&
-	  test_must_fail flux kvs get $KEY.double
+	  test_must_fail flux kvs get --json $KEY.double
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.string &&
-	  test_must_fail flux kvs get $KEY.string
+	  test_must_fail flux kvs get --json $KEY.string
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.emptystring &&
-	  test_must_fail flux kvs get $KEY.emptystring
+	  test_must_fail flux kvs get --json $KEY.emptystring
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.jsonnull &&
-	  test_must_fail flux kvs get $KEY.jsonnull
+	  test_must_fail flux kvs get --json $KEY.jsonnull
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.strnull &&
-	  test_must_fail flux kvs get $KEY.strnull
+	  test_must_fail flux kvs get --json $KEY.strnull
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.booleantrue &&
-	  test_must_fail flux kvs get $KEY.booleantrue
+	  test_must_fail flux kvs get --json $KEY.booleantrue
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.booleanfalse &&
-	  test_must_fail flux kvs get $KEY.booleanfalse
+	  test_must_fail flux kvs get --json $KEY.booleanfalse
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.array &&
-	  test_must_fail flux kvs get $KEY.array
+	  test_must_fail flux kvs get --json $KEY.array
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.object &&
-	  test_must_fail flux kvs get $KEY.object
+	  test_must_fail flux kvs get --json $KEY.object
 '
 test_expect_success 'kvs: unlink dir works' '
         flux kvs unlink $SUBDIR1 &&
@@ -194,7 +194,7 @@ test_expect_success 'kvs: put (multiple)' '
 	flux kvs put --json $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
 '
 test_expect_success 'kvs: get (multiple)' '
-	flux kvs get $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output &&
+	flux kvs get --json $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output &&
 	cat >expected <<EOF &&
 42
 3.140000
@@ -231,12 +231,12 @@ EOF
 '
 test_expect_success 'kvs: unlink (multiple)' '
 	flux kvs unlink $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f &&
-          test_must_fail flux kvs get $KEY.a &&
-          test_must_fail flux kvs get $KEY.b &&
-          test_must_fail flux kvs get $KEY.c &&
-          test_must_fail flux kvs get $KEY.d &&
-          test_must_fail flux kvs get $KEY.e &&
-          test_must_fail flux kvs get $KEY.f
+          test_must_fail flux kvs get --json $KEY.a &&
+          test_must_fail flux kvs get --json $KEY.b &&
+          test_must_fail flux kvs get --json $KEY.c &&
+          test_must_fail flux kvs get --json $KEY.d &&
+          test_must_fail flux kvs get --json $KEY.e &&
+          test_must_fail flux kvs get --json $KEY.f
 '
 test_expect_success 'kvs: unlink -R works' '
         flux kvs unlink -R $DIR &&
@@ -400,11 +400,11 @@ test_expect_success 'kvs: ls key. fails if key does not exist' '
 #
 
 test_expect_success 'kvs: get a nonexistent key' '
-	test_must_fail flux kvs get NOT.A.KEY
+	test_must_fail flux kvs get --json NOT.A.KEY
 '
 test_expect_success 'kvs: try to retrieve a directory as key should fail' '
         flux kvs mkdir $DIR.a.b.c &&
-	test_must_fail flux kvs get $DIR
+	test_must_fail flux kvs get --json $DIR
 '
 
 #
@@ -510,7 +510,7 @@ test_expect_success 'kvs: link works' '
 	TARGET=$DIR.target &&
 	flux kvs put --json $TARGET=\"foo\" &&
 	flux kvs link $TARGET $DIR.link &&
-	OUTPUT=$(flux kvs get $DIR.link) &&
+	OUTPUT=$(flux kvs get --json $DIR.link) &&
 	test "$OUTPUT" = "foo"
 '
 test_expect_success 'kvs: readlink works' '
@@ -548,13 +548,13 @@ test_expect_success 'kvs: link: path resolution when intermediate component is a
 	flux kvs unlink -Rf $DIR &&
 	flux kvs put --json $DIR.a.b.c=42 &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
-	OUTPUT=$(flux kvs get $DIR.Z.Y.c) &&
+	OUTPUT=$(flux kvs get --json $DIR.Z.Y.c) &&
 	test "$OUTPUT" = "42"
 '
 test_expect_success 'kvs: link: path resolution with intermediate link and nonexistent key' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
-	test_must_fail flux kvs get $DIR.Z.Y
+	test_must_fail flux kvs get --json $DIR.Z.Y
 '
 test_expect_success 'kvs: link: intermediate link points to another link' '
 	flux kvs unlink -Rf $DIR &&
@@ -657,14 +657,14 @@ test_expect_success 'kvs: link: error on link depth' '
 	flux kvs link $DIR.i $DIR.j &&
 	flux kvs link $DIR.j $DIR.k &&
 	flux kvs link $DIR.k $DIR.l &&
-        test_must_fail flux kvs get $DIR.l
+        test_must_fail flux kvs get --json $DIR.l
 '
 
 test_expect_success 'kvs: link: error on link depth, loop' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs link $DIR.link1 $DIR.link2 &&
 	flux kvs link $DIR.link2 $DIR.link1 &&
-        test_must_fail flux kvs get $DIR.link1
+        test_must_fail flux kvs get --json $DIR.link1
 '
 
 #
@@ -674,8 +674,8 @@ test_expect_success 'kvs: copy works' '
         flux kvs unlink -Rf $DIR &&
 	flux kvs put --json $DIR.src=\"foo\" &&
         flux kvs copy $DIR.src $DIR.dest &&
-	OUTPUT1=$(flux kvs get $DIR.src) &&
-	OUTPUT2=$(flux kvs get $DIR.dest) &&
+	OUTPUT1=$(flux kvs get --json $DIR.src) &&
+	OUTPUT2=$(flux kvs get --json $DIR.dest) &&
 	test "$OUTPUT1" = "foo" &&
 	test "$OUTPUT2" = "foo"
 '
@@ -684,8 +684,8 @@ test_expect_success 'kvs: move works' '
         flux kvs unlink -Rf $DIR &&
 	flux kvs put --json $DIR.src=\"foo\" &&
         flux kvs move $DIR.src $DIR.dest &&
-	test_must_fail flux kvs get $DIR.src &&
-	OUTPUT=$(flux kvs get $DIR.dest) &&
+	test_must_fail flux kvs get --json $DIR.src &&
+	OUTPUT=$(flux kvs get --json $DIR.dest) &&
 	test "$OUTPUT" = "foo"
 '
 
@@ -726,7 +726,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: version and wait' '
 
 wait_watch_put() {
         i=0
-        while [ "$(flux kvs get $1 2> /dev/null)" != "$2" ] && [ $i -lt 50 ]
+        while [ "$(flux kvs get --json $1 2> /dev/null)" != "$2" ] && [ $i -lt 50 ]
         do
                 sleep 0.1
                 i=$((i + 1))
@@ -740,7 +740,7 @@ wait_watch_put() {
 
 wait_watch_empty() {
         i=0
-        while flux kvs get $1 2> /dev/null && [ $i -lt 50 ]
+        while flux kvs get --json $1 2> /dev/null && [ $i -lt 50 ]
         do
                 sleep 0.1
                 i=$((i + 1))

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -438,6 +438,39 @@ test_expect_success 'kvs: zero-length value does not cause ls -FR to fail' '
 '
 
 #
+# empty string values
+#
+test_expect_success 'kvs: empty string value made by put with no options' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a= &&
+	dd if=/dev/zero count=1 bs=1 of=empty.expected &&
+	flux kvs get --raw $DIR.a >empty.actual &&
+	test_cmp empty.expected empty.actual
+'
+test_expect_success 'kvs: empty string value can be retrieved by get' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a= &&
+	echo >empty2.expected &&
+	flux kvs get $DIR.a >empty2.actual &&
+	test_cmp empty2.expected empty2.actual
+'
+test_expect_success 'kvs: empty string value NOT handled by get --json' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a= &&
+	test_must_fail flux kvs get --json $DIR.a
+'
+test_expect_success 'kvs: empty string value does not cause dir to fail' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a= &&
+	flux kvs dir $DIR | grep -q "a ="
+'
+test_expect_success 'kvs: empty string value does not cause ls -FR to fail' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a= &&
+	flux kvs ls -FR $DIR | grep -q "a"
+'
+
+#
 # treeobj tests
 #
 test_expect_success 'kvs: treeobj of all types handled by get --treeobj' '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -27,7 +27,7 @@ SUBDIR2=test.a.b.e
 test_kvs_key() {
 	flux kvs get "$1" >output
 	echo "$2" >expected
-	test_cmp output expected
+	test_cmp expected output
 }
 
 #
@@ -35,34 +35,34 @@ test_kvs_key() {
 #
 
 test_expect_success 'kvs: integer put' '
-	flux kvs put $KEY.integer=42
+	flux kvs put --json $KEY.integer=42
 '
 test_expect_success 'kvs: double put' '
-	flux kvs put $KEY.double=3.14
+	flux kvs put --json $KEY.double=3.14
 '
 test_expect_success 'kvs: string put' '
-	flux kvs put $KEY.string=foo
+	flux kvs put --json $KEY.string=foo
 '
 test_expect_success 'kvs: empty string put' '
-	flux kvs put $KEY.emptystring=
+	flux kvs put --json $KEY.emptystring=
 '
 test_expect_success 'kvs: null is converted to json null' '
-	flux kvs put $KEY.jsonnull=null
+	flux kvs put --json $KEY.jsonnull=null
 '
 test_expect_success 'kvs: quoted null is converted to string' '
-	flux kvs put $KEY.strnull=\"null\"
+	flux kvs put --json $KEY.strnull=\"null\"
 '
 test_expect_success 'kvs: boolean true put' '
-	flux kvs put $KEY.booleantrue=true
+	flux kvs put --json $KEY.booleantrue=true
 '
 test_expect_success 'kvs: boolean false put' '
-	flux kvs put $KEY.booleanfalse=false
+	flux kvs put --json $KEY.booleanfalse=false
 '
 test_expect_success 'kvs: array put' '
-	flux kvs put $KEY.array="[1,3,5]"
+	flux kvs put --json $KEY.array="[1,3,5]"
 '
 test_expect_success 'kvs: object put' '
-	flux kvs put $KEY.object="{\"a\":42}"
+	flux kvs put --json $KEY.object="{\"a\":42}"
 '
 test_expect_success 'kvs: mkdir' '
 	flux kvs mkdir $SUBDIR1
@@ -191,7 +191,7 @@ test_expect_success 'kvs: unlink -R works' '
 #
 
 test_expect_success 'kvs: put (multiple)' '
-	flux kvs put $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
+	flux kvs put --json $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
 '
 test_expect_success 'kvs: get (multiple)' '
 	flux kvs get $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output &&
@@ -244,11 +244,11 @@ test_expect_success 'kvs: unlink -R works' '
 '
 test_expect_success 'kvs: create a dir with keys and subdir' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a=69 &&
-        flux kvs put $DIR.b=70 &&
-        flux kvs put $DIR.c.d.e.f.g=3.14 &&
-        flux kvs put $DIR.d=\"snerg\" &&
-        flux kvs put $DIR.e=true &&
+	flux kvs put --json $DIR.a=69 &&
+        flux kvs put --json $DIR.b=70 &&
+        flux kvs put --json $DIR.c.d.e.f.g=3.14 &&
+        flux kvs put --json $DIR.d=\"snerg\" &&
+        flux kvs put --json $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
@@ -262,11 +262,11 @@ EOF
 
 test_expect_success 'kvs: directory with multiple subdirs' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a=69 &&
-        flux kvs put $DIR.b.c.d.e.f.g=70 &&
-        flux kvs put $DIR.c.a.b=3.14 &&
-        flux kvs put $DIR.d=\"snerg\" &&
-        flux kvs put $DIR.e=true &&
+	flux kvs put --json $DIR.a=69 &&
+        flux kvs put --json $DIR.b.c.d.e.f.g=70 &&
+        flux kvs put --json $DIR.c.a.b=3.14 &&
+        flux kvs put --json $DIR.d=\"snerg\" &&
+        flux kvs put --json $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
@@ -283,7 +283,7 @@ EOF
 #
 test_expect_success 'kvs: ls -1F DIR works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a=69 &&
+	flux kvs put --json $DIR.a=69 &&
 	flux kvs mkdir $DIR.b &&
 	flux kvs link b $DIR.c &&
 	flux kvs ls -1F $DIR >output &&
@@ -296,7 +296,7 @@ test_expect_success 'kvs: ls -1F DIR works' '
 '
 test_expect_success 'kvs: ls -1Fd DIR.a DIR.b DIR.c works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a=69 &&
+	flux kvs put --json $DIR.a=69 &&
 	flux kvs mkdir $DIR.b &&
 	flux kvs link b $DIR.c &&
 	flux kvs ls -1Fd $DIR.a $DIR.b $DIR.c >output &&
@@ -309,8 +309,8 @@ test_expect_success 'kvs: ls -1Fd DIR.a DIR.b DIR.c works' '
 '
 test_expect_success 'kvs: ls -1RF shows directory titles' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a=69 &&
-	flux kvs put $DIR.b.d=42 &&
+	flux kvs put --json $DIR.a=69 &&
+	flux kvs put --json $DIR.b.d=42 &&
 	flux kvs link b $DIR.c &&
 	flux kvs ls -1RF $DIR | grep : | wc -l >output &&
 	cat >expected <<-EOF &&
@@ -387,7 +387,7 @@ test_expect_success 'kvs: ls key. works' '
 '
 test_expect_success 'kvs: ls key. fails if key is not a directory' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a=42 &&
+	flux kvs put --json $DIR.a=42 &&
 	test_must_fail flux kvs ls -d $DIR.a.
 '
 test_expect_success 'kvs: ls key. fails if key does not exist' '
@@ -412,10 +412,10 @@ test_expect_success 'kvs: try to retrieve a directory as key should fail' '
 #
 
 test_expect_success 'kvs: put with invalid input' '
-	test_must_fail flux kvs put NOVALUE
+	test_must_fail flux kvs put --json NOVALUE
 '
 test_expect_success 'kvs: put key of . fails' '
-	test_must_fail flux kvs put .=1
+	test_must_fail flux kvs put --json .=1
 '
 
 #
@@ -428,7 +428,7 @@ test_empty_directory() {
 }
 
 test_expect_success 'kvs: try to retrieve key as directory should fail' '
-        flux kvs put $DIR.a.b.c.d=42 &&
+        flux kvs put --json $DIR.a.b.c.d=42 &&
 	test_must_fail flux kvs dir $DIR.a.b.c.d
 '
 test_expect_success 'kvs: empty directory can be created' '
@@ -462,7 +462,7 @@ test_expect_success 'kvs: unlink -R works' '
 '
 test_expect_success 'kvs: empty directory remains after key removed' '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a=1 &&
+        flux kvs put --json $DIR.a=1 &&
         test_kvs_key $DIR.a 1 &&
         flux kvs unlink $DIR.a &&
 	test_empty_directory $DIR
@@ -473,32 +473,32 @@ test_expect_success 'kvs: empty directory remains after key removed' '
 #
 test_expect_success 'kvs: put with leading path separators works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put ......$DIR.a.b.c=42 &&
+	flux kvs put --json ......$DIR.a.b.c=42 &&
 	test_kvs_key $DIR.a.b.c 42
 '
 test_expect_success 'kvs: put with trailing path separators works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c........=43 &&
+	flux kvs put --json $DIR.a.b.c........=43 &&
 	test_kvs_key $DIR.a.b.c 43
 '
 test_expect_success 'kvs: put with extra embedded path separators works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.....a....b...c=44 &&
+	flux kvs put --json $DIR.....a....b...c=44 &&
 	test_kvs_key $DIR.a.b.c 44
 '
 test_expect_success 'kvs: get with leading path separators works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c=42 &&
+	flux kvs put --json $DIR.a.b.c=42 &&
 	test_kvs_key ......$DIR.a.b.c 42
 '
 test_expect_success 'kvs: get with trailing path separators works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c=43 &&
+	flux kvs put --json $DIR.a.b.c=43 &&
 	test_kvs_key $DIR.a.b.c........ 43
 '
 test_expect_success 'kvs: get with extra embedded path separators works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c=44 &&
+	flux kvs put --json $DIR.a.b.c=44 &&
 	test_kvs_key $DIR.....a....b...c 44
 '
 
@@ -508,14 +508,14 @@ test_expect_success 'kvs: get with extra embedded path separators works' '
 
 test_expect_success 'kvs: link works' '
 	TARGET=$DIR.target &&
-	flux kvs put $TARGET=\"foo\" &&
+	flux kvs put --json $TARGET=\"foo\" &&
 	flux kvs link $TARGET $DIR.link &&
 	OUTPUT=$(flux kvs get $DIR.link) &&
 	test "$OUTPUT" = "foo"
 '
 test_expect_success 'kvs: readlink works' '
 	TARGET=$DIR.target &&
-	flux kvs put $TARGET=\"foo\" &&
+	flux kvs put --json $TARGET=\"foo\" &&
 	flux kvs link $TARGET $DIR.link &&
 	OUTPUT=$(flux kvs readlink $DIR.link) &&
 	test "$OUTPUT" = "$TARGET"
@@ -523,8 +523,8 @@ test_expect_success 'kvs: readlink works' '
 test_expect_success 'kvs: readlink works (multiple inputs)' '
 	TARGET1=$DIR.target1 &&
 	TARGET2=$DIR.target2 &&
-	flux kvs put $TARGET1=\"foo1\" &&
-	flux kvs put $TARGET2=\"foo2\" &&
+	flux kvs put --json $TARGET1=\"foo1\" &&
+	flux kvs put --json $TARGET2=\"foo2\" &&
 	flux kvs link $TARGET1 $DIR.link1 &&
 	flux kvs link $TARGET2 $DIR.link2 &&
 	flux kvs readlink $DIR.link1 $DIR.link2 >output &&
@@ -536,7 +536,7 @@ EOF
 '
 test_expect_success 'kvs: readlink fails on regular value' '
         flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.target=42 &&
+	flux kvs put --json $DIR.target=42 &&
 	! flux kvs readlink $DIR.target
 '
 test_expect_success 'kvs: readlink fails on directory' '
@@ -546,7 +546,7 @@ test_expect_success 'kvs: readlink fails on directory' '
 '
 test_expect_success 'kvs: link: path resolution when intermediate component is a link' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c=42 &&
+	flux kvs put --json $DIR.a.b.c=42 &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
 	OUTPUT=$(flux kvs get $DIR.Z.Y.c) &&
 	test "$OUTPUT" = "42"
@@ -558,7 +558,7 @@ test_expect_success 'kvs: link: path resolution with intermediate link and nonex
 '
 test_expect_success 'kvs: link: intermediate link points to another link' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c=42 &&
+	flux kvs put --json $DIR.a.b.c=42 &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
 	flux kvs link $DIR.Z.Y $DIR.X.W &&
 	test_kvs_key $DIR.X.W.c 42
@@ -568,7 +568,7 @@ test_expect_success 'kvs: link: intermediate links are followed by put' '
 	flux kvs mkdir $DIR.a &&
 	flux kvs link $DIR.a $DIR.link &&
 	flux kvs readlink $DIR.link >/dev/null &&
-	flux kvs put $DIR.link.X=42 &&
+	flux kvs put --json $DIR.link.X=42 &&
 	flux kvs readlink $DIR.link >/dev/null &&
 	test_kvs_key $DIR.link.X 42 &&
 	test_kvs_key $DIR.a.X 42
@@ -579,7 +579,7 @@ test_expect_success 'kvs: link: kvs_copy removes linked destination' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs mkdir $DIR.a &&
 	flux kvs link $DIR.a $DIR.link &&
-	flux kvs put $DIR.a.X=42 &&
+	flux kvs put --json $DIR.a.X=42 &&
 	flux kvs copy $DIR.a $DIR.link &&
 	! flux kvs readlink $DIR.link >/dev/null &&
 	test_kvs_key $DIR.link.X 42
@@ -590,7 +590,7 @@ test_expect_success 'kvs: link: kvs_move works' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs mkdir $DIR.a &&
 	flux kvs link $DIR.a $DIR.link &&
-	flux kvs put $DIR.a.X=42 &&
+	flux kvs put --json $DIR.a.X=42 &&
 	flux kvs move $DIR.a $DIR.link &&
 	! flux kvs readlink $DIR.link >/dev/null &&
 	test_kvs_key $DIR.link.X 42 &&
@@ -599,7 +599,7 @@ test_expect_success 'kvs: link: kvs_move works' '
 
 test_expect_success 'kvs: link: kvs_copy does not follow links (top)' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.X=42 &&
+	flux kvs put --json $DIR.a.X=42 &&
 	flux kvs link $DIR.a $DIR.link &&
 	flux kvs copy $DIR.link $DIR.copy &&
 	LINKVAL=$(flux kvs readlink $DIR.copy) &&
@@ -608,7 +608,7 @@ test_expect_success 'kvs: link: kvs_copy does not follow links (top)' '
 
 test_expect_success 'kvs: link: kvs_copy does not follow links (mid)' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.X=42 &&
+	flux kvs put --json $DIR.a.b.X=42 &&
 	flux kvs link $DIR.a.b $DIR.a.link &&
 	flux kvs copy $DIR.a $DIR.copy &&
 	LINKVAL=$(flux kvs readlink $DIR.copy.link) &&
@@ -617,7 +617,7 @@ test_expect_success 'kvs: link: kvs_copy does not follow links (mid)' '
 
 test_expect_success 'kvs: link: kvs_copy does not follow links (bottom)' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.X=42 &&
+	flux kvs put --json $DIR.a.b.X=42 &&
 	flux kvs link $DIR.a.b.X $DIR.a.b.link &&
 	flux kvs copy $DIR.a $DIR.copy &&
 	LINKVAL=$(flux kvs readlink $DIR.copy.b.link) &&
@@ -635,7 +635,7 @@ test_expect_success 'kvs: link: readlink on dangling link' '
 '
 test_expect_success 'kvs: link: readlink works on non-dangling link' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.a.b.c="foo" &&
+	flux kvs put --json $DIR.a.b.c="foo" &&
 	flux kvs link $DIR.a.b.c $DIR.link &&
 	OUTPUT=$(flux kvs readlink $DIR.link) &&
 	test "$OUTPUT" = "$DIR.a.b.c"
@@ -645,7 +645,7 @@ test_expect_success 'kvs: link: readlink works on non-dangling link' '
 
 test_expect_success 'kvs: link: error on link depth' '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a=1 &&
+        flux kvs put --json $DIR.a=1 &&
 	flux kvs link $DIR.a $DIR.b &&
 	flux kvs link $DIR.b $DIR.c &&
 	flux kvs link $DIR.c $DIR.d &&
@@ -672,7 +672,7 @@ test_expect_success 'kvs: link: error on link depth, loop' '
 #
 test_expect_success 'kvs: copy works' '
         flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.src=\"foo\" &&
+	flux kvs put --json $DIR.src=\"foo\" &&
         flux kvs copy $DIR.src $DIR.dest &&
 	OUTPUT1=$(flux kvs get $DIR.src) &&
 	OUTPUT2=$(flux kvs get $DIR.dest) &&
@@ -682,7 +682,7 @@ test_expect_success 'kvs: copy works' '
 
 test_expect_success 'kvs: move works' '
         flux kvs unlink -Rf $DIR &&
-	flux kvs put $DIR.src=\"foo\" &&
+	flux kvs put --json $DIR.src=\"foo\" &&
         flux kvs move $DIR.src $DIR.dest &&
 	test_must_fail flux kvs get $DIR.src &&
 	OUTPUT=$(flux kvs get $DIR.dest) &&
@@ -709,7 +709,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: version and wait' '
         VERS=$((VERS + 1))
         flux kvs wait $VERS &
         kvswaitpid=$! &&
-        flux kvs put $DIR.xxx=99 &&
+        flux kvs put --json $DIR.xxx=99 &&
         test_expect_code 0 wait $kvswaitpid
 '
 
@@ -775,13 +775,13 @@ wait_watch_current() {
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.foo=0 &&
+        flux kvs put --json $DIR.foo=0 &&
         wait_watch_put "$DIR.foo" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
         wait_watch_current "0"
-        flux kvs put $DIR.foo=1 &&
+        flux kvs put --json $DIR.foo=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	0
@@ -797,7 +797,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist' 
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
         wait_watch_current "nil" &&
-        flux kvs put $DIR.foo=1 &&
+        flux kvs put --json $DIR.foo=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	nil
@@ -808,7 +808,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist' 
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.foo=0 &&
+        flux kvs put --json $DIR.foo=0 &&
         wait_watch_put "$DIR.foo" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
@@ -825,13 +825,13 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.foo=0 &&
+        flux kvs put --json $DIR.foo=0 &&
         wait_watch_put "$DIR.foo" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
         wait_watch_current "0" &&
-        flux kvs put $DIR.foo.bar.baz=1 &&
+        flux kvs put --json $DIR.foo.bar.baz=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	0
@@ -844,14 +844,14 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
+        flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
         wait_watch_put "$DIR.a.a" "0" &&
         wait_watch_put "$DIR.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         wait_watch_current "======================" &&
-        flux kvs put $DIR.a.a=1 &&
+        flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	$DIR.a.
@@ -869,7 +869,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist' 
 	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         wait_watch_current "nil" &&
-        flux kvs put $DIR.a.a=1 &&
+        flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	nil
@@ -882,7 +882,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist' 
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
+        flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         wait_watch_put "$DIR.a.a.a" "0" &&
         wait_watch_put "$DIR.a.a.b" "0"
         rm -f watch_out
@@ -902,14 +902,14 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
+        flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         wait_watch_put "$DIR.a.a.a" "0" &&
         wait_watch_put "$DIR.a.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
         wait_watch_current "======================" &&
-        flux kvs put $DIR.a=1 &&
+        flux kvs put --json $DIR.a=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	$DIR.a.a.
@@ -925,14 +925,14 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
 # $DIR.a is no longer valid and we should see 'nil' as a result.
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, prefix path converted into a key'  '
         flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a.a.a=0 $DIR.a.a.b=0 &&
+        flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         wait_watch_put "$DIR.a.a.a" "0" &&
         wait_watch_put "$DIR.a.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
         wait_watch_current "======================" &&
-        flux kvs put $DIR=1 &&
+        flux kvs put --json $DIR=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
 	$DIR.a.a.
@@ -965,14 +965,14 @@ sort_watch_output() {
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
         flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
+        flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
         wait_watch_put "$DIR.a.a" "0" &&
         wait_watch_put "$DIR.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -R -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         wait_watch_current "======================" &&
-        flux kvs put $DIR.a.a=1 &&
+        flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
         sort_watch_output
 	cat >expected <<-EOF &&
@@ -988,14 +988,14 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R and -d'  '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put $DIR.a.a=0 $DIR.a.b=0 &&
+        flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
         wait_watch_put "$DIR.a.a" "0" &&
         wait_watch_put "$DIR.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -R -d -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         wait_watch_current "======================" &&
-        flux kvs put $DIR.a.a=1 &&
+        flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
         sort_watch_output
 	cat >expected <<-EOF &&

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -471,6 +471,40 @@ test_expect_success 'kvs: empty string value does not cause ls -FR to fail' '
 '
 
 #
+# raw value tests
+#
+test_expect_success 'kvs: put/get --raw works with multiple key=val pairs' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a=xyz $DIR.b=zyx &&
+	printf "%s" 'xyzzyx' >twovals.expected &&
+	flux kvs get --raw $DIR.a $DIR.b >twovals.actual &&
+	test_cmp twovals.expected twovals.actual
+'
+test_expect_success 'kvs: put --raw a=- reads value from stdin' '
+	flux kvs unlink -Rf $DIR &&
+	printf "%s" "abc" | flux kvs put --raw $DIR.a=- &&
+	printf "%s" "abc" >rawstdin.expected &&
+	flux kvs get --raw $DIR.a >rawstdin.actual &&
+	test_cmp rawstdin.expected rawstdin.actual
+'
+test_expect_success 'kvs: put --raw a=- b=42 works' '
+	flux kvs unlink -Rf $DIR &&
+	printf "%s" "abc" | flux kvs put --raw $DIR.a=- $DIR.b=42 &&
+	printf "%s" "abc42" >rawstdin2.expected &&
+	flux kvs get --raw $DIR.a $DIR.b >rawstdin2.actual &&
+	test_cmp rawstdin2.expected rawstdin2.actual
+'
+test_expect_success 'kvs: put --raw a=- b=- works with a getting all of stdin' '
+	flux kvs unlink -Rf $DIR &&
+	printf "%s" "abc" | flux kvs put --raw $DIR.a=- $DIR.b=- &&
+	printf "%s" "abc" >rawstdin3a.expected &&
+	flux kvs get --raw $DIR.a >rawstdin3a.actual &&
+	flux kvs get --raw $DIR.b >rawstdin3b.actual &&
+	test_cmp rawstdin3a.expected rawstdin3a.actual &&
+	test_cmp /dev/null rawstdin3b.actual
+'
+
+#
 # treeobj tests
 #
 test_expect_success 'kvs: treeobj of all types handled by get --treeobj' '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -396,6 +396,48 @@ test_expect_success 'kvs: ls key. fails if key does not exist' '
 '
 
 #
+# zero-length values
+#
+test_expect_success 'kvs: zero-length value handled by put/get --raw' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a= &&
+	flux kvs get --raw $DIR.a >empty.output &&
+	test_cmp /dev/null empty.output
+'
+test_expect_success 'kvs: zero-length value handled by get with no options' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a= &&
+	flux kvs get $DIR.a >empty2.output &&
+	test_cmp /dev/null empty2.output
+'
+test_expect_success 'kvs: zero-length value handled by get --treeobj' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a= &&
+	flux kvs get --treeobj $DIR.a
+'
+test_expect_success 'kvs: zero-length value NOT handled by get --json' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a= &&
+	test_must_fail flux kvs get --json $DIR.a
+'
+test_expect_success 'kvs: zero-length value NOT made by put with no options' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a= &&
+	flux kvs get --raw $DIR.a >onenull.output &&
+	test_must_fail diff -q /dev/null onenull.output
+'
+test_expect_success 'kvs: zero-length value does not cause dir to fail' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a= &&
+	flux kvs dir $DIR
+'
+test_expect_success 'kvs: zero-length value does not cause ls -FR to fail' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put --raw $DIR.a= &&
+	flux kvs ls -FR $DIR
+'
+
+#
 # get corner case tests
 #
 

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -112,13 +112,13 @@ test_expect_success 'kvs: object type' '
 	test_kvs_type $KEY object
 '
 
-test_expect_success 'kvs: put using no-merge flag' '
+test_expect_success 'kvs: put using --no-merge flag' '
 	flux kvs unlink -Rf $TEST &&
-	${KVSBASIC} put-no-merge $DIR.a=69 &&
-        ${KVSBASIC} put-no-merge $DIR.b.c.d.e.f.g=70 &&
-        ${KVSBASIC} put-no-merge $DIR.c.a.b=3.14 &&
-        ${KVSBASIC} put-no-merge $DIR.d=\"snerg\" &&
-        ${KVSBASIC} put-no-merge $DIR.e=true &&
+	flux kvs put --no-merge --json $DIR.a=69 &&
+        flux kvs put --no-merge --json $DIR.b.c.d.e.f.g=70 &&
+        flux kvs put --no-merge --json $DIR.c.a.b=3.14 &&
+        flux kvs put --no-merge --json $DIR.d=\"snerg\" &&
+        flux kvs put --no-merge --json $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -29,7 +29,7 @@ KEY=test.a.b.c
 #
 #
 test_kvs_key() {
-	flux kvs get "$1" >output
+	flux kvs get --json "$1" >output
 	echo "$2" >expected
 	test_cmp output expected
 	#if ! test "$OUTPUT" = "$2"; then
@@ -201,7 +201,7 @@ test_expect_success 'kvs: put-treeobj: clobbers destination' '
 	flux kvs put --json $TEST.a=42 &&
 	${KVSBASIC} get-treeobj . >snapshot2 &&
 	${KVSBASIC} put-treeobj $TEST.a="`cat snapshot2`" &&
-	! flux kvs get $TEST.a &&
+	! flux kvs get --json $TEST.a &&
 	flux kvs dir $TEST.a
 '
 
@@ -294,7 +294,7 @@ test_expect_success 'kvs: valref that points to content store data can be read' 
         flux kvs unlink -Rf $TEST &&
 	echo "$largeval" | flux content store &&
 	${KVSBASIC} put-treeobj $TEST.largeval2="{\"data\":[\"${largevalhash}\"],\"type\":\"valref\",\"ver\":1}" &&
-        flux kvs get $TEST.largeval2 | grep $largeval
+        flux kvs get --json $TEST.largeval2 | grep $largeval
 '
 
 test_expect_success 'kvs: valref that points to zero size content store data can be read' '
@@ -400,13 +400,13 @@ test_expect_success 'kvs: store 3x4 directory tree using kvsdir_put functions' '
 test_expect_success 'kvs: put on rank 0, exists on all ranks' '
 	flux kvs put --json $TEST.xxx=99 &&
 	VERS=$(flux kvs version) &&
-	flux exec sh -c "flux kvs wait ${VERS} && flux kvs get $TEST.xxx"
+	flux exec sh -c "flux kvs wait ${VERS} && flux kvs get --json $TEST.xxx"
 '
 
 test_expect_success 'kvs: unlink on rank 0, does not exist all ranks' '
 	flux kvs unlink -Rf $TEST.xxx &&
 	VERS=$(flux kvs version) &&
-	flux exec sh -c "flux kvs wait ${VERS} && ! flux kvs get $TEST.xxx"
+	flux exec sh -c "flux kvs wait ${VERS} && ! flux kvs get --json $TEST.xxx"
 '
 
 # commit test

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -261,12 +261,6 @@ test_expect_success 'kvs: get --at: works on outdated root' '
 	test $(flux kvs get --at $ROOTREF $TEST.a.b.c) = 42
 '
 
-test_expect_success 'kvs: zero size raw value can be stored and retrieved' '
-	flux kvs unlink -Rf $TEST &&
-	flux kvs put --raw $TEST.empty=-  </dev/null &&
-	test $(flux kvs get --raw $TEST.empty |wc -c) -eq 0
-'
-
 test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs mkdir $TEST.dirsize &&
 	flux kvs put --json $TEST.dirsize.a=1 &&

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -272,7 +272,7 @@ test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs put --json $TEST.dirsize.a=1 &&
 	flux kvs put --json $TEST.dirsize.b=2 &&
 	flux kvs put --json $TEST.dirsize.c=3 &&
-	OUTPUT=$(${KVSBASIC} dirsize $TEST.dirsize) &&
+	OUTPUT=$(flux kvs ls -1 $TEST.dirsize | wc -l) &&
 	test "$OUTPUT" = "3"
 '
 

--- a/t/t1002-kvs-extra.t
+++ b/t/t1002-kvs-extra.t
@@ -45,24 +45,24 @@ test_kvs_type () {
 }
 
 test_expect_success 'kvs: integer put' '
-	flux kvs put $KEY=42 
+	flux kvs put --json $KEY=42 
 '
 test_expect_success 'kvs: integer type' '
 	test_kvs_type $KEY int
 '
 test_expect_success 'kvs: value can be empty' '
-	flux kvs put $KEY= &&
+	flux kvs put --json $KEY= &&
 	  test_kvs_key $KEY "" &&
 	  test_kvs_type $KEY string
 '
 test_expect_success 'kvs: null is converted to json null' '
-	flux kvs put $KEY=null &&
+	flux kvs put --json $KEY=null &&
 	  test_kvs_key $KEY nil &&
 	  test_kvs_type $KEY null
 '
 
 test_expect_success 'kvs: quoted null is converted to string' '
-	flux kvs put $KEY=\"null\" &&
+	flux kvs put --json $KEY=\"null\" &&
 	  test_kvs_key $KEY null &&
 	  test_kvs_type $KEY string
 '
@@ -70,19 +70,19 @@ test_expect_success 'kvs: quoted null is converted to string' '
 KEY=$TEST.b.c.d
 DIR=$TEST.b.c
 test_expect_success 'kvs: string put' '
-	flux kvs put $KEY="Hello world"
+	flux kvs put --json $KEY="Hello world"
 '
 test_expect_success 'kvs: string type' '
 	test_kvs_type $KEY string
 '
 test_expect_success 'kvs: boolean put' '
-	flux kvs put $KEY=true
+	flux kvs put --json $KEY=true
 '
 test_expect_success 'kvs: boolean type' '
 	test_kvs_type $KEY boolean
 '
 test_expect_success 'kvs: put double' '
-	flux kvs put $KEY=3.14159
+	flux kvs put --json $KEY=3.14159
 '
 test_expect_success 'kvs: double type' '
 	test_kvs_type $KEY double
@@ -90,7 +90,7 @@ test_expect_success 'kvs: double type' '
 
 # issue 875
 test_expect_success 'kvs: integer can be read as int, int64, or double' '
-	flux kvs put $TEST.a=2 &&
+	flux kvs put --json $TEST.a=2 &&
 	test_kvs_type $TEST.a int &&
 	test $($GETAS -t int $TEST.a) = "2" &&
 	test $($GETAS -t int -d $TEST a) = "2" &&
@@ -100,13 +100,13 @@ test_expect_success 'kvs: integer can be read as int, int64, or double' '
 	test $($GETAS -t double -d $TEST a | cut -d. -f1) = "2"
 '
 test_expect_success 'kvs: array put' '
-	flux kvs put $KEY="[1,3,5,7]"
+	flux kvs put --json $KEY="[1,3,5,7]"
 '
 test_expect_success 'kvs: array type' '
 	test_kvs_type $KEY array
 '
 test_expect_success 'kvs: object put' '
-	flux kvs put $KEY="{\"a\":42}"
+	flux kvs put --json $KEY="{\"a\":42}"
 '
 test_expect_success 'kvs: object type' '
 	test_kvs_type $KEY object
@@ -132,11 +132,11 @@ EOF
 
 test_expect_success 'kvs: directory with multiple subdirs using dirat' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $DIR.a=69 &&
-        flux kvs put $DIR.b.c.d.e.f.g=70 &&
-        flux kvs put $DIR.c.a.b=3.14 &&
-        flux kvs put $DIR.d=\"snerg\" &&
-        flux kvs put $DIR.e=true &&
+	flux kvs put --json $DIR.a=69 &&
+        flux kvs put --json $DIR.b.c.d.e.f.g=70 &&
+        flux kvs put --json $DIR.c.a.b=3.14 &&
+        flux kvs put --json $DIR.d=\"snerg\" &&
+        flux kvs put --json $DIR.e=true &&
         DIRREF=$(${KVSBASIC} get-treeobj $DIR) &&
 	${KVSBASIC} dirat -r $DIRREF . | sort >output &&
 	cat >expected <<EOF &&
@@ -171,7 +171,7 @@ test_expect_success 'kvs: get-treeobj: returns dirref object for directory' '
 
 test_expect_success 'kvs: get-treeobj: returns val object for small value' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $TEST.a=b &&
+	flux kvs put --json $TEST.a=b &&
 	${KVSBASIC} get-treeobj $TEST.a | grep -q \"val\"
 '
 
@@ -183,7 +183,7 @@ test_expect_success 'kvs: get-treeobj: returns value ref for large value' '
 
 test_expect_success 'kvs: get-treeobj: returns link value for symlink' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $TEST.a.b.X=42 &&
+	flux kvs put --json $TEST.a.b.X=42 &&
 	flux kvs link $TEST.a.b.X $TEST.a.b.link &&
 	${KVSBASIC} get-treeobj $TEST.a.b.link | grep -q \"symlink\"
 '
@@ -198,7 +198,7 @@ test_expect_success 'kvs: put-treeobj: can make root snapshot' '
 
 test_expect_success 'kvs: put-treeobj: clobbers destination' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $TEST.a=42 &&
+	flux kvs put --json $TEST.a=42 &&
 	${KVSBASIC} get-treeobj . >snapshot2 &&
 	${KVSBASIC} put-treeobj $TEST.a="`cat snapshot2`" &&
 	! flux kvs get $TEST.a &&
@@ -243,21 +243,21 @@ test_expect_success 'kvs: getat: fails bad on dirent' '
 
 test_expect_success 'kvs: getat: works on root from get-treeobj' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
+	flux kvs put --json $TEST.a.b.c=42 &&
 	test $(${KVSBASIC} getat $(${KVSBASIC} get-treeobj .) $TEST.a.b.c) = 42
 '
 
 test_expect_success 'kvs: getat: works on subdir from get-treeobj' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
+	flux kvs put --json $TEST.a.b.c=42 &&
 	test $(${KVSBASIC} getat $(${KVSBASIC} get-treeobj $TEST.a.b) c) = 42
 '
 
 test_expect_success 'kvs: getat: works on outdated root' '
 	flux kvs unlink -Rf $TEST &&
-	flux kvs put $TEST.a.b.c=42 &&
+	flux kvs put --json $TEST.a.b.c=42 &&
 	ROOTREF=$(${KVSBASIC} get-treeobj .) &&
-	flux kvs put $TEST.a.b.c=43 &&
+	flux kvs put --json $TEST.a.b.c=43 &&
 	test $(${KVSBASIC} getat $ROOTREF $TEST.a.b.c) = 42
 '
 
@@ -269,9 +269,9 @@ test_expect_success 'kvs: zero size raw value can be stored and retrieved' '
 
 test_expect_success 'kvs: kvsdir_get_size works' '
 	flux kvs mkdir $TEST.dirsize &&
-	flux kvs put $TEST.dirsize.a=1 &&
-	flux kvs put $TEST.dirsize.b=2 &&
-	flux kvs put $TEST.dirsize.c=3 &&
+	flux kvs put --json $TEST.dirsize.a=1 &&
+	flux kvs put --json $TEST.dirsize.b=2 &&
+	flux kvs put --json $TEST.dirsize.c=3 &&
 	OUTPUT=$(${KVSBASIC} dirsize $TEST.dirsize) &&
 	test "$OUTPUT" = "3"
 '
@@ -284,7 +284,7 @@ largevalhash="sha1-79da8e5c9dbe65c6460377d3f09b8f535ceb7d9d"
 
 test_expect_success 'kvs: large put stores raw data into content store' '
 	flux kvs unlink -Rf $TEST &&
- 	flux kvs put $TEST.largeval=$largeval &&
+ 	flux kvs put --json $TEST.largeval=$largeval &&
  	${KVSBASIC} get-treeobj $TEST.largeval | grep -q \"valref\" &&
  	${KVSBASIC} get-treeobj $TEST.largeval | grep -q ${largevalhash} &&
         flux content load ${largevalhash} | grep $largeval
@@ -384,8 +384,8 @@ test_expect_success 'kvs: store 2x4 directory tree and walk' '
 # exercise kvsdir_get_symlink, _double, _boolean, 
 test_expect_success 'kvs: add other types to 2x4 directory and walk' '
 	flux kvs link $TEST.dtree $TEST.dtree.link &&
-	flux kvs put $TEST.dtree.double=3.14 &&
-	flux kvs put $TEST.dtree.booelan=true &&
+	flux kvs put --json $TEST.dtree.double=3.14 &&
+	flux kvs put --json $TEST.dtree.booelan=true &&
 	test $(flux kvs dir -R $TEST.dtree | wc -l) = 19
 '
 
@@ -398,7 +398,7 @@ test_expect_success 'kvs: store 3x4 directory tree using kvsdir_put functions' '
 # test synchronization based on commit sequence no.
 
 test_expect_success 'kvs: put on rank 0, exists on all ranks' '
-	flux kvs put $TEST.xxx=99 &&
+	flux kvs put --json $TEST.xxx=99 &&
 	VERS=$(flux kvs version) &&
 	flux exec sh -c "flux kvs wait ${VERS} && flux kvs get $TEST.xxx"
 '

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -29,8 +29,8 @@ test_expect_success 'wreckrun: -T, --walltime works' '
 	test_expect_code 142 flux wreckrun --walltime=1s -n${SIZE} sleep 15
 '
 test_expect_success 'wreckrun: -T, --walltime allows override of default signal' '
-        flux kvs put lwj.walltime-signal=SIGTERM &&
-        test_when_finished flux kvs put lwj.walltime-signal= &&
+        flux kvs put --json lwj.walltime-signal=SIGTERM &&
+        test_when_finished flux kvs put --json lwj.walltime-signal= &&
 	test_expect_code 143 flux wreckrun -T 1s -n${SIZE} sleep 5
 '
 test_expect_success 'wreckrun: -T, --walltime allows per-job override of default signal' '
@@ -230,7 +230,7 @@ test_expect_success MULTICORE 'wreckrun: supports per-task affinity assignment' 
 	test_cmp expected_cpus2 output_cpus2
 '
 test_expect_success 'wreckrun: top level environment' '
-	flux kvs put lwj.environ="{ \"TEST_ENV_VAR\": \"foo\" }" &&
+	flux kvs put --json lwj.environ="{ \"TEST_ENV_VAR\": \"foo\" }" &&
 	run_timeout 5 flux wreckrun -n2 printenv TEST_ENV_VAR > output_top_env &&
 	cat <<-EOF >expected_top_env &&
 	foo
@@ -285,9 +285,9 @@ test_expect_success 'wreckrun: --error supported' '
         $WAITFILE -v --timeout=1 -p "this is stdout" test2.out
 '
 test_expect_success 'wreckrun: kvs config output for all jobs' '
-	test_when_finished "flux kvs put lwj.output=" &&
-	flux kvs put lwj.output.labelio=true &&
-	flux kvs put lwj.output.files.stdout=test3.out &&
+	test_when_finished "flux kvs put --json lwj.output=" &&
+	flux kvs put --json lwj.output.labelio=true &&
+	flux kvs put --json lwj.output.files.stdout=test3.out &&
 	flux wreckrun -n${SIZE} echo foo &&
 	for i in $(seq 0 $((${SIZE}-1)))
 		do echo "$i: foo"

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -182,25 +182,25 @@ test_expect_success 'wreckrun: -N without -n works' '
 test_expect_success 'wreckrun: -N without -n sets ntasks in kvs' '
 	flux wreckrun -l -N${SIZE} /bin/true &&
 	LWJ=$(last_job_path) &&
-	n=$(flux kvs get ${LWJ}.ntasks) &&
+	n=$(flux kvs get --json ${LWJ}.ntasks) &&
 	test "$n" = "${SIZE}"
 '
 test_expect_success 'wreckrun: -n without -N sets nnnodes in kvs' '
 	flux wreckrun -l -n${SIZE} /bin/true &&
 	LWJ=$(last_job_path) &&
-	n=$(flux kvs get ${LWJ}.nnodes) &&
+	n=$(flux kvs get --json ${LWJ}.nnodes) &&
 	test "$n" = "${SIZE}"
 '
 test_expect_success 'wreckrun: -t1 -N${SIZE} sets ntasks in kvs' '
 	flux wreckrun -l -t1 -N${SIZE} /bin/true &&
 	LWJ=$(last_job_path) &&
-	n=$(flux kvs get ${LWJ}.ntasks) &&
+	n=$(flux kvs get --json ${LWJ}.ntasks) &&
 	test "$n" = "${SIZE}"
 '
 test_expect_success 'wreckrun: -t1 -n${SIZE} sets nnodes in kvs' '
 	flux wreckrun -l -t1 -n${SIZE} /bin/true &&
 	LWJ=$(last_job_path) &&
-	n=$(flux kvs get ${LWJ}.nnodes) &&
+	n=$(flux kvs get --json ${LWJ}.nnodes) &&
 	test "$n" = "${SIZE}"
 '
 
@@ -374,7 +374,7 @@ test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded'
 check_complete_link() {
     for i in `seq 0 5`; do
         lastepoch=$(flux kvs dir lwj-complete | awk -F. '{print $2}' | sort -n | tail -1)
-        flux kvs get lwj-complete.${lastepoch}.${1}.state && return 0
+        flux kvs get --json lwj-complete.${lastepoch}.${1}.state && return 0
         sleep 0.2
     done
     return 1

--- a/t/t2001-jsc.t
+++ b/t/t2001-jsc.t
@@ -208,7 +208,7 @@ test_expect_success 'jstat 8: query detects bad inputs' '
 
 test_expect_success 'jstat 9: update state-pair' "
     flux jstat update 1 state-pair '{\"state-pair\": {\"ostate\": 13, \"nstate\": 12}}' &&
-    flux kvs get $(flux wreck kvs-path 1).state > output.9.1 &&
+    flux kvs get --json $(flux wreck kvs-path 1).state > output.9.1 &&
     cat >expected.9.1 <<-EOF &&
 cancelled
 EOF
@@ -216,15 +216,15 @@ EOF
 "
 
 test_expect_success 'jstat 10: update procdescs' "
-    flux kvs get $(flux wreck kvs-path 1).0.procdesc > output.10.1 &&
+    flux kvs get --json $(flux wreck kvs-path 1).0.procdesc > output.10.1 &&
     flux jstat update 1 pdesc '{\"pdesc\": {\"procsize\":1, \"hostnames\":[\"0\"], \"executables\":[\"fake\"], \"pdarray\":[{\"pid\":8482,\"eindx\":0,\"hindx\":0}]}}' &&
-    flux kvs get $(flux wreck kvs-path 1).0.procdesc > output.10.2 &&
+    flux kvs get --json $(flux wreck kvs-path 1).0.procdesc > output.10.2 &&
     test_expect_code 1 diff output.10.1 output.10.2 
 "
 
 test_expect_success 'jstat 11: update rdesc' "
     flux jstat update 1 rdesc '{\"rdesc\": {\"nnodes\": 128, \"ntasks\": 128, \"walltime\":3600}}' &&
-    flux kvs get $(flux wreck kvs-path 1).ntasks > output.11.1 &&
+    flux kvs get --json $(flux wreck kvs-path 1).ntasks > output.11.1 &&
     cat > expected.11.1 <<-EOF &&
 128
 EOF
@@ -233,7 +233,7 @@ EOF
 
 test_expect_success 'jstat 12: update rdl' "
     flux jstat update 1 rdl '{\"rdl\": \"fake_rdl_string\"}' &&
-    flux kvs get $(flux wreck kvs-path 1).rdl > output.12.1 &&
+    flux kvs get --json $(flux wreck kvs-path 1).rdl > output.12.1 &&
     cat > expected.12.1 <<-EOF &&
 fake_rdl_string
 EOF
@@ -242,7 +242,7 @@ EOF
 
 test_expect_success 'jstat 13: update rdl_alloc' "
     flux jstat update 1 rdl_alloc '{\"rdl_alloc\": [{\"contained\": {\"cmbdrank\": 0, \"cmbdncores\": 102}}]}' &&
-    flux kvs get $(flux wreck kvs-path 1).rank.0.cores > output.13.1 &&
+    flux kvs get --json $(flux wreck kvs-path 1).rank.0.cores > output.13.1 &&
     cat > expected.13.1 <<-EOF &&
 102
 EOF

--- a/t/t2002-pmi.t
+++ b/t/t2002-pmi.t
@@ -93,7 +93,7 @@ test_expect_success 'pmi: wreck preputs PMI_process_mapping into kvs' '
 	#!/bin/sh
         if test \${FLUX_TASK_RANK} -eq 0; then
           KVS_PATH=\$(flux wreck kvs-path \${FLUX_JOB_ID})
-          flux kvs get \${KVS_PATH}.pmi.PMI_process_mapping
+          flux kvs get --json \${KVS_PATH}.pmi.PMI_process_mapping
         fi
 	EOF
 	chmod +x print-pmi-map.sh &&

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -115,16 +115,16 @@ test_expect_success HAVE_LSTOPO 'hwloc: test failure of lstopo command' '
 '
 
 test_expect_success 'hwloc: no broken down resource info by default' '
-    test_must_fail flux kvs get resource.hwloc.by_rank.0.Machine_0.OSName
+    test_must_fail flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
 '
 
 test_expect_success 'hwloc: reload --walk-topology=yes works' '
     flux hwloc reload --walk-topology=yes &&
-    flux kvs get resource.hwloc.by_rank.0.Machine_0.OSName
+    flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
 '
 test_expect_success 'hwloc: reload --walk-topology=no removes broken down topo' '
     flux hwloc reload --walk-topology=no &&
-    test_must_fail flux kvs get resource.hwloc.by_rank.0.Machine_0.OSName
+    test_must_fail flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
 '
 
 test_expect_success 'hwloc: reload fails on invalid rank' '
@@ -133,7 +133,7 @@ test_expect_success 'hwloc: reload fails on invalid rank' '
 '
 
 test_expect_success 'hwloc: HostName is populated in by_rank' '
-    HW_HOST=$(flux kvs get resource.hwloc.by_rank.0.HostName) &&
+    HW_HOST=$(flux kvs get --json resource.hwloc.by_rank.0.HostName) &&
     REAL_HOST=$(hostname) &&
     test x"$HW_HOST" = x"$REAL_HOST"
 '


### PR DESCRIPTION
This PR updates the `flux kvs` command to handle non-JSON values.  These deficiencies were discussed  in #1158 and #1159.

A summary of the changes proposed here are:
* `flux kvs dir` displays non-JSON values
* `flux kvs dir` truncates output to fit terminal width, controlled with `--width=COLS`
* `flux kvs put` and `flux kvs get` now accept the `--raw`, `--json`, and `--treeobj` options to allow greater control over how values are stored and interpreted.

As a reminder the KVS just stores raw values now, imposing no structure.  We have convenience functions for get/put of strings (NULL terminated), and JSON (encoded as strings).  The get/put subcommands now default to storing strings, as opposed to JSON-encoded strings.  The `--json` option was  added to emulate the past behavior.  The `--raw` options was added to allow non-NULL terminated byte sequences to be stored and retrieved.  The `--treeobj` option was added so that snapshots could be manipulated and metadata could be examined conveniently.

Man pages updated and sharness tests added.