### PR TITLE
kvs: [cleanup] fix blobref_t typedef and unfortunate variable names

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -521,7 +521,7 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *w,
     const void *data;
     int len;
     struct cache_entry *e = NULL;
-    char blobref[BLOBREF_MAX_STRING_SIZE];
+    blobref_t blobref;
     int rc = -1;
 
     if (flux_request_decode_raw (msg, NULL, &data, &len) < 0)
@@ -530,8 +530,7 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *w,
         errno = EFBIG;
         goto done;
     }
-    if (blobref_hash (cache->hash_name, (uint8_t *)data, len,
-                      blobref, sizeof (blobref)) < 0)
+    if (blobref_hash (cache->hash_name, (uint8_t *)data, len, blobref) < 0)
         goto done;
 
     if (!(e = lookup_entry (cache, blobref))) {

--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -742,33 +742,6 @@ void test_corner_cases (void)
     json_decref (symlink);
 }
 
-void test_hash (void)
-{
-    char buf[128];
-    json_t *o;
-
-    ok (treeobj_hash (NULL, NULL, NULL, -1) < 0
-        && errno == EINVAL,
-        "treeobj_hash fails with EINVAL on bad input");
-
-    o = json_object ();
-    ok (treeobj_hash ("sha1", o, buf, 128) < 0
-        && errno == EINVAL,
-        "treeobj_hash fails with EINVAL on non-treeobj");
-    json_decref (o);
-
-    o = treeobj_create_val ("foo", 3);
-
-    ok (treeobj_hash ("sha1", o, buf, 1) < 0
-        && errno == EINVAL,
-        "treeobj_hash fails with EINVAL on too small buffer");
-
-    ok (treeobj_hash ("sha1", o, buf, 128) == 0,
-        "treeobj_hash success");
-
-    json_decref (o);
-}
-
 int main(int argc, char** argv)
 {
     plan (NO_PLAN);
@@ -784,7 +757,6 @@ int main(int argc, char** argv)
     test_corner_cases ();
 
     test_codec ();
-    test_hash ();
 
     done_testing();
 }

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -516,7 +516,7 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
                                    void *data, int len)
 {
     json_t *valref = NULL;
-    char blobref[BLOBREF_MAX_STRING_SIZE];
+    blobref_t blobref;
     int blob_len;
 
     if (!(valref = treeobj_create_valref (NULL)))
@@ -525,8 +525,7 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
         blob_len = len;
         if (maxblob > 0 && len > maxblob)
             blob_len = maxblob;
-        if (blobref_hash (hashtype, data, blob_len,
-                          blobref, sizeof (blobref)) < 0)
+        if (blobref_hash (hashtype, data, blob_len, blobref) < 0)
             goto error;
         if (treeobj_append_blobref (valref, blobref) < 0)
             goto error;

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -569,32 +569,6 @@ char *treeobj_encode (const json_t *obj)
     return json_dumps (obj, JSON_COMPACT|JSON_SORT_KEYS);
 }
 
-int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
-{
-    char *tmp = NULL;
-    int rc = -1;
-
-    if (!hash_name || !obj || !s || size <= 0) {
-        errno = EINVAL;
-        goto error;
-    }
-
-    if (treeobj_validate (obj) < 0)
-        goto error;
-
-    if (!(tmp = treeobj_encode (obj)))
-        goto error;
-
-    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp),
-                      s, size) < 0)
-        goto error;
-
-    rc = 0;
- error:
-    free (tmp);
-    return rc;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -114,11 +114,6 @@ json_t *treeobj_decode (const char *buf);
 json_t *treeobj_decodeb (const char *buf, size_t buflen);
 char *treeobj_encode (const json_t *obj);
 
-/* Calculate hash of a treeobj
- * Returns 0 on success, -1 on error with errno set
- */
-int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size);
-
 #endif /* !_FLUX_KVS_TREEOBJ_H */
 
 /*

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -12,23 +12,23 @@ typedef char blobref_t[BLOBREF_MAX_STRING_SIZE];
  * The hash algorithm is selected by the blobref prefix.
  * Returns hash length on success, or -1 on error, with errno set.
  */
-int blobref_strtohash (const char *s, void *hash, int size);
+int blobref_strtohash (const char *blobref, void *hash, int size);
 
-/* Convert a hash digest to null-terminated blobref string in 's'.
+/* Convert a hash digest to null-terminated blobref string in 'blobref'.
  * The hash algorithm is selected by 'hashtype', e.g. "sha1".
  * Returns 0 on success, -1 on error, with errno set.
  */
 int blobref_hashtostr (const char *hashtype,
                        const void *hash, int len,
-                       char *s, int size);
+                       blobref_t blobref);
 
-/* Compute hash over data and return null-terminated blobref string in 's'.
- * The hash algorithm is selected by 'hashtype', e.g. "sha1".
+/* Compute hash over data and return null-terminated blobref string in
+ * 'blobref'.  The hash algorithm is selected by 'hashtype', e.g. "sha1".
  * Returns 0 on success, -1 on error with errno set.
  */
 int blobref_hash (const char *hashtype,
                   const void *data, int len,
-                  char *s, int size);
+                  blobref_t blobref);
 
 /* Check validity of blobref string.
  */

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -6,6 +6,8 @@
 
 #include <stdint.h>
 
+typedef char blobref_t[BLOBREF_MAX_STRING_SIZE];
+
 /* Convert a blobref string to hash digest.
  * The hash algorithm is selected by the blobref prefix.
  * Returns hash length on success, or -1 on error, with errno set.

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -32,13 +32,9 @@ int main(int argc, char** argv)
 
     /* invalid args */
     errno = 0;
