### PR TITLE
libflux/rpc: Rename flux_mrpcf() and flux_mrpc_getf()

### DIFF
--- a/doc/man3/flux_mrpc.adoc
+++ b/doc/man3/flux_mrpc.adoc
@@ -15,12 +15,12 @@ SYNOPSIS
 flux_mrpc_t *flux_mrpc (flux_t *h, const char *topic, const char *json_str,
                         const char *nodeset, int flags);
 
-flux_mrpc_t *flux_mrpcf (flux_t *h, const char *topic, const char *nodeset,
-                         int flags, const char *fmt, ...);
+flux_mrpc_t *flux_mrpc_pack (flux_t *h, const char *topic, const char *nodeset,
+                             int flags, const char *fmt, ...);
 
 int flux_mrpc_get (flux_mrpc_t *mrpc, const char **json_str);
 
-int flux_mrpc_getf (flux_mrpc_t *mrpc, const char *fmt, ...);
+int flux_mrpc_get_unpack (flux_mrpc_t *mrpc, const char *fmt, ...);
 
 int flux_mrpc_get_raw (flux_mrpc_t *mrpc, const void **data, int *len);
 
@@ -87,7 +87,7 @@ a response containing an error, `flux_mrpc_get_nodeid()` will succeed,
 while `flux_mrpc_get()` will fail.  This allows the failing nodeid to
 be determined.
 
-`flux_mrpcf()` is a variant of `flux_mrpc()` that constructs a
+`flux_mrpc_pack()` is a variant of `flux_mrpc()` that constructs a
 JSON payload based on the provided _fmt_ string and variable arguments.
 The _fmt_ string and variable arguments are passed internally to
 jansson's `json_pack()` function.  See below for details.
@@ -116,7 +116,7 @@ include::JSON_PACK.adoc[]
 RETURN VALUE
 ------------
 
