### PR TITLE
kvs: support non-instance owners of namespaces

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -55,8 +55,10 @@ arguments are described below.
 
 COMMANDS
 --------
-*namespace-create* 'name' ['name...']::
-Create a new kvs namespace.
+*namespace-create* [-o owner] 'name' ['name...']::
+Create a new kvs namespace.  User may specify an alternate userid of a
+user that owns the namespace via '-o'.  Specifying an alternate owner
+would allow a non-instance owner to read/write to a namespace.
 
 *namespace-remove* 'name' ['name...']::
 Remove a kvs namespace.

--- a/doc/man3/flux_kvs_namespace_create.adoc
+++ b/doc/man3/flux_kvs_namespace_create.adoc
@@ -14,6 +14,7 @@ SYNOPSIS
 
  flux_future_t *flux_kvs_namespace_create (flux_t *h,
                                            const char *namespace,
+                                           uint32_t owner,
                                            int flags);
 
  flux_future_t *flux_kvs_namespace_remove (flux_t *h,
@@ -24,7 +25,9 @@ DESCRIPTION
 
 `flux_kvs_namespace_create()` creates a KVS namespace.  Within a
 namespace, users can get/put KVS values completely independent of
-other KVS namespaces.
+other KVS namespaces.  An owner of the namespace other than the
+instance owner can be chosen by setting _owner_.  Otherwise, _owner_
+can be set to FLUX_USERID_UNKNOWN.
 
 `flux_kvs_namespace_remove()` removes a KVS namespace.
 

--- a/src/cmd/builtin/user.c
+++ b/src/cmd/builtin/user.c
@@ -225,6 +225,7 @@ static int internal_user_lookup (optparse_t *p, int ac, char *av[])
         exit (1);
     }
     userid = strtoul (av[n], &endptr, 10);
+
     if (*endptr != '\0')
         userid = lookup_user (av[n]);
     if (userid == FLUX_USERID_UNKNOWN)

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -60,6 +60,13 @@ static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,
 
 #define min(a,b) ((a)<(b)?(a):(b))
 
+static struct optparse_option namespace_create_opts[] =  {
+    { .name = "owner", .key = 'o', .has_arg = 1,
+      .usage = "Specify alternate namespace owner via userid",
+    },
+    OPTPARSE_TABLE_END
+};
+
 static struct optparse_option readlink_opts[] =  {
     { .name = "at", .key = 'a', .has_arg = 1,
       .usage = "Lookup relative to RFC 11 snapshot reference",
@@ -176,7 +183,7 @@ static struct optparse_subcommand subcommands[] = {
       "Create a KVS namespace",
       cmd_namespace_create,
       0,
-      NULL
+      namespace_create_opts
     },
     { "namespace-remove",
       "name [name...]",
@@ -355,17 +362,26 @@ int cmd_namespace_create (optparse_t *p, int argc, char **argv)
     flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
     flux_future_t *f;
     int optindex, i;
+    uint32_t owner = FLUX_USERID_UNKNOWN;
+    const char *str;
 
     optindex = optparse_option_index (p);
     if ((optindex - argc) == 0) {
         optparse_print_usage (p);
         exit (1);
     }
+
+    if ((str = optparse_get_str (p, "owner", NULL))) {
+        char *endptr;
+        owner = strtoul (str, &endptr, 10);
+        if (*endptr != '\0')
+            log_err_exit ("--owner requires an unsigned integer argument");
+    }
+
     for (i = optindex; i < argc; i++) {
         const char *name = argv[i];
         int flags = 0;
-        if (!(f = flux_kvs_namespace_create (h, name, FLUX_USERID_UNKNOWN,
-                                             flags))
+        if (!(f = flux_kvs_namespace_create (h, name, owner, flags))
             || flux_future_get (f, NULL) < 0)
             log_err_exit ("%s", name);
         flux_future_destroy (f);

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -364,7 +364,8 @@ int cmd_namespace_create (optparse_t *p, int argc, char **argv)
     for (i = optindex; i < argc; i++) {
         const char *name = argv[i];
         int flags = 0;
-        if (!(f = flux_kvs_namespace_create (h, name, flags))
+        if (!(f = flux_kvs_namespace_create (h, name, FLUX_USERID_UNKNOWN,
+                                             flags))
             || flux_future_get (f, NULL) < 0)
             log_err_exit ("%s", name);
         flux_future_destroy (f);

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -25,6 +25,8 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <unistd.h>
+
 #include <flux/core.h>
 
 const char *get_kvs_namespace (void)
@@ -42,9 +44,11 @@ flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
         return NULL;
     }
 
+    /* N.B. uid cast to int */
     return flux_rpc_pack (h, "kvs.namespace.create", 0, 0,
-                          "{ s:s s:i }",
+                          "{ s:s s:i s:i }",
                           "namespace", namespace,
+                          "owner", geteuid (),
                           "flags", flags);
 }
 

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -37,18 +37,18 @@ const char *get_kvs_namespace (void)
 }
 
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
-                                          int flags)
+                                          uint32_t owner, int flags)
 {
     if (!namespace || flags) {
         errno = EINVAL;
         return NULL;
     }
 
-    /* N.B. uid cast to int */
+    /* N.B. owner cast to int */
     return flux_rpc_pack (h, "kvs.namespace.create", 0, 0,
                           "{ s:s s:i s:i }",
                           "namespace", namespace,
-                          "owner", geteuid (),
+                          "owner", owner,
                           "flags", flags);
 }
 

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -33,7 +33,7 @@ enum {
  *   consistent".
  */
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
-                                          int flags);
+                                          uint32_t owner, int flags);
 flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *namespace);
 
 /* Synchronization:

--- a/src/common/libkvs/test/kvs.c
+++ b/src/common/libkvs/test/kvs.c
@@ -15,7 +15,7 @@ void errors (void)
     /* check simple error cases */
 
     errno = 0;
