### PR TITLE
kvs: Fix namespace rolemask/owner corner case

### DIFF
--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -104,6 +104,7 @@ struct lookup {
         LOOKUP_STATE_INIT,
         LOOKUP_STATE_CHECK_NAMESPACE,
         LOOKUP_STATE_CHECK_ROOT,
+        LOOKUP_STATE_WALK_INIT,
         LOOKUP_STATE_WALK,
         LOOKUP_STATE_VALUE,
         LOOKUP_STATE_FINISHED,
@@ -840,17 +841,6 @@ lookup_process_t lookup (lookup_t *lh)
                 }
             }
 
-            if (!(lh->root_dirent = treeobj_create_dirref (lh->root_ref))) {
-                lh->errnum = errno;
-                goto error;
-            }
-
-            /* initialize walk - first depth is level 0 */
-            if (!walk_levels_push (lh, lh->path, 0)) {
-                lh->errnum = errno;
-                goto error;
-            }
-
             lh->state = LOOKUP_STATE_CHECK_ROOT;
             /* fallthrough */
         case LOOKUP_STATE_CHECK_ROOT:
@@ -896,6 +886,21 @@ lookup_process_t lookup (lookup_t *lh)
                     }
                 }
                 goto done;
+            }
+
+            lh->state = LOOKUP_STATE_WALK_INIT;
+            /* fallthrough */
+        case LOOKUP_STATE_WALK_INIT:
+            /* initialize walk - first depth is level 0 */
+
+            if (!(lh->root_dirent = treeobj_create_dirref (lh->root_ref))) {
+                lh->errnum = errno;
+                goto error;
+            }
+
+            if (!walk_levels_push (lh, lh->path, 0)) {
+                lh->errnum = errno;
+                goto error;
             }
 
             lh->state = LOOKUP_STATE_WALK;

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -876,7 +876,6 @@ lookup_process_t lookup (lookup_t *lh)
                                                 lh->root_ref,
                                                 lh->current_epoch))
                         || !cache_entry_get_valid (entry)) {
-                        lh->state = LOOKUP_STATE_CHECK_ROOT;
                         lh->missing_ref = lh->root_ref;
                         return LOOKUP_PROCESS_LOAD_MISSING_REFS;
                     }

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -473,8 +473,21 @@ void verify_value (struct cache *cache,
                    const char *key,
                    const char *val)
 {
+    struct kvsroot *root;
     lookup_t *lh;
     json_t *test, *o;
+
+    /* Need to make sure the namespace exists before doing a lookup */
+    if (!(root = kvsroot_mgr_lookup_root (krm, KVS_PRIMARY_NAMESPACE))) {
+        ok ((root = kvsroot_mgr_create_root (krm,
+                                             cache,
+                                             "sha1",
+                                             KVS_PRIMARY_NAMESPACE,
+                                             0,
+                                             0)) != NULL,
+            "kvsroot_mgr_create_root works");
+    }
+    kvsroot_setroot (krm, root, root_ref, 0);
 
     ok ((lh = lookup_create (cache,
                              krm,

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -1310,6 +1310,20 @@ void lookup_security (void) {
         "lookup_create on val with rolemask user and invalid owner");
     check_error (lh, EPERM, "lookup_create on val with rolemask user and invalid owner");
 
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             root_ref,
+                             "val",
+                             FLUX_ROLE_USER,
+                             6,
+                             0,
+                             NULL,
+                             NULL)) != NULL,
+        "lookup_create on val with rolemask user and invalid owner w/ root_ref");
+    check_error (lh, EPERM, "lookup_create on val with rolemask user and invalid owner w/ root_ref");
+
     cache_destroy (cache);
     kvsroot_mgr_destroy (krm);
 }

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -184,6 +184,15 @@ test_expect_success 'kvs: get fails on other ranks (wrong user)' '
                                 flux kvs --namespace=$NAMESPACETMP-USER get $DIR.test"
 '
 
+test_expect_success 'kvs: get fails (wrong user, with at reference)' '
+        set_userid 9999 &&
+        ref=`flux kvs --namespace=$NAMESPACETMP-USER get --treeobj .` &&
+        unset_userid &&
+        set_userid 9000 &&
+      	! flux kvs --namespace=$NAMESPACETMP-USER get --at ${ref} --json $DIR.test &&
+        unset_userid
+'
+
 test_expect_success NO_CHAIN_LINT 'kvs: watch works (user)'  '
         set_userid 9999 &&
         flux kvs --namespace=$NAMESPACETMP-USER unlink -Rf $DIR &&


### PR DESCRIPTION
I realized I had a corner case in my recent PR (#1390) in which a namespace wouldn't get its rolemask/owner checked.

In addition, added a tiny cleanup & minor refactoring to this PR.