-`flux_mrpc()` and `flux_mrpcf()` returns a flux_mrpc_t object
+`flux_mrpc()` and `flux_mrpc_pack()` returns a flux_mrpc_t object
 on success.  On error, NULL is returned, and errno is set
 appropriately.
 

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -285,16 +285,16 @@ static void request_hwloc_reload (flux_t *h, const char *nodeset,
     flux_mrpc_t *mrpc;
 
     if (!walk_topology) {
-        if (!(mrpc = flux_mrpcf (h, "resource-hwloc.reload",
-                                 nodeset, 0, "{}")))
-            log_err_exit ("flux_mrpcf");
+        if (!(mrpc = flux_mrpc_pack (h, "resource-hwloc.reload",
+                                     nodeset, 0, "{}")))
+            log_err_exit ("flux_mrpc_pack");
     }
     else {
         bool v = hwloc_reload_bool_value (walk_topology);
 
-        if (!(mrpc = flux_mrpcf (h, "resource-hwloc.reload", nodeset, 0,
-                                 "{ s:b }", "walk_topology", v)))
-            log_err_exit ("flux_mrpcf");
+        if (!(mrpc = flux_mrpc_pack (h, "resource-hwloc.reload", nodeset, 0,
+                                     "{ s:b }", "walk_topology", v)))
+            log_err_exit ("flux_mrpc_pack");
     }
 
     do {

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -106,14 +106,14 @@ void ping_continuation (flux_mrpc_t *mrpc, void *arg)
     tstat_t *tstat = pdata->tstat;
     uint32_t rolemask, userid;
 
-    if (flux_mrpc_getf (mrpc, "{ s:i s:I s:I s:s s:s s:i s:i !}",
-                       "seq", &seq,
-                       "time.tv_sec", &sec,
-                       "time.tv_nsec", &nsec,
-                       "pad", &pad,
-                       "route", &route,
-                       "userid", &userid,
-                       "rolemask", &rolemask) < 0) {
+    if (flux_mrpc_get_unpack (mrpc, "{ s:i s:I s:I s:s s:s s:i s:i !}",
+                              "seq", &seq,
+                              "time.tv_sec", &sec,
+                              "time.tv_nsec", &nsec,
+                              "pad", &pad,
+                              "route", &route,
+                              "userid", &userid,
+                              "rolemask", &rolemask) < 0) {
         log_err ("%s!%s", ctx->rank, ctx->topic);
         goto done;
     }
@@ -173,14 +173,14 @@ void send_ping (struct ping_ctx *ctx)
 
     monotime (&t0);
 
-    mrpc = flux_mrpcf (ctx->h, ctx->topic, ctx->rank, 0,
+    mrpc = flux_mrpc_pack (ctx->h, ctx->topic, ctx->rank, 0,
                            "{s:i s:I s:I s:s}",
                            "seq", ctx->send_count,
                            "time.tv_sec", (uint64_t)t0.tv_sec,
                            "time.tv_nsec", (uint64_t)t0.tv_nsec,
                            "pad", ctx->pad);
     if (!mrpc)
-        log_err_exit ("flux_mrpcf");
+        log_err_exit ("flux_mrpc_pack");
     if (flux_mrpc_aux_set (mrpc, "ping", pdata, ping_data_free) < 0)
         log_err_exit ("flux_mrpc_aux_set");
     if (flux_mrpc_then (mrpc, ping_continuation, ctx) < 0)

--- a/src/common/libflux/mrpc.c
+++ b/src/common/libflux/mrpc.c
@@ -256,7 +256,7 @@ done:
     return rc;
 }
 
-static int flux_mrpc_vgetf (flux_mrpc_t *mrpc, const char *fmt, va_list ap)
+static int flux_mrpc_vget_unpack (flux_mrpc_t *mrpc, const char *fmt, va_list ap)
 {
     int rc = -1;
     const char *json_str;
@@ -277,13 +277,13 @@ done:
     return rc;
 }
 
-int flux_mrpc_getf (flux_mrpc_t *mrpc, const char *fmt, ...)
+int flux_mrpc_get_unpack (flux_mrpc_t *mrpc, const char *fmt, ...)
 {
     va_list ap;
     int rc;
 
     va_start (ap, fmt);
-    rc = flux_mrpc_vgetf (mrpc, fmt, ap);
+    rc = flux_mrpc_vget_unpack (mrpc, fmt, ap);
     va_end (ap);
 
     return rc;
@@ -505,12 +505,12 @@ done:
     return rc;
 }
 
-flux_mrpc_t *flux_mrpcf (flux_t *h,
-                         const char *topic,
-                         const char *nodeset,
-                         int flags,
-                         const char *fmt,
-                         ...)
+flux_mrpc_t *flux_mrpc_pack (flux_t *h,
+                             const char *topic,
+                             const char *nodeset,
+                             int flags,
+                             const char *fmt,
+                             ...)
 {
     flux_msg_t *msg;
     flux_mrpc_t *rc = NULL;

--- a/src/common/libflux/mrpc.h
+++ b/src/common/libflux/mrpc.h
@@ -26,8 +26,8 @@ flux_mrpc_t *flux_mrpc (flux_t *h, const char *topic, const char *json_str,
 /* Variant of flux_mrpc that encodes a json payload using jansson
  * pack format strings.
  */
-flux_mrpc_t *flux_mrpcf (flux_t *h, const char *topic, const char *nodeset,
-                         int flags, const char *fmt, ...);
+flux_mrpc_t *flux_mrpc_pack (flux_t *h, const char *topic, const char *nodeset,
+                             int flags, const char *fmt, ...);
 
 /* Destroy an mrpc, invalidating previous payload returned by flux_mrpc_get().
  */
@@ -48,7 +48,7 @@ int flux_mrpc_get (flux_mrpc_t *mrpc, const char **json_str);
  * jansson pack/unpack format strings.  Returned items are
  * invalidated by flux_mrpc_destroy() or flux_mrpc_next().
  */
-int flux_mrpc_getf (flux_mrpc_t *mrpc, const char *fmt, ...);
+int flux_mrpc_get_unpack (flux_mrpc_t *mrpc, const char *fmt, ...);
 
 /* Wait for response if necessary, then decode nodeid request was sent to.
  * This function succedes even if the RPC service is returning an error.

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -18,7 +18,7 @@ void send_watch_requests (flux_t *h, const char *key)
     int flags = KVS_WATCH_FIRST;
     flux_mrpc_t *r;
 
-    if (!(r = flux_mrpcf (h, "kvs.watch", "all", 0, "{s:s s:s s:i s:n}",
+    if (!(r = flux_mrpc_pack (h, "kvs.watch", "all", 0, "{s:s s:s s:i s:n}",
                                                     "key", key,
                                                     "namespace", KVS_PRIMARY_NAMESPACE,
                                                     "flags", flags,
@@ -42,7 +42,7 @@ int count_watchers (flux_t *h)
         log_err_exit ("flux_mrpc kvs.stats.get");
     do {
         json_t *ns, *p;
-        if (flux_mrpc_getf (r, "{ s:o }", "namespace", &ns) < 0)
+        if (flux_mrpc_get_unpack (r, "{ s:o }", "namespace", &ns) < 0)
             log_err_exit ("kvs.stats.get namespace");
         if (json_unpack (ns, "{ s:o }", KVS_PRIMARY_NAMESPACE, &p) < 0)
             log_err_exit ("kvs.stats.get %s", KVS_PRIMARY_NAMESPACE);

--- a/t/rpc/mrpc.c
+++ b/t/rpc/mrpc.c
@@ -166,7 +166,7 @@ static void thenf_cb (flux_mrpc_t *r, void *arg)
     uint32_t nodeid;
 
     if (flux_mrpc_get_nodeid (r, &nodeid) < 0
-            || flux_mrpc_getf (r, "{}") < 0
+            || flux_mrpc_get_unpack (r, "{}") < 0
             || !nodeset_add_rank (then_ns, nodeid)
             || ++then_count == 128) {
         flux_reactor_stop (flux_get_reactor (h));
@@ -417,84 +417,84 @@ void test_mrpcf (flux_t *h)
     rpctest_set_size (h, 1);
 
     errno = 0;
-    ok (!(r = flux_mrpcf (h, NULL, "all", 0, "{}")) && errno == EINVAL,
-        "flux_mrpcf with NULL topic fails with EINVAL");
+    ok (!(r = flux_mrpc_pack (h, NULL, "all", 0, "{}")) && errno == EINVAL,
+        "flux_mrpc_pack with NULL topic fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_mrpcf (h, "bar", NULL, 0, "{}")) && errno == EINVAL,
-        "flux_mrpcf with NULL nodeset fails with EINVAL");
+    ok (!(r = flux_mrpc_pack (h, "bar", NULL, 0, "{}")) && errno == EINVAL,
+        "flux_mrpc_pack with NULL nodeset fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_mrpcf (h, "bar", "xyz", 0, "{}")) && errno == EINVAL,
-        "flux_mrpcf with bad nodeset fails with EINVAL");
+    ok (!(r = flux_mrpc_pack (h, "bar", "xyz", 0, "{}")) && errno == EINVAL,
+        "flux_mrpc_pack with bad nodeset fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_mrpcf (h, "bar", "all", 0, NULL)) && errno == EINVAL,
-        "flux_mrpcf with NULL fmt fails with EINVAL");
+    ok (!(r = flux_mrpc_pack (h, "bar", "all", 0, NULL)) && errno == EINVAL,
+        "flux_mrpc_pack with NULL fmt fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_mrpcf (h, "bar", "all", 0, "")) && errno == EINVAL,
-        "flux_mrpcf with empty string fmt fails with EINVAL");
+    ok (!(r = flux_mrpc_pack (h, "bar", "all", 0, "")) && errno == EINVAL,
+        "flux_mrpc_pack with empty string fmt fails with EINVAL");
     errno = 0;
-    ok (!(r = flux_mrpcf (h, "bar", "all", 0, "{ s }", "foo")) && errno == EINVAL,
-        "flux_mrpcf with bad string fmt fails with EINVAL");
+    ok (!(r = flux_mrpc_pack (h, "bar", "all", 0, "{ s }", "foo")) && errno == EINVAL,
+        "flux_mrpc_pack with bad string fmt fails with EINVAL");
 
     /* working empty payload RPC */
     old_count = hello_count;
-    ok ((r = flux_mrpcf (h, "rpcftest.hello", "all", 0, "{}")) != NULL,
-        "flux_mrpcf all works");
+    ok ((r = flux_mrpc_pack (h, "rpcftest.hello", "all", 0, "{}")) != NULL,
+        "flux_mrpc_pack all works");
     if (!r)
         BAIL_OUT ("can't continue without successful rpc call");
     check_count = 0;
     while (flux_mrpc_check (r) == false)
         check_count++;
     diag ("flux_mrpc_check returned true after %d tries", check_count);
-    ok (flux_mrpc_getf (r, "{}") == 0,
-        "flux_mrpc_getf works");
+    ok (flux_mrpc_get_unpack (r, "{}") == 0,
+        "flux_mrpc_get_unpack works");
     ok (hello_count == old_count + 1,
         "rpc was called once");
     flux_mrpc_destroy (r);
 
     /* working empty payload RPC for "any" */
     old_count = hello_count;
-    ok ((r = flux_mrpcf (h, "rpcftest.hello", "any", 0, "{}")) != NULL,
-        "flux_mrpcf any works");
+    ok ((r = flux_mrpc_pack (h, "rpcftest.hello", "any", 0, "{}")) != NULL,
+        "flux_mrpc_pack any works");
     if (!r)
         BAIL_OUT ("can't continue without successful rpc call");
     check_count = 0;
     while (flux_mrpc_check (r) == false)
         check_count++;
     diag ("flux_mrpc_check returned true after %d tries", check_count);
-    ok (flux_mrpc_getf (r, "{}") == 0,
-        "flux_mrpc_getf works");
+    ok (flux_mrpc_get_unpack (r, "{}") == 0,
+        "flux_mrpc_get_unpack works");
     ok (hello_count == old_count + 1,
         "rpc was called once");
     flux_mrpc_destroy (r);
 
     /* working empty payload RPC for "upstream" */
     old_count = hello_count;
-    ok ((r = flux_mrpcf (h, "rpcftest.hello", "upstream", 0, "{}")) != NULL,
-        "flux_mrpcf upstream works");
+    ok ((r = flux_mrpc_pack (h, "rpcftest.hello", "upstream", 0, "{}")) != NULL,
+        "flux_mrpc_pack upstream works");
     if (!r)
         BAIL_OUT ("can't continue without successful rpc call");
     check_count = 0;
     while (flux_mrpc_check (r) == false)
         check_count++;
     diag ("flux_mrpc_check returned true after %d tries", check_count);
-    ok (flux_mrpc_getf (r, "{}") == 0,
-        "flux_mrpc_getf works");
+    ok (flux_mrpc_get_unpack (r, "{}") == 0,
+        "flux_mrpc_get_unpack works");
     ok (hello_count == old_count + 1,
         "rpc was called once");
     flux_mrpc_destroy (r);
 
     /* cause remote EPROTO (unexpected payload) - picked up in _getf() */
-    ok ((r = flux_mrpcf (h, "rpcftest.hello", "all", 0,
-                              "{ s:i }", "foo", 42)) != NULL,
-        "flux_mrpcf all works");
+    ok ((r = flux_mrpc_pack (h, "rpcftest.hello", "all", 0,
+                             "{ s:i }", "foo", 42)) != NULL,
+        "flux_mrpc_pack all works");
     check_count = 0;
     while (flux_mrpc_check (r) == false)
         check_count++;
     diag ("flux_mrpc_check returned true after %d tries", check_count);
     errno = 0;
-    ok (flux_mrpc_getf (r, "{}") < 0
+    ok (flux_mrpc_get_unpack (r, "{}") < 0
         && errno == EPROTO,
-        "flux_mrpc_getf fails with EPROTO (unexpected payload)");
+        "flux_mrpc_get_unpack fails with EPROTO (unexpected payload)");
     flux_mrpc_destroy (r);
 
     /* fake that we have a larger session */
@@ -502,17 +502,17 @@ void test_mrpcf (flux_t *h)
 
     /* repeat working empty-payload RPC test (now with 128 nodes) */
     old_count = hello_count;
-    ok ((r = flux_mrpcf (h, "rpcftest.hello", "all", 0, "{}")) != NULL,
-        "flux_mrpcf [0-%d] works",
+    ok ((r = flux_mrpc_pack (h, "rpcftest.hello", "all", 0, "{}")) != NULL,
+        "flux_mrpc_pack [0-%d] works",
         fake_size - 1);
     count = 0;
     do {
-        if (flux_mrpc_getf (r, "{}") < 0)
+        if (flux_mrpc_get_unpack (r, "{}") < 0)
             break;
         count++;
     } while (flux_mrpc_next (r) == 0);
     ok (count == fake_size,
-        "flux_mrpc_getf succeded %d times", fake_size);
+        "flux_mrpc_get_unpack succeded %d times", fake_size);
 
     cmp_ok (hello_count - old_count, "==", fake_size,
         "rpc was called %d times", fake_size);
@@ -520,25 +520,25 @@ void test_mrpcf (flux_t *h)
 
     /* same with a subset */
     old_count = hello_count;
-    ok ((r = flux_mrpcf (h, "rpcftest.hello", "[0-63]", 0, "{}")) != NULL,
-        "flux_mrpcf [0-%d] works", 64 - 1);
+    ok ((r = flux_mrpc_pack (h, "rpcftest.hello", "[0-63]", 0, "{}")) != NULL,
+        "flux_mrpc_pack [0-%d] works", 64 - 1);
     count = 0;
     do {
         if (flux_mrpc_get_nodeid (r, &nodeid) < 0
-                || flux_mrpc_getf (r, "{}") < 0 || nodeid != count)
+                || flux_mrpc_get_unpack (r, "{}") < 0 || nodeid != count)
             break;
         count++;
     } while (flux_mrpc_next (r) == 0);
     ok (count == 64,
-        "flux_mrpc_getf succeded %d times, with correct nodeid map", 64);
+        "flux_mrpc_get_unpack succeded %d times, with correct nodeid map", 64);
 
     cmp_ok (hello_count - old_count, "==", 64,
         "rpc was called %d times", 64);
     flux_mrpc_destroy (r);
 
     /* same with echo payload */
-    ok ((r = flux_mrpcf (h, "rpctest.echo", "[0-63]", 0, "{}")) != NULL,
-        "flux_mrpcf [0-%d] ok", 64 - 1);
+    ok ((r = flux_mrpc_pack (h, "rpctest.echo", "[0-63]", 0, "{}")) != NULL,
+        "flux_mrpc_pack [0-%d] ok", 64 - 1);
     count = 0;
     do {
         if (flux_mrpc_get (r, &json_str) < 0
@@ -552,8 +552,8 @@ void test_mrpcf (flux_t *h)
 
     /* detect partial failure without response */
     nodeid_fake_error = 20;
-    ok ((r = flux_mrpcf (h, "rpcftest.nodeid", "[0-63]", 0, "{}")) != NULL,
-        "flux_mrpcf [0-%d] ok", 64 - 1);
+    ok ((r = flux_mrpc_pack (h, "rpcftest.nodeid", "[0-63]", 0, "{}")) != NULL,
+        "flux_mrpc_pack [0-%d] ok", 64 - 1);
     int fail_count = 0;
     uint32_t fail_nodeid_last = FLUX_NODEID_ANY;
     int fail_errno_last = 0;
@@ -561,7 +561,7 @@ void test_mrpcf (flux_t *h)
     int flags;
     do {
         if (flux_mrpc_get_nodeid (r, &nodeid) < 0
-            || flux_mrpc_getf (r, "{ s:i s:i s:i !}",
+            || flux_mrpc_get_unpack (r, "{ s:i s:i s:i !}",
                               "errnum", &errnum,
                               "nodeid", &nodeid,
                               "flags", &flags) < 0
@@ -572,15 +572,15 @@ void test_mrpcf (flux_t *h)
         }
     } while (flux_mrpc_next (r) == 0);
     ok (fail_count == 1 && fail_nodeid_last == 20 && fail_errno_last == EPERM,
-        "flux_mrpc_getf correctly reports single error");
+        "flux_mrpc_get_unpack correctly reports single error");
     flux_mrpc_destroy (r);
 
     /* test that a fatal handle error causes flux_mrpc_next () to fail */
     flux_fatal_set (h, NULL, NULL); /* reset handler and flag */
     ok (flux_fatality (h) == false,
         "flux_fatality says all is well");
-    ok ((r = flux_mrpcf (h, "rpctest.nodeid", "[0-1]", 0, "{}")) != NULL,
-        "flux_mrpcf [0-1] ok");
+    ok ((r = flux_mrpc_pack (h, "rpctest.nodeid", "[0-1]", 0, "{}")) != NULL,
+        "flux_mrpc_pack [0-1] ok");
     flux_fatal_error (h, __FUNCTION__, "Foo");
     ok (flux_fatality (h) == true,
         "flux_fatality shows simulated failure");
@@ -599,8 +599,8 @@ void test_mrpcf_then (flux_t *h)
     ok ((then_ns = nodeset_create ()) != NULL,
         "nodeset created ok");
     then_count = 0;
-    ok ((then_r = flux_mrpcf (h, "rpcftest.hello", "[0-127]", 0, "{}")) != NULL,
-        "flux_mrpcf [0-127] ok");
+    ok ((then_r = flux_mrpc_pack (h, "rpcftest.hello", "[0-127]", 0, "{}")) != NULL,
+        "flux_mrpc_pack [0-127] ok");
     ok (flux_mrpc_then (then_r, thenf_cb, h) == 0,
         "flux_mrpc_then works");
     ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,


### PR DESCRIPTION
For consistency, rename flux_mrpcf() to flux_mrpc_pack()
and rename flux_mrpc_getf() to flux_mrpc_get_unpack() just
as the changes were done in these prior commits.

libflux/rpc: rename rpcf->rpc_pack

9a5c28b170315e3fac5b8031cf5268e48c1cf078

and

libflux/rpc: rename rpc_getf->rpc_get_unpack

1a3626ba318f6adcba9479dc5cdc01240b8029a6

Fixes #1290