### PR TITLE
wreck: rework job.submit, job.create, wrexecd.run handlers with continuations

### DIFF
--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -50,6 +50,27 @@ wrexecd_LDADD = \
 	$(wrexecd_libs) \
 	$(ZMQ_LIBS) $(LUA_LIB) $(LIBPTHREAD)
 
+TESTS = \
+	test_wreck_job.t
+
+test_ldadd = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD)
+
+test_cppflags = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap
+
+check_PROGRAMS = $(TESTS)
+
+test_wreck_job_t_SOURCES = test/wreck_job.c
+test_wreck_job_t_CPPFLAGS = $(test_cppflags)
+test_wreck_job_t_LDADD = \
+	$(top_builddir)/src/modules/wreck/wreck_job.o \
+	$(test_ldadd)
+
 dist_wreckscripts_SCRIPTS = \
 	lua.d/01-env.lua \
 	lua.d/02-affinity.lua \

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -30,7 +30,7 @@ fluxlibexec_PROGRAMS = \
 fluxmod_libadd = $(top_builddir)/src/common/libflux-core.la \
 		 $(top_builddir)/src/common/libflux-internal.la
 
-job_la_SOURCES = job.c rcalc.c rcalc.h
+job_la_SOURCES = job.c rcalc.c rcalc.h wreck_job.c wreck_job.h
 job_la_LDFLAGS = $(AM_LDFLAGS) $(fluxmod_ldflags) -module
 job_la_LIBADD = $(fluxmod_libadd)
 

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -385,9 +385,6 @@ static void job_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto out;
     if (json_str && !(o = json_tokener_parse (json_str)))
         goto out;
-    if (strcmp (topic, "job.shutdown") == 0) {
-        flux_reactor_stop (flux_get_reactor (h));
-    }
     else if ((strcmp (topic, "job.create") == 0)
             || ((strcmp (topic, "job.submit") == 0)
                  && sched_loaded (h)))
