### PR TITLE
jobspec: replace minus operator to multiplication

### DIFF
--- a/src/common/libjobspec/jobspec.cpp
+++ b/src/common/libjobspec/jobspec.cpp
@@ -118,7 +118,7 @@ void parse_yaml_count (Resource& res, const YAML::Node &cnode)
     res.count.oper = cnode["operator"].as<char>();
     switch (res.count.oper) {
     case '+':
-    case '-':
+    case '*':
     case '^':
         break;
     default:


### PR DESCRIPTION
Make the implementation come to compliance with RFC14's JRC rule section.
Tested with resource-query and this one-liner seems enough.