### PR TITLE
wreck: Add support for node exclusion and inclusion

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -142,6 +142,57 @@ prog:SubCommand {
 }
 
 prog:SubCommand {
+ name = "exclude",
+ description = "Exclude a node from running future jobs",
+ usage = "NODENAME",
+ options = {
+   { name = "kill", char = "k",
+     usage = "kill the jobs to which the node is allocated"
+   }
+ },
+ handler = function (self, arg)
+    local function toboolean(X)
+         return not not X
+    end
+
+    local nodename = arg[1]
+    if not nodename then
+        self:die ("Required argument NODENAME missing.")
+    end
+    local resp, err = f:rpc ("sched.exclude", { node = nodename, kill = toboolean (self.opt.k) })
+
+    if not resp then
+        if err == "Function not implemented" then
+            prog:die ("Node exclusion is not supported when scheduler not loaded")
+        else
+            prog:die ("Unable to exclude node %s: %s\n", nodename, err)
+        end
+    end
+ end
+}
+
+prog:SubCommand {
+ name = "include",
+ description = "Include a node for scheduling",
+ usage = "NODENAME",
+ handler = function (self, arg)
+    local nodename = arg[1]
+    if not nodename then
+        self:die ("Required argument NODENAME missing.")
+    end
+    local resp, err = f:rpc ("sched.include", { node = nodename })
+    if not resp then
+        if err == "Function not implemented" then
+            prog:die ("Node inclusion is not supported when scheduler not loaded")
+        else
+            prog:die ("Unable to include node %s: %s\n", nodename, err)
+        end
+    end
+ end
+}
+
+
+prog:SubCommand {
  name = "kill",
  description = "Kill a running job",
  usage = "[OPTIONS] JOBID",

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -428,6 +428,21 @@ test_expect_success 'flux-wreck cancel: falls back to SIGKILL with -f' '
 	test_cmp expected.cancel-f output.cancel-f
 '
 
+test_expect_success NO_SCHED 'flux-wreck exclude: fails when sched not loaded' '
+    test_must_fail flux wreck exclude myhost 2>err.exclude &&
+    cat >expected.exclude <<-EOF
+    flux-wreck: Node exclusion is not supported when scheduler not loaded
+    EOF
+    test_cmp expected.exclude err.exclude
+'
+test_expect_success NO_SCHED 'flux-wreck include: fails when sched not loaded' '
+    test_must_fail flux wreck include myhost 2>err.include &&
+    cat >expected.include <<-EOF
+    flux-wreck: Node inclusion is not supported when scheduler not loaded
+    EOF
+    test_cmp expected.include err.include
+'
+
 check_complete_link() {
     for i in `seq 0 5`; do
         lastepoch=$(flux kvs dir lwj-complete | awk -F. '{print $2}' | sort -n | tail -1)


### PR DESCRIPTION
This is an experimental PR. Please don't merge yet.

Add support for exclusion and inclusion by node name.

Only supported when the scheduler is loaded.

This is required to test out the new experimental feature added in sched: #PR [305](https://github.com/flux-framework/flux-sched/pull/305)