### PR TITLE
update minimum hwloc version to 1.11.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,7 +198,7 @@ X_AC_ZEROMQ
 X_AC_MUNGE
 X_AC_JANSSON
 X_AC_YAMLCPP
-PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.4], [], [])
+PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -14,7 +14,7 @@ https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.
 https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz \
 https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz \
 http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz \
-http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.0.tar.gz \
+http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.1.tar.gz \
 http://www.digip.org/jansson/releases/jansson-2.9.tar.gz \
 http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz \
 https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \


### PR DESCRIPTION
This bumps the minimum hwloc version to 1.11.1 to address an assertion failure, as sleuthed out by @grondo and @dongahn over in flux-framework/flux-sched#316.