### PR TITLE
implement per-job private KVS namespace

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -454,7 +454,7 @@ prog:SubCommand {
         if tonumber (id) then
             local j, err = LWJ.open (f, id, dir)
             if not j then self:die ("job%d: %s", id, err) end
-            local uri, err = f:kvs_get (kvs_path (id, "flux.remote_uri"))
+            local uri, err = f:kvs_get (kvs_path (id, "guest.flux.remote_uri"))
             if self.opt.b then
                 if err then self:die ("job%d: not a Flux instance", id) end
                 printf ("%s\n", uri)

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2598,6 +2598,8 @@ static int namespace_create (kvs_ctx_t *ctx, const char *namespace,
         goto cleanup_remove_root;
     }
 
+    json_decref (rootdir);
+    free (data);
     return 0;
 
 cleanup_remove_root:

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -527,13 +527,14 @@ static void exec_close_fd (void *arg, int fd)
 static void exec_handler (const char *exe, int64_t id, const char *kvspath)
 {
     pid_t sid;
-    int argc = 2;
+    int argc = 3;
     char **av = malloc ((sizeof (char *)) * (argc + 2));
 
     if ((av == NULL)
      || ((av [0] = strdup (exe)) == NULL)
      || (asprintf (&av[1], "--lwj-id=%"PRId64, id) < 0)
-     || (asprintf (&av[2], "--kvs-path=%s", kvspath) < 0)) {
+     || (asprintf (&av[2], "--kvs-path=%s", kvspath) < 0)
+     || (asprintf (&av[3], "--kvs-guest=ns:job%lld/.", (long long)id) < 0)) {
         fprintf (stderr, "Out of Memory trying to exec wrexecd!\n");
         exit (1);
     }

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -679,6 +679,113 @@ static void runevent_cb (flux_t *h, flux_msg_handler_t *w,
     Jput (in);
 }
 
+/* Generic continuation for handling commit or namespace removal.
+ * In both cases we just log error, if any, and destroy future.
+ */
+static void finevent_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    if (flux_future_get (f, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    flux_future_destroy (f);
+}
+
+/* Handle response to lookup of guestns link target (a snapshot reference).
+ * Replace link with snapshot reference and commit.
+ * This starts two more RPC's, one to commit guestns update, and one
+ * to remove namespace.
+ */
+static void finevent_lookup_continuation (flux_future_t *f, void *arg)
+{
+    const char *key = flux_kvs_lookup_get_key (f);
+    flux_t *h = flux_future_get_flux (f);
+    char *ns = arg;
+    const char *snapshot;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f_next;
+
+    if (flux_kvs_lookup_get_treeobj (f, &snapshot) < 0) {
+        flux_log_error (h, "%s: flux_kvs_lookup_get_treeobj %s",
+                        __FUNCTION__, key);
+        goto done;
+    }
+    if (!(txn = flux_kvs_txn_create ())) {
+        flux_log_error (h, "%s: flux_kvs_txn_create", __FUNCTION__);
+        goto done;
+    }
+    if (flux_kvs_txn_put_treeobj (txn, 0, key, snapshot) < 0) {
+        flux_log_error (h, "%s: flux_lookup_put_treeobj %s", __FUNCTION__, key);
+        goto done;
+    }
+    /* start first RPC to update guestns with snapshot reference */
+    if (!(f_next = flux_kvs_commit (h, 0, txn))) {
+        flux_log_error (h, "%s: flux_kvs_commit", __FUNCTION__);
+        goto done;
+    }
+    if (flux_future_then (f_next, -1., finevent_continuation, NULL) < 0) {
+        flux_log_error (h, "%s: flux_future_then", __FUNCTION__);
+        flux_future_destroy (f_next);
+        goto done;
+    }
+    /* start second RPC to remove namespace, in parallel with above */
+    if (!(f_next = flux_kvs_namespace_remove (h, ns))) {
+        flux_log_error (h, "%s: flux_namespace_remove", __FUNCTION__);
+        goto done;
+    }
+    if (flux_future_then (f_next, -1., finevent_continuation, NULL) < 0) {
+        flux_log_error (h, "%s: flux_future_then", __FUNCTION__);
+        flux_future_destroy (f_next);
+        goto done;
+    }
+done:
+    flux_kvs_txn_destroy (txn);
+    flux_future_destroy (f);
+    free (ns);
+}
+
+/* Job entered complete or failed state.
+ * Perform cleanup:
+ * - get snapshot of job's private namespace
+ * - delete namespace
+ * - replace symlink to namespace with snapshot
+ */
+static void finevent_cb (flux_t *h, flux_msg_handler_t *w,
+                         const flux_msg_t *msg, void *arg)
+{
+    const char *topic;
+    const char *kvs_path;
+    char *ns;
+    int64_t jobid;
+    char key[MAX_JOB_PATH];
+    flux_future_t *f;
+
+    if (flux_event_unpack (msg, &topic, "{ s:I s:s }",
+                                        "jobid", &jobid,
+                                        "kvs_path", &kvs_path) < 0) {
+        flux_log_error (h, "%s: flux_event_decode", __FUNCTION__);
+        return;
+    }
+    if (snprintf (key, sizeof (key), "%s.guest", kvs_path) >= sizeof (key)) {
+        flux_log (h, LOG_ERR, "%s: buffer overflow", __FUNCTION__);
+        return;
+    }
+    if (asprintf (&ns, "job%lld", (long long)jobid) < 0) {
+        flux_log_error (h, "%s: asprintf", __FUNCTION__);
+        return;
+    }
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key))) {
+        flux_log_error (h, "%s: flux_kvs_lookup", __FUNCTION__);
+        free (ns);
+        return;
+    }
+    if (flux_future_then (f, -1., finevent_lookup_continuation, ns) < 0) {
+        flux_log_error (h, "%s: flux_future_then", __FUNCTION__);
+        flux_future_destroy (f);
+        free (ns);
+        return;
+    }
+}
+
 static const struct flux_msg_handler_spec mtab[] = {
     { FLUX_MSGTYPE_REQUEST, "job.create", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.submit", job_request_cb, 0 },
@@ -686,6 +793,8 @@ static const struct flux_msg_handler_spec mtab[] = {
     { FLUX_MSGTYPE_REQUEST, "job.shutdown", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.kvspath",  job_kvspath_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "wrexec.run.*", runevent_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "wreck.state.complete", finevent_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "wreck.state.failed", finevent_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END
 };
 
@@ -727,6 +836,13 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (flux_get_rank (h, &broker_rank) < 0) {
         flux_log_error (h, "flux_get_rank");
         goto done;
+    }
+    if (broker_rank == 0) {
+        if (flux_event_subscribe (h, "wreck.state.complete") < 0
+                    || flux_event_subscribe (h, "wreck.state.failed") < 0) {
+            flux_log_error (h, "flux_event_subscribe");
+            goto done;
+        }
     }
 
     if (!(local_uri = flux_attr_get (h, "local-uri", NULL))) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -71,6 +71,7 @@ TESTS = \
 	t2006-joblog.t \
 	t2007-caliper.t \
 	t2008-althash.t \
+	t2009-job-schema.t \
 	t2100-aggregate.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
@@ -151,6 +152,7 @@ check_SCRIPTS = \
 	t2006-joblog.t \
 	t2007-caliper.t \
 	t2008-althash.t \
+	t2009-job-schema.t \
 	t2100-aggregate.t \
 	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
@@ -170,7 +172,8 @@ check_SCRIPTS = \
 	lua/t1003-iowatcher.t \
 	lua/t1004-statwatcher.t \
 	lua/t1005-fdwatcher.t \
-	$(top_builddir)/t/t9990-python-tests.t
+	$(top_builddir)/t/t9990-python-tests.t \
+	kvs/guestkvs
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/kvs/guestkvs
+++ b/t/kvs/guestkvs
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec flux kvs --namespace=job${FLUX_JOB_ID} "$@"

--- a/t/t2003-recurse.t
+++ b/t/t2003-recurse.t
@@ -61,17 +61,17 @@ test_expect_success 'recurse: FLUX_JOB_KVSPATH is set in child job' '
 	test -s kvspath
 '
 
-test_expect_success 'recurse: flux.local_uri is set in enclosing KVS' '
+test_expect_success 'recurse: guest.flux.local_uri is set in enclosing KVS' '
 	flux wreckrun -n1 -N1 flux start flux getattr local-uri >curi &&
-	key=$(flux wreck kvs-path $(flux wreck last-jobid)).flux.local_uri &&
-	flux kvs get --json $key >curi.out &&
+	kvsdir=$(flux wreck kvs-path $(flux wreck last-jobid)) &&
+	flux kvs get --json ${kvsdir}.guest.flux.local_uri >curi.out &&
 	test_cmp curi curi.out
 '
 
-test_expect_success 'recurse: flux.remote_uri is set in enclosing KVS' '
+test_expect_success 'recurse: guest.flux.remote_uri is set in enclosing KVS' '
 	flux wreckrun -n1 -N1 flux start flux getattr local-uri >curi2 &&
-	key=$(flux wreck kvs-path $(flux wreck last-jobid)).flux.remote_uri &&
-	flux kvs get --json $key >ruri.out &&
+	kvsdir=$(flux wreck kvs-path $(flux wreck last-jobid)) &&
+	flux kvs get --json ${kvsdir}.guest.flux.remote_uri >ruri.out &&
 	grep -q "$(sed -e ,local://,, <curi2)" ruri.out
 '
 

--- a/t/t2009-job-schema.t
+++ b/t/t2009-job-schema.t
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+
+test_description='Test KVS job schema adherence
+
+Test that KVS job schema adheres to RFC 16
+'
+
+. `dirname $0`/sharness.sh
+SIZE=${FLUX_TEST_SIZE:-4}
+test_under_flux ${SIZE} wreck
+
+GUESTKVS=${FLUX_SOURCE_DIR}/t/kvs/guestkvs
+
+#  Return the previous jobid
+last_job_id() {
+	flux wreck last-jobid
+}
+#  Return previous job path in kvs
+last_job_path() {
+	flux wreck last-jobid -p
+}
+
+test_expect_success 'schema: FLUX_JOB_KVSPATH points to private namespace' '
+	flux wreckrun printenv FLUX_JOB_KVSPATH >kvspath.out &&
+	echo "ns:job$(last_job_id)/." >kvspath.exp
+	test_cmp kvspath.exp kvspath.out
+'
+
+# during execution guest is a symlink
+# after execution guest is a directory
+test_expect_success 'schema: guest namespace converted on completion' '
+	flux wreckrun /bin/true &&
+	test_must_fail flux kvs readlink $(last_job_path).guest
+'
+
+test_expect_success 'schema: guest namespace content preserved' '
+	flux wreckrun ${GUESTKVS} put a=42 &&
+	echo 42 >guesta.exp &&
+	flux kvs get $(last_job_path).guest.a >guesta.out &&
+	test_cmp guesta.exp guesta.out
+'
+
+test_done


### PR DESCRIPTION
Now that we have @chu11's excellent work on private KVS namespaces merged, it seems useful to implement per-job "guest" namespaces as envisioned in [RFC 16](https://github.com/flux-framework/rfc/blob/master/spec_16.adoc).  This PR arranges for the job module to create a guest namespace named `job<jobid>` during job creation, and to "reap" it when the job reaches a terminal state.

During execution, the job may access the the namespace via the FLUX_JOB_KVSPATH environment variable, which is set to the direct namespace path, e.g. `ns:job<jobid>/.`.   The enclosing instance can access it via the `lwj.X.Y.<jobid>.guest` symlink.  After the job completes or fails, the namespace is "reaped", e.g. the symlink is replaced with a snapshot of the final content of the private namespace and the namespace is deleted.

Migrating job data to a private namespace can potentially reduce the bottleneck on serialized commits in the primary KVS namespace and protects the instance against an unintentional KVS DoS by programs that use the KVS heavily.

In this PR, the only data placed in the private namespace is the `flux.local_uri` and `flux.remote_uri` values recently added in support of `flux wreck uri`.  It is empty if the job is not a flux instance.  In a future PR we may want to migrate stdio and other per-job info.