### PR TITLE
kvs: refactor with internal kvsroot file

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -43,7 +43,8 @@ TESTS = \
 	test_fence.t \
 	test_commit.t \
 	test_kvs_util.t \
-	test_msg_cb_handler.t
+	test_msg_cb_handler.t \
+	test_kvsroot.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
@@ -118,4 +119,16 @@ test_msg_cb_handler_t_SOURCES = test/msg_cb_handler.c
 test_msg_cb_handler_t_CPPFLAGS = $(test_cppflags)
 test_msg_cb_handler_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
+	$(test_ldadd)
+
+test_kvsroot_t_SOURCES = test/kvsroot.c
+test_kvsroot_t_CPPFLAGS = $(test_cppflags)
+test_kvsroot_t_LDADD = \
+	$(top_builddir)/src/modules/kvs/kvsroot.o \
+	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/commit.o \
+	$(top_builddir)/src/modules/kvs/cache.o \
+	$(top_builddir)/src/modules/kvs/fence.o \
+	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
+	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -26,7 +26,9 @@ kvs_la_SOURCES = \
 	commit.h \
 	commit.c \
 	msg_cb_handler.h \
-	msg_cb_handler.c
+	msg_cb_handler.c \
+	kvsroot.h \
+	kvsroot.c
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2126,7 +2126,7 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
         goto done;
 
     /* if no roots are initialized, respond with all zeroes as stats */
-    if (zhash_size (ctx->km->roothash)) {
+    if (kvsroot_mgr_root_count (ctx->km) > 0) {
         if (cache_get_stats (ctx->cache, &ts, &size, &incomplete, &dirty) < 0)
             goto done;
     }
@@ -2156,7 +2156,7 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
         goto done;
     }
 
-    if (zhash_size (ctx->km->roothash)) {
+    if (kvsroot_mgr_root_count (ctx->km) > 0) {
         if (kvsroot_iter (ctx->km->roothash, stats_get_root_cb, nsstats) < 0) {
             flux_log_error (h, "%s: kvsroot_iter", __FUNCTION__);
             goto done;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -147,7 +147,7 @@ static kvs_ctx_t *getctx (flux_t *h)
             saved_errno = ENOMEM;
             goto error;
         }
-        if (!(ctx->km = kvsroot_mgr_create ())) {
+        if (!(ctx->km = kvsroot_mgr_create (ctx->h, ctx))) {
             saved_errno = ENOMEM;
             goto error;
         }
@@ -346,9 +346,7 @@ static void getroot_completion (flux_future_t *f, void *arg)
                                               ctx->cache,
                                               ctx->hash_name,
                                               namespace,
-                                              flags,
-                                              ctx->h,
-                                              ctx))) {
+                                              flags))) {
             flux_log_error (ctx->h, "%s: kvsroot_mgr_create_root", __FUNCTION__);
             goto error;
         }
@@ -2249,9 +2247,7 @@ static int namespace_create (kvs_ctx_t *ctx, const char *namespace, int flags)
                                           ctx->cache,
                                           ctx->hash_name,
                                           namespace,
-                                          flags,
-                                          ctx->h,
-                                          ctx))) {
+                                          flags))) {
         flux_log_error (ctx->h, "%s: kvsroot_mgr_create_root", __FUNCTION__);
         goto cleanup;
     }
@@ -2582,9 +2578,7 @@ int mod_main (flux_t *h, int argc, char **argv)
                                                   ctx->cache,
                                                   ctx->hash_name,
                                                   KVS_PRIMARY_NAMESPACE,
