### PR TITLE
kvs: Refactor prep work for namespace prefix support

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -87,6 +87,9 @@ test_lookup_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
 	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
+	$(top_builddir)/src/modules/kvs/kvsroot.o \
+	$(top_builddir)/src/modules/kvs/kvstxn.o \
+	$(top_builddir)/src/modules/kvs/treq.o \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \
 	$(test_ldadd)
 
@@ -103,6 +106,8 @@ test_kvstxn_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/kvstxn.o \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/lookup.o \
+	$(top_builddir)/src/modules/kvs/kvsroot.o \
+	$(top_builddir)/src/modules/kvs/treq.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
 	$(top_builddir)/src/modules/kvs/msg_cb_handler.o \
 	$(top_builddir)/src/modules/kvs/kvs_util.o \

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1238,7 +1238,6 @@ static void lookup_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
     /* if bad lh, then first time rpc and not a replay */
     if (lookup_validate (arg) == false) {
-        struct kvsroot *root;
         bool stall = false;
         uint32_t rolemask, userid;
 
@@ -1252,8 +1251,8 @@ static void lookup_request_cb (flux_t *h, flux_msg_handler_t *mh,
             goto done;
         }
 
-        if (!(root = getroot (ctx, namespace, mh, msg, lookup_request_cb,
-                              &stall))) {
+        if (!getroot (ctx, namespace, mh, msg, lookup_request_cb,
+                      &stall)) {
             if (stall)
                 goto stall;
             goto done;
@@ -1282,7 +1281,7 @@ static void lookup_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                   ctx->krm,
                                   ctx->epoch,
                                   namespace,
-                                  root_ref ? root_ref : root->ref,
+                                  root_ref ? root_ref : NULL,
                                   key,
                                   rolemask,
                                   userid,
@@ -1423,7 +1422,7 @@ static void watch_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                   ctx->krm,
                                   ctx->epoch,
                                   namespace,
-                                  root->ref,
+                                  NULL,
                                   key,
                                   rolemask,
                                   userid,

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -15,6 +15,9 @@ typedef int (*lookup_ref_f)(lookup_t *c,
                             void *data);
 
 /* Initialize a lookup handle
+ *
+ * - root_ref is optional.  If not specified, will use root ref
+ *   specified in namespace.
  */
 lookup_t *lookup_create (struct cache *cache,
                          kvsroot_mgr_t *krm,

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -3,6 +3,7 @@
 
 #include <flux/core.h>
 #include "cache.h"
+#include "kvsroot.h"
 
 typedef struct lookup lookup_t;
 
@@ -16,10 +17,13 @@ typedef int (*lookup_ref_f)(lookup_t *c,
 /* Initialize a lookup handle
  */
 lookup_t *lookup_create (struct cache *cache,
+                         kvsroot_mgr_t *krm,
                          int current_epoch,
                          const char *namespace,
                          const char *root_ref,
                          const char *path,
+                         uint32_t rolemask,
+                         uint32_t userid,
                          int flags,
                          flux_t *h,
                          void *aux);

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -7,6 +7,12 @@
 
 typedef struct lookup lookup_t;
 
+typedef enum {
+    LOOKUP_PROCESS_ERROR = 1,
+    LOOKUP_PROCESS_LOAD_MISSING_REFS = 2,
+    LOOKUP_PROCESS_FINISHED = 3,
+} lookup_process_t;
+
 /* ref - missing reference
  * raw_data - true if reference points to raw data
  */
@@ -79,16 +85,23 @@ int lookup_set_current_epoch (lookup_t *lh, int epoch);
 
 /* Lookup the key path in the KVS cache starting at root.
  *
- * Return true on success or error.  After return, error should be
- * checked via lookup_get_errnum().  On success, value of resulting
- * lookup can be retrieved via lookup_get_value().
+ * Returns LOOKUP_PROCESS_ERROR on error,
+ * LOOKUP_PROCESS_LOAD_MISSING_REFS on stall & load,
+ * LOOKUP_PROCESS_FINISHED on all done and success.
  *
- * Return false if key name cannot be resolved.  Get missing
- * references via lookup_iter_missing_refs().  Caller should then use
- * missing reference to load missing reference into KVS cache via rpc
- * or otherwise.
+ * On error, error should be retrieved via lookup_get_errnum().
+ *
+ * On stall & load, Get missing references via
+ * lookup_iter_missing_refs().  Caller should then use missing
+ * reference to load missing reference into KVS cache via rpc or
+ * otherwise.
+ *
+ * On success, value of resulting lookup can be retrieved via
+ * lookup_get_value().
+ *
+ * Return false if key name cannot be resolved.
  */
-bool lookup (lookup_t *lh);
+lookup_process_t lookup (lookup_t *lh);
 
 #endif /* !_FLUX_KVS_LOOKUP_H */
 

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -489,7 +489,7 @@ void verify_value (struct cache *cache,
                              NULL)) != NULL,
         "lookup_create key %s", key);
 
-    ok (lookup (lh) == true,
+    ok (lookup (lh) == LOOKUP_PROCESS_FINISHED,
         "lookup found result");
 
     if (val) {

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -12,6 +12,7 @@
 #include "src/common/libkvs/kvs_txn_private.h"
 #include "src/modules/kvs/cache.h"
 #include "src/modules/kvs/kvstxn.h"
+#include "src/modules/kvs/kvsroot.h"
 #include "src/modules/kvs/lookup.h"
 #include "src/modules/kvs/kvs_util.h"
 
@@ -467,6 +468,7 @@ int cache_count_dirty_cb (kvstxn_t *kt, struct cache_entry *entry, void *data)
 }
 
 void verify_value (struct cache *cache,
+                   kvsroot_mgr_t *krm,
                    const char *root_ref,
                    const char *key,
                    const char *val)
@@ -475,10 +477,13 @@ void verify_value (struct cache *cache,
     json_t *test, *o;
 
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              key,
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -505,6 +510,7 @@ void verify_value (struct cache *cache,
 void kvstxn_basic_kvstxn_process_test (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     int count = 0;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
@@ -512,6 +518,9 @@ void kvstxn_basic_kvstxn_process_test (void)
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -540,7 +549,7 @@ void kvstxn_basic_kvstxn_process_test (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "key1", "1");
+    verify_value (cache, krm, newroot, "key1", "1");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -554,6 +563,7 @@ void kvstxn_basic_kvstxn_process_test (void)
 void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     int count = 0;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
@@ -561,6 +571,9 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -616,8 +629,8 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "key1", "1");
-    verify_value (cache, newroot, "dir.key2", "2");
+    verify_value (cache, krm, newroot, "key1", "1");
+    verify_value (cache, krm, newroot, "dir.key2", "2");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -625,12 +638,14 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
         "kvstxn_mgr_get_ready_transaction returns NULL, no more kvstxns");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     int count = 0;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
@@ -638,6 +653,9 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -685,8 +703,8 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "foo.key1", "1");
-    verify_value (cache, newroot, "bar.key2", "2");
+    verify_value (cache, krm, newroot, "foo.key1", "1");
+    verify_value (cache, krm, newroot, "bar.key2", "2");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -709,7 +727,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "baz.key3", "3");
+    verify_value (cache, krm, newroot, "baz.key3", "3");
 
     /* now the ready queue should be empty */
 
@@ -717,17 +735,22 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
         "kvstxn_mgr_get_ready_transaction returns NULL, no more kvstxns");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_basic_kvstxn_process_test_invalid_transaction (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *ktbad, *kt;
     blobref_t rootref;
 
     cache = create_cache_with_empty_rootdir (rootref);
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -753,12 +776,14 @@ void kvstxn_basic_kvstxn_process_test_invalid_transaction (void)
         "kvstxn_process fails on bad kvstxn");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_basic_root_not_dir (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -766,6 +791,8 @@ void kvstxn_basic_root_not_dir (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* make a non-dir root */
     root = treeobj_create_val ("abcd", 4);
@@ -798,6 +825,7 @@ void kvstxn_basic_root_not_dir (void)
         "kvstxn_get_errnum return EINVAL");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -829,6 +857,7 @@ int rootref_cb (kvstxn_t *kt, const char *ref, void *data)
 void kvstxn_process_root_missing (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     blobref_t rootref;
@@ -838,6 +867,8 @@ void kvstxn_process_root_missing (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
@@ -888,9 +919,10 @@ void kvstxn_process_root_missing (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "key1", "1");
+    verify_value (cache, krm, newroot, "key1", "1");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -919,6 +951,7 @@ int missingref_cb (kvstxn_t *kt, const char *ref, void *data)
 void kvstxn_process_missing_ref (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -930,6 +963,8 @@ void kvstxn_process_missing_ref (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -999,9 +1034,10 @@ void kvstxn_process_missing_ref (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "dir.val", "52");
+    verify_value (cache, krm, newroot, "dir.val", "52");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -1024,6 +1060,7 @@ int cache_error_cb (kvstxn_t *kt, struct cache_entry *entry, void *data)
 void kvstxn_process_error_callbacks (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1033,6 +1070,8 @@ void kvstxn_process_error_callbacks (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1093,6 +1132,7 @@ void kvstxn_process_error_callbacks (void)
         "kvstxn_iter_dirty_cache_entries errors on callback error & returns correct errno");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -1116,6 +1156,7 @@ int cache_error_partway_cb (kvstxn_t *kt, struct cache_entry *entry, void *data)
 void kvstxn_process_error_callbacks_partway (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     struct error_partway_data epd = { .total_calls = 0, .success_returns = 0};
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
@@ -1126,6 +1167,8 @@ void kvstxn_process_error_callbacks_partway (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1184,12 +1227,14 @@ void kvstxn_process_error_callbacks_partway (void)
         "correct number of successful returns from dirty cache callback");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_invalid_operation (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1197,6 +1242,8 @@ void kvstxn_process_invalid_operation (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is an empty root */
     root = treeobj_create_dir ();
@@ -1229,6 +1276,7 @@ void kvstxn_process_invalid_operation (void)
         "kvstxn_get_errnum return EINVAL");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -1283,6 +1331,7 @@ void kvstxn_process_malformed_operation (void)
 void kvstxn_process_invalid_hash (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1290,6 +1339,8 @@ void kvstxn_process_invalid_hash (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is an empty root */
     root = treeobj_create_dir ();
@@ -1322,12 +1373,14 @@ void kvstxn_process_invalid_hash (void)
         "kvstxn_get_errnum return EINVAL %d", kvstxn_get_errnum (kt));
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_follow_link (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1338,6 +1391,8 @@ void kvstxn_process_follow_link (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1392,15 +1447,17 @@ void kvstxn_process_follow_link (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "symlink.val", "52");
+    verify_value (cache, krm, newroot, "symlink.val", "52");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_dirval_test (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1410,6 +1467,8 @@ void kvstxn_process_dirval_test (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1453,15 +1512,17 @@ void kvstxn_process_dirval_test (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "dir.val", "52");
+    verify_value (cache, krm, newroot, "dir.val", "52");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_delete_test (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1472,6 +1533,8 @@ void kvstxn_process_delete_test (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1524,15 +1587,17 @@ void kvstxn_process_delete_test (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "dir.val", NULL);
+    verify_value (cache, krm, newroot, "dir.val", NULL);
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_delete_nosubdir_test (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1541,6 +1606,8 @@ void kvstxn_process_delete_nosubdir_test (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is an empty root */
     root = treeobj_create_dir ();
@@ -1570,15 +1637,17 @@ void kvstxn_process_delete_nosubdir_test (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "noexistdir.val", NULL);
+    verify_value (cache, krm, newroot, "noexistdir.val", NULL);
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_delete_filevalinpath_test (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1589,6 +1658,8 @@ void kvstxn_process_delete_filevalinpath_test (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1636,15 +1707,17 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "dir.val.valbaz", NULL);
+    verify_value (cache, krm, newroot, "dir.val.valbaz", NULL);
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_bad_dirrefs (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1655,6 +1728,8 @@ void kvstxn_process_bad_dirrefs (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1708,6 +1783,7 @@ void kvstxn_process_bad_dirrefs (void)
         "kvstxn_get_errnum return ENOTRECOVERABLE");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -1733,6 +1809,7 @@ int cache_count_treeobj_cb (kvstxn_t *kt, struct cache_entry *entry, void *data)
 void kvstxn_process_big_fileval (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1745,6 +1822,8 @@ void kvstxn_process_big_fileval (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -1796,7 +1875,7 @@ void kvstxn_process_big_fileval (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "val", "smallstr");
+    verify_value (cache, krm, newroot, "val", "smallstr");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -1836,9 +1915,10 @@ void kvstxn_process_big_fileval (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "val", bigstr);
+    verify_value (cache, krm, newroot, "val", bigstr);
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
@@ -1848,6 +1928,7 @@ void kvstxn_process_big_fileval (void)
 void kvstxn_process_giant_dir (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -1858,6 +1939,8 @@ void kvstxn_process_giant_dir (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is.
      *
@@ -1950,9 +2033,9 @@ void kvstxn_process_giant_dir (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "dir.val0200", "foo");
-    verify_value (cache, newroot, "dir.val0090", "bar");
-    verify_value (cache, newroot, "dir.val00D0", NULL);
+    verify_value (cache, krm, newroot, "dir.val0200", "foo");
+    verify_value (cache, krm, newroot, "dir.val0090", "bar");
+    verify_value (cache, krm, newroot, "dir.val00D0", NULL);
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -1960,12 +2043,14 @@ void kvstxn_process_giant_dir (void)
         "kvstxn_mgr_get_ready_transaction returns NULL, no more kvstxns");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_append (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     int count = 0;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
@@ -1976,6 +2061,8 @@ void kvstxn_process_append (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -2033,7 +2120,7 @@ void kvstxn_process_append (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "val", "abcdefgh");
+    verify_value (cache, krm, newroot, "val", "abcdefgh");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -2064,7 +2151,7 @@ void kvstxn_process_append (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "valref", "ABCDEFGH");
+    verify_value (cache, krm, newroot, "valref", "ABCDEFGH");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -2094,17 +2181,19 @@ void kvstxn_process_append (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "newval", "foobar");
+    verify_value (cache, krm, newroot, "newval", "foobar");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_append_errors (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
     json_t *root;
@@ -2112,6 +2201,8 @@ void kvstxn_process_append_errors (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This root is
      *
@@ -2171,12 +2262,14 @@ void kvstxn_process_append_errors (void)
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 
 void kvstxn_process_fallback_merge (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     int count = 0;
     kvstxn_mgr_t *ktm;
     kvstxn_t *kt;
@@ -2184,6 +2277,9 @@ void kvstxn_process_fallback_merge (void)
     const char *newroot;
 
     cache = create_cache_with_empty_rootdir (rootref);
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -2229,8 +2325,8 @@ void kvstxn_process_fallback_merge (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "key1", "42");
-    verify_value (cache, newroot, "key2", "43");
+    verify_value (cache, krm, newroot, "key1", "42");
+    verify_value (cache, krm, newroot, "key2", "43");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -2291,7 +2387,7 @@ void kvstxn_process_fallback_merge (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    verify_value (cache, newroot, "key3", "44");
+    verify_value (cache, krm, newroot, "key3", "44");
 
     kvstxn_mgr_remove_transaction (ktm, kt, false);
 
@@ -2319,6 +2415,7 @@ void kvstxn_process_fallback_merge (void)
         "kvstxn_mgr_get_ready_transaction returns NULL, no more transactions");
 
     kvstxn_mgr_destroy (ktm);
+    kvsroot_mgr_destroy (krm);
     cache_destroy (cache);
 }
 

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -1203,6 +1203,29 @@ void lookup_errors (void) {
         "lookup_create on dirref_multi, part of path");
     check_error (lh, ENOTRECOVERABLE, "lookup dirref_multi, part of path");
 
+    /* This last test to just to make sure if we call lookup ()
+     * multiple times, we can the same error each time.
+     */
+
+    /* Lookup with an invalid root_ref, should get EINVAL */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             valref_ref,
+                             "val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL,
+                             NULL)) != NULL,
+        "lookup_create on bad root_ref for double call test");
+    ok (lookup (lh) == LOOKUP_PROCESS_ERROR,
+        "lookup returns LOOKUP_PROCESS_ERROR on first call");
+    ok (lookup (lh) == LOOKUP_PROCESS_ERROR,
+        "lookup still returns LOOKUP_PROCESS_ERROR on second call");
+    lookup_destroy (lh);
+
     cache_destroy (cache);
     kvsroot_mgr_destroy (krm);
 }

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -122,17 +122,23 @@ int lookup_ref_error (lookup_t *c,
 void basic_api (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     const char *tmp;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((lh = lookup_create (cache,
+                             krm,
                              42,
                              KVS_PRIMARY_NAMESPACE,
                              "root.ref.foo",
                              "path.bar",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ,
                              NULL,
                              &aux_global)) != NULL,
@@ -161,18 +167,23 @@ void basic_api (void)
     lookup_destroy (lh);
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 void basic_api_errors (void)
 {
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
 
     ok (lookup_create (NULL,
+                       NULL,
                        0,
                        NULL,
                        NULL,
                        NULL,
+                       FLUX_ROLE_OWNER,
+                       0,
                        0,
                        NULL,
                        NULL) == NULL,
@@ -180,12 +191,17 @@ void basic_api_errors (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     ok ((lh = lookup_create (cache,
+                             krm,
                              42,
                              KVS_PRIMARY_NAMESPACE,
                              "root.ref.foo",
                              "path.bar",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -245,6 +261,7 @@ void basic_api_errors (void)
     lookup_destroy (lh);
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 void check_common (lookup_t *lh,
@@ -398,12 +415,15 @@ void lookup_root (void) {
     json_t *root;
     json_t *test;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t valref_ref;
     blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -423,10 +443,13 @@ void lookup_root (void) {
 
     /* flags = 0, should error EISDIR */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              ".",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -435,10 +458,13 @@ void lookup_root (void) {
 
     /* flags = FLUX_KVS_READDIR, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              ".",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -447,10 +473,13 @@ void lookup_root (void) {
 
     /* flags = FLUX_KVS_TREEOBJ, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              ".",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -461,10 +490,13 @@ void lookup_root (void) {
 
     /* flags = FLUX_KVS_READDIR, bad root_ref, should error EINVAL */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              valref_ref,
                              ".",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -472,6 +504,7 @@ void lookup_root (void) {
     check_error (lh, EINVAL, "root w/ FLUX_KVS_READDIR, bad root_ref, should EINVAL");
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 /* lookup basic tests */
@@ -484,6 +517,7 @@ void lookup_basic (void) {
     json_t *valref_multi_with_dirref;
     json_t *test;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t valref_ref;
     blobref_t valref2_ref;
@@ -493,6 +527,8 @@ void lookup_basic (void) {
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -561,10 +597,13 @@ void lookup_basic (void) {
 
     /* lookup dir via dirref */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -573,10 +612,13 @@ void lookup_basic (void) {
 
     /* lookup value via valref */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -591,10 +633,13 @@ void lookup_basic (void) {
      *    treeobj of whatever the dirref was pointing to.
      */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.valref_with_dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -603,10 +648,13 @@ void lookup_basic (void) {
 
     /* Lookup value via valref with multiple blobrefs */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.valref_multi",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -621,10 +669,13 @@ void lookup_basic (void) {
      *    treeobj of whatever the dirref was pointing to.
      */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.valref_multi_with_dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -633,10 +684,13 @@ void lookup_basic (void) {
 
     /* lookup value via val */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -647,10 +701,13 @@ void lookup_basic (void) {
 
     /* lookup dir via dir */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.dir",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -659,10 +716,13 @@ void lookup_basic (void) {
 
     /* lookup symlink */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -673,10 +733,13 @@ void lookup_basic (void) {
 
     /* lookup dirref treeobj */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -687,10 +750,13 @@ void lookup_basic (void) {
 
     /* lookup valref treeobj */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -701,10 +767,13 @@ void lookup_basic (void) {
 
     /* lookup val treeobj */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -715,10 +784,13 @@ void lookup_basic (void) {
 
     /* lookup dir treeobj */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.dir",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -727,10 +799,13 @@ void lookup_basic (void) {
 
     /* lookup symlink treeobj */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref.symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_TREEOBJ,
                              NULL,
                              NULL)) != NULL,
@@ -740,6 +815,7 @@ void lookup_basic (void) {
     json_decref (test);
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 /* lookup tests reach an error or "non-good" result */
@@ -749,6 +825,7 @@ void lookup_errors (void) {
     json_t *dir;
     json_t *dirref_multi;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t dirref_ref;
     blobref_t valref_ref;
@@ -756,6 +833,8 @@ void lookup_errors (void) {
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -809,10 +888,13 @@ void lookup_errors (void) {
     /* Lookup non-existent field.  Not ENOENT - caller of lookup
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "foo",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -822,10 +904,13 @@ void lookup_errors (void) {
     /* Lookup path w/ val in middle, Not ENOENT - caller of lookup
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "val.foo",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -835,10 +920,13 @@ void lookup_errors (void) {
     /* Lookup path w/ valref in middle, Not ENOENT - caller of lookup
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "valref.foo",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -847,10 +935,13 @@ void lookup_errors (void) {
 
     /* Lookup path w/ dir in middle, should get ENOTRECOVERABLE */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dir.foo",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -859,10 +950,13 @@ void lookup_errors (void) {
 
     /* Lookup path w/ infinite link loop, should get ELOOP */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "symlink1",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -871,10 +965,13 @@ void lookup_errors (void) {
 
     /* Lookup a dirref, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -883,10 +980,13 @@ void lookup_errors (void) {
 
     /* Lookup a dir, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dir",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -895,10 +995,13 @@ void lookup_errors (void) {
 
     /* Lookup a valref, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -907,10 +1010,13 @@ void lookup_errors (void) {
 
     /* Lookup a val, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -919,10 +1025,13 @@ void lookup_errors (void) {
 
     /* Lookup a dirref, but don't expect a dir, should get EISDIR. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -931,10 +1040,13 @@ void lookup_errors (void) {
 
     /* Lookup a dir, but don't expect a dir, should get EISDIR. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dir",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -943,10 +1055,13 @@ void lookup_errors (void) {
 
     /* Lookup a valref, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -955,10 +1070,13 @@ void lookup_errors (void) {
 
     /* Lookup a val, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -967,10 +1085,13 @@ void lookup_errors (void) {
 
     /* Lookup a symlink, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK | FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -979,10 +1100,13 @@ void lookup_errors (void) {
 
     /* Lookup a dirref that doesn't point to a dir, should get ENOTRECOVERABLE. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref_bad",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -992,10 +1116,13 @@ void lookup_errors (void) {
     /* Lookup a dirref that doesn't point to a dir, in middle of path,
      * should get ENOTRECOVERABLE. */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref_bad.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1004,10 +1131,13 @@ void lookup_errors (void) {
 
     /* Lookup with an invalid root_ref, should get EINVAL */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              valref_ref,
                              "val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1016,10 +1146,13 @@ void lookup_errors (void) {
 
     /* Lookup dirref with multiple blobrefs, should get ENOTRECOVERABLE */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref_multi",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1029,10 +1162,13 @@ void lookup_errors (void) {
     /* Lookup path w/ dirref w/ multiple blobrefs in middle, should
      * get ENOTRECOVERABLE */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref_multi.foo",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1040,6 +1176,7 @@ void lookup_errors (void) {
     check_error (lh, ENOTRECOVERABLE, "lookup dirref_multi, part of path");
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 /* lookup link tests */
@@ -1051,6 +1188,7 @@ void lookup_links (void) {
     json_t *dir;
     json_t *test;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t valref_ref;
     blobref_t dirref3_ref;
@@ -1060,6 +1198,8 @@ void lookup_links (void) {
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -1125,10 +1265,13 @@ void lookup_links (void) {
 
     /* lookup val, follow two links */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref.symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1139,10 +1282,13 @@ void lookup_links (void) {
 
     /* lookup val, link is middle of path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1153,10 +1299,13 @@ void lookup_links (void) {
 
     /* lookup valref, link is middle of path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref.valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1167,10 +1316,13 @@ void lookup_links (void) {
 
     /* lookup dir, link is middle of path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref.dir",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1179,10 +1331,13 @@ void lookup_links (void) {
 
     /* lookup dirref, link is middle of path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref.dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1191,10 +1346,13 @@ void lookup_links (void) {
 
     /* lookup symlink, link is middle of path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref.symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -1205,10 +1363,13 @@ void lookup_links (void) {
 
     /* lookup val, link is last part in path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1219,10 +1380,13 @@ void lookup_links (void) {
 
     /* lookup valref, link is last part in path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1233,10 +1397,13 @@ void lookup_links (void) {
 
     /* lookup dir, link is last part in path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dir",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1245,10 +1412,13 @@ void lookup_links (void) {
 
     /* lookup dirref, link is last part in path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2dirref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1257,10 +1427,13 @@ void lookup_links (void) {
 
     /* lookup symlink, link is last part in path */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.link2symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READLINK,
                              NULL,
                              NULL)) != NULL,
@@ -1270,6 +1443,7 @@ void lookup_links (void) {
     json_decref (test);
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 /* lookup alternate root tests */
@@ -1279,12 +1453,16 @@ void lookup_alt_root (void) {
     json_t *dirref2;
     json_t *test;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t dirref1_ref;
     blobref_t dirref2_ref;
     blobref_t root_ref;
+
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -1317,10 +1495,13 @@ void lookup_alt_root (void) {
 
     /* lookup val, alt root-ref dirref1_ref */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              dirref1_ref,
                              "val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1331,10 +1512,13 @@ void lookup_alt_root (void) {
 
     /* lookup val, alt root-ref dirref2_ref */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              dirref2_ref,
                              "val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1344,17 +1528,21 @@ void lookup_alt_root (void) {
     json_decref (test);
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 /* lookup stall tests on root */
 void lookup_stall_root (void) {
     json_t *root;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t root_ref;
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -1370,10 +1558,13 @@ void lookup_stall_root (void) {
 
     /* lookup root ".", should stall on root */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              ".",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1387,10 +1578,13 @@ void lookup_stall_root (void) {
 
     /* lookup root ".", now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              ".",
+                             FLUX_ROLE_OWNER,
+                             0,
                              FLUX_KVS_READDIR,
                              NULL,
                              NULL)) != NULL,
@@ -1398,6 +1592,7 @@ void lookup_stall_root (void) {
     check_value (lh, root, "root \".\" #2");
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 /* lookup stall tests */
@@ -1408,6 +1603,7 @@ void lookup_stall (void) {
     json_t *dirref2;
     json_t *test;
     struct cache *cache;
+    kvsroot_mgr_t *krm;
     lookup_t *lh;
     blobref_t valref1_ref;
     blobref_t valref2_ref;
@@ -1421,6 +1617,8 @@ void lookup_stall (void) {
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
 
     /* This cache is
      *
@@ -1495,10 +1693,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.val, should stall on root */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1519,10 +1720,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.val, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1533,10 +1737,13 @@ void lookup_stall (void) {
 
     /* lookup symlink.val, should stall */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "symlink.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1552,10 +1759,13 @@ void lookup_stall (void) {
 
     /* lookup symlink.val, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "symlink.val",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1566,10 +1776,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valref, should stall */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1585,10 +1798,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valref, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valref",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1599,10 +1815,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valref_multi, should stall */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valref_multi",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1620,10 +1839,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valref_multi, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valref_multi",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1634,10 +1856,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valref_multi2, should stall */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valref_multi2",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1655,10 +1880,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valref_multi2, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valref_multi2",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1669,10 +1897,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valrefmisc, should stall */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valrefmisc",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1689,10 +1920,13 @@ void lookup_stall (void) {
 
     /* lookup dirref1.valrefmisc_multi, should stall */
     ok ((lh = lookup_create (cache,
+                             krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
                              root_ref,
                              "dirref1.valrefmisc_multi",
+                             FLUX_ROLE_OWNER,
+                             0,
                              0,
                              NULL,
                              NULL)) != NULL,
@@ -1708,6 +1942,7 @@ void lookup_stall (void) {
     lookup_destroy (lh);
 
     cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
 }
 
 int main (int argc, char *argv[])

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -238,7 +238,7 @@ void basic_api_errors (void)
 
     ok (lookup_validate (NULL) == false,
         "lookup_validate fails on NULL pointer");
-    ok (lookup (NULL) == true,
+    ok (lookup (NULL) == LOOKUP_PROCESS_ERROR,
         "lookup does not segfault on NULL pointer");
     ok (lookup_get_errnum (NULL) == EINVAL,
         "lookup_get_errnum returns EINVAL on NULL pointer");
@@ -263,7 +263,7 @@ void basic_api_errors (void)
 
     ok (lookup_validate (lh) == false,
         "lookup_validate fails on bad pointer");
-    ok (lookup (lh) == true,
+    ok (lookup (lh) == LOOKUP_PROCESS_ERROR,
         "lookup does not segfault on bad pointer");
     ok (lookup_get_errnum (lh) == EINVAL,
         "lookup_get_errnum returns EINVAL on bad pointer");
@@ -287,7 +287,7 @@ void basic_api_errors (void)
 }
 
 void check_common (lookup_t *lh,
-                   bool lookup_result,
+                   lookup_process_t lookup_result,
                    int get_errnum_result,
                    bool check_is_val_treeobj,
                    json_t *get_value_result,
@@ -376,7 +376,7 @@ void check_value (lookup_t *lh,
                   const char *msg)
 {
     check_common (lh,
-                  true,
+                  LOOKUP_PROCESS_FINISHED,
                   0,
                   false,
                   get_value_result,
@@ -390,7 +390,7 @@ void check_treeobj_val_result (lookup_t *lh,
                                const char *msg)
 {
     check_common (lh,
-                  true,
+                  LOOKUP_PROCESS_FINISHED,
                   0,
                   true,
                   NULL,         /* doesn't matter */
@@ -407,7 +407,7 @@ void check_stall (lookup_t *lh,
                   const char *msg)
 {
     check_common (lh,
-                  false,
+                  LOOKUP_PROCESS_LOAD_MISSING_REFS,
                   get_errnum_result,
                   false,
                   NULL,
@@ -422,7 +422,7 @@ void check_error (lookup_t *lh,
                   const char *msg)
 {
     check_common (lh,
-                  true,
+                  LOOKUP_PROCESS_ERROR,
                   get_errnum_result,
                   false,
                   NULL,
@@ -2024,7 +2024,7 @@ void lookup_stall (void) {
         "lookup_create stalltest dirref1.valrefmisc");
     /* don't call check_stall, this is primarily to test if callback
      * functions returning errors are caught */
-    ok (lookup (lh) == false,
+    ok (lookup (lh) == LOOKUP_PROCESS_LOAD_MISSING_REFS,
         "dirref1.valrefmisc: lookup stalled");
     errno = 0;
     ok (lookup_iter_missing_refs (lh, lookup_ref_error, NULL) < 0
@@ -2047,7 +2047,7 @@ void lookup_stall (void) {
         "lookup_create stalltest dirref1.valrefmisc_multi");
     /* don't call check_stall, this is primarily to test if callback
      * functions returning errors are caught */
-    ok (lookup (lh) == false,
+    ok (lookup (lh) == LOOKUP_PROCESS_LOAD_MISSING_REFS,
         "dirref1.valrefmisc_multi: lookup stalled");
     errno = 0;
     ok (lookup_iter_missing_refs (lh, lookup_ref_error, NULL) < 0

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <limits.h>
 #include <jansson.h>
+#include <unistd.h>
+#include <sys/types.h>
 #include <assert.h>
 
 #include "src/common/libtap/tap.h"
@@ -119,6 +121,21 @@ int lookup_ref_error (lookup_t *c,
     return -1;
 }
 
+void setup_kvsroot (kvsroot_mgr_t *krm, struct cache *cache, const char *ref)
+{
+    struct kvsroot *root;
+
+    ok ((root = kvsroot_mgr_create_root (krm,
+                                         cache,
+                                         "sha1",
+                                         KVS_PRIMARY_NAMESPACE,
+                                         getuid (),
+                                         0)) != NULL,
+        "kvsroot_mgr_create_root works");
+
+    kvsroot_setroot (krm, root, ref, 0);
+}
+
 void basic_api (void)
 {
     struct cache *cache;
@@ -130,12 +147,13 @@ void basic_api (void)
         "cache_create works");
     ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
         "kvsroot_mgr_create works");
+    setup_kvsroot (krm, cache, "root.ref.foo");
 
     ok ((lh = lookup_create (cache,
                              krm,
                              42,
                              KVS_PRIMARY_NAMESPACE,
-                             "root.ref.foo",
+                             NULL,
                              "path.bar",
                              FLUX_ROLE_OWNER,
                              0,
@@ -193,12 +211,13 @@ void basic_api_errors (void)
         "cache_create works");
     ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
         "kvsroot_mgr_create works");
+    setup_kvsroot (krm, cache, "root.ref.foo");
 
     ok ((lh = lookup_create (cache,
                              krm,
                              42,
                              KVS_PRIMARY_NAMESPACE,
-                             "root.ref.foo",
+                             NULL,
                              "path.bar",
                              FLUX_ROLE_OWNER,
                              0,
@@ -441,12 +460,14 @@ void lookup_root (void) {
     treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* flags = 0, should error EISDIR */
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              ".",
                              FLUX_ROLE_OWNER,
                              0,
@@ -461,7 +482,7 @@ void lookup_root (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              ".",
                              FLUX_ROLE_OWNER,
                              0,
@@ -476,7 +497,7 @@ void lookup_root (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              ".",
                              FLUX_ROLE_OWNER,
                              0,
@@ -595,12 +616,14 @@ void lookup_basic (void) {
     treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* lookup dir via dirref */
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -615,7 +638,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -636,7 +659,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.valref_with_dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -651,7 +674,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.valref_multi",
                              FLUX_ROLE_OWNER,
                              0,
@@ -672,7 +695,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.valref_multi_with_dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -687,7 +710,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -704,7 +727,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.dir",
                              FLUX_ROLE_OWNER,
                              0,
@@ -719,7 +742,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.symlink",
                              FLUX_ROLE_OWNER,
                              0,
@@ -736,7 +759,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -753,7 +776,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -770,7 +793,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -787,7 +810,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.dir",
                              FLUX_ROLE_OWNER,
                              0,
@@ -802,7 +825,7 @@ void lookup_basic (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref.symlink",
                              FLUX_ROLE_OWNER,
                              0,
@@ -885,13 +908,15 @@ void lookup_errors (void) {
     treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* Lookup non-existent field.  Not ENOENT - caller of lookup
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "foo",
                              FLUX_ROLE_OWNER,
                              0,
@@ -907,7 +932,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "val.foo",
                              FLUX_ROLE_OWNER,
                              0,
@@ -923,7 +948,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "valref.foo",
                              FLUX_ROLE_OWNER,
                              0,
@@ -938,7 +963,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dir.foo",
                              FLUX_ROLE_OWNER,
                              0,
@@ -953,7 +978,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "symlink1",
                              FLUX_ROLE_OWNER,
                              0,
@@ -968,7 +993,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -983,7 +1008,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dir",
                              FLUX_ROLE_OWNER,
                              0,
@@ -998,7 +1023,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1013,7 +1038,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1028,7 +1053,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1043,7 +1068,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dir",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1058,7 +1083,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1073,7 +1098,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1088,7 +1113,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "symlink",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1103,7 +1128,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref_bad",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1119,7 +1144,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref_bad.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1149,7 +1174,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref_multi",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1165,7 +1190,7 @@ void lookup_errors (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref_multi.foo",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1263,12 +1288,14 @@ void lookup_links (void) {
     treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* lookup val, follow two links */
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref.symlink",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1285,7 +1312,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1302,7 +1329,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref.valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1319,7 +1346,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref.dir",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1334,7 +1361,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref.dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1349,7 +1376,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref.symlink",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1366,7 +1393,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1383,7 +1410,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1400,7 +1427,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dir",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1415,7 +1442,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2dirref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1430,7 +1457,7 @@ void lookup_links (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.link2symlink",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1493,6 +1520,8 @@ void lookup_alt_root (void) {
     treeobj_hash ("sha1", root, root_ref);
     cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* lookup val, alt root-ref dirref1_ref */
     ok ((lh = lookup_create (cache,
                              krm,
@@ -1554,6 +1583,8 @@ void lookup_stall_root (void) {
     treeobj_insert_entry (root, "val", treeobj_create_val ("foo", 3));
     treeobj_hash ("sha1", root, root_ref);
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* do not insert entries into cache until later for these stall tests */
 
     /* lookup root ".", should stall on root */
@@ -1561,7 +1592,7 @@ void lookup_stall_root (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              ".",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1581,7 +1612,7 @@ void lookup_stall_root (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              ".",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1689,6 +1720,8 @@ void lookup_stall (void) {
     treeobj_insert_entry (root, "symlink", treeobj_create_symlink ("dirref2"));
     treeobj_hash ("sha1", root, root_ref);
 
+    setup_kvsroot (krm, cache, root_ref);
+
     /* do not insert entries into cache until later for these stall tests */
 
     /* lookup dirref1.val, should stall on root */
@@ -1696,7 +1729,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1723,7 +1756,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1762,7 +1795,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "symlink.val",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1779,7 +1812,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1801,7 +1834,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valref",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1818,7 +1851,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valref_multi",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1842,7 +1875,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valref_multi",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1859,7 +1892,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valref_multi2",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1883,7 +1916,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valref_multi2",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1900,7 +1933,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valrefmisc",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1923,7 +1956,7 @@ void lookup_stall (void) {
                              krm,
                              1,
                              KVS_PRIMARY_NAMESPACE,
-                             root_ref,
+                             NULL,
                              "dirref1.valrefmisc_multi",
                              FLUX_ROLE_OWNER,
                              0,

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -156,7 +156,7 @@ void basic_api (void)
                              krm,
                              42,
                              KVS_PRIMARY_NAMESPACE,
-                             NULL,
+                             "root.ref.foo",
                              "path.bar",
                              FLUX_ROLE_OWNER,
                              0,
@@ -1290,19 +1290,19 @@ void lookup_security (void) {
     check_value (lh, test, "lookup val with rolemask user and valid owner");
     json_decref (test);
 
-    ok (!lookup_create (cache,
-                        krm,
-                        1,
-                        KVS_PRIMARY_NAMESPACE,
-                        NULL,
-                        "val",
-                        FLUX_ROLE_USER,
-                        6,
-                        0,
-                        NULL,
-                        NULL)
-        && errno == EPERM,
-        "lookup_create on val with rolemask user and invalid owner, returns EPERM");
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
+                             "val",
+                             FLUX_ROLE_USER,
+                             6,
+                             0,
+                             NULL,
+                             NULL)) != NULL,
+        "lookup_create on val with rolemask user and invalid owner");
+    check_error (lh, EPERM, "lookup_create on val with rolemask user and invalid owner");
 
     cache_destroy (cache);
     kvsroot_mgr_destroy (krm);


### PR DESCRIPTION
This PR does a lot of refactoring on the internal kvs lookup API.  The two major accomplishments of this PR are:

1) Allow kvs namespaces to be looked up within the lookup API itself.

2) When a namespace is missing/not available, inform callers that it is missing and has to be brought in.

Then of course there are tons of unit tests along the way.
