### PR TITLE
kvs: [cleanup] improve isolation in internal cache

### DIFF
--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -53,7 +53,7 @@ int flux_kvs_wait_version (flux_t *h, int version)
     if (!(f = flux_rpc_pack (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i }",
                              "rootseq", version)))
         goto done;
-    /* N.B. response contains (rootseq, rootdir) but we don't need it.
+    /* N.B. response contains (rootseq, rootref) but we don't need it.
      */
     if (flux_future_get (f, NULL) < 0)
         goto done;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -199,28 +199,6 @@ const json_t *cache_entry_get_treeobj (struct cache_entry *hp)
     return hp->o;
 }
 
-int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
-{
-    char *s = NULL;
-    int saved_errno;
-    int rc = -1;
-
-    if (!hp || !o || treeobj_validate (o) < 0) {
-        errno = EINVAL;
-        goto done;
-    }
-    if (!(s = treeobj_encode (o)))
-        goto done;
-    if (cache_entry_set_raw (hp, s, strlen (s)) < 0)
-        goto done;
-    rc = 0;
-done:
-    saved_errno = errno;
-    free (s);
-    errno = saved_errno;
-    return rc;
-}
-
 void cache_entry_destroy (void *arg)
 {
     struct cache_entry *hp = arg;

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -70,21 +70,17 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * both set accessors.
  *
  * Generally speaking, a cache entry can only be set once.  An attempt
- * to set new data in a cache entry will silently succeed.  A buffer
- * passed to cache_entry_set_raw() will be freed for a cache entry
- * that already has data stored.  A treeobj object passed to
- * cache_entry_set_treeobj() will be json_decref()'d for a cache entry
- * that alrdady has data stored.
+ * to set new data in a cache entry will silently succeed.
  *
  * cache_entry_set_raw() & cache_entry_set_treeobj() &
  * cache_entry_clear_data() returns -1 on error, 0 on success
  */
 int cache_entry_get_raw (struct cache_entry *hp, const void **data,
                          int *len);
-int cache_entry_set_raw (struct cache_entry *hp, void *data, int len);
+int cache_entry_set_raw (struct cache_entry *hp, const void *data, int len);
 
 const json_t *cache_entry_get_treeobj (struct cache_entry *hp);
-int cache_entry_set_treeobj (struct cache_entry *hp, json_t *o);
+int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -13,7 +13,7 @@ struct cache;
 /* Create/destroy cache entry.
  *
  * cache_entry_create() creates an empty cache entry.  Data can be set
- * in an entry via cache_entry_set_raw() or cache_entry_set_treeobj().
+ * in an entry via cache_entry_set_raw().
  */
 struct cache_entry *cache_entry_create (void);
 void cache_entry_destroy (void *arg);
@@ -55,12 +55,6 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * if it is non-NULL.  If 'data' is non-NULL, 'len' must be > 0.  If
  * 'data' is NULL, 'len' must be zero.
  *
- * treeobj set accessor is a convenience function that will take a treeobj
- * object and extract the raw data string from it and store that in
- * the cache entry.  The treeobj object 'o' is also cached internally for
- * later retrieval.  The create transfers ownership of 'o' to the
- * cache entry. 'o' must be non-NULL.
- *
  * treeobj get accessor is a convenience function that will return the
  * treeobj object equivalent of the raw data stored internally.  If the
  * internal raw data is not a valid treeobj object (i.e. improperly
@@ -72,15 +66,14 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * Generally speaking, a cache entry can only be set once.  An attempt
  * to set new data in a cache entry will silently succeed.
  *
- * cache_entry_set_raw() & cache_entry_set_treeobj() &
- * cache_entry_clear_data() returns -1 on error, 0 on success
+ * cache_entry_set_raw() & cache_entry_clear_data()
+ * return -1 on error, 0 on success
  */
 int cache_entry_get_raw (struct cache_entry *hp, const void **data,
                          int *len);
 int cache_entry_set_raw (struct cache_entry *hp, const void *data, int len);
 
 const json_t *cache_entry_get_treeobj (struct cache_entry *hp);
-int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -159,7 +159,7 @@ const char *commit_get_newroot_ref (commit_t *c)
  * blobref in the cache, any waiters for a valid cache entry would
  * have been satisfied when the dirty cache entry was put onto
  * this dirty cache list (i.e. in store_cache() below when
- * cache_entry_set_treeobj() was called).
+ * cache_entry_set_raw() was called).
  */
 void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
 {
@@ -206,7 +206,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
                         bool is_raw, href_t ref, struct cache_entry **hpp)
 {
     struct cache_entry *hp;
-    int saved_errno, rc = -1;
+    int saved_errno, rc;
     const char *xdata;
     char *data = NULL;
     int xlen, len;
@@ -231,40 +231,38 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
             free (data);
             data = NULL;
         }
-        blobref_hash (c->cm->hash_name, data, len, ref, sizeof (href_t));
     }
     else {
-        if (treeobj_hash (c->cm->hash_name, o, ref, sizeof (href_t)) < 0) {
-            flux_log_error (c->cm->h, "treeobj_hash");
+        if (treeobj_validate (o) < 0 || !(data = treeobj_encode (o))) {
+            flux_log_error (c->cm->h, "%s: treeobj_encode", __FUNCTION__);
             goto error;
         }
+        len = strlen (data);
+    }
+    if (blobref_hash (c->cm->hash_name, data, len, ref, sizeof (href_t)) < 0) {
+        flux_log_error (c->cm->h, "%s: blobref_hash", __FUNCTION__);
+        goto error;
     }
     if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
-        if (!(hp = cache_entry_create ()))
+        if (!(hp = cache_entry_create ())) {
+            flux_log_error (c->cm->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
+        }
         cache_insert (c->cm->cache, ref, hp);
     }
     if (cache_entry_get_valid (hp)) {
         c->cm->noop_stores++;
         rc = 0;
-    } else {
-        if (is_raw) {
-            if (cache_entry_set_raw (hp, data, len) < 0) {
-                int ret;
-                ret = cache_remove_entry (c->cm->cache, ref);
-                assert (ret == 1);
-                goto error;
-            }
-        }
-        else {
-            if (cache_entry_set_treeobj (hp, o) < 0) {
-                int ret;
-                ret = cache_remove_entry (c->cm->cache, ref);
-                assert (ret == 1);
-                goto error;
-            }
+    }
+    else {
+        if (cache_entry_set_raw (hp, data, len) < 0) {
+            int ret;
+            ret = cache_remove_entry (c->cm->cache, ref);
+            assert (ret == 1);
+            goto error;
         }
         if (cache_entry_set_dirty (hp, true) < 0) {
+            flux_log_error (c->cm->h, "%s: cache_entry_set_dirty",__FUNCTION__);
             int ret;
             ret = cache_remove_entry (c->cm->cache, ref);
             assert (ret == 1);
@@ -280,7 +278,7 @@ error:
     saved_errno = errno;
     free (data);
     errno = saved_errno;
-    return rc;
+    return -1;
 }
 
 /* Store DIRVAL objects, converting them to DIRREFs.

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1236,7 +1236,7 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (flux_respond_pack (h, msg, "{ s:i s:s }",
                            "rootseq", ctx->root.seq,
-                           "rootdir", ctx->root.ref) < 0) {
+                           "rootref", ctx->root.ref) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }
@@ -1257,7 +1257,7 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto error;
     if (flux_respond_pack (h, msg, "{ s:i s:s }",
                            "rootseq", ctx->root.seq,
-                           "rootdir", ctx->root.ref) < 0) {
+                           "rootref", ctx->root.ref) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }
@@ -1280,7 +1280,7 @@ static int getroot_rpc (kvs_ctx_t *ctx, int *rootseq, href_t rootref)
     }
     if (flux_rpc_get_unpack (f, "{ s:i s:s }",
                              "rootseq", rootseq,
-                             "rootdir", &ref) < 0) {
+                             "rootref", &ref) < 0) {
         saved_errno = errno;
         flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
         goto done;
@@ -1355,9 +1355,9 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
 
     if (flux_event_unpack (msg, NULL, "{ s:i s:s s:o s:o }",
                            "rootseq", &rootseq,
-                           "rootdir", &rootref,
+                           "rootref", &rootref,
                            "names", &names,
-                           "rootdirval", &root) < 0) {
+                           "rootdir", &root) < 0) {
         flux_log_error (ctx->h, "%s: flux_event_unpack", __FUNCTION__);
         return;
     }
@@ -1437,9 +1437,9 @@ static int setroot_event_send (kvs_ctx_t *ctx, json_t *names)
     }
     if (!(msg = flux_event_pack ("kvs.setroot", "{ s:i s:s s:O s:O }",
                                  "rootseq", ctx->root.seq,
-                                 "rootdir", ctx->root.ref,
+                                 "rootref", ctx->root.ref,
                                  "names", names,
-                                 "rootdirval", root))) {
+                                 "rootdir", root))) {
         saved_errno = errno;
         flux_log_error (ctx->h, "%s: flux_event_pack", __FUNCTION__);
         goto done;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -63,11 +63,15 @@ const int max_lastuse_age = 5;
  */
 const bool event_includes_rootdir = true;
 
+struct kvsroot {
+    int seq;
+    href_t ref;
+};
+
 typedef struct {
     int magic;
     struct cache *cache;    /* blobref => cache_entry */
-    href_t rootdir;         /* current root blobref */
-    int rootseq;            /* current root version (for ordering) */
+    struct kvsroot root;
     commit_mgr_t *cm;
     waitqueue_t *watchlist;
     int watchlist_lastrun_epoch;
@@ -378,12 +382,12 @@ error:
     return rc;
 }
 
-static void setroot (kvs_ctx_t *ctx, const char *rootdir, int rootseq)
+static void setroot (kvs_ctx_t *ctx, const char *rootref, int rootseq)
 {
-    if (rootseq == 0 || rootseq > ctx->rootseq) {
-        assert (strlen (rootdir) < sizeof (href_t));
-        strcpy (ctx->rootdir, rootdir);
-        ctx->rootseq = rootseq;
+    if (rootseq == 0 || rootseq > ctx->root.seq) {
+        assert (strlen (rootref) < sizeof (href_t));
+        strcpy (ctx->root.ref, rootref);
+        ctx->root.seq = rootseq;
         /* log error on wait_runqueue(), don't error out.  watchers
          * may miss value change, but will never get older one.
          * Maintains consistency model */
@@ -461,7 +465,7 @@ static void commit_apply (commit_t *c)
 
     if ((ret = commit_process (c,
                                ctx->epoch,
-                               ctx->rootdir)) == COMMIT_PROCESS_ERROR) {
+                               ctx->root.ref)) == COMMIT_PROCESS_ERROR) {
         errnum = commit_get_errnum (c);
         goto done;
     }
@@ -523,7 +527,7 @@ static void commit_apply (commit_t *c)
     /* else ret == COMMIT_PROCESS_FINISHED */
 
     /* This is the transaction that finalizes the commit by replacing
-     * ctx->rootdir with newroot, incrementing the root seq,
+     * ctx->root.ref with newroot, incrementing ctx->root.seq,
      * and sending out the setroot event for "eventual consistency"
      * of other nodes.
      */
@@ -537,7 +541,7 @@ done:
             flux_log (ctx->h, LOG_DEBUG, "aggregated %d commits (%d ops)",
                       count, opcount);
         }
-        setroot (ctx, commit_get_newroot_ref (c), ctx->rootseq + 1);
+        setroot (ctx, commit_get_newroot_ref (c), ctx->root.seq + 1);
         setroot_event_send (ctx, fence_get_json_names (f));
     } else {
         fence_t *f = commit_get_fence (c);
@@ -646,7 +650,7 @@ static void heartbeat_cb (flux_t *h, flux_msg_handler_t *w,
         ctx->watchlist_lastrun_epoch = ctx->epoch;
     }
     /* "touch" root */
-    (void)cache_lookup (ctx->cache, ctx->rootdir, ctx->epoch);
+    (void)cache_lookup (ctx->cache, ctx->root.ref, ctx->epoch);
 
     if (cache_expire_entries (ctx->cache, ctx->epoch, max_lastuse_age) < 0)
         flux_log_error (ctx->h, "%s: cache_expire_entries", __FUNCTION__);
@@ -711,7 +715,7 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
 
         if (!(lh = lookup_create (ctx->cache,
                                   ctx->epoch,
-                                  ctx->rootdir,
+                                  ctx->root.ref,
                                   root_ref,
                                   key,
                                   h,
@@ -833,7 +837,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
 
         if (!(lh = lookup_create (ctx->cache,
                                   ctx->epoch,
-                                  ctx->rootdir,
+                                  ctx->root.ref,
                                   NULL,
                                   key,
                                   h,
@@ -1219,7 +1223,7 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         goto error;
     }
-    if (ctx->rootseq < rootseq) {
+    if (ctx->root.seq < rootseq) {
         if (!(wait = wait_create_msg_handler (h, w, msg, sync_request_cb, arg)))
             goto error;
         if (wait_addqueue (ctx->watchlist, wait) < 0) {
@@ -1231,8 +1235,8 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
         return; /* stall */
     }
     if (flux_respond_pack (h, msg, "{ s:i s:s }",
-                           "rootseq", ctx->rootseq,
-                           "rootdir", ctx->rootdir) < 0) {
+                           "rootseq", ctx->root.seq,
+                           "rootdir", ctx->root.ref) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }
@@ -1252,8 +1256,8 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
     if (flux_respond_pack (h, msg, "{ s:i s:s }",
-                           "rootseq", ctx->rootseq,
-                           "rootdir", ctx->rootdir) < 0) {
+                           "rootseq", ctx->root.seq,
+                           "rootdir", ctx->root.ref) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }
@@ -1264,7 +1268,7 @@ error:
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static int getroot_rpc (kvs_ctx_t *ctx, int *rootseq, href_t rootdir)
+static int getroot_rpc (kvs_ctx_t *ctx, int *rootseq, href_t rootref)
 {
     flux_future_t *f;
     const char *ref;
@@ -1285,7 +1289,7 @@ static int getroot_rpc (kvs_ctx_t *ctx, int *rootseq, href_t rootdir)
         saved_errno = EPROTO;
         goto done;
     }
-    strcpy (rootdir, ref);
+    strcpy (rootref, ref);
     rc = 0;
 done:
     flux_future_destroy (f);
@@ -1338,20 +1342,20 @@ done:
     return rc;
 }
 
-/* Alter the (rootdir, rootseq) in response to a setroot event.
+/* Alter the (rootref, rootseq) in response to a setroot event.
  */
 static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
     int rootseq;
-    const char *rootdir;
+    const char *rootref;
     json_t *root = NULL;
     json_t *names = NULL;
 
     if (flux_event_unpack (msg, NULL, "{ s:i s:s s:o s:o }",
                            "rootseq", &rootseq,
-                           "rootdir", &rootdir,
+                           "rootdir", &rootref,
                            "names", &names,
                            "rootdirval", &root) < 0) {
         flux_log_error (ctx->h, "%s: flux_event_unpack", __FUNCTION__);
@@ -1359,7 +1363,7 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
     }
 
     finalize_fences_bynames (ctx, names, 0);
-    /* Copy of root object (corresponding to rootdir blobref) was included
+    /* Copy of root object (corresponding to rootref) was included
      * in the setroot event as an optimization, since it would otherwise
      * be loaded from the content store on next KVS access - immediate
      * if there are watchers.  Store this object in the KVS cache
@@ -1367,7 +1371,7 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
      */
     if (!json_is_null (root)) {
         struct cache_entry *hp;
-        if ((hp = cache_lookup (ctx->cache, rootdir, ctx->epoch))) {
+        if ((hp = cache_lookup (ctx->cache, rootref, ctx->epoch))) {
             if (!cache_entry_get_valid (hp)) {
                 /* On error, bad that we can't cache new root, but
                  * no consistency issue by not caching.  We will still
@@ -1402,10 +1406,10 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
                 cache_entry_destroy (hp);
             }
             else
-                cache_insert (ctx->cache, rootdir, hp);
+                cache_insert (ctx->cache, rootref, hp);
         }
     }
-    setroot (ctx, rootdir, rootseq);
+    setroot (ctx, rootref, rootseq);
 }
 
 static int setroot_event_send (kvs_ctx_t *ctx, json_t *names)
@@ -1419,7 +1423,7 @@ static int setroot_event_send (kvs_ctx_t *ctx, json_t *names)
 
     if (event_includes_rootdir) {
         struct cache_entry *hp;
-        if ((hp = cache_lookup (ctx->cache, ctx->rootdir, ctx->epoch)))
+        if ((hp = cache_lookup (ctx->cache, ctx->root.ref, ctx->epoch)))
             root = cache_entry_get_treeobj (hp);
         assert (root != NULL); // root entry is always in cache on rank 0
     }
@@ -1432,8 +1436,8 @@ static int setroot_event_send (kvs_ctx_t *ctx, json_t *names)
         root = nullobj;
     }
     if (!(msg = flux_event_pack ("kvs.setroot", "{ s:i s:s s:O s:O }",
-                                 "rootseq", ctx->rootseq,
-                                 "rootdir", ctx->rootdir,
+                                 "rootseq", ctx->root.seq,
+                                 "rootdir", ctx->root.ref,
                                  "names", names,
                                  "rootdirval", root))) {
         saved_errno = errno;
@@ -1530,7 +1534,7 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *w,
                            "#watchers", wait_queue_length (ctx->watchlist),
                            "#no-op stores", commit_mgr_get_noop_stores (ctx->cm),
                            "#faults", ctx->faults,
-                           "store revision", ctx->rootseq) < 0) {
+                           "store revision", ctx->root.seq) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto done;
     }
@@ -1600,7 +1604,7 @@ static void process_args (kvs_ctx_t *ctx, int ac, char **av)
     }
 }
 
-/* Store initial rootdir in local cache, and flush to content
+/* Store initial root in local cache, and flush to content
  * cache synchronously. If 'rootdir' is NULL, store an empty one.
  * The corresponding blobref is written into 'ref'.
  */
@@ -1696,13 +1700,13 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     }
     if (ctx->rank == 0) {
-        href_t href;
+        href_t rootref;
 
-        if (store_initial_rootdir (ctx, NULL, href) < 0) {
+        if (store_initial_rootdir (ctx, NULL, rootref) < 0) {
             flux_log_error (h, "storing initial root object");
             goto done;
         }
-        setroot (ctx, href, 0);
+        setroot (ctx, rootref, 0);
     } else {
         href_t href;
         int rootseq;

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -10,6 +10,28 @@
 #include "src/modules/kvs/waitqueue.h"
 #include "src/modules/kvs/cache.h"
 
+static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
+{
+    char *s = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!hp || !o || treeobj_validate (o) < 0) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(s = treeobj_encode (o)))
+        goto done;
+    if (cache_entry_set_raw (hp, s, strlen (s)) < 0)
+        goto done;
+    rc = 0;
+done:
+    saved_errno = errno;
+    free (s);
+    errno = saved_errno;
+    return rc;
+}
+
 void wait_cb (void *arg)
 {
     int *count = arg;

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -18,6 +18,28 @@
 
 static int test_global = 5;
 
+static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
+{
+    char *s = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!hp || !o || treeobj_validate (o) < 0) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(s = treeobj_encode (o)))
+        goto done;
+    if (cache_entry_set_raw (hp, s, strlen (s)) < 0)
+        goto done;
+    rc = 0;
+done:
+    saved_errno = errno;
+    free (s);
+    errno = saved_errno;
+    return rc;
+}
+
 /* convenience function */
 static struct cache_entry *create_cache_entry_raw (void *data, int len)
 {

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -20,6 +20,28 @@ struct lookup_ref_data
     int count;
 };
 
+static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
+{
+    char *s = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!hp || !o || treeobj_validate (o) < 0) {
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(s = treeobj_encode (o)))
+        goto done;
+    if (cache_entry_set_raw (hp, s, strlen (s)) < 0)
+        goto done;
+    rc = 0;
+done:
+    saved_errno = errno;
+    free (s);
+    errno = saved_errno;
+    return rc;
+}
+
 /* convenience function */
 static struct cache_entry *create_cache_entry_raw (void *data, int len)
 {


### PR DESCRIPTION
As discussed in #1264, `cache_entry_set_raw()` and `cache_entry_set_treeobj()` take ownership of a data/json_t pointer allocated in the caller.  The caller must be trusted not to free or modify the data afterward, or the cache will be corrupted.  This seems a bit unsafe.

Copy the data, increasing isolation between the cache and its callers.

In the treeobj case, avoid caching the json_t object directly, since it is hard to ensure that the caller won't change it later.  We could `json_deep_copy()` it, but it is perhaps cheaper to skip caching it here, and instead allow the object to be regenerated from the encoded data on first use (if it gets used at all).

Plus one small optimization:  avoid an extra call to treeobj_encode in the commit path, where we had to first encode the object to compute its hash key, then again to store it.  Just encode it once, then compute the hash key, then store the raw data.
