### PR TITLE
kvs: cleanup callback names

### DIFF
--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -47,7 +47,7 @@ flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *namespace,
     }
 
     /* N.B. owner cast to int */
-    return flux_rpc_pack (h, "kvs.namespace.create", 0, 0,
+    return flux_rpc_pack (h, "kvs.namespace-create", 0, 0,
                           "{ s:s s:i s:i }",
                           "namespace", namespace,
                           "owner", owner,
@@ -61,7 +61,7 @@ flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *namespace)
         return NULL;
     }
 
-    return flux_rpc_pack (h, "kvs.namespace.remove", 0, 0,
+    return flux_rpc_pack (h, "kvs.namespace-remove", 0, 0,
                           "{ s:s }",
                           "namespace", namespace);
 }
@@ -76,7 +76,7 @@ flux_kvs_namespace_itr_t *flux_kvs_namespace_list (flux_t *h)
         errno = EINVAL;
         goto error;
     }
-    if (!(f = flux_rpc (h, "kvs.namespace.list", NULL, FLUX_NODEID_ANY, 0)))
+    if (!(f = flux_rpc (h, "kvs.namespace-list", NULL, FLUX_NODEID_ANY, 0)))
         goto error;
     if (flux_rpc_get_unpack (f, "{ s:O }", "namespaces", &array) < 0)
         goto error;

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -46,7 +46,7 @@ flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
             errno = EINVAL;
             return NULL;
         }
-        return flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
+        return flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
                                  "{s:s s:i s:s s:i s:O}",
                                  "name", name,
                                  "nprocs", nprocs,
