### PR TITLE
kvs: Support namespace prefix in key passed in by user

### DIFF
--- a/src/modules/kvs/kvs_util.c
+++ b/src/modules/kvs/kvs_util.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+#include <errno.h>
 
 char *kvs_util_normalize_key (const char *key, bool *want_directory)
 {
@@ -67,6 +68,66 @@ char *kvs_util_normalize_key (const char *key, bool *want_directory)
             *want_directory = has_sep_suffix;
     }
     return cpy;
+}
+
+int kvs_namespace_prefix (const char *key,
+                           char **namespace_prefix,
+                           char **key_suffix)
+{
+
+    if (key && !strncmp (key, "ns:", 3)) {
+        char *ptr;
+        char *cpy;
+
+        if (!(ptr = strchr (key + 3, '/'))) {
+            errno = EINVAL;
+            return -1;
+        }
+
+        /* Ensure user listed a namespace, i.e. not "ns:/" */
+        if (!((ptr - (key + 3)) > 0)) {
+            errno = EINVAL;
+            return -1;
+        }
+
+        /* Ensures user did not pass in key of "ns:X/",
+         * i.e. namespace only
+         */
+        if (*(ptr + 1) == '\0') {
+            errno = EINVAL;
+            return -1;
+        }
+
+        /* Ensure no chained namespaces */
+        if (strstr (ptr + 1, "ns:")) {
+            errno = EINVAL;
+            return -1;
+        }
+
+        if (!(cpy = strdup (key + 3))) {
+            errno = ENOMEM;
+            return -1;
+        }
+        (*(cpy + (ptr - (key + 3)))) = '\0';
+
+        if (key_suffix) {
+            char *keyptr = (cpy + (ptr - (key + 3)) + 1);
+            if (!((*key_suffix) = strdup (keyptr))) {
+                free (cpy);
+                errno = ENOMEM;
+                return -1;
+            }
+        }
+
+        if (namespace_prefix)
+            (*namespace_prefix) = cpy;
+        else
+            free (cpy);
+
+        return 1;
+    }
+
+    return 0;
 }
 
 /*

--- a/src/modules/kvs/kvs_util.h
+++ b/src/modules/kvs/kvs_util.h
@@ -8,6 +8,20 @@
  */
 char *kvs_util_normalize_key (const char *key, bool *want_directory);
 
