### PR TITLE
kvs: Support ability to list namespaces

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -63,6 +63,9 @@ would allow a non-instance owner to read/write to a namespace.
 *namespace-remove* 'name' ['name...']::
 Remove a kvs namespace.
 
+*namespace-list*::
+List all current namespaces and info on each namespace.
+
 *get* [-j|-r|-t] [-a treeobj] 'key' ['key...']::
 Retrieve the value stored under 'key'.  If nothing has been stored under
 'key', display an error message.  If no options, value is displayed with

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -46,6 +46,7 @@ MAN3_FILES_PRIMARY = \
 	flux_kvs_commit.3 \
 	flux_kvs_txn_create.3 \
 	flux_kvs_namespace_create.3 \
+	flux_kvs_namespace_list.3 \
 	flux_kvs_set_namespace.3
 
 # These files are generated as roff .so includes of a primary page.
@@ -143,6 +144,9 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_txn_put_raw.3 \
 	# flux_kvs_txn_put_treeobj.3 \
 	flux_kvs_namespace_remove.3 \
+	flux_kvs_namespace_itr_next.3 \
+	flux_kvs_namespace_itr_rewind.3 \
+	flux_kvs_namespace_itr_destroy.3 \
 	flux_kvs_get_namespace.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
@@ -259,6 +263,9 @@ flux_kvs_txn_symlink.3: flux_kvs_txn_create.3
 flux_kvs_txn_put_raw.3: flux_kvs_txn_create.3
 # flux_kvs_txn_put_treeobj.3: flux_kvs_txn_create.3
 flux_kvs_namespace_remove.3: flux_kvs_namespace_create.3
+flux_kvs_namespace_itr_next.3: flux_kvs_namespace_list.3
+flux_kvs_namespace_itr_rewind.3: flux_kvs_namespace_list.3
+flux_kvs_namespace_itr_destroy.3: flux_kvs_namespace_list.3
 flux_kvs_get_namespace.3: flux_kvs_set_namespace.3
 
 flux_open.3: topen.c

--- a/doc/man3/flux_kvs_namespace_list.adoc
+++ b/doc/man3/flux_kvs_namespace_list.adoc
@@ -1,0 +1,75 @@
+flux_kvs_namespace_list(3)
+==========================
+:doctype: manpage
+
+
+NAME
+----
+flux_kvs_namespace_list, flux_kvs_namespace_itr_next, flux_kvs_namespace_itr_rewind, flux_kvs_namespace_itr_destroy - list iterator for namespaces
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_kvs_namespace_itr_t *flux_kvs_namespace_list (flux_t *h);
+
+ const char *flux_kvs_namespace_itr_next (flux_kvs_namespace_itr_t *itr,
+                                          uint32_t *owner,
+                                          int *flags);
+
+ void flux_kvs_namespace_itr_rewind (flux_kvs_namespace_itr_t *itr);
+
+ void flux_kvs_namespace_itr_destroy (flux_kvs_namespace_itr_t *itr);
+
+DESCRIPTION
+-----------
+
+`flux_kvs_namespace_list()` creates an iterator in which to iterate
+through a list of KVS namespaces.  `flux_kvs_namespace_itr_next()` can
+be used to retrieve data, `flux_kvs_namespace_itr_rewind()` to reset
+to the beginning of an iterator, and `flux_kvs_namespace_itr_destroy()`
+to destroy the iterator.
+
+RETURN VALUE
+------------
+
+`flux_kvs_namespace_list()` returns an iterator on success or NULL
+on failure.  `flux_kvs_namespace_itr_next()` returns the namespace
+name on success, or NULL on failure or when reaching the end of
+the list.
+
+
+ERRORS
+------
+
+EINVAL::
+One of the arguments was invalid.
+
+ENOMEM::
+Out of memory.
+
+EPROTO::
+A request was malformed.
+
+ENOTSUP::
+Attempt to remove illegal namespace.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_kvs_namespace_create(3)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -408,3 +408,4 @@ mh
 namespaces
 ENOTSUP
 EOVERFLOW
+itr

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -27,9 +27,16 @@
 #endif
 #include <unistd.h>
 
+#include <jansson.h>
 #include <flux/core.h>
 
 #define FLUX_HANDLE_KVS_NAMESPACE "kvsnamespace"
+
+struct flux_kvs_namespace_itr {
+    json_t *namespace_array;
+    int size;
+    int index;
+};
 
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
                                           uint32_t owner, int flags)
@@ -57,6 +64,90 @@ flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *namespace)
     return flux_rpc_pack (h, "kvs.namespace.remove", 0, 0,
                           "{ s:s }",
                           "namespace", namespace);
