### PR TITLE
[cleanup] use a better variable name for flux_msg_handler_t internally

### DIFF
--- a/doc/man3/flux_msg_handler_create.adoc
+++ b/doc/man3/flux_msg_handler_create.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
  #include <flux/core.h>
 
  typedef void (*flux_msg_handler_f)(flux_t *h,
-                                    flux_msg_handler_t *w,
+                                    flux_msg_handler_t *mh,
                                     const flux_msg_t *msg,
                                     void *arg);
 
@@ -24,11 +24,11 @@ SYNOPSIS
                           flux_msg_handler_f callback,
                           void *arg);
 
- void flux_msg_handler_destroy (flux_msg_handler_t *w);
+ void flux_msg_handler_destroy (flux_msg_handler_t *mh);
 
- void flux_msg_handler_start (flux_msg_handler_t *w);
+ void flux_msg_handler_start (flux_msg_handler_t *mh);
 
- void flux_msg_handler_stop (flux_msg_handler_t *w);
+ void flux_msg_handler_stop (flux_msg_handler_t *mh);
 
 
 DESCRIPTION

--- a/doc/man3/treduce.c
+++ b/doc/man3/treduce.c
@@ -73,7 +73,7 @@ void reduce (flux_reduce_t *r, int batchnum, void *arg)
     }
 }
 