-                                                  0,
-                                                  ctx->h,
-                                                  ctx))) {
+                                                  0))) {
                 flux_log_error (h, "kvsroot_mgr_create_root");
                 goto done;
             }

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -1,0 +1,138 @@
+/*****************************************************************************\
+ *  Copyright (c) 2015 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <czmq.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "kvsroot.h"
+
+static void destroy_root (void *data)
+{
+    if (data) {
+        struct kvsroot *root = data;
+        if (root->namespace)
+            free (root->namespace);
+        if (root->cm)
+            commit_mgr_destroy (root->cm);
+        if (root->watchlist)
+            wait_queue_destroy (root->watchlist);
+        free (data);
+    }
+}
+
+void remove_root (zhash_t *roothash, const char *namespace)
+{
+    zhash_delete (roothash, namespace);
+}
+
+struct kvsroot *lookup_root (zhash_t *roothash, const char *namespace)
+{
+    return zhash_lookup (roothash, namespace);
+}
+
+struct kvsroot *lookup_root_safe (zhash_t *roothash, const char *namespace)
+{
+    struct kvsroot *root;
+
+    if ((root = lookup_root (roothash, namespace))) {
+        if (root->remove)
+            root = NULL;
+    }
+    return root;
+}
+
+struct kvsroot *create_root (zhash_t *roothash,
+                             struct cache *cache,
+                             const char *hash_name,
+                             const char *namespace,
+                             int flags,
+                             flux_t *h,
+                             void *arg)
+{
+    struct kvsroot *root;
+    int save_errnum;
+
+    if (!(root = calloc (1, sizeof (*root)))) {
+        flux_log_error (h, "calloc");
+        return NULL;
+    }
+
+    if (!(root->namespace = strdup (namespace))) {
+        flux_log_error (h, "strdup");
+        goto error;
+    }
+
+    if (!(root->cm = commit_mgr_create (cache,
+                                        root->namespace,
+                                        hash_name,
+                                        h,
+                                        arg))) {
+        flux_log_error (h, "commit_mgr_create");
+        goto error;
+    }
+
+    if (!(root->watchlist = wait_queue_create ())) {
+        flux_log_error (h, "wait_queue_create");
+        goto error;
+    }
+
+    root->flags = flags;
+    root->remove = false;
+
+    if (zhash_insert (roothash, namespace, root) < 0) {
+        flux_log_error (h, "zhash_insert");
+        goto error;
+    }
+
+    if (!zhash_freefn (roothash, namespace, destroy_root)) {
+        flux_log_error (h, "zhash_freefn");
+        save_errnum = errno;
+        zhash_delete (roothash, namespace);
+        errno = save_errnum;
+        goto error;
+    }
+
+    return root;
+
+ error:
+    save_errnum = errno;
+    destroy_root (root);
+    errno = save_errnum;
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -38,6 +38,36 @@
 
 #include "kvsroot.h"
 
+kvsroot_mgr_t *kvsroot_mgr_create (void)
+{
+    kvsroot_mgr_t *km = NULL;
+    int saved_errno;
+
+    if (!(km = calloc (1, sizeof (*km)))) {
+        saved_errno = ENOMEM;
+        goto error;
+    }
+    if (!(km->roothash = zhash_new ())) {
+        saved_errno = ENOMEM;
+        goto error;
+    }
+    return km;
+
+ error:
+    kvsroot_mgr_destroy (km);
+    errno = saved_errno;
+    return NULL;
+}
+
+void kvsroot_mgr_destroy (kvsroot_mgr_t *km)
+{
+    if (km) {
+        if (km->roothash)
+            zhash_destroy (&km->roothash);
+        free (km);
+    }
+}
+
 static void kvsroot_destroy (void *data)
 {
     if (data) {

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -68,6 +68,11 @@ void kvsroot_mgr_destroy (kvsroot_mgr_t *km)
     }
 }
 
+int kvsroot_mgr_root_count (kvsroot_mgr_t *km)
+{
+    return zhash_size (km->roothash);
+}
+
 static void kvsroot_destroy (void *data)
 {
     if (data) {

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -163,6 +163,26 @@ struct kvsroot *kvsroot_create (zhash_t *roothash,
     return NULL;
 }
 
+int kvsroot_iter (zhash_t *roothash, kvsroot_root_f cb, void *arg)
+{
+    struct kvsroot *root;
+
+    root = zhash_first (roothash);
+    while (root) {
+        int ret;
+
+        if ((ret = cb (root, arg)) < 0)
+            return -1;
+
+        if (ret == 1)
+            break;
+
+        root = zhash_next (roothash);
+    }
+
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -38,7 +38,7 @@
 
 #include "kvsroot.h"
 
-static void destroy_root (void *data)
+static void kvsroot_destroy (void *data)
 {
     if (data) {
         struct kvsroot *root = data;
@@ -52,34 +52,34 @@ static void destroy_root (void *data)
     }
 }
 
-void remove_root (zhash_t *roothash, const char *namespace)
+void kvsroot_remove (zhash_t *roothash, const char *namespace)
 {
     zhash_delete (roothash, namespace);
 }
 
-struct kvsroot *lookup_root (zhash_t *roothash, const char *namespace)
+struct kvsroot *kvsroot_lookup (zhash_t *roothash, const char *namespace)
 {
     return zhash_lookup (roothash, namespace);
 }
 
-struct kvsroot *lookup_root_safe (zhash_t *roothash, const char *namespace)
+struct kvsroot *kvsroot_lookup_safe (zhash_t *roothash, const char *namespace)
 {
     struct kvsroot *root;
 
-    if ((root = lookup_root (roothash, namespace))) {
+    if ((root = kvsroot_lookup (roothash, namespace))) {
         if (root->remove)
             root = NULL;
     }
     return root;
 }
 
-struct kvsroot *create_root (zhash_t *roothash,
-                             struct cache *cache,
-                             const char *hash_name,
-                             const char *namespace,
-                             int flags,
-                             flux_t *h,
-                             void *arg)
+struct kvsroot *kvsroot_create (zhash_t *roothash,
+                                struct cache *cache,
+                                const char *hash_name,
+                                const char *namespace,
+                                int flags,
+                                flux_t *h,
+                                void *arg)
 {
     struct kvsroot *root;
     int save_errnum;
@@ -116,7 +116,7 @@ struct kvsroot *create_root (zhash_t *roothash,
         goto error;
     }
 
-    if (!zhash_freefn (roothash, namespace, destroy_root)) {
+    if (!zhash_freefn (roothash, namespace, kvsroot_destroy)) {
         flux_log_error (h, "zhash_freefn");
         save_errnum = errno;
         zhash_delete (roothash, namespace);
@@ -128,7 +128,7 @@ struct kvsroot *create_root (zhash_t *roothash,
 
  error:
     save_errnum = errno;
-    destroy_root (root);
+    kvsroot_destroy (root);
     errno = save_errnum;
     return NULL;
 }

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -10,6 +10,12 @@
 #include "waitqueue.h"
 #include "src/common/libutil/blobref.h"
 
+struct kvsroot_mgr {
+    zhash_t *roothash;
+};
+
+typedef struct kvsroot_mgr kvsroot_mgr_t;
+
 struct kvsroot {
     char *namespace;
     int seq;
@@ -20,6 +26,10 @@ struct kvsroot {
     int flags;
     bool remove;
 };
+
+kvsroot_mgr_t *kvsroot_mgr_create (void);
+
+void kvsroot_mgr_destroy (kvsroot_mgr_t *km);
 
 void kvsroot_remove (zhash_t *roothash, const char *namespace);
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -27,6 +27,9 @@ struct kvsroot {
     bool remove;
 };
 
+/* return -1 on error, 0 on success, 1 on success & to stop iterating */
+typedef int (*kvsroot_root_f)(struct kvsroot *root, void *arg);
+
 kvsroot_mgr_t *kvsroot_mgr_create (void);
 
 void kvsroot_mgr_destroy (kvsroot_mgr_t *km);
