### PR TITLE
bindings/lua: fix clock_gettime workaround

### DIFF
--- a/src/bindings/lua/flux/posix.lua
+++ b/src/bindings/lua/flux/posix.lua
@@ -34,7 +34,7 @@ end
 
 -- Use non-deprecated version of clock_gettime if available:
 local status, time = pcall (require, 'posix.time')
-if time then
+if time and time.clock_gettime then
     local _clock_gettime = time.clock_gettime
     local CLOCK_REALTIME = time.CLOCK_REALTIME
     rc.clock_gettime = function ()


### PR DESCRIPTION
The workaround for broken `posix.clock_gettime` legacy function in
luaposix 34 wasn't quite correct, and breaks on versions that
include a `posix.time` module, but don't include `clock_gettime` in
that module. This fix checks to ensure `clock_gettime` is actually
available before trying to use it.