@@ -663,7 +660,6 @@ static const struct flux_msg_handler_spec mtab[] = {
     { FLUX_MSGTYPE_REQUEST, "job.create", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.submit", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.submit-nocreate", job_submit_only, 0 },
-    { FLUX_MSGTYPE_REQUEST, "job.shutdown", job_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "job.kvspath",  job_kvspath_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "wrexec.run.*", runevent_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END

--- a/src/modules/wreck/test/wreck_job.c
+++ b/src/modules/wreck/test/wreck_job.c
@@ -1,0 +1,96 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/modules/wreck/wreck_job.h"
+
+static int free_fun_count = 0;
+void free_fun (void *arg)
+{
+    free_fun_count++;
+}
+
+void basic (void)
+{
+    struct wreck_job *job;
+    const char *s;
+
+    job = wreck_job_create ();
+    ok (job != NULL,
+        "wreck_job_create works");
+    wreck_job_set_state (job, "submitted");
+    s = wreck_job_get_state (job);
+    ok (s != NULL && !strcmp (s, "submitted"),
+        "wreck_job_get/set_state works");
+
+    wreck_job_set_aux (job, job, free_fun);
+    ok (wreck_job_get_aux (job) == job,
+        "wreck_job_get/set_aux works");
+
+    wreck_job_set_aux (job, job, free_fun);
+    ok (free_fun_count == 1,
+        "wreck_job_set_aux calls destructor when aux overwritten");
+    wreck_job_destroy (job);
+    ok (free_fun_count == 2,
+        "wreck_job_destry calls aux destructor");
+}
+
+void hash (void)
+{
+    zhash_t *h = zhash_new ();
+    struct wreck_job *job;
+
+    if (!h)
+        BAIL_OUT ("zhash_new failed");
+
+    job = wreck_job_create ();
+    if (!job)
+        BAIL_OUT ("wreck_job_create failed");
+    job->id = 42;
+    ok (wreck_job_insert (job, h) == 0 && zhash_size (h) == 1,
+        "wreck_job_insert 42 works");
+
+    job = wreck_job_create ();
+    if (!job)
+        BAIL_OUT ("wreck_job_create failed");
+    job->id = 43;
+    ok (wreck_job_insert (job, h) == 0 && zhash_size (h) == 2,
+        "wreck_job_insert 43 works");
+
+    job = wreck_job_lookup (42, h);
+    ok (job != NULL && job->id == 42,
+        "wreck_job_lookup 42 works");
+    wreck_job_set_aux (job, job, free_fun);
+
+    job = wreck_job_lookup (43, h);
+    ok (job != NULL && job->id == 43,
+        "wreck_job_lookup 43 works");
+    wreck_job_set_aux (job, job, free_fun);
+
+    errno = 0;
+    job = wreck_job_lookup (2, h);
+    ok (job == NULL && errno == ENOENT,
+        "wreck_job_lookup 2 fails with ENOENT");
+
+    free_fun_count = 0;
+    zhash_destroy (&h);
+    ok (free_fun_count == 2,
+        "zhash_destroy frees jobs");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic ();
+    hash ();
+
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/wreck/wreck_job.c
+++ b/src/modules/wreck/wreck_job.c
@@ -1,0 +1,120 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "wreck_job.h"
+
+typedef char hashkey_t[16];
+
+static char *idkey (hashkey_t key, int64_t id)
+{
+    size_t keysz = sizeof (hashkey_t);
+    int n = snprintf (key, keysz, "%lld", (long long)id);
+    assert (n < keysz);
+    return key;
+}
+
+void wreck_job_destroy (struct wreck_job *job)
+{
+    if (job) {
+        int saved_errno = errno;
+        if (job->aux_destroy)
+            job->aux_destroy (job->aux);
+        free (job->kvs_path);
+        free (job);
+        errno = saved_errno;
+    }
+}
+
+struct wreck_job *wreck_job_create (void)
+{
+    struct wreck_job *job;
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    return job;
+}
+
+void wreck_job_set_state (struct wreck_job *job, const char *status)
+{
+    assert (strlen (status) < sizeof (job->state));
+    strcpy (job->state, status);
+}
+
+const char *wreck_job_get_state (struct wreck_job *job)
+{
+    return job->state;
+}
+
+int wreck_job_insert (struct wreck_job *job, zhash_t *hash)
+{
+    hashkey_t key;
+    if (zhash_lookup (hash, idkey (key, job->id)) != NULL) {
+        errno = EEXIST;
+        return -1;
+    }
+    zhash_update (hash, key, job);
+    zhash_freefn (hash, key, (zhash_free_fn *)wreck_job_destroy);
+    return 0;
+}
+
+struct wreck_job *wreck_job_lookup (int64_t id, zhash_t *hash)
+{
+    hashkey_t key;
+    struct wreck_job *job;
+
+    if (!(job = zhash_lookup (hash, idkey (key, id)))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return job;
+}
+
+void wreck_job_delete (int64_t id, zhash_t *hash)
+{
+    hashkey_t key;
+    zhash_delete (hash, idkey (key, id));
+}
+
+void wreck_job_set_aux (struct wreck_job *job, void *item, flux_free_f destroy)
+{
+    if (job->aux_destroy)
+        job->aux_destroy (job->aux);
+    job->aux = item;
+    job->aux_destroy = destroy;
+}
+
+void *wreck_job_get_aux (struct wreck_job *job)
+{
+    return job->aux;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/wreck/wreck_job.h
+++ b/src/modules/wreck/wreck_job.h
@@ -1,0 +1,56 @@
+#ifndef HAVE_WJOB_H
+#define HAVE_WJOB_H
+
+#include <stdint.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+struct wreck_job {
+    int64_t id;
+    char *kvs_path;
+    char state[16];
+    int nnodes;
+    int ntasks;
+    int ncores;
+    int walltime;
+    void *aux;
+    flux_free_f aux_destroy;
+};
+
+void wreck_job_destroy (struct wreck_job *job);
+struct wreck_job *wreck_job_create (void);
+
+/* Set job status.
+ * 'status' must be a string of 15 characters or less or function will assert.
+ */
+void wreck_job_set_state (struct wreck_job *job, const char *status);
+const char *wreck_job_get_state (struct wreck_job *job);
+
+/* Insert job into hash.
+ * wreck_job_destroy() will be called upon wreck_job_delete() of this entry,
+ * or destruction of the hash.
+ * Returns 0 on success, -1 on on failure, with errno set.
+ */
+int wreck_job_insert (struct wreck_job *job, zhash_t *hash);
+
+/* Remove job from hash, invoking destructor.
+ * This is a no-op if 'id' is not found in the hash.
+ */
+void wreck_job_delete (int64_t id, zhash_t *hash);
+
+/* Look up job in hash by id.
+ * Returns job on success, NULL on failure.
+ */
+struct wreck_job *wreck_job_lookup (int64_t id, zhash_t *hash);
+
+/* Associate data and optional destructor with job.
+ */
+void wreck_job_set_aux (struct wreck_job *job, void *item, flux_free_f destroy);
+void *wreck_job_get_aux (struct wreck_job *job);
+
+
+#endif /* !HAVE_WJOB_H */
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This is a hopefully somewhat better structured version of PR #1471.

This one doesn't add a hash of active jobs and doesn't limt the job module's ability to ingest jobs on ranks other than 0.

It adds a `struct wjob` data structure (with unit tests), and reworks the `job.submit`, `job.create`, and `wrexecd.run` request handlers to manipulate the KVS etc using continuations  rather than synchronous RPC's, to improve job module responsiveness.

It also satisfies a long standing feature request for an ability to synchronously publish events; that is, get a response indicating that the event has received a sequence number, as discussed in #337 and #342.  That was necessary to remove the final synchronous step in job.create and job.submit, where the handlers block listening for an event to be published before sending the response to the user.

FWIW I reran a little script inspired by @trws that that submits 50K jobs (wtih the sched module check disabled), running 200 submits in parallel:
```sh
#!/bin/bash
ulimit 65536
seq 1 50000 | xargs -n 1 -P 200  \
    flux submit -n 1 sleep 0
```
Before this PR I got 134 job per second.  After I get 442.

I haven't tried to probe the effect on job launch, but it should improve latency under load - for example if there are many small jobs being launched, the overhead of checking a new job _not_ targetting the local rank should not slow down (as much) the launch of one that _does_ target the local rank, since new events can start to be handled before the last one has completed.  E.g. there could be many fetches of `R_lite` for different jobs occurring simultaneously on each rank.

Sorry the "rework" commits are basically unreadable.  They each effectively rewrite a handler and its helper functions as a chain of continuations.  It might be better to look at the final result.