+/* Check if key contains a namespace within it with the "ns:X/" prefix
+ * format, e.g.
+ *
+ * key_orig = "ns:foo/bar"
+ *
+ * Indicates a namespace of "foo" and the key "bar".  Returns 1 if
+ * namespace prefix exists, 0 if not, -1 on error.  Returns prefix and
+ * suffix in namespace_prefix and key_suffix appropriately.  Caller is
+ * responsible for freeing memory from return pointers.
+ */
+int kvs_namespace_prefix (const char *key,
+                          char **namespace_prefix,
+                          char **key_suffix);
+
 #endif  /* !_FLUX_KVS_UTIL_H */
 
 /*

--- a/src/modules/kvs/test/kvs_util.c
+++ b/src/modules/kvs/test/kvs_util.c
@@ -3,21 +3,15 @@
 #endif
 #include <stdbool.h>
 #include <string.h>
+#include <errno.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/modules/kvs/kvs_util.h"
 
-int main (int argc, char *argv[])
+void kvs_util_normalize_key_path_tests (void)
 {
     char *s;
     bool dirflag;
-
-    plan (NO_PLAN);
-
-    s = kvs_util_normalize_key ("a.b.c.d.e", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
-        "kvs_util_normalize_key works on normal key");
-    free (s);
 
     s = kvs_util_normalize_key ("a.b.c..d.e", &dirflag);
     ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
@@ -58,6 +52,86 @@ int main (int argc, char *argv[])
     ok (s != NULL && !strcmp (s, "."),
         "kvs_util_normalize_key transforms several standalone separators to one");
     free (s);
+}
+
+void kvs_namespace_prefix_tests (void)
+{
+    char *namespace_prefix, *key_suffix;
+
+    ok (kvs_namespace_prefix (NULL, NULL, NULL) == 0,
+        "kvs_namespace_prefix returns 0 on all NULL inputs");
+
+    ok (kvs_namespace_prefix ("foo", NULL, NULL) == 0,
+        "kvs_namespace_prefix returns 0 on just a keyname");
+
+    ok (kvs_namespace_prefix ("foo/bar", NULL, NULL) == 0,
+        "kvs_namespace_prefix returns 0 on key with just a slash");
+
+    ok (kvs_namespace_prefix ("ns:foo", NULL, NULL) < 0
+        && errno == EINVAL,
+        "kvs_namespace_prefix returns -1 on key with just a ns: and no slash");
+
+    ok (kvs_namespace_prefix ("ns:foo/", NULL, NULL) < 0
+        && errno == EINVAL,
+        "kvs_namespace_prefix returns -1 on key with only a namespace");
+
+    ok (kvs_namespace_prefix ("ns:/bar", NULL, NULL) < 0
+        && errno == EINVAL,
+        "kvs_namespace_prefix returns -1 on key without namespace between ns: and /");
+
+    ok (kvs_namespace_prefix ("ns:foo/ns:bar", NULL, NULL) < 0
+        && errno == EINVAL,
+        "kvs_namespace_prefix returns -1 on key with chained namespaces");
+
+    ok (kvs_namespace_prefix ("ns:foo/bar", &namespace_prefix, &key_suffix) == 1,
+        "kvs_namespace_prefix returns 1 on key with a namespace prefix");
+
+    ok (!strcmp (namespace_prefix, "foo"),
+        "kvs_namespace_prefix returned correct namespace");
+
+    ok (!strcmp (key_suffix, "bar"),
+        "kvs_key_suffix_parse returned correct key_suffix");
+
+    free (namespace_prefix);
+    free (key_suffix);
+
+    ok (kvs_namespace_prefix ("ns:baz/boo", &namespace_prefix, NULL) == 1,
+        "kvs_namespace_prefix returns 1, pass in only prefix pointer");
+
+    ok (!strcmp (namespace_prefix, "baz"),
+        "kvs_namespace_prefix returned correct namespace");
+
+    free (namespace_prefix);
+
+    ok (kvs_namespace_prefix ("ns:baz/boo", NULL, &key_suffix) == 1,
+        "kvs_namespace_prefix returns 1, pass in only prefix pointer");
+
+    ok (!strcmp (key_suffix, "boo"),
+        "kvs_key_suffix_parse returned correct key_suffix");
+
+    free (key_suffix);
+
+    ok (kvs_namespace_prefix ("ns:foo/.", &namespace_prefix, &key_suffix) == 1,
+        "kvs_namespace_prefix returns 1 on key with a namespace prefix and . suffix");
+
+    ok (!strcmp (namespace_prefix, "foo"),
+        "kvs_namespace_prefix returned correct namespace");
+
+    ok (!strcmp (key_suffix, "."),
+        "kvs_key_suffix_parse returned correct key_suffix");
+
+    free (namespace_prefix);
+    free (key_suffix);
+}
+
+
+int main (int argc, char *argv[])
+{
+
+    plan (NO_PLAN);
+
+    kvs_util_normalize_key_path_tests ();
+    kvs_namespace_prefix_tests ();
 
     done_testing ();
     return (0);

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -29,6 +29,7 @@ NAMESPACETEST=namespacetest
 NAMESPACETMP=namespacetmp
 NAMESPACERANK1=namespacerank1
 NAMESPACEORDER=namespaceorder
+NAMESPACEPREFIX=namespaceprefix
 
 namespace_create_loop() {
         i=0
@@ -317,11 +318,11 @@ test_expect_success 'kvs: namespace order setup' '
         test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.ordertest 3
 '
 
-test_expect_success 'kvs: no namespace specified, defaults to primary namespace' '
+test_expect_success 'kvs: no namespace specified, lookup defaults to primary namespace' '
         test_kvs_key $DIR.ordertest 1
 '
 
-test_expect_success 'kvs: namespace specified in environment variable works' '
+test_expect_success 'kvs: lookup - namespace specified in environment variable works' '
         export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-1 &&
         test_kvs_key $DIR.ordertest 2 &&
         unset FLUX_KVS_NAMESPACE &&
@@ -330,11 +331,92 @@ test_expect_success 'kvs: namespace specified in environment variable works' '
         unset FLUX_KVS_NAMESPACE
 '
 
-test_expect_success 'kvs: namespace specified in command line overrides environment variable' '
+test_expect_success 'kvs: lookup - namespace specified in command line overrides environment variable' '
         export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
         test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.ordertest 2 &&
         test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.ordertest 3 &&
         unset FLUX_KVS_NAMESPACE
+'
+
+test_expect_success 'kvs: lookup - namespace specified in key overrides command line & environment variable' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
+        test_kvs_key_namespace $NAMESPACEORDER-BAD ns:primary/$DIR.ordertest 1 &&
+        test_kvs_key_namespace $NAMESPACEORDER-BAD ns:${NAMESPACEORDER}-1/$DIR.ordertest 2 &&
+        test_kvs_key_namespace $NAMESPACEORDER-BAD ns:${NAMESPACEORDER}-2/$DIR.ordertest 3 &&
+        unset FLUX_KVS_NAMESPACE
+'
+
+test_expect_success 'kvs: no namespace specified, put defaults to primary namespace' '
+        flux kvs put $DIR.puttest=1 &&
+        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.puttest 1
+'
+
+test_expect_success 'kvs: put - namespace specified in environment variable works' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-1 &&
+        flux kvs put $DIR.puttest=2 &&
+        unset FLUX_KVS_NAMESPACE &&
+        test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.puttest 2 &&
+        export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-2 &&
+        flux kvs put $DIR.puttest=3 &&
+        unset FLUX_KVS_NAMESPACE &&
+        test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.puttest 3
+'
+
+test_expect_success 'kvs: put - namespace specified in command line overrides environment variable' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
+        flux kvs --namespace=$NAMESPACEORDER-1 put $DIR.puttest=4 &&
+        flux kvs --namespace=$NAMESPACEORDER-2 put $DIR.puttest=5 &&
+        unset FLUX_KVS_NAMESPACE &&
+        test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.puttest 4 &&
+        test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.puttest 5
+'
+
+test_expect_success 'kvs: put - namespace specified in key overrides command line & environment variable' '
+        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
+        flux kvs --namespace=$NAMESPACEORDER-BAD put ns:${NAMESPACEORDER}-1/$DIR.puttest=6 &&
+        flux kvs --namespace=$NAMESPACEORDER-BAD put ns:${NAMESPACEORDER}-2/$DIR.puttest=7 &&
+        unset FLUX_KVS_NAMESPACE &&
+        test_kvs_key_namespace ${NAMESPACEORDER}-1 $DIR.puttest 6 &&
+        test_kvs_key_namespace ${NAMESPACEORDER}-2 $DIR.puttest 7
+'
+
+#
+# Namespace prefix tests
+#
+
+test_expect_success 'kvs: namespace prefix setup' '
+	flux kvs namespace-create $NAMESPACEPREFIX-1 &&
+	flux kvs namespace-create $NAMESPACEPREFIX-2 &&
+	flux kvs namespace-create $NAMESPACEPREFIX-watchprefix &&
+        flux kvs --namespace=$NAMESPACEPREFIX-1 put $DIR.prefixtest=1 &&
+        flux kvs --namespace=$NAMESPACEPREFIX-2 put $DIR.prefixtest=2 &&
+        test_kvs_key_namespace $NAMESPACEPREFIX-1 $DIR.prefixtest 1 &&
+        test_kvs_key_namespace $NAMESPACEPREFIX-2 $DIR.prefixtest 2
+'
+
+test_expect_success 'kvs: lookup - namespace chain fails' '
+        ! flux kvs get ns:${NAMESPACEPREFIX}-1/ns:${NAMESPACEPREFIX}-2/$DIR.prefixtest
+'
+
+test_expect_success 'kvs: put - fails across multiple namespaces' '
+        ! flux kvs put ns:${NAMESPACEPREFIX}-1/$DIR.puttest.a=1 ns:${NAMESPACEPREFIX}-2/$DIR.puttest.b=2
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs: watch a key with namespace prefix'  '
+        flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix unlink -Rf $DIR &&
+        flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix put --json $DIR.watch=0 &&
+        wait_watch_put_namespace ${NAMESPACEPREFIX}-watchprefix "$DIR.watch" "0"
+        rm -f watch_out
+        stdbuf -oL flux kvs watch -o -c 1 ns:${NAMESPACEPREFIX}-watchprefix/$DIR.watch >watch_out &
+        watchpid=$! &&
+        wait_watch_file watch_out "0"
+        flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix put --json $DIR.watch=1 &&
+        wait $watchpid
+cat >expected <<-EOF &&
+0
+1
+EOF
+        test_cmp watch_out expected
 '
 
 #


### PR DESCRIPTION
This is the first half of the big patches to support namespace prefixes in issue #1341.

The first patches in this series are to support parsing of namespace prefixes.  Then the support is added into the internal lookup and kvstxn APIs.  Then finally some unit tests are added.

Note that I know I did not add documentation for namespace prefixes.  I will do that later on as #1341 is completed.