### PR TITLE
jsc: Make jsc_job_state2num public

### DIFF
--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -105,7 +105,7 @@ const char *jsc_job_num2state (job_state_t i)
     return NULL;
 }
 
-static int jsc_job_state2num (const char *s)
+int jsc_job_state2num (const char *s)
 {
     stab_t *ss = job_state_tab;
     while (ss->s != NULL) {

--- a/src/common/libjsc/jstatctl.h
+++ b/src/common/libjsc/jstatctl.h
@@ -123,6 +123,7 @@ int jsc_update_jcb (flux_t *h, int64_t jobid, const char *key, const char *jcb);
  * A convenience routine (returning the internal state name correponding to "s.")
  */
 const char *jsc_job_num2state (job_state_t s);
+int jsc_job_state2num (const char *s);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Promote jsc_job_state2num () to be public as this convenience routine can help w/ writing test cases for schedulers.

This should have been public as it is paired with jsc_job_num2state () anyway.