### PR TITLE
cmd/flux-kvs: Update dir and ls usage

### DIFF
--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -152,7 +152,7 @@ $DIR.d.
 EOF
 	test_cmp expected output
 '
-test_expect_success 'kvs: dir -R' '
+test_expect_success 'kvs: dir -R DIR' '
 	flux kvs put --json $DIR.a=42 $DIR.b=3.14 $DIR.c=foo $DIR.d=true $DIR.e="[1,3,5]" $DIR.f="{\"a\":42}" &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
@@ -165,7 +165,7 @@ $DIR.f = {"a": 42}
 EOF
 	test_cmp expected output
 '
-test_expect_success 'kvs: dir -R -d' '
+test_expect_success 'kvs: dir -R -d DIR' '
 	flux kvs dir -R -d $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a
@@ -176,6 +176,58 @@ $DIR.e
 $DIR.f
 EOF
 	test_cmp expected output
+'
+
+test_expect_success 'kvs: kvs dir -R DIR with period end' '
+	flux kvs dir -R $DIR. | sort >output &&
+        cat >expected <<EOF &&
+$DIR.a = 42
+$DIR.b = 3.140000
+$DIR.c = foo
+$DIR.d = true
+$DIR.e = [1, 3, 5]
+$DIR.f = {"a": 42}
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: kvs dir -R -d DIR with period end' '
+	flux kvs dir -R -d $DIR. | sort >output &&
+        cat >expected <<EOF &&
+$DIR.a
+$DIR.b
+$DIR.c
+$DIR.d
+$DIR.e
+$DIR.f
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: kvs dir -R on root "."' '
+	flux kvs dir -R "." | sort >output &&
+        cat >expected <<EOF &&
+$DIR.a = 42
+$DIR.b = 3.140000
+$DIR.c = foo
+$DIR.d = true
+$DIR.e = [1, 3, 5]
+$DIR.f = {"a": 42}
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: kvs dir -R -d on root "."' '
+	flux kvs dir -R -d "." | sort >output &&
+        cat >expected <<EOF &&
+$DIR.a
+$DIR.b
+$DIR.c
+$DIR.d
+$DIR.e
+$DIR.f
+EOF
+        test_cmp expected output
 '
 
 test_expect_success 'kvs: unlink dir works' '
@@ -540,12 +592,35 @@ EOF
 #
 # ls tests
 #
+test_expect_success 'kvs: ls -1F works' '
+	flux kvs ls -1F >output &&
+	cat >expected <<-EOF &&
+	test.
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls -1F . works' '
+	flux kvs ls -1F . >output &&
+	cat >expected <<-EOF &&
+	test.
+	EOF
+	test_cmp expected output
+'
 test_expect_success 'kvs: ls -1F DIR works' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs put --json $DIR.a=69 &&
 	flux kvs mkdir $DIR.b &&
 	flux kvs link b $DIR.c &&
 	flux kvs ls -1F $DIR >output &&
+	cat >expected <<-EOF &&
+	a
+	b.
+	c@
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls -1F DIR. works' '
+	flux kvs ls -1F $DIR. >output &&
 	cat >expected <<-EOF &&
 	a
 	b.

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -402,14 +402,6 @@ test_expect_success 'kvs: put - fails across multiple namespaces' '
         ! flux kvs put ns:${NAMESPACEPREFIX}-1/$DIR.puttest.a=1 ns:${NAMESPACEPREFIX}-2/$DIR.puttest.b=2
 '
 
-test_expect_success 'kvs: namespace prefix works with ls' '
-        flux kvs ls ns:${NAMESPACEPREFIX}-1/. | sort >output &&
-        cat >expected <<EOF &&
-test
-EOF
-        test_cmp expected output
-'
-
 # Note double period, will be resolved in issue #1391 fix
 test_expect_success 'kvs: namespace prefix works with dir' '
         flux kvs dir ns:${NAMESPACEPREFIX}-1/. | sort >output &&

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -419,11 +419,26 @@ EOF
         test_cmp expected output
 '
 
