### PR TITLE
build: drop man page stub that cannot be generated

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -139,7 +139,7 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_txn_unlink.3 \
 	flux_kvs_txn_symlink.3 \
 	flux_kvs_txn_put_raw.3 \
-	flux_kvs_txn_put_treeobj.3
+	# flux_kvs_txn_put_treeobj.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -253,7 +253,7 @@ flux_kvs_txn_mkdir.3: flux_kvs_txn_create.3
 flux_kvs_txn_unlink.3: flux_kvs_txn_create.3
 flux_kvs_txn_symlink.3: flux_kvs_txn_create.3
 flux_kvs_txn_put_raw.3: flux_kvs_txn_create.3
-flux_kvs_txn_put_treeobj.3: flux_kvs_txn_create.3
+# flux_kvs_txn_put_treeobj.3: flux_kvs_txn_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c


### PR DESCRIPTION
Apparently we've asked asciidoc to generate one too many
man page stubs from flux_kvs_txn_create.adoc.

Since it's not generated, make install fails.  For now,
drop the stub from the Makefile.am so make install can work.

Fixes #1256