### PR TITLE
flux-wreck cancel: fall back to kill -9 if job is not pending

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -118,14 +118,19 @@ end
 prog:SubCommand {
  name = "cancel",
  description = "Cancel a pending job",
- usage = "JOBID",
+ usage = "[-f|--force] JOBID",
+ options = {
+    { name = "force", char = "f",
+      usage = "Force cancel even if scheduler is not loaded"
+    },
+ },
  handler = function (self, arg)
     local id = check_jobid_arg (self, arg[1])
     local resp, err = f:rpc ("sched.cancel", { jobid = tonumber (id) })
     if not resp then
-        if err == "Function not implemented" then
+        if err == "Function not implemented" and not self.opt.f then
             prog:die ("job cancel not supported when scheduler not loaded")
-        elseif err == "Invalid argument" then
+        elseif self.opt.f or err == "Invalid argument" then
             prog:log ("Sending SIGKILL to %d\n", id)
             local rc, err = f:sendevent ({signal = 9}, "wreck.%d.kill", id)
             if not rc then self:die ("signal: %s\n", err) end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -123,10 +123,14 @@ prog:SubCommand {
     local id = check_jobid_arg (self, arg[1])
     local resp, err = f:rpc ("sched.cancel", { jobid = tonumber (id) })
     if not resp then
-	if err == "Function not implemented" then
+        if err == "Function not implemented" then
             prog:die ("job cancel not supported when scheduler not loaded")
-	else
-	    prog:die ("Unable to cancel %d: %s\n", id, err)
+        elseif err == "Invalid argument" then
+            prog:log ("Sending SIGKILL to %d\n", id)
+            local rc, err = f:sendevent ({signal = 9}, "wreck.%d.kill", id)
+            if not rc then self:die ("signal: %s\n", err) end
+        else
+            prog:die ("Unable to cancel %d: %s\n", id, err)
         end
     end
  end


### PR DESCRIPTION
This addresses issue #1379 with a couple minor changes to `flux wreck cancel`. When sched is loaded and it gets `EINVAL` error, `cancel` will fall back to equivalent of `flux wreck kill -9` on the job.

I also added a `-f, --force` option which allows `flux wreck cancel` to work even if sched is not loaded, mainly so the code could be tested in `t2000-wreck.t`.