+}
+
+flux_kvs_namespace_itr_t *flux_kvs_namespace_list (flux_t *h)
+{
+    flux_future_t *f;
+    json_t *array = NULL;
+    flux_kvs_namespace_itr_t *itr = NULL;
+
+    if (!h) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(f = flux_rpc (h, "kvs.namespace.list", NULL, FLUX_NODEID_ANY, 0)))
+        goto error;
+    if (flux_rpc_get_unpack (f, "{ s:O }", "namespaces", &array) < 0)
+        goto error;
+    if (!json_is_array (array)) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(itr = calloc (1, sizeof (*itr)))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    itr->namespace_array = array;
+    itr->size = json_array_size (array);
+    itr->index = 0;
+    return itr;
+
+error:
+    flux_kvs_namespace_itr_destroy (itr);
+    json_decref (array);
+    return NULL;
+}
+
+const char *flux_kvs_namespace_itr_next (flux_kvs_namespace_itr_t *itr,
+                                         uint32_t *owner,
+                                         int *flags)
+{
+    const char *namespace;
+    uint32_t owner_tmp;
+    int flags_tmp;
+    json_t *o;
+
+    if (!itr) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (itr->size == itr->index) {
+        errno = 0;
+        return NULL;
+    }
+
+    if (!(o = json_array_get (itr->namespace_array, itr->index))) {
+        errno = EPROTO;
+        return NULL;
+    }
+
+    if (json_unpack (o, "{ s:s s:i s:i }",
+                     "namespace", &namespace,
+                     "owner", &owner_tmp,
+                     "flags", &flags_tmp) < 0)
+        return NULL;
+    if (owner)
+        (*owner) = owner_tmp;
+    if (flags)
+        (*flags) = flags_tmp;
+    itr->index++;
+    return namespace;
+}
+
+void flux_kvs_namespace_itr_rewind (flux_kvs_namespace_itr_t *itr)
+{
+    if (itr)
+        itr->index = 0;
+}
+
+void flux_kvs_namespace_itr_destroy (flux_kvs_namespace_itr_t *itr)
+{
+    if (itr) {
+        json_decref (itr->namespace_array);
+        free (itr);
+    }
 }
 
 int flux_kvs_set_namespace (flux_t *h, const char *namespace)

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -23,6 +23,8 @@ enum {
     FLUX_KVS_APPEND = 32,
 };
 
+typedef struct flux_kvs_namespace_itr flux_kvs_namespace_itr_t;
+
 /* Namespace
  * - namespace create only creates the namespace on rank 0.  Other
  *   ranks initialize against that namespace the first time they use
@@ -38,6 +40,19 @@ enum {
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *name_space,
                                           uint32_t owner, int flags);
 flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *name_space);
+
+/* Namespace list
+ * - Returns flux_kvs_namespace_itr_t for iterating through namespaces.
+ *
+ *   NOTE: Take care to avoid conflicting with C++'s keyword "namespace"
+ *   in the external interfaces.
+ */
+flux_kvs_namespace_itr_t *flux_kvs_namespace_list (flux_t *h);
+const char *flux_kvs_namespace_itr_next (flux_kvs_namespace_itr_t *itr,
+                                         uint32_t *owner,
+                                         int *flags);
+void flux_kvs_namespace_itr_rewind (flux_kvs_namespace_itr_t *itr);
+void flux_kvs_namespace_itr_destroy (flux_kvs_namespace_itr_t *itr);
 
 /* Namespace Selection
  * - configure a KVS namespace to use in all kvs operations using this

--- a/src/common/libkvs/test/kvs.c
+++ b/src/common/libkvs/test/kvs.c
@@ -21,6 +21,21 @@ void errors (void)
     ok (flux_kvs_namespace_remove (NULL, NULL) == NULL && errno == EINVAL,
         "flux_kvs_namespace_remove fails on bad input");
 
+    errno = 0;
+    ok (flux_kvs_namespace_list (NULL) == NULL && errno == EINVAL,
+        "flux_kvs_namespace_list fails on bad input");
+
+    errno = 0;
+    ok (flux_kvs_namespace_itr_next (NULL, NULL, NULL) == NULL && errno == EINVAL,
+        "flux_kvs_namespace_itr_next fails on bad input");
+
+    /* flux_kvs_namespace_itr_rewind() works on NULL pointer */
+    flux_kvs_namespace_itr_rewind (NULL);
+
+    /* flux_kvs_namespace_itr_destroy() works on NULL pointer */
+    flux_kvs_namespace_itr_destroy (NULL);
+
+    errno = 0;
     ok (flux_kvs_set_namespace (NULL, NULL) < 0 && errno == EINVAL,
         "flux_kvs_set_namespace fails on bad input");
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2497,6 +2497,61 @@ static void namespace_remove_event_cb (flux_t *h, flux_msg_handler_t *mh,
     start_root_remove (ctx, namespace);
 }
 
