### PR TITLE
Fix flux-wreck purge

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -245,7 +245,7 @@ prog:SubCommand {
  usage = "",
  description = "List jobs in kvs",
  handler = function (self, arg)
-    local dirs = wreck.joblist{ flux = f }
+    local dirs = wreck.joblist{ flux = f } or {}
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
     printf (fmt, "ID", "NTASKS", "STATE", "START", "RUNTIME", "RANKS", "COMMAND")
@@ -268,7 +268,7 @@ prog:SubCommand {
  usage = "",
  description = "List timings of jobs in kvs",
  handler = function (self, arg) 
-    local dirs = wreck.joblist{ flux = f }
+    local dirs = wreck.joblist{ flux = f } or {}
     if #dirs == 0 then return end
     local fmt = "%6s %12s %12s %12s %12s %12s\n"
     printf (fmt, "ID", "NTASKS", "STARTING", "RUNNING", "COMPLETE", "TOTAL")
@@ -350,7 +350,7 @@ prog:SubCommand {
     ---
     -- Gather LWJ path list
     --
-    local dirs = wreck.joblist{ flux = f }
+    local dirs = wreck.joblist{ flux = f } or {}
     if verbose then
         self:log ("%4.03fs: got lwj list (%d entries)\n", tt:get0(), #dirs)
     end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -418,7 +418,7 @@ prog:SubCommand {
         --
         local hl = require 'flux.hostlist' .new (table.concat (r, ",")):uniq ()
         if self.opt.R then
-            f:commit()
+            f:kvs_commit()
             if verbose then
                 self:log ("%4.03fs: unlinked %d entries\n", tt:get0(), #hl)
             end

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -361,6 +361,13 @@ test_expect_success 'flux-wreck: ls works' '
 	flux wreck ls | sort -n >ls.out &&
 	tail -1 ls.out | grep "hostname$"
 '
+test_expect_success 'flux-wreck: purge works' '
+	flux wreck purge &&
+	flux wreck purge -t 2 -R &&
+	flux wreck ls &&
+	COUNT=$(flux wreck ls | grep -v NTASKS | wc -l) &&
+	test "$COUNT" = 2
+'
 
 flux module list | grep -q sched || test_set_prereq NO_SCHED
 test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded' '


### PR DESCRIPTION
Fix typo/incorrect method call in `flux wreck purge` as noticed by @trws in #1356.

Also added a quick sanity of check of `flux wreck purge` in tests (don't know why this was never done!), and a few other runtime fixes I stumbled across during testing.