### PR TITLE
Collection of small fixes for splash project

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -450,11 +450,15 @@ end
 local logstream = {}
 logstream.__index = logstream
 
+local function logstream_print_line (iow, line)
+    io.stderr:write (string.format ("rank%d: Error: %s\n", iow.id, line))
+end
+
 function logstream:dump ()
     for _, iow in pairs (self.watchers) do
         local r, err = iow.kz:read ()
         while r and r.data and not r.eof do
-           io.stderr:write (r.data.."\n")
+           logstream_print_line (iow, r.data)
            r, err = iow.kz:read ()
         end
     end
@@ -474,9 +478,10 @@ function wreck.logstream (arg)
             key = key,
             handler = function (iow, r)
                 if not r then return end
-                io.stderr:write (r.."\n")
+                logstream_print_line (iow, r)
             end
         }
+        iow.id = i
         table.insert (l.watchers, iow)
     end
     return setmetatable (l, logstream)

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -476,8 +476,14 @@ function wreck.logstream (arg)
         local key = kvs_path (f, arg.jobid)..".log."..i
         local iow, err = f:iowatcher {
             key = key,
-            handler = function (iow, r)
-                if not r then return end
+            kz_flags = arg.oneshot and { "nofollow" },
+            handler = function (iow, r, err)
+                if not r then
+                    if err then
+                        io.stderr:write ("logstream kz error "..err.."\n")
+                    end
+                    return
+                end
                 logstream_print_line (iow, r)
             end
         }

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -465,8 +465,8 @@ function wreck.logstream (arg)
     local f = arg.flux
     if not f then return nil, "flux argument member required" end
     local rc, err = initialize_args (arg)
-    if not arg.nnodes then return nil, "nnodes argument required" end
     if not rc then return nil, err end
+    if not arg.nnodes then return nil, "nnodes argument required" end
     l.watchers = {}
     for i = 0, arg.nnodes - 1 do
         local key = kvs_path (f, arg.jobid)..".log."..i

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -272,10 +272,14 @@ function wreck:parse_cmdline (arg)
 
     self.nnodes = self.opts.N and tonumber (self.opts.N)
 
+    if not self.opts.t then
+        self.opts.t = 1
+    end
+
     -- If nnodes was provided but -n, --ntasks not set, then
     --  set ntasks to nnodes.
     if self.opts.N and not self.opts.n then
-        self.ntasks = self.nnodes
+        self.ntasks = self.nnodes * self.opts.t
     else
         self.ntasks = self.opts.n and tonumber (self.opts.n) or 1
     end

--- a/src/bindings/lua/wreck/io.lua
+++ b/src/bindings/lua/wreck/io.lua
@@ -101,6 +101,7 @@ function ioplex.create (arg)
         kvspath       = arg.kvspath,
         on_completion = arg.on_completion,
         log_err       = arg.log_err,
+        nofollow      = arg.nofollow,
         removed = {},
         output = {},
         files = {}
@@ -159,10 +160,14 @@ local function ioplex_taskid_start (self, flux, taskid, stream)
     local of = self.output[taskid][stream]
     if not of then return nil, "No stream "..stream.." for task " .. taskid  end
 
