### PR TITLE
kvs: Refactor in preparation for private namespaces

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -42,6 +42,9 @@ arguments are described below.
 
 COMMANDS
 --------
+*namespace-create* 'name' ['name...']::
+Create a namespace in which kvs values will be read/written to.
+
 *get* [-j|-r|-t] [-a treeobj] 'key' ['key...']::
 Retrieve the value stored under 'key'.  If nothing has been stored under
 'key', display an error message.  If no options, value is displayed with

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -44,7 +44,8 @@ MAN3_FILES_PRIMARY = \
 	flux_future_create.3 \
 	flux_kvs_lookup.3 \
 	flux_kvs_commit.3 \
-	flux_kvs_txn_create.3
+	flux_kvs_txn_create.3 \
+	flux_kvs_namespace_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man3/flux_kvs_commit.adoc
+++ b/doc/man3/flux_kvs_commit.adoc
@@ -48,6 +48,11 @@ block until the response has been received.  Both accept an optional timeout.
 was successful, indicating the entire transaction was committed, or -1
 on failure, indicating none of the transaction was committed.
 
+By default, both `flux_kvs_commit()` and `flux_kvs_fence()` operate on
+the default KVS namespace.  To use a different namespace, set the
+environment variable FLUX_KVS_NAMESPACE to the namespace you wish to
+use.
+
 FLAGS
 -----
 

--- a/doc/man3/flux_kvs_commit.adoc
+++ b/doc/man3/flux_kvs_commit.adoc
@@ -88,6 +88,8 @@ A request was malformed.
 ENOSYS::
 The KVS module is not loaded.
 
+ENOTSUP::
+An unknown namespace was requested.
 
 AUTHOR
 ------

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -150,6 +150,8 @@ EFBIG::
 ENOSYS::
 The KVS module is not loaded.
 
+ENOTSUP::
+An unknown namespace was requested.
 
 AUTHOR
 ------

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -48,6 +48,11 @@ _treeobj_ is a serialized RFC 11 object that references a particular
 static set of content within the KVS, effectively a snapshot.
 See `flux_kvs_lookup_get_treeobj()` below.
 
+By default, both `flux_kvs_lookup()` and `flux_kvs_lookupat()` operate
+on the default KVS namespace.  To use a different namespace, set the
+environment variable FLUX_KVS_NAMESPACE to the namespace you wish to
+use.
+
 All the functions below are variations on a common theme.  First they
 complete the lookup RPC by blocking on the response, if not already received.
 Then they interpret the result in different ways.  They may be called more

--- a/doc/man3/flux_kvs_namespace_create.adoc
+++ b/doc/man3/flux_kvs_namespace_create.adoc
@@ -1,0 +1,74 @@
+flux_kvs_namespace_create(3)
+============================
+:doctype: manpage
+
+
+NAME
+----
+flux_kvs_namespace_create - create a KVS namespace
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_kvs_namespace_create (flux_t *h,
+                                           const char *namespace,
+                                           int flags);
+
+DESCRIPTION
+-----------
+
+`flux_kvs_namespace_create()` creates a KVS namespace.  Within a
+namespace, users can get/put KVS values completely independent of
+other KVS namespaces.
+
+FLAGS
+-----
+
+The _flags_ mask is currently unused and should be set to 0.
+
+
+RETURN VALUE
+------------
+
+`flux_kvs_namespace_create()` returns a `flux_future_t` on success, or
+NULL on failure with errno set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+One of the arguments was invalid.
+
+ENOMEM::
+Out of memory.
+
+EPROTO::
+A request was malformed.
+
+ENOSYS::
+The KVS module is not loaded.
+
+EEXIST::
+The namespace already exists.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_kvs_lookup(3), flux_kvs_commit(3)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -405,3 +405,4 @@ vpack
 dirref
 lookups
 mh
+namespaces

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -406,3 +406,4 @@ dirref
 lookups
 mh
 namespaces
+ENOTSUP

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -13,6 +13,7 @@ noinst_LTLIBRARIES = libkvs.la
 
 libkvs_la_SOURCES = \
 	kvs.c \
+	kvs_private.h \
 	kvs_lookup.c \
 	kvs_dir.c \
 	kvs_dir_private.h \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -34,6 +34,7 @@ fluxcoreinclude_HEADERS = \
 	kvs_commit.h
 
 TESTS = \
+	test_kvs.t \
 	test_kvs_txn.t \
 	test_kvs_lookup.t \
 	test_kvs_dir.t \
@@ -56,6 +57,10 @@ test_ldadd = \
 test_cppflags = \
 	$(AM_CPPFLAGS) \
 	-I$(top_srcdir)/src/common/libtap
+
+test_kvs_t_SOURCES = test/kvs.c
+test_kvs_t_CPPFLAGS = $(test_cppflags)
+test_kvs_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_kvs_txn_t_SOURCES = test/kvs_txn.c
 test_kvs_txn_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -27,6 +27,20 @@
 #endif
 #include <flux/core.h>
 
+flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
+                                          int flags)
+{
+    if (!namespace || flags) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    return flux_rpc_pack (h, "kvs.namespace.create", 0, 0,
+                          "{ s:s s:i }",
+                          "namespace", namespace,
+                          "flags", flags);
+}
+
 int flux_kvs_get_version (flux_t *h, int *versionp)
 {
     flux_future_t *f;

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -27,6 +27,13 @@
 #endif
 #include <flux/core.h>
 
+const char *get_kvs_namespace (void)
+{
+    if (getenv ("FLUX_KVS_NAMESPACE"))
+        return getenv ("FLUX_KVS_NAMESPACE");
+    return KVS_PRIMARY_NAMESPACE;
+}
+
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
                                           int flags)
 {
@@ -44,7 +51,7 @@ flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
 int flux_kvs_get_version (flux_t *h, int *versionp)
 {
     flux_future_t *f;
-    const char *namespace = KVS_PRIMARY_NAMESPACE;
+    const char *namespace = get_kvs_namespace ();
     int version;
     int rc = -1;
 
@@ -64,7 +71,7 @@ done:
 int flux_kvs_wait_version (flux_t *h, int version)
 {
     flux_future_t *f;
-    const char *namespace = KVS_PRIMARY_NAMESPACE;
+    const char *namespace = get_kvs_namespace ();
     int ret = -1;
 
     if (!(f = flux_rpc_pack (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i s:s }",

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -30,10 +30,12 @@
 int flux_kvs_get_version (flux_t *h, int *versionp)
 {
     flux_future_t *f;
+    const char *namespace = KVS_PRIMARY_NAMESPACE;
     int version;
     int rc = -1;
 
-    if (!(f = flux_rpc (h, "kvs.getroot", NULL, FLUX_NODEID_ANY, 0)))
+    if (!(f = flux_rpc_pack (h, "kvs.getroot", FLUX_NODEID_ANY, 0, "{ s:s }",
+                             "namespace", namespace)))
         goto done;
     if (flux_rpc_get_unpack (f, "{ s:i }", "rootseq", &version) < 0)
         goto done;
@@ -48,10 +50,12 @@ done:
 int flux_kvs_wait_version (flux_t *h, int version)
 {
     flux_future_t *f;
+    const char *namespace = KVS_PRIMARY_NAMESPACE;
     int ret = -1;
 
-    if (!(f = flux_rpc_pack (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i }",
-                             "rootseq", version)))
+    if (!(f = flux_rpc_pack (h, "kvs.sync", FLUX_NODEID_ANY, 0, "{ s:i s:s }",
+                             "rootseq", version,
+                             "namespace", namespace)))
         goto done;
     /* N.B. response contains (rootseq, rootref) but we don't need it.
      */

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -30,6 +30,7 @@ flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
 /* Synchronization:
  * Process A commits data, then gets the store version V and sends it to B.
  * Process B waits for the store version to be >= V, then reads data.
+ * To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE.
  */
 int flux_kvs_get_version (flux_t *h, int *versionp);
 int flux_kvs_wait_version (flux_t *h, int version);

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -23,6 +23,10 @@ enum {
     FLUX_KVS_APPEND = 32,
 };
 
+/* Namespace */
+flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
+                                          int flags);
+
 /* Synchronization:
  * Process A commits data, then gets the store version V and sends it to B.
  * Process B waits for the store version to be >= V, then reads data.

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-#define KVS_PRIMARY_ROOT_KEY "primary"
+#define KVS_PRIMARY_NAMESPACE "primary"
 
 enum {
     FLUX_KVS_READDIR = 1,

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -14,6 +14,8 @@
 extern "C" {
 #endif
 
+#define KVS_PRIMARY_ROOT_KEY "primary"
+
 enum {
     FLUX_KVS_READDIR = 1,
     FLUX_KVS_READLINK = 2,

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -29,13 +29,14 @@
 #include <czmq.h>
 #include <flux/core.h>
 
+#include "kvs_private.h"
 #include "kvs_txn_private.h"
 #include "src/common/libutil/blobref.h"
 
 flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
                                int nprocs, flux_kvs_txn_t *txn)
 {
-    const char *namespace = KVS_PRIMARY_NAMESPACE;
+    const char *namespace = get_kvs_namespace ();
 
     if (txn) {
         json_t *ops;

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -35,6 +35,8 @@
 flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
                                int nprocs, flux_kvs_txn_t *txn)
 {
+    const char *namespace = KVS_PRIMARY_NAMESPACE;
+
     if (txn) {
         json_t *ops;
         if (!(ops = txn_get_ops (txn))) {
@@ -42,16 +44,18 @@ flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
             return NULL;
         }
         return flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
-                                 "{s:s s:i s:i s:O}",
+                                 "{s:s s:i s:s s:i s:O}",
                                  "name", name,
                                  "nprocs", nprocs,
+                                 "namespace", namespace,
                                  "flags", flags,
                                  "ops", ops);
     } else {
         return flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
-                                 "{s:s s:i s:i s:[]}",
+                                 "{s:s s:i s:s s:i s:[]}",
                                  "name", name,
                                  "nprocs", nprocs,
+                                 "namespace", namespace,
                                  "flags", flags,
                                  "ops");
     }

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -9,6 +9,8 @@ enum kvs_commit_flags {
     FLUX_KVS_NO_MERGE = 1, /* disallow commits to be mergeable with others */
 };
 
+/* To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE */
+
 flux_future_t *flux_kvs_commit (flux_t *h, int flags, flux_kvs_txn_t *txn);
 
 flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -99,6 +99,7 @@ flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key)
 {
     struct lookup_ctx *ctx;
     flux_future_t *f;
+    const char *namespace = KVS_PRIMARY_NAMESPACE;
 
     if (!h || !key || strlen (key) == 0 || validate_lookup_flags (flags) < 0) {
         errno = EINVAL;
@@ -106,9 +107,11 @@ flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key)
     }
     if (!(ctx = alloc_ctx (h, flags, key)))
         return NULL;
-    if (!(f = flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0, "{s:s s:i}",
-                                                         "key", key,
-                                                         "flags", flags))) {
+    if (!(f = flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0,
+                             "{s:s s:s s:i}",
+                             "key", key,
+                             "namespace", namespace,
+                             "flags", flags))) {
         free_ctx (ctx);
         return NULL;
     }
@@ -140,6 +143,8 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
         }
     }
     else {
+        const char *namespace = KVS_PRIMARY_NAMESPACE;
+
         if (!(ctx->atref = strdup (treeobj)))
             return NULL;
         if (!(obj = json_loads (treeobj, 0, NULL))) {
@@ -147,9 +152,11 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
             return NULL;
         }
         if (!(f = flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0,
-                                    "{s:s s:i s:O}", "key", key,
-                                                     "flags", flags,
-                                                     "rootdir", obj))) {
+                                 "{s:s s:s s:i s:O}",
+                                 "key", key,
+                                 "namespace", namespace,
+                                 "flags", flags,
+                                 "rootdir", obj))) {
             free_ctx (ctx);
             json_decref (obj);
             return NULL;

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -32,6 +32,7 @@
 #include <czmq.h>
 #include <flux/core.h>
 
+#include "kvs_private.h"
 #include "kvs_dir_private.h"
 #include "kvs_lookup.h"
 #include "treeobj.h"
@@ -99,7 +100,7 @@ flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key)
 {
     struct lookup_ctx *ctx;
     flux_future_t *f;
-    const char *namespace = KVS_PRIMARY_NAMESPACE;
+    const char *namespace = get_kvs_namespace ();
 
     if (!h || !key || strlen (key) == 0 || validate_lookup_flags (flags) < 0) {
         errno = EINVAL;
@@ -143,7 +144,7 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
         }
     }
     else {
-        const char *namespace = KVS_PRIMARY_NAMESPACE;
+        const char *namespace = get_kvs_namespace ();
 
         if (!(ctx->atref = strdup (treeobj)))
             return NULL;

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+/* To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE */
+
 flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key);
 flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
                                   const char *treeobj);

