### PR TITLE
kvs: have two request handlers for commits & fences

### DIFF
--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -95,9 +95,8 @@ flux_future_t *flux_kvs_commit (flux_t *h, int flags, flux_kvs_txn_t *txn)
             goto cleanup;
         }
         if (!(f = flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
-                                 "{s:s s:i s:s s:i s:O}",
+                                 "{s:s s:s s:i s:O}",
                                  "name", name,
-                                 "nprocs", 1,
                                  "namespace", namespace,
                                  "flags", flags,
                                  "ops", ops))) {
@@ -106,9 +105,8 @@ flux_future_t *flux_kvs_commit (flux_t *h, int flags, flux_kvs_txn_t *txn)
         }
     } else {
         if (!(f = flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
-                                 "{s:s s:i s:s s:i s:[]}",
+                                 "{s:s s:s s:i s:[]}",
                                  "name", name,
-                                 "nprocs", 1,
                                  "namespace", namespace,
                                  "flags", flags,
                                  "ops"))) {

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -101,7 +101,6 @@ test_kvstxn_t_SOURCES = test/kvstxn.c
 test_kvstxn_t_CPPFLAGS = $(test_cppflags)
 test_kvstxn_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/kvstxn.o \
-	$(top_builddir)/src/modules/kvs/treq.o \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/lookup.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -885,9 +885,9 @@ static void kvstxn_apply (kvstxn_t *kt)
     namespace = kvstxn_get_namespace (kt);
     assert (namespace);
 
-    /* Between call to kvstxn_mgr_process_transaction_request() and here,
-     * possible namespace marked for removal.  Also namespace could
-     * have been removed if we waited and this is a replay.
+    /* Between call to kvstxn_mgr_add_transaction() and here, possible
+     * namespace marked for removal.  Also namespace could have been
+     * removed if we waited and this is a replay.
      *
      * root should never be NULL, as it should not be garbage
      * collected until all ready transactions have been processed.
@@ -1741,8 +1741,11 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
      * the ready queue */
     treq_set_processed (tr, true);
 
-    if (kvstxn_mgr_process_transaction_request (root->ktm, tr) < 0) {
-        flux_log_error (h, "%s: kvstxn_mgr_process_transaction_request",
+    if (kvstxn_mgr_add_transaction (root->ktm,
+                                    treq_get_name (tr),
+                                    treq_get_ops (tr),
+                                    treq_get_flags (tr)) < 0) {
+        flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                         __FUNCTION__);
         goto error;
     }
@@ -1813,8 +1816,11 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
          * the ready queue */
         treq_set_processed (tr, true);
 
-        if (kvstxn_mgr_process_transaction_request (root->ktm, tr) < 0) {
-            flux_log_error (h, "%s: kvstxn_mgr_process_transaction_request",
+        if (kvstxn_mgr_add_transaction (root->ktm,
+                                        treq_get_name (tr),
+                                        treq_get_ops (tr),
+                                        treq_get_flags (tr)) < 0) {
+            flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                             __FUNCTION__);
             goto error;
         }
@@ -1910,8 +1916,11 @@ static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *mh,
          * the ready queue */
         treq_set_processed (tr, true);
 
-        if (kvstxn_mgr_process_transaction_request (root->ktm, tr) < 0) {
-            flux_log_error (h, "%s: kvstxn_mgr_process_transaction_request",
+        if (kvstxn_mgr_add_transaction (root->ktm,
+                                        treq_get_name (tr),
+                                        treq_get_ops (tr),
+                                        treq_get_flags (tr)) < 0) {
+            flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                             __FUNCTION__);
             goto error;
         }
@@ -1998,8 +2007,11 @@ static void fence_request_cb (flux_t *h, flux_msg_handler_t *mh,
              * the ready queue */
             treq_set_processed (tr, true);
 
-            if (kvstxn_mgr_process_transaction_request (root->ktm, tr) < 0) {
-                flux_log_error (h, "%s: kvstxn_mgr_process_transaction_request",
+            if (kvstxn_mgr_add_transaction (root->ktm,
+                                            treq_get_name (tr),
+                                            treq_get_ops (tr),
+                                            treq_get_flags (tr)) < 0) {
+                flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                                 __FUNCTION__);
                 goto error;
             }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1720,23 +1720,15 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(tr = treq_mgr_lookup_transaction (root->trm, name))) {
-        if (!(tr = treq_create (name, 1, flags))) {
-            flux_log_error (h, "%s: treq_create", __FUNCTION__);
-            goto error;
-        }
-        if (treq_mgr_add_transaction (root->trm, tr) < 0) {
-            saved_errno = errno;
-            flux_log_error (h, "%s: treq_mgr_add_transaction", __FUNCTION__);
-            treq_destroy (tr);
-            errno = saved_errno;
-            goto error;
-        }
+    if (!(tr = treq_create (name, 1, flags))) {
+        flux_log_error (h, "%s: treq_create", __FUNCTION__);
+        goto error;
     }
-
-    if (treq_get_flags (tr) != flags
-        || treq_get_nprocs (tr) != 1) {
-        errno = EINVAL;
+    if (treq_mgr_add_transaction (root->trm, tr) < 0) {
+        saved_errno = errno;
+        flux_log_error (h, "%s: treq_mgr_add_transaction", __FUNCTION__);
+        treq_destroy (tr);
+        errno = saved_errno;
         goto error;
     }
 
@@ -1793,23 +1785,15 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(tr = treq_mgr_lookup_transaction (root->trm, name))) {
-        if (!(tr = treq_create (name, 1, flags))) {
-            flux_log_error (h, "%s: treq_create", __FUNCTION__);
-            goto error;
-        }
-        if (treq_mgr_add_transaction (root->trm, tr) < 0) {
-            saved_errno = errno;
-            flux_log_error (h, "%s: treq_mgr_add_transaction", __FUNCTION__);
-            treq_destroy (tr);
-            errno = saved_errno;
-            goto error;
-        }
+    if (!(tr = treq_create (name, 1, flags))) {
+        flux_log_error (h, "%s: treq_create", __FUNCTION__);
+        goto error;
     }
-
-    if (treq_get_flags (tr) != flags
-        || treq_get_nprocs (tr) != 1) {
-        errno = EINVAL;
+    if (treq_mgr_add_transaction (root->trm, tr) < 0) {
+        saved_errno = errno;
+        flux_log_error (h, "%s: treq_mgr_add_transaction", __FUNCTION__);
+        treq_destroy (tr);
+        errno = saved_errno;
         goto error;
     }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1699,7 +1699,7 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
     struct kvsroot *root;
     const char *namespace;
     const char *name;
-    int nprocs, flags;
+    int saved_errno, nprocs, flags;
     json_t *ops = NULL;
     treq_t *tr;
 
@@ -1727,8 +1727,10 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
             goto error;
         }
         if (treq_mgr_add_transaction (root->trm, tr) < 0) {
+            saved_errno = errno;
             flux_log_error (h, "%s: treq_mgr_add_transaction", __FUNCTION__);
             treq_destroy (tr);
+            errno = saved_errno;
             goto error;
         }
     }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -89,17 +89,19 @@ static void kvstxn_destroy (kvstxn_t *kt)
     }
 }
 
-static kvstxn_t *kvstxn_create (treq_t *tr, kvstxn_mgr_t *ktm)
+static kvstxn_t *kvstxn_create (kvstxn_mgr_t *ktm,
+                                const char *name,
+                                json_t *ops,
+                                int flags)
 {
     kvstxn_t *kt;
-    const char *name;
     int saved_errno;
 
     if (!(kt = calloc (1, sizeof (*kt)))) {
         saved_errno = ENOMEM;
         goto error;
     }
-    if (!(kt->ops = json_copy (treq_get_ops (tr)))) {
+    if (!(kt->ops = json_copy (ops))) {
         saved_errno = ENOMEM;
         goto error;
     }
@@ -107,7 +109,7 @@ static kvstxn_t *kvstxn_create (treq_t *tr, kvstxn_mgr_t *ktm)
         saved_errno = ENOMEM;
         goto error;
     }
-    if ((name = treq_get_name (tr))) {
+    if (name) {
         json_t *s;
         if (!(s = json_string (name))) {
             saved_errno = ENOMEM;
@@ -119,7 +121,7 @@ static kvstxn_t *kvstxn_create (treq_t *tr, kvstxn_mgr_t *ktm)
             goto error;
         }
     }
-    kt->flags = treq_get_flags (tr);
+    kt->flags = flags;
     if (!(kt->missing_refs_list = zlist_new ())) {
         saved_errno = ENOMEM;
         goto error;
@@ -990,7 +992,10 @@ int kvstxn_mgr_process_transaction_request (kvstxn_mgr_t *ktm, treq_t *tr)
         if (treq_get_processed (tr))
             return 0;
 
-        if (!(kt = kvstxn_create (tr, ktm)))
+        if (!(kt = kvstxn_create (ktm,
+                                  treq_get_name (tr),
+                                  treq_get_ops (tr),
+                                  treq_get_flags (tr))))
             return -1;
 
         if (zlist_append (ktm->ready, kt) < 0) {

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -983,14 +983,22 @@ void kvstxn_mgr_destroy (kvstxn_mgr_t *ktm)
     }
 }
 
-int kvstxn_mgr_process_transaction_request (kvstxn_mgr_t *ktm, treq_t *tr)
+int kvstxn_mgr_add_transaction (kvstxn_mgr_t *ktm,
+                                const char *name,
+                                json_t *ops,
+                                int flags)
 {
     kvstxn_t *kt;
 
+    if (!name || !ops) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (!(kt = kvstxn_create (ktm,
-                              treq_get_name (tr),
-                              treq_get_ops (tr),
-                              treq_get_flags (tr))))
+                              name,
+                              ops,
+                              flags)))
         return -1;
 
     if (zlist_append (ktm->ready, kt) < 0) {

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -111,15 +111,14 @@ kvstxn_mgr_t *kvstxn_mgr_create (struct cache *ktache,
 
 void kvstxn_mgr_destroy (kvstxn_mgr_t *ktm);
 
-/* kvstxn_mgr_process_transaction_request() should be called once per
- * transaction (commit or fence) request, after
- * treq_add_request_ops() has been called.
+/* kvstxn_mgr_process_transaction_request() will internally create a
+ * kvstxn_t and store it in the queue of ready to process
+ * transactions.
  *
- * If conditions are correct, will internally create at kvstxn_t and
- * store it to a queue of ready to process kvstxns.
- *
- * The treq_t will have its processed flag set to true if a kvstxn_t
- * is created and queued.  See treq_get/set_processed().
+ * This should be called once per transaction (commit or fence)
+ * request, after treq_add_request_ops() has been called and the
+ * transaction has met conditions for being ready
+ * (i.e. treq_count_reached() == true for fences).
  */
 int kvstxn_mgr_process_transaction_request (kvstxn_mgr_t *ktm, treq_t *tr);
 

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -5,7 +5,6 @@
 #include <czmq.h>
 
 #include "cache.h"
-#include "treq.h"
 #include "src/common/libutil/blobref.h"
 
 typedef struct kvstxn_mgr kvstxn_mgr_t;
@@ -111,16 +110,16 @@ kvstxn_mgr_t *kvstxn_mgr_create (struct cache *ktache,
 
 void kvstxn_mgr_destroy (kvstxn_mgr_t *ktm);
 
-/* kvstxn_mgr_process_transaction_request() will internally create a
- * kvstxn_t and store it in the queue of ready to process
- * transactions.
+/* kvstxn_mgr_add_transaction() will internally create a kvstxn_t and
+ * store it in the queue of ready to process transactions.
  *
  * This should be called once per transaction (commit or fence)
- * request, after treq_add_request_ops() has been called and the
- * transaction has met conditions for being ready
- * (i.e. treq_count_reached() == true for fences).
+ * request.
  */
-int kvstxn_mgr_process_transaction_request (kvstxn_mgr_t *ktm, treq_t *tr);
+int kvstxn_mgr_add_transaction (kvstxn_mgr_t *ktm,
+                                const char *name,
+                                json_t *ops,
+                                int flags);
 
 /* returns true if there is a transaction ready for processing and is
  * not blocked, false if not.

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -169,20 +169,10 @@ void basic_kvstxn_mgr_tests (void)
     struct cache *cache;
     struct kvsroot *root;
     kvstxn_t *kt;
-    treq_t *tr;
     json_t *ops = NULL;
     void *tmpaux;
 
     cache = cache_create ();
-
-    tr = treq_create ("foo", 1, 0);
-    ops = json_array ();
-    /* not a real operation */
-    json_array_append_new (ops, json_string ("foo"));
-
-    treq_add_request_ops (tr, ops);
-
-    json_decref (ops);
 
     ok ((km = kvsroot_mgr_create (NULL, &global)) != NULL,
         "kvsroot_mgr_create works");
@@ -195,8 +185,17 @@ void basic_kvstxn_mgr_tests (void)
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 
-    ok (kvstxn_mgr_process_transaction_request (root->ktm, tr) == 0,
-        "kvstxn_mgr_process_transaction_request works");
+    ops = json_array ();
+    /* not a real operation */
+    json_array_append_new (ops, json_string ("foo"));
+
+    ok (kvstxn_mgr_add_transaction (root->ktm,
+                                    "foo",
+                                    ops,
+                                    0) == 0,
+        "kvstxn_mgr_add_transaction works");
+
+    json_decref (ops);
 
     ok ((kt = kvstxn_mgr_get_ready_transaction (root->ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -161,20 +161,17 @@ void kvstxn_mgr_basic_tests (void)
 
     kvstxn_mgr_clear_noop_stores (ktm);
 
-    ok ((tr = treq_create ("transaction1", 1, 0)) != NULL,
-        "treq_create works");
-
-    ok (kvstxn_mgr_process_transaction_request (ktm, tr) == 0,
-        "kvstxn_mgr_process_transaction_request works");
-
     ok (kvstxn_mgr_ready_transaction_count (ktm) == 0,
-        "kvstxn_mgr_ready_transaction_count is 0");
+        "kvstxn_mgr_ready_transaction_count is initially 0");
 
     ok (kvstxn_mgr_transaction_ready (ktm) == false,
-        "kvstxn_mgr_transaction_ready says no transactions are ready");
+        "kvstxn_mgr_transaction_ready initially says no transactions are ready");
 
     ok (kvstxn_mgr_get_ready_transaction (ktm) == NULL,
-        "kvstxn_mgr_get_ready_transaction returns NULL for no ready kvstxns");
+        "kvstxn_mgr_get_ready_transaction initially returns NULL for no ready transactions");
+
+    ok ((tr = treq_create ("transaction1", 1, 0)) != NULL,
+        "treq_create works");
 
     ops = json_array ();
     ops_append (ops, "key1", "1", 0);
@@ -189,12 +186,6 @@ void kvstxn_mgr_basic_tests (void)
 
     ok (kvstxn_mgr_ready_transaction_count (ktm) == 1,
         "kvstxn_mgr_ready_transaction_count is 1");
-
-    ok (kvstxn_mgr_process_transaction_request (ktm, tr) == 0,
-        "kvstxn_mgr_process_transaction_request works again");
-
-    ok (kvstxn_mgr_ready_transaction_count (ktm) == 1,
-        "kvstxn_mgr_ready_transaction_count is still 1, didn't double add");
 
     ok (kvstxn_mgr_transaction_ready (ktm) == true,
         "kvstxn_mgr_transaction_ready says a transaction is ready");


### PR DESCRIPTION
Instead of sending all commit and fence RPCs to the same kvs handler, have one for commits (```kvs.commit```) and one for fences (```kvs.fence```).

This makes the code far clearer on how commits and fences are different.

A) commits do not require "nprocs" and "name" to be sent in their  RPCs, so they are now removed.

B) a nice chunk of code is not needed for commits b/c nprocs is always 1 (i.e. don't need to do a lookup), so all that code is now removed in the commit path.

This completes issue #1344.

I was curious if this would improve performance, as commits are now far simpler than fences (less allocations, etc.).  A soak test showed:

before

```
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
  0.210   0.230   0.240   0.238   0.240   0.300 
```

after

```
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
 0.2100  0.2300  0.2400  0.2364  0.2400  0.3000 
```

Granted only 1 run over 1000 jobs, but mean is a tad better.