### PR TITLE
flux-wreck: address scalability issue in 'ls' and 'timing' subcommands

### DIFF
--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -27,9 +27,11 @@ COMMANDS
 *help* 'cmd'
 Print help. If 'cmd' is provided, print help for that sub-command.
 
-*ls*
+*ls* [-n, --max=COUNT] [JOBIDS...]::
 Display a list of wreck jobs currently in kvs, along with their current
-states.
+states. If '-n, --max' option is provided, then display at most 'COUNT'
+jobs (default: 25). If an optional list of 'JOBIDS' is provided on the
+command line, then display only those jobs.
 
 *attach* [--status] [--label-io] 'jobid'::
 Attach to output of a running or completed job. If input was not previously
@@ -49,9 +51,12 @@ if a job scheduler module is loaded.
 Send SIGTERM to running job 'jobid'. If '--signal' is used, send signal 'N'
 where 'N' may  be a signal number or name such as 'SIGKILL'.
 
-*timing*::
-List timing information for lwj entries in Flux KVS. This command lists
-four specific intervals in the wreck job lifecycle:
+*timing* [-n, --max=COUNT] [JOBIDS...]::
+List timing information for lwj entries in Flux KVS. if '-n, --max' option is
+provided, then display at most 'COUNT' jobs (default: 25). If an optional list
+of 'JOBIDS' is provided on the command line, then display timing information
+for only those jobs. This command lists four specific intervals in the wreck
+job lifecycle:
  'STARTING'::: Time from LWJ entry creation until the job reaches the
               "starting" state. The "starting" state is when the first
               rexec daemon receives the request to launch tasks.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -409,3 +409,4 @@ namespaces
 ENOTSUP
 EOVERFLOW
 itr
+JOBIDS

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -259,10 +259,16 @@ end
 
 prog:SubCommand {
  name = "ls",
- usage = "",
+ usage = "[OPTIONS]",
+ options = {
+  { name = "max", char = 'n', arg="COUNT",
+    usage = "Display at most COUNT jobs",
+  }
+ },
  description = "List jobs in kvs",
  handler = function (self, arg)
-    local dirs = wreck.joblist{ flux = f } or {}
+    local max = tonumber (self.opt.n) or 25
+    local dirs = wreck.joblist{ flux = f, max = max } or {}
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
     printf (fmt, "ID", "NTASKS", "STATE", "START", "RUNTIME", "RANKS", "COMMAND")
@@ -282,10 +288,16 @@ prog:SubCommand {
 
 prog:SubCommand {
  name = "timing",
- usage = "",
+ usage = "[OPTIONS]",
+ options = {
+  { name = "max", char = 'n', arg="COUNT",
+    usage = "Display at most COUNT jobs",
+  }
+ },
  description = "List timings of jobs in kvs",
  handler = function (self, arg) 
-    local dirs = wreck.joblist{ flux = f } or {}
+    local max = tonumber (self.opt.n) or 25
+    local dirs = wreck.joblist{ flux = f, max = max } or {}
     if #dirs == 0 then return end
     local fmt = "%6s %12s %12s %12s %12s %12s\n"
     printf (fmt, "ID", "NTASKS", "STARTING", "RUNNING", "COMPLETE", "TOTAL")

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -257,9 +257,28 @@ local function seconds_to_string (s)
     return f ("%.03fs", s)
 end
 
+local function bracketify (args)
+    local r = {}
+    for _,v in ipairs (args) do
+        table.insert (r, "[" .. v .. "]")
+    end
+    return (r)
+end
+
+local function joblist_from_args (self, args)
+    local max = tonumber (self.opt.n) or 25
+    if #args == 0 then
+        return wreck.joblist{ flux = f, max = max }
+    end
+    -- otherwise use dirs on cmdline
+    local hl,err = hostlist.union (unpack (bracketify (args)))
+    if not hl then return nil, err end
+    return wreck.jobids_to_kvspath { flux = f, jobids = hl:expand() }
+end
+
 prog:SubCommand {
  name = "ls",
- usage = "[OPTIONS]",
+ usage = "[OPTIONS] [JOBIDs]",
  options = {
   { name = "max", char = 'n', arg="COUNT",
     usage = "Display at most COUNT jobs",
@@ -267,8 +286,8 @@ prog:SubCommand {
  },
  description = "List jobs in kvs",
  handler = function (self, arg)
-    local max = tonumber (self.opt.n) or 25
-    local dirs = wreck.joblist{ flux = f, max = max } or {}
+    local dirs,err = joblist_from_args (self, arg)
+    if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
     printf (fmt, "ID", "NTASKS", "STATE", "START", "RUNTIME", "RANKS", "COMMAND")
@@ -288,7 +307,7 @@ prog:SubCommand {
 
 prog:SubCommand {
  name = "timing",
- usage = "[OPTIONS]",
+ usage = "[OPTIONS] [JOBIDs]...",
  options = {
   { name = "max", char = 'n', arg="COUNT",
     usage = "Display at most COUNT jobs",
@@ -296,8 +315,8 @@ prog:SubCommand {
  },
  description = "List timings of jobs in kvs",
  handler = function (self, arg) 
-    local max = tonumber (self.opt.n) or 25
-    local dirs = wreck.joblist{ flux = f, max = max } or {}
+    local dirs,err = joblist_from_args (self, arg)
+    if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %12s %12s %12s %12s %12s\n"
     printf (fmt, "ID", "NTASKS", "STARTING", "RUNNING", "COMPLETE", "TOTAL")

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -361,6 +361,14 @@ test_expect_success 'flux-wreck: ls works' '
 	flux wreck ls | sort -n >ls.out &&
 	tail -1 ls.out | grep "hostname$"
 '
+test_expect_success 'flux-wreck: ls -n, --max works' '
+        test $(flux wreck ls --max=1 | wc -l) = 2
+'
+test_expect_success 'flux-wreck: ls JOBID works' '
+        LASTID=$(last_job_id) &&
+	flux wreck ls $LASTID > ls-jobid.out &&
+        tail -1 ls-jobid.out | grep "^ *$LASTID"
+'
 test_expect_success 'flux-wreck: purge works' '
 	flux wreck purge &&
 	flux wreck purge -t 2 -R &&


### PR DESCRIPTION
The `flux-wreck ls` and `timing` commands currently always attempt to list information for *all* jobs stored in the kvs. For large sessions running many jobs, the commands will always be very slow, and in some cases won't work if the table of jobs grows beyond the max size of a Lua table.

This PR addresses this problem with the following changes to these commands:

 * By default, `flux-wreck ls` and `flux-wreck timing` will only list the last (by jobid number) 25 jobs in the kvs. This can be adjusted with a new `-n, --max=COUNT` option.
 * These commands can now accept a list of JOBIDs as arguments (after all option arguments). The JOBIDs can appear as host ranges for convenience or multiple arguments on the command line, e.g: `flux wreck ls 1 2 3 4 5 10` or `flux wreck ls 1-5,10` or `flux wreck ls 1-5 10`

There may still be a scalability issue with the `purge` command, but `purge` does have to list all jobs for now so it knows how many it can remove. If this is an issue it may be addressed in some other manner and will get a different issue opened.

Fixes issue #1366