@@ -47,6 +50,8 @@ struct kvsroot *kvsroot_create (zhash_t *roothash,
                                 int flags,
                                 flux_t *h,
                                 void *arg);
+
+int kvsroot_iter (zhash_t *roothash, kvsroot_root_f cb, void *arg);
 
 #endif /* !_FLUX_KVS_KVSROOT_H */
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -34,6 +34,8 @@ kvsroot_mgr_t *kvsroot_mgr_create (void);
 
 void kvsroot_mgr_destroy (kvsroot_mgr_t *km);
 
+int kvsroot_mgr_root_count (kvsroot_mgr_t *km);
+
 void kvsroot_remove (zhash_t *roothash, const char *namespace);
 
 /* returns NULL if not found */

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -39,7 +39,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
                                          const char *namespace,
                                          int flags);
 
-void kvsroot_mgr_remove_root (kvsroot_mgr_t *km, const char *namespace);
+int kvsroot_mgr_remove_root (kvsroot_mgr_t *km, const char *namespace);
 
 /* returns NULL if not found */
 struct kvsroot *kvsroot_mgr_lookup_root (kvsroot_mgr_t *km,

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -25,7 +25,9 @@ struct kvsroot {
 /* return -1 on error, 0 on success, 1 on success & to stop iterating */
 typedef int (*kvsroot_root_f)(struct kvsroot *root, void *arg);
 
-kvsroot_mgr_t *kvsroot_mgr_create (void);
+/* flux_t optional, if NULL logging will go to stderr */
+/* void *arg passed as arg value to commit_mgr_create() internally */
+kvsroot_mgr_t *kvsroot_mgr_create (flux_t *h, void *arg);
 
 void kvsroot_mgr_destroy (kvsroot_mgr_t *km);
 
@@ -35,9 +37,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
                                          struct cache *cache,
                                          const char *hash_name,
                                          const char *namespace,
-                                         int flags,
-                                         flux_t *h,
-                                         void *arg);
+                                         int flags);
 
 void kvsroot_mgr_remove_root (kvsroot_mgr_t *km, const char *namespace);
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -21,22 +21,22 @@ struct kvsroot {
     bool remove;
 };
 
