### PR TITLE
store rank 0 instance URIs in enclosing instance KVS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,12 @@ AC_PKGCONFIG
 AS_VAR_SET(fluxrcdir, $sysconfdir/flux)
 AC_SUBST(fluxrcdir)
 
+AS_VAR_SET(fluxrc1dir, $sysconfdir/flux/rc1.d)
+AC_SUBST(fluxrc1dir)
+
+AS_VAR_SET(fluxrc3dir, $sysconfdir/flux/rc3.d)
+AC_SUBST(fluxrc3dir)
+
 AS_VAR_SET(fluxcfdir, $sysconfdir/flux/conf.d)
 AC_SUBST(fluxcfdir)
 

--- a/doc/man1/flux-wreck.adoc
+++ b/doc/man1/flux-wreck.adoc
@@ -33,6 +33,15 @@ states. If '-n, --max' option is provided, then display at most 'COUNT'
 jobs (default: 25). If an optional list of 'JOBIDS' is provided on the
 command line, then display only those jobs.
 
+*uri* [-n, --max=COUNT] [-b, --bare] [JOBIDS...]::
+Display a list of wreck jobs currently in kvs, with abbreviated job info,
+and a URI that can be used to contact the rank 0 broker if the job is a
+Flux instance.  The field is blank for other types of jobs.
+If '-n, --max' option is provided, then display at most 'COUNT'
+jobs (default: 25). If '-b, --bare' option is provided, display only the
+URI for a single job so that it can be parsed by scripts.  If an optional
+list of 'JOBIDS' is provided on the command line, then display only those jobs.
+
 *attach* [--status] [--label-io] 'jobid'::
 Attach to output of a running or completed job. If input was not previously
 connected, also attach to stdin. With '--status', also report job status

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -11,6 +11,9 @@ dist_fluxrc_SCRIPTS = \
         rc1 \
         rc3
 
+dist_fluxrc1_SCRIPTS = \
+        rc1.d/01-enclosing-instance
+
 flux/curve:
 	$(AM_V_GEN)$(top_builddir)/src/cmd/flux keygen --force
 

