### PR TITLE
libkz: avoid blocking RPCs in reactor callbacks

### DIFF
--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1362,7 +1362,7 @@ static int l_iowatcher_add (lua_State *L)
     }
     lua_getfield (L, 2, "key");
     if (!lua_isnil (L, -1)) {
-        int flags = KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK | KZ_FLAGS_NOEXIST;
+        int flags = KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK;
         kz_t *kz;
         const char *key = lua_tostring (L, -1);
         if ((kz = kz_open (f, key, flags)) == NULL)
@@ -2023,7 +2023,7 @@ static int l_flux_kz_open (lua_State *L)
     if (mode == NULL)
         mode = "r";
     if (mode[0] == 'r')
-        flags = KZ_FLAGS_READ | KZ_FLAGS_NOEXIST | KZ_FLAGS_NONBLOCK;
+        flags = KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK;
     else if (mode[0] == 'w')
         flags = KZ_FLAGS_WRITE;
     else

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1300,29 +1300,18 @@ static void iowatcher_kz_ready_cb (kz_t *kz, void *arg)
     lua_getfield (L, t, "userdata");
     assert (lua_isuserdata (L, -1));
 
-    while ((len = kz_get (kz, &data)) >= 0) {
-        /*
-         *  Recreate stack on each iteration:
-         */
-        lua_pushvalue (L, 2);
-        assert (lua_isfunction (L, -1));
-        lua_pushvalue (L, 3);
-        assert (lua_isuserdata (L, -1));
-
-        if (len > 0) {
-            lua_pushlstring (L, data, len);
-            free (data);
-        }
-        if (len == 0)
-            lua_pushnil (L);
-
-        if (lua_pcall (L, 2, 1, 0)) {
+    len = kz_get (kz, &data);
+    if (len > 0) {
+        lua_pushlstring (L, data, len);
+        free (data);
+    }
+    if (len == 0)
+        lua_pushnil (L);
+    if (len >= 0) {
+        if (lua_pcall (L, 2, 1, 0))
             fprintf (stderr, "kz_ready: %s\n",  lua_tostring (L, -1));
-            break;
-        }
-        if (len == 0)
-            break;
-        lua_pop (L, 1);
+        else
+            lua_pop (L, 1);
     }
 
     lua_settop (L, 0);

--- a/src/bindings/python/flux/kz.py
+++ b/src/bindings/python/flux/kz.py
@@ -57,8 +57,7 @@ def attach(flux_handle,
            stream,
            prefix=None,
            flags=(RAW.KZ_FLAGS_READ
-                  | RAW.KZ_FLAGS_NONBLOCK
-                  | RAW.KZ_FLAGS_NOEXIST)):
+                  | RAW.KZ_FLAGS_NONBLOCK)):
     handle = RAW.kz_open(flux_handle, key, flags)
     warg = (stream, prefix, handle)
     KZWATCHES[key] = warg
@@ -78,8 +77,7 @@ class KZStream(WrapperPimpl):
         def __init__(self,
                      flux_handle,
                      name,
-                     flags=(RAW.KZ_FLAGS_READ | RAW.KZ_FLAGS_NONBLOCK |
-                            RAW.KZ_FLAGS_NOEXIST),
+                     flags=(RAW.KZ_FLAGS_READ | RAW.KZ_FLAGS_NONBLOCK),
                      handle=None,
                      prefix=False):
             self.destroyer = RAW.kz_close
@@ -113,8 +111,7 @@ class KZStream(WrapperPimpl):
     def __init__(self,
                  flux_handle,
                  name,
-                 flags=(RAW.KZ_FLAGS_READ | RAW.KZ_FLAGS_NONBLOCK |
-                        RAW.KZ_FLAGS_NOEXIST),
+                 flags=(RAW.KZ_FLAGS_READ | RAW.KZ_FLAGS_NONBLOCK),
                  handle=None,
                  prefix=False):
         super(KZStream, self).__init__()

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -399,11 +399,16 @@ int kz_set_ready_cb (kz_t *kz, kz_ready_f ready_cb, void *arg)
     }
     kz->ready_cb = ready_cb;
     kz->ready_arg = arg;
