### PR TITLE
kvs: refactor commit & fence

### DIFF
--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -38,7 +38,9 @@ int commit_get_errnum (commit_t *c);
 int commit_get_aux_errnum (commit_t *c);
 int commit_set_aux_errnum (commit_t *c, int errnum);
 
-fence_t *commit_get_fence (commit_t *c);
+json_t *commit_get_ops (commit_t *c);
+json_t *commit_get_names (commit_t *c);
+int commit_get_flags (commit_t *c);
 
 /* returns namespace passed into commit_mgr_create() */
 const char *commit_get_namespace (commit_t *c);
@@ -117,7 +119,8 @@ int commit_mgr_add_fence (commit_mgr_t *cm, fence_t *f);
 /* Lookup a fence previously stored via commit_mgr_add_fence(), via name */
 fence_t *commit_mgr_lookup_fence (commit_mgr_t *cm, const char *name);
 
-/* Iterate through all not-ready fences
+/* Iterate through all fences in that have never had its operations
+ * converted to a ready commit_t
  * - this is typically called during a needed cleanup path
  */
 int commit_mgr_iter_not_ready_fences (commit_mgr_t *cm, commit_fence_f cb,

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -171,63 +171,6 @@ int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data)
     return 0;
 }
 
-int fence_merge (fence_t *dest, fence_t *src)
-{
-    json_t *names = NULL;
-    json_t *ops = NULL;
-    int i, len, saved_errno;
-
-    if ((dest->flags & FLUX_KVS_NO_MERGE) || (src->flags & FLUX_KVS_NO_MERGE))
-        return 0;
-
-    if ((len = json_array_size (src->names))) {
-        if (!(names = json_copy (dest->names))) {
-            saved_errno = ENOMEM;
-            goto error;
-        }
-        for (i = 0; i < len; i++) {
-            json_t *name;
-            if ((name = json_array_get (src->names, i))) {
-                if (json_array_append (names, name) < 0) {
-                    saved_errno = ENOMEM;
-                    goto error;
-                }
-            }
-        }
-    }
-    if ((len = json_array_size (src->ops))) {
-        if (!(ops = json_copy (dest->ops))) {
-            saved_errno = ENOMEM;
-            goto error;
-        }
-        for (i = 0; i < len; i++) {
-            json_t *op;
-            if ((op = json_array_get (src->ops, i))) {
-                if (json_array_append (ops, op) < 0) {
-                    saved_errno = ENOMEM;
-                    goto error;
-                }
-            }
-        }
-    }
-
-    if (names) {
-        json_decref (dest->names);
-        dest->names = names;
-    }
-    if (ops) {
-        json_decref (dest->ops);
-        dest->ops = ops;
-    }
-    return 1;
-
-error:
-    json_decref (names);
-    json_decref (ops);
-    errno = saved_errno;
-    return -1;
-}
-
 int fence_get_aux_int (fence_t *f)
 {
     return f->aux_int;

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -15,12 +15,11 @@ void fence_destroy (fence_t *f);
 /* if number of calls to fence_add_request_data() is == nprocs */
 bool fence_count_reached (fence_t *f);
 
+const char *fence_get_name (fence_t *f);
 int fence_get_nprocs (fence_t *f);
 int fence_get_flags (fence_t *f);
 
 json_t *fence_get_json_ops (fence_t *f);
-
-json_t *fence_get_json_names (fence_t *f);
 
 /* fence_add_request_ops() should be called with ops on each
  * request, even if ops is NULL

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -40,11 +40,6 @@ int fence_add_request_copy (fence_t *f, const flux_msg_t *request);
  */
 int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data);
 
