### PR TITLE
anonymous enums kill bindings

### DIFF
--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define KVS_PRIMARY_NAMESPACE "primary"
 
-enum {
+enum kvs_op {
     FLUX_KVS_READDIR = 1,
     FLUX_KVS_READLINK = 2,
     FLUX_KVS_TREEOBJ = 16,


### PR DESCRIPTION
Subject says it all, no clue why this works elsewhere but a build on toss2 died without this change.