### PR TITLE
libflux: clean up bulk message handler registration functions

### DIFF
--- a/doc/man3/flux_msg_handler_addvec.adoc
+++ b/doc/man3/flux_msg_handler_addvec.adoc
@@ -18,14 +18,14 @@ SYNOPSIS
      const char *topic_glob;
      flux_msg_handler_f cb;
      uint32_t rolemask;
-     flux_msg_handler_t *w;
  };
 
  int flux_msg_handler_addvec (flux_t *h,
-                              struct flux_msg_handler_spec tab[],
-                              void *arg);
+                              const struct flux_msg_handler_spec tab[],
+                              void *arg,
+                              flux_msg_handler_t **handlers[]);
 
- void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
+ void flux_msg_handler_delvec (flux_msg_handler_t *handlers[]);
 
 
 DESCRIPTION
@@ -33,10 +33,11 @@ DESCRIPTION
 
 `flux_msg_handler_addvec()` creates and starts an array of message handlers,
 terminated by FLUX_MSGHANDLER_TABLE_END.  The new message handler objects
-are stored in the array.
+are assigned to an internally allocated array, returned in _handlers_.
+The last entry in the array is set to NULL.
 
-`flux_msg_handler_delvec()` stops and destroys an array of message handler
-objects, terminated by FLUX_MSGHANDLER_TABLE_END.
+`flux_msg_handler_delvec()` stops and destroys an array of message handlers
+returned from `flux_msg_handler_addvec()`.
 
 These functions are convenience functions which call
 `flux_msg_handler_create(3)`, `flux_msg_handler_start(3)`; and

--- a/doc/man3/flux_msg_handler_addvec.adoc
+++ b/doc/man3/flux_msg_handler_addvec.adoc
@@ -5,7 +5,8 @@ flux_msg_handler_addvec(3)
 
 NAME
 ----
-flux_msg_handler_addvec, flux_msg_handler_delvec - bulk add/remove message handlers
+flux_msg_handler_addvec,
+flux_msg_handler_delvec - bulk add/remove message handlers
 
 
 SYNOPSIS
@@ -14,7 +15,7 @@ SYNOPSIS
 
  struct flux_msg_handler_spec {
      int typemask;
-     char *topic_glob;
+     const char *topic_glob;
      flux_msg_handler_f cb;
      uint32_t rolemask;
      flux_msg_handler_t *w;

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -103,9 +103,9 @@ void heartbeat_cb (flux_t *h, flux_msg_handler_t *mh,
         free (item);
 }
 
-struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_EVENT,     "hb",              heartbeat_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,   "treduce.forward", forward_cb, 0, NULL },
+const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT,     "hb",              heartbeat_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "treduce.forward", forward_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -123,6 +123,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     uint32_t rank;
     double timeout = 0.;
     int flags;
+    flux_msg_handler_t **handlers = NULL;
 
     if (argc == 1) {
         timeout = strtod (argv[0], NULL);
@@ -139,11 +140,11 @@ int mod_main (flux_t *h, int argc, char **argv)
         return -1;
     if (flux_event_subscribe (h, "hb") < 0)
         return -1;
-    if (flux_msg_handler_addvec (h, htab, &ctx) < 0)
+    if (flux_msg_handler_addvec (h, htab, &ctx, &handlers) < 0)
         return -1;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
         return -1;
-    flux_msg_handler_delvec (htab);
+    flux_msg_handler_delvec (handlers);
     return 0;
 }
 

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -20,7 +20,7 @@ void attr_destroy (attr_t *attrs);
 /* Register/unregister message handlers
  */
 int attr_register_handlers (attr_t *attrs, flux_t *h);
-void attr_unregister_handlers (void);
+void attr_unregister_handlers (attr_t *attrs);
 
 /* Delete an attribute
  */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -158,6 +158,7 @@ static void broker_handle_signals (broker_ctx_t *ctx, zlist_t *sigwatchers);
 static void broker_unhandle_signals (zlist_t *sigwatchers);
 
 static void broker_add_services (broker_ctx_t *ctx);
