### PR TITLE
kvs: Make getroot() asynchronous

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -24,7 +24,9 @@ kvs_la_SOURCES = \
 	fence.h \
 	fence.c \
 	commit.h \
-	commit.c
+	commit.c \
+	msg_cb_handler.h \
+	msg_cb_handler.c
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \
@@ -38,7 +40,8 @@ TESTS = \
 	test_lookup.t \
 	test_fence.t \
 	test_commit.t \
-	test_kvs_util.t
+	test_kvs_util.t \
+	test_msg_cb_handler.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
@@ -61,6 +64,7 @@ test_waitqueue_t_SOURCES = test/waitqueue.c
 test_waitqueue_t_CPPFLAGS = $(test_cppflags)
 test_waitqueue_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)
 
@@ -69,6 +73,7 @@ test_cache_t_CPPFLAGS = $(test_cppflags)
 test_cache_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)
 
@@ -78,6 +83,7 @@ test_lookup_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/lookup.o \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)
 
@@ -96,6 +102,7 @@ test_commit_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/lookup.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)
 
@@ -103,4 +110,10 @@ test_kvs_util_t_SOURCES = test/kvs_util.c
 test_kvs_util_t_CPPFLAGS = $(test_cppflags)
 test_kvs_util_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \
+	$(test_ldadd)
+
+test_msg_cb_handler_t_SOURCES = test/msg_cb_handler.c
+test_msg_cb_handler_t_CPPFLAGS = $(test_cppflags)
+test_msg_cb_handler_t_LDADD = \
+	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
 	$(test_ldadd)

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1324,7 +1324,7 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!lookup (lh)) {
         struct kvs_cb_data cbd;
 
-        if (!(wait = wait_create_msg_handler (h, mh, msg, get_request_cb, lh)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg, lh, get_request_cb)))
             goto done;
 
         cbd.ctx = ctx;
@@ -1471,8 +1471,8 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!lookup (lh)) {
         struct kvs_cb_data cbd;
 
-        if (!(wait = wait_create_msg_handler (h, mh, msg,
-                                              watch_request_cb, lh)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg, lh,
+                                              watch_request_cb)))
             goto done;
 
         cbd.ctx = ctx;
@@ -1543,8 +1543,8 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *mh,
             goto done;
         }
 
