### PR TITLE
jobspec: Use "yaml-cpp" instead of "Yaml-cpp"

### DIFF
--- a/src/common/libjobspec/flux-jobspec.pc.in
+++ b/src/common/libjobspec/flux-jobspec.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: flux-jobspec
 Description: Flux Resource Manager Jobspec Parser
 Version: @PACKAGE_VERSION@
-Requires: Yaml-cpp
+Requires: yaml-cpp
 Libs: -L${libdir} -lflux-jobspec
 Cflags: -I${includedir}


### PR DESCRIPTION
Fix a flux-sched autoconf problem when it uses
PKG_CHECK_MODULES to gather libraray info on jobspec
package.

Apparently pkg-config doesn't like the dependent
package name: "Yaml-cpp."

On quartz:
$ uname -a
Linux quartz1916 3.10.0-693.5.2.1chaos.ch6.x86_64 #1
SMP Wed Oct 25 16:20:31 PDT 2017 x86_64 x86_64 x86_64 GNU/Linux

$ pkg-config --cflags flux-jobspec
Package Yaml-cpp was not found in the pkg-config search path.
Perhaps you should add the directory containing `Yaml-cpp.pc'
to the PKG_CONFIG_PATH environment variable
Package 'Yaml-cpp', required by 'flux-jobspec', not found

Get a simiar configure error when
PKG_CHECK_MODULES([JOBSPEC],[flux-jobspec],[],[]) is used.