### PR TITLE
kvs: add flux_kvs_lookup_get_key()

### DIFF
--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -31,6 +31,8 @@ SYNOPSIS
 
  int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target);
 
+ const char *flux_kvs_lookup_get_key (flux_future_t *f);
+
 
 DESCRIPTION
 -----------
@@ -85,6 +87,9 @@ function should work on all.
 e.g. in response to a lookup with the FLUX_KVS_READLINK flag set.
 The result is parsed and symlink target is assigned to _target_.
 
+`flux_kvs_lookup_get_key()` accesses the key argument from the original
+lookup.
+
 These functions may be used asynchronously.  See `flux_future_then(3)` for
 details.
 
@@ -121,6 +126,9 @@ RETURN VALUE
 `flux_kvs_lookup_get_raw()`, `flux_kvs_lookup_get_dir()`,
 `flux_kvs_lookup_get_treeobj()`, and `flux_kvs_lookup_get_symlink()`
 return 0 on success, or -1 on failure with errno set appropriately.
+
+`flux_kvs_lookup_get_key()` returns key on success, or NULL with errno
+set to EINVAL if its future argument did not come from a KVS lookup.
 
 
 ERRORS

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -345,6 +345,17 @@ int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target)
     return 0;
 }
 
+const char *flux_kvs_lookup_get_key (flux_future_t *f)
+{
+    struct lookup_ctx *ctx;
+
+    if (!(ctx = flux_future_aux_get (f, auxkey))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ctx->key;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -16,6 +16,8 @@ int flux_kvs_lookup_get_treeobj (flux_future_t *f, const char **treeobj);
 int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dir);
 int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target);
 
+const char *flux_kvs_lookup_get_key (flux_future_t *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libkvs/test/kvs_lookup.c
+++ b/src/common/libkvs/test/kvs_lookup.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include <flux/core.h>
 
 #include "src/common/libflux/flux.h"
 #include "kvs_lookup.h"
@@ -11,6 +12,7 @@
 
 void errors (void)
 {
+    flux_future_t *f;
     /* check simple error cases */
 
     errno = 0;
@@ -32,6 +34,17 @@ void errors (void)
     errno = 0;
     ok (flux_kvs_lookup_get_raw (NULL, NULL, NULL) < 0 && errno == EINVAL,
         "flux_kvs_lookup_get_raw fails on bad input");
+
+    errno = 0;
+    ok (flux_kvs_lookup_get_key (NULL) == NULL && errno == EINVAL,
+        "flux_kvs_lookup_get_key future=NULL fails with EINVAL");
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+    errno = 0;
+    ok (flux_kvs_lookup_get_key (f) == NULL && errno == EINVAL,
+        "flux_kvs_lookup_get_key future=(wrong type) fails with EINVAL");
+    flux_future_destroy (f);
 }
 
 int main (int argc, char *argv[])


### PR DESCRIPTION
When writing code that uses `flux_kvs_lookup()` with continuations, it's useful to be able to access the original key from within the continuation, so the continuation can be shared for multiple lookups  This PR adds an accessor for the key.

Tests and docs updated.