### PR TITLE
modules/kvs: Fix potential to exceed nprocs

### DIFF
--- a/doc/man3/flux_kvs_commit.adoc
+++ b/doc/man3/flux_kvs_commit.adoc
@@ -91,6 +91,10 @@ The KVS module is not loaded.
 ENOTSUP::
 An unknown namespace was requested.
 
+EOVERFLOW::
+`flux_kvs_fence()` has been called too many times and _nprocs_ has
+been exceeded.
+
 AUTHOR
 ------
 This page is maintained by the Flux community.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -407,3 +407,4 @@ lookups
 mh
 namespaces
 ENOTSUP
+EOVERFLOW

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -93,7 +93,8 @@ error:
 
 bool fence_count_reached (fence_t *f)
 {
-    return (f->count >= f->nprocs);
+    assert (f->count <= f->nprocs);
+    return (f->count == f->nprocs);
 }
 
 int fence_get_flags (fence_t *f)
@@ -120,6 +121,11 @@ int fence_add_request_data (fence_t *f, json_t *ops)
 {
     json_t *op;
     int i;
+
+    if (f->count == f->nprocs) {
+        errno = EOVERFLOW;
+        return -1;
+    }
 
     if (ops) {
         for (i = 0; i < json_array_size (ops); i++) {

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -73,6 +73,10 @@ void basic_api_tests (void)
     ok (json_equal (ops, o) == true,
         "initial fence_get_json_ops match");
 
+    ok (fence_add_request_data (f, ops) < 0
+        && errno == EOVERFLOW,
+        "fence_add_request_data fails with EOVERFLOW when exceeding nprocs");
+
     json_decref (ops);
 
     ok (fence_iter_request_copies (f, msg_cb, &count) == 0,


### PR DESCRIPTION
Fix corner case in which nprocs could be exceeded and additional
operations appended onto a fence.  Now, user will receive an EOVERFLOW
error if they have exceeded the nprocs count.