+    local flags = {}
+    if self.nofollow then table.insert (flags, "nofollow") end
+
     local f = flux
     local key = string.format ("%s.%d.%s", self.kvspath, taskid, stream)
     local iow, err = f:iowatcher {
         key = key,
+        kz_flags = flags,
         handler =  function (iow, data, err)
             if err or not data then
                 -- protect against multiple close callback calls
@@ -204,6 +209,7 @@ function ioplex:start (h)
             ioplex_taskid_start (self, flux, taskid, stream)
         end
     end
+    self.started = true
 end
 
 --- redirect a stream from a task to named stream "path".

--- a/src/bindings/lua/wreck/io.lua
+++ b/src/bindings/lua/wreck/io.lua
@@ -47,6 +47,7 @@ function ostream:open ()
             self.fp = io[self.filename]
         else
             self.fp, err = io.open (self.filename, self.flag)
+            self.fp:setvbuf 'line'
         end
         if not self.fp then return nil, self.filename..": "..err end
     end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -275,12 +275,15 @@ end
 function LWJ:exit_string ()
     local flux = require 'flux'
     local state = self.state
-    local max = self.lwj.exit_status.max
-    if max then
-        local s, code, core = flux.exitstatus (max)
-        state = s
-        if s == "exited" and code > 0 then
-            state = "failed"
+    local exit_status = self.lwj.exit_status
+    if exit_status then
+        local max = exit_status.max
+        if max then
+            local s, code, core = flux.exitstatus (max)
+            state = s
+            if s == "exited" and code > 0 then
+                state = "failed"
+            end
         end
     end
     return state

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -85,6 +85,12 @@ prog:SubCommand {
     if not taskio then
         self:die ("Failed to connect to job %d: %s\n", id, err)
     end
+
+    local log, err = wreck.logstream { flux = f, jobid = id }
+    if not log then
+        self:die ("Failed to open logstream to job %d: %s\n", id, err)
+    end
+
     if state ~= "complete" and state ~= "reaped" then
         local kz, err = f:kz_open (kvs_path (id, "input.files.stdin"), "w")
         if kz then
@@ -99,6 +105,7 @@ prog:SubCommand {
         end
     end
     if not taskio:complete() then f:reactor () end
+    log:dump()
     if self.opt.s then
         self.parent:run {"status", id}
     end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -106,6 +106,21 @@ prog:SubCommand {
  end
 }
 
+prog:SubCommand {
+  name = "dumplog",
+  description = "Dump error log stream for a wreck job",
+  usage = "[OPTIONS] JOBID",
+  options = nil,
+  handler = function (self, arg)
+      local id = check_jobid_arg (self, arg[1])
+      local log, err = wreck.logstream { jobid = id, flux = f, oneshot = true }
+      if not log then
+          self:die ("Failed to open logstream to job %d: %s\n", id, err)
+      end
+      f:reactor()
+  end
+}
+
 local function opt_sig (s)
     if not s then return posix.SIGTERM end
     if tonumber (s) then return tonumber (s) end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -416,11 +416,12 @@ prog:SubCommand {
         local id = dir:match ("(%d+)$")
         if tonumber (id) then
             local j, err = LWJ.open (f, id, dir)
-            if not j then self:die ("job%d: %s", id, err) end
-            printf (fmt, id, j.ntasks, j:state_string(), j.start,
+            if j then
+                printf (fmt, id, j.ntasks, j:state_string(), j.start,
                     seconds_to_string (j.runtime),
                     tostring (j:ranks()),
                     j.command:match ("([^/]+)$"))
+            end
         end
     end
  end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -70,6 +70,8 @@ prog:SubCommand {
        usage = "Include status after all output" },
      { name = "label-io",  char = "l",
        usage = "Label lines of output with task id" },
+     { name = "no-follow",  char = "n",
+       usage = "Don't wait for EOF on all output streams before exiting" },
  },
  handler = function (self, arg)
     local id = check_jobid_arg (self, arg[1])
@@ -78,6 +80,7 @@ prog:SubCommand {
         flux = f,
         jobid = id,
         labelio = self.opt.l,
+        nofollow = self.opt.n,
         on_completion = function ()
             f:reactor_stop()
         end

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -54,7 +54,7 @@ end
 local function fake_resource_array (wreck, nnodes)
     local res = {}
     local total = 0
-    local ppn = wreck.tasks_per_node or math.ceil (wreck.ntasks / nnodes)
+    local ppn = math.ceil (wreck.ntasks / nnodes)
     for i = 0, nnodes - 1 do
         local n = tonumber (ppn)
         if (total + ppn) > tonumber (wreck.ntasks) then

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -393,6 +393,15 @@ error:
     return -1;
 }
 
+static void kz_unwatch (kz_t *kz)
+{
+    if (kz->watching) {
+        const char *key = clear_key (kz);
+        if (flux_kvs_unwatch (kz->h, key) >= 0)
+            kz->watching = false;
+    }
+}
+
 /* Handle response for lookup of next block (kz->seq).
  * Notify user, who should call kz_get() or kz_get_json() to consume it.
  */
@@ -415,15 +424,9 @@ static void lookup_continuation (flux_future_t *f, void *arg)
      * disable the KVS watcher (if any) as we're done.
      * Otherwise, go get the next block.
      */
-    if (kz->eof) {
-        if (kz->watching) {
-            const char *key = clear_key (kz);
-            if (flux_kvs_unwatch (kz->h, key) >= 0)
-                kz->watching = false;
-        }
-        return;
-    }
-    if (lookup_next (kz) < 0)
+    if (kz->eof)
+        kz_unwatch (kz);
+    else if (lookup_next (kz) < 0)
         goto error;
     return;
 error:
@@ -474,6 +477,24 @@ static int lookup_next (kz_t *kz)
             kz->lookup_f = NULL;
             return -1;
         }
+    }
+    /* For NOFOLLOW, simulate EOF once all known blocks consumed */
+    else if (kz->flags & KZ_FLAGS_NOFOLLOW) {
+        kz->eof = true;
+         /*
+          *  Calling unwatch on the kz here may not be necessary as NOFOLLOW
+          *   implies we never needed to set the watch below. Howver, it is
+          *   harmless to call kz_unwatch() on a kz object without a watch
+          *   installed, and there may be a rare or future case where a watch
+          *   is somehow being used with NOFOLLOW, so it is safer to cover
+          *   this case here.
+          */
+        kz_unwatch (kz);
+        /*
+         *  Now call users ready_cb to process our simulated EOF
+         */
+        if (kz->ready_cb)
+            kz->ready_cb (kz, kz->ready_arg);
     }
     /* EOF not yet reached, but all known blocks have been consumed.
      * Time to KVS watch the stream directory for more entries.

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -482,7 +482,6 @@ static int lookup_next (kz_t *kz)
         if (!kz->watching) {
             kz->watching = true; // N.B. careful to avoid infinite loop here!
             const char *key = clear_key (kz);
-            flux_log (kz->h, LOG_DEBUG, "%s: watch %s", __FUNCTION__, key);
             if (flux_kvs_watch_dir (kz->h, kvswatch_cb, kz, "%s", key) < 0)
                 return -1;
         }

--- a/src/common/libkz/kz.h
+++ b/src/common/libkz/kz.h
@@ -13,6 +13,7 @@ enum kz_flags {
     KZ_FLAGS_MODEMASK       = 0x0003,
 
     KZ_FLAGS_NONBLOCK       = 0x0010, /* currently only applies to reads */
+    KZ_FLAGS_NOFOLLOW       = 0x0020, /* currently only applies to reads */
 
     KZ_FLAGS_RAW            = 0x0200, /* use only *_json I/O methods */
     KZ_FLAGS_NOCOMMIT_OPEN  = 0x0400, /* skip commit at open (FLAGS_WRITE) */

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -198,7 +198,7 @@ static int aggregate_forward (flux_t *h, struct aggregate *ag)
     int rc = 0;
     flux_future_t *f;
     json_object *o = aggregate_tojson (ag);
-    flux_log (h, LOG_INFO, "forward: %s: count=%d total=%d\n",
+    flux_log (h, LOG_DEBUG, "forward: %s: count=%d total=%d\n",
                  ag->key, ag->count, ag->total);
     if (!(f = flux_rpc (h, "aggregator.push", Jtostr (o),
                              FLUX_NODEID_UPSTREAM, 0)) ||
@@ -240,7 +240,7 @@ static int aggregate_sink (flux_t *h, struct aggregate *ag)
     flux_kvs_txn_t *txn = NULL;
     flux_future_t *f = NULL;
 
-    flux_log (h, LOG_INFO, "sink: %s: count=%d total=%d",
+    flux_log (h, LOG_DEBUG, "sink: %s: count=%d total=%d",
                 ag->key, ag->count, ag->total);
 
     /* Fail on key == "." */
@@ -294,7 +294,7 @@ static void aggregate_try_sink (flux_t *h, struct aggregate *ag)
         double t = ag->timeout;
         if (t <= 1e-3)
             t = .250;
-        flux_log (h, LOG_INFO, "sink: %s: retry  in %.3fs", ag->key, t);
+        flux_log (h, LOG_DEBUG, "sink: %s: retry  in %.3fs", ag->key, t);
         /* On failure, retry just once, then abort */
         w = flux_timer_watcher_create (flux_get_reactor (h),
                                        t, 0.,
@@ -511,7 +511,7 @@ static void push_cb (flux_t *h, flux_msg_handler_t *mh,
     if ((rc = aggregate_push_json (ag, in)) < 0)
         goto done;
 
-    flux_log (ctx->h, LOG_INFO, "push: %s: count=%d fwd_count=%d total=%d",
+    flux_log (ctx->h, LOG_DEBUG, "push: %s: count=%d fwd_count=%d total=%d",
                       ag->key, ag->count, ag->fwd_count, ag->total);
     if (ctx->rank > 0) {
         if ((ag->count == ag->total

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -578,7 +578,7 @@ static bool lwj_targets_this_node (flux_t *h, const char *kvspath)
     snprintf (key, sizeof (key), "%s.rank", kvspath);
     if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key))
             || flux_kvs_lookup_get_dir (f, &dir) < 0) {
-        flux_log (h, LOG_INFO, "No dir %s.rank: %s",
+        flux_log (h, LOG_DEBUG, "No dir %s.rank: %s",
                   kvspath, flux_strerror (errno));
         goto done;
     }
@@ -601,12 +601,14 @@ static bool Rlite_targets_this_node (flux_t *h, const char *kvspath)
     snprintf (key, sizeof (key), "%s.R_lite", kvspath);
     if (!(f = flux_kvs_lookup (h, 0, key))
        || flux_kvs_lookup_get (f, &R_lite) < 0)  {
-        flux_log (h, LOG_INFO, "No %s.R_lite: %s",
-                 kvspath, flux_strerror (errno));
+        if (broker_rank == 0)
+            flux_log (h, LOG_INFO, "No %s.R_lite: %s",
+                      kvspath, flux_strerror (errno));
         goto done;
     }
     if (!(r = rcalc_create (R_lite))) {
-        flux_log (h, LOG_ERR, "Unable to parse %s.R_lite", kvspath);
+        if (broker_rank == 0)
+            flux_log (h, LOG_ERR, "Unable to parse %s.R_lite", kvspath);
         goto done;
     }
     if (rcalc_has_rank (r, broker_rank))

--- a/src/modules/wreck/lua.d/output.lua
+++ b/src/modules/wreck/lua.d/output.lua
@@ -80,7 +80,13 @@ end
 function rexecd_exit ()
     if wreck.nodeid ~= 0 or not taskio then return end
     while not taskio:complete() do
-        wreck.flux:reactor ("once")
+        local rc, err = wreck.flux:reactor ("once")
+        if not rc then
+            log_err ("rexecd_exit: reactor once failed: %s", err or "No error")
+            return
+        end
     end
     wreck:log_msg ("File io complete")
 end
+
+-- vi: ts=4 sw=4 expandtab

--- a/src/modules/wreck/lua.d/output.lua
+++ b/src/modules/wreck/lua.d/output.lua
@@ -39,6 +39,10 @@ local function log (fmt, ...)
     wreck:log_msg (fmt, ...)
 end
 
+local function log_err (fmt, ...)
+    wreck:log_error (fmt, ...)
+end
+
 function rexecd_init ()
     if wreck.nodeid ~= 0 then return end
 
@@ -49,7 +53,8 @@ function rexecd_init ()
     taskio, err = ioplex.create {
         flux = wreck.flux,
         jobid = wreck.id,
-        labelio = output.labelio and output.labelio ~= false
+        labelio = output.labelio and output.labelio ~= false,
+        log_err = log_err
     }
     if not taskio then wreck:log_msg ("Error: %s", err) end
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -420,15 +420,11 @@ static void wreck_pmi_line (struct task_info *t, const char *line)
 static int wreck_pmi_cb (zio_t *z, const char *s, int len, void *arg)
 {
     struct task_info *t = arg;
-    struct prog_ctx *ctx = t->ctx;
 
     if (len > 0) /* !eof */
         wreck_pmi_line (t, s);
-    else {
-        /* client closed connection? */
-        wlog_debug (ctx, "wreck_pmi_cb: client closed PMI_FD");
+    else /* client closed fd */
         wreck_pmi_close (t);
-    }
     return (0);
 }
 

--- a/t/t1104-kz.t
+++ b/t/t1104-kz.t
@@ -56,4 +56,19 @@ test_expect_success 'kz: KZ_FLAGS_NONBLOCK works for kz to kz copy' '
 	test_cmp kztest.7.in kztest.7.out
 '
 
+test_expect_success 'kz: KZ_FLAGS_NOFOLLOW works in non-blocking mode' '
+	dd if=/dev/urandom bs=4096 count=32 2>/dev/null >kztest.8.in &&
+	${KZCOPY} --no-follow - kztest.8 <kztest.8.in &&
+	run_timeout 2 \
+            ${KZCOPY} --non-blocking --no-follow kztest.8 - >kztest.8.out &&
+	test_cmp kztest.8.in kztest.8.out
+'
+
+test_expect_success 'kz: KZ_FLAGS_NOFOLLOW works in blocking mode' '
+	dd if=/dev/urandom bs=4096 count=32 2>/dev/null >kztest.8.in &&
+	${KZCOPY} --no-follow - kztest.8 <kztest.8.in &&
+	run_timeout 2 \
+            ${KZCOPY} --no-follow kztest.8 - >kztest.8.out &&
+	test_cmp kztest.8.in kztest.8.out
+'
 test_done

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -430,14 +430,14 @@ test_expect_success 'flux-wreck cancel: falls back to SIGKILL with -f' '
 
 test_expect_success NO_SCHED 'flux-wreck exclude: fails when sched not loaded' '
 	test_must_fail flux wreck exclude myhost 2>err.exclude &&
-	cat >expected.exclude <<-EOF
+	cat >expected.exclude <<-EOF &&
 	flux-wreck: Node exclusion is not supported when scheduler not loaded
 	EOF
 	test_cmp expected.exclude err.exclude
 '
 test_expect_success NO_SCHED 'flux-wreck include: fails when sched not loaded' '
 	test_must_fail flux wreck include myhost 2>err.include &&
-	cat >expected.include <<-EOF
+	cat >expected.include <<-EOF &&
 	flux-wreck: Node inclusion is not supported when scheduler not loaded
 	EOF
 	test_cmp expected.include err.include

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -395,6 +395,14 @@ test_expect_success 'flux-wreck: ls JOBID works' '
 	flux wreck ls $LASTID > ls-jobid.out &&
         tail -1 ls-jobid.out | grep "^ *$LASTID"
 '
+test_expect_success 'flux-wreck: ls RANGE ignores missing jobids' '
+	LASTID=$(last_job_id) &&
+	LWJ=$(last_job_path) &&
+	flux wreckrun hostname &&
+	flux kvs unlink -R $LWJ &&
+	flux wreck ls $((${LASTID}-1))-$((${LASTID}+1)) > ls-range.out &&
+	test $(cat ls-range.out | wc -l) = 3
+'
 test_expect_success 'flux-wreck: purge works' '
 	flux wreck purge &&
 	flux wreck purge -t 2 -R &&

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -429,18 +429,18 @@ test_expect_success 'flux-wreck cancel: falls back to SIGKILL with -f' '
 '
 
 test_expect_success NO_SCHED 'flux-wreck exclude: fails when sched not loaded' '
-    test_must_fail flux wreck exclude myhost 2>err.exclude &&
-    cat >expected.exclude <<-EOF
-    flux-wreck: Node exclusion is not supported when scheduler not loaded
-    EOF
-    test_cmp expected.exclude err.exclude
+	test_must_fail flux wreck exclude myhost 2>err.exclude &&
+	cat >expected.exclude <<-EOF
+	flux-wreck: Node exclusion is not supported when scheduler not loaded
+	EOF
+	test_cmp expected.exclude err.exclude
 '
 test_expect_success NO_SCHED 'flux-wreck include: fails when sched not loaded' '
-    test_must_fail flux wreck include myhost 2>err.include &&
-    cat >expected.include <<-EOF
-    flux-wreck: Node inclusion is not supported when scheduler not loaded
-    EOF
-    test_cmp expected.include err.include
+	test_must_fail flux wreck include myhost 2>err.include &&
+	cat >expected.include <<-EOF
+	flux-wreck: Node inclusion is not supported when scheduler not loaded
+	EOF
+	test_cmp expected.include err.include
 '
 
 check_complete_link() {

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -347,6 +347,22 @@ test_expect_success 'flux-wreck: attach --label-io' '
         sort expected.attach-l > x && mv x expected.attach-l &&
         test_cmp expected.attach-l output.attach-l
 '
+test_expect_success 'wreck: attach --no-follow works' '
+	flux wreckrun -d -l -n4 sh -c "echo before; sleep 30; echo after" &&
+	test_when_finished flux wreck kill $(last_job_id) &&
+	run_timeout 5 flux wreck attach --no-follow $(last_job_id) >output.attach-n &&
+	cat >expected.attach-n <<-EOF &&
+	before
+	before
+	before
+	before
+	EOF
+	test_cmp expected.attach-n output.attach-n
+'
+test_expect_success 'wreck: dumplog works' '
+	test_must_fail flux wreckrun --input=bad.file hostname &&
+	flux wreck dumplog $(last_job_id) 2>&1 | grep "^rank0: .*bad.file"
+'
 test_expect_success 'flux-wreck: status' '
         flux wreckrun -n4 /bin/true &&
         id=$(last_job_id) &&

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -203,6 +203,12 @@ test_expect_success 'wreckrun: -t1 -n${SIZE} sets nnodes in kvs' '
 	n=$(flux kvs get --json ${LWJ}.nnodes) &&
 	test "$n" = "${SIZE}"
 '
+test_expect_success 'wreckrun: -t2 -N${SIZE} sets correct ntasks in kvs' '
+	flux wreckrun -l -t2 -N${SIZE} /bin/true &&
+	LWJ=$(last_job_path) &&
+	n=$(flux kvs get --json ${LWJ}.ntasks) &&
+	test "$n" = $((${SIZE}*2))
+'
 
 test_expect_success 'wreckrun: fallback to old rank.N.cores format works' '
 	flux wreckrun -N2 -n2 \


### PR DESCRIPTION
Here's a collection of small fixes related to the splash use case for consideration.

This PR includes:
 * General reduction in logging including removal of unnecessary log messages, reduction of some "info" level log messaages to debug, and fix for #1439 to log only from rank 0 instead of all ranks
 * Fix for crash in `flux-wreck status` when `exit_status` is not in kvs yet (#1437)
 * Increase NOFILE_LIMIT in wrexecd (#1441)
 * Error checking during task setup in wrexecd (#1441)
 * Add line buffering to output files with `flux submit/wreckrun -O file`
 * Check for errors from kz stream in output.lua and log errors  (#1427)
 * Terminate io "flush" loop early on encountering any error from `f:reactor ("once")` 
 * New command `flux-wreck dumplog ID` to dump the "logstream" error log for a job
 * Add new KZ_FLAGS_NOFOLLOW flag as suggested by @garlick (#1420)
 * Add `-n, --no-follow` option to `flux-wreck attach` to use KZ_FLAGS_NOFOLLOW (#1420)

Might need to add more testing (e.g. of `flux wreck attach -n`) but since there is lots of little things in here I wanted to get an early review.