-/* Merge src ops & names into dest ops & names
- * - return 1 on merge success, 0 on no-merge, -1 on error
- */
-int fence_merge (fence_t *dest, fence_t *src);
-
 /* Auxiliary convenience data
  */
 int fence_get_aux_int (fence_t *f);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -974,21 +974,20 @@ static void commit_apply (commit_t *c)
      */
 done:
     if (errnum == 0) {
-        fence_t *f = commit_get_fence (c);
+        json_t *names = commit_get_names (c);
         int count;
-        if ((count = json_array_size (fence_get_json_names (f))) > 1) {
+        if ((count = json_array_size (names)) > 1) {
             int opcount = 0;
-            opcount = json_array_size (fence_get_json_ops (f));
+            opcount = json_array_size (commit_get_ops (c));
             flux_log (ctx->h, LOG_DEBUG, "aggregated %d commits (%d ops)",
                       count, opcount);
         }
         setroot (ctx, root, commit_get_newroot_ref (c), root->seq + 1);
-        setroot_event_send (ctx, root, fence_get_json_names (f));
+        setroot_event_send (ctx, root, names);
     } else {
-        fence_t *f = commit_get_fence (c);
         flux_log (ctx->h, LOG_ERR, "commit failed: %s",
                   flux_strerror (errnum));
-        error_event_send (ctx, root->namespace, fence_get_json_names (f),
+        error_event_send (ctx, root->namespace, commit_get_names (c),
                           errnum);
     }
     wait_destroy (wait);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2373,12 +2373,20 @@ error:
 static int root_remove_process_fences (fence_t *f, void *data)
 {
     struct kvs_cb_data *cbd = data;
+    json_t *names = NULL;
 
     /* Not ready fences will never finish, must alert them with
      * ENOTSUP that namespace removed.  Final call to
      * commit_mgr_remove_fence() done in finalize_fences_bynames() */
-    finalize_fences_bynames (cbd->ctx, cbd->root, fence_get_json_names (f),
-                             ENOTSUP);
+
+    if (!(names = json_pack ("[ s ]", fence_get_name (f)))) {
+        flux_log_error (cbd->ctx->h, "%s: json_pack", __FUNCTION__);
+        errno = ENOMEM;
+        return -1;
+    }
+
+    finalize_fences_bynames (cbd->ctx, cbd->root, names, ENOTSUP);
+    json_decref (names);
     return 0;
 }
 

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -141,7 +141,6 @@ void commit_mgr_basic_tests (void)
     commit_mgr_t *cm;
     commit_t *c;
     fence_t *f, *tf;
-    fence_t *f1, *f2;
     blobref_t rootref;
 
     ok (commit_mgr_create (NULL, NULL, NULL, NULL, NULL) == NULL
@@ -240,20 +239,6 @@ void commit_mgr_basic_tests (void)
 
     ok (commit_mgr_lookup_fence (cm, "fence1") == NULL,
         "commit_mgr_lookup_fence can't find removed fence");
-
-    ok ((f1 = fence_create ("fenceF1", 1, 0)) != NULL,
-        "fence_create works");
-    ok ((f2 = fence_create ("fenceF2", 1, 0)) != NULL,
-        "fence_create works");
-    ok (fence_merge (f1, f2) == 1,
-        "fence_merge works");
-
-    ok (commit_mgr_add_fence (cm, f1) < 0
-        && errno == EINVAL,
-        "commit_mgr_add_fence fails on fence with multiple names");
-
-    fence_destroy (f1);
-    fence_destroy (f2);
 
     commit_mgr_destroy (cm);
     cache_destroy (cache);

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -293,29 +293,29 @@ void create_ready_commit (commit_mgr_t *cm,
 void verify_ready_commit (commit_mgr_t *cm,
                           json_t *names,
                           json_t *ops,
+                          int flags,
                           const char *extramsg)
 {
     json_t *o;
     commit_t *c;
-    fence_t *f;
 
     ok ((c = commit_mgr_get_ready_commit (cm)) != NULL,
         "commit_mgr_get_ready_commit returns ready commit");
 
-    ok ((f = commit_get_fence (c)) != NULL,
-        "commit_get_fence returns commit fence");
-
-    ok ((o = fence_get_json_names (f)) != NULL,
-        "fence_get_json_names works");
+    ok ((o = commit_get_names (c)) != NULL,
+        "commit_get_names works");
 
     ok (json_equal (names, o) == true,
         "names match %s", extramsg);
 
-    ok ((o = fence_get_json_ops (f)) != NULL,
-        "fence_get_json_ops works");
+    ok ((o = commit_get_ops (c)) != NULL,
+        "commit_get_ops works");
 
     ok (json_equal (ops, o) == true,
         "ops match %s", extramsg);
+
+    ok (commit_get_flags (c) == flags,
+        "flags do not match");
 }
 
 void clear_ready_commits (commit_mgr_t *cm)
@@ -358,7 +358,7 @@ void commit_mgr_merge_tests (void)
     ops_append (ops, "key1", "1", 0);
     ops_append (ops, "key2", "2", 0);
 
-    verify_ready_commit (cm, names, ops, "merged fence");
+    verify_ready_commit (cm, names, ops, 0, "merged fence");
 
     json_decref (names);
     json_decref (ops);
@@ -383,7 +383,7 @@ void commit_mgr_merge_tests (void)
     ops = json_array ();
     ops_append (ops, "key1", "1", 0);
 
-    verify_ready_commit (cm, names, ops, "unmerged fence");
+    verify_ready_commit (cm, names, ops, FLUX_KVS_NO_MERGE, "unmerged fence");
 
     json_decref (names);
     json_decref (ops);
@@ -408,7 +408,7 @@ void commit_mgr_merge_tests (void)
     ops = json_array ();
     ops_append (ops, "key1", "1", 0);
 
-    verify_ready_commit (cm, names, ops, "unmerged fence");
+    verify_ready_commit (cm, names, ops, 0, "unmerged fence");
 
     json_decref (names);
     json_decref (ops);
@@ -451,7 +451,7 @@ void commit_basic_tests (void)
                                  &test_global)) != NULL,
         "commit_mgr_create works");
 
-    create_ready_commit (cm, "fence1", "key1", "1", 0, 0);
+    create_ready_commit (cm, "fence1", "key1", "1", 0, 0x44);
 
     names = json_array ();
     json_array_append (names, json_string ("fence1"));
@@ -459,7 +459,7 @@ void commit_basic_tests (void)
     ops = json_array ();
     ops_append (ops, "key1", "1", 0);
 
-    verify_ready_commit (cm, names, ops, "basic test");
+    verify_ready_commit (cm, names, ops, 0x44, "basic test");
 
     json_decref (names);
     json_decref (ops);

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -775,11 +775,10 @@ int commit_fence_count_cb (fence_t *f, void *data)
 int commit_fence_remove_cb (fence_t *f, void *data)
 {
     commit_mgr_t *cm = data;
-    json_t *names = fence_get_json_names (f);
 
     /* in this test no merging has been done, just get the first name
      * in the array */
-    commit_mgr_remove_fence (cm, json_string_value (json_array_get (names, 0)));
+    commit_mgr_remove_fence (cm, fence_get_name (f));
     return 0;
 }
 

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -233,62 +233,6 @@ fence_t *create_fence (const char *name, const char *opname, int flags)
     return f;
 }
 