-    if (!kz->watching) {
-        const char *key = clear_key (kz);
+    const char *key = clear_key (kz);
+    if (kz->ready_cb != NULL && !kz->watching) {
         if (flux_kvs_watch_dir (kz->h, kvswatch_cb, kz, "%s", key) < 0)
             return -1;
         kz->watching = true;
+    }
+    if (kz->ready_cb == NULL && kz->watching) {
+        if (flux_kvs_unwatch (kz->h, key) < 0)
+            return -1;
+        kz->watching = false;
     }
     return 0;
 }

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -84,13 +84,14 @@ struct kz_struct {
 
 static void kz_destroy (kz_t *kz)
 {
-    if (kz->name)
+    if (kz) {
+        int saved_errno = errno;
         free (kz->name);
-    if (kz->dir)
         flux_kvsdir_destroy (kz->dir);
-    if (kz->grpname)
         free (kz->grpname);
-    free (kz);
+        free (kz);
+        errno = saved_errno;
+    }
 }
 
 static bool key_exists (flux_t *h, const char *key)

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -156,19 +156,6 @@ kz_t *kz_open (flux_t *h, const char *name, int flags)
             if (flux_kvs_commit_anon (h, 0) < 0)
                 goto error;
         }
-    } else if ((flags & KZ_FLAGS_READ)) {
-        if (!(flags & KZ_FLAGS_NOEXIST)) {
-            const flux_kvsdir_t *dir;
-            flux_future_t *f;
-
-            if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, name))
-                || flux_kvs_lookup_get_dir (f, &dir) < 0
-                || !(kz->dir = flux_kvsdir_copy (dir))) {
-                flux_future_destroy (f);
-                goto error;
-            }
-            flux_future_destroy (f);
-        }
     }
     return kz;
 error:

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -69,7 +69,6 @@
 struct kz_struct {
     int flags;
     char *name;
-    char *stream;
     flux_t *h;
     int seq;
     flux_kvsdir_t *dir;
@@ -116,10 +115,6 @@ kz_t *kz_open (flux_t *h, const char *name, int flags)
 
     kz->flags = flags;
     kz->name = xstrdup (name);
-    if ((kz->stream = strchr (kz->name, '.')))
-        kz->stream++;
-    else
-        kz->stream = kz->name;
     kz->h = h;
 
     if ((flags & KZ_FLAGS_WRITE)) {

--- a/src/common/libkz/kz.h
+++ b/src/common/libkz/kz.h
@@ -61,7 +61,7 @@ int kz_close (kz_t *kz);
 
 /* Register a callback that will be called when data is available to
  * be read from kz.  Call kz_open with (KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK).
- * Your function should call kz_get() until it returns -1, errno = EAGAIN.
+ * Your function may call kz_get() once without blocking.
  */
 int kz_set_ready_cb (kz_t *kz, kz_ready_f ready_cb, void *arg);
 

--- a/src/common/libkz/kz.h
+++ b/src/common/libkz/kz.h
@@ -16,7 +16,6 @@ enum kz_flags {
     KZ_FLAGS_NOEXIST        = 0x0020, /* allow open for reading to succeed */
                                       /*   even if stream doesn't exist yet */
 
-    KZ_FLAGS_TRUNC          = 0x0100, /* remove contents before writing */
     KZ_FLAGS_RAW            = 0x0200, /* use only *_json I/O methods */
     KZ_FLAGS_NOCOMMIT_OPEN  = 0x0400, /* skip commit at open (FLAGS_WRITE) */
     KZ_FLAGS_NOCOMMIT_PUT   = 0x0800, /* skip commit at put */
@@ -26,6 +25,7 @@ enum kz_flags {
 };
 
 /* Prepare to read or write a KVS stream.
+ * If open for writing, any existing content is overwritten.
  */
 kz_t *kz_open (flux_t *h, const char *name, int flags);
 

--- a/src/common/libkz/kz.h
+++ b/src/common/libkz/kz.h
@@ -13,8 +13,6 @@ enum kz_flags {
     KZ_FLAGS_MODEMASK       = 0x0003,
 
     KZ_FLAGS_NONBLOCK       = 0x0010, /* currently only applies to reads */
-    KZ_FLAGS_NOEXIST        = 0x0020, /* allow open for reading to succeed */
-                                      /*   even if stream doesn't exist yet */
 
     KZ_FLAGS_RAW            = 0x0200, /* use only *_json I/O methods */
     KZ_FLAGS_NOCOMMIT_OPEN  = 0x0400, /* skip commit at open (FLAGS_WRITE) */
@@ -26,6 +24,7 @@ enum kz_flags {
 
 /* Prepare to read or write a KVS stream.
  * If open for writing, any existing content is overwritten.
+ * If open for reading, KVS directory for stream need not exist
  */
 kz_t *kz_open (flux_t *h, const char *name, int flags);
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -451,11 +451,11 @@ int io_cb (zio_t *z, const char *s, int len, void *arg)
 void kz_stdin (kz_t *kz, struct task_info *t)
 {
     char *json_str;
-    while ((json_str = kz_get_json (kz))) {
+    if ((json_str = kz_get_json (kz))) {
         zio_write_json (t->zio [IN], json_str);
         free (json_str);
     }
-    if (errno != 0 && errno != EAGAIN)
+    else if (errno != 0 && errno != EAGAIN)
         wlog_err (t->ctx, "kz_get_json: %s", flux_strerror (errno));
     return;
 }

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -478,8 +478,7 @@ kz_t *task_kz_open (struct task_info *t, int type)
     int flags = prog_ctx_io_flags (ctx);
 
     if (type == IN)
-        flags |= KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK | KZ_FLAGS_NOEXIST
-                 | KZ_FLAGS_RAW;
+        flags |= KZ_FLAGS_READ | KZ_FLAGS_NONBLOCK | KZ_FLAGS_RAW;
     else
         flags |= KZ_FLAGS_WRITE;
 

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -202,16 +202,14 @@ static void attach_stdout_ready_cb (kz_t *kz, void *arg)
     char *data;
     int len;
 
-    do {
-        if ((len = kz_get (kz, &data)) < 0) {
-            if (errno != EAGAIN)
-                log_err_exit ("kz_get stdout");
-        } else if (len > 0) {
-            if (write_all (STDOUT_FILENO, data, len) < 0)
-                log_err_exit ("write_all stdout");
-            free (data);
-        }
-    } while (len > 0);
+    if ((len = kz_get (kz, &data)) < 0) {
+        if (errno != EAGAIN)
+            log_err_exit ("kz_get stdout");
+    } else if (len > 0) {
+        if (write_all (STDOUT_FILENO, data, len) < 0)
+            log_err_exit ("write_all stdout");
+        free (data);
+    }
     if (len == 0) { /* EOF */
         if (--ctx->readers == 0)
             flux_reactor_stop (flux_get_reactor (ctx->h));
@@ -224,16 +222,14 @@ static void attach_stderr_ready_cb (kz_t *kz, void *arg)
     int len;
     char *data;
 
-    do {
-        if ((len = kz_get (kz, &data)) < 0) {
-            if (errno != EAGAIN)
-                log_err_exit ("kz_get stderr");
-        } else if (len > 0) {
-            if (write_all (STDERR_FILENO, data, len) < 0)
-                log_err_exit ("write_all stderr");
-            free (data);
-        }
-    } while (len > 0);
+    if ((len = kz_get (kz, &data)) < 0) {
+        if (errno != EAGAIN)
+            log_err_exit ("kz_get stderr");
+    } else if (len > 0) {
+        if (write_all (STDERR_FILENO, data, len) < 0)
+            log_err_exit ("write_all stderr");
+        free (data);
+    }
     if (len == 0) { /* EOF */
         if (--ctx->readers == 0)
             flux_reactor_stop (flux_get_reactor (ctx->h));

--- a/t/kz/kzutil.c
+++ b/t/kz/kzutil.c
@@ -53,14 +53,13 @@ static void copy (flux_t *h, const char *src, const char *dst, int kzoutflags,
 static void attach (flux_t *h, const char *key, bool raw, int kzoutflags,
                    int blocksize);
 
-#define OPTIONS "ha:crk:tb:d"
+#define OPTIONS "ha:crk:b:d"
 static const struct option longopts[] = {
     {"help",         no_argument,        0, 'h'},
     {"attach",       required_argument,  0, 'a'},
     {"copy",         no_argument,        0, 'c'},
     {"key",          required_argument,  0, 'k'},
     {"raw-tty",      no_argument,        0, 'r'},
-    {"trunc",        no_argument,        0, 't'},
     {"delay-commit", no_argument,        0, 'd'},
     {"blocksize",    required_argument,  0, 'b'},
     { 0, 0, 0, 0 },
@@ -74,7 +73,6 @@ void usage (void)
 "Where OPTIONS are:\n"
 "  -k,--key NAME         stdio should use the specified KVS dir\n"
 "  -r,--raw-tty          attach tty in raw mode\n"
-"  -t,--trunc            truncate KVS on write\n"
 "  -b,--blocksize BYTES  set stdin blocksize (default 4096)\n"
 "  -d,--delay-commit     flush data to KVS lazily (defer commit until close)\n"
 );
@@ -109,9 +107,6 @@ int main (int argc, char *argv[])
                 break;
             case 'r': /* --raw-tty */
                 rawtty = true;
-                break;
-            case 't': /* --trunc */
-                kzoutflags |= KZ_FLAGS_TRUNC;
                 break;
             case 'd': /* --delay-commit */
                 kzoutflags |= KZ_FLAGS_DELAYCOMMIT;

--- a/t/t1104-kz.t
+++ b/t/t1104-kz.t
@@ -12,7 +12,7 @@ test_expect_success 'kz: hello world copy in, copy out' '
 	${FLUX_BUILD_DIR}/t/kz/kzutil --b 4096 -c - kztest.1 <kztest.1.in &&
 	test $(flux kvs dir kztest.1 | wc -l) -eq 2 &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil -c kztest.1 - >kztest.1.out &&
-	test_cmp kztest.1.in kztest.1.out 
+	test_cmp kztest.1.in kztest.1.out
 '
 
 test_expect_success 'kz: 128K urandom copy in, copy out' '
@@ -23,19 +23,11 @@ test_expect_success 'kz: 128K urandom copy in, copy out' '
 	test_cmp kztest.2.in kztest.2.out
 '
 
-test_expect_success 'kz: write to existing stream (without KZ_FLAGS_TRUNC) fails' '
-	echo "hello world" >kztest.3.in &&
-	${FLUX_BUILD_DIR}/t/kz/kzutil -c - kztest.3 <kztest.3.in &&
-	! ${FLUX_BUILD_DIR}/t/kz/kzutil -c - kztest.3 <kztest.3.in
-'
-
-# Write a multi-block stream, then overwrite it with hello world and make
-# sure we only have hello world afterwards
-test_expect_success 'kz: KZ_FLAGS_TRUNC truncates original content' '
+test_expect_success 'kz: second writer truncates original content' '
 	dd if=/dev/urandom bs=4096 count=32 2>/dev/null >kztest.4.in &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil -b 4096 -c - kztest.4 <kztest.4.in &&
 	echo "hello world" >kztest.4.in2 &&
-	${FLUX_BUILD_DIR}/t/kz/kzutil -t -c - kztest.4 <kztest.4.in2 &&
+	${FLUX_BUILD_DIR}/t/kz/kzutil -c - kztest.4 <kztest.4.in2 &&
 	${FLUX_BUILD_DIR}/t/kz/kzutil -c kztest.4 - >kztest.4.out &&
 	test_cmp kztest.4.in2 kztest.4.out
 '


### PR DESCRIPTION
Here are some changes libkz to defer the `kz_ready_f` callback until data is actually available, so it doesn't have to be fetched with a synchronous RPC from the callback.  I hope this will solve the excessive re-queue calls noted in #1406.

There is some other unrelated cleanup too - just what I needed to fix up to keep my sanity in this old code.

@grondo if you have a chance to look at the changes in the lua bindings and wrexecd I'd appreciate it.  The goal there was to avoid looping on `kz_get()` in the user callback since only the first call will be non-blocking.