--- a/etc/rc1.d/01-enclosing-instance
+++ b/etc/rc1.d/01-enclosing-instance
@@ -1,0 +1,18 @@
+# Inform the enclosing instance (if any) of the URI's for this instance
+
+update_parent() {
+    local parent_uri=$(flux getattr parent-uri)
+    local key_prefix=${FLUX_JOB_KVSPATH}.flux
+    local local_uri=${FLUX_URI}
+    local remote_uri="ssh://$(hostname)/$(echo $local_uri|sed 's,^.*://,,')"
+
+    FLUX_URI=${parent_uri} \
+        flux kvs put --json ${key_prefix}.local_uri=${local_uri}
+    FLUX_URI=${parent_uri} \
+        flux kvs put --json ${key_prefix}.remote_uri=${remote_uri}
+}
+
+# Only run this on rank 0
+if test -n "${FLUX_JOB_KVSPATH}" -a $(flux getattr rank) -eq 0; then
+    update_parent
+fi

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -348,6 +348,47 @@ prog:SubCommand {
 }
 
 prog:SubCommand {
+ name = "uri",
+ usage = "[OPTIONS] [JOBIDs]",
+ options = {
+  { name = "max", char = 'n', arg="COUNT",
+    usage = "Display at most COUNT jobs",
+  },
+  { name = "bare", char = 'b',
+    usage = "Dispaly only the URI",
+  }
+ },
+ description = "List FLUX_URI for jobs that are Flux instances",
+ handler = function (self, arg)
+    local dirs,err = joblist_from_args (self, arg)
+    if not dirs then self:die (err) end
+    if #dirs == 0 then return end
+    local fmt = "%6s %6s %-9s %-40s %-.13s\n";
+    if self.opt.b then
+        if #dirs > 1 then self:die ("--bare only works with one job") end
+    else
+        printf (fmt, "ID", "NTASKS", "STATE", "FLUX_URI", "COMMAND")
+    end
+    for _,dir in pairs (dirs) do
+        local id = dir:match ("(%d+)$")
+        if tonumber (id) then
+            local j, err = LWJ.open (f, id, dir)
+            if not j then self:die ("job%d: %s", id, err) end
+            local uri, err = f:kvs_get (kvs_path (id, "flux.remote_uri"))
+            if self.opt.b then
+                if err then self:die ("job%d: not a Flux instance", id) end
+                printf ("%s\n", uri)
+            else
+               if err then uri = "" end
+                printf (fmt, id, j.ntasks, j:state_string(), uri,
+                        j.command:match ("([^/]+)$"))
+           end
+        end
+    end
+ end
+}
+
+prog:SubCommand {
  name = "timing",
  usage = "[OPTIONS] [JOBIDs]...",
  options = {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1929,6 +1929,7 @@ int exec_commands (struct prog_ctx *ctx)
     prog_ctx_setenvf (ctx, "FLUX_JOB_NNODES",1, "%d", ctx->nnodes);
     prog_ctx_setenvf (ctx, "FLUX_NODE_ID",   1, "%d", ctx->rankinfo.nodeid);
     prog_ctx_setenvf (ctx, "FLUX_JOB_SIZE",  1, "%d", ctx->total_ntasks);
+    prog_ctx_setenvf (ctx, "FLUX_JOB_KVSPATH", 1, "%s", ctx->kvspath);
     gtid_list_create (ctx, buf, sizeof (buf));
     prog_ctx_setenvf (ctx, "FLUX_LOCAL_RANKS",  1, "%s", buf);
 

--- a/t/t2003-recurse.t
+++ b/t/t2003-recurse.t
@@ -6,7 +6,7 @@ test_description='Test that Flux can launch Flux'
 . `dirname $0`/sharness.sh
 
 mock_bootstrap_instance
-test_under_flux 4 wreck
+test_under_flux 4
 
 test_expect_success 'recurse: Flux launches Flux ' '
 	printenv FLUX_URI >old_uri &&
@@ -53,6 +53,32 @@ test_expect_success 'recurse: Flux launches Flux launches Flux' '
 			echo hello >hello_out &&
 	echo hello >hello_expected &&
 	test_cmp hello_expected hello_out
+'
+
+test_expect_success 'recurse: FLUX_JOB_KVSPATH is set in child job' '
+	flux wreckrun -n1 -N1 flux start \
+		printenv FLUX_JOB_KVSPATH >kvspath &&
+	test -s kvspath
+'
+
+test_expect_success 'recurse: flux.local_uri is set in enclosing KVS' '
+	flux wreckrun -n1 -N1 flux start flux getattr local-uri >curi &&
+	key=$(flux wreck kvs-path $(flux wreck last-jobid)).flux.local_uri &&
+	flux kvs get --json $key >curi.out &&
+	test_cmp curi curi.out
+'
+
+test_expect_success 'recurse: flux.remote_uri is set in enclosing KVS' '
+	flux wreckrun -n1 -N1 flux start flux getattr local-uri >curi2 &&
+	key=$(flux wreck kvs-path $(flux wreck last-jobid)).flux.remote_uri &&
+	flux kvs get --json $key >ruri.out &&
+	grep -q "$(sed -e ,local://,, <curi2)" ruri.out
+'
+
+test_expect_success 'recurse: flux wreck uri works for child job' '
+	flux wreckrun -n1 -N1 flux start flux getattr local-uri >child_uri &&
+	flux wreck uri --bare $(flux wreck last-jobid) >list_uri &&
+	grep -q "$(sed -e ,local://,, <child_uri)" list_uri
 '
 
 test_done


### PR DESCRIPTION
This PR is an attempt to address #1422 by writing an instance's rank 0 FLUX_URI and a derived ssh:// URI to `lwj.X.X.X.flux.local-uri` and `lwj.X.X.X.flux.remote-uri` in the enclosing instance.

I need to provide a test but thought I'd post early to get any feedback from @trws.