-        if (!(watcher = wait_create_msg_handler (h, mh, cpy,
-                                                 watch_request_cb, ctx)))
+        if (!(watcher = wait_create_msg_handler (h, mh, cpy, ctx,
+                                                 watch_request_cb)))
             goto done;
         if (wait_addqueue (root->watchlist, watcher) < 0) {
             saved_errno = errno;
@@ -1882,8 +1882,8 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
     }
 
     if (root->seq < rootseq) {
-        if (!(wait = wait_create_msg_handler (h, mh, msg,
-                                              sync_request_cb, arg)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg, arg,
+                                              sync_request_cb)))
             goto error;
         if (wait_addqueue (root->watchlist, wait) < 0) {
             saved_errno = errno;

--- a/src/modules/kvs/msg_cb_handler.c
+++ b/src/modules/kvs/msg_cb_handler.c
@@ -1,0 +1,93 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "msg_cb_handler.h"
+
+struct msg_cb_handler {
+    flux_t *h;
+    flux_msg_handler_t *mh;
+    flux_msg_t *msg;
+    void *arg;
+    flux_msg_handler_f cb;
+};
+
+msg_cb_handler_t *msg_cb_handler_create (flux_t *h, flux_msg_handler_t *mh,
+                                         const flux_msg_t *msg, void *arg,
+                                         flux_msg_handler_f cb)
+{
+    msg_cb_handler_t *mcb;
+
+    mcb = calloc (1, sizeof (*mcb));
+    if (mcb) {
+        mcb->h = h;
+        mcb->mh = mh;
+        mcb->arg = arg;
+        mcb->cb = cb;
+        if (msg && !(mcb->msg = flux_msg_copy (msg, true))) {
+            msg_cb_handler_destroy (mcb);
+            errno = ENOMEM;
+            return NULL;
+        }
+    }
+    return mcb;
+}
+
+void msg_cb_handler_destroy (msg_cb_handler_t *mcb)
+{
+    if (mcb) {
+        if (mcb->msg)
+            flux_msg_destroy (mcb->msg);
+        free (mcb);
+    }
+}
+
+void msg_cb_handler_call (msg_cb_handler_t *mcb)
+{
+    if (mcb && mcb->cb)
+        mcb->cb (mcb->h, mcb->mh, mcb->msg, mcb->arg);
+}
+
+const flux_msg_t *msg_cb_handler_get_msgcopy (msg_cb_handler_t *mcb)
+{
+    if (mcb)
+        return mcb->msg;
+    return NULL;
+}
+
+void msg_cb_handler_set_cb (msg_cb_handler_t *mcb, flux_msg_handler_f cb)
+{
+    if (mcb)
+        mcb->cb = cb;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/kvs/msg_cb_handler.h
+++ b/src/modules/kvs/msg_cb_handler.h
@@ -1,0 +1,29 @@
+#ifndef _FLUX_KVS_MSG_CB_HANDLER_H
+#define _FLUX_KVS_MSG_CB_HANDLER_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+/* A common set of code for managing message callbacks */
+
+typedef struct msg_cb_handler msg_cb_handler_t;
+
+msg_cb_handler_t *msg_cb_handler_create (flux_t *h, flux_msg_handler_t *w,
+                                         const flux_msg_t *msg, void *arg,
+                                         flux_msg_handler_f cb);
+
+void msg_cb_handler_destroy (msg_cb_handler_t *mcb);
+
+void msg_cb_handler_call (msg_cb_handler_t *mcb);
+
+const flux_msg_t *msg_cb_handler_get_msgcopy (msg_cb_handler_t *mcb);
+
+/* set a new callback handler */
+void msg_cb_handler_set_cb (msg_cb_handler_t *mcb, flux_msg_handler_f cb);
+
+#endif /* !_FLUX_KVS_MSG_CB_HANDLER_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/kvs/test/msg_cb_handler.c
+++ b/src/modules/kvs/test/msg_cb_handler.c
@@ -1,0 +1,82 @@
+#include "src/modules/kvs/msg_cb_handler.h"
+#include "src/common/libflux/message.h"
+#include "src/common/libtap/tap.h"
+
+void msghand (flux_t *h, flux_msg_handler_t *mh,
+              const flux_msg_t *msg, void *arg)
+{
+    int *count = arg;
+    (*count)++;
+}
+int main (int argc, char *argv[])
+{
+    msg_cb_handler_t *mcb;
+    flux_msg_t *msg;
+    const flux_msg_t *cpy;
+    const char *str;
+    int count;
+
+    plan (NO_PLAN);
+
+    /* corner cases */
+
+    msg_cb_handler_destroy (NULL);
+
+    ok (!msg_cb_handler_get_msgcopy (NULL),
+        "msg_cb_handler_get_msgcopy returns NULL on bad input");
+
+    /* test empty callback handler */
+
+    ok ((mcb = msg_cb_handler_create (NULL, NULL, NULL, NULL, NULL)) != NULL,
+        "msg_cb_handler_create works with all NULL inputs");
+
+    msg_cb_handler_call (mcb);
+
+    ok (!msg_cb_handler_get_msgcopy (mcb),
+        "msg_cb_handler_get_msgcopy returns NULL for message copy on empty handler");
+
+    msg_cb_handler_destroy (mcb);
+
+    /* test filled callback handler */
+
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
+        "flux_msg_create works");
+
+    ok (!flux_msg_pack (msg, "{ s:s }", "foo", "bar"),
+        "flux_msg_pack works");
+
+    /* msg handler cb & msg cannot be NULL */
+    ok ((mcb = msg_cb_handler_create (NULL, NULL, msg, &count, msghand)) != NULL,
+        "msg_cb_handler_create works");
+
+    count = 0;
+    msg_cb_handler_call (mcb);
+    ok (count == 1,
+        "msg_cb_handler_call calls callback correctly");
+
+    msg_cb_handler_set_cb (mcb, NULL);
+
+    count = 0;
+    msg_cb_handler_call (mcb);
+    ok (count == 0,
+        "msg_cb_handler_call doesn't call callback after it was changed");
+
+    ok ((cpy = msg_cb_handler_get_msgcopy (mcb)) != NULL,
+        "msg_cb_handler_get_msgcopy returns message copy");
+
+    ok (!flux_msg_unpack (cpy, "{ s:s }", "foo", &str)
+        && !strcmp (str, "bar"),
+        "msg_cb_handler_get_msgcopy returned correct msg copy");
+
+    msg_cb_handler_destroy (mcb);
+
+    flux_msg_destroy (msg);
+    done_testing ();
+    return (0);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -95,7 +95,7 @@ int main (int argc, char *argv[])
     msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
     ok (msg != NULL,
         "flux_msg_create works");
-    w = wait_create_msg_handler (NULL, NULL, msg, msghand, &count);
+    w = wait_create_msg_handler (NULL, NULL, msg, &count, msghand);
     ok (w != NULL,
         "wait_create_msg_handler with non-NULL msg works");
     flux_msg_destroy (msg);
@@ -140,7 +140,7 @@ int main (int argc, char *argv[])
             break;
         if (flux_msg_enable_route (msg) < 0 || flux_msg_push_route (msg, s) < 0)
             break;
-        if (!(w = wait_create_msg_handler (NULL, NULL, msg, msghand, &count)))
+        if (!(w = wait_create_msg_handler (NULL, NULL, msg, &count, msghand)))
             break;
         flux_msg_destroy (msg); /* msg was copied into wait_t */
         if (wait_addqueue (q, w) < 0)

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -65,8 +65,8 @@ wait_t *wait_create (wait_cb_f cb, void *arg)
 }
 
 wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *mh,
-                                 const flux_msg_t *msg,
-                                 flux_msg_handler_f cb, void *arg)
+                                 const flux_msg_t *msg, void *arg,
+                                 flux_msg_handler_f cb)
 {
     wait_t *w = wait_create (NULL, NULL);
     if (w) {

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -29,14 +29,7 @@
 #include <flux/core.h>
 
 #include "waitqueue.h"
-
-struct handler {
-    flux_msg_handler_f cb;
-    flux_t *h;
-    flux_msg_handler_t *mh;
-    flux_msg_t *msg;
-    void *arg;
-};
+#include "msg_cb_handler.h"
 
 #define WAIT_MAGIC 0xafad7777
 struct wait_struct {
@@ -44,7 +37,7 @@ struct wait_struct {
     int usecount;
     wait_cb_f cb;
     void *cb_arg;
-    struct handler hand; /* optional special case */
+    msg_cb_handler_t *mcb;      /* optional special case */
 };
 
 #define WAITQUEUE_MAGIC 0xafad7778
@@ -77,13 +70,10 @@ wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *mh,
 {
     wait_t *w = wait_create (NULL, NULL);
     if (w) {
-        w->hand.cb = cb;
-        w->hand.arg = arg;
-        w->hand.h = h;
-        w->hand.mh = mh;
-        if (msg && !(w->hand.msg = flux_msg_copy (msg, true))) {
+        if (!(w->mcb = msg_cb_handler_create (h, mh, msg, arg, cb))) {
+            int saved_errno = errno;
             wait_destroy (w);
-            errno = ENOMEM;
+            errno = saved_errno;
             return NULL;
         }
     }
@@ -95,7 +85,7 @@ void wait_destroy (wait_t *w)
     if (w) {
         assert (w->magic == WAIT_MAGIC);
         assert (w->usecount == 0);
-        flux_msg_destroy (w->hand.msg);
+        msg_cb_handler_destroy (w->mcb);
         w->magic = ~WAIT_MAGIC;
         free (w);
     }
@@ -155,8 +145,8 @@ static void wait_runone (wait_t *w)
     if (--w->usecount == 0) {
         if (w->cb)
             w->cb (w->cb_arg);
-        else if (w->hand.cb)
-            w->hand.cb (w->hand.h, w->hand.mh, w->hand.msg, w->hand.arg);
+        else if (w->mcb)
+            msg_cb_handler_call (w->mcb);
         wait_destroy (w);
     }
 }
@@ -202,7 +192,11 @@ int wait_destroy_msg (waitqueue_t *q, wait_test_msg_f cb, void *arg)
 
     w = zlist_first (q->q);
     while (w) {
-        if (w->hand.msg && cb != NULL && cb (w->hand.msg, arg)) {
+        const flux_msg_t *msgcpy = NULL;
+
+        if (w->mcb)
+            msgcpy = msg_cb_handler_get_msgcopy (w->mcb);
+        if (msgcpy && cb != NULL && cb (msgcpy, arg)) {
             if (!tmp && !(tmp = zlist_new ())) {
                 saved_errno = ENOMEM;
                 goto error;
@@ -211,7 +205,9 @@ int wait_destroy_msg (waitqueue_t *q, wait_test_msg_f cb, void *arg)
                 saved_errno = ENOMEM;
                 goto error;
             }
-            w->hand.cb = NULL; // prevent wait_runone from restarting handler
+            /* prevent wait_runone from restarting handler by clearing
+             * callback function */
+            msg_cb_handler_set_cb (w->mcb, NULL);
             count++;
         }
         w = zlist_next (q->q);

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -55,7 +55,7 @@ int wait_runqueue (waitqueue_t *q);
  * The message handler will be reinvoked once the wait_t usecount reaches zero.
  * Message will be copied and destroyed with the wait_t.
  */
-wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *w,
+wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *mh,
                                  const flux_msg_t *msg, void *arg,
                                  flux_msg_handler_f cb);
 

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -56,8 +56,8 @@ int wait_runqueue (waitqueue_t *q);
  * Message will be copied and destroyed with the wait_t.
  */
 wait_t *wait_create_msg_handler (flux_t *h, flux_msg_handler_t *w,
-                                 const flux_msg_t *msg,
-                                 flux_msg_handler_f cb, void *arg);
+                                 const flux_msg_t *msg, void *arg,
+                                 flux_msg_handler_f cb);
 
 /* Destroy all wait_t's fitting message match critieria, tested with
  * wait_test_msg_f callback.


### PR DESCRIPTION
Per discussion in #1197, make ```getroot()``` call asynchronous.

In this PR, a ```struct getroot_handler``` was added to handle information needed in getroot continuation calls.  Two design notes on this:

1) The getroot call is needed in kvs.get, kvs.watch, kvs.sync, and kvs.fence.  This collection of request handlers were different enough from each other that it seemed more work than would be reasonable to place the getroot call within the lookup interface, commit interface, and whatever I would do for kvs.sync.  So I elected to handle getroot asynchronous-ness outside of those interfaces.

2) This getroot handler code is 90% similar to what is in ```waitqueue.c``` code.  But b/c of the abstraction of ```wait_t```, I couldn't quite exploit using it.  Refactoring a common "callback handler" set of functions could be done, but I punted on this for the time being.