-    ok (blobref_hash ("nerf", data, sizeof (data), ref, sizeof (ref)) < 0
+    ok (blobref_hash ("nerf", data, sizeof (data), ref) < 0
         && errno == EINVAL,
         "blobref_hash fails EINVAL with unknown hash name");
-    errno = 0;
-    ok (blobref_hash ("sha1", data, sizeof (data), ref, 2) < 0
-        && errno == EINVAL,
-        "blobref_hash fails EINVAL with runt ref buffer");
 
     errno = 0;
     ok (blobref_strtohash (badref[0], digest, sizeof (digest)) < 0
@@ -63,45 +59,41 @@ int main(int argc, char** argv)
 
     memset (digest, 6, sizeof (digest));
     errno = 0;
-    ok (blobref_hashtostr ("nerf", digest, SHA1_DIGEST_SIZE, ref, sizeof (ref)) < 0
+    ok (blobref_hashtostr ("nerf", digest, SHA1_DIGEST_SIZE, ref) < 0
         && errno == EINVAL,
         "blobref_hashtostr fails EINVAL with unknown hash");
     errno = 0;
-    ok (blobref_hashtostr ("sha1", digest, SHA256_BLOCK_SIZE, ref, sizeof (ref)) < 0
+    ok (blobref_hashtostr ("sha1", digest, SHA256_BLOCK_SIZE, ref) < 0
         && errno == EINVAL,
         "blobref_hashtostr fails EINVAL with wrong digest size for hash");
-    errno = 0;
-    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref, 2) < 0
-        && errno == EINVAL,
-        "blobref_hashtostr fails EINVAL with runt ref");
 
     /* sha1 */
-    ok (blobref_hash ("sha1", NULL, 0, ref, sizeof (ref)) == 0,
+    ok (blobref_hash ("sha1", NULL, 0, ref) == 0,
         "blobref_hash sha1 handles zero length data");
     diag ("%s", ref);
-    ok (blobref_hash ("sha1", data, sizeof (data), ref, sizeof (ref)) == 0,
+    ok (blobref_hash ("sha1", data, sizeof (data), ref) == 0,
         "blobref_hash sha1 works");
     diag ("%s", ref);
 
     ok (blobref_strtohash (ref, digest, sizeof (digest)) == SHA1_DIGEST_SIZE,
         "blobref_strtohash returns expected size hash");
-    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref2, sizeof (ref2)) == 0,
+    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref2) == 0,
         "blobref_hashtostr back again works");
     diag ("%s", ref2);
     ok (strcmp (ref, ref2) == 0,
         "and blobrefs match");
 
     /* sha256 */
-    ok (blobref_hash ("sha256", NULL, 0, ref, sizeof (ref)) == 0,
+    ok (blobref_hash ("sha256", NULL, 0, ref) == 0,
         "blobref_hash sha256 handles zero length data");
     diag ("%s", ref);
-    ok (blobref_hash ("sha256", data, sizeof (data), ref, sizeof (ref)) == 0,
+    ok (blobref_hash ("sha256", data, sizeof (data), ref) == 0,
         "blobref_hash sha256 works");
     diag ("%s", ref);
 
     ok (blobref_strtohash (ref, digest, sizeof (digest)) == SHA256_BLOCK_SIZE,
         "blobref_strtohash returns expected size hash");
-    ok (blobref_hashtostr ("sha256", digest, SHA256_BLOCK_SIZE, ref2, sizeof (ref2)) == 0,
+    ok (blobref_hashtostr ("sha256", digest, SHA256_BLOCK_SIZE, ref2) == 0,
         "blobref_hashtostr back again works");
     diag ("%s", ref2);
     ok (strcmp (ref, ref2) == 0,

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -21,8 +21,8 @@ const char *goodref[] = {
 
 int main(int argc, char** argv)
 {
-    char ref[BLOBREF_MAX_STRING_SIZE];
-    char ref2[BLOBREF_MAX_STRING_SIZE];
+    blobref_t ref;
+    blobref_t ref2;
     uint8_t digest[BLOBREF_MAX_DIGEST_SIZE];
     uint8_t data[1024];
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -330,7 +330,7 @@ void store_cb (flux_t *h, flux_msg_handler_t *w,
     const void *data;
     int size, hash_len;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
-    char blobref[BLOBREF_MAX_STRING_SIZE] = "-";
+    blobref_t blobref = "-";
     int uncompressed_size = -1;
     int rc = -1;
     int old_state;
@@ -345,8 +345,7 @@ void store_cb (flux_t *h, flux_msg_handler_t *w,
         errno = EFBIG;
         goto done;
     }
-    if (blobref_hash (ctx->hashfun, (uint8_t *)data, size,
-                      blobref,sizeof (blobref)) < 0)
+    if (blobref_hash (ctx->hashfun, (uint8_t *)data, size, blobref) < 0)
         goto done;
     if ((hash_len = blobref_strtohash (blobref, hash, sizeof (hash))) < 0)
         goto done;

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -23,7 +23,6 @@ kvs_la_SOURCES = \
 	lookup.c \
 	fence.h \
 	fence.c \
-	types.h \
 	commit.h \
 	commit.c
 

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -69,38 +69,38 @@ struct cache {
 
 struct cache_entry *cache_entry_create (void)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
 
-    if (!(hp = calloc (1, sizeof (*hp)))) {
+    if (!(entry = calloc (1, sizeof (*entry)))) {
         errno = ENOMEM;
         return NULL;
     }
-    return hp;
+    return entry;
 }
 
-bool cache_entry_get_valid (struct cache_entry *hp)
+bool cache_entry_get_valid (struct cache_entry *entry)
 {
-    return (hp && hp->valid);
+    return (entry && entry->valid);
 }
 
-bool cache_entry_get_dirty (struct cache_entry *hp)
+bool cache_entry_get_dirty (struct cache_entry *entry)
 {
-    return (hp && hp->valid && hp->dirty);
+    return (entry && entry->valid && entry->dirty);
 }
 
-int cache_entry_set_dirty (struct cache_entry *hp, bool val)
+int cache_entry_set_dirty (struct cache_entry *entry, bool val)
 {
-    if (hp && hp->valid) {
-        if ((val && hp->dirty) || (!val && !hp->dirty))
+    if (entry && entry->valid) {
+        if ((val && entry->dirty) || (!val && !entry->dirty))
             ; /* no-op */
-        else if (val && !hp->dirty)
-            hp->dirty = true;
-        else if (!val && hp->dirty) {
-            hp->dirty = false;
-            if (hp->waitlist_notdirty) {
-                if (wait_runqueue (hp->waitlist_notdirty) < 0) {
+        else if (val && !entry->dirty)
+            entry->dirty = true;
+        else if (!val && entry->dirty) {
+            entry->dirty = false;
+            if (entry->waitlist_notdirty) {
+                if (wait_runqueue (entry->waitlist_notdirty) < 0) {
                     /* set back dirty bit to orig */
-                    hp->dirty = true;
+                    entry->dirty = true;
                     return -1;
                 }
             }
@@ -110,58 +110,58 @@ int cache_entry_set_dirty (struct cache_entry *hp, bool val)
     return -1;
 }
 
-int cache_entry_clear_dirty (struct cache_entry *hp)
+int cache_entry_clear_dirty (struct cache_entry *entry)
 {
-    if (hp && hp->valid) {
-        if (hp->dirty
-            && (!hp->waitlist_notdirty
-                || !wait_queue_length (hp->waitlist_notdirty)))
-            hp->dirty = false;
+    if (entry && entry->valid) {
+        if (entry->dirty
+            && (!entry->waitlist_notdirty
+                || !wait_queue_length (entry->waitlist_notdirty)))
+            entry->dirty = false;
         return 0;
     }
     return -1;
 }
 
-int cache_entry_force_clear_dirty (struct cache_entry *hp)
+int cache_entry_force_clear_dirty (struct cache_entry *entry)
 {
-    if (hp && hp->valid) {
-        if (hp->dirty) {
-            if (hp->waitlist_notdirty) {
-                wait_queue_destroy (hp->waitlist_notdirty);
-                hp->waitlist_notdirty = NULL;
+    if (entry && entry->valid) {
+        if (entry->dirty) {
+            if (entry->waitlist_notdirty) {
+                wait_queue_destroy (entry->waitlist_notdirty);
+                entry->waitlist_notdirty = NULL;
             }
-            hp->dirty = false;
+            entry->dirty = false;
         }
         return 0;
     }
     return -1;
 }
 
-int cache_entry_get_raw (struct cache_entry *hp, const void **data,
+int cache_entry_get_raw (struct cache_entry *entry, const void **data,
                          int *len)
 {
-    if (!hp || !hp->valid)
+    if (!entry || !entry->valid)
         return -1;
     if (data)
-        (*data) = hp->data;
+        (*data) = entry->data;
     if (len)
-        (*len) = hp->len;
+        (*len) = entry->len;
     return 0;
 }
 
-int cache_entry_set_raw (struct cache_entry *hp, const void *data, int len)
+int cache_entry_set_raw (struct cache_entry *entry, const void *data, int len)
 {
     void *cpy = NULL;
 
-    if (!hp || (data && len <= 0) || (!data && len)) {
+    if (!entry || (data && len <= 0) || (!data && len)) {
         errno = EINVAL;
         return -1;
     }
     /* It should be a no-op if the entry is already set.
      * However, as a sanity check, make sure proposed and existing values match.
      */
-    if (hp->valid) {
-        if (len != hp->len || memcmp (data, hp->data, len) != 0) {
+    if (entry->valid) {
+        if (len != entry->len || memcmp (data, entry->data, len) != 0) {
             errno = EBADE;
             return -1;
         }
@@ -172,68 +172,68 @@ int cache_entry_set_raw (struct cache_entry *hp, const void *data, int len)
             return -1;
         memcpy (cpy, data, len);
     }
-    hp->data = cpy;
-    hp->len = len;
-    hp->valid = true;
-    if (hp->waitlist_valid) {
-        if (wait_runqueue (hp->waitlist_valid) < 0)
+    entry->data = cpy;
+    entry->len = len;
+    entry->valid = true;
+    if (entry->waitlist_valid) {
+        if (wait_runqueue (entry->waitlist_valid) < 0)
             goto reset_invalid;
     }
     return 0;
 reset_invalid:
-    free (hp->data);
-    hp->data = NULL;
-    hp->len = 0;
-    hp->valid = false;
+    free (entry->data);
+    entry->data = NULL;
+    entry->len = 0;
+    entry->valid = false;
     return -1;
 }
 
-const json_t *cache_entry_get_treeobj (struct cache_entry *hp)
+const json_t *cache_entry_get_treeobj (struct cache_entry *entry)
 {
-    if (!hp || !hp->valid || !hp->data)
+    if (!entry || !entry->valid || !entry->data)
         return NULL;
-    if (!hp->o) {
-        if (!(hp->o = treeobj_decodeb (hp->data, hp->len)))
+    if (!entry->o) {
+        if (!(entry->o = treeobj_decodeb (entry->data, entry->len)))
             return NULL;
     }
-    return hp->o;
+    return entry->o;
 }
 
 void cache_entry_destroy (void *arg)
 {
-    struct cache_entry *hp = arg;
-    if (hp) {
-        free (hp->data);
-        json_decref (hp->o);
-        if (hp->waitlist_notdirty)
-            wait_queue_destroy (hp->waitlist_notdirty);
-        if (hp->waitlist_valid)
-            wait_queue_destroy (hp->waitlist_valid);
-        free (hp);
+    struct cache_entry *entry = arg;
+    if (entry) {
+        free (entry->data);
+        json_decref (entry->o);
+        if (entry->waitlist_notdirty)
+            wait_queue_destroy (entry->waitlist_notdirty);
+        if (entry->waitlist_valid)
+            wait_queue_destroy (entry->waitlist_valid);
+        free (entry);
     }
 }
 
-int cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait)
+int cache_entry_wait_notdirty (struct cache_entry *entry, wait_t *wait)
 {
     if (wait) {
-        if (!hp->waitlist_notdirty) {
-            if (!(hp->waitlist_notdirty = wait_queue_create ()))
+        if (!entry->waitlist_notdirty) {
+            if (!(entry->waitlist_notdirty = wait_queue_create ()))
                 return -1;
         }
-        if (wait_addqueue (hp->waitlist_notdirty, wait) < 0)
+        if (wait_addqueue (entry->waitlist_notdirty, wait) < 0)
             return -1;
     }
     return 0;
 }
 
-int cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait)
+int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait)
 {
     if (wait) {
-        if (!hp->waitlist_valid) {
-            if (!(hp->waitlist_valid = wait_queue_create ()))
+        if (!entry->waitlist_valid) {
+            if (!(entry->waitlist_valid = wait_queue_create ()))
                 return -1;
         }
-        if (wait_addqueue (hp->waitlist_valid, wait) < 0)
+        if (wait_addqueue (entry->waitlist_valid, wait) < 0)
             return -1;
     }
     return 0;
@@ -242,29 +242,30 @@ int cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait)
 struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
                                   int current_epoch)
 {
-    struct cache_entry *hp = zhash_lookup (cache->zh, ref);
-    if (hp && current_epoch > hp->lastuse_epoch)
-        hp->lastuse_epoch = current_epoch;
-    return hp;
+    struct cache_entry *entry = zhash_lookup (cache->zh, ref);
+    if (entry && current_epoch > entry->lastuse_epoch)
+        entry->lastuse_epoch = current_epoch;
+    return entry;
 }
 
-void cache_insert (struct cache *cache, const char *ref, struct cache_entry *hp)
+void cache_insert (struct cache *cache, const char *ref,
+                   struct cache_entry *entry)
 {
-    int rc = zhash_insert (cache->zh, ref, hp);
+    int rc = zhash_insert (cache->zh, ref, entry);
     assert (rc == 0);
     zhash_freefn (cache->zh, ref, cache_entry_destroy);
 }
 
 int cache_remove_entry (struct cache *cache, const char *ref)
 {
-    struct cache_entry *hp = zhash_lookup (cache->zh, ref);
+    struct cache_entry *entry = zhash_lookup (cache->zh, ref);
 
-    if (hp
-        && !hp->dirty
-        && (!hp->waitlist_notdirty
-            || !wait_queue_length (hp->waitlist_notdirty))
-        && (!hp->waitlist_valid
-            || !wait_queue_length (hp->waitlist_valid))) {
+    if (entry
+        && !entry->dirty
+        && (!entry->waitlist_notdirty
+            || !wait_queue_length (entry->waitlist_notdirty))
+        && (!entry->waitlist_valid
+            || !wait_queue_length (entry->waitlist_valid))) {
         zhash_delete (cache->zh, ref);
         return 1;
     }
@@ -276,20 +277,20 @@ int cache_count_entries (struct cache *cache)
     return zhash_size (cache->zh);
 }
 
-static int cache_entry_age (struct cache_entry *hp, int current_epoch)
+static int cache_entry_age (struct cache_entry *entry, int current_epoch)
 {
-    if (!hp)
+    if (!entry)
         return -1;
-    if (hp->lastuse_epoch == 0)
-        hp->lastuse_epoch = current_epoch;
-    return current_epoch - hp->lastuse_epoch;
+    if (entry->lastuse_epoch == 0)
+        entry->lastuse_epoch = current_epoch;
+    return current_epoch - entry->lastuse_epoch;
 }
 
 int cache_expire_entries (struct cache *cache, int current_epoch, int thresh)
 {
     zlist_t *keys;
     char *ref;
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     int count = 0;
 
     if (!(keys = zhash_keys (cache->zh))) {
@@ -297,10 +298,11 @@ int cache_expire_entries (struct cache *cache, int current_epoch, int thresh)
         return -1;
     }
     while ((ref = zlist_pop (keys))) {
-        if ((hp = zhash_lookup (cache->zh, ref))
-            && !cache_entry_get_dirty (hp)
-            && cache_entry_get_valid (hp)
-            && (thresh == 0 || cache_entry_age (hp, current_epoch) > thresh)) {
+        if ((entry = zhash_lookup (cache->zh, ref))
+            && !cache_entry_get_dirty (entry)
+            && cache_entry_get_valid (entry)
+            && (thresh == 0
+                || cache_entry_age (entry, current_epoch) > thresh)) {
                 zhash_delete (cache->zh, ref);
                 count++;
         }
@@ -314,7 +316,7 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
                      int *incompletep, int *dirtyp)
 {
     zlist_t *keys = NULL;
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     char *ref;
     int size = 0;
     int incomplete = 0;
@@ -327,18 +329,18 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
         goto cleanup;
     }
     while ((ref = zlist_pop (keys))) {
-        hp = zhash_lookup (cache->zh, ref);
-        if (cache_entry_get_valid (hp)) {
+        entry = zhash_lookup (cache->zh, ref);
+        if (cache_entry_get_valid (entry)) {
             int obj_size = 0;
 
-            if (hp->valid)
-                obj_size = hp->len;
+            if (entry->valid)
+                obj_size = entry->len;
 
             size += obj_size;
             tstat_push (ts, obj_size);
         } else
             incomplete++;
-        if (cache_entry_get_dirty (hp))
+        if (cache_entry_get_dirty (entry))
             dirty++;
         free (ref);
     }
@@ -359,18 +361,18 @@ cleanup:
 int cache_wait_destroy_msg (struct cache *cache, wait_test_msg_f cb, void *arg)
 {
     const char *key;
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     int n, count = 0;
     int rc = -1;
 
-    FOREACH_ZHASH (cache->zh, key, hp) {
-        if (hp->waitlist_valid) {
-            if ((n = wait_destroy_msg (hp->waitlist_valid, cb, arg)) < 0)
+    FOREACH_ZHASH (cache->zh, key, entry) {
+        if (entry->waitlist_valid) {
+            if ((n = wait_destroy_msg (entry->waitlist_valid, cb, arg)) < 0)
                 goto done;
             count += n;
         }
-        if (hp->waitlist_notdirty) {
-            if ((n = wait_destroy_msg (hp->waitlist_notdirty, cb, arg)) < 0)
+        if (entry->waitlist_notdirty) {
+            if ((n = wait_destroy_msg (entry->waitlist_notdirty, cb, arg)) < 0)
                 goto done;
             count += n;
         }

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -21,18 +21,18 @@ void cache_entry_destroy (void *arg);
 /* Return true if cache entry contains valid data.  False would
  * indicate that a load RPC is in progress.
  */
-bool cache_entry_get_valid (struct cache_entry *hp);
+bool cache_entry_get_valid (struct cache_entry *entry);
 
 /* Get/set cache entry's dirty bit.
  * The dirty bit indicates that a store RPC is in progress.
  * A true->false transitions runs the entry's wait queue, if any.
  * cache_entry_set_dirty() returns -1 on error, 0 on success
  */
-bool cache_entry_get_dirty (struct cache_entry *hp);
-int cache_entry_set_dirty (struct cache_entry *hp, bool val);
+bool cache_entry_get_dirty (struct cache_entry *entry);
+int cache_entry_set_dirty (struct cache_entry *entry, bool val);
 
 /* cache_entry_clear_dirty() is similar to calling
- * cache_entry_set_dirty(hp,false), but it will not set the dirty bit
+ * cache_entry_set_dirty(entry,false), but it will not set the dirty bit
  * to false if there are waiters for notdirty
  * (i.e. cache_entry_wait_notdirty() has been called on this entry).
  * This is typically called in an error path where the caller wishes
@@ -46,8 +46,8 @@ int cache_entry_set_dirty (struct cache_entry *hp, bool val);
  * what and destroy the internal wait queue of dirty bit waiters.  It
  * should be only used in emergency error handling cases.
  */
-int cache_entry_clear_dirty (struct cache_entry *hp);
-int cache_entry_force_clear_dirty (struct cache_entry *hp);
+int cache_entry_clear_dirty (struct cache_entry *entry);
+int cache_entry_force_clear_dirty (struct cache_entry *entry);
 
 /* Accessors for cache entry data.
  *
@@ -69,19 +69,19 @@ int cache_entry_force_clear_dirty (struct cache_entry *hp);
  * cache_entry_set_raw() & cache_entry_clear_data()
  * return -1 on error, 0 on success
  */
-int cache_entry_get_raw (struct cache_entry *hp, const void **data,
+int cache_entry_get_raw (struct cache_entry *entry, const void **data,
                          int *len);
-int cache_entry_set_raw (struct cache_entry *hp, const void *data, int len);
+int cache_entry_set_raw (struct cache_entry *entry, const void *data, int len);
 
-const json_t *cache_entry_get_treeobj (struct cache_entry *hp);
+const json_t *cache_entry_get_treeobj (struct cache_entry *entry);
 
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a
  * load or store RPC.
  * Returns -1 on error, 0 on success
  */
-int cache_entry_wait_notdirty (struct cache_entry *hp, wait_t *wait);
-int cache_entry_wait_valid (struct cache_entry *hp, wait_t *wait);
+int cache_entry_wait_notdirty (struct cache_entry *entry, wait_t *wait);
+int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait);
 
 /* Create/destroy the cache container and its contents.
  */
@@ -99,7 +99,7 @@ struct cache_entry *cache_lookup (struct cache *cache,
  * Ownership of the cache entry is transferred to the cache.
  */
 void cache_insert (struct cache *cache, const char *ref,
-                   struct cache_entry *hp);
+                   struct cache_entry *entry);
 
 /* Remove a cache_entry from the cache.  Will not be removed if dirty
  * or there are any waiters of any sort.

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -179,7 +179,7 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
         ret = cache_entry_get_raw (hp, &data, &len);
         assert (ret == 0);
 
-        blobref_hash (c->cm->hash_name, data, len, ref, sizeof (blobref_t));
+        blobref_hash (c->cm->hash_name, data, len, ref);
 
         ret = cache_remove_entry (c->cm->cache, ref);
         assert (ret == 1);
@@ -239,7 +239,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         }
         len = strlen (data);
     }
-    if (blobref_hash (c->cm->hash_name, data, len, ref, sizeof (blobref_t)) < 0) {
+    if (blobref_hash (c->cm->hash_name, data, len, ref) < 0) {
         flux_log_error (c->cm->h, "%s: blobref_hash", __FUNCTION__);
         goto error;
     }

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -59,7 +59,7 @@ struct commit {
     fence_t *f;
     int blocked:1;
     json_t *rootcpy;   /* working copy of root dir */
-    href_t newroot;
+    blobref_t newroot;
     zlist_t *missing_refs_list;
     zlist_t *dirty_cache_entries_list;
     commit_mgr_t *cm;
@@ -165,7 +165,7 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
 {
     if (c->state == COMMIT_STATE_STORE
         || c->state == COMMIT_STATE_PRE_FINISHED) {
-        href_t ref;
+        blobref_t ref;
         const void *data;
         int len;
         int ret;
@@ -179,7 +179,7 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
         ret = cache_entry_get_raw (hp, &data, &len);
         assert (ret == 0);
 
-        blobref_hash (c->cm->hash_name, data, len, ref, sizeof (href_t));
+        blobref_hash (c->cm->hash_name, data, len, ref, sizeof (blobref_t));
 
         ret = cache_remove_entry (c->cm->cache, ref);
         assert (ret == 1);
@@ -203,7 +203,7 @@ static void cleanup_dirty_cache_list (commit_t *c)
  * entry needs to be flushed to content store
  */
 static int store_cache (commit_t *c, int current_epoch, json_t *o,
-                        bool is_raw, href_t ref, struct cache_entry **hpp)
+                        bool is_raw, blobref_t ref, struct cache_entry **hpp)
 {
     struct cache_entry *hp;
     int saved_errno, rc;
@@ -239,7 +239,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         }
         len = strlen (data);
     }
-    if (blobref_hash (c->cm->hash_name, data, len, ref, sizeof (href_t)) < 0) {
+    if (blobref_hash (c->cm->hash_name, data, len, ref, sizeof (blobref_t)) < 0) {
         flux_log_error (c->cm->h, "%s: blobref_hash", __FUNCTION__);
         goto error;
     }
@@ -290,7 +290,7 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
     json_t *dir_entry;
     json_t *dir_data;
     json_t *tmp;
-    href_t ref;
+    blobref_t ref;
     int ret;
     struct cache_entry *hp;
     void *iter;
@@ -364,7 +364,7 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
 }
 
 static int commit_val_data_to_cache (commit_t *c, int current_epoch,
-                                     json_t *val, href_t ref)
+                                     json_t *val, blobref_t ref)
 {
     struct cache_entry *hp;
     json_t *val_data;
@@ -406,7 +406,7 @@ static int commit_append (commit_t *c, int current_epoch, json_t *dirent,
             return -1;
     }
     else if (treeobj_is_valref (entry)) {
-        href_t ref;
+        blobref_t ref;
         json_t *cpy;
 
         /* treeobj is valref, so we need to append the new data's
@@ -439,7 +439,7 @@ static int commit_append (commit_t *c, int current_epoch, json_t *dirent,
     }
     else if (treeobj_is_val (entry)) {
         json_t *tmp;
-        href_t ref1, ref2;
+        blobref_t ref1, ref2;
 
         /* treeobj entry is val, so we need to convert the treeobj
          * into a valref first.  Then the procedure is basically the
@@ -674,7 +674,7 @@ done:
 
 commit_process_t commit_process (commit_t *c,
                                  int current_epoch,
-                                 const href_t rootdir_ref)
+                                 const blobref_t rootdir_ref)
 {
     /* Incase user calls commit_process() again */
     if (c->errnum)

--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -161,7 +161,7 @@ const char *commit_get_newroot_ref (commit_t *c)
  * this dirty cache list (i.e. in store_cache() below when
  * cache_entry_set_raw() was called).
  */
-void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
+void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *entry)
 {
     if (c->state == COMMIT_STATE_STORE
         || c->state == COMMIT_STATE_PRE_FINISHED) {
@@ -170,13 +170,13 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
         int len;
         int ret;
 
-        assert (cache_entry_get_valid (hp) == true);
-        assert (cache_entry_get_dirty (hp) == true);
-        ret = cache_entry_clear_dirty (hp);
+        assert (cache_entry_get_valid (entry) == true);
+        assert (cache_entry_get_dirty (entry) == true);
+        ret = cache_entry_clear_dirty (entry);
         assert (ret == 0);
-        assert (cache_entry_get_dirty (hp) == false);
+        assert (cache_entry_get_dirty (entry) == false);
 
-        ret = cache_entry_get_raw (hp, &data, &len);
+        ret = cache_entry_get_raw (entry, &data, &len);
         assert (ret == 0);
 
         blobref_hash (c->cm->hash_name, data, len, ref);
@@ -188,10 +188,10 @@ void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp)
 
 static void cleanup_dirty_cache_list (commit_t *c)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
 
-    while ((hp = zlist_pop (c->dirty_cache_entries_list)))
-        commit_cleanup_dirty_cache_entry (c, hp);
+    while ((entry = zlist_pop (c->dirty_cache_entries_list)))
+        commit_cleanup_dirty_cache_entry (c, entry);
 }
 
 /* Store object 'o' under key 'ref' in local cache.
@@ -203,9 +203,9 @@ static void cleanup_dirty_cache_list (commit_t *c)
  * entry needs to be flushed to content store
  */
 static int store_cache (commit_t *c, int current_epoch, json_t *o,
-                        bool is_raw, blobref_t ref, struct cache_entry **hpp)
+                        bool is_raw, blobref_t ref, struct cache_entry **entryp)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     int saved_errno, rc;
     const char *xdata;
     char *data = NULL;
@@ -243,25 +243,25 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         flux_log_error (c->cm->h, "%s: blobref_hash", __FUNCTION__);
         goto error;
     }
-    if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))) {
-        if (!(hp = cache_entry_create ())) {
+    if (!(entry = cache_lookup (c->cm->cache, ref, current_epoch))) {
+        if (!(entry = cache_entry_create ())) {
             flux_log_error (c->cm->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
         }
-        cache_insert (c->cm->cache, ref, hp);
+        cache_insert (c->cm->cache, ref, entry);
     }
-    if (cache_entry_get_valid (hp)) {
+    if (cache_entry_get_valid (entry)) {
         c->cm->noop_stores++;
         rc = 0;
     }
     else {
-        if (cache_entry_set_raw (hp, data, len) < 0) {
+        if (cache_entry_set_raw (entry, data, len) < 0) {
             int ret;
             ret = cache_remove_entry (c->cm->cache, ref);
             assert (ret == 1);
             goto error;
         }
-        if (cache_entry_set_dirty (hp, true) < 0) {
+        if (cache_entry_set_dirty (entry, true) < 0) {
             flux_log_error (c->cm->h, "%s: cache_entry_set_dirty",__FUNCTION__);
             int ret;
             ret = cache_remove_entry (c->cm->cache, ref);
@@ -270,7 +270,7 @@ static int store_cache (commit_t *c, int current_epoch, json_t *o,
         }
         rc = 1;
     }
-    *hpp = hp;
+    *entryp = entry;
     free (data);
     return rc;
 
@@ -292,7 +292,7 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
     json_t *tmp;
     blobref_t ref;
     int ret;
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     void *iter;
 
     assert (treeobj_is_dir (dir));
@@ -311,11 +311,11 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
             if (commit_unroll (c, current_epoch, dir_entry) < 0) /* depth first */
                 return -1;
             if ((ret = store_cache (c, current_epoch, dir_entry,
-                                    false, ref, &hp)) < 0)
+                                    false, ref, &entry)) < 0)
                 return -1;
             if (ret) {
-                if (zlist_push (c->dirty_cache_entries_list, hp) < 0) {
-                    commit_cleanup_dirty_cache_entry (c, hp);
+                if (zlist_push (c->dirty_cache_entries_list, entry) < 0) {
+                    commit_cleanup_dirty_cache_entry (c, entry);
                     errno = ENOMEM;
                     return -1;
                 }
@@ -339,11 +339,11 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
             assert (str);
             if (strlen (str) > BLOBREF_MAX_STRING_SIZE) {
                 if ((ret = store_cache (c, current_epoch, val_data,
-                                        true, ref, &hp)) < 0)
+                                        true, ref, &entry)) < 0)
                     return -1;
                 if (ret) {
-                    if (zlist_push (c->dirty_cache_entries_list, hp) < 0) {
-                        commit_cleanup_dirty_cache_entry (c, hp);
+                    if (zlist_push (c->dirty_cache_entries_list, entry) < 0) {
+                        commit_cleanup_dirty_cache_entry (c, entry);
                         errno = ENOMEM;
                         return -1;
                     }
@@ -366,7 +366,7 @@ static int commit_unroll (commit_t *c, int current_epoch, json_t *dir)
 static int commit_val_data_to_cache (commit_t *c, int current_epoch,
                                      json_t *val, blobref_t ref)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     json_t *val_data;
     int ret;
 
@@ -374,12 +374,12 @@ static int commit_val_data_to_cache (commit_t *c, int current_epoch,
         return -1;
 
     if ((ret = store_cache (c, current_epoch, val_data,
-                            true, ref, &hp)) < 0)
+                            true, ref, &entry)) < 0)
         return -1;
 
     if (ret) {
-        if (zlist_push (c->dirty_cache_entries_list, hp) < 0) {
-            commit_cleanup_dirty_cache_entry (c, hp);
+        if (zlist_push (c->dirty_cache_entries_list, entry) < 0) {
+            commit_cleanup_dirty_cache_entry (c, entry);
             errno = ENOMEM;
             return -1;
         }
@@ -544,7 +544,7 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
         } else if (treeobj_is_dir (dir_entry)) {
             subdir = dir_entry;
         } else if (treeobj_is_dirref (dir_entry)) {
-            struct cache_entry *hp;
+            struct cache_entry *entry;
             const char *ref;
             const json_t *subdirtmp;
             int refcount;
@@ -566,13 +566,13 @@ static int commit_link_dirent (commit_t *c, int current_epoch,
                 goto done;
             }
 
-            if (!(hp = cache_lookup (c->cm->cache, ref, current_epoch))
-                || !cache_entry_get_valid (hp)) {
+            if (!(entry = cache_lookup (c->cm->cache, ref, current_epoch))
+                || !cache_entry_get_valid (entry)) {
                 *missing_ref = ref;
                 goto success; /* stall */
             }
 
-            if (!(subdirtmp = cache_entry_get_treeobj (hp))) {
+            if (!(subdirtmp = cache_entry_get_treeobj (entry))) {
                 saved_errno = ENOTRECOVERABLE;
                 goto done;
             }
@@ -686,7 +686,7 @@ commit_process_t commit_process (commit_t *c,
         {
             /* Make a copy of the root directory.
              */
-            struct cache_entry *hp;
+            struct cache_entry *entry;
             const json_t *rootdir;
 
             /* Caller didn't call commit_iter_missing_refs() */
@@ -695,10 +695,10 @@ commit_process_t commit_process (commit_t *c,
 
             c->state = COMMIT_STATE_LOAD_ROOT;
 
-            if (!(hp = cache_lookup (c->cm->cache,
-                                     rootdir_ref,
-                                     current_epoch))
-                || !cache_entry_get_valid (hp)) {
+            if (!(entry = cache_lookup (c->cm->cache,
+                                        rootdir_ref,
+                                        current_epoch))
+                || !cache_entry_get_valid (entry)) {
 
                 if (zlist_push (c->missing_refs_list,
                                 (void *)rootdir_ref) < 0) {
@@ -708,7 +708,7 @@ commit_process_t commit_process (commit_t *c,
                 goto stall_load;
             }
 
-            if (!(rootdir = cache_entry_get_treeobj (hp))) {
+            if (!(rootdir = cache_entry_get_treeobj (entry))) {
                 c->errnum = ENOTRECOVERABLE;
                 return COMMIT_PROCESS_ERROR;
             }
@@ -790,7 +790,7 @@ commit_process_t commit_process (commit_t *c,
              * Flushes to content cache are asynchronous but we don't
              * proceed until they are completed.
              */
-            struct cache_entry *hp;
+            struct cache_entry *entry;
             int sret;
 
             if (commit_unroll (c, current_epoch, c->rootcpy) < 0)
@@ -800,11 +800,11 @@ commit_process_t commit_process (commit_t *c,
                                           c->rootcpy,
                                           false,
                                           c->newroot,
-                                          &hp)) < 0)
+                                          &entry)) < 0)
                      c->errnum = errno;
             else if (sret
-                     && zlist_push (c->dirty_cache_entries_list, hp) < 0) {
-                commit_cleanup_dirty_cache_entry (c, hp);
+                     && zlist_push (c->dirty_cache_entries_list, entry) < 0) {
+                commit_cleanup_dirty_cache_entry (c, entry);
                 c->errnum = ENOMEM;
             }
 
@@ -881,7 +881,7 @@ int commit_iter_dirty_cache_entries (commit_t *c,
                                      commit_cache_entry_f cb,
                                      void *data)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     int saved_errno, rc = 0;
 
     if (c->state != COMMIT_STATE_PRE_FINISHED) {
@@ -889,8 +889,8 @@ int commit_iter_dirty_cache_entries (commit_t *c,
         return -1;
     }
 
-    while ((hp = zlist_pop (c->dirty_cache_entries_list))) {
-        if (cb (c, hp, data) < 0) {
+    while ((entry = zlist_pop (c->dirty_cache_entries_list))) {
+        if (cb (c, entry, data) < 0) {
             saved_errno = errno;
             rc = -1;
             break;

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -6,7 +6,7 @@
 
 #include "cache.h"
 #include "fence.h"
-#include "types.h"
+#include "src/common/libutil/blobref.h"
 
 typedef struct commit_mgr commit_mgr_t;
 typedef struct commit commit_t;
@@ -68,7 +68,7 @@ const char *commit_get_newroot_ref (commit_t *c);
  */
 commit_process_t commit_process (commit_t *c,
                                  int current_epoch,
-                                 const href_t rootdir_ref);
+                                 const blobref_t rootdir_ref);
 
 /* on commit stall, iterate through all missing refs that the caller
  * should load into the cache

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -25,7 +25,7 @@ typedef enum {
 typedef int (*commit_ref_f)(commit_t *c, const char *ref, void *data);
 
 typedef int (*commit_cache_entry_f)(commit_t *c,
-                                     struct cache_entry *hp,
+                                     struct cache_entry *entry,
                                      void *data);
 
 int commit_get_errnum (commit_t *c);
@@ -91,7 +91,7 @@ int commit_iter_dirty_cache_entries (commit_t *c,
  * should only be used for error cleanup in the callback function used in
  * commit_iter_dirty_cache_entries().
  */
-void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *hp);
+void commit_cleanup_dirty_cache_entry (commit_t *c, struct cache_entry *entry);
 
 /*
  * commit_mgr_t API

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1361,7 +1361,7 @@ static void prime_cache_with_rootdir (kvs_ctx_t *ctx, json_t *rootdir)
         goto done;
     }
     len = strlen (data);
-    if (blobref_hash (ctx->hash_name, data, len, ref, sizeof (blobref_t)) < 0) {
+    if (blobref_hash (ctx->hash_name, data, len, ref) < 0) {
         flux_log_error (ctx->h, "%s: blobref_hash", __FUNCTION__);
         goto done;
     }
@@ -1634,7 +1634,7 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, const json_t *rootdir,
     if (!(data = treeobj_encode (rootdir)))
         goto error;
     len = strlen (data);
-    if (blobref_hash (ctx->hash_name, data, len, ref, sizeof (blobref_t)) < 0) {
+    if (blobref_hash (ctx->hash_name, data, len, ref) < 0) {
         flux_log_error (ctx->h, "%s: blobref_hash", __FUNCTION__);
         goto error;
     }

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -10,19 +10,19 @@
 #include "src/modules/kvs/waitqueue.h"
 #include "src/modules/kvs/cache.h"
 
-static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
+static int cache_entry_set_treeobj (struct cache_entry *entry, const json_t *o)
 {
     char *s = NULL;
     int saved_errno;
     int rc = -1;
 
-    if (!hp || !o || treeobj_validate (o) < 0) {
+    if (!entry || !o || treeobj_validate (o) < 0) {
         errno = EINVAL;
         goto done;
     }
     if (!(s = treeobj_encode (o)))
         goto done;
-    if (cache_entry_set_raw (hp, s, strlen (s)) < 0)
+    if (cache_entry_set_raw (entry, s, strlen (s)) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libutil/blobref.h"
 #include "src/common/libkvs/kvs.h"
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libkvs/kvs_txn_private.h"
@@ -14,7 +15,6 @@
 #include "src/modules/kvs/lookup.h"
 #include "src/modules/kvs/fence.h"
 #include "src/modules/kvs/kvs_util.h"
-#include "src/modules/kvs/types.h"
 
 static int test_global = 5;
 
@@ -92,7 +92,7 @@ void ops_append (json_t *array, const char *key, const char *value, int flags)
     json_array_append_new (array, op);
 }
 
-struct cache *create_cache_with_empty_rootdir (href_t ref)
+struct cache *create_cache_with_empty_rootdir (blobref_t ref)
 {
     struct cache *cache;
     struct cache_entry *hp;
@@ -102,7 +102,7 @@ struct cache *create_cache_with_empty_rootdir (href_t ref)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
-    ok (treeobj_hash ("sha1", rootdir, ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", rootdir, ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
     ok ((hp = create_cache_entry_treeobj (rootdir)) != NULL,
         "create_cache_entry_treeobj works");
@@ -117,7 +117,7 @@ void commit_mgr_basic_tests (void)
     commit_mgr_t *cm;
     commit_t *c;
     fence_t *f, *tf;
-    href_t rootref;
+    blobref_t rootref;
 
     cache = create_cache_with_empty_rootdir (rootref);
 
@@ -262,7 +262,7 @@ void commit_mgr_merge_tests (void)
     struct cache *cache;
     json_t *names, *ops = NULL;
     commit_mgr_t *cm;
-    href_t rootref;
+    blobref_t rootref;
 
     cache = create_cache_with_empty_rootdir (rootref);
 
@@ -366,7 +366,7 @@ void commit_basic_tests (void)
     json_t *names, *ops = NULL;
     commit_mgr_t *cm;
     commit_t *c;
-    href_t rootref;
+    blobref_t rootref;
 
     cache = create_cache_with_empty_rootdir (rootref);
 
@@ -472,7 +472,7 @@ void commit_basic_commit_process_test (void)
     int count = 0;
     commit_mgr_t *cm;
     commit_t *c;
-    href_t rootref;
+    blobref_t rootref;
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
@@ -517,7 +517,7 @@ void commit_basic_commit_process_test_multiple_fences (void)
     int count = 0;
     commit_mgr_t *cm;
     commit_t *c;
-    href_t rootref;
+    blobref_t rootref;
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
@@ -590,7 +590,7 @@ void commit_basic_commit_process_test_multiple_fences_merge (void)
     int count = 0;
     commit_mgr_t *cm;
     commit_t *c;
-    href_t rootref;
+    blobref_t rootref;
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
@@ -645,7 +645,7 @@ void commit_basic_root_not_dir (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t root_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -653,7 +653,7 @@ void commit_basic_root_not_dir (void)
     /* make a non-dir root */
     root = treeobj_create_val ("abcd", 4);
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -710,7 +710,7 @@ void commit_process_root_missing (void)
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
-    href_t rootref;
+    blobref_t rootref;
     struct rootref_data rd;
     json_t *rootdir;
     const char *newroot;
@@ -721,7 +721,7 @@ void commit_process_root_missing (void)
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
 
-    ok (treeobj_hash ("sha1", rootdir, rootref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", rootdir, rootref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     json_decref (rootdir);
@@ -798,8 +798,8 @@ void commit_process_missing_ref (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
     struct missingref_data md;
     const char *newroot;
 
@@ -819,7 +819,7 @@ void commit_process_missing_ref (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     /* don't add dir entry, we want it to miss  */
@@ -827,7 +827,7 @@ void commit_process_missing_ref (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -899,8 +899,8 @@ void commit_process_error_callbacks (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -918,7 +918,7 @@ void commit_process_error_callbacks (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     /* don't add dir entry, we want it to miss  */
@@ -926,7 +926,7 @@ void commit_process_error_callbacks (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -988,8 +988,8 @@ void commit_process_error_callbacks_partway (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1007,7 +1007,7 @@ void commit_process_error_callbacks_partway (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1015,7 +1015,7 @@ void commit_process_error_callbacks_partway (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1056,7 +1056,7 @@ void commit_process_invalid_operation (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t root_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1064,7 +1064,7 @@ void commit_process_invalid_operation (void)
     /* This root is an empty root */
     root = treeobj_create_dir ();
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1096,7 +1096,7 @@ void commit_process_malformed_operation (void)
     struct cache *cache;
     commit_mgr_t *cm;
     commit_t *c;
-    href_t root_ref;
+    blobref_t root_ref;
     fence_t *f;
     json_t *ops, *badop;
 
@@ -1151,7 +1151,7 @@ void commit_process_invalid_hash (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t root_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1159,7 +1159,7 @@ void commit_process_invalid_hash (void)
     /* This root is an empty root */
     root = treeobj_create_dir ();
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1193,8 +1193,8 @@ void commit_process_follow_link (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1214,7 +1214,7 @@ void commit_process_follow_link (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1223,7 +1223,7 @@ void commit_process_follow_link (void)
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dir"));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1262,7 +1262,7 @@ void commit_process_dirval_test (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
+    blobref_t root_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1281,7 +1281,7 @@ void commit_process_dirval_test (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", dir);
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1319,8 +1319,8 @@ void commit_process_delete_test (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1339,7 +1339,7 @@ void commit_process_delete_test (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1347,7 +1347,7 @@ void commit_process_delete_test (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1385,7 +1385,7 @@ void commit_process_delete_nosubdir_test (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t root_ref;
+    blobref_t root_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1394,7 +1394,7 @@ void commit_process_delete_nosubdir_test (void)
     /* This root is an empty root */
     root = treeobj_create_dir ();
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1428,8 +1428,8 @@ void commit_process_delete_filevalinpath_test (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1448,7 +1448,7 @@ void commit_process_delete_filevalinpath_test (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1456,7 +1456,7 @@ void commit_process_delete_filevalinpath_test (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1491,8 +1491,8 @@ void commit_process_bad_dirrefs (void)
     json_t *root;
     json_t *dirref;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1510,7 +1510,7 @@ void commit_process_bad_dirrefs (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1521,7 +1521,7 @@ void commit_process_bad_dirrefs (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", dirref);
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1573,7 +1573,7 @@ void commit_process_big_fileval (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t root_ref;
+    blobref_t root_ref;
     const char *newroot;
     int bigstrsize = BLOBREF_MAX_STRING_SIZE * 2;
     char bigstr[bigstrsize];
@@ -1592,7 +1592,7 @@ void commit_process_big_fileval (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1685,8 +1685,8 @@ void commit_process_giant_dir (void)
     commit_t *c;
     json_t *root;
     json_t *dir;
-    href_t root_ref;
-    href_t dir_ref;
+    blobref_t root_ref;
+    blobref_t dir_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1738,7 +1738,7 @@ void commit_process_giant_dir (void)
     treeobj_insert_entry (dir, "val0e00", treeobj_create_val ("E", 1));
     treeobj_insert_entry (dir, "valF000", treeobj_create_val ("f", 1));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1746,7 +1746,7 @@ void commit_process_giant_dir (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (dir, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1799,8 +1799,8 @@ void commit_process_append (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t valref_ref;
-    href_t root_ref;
+    blobref_t valref_ref;
+    blobref_t root_ref;
     const char *newroot;
 
     ok ((cache = cache_create ()) != NULL,
@@ -1816,14 +1816,14 @@ void commit_process_append (void)
      * "valref" : valref to valref_ref
      */
 
-    blobref_hash ("sha1", "ABCD", 4, valref_ref, sizeof (href_t));
+    blobref_hash ("sha1", "ABCD", 4, valref_ref, sizeof (blobref_t));
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("ABCD"), 4));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "val", treeobj_create_val ("abcd", 4));
     treeobj_insert_entry (root, "valref", treeobj_create_val ("ABCD", 4));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1933,7 +1933,7 @@ void commit_process_append_errors (void)
     commit_mgr_t *cm;
     commit_t *c;
     json_t *root;
-    href_t root_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1949,7 +1949,7 @@ void commit_process_append_errors (void)
     treeobj_insert_entry (root, "dir", treeobj_create_dir ());
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dir"));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (href_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -18,6 +18,30 @@
 
 static int test_global = 5;
 
+static int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
+{
+    char *tmp = NULL;
+    int rc = -1;
+
+    if (!hash_name || !obj || !s || size <= 0) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (treeobj_validate (obj) < 0)
+        goto error;
+
+    if (!(tmp = treeobj_encode (obj)))
+        goto error;
+
+    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp), s, size) < 0)
+        goto error;
+    rc = 0;
+error:
+    free (tmp);
+    return rc;
+}
+
 static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
 {
     char *s = NULL;

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -18,12 +18,12 @@
 
 static int test_global = 5;
 
-static int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
+static int treeobj_hash (const char *hash_name, json_t *obj, blobref_t blobref)
 {
     char *tmp = NULL;
     int rc = -1;
 
-    if (!hash_name || !obj || !s || size <= 0) {
+    if (!hash_name || !obj || !blobref) {
         errno = EINVAL;
         goto error;
     }
@@ -34,7 +34,7 @@ static int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
     if (!(tmp = treeobj_encode (obj)))
         goto error;
 
-    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp), s, size) < 0)
+    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp), blobref) < 0)
         goto error;
     rc = 0;
 error:
@@ -126,7 +126,7 @@ struct cache *create_cache_with_empty_rootdir (blobref_t ref)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
-    ok (treeobj_hash ("sha1", rootdir, ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", rootdir, ref) == 0,
         "treeobj_hash worked");
     ok ((hp = create_cache_entry_treeobj (rootdir)) != NULL,
         "create_cache_entry_treeobj works");
@@ -677,7 +677,7 @@ void commit_basic_root_not_dir (void)
     /* make a non-dir root */
     root = treeobj_create_val ("abcd", 4);
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -745,7 +745,7 @@ void commit_process_root_missing (void)
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
 
-    ok (treeobj_hash ("sha1", rootdir, rootref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", rootdir, rootref) == 0,
         "treeobj_hash worked");
 
     json_decref (rootdir);
@@ -843,7 +843,7 @@ void commit_process_missing_ref (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     /* don't add dir entry, we want it to miss  */
@@ -851,7 +851,7 @@ void commit_process_missing_ref (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -942,7 +942,7 @@ void commit_process_error_callbacks (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     /* don't add dir entry, we want it to miss  */
@@ -950,7 +950,7 @@ void commit_process_error_callbacks (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1031,7 +1031,7 @@ void commit_process_error_callbacks_partway (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1039,7 +1039,7 @@ void commit_process_error_callbacks_partway (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1088,7 +1088,7 @@ void commit_process_invalid_operation (void)
     /* This root is an empty root */
     root = treeobj_create_dir ();
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1183,7 +1183,7 @@ void commit_process_invalid_hash (void)
     /* This root is an empty root */
     root = treeobj_create_dir ();
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1238,7 +1238,7 @@ void commit_process_follow_link (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1247,7 +1247,7 @@ void commit_process_follow_link (void)
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dir"));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1305,7 +1305,7 @@ void commit_process_dirval_test (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", dir);
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1363,7 +1363,7 @@ void commit_process_delete_test (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1371,7 +1371,7 @@ void commit_process_delete_test (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1418,7 +1418,7 @@ void commit_process_delete_nosubdir_test (void)
     /* This root is an empty root */
     root = treeobj_create_dir ();
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1472,7 +1472,7 @@ void commit_process_delete_filevalinpath_test (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1480,7 +1480,7 @@ void commit_process_delete_filevalinpath_test (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1534,7 +1534,7 @@ void commit_process_bad_dirrefs (void)
     dir = treeobj_create_dir ();
     treeobj_insert_entry (dir, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1545,7 +1545,7 @@ void commit_process_bad_dirrefs (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dir", dirref);
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1616,7 +1616,7 @@ void commit_process_big_fileval (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "val", treeobj_create_val ("42", 2));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1762,7 +1762,7 @@ void commit_process_giant_dir (void)
     treeobj_insert_entry (dir, "val0e00", treeobj_create_val ("E", 1));
     treeobj_insert_entry (dir, "valF000", treeobj_create_val ("f", 1));
 
-    ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", dir, dir_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
@@ -1770,7 +1770,7 @@ void commit_process_giant_dir (void)
     root = treeobj_create_dir ();
     treeobj_insert_entry (dir, "dir", treeobj_create_dirref (dir_ref));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1840,14 +1840,14 @@ void commit_process_append (void)
      * "valref" : valref to valref_ref
      */
 
-    blobref_hash ("sha1", "ABCD", 4, valref_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "ABCD", 4, valref_ref);
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("ABCD"), 4));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "val", treeobj_create_val ("abcd", 4));
     treeobj_insert_entry (root, "valref", treeobj_create_val ("ABCD", 4));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
@@ -1973,7 +1973,7 @@ void commit_process_append_errors (void)
     treeobj_insert_entry (root, "dir", treeobj_create_dir ());
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dir"));
 
-    ok (treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t)) == 0,
+    ok (treeobj_hash ("sha1", root, root_ref) == 0,
         "treeobj_hash worked");
 
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -19,6 +19,30 @@ struct lookup_ref_data
     int count;
 };
 
+static int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
+{
+    char *tmp = NULL;
+    int rc = -1;
+
+    if (!hash_name || !obj || !s || size <= 0) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (treeobj_validate (obj) < 0)
+        goto error;
+
+    if (!(tmp = treeobj_encode (obj)))
+        goto error;
+
+    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp), s, size) < 0)
+        goto error;
+    rc = 0;
+error:
+    free (tmp);
+    return rc;
+}
+
 static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
 {
     char *s = NULL;

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -19,12 +19,12 @@ struct lookup_ref_data
     int count;
 };
 
-static int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
+static int treeobj_hash (const char *hash_name, json_t *obj, blobref_t blobref)
 {
     char *tmp = NULL;
     int rc = -1;
 
-    if (!hash_name || !obj || !s || size <= 0) {
+    if (!hash_name || !obj || !blobref) {
         errno = EINVAL;
         goto error;
     }
@@ -35,7 +35,7 @@ static int treeobj_hash (const char *hash_name, json_t *obj, char *s, int size)
     if (!(tmp = treeobj_encode (obj)))
         goto error;
 
-    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp), s, size) < 0)
+    if (blobref_hash (hash_name, (uint8_t *)tmp, strlen (tmp), blobref) < 0)
         goto error;
     rc = 0;
 error:
@@ -453,11 +453,11 @@ void lookup_root (void) {
      * treeobj dir, no entries
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref);
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     root = treeobj_create_dir ();
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* flags = 0, should error EISDIR */
@@ -553,16 +553,16 @@ void lookup_basic (void) {
      * "dirref" : dirref to dirref_ref
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref);
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
-    blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "efgh", 4, valref2_ref);
     cache_insert (cache, valref2_ref, create_cache_entry_raw (strdup ("efgh"), 4));
 
     dirref_test = treeobj_create_dir ();
     treeobj_insert_entry (dirref_test, "dummy", treeobj_create_val ("dummy", 5));
 
-    treeobj_hash ("sha1", dirref_test, dirref_test_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref_test, dirref_test_ref);
     cache_insert (cache, dirref_test_ref, create_cache_entry_treeobj (dirref_test));
 
     dir = treeobj_create_dir ();
@@ -585,13 +585,13 @@ void lookup_basic (void) {
 
     treeobj_insert_entry (dirref, "valref_multi_with_dirref", valref_multi_with_dirref);
 
-    treeobj_hash ("sha1", dirref, dirref_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref, dirref_ref);
     cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref", treeobj_create_dirref (dirref_ref));
 
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup dir via dirref */
@@ -799,12 +799,12 @@ void lookup_errors (void) {
      * "dirref_multi" : dirref to [ dirref_ref, dirref_ref ]
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref);
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     dirref = treeobj_create_dir ();
     treeobj_insert_entry (dirref, "val", treeobj_create_val ("bar", 3));
-    treeobj_hash ("sha1", dirref, dirref_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref, dirref_ref);
     cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     dir = treeobj_create_dir ();
@@ -825,7 +825,7 @@ void lookup_errors (void) {
 
     treeobj_insert_entry (root, "dirref_multi", dirref_multi);
 
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* Lookup non-existent field.  Not ENOENT - caller of lookup
@@ -1091,12 +1091,12 @@ void lookup_links (void) {
      * "dirref2" : dirref to "dirref2_ref
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref);
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     dirref3 = treeobj_create_dir ();
     treeobj_insert_entry (dirref3, "val", treeobj_create_val ("baz", 3));
-    treeobj_hash ("sha1", dirref3, dirref3_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref3, dirref3_ref);
     cache_insert (cache, dirref3_ref, create_cache_entry_treeobj (dirref3));
 
     dir = treeobj_create_dir ();
@@ -1108,7 +1108,7 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref2, "dir", dir);
     treeobj_insert_entry (dirref2, "dirref", treeobj_create_dirref (dirref3_ref));
     treeobj_insert_entry (dirref2, "symlink", treeobj_create_symlink ("dirref2.val"));
-    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref2, dirref2_ref);
     cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     dirref1 = treeobj_create_dir ();
@@ -1117,13 +1117,13 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref1, "link2valref", treeobj_create_symlink ("dirref2.valref"));
     treeobj_insert_entry (dirref1, "link2dir", treeobj_create_symlink ("dirref2.dir"));
     treeobj_insert_entry (dirref1, "link2symlink", treeobj_create_symlink ("dirref2.symlink"));
-    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref1, dirref1_ref);
     cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup val, follow two links */
@@ -1293,18 +1293,18 @@ void lookup_alt_root (void) {
 
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "val", treeobj_create_val ("foo", 3));
-    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref1, dirref1_ref);
     cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     dirref2 = treeobj_create_dir ();
     treeobj_insert_entry (dirref2, "val", treeobj_create_val ("bar", 3));
-    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref2, dirref2_ref);
     cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup val, alt root-ref dirref1_ref */
@@ -1354,7 +1354,7 @@ void lookup_stall_root (void) {
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "val", treeobj_create_val ("foo", 3));
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
 
     /* do not insert entries into cache until later for these stall tests */
 
@@ -1446,12 +1446,12 @@ void lookup_stall (void) {
      *
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref1_ref, sizeof (blobref_t));
-    blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (blobref_t));
-    blobref_hash ("sha1", "ijkl", 4, valref3_ref, sizeof (blobref_t));
-    blobref_hash ("sha1", "mnop", 4, valref4_ref, sizeof (blobref_t));
-    blobref_hash ("sha1", "foobar", 4, valrefmisc1_ref, sizeof (blobref_t));
-    blobref_hash ("sha1", "foobaz", 4, valrefmisc2_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "abcd", 4, valref1_ref);
+    blobref_hash ("sha1", "efgh", 4, valref2_ref);
+    blobref_hash ("sha1", "ijkl", 4, valref3_ref);
+    blobref_hash ("sha1", "mnop", 4, valref4_ref);
+    blobref_hash ("sha1", "foobar", 4, valrefmisc1_ref);
+    blobref_hash ("sha1", "foobaz", 4, valrefmisc2_ref);
 
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "val", treeobj_create_val ("foo", 3));
@@ -1467,17 +1467,17 @@ void lookup_stall (void) {
     treeobj_append_blobref (valref_tmp, valrefmisc2_ref);
     treeobj_insert_entry (dirref1, "valrefmisc_multi", valref_tmp);
 
-    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref1, dirref1_ref);
 
     dirref2 = treeobj_create_dir ();
     treeobj_insert_entry (dirref2, "val", treeobj_create_val ("bar", 3));
-    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", dirref2, dirref2_ref);
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dirref2"));
-    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
+    treeobj_hash ("sha1", root, root_ref);
 
     /* do not insert entries into cache until later for these stall tests */
 

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -11,7 +11,6 @@
 #include "src/modules/kvs/cache.h"
 #include "src/modules/kvs/lookup.h"
 #include "src/modules/kvs/kvs_util.h"
-#include "src/modules/kvs/types.h"
 #include "src/common/libutil/blobref.h"
 
 struct lookup_ref_data
@@ -415,8 +414,8 @@ void lookup_root (void) {
     json_t *test;
     struct cache *cache;
     lookup_t *lh;
-    href_t valref_ref;
-    href_t root_ref;
+    blobref_t valref_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -430,11 +429,11 @@ void lookup_root (void) {
      * treeobj dir, no entries
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (href_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     root = treeobj_create_dir ();
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* flags = 0, should error EISDIR */
@@ -497,11 +496,11 @@ void lookup_basic (void) {
     json_t *test;
     struct cache *cache;
     lookup_t *lh;
-    href_t valref_ref;
-    href_t valref2_ref;
-    href_t dirref_ref;
-    href_t dirref_test_ref;
-    href_t root_ref;
+    blobref_t valref_ref;
+    blobref_t valref2_ref;
+    blobref_t dirref_ref;
+    blobref_t dirref_test_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -530,16 +529,16 @@ void lookup_basic (void) {
      * "dirref" : dirref to dirref_ref
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (href_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
-    blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (href_t));
+    blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (blobref_t));
     cache_insert (cache, valref2_ref, create_cache_entry_raw (strdup ("efgh"), 4));
 
     dirref_test = treeobj_create_dir ();
     treeobj_insert_entry (dirref_test, "dummy", treeobj_create_val ("dummy", 5));
 
-    treeobj_hash ("sha1", dirref_test, dirref_test_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref_test, dirref_test_ref, sizeof (blobref_t));
     cache_insert (cache, dirref_test_ref, create_cache_entry_treeobj (dirref_test));
 
     dir = treeobj_create_dir ();
@@ -562,13 +561,13 @@ void lookup_basic (void) {
 
     treeobj_insert_entry (dirref, "valref_multi_with_dirref", valref_multi_with_dirref);
 
-    treeobj_hash ("sha1", dirref, dirref_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref, dirref_ref, sizeof (blobref_t));
     cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref", treeobj_create_dirref (dirref_ref));
 
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup dir via dirref */
@@ -749,9 +748,9 @@ void lookup_errors (void) {
     json_t *dirref_multi;
     struct cache *cache;
     lookup_t *lh;
-    href_t dirref_ref;
-    href_t valref_ref;
-    href_t root_ref;
+    blobref_t dirref_ref;
+    blobref_t valref_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -776,12 +775,12 @@ void lookup_errors (void) {
      * "dirref_multi" : dirref to [ dirref_ref, dirref_ref ]
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (href_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     dirref = treeobj_create_dir ();
     treeobj_insert_entry (dirref, "val", treeobj_create_val ("bar", 3));
-    treeobj_hash ("sha1", dirref, dirref_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref, dirref_ref, sizeof (blobref_t));
     cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     dir = treeobj_create_dir ();
@@ -802,7 +801,7 @@ void lookup_errors (void) {
 
     treeobj_insert_entry (root, "dirref_multi", dirref_multi);
 
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* Lookup non-existent field.  Not ENOENT - caller of lookup
@@ -1032,11 +1031,11 @@ void lookup_links (void) {
     json_t *test;
     struct cache *cache;
     lookup_t *lh;
-    href_t valref_ref;
-    href_t dirref3_ref;
-    href_t dirref2_ref;
-    href_t dirref1_ref;
-    href_t root_ref;
+    blobref_t valref_ref;
+    blobref_t dirref3_ref;
+    blobref_t dirref2_ref;
+    blobref_t dirref1_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1068,12 +1067,12 @@ void lookup_links (void) {
      * "dirref2" : dirref to "dirref2_ref
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (href_t));
+    blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (blobref_t));
     cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     dirref3 = treeobj_create_dir ();
     treeobj_insert_entry (dirref3, "val", treeobj_create_val ("baz", 3));
-    treeobj_hash ("sha1", dirref3, dirref3_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref3, dirref3_ref, sizeof (blobref_t));
     cache_insert (cache, dirref3_ref, create_cache_entry_treeobj (dirref3));
 
     dir = treeobj_create_dir ();
@@ -1085,7 +1084,7 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref2, "dir", dir);
     treeobj_insert_entry (dirref2, "dirref", treeobj_create_dirref (dirref3_ref));
     treeobj_insert_entry (dirref2, "symlink", treeobj_create_symlink ("dirref2.val"));
-    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (blobref_t));
     cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     dirref1 = treeobj_create_dir ();
@@ -1094,13 +1093,13 @@ void lookup_links (void) {
     treeobj_insert_entry (dirref1, "link2valref", treeobj_create_symlink ("dirref2.valref"));
     treeobj_insert_entry (dirref1, "link2dir", treeobj_create_symlink ("dirref2.dir"));
     treeobj_insert_entry (dirref1, "link2symlink", treeobj_create_symlink ("dirref2.symlink"));
-    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (blobref_t));
     cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup val, follow two links */
@@ -1249,9 +1248,9 @@ void lookup_alt_root (void) {
     json_t *test;
     struct cache *cache;
     lookup_t *lh;
-    href_t dirref1_ref;
-    href_t dirref2_ref;
-    href_t root_ref;
+    blobref_t dirref1_ref;
+    blobref_t dirref2_ref;
+    blobref_t root_ref;
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
 
@@ -1270,18 +1269,18 @@ void lookup_alt_root (void) {
 
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "val", treeobj_create_val ("foo", 3));
-    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (blobref_t));
     cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     dirref2 = treeobj_create_dir ();
     treeobj_insert_entry (dirref2, "val", treeobj_create_val ("bar", 3));
-    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (blobref_t));
     cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup val, alt root-ref dirref1_ref */
@@ -1318,7 +1317,7 @@ void lookup_stall_root (void) {
     json_t *root;
     struct cache *cache;
     lookup_t *lh;
-    href_t root_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1331,7 +1330,7 @@ void lookup_stall_root (void) {
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "val", treeobj_create_val ("foo", 3));
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
 
     /* do not insert entries into cache until later for these stall tests */
 
@@ -1374,15 +1373,15 @@ void lookup_stall (void) {
     json_t *test;
     struct cache *cache;
     lookup_t *lh;
-    href_t valref1_ref;
-    href_t valref2_ref;
-    href_t valref3_ref;
-    href_t valref4_ref;
-    href_t valrefmisc1_ref;
-    href_t valrefmisc2_ref;
-    href_t dirref1_ref;
-    href_t dirref2_ref;
-    href_t root_ref;
+    blobref_t valref1_ref;
+    blobref_t valref2_ref;
+    blobref_t valref3_ref;
+    blobref_t valref4_ref;
+    blobref_t valrefmisc1_ref;
+    blobref_t valrefmisc2_ref;
+    blobref_t dirref1_ref;
+    blobref_t dirref2_ref;
+    blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1423,12 +1422,12 @@ void lookup_stall (void) {
      *
      */
 
-    blobref_hash ("sha1", "abcd", 4, valref1_ref, sizeof (href_t));
-    blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (href_t));
-    blobref_hash ("sha1", "ijkl", 4, valref3_ref, sizeof (href_t));
-    blobref_hash ("sha1", "mnop", 4, valref4_ref, sizeof (href_t));
-    blobref_hash ("sha1", "foobar", 4, valrefmisc1_ref, sizeof (href_t));
-    blobref_hash ("sha1", "foobaz", 4, valrefmisc2_ref, sizeof (href_t));
+    blobref_hash ("sha1", "abcd", 4, valref1_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "ijkl", 4, valref3_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "mnop", 4, valref4_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "foobar", 4, valrefmisc1_ref, sizeof (blobref_t));
+    blobref_hash ("sha1", "foobaz", 4, valrefmisc2_ref, sizeof (blobref_t));
 
     dirref1 = treeobj_create_dir ();
     treeobj_insert_entry (dirref1, "val", treeobj_create_val ("foo", 3));
@@ -1444,17 +1443,17 @@ void lookup_stall (void) {
     treeobj_append_blobref (valref_tmp, valrefmisc2_ref);
     treeobj_insert_entry (dirref1, "valrefmisc_multi", valref_tmp);
 
-    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (blobref_t));
 
     dirref2 = treeobj_create_dir ();
     treeobj_insert_entry (dirref2, "val", treeobj_create_val ("bar", 3));
-    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (href_t));
+    treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (blobref_t));
 
     root = treeobj_create_dir ();
     treeobj_insert_entry (root, "dirref1", treeobj_create_dirref (dirref1_ref));
     treeobj_insert_entry (root, "dirref2", treeobj_create_dirref (dirref2_ref));
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dirref2"));
-    treeobj_hash ("sha1", root, root_ref, sizeof (href_t));
+    treeobj_hash ("sha1", root, root_ref, sizeof (blobref_t));
 
     /* do not insert entries into cache until later for these stall tests */
 

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -43,19 +43,19 @@ error:
     return rc;
 }
 
-static int cache_entry_set_treeobj (struct cache_entry *hp, const json_t *o)
+static int cache_entry_set_treeobj (struct cache_entry *entry, const json_t *o)
 {
     char *s = NULL;
     int saved_errno;
     int rc = -1;
 
-    if (!hp || !o || treeobj_validate (o) < 0) {
+    if (!entry || !o || treeobj_validate (o) < 0) {
         errno = EINVAL;
         goto done;
     }
     if (!(s = treeobj_encode (o)))
         goto done;
-    if (cache_entry_set_raw (hp, s, strlen (s)) < 0)
+    if (cache_entry_set_raw (entry, s, strlen (s)) < 0)
         goto done;
     rc = 0;
 done:
@@ -68,32 +68,32 @@ done:
 /* convenience function */
 static struct cache_entry *create_cache_entry_raw (void *data, int len)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     int ret;
 
     assert (data);
     assert (len);
 
-    hp = cache_entry_create ();
-    assert (hp);
-    ret = cache_entry_set_raw (hp, data, len);
+    entry = cache_entry_create ();
+    assert (entry);
+    ret = cache_entry_set_raw (entry, data, len);
     assert (ret == 0);
-    return hp;
+    return entry;
 }
 
 /* convenience function */
 static struct cache_entry *create_cache_entry_treeobj (json_t *o)
 {
-    struct cache_entry *hp;
+    struct cache_entry *entry;
     int ret;
 
     assert (o);
 
-    hp = cache_entry_create ();
-    assert (hp);
-    ret = cache_entry_set_treeobj (hp, o);
+    entry = cache_entry_create ();
+    assert (entry);
+    ret = cache_entry_set_treeobj (entry, o);
     assert (ret == 0);
-    return hp;
+    return entry;
 }
 
 int lookup_ref (lookup_t *c,

--- a/src/modules/kvs/types.h
+++ b/src/modules/kvs/types.h
@@ -1,8 +1,0 @@
-#ifndef _FLUX_KVS_TYPES_H
-#define _FLUX_KVS_TYPES_H
-
-#include "src/common/libutil/blobref.h"
-
-typedef char href_t[BLOBREF_MAX_STRING_SIZE];
-
-#endif  /* _FLUX_KVS_TYPES_H */

--- a/t/kvs/blobref.c
+++ b/t/kvs/blobref.c
@@ -18,7 +18,7 @@ int main (int argc, char *argv[])
     uint8_t *data;
     int size;
     char *hashtype;
-    char blobref[BLOBREF_MAX_STRING_SIZE];
+    blobref_t blobref;
 
     if (argc != 2) {
         fprintf (stderr, "Usage: cat file | blobref hashtype\n");
@@ -29,7 +29,7 @@ int main (int argc, char *argv[])
     if ((size = read_all (STDIN_FILENO, &data)) < 0)
         log_err_exit ("read");
 
-    if (blobref_hash (hashtype, data, size, blobref, sizeof (blobref)) < 0)
+    if (blobref_hash (hashtype, data, size, blobref) < 0)
         log_err_exit ("blobref_hash");
     printf ("%s\n", blobref);
     return 0;


### PR DESCRIPTION
This is mainly cosmetic.  As noted in #1222 the use of the "hp" variable name to refer to an internal KVS cache entry is ubiquitous and confusing.  Change it to "entry".

Drop the `href_t` typedef in the KVS and create an identical definition called `blobref_t` over in libutil/blobref.h.  Change some of the blobref functions to accept the fixed length char array rather than char pointer and length to make less verbose to use by its primary user in the KVS.

Drop the `treeobj_hash()` function which no longer has any users (replicating it in unit tests that need it, and changing it to use a blobref_t argument).