+static void broker_remove_services (void);
 
 static int load_module_byname (broker_ctx_t *ctx, const char *name,
                                const char *argz, size_t argz_len,
@@ -669,6 +670,7 @@ int main (int argc, char *argv[])
     hello_destroy (ctx.hello);
     attr_destroy (ctx.attrs);
     shutdown_destroy (ctx.shutdown);
+    broker_remove_services ();
     flux_close (ctx.h);
     flux_reactor_destroy (ctx.reactor);
     if (ctx.subscriptions) {
@@ -1741,6 +1743,13 @@ static void broker_add_services (broker_ctx_t *ctx)
 
     if (flux_msg_handler_addvec (ctx->h, handlers, ctx) < 0)
         log_err_exit ("error registering message handlers");
+}
+
+/* Unregister message handlers
+ */
+static void broker_remove_services (void)
+{
+    flux_msg_handler_delvec (handlers);
 }
 
 /**

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -668,6 +668,7 @@ int main (int argc, char *argv[])
     service_switch_destroy (ctx.services);
     hello_destroy (ctx.hello);
     attr_destroy (ctx.attrs);
+    shutdown_destroy (ctx.shutdown);
     flux_close (ctx.h);
     flux_reactor_destroy (ctx.reactor);
     if (ctx.subscriptions) {

--- a/src/broker/heaptrace.c
+++ b/src/broker/heaptrace.c
@@ -38,6 +38,8 @@
 #include <flux/core.h>
 #include "heaptrace.h"
 
+static flux_msg_handler_t **handlers = NULL;
+
 static void start_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
@@ -111,10 +113,10 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-static struct flux_msg_handler_spec handlers[] = {
-    { FLUX_MSGTYPE_REQUEST, "heaptrace.start",  start_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "heaptrace.dump",   dump_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "heaptrace.stop",   stop_cb, 0, NULL },
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "heaptrace.start",  start_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "heaptrace.dump",   dump_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "heaptrace.stop",   stop_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -126,7 +128,7 @@ static void heaptrace_finalize (void *arg)
 int heaptrace_initialize (flux_t *h)
 {
     char *dummy = "hello";
-    if (flux_msg_handler_addvec (h, handlers, NULL) < 0)
+    if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0)
         return -1;
     flux_aux_set (h, "flux::heaptrace", dummy, heaptrace_finalize);
     return 0;

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -63,6 +63,7 @@ void shutdown_destroy (shutdown_t *s)
     if (s) {
         if (s->shutdown)
             flux_msg_handler_destroy (s->shutdown);
+        shutdown_disarm (s);
         if (s->h)
             (void)flux_event_unsubscribe (s->h, "shutdown");
         free (s);

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -875,9 +875,9 @@ error:
     return -1;
 }
 
-static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_EVENT,     NULL, event_cb, 0, NULL },
-    { FLUX_MSGTYPE_RESPONSE,  NULL, response_cb, 0, NULL },
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT,     NULL, event_cb, 0 },
+    { FLUX_MSGTYPE_RESPONSE,  NULL, response_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END
 };
 
@@ -900,6 +900,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
     const char *job;
     const char *optarg;
     int optindex;
+    flux_msg_handler_t **handlers = NULL;
 
     log_init ("flux-proxy");
 
@@ -978,7 +979,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
 
     /* Create/start event/response message watchers
      */
-    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msg_watcher_addvec");
         goto done;
     }
@@ -990,7 +991,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
         goto done;
     }
 done:
-    flux_msg_handler_delvec (htab);
+    flux_msg_handler_delvec (handlers);
     flux_watcher_destroy (ctx->listen_w);
     if (ctx->listen_fd >= 0) {
         if (close (ctx->listen_fd) < 0)

--- a/src/common/libflux/msg_handler.h
+++ b/src/common/libflux/msg_handler.h
@@ -36,13 +36,14 @@ struct flux_msg_handler_spec {
     const char *topic_glob;
     flux_msg_handler_f cb;
     uint32_t rolemask;
-    flux_msg_handler_t *w;
 };
-#define FLUX_MSGHANDLER_TABLE_END { 0, NULL, NULL, 0, NULL }
+#define FLUX_MSGHANDLER_TABLE_END { 0, NULL, NULL, 0 }
 
-int flux_msg_handler_addvec (flux_t *h, struct flux_msg_handler_spec tab[],
-                             void *arg);
-void flux_msg_handler_delvec (struct flux_msg_handler_spec tab[]);
+int flux_msg_handler_addvec (flux_t *h,
+                             const struct flux_msg_handler_spec tab[],
+                             void *arg,
+                             flux_msg_handler_t **msg_handlers[]);
+void flux_msg_handler_delvec (flux_msg_handler_t *msg_handlers[]);
 
 /* Requeue any unmatched messages, if handle was cloned.
  */

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -1147,7 +1147,7 @@ static int notify_status_obj (flux_t *h, jsc_handler_obj_f func, void *d)
         rc = -1;
         goto done;
     }