+# Note double period, will be resolved in issue #1391 fix
+test_expect_success 'kvs: namespace prefix works with dir, no key specified' '
+        flux kvs dir ns:${NAMESPACEPREFIX}-1/ | sort >output &&
+        cat >expected <<EOF &&
+ns:${NAMESPACEPREFIX}-1/..test.
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with ls, no key specified' '
+        flux kvs ls ns:${NAMESPACEPREFIX}-1/ | sort >output &&
+        cat >expected <<EOF &&
+test
+EOF
+        test_cmp expected output
+'
+
 test_expect_success 'kvs: namespace prefix with key suffix fails' '
         ! flux kvs get ns:${NAMESPACEPREFIX}-1/ &&
         ! flux kvs put ns:${NAMESPACEPREFIX}-1/ &&
-        ! flux kvs dir ns:${NAMESPACEPREFIX}-1/ &&
-        ! flux kvs ls ns:${NAMESPACEPREFIX}-1/ &&
         ! flux kvs watch ns:${NAMESPACEPREFIX}-1/
 '
 

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -402,11 +402,10 @@ test_expect_success 'kvs: put - fails across multiple namespaces' '
         ! flux kvs put ns:${NAMESPACEPREFIX}-1/$DIR.puttest.a=1 ns:${NAMESPACEPREFIX}-2/$DIR.puttest.b=2
 '
 
-# Note double period, will be resolved in issue #1391 fix
 test_expect_success 'kvs: namespace prefix works with dir' '
         flux kvs dir ns:${NAMESPACEPREFIX}-1/. | sort >output &&
         cat >expected <<EOF &&
-ns:${NAMESPACEPREFIX}-1/..test.
+ns:${NAMESPACEPREFIX}-1/test.
 EOF
         test_cmp expected output
 '
@@ -419,11 +418,10 @@ EOF
         test_cmp expected output
 '
 
-# Note double period, will be resolved in issue #1391 fix
 test_expect_success 'kvs: namespace prefix works with dir, no key specified' '
         flux kvs dir ns:${NAMESPACEPREFIX}-1/ | sort >output &&
         cat >expected <<EOF &&
-ns:${NAMESPACEPREFIX}-1/..test.
+ns:${NAMESPACEPREFIX}-1/test.
 EOF
         test_cmp expected output
 '
@@ -432,6 +430,66 @@ test_expect_success 'kvs: namespace prefix works with ls, no key specified' '
         flux kvs ls ns:${NAMESPACEPREFIX}-1/ | sort >output &&
         cat >expected <<EOF &&
 test
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with dir -R' '
+        flux kvs dir -R ns:${NAMESPACEPREFIX}-1/. | sort >output &&
+        cat >expected <<EOF &&
+ns:${NAMESPACEPREFIX}-1/$DIR.prefixtest = 1
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with ls -R' '
+        flux kvs ls -R ns:${NAMESPACEPREFIX}-1/. >output &&
+        cat >expected <<EOF &&
+ns:namespaceprefix-1/.:
+test
+
+ns:namespaceprefix-1/test:
+a
+
+ns:namespaceprefix-1/test.a:
+b
+
+ns:namespaceprefix-1/test.a.b:
+prefixtest
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with dir -R DIR' '
+        flux kvs dir -R ns:${NAMESPACEPREFIX}-1/$DIR | sort >output &&
+        cat >expected <<EOF &&
+ns:${NAMESPACEPREFIX}-1/$DIR.prefixtest = 1
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with ls -R DIR' '
+        flux kvs ls -R ns:${NAMESPACEPREFIX}-1/$DIR | sort >output &&
+        cat >expected <<EOF &&
+ns:${NAMESPACEPREFIX}-1/$DIR:
+prefixtest
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with dir -R DIR.' '
+        flux kvs dir -R ns:${NAMESPACEPREFIX}-1/$DIR. | sort >output &&
+        cat >expected <<EOF &&
+ns:${NAMESPACEPREFIX}-1/$DIR.prefixtest = 1
+EOF
+        test_cmp expected output
+'
+
+test_expect_success 'kvs: namespace prefix works with ls -R DIR.' '
+        flux kvs ls -R ns:${NAMESPACEPREFIX}-1/$DIR | sort >output &&
+        cat >expected <<EOF &&
+ns:${NAMESPACEPREFIX}-1/$DIR:
+prefixtest
 EOF
         test_cmp expected output
 '


### PR DESCRIPTION
With the dir and ls commands in flux-kvs, if a user specifies a
namespace prefix without a key, assume the user desires the root
(i.e. ".") directory within that namespace.

Update/adjust unit tests appropriately.

Fixes #1434