@@ -54,7 +54,7 @@ flux_future_t *flux_kvs_fence (flux_t *h, int flags, const char *name,
                                  "flags", flags,
                                  "ops", ops);
     } else {
-        return flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
+        return flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
                                  "{s:s s:i s:s s:i s:[]}",
                                  "name", name,
                                  "nprocs", nprocs,

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -109,7 +109,7 @@ flux_future_t *flux_kvs_lookup (flux_t *h, int flags, const char *key)
         return NULL;
     if (!(ctx = alloc_ctx (h, flags, key)))
         return NULL;
-    if (!(f = flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h, "kvs.lookup", FLUX_NODEID_ANY, 0,
                              "{s:s s:s s:i}",
                              "key", key,
                              "namespace", namespace,
@@ -155,7 +155,7 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
             errno = EINVAL;
             return NULL;
         }
-        if (!(f = flux_rpc_pack (h, "kvs.get", FLUX_NODEID_ANY, 0,
+        if (!(f = flux_rpc_pack (h, "kvs.lookup", FLUX_NODEID_ANY, 0,
                                  "{s:s s:s s:i s:O}",
                                  "key", key,
                                  "namespace", namespace,

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -216,7 +216,7 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *namespace)
             goto cleanup;
         }
 
-        if (flux_event_subscribe (ctx->h, "kvs.namespace.remove") < 0) {
+        if (flux_event_subscribe (ctx->h, "kvs.namespace-remove") < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }
@@ -224,7 +224,7 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *namespace)
         ctx->events_init = true;
     }
 
-    if (asprintf (&setroot_topic, "kvs.setroot.%s", namespace) < 0) {
+    if (asprintf (&setroot_topic, "kvs.setroot-%s", namespace) < 0) {
         errno = ENOMEM;
         goto cleanup;
     }
@@ -234,7 +234,7 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *namespace)
         goto cleanup;
     }
 
-    if (asprintf (&error_topic, "kvs.error.%s", namespace) < 0) {
+    if (asprintf (&error_topic, "kvs.error-%s", namespace) < 0) {
         errno = ENOMEM;
         goto cleanup;
     }
@@ -257,7 +257,7 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *namespace)
     char *error_topic = NULL;
     int rc = -1;
 
-    if (asprintf (&setroot_topic, "kvs.setroot.%s", namespace) < 0) {
+    if (asprintf (&setroot_topic, "kvs.setroot-%s", namespace) < 0) {
         errno = ENOMEM;
         goto cleanup;
     }
@@ -267,7 +267,7 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *namespace)
         goto cleanup;
     }
 
-    if (asprintf (&error_topic, "kvs.error.%s", namespace) < 0) {
+    if (asprintf (&error_topic, "kvs.error-%s", namespace) < 0) {
         errno = ENOMEM;
         goto cleanup;
     }
@@ -778,7 +778,7 @@ static int setroot_event_send (kvs_ctx_t *ctx, struct kvsroot *root,
         root_dir = nullobj;
     }
 
-    if (asprintf (&setroot_topic, "kvs.setroot.%s", root->namespace) < 0) {
+    if (asprintf (&setroot_topic, "kvs.setroot-%s", root->namespace) < 0) {
         saved_errno = ENOMEM;
         flux_log_error (ctx->h, "%s: asprintf", __FUNCTION__);
         goto done;
@@ -819,7 +819,7 @@ static int error_event_send (kvs_ctx_t *ctx, const char *namespace,
     char *error_topic = NULL;
     int saved_errno, rc = -1;
 
-    if (asprintf (&error_topic, "kvs.error.%s", namespace) < 0) {
+    if (asprintf (&error_topic, "kvs.error-%s", namespace) < 0) {
         saved_errno = ENOMEM;
         flux_log_error (ctx->h, "%s: asprintf", __FUNCTION__);
         goto done;
@@ -2429,7 +2429,7 @@ static int namespace_remove (kvs_ctx_t *ctx, const char *namespace)
         goto done;
     }
 
-    if (!(msg = flux_event_pack ("kvs.namespace.remove", "{ s:s }",
+    if (!(msg = flux_event_pack ("kvs.namespace-remove", "{ s:s }",
                                  "namespace", namespace))) {
         saved_errno = errno;
         flux_log_error (ctx->h, "%s: flux_event_pack", __FUNCTION__);
@@ -2560,8 +2560,8 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "kvs.stats.get",  stats_get_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs.stats.clear",stats_clear_request_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "kvs.stats.clear",stats_clear_event_cb, 0 },
-    { FLUX_MSGTYPE_EVENT,   "kvs.setroot.*",  setroot_event_cb, 0 },
-    { FLUX_MSGTYPE_EVENT,   "kvs.error.*",    error_event_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.setroot-*",  setroot_event_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.error-*",    error_event_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs.getroot",
                             getroot_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.dropcache",  dropcache_request_cb, 0 },
@@ -2579,13 +2579,13 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "kvs.commit",
                             commit_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.relaycommit", relaycommit_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs.namespace.create",
+    { FLUX_MSGTYPE_REQUEST, "kvs.namespace-create",
                             namespace_create_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs.namespace.remove",
+    { FLUX_MSGTYPE_REQUEST, "kvs.namespace-remove",
                             namespace_remove_request_cb, 0 },
-    { FLUX_MSGTYPE_EVENT,   "kvs.namespace.remove",
+    { FLUX_MSGTYPE_EVENT,   "kvs.namespace-remove",
                             namespace_remove_event_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs.namespace.list",
+    { FLUX_MSGTYPE_REQUEST, "kvs.namespace-list",
                             namespace_list_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1203,8 +1203,8 @@ static int lookup_load_cb (lookup_t *lh, const char *ref, void *data)
     return 0;
 }
 
-static void get_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                            const flux_msg_t *msg, void *arg)
+static void lookup_request_cb (flux_t *h, flux_msg_handler_t *mh,
+                               const flux_msg_t *msg, void *arg)
 {
     kvs_ctx_t *ctx = NULL;
     int flags;
@@ -1234,7 +1234,7 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *mh,
             goto done;
         }
 
-        if (!(root = getroot (ctx, namespace, mh, msg, get_request_cb,
+        if (!(root = getroot (ctx, namespace, mh, msg, lookup_request_cb,
                               &stall))) {
             if (stall)
                 goto stall;
@@ -1302,7 +1302,8 @@ static void get_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!lookup (lh)) {
         struct kvs_cb_data cbd;
 
-        if (!(wait = wait_create_msg_handler (h, mh, msg, lh, get_request_cb)))
+        if (!(wait = wait_create_msg_handler (h, mh, msg, lh,
+                                              lookup_request_cb)))
             goto done;
 
         cbd.ctx = ctx;
@@ -2571,8 +2572,8 @@ static const struct flux_msg_handler_spec htab[] = {
                             unwatch_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.sync",
                             sync_request_cb, FLUX_ROLE_USER },
-    { FLUX_MSGTYPE_REQUEST, "kvs.get",
-                            get_request_cb, FLUX_ROLE_USER },
+    { FLUX_MSGTYPE_REQUEST, "kvs.lookup",
+                            lookup_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.watch",
                             watch_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.commit",


### PR DESCRIPTION
Minor cleanup of the callback names in the kvs module.  Some changes reflect more current naming styles within the KVS, and some were to remove use of periods per RFC 5.