### PR TITLE
kvs: Refactor commit & fence - part 2

### DIFF
--- a/src/modules/kvs/commit.c
+++ b/src/modules/kvs/commit.c
@@ -1064,15 +1064,8 @@ error:
     return -1;
 }
 
-int commit_mgr_process_fence_request (commit_mgr_t *cm, const char *name)
+int commit_mgr_process_fence_request (commit_mgr_t *cm, fence_t *f)
 {
-    fence_t *f;
-
-    if (!(f = commit_mgr_lookup_fence (cm, name))) {
-        errno = EINVAL;
-        return -1;
-    }
-
     if (fence_count_reached (f)) {
         commit_t *c;
         int aux_int = fence_get_aux_int (f);

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -131,6 +131,9 @@ int commit_mgr_iter_not_ready_fences (commit_mgr_t *cm, commit_fence_f cb,
  *
  * If conditions are correct, will internally create at commit_t and
  * store it to a queue of ready to process commits.
+ *
+ * The fence_t will have its processed flag set to true if a commit_t
+ * is created and queued.  See fence_get/set_processed().
  */
 int commit_mgr_process_fence_request (commit_mgr_t *cm, fence_t *f);
 

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -28,8 +28,6 @@ typedef int (*commit_cache_entry_f)(commit_t *c,
                                      struct cache_entry *entry,
                                      void *data);
 
-typedef int (*commit_fence_f)(fence_t *f, void *data);
-
 int commit_get_errnum (commit_t *c);
 
 /* if user wishes to stall, but needs future knowledge to fail and
@@ -113,19 +111,6 @@ commit_mgr_t *commit_mgr_create (struct cache *cache,
 
 void commit_mgr_destroy (commit_mgr_t *cm);
 
-/* Add fence into the commit manager */
-int commit_mgr_add_fence (commit_mgr_t *cm, fence_t *f);
-
-/* Lookup a fence previously stored via commit_mgr_add_fence(), via name */
-fence_t *commit_mgr_lookup_fence (commit_mgr_t *cm, const char *name);
-
-/* Iterate through all fences in that have never had its operations
- * converted to a ready commit_t
- * - this is typically called during a needed cleanup path
- */
-int commit_mgr_iter_not_ready_fences (commit_mgr_t *cm, commit_fence_f cb,
-                                      void *data);
-
 /* commit_mgr_process_fence_request() should be called once per fence
  * request, after fence_add_request_data() has been called.
  *
@@ -151,14 +136,8 @@ commit_t *commit_mgr_get_ready_commit (commit_mgr_t *cm);
  */
 void commit_mgr_remove_commit (commit_mgr_t *cm, commit_t *c);
 
-/* remove a fence from the commit manager */
-int commit_mgr_remove_fence (commit_mgr_t *cm, const char *name);
-
 int commit_mgr_get_noop_stores (commit_mgr_t *cm);
 void commit_mgr_clear_noop_stores (commit_mgr_t *cm);
-
-/* Get count of fences stored */
-int commit_mgr_fences_count (commit_mgr_t *cm);
 
 /* return count of ready commits */
 int commit_mgr_ready_commit_count (commit_mgr_t *cm);

--- a/src/modules/kvs/commit.h
+++ b/src/modules/kvs/commit.h
@@ -132,7 +132,7 @@ int commit_mgr_iter_not_ready_fences (commit_mgr_t *cm, commit_fence_f cb,
  * If conditions are correct, will internally create at commit_t and
  * store it to a queue of ready to process commits.
  */
-int commit_mgr_process_fence_request (commit_mgr_t *cm, const char *name);
+int commit_mgr_process_fence_request (commit_mgr_t *cm, fence_t *f);
 
 /* returns true if there are commits ready for processing and are not
  * blocked, false if not.

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -51,6 +51,7 @@ struct fence {
     zlist_t *requests;
     json_t *ops;
     int flags;
+    bool processed;
     int aux_int;
 };
 
@@ -218,6 +219,7 @@ fence_t *fence_create (const char *name, int nprocs, int flags)
     }
     f->nprocs = nprocs;
     f->flags = flags;
+    f->processed = false;
     f->aux_int = 0;
 
     return f;
@@ -301,6 +303,16 @@ int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data)
     }
 
     return 0;
+}
+
+bool fence_get_processed (fence_t *f)
+{
+    return f->processed;
+}
+
+void fence_set_processed (fence_t *f, bool p)
+{
+    f->processed = p;
 }
 
 int fence_get_aux_int (fence_t *f)

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -52,7 +52,6 @@ struct fence {
     json_t *ops;
     int flags;
     bool processed;
-    int aux_int;
 };
 
 /*
@@ -109,8 +108,6 @@ int fence_mgr_add_fence (fence_mgr_t *fm, fence_t *f)
         goto error;
     }
 
-    /* initial fence aux int to 0 */
-    fence_set_aux_int (f, 0);
     zhash_freefn (fm->fences,
                   fence_get_name (f),
                   (zhash_free_fn *)fence_destroy);
@@ -220,7 +217,6 @@ fence_t *fence_create (const char *name, int nprocs, int flags)
     f->nprocs = nprocs;
     f->flags = flags;
     f->processed = false;
-    f->aux_int = 0;
 
     return f;
 error:
@@ -313,16 +309,6 @@ bool fence_get_processed (fence_t *f)
 void fence_set_processed (fence_t *f, bool p)
 {
     f->processed = p;
-}
-
-int fence_get_aux_int (fence_t *f)
-{
-    return f->aux_int;
-}
-
-void fence_set_aux_int (fence_t *f, int n)
-{
-    f->aux_int = n;
 }
 
 /*

--- a/src/modules/kvs/fence.c
+++ b/src/modules/kvs/fence.c
@@ -123,8 +123,7 @@ fence_t *fence_mgr_lookup_fence (fence_mgr_t *fm, const char *name)
     return zhash_lookup (fm->fences, name);
 }
 
-int fence_mgr_iter_not_ready_fences (fence_mgr_t *fm, fence_itr_f cb,
-                                     void *data)
+int fence_mgr_iter_fences (fence_mgr_t *fm, fence_itr_f cb, void *data)
 {
     fence_t *f;
     char *name;
@@ -133,10 +132,8 @@ int fence_mgr_iter_not_ready_fences (fence_mgr_t *fm, fence_itr_f cb,
 
     f = zhash_first (fm->fences);
     while (f) {
-        if (!fence_count_reached (f)) {
-            if (cb (f, data) < 0)
-                goto error;
-        }
+        if (cb (f, data) < 0)
+            goto error;
 
         f = zhash_next (fm->fences);
     }

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -76,11 +76,6 @@ int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data);
 bool fence_get_processed (fence_t *f);
 void fence_set_processed (fence_t *f, bool p);
 
-/* Auxiliary convenience data
- */
-int fence_get_aux_int (fence_t *f);
-void fence_set_aux_int (fence_t *f, int n);
-
 #endif /* !_FLUX_KVS_FENCE_H */
 
 /*

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -71,6 +71,11 @@ int fence_add_request_copy (fence_t *f, const flux_msg_t *request);
  */
 int fence_iter_request_copies (fence_t *f, fence_msg_cb cb, void *data);
 
+/* convenience processing flag
+ */
+bool fence_get_processed (fence_t *f);
+void fence_set_processed (fence_t *f, bool p);
+
 /* Auxiliary convenience data
  */
 int fence_get_aux_int (fence_t *f);

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -4,9 +4,45 @@
 #include <czmq.h>
 #include <jansson.h>
 
+typedef struct fence_mgr fence_mgr_t;
+
 typedef struct fence fence_t;
 
+typedef int (*fence_itr_f)(fence_t *f, void *data);
+
 typedef int (*fence_msg_cb)(fence_t *f, const flux_msg_t *req, void *data);
+
+/*
+ * fence_mgr_t API
+ */
+
+/* flux_t is optional, if NULL logging will go to stderr */
+fence_mgr_t *fence_mgr_create (void);
+
+void fence_mgr_destroy (fence_mgr_t *fm);
+
+/* Add fence into the fence manager */
+int fence_mgr_add_fence (fence_mgr_t *fm, fence_t *f);
+
+/* Lookup a fence previously stored via fence_mgr_add_fence(), via name */
+fence_t *fence_mgr_lookup_fence (fence_mgr_t *fm, const char *name);
+
+/* Iterate through all fences in that have never had its operations
+ * converted to a ready fence_t
+ * - this is typically called during a needed cleanup path
+ */
+int fence_mgr_iter_not_ready_fences (fence_mgr_t *fm, fence_itr_f cb,
+                                     void *data);
+
+/* remove a fence from the fence manager */
+int fence_mgr_remove_fence (fence_mgr_t *fm, const char *name);
+
+/* Get count of fences stored */
+int fence_mgr_fences_count (fence_mgr_t *fm);
+
+/*
+ * fence_t API
+ */
 
 fence_t *fence_create (const char *name, int nprocs, int flags);
 

--- a/src/modules/kvs/fence.h
+++ b/src/modules/kvs/fence.h
@@ -27,12 +27,8 @@ int fence_mgr_add_fence (fence_mgr_t *fm, fence_t *f);
 /* Lookup a fence previously stored via fence_mgr_add_fence(), via name */
 fence_t *fence_mgr_lookup_fence (fence_mgr_t *fm, const char *name);
 
-/* Iterate through all fences in that have never had its operations
- * converted to a ready fence_t
- * - this is typically called during a needed cleanup path
- */
-int fence_mgr_iter_not_ready_fences (fence_mgr_t *fm, fence_itr_f cb,
-                                     void *data);
+/* Iterate through all fences */
+int fence_mgr_iter_fences (fence_mgr_t *fm, fence_itr_f cb, void *data);
 
 /* remove a fence from the fence manager */
 int fence_mgr_remove_fence (fence_mgr_t *fm, const char *name);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1738,7 +1738,7 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (commit_mgr_process_fence_request (root->cm, name) < 0) {
+    if (commit_mgr_process_fence_request (root->cm, f) < 0) {
         flux_log_error (h, "%s: commit_mgr_process_fence_request", __FUNCTION__);
         goto error;
     }
@@ -1813,7 +1813,7 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
             goto error;
         }
 
-        if (commit_mgr_process_fence_request (root->cm, name) < 0) {
+        if (commit_mgr_process_fence_request (root->cm, f) < 0) {
             flux_log_error (h, "%s: commit_mgr_process_fence_request",
                             __FUNCTION__);
             goto error;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1126,7 +1126,7 @@ static int heartbeat_root_cb (struct kvsroot *root, void *arg)
 
     if (root->remove) {
         if (!wait_queue_length (root->watchlist)
-            && !commit_mgr_fences_count (root->cm)
+            && !fence_mgr_fences_count (root->fm)
             && !commit_mgr_ready_commit_count (root->cm)) {
 
             if (event_unsubscribe (ctx, root->namespace) < 0)
@@ -1143,7 +1143,7 @@ static int heartbeat_root_cb (struct kvsroot *root, void *arg)
              && strcasecmp (root->namespace, KVS_PRIMARY_NAMESPACE)
              && (ctx->epoch - root->watchlist_lastrun_epoch) > max_namespace_age
              && !wait_queue_length (root->watchlist)
-             && !commit_mgr_fences_count (root->cm)
+             && !fence_mgr_fences_count (root->fm)
              && !commit_mgr_ready_commit_count (root->cm)) {
         /* remove a root if it not the primary one, has timed out
          * on a follower node, and it does not have any watchers,
@@ -1675,10 +1675,10 @@ static void finalize_fences_bynames (kvs_ctx_t *ctx, struct kvsroot *root,
             flux_log_error (ctx->h, "%s: parsing array[%d]", __FUNCTION__, i);
             return;
         }
-        if ((f = commit_mgr_lookup_fence (root->cm, json_string_value (name)))) {
+        if ((f = fence_mgr_lookup_fence (root->fm, json_string_value (name)))) {
             fence_iter_request_copies (f, finalize_fence_req, &cbd);
-            if (commit_mgr_remove_fence (root->cm, json_string_value (name)) < 0)
-                flux_log_error (ctx->h, "%s: commit_mgr_remove_fence",
+            if (fence_mgr_remove_fence (root->fm, json_string_value (name)) < 0)
+                flux_log_error (ctx->h, "%s: fence_mgr_remove_fence",
                                 __FUNCTION__);
         }
     }
@@ -1715,13 +1715,13 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(f = commit_mgr_lookup_fence (root->cm, name))) {
+    if (!(f = fence_mgr_lookup_fence (root->fm, name))) {
         if (!(f = fence_create (name, nprocs, flags))) {
             flux_log_error (h, "%s: fence_create", __FUNCTION__);
             goto error;
         }
-        if (commit_mgr_add_fence (root->cm, f) < 0) {
-            flux_log_error (h, "%s: commit_mgr_add_fence", __FUNCTION__);
+        if (fence_mgr_add_fence (root->fm, f) < 0) {
+            flux_log_error (h, "%s: fence_mgr_add_fence", __FUNCTION__);
             fence_destroy (f);
             goto error;
         }
@@ -1785,14 +1785,14 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(f = commit_mgr_lookup_fence (root->cm, name))) {
+    if (!(f = fence_mgr_lookup_fence (root->fm, name))) {
         if (!(f = fence_create (name, nprocs, flags))) {
             flux_log_error (h, "%s: fence_create", __FUNCTION__);
             goto error;
         }
-        if (commit_mgr_add_fence (root->cm, f) < 0) {
+        if (fence_mgr_add_fence (root->fm, f) < 0) {
             saved_errno = errno;
-            flux_log_error (h, "%s: commit_mgr_add_fence", __FUNCTION__);
+            flux_log_error (h, "%s: fence_mgr_add_fence", __FUNCTION__);
             fence_destroy (f);
             errno = saved_errno;
             goto error;
@@ -2145,7 +2145,7 @@ static int stats_get_root_cb (struct kvsroot *root, void *arg)
                          "#no-op stores",
                          commit_mgr_get_noop_stores (root->cm),
                          "#fences",
-                         commit_mgr_fences_count (root->cm),
+                         fence_mgr_fences_count (root->fm),
                          "#readycommits",
                          commit_mgr_ready_commit_count (root->cm),
                          "store revision", root->seq))) {
@@ -2373,20 +2373,23 @@ error:
 static int root_remove_process_fences (fence_t *f, void *data)
 {
     struct kvs_cb_data *cbd = data;
-    json_t *names = NULL;
 
-    /* Not ready fences will never finish, must alert them with
-     * ENOTSUP that namespace removed.  Final call to
-     * commit_mgr_remove_fence() done in finalize_fences_bynames() */
+    /* Fences that never reached their nprocs count will never finish,
+     * must alert them with ENOTSUP that namespace removed.  Final
+     * call to fence_mgr_remove_fence() done in
+     * finalize_fences_bynames() */
+    if (!fence_get_processed (f)) {
+        json_t *names = NULL;
 
-    if (!(names = json_pack ("[ s ]", fence_get_name (f)))) {
-        flux_log_error (cbd->ctx->h, "%s: json_pack", __FUNCTION__);
-        errno = ENOMEM;
-        return -1;
+        if (!(names = json_pack ("[ s ]", fence_get_name (f)))) {
+            flux_log_error (cbd->ctx->h, "%s: json_pack", __FUNCTION__);
+            errno = ENOMEM;
+            return -1;
+        }
+
+        finalize_fences_bynames (cbd->ctx, cbd->root, names, ENOTSUP);
+        json_decref (names);
     }
-
-    finalize_fences_bynames (cbd->ctx, cbd->root, names, ENOTSUP);
-    json_decref (names);
     return 0;
 }
 
@@ -2417,10 +2420,10 @@ static void start_root_remove (kvs_ctx_t *ctx, const char *namespace)
          * commit_request_cb() and relaycommit_request_cb() ensure this.
          */
 
-        if (commit_mgr_iter_not_ready_fences (root->cm,
-                                              root_remove_process_fences,
-                                              &cbd) < 0)
-            flux_log_error (ctx->h, "%s: commit_mgr_iter_fences", __FUNCTION__);
+        if (fence_mgr_iter_fences (root->fm,
+                                   root_remove_process_fences,
+                                   &cbd) < 0)
+            flux_log_error (ctx->h, "%s: fence_mgr_iter_fences", __FUNCTION__);
     }
 }
 

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -98,6 +98,8 @@ static void kvsroot_destroy (void *data)
             free (root->namespace);
         if (root->cm)
             commit_mgr_destroy (root->cm);
+        if (root->fm)
+            fence_mgr_destroy (root->fm);
         if (root->watchlist)
             wait_queue_destroy (root->watchlist);
         free (data);
@@ -136,6 +138,11 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *km,
                                         km->h,
                                         km->arg))) {
         flux_log_error (km->h, "commit_mgr_create");
+        goto error;
+    }
+
+    if (!(root->fm = fence_mgr_create ())) {
+        flux_log_error (km->h, "fence_mgr_create");
         goto error;
     }
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -6,6 +6,7 @@
 
 #include "cache.h"
 #include "commit.h"
+#include "fence.h"
 #include "waitqueue.h"
 #include "src/common/libutil/blobref.h"
 
@@ -17,6 +18,7 @@ struct kvsroot {
     int seq;
     blobref_t ref;
     commit_mgr_t *cm;
+    fence_mgr_t *fm;
     waitqueue_t *watchlist;
     int watchlist_lastrun_epoch;
     int flags;

--- a/src/modules/kvs/test/commit.c
+++ b/src/modules/kvs/test/commit.c
@@ -185,11 +185,7 @@ void commit_mgr_basic_tests (void)
     ok (commit_mgr_fences_count (cm) == 1,
         "commit_mgr_fences_count returns 1 when fence submitted");
 
-    ok (commit_mgr_process_fence_request (cm, "fenceBAD") < 0
-        && errno == EINVAL,
-        "commit_mgr_process_fence_request fails on invalid fence");
-
-    ok (commit_mgr_process_fence_request (cm, "fence1") == 0,
+    ok (commit_mgr_process_fence_request (cm, f) == 0,
         "commit_mgr_process_fence_request works");
 
     ok (commit_mgr_ready_commit_count (cm) == 0,
@@ -209,13 +205,13 @@ void commit_mgr_basic_tests (void)
 
     json_decref (ops);
 
-    ok (commit_mgr_process_fence_request (cm, "fence1") == 0,
+    ok (commit_mgr_process_fence_request (cm, f) == 0,
         "commit_mgr_process_fence_request works");
 
     ok (commit_mgr_ready_commit_count (cm) == 1,
         "commit_mgr_ready_commit_count is 1");
 
-    ok (commit_mgr_process_fence_request (cm, "fence1") == 0,
+    ok (commit_mgr_process_fence_request (cm, f) == 0,
         "commit_mgr_process_fence_request works again");
 
     ok (commit_mgr_ready_commit_count (cm) == 1,
@@ -268,7 +264,7 @@ void create_ready_commit (commit_mgr_t *cm,
     ok (commit_mgr_add_fence (cm, f) == 0,
         "commit_mgr_add_fence works");
 
-    ok (commit_mgr_process_fence_request (cm, name) == 0,
+    ok (commit_mgr_process_fence_request (cm, f) == 0,
         "commit_mgr_process_fence_request works");
 
     ok (commit_mgr_commits_ready (cm) == true,
@@ -859,7 +855,7 @@ void commit_basic_iter_not_ready_tests (void)
 
     json_decref (ops);
 
-    ok (commit_mgr_process_fence_request (cm, "fence1") == 0,
+    ok (commit_mgr_process_fence_request (cm, f1) == 0,
         "commit_mgr_process_fence_request works");
 
     count = 0;
@@ -1358,7 +1354,7 @@ void commit_process_malformed_operation (void)
      */
     ok (commit_mgr_add_fence (cm, f) == 0,
         "commit_mgr_add_fence works");
-    ok (commit_mgr_process_fence_request (cm, "malformed") == 0,
+    ok (commit_mgr_process_fence_request (cm, f) == 0,
         "commit_mgr_process_fence_request works");
 
     /* Process ready commit and verify EPROTO error

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -97,6 +97,14 @@ void fence_basic_tests (void)
     ok (fence_count_reached (f) == true,
         "later fence_count_reached() is true");
 
+    ok (fence_get_processed (f) == false,
+        "fence_get_processed returns false initially");
+
+    fence_set_processed (f, true);
+
+    ok (fence_get_processed (f) == true,
+        "fence_get_processed returns true");
+
     ok (fence_get_aux_int (f) == 0,
         "fence_get_aux_int returns 0 initially");
 

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -27,7 +27,7 @@ int msg_cb_error (fence_t *f, const flux_msg_t *req, void *data)
     return -1;
 }
 
-void basic_api_tests (void)
+void fence_basic_tests (void)
 {
     fence_t *f;
     json_t *ops;
@@ -110,7 +110,7 @@ void basic_api_tests (void)
     fence_destroy (f);
 }
 
-void ops_tests (void)
+void fence_ops_tests (void)
 {
     fence_t *f;
     json_t *ops;
@@ -167,7 +167,7 @@ void ops_tests (void)
     fence_destroy (f);
 }
 
-void request_tests (void)
+void fence_request_tests (void)
 {
     fence_t *f;
     flux_msg_t *request;
@@ -210,13 +210,136 @@ void request_tests (void)
     fence_destroy (f);
 }
 
+void fence_mgr_basic_tests (void)
+{
+    fence_mgr_t *fm;
+    fence_t *f, *tf;
+
+    ok ((fm = fence_mgr_create ()) != NULL,
+        "fence_mgr_create works");
+
+    ok (fence_mgr_fences_count (fm) == 0,
+        "fence_mgr_fences_count returns 0 when no fences added");
+
+    ok ((f = fence_create ("fence1", 1, 0)) != NULL,
+        "fence_create works");
+
+    ok (fence_mgr_add_fence (fm, f) == 0,
+        "fence_mgr_add_fence works");
+
+    ok (fence_mgr_add_fence (fm, f) < 0,
+        "fence_mgr_add_fence fails on duplicate fence");
+
+    ok ((tf = fence_mgr_lookup_fence (fm, "fence1")) != NULL,
+        "fence_mgr_lookup_fence works");
+
+    ok (f == tf,
+        "fence_mgr_lookup_fence returns correct fence");
+
+    ok (fence_mgr_lookup_fence (fm, "invalid") == NULL,
+        "fence_mgr_lookup_fence can't find invalid fence");
+
+    ok (fence_mgr_fences_count (fm) == 1,
+        "fence_mgr_fences_count returns 1 when fence submitted");
+
+    fence_mgr_remove_fence (fm, "fence1");
+
+    ok (fence_mgr_fences_count (fm) == 0,
+        "fence_mgr_fences_count returns 0 after fence remove");
+
+    ok (fence_mgr_lookup_fence (fm, "fence1") == NULL,
+        "fence_mgr_lookup_fence can't find removed fence");
+
+    fence_mgr_destroy (fm);
+}
+
+int fence_count_cb (fence_t *f, void *data)
+{
+    int *count = data;
+    (*count)++;
+    return 0;
+}
+
+int fence_remove_cb (fence_t *f, void *data)
+{
+    fence_mgr_t *fm = data;
+
+    fence_mgr_remove_fence (fm, fence_get_name (f));
+    return 0;
+}
+
+int fence_add_error_cb (fence_t *f, void *data)
+{
+    fence_mgr_t *fm = data;
+    fence_t *f2;
+
+    f2 = fence_create ("foobar", 1, 0);
+
+    if (fence_mgr_add_fence (fm, f2) < 0)
+        return -1;
+    return 0;
+}
+
+int fence_error_cb (fence_t *f, void *data)
+{
+    return -1;
+}
+
+void fence_mgr_iter_tests (void)
+{
+    fence_mgr_t *fm;
+    fence_t *f;
+    int count;
+
+    ok ((fm = fence_mgr_create ()) != NULL,
+        "fence_mgr_create works");
+
+    count = 0;
+    ok (fence_mgr_iter_fences (fm, fence_count_cb, &count) == 0
+        && count == 0,
+        "fence_mgr_iter_fences success when no fences submitted");
+
+    ok ((f = fence_create ("fence1", 1, 0)) != NULL,
+        "fence_create works");
+
+    ok (fence_mgr_add_fence (fm, f) == 0,
+        "fence_mgr_add_fence works");
+
+    ok (fence_mgr_fences_count (fm) == 1,
+        "fence_mgr_fences_count returns correct count of fences");
+
+    ok (fence_mgr_iter_fences (fm, fence_error_cb, NULL) < 0,
+        "fence_mgr_iter_fences error on callback error");
+
+    ok (fence_mgr_iter_fences (fm, fence_add_error_cb, fm) < 0
+        && errno == EAGAIN,
+        "fence_mgr_iter_fences error on callback error trying to add fence");
+
+    ok (fence_mgr_iter_fences (fm, fence_remove_cb, fm) == 0,
+        "fence_mgr_iter_fences success on remove");
+
+    count = 0;
+    ok (fence_mgr_iter_fences (fm, fence_count_cb, &count) == 0,
+        "fence_mgr_iter_fences success on count");
+
+    ok (count == 0,
+        "fence_mgr_iter_fences returned correct count of fences");
+
+    ok (fence_mgr_fences_count (fm) == 0,
+        "fence_mgr_fences_count returns correct count of fences");
+
+    fence_mgr_destroy (fm);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
-    basic_api_tests ();
-    ops_tests ();
-    request_tests ();
+    fence_basic_tests ();
+    fence_ops_tests ();
+    fence_request_tests ();
+    fence_mgr_basic_tests ();
+    fence_mgr_iter_tests ();
 
     done_testing ();
     return (0);

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -105,14 +105,6 @@ void fence_basic_tests (void)
     ok (fence_get_processed (f) == true,
         "fence_get_processed returns true");
 
-    ok (fence_get_aux_int (f) == 0,
-        "fence_get_aux_int returns 0 initially");
-
-    fence_set_aux_int (f, 5);
-
-    ok (fence_get_aux_int (f) == 5,
-        "fence_get_aux_int returns 5 after set");
-
     flux_msg_destroy (request);
 
     fence_destroy (f);

--- a/src/modules/kvs/test/fence.c
+++ b/src/modules/kvs/test/fence.c
@@ -210,25 +210,6 @@ void request_tests (void)
     fence_destroy (f);
 }
 
-fence_t *create_fence (const char *name, const char *opname, int flags)
-{
-    fence_t *f;
-    json_t *ops;
-
-    ok ((f = fence_create (name, 1, flags)) != NULL,
-        "fence_create works");
-
-    ops = json_array ();
-    json_array_append_new (ops, json_string (opname));
-
-    ok (fence_add_request_ops (f, ops) == 0,
-        "fence_add_request_ops add works");
-
-    json_decref (ops);
-
-    return f;
-}
-
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -198,7 +198,7 @@ void basic_commit_mgr_tests (void)
     ok (commit_mgr_add_fence (root->cm, f) == 0,
         "commit_mgr_add_fence works");
 
-    ok (commit_mgr_process_fence_request (root->cm, "foo") == 0,
+    ok (commit_mgr_process_fence_request (root->cm, f) == 0,
         "commit_mgr_process_fence_request works");
 
     ok ((c = commit_mgr_get_ready_commit (root->cm)) != NULL,

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -195,9 +195,6 @@ void basic_commit_mgr_tests (void)
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 
-    ok (commit_mgr_add_fence (root->cm, f) == 0,
-        "commit_mgr_add_fence works");
-
     ok (commit_mgr_process_fence_request (root->cm, f) == 0,
         "commit_mgr_process_fence_request works");
 


### PR DESCRIPTION
Following up #1343, this de-couples portions of the "commit manager" and creates a new "fence manager".  As the internal commit API and internal fence API were decoupled in #1343, additional portions could be spliced off.