### PR TITLE
kvs: don't check namespace if user passes in at reference

### DIFF
--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -71,6 +71,7 @@ struct lookup {
 
     char *namespace;
     char *root_ref;
+    bool root_ref_set_by_user;  /* if root_ref passed in by user */
 
     char *path;
 
@@ -608,6 +609,7 @@ lookup_t *lookup_create (struct cache *cache,
             saved_errno = ENOMEM;
             goto cleanup;
         }
+        lh->root_ref_set_by_user = true;
     }
 
     lh->h = h;
@@ -791,6 +793,10 @@ int lookup_set_current_epoch (lookup_t *lh, int epoch)
 static int namespace_still_valid (lookup_t *lh)
 {
     struct kvsroot *root;
+
+    /* If user set root_ref, no need to do this check */
+    if (lh->root_ref_set_by_user)
+        return 0;
 
     if (!(root = kvsroot_mgr_lookup_root_safe (lh->krm, lh->namespace))) {
         lh->errnum = ENOTSUP;

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -3057,7 +3057,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3");
 
-    cache_insert (cache, valref_ref, create_cache_entry_treeobj (valref));
+    cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3155,7 +3155,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3");
 
-    cache_insert (cache, valref_ref, create_cache_entry_treeobj (valref));
+    cache_insert (cache, valref_ref, create_cache_entry_raw (strdup ("abcd"), 4));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -184,6 +184,15 @@ test_expect_success 'kvs: get fails on other ranks (wrong user)' '
                                 flux kvs --namespace=$NAMESPACETMP-USER get $DIR.test"
 '
 
+test_expect_success 'kvs: get works (wrong user, but with at reference)' '
+        set_userid 9999 &&
+        ref=`flux kvs --namespace=$NAMESPACETMP-USER get --treeobj .` &&
+        unset_userid &&
+        set_userid 9000 &&
+        flux kvs --namespace=$NAMESPACETMP-USER get --at ${ref} --json $DIR.test &&
+        unset_userid
+'
+
 test_expect_success NO_CHAIN_LINT 'kvs: watch works (user)'  '
         set_userid 9999 &&
         flux kvs --namespace=$NAMESPACETMP-USER unlink -Rf $DIR &&


### PR DESCRIPTION
Fixes issue #1401, where on replays namespaces were always checked for validity even if user originally passed in at reference.

At unit tests appropriately.