### PR TITLE
wreck: minor improvements to flux-wreck util

### DIFF
--- a/src/bindings/lua/flux/Subcommander.lua
+++ b/src/bindings/lua/flux/Subcommander.lua
@@ -160,7 +160,7 @@ end
 function Command:SubCommand (t)
     assert (t and t.name and t.handler)
     t.shortprog = t.name
-    t.prog = self.name.." "..t.name
+    t.prog = self.prog.." "..t.name
     t.parent = self
 
     if not self.Commands then self.Commands = {} end

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -624,7 +624,10 @@ function wreck.joblist (arg)
     end
 
     local dir, err = f:kvsdir ("lwj")
-    if not dir then return nil, err end
+    if not dir then
+        if err:match ("No such") then err = "No job information in KVS" end
+        return nil, err
+    end
 
     return reverse (visit (dir))
 end


### PR DESCRIPTION
Very minor fix to flux-wreck `ls` `timing` etc. for confusing error message from when there are no jobs in the kvs yet (#1416). Also fixed a typo causing `flux-wreck` error messages to include the full path to the script instead of a short name.

I didn't have time to go through `flux-wreck` script and fix other cases where `strerror (errno)` is attempted to be passed off as a helpful error. Sorry.