### PR TITLE
build: detect broken libyaml-cpp during configure

### DIFF
--- a/config/x_ac_yamlcpp.m4
+++ b/config/x_ac_yamlcpp.m4
@@ -10,6 +10,13 @@ AC_DEFUN([X_AC_YAMLCPP], [
         CFLAGS="$CFLAGS $YAMLCPP_CFLAGS"
         AC_LANG_PUSH([C++])
 
+        AC_MSG_CHECKING([whether yaml-cpp/yaml.h is usable])
+        AC_PREPROC_IFELSE(
+            [AC_LANG_PROGRAM([#include <yaml-cpp/yaml.h>], [])],
+                [AC_MSG_RESULT([yes])],
+                [AC_MSG_FAILURE([yaml-cpp/yaml.h doesn't appear to be usable.])]
+        )
+
         # YAML::Node::Mark() is only present in yaml-cpp beginning
         # with release 0.5.3.
         AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <yaml-cpp/yaml.h>],


### PR DESCRIPTION
When yamlcpp support is found, check that the yaml-cpp/yaml.h header can be included without error, and issue a fatal error from configure if not.

(Sorry, not much time to get anything else done today so I decided to tackle this one)