-void remove_root (zhash_t *roothash, const char *namespace);
+void kvsroot_remove (zhash_t *roothash, const char *namespace);
 
 /* returns NULL if not found */
-struct kvsroot *lookup_root (zhash_t *roothash, const char *namespace);
+struct kvsroot *kvsroot_lookup (zhash_t *roothash, const char *namespace);
 
 /* safe lookup, will return NULL if root in process of being removed,
  * i.e. remove flag set to true */
-struct kvsroot *lookup_root_safe (zhash_t *roothash, const char *namespace);
+struct kvsroot *kvsroot_lookup_safe (zhash_t *roothash, const char *namespace);
 
-struct kvsroot *create_root (zhash_t *roothash,
-                             struct cache *cache,
-                             const char *hash_name,
-                             const char *namespace,
-                             int flags,
-                             flux_t *h,
-                             void *arg);
+struct kvsroot *kvsroot_create (zhash_t *roothash,
+                                struct cache *cache,
+                                const char *hash_name,
+                                const char *namespace,
+                                int flags,
+                                flux_t *h,
+                                void *arg);
 
 #endif /* !_FLUX_KVS_KVSROOT_H */
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -3,16 +3,11 @@
 
 #include <stdbool.h>
 #include <flux/core.h>
-#include <czmq.h>
 
 #include "cache.h"
 #include "commit.h"
 #include "waitqueue.h"
 #include "src/common/libutil/blobref.h"
-
-struct kvsroot_mgr {
-    zhash_t *roothash;
-};
 
 typedef struct kvsroot_mgr kvsroot_mgr_t;
 
@@ -36,24 +31,26 @@ void kvsroot_mgr_destroy (kvsroot_mgr_t *km);
 
 int kvsroot_mgr_root_count (kvsroot_mgr_t *km);
 
-void kvsroot_remove (zhash_t *roothash, const char *namespace);
+struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
+                                         struct cache *cache,
+                                         const char *hash_name,
+                                         const char *namespace,
+                                         int flags,
+                                         flux_t *h,
+                                         void *arg);
+
+void kvsroot_mgr_remove_root (kvsroot_mgr_t *km, const char *namespace);
 
 /* returns NULL if not found */
-struct kvsroot *kvsroot_lookup (zhash_t *roothash, const char *namespace);
+struct kvsroot *kvsroot_mgr_lookup_root (kvsroot_mgr_t *km,
+                                         const char *namespace);
 
 /* safe lookup, will return NULL if root in process of being removed,
  * i.e. remove flag set to true */
-struct kvsroot *kvsroot_lookup_safe (zhash_t *roothash, const char *namespace);
+struct kvsroot *kvsroot_mgr_lookup_root_safe (kvsroot_mgr_t *km,
+                                              const char *namespace);
 
