### PR TITLE
kvs: do not store NUL byte on json encoded strings in kvs server

### DIFF
--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -190,7 +190,7 @@ json_t *cache_entry_get_json (struct cache_entry *hp)
     if (!hp || !hp->valid || !hp->data)
         return NULL;
     if (!hp->o) {
-        if (!(hp->o = json_loads (hp->data, JSON_DECODE_ANY, NULL)))
+        if (!(hp->o = json_loadb (hp->data, hp->len, JSON_DECODE_ANY, NULL)))
             return NULL;
     }
     return hp->o;
@@ -218,7 +218,7 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
             if (!(hp->data = kvs_util_json_dumps (o)))
                 return -1;
 
-            hp->len = strlen (hp->data) + 1;
+            hp->len = strlen (hp->data);
             hp->o = o;
             hp->valid = true;
 

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -147,7 +147,7 @@ const char *commit_get_newroot_ref (commit_t *c)
  * bit.
  *
  * As of the writing of this code, it should also be impossible
- * for the cache_entry_removal() to fail.  In the rare case of two
+ * for the cache_remove_entry() to fail.  In the rare case of two
  * callers kvs-get and kvs.put-ing items that end up at the
  * blobref in the cache, any waiters for a valid cache entry would
  * have been satisfied when the dirty cache entry was put onto

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -81,7 +81,7 @@ int kvs_util_json_hash (const char *hash_name, json_t *o, href_t ref)
 
     if (!(s = kvs_util_json_dumps (o)))
         goto error;
-    if (blobref_hash (hash_name, (uint8_t *)s, strlen (s) + 1,
+    if (blobref_hash (hash_name, (uint8_t *)s, strlen (s),
                       ref, sizeof (href_t)) < 0)
         goto error;
     rc = 0;

--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -43,7 +43,7 @@ char *kvs_util_json_dumps (json_t *o)
     /* Must pass JSON_ENCODE_ANY, can be called on any object.  Must
      * set JSON_SORT_KEYS, two different objects with different
      * internal order should map to same string (and reference when
-     * used by json_hash()).
+     * used by kvs_util_json_hash()).
      */
     int flags = JSON_ENCODE_ANY | JSON_COMPACT | JSON_SORT_KEYS;
     char *s;

--- a/src/modules/kvs/kvs_util.h
+++ b/src/modules/kvs/kvs_util.h
@@ -8,7 +8,7 @@
 
 /* Get compact string representation of json object, or json null
  * object if o is NULL.  Use this function for consistency, especially
- * when dealing with data that may be hashed via json_hash().
+ * when dealing with data that may be hashed via kvs_util_json_hash().
  *
  * Returns NULL on error
  */

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -298,7 +298,7 @@ void cache_entry_raw_and_json_tests (void)
 
     ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_set_raw (e, data, strlen (data) + 1) == 0,
+    ok (cache_entry_set_raw (e, data, strlen (data)) == 0,
         "cache_entry_set_raw success");
     ok ((otmp = cache_entry_get_json (e)) != NULL,
         "cache_entry_get_json returns non-NULL for json-legal raw data");
@@ -319,7 +319,7 @@ void cache_entry_raw_and_json_tests (void)
         "cache_entry_get_raw returns success for get json raw data");
     ok (datatmp && strcmp (datatmp, "\"abcd\"") == 0,
         "raw data matches expected string version of json");
-    ok (datatmp && (len == strlen ("\"abcd\"") + 1),
+    ok (datatmp && (len == strlen ("\"abcd\"")),
         "raw data length matches expected length of json string");
     cache_entry_destroy (e);
 }


### PR DESCRIPTION
This is the server equivalent of PR #1262 / issue #1261.  Although not necessary, PR #1262 should probably be merged first.