### PR TITLE
build: add --disable-jobspec opt-out configuration

### DIFF
--- a/config/x_ac_yamlcpp.m4
+++ b/config/x_ac_yamlcpp.m4
@@ -1,9 +1,17 @@
 AC_DEFUN([X_AC_YAMLCPP], [
 
-    PKG_CHECK_MODULES([YAMLCPP], [yaml-cpp >= 0.5.1],
-                      [enable_jobspec=yes], [enable_jobspec=no])
+    AC_ARG_ENABLE([jobspec],
+        AS_HELP_STRING([--disable-jobspec],
+            [Disable compilation of jobspec library]))
 
-    if test "$enable_jobspec" = yes; then
+    AS_IF([test "x$enable_jobspec" != "xno"], [
+
+        PKG_CHECK_MODULES([YAMLCPP], [yaml-cpp >= 0.5.1],
+                          ,
+			  [AC_MSG_ERROR(dnl
+[Required yaml-cpp package version not installed.
+Add --disable-jobspec, or set the PKG_CONFIG_PATH env var appropriately.])])
+
         ac_save_LIBS="$LIBS"
         LIBS="$LIBS $YAMLCPP_LIBS"
         ac_save_CFLAGS="$CFLAGS"
@@ -28,8 +36,8 @@ AC_DEFUN([X_AC_YAMLCPP], [
         AC_LANG_POP([C++])
         LIBS="$ac_save_LIBS"
         CFLAGS="$ac_save_CFLAGS"
-    fi
+    ])
 
-    AM_CONDITIONAL([ENABLE_JOBSPEC], [test "$enable_jobspec" = yes])
+    AM_CONDITIONAL([ENABLE_JOBSPEC], [test "x$enable_jobspec" != "xno"])
   ]
 )


### PR DESCRIPTION
As proposed in #1360, alter build system to build the jobspec library by default, failing at configure time if prereqs are missing, unless opting out with `configure --disable-jobspec`.

The enable option is added in configure.ac, and the call to the X_AC_YAML_CPP macro is made conditional on lack of `--disable-jobspec`.

The X_AC_YAML_CPP macro is modified so that PKG_CHECK_MODULES on yaml-cpp takes its normally fatal default _action-if-notfound_.