-struct kvsroot *kvsroot_create (zhash_t *roothash,
-                                struct cache *cache,
-                                const char *hash_name,
-                                const char *namespace,
-                                int flags,
-                                flux_t *h,
-                                void *arg);
-
-int kvsroot_iter (zhash_t *roothash, kvsroot_root_f cb, void *arg);
+int kvsroot_mgr_iter_roots (kvsroot_mgr_t *km, kvsroot_root_f cb, void *arg);
 
 #endif /* !_FLUX_KVS_KVSROOT_H */
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -1,0 +1,45 @@
+#ifndef _FLUX_KVS_KVSROOT_H
+#define _FLUX_KVS_KVSROOT_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "cache.h"
+#include "commit.h"
+#include "waitqueue.h"
+#include "src/common/libutil/blobref.h"
+
+struct kvsroot {
+    char *namespace;
+    int seq;
+    blobref_t ref;
+    commit_mgr_t *cm;
+    waitqueue_t *watchlist;
+    int watchlist_lastrun_epoch;
+    int flags;
+    bool remove;
+};
+
+void remove_root (zhash_t *roothash, const char *namespace);
+
+/* returns NULL if not found */
+struct kvsroot *lookup_root (zhash_t *roothash, const char *namespace);
+
+/* safe lookup, will return NULL if root in process of being removed,
+ * i.e. remove flag set to true */
+struct kvsroot *lookup_root_safe (zhash_t *roothash, const char *namespace);
+
+struct kvsroot *create_root (zhash_t *roothash,
+                             struct cache *cache,
+                             const char *hash_name,
+                             const char *namespace,
+                             int flags,
+                             flux_t *h,
+                             void *arg);
+
+#endif /* !_FLUX_KVS_KVSROOT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -1,0 +1,227 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libkvs/kvs.h"
+#include "src/modules/kvs/kvsroot.h"
+#include "src/modules/kvs/fence.h"
+
+int global = 0;
+
+void basic_api_tests (void)
+{
+    kvsroot_mgr_t *km;
+    struct cache *cache;
+    struct kvsroot *root;
+    struct kvsroot *tmproot;
+
+    cache = cache_create ();
+
+    ok ((km = kvsroot_mgr_create (NULL, &global)) != NULL,
+        "kvsroot_mgr_create works");
+
+    ok (kvsroot_mgr_root_count (km) == 0,
+        "kvsroot_mgr_root_count returns correct count of roots");
+
+    ok ((root = kvsroot_mgr_create_root (km,
+                                         cache,
+                                         "sha1",
+                                         KVS_PRIMARY_NAMESPACE,
+                                         0)) != NULL,
+         "kvsroot_mgr_create_root works");
+
+    ok (kvsroot_mgr_root_count (km) == 1,
+        "kvsroot_mgr_root_count returns correct count of roots");
+
+    ok ((tmproot = kvsroot_mgr_lookup_root (km, KVS_PRIMARY_NAMESPACE)) != NULL,
+        "kvsroot_mgr_lookup_root works");
+
+    ok (tmproot == root,
+        "kvsroot_mgr_lookup_root returns correct root");
+
+    ok ((tmproot = kvsroot_mgr_lookup_root_safe (km, KVS_PRIMARY_NAMESPACE)) != NULL,
+        "kvsroot_mgr_lookup_root_safe works");
+
+    ok (tmproot == root,
+        "kvsroot_mgr_lookup_root_safe returns correct root");
+
+    root->remove = true;
+
+    ok ((tmproot = kvsroot_mgr_lookup_root (km, KVS_PRIMARY_NAMESPACE)) != NULL,
+        "kvsroot_mgr_lookup_root works");
+
+    ok (tmproot == root,
+        "kvsroot_mgr_lookup_root returns correct root");
+
+    ok (kvsroot_mgr_lookup_root_safe (km, KVS_PRIMARY_NAMESPACE) == NULL,
+        "kvsroot_mgr_lookup_root_safe returns NULL on root marked removed");
+
+    ok (kvsroot_mgr_remove_root (km, KVS_PRIMARY_NAMESPACE) == 0,
+        "kvsroot_mgr_remove_root works");
+
+    ok (kvsroot_mgr_lookup_root (km, KVS_PRIMARY_NAMESPACE) == NULL,
+        "kvsroot_mgr_lookup_root returns NULL after namespace removed");
+
+    ok (kvsroot_mgr_lookup_root_safe (km, KVS_PRIMARY_NAMESPACE) == NULL,
+        "kvsroot_mgr_lookup_root_safe returns NULL after namespace removed");
+
+    kvsroot_mgr_destroy (km);
+
+    /* destroy works with NULL */
+    kvsroot_mgr_destroy (NULL);
+
+    cache_destroy (cache);
+}
+
+int count_roots_cb (struct kvsroot *root, void *arg)
+{
+    int *count = arg;
+    (*count)++;
+    return 0;
+}
+
+int count_roots_early_exit_cb (struct kvsroot *root, void *arg)
+{
+    int *count = arg;
+    (*count)++;
+    return 1;
+}
+
+int roots_error_cb (struct kvsroot *root, void *arg)
+{
+    return -1;
+}
+
+
+int roots_remove_cb (struct kvsroot *root, void *arg)
+{
+    kvsroot_mgr_t *km = arg;
+    kvsroot_mgr_remove_root (km, root->namespace);
+    return 1;
+}
+
+void basic_iter_tests (void)
+{
+    kvsroot_mgr_t *km;
+    struct cache *cache;
+    struct kvsroot *root;
+    int count;
+
+    cache = cache_create ();
+
+    ok ((km = kvsroot_mgr_create (NULL, &global)) != NULL,
+        "kvsroot_mgr_create works");
+
+    ok ((root = kvsroot_mgr_create_root (km,
+                                         cache,
+                                         "sha1",
+                                         "foo",
+                                         0)) != NULL,
+         "kvsroot_mgr_create_root works");
+
+    ok ((root = kvsroot_mgr_create_root (km,
+                                         cache,
+                                         "sha1",
+                                         "bar",
+                                         0)) != NULL,
+         "kvsroot_mgr_create_root works");
+
+    ok (kvsroot_mgr_root_count (km) == 2,
+        "kvsroot_mgr_root_count returns correct count of roots");
+
+    count = 0;
+    ok (kvsroot_mgr_iter_roots (km, count_roots_cb, &count) == 0,
+        "kvsroot_mgr_iter_roots works");
+
+    ok (count == 2,
+        "kvsroot_mgr_iter_roots called callback correct number of times");
+
+    count = 0;
+    ok (kvsroot_mgr_iter_roots (km, count_roots_early_exit_cb, &count) == 0,
+        "kvsroot_mgr_iter_roots works if exitting midway");
+
+    ok (count == 1,
+        "kvsroot_mgr_iter_roots called callback correct number of times");
+
+    ok (kvsroot_mgr_iter_roots (km, roots_error_cb, NULL) < 0,
+        "kvsroot_mgr_iter_roots errors on error in callback");
+
+    ok (kvsroot_mgr_iter_roots (km, roots_remove_cb, km) == 0,
+        "kvsroot_mgr_iter_roots works on remove callback");
+
+    ok (kvsroot_mgr_root_count (km) == 1,
+        "kvsroot_mgr_root_count returns correct count of roots after a removal");
+
+    kvsroot_mgr_destroy (km);
+    cache_destroy (cache);
+}
+
+void basic_commit_mgr_tests (void)
+{
+    kvsroot_mgr_t *km;
+    struct cache *cache;
+    struct kvsroot *root;
+    commit_t *c;
+    fence_t *f;
+    json_t *ops = NULL;
+    void *tmpaux;
+
+    cache = cache_create ();
+
+    f = fence_create ("foo", 1, 0);
+    ops = json_array ();
+    /* not a real operation */
+    json_array_append_new (ops, json_string ("foo"));
+
+    fence_add_request_data (f, ops);
+
+    json_decref (ops);
+
+    ok ((km = kvsroot_mgr_create (NULL, &global)) != NULL,
+        "kvsroot_mgr_create works");
+
+    ok ((root = kvsroot_mgr_create_root (km,
+                                         cache,
+                                         "sha1",
+                                         KVS_PRIMARY_NAMESPACE,
+                                         0)) != NULL,
+         "kvsroot_mgr_create_root works");
+
+    ok (commit_mgr_add_fence (root->cm, f) == 0,
+        "commit_mgr_add_fence works");
+
+    ok (commit_mgr_process_fence_request (root->cm, "foo") == 0,
+        "commit_mgr_process_fence_request works");
+
+    ok ((c = commit_mgr_get_ready_commit (root->cm)) != NULL,
+        "commit_mgr_get_ready_commit returns ready commit");
+
+    ok ((tmpaux = commit_get_aux (c)) != NULL,
+        "commit_get_aux returns non-NULL aux");
+
+    ok (tmpaux == &global,
+        "commit_get_aux returns correct aux value");
+
+    kvsroot_mgr_destroy (km);
+    cache_destroy (cache);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic_api_tests ();
+    basic_iter_tests ();
+    basic_commit_mgr_tests ();
+
+    done_testing ();
+    return (0);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This branch isn't ready for merging (need to add documentation & unit tests) but thought I'd push to ask for comments.

I had originally gone down the path of abstracting the kvsroot way more than what is done in this PR.  But as I was refactoring, it became clear abstracting ```struct kvsroot``` was creating a complex and probably unnecessary level of abstraction.

For example, abstracting ```start_root_remove()``` in ```kvs.c```.  It's a good idea to want to abstract it away, but its difficult to abstract away the cleanup of fences sitting in the commit manager.  Do we ask the user to pass in a callback function to deal with the cleanup of fences?  We aren't abstracting very well if we're asking the user for that.

I briefly considered moving everything related to commits into ```kvsroot.c```, but seemed like too much.  So I think other refactoring needs to be done before moving onto refactoring kvsroot more.  Some thoughts for the future.

- rethink how fences are cleaned up in its entirety (i.e. lookup stored msg copies based on name maybe not best).  Perhaps some callback mechanism would work (i.e. when fence deleted, callback something to complete it.)
- rethink entire abstraction of "fences" in ```fence.[ch]```.  Perhaps everything should be collapsed into the commit manager in some way.
