### PR TITLE
cmd/flux-kvs: Fix dir -R corner case

### DIFF
--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1118,7 +1118,10 @@ static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,
                 if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READDIR, key, rootref))
                         || flux_kvs_lookup_get_dir (f, &ndir) < 0)
                     log_err_exit ("%s", key);
-                dump_kvs_dir (ndir, maxcol, Ropt, dopt);
+                if (flux_kvsdir_get_size (ndir) == 0)
+                    printf ("%s.\n", key);
+                else
+                    dump_kvs_dir (ndir, maxcol, Ropt, dopt);
                 flux_future_destroy (f);
             } else
                 printf ("%s.\n", key);

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -152,6 +152,13 @@ $DIR.d.
 EOF
 	test_cmp expected output
 '
+test_expect_success 'kvs: dir -R lists subdir' '
+	flux kvs dir -R $DIR | sort >output &&
+	cat >expected <<EOF &&
+$DIR.d.
+EOF
+	test_cmp expected output
+'
 test_expect_success 'kvs: dir -R DIR' '
 	flux kvs put --json $DIR.a=42 $DIR.b=3.14 $DIR.c=foo $DIR.d=true $DIR.e="[1,3,5]" $DIR.f="{\"a\":42}" &&
 	flux kvs dir -R $DIR | sort >output &&


### PR DESCRIPTION
Fix output corner case where empty directories were not
output with dir -R.

Add unit test coverage.

Fixes #1449