-void merge_tests (void)
-{
-    fence_t *f1, *f2;
-    json_t *names, *ops;
-    json_t *o;
-
-    f1 = create_fence ("foo", "A", 0);
-    f2 = create_fence ("bar", "B", 0);
-
-    ok (fence_merge (f1, f2) == 1,
-        "fence_merge success");
-
-    ok ((o = fence_get_json_names (f1)) != NULL,
-        "fence_get_json_names works");
-
-    names = json_array ();
-    json_array_append_new (names, json_string ("foo"));
-    json_array_append_new (names, json_string ("bar"));
-
-    ok (json_equal (names, o) == true,
-        "fence_get_json_names match");
-
-    json_decref (names);
-
-    ok ((o = fence_get_json_ops (f1)) != NULL,
-        "fence_get_json_ops works");
-
-    ops = json_array ();
-    json_array_append_new (ops, json_string ("A"));
-    json_array_append_new (ops, json_string ("B"));
-
-    ok (json_equal (ops, o) == true,
-        "fence_get_json_ops match");
-
-    fence_destroy (f1);
-    fence_destroy (f2);
-
-    f1 = create_fence ("foo", "A", FLUX_KVS_NO_MERGE);
-    f2 = create_fence ("bar", "B", 0);
-
-    ok (fence_merge (f1, f2) == 0,
-        "fence_merge no merge");
-
-    fence_destroy (f1);
-    fence_destroy (f2);
-
-    f1 = create_fence ("foo", "A", 0);
-    f2 = create_fence ("bar", "B", FLUX_KVS_NO_MERGE);
-
-    ok (fence_merge (f1, f2) == 0,
-        "fence_merge no merge");
-
-    fence_destroy (f1);
-    fence_destroy (f2);
-}
-
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -296,7 +240,6 @@ int main (int argc, char *argv[])
     basic_api_tests ();
     ops_tests ();
     request_tests ();
-    merge_tests ();
 
     done_testing ();
     return (0);

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -30,9 +30,10 @@ int msg_cb_error (fence_t *f, const flux_msg_t *req, void *data)
 void basic_api_tests (void)
 {
     fence_t *f;
-    json_t *names, *ops;
+    json_t *ops;
     json_t *o;
     flux_msg_t *request;
+    const char *name;
     int count = 0;
 
     ok (fence_create (NULL, 0, 0) == NULL,
@@ -44,22 +45,17 @@ void basic_api_tests (void)
     ok (fence_count_reached (f) == false,
         "initial fence_count_reached() is false");
 
+    ok ((name = fence_get_name (f)) != NULL,
+        "fence_get_name works");
+
+    ok (strcmp (name, "foo") == 0,
+        "fence_get_name returns the correct name");
+
     ok (fence_get_nprocs (f) == 1,
         "fence_get_nprocs works");
 
     ok (fence_get_flags (f) == 3,
         "fence_get_flags works");
-
-    ok ((o = fence_get_json_names (f)) != NULL,
-        "initial fence_get_json_names works");
-
-    names = json_array ();
-    json_array_append_new (names, json_string ("foo"));
-
-    ok (json_equal (names, o) == true,
-        "initial fence_get_json_names match");
-
-    json_decref (names);
 
     /* for test ops can be anything */
     ops = json_array ();


### PR DESCRIPTION
In preparation for issue #1337 and not making that PR huge, this does a decent-refactoring on the commit & fence.  The core change is the commit & fence data structures are now more decoupled.  The commit data structure no longer contains a pointer to a fence and instead copies data in from the fence and stores it internally.  The need for this is hopefully somewhat obvious for #1337 .

As a consequence, the internal fence data structure was cleaned up.  I'm really happy with this refactoring, as the fence data structure now logically represents a "fence" more accurately.  In that fences are no longer mergeable, can't have > 1 name, can't have more than one fence's operations stored in it, etc.