-    if (flux_msg_handler_addvec (h, htab, (void *)ctx, &handlers) < 0) {
+    if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0) {
         flux_log_error (h, "registering resource event handler");
         rc = -1;
         goto done;

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -530,31 +530,31 @@ done:
 }
 
 
-static struct flux_msg_handler_spec htab[] = {
-    //{ FLUX_MSGTYPE_EVENT,      "hb",               hb_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,   "aggregator.push",  push_cb, 0, NULL },
+static const struct flux_msg_handler_spec htab[] = {
+    //{ FLUX_MSGTYPE_EVENT,      "hb",               hb_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "aggregator.push",  push_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
 int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
+    flux_msg_handler_t **handlers = NULL;
     struct aggregator *ctx = aggregator_create (h);
     if (!ctx)
         goto done;
 
-    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msg_handler_advec");
         goto done;
     }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done_delvec;
+        goto done;
     }
     rc = 0;
-done_delvec:
-    flux_msg_handler_delvec (htab);
 done:
+    flux_msg_handler_delvec (handlers);
     aggregator_destroy (ctx);
     return rc;
 }

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -327,9 +327,9 @@ static void timeout_cb (flux_reactor_t *r, flux_watcher_t *w,
 }
 
 static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,     "barrier.enter",       enter_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,     "barrier.disconnect",  disconnect_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_EVENT,       "barrier.exit",        exit_event_cb, 0, NULL },
+    { FLUX_MSGTYPE_REQUEST, "barrier.enter",       enter_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "barrier.disconnect",  disconnect_request_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "barrier.exit",        exit_event_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -337,6 +337,7 @@ int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
     barrier_ctx_t *ctx = getctx (h);
+    flux_msg_handler_t **handlers = NULL;
 
     if (!ctx)
         goto done;
@@ -344,18 +345,17 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "flux_event_subscribe");
         goto done;
     }
-    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
     }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done_unreg;
+        goto done;
     }
     rc = 0;
-done_unreg:
-    flux_msg_handler_delvec (htab);
 done:
+    flux_msg_handler_delvec (handlers);
     return rc;
 }
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -907,13 +907,13 @@ static void cron_ls_handler (flux_t *h, flux_msg_handler_t *w,
 
 /**************************************************************************/
 
-static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,     "cron.create",   cron_create_handler, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,     "cron.delete",   cron_delete_handler, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,     "cron.list",     cron_ls_handler, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,     "cron.stop",     cron_stop_handler, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,     "cron.start",    cron_start_handler, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,     "cron.sync",     cron_sync_handler, 0, NULL },
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,     "cron.create",   cron_create_handler, 0 },
+    { FLUX_MSGTYPE_REQUEST,     "cron.delete",   cron_delete_handler, 0 },
+    { FLUX_MSGTYPE_REQUEST,     "cron.list",     cron_ls_handler, 0 },
+    { FLUX_MSGTYPE_REQUEST,     "cron.stop",     cron_stop_handler, 0 },
+    { FLUX_MSGTYPE_REQUEST,     "cron.start",    cron_start_handler, 0 },
+    { FLUX_MSGTYPE_REQUEST,     "cron.sync",     cron_sync_handler, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -941,19 +941,20 @@ static void process_args (cron_ctx_t *ctx, int ac, char **av)
 int mod_main (flux_t *h, int ac, char **av)
 {
     int rc = -1;
+    flux_msg_handler_t **handlers = NULL;
     cron_ctx_t *ctx = cron_ctx_create (h);
 
     process_args (ctx, ac, av);
 
-    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msg_handler_addvec");
         goto done;
     }
     if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
         flux_log_error (h, "flux_reactor_run");
-    flux_msg_handler_delvec (htab);
-    cron_ctx_destroy (ctx);
 done:
+    flux_msg_handler_delvec (handlers);
+    cron_ctx_destroy (ctx);
     return rc;
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1575,23 +1575,23 @@ static void stats_clear_request_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static struct flux_msg_handler_spec handlers[] = {
-    { FLUX_MSGTYPE_REQUEST, "kvs.stats.get",  stats_get_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.stats.clear",stats_clear_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_EVENT,   "kvs.stats.clear",stats_clear_event_cb, 0, NULL },
-    { FLUX_MSGTYPE_EVENT,   "kvs.setroot",    setroot_event_cb, 0, NULL },
-    { FLUX_MSGTYPE_EVENT,   "kvs.error",      error_event_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.getroot",    getroot_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.dropcache",  dropcache_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_EVENT,   "kvs.dropcache",  dropcache_event_cb, 0, NULL },
-    { FLUX_MSGTYPE_EVENT,   "hb",             heartbeat_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.disconnect", disconnect_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.unwatch",    unwatch_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.sync",       sync_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.get",        get_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.watch",      watch_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.fence",      fence_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "kvs.relayfence", relayfence_request_cb, 0, NULL },
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "kvs.stats.get",  stats_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.stats.clear",stats_clear_request_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.stats.clear",stats_clear_event_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.setroot",    setroot_event_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.error",      error_event_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.getroot",    getroot_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.dropcache",  dropcache_request_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.dropcache",  dropcache_event_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "hb",             heartbeat_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.disconnect", disconnect_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.unwatch",    unwatch_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.sync",       sync_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.get",        get_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.watch",      watch_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.fence",      fence_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.relayfence", relayfence_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -1687,6 +1687,7 @@ error:
 int mod_main (flux_t *h, int argc, char **argv)
 {
     kvs_ctx_t *ctx = getctx (h);
+    flux_msg_handler_t **handlers = NULL;
     int rc = -1;
 
     if (!ctx) {
@@ -1719,18 +1720,17 @@ int mod_main (flux_t *h, int argc, char **argv)
         }
         setroot (ctx, rootref, rootseq);
     }
-    if (flux_msg_handler_addvec (h, handlers, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msg_handler_addvec");
         goto done;
     }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done_delvec;
+        goto done;
     }
     rc = 0;
-done_delvec:
-    flux_msg_handler_delvec (handlers);
 done:
+    flux_msg_handler_delvec (handlers);
     return rc;
 }
 

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -350,12 +350,12 @@ static void disconnect (flux_t *h, flux_msg_handler_t *mh,
     }
 }
 
-static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  "userdb.lookup", lookup, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,  "userdb.addrole", addrole, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,  "userdb.delrole", delrole, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,  "userdb.getnext", getnext, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST,  "userdb.disconnect", disconnect, 0, NULL },
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "userdb.lookup", lookup, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "userdb.addrole", addrole, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "userdb.delrole", delrole, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "userdb.getnext", getnext, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "userdb.disconnect", disconnect, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -363,6 +363,7 @@ int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
     userdb_ctx_t *ctx;
+    flux_msg_handler_t **handlers = NULL;
     struct user *up;
 
     if (!(ctx = getctx (h, argc, argv))) {
@@ -372,18 +373,17 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "failed to add owner to userdb");
         goto done;
     }
-    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
     }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done_unreg;
+        goto done;
     }
     rc = 0;
-done_unreg:
-    flux_msg_handler_delvec (htab);
 done:
+    flux_msg_handler_delvec (handlers);
     return rc;
 }
 

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -382,18 +382,18 @@ error:
     flux_reactor_stop_error (flux_get_reactor (h));
 }
 
-struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "req.null",              null_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.echo",              echo_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.err",               err_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.src",               src_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.nsrc",              nsrc_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.sink",              sink_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.xping",             xping_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_RESPONSE, "req.ping",             ping_response_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.clog",              clog_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.flush",             flush_request_cb, 0, NULL },
-    { FLUX_MSGTYPE_REQUEST, "req.count",             count_request_cb, 0, NULL },
+const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "req.null",              null_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.echo",              echo_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.err",               err_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.src",               src_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.nsrc",              nsrc_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.sink",              sink_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.xping",             xping_request_cb, 0 },
+    { FLUX_MSGTYPE_RESPONSE, "req.ping",             ping_response_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.clog",              clog_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.flush",             flush_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "req.count",             count_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -401,13 +401,14 @@ int mod_main (flux_t *h, int argc, char **argv)
 {
     int saved_errno;
     t_req_ctx_t *ctx = getctx (h);
+    flux_msg_handler_t **handlers = NULL;
 
     if (!ctx) {
         saved_errno = errno;
         flux_log_error (h, "error allocating context");
         goto error;
     }
-    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         saved_errno = errno;
         flux_log_error (h, "flux_msg_handler_addvec");
         goto error;
@@ -415,10 +416,10 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         saved_errno = errno;
         flux_log_error (h, "flux_reactor_run");
-        flux_msg_handler_delvec (htab);
+        flux_msg_handler_delvec (handlers);
         goto error;
     }
-    flux_msg_handler_delvec (htab);
+    flux_msg_handler_delvec (handlers);
     return 0;
 error:
     errno = saved_errno;

--- a/t/rpc/mrpc.c
+++ b/t/rpc/mrpc.c
@@ -119,19 +119,19 @@ done:
         (void)flux_respond_pack (h, msg, "{}");
 }
 
-static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",         rpcftest_hello_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpcftest.nodeid",        rpcftest_nodeid_cb, 0, NULL},
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",          rpctest_hello_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",         rpcftest_hello_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",           rpctest_echo_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",         rpctest_nodeid_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.nodeid",        rpcftest_nodeid_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
-const int htablen = sizeof (htab) / sizeof (htab[0]);
 
 int test_server (flux_t *h, void *arg)
 {
-    if (flux_msg_handler_addvec (h, htab, NULL) < 0) {
+    flux_msg_handler_t **handlers = NULL;
+    if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0) {
         diag ("flux_msg_handler_addvec failed");
         return -1;
     }
@@ -139,7 +139,7 @@ int test_server (flux_t *h, void *arg)
         diag ("flux_reactor_run failed");
         return -1;
     }
-    flux_msg_handler_delvec (htab);
+    flux_msg_handler_delvec (handlers);
     return 0;
 }
 

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -110,19 +110,20 @@ void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
         (void)flux_respond_pack (h, msg, "{}");
 }
 
-static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.incr",    rpctest_incr_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",   rpctest_hello_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",  rpcftest_hello_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",    rpctest_echo_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.rawecho", rpctest_rawecho_cb, 0, NULL},
-    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",  rpctest_nodeid_cb, 0, NULL},
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.incr",    rpctest_incr_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",   rpctest_hello_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",  rpcftest_hello_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",    rpctest_echo_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.rawecho", rpctest_rawecho_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",  rpctest_nodeid_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
 int test_server (flux_t *h, void *arg)
 {
-    if (flux_msg_handler_addvec (h, htab, NULL) < 0) {
+    flux_msg_handler_t **handlers = NULL;
+    if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0) {
         diag ("flux_msg_handler_addvec failed");
         return -1;
     }
@@ -130,7 +131,7 @@ int test_server (flux_t *h, void *arg)
         diag ("flux_reactor_run failed");
         return -1;
     }
-    flux_msg_handler_delvec (htab);
+    flux_msg_handler_delvec (handlers);
     return 0;
 }
 


### PR DESCRIPTION
This is following up on an idea @morrone had in #1135 to clean up the bulk message handler reg/unreg functions.  The `flux_msg_handler_t` member is dropped from `struct flux_msg_handler_spec`, and instead a new array of message handlers is returned from `flux_msg_handler_addvec()`.

`flux_msg_handler_delvec()` then accepts the array of message handlers, destroying them and freeing the array.

In addition, a small mention about rolemask security is added to the message handler man pages.

Updated users, tests, and man pages.

This will require a PR to flux-sched.  Please don't merge until that's queued up.