### PR TITLE
kvs: minor cleanup & refactoring

### DIFF
--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -104,6 +104,7 @@ struct lookup {
         LOOKUP_STATE_INIT,
         LOOKUP_STATE_CHECK_NAMESPACE,
         LOOKUP_STATE_CHECK_ROOT,
+        LOOKUP_STATE_WALK_INIT,
         LOOKUP_STATE_WALK,
         LOOKUP_STATE_VALUE,
         LOOKUP_STATE_FINISHED,
@@ -840,17 +841,6 @@ lookup_process_t lookup (lookup_t *lh)
                 }
             }
 
-            if (!(lh->root_dirent = treeobj_create_dirref (lh->root_ref))) {
-                lh->errnum = errno;
-                goto error;
-            }
-
-            /* initialize walk - first depth is level 0 */
-            if (!walk_levels_push (lh, lh->path, 0)) {
-                lh->errnum = errno;
-                goto error;
-            }
-
             lh->state = LOOKUP_STATE_CHECK_ROOT;
             /* fallthrough */
         case LOOKUP_STATE_CHECK_ROOT:
@@ -896,6 +886,21 @@ lookup_process_t lookup (lookup_t *lh)
                     }
                 }
                 goto done;
+            }
+
+            lh->state = LOOKUP_STATE_WALK_INIT;
+            /* fallthrough */
+        case LOOKUP_STATE_WALK_INIT:
+            /* initialize walk - first depth is level 0 */
+
+            if (!(lh->root_dirent = treeobj_create_dirref (lh->root_ref))) {
+                lh->errnum = errno;
+                goto error;
+            }
+
+            if (!walk_levels_push (lh, lh->path, 0)) {
+                lh->errnum = errno;
+                goto error;
             }
 
             lh->state = LOOKUP_STATE_WALK;

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -876,7 +876,6 @@ lookup_process_t lookup (lookup_t *lh)
                                                 lh->root_ref,
                                                 lh->current_epoch))
                         || !cache_entry_get_valid (entry)) {
-                        lh->state = LOOKUP_STATE_CHECK_ROOT;
                         lh->missing_ref = lh->root_ref;
                         return LOOKUP_PROCESS_LOAD_MISSING_REFS;
                     }


### PR DESCRIPTION
These are two patches pulled out of #1397.  The primary fix from #1397 was dropped, but these remaining cleanups/minor refactor can still be applied.