### PR TITLE
modules/kvs: Enhance debug error messages

### DIFF
--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -529,9 +529,9 @@ static int kvstxn_append (kvstxn_t *kt, int current_epoch, json_t *dirent,
         return -1;
     }
     else {
-        char *s = json_dumps (entry, 0);
-        flux_log (kt->ktm->h, LOG_ERR, "%s: corrupt treeobj: %s",
-                  __FUNCTION__, s);
+        char *s = json_dumps (entry, JSON_ENCODE_ANY);
+        flux_log (kt->ktm->h, LOG_ERR, "%s: corrupt treeobj: %p, %s",
+                  __FUNCTION__, entry, s);
         free (s);
         errno = ENOTRECOVERABLE;
         return -1;

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -455,11 +455,12 @@ static lookup_process_t walk (lookup_t *lh)
                 goto done;
             }
             else {
-                char *s = json_dumps (wl->dirent, 0);
+                char *s = json_dumps (wl->dirent, JSON_ENCODE_ANY);
                 flux_log (lh->h, LOG_ERR,
                           "%s: unknown/unexpected dirent type: "
-                          "lh->path=%s pathcomp=%s: wl->dirent=%s ",
-                          __FUNCTION__, lh->path, pathcomp, s);
+                          "lh->path=%s pathcomp=%s wl->dirent(ptr)=%p "
+                          "wl->dirent(str)=%s",
+                          __FUNCTION__, lh->path, pathcomp, wl->dirent, s);
                 free (s);
                 lh->errnum = ENOTRECOVERABLE;
                 goto error;
@@ -1237,9 +1238,9 @@ lookup_process_t lookup (lookup_t *lh)
                     goto error;
                 }
             } else {
-                char *s = json_dumps (lh->wdirent, 0);
-                flux_log (lh->h, LOG_ERR, "%s: corrupt dirent: %s",
-                          __FUNCTION__, s);
+                char *s = json_dumps (lh->wdirent, JSON_ENCODE_ANY);
+                flux_log (lh->h, LOG_ERR, "%s: corrupt dirent: %p, %s",
+                          __FUNCTION__, lh->wdirent, s);
                 free (s);
                 lh->errnum = ENOTRECOVERABLE;
                 goto error;


### PR DESCRIPTION
Add JSON_ENCODE_ANY in calls to json_dumps() to output additional
information on error/debug paths.

In addition, output pointer to original json object, to differentiate
between a NULL C pointer and the possible "null" json value.