### PR TITLE
generalize valgrind suppression for getaddrinfo

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -47,16 +47,11 @@
    <ipaddr_getprimary>
    Memcheck:Leak
    fun:malloc
-   obj:*
-   obj:*
-   obj:*
-   obj:*
+   ...
    fun:gaih_inet.constprop.5
    fun:getaddrinfo
    fun:ipaddr_getprimary
-   fun:calc_endpoint.isra.8
-   fun:boot_pmi
-   fun:main
+   ...
 }
 {
    <libdl_lookup_symbol_x>


### PR DESCRIPTION
As noted in #1240, the valgrind test fails when building under spack on recent ubuntu because the stack trace for getaddrinfo() leak is slightly different than the existing suppression entry in this environment. This PR just generalizes that suppression so that *any* leak under getaddrinfo() is suppressed.