+static int namespace_list_cb (struct kvsroot *root, void *arg)
+{
+    json_t *namespaces = arg;
+    json_t *o;
+
+    /* do not list namespaces marked for removal */
+    if (root->remove)
+        return 0;
+
+    if (!(o = json_pack ("{ s:s s:i s:i }",
+                         "namespace", root->namespace,
+                         "owner", root->owner,
+                         "flags", root->flags))) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    json_array_append_new (namespaces, o);
+    return 0;
+}
+
+static void namespace_list_request_cb (flux_t *h, flux_msg_handler_t *mh,
+                                       const flux_msg_t *msg, void *arg)
+{
+    kvs_ctx_t *ctx = arg;
+    json_t *namespaces = NULL;
+    int rc = -1;
+
+    if (!(namespaces = json_array ())) {
+        errno = ENOMEM;
+        goto done;
+    }
+
+    if (kvsroot_mgr_iter_roots (ctx->km, namespace_list_cb,
+                                namespaces) < 0) {
+        flux_log_error (h, "%s: kvsroot_mgr_iter_roots", __FUNCTION__);
+        goto done;
+    }
+
+    if (flux_respond_pack (h, msg, "{ s:O }",
+                           "namespaces",
+                           namespaces) < 0) {
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto done;
+    }
+
+    rc = 0;
+done:
+    if (rc < 0) {
+        if (flux_respond (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    }
+    json_decref (namespaces);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "kvs.stats.get",  stats_get_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs.stats.clear",stats_clear_request_cb, 0 },
@@ -2526,6 +2581,8 @@ static const struct flux_msg_handler_spec htab[] = {
                             namespace_remove_request_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "kvs.namespace.remove",
                             namespace_remove_event_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.namespace.list",
+                            namespace_list_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2356,6 +2356,9 @@ static void namespace_create_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
+    if (owner == FLUX_USERID_UNKNOWN)
+        owner = geteuid ();
+
     if (namespace_create (ctx, namespace, owner, flags) < 0) {
         flux_log_error (h, "%s: namespace_create", __FUNCTION__);
         goto error;

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -77,6 +77,10 @@ wait_fencecount_nonzero() {
 # Basic tests in default primary namespace
 #
 
+test_expect_success 'kvs: primary namespace exists/is listed' '
+        flux kvs namespace-list | grep primary
+'
+
 test_expect_success 'kvs: create primary namespace fails' '
 	! flux kvs namespace-create $PRIMARYNAMESPACE
 '
@@ -157,8 +161,16 @@ test_expect_success 'kvs: namespace create on rank 0 works' '
 	flux kvs namespace-create $NAMESPACETEST
 '
 
+test_expect_success 'kvs: new namespace exists/is listed' '
+        flux kvs namespace-list | grep $NAMESPACETEST
+'
+
 test_expect_success 'kvs: namespace create on rank 1 works' '
 	flux exec -r 1 sh -c "flux kvs namespace-create $NAMESPACERANK1"
+'
+
+test_expect_success 'kvs: new namespace exists/is listed' '
+        flux kvs namespace-list | grep $NAMESPACERANK1
 '
 
 test_expect_success 'kvs: put/get value in new namespace works' '
@@ -237,6 +249,10 @@ test_expect_success 'kvs: namespace can be re-created after remove' '
         test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.recreate 1 &&
 	flux kvs namespace-remove $NAMESPACETMP-BASIC &&
         ! flux kvs --namespace=$NAMESPACETMP-BASIC get --json $DIR.recreate
+'
+
+test_expect_success 'kvs: removed namespace not listed' '
+        ! flux kvs namespace-list | grep $NAMESPACETMP-BASIC
 '
 
 #

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -140,6 +140,10 @@ test_expect_success 'kvs: namespace create works (owner, for user)' '
 	flux kvs namespace-create -o 9999 $NAMESPACETMP-USER
 '
 
+test_expect_success 'kvs: namespace listed with correct owner' '
+        flux kvs namespace-list | grep $NAMESPACETMP-USER | grep 9999
+'
+
 test_expect_success 'kvs: namespace put/get works (user)' '
         set_userid 9999 &&
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.test=1 &&


### PR DESCRIPTION
Support a simple iterator to allow users to list the KVS namespaces that exist, along with the owner and current flags.  The ```flux kvs namespace-list``` option would list something like this:

```
NAMESPACE             OWNER      FLAGS
primary                8556 0x00000000
```

