### PR TITLE
job: emit gpu request information

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -43,6 +43,7 @@ local default_opts = {
     ['help']    = { char = 'h'  },
     ['verbose'] = { char = 'v'  },
     ['ntasks']  = { char = 'n', arg = "N" },
+    ['ngpus']  = { char = 'g', arg = "g" },
     ['cores-per-task']  = { char = 'c', arg = "N" },
     ['nnodes']  = { char = 'N', arg = "N" },
     ['tasks-per-node']  =
@@ -289,6 +290,11 @@ function wreck:parse_cmdline (arg)
         self.ncores = self.ntasks
     end
 
+    self.ngpus = 0
+    if self.opts.g then
+        self.ngpus = self.opts.g
+    end
+
     self.tasks_per_node = self.opts.t
 
     self.cmdline = {}
@@ -355,6 +361,7 @@ function wreck:jobreq ()
         environ = self.opts.S and {} or get_job_env { flux = self.flux },
         cwd =     posix.getcwd (),
         walltime =self.walltime or 0,
+        ngpus = self.ngpus or 0,
 
         ["opts.nnodes"] = self.opts.N,
         ["opts.ntasks"]  = self.opts.n,

--- a/src/common/libjsc/jstatctl.h
+++ b/src/common/libjsc/jstatctl.h
@@ -70,6 +70,7 @@ typedef int (*jsc_handler_f)(const char *base_jcb, void *arg, int errnum);
 # define JSC_RDESC_NNODES "nnodes"
 # define JSC_RDESC_NTASKS "ntasks"
 # define JSC_RDESC_NCORES "ncores"
+# define JSC_RDESC_NGPUS "ngpus"
 # define JSC_RDESC_WALLTIME "walltime"
 #define JSC_RDL "rdl"
 #define JSC_RDL_ALLOC "rdl_alloc"

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -171,6 +171,7 @@ static void send_create_event (flux_t *h, int64_t id,
     int nnodes = 0;
     int ntasks = 0;
     int ncores = 0;
+    int ngpus = 0;
     int walltime = 0;
 
     char *topic;
@@ -188,14 +189,19 @@ static void send_create_event (flux_t *h, int64_t id,
         nnodes = val;
     if (Jget_int (req, "ncores", &val))
         ncores = val;
+    if (Jget_int (req, "ngpus", &val))
+        ngpus = val;
     if (Jget_int (req, "walltime", &val))
         walltime = val;
 
-    msg = flux_event_pack (topic, "{s:I,s:s,s:i,s:i,s:i,s:i}",
+    printf ("ngpus from job: %d\n", (int)ngpus);
+
+    msg = flux_event_pack (topic, "{s:I,s:s,s:i,s:i,s:i,s:i,s:i}",
                           "jobid", id, "kvs_path", path,
                           "ntasks", ntasks,
                           "ncores", ncores,
                           "nnodes", nnodes,
+                          "ngpus", ngpus,
                           "walltime", walltime);
 
     if (msg == NULL) {


### PR DESCRIPTION
Very slightly modified version of @twrs' change to support gpu scheduling within flux-sched.

Unfortunately, `make check` on quartz fails w/

```
make[1]: Entering directory `/g/g0/dahn/workspace/flux-cancel/flux-core/t'
make  module/parent.la module/child.la request/req.la shmem/backtoback.t loop/handle.t loop/dispatch.t loop/reactor.t loop/reduce.t loop/log.t loop/logstderr rpc/rpc.t rpc/mrpc.t rolemask/loop.t kz/kzutil kvs/torture kvs/dtree kvs/blobref kvs/hashtest kvs/watch kvs/watch_disconnect kvs/commit kvs/transactionmerge kvs/fence_namespace_remove kvs/fence_invalid module/basic request/treq barrier/tbarrier wreck/rcalc  \
  t0000-sharness.t t0001-basic.t t0002-request.t t0003-module.t t0004-event.t t0005-exec.t t0007-ping.t t0008-attr.t t0009-dmesg.t t0010-generic-utils.t t0011-content-cache.t t0012-content-sqlite.t t0013-config-file.t t0014-runlevel.t t0015-cron.t t0016-cron-faketime.t t0017-security.t t1000-kvs.t t1001-kvs-internals.t t1002-kvs-watch.t t1003-kvs-stress.t t1004-kvs-namespace.t t1005-kvs-security.t t1101-barrier-basic.t t1102-cmddriver.t t1103-apidisconnect.t t1104-kz.t t1105-proxy.t t2000-wreck.t t2001-jsc.t t2002-pmi.t t2003-recurse.t t2004-hydra.t t2005-hwloc-basic.t t2006-joblog.t t2007-caliper.t t2008-althash.t t2100-aggregate.t t3000-mpi-basic.t t4000-issues-test-driver.t t5000-valgrind.t issues/t0441-kvs-put-get.sh issues/t0505-msg-handler-reg.lua issues/t0821-kvs-segfault.sh lua/t0001-send-recv.t lua/t0002-rpc.t lua/t0003-events.t lua/t0004-getattr.t lua/t0007-alarm.t lua/t0009-sequences.t lua/t1000-reactor.t lua/t1001-timeouts.t lua/t1002-kvs.t lua/t1003-iowatcher.t lua/t1004-statwatcher.t lua/t1005-fdwatcher.t ../t/t9990-python-tests.t scripts/event-trace.lua scripts/event-trace-bypass.lua scripts/kvs-watch-until.lua scripts/kvs-get-ex.lua scripts/cpus-allowed.lua scripts/waitfile.lua scripts/t0004-event-helper.sh scripts/tssh valgrind/valgrind-workload.sh kvs/kvs-helper.sh hwloc-data/1N/shared/02-brokers/0.xml hwloc-data/1N/shared/02-brokers/1.xml hwloc-data/1N/nonoverlapping/02-brokers/0.xml hwloc-data/1N/nonoverlapping/02-brokers/1.xml valgrind/valgrind.supp conf.d/private.conf conf.d/shared.conf conf.d/shared_ipc.conf conf.d/shared_none.conf conf.d/bad-toml.conf conf.d/bad-missing.conf conf.d/bad-rank.conf conf.d/priv2.0.conf conf.d/priv2.1.conf
make[2]: Entering directory `/g/g0/dahn/workspace/flux-cancel/flux-core/t'
  CC       module/module_parent_la-parent.lo
  CC       module/module_child_la-child.lo
  CC       request/request_req_la-req.lo
  CC       shmem/shmem_backtoback_t-backtoback.o
  CC       loop/loop_handle_t-handle.o
  CC       loop/loop_dispatch_t-dispatch.o
  CC       loop/loop_reactor_t-reactor.o
  CC       loop/loop_reduce_t-reduce.o
  CC       loop/loop_log_t-log.o
  CC       loop/loop_logstderr-logstderr.o
  CC       rpc/rpc_rpc_t-rpc.o
  CC       rpc/rpc_rpc_t-util.o
  CC       rpc/rpc_mrpc_t-mrpc.o
  CC       rpc/rpc_mrpc_t-util.o
  CC       rolemask/rolemask_loop_t-loop.o
make[2]: *** No rule to make target `kz/kzutil.c', needed by `kz/kz_kzutil-kzutil.o'.  Stop.
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/g/g0/dahn/workspace/flux-cancel/flux-core/t'
make[1]: *** [check-am] Error 2
make[1]: Leaving directory `/g/g0/dahn/workspace/flux-cancel/flux-core/t'
make: *** [check-recursive] Error 1
```

My config line was: ./configure --prefix=/g/g0/dahn/workspace/flux-cancel/inst --disable-python