### PR TITLE
kvs: Fix corner case in which symlink points to root dir

### DIFF
--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -343,15 +343,23 @@ static lookup_process_t walk (lookup_t *lh)
                     goto error;
                 }
 
-                /* "recursively" determine link dirent */
-                if (!(wl = walk_levels_push (lh,
-                                             linkstr,
-                                             wl->depth + 1))) {
-                    lh->errnum = errno;
-                    goto error;
+                /* if symlink is root, no need to recurse, just get
+                 * root_dirent and continue on.
+                 */
+                if (!strcmp (linkstr, ".")) {
+                    wl->dirent = lh->root_dirent;
                 }
+                else {
+                    /* "recursively" determine link dirent */
+                    if (!(wl = walk_levels_push (lh,
+                                                 linkstr,
+                                                 wl->depth + 1))) {
+                        lh->errnum = errno;
+                        goto error;
+                    }
 
-                continue;
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
Fix corner case in which a symlink in the kvs points to the root dir, i.e. ```"."```.

I discovered this corner case while working on #1341.  I realized users will probably often do:

```
mysymlink -> namespace/.
```

i.e. a symlink simply points to the root of another namespace.  But root dirs were not handled at all within symlinks.
