### PR TITLE
job module: add active job hash

### DIFF
--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -349,7 +349,7 @@ static void job_submit_nocreate (flux_t *h, flux_msg_handler_t *w,
     const char *json_str;
     json_object *o = NULL;
 
-    if (!sched_loaded (h)) {
+    if (broker_rank > 0 || !sched_loaded (h)) {
         errno = ENOSYS;
         goto error;
     }
@@ -381,7 +381,7 @@ static void job_submit_cb (flux_t *h, flux_msg_handler_t *w,
     const char *json_str;
     json_object *o = NULL;
 
-    if (!sched_loaded (h)) {
+    if (broker_rank > 0 || !sched_loaded (h)) {
         errno = ENOSYS;
         goto error;
     }
@@ -409,6 +409,10 @@ static void job_create_cb (flux_t *h, flux_msg_handler_t *w,
     const char *json_str;
     json_object *o = NULL;
 
+    if (broker_rank > 0) {
+        errno = ENOSYS;
+        goto error;
+    }
     if (flux_msg_get_json (msg, &json_str) < 0)
         goto error;
     if (!json_str || !(o = json_tokener_parse (json_str))) {

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -385,9 +385,6 @@ static void job_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto out;
     if (json_str && !(o = json_tokener_parse (json_str)))
         goto out;
-    if (strcmp (topic, "job.shutdown") == 0) {
-        flux_reactor_stop (flux_get_reactor (h));
-    }
     else if ((strcmp (topic, "job.create") == 0)
             || ((strcmp (topic, "job.submit") == 0)
                  && sched_loaded (h)))
@@ -663,7 +660,6 @@ static const struct flux_msg_handler_spec mtab[] = {
     { FLUX_MSGTYPE_REQUEST, "job.create", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.submit", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.submit-nocreate", job_submit_only, 0 },
-    { FLUX_MSGTYPE_REQUEST, "job.shutdown", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.kvspath",  job_kvspath_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "wrexec.run.*", runevent_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END


### PR DESCRIPTION
This is a WIP, not ready for merging.

This is cleanup of the job module, some of which was factored out of #1460.  It creates a hash of active jobs in the job module on rank 0.  In the initial push, submit/create request handlers and their helpers are refactored to use the `struct job` hash entry.  The hash is maintained, but is otherwise not used.

Planned work includes
* a job.update-state request, to centralize KVS state update and event generation
* a job.list-active request, to list active jobs
* eliminate synchronous RPC's, where possible with low effort