-void forward_cb (flux_t *h, flux_msg_handler_t *w,
+void forward_cb (flux_t *h, flux_msg_handler_t *mh,
                  const flux_msg_t *msg, void *arg)
 {
     struct context *ctx = arg;
@@ -94,7 +94,7 @@ void forward_cb (flux_t *h, flux_msg_handler_t *w,
     Jput (in);
 }
 
-void heartbeat_cb (flux_t *h, flux_msg_handler_t *w,
+void heartbeat_cb (flux_t *h, flux_msg_handler_t *mh,
                    const flux_msg_t *msg, void *arg)
 {
     struct context *ctx = arg;

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -404,3 +404,4 @@ kvsdir
 vpack
 dirref
 lookups
+mh

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -316,7 +316,7 @@ const char *attr_next (attr_t *attrs)
  ** Service
  **/
 
-void getattr_request_cb (flux_t *h, flux_msg_handler_t *w,
+void getattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     attr_t *attrs = arg;
@@ -342,7 +342,7 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void setattr_request_cb (flux_t *h, flux_msg_handler_t *w,
+void setattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     attr_t *attrs = arg;
@@ -375,7 +375,7 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void lsattr_request_cb (flux_t *h, flux_msg_handler_t *w,
+void lsattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     attr_t *attrs = arg;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1496,7 +1496,7 @@ static void broker_unhandle_signals (zlist_t *sigwatchers)
  ** Built-in services
  **/
 
-static void cmb_rmmod_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_rmmod_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1521,7 +1521,7 @@ error:
     free (name);
 }
 
-static void cmb_insmod_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_insmod_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1550,7 +1550,7 @@ error:
     free (argz);
 }
 
-static void cmb_lsmod_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_lsmod_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1575,7 +1575,7 @@ error:
         flux_modlist_destroy (mods);
 }
 
-static void cmb_lspeer_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_lspeer_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1591,7 +1591,7 @@ static void cmb_lspeer_cb (flux_t *h, flux_msg_handler_t *w,
     free (out);
 }
 
-static void cmb_panic_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_panic_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     const char *s = NULL;
@@ -1608,7 +1608,7 @@ error:
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static void cmb_event_mute_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_event_mute_cb (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1620,7 +1620,7 @@ static void cmb_event_mute_cb (flux_t *h, flux_msg_handler_t *w,
     /* no response */
 }
 
-static void cmb_disconnect_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg)
 {
     char *sender = NULL;;
@@ -1632,7 +1632,7 @@ static void cmb_disconnect_cb (flux_t *h, flux_msg_handler_t *w,
     /* no response */
 }
 
-static void cmb_sub_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_sub_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1659,7 +1659,7 @@ error:
     free (uuid);
 }
 
-static void cmb_unsub_cb (flux_t *h, flux_msg_handler_t *w,
+static void cmb_unsub_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -347,7 +347,7 @@ done:
     return rc;
 }
 
-void content_load_request (flux_t *h, flux_msg_handler_t *w,
+void content_load_request (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -514,7 +514,7 @@ done:
     return rc;
 }
 
-static void content_store_request (flux_t *h, flux_msg_handler_t *w,
+static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -632,7 +632,7 @@ static int cache_flush (content_cache_t *cache)
     return rc;
 }
 
-static void content_backing_request (flux_t *h, flux_msg_handler_t *w,
+static void content_backing_request (flux_t *h, flux_msg_handler_t *mh,
                                      const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -672,7 +672,7 @@ done:
  * N.B. this walks the entire cache in one go.
  */
 
-static void content_dropcache_request (flux_t *h, flux_msg_handler_t *w,
+static void content_dropcache_request (flux_t *h, flux_msg_handler_t *mh,
                                        const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -715,7 +715,7 @@ done:
 /* Return stats about the cache.
  */
 
-static void content_stats_request (flux_t *h, flux_msg_handler_t *w,
+static void content_stats_request (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -758,7 +758,7 @@ static void flush_respond (content_cache_t *cache)
                         __FUNCTION__);
 }
 
-static void content_flush_request (flux_t *h, flux_msg_handler_t *w,
+static void content_flush_request (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;
@@ -841,7 +841,7 @@ done:
     return rc;
 }
 
-static void heartbeat_event (flux_t *h, flux_msg_handler_t *w,
+static void heartbeat_event (flux_t *h, flux_msg_handler_t *mh,
                              const flux_msg_t *msg, void *arg)
 {
     content_cache_t *cache = arg;

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -202,7 +202,7 @@ done:
     return rc;
 }
 
-static void write_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void write_request_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     exec_t *x = arg;
@@ -235,7 +235,7 @@ out:
         flux_log_error (h, "write_request_cb: flux_respond_pack");
 }
 
-static void signal_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void signal_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg)
 {
     exec_t *x = arg;
@@ -346,7 +346,7 @@ error:
     return -1;
 }
 
-static void exec_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void exec_request_cb (flux_t *h, flux_msg_handler_t *mh,
                              const flux_msg_t *msg, void *arg)
 {
     exec_t *x = arg;
@@ -475,7 +475,7 @@ error:
     return NULL;
 }
 
-static void ps_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void ps_request_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     struct subprocess *p;

--- a/src/broker/heaptrace.c
+++ b/src/broker/heaptrace.c
@@ -38,7 +38,7 @@
 #include <flux/core.h>
 #include "heaptrace.h"
 
-static void start_cb (flux_t *h, flux_msg_handler_t *w,
+static void start_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     const char *filename;
@@ -63,7 +63,7 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-static void dump_cb (flux_t *h, flux_msg_handler_t *w,
+static void dump_cb (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     const char *reason;
@@ -88,7 +88,7 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-static void stop_cb (flux_t *h, flux_msg_handler_t *w,
+static void stop_cb (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     if (flux_request_decode (msg, NULL, NULL) < 0)

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -38,7 +38,7 @@ struct heartbeat_struct {
     flux_t *h;
     double rate;
     flux_watcher_t *timer;
-    flux_msg_handler_t *handler;
+    flux_msg_handler_t *mh;
     int send_epoch;
     int epoch;
 };
@@ -52,7 +52,7 @@ void heartbeat_destroy (heartbeat_t *hb)
 {
     if (hb) {
         flux_watcher_destroy (hb->timer);
-        flux_msg_handler_destroy (hb->handler);
+        flux_msg_handler_destroy (hb->mh);
         free (hb);
     }
 }
@@ -116,7 +116,7 @@ int heartbeat_get_epoch (heartbeat_t *hb)
     return hb->epoch;
 }
 
-static void event_cb (flux_t *h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     heartbeat_t *hb = arg;
@@ -167,9 +167,9 @@ int heartbeat_start (heartbeat_t *hb)
         flux_watcher_start (hb->timer);
     }
     match.topic_glob = "hb";
-    if (!(hb->handler = flux_msg_handler_create (hb->h, match, event_cb, hb)))
+    if (!(hb->mh = flux_msg_handler_create (hb->h, match, event_cb, hb)))
         return -1;
-    flux_msg_handler_start (hb->handler);
+    flux_msg_handler_start (hb->mh);
     return 0;
 }
 
@@ -177,8 +177,8 @@ void heartbeat_stop (heartbeat_t *hb)
 {
     if (hb->timer)
         flux_watcher_stop (hb->timer);
-    if (hb->handler)
-        flux_msg_handler_stop (hb->handler);
+    if (hb->mh)
+        flux_msg_handler_stop (hb->mh);
 }
 
 /*

--- a/src/broker/hello.c
+++ b/src/broker/hello.c
@@ -54,7 +54,7 @@ struct hello_struct {
     flux_reduce_t *reduce;
 };
 
-static void join_request (flux_t *h, flux_msg_handler_t *w,
+static void join_request (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg);
 
 static void r_reduce (flux_reduce_t *r, int batch, void *arg);
@@ -212,7 +212,7 @@ done:
 
 /* handle a message sent from downstream via downstream's r_forward op.
  */
-static void join_request (flux_t *h, flux_msg_handler_t *w,
+static void join_request (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     hello_t *hello = arg;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -85,7 +85,7 @@ typedef struct {
     bool mute;
 } child_t;
 
-static void heartbeat_handler (flux_t *h, flux_msg_handler_t *w,
+static void heartbeat_handler (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg);
 
 static void endpoint_destroy (struct endpoint *ep)
@@ -290,7 +290,7 @@ done:
     return rc;
 }
 
-static void heartbeat_handler (flux_t *h, flux_msg_handler_t *w,
+static void heartbeat_handler (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg)
 {
     overlay_t *ov = arg;

--- a/src/broker/sequence.c
+++ b/src/broker/sequence.c
@@ -206,7 +206,7 @@ static int handle_seq_fetch (flux_t *h, seqhash_t *s, const flux_msg_t *msg)
                               "value", v);
 }
 
-static void sequence_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void sequence_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                  const flux_msg_t *msg, void *arg)
 {
     seqhash_t *seq = arg;

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -86,7 +86,7 @@ static void timer_handler (flux_reactor_t *r, flux_watcher_t *w,
 /* On receipt of the shutdown event message, begin the grace timer,
  * and log the "shutdown in..." message on rank 0.
  */
-void shutdown_handler (flux_t *h, flux_msg_handler_t *w,
+void shutdown_handler (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     shutdown_t *s = arg;

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -587,7 +587,7 @@ disconnect:
  * Look up the sender uuid in clients hash and deliver.
  * Responses for disconnected clients are silently discarded.
  */
-static void response_cb (flux_t *h, flux_msg_handler_t *w,
+static void response_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     proxy_ctx_t *ctx = arg;
@@ -632,7 +632,7 @@ done:
 /* Received an event message from broker.
  * Find all subscribers and deliver.
  */
-static void event_cb (flux_t *h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     proxy_ctx_t *ctx = arg;

--- a/src/common/libflux/msg_handler.h
+++ b/src/common/libflux/msg_handler.h
@@ -10,24 +10,26 @@ extern "C" {
 
 typedef struct flux_msg_handler flux_msg_handler_t;
 
-typedef void (*flux_msg_handler_f)(flux_t *h, flux_msg_handler_t *w,
+typedef void (*flux_msg_handler_f)(flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg);
 
 flux_msg_handler_t *flux_msg_handler_create (flux_t *h,
                                              const struct flux_match match,
                                              flux_msg_handler_f cb, void *arg);
 
-void flux_msg_handler_destroy (flux_msg_handler_t *w);
+void flux_msg_handler_destroy (flux_msg_handler_t *mh);
 
-void flux_msg_handler_start (flux_msg_handler_t *w);
-void flux_msg_handler_stop (flux_msg_handler_t *w);
+void flux_msg_handler_start (flux_msg_handler_t *mh);
+void flux_msg_handler_stop (flux_msg_handler_t *mh);
 
 /* By default, only messages from FLUX_ROLE_OWNER are delivered to handler.
  * Use _allow_rolemask() add roles, _deny_rolemask() to remove them.
  * (N.B. FLUX_ROLE_OWNER cannot be denied)
  */
-void flux_msg_handler_allow_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
-void flux_msg_handler_deny_rolemask (flux_msg_handler_t *w, uint32_t rolemask);
+void flux_msg_handler_allow_rolemask (flux_msg_handler_t *mh,
+                                      uint32_t rolemask);
+void flux_msg_handler_deny_rolemask (flux_msg_handler_t *mh,
+                                     uint32_t rolemask);
 
 struct flux_msg_handler_spec {
     int typemask;

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -1077,7 +1077,7 @@ static bool job_is_finished (const char *state)
     return false;
 }
 
-static void job_state_cb (flux_t *h, flux_msg_handler_t *w,
+static void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     int64_t jobid = -1;

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -466,7 +466,7 @@ aggregator_new_aggregate (struct aggregator *ctx, const char *key,
 /*
  *  Callback for "aggregator.push"
  */
-static void push_cb (flux_t *h, flux_msg_handler_t *w,
+static void push_cb (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     int rc = -1;

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -188,7 +188,7 @@ done:
  * notification upon barrier termination.
  */
 
-static void enter_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void enter_request_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     barrier_ctx_t *ctx = arg;
@@ -246,7 +246,7 @@ done:
  * participating in.
  */
 
-static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     barrier_ctx_t *ctx = arg;
@@ -282,7 +282,7 @@ done:
     return rc;
 }
 
-static void exit_event_cb (flux_t *h, flux_msg_handler_t *w,
+static void exit_event_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     barrier_ctx_t *ctx = arg;

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -779,7 +779,7 @@ static bool allowed_message (client_t *c, const flux_msg_t *msg)
  * Look up the sender uuid in clients hash and deliver.
  * Responses for disconnected clients are silently discarded.
  */
-static void response_cb (flux_t *h, flux_msg_handler_t *w,
+static void response_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     mod_local_ctx_t *ctx = arg;
@@ -827,7 +827,7 @@ done:
 /* Received an event message from broker.
  * Find all subscribers and deliver.
  */
-static void event_cb (flux_t *h, flux_msg_handler_t *w,
+static void event_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     mod_local_ctx_t *ctx = arg;
@@ -861,10 +861,10 @@ static void event_cb (flux_t *h, flux_msg_handler_t *w,
 
 /* Accept a connection from new client.
  */
-static void listener_cb (flux_reactor_t *r, flux_watcher_t *w,
+static void listener_cb (flux_reactor_t *r, flux_watcher_t *mh,
                          int revents, void *arg)
 {
-    int fd = flux_fd_watcher_get_fd (w);
+    int fd = flux_fd_watcher_get_fd (mh);
     mod_local_ctx_t *ctx = arg;
     flux_t *h = ctx->h;
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -242,7 +242,7 @@ int grow_lzo_buf (sqlite_ctx_t *ctx, size_t size)
     return 0;
 }
 
-void load_cb (flux_t *h, flux_msg_handler_t *w,
+void load_cb (flux_t *h, flux_msg_handler_t *mh,
               const flux_msg_t *msg, void *arg)
 {
     sqlite_ctx_t *ctx = arg;
@@ -323,7 +323,7 @@ done:
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }
 
-void store_cb (flux_t *h, flux_msg_handler_t *w,
+void store_cb (flux_t *h, flux_msg_handler_t *mh,
                const flux_msg_t *msg, void *arg)
 {
     sqlite_ctx_t *ctx = arg;
@@ -419,7 +419,7 @@ done:
 /* Intercept broker shutdown event.  If broker is shutting down,
  * avoid transferring data back to the content cache at unload time.
  */
-void broker_shutdown_cb (flux_t *h, flux_msg_handler_t *w,
+void broker_shutdown_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     sqlite_ctx_t *ctx = arg;
@@ -431,7 +431,7 @@ void broker_shutdown_cb (flux_t *h, flux_msg_handler_t *w,
  * Tell content cache to disable backing store,
  * then write everything back to it before exiting.
  */
-void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
+void shutdown_cb (flux_t *h, flux_msg_handler_t *mh,
                   const flux_msg_t *msg, void *arg)
 {
     sqlite_ctx_t *ctx = arg;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -589,7 +589,7 @@ static void commit_check_cb (flux_reactor_t *r, flux_watcher_t *w,
     }
 }
 
-static void dropcache_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void dropcache_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                   const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -612,7 +612,7 @@ done:
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static void dropcache_event_cb (flux_t *h, flux_msg_handler_t *w,
+static void dropcache_event_cb (flux_t *h, flux_msg_handler_t *mh,
                                 const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -630,7 +630,7 @@ static void dropcache_event_cb (flux_t *h, flux_msg_handler_t *w,
                   expcount, size);
 }
 
-static void heartbeat_cb (flux_t *h, flux_msg_handler_t *w,
+static void heartbeat_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -670,7 +670,7 @@ static int lookup_load_cb (lookup_t *lh, const char *ref, void *data)
     return 0;
 }
 
-static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void get_request_cb (flux_t *h, flux_msg_handler_t *mh,
                             const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = NULL;
@@ -745,7 +745,7 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (!lookup (lh)) {
         struct kvs_cb_data cbd;
 
-        if (!(wait = wait_create_msg_handler (h, w, msg, get_request_cb, lh)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg, get_request_cb, lh)))
             goto done;
 
         cbd.ctx = ctx;
@@ -805,7 +805,7 @@ stall:
     json_decref (val);
 }
 
-static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void watch_request_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = NULL;
@@ -869,7 +869,8 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (!lookup (lh)) {
         struct kvs_cb_data cbd;
 
-        if (!(wait = wait_create_msg_handler (h, w, msg, watch_request_cb, lh)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg,
+                                              watch_request_cb, lh)))
             goto done;
 
         cbd.ctx = ctx;
@@ -937,7 +938,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *w,
             flux_log_error (h, "%s: flux_msg_pack", __FUNCTION__);
             goto done;
         }
-        if (!(watcher = wait_create_msg_handler (h, w, cpy,
+        if (!(watcher = wait_create_msg_handler (h, mh, cpy,
                                                  watch_request_cb, ctx)))
             goto done;
         if (wait_addqueue (ctx->watchlist, watcher) < 0) {
@@ -1004,7 +1005,7 @@ done:
     return match;
 }
 
-static void unwatch_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void unwatch_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                 const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1089,7 +1090,7 @@ static void finalize_fences_bynames (kvs_ctx_t *ctx, json_t *names, int errnum)
 
 /* kvs.relayfence (rank 0 only, no response).
  */
-static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1139,7 +1140,7 @@ static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *w,
 /* kvs.fence
  * Sent from users to local kvs module.
  */
-static void fence_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void fence_request_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1210,7 +1211,7 @@ error:
 
 /* For wait_version().
  */
-static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
                              const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1223,7 +1224,8 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto error;
     }
     if (ctx->root.seq < rootseq) {
-        if (!(wait = wait_create_msg_handler (h, w, msg, sync_request_cb, arg)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg,
+                                              sync_request_cb, arg)))
             goto error;
         if (wait_addqueue (ctx->watchlist, wait) < 0) {
             saved_errno = errno;
@@ -1247,7 +1249,7 @@ error:
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 }
 
-static void getroot_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                 const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1297,7 +1299,7 @@ done:
     return rc;
 }
 
-static void error_event_cb (flux_t *h, flux_msg_handler_t *w,
+static void error_event_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1383,7 +1385,7 @@ done:
 
 /* Alter the (rootref, rootseq) in response to a setroot event.
  */
-static void setroot_event_cb (flux_t *h, flux_msg_handler_t *w,
+static void setroot_event_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1475,7 +1477,7 @@ static bool disconnect_cmp (const flux_msg_t *msg, void *arg)
     return match;
 }
 
-static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1499,7 +1501,7 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *w,
     free (sender);
 }
 
-static void stats_get_cb (flux_t *h, flux_msg_handler_t *w,
+static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
@@ -1555,14 +1557,14 @@ static void stats_clear (kvs_ctx_t *ctx)
     commit_mgr_clear_noop_stores (ctx->cm);
 }
 
-static void stats_clear_event_cb (flux_t *h, flux_msg_handler_t *w,
+static void stats_clear_event_cb (flux_t *h, flux_msg_handler_t *mh,
                                   const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;
     stats_clear (ctx);
 }
 
-static void stats_clear_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void stats_clear_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                     const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = arg;

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -8,7 +8,8 @@ void wait_cb (void *arg)
     (*count)++;
 }
 
-void msghand (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, void *arg)
+void msghand (flux_t *h, flux_msg_handler_t *mh,
+              const flux_msg_t *msg, void *arg)
 {
     int *count = arg;
     (*count)++;

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -33,7 +33,7 @@
 struct handler {
     flux_msg_handler_f cb;
     flux_t *h;
-    flux_msg_handler_t *w;
+    flux_msg_handler_t *mh;
     flux_msg_t *msg;
     void *arg;
 };
@@ -71,7 +71,7 @@ wait_t *wait_create (wait_cb_f cb, void *arg)
     return w;
 }
 
-wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *wh,
+wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *mh,
                                  const flux_msg_t *msg,
                                  flux_msg_handler_f cb, void *arg)
 {
@@ -80,7 +80,7 @@ wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *wh,
         w->hand.cb = cb;
         w->hand.arg = arg;
         w->hand.h = h;
-        w->hand.w = wh;
+        w->hand.mh = mh;
         if (msg && !(w->hand.msg = flux_msg_copy (msg, true))) {
             wait_destroy (w);
             errno = ENOMEM;
@@ -156,7 +156,7 @@ static void wait_runone (wait_t *w)
         if (w->cb)
             w->cb (w->cb_arg);
         else if (w->hand.cb)
-            w->hand.cb (w->hand.h, w->hand.w, w->hand.msg, w->hand.arg);
+            w->hand.cb (w->hand.h, w->hand.mh, w->hand.msg, w->hand.arg);
         wait_destroy (w);
     }
 }

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -434,7 +434,7 @@ static int decode_reload_request (flux_t *h, resource_ctx_t *ctx,
 }
 
 static void reload_request_cb (flux_t *h,
-                               flux_msg_handler_t *watcher,
+                               flux_msg_handler_t *mh,
                                const flux_msg_t *msg,
                                void *arg)
 {
@@ -450,7 +450,7 @@ static void reload_request_cb (flux_t *h,
 }
 
 static void topo_request_cb (flux_t *h,
-                             flux_msg_handler_t *watcher,
+                             flux_msg_handler_t *mh,
                              const flux_msg_t *msg,
                              void *arg)
 {

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -208,7 +208,7 @@ static void user_delete (userdb_ctx_t *ctx, uint32_t userid)
     zhash_delete (ctx->db, key);
 }
 
-static void lookup (flux_t *h, flux_msg_handler_t *w,
+static void lookup (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
     userdb_ctx_t *ctx = arg;
@@ -233,7 +233,7 @@ error:
         flux_log_error (h, "%s", __FUNCTION__);
 }
 
-static void addrole (flux_t *h, flux_msg_handler_t *w,
+static void addrole (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     userdb_ctx_t *ctx = arg;
@@ -264,7 +264,7 @@ error:
         flux_log_error (h, "%s", __FUNCTION__);
 }
 
-static void delrole (flux_t *h, flux_msg_handler_t *w,
+static void delrole (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     userdb_ctx_t *ctx = arg;
@@ -300,7 +300,7 @@ static int compare_keys (const char *s1, const char *s2)
     return 0;
 }
 
-static void getnext (flux_t *h, flux_msg_handler_t *w,
+static void getnext (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     userdb_ctx_t *ctx = arg;
@@ -339,7 +339,7 @@ error:
     free (uuid);
 }
 
-static void disconnect (flux_t *h, flux_msg_handler_t *w,
+static void disconnect (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     userdb_ctx_t *ctx = arg;

--- a/t/module/parent.c
+++ b/t/module/parent.c
@@ -112,7 +112,7 @@ static flux_modlist_t *module_list (void)
     return mods;
 }
 
-static void insmod_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void insmod_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -149,7 +149,7 @@ done:
         free (argz);
 }
 
-static void rmmod_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void rmmod_request_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -182,7 +182,7 @@ done:
         free (name);
 }
 
-static void lsmod_request_cb (flux_t *h, flux_msg_handler_t *w,
+static void lsmod_request_cb (flux_t *h, flux_msg_handler_t *mh,
                               const flux_msg_t *msg, void *arg)
 {
     flux_modlist_t *mods = NULL;

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -61,7 +61,7 @@ error:
 
 /* Return number of queued clog requests
  */
-void count_request_cb (flux_t *h, flux_msg_handler_t *w,
+void count_request_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     t_req_ctx_t *ctx = getctx (h);
@@ -75,7 +75,7 @@ void count_request_cb (flux_t *h, flux_msg_handler_t *w,
 
 /* Don't reply to request - just queue it for later.
  */
-void clog_request_cb (flux_t *h, flux_msg_handler_t *w,
+void clog_request_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     t_req_ctx_t *ctx = getctx (h);
@@ -87,7 +87,7 @@ void clog_request_cb (flux_t *h, flux_msg_handler_t *w,
 
 /* Reply to all queued requests.
  */
-void flush_request_cb (flux_t *h, flux_msg_handler_t *w,
+void flush_request_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     t_req_ctx_t *ctx = getctx (h);
@@ -106,7 +106,7 @@ void flush_request_cb (flux_t *h, flux_msg_handler_t *w,
 /* Accept a json payload, verify it and return error if it doesn't
  * match expected.
  */
-void sink_request_cb (flux_t *h, flux_msg_handler_t *w,
+void sink_request_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -135,7 +135,7 @@ done:
 
 /* Return a fixed json payload
  */
-void src_request_cb (flux_t *h, flux_msg_handler_t *w,
+void src_request_cb (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     json_object *o = Jnew ();
@@ -148,7 +148,7 @@ void src_request_cb (flux_t *h, flux_msg_handler_t *w,
 
 /* Return 'n' sequenced responses.
  */
-void nsrc_request_cb (flux_t *h, flux_msg_handler_t *w,
+void nsrc_request_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -186,7 +186,7 @@ done:
 
 /* Always return an error 42
  */
-void err_request_cb (flux_t *h, flux_msg_handler_t *w,
+void err_request_cb (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     if (flux_respond (h, msg, 42, NULL) < 0)
@@ -195,7 +195,7 @@ void err_request_cb (flux_t *h, flux_msg_handler_t *w,
 
 /* Echo a json payload back to requestor.
  */
-void echo_request_cb (flux_t *h, flux_msg_handler_t *w,
+void echo_request_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     const char *json_str;
@@ -219,7 +219,7 @@ done:
 
 /* Proxy ping.
  */
-void xping_request_cb (flux_t *h, flux_msg_handler_t *w,
+void xping_request_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     t_req_ctx_t *ctx = arg;
@@ -277,7 +277,7 @@ error:
 /* Handle ping response for proxy ping.
  * Match it with a request and respond to that request.
  */
-void ping_response_cb (flux_t *h, flux_msg_handler_t *w,
+void ping_response_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     t_req_ctx_t *ctx = arg;
@@ -322,7 +322,7 @@ done:
 /* Handle the simplest possible request.
  * Verify that everything is as expected; log it and stop the reactor if not.
  */
-void null_request_cb (flux_t *h, flux_msg_handler_t *w,
+void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     t_req_ctx_t *ctx = arg;

--- a/t/rolemask/loop.c
+++ b/t/rolemask/loop.c
@@ -96,7 +96,7 @@ static void check_rpc_oneway_faked (flux_t *h)
 }
 
 static bool testrpc1_called;
-static void testrpc1 (flux_t *h, flux_msg_handler_t *w,
+static void testrpc1 (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     diag ("testrpc1 handler invoked");
@@ -120,19 +120,19 @@ flux_msg_handler_t *testrpc1_handler_create (flux_t *h)
 static void check_rpc_default_policy (flux_t *h)
 {
     flux_future_t *f;
-    flux_msg_handler_t *w;
+    flux_msg_handler_t *mh;
     struct creds saved, new, cr;
     int rc;
 
-    ok ((w = testrpc1_handler_create (h)) != NULL,
+    ok ((mh = testrpc1_handler_create (h)) != NULL,
         "created message handler with default policy");
-    if (w == NULL)
+    if (mh == NULL)
         BAIL_OUT ("flux_msg_handler_create: %s", flux_strerror (errno));
 
     /* This should be a no-op since "deny all" can't deny FLUX_ROLE_OWNER,
      * and the default policy is to require FLUX_ROLE_OWNER.
      */
-    flux_msg_handler_deny_rolemask (w, FLUX_ROLE_ALL);
+    flux_msg_handler_deny_rolemask (mh, FLUX_ROLE_ALL);
 
 
     /* Attempt with default creds.
@@ -176,21 +176,21 @@ static void check_rpc_default_policy (flux_t *h)
     ok (cred_set (h, &saved) == 0,
         "restored connector creds");
 
-    flux_msg_handler_destroy (w);
+    flux_msg_handler_destroy (mh);
 }
 
 static void check_rpc_open_policy (flux_t *h)
 {
     flux_future_t *f;
-    flux_msg_handler_t *w;
+    flux_msg_handler_t *mh;
     struct creds saved, new, cr;
     int rc;
 
-    ok ((w = testrpc1_handler_create (h)) != NULL,
+    ok ((mh = testrpc1_handler_create (h)) != NULL,
         "created message handler with open policy");
-    if (w == NULL)
+    if (mh == NULL)
         BAIL_OUT ("flux_msg_handler_create: %s", flux_strerror (errno));
-    flux_msg_handler_allow_rolemask (w, FLUX_ROLE_ALL);
+    flux_msg_handler_allow_rolemask (mh, FLUX_ROLE_ALL);
 
     /* Attempt with default creds.
      */
@@ -230,23 +230,23 @@ static void check_rpc_open_policy (flux_t *h)
     ok (cred_set (h, &saved) == 0,
         "restored connector creds");
 
-    flux_msg_handler_destroy (w);
+    flux_msg_handler_destroy (mh);
 }
 
 static void check_rpc_targetted_policy (flux_t *h)
 {
     flux_future_t *f;
-    flux_msg_handler_t *w;
+    flux_msg_handler_t *mh;
     struct creds saved, new, cr;
     uint32_t allow = 0x1000;
     int rc;
 
-    ok ((w = testrpc1_handler_create (h)) != NULL,
+    ok ((mh = testrpc1_handler_create (h)) != NULL,
         "created message handler with targetted policy");
-    if (w == NULL)
+    if (mh == NULL)
         BAIL_OUT ("flux_msg_handler_create: %s", flux_strerror (errno));
-    flux_msg_handler_deny_rolemask (w, FLUX_ROLE_ALL);
-    flux_msg_handler_allow_rolemask (w, allow);
+    flux_msg_handler_deny_rolemask (mh, FLUX_ROLE_ALL);
+    flux_msg_handler_allow_rolemask (mh, allow);
 
     ok (cred_get (h, &saved) == 0
         && saved.userid == geteuid() && saved.rolemask == FLUX_ROLE_OWNER,
@@ -308,7 +308,7 @@ static void check_rpc_targetted_policy (flux_t *h)
 
     ok (cred_set (h, &saved) == 0,
         "restored connector creds");
-    flux_msg_handler_destroy (w);
+    flux_msg_handler_destroy (mh);
 }
 
 static void fatal_err (const char *message, void *arg)

--- a/t/rpc/mrpc.c
+++ b/t/rpc/mrpc.c
@@ -13,7 +13,7 @@ static uint32_t fake_rank = 0;
 
 /* request nodeid and flags returned in response */
 static int nodeid_fake_error = -1;
-void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -39,7 +39,7 @@ done:
     Jput (o);
 }
 
-void rpcftest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
+void rpcftest_nodeid_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -63,7 +63,7 @@ done:
 }
 
 /* request payload echoed in response */
-void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -83,7 +83,7 @@ done:
 
 /* no-payload response */
 static int hello_count = 0;
-void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -102,7 +102,7 @@ done:
     (void)flux_respond (h, msg, errnum, NULL);
 }
 
-void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
+void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -6,7 +6,7 @@
 #include "util.h"
 
 /* increment integer and send it back */
-void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *mh,
                      const flux_msg_t *msg, void *arg)
 {
     int i;
@@ -18,7 +18,7 @@ void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *w,
 }
 
 /* request nodeid and flags returned in response */
-void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -40,7 +40,7 @@ done:
 }
 
 /* request payload echoed in response */
-void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -59,7 +59,7 @@ done:
 }
 
 /* raw request payload echoed in response */
-void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -75,7 +75,7 @@ done:
 }
 
 /* no-payload response */
-void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *w,
+void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;
@@ -94,7 +94,7 @@ done:
         diag ("%s: flux_respond: %s", __FUNCTION__, flux_strerror (errno));
 }
 
-void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *w,
+void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     int errnum = 0;

--- a/t/rpc/util.c
+++ b/t/rpc/util.c
@@ -13,7 +13,7 @@
 struct test_server {
     flux_t *c;
     flux_t *s;
-    flux_msg_handler_t *w;
+    flux_msg_handler_t *mh;
     test_server_f cb;
     void *arg;
     pthread_t thread;
@@ -21,7 +21,7 @@ struct test_server {
     zuuid_t *uuid;
 };
 
-void shutdown_cb (flux_t *h, flux_msg_handler_t *w,
+void shutdown_cb (flux_t *h, flux_msg_handler_t *mh,
                   const flux_msg_t *msg, void *arg)
 {
     flux_reactor_stop (flux_get_reactor (h));
@@ -71,7 +71,7 @@ done:
 static void test_server_destroy (struct test_server *a)
 {
     if (a) {
-        flux_msg_handler_destroy (a->w);
+        flux_msg_handler_destroy (a->mh);
         flux_close (a->s);
         zuuid_destroy (&a->uuid);
         free (a);
@@ -123,12 +123,12 @@ flux_t *test_server_create (test_server_f cb, void *arg)
      */
     struct flux_match match = FLUX_MATCH_REQUEST;
     match.topic_glob = "shutdown";
-    if (!(a->w = flux_msg_handler_create (a->s, match, shutdown_cb, a))) {
+    if (!(a->mh = flux_msg_handler_create (a->s, match, shutdown_cb, a))) {
         diag ("%s: flux_msg_handler_create: %s\n",
              __FUNCTION__, flux_strerror (errno));
         goto error;
     }
-    flux_msg_handler_start (a->w);
+    flux_msg_handler_start (a->mh);
 
     /* Start server thread
      */


### PR DESCRIPTION
@chu11 pointed out that using a variable named `w` to represent a message handler was confusing.

Change to `mh` where needed.

Perhaps most importantly, change it in the public header and man page.