### PR TITLE
wreck: add flux-wreck cancel command

### DIFF
--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -41,6 +41,10 @@ Return the status of running or completed job 'jobid'. Prints the current
 job status, and if exited, the exit codes of all tasks. This command will
 exit with the highest exit code of all tasks.
 
+*cancel* 'jobid'::
+Make a request to the scheduler to cancel a pending job 'jobid'. Only supported
+if a job scheduler module is loaded.
+
 *kill* [--signal=N] 'jobid'::
 Send SIGTERM to running job 'jobid'. If '--signal' is used, send signal 'N'
 where 'N' may  be a signal number or name such as 'SIGKILL'.

--- a/src/bindings/lua/flux/posix.lua
+++ b/src/bindings/lua/flux/posix.lua
@@ -31,5 +31,17 @@ if not status then
                     " Please check LUA_PATH or install package\n")
     os.exit (1)
 end
+
+-- Use non-deprecated version of clock_gettime if available:
+local status, time = pcall (require, 'posix.time')
+if time then
+    local _clock_gettime = time.clock_gettime
+    local CLOCK_REALTIME = time.CLOCK_REALTIME
+    rc.clock_gettime = function ()
+        local ts = _clock_gettime (CLOCK_REALTIME)
+        return ts.tv_sec, ts.tv_nsec
+    end
+end
+
 return rc
 -- vi: ts=4 sw=4 expandtab

--- a/src/bindings/lua/flux/timer.lua
+++ b/src/bindings/lua/flux/timer.lua
@@ -29,6 +29,10 @@ local T = {}
 T.__index = T
 local clock_gettime = require 'flux.posix'.clock_gettime
 
+-- Use version of clock_gettime from posix.time if it exists, o/w fallback to
+--  version from posix/deprecated.lua
+--
+
 local getsec = function ()
     local s,ns = clock_gettime()
     return (s + (ns / 1000000000))

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -26,7 +26,7 @@
 -- flux-cron: Flux's cron request cmdline utility
 --
 local f, err = require 'flux' .new()
-local posix = require 'posix'
+local posix = require 'flux.posix'
 
 local program = require 'flux.Subcommander'.create {
     name = "flux-cron",

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -28,7 +28,7 @@
 local f, err = require 'flux' .new()
 local wreck = require 'wreck'
 local hostlist = require 'flux.hostlist'
-local posix = require 'posix'
+local posix = require 'flux.posix'
 local prog = require 'flux.Subcommander'.create {
     usage = "COMMAND [OPTIONS]",
     handler = function (self, arg)

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -116,6 +116,23 @@ local function opt_sig (s)
 end
 
 prog:SubCommand {
+ name = "cancel",
+ description = "Cancel a pending job",
+ usage = "JOBID",
+ handler = function (self, arg)
+    local id = check_jobid_arg (self, arg[1])
+    local resp, err = f:rpc ("sched.cancel", { jobid = id })
+    if not resp then
+	if err == "Function not implemented" then
+            prog:die ("job cancel not supported when scheduler not loaded")
+	else
+	    prog:die ("Unable to cancel %d: %s\n", id, err)
+        end
+    end
+ end
+}
+
+prog:SubCommand {
  name = "kill",
  description = "Kill a running job",
  usage = "[OPTIONS] JOBID",

--- a/src/modules/wreck/lua.d/01-env.lua
+++ b/src/modules/wreck/lua.d/01-env.lua
@@ -14,7 +14,7 @@ end
 -- Set common environment and working directory for all tasks
 --
 function rexecd_init ()
-    local posix = require 'posix'
+    local posix = require 'flux.posix'
 
     -- Initialize environment with top level lwj.environ
     local k = wreck.flux:kvsdir("lwj")
@@ -39,7 +39,7 @@ end
 --  from lwj.{environ,cwd}:
 --
 function rexecd_task_init ()
-    local posix = require 'posix'
+    local posix = require 'flux.posix'
     local taskid = wreck.taskid;
 
     local task = wreck.by_task

--- a/src/modules/wreck/lua.d/timeout.lua
+++ b/src/modules/wreck/lua.d/timeout.lua
@@ -2,7 +2,7 @@
 -- Register timer on nodeid 0 if kvs `walltime` is set for this job.
 --  Kill job on timeout if reached.
 --
-local posix = require 'posix'
+local posix = require 'flux.posix'
 
 local function signal_to_number (s)
     if not s then return nil end

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -378,6 +378,14 @@ test_expect_success NO_SCHED 'flux-submit: returns ENOSYS when sched not loaded'
 	test_cmp expected.submit err.submit
 '
 
+test_expect_success NO_SCHED 'flux-wreck cancel: fails when sched not loaded' '
+	test_must_fail flux wreck cancel 1 2>err.cancel &&
+	cat >expected.cancel <<-EOF &&
+	flux-wreck: job cancel not supported when scheduler not loaded
+	EOF
+	test_cmp expected.cancel err.cancel
+'
+
 check_complete_link() {
     for i in `seq 0 5`; do
         lastepoch=$(flux kvs dir lwj-complete | awk -F. '{print $2}' | sort -n | tail -1)


### PR DESCRIPTION
This adds a `flux wreck cancel` command in support of #1359.

Along the way I was hitting #1364 in travis so had to add a workaround for that here as well.

The actual implementation of `flux wreck cancel` is very simple and the majority of the important work will be on the sched side.