### PR TITLE
kvs: do not generate uuid for commit transactions, use fixed algorithm for 'name'

### DIFF
--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -108,6 +108,21 @@ void treq_basic_tests (void)
     flux_msg_destroy (request);
 
     treq_destroy (tr);
+
+    ok (treq_create_rank (1, 2, -1, 0) == NULL,
+        "treq_create_rank fails on bad input");
+
+    ok ((tr = treq_create_rank (214, 3577, 2, 4)) != NULL,
+        "treq_create_rank works");
+
+    ok ((name = treq_get_name (tr)) != NULL,
+        "treq_get_name works");
+
+    ok (strstr (name, "214") != NULL,
+        "treq_get_name returns name with rank in it");
+
+    ok (strstr (name, "3577") != NULL,
+        "treq_get_name returns name with seq in it");
 }
 
 void treq_ops_tests (void)

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -195,12 +195,12 @@ void treq_destroy (treq_t *tr)
     }
 }
 
-treq_t *treq_create (const char *name, int nprocs, int flags)
+static treq_t *treq_create_common (int nprocs, int flags)
 {
     treq_t *tr = NULL;
     int saved_errno;
 
-    if (!name || nprocs <= 0) {
+    if (nprocs <= 0) {
         saved_errno = EINVAL;
         goto error;
     }
@@ -210,13 +210,58 @@ treq_t *treq_create (const char *name, int nprocs, int flags)
         saved_errno = ENOMEM;
         goto error;
     }
+    tr->nprocs = nprocs;
+    tr->flags = flags;
+    tr->processed = false;
+
+    return tr;
+error:
+    treq_destroy (tr);
+    errno = saved_errno;
+    return NULL;
+}
+
+treq_t *treq_create (const char *name, int nprocs, int flags)
+{
+    treq_t *tr = NULL;
+    int saved_errno;
+
+    if (!name) {
+        saved_errno = EINVAL;
+        goto error;
+    }
+
+    if (!(tr = treq_create_common (nprocs, flags))) {
+        saved_errno = EINVAL;
+        goto error;
+    }
+
     if (!(tr->name = strdup (name))) {
         saved_errno = ENOMEM;
         goto error;
     }
-    tr->nprocs = nprocs;
-    tr->flags = flags;
-    tr->processed = false;
+
+    return tr;
+error:
+    treq_destroy (tr);
+    errno = saved_errno;
+    return NULL;
+}
+
+treq_t *treq_create_rank (uint32_t rank, uint32_t seq, int nprocs, int flags)
+{
+    treq_t *tr = NULL;
+    int saved_errno;
+
+    if (!(tr = treq_create_common (nprocs, flags))) {
+        saved_errno = EINVAL;
+        goto error;
+    }
+
+    if (asprintf (&(tr->name), "treq.%u.%u", rank, seq) < 0) {
+        saved_errno = ENOMEM;
+        goto error;
+    }
 
     return tr;
 error:

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -248,7 +248,7 @@ error:
     return NULL;
 }
 
-treq_t *treq_create_rank (uint32_t rank, uint32_t seq, int nprocs, int flags)
+treq_t *treq_create_rank (uint32_t rank, unsigned int seq, int nprocs, int flags)
 {
     treq_t *tr = NULL;
     int saved_errno;

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -45,7 +45,7 @@ int treq_mgr_transactions_count (treq_mgr_t *trm);
 treq_t *treq_create (const char *name, int nprocs, int flags);
 
 /* treq_create_rank - internally will create name based on rank & seq */
-treq_t *treq_create_rank (uint32_t rank, uint32_t seq, int nprocs, int flags);
+treq_t *treq_create_rank (uint32_t rank, unsigned int seq, int nprocs, int flags);
 
 void treq_destroy (treq_t *tr);
 

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -41,7 +41,11 @@ int treq_mgr_transactions_count (treq_mgr_t *trm);
  * treq_t API
  */
 
+/* treq_create - name is passed in */
 treq_t *treq_create (const char *name, int nprocs, int flags);
+
+/* treq_create_rank - internally will create name based on rank & seq */
+treq_t *treq_create_rank (uint32_t rank, uint32_t seq, int nprocs, int flags);
 
 void treq_destroy (treq_t *tr);
 


### PR DESCRIPTION
As discussed in #1446, do not generate a uuid for commit transactions, which is expensive.  Instead, use a fixed algorithm to generate a name for each transaction, using the rank and sequence number incremented on each rank.

The commit RPC no longer needs to include the "name" field anymore as a result.  As the name can be generated within the kvs module.