--- a/src/common/libkvs/kvs_private.h
+++ b/src/common/libkvs/kvs_private.h
@@ -1,0 +1,10 @@
+#ifndef _KVS_PRIVATE_H
+#define _KVS_PRIVATE_H
+
+const char *get_kvs_namespace (void);
+
+#endif /* !_KVS_PRIVATE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/kvs_watch.c
+++ b/src/common/libkvs/kvs_watch.c
@@ -147,10 +147,13 @@ static kvs_watcher_t *lookup_watcher (flux_t *h, uint32_t matchtag)
 int flux_kvs_unwatch (flux_t *h, const char *key)
 {
     flux_future_t *f = NULL;
+    const char *namespace = KVS_PRIMARY_NAMESPACE;
     int rc = -1;
 
     if (!(f = flux_rpc_pack (h, "kvs.unwatch", FLUX_NODEID_ANY, 0,
-                             "{s:s}", "key", key)))
+                             "{s:s s:s}",
+                             "key", key,
+                             "namespace", namespace)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
         goto done;
@@ -232,6 +235,7 @@ static flux_future_t *kvs_watch_rpc (flux_t *h, const char *key,
                                      const char *json_str, int flags)
 {
     flux_future_t *f;
+    const char *namespace = KVS_PRIMARY_NAMESPACE;
     json_t *val = NULL;
     int saved_errno;
 
@@ -242,8 +246,9 @@ static flux_future_t *kvs_watch_rpc (flux_t *h, const char *key,
         goto error;
     }
     if (!(f = flux_rpc_pack (h, "kvs.watch", FLUX_NODEID_ANY, 0,
-                             "{s:s s:i s:o}",
+                             "{s:s s:s s:i s:o}",
                              "key", key,
+                             "namespace", namespace,
                              "flags", flags,
                              "val", val))) {
         goto error;

--- a/src/common/libkvs/kvs_watch.c
+++ b/src/common/libkvs/kvs_watch.c
@@ -30,6 +30,7 @@
 #include <czmq.h>
 
 #include "treeobj.h"
+#include "kvs_private.h"
 #include "kvs_dir_private.h"
 
 typedef enum {
@@ -147,7 +148,7 @@ static kvs_watcher_t *lookup_watcher (flux_t *h, uint32_t matchtag)
 int flux_kvs_unwatch (flux_t *h, const char *key)
 {
     flux_future_t *f = NULL;
-    const char *namespace = KVS_PRIMARY_NAMESPACE;
+    const char *namespace = get_kvs_namespace ();
     int rc = -1;
 
     if (!(f = flux_rpc_pack (h, "kvs.unwatch", FLUX_NODEID_ANY, 0,
@@ -235,7 +236,7 @@ static flux_future_t *kvs_watch_rpc (flux_t *h, const char *key,
                                      const char *json_str, int flags)
 {
     flux_future_t *f;
-    const char *namespace = KVS_PRIMARY_NAMESPACE;
+    const char *namespace = get_kvs_namespace ();
     json_t *val = NULL;
     int saved_errno;
 

--- a/src/common/libkvs/kvs_watch.h
+++ b/src/common/libkvs/kvs_watch.h
@@ -40,6 +40,7 @@ typedef int (*kvs_set_dir_f)(const char *key, flux_kvsdir_t *dir, void *arg,
  * Callback is triggered once during registration to get the initial value.
  * Once the reactor is (re-)entered, it will then be called each time the
  * key changes.
+ * To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE
  */
 int flux_kvs_watch (flux_t *h, const char *key, kvs_set_f set, void *arg);
 
@@ -49,6 +50,7 @@ int flux_kvs_watch (flux_t *h, const char *key, kvs_set_f set, void *arg);
  * KVS's hash tree namespace organization, this function will be called
  * whenever any key under this directory changes, since that forces the
  * hash references to change on parents, all the way to the root.
+ * To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE
  */
 int flux_kvs_watch_dir (flux_t *h, kvs_set_dir_f set, void *arg,
                         const char *fmt, ...)
@@ -56,6 +58,7 @@ int flux_kvs_watch_dir (flux_t *h, kvs_set_dir_f set, void *arg,
 
 /* Cancel a flux_kvs_watch(), freeing server-side state, and unregistering
  * any callback.  Returns 0 on success, or -1 with errno set on error.
+ * To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE
  */
 int flux_kvs_unwatch (flux_t *h, const char *key);
 
@@ -70,6 +73,8 @@ int flux_kvs_unwatch (flux_t *h, const char *key);
  *
  * If 'key' initially exists, then is removed, the function fails with
  * ENOENT and the initial value is not freed.
+ *
+ * To use an alternate namespace, set environment variable FLUX_KVS_NAMESPACE
  */
 int flux_kvs_watch_once (flux_t *h, const char *key, char **json_str);
 

--- a/src/common/libkvs/test/kvs.c
+++ b/src/common/libkvs/test/kvs.c
@@ -7,6 +7,7 @@
 
 #include "src/common/libflux/flux.h"
 #include "kvs.h"
+#include "kvs_private.h"
 #include "src/common/libtap/tap.h"
 
 void errors (void)
@@ -18,12 +19,31 @@ void errors (void)
         "flux_kvs_namespace_create fails on bad input");
 }
 
+void namespace (void)
+{
+    const char *str;
+
+    ok (setenv ("FLUX_KVS_NAMESPACE", "FOOBAR", 1) == 0,
+        "setenv FLUX_KVS_NAMESPACE success");
+    ok ((str = get_kvs_namespace ()) != NULL,
+        "get_kvs_namespace returns non-NULL");
+    ok (!strcmp (str, "FOOBAR"),
+        "get_kvs_namespace returns correct non-default namespace");
+    ok (unsetenv ("FLUX_KVS_NAMESPACE") == 0,
+        "unsetenv FLUX_KVS_NAMESPACE success");
+    ok ((str = get_kvs_namespace ()) != NULL,
+        "get_kvs_namespace returns non-NULL");
+    ok (!strcmp (str, KVS_PRIMARY_NAMESPACE),
+        "get_kvs_namespace returns correct default namespace");
+}
+
 int main (int argc, char *argv[])
 {
 
     plan (NO_PLAN);
 
     errors ();
+    namespace ();
 
     done_testing();
     return (0);

--- a/src/common/libkvs/test/kvs.c
+++ b/src/common/libkvs/test/kvs.c
@@ -1,0 +1,35 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libflux/flux.h"
+#include "kvs.h"
+#include "src/common/libtap/tap.h"
+
+void errors (void)
+{
+    /* check simple error cases */
+
+    errno = 0;
+    ok (flux_kvs_namespace_create (NULL, NULL, 5) == NULL && errno == EINVAL,
+        "flux_kvs_namespace_create fails on bad input");
+}
+
+int main (int argc, char *argv[])
+{
+
+    plan (NO_PLAN);
+
+    errors ();
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -455,17 +455,11 @@ static int commit_cache_cb (commit_t *c, struct cache_entry *entry, void *data)
  */
 static void commit_apply (commit_t *c)
 {
-    kvs_ctx_t *ctx = commit_get_aux (c);
-    struct kvsroot *root;
+    struct kvsroot *root = commit_get_aux (c);
+    kvs_ctx_t *ctx = root->ctx;
     wait_t *wait = NULL;
     int errnum = 0;
     commit_process_t ret;
-
-    root = zhash_lookup (ctx->roothash, KVS_PRIMARY_NAMESPACE);
-
-    /* root must exist in hash by this point b/c we were called
-     * after a fence/commit request */
-    assert (root);
 
     if ((errnum = commit_get_aux_errnum (c)))
         goto done;
@@ -1436,7 +1430,7 @@ static struct kvsroot *create_root (kvs_ctx_t *ctx, const char *namespace) {
     }
 
     if (!(root->cm = commit_mgr_create (ctx->cache, ctx->hash_name,
-                                        ctx->h, ctx))) {
+                                        ctx->h, root))) {
         flux_log_error (ctx->h, "commit_mgr_create");
         goto error;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -52,6 +52,7 @@ TESTS = \
 	t1001-kvs-internals.t \
 	t1002-kvs-watch.t \
 	t1003-kvs-stress.t \
+	t1004-kvs-namespace.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -125,6 +126,7 @@ check_SCRIPTS = \
 	t1001-kvs-internals.t \
 	t1002-kvs-watch.t \
 	t1003-kvs-stress.t \
+	t1004-kvs-namespace.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -473,11 +473,16 @@ static int simulwatch_cb (const char *key, const char *json_str, void *arg, int 
 int get_watch_stats (flux_t *h, int *count)
 {
     flux_future_t *f;
+    json_t *ns, *p;
     int rc = -1;
 
     if (!(f = flux_rpc (h, "kvs.stats.get", NULL, FLUX_NODEID_ANY, 0)))
         goto done;
-    if (flux_rpc_get_unpack (f, "{ s:i }", "#watchers", count) < 0)
+    if (flux_rpc_get_unpack (f, "{ s:o }", "namespace", &ns) < 0)
+        goto done;
+    if (json_unpack (ns, "{ s:o }", KVS_PRIMARY_NAMESPACE, &p) < 0)
+        goto done;
+    if (json_unpack (p, "{ s:i }", "#watchers", count) < 0)
         goto done;
     rc = 0;
 done:

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -18,8 +18,9 @@ void send_watch_requests (flux_t *h, const char *key)
     int flags = KVS_WATCH_FIRST;
     flux_mrpc_t *r;
 
-    if (!(r = flux_mrpcf (h, "kvs.watch", "all", 0, "{s:s s:i s:n}",
+    if (!(r = flux_mrpcf (h, "kvs.watch", "all", 0, "{s:s s:s s:i s:n}",
                                                     "key", key,
+                                                    "namespace", KVS_PRIMARY_NAMESPACE,
                                                     "flags", flags,
                                                     "val")))
         log_err_exit ("flux_mrpc kvs.watch");

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -41,7 +41,12 @@ int count_watchers (flux_t *h)
     if (!(r = flux_mrpc (h, "kvs.stats.get", NULL, "all", 0)))
         log_err_exit ("flux_mrpc kvs.stats.get");
     do {
-        if (flux_mrpc_getf (r, "{s:i}", "#watchers", &n) < 0)
+        json_t *ns, *p;
+        if (flux_mrpc_getf (r, "{ s:o }", "namespace", &ns) < 0)
+            log_err_exit ("kvs.stats.get namespace");
+        if (json_unpack (ns, "{ s:o }", KVS_PRIMARY_NAMESPACE, &p) < 0)
+            log_err_exit ("kvs.stats.get %s", KVS_PRIMARY_NAMESPACE);
+        if (json_unpack (p, "{ s:i }", "#watchers", &n) < 0)
             log_err_exit ("kvs.stats.get #watchers");
         count += n;
     } while (flux_mrpc_next (r) == 0);

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -1,0 +1,485 @@
+#!/bin/sh
+
+test_description='Test flux-kvs and kvs in flux session
+
+These are tests for ensuring multiple namespaces work.
+'
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE} kvs
+echo "# $0: flux session size will be ${SIZE}"
+
+DIR=test.a.b
+KEY=test.a.b.c
+
+# Just in case its set in the environment
+unset FLUX_KVS_NAMESPACE
+
+PRIMARYNAMESPACE=primary
+NAMESPACETEST=namespacetest
+NAMESPACERANK1=namespacerank1
+
+test_kvs_key() {
+	flux kvs get --json "$1" >output
+	echo "$2" >expected
+	test_cmp expected output
+}
+
+test_kvs_key_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs get --json "$2" >output
+	echo "$3" >expected
+        unset FLUX_KVS_NAMESPACE
+	test_cmp expected output
+}
+
+put_kvs_key_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs put --json "$2=$3"
+        unset FLUX_KVS_NAMESPACE
+}
+
+dir_kvs_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs dir "$2" | sort > $3
+        unset FLUX_KVS_NAMESPACE
+}
+
+unlink_kvs_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs unlink $2
+        unset FLUX_KVS_NAMESPACE
+}
+
+unlink_kvs_dir_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs unlink -Rf $2
+        unset FLUX_KVS_NAMESPACE
+}
+
+version_kvs_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	version=`flux kvs version`
+        eval $2=$version
+        unset FLUX_KVS_NAMESPACE
+}
+
+get_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs get --json "$2"
+        eval $3="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+dir_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs dir "$2"
+        eval $3="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+wait_watch_namespace_put() {
+        export FLUX_KVS_NAMESPACE=$1
+        i=0
+        while [ "$(flux kvs get --json $2 2> /dev/null)" != "$3" ] && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        unset FLUX_KVS_NAMESPACE
+        if [ $i -eq 50 ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+wait_watch_current() {
+        i=0
+        while [ "$(tail -n 1 $1 2> /dev/null)" != "$2" ] && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ $i -eq 50 ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+#
+# Basic tests in default primary namespace
+#
+
+test_expect_success 'kvs: create primary namespace fails' '
+	! flux kvs namespace-create $PRIMARYNAMESPACE
+'
+
+test_expect_success 'kvs: get with primary namespace works' '
+        flux kvs put --json $DIR.test=1 &&
+        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1
+'
+
+test_expect_success 'kvs: put with primary namespace works' '
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 2 &&
+        test_kvs_key $DIR.test 2
+'
+
+test_expect_success 'kvs: put/get with primary namespace works' '
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 3 &&
+        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 3
+'
+
+test_expect_success 'kvs: unlink with primary namespace works' '
+        unlink_kvs_namespace $PRIMARYNAMESPACE $DIR.test &&
+        test_must_fail flux kvs get --json $DIR.test
+'
+
+test_expect_success 'kvs: dir with primary namespace works' '
+        flux kvs put --json $DIR.a=1 &&
+        flux kvs put --json $DIR.b=2 &&
+        flux kvs put --json $DIR.c=3 &&
+        dir_kvs_namespace $PRIMARYNAMESPACE $DIR output &&
+        cat >expected <<EOF &&
+$DIR.a = 1
+$DIR.b = 2
+$DIR.c = 3
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: unlink dir primary namespace works' '
+        unlink_kvs_dir_namespace $PRIMARYNAMESPACE $DIR &&
+        dir_kvs_namespace_exitvalue $PRIMARYNAMESPACE $DIR exitvalue &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: wait on primary namespace works' '
+        VERS=$(flux kvs version)
+        VERS=$((VERS + 1))
+        export FLUX_KVS_NAMESPACE=$PRIMARYNAMESPACE
+        flux kvs wait $VERS &
+        kvswaitpid=$!
+        flux kvs put --json $DIR.xxx=99
+        unset FLUX_KVS_NAMESPACE
+        test_expect_code 0 wait $kvswaitpid
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key in primary namespace works'  '
+        unlink_kvs_dir_namespace $PRIMARYNAMESPACE $DIR &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.watch 0 &&
+        wait_watch_namespace_put $PRIMARYNAMESPACE "$DIR.watch" "0"
+        rm -f watch_out
+        export FLUX_KVS_NAMESPACE=$PRIMARYNAMESPACE
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >watch_out &
+        watchpid=$! &&
+        wait_watch_current watch_out "0"
+        flux kvs put --json $DIR.watch=1 &&
+        wait $watchpid
+        unset FLUX_KVS_NAMESPACE
+cat >expected <<-EOF &&
+0
+1
+EOF
+        test_cmp watch_out expected
+'
+
+#
+# Basic tests in new namespace
+#
+
+test_expect_success 'kvs: namespace create on rank 0 works' '
+	flux kvs namespace-create $NAMESPACETEST
+'
+
+test_expect_success 'kvs: namespace create on rank 1 works' '
+	flux exec -r 1 sh -c "flux kvs namespace-create $NAMESPACERANK1"
+'
+
+test_expect_success 'kvs: put/get value in new namespace works' '
+        put_kvs_key_namespace $NAMESPACETEST $DIR.test 1 &&
+        test_kvs_key_namespace $NAMESPACETEST $DIR.test 1
+'
+
+test_expect_success 'kvs: unlink in new namespace works' '
+        unlink_kvs_namespace $NAMESPACETEST $DIR.test &&
+        get_kvs_namespace_exitvalue $NAMESPACETEST $DIR.test exitvalue &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: dir in new namespace works' '
+        put_kvs_key_namespace $NAMESPACETEST $DIR.a 4 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.b 5 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.c 6 &&
+        dir_kvs_namespace $NAMESPACETEST $DIR output &&
+        cat >expected <<EOF &&
+$DIR.a = 4
+$DIR.b = 5
+$DIR.c = 6
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: unlink dir in new namespace works' '
+        unlink_kvs_dir_namespace $NAMESPACETEST $DIR &&
+        dir_kvs_namespace_exitvalue $NAMESPACETEST $DIR exitvalue &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: wait in new namespace works' '
+        version_kvs_namespace $NAMESPACETEST VERS
+        VERS=$((VERS + 1))
+        export FLUX_KVS_NAMESPACE=$NAMESPACETEST
+        flux kvs wait $VERS &
+        kvswaitpid=$!
+        flux kvs put --json $DIR.xxx=99
+        unset FLUX_KVS_NAMESPACE
+        test_expect_code 0 wait $kvswaitpid
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key in new namespace works'  '
+        unlink_kvs_dir_namespace $NAMESPACETEST $DIR &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.watch 0 &&
+        wait_watch_namespace_put $NAMESPACETEST "$DIR.watch" "0"
+        rm -f watch_out
+        export FLUX_KVS_NAMESPACE=$NAMESPACETEST
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >watch_out &
+        watchpid=$! &&
+        wait_watch_current watch_out "0"
+        flux kvs put --json $DIR.watch=1 &&
+        wait $watchpid
+        unset FLUX_KVS_NAMESPACE
+cat >expected <<-EOF &&
+0
+1
+EOF
+        test_cmp watch_out expected
+'
+
+#
+# Basic tests, data in new namespace available across ranks
+#
+
+test_expect_success 'kvs: put value in new namespace, available on other ranks' '
+        unlink_kvs_dir_namespace $NAMESPACETEST $DIR &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.all 1 &&
+        version_kvs_namespace $NAMESPACETEST VERS &&
+        flux exec sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACETEST; flux kvs wait ${VERS} && flux kvs get $DIR.all"
+'
+
+test_expect_success 'kvs: unlink value in new namespace, does not exist all ranks' '
+        unlink_kvs_namespace $NAMESPACETEST $DIR.all &&
+        version_kvs_namespace $NAMESPACETEST VERS &&
+        flux exec sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACETEST; flux kvs wait ${VERS} && ! flux kvs get $DIR.all"
+'
+
+#
+# Namespace corner case tests
+#
+
+NAMESPACEBAD=namespacebad
+
+test_expect_success 'kvs: namespace create on existing namespace fails' '
+	! flux kvs namespace-create $NAMESPACETEST
+'
+
+test_expect_success 'kvs: namespace create on existing namespace fails on rank 1' '
+	! flux exec -r 1 sh -c "flux kvs namespace-create $NAMESPACETEST"
+'
+
+test_expect_success 'kvs: get fails on invalid namespace' '
+        get_kvs_namespace_exitvalue $NAMESPACEBAD $DIR.test exitvalue &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: get fails on invalid namespace on rank 1' '
+	! flux exec -r 1 sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACEBAD ; flux kvs get $DIR.test"
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: put fails on invalid namespace' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACEBAD
+	flux kvs put --json $DIR.test=1
+        exitvalue=$?
+        unset FLUX_KVS_NAMESPACE
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: put fails on invalid namespace on rank 1' '
+        ! flux exec -r 1 sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACEBAD ; flux kvs put $DIR.test=1"
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: version fails on invalid namespace' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACEBAD
+	flux kvs version
+        exitvalue=$?
+        unset FLUX_KVS_NAMESPACE
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: version fails on invalid namespace on rank 1' '
+	! flux exec -r 1 sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACEBAD ; flux kvs version"
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: wait fails on invalid namespace' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACEBAD
+	flux kvs wait 1
+        exitvalue=$?
+        unset FLUX_KVS_NAMESPACE
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: wait fails on invalid namespace on rank 1' '
+        ! flux exec -r 1 sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACEBAD ; flux kvs wait 1"
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch fails on invalid namespace' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACEBAD
+	flux kvs watch -c 1 $DIR.test
+        exitvalue=$?
+        unset FLUX_KVS_NAMESPACE
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: watch fails on invalid namespace on rank 1' '
+        ! flux exec -r 1 sh -c "export FLUX_KVS_NAMESPACE=$NAMESPACEBAD ; flux kvs watch -c 1 $DIR.test"
+'
+
+#
+# Basic tests - no pollution between namespaces
+#
+
+test_expect_success 'kvs: put/get in different namespaces works' '
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.test 2 &&
+        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1 &&
+        test_kvs_key_namespace $NAMESPACETEST $DIR.test 2
+'
+
+test_expect_success 'kvs: unlink in different namespaces works' '
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.testA 1 &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.testB 1 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.testA 2 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.testB 2 &&
+        unlink_kvs_namespace $PRIMARYNAMESPACE $DIR.testA &&
+        unlink_kvs_namespace $NAMESPACETEST $DIR.testB &&
+        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.testB 1 &&
+        test_kvs_key_namespace $NAMESPACETEST $DIR.testA 2 &&
+        get_kvs_namespace_exitvalue $PRIMARYNAMESPACE $DIR.testA exitvalue &&
+        test $exitvalue -ne 0 &&
+        get_kvs_namespace_exitvalue $NAMESPACETEST $DIR.testB exitvalue &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: dir in different namespace works' '
+        unlink_kvs_dir_namespace $PRIMARYNAMESPACE $DIR &&
+        unlink_kvs_dir_namespace $NAMESPACETEST $DIR &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.a 10 &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.b 11 &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.c 12 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.a 13 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.b 14 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.c 15 &&
+        dir_kvs_namespace $PRIMARYNAMESPACE $DIR primaryoutput &&
+        dir_kvs_namespace $NAMESPACETEST $DIR testoutput &&
+        cat >primaryexpected <<EOF &&
+$DIR.a = 10
+$DIR.b = 11
+$DIR.c = 12
+EOF
+        cat >testexpected <<EOF &&
+$DIR.a = 13
+$DIR.b = 14
+$DIR.c = 15
+EOF
+        test_cmp primaryexpected primaryoutput &&
+        test_cmp testexpected testoutput
+'
+
+test_expect_success 'kvs: unlink dir in different namespaces works' '
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.subdirA.A A &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.subdirA.B B &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.subdirB.A A &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.subdirB.A B &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.subdirA.A A &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.subdirA.B B &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.subdirB.A A &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.subdirB.A B &&
+        unlink_kvs_dir_namespace $PRIMARYNAMESPACE $DIR.subdirA &&
+        unlink_kvs_dir_namespace $NAMESPACETEST $DIR.subdirB &&
+        dir_kvs_namespace_exitvalue $PRIMARYNAMESPACE $DIR.subdirA exitvalue &&
+        test $exitvalue -ne 0 &&
+        dir_kvs_namespace_exitvalue $PRIMARYNAMESPACE $DIR.subdirB exitvalue &&
+        test $exitvalue -eq 0 &&
+        dir_kvs_namespace_exitvalue $NAMESPACETEST $DIR.subdirA exitvalue &&
+        test $exitvalue -eq 0 &&
+        dir_kvs_namespace_exitvalue $NAMESPACETEST $DIR.subdirB exitvalue &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: wait in different namespaces works' '
+        export FLUX_KVS_NAMESPACE=$PRIMARYNAMESPACE
+        PRIMARYVERS=$(flux kvs version)
+        PRIMARYVERS=$((PRIMARYVERS + 1))
+        flux kvs wait $PRIMARYVERS &
+        primarykvswaitpid=$!
+        unset FLUX_KVS_NAMESPACE
+
+        export FLUX_KVS_NAMESPACE=$NAMESPACETEST
+        TESTVERS=$(flux kvs version)
+        TESTVERS=$((TESTVERS + 1))
+        flux kvs wait $TESTVERS &
+        testkvswaitpid=$!
+        unset FLUX_KVS_NAMESPACE
+
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.xxx X
+        put_kvs_key_namespace $NAMESPACETEST $DIR.xxx X
+
+        test_expect_code 0 wait $primarykvswaitpid
+        test_expect_code 0 wait $testkvswaitpid
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key in different namespaces works'  '
+        unlink_kvs_dir_namespace $PRIMARYNAMESPACE $DIR &&
+        unlink_kvs_dir_namespace $NAMESPACETEST $DIR &&
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.watch 0 &&
+        wait_watch_namespace_put $PRIMARYNAMESPACE "$DIR.watch" "0"
+        put_kvs_key_namespace $NAMESPACETEST $DIR.watch 1 &&
+        wait_watch_namespace_put $NAMESPACETEST "$DIR.watch" "1"
+        rm -f primary_watch_out
+        rm -f test_watch_out
+
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >primary_watch_out &
+        primarywatchpid=$! &&
+        wait_watch_current primary_watch_out "0"
+
+        export FLUX_KVS_NAMESPACE=$NAMESPACETEST
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >test_watch_out &
+        testwatchpid=$! &&
+        wait_watch_current test_watch_out "1"
+        unset FLUX_KVS_NAMESPACE
+
+        put_kvs_key_namespace $PRIMARYNAMESPACE $DIR.watch 1 &&
+        put_kvs_key_namespace $NAMESPACETEST $DIR.watch 2 &&
+        wait $primarywatchpid &&
+        wait $testwatchpid
+cat >primaryexpected <<-EOF &&
+0
+1
+EOF
+cat >testexpected <<-EOF &&
+1
+2
+EOF
+        test_cmp primaryexpected primary_watch_out &&
+        test_cmp testexpected test_watch_out
+'
+
+test_done

--- a/t/t1103-apidisconnect.t
+++ b/t/t1103-apidisconnect.t
@@ -12,7 +12,7 @@ test_under_flux ${SIZE} kvs
 check_kvs_watchers() {
 	local i n
 	for i in `seq 1 $2`; do
-	    n=`flux module stats --parse "#watchers" kvs`
+	    n=`flux module stats --parse "namespace.primary.#watchers" kvs`
 	    echo "Try $i: $n"
 	    test $n -eq $1 && return 0
 	    sleep 1
@@ -22,7 +22,7 @@ check_kvs_watchers() {
 
 
 test_expect_success 'kvs watcher gets disconnected on client exit' '
-	before_watchers=`flux module stats --parse "#watchers" kvs` &&
+	before_watchers=`flux module stats --parse "namespace.primary.#watchers" kvs` &&
 	echo "waiters before test: $before_watchers" &&
 	test_expect_code 142 run_timeout 1 flux kvs watch noexist &&
 	check_kvs_watchers $before_watchers 3

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -387,12 +387,12 @@ test_expect_success 'wreck job is linked in lwj-complete after failure' '
 
 test_expect_success 'wreck: no KVS watchers leaked after 10 jobs' '
 	flux exec -r 1-$(($SIZE-1)) -l \
-		flux module stats --parse "#watchers" kvs | sort -n >w.before &&
+		flux module stats --parse "namespace.primary.#watchers" kvs | sort -n >w.before &&
 	for i in `seq 1 10`; do
 		flux wreckrun --ntasks $SIZE /bin/true
 	done &&
 	flux exec -r 1-$(($SIZE-1)) -l \
-		flux module stats --parse "#watchers" kvs | sort -n >w.after &&
+		flux module stats --parse "namespace.primary.#watchers" kvs | sort -n >w.after &&
 	test_cmp w.before w.after
 '
 


### PR DESCRIPTION
As described in #1197, here is the part 1 pull request where we refactor the KVS to not initialize itself automatically and we store KVS metadata in a hash table.  All in preparation for private namespace support.

After doing this, I'm debating if this should be a separate PR, b/c there's going to be a fair amount of code paths that I don't believe can be tested until private namespace support is added.

We'll see what the coverage looks like after it goes through travis and determine if we should have this as part of the mega-PR later on for private namespaces.
