### PR TITLE
kvs: refactor server cache functions

### DIFF
--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -590,7 +590,7 @@ void test_symlink (void)
     ok (treeobj_is_symlink (o),
         "treeobj_is_symlink returns true");
     ok ((data = treeobj_get_data (o)) != NULL && json_is_string (data),
-        "treobj_get_data returned string");
+        "treeobj_get_data returned string");
     ok (!strcmp (json_string_value (data), "a.b.c"),
         "and string has right content");
     json_decref (o);

--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -36,23 +36,40 @@ void diag_json (json_t *o)
 
 void test_codec (void)
 {
-    json_t *cpy, *dir = create_large_dir ();
+    json_t *cpy1, *cpy2, *dir = create_large_dir ();
     char *s, *p;
 
     if (!dir)
         BAIL_OUT ("could not create %d-entry dir", large_dir_entries);
+
+    ok (treeobj_decode (NULL) == NULL,
+        "treeobj_decode fails on bad input");
+    ok (treeobj_decodeb (NULL, 0) == NULL,
+        "treeobj_decodeb fails on bad input");
+
     s = treeobj_encode (dir);
     ok (s != NULL,
         "encoded %d-entry dir", large_dir_entries);
     if (!s)
         BAIL_OUT ("could not encode %d-entry dir", large_dir_entries);
-    ok ((cpy = treeobj_decode (s)) != NULL,
-        "decoded %d-entry dir", large_dir_entries);
-    if (!cpy)
+
+    ok ((cpy1 = treeobj_decode (s)) != NULL,
+        "decoded %d-entry dir via treeobj_decode", large_dir_entries);
+    if (!cpy1)
         diag ("%m");
-    if (!cpy)
+
+    ok ((cpy2 = treeobj_decodeb (s, strlen (s))) != NULL,
+        "decoded %d-entry dir via treeobj_decodeb", large_dir_entries);
+    if (!cpy2)
+        diag ("%m");
+
+    ok (json_equal (cpy1, cpy2) == 1,
+        "treeobj_decode and treeobj_decodeb returned identical objects");
+
+    if (!cpy1)
         BAIL_OUT ("could not continue");
-    p = treeobj_encode (cpy);
+
+    p = treeobj_encode (cpy1);
     ok (p != NULL,
         "re-encoded %d-entry dir", large_dir_entries);
     ok (strcmp (p, s) == 0,
@@ -60,7 +77,8 @@ void test_codec (void)
     free (p);
 
     free (s);
-    json_decref (cpy);
+    json_decref (cpy1);
+    json_decref (cpy2);
     json_decref (dir);
 }
 

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -478,8 +478,17 @@ error:
 
 json_t *treeobj_decode (const char *buf)
 {
+    if (!buf) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return treeobj_decodeb (buf, strlen (buf));
+}
+
+json_t *treeobj_decodeb (const char *buf, size_t buflen)
+{
     json_t *obj = NULL;
-    if (!(obj = json_loads (buf, 0, NULL))
+    if (!(obj = json_loadb (buf, buflen, 0, NULL))
             || treeobj_validate (obj) < 0) {
         errno = EPROTO;
         goto error;

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -101,6 +101,7 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
  * The return value of treeobj_encode must be destroyed with free().
  */
 json_t *treeobj_decode (const char *buf);
+json_t *treeobj_decodeb (const char *buf, size_t buflen);
 char *treeobj_encode (json_t *obj);
 
 #endif /* !_FLUX_KVS_TREEOBJ_H */

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -294,14 +294,6 @@ struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
     return hp;
 }
 
-json_t *cache_lookup_and_get_treeobj (struct cache *cache,
-                                      const char *ref,
-                                      int current_epoch)
-{
-    struct cache_entry *hp = cache_lookup (cache, ref, current_epoch);
-    return cache_entry_get_valid (hp) ? cache_entry_get_treeobj (hp) : NULL;
-}
-
 void cache_insert (struct cache *cache, const char *ref, struct cache_entry *hp)
 {
     int rc = zhash_insert (cache->zh, ref, hp);

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -40,6 +40,7 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "src/common/libkvs/treeobj.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libutil/log.h"
@@ -54,9 +55,9 @@ struct cache_entry {
     waitqueue_t *waitlist_valid;
     void *data;             /* value raw data */
     int len;
-    json_t *o;              /* value json object */
+    json_t *o;              /* value treeobj object */
     int lastuse_epoch;      /* time of last use for cache expiry */
-    bool valid;             /* flag indicating if raw data or json
+    bool valid;             /* flag indicating if raw data or treeobj
                              * set, don't use data == NULL as test, as
                              * zero length data can be valid */
     bool dirty;
@@ -185,18 +186,18 @@ int cache_entry_set_raw (struct cache_entry *hp, void *data, int len)
     return -1;
 }
 
-json_t *cache_entry_get_json (struct cache_entry *hp)
+json_t *cache_entry_get_treeobj (struct cache_entry *hp)
 {
     if (!hp || !hp->valid || !hp->data)
         return NULL;
     if (!hp->o) {
-        if (!(hp->o = json_loadb (hp->data, hp->len, JSON_DECODE_ANY, NULL)))
+        if (!(hp->o = treeobj_decodeb (hp->data, hp->len)))
             return NULL;
     }
     return hp->o;
 }
 
-int cache_entry_set_json (struct cache_entry *hp, json_t *o)
+int cache_entry_set_treeobj (struct cache_entry *hp, json_t *o)
 {
     if (hp && o) {
         if (hp->valid) {
@@ -215,7 +216,12 @@ int cache_entry_set_json (struct cache_entry *hp, json_t *o)
             assert (!hp->data);
             assert (!hp->o);
 
-            if (!(hp->data = kvs_util_json_dumps (o)))
+            if (treeobj_validate (o) < 0) {
+                errno = EINVAL;
+                return -1;
+            }
+
+            if (!(hp->data = treeobj_encode (o)))
                 return -1;
 
             hp->len = strlen (hp->data);
@@ -288,12 +294,12 @@ struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
     return hp;
 }
 
-json_t *cache_lookup_and_get_json (struct cache *cache,
-                                   const char *ref,
-                                   int current_epoch)
+json_t *cache_lookup_and_get_treeobj (struct cache *cache,
+                                      const char *ref,
+                                      int current_epoch)
 {
     struct cache_entry *hp = cache_lookup (cache, ref, current_epoch);
-    return cache_entry_get_valid (hp) ? cache_entry_get_json (hp) : NULL;
+    return cache_entry_get_valid (hp) ? cache_entry_get_treeobj (hp) : NULL;
 }
 
 void cache_insert (struct cache *cache, const char *ref, struct cache_entry *hp)

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -105,15 +105,6 @@ void cache_destroy (struct cache *cache);
 struct cache_entry *cache_lookup (struct cache *cache,
                                   const char *ref, int current_epoch);
 
-/* Look up a cache entry and get treeobj of cache entry only if entry
- * contains a valid treeobj.  This is a convenience function that is
- * effectively successful if calls to cache_lookup() and
- * cache_entry_get_treeobj() are both successful.
- */
-json_t *cache_lookup_and_get_treeobj (struct cache *cache,
-                                      const char *ref,
-                                      int current_epoch);
-
 /* Insert an entry in the cache by blobref 'ref'.
  * Ownership of the cache entry is transferred to the cache.
  */

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -13,7 +13,7 @@ struct cache;
 /* Create/destroy cache entry.
  *
  * cache_entry_create() creates an empty cache entry.  Data can be set
- * in an entry via cache_entry_set_raw() or cache_entry_set_json().
+ * in an entry via cache_entry_set_raw() or cache_entry_set_treeobj().
  */
 struct cache_entry *cache_entry_create (void);
 void cache_entry_destroy (void *arg);
@@ -55,15 +55,15 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * if it is non-NULL.  If 'data' is non-NULL, 'len' must be > 0.  If
  * 'data' is NULL, 'len' must be zero.
  *
- * json set accessor is a convenience function that will take a json
+ * treeobj set accessor is a convenience function that will take a treeobj
  * object and extract the raw data string from it and store that in
- * the cache entry.  The json object 'o' is also cached internally for
+ * the cache entry.  The treeobj object 'o' is also cached internally for
  * later retrieval.  The create transfers ownership of 'o' to the
  * cache entry. 'o' must be non-NULL.
  *
- * json get accessor is a convenience function that will return the
- * json object equivalent of the raw data stored internally.  If the
- * internal raw data is not a valid json object (i.e. improperly
+ * treeobj get accessor is a convenience function that will return the
+ * treeobj object equivalent of the raw data stored internally.  If the
+ * internal raw data is not a valid treeobj object (i.e. improperly
  * formatted or zero length), an error will be result.
  *
  * An invalid->valid transition runs the entry's wait queue, if any in
@@ -72,18 +72,18 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * Generally speaking, a cache entry can only be set once.  An attempt
  * to set new data in a cache entry will silently succeed.  A buffer
  * passed to cache_entry_set_raw() will be freed for a cache entry
- * that already has data stored.  A json object passed to
- * cache_entry_set_json() will be json_decref()'d for a cache entry
+ * that already has data stored.  A treeobj object passed to
+ * cache_entry_set_treeobj() will be json_decref()'d for a cache entry
  * that alrdady has data stored.
  *
- * cache_entry_set_raw() & cache_entry_set_json() &
+ * cache_entry_set_raw() & cache_entry_set_treeobj() &
  * cache_entry_clear_data() returns -1 on error, 0 on success
  */
 int cache_entry_get_raw (struct cache_entry *hp, void **data, int *len);
 int cache_entry_set_raw (struct cache_entry *hp, void *data, int len);
 
-json_t *cache_entry_get_json (struct cache_entry *hp);
-int cache_entry_set_json (struct cache_entry *hp, json_t *o);
+json_t *cache_entry_get_treeobj (struct cache_entry *hp);
+int cache_entry_set_treeobj (struct cache_entry *hp, json_t *o);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a
@@ -105,14 +105,14 @@ void cache_destroy (struct cache *cache);
 struct cache_entry *cache_lookup (struct cache *cache,
                                   const char *ref, int current_epoch);
 
-/* Look up a cache entry and get json of cache entry only if entry
- * contains valid json.  This is a convenience function that is
+/* Look up a cache entry and get treeobj of cache entry only if entry
+ * contains a valid treeobj.  This is a convenience function that is
  * effectively successful if calls to cache_lookup() and
- * cache_entry_get_json() are both successful.
+ * cache_entry_get_treeobj() are both successful.
  */
-json_t *cache_lookup_and_get_json (struct cache *cache,
-                                   const char *ref,
-                                   int current_epoch);
+json_t *cache_lookup_and_get_treeobj (struct cache *cache,
+                                      const char *ref,
+                                      int current_epoch);
 
 /* Insert an entry in the cache by blobref 'ref'.
  * Ownership of the cache entry is transferred to the cache.

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -159,7 +159,7 @@ const char *commit_get_newroot_ref (commit_t *c)
  * blobref in the cache, any waiters for a valid cache entry would
  * have been satisfied when the dirty cache entry was put onto
  * this dirty cache list (i.e. in store_cache() below when
- * cache_entry_set_json() was called).
+ * cache_entry_set_treeobj() was called).
  */
 void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
 {
@@ -198,7 +198,7 @@ static void cleanup_dirty_cache_list (commit_t *c)
  * Object reference is still owned by the caller.
  * 'is_raw' indicates this data is a json string w/ base64 value and
  * should be flushed to the content store as raw data after it is
- * decoded.
+ * decoded.  Otherwise, the json object should be a treeobj.
  * Returns -1 on error, 0 on success entry already there, 1 on success
  * entry needs to be flushed to content store
  */
@@ -267,7 +267,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         }
         else {
             json_incref (o);
-            if (cache_entry_set_json (hp, o) < 0) {
+            if (cache_entry_set_treeobj (hp, o) < 0) {
                 int ret;
                 saved_errno = errno;
                 json_decref (o);
@@ -577,9 +577,9 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
                 goto done;
             }
 
-            if (!(subdir = cache_lookup_and_get_json (c->cm->cache,
-                                                      ref,
-                                                      current_epoch))) {
+            if (!(subdir = cache_lookup_and_get_treeobj (c->cm->cache,
+                                                         ref,
+                                                         current_epoch))) {
                 *missing_ref = ref;
                 goto success; /* stall */
             }
@@ -701,9 +701,9 @@ commit_process_t commit_process (commit_t *c,
 
             c->state = COMMIT_STATE_LOAD_ROOT;
 
-            if (!(rootdir = cache_lookup_and_get_json (c->cm->cache,
-                                                       rootdir_ref,
-                                                       current_epoch))) {
+            if (!(rootdir = cache_lookup_and_get_treeobj (c->cm->cache,
+                                                          rootdir_ref,
+                                                          current_epoch))) {
                 if (zlist_push (c->missing_refs_list,
                                 (void *)rootdir_ref) < 0) {
                     c->errnum = ENOMEM;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1382,8 +1382,8 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
                  * no consistency issue by not caching.  We will still
                  * set new root below via setroot().
                  */
-                if (cache_entry_set_json (hp, json_incref (root)) < 0) {
-                    flux_log_error (ctx->h, "%s: cache_entry_set_json",
+                if (cache_entry_set_treeobj (hp, json_incref (root)) < 0) {
+                    flux_log_error (ctx->h, "%s: cache_entry_set_treeobj",
                                     __FUNCTION__);
                     json_decref (root);
                 }
@@ -1406,8 +1406,8 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
                 flux_log_error (ctx->h, "%s: cache_entry_create",
                                 __FUNCTION__);
             }
-            else if (cache_entry_set_json (hp, json_incref (root)) < 0) {
-                flux_log_error (ctx->h, "%s: cache_entry_set_json",
+            else if (cache_entry_set_treeobj (hp, json_incref (root)) < 0) {
+                flux_log_error (ctx->h, "%s: cache_entry_set_treeobj",
                                 __FUNCTION__);
                 json_decref (root);
                 cache_entry_destroy (hp);
@@ -1431,7 +1431,7 @@ static int setroot_event_send (kvs_ctx_t *ctx, json_t *names)
     if (event_includes_rootdir) {
         struct cache_entry *hp;
         if ((hp = cache_lookup (ctx->cache, ctx->rootdir, ctx->epoch)))
-            root = cache_entry_get_json (hp);
+            root = cache_entry_get_treeobj (hp);
         assert (root != NULL); // root entry is always in cache on rank 0
     }
     else {
@@ -1641,9 +1641,9 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, json_t *o, href_t ref)
         void *data;
         int len;
         assert (o);
-        if (cache_entry_set_json (hp, o) < 0) {
+        if (cache_entry_set_treeobj (hp, o) < 0) {
             saved_errno = errno;
-            flux_log_error (ctx->h, "%s: cache_entry_set_json",
+            flux_log_error (ctx->h, "%s: cache_entry_set_treeobj",
                             __FUNCTION__);
             ret = cache_remove_entry (ctx->cache, ref);
             assert (ret == 1);

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -256,11 +256,11 @@ static bool walk (lookup_t *lh)
                 lh->missing_ref = refstr;
                 goto stall;
             }
-            if (!(dir = cache_entry_get_json (hp))) {
-                /* dirref pointed to non json error, special case when
+            if (!(dir = cache_entry_get_treeobj (hp))) {
+                /* dirref pointed to non treeobj error, special case when
                  * root_dirent is bad, is EINVAL from user.
                  */
-                flux_log (lh->h, LOG_ERR, "dirref points to non-json");
+                flux_log (lh->h, LOG_ERR, "dirref points to non-treeobj");
                 if (wl->depth == 0 && wl->dirent == lh->root_dirent)
                     lh->errnum = EINVAL;
                 else
@@ -812,8 +812,9 @@ bool lookup (lookup_t *lh)
                         lh->missing_ref = lh->root_ref;
                         goto stall;
                     }
-                    if (!(valtmp = cache_entry_get_json (hp))) {
-                        flux_log (lh->h, LOG_ERR, "root_ref points to non-json");
+                    if (!(valtmp = cache_entry_get_treeobj (hp))) {
+                        flux_log (lh->h, LOG_ERR,
+                                  "root_ref points to non-treeobj");
                         lh->errnum = EINVAL;
                         goto done;
                     }
@@ -875,8 +876,8 @@ bool lookup (lookup_t *lh)
                     lh->missing_ref = reftmp;
                     goto stall;
                 }
-                if (!(valtmp = cache_entry_get_json (hp))) {
-                    flux_log (lh->h, LOG_ERR, "dirref points to non-json");
+                if (!(valtmp = cache_entry_get_treeobj (hp))) {
+                    flux_log (lh->h, LOG_ERR, "dirref points to non-treeobj");
                     lh->errnum = ENOTRECOVERABLE;
                     goto done;
                 }

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -600,12 +600,8 @@ void cache_expiration_tests (void)
         "cache contains 1 entry after insert");
     ok (cache_lookup (cache, "yyy1", 0) == NULL,
         "cache_lookup of wrong hash fails");
-    ok (cache_lookup_and_get_treeobj (cache, "yyy1", 0) == NULL,
-        "cache_lookup_and_get_treeobj of wrong hash fails");
     ok ((e2 = cache_lookup (cache, "xxx1", 42)) != NULL,
         "cache_lookup of correct hash works (last use=42)");
-    ok (cache_lookup_and_get_treeobj (cache, "xxx1", 0) == NULL,
-        "cache_lookup_and_get_treeobj of correct hash, but non valid entry fails");
     ok (cache_entry_get_treeobj (e2) == NULL,
         "no treeobj object found");
     ok (cache_count_entries (cache) == 1,
@@ -642,10 +638,6 @@ void cache_expiration_tests (void)
     ok ((otmp = cache_entry_get_treeobj (e4)) != NULL,
         "cache_entry_get_treeobj found entry");
     otest = treeobj_create_val ("foo", 3);
-    ok (json_equal (otmp, otest) == 1,
-        "expected treeobj object found");
-    ok ((otmp = cache_lookup_and_get_treeobj (cache, "xxx2", 0)) != NULL,
-        "cache_lookup_and_get_treeobj of correct hash and valid entry works");
     ok (json_equal (otmp, otest) == 1,
         "expected treeobj object found");
     json_decref (otest);

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -1696,7 +1696,6 @@ void commit_process_giant_dir (void)
      *
      */
 
-    dir = json_object();
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val0000", treeobj_create_val ("0", 1));
     treeobj_insert_entry (dir, "val0010", treeobj_create_val ("1", 1));

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -35,7 +35,7 @@ static struct cache_entry *create_cache_entry_raw (void *data, int len)
 }
 
 /* convenience function */
-static struct cache_entry *create_cache_entry_json (json_t *o)
+static struct cache_entry *create_cache_entry_treeobj (json_t *o)
 {
     struct cache_entry *hp;
     int ret;
@@ -44,12 +44,12 @@ static struct cache_entry *create_cache_entry_json (json_t *o)
 
     hp = cache_entry_create ();
     assert (hp);
-    ret = cache_entry_set_json (hp, o);
+    ret = cache_entry_set_treeobj (hp, o);
     assert (ret == 0);
     return hp;
 }
 
-/* Append a json object containing
+/* Append a treeobj object containing
  *     { "key" : key, flags : <num>, "dirent" : <treeobj> } }
  * or
  *     { "key" : key, flags : <num>, "dirent" : null }
@@ -82,8 +82,8 @@ struct cache *create_cache_with_empty_rootdir (href_t ref)
         "cache_create works");
     ok (kvs_util_json_hash ("sha1", rootdir, ref) == 0,
         "kvs_util_json_hash worked");
-    ok ((hp = create_cache_entry_json (rootdir)) != NULL,
-        "create_cache_entry_json works");
+    ok ((hp = create_cache_entry_treeobj (rootdir)) != NULL,
+        "create_cache_entry_treeobj works");
     cache_insert (cache, ref, hp);
     return cache;
 }
@@ -634,7 +634,7 @@ void commit_basic_root_not_dir (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -675,8 +675,8 @@ int rootref_cb (commit_t *c, const char *ref, void *data)
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
 
-    ok ((hp = create_cache_entry_json (rootdir)) != NULL,
-        "create_cache_entry_json works");
+    ok ((hp = create_cache_entry_treeobj (rootdir)) != NULL,
+        "create_cache_entry_treeobj works");
 
     cache_insert (rd->cache, ref, hp);
 
@@ -761,8 +761,8 @@ int missingref_cb (commit_t *c, const char *ref, void *data)
     ok (strcmp (ref, md->dir_ref) == 0,
         "missing reference is what we expect it to be");
 
-    ok ((hp = create_cache_entry_json (md->dir)) != NULL,
-        "create_cache_entry_json works");
+    ok ((hp = create_cache_entry_treeobj (md->dir)) != NULL,
+        "create_cache_entry_treeobj works");
 
     cache_insert (md->cache, ref, hp);
 
@@ -808,7 +808,7 @@ void commit_process_missing_ref (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -907,7 +907,7 @@ void commit_process_error_callbacks (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -927,7 +927,7 @@ void commit_process_error_callbacks (void)
 
     /* insert cache entry now, want don't want missing refs on next
      * commit_process call */
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -988,7 +988,7 @@ void commit_process_error_callbacks_partway (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -996,7 +996,7 @@ void commit_process_error_callbacks_partway (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1045,7 +1045,7 @@ void commit_process_invalid_operation (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1140,7 +1140,7 @@ void commit_process_invalid_hash (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "foobar", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1195,7 +1195,7 @@ void commit_process_follow_link (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1204,7 +1204,7 @@ void commit_process_follow_link (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
@@ -1262,7 +1262,7 @@ void commit_process_dirval_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1320,7 +1320,7 @@ void commit_process_delete_test (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1328,7 +1328,7 @@ void commit_process_delete_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1375,7 +1375,7 @@ void commit_process_delete_nosubdir_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1429,7 +1429,7 @@ void commit_process_delete_filevalinpath_test (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
@@ -1437,7 +1437,7 @@ void commit_process_delete_filevalinpath_test (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1491,7 +1491,7 @@ void commit_process_bad_dirrefs (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     dirref = treeobj_create_dirref (dir_ref);
     treeobj_append_blobref (dirref, dir_ref);
@@ -1502,7 +1502,7 @@ void commit_process_bad_dirrefs (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1527,19 +1527,19 @@ void commit_process_bad_dirrefs (void)
 }
 
 struct cache_count {
-    int json_count;
+    int treeobj_count;
     int total_count;
 };
 
-int cache_count_json_cb (commit_t *c, struct cache_entry *hp, void *data)
+int cache_count_treeobj_cb (commit_t *c, struct cache_entry *hp, void *data)
 {
     struct cache_count *cache_count = data;
 
     /* we count "raw-ness" of a cache entry by determining if the
-     * cache entry holds a valid json object.
+     * cache entry holds a valid treeobj object.
      */
-    if (cache_entry_get_json (hp) != NULL)
-        cache_count->json_count++;
+    if (cache_entry_get_treeobj (hp) != NULL)
+        cache_count->treeobj_count++;
     cache_count->total_count++;
 
     return 0;
@@ -1573,7 +1573,7 @@ void commit_process_big_fileval (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1589,13 +1589,14 @@ void commit_process_big_fileval (void)
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
 
-    cache_count.json_count = 0;
+    cache_count.treeobj_count = 0;
     cache_count.total_count = 0;
-    ok (commit_iter_dirty_cache_entries (c, cache_count_json_cb, &cache_count) == 0,
+    ok (commit_iter_dirty_cache_entries (c, cache_count_treeobj_cb,
+                                         &cache_count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (cache_count.json_count == 1,
-        "correct number of cache entries were json");
+    ok (cache_count.treeobj_count == 1,
+        "correct number of cache entries were treeobj");
 
     ok (cache_count.total_count == 1,
         "correct number of cache entries were dirty");
@@ -1625,16 +1626,17 @@ void commit_process_big_fileval (void)
     ok (commit_process (c, 1, root_ref) == COMMIT_PROCESS_DIRTY_CACHE_ENTRIES,
         "commit_process returns COMMIT_PROCESS_DIRTY_CACHE_ENTRIES");
 
-    cache_count.json_count = 0;
+    cache_count.treeobj_count = 0;
     cache_count.total_count = 0;
-    ok (commit_iter_dirty_cache_entries (c, cache_count_json_cb, &cache_count) == 0,
+    ok (commit_iter_dirty_cache_entries (c, cache_count_treeobj_cb,
+                                         &cache_count) == 0,
         "commit_iter_dirty_cache_entries works for dirty cache entries");
 
     /* this entry should be not be json, it's raw b/c large val
      * converted into valref, but with change there are now two dirty entries */
 
-    ok (cache_count.json_count == 1,
-        "correct number of cache entries were json");
+    ok (cache_count.treeobj_count == 1,
+        "correct number of cache entries were treeobj");
 
     ok (cache_count.total_count == 2,
         "correct number of cache entries were dirty");
@@ -1717,7 +1719,7 @@ void commit_process_giant_dir (void)
     ok (kvs_util_json_hash ("sha1", dir, dir_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_json (dir));
+    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (dir, "dir", treeobj_create_dirref (dir_ref));
@@ -1725,7 +1727,7 @@ void commit_process_giant_dir (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1802,7 +1804,7 @@ void commit_process_append (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");
@@ -1928,7 +1930,7 @@ void commit_process_append_errors (void)
     ok (kvs_util_json_hash ("sha1", root, root_ref) == 0,
         "kvs_util_json_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((cm = commit_mgr_create (cache, "sha1", NULL, &test_global)) != NULL,
         "commit_mgr_create works");

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -37,7 +37,7 @@ static struct cache_entry *create_cache_entry_raw (void *data, int len)
 }
 
 /* convenience function */
-static struct cache_entry *create_cache_entry_json (json_t *o)
+static struct cache_entry *create_cache_entry_treeobj (json_t *o)
 {
     struct cache_entry *hp;
     int ret;
@@ -46,7 +46,7 @@ static struct cache_entry *create_cache_entry_json (json_t *o)
 
     hp = cache_entry_create ();
     assert (hp);
-    ret = cache_entry_set_json (hp, o);
+    ret = cache_entry_set_treeobj (hp, o);
     assert (ret == 0);
     return hp;
 }
@@ -413,7 +413,7 @@ void lookup_root (void) {
 
     root = treeobj_create_dir ();
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* flags = 0, should error EISDIR */
     ok ((lh = lookup_create (cache,
@@ -518,7 +518,7 @@ void lookup_basic (void) {
     treeobj_insert_entry (dirref_test, "dummy", treeobj_create_val ("dummy", 5));
 
     kvs_util_json_hash ("sha1", dirref_test, dirref_test_ref);
-    cache_insert (cache, dirref_test_ref, create_cache_entry_json (dirref_test));
+    cache_insert (cache, dirref_test_ref, create_cache_entry_treeobj (dirref_test));
 
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("bar", 3));
@@ -541,13 +541,13 @@ void lookup_basic (void) {
     treeobj_insert_entry (dirref, "valref_multi_with_dirref", valref_multi_with_dirref);
 
     kvs_util_json_hash ("sha1", dirref, dirref_ref);
-    cache_insert (cache, dirref_ref, create_cache_entry_json (dirref));
+    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref", treeobj_create_dirref (dirref_ref));
 
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup dir via dirref */
     ok ((lh = lookup_create (cache,
@@ -775,7 +775,7 @@ void lookup_errors (void) {
     dirref = treeobj_create_dir ();
     treeobj_insert_entry (dirref, "val", treeobj_create_val ("bar", 3));
     kvs_util_json_hash ("sha1", dirref, dirref_ref);
-    cache_insert (cache, dirref_ref, create_cache_entry_json (dirref));
+    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("baz", 3));
@@ -800,7 +800,7 @@ void lookup_errors (void) {
     treeobj_insert_entry (root, "dirref_multi", dirref_multi);
 
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* Lookup non-existent field.  Not ENOENT - caller of lookup
      * decides what to do with entry not found */
@@ -1084,7 +1084,7 @@ void lookup_links (void) {
     dirref3 = treeobj_create_dir ();
     treeobj_insert_entry (dirref3, "val", treeobj_create_val ("baz", 3));
     kvs_util_json_hash ("sha1", dirref3, dirref3_ref);
-    cache_insert (cache, dirref3_ref, create_cache_entry_json (dirref3));
+    cache_insert (cache, dirref3_ref, create_cache_entry_treeobj (dirref3));
 
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("bar", 3));
@@ -1096,7 +1096,7 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref2, "dirref", treeobj_create_dirref (dirref3_ref));
     treeobj_insert_entry (dirref2, "symlink", treeobj_create_symlink ("dirref2.val"));
     kvs_util_json_hash ("sha1", dirref2, dirref2_ref);
-    cache_insert (cache, dirref2_ref, create_cache_entry_json (dirref2));
+    cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "link2dirref", treeobj_create_symlink ("dirref2"));
@@ -1105,13 +1105,13 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref1, "link2dir", treeobj_create_symlink ("dirref2.dir"));
     treeobj_insert_entry (dirref1, "link2symlink", treeobj_create_symlink ("dirref2.symlink"));
     kvs_util_json_hash ("sha1", dirref1, dirref1_ref);
-    cache_insert (cache, dirref1_ref, create_cache_entry_json (dirref1));
+    cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup val, follow two links */
     ok ((lh = lookup_create (cache,
@@ -1281,18 +1281,18 @@ void lookup_alt_root (void) {
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "val", treeobj_create_val ("foo", 3));
     kvs_util_json_hash ("sha1", dirref1, dirref1_ref);
-    cache_insert (cache, dirref1_ref, create_cache_entry_json (dirref1));
+    cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     dirref2 = treeobj_create_dir ();
     treeobj_insert_entry (dirref2, "val", treeobj_create_val ("bar", 3));
     kvs_util_json_hash ("sha1", dirref2, dirref2_ref);
-    cache_insert (cache, dirref2_ref, create_cache_entry_json (dirref2));
+    cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
     kvs_util_json_hash ("sha1", root, root_ref);
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup val, alt root-ref dirref1_ref */
     ok ((lh = lookup_create (cache,
@@ -1356,7 +1356,7 @@ void lookup_stall_root (void) {
         "lookup_create stalltest \".\"");
     check_stall (lh, EAGAIN, 1, root_ref, "root \".\" stall");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup root ".", should succeed */
     check (lh, 0, root, "root \".\" #1");
@@ -1479,12 +1479,12 @@ void lookup_stall (void) {
         "lookup_create stalltest dirref1.val");
     check_stall (lh, EAGAIN, 1, root_ref, "dirref1.val stall #1");
 
-    cache_insert (cache, root_ref, create_cache_entry_json (root));
+    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* next call to lookup, should stall */
     check_stall (lh, EAGAIN, 1, dirref1_ref, "dirref1.val stall #2");
 
-    cache_insert (cache, dirref1_ref, create_cache_entry_json (dirref1));
+    cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     /* final call to lookup, should succeed */
     test = treeobj_create_val ("foo", 3);
@@ -1515,7 +1515,7 @@ void lookup_stall (void) {
         "lookup_create stalltest symlink.val");
     check_stall (lh, EAGAIN, 1, dirref2_ref, "symlink.val stall");
 
-    cache_insert (cache, dirref2_ref, create_cache_entry_json (dirref2));
+    cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     /* lookup symlink.val, should succeed */
     test = treeobj_create_val ("bar", 3);


### PR DESCRIPTION
This is part one if issue #1264.  A minor refactor, renaming several "json" functions to "treeobj" and adjusting the logic accordingly.

I'm splitting it up b/c the second half of #1264 is growing and seems particularly distinct.