### PR TITLE
flux-wreck cancel should send jobid as JSON number

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -121,7 +121,7 @@ prog:SubCommand {
  usage = "JOBID",
  handler = function (self, arg)
     local id = check_jobid_arg (self, arg[1])
-    local resp, err = f:rpc ("sched.cancel", { jobid = id })
+    local resp, err = f:rpc ("sched.cancel", { jobid = tonumber (id) })
     if not resp then
 	if err == "Function not implemented" then
             prog:die ("job cancel not supported when scheduler not loaded")

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -158,13 +158,6 @@ local f, err = flux.new()
 if not f then wreck:die ("Connecting to flux failed: %s\n", err) end
 
 --
---  Create a job request as Lua table:
---
-local jobreq = wreck:jobreq (f)
-wreck:verbose ("%4.03fs: Sending LWJ request for %d tasks (cmdline \"%s\")\n",
-    tt:get0(), wreck.ntasks, table.concat (wreck.cmdline, ' '))
-
---
 --  Create a new job in kvs
 --
 local jobid, err = wreck:createjob ()


### PR DESCRIPTION
Fix for encoding of `jobid` argument in `sched.cancel` command sent by `flux wreck cancel` as noted by @dongahn.

Also included is some removal of duplicated code in `flux wreckrun`