-    ok (flux_kvs_namespace_create (NULL, NULL, 5) == NULL && errno == EINVAL,
+    ok (flux_kvs_namespace_create (NULL, NULL, 0, 5) == NULL && errno == EINVAL,
         "flux_kvs_namespace_create fails on bad input");
 
     errno = 0;

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -108,6 +108,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
                                          struct cache *cache,
                                          const char *hash_name,
                                          const char *namespace,
+                                         uint32_t owner,
                                          int flags)
 {
     struct kvsroot *root;
@@ -143,6 +144,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
         goto error;
     }
 
+    root->owner = owner;
     root->flags = flags;
     root->remove = false;
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -13,6 +13,7 @@ typedef struct kvsroot_mgr kvsroot_mgr_t;
 
 struct kvsroot {
     char *namespace;
+    uint32_t owner;
     int seq;
     blobref_t ref;
     commit_mgr_t *cm;
@@ -37,6 +38,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
                                          struct cache *cache,
                                          const char *hash_name,
                                          const char *namespace,
+                                         uint32_t owner,
                                          int flags);
 
 int kvsroot_mgr_remove_root (kvsroot_mgr_t *km, const char *namespace);

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -2,6 +2,7 @@
 #include "config.h"
 #endif
 #include <stdbool.h>
+#include <unistd.h>
 #include <jansson.h>
 
 #include "src/common/libtap/tap.h"
@@ -30,6 +31,7 @@ void basic_api_tests (void)
                                          cache,
                                          "sha1",
                                          KVS_PRIMARY_NAMESPACE,
+                                         geteuid (),
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 
@@ -119,6 +121,7 @@ void basic_iter_tests (void)
                                          cache,
                                          "sha1",
                                          "foo",
+                                         geteuid (),
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 
@@ -126,6 +129,7 @@ void basic_iter_tests (void)
                                          cache,
                                          "sha1",
                                          "bar",
+                                         geteuid (),
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 
@@ -187,6 +191,7 @@ void basic_commit_mgr_tests (void)
                                          cache,
                                          "sha1",
                                          KVS_PRIMARY_NAMESPACE,
+                                         geteuid (),
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -53,6 +53,7 @@ TESTS = \
 	t1002-kvs-watch.t \
 	t1003-kvs-stress.t \
 	t1004-kvs-namespace.t \
+	t1005-kvs-security.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -127,6 +128,7 @@ check_SCRIPTS = \
 	t1002-kvs-watch.t \
 	t1003-kvs-stress.t \
 	t1004-kvs-namespace.t \
+	t1005-kvs-security.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -1,0 +1,398 @@
+#!/bin/sh
+
+test_description='Test flux-kvs and kvs in flux session
+
+These are tests for ensuring multiple namespaces work.
+'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE} kvs
+echo "# $0: flux session size will be ${SIZE}"
+
+DIR=test.a.b
+
+# Just in case its set in the environment
+unset FLUX_KVS_NAMESPACE
+
+NAMESPACETMP=namespacetmp
+
+test_kvs_key_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs get --json "$2" >output
+	echo "$3" >expected
+        unset FLUX_KVS_NAMESPACE
+	test_cmp expected output
+}
+
+put_kvs_key_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs put --json "$2=$3"
+        unset FLUX_KVS_NAMESPACE
+}
+
+unlink_kvs_dir_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+        flux kvs unlink -Rf $2
+        unset FLUX_KVS_NAMESPACE
+}
+
+version_kvs_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+        version=`flux kvs version`
+        eval $2=$version
+        unset FLUX_KVS_NAMESPACE
+}
+
+put_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs put --json "$2=$3"
+        eval $4="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+get_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs get --json "$2"
+        eval $3="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+watch_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs watch -o -c 1 "$2"
+        eval $3="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+version_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs version
+        eval $2="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+wait_kvs_namespace_exitvalue() {
+        export FLUX_KVS_NAMESPACE=$1
+	flux kvs wait $2
+        eval $3="$?"
+        unset FLUX_KVS_NAMESPACE
+}
+
+wait_watch_put_namespace() {
+        export FLUX_KVS_NAMESPACE=$1
+        wait_watch_put $2 $3
+        exitvalue=$?
+        unset FLUX_KVS_NAMESPACE
+        return $exitvalue
+}
+
+set_userid() {
+        export FLUX_HANDLE_USERID=$1
+        export FLUX_HANDLE_ROLEMASK=0x2
+}
+
+unset_userid() {
+        unset FLUX_HANDLE_USERID
+        unset FLUX_HANDLE_ROLEMASK
+}
+
+#
+# Basic tests, make sure only instance owner can perform operations
+# and non-namespace owner can't perform operations
+#
+
+test_expect_success 'kvs: namespace create fails (user)' '
+        set_userid 9999 &&
+	! flux kvs namespace-create $NAMESPACETMP-OWNER &&
+        unset_userid
+'
+
+test_expect_success 'kvs: namespace create works (owner)' '
+	flux kvs namespace-create $NAMESPACETMP-OWNER
+'
+
+test_expect_success 'kvs: put fails (user)' '
+        set_userid 9999 &&
+        put_kvs_namespace_exitvalue $NAMESPACETMP-OWNER $DIR.test 1 exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: put works (owner)' '
+        put_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.test 1 &&
+        test_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.test 1
+'
+
+test_expect_success 'kvs: get fails (user)' '
+        set_userid 9999 &&
+        get_kvs_namespace_exitvalue $NAMESPACETMP-OWNER $DIR.test exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: get fails on other ranks (user)' '
+        ! flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-OWNER \
+                                FLUX_HANDLE_USERID=9999 \
+                                FLUX_HANDLE_ROLEMASK=0x2 \
+                                flux kvs get $DIR.test"
+'
+
+test_expect_success 'kvs: get works on other ranks (owner)' '
+        flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-OWNER \
+                              flux kvs get $DIR.test"
+'
+
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
+        unlink_kvs_dir_namespace $NAMESPACETMP-OWNER $DIR &&
+        put_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.watch 0 &&
+        wait_watch_put_namespace $NAMESPACETMP-OWNER "$DIR.watch" "0"
+        rm -f watch_out
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-OWNER
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >watch_out &
+        watchpid=$! &&
+        wait_watch_file watch_out "0"
+        flux kvs put --json $DIR.watch=1 &&
+        wait $watchpid
+        unset FLUX_KVS_NAMESPACE
+cat >expected <<-EOF &&
+0
+1
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch fails (user)' '
+        set_userid 9999 &&
+        watch_kvs_namespace_exitvalue $NAMESPACETMP-OWNER $DIR.test exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: version fails (user)' '
+        set_userid 9999 &&
+        version_kvs_namespace_exitvalue $NAMESPACETMP-OWNER exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: version fails on other ranks (user)' '
+        ! flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-OWNER \
+                                FLUX_HANDLE_USERID=9999 \
+                                FLUX_HANDLE_ROLEMASK=0x2 \
+                                flux kvs version"
+'
+
+test_expect_success 'kvs: wait fails (user)' '
+        set_userid 9999 &&
+        wait_kvs_namespace_exitvalue $NAMESPACETMP-OWNER $DIR.test exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: namespace remove fails (user)' '
+        set_userid 9999 &&
+	! flux kvs namespace-remove $NAMESPACETMP-OWNER &&
+        unset_userid
+'
+
+test_expect_success 'kvs: namespace remove works (owner)' '
+        put_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.tmp 1 &&
+        test_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.tmp 1 &&
+        flux kvs namespace-remove $NAMESPACETMP-OWNER &&
+        get_kvs_namespace_exitvalue $NAMESPACETMP-OWNER $DIR.tmp exitvalue &&
+        test $exitvalue -ne 0
+'
+
+#
+# Namespace tests owned by user
+#
+
+test_expect_success 'kvs: namespace create works (owner, for user)' '
+	flux kvs namespace-create -o 9999 $NAMESPACETMP-USER
+'
+
+test_expect_success 'kvs: namespace put/get works (user)' '
+        set_userid 9999 &&
+        put_kvs_key_namespace $NAMESPACETMP-USER $DIR.test 1 &&
+        test_kvs_key_namespace $NAMESPACETMP-USER $DIR.test 1 &&
+        unset_userid
+'
+
+test_expect_success 'kvs: put/get works (owner)' '
+        put_kvs_key_namespace $NAMESPACETMP-USER $DIR.test 2 &&
+        test_kvs_key_namespace $NAMESPACETMP-USER $DIR.test 2
+'
+
+test_expect_success 'kvs: put fails (wrong user)' '
+        set_userid 9000 &&
+        put_kvs_namespace_exitvalue $NAMESPACETMP-USER $DIR.test 1 exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: get works on other ranks (user)' '
+        flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER \
+                              FLUX_HANDLE_USERID=9999 \
+                              FLUX_HANDLE_ROLEMASK=0x2 \
+                              flux kvs get $DIR.test"
+'
+
+test_expect_success 'kvs: get works on other ranks (owner)' '
+        flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER \
+                              flux kvs get $DIR.test"
+'
+
+test_expect_success 'kvs: get fails (wrong user)' '
+        set_userid 9000 &&
+        get_kvs_namespace_exitvalue $NAMESPACETMP-USER $DIR.test exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: get fails on other ranks (wrong user)' '
+        ! flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER \
+                                FLUX_HANDLE_USERID=9000 \
+                                FLUX_HANDLE_ROLEMASK=0x2 \
+                                flux kvs get $DIR.test"
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch works (user)'  '
+        set_userid 9999 &&
+        unlink_kvs_dir_namespace $NAMESPACETMP-USER $DIR &&
+        put_kvs_key_namespace $NAMESPACETMP-USER $DIR.watch 0 &&
+        wait_watch_put_namespace $NAMESPACETMP-USER "$DIR.watch" "0"
+        rm -f watch_out
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >watch_out &
+        watchpid=$! &&
+        wait_watch_file watch_out "0"
+        flux kvs put --json $DIR.watch=1 &&
+        wait $watchpid
+        unset FLUX_KVS_NAMESPACE
+        unset_userid
+cat >expected <<-EOF &&
+0
+1
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
+        unlink_kvs_dir_namespace $NAMESPACETMP-USER $DIR &&
+        put_kvs_key_namespace $NAMESPACETMP-USER $DIR.watch 0 &&
+        wait_watch_put_namespace $NAMESPACETMP-USER "$DIR.watch" "0"
+        rm -f watch_out
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER
+        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >watch_out &
+        watchpid=$! &&
+        wait_watch_file watch_out "0"
+        flux kvs put --json $DIR.watch=1 &&
+        wait $watchpid
+        unset FLUX_KVS_NAMESPACE
+cat >expected <<-EOF &&
+0
+1
+EOF
+        test_cmp watch_out expected
+'
+
+test_expect_success 'kvs: watch fails (wrong user)' '
+        set_userid 9000 &&
+        watch_kvs_namespace_exitvalue $NAMESPACETMP-USER $DIR.test exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: version & wait works (user)' '
+        set_userid 9999
+        version_kvs_namespace $NAMESPACETMP-USER VERS
+        VERS=$((VERS + 1))
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER
+        flux kvs wait $VERS &
+        kvswaitpid=$!
+        flux kvs put --json $DIR.xxx=99
+        unset FLUX_KVS_NAMESPACE
+        unset_userid
+        test_expect_code 0 wait $kvswaitpid
+'
+
+test_expect_success 'kvs: version works on other ranks (user)' '
+        flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER \
+                              FLUX_HANDLE_USERID=9999 \
+                              FLUX_HANDLE_ROLEMASK=0x2 \
+                              flux kvs version"
+'
+
+test_expect_success 'kvs: version works on other ranks (owner)' '
+        flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER \
+                              flux kvs version"
+'
+
+test_expect_success 'kvs: version fails (wrong user)' '
+        set_userid 9000 &&
+        version_kvs_namespace_exitvalue $NAMESPACETMP-USER exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: version fails on other ranks (wrong user)' '
+        ! flux exec -r 1 sh -c "FLUX_KVS_NAMESPACE=$NAMESPACETMP-USER \
+                                FLUX_HANDLE_USERID=9000 \
+                                FLUX_HANDLE_ROLEMASK=0x2 \
+                                flux kvs version"
+'
+
+test_expect_success 'kvs: wait fails (wrong user)' '
+        set_userid 9000 &&
+        wait_kvs_namespace_exitvalue $NAMESPACETMP-USER $DIR.test exitvalue &&
+        unset_userid &&
+        test $exitvalue -ne 0
+'
+
+test_expect_success 'kvs: namespace remove still fails (user)' '
+        set_userid 9999 &&
+        ! flux kvs namespace-remove $NAMESPACETMP-USER &&
+        unset_userid
+'
+
+test_expect_success 'kvs: namespace remove still works (owner)' '
+        put_kvs_key_namespace $NAMESPACETMP-USER $DIR.tmp 1 &&
+        test_kvs_key_namespace $NAMESPACETMP-USER $DIR.tmp 1 &&
+        flux kvs namespace-remove $NAMESPACETMP-USER &&
+        get_kvs_namespace_exitvalue $NAMESPACETMP-USER $DIR.tmp exitvalue &&
+        test $exitvalue -ne 0
+'
+
+#
+# Basic tests, user can't perform non-namespace operations
+#
+
+test_expect_success 'kvs: dropcache fails (user)' '
+        set_userid 9999 &&
+        ! flux kvs dropcache &&
+        unset_userid
+'
+
+test_expect_success 'kvs: stats fails (user)' '
+        set_userid 9999 &&
+        ! flux module stats kvs &&
+        unset_userid
+'
+
+test_expect_success 'kvs: stats clear fails (user)' '
+        set_userid 9999 &&
+        ! flux module stats -c kvs &&
+        unset_userid
+'
+
+test_done


### PR DESCRIPTION
This PR allows instance owners to create a namespace that is owned by a non-instance owner, and thus can let that non-instance owner read/write to that KVS namespace.  In this implementation, only a single non-instance owner can read/write to a namespace.  Instance owners are always able to read/write to any namespace under their creation.  Only instance owners are only able to create/remove a namespace.

After writing the unit tests, I realized there's a lot of cleanup that could be done in both the t1004 kvs tests and t1005 kvs tests (sharing common code, writing better common functions, etc.).  But I am going to let that cleanup be for another day, to limit churn in this PR.