### PR TITLE
wreck: track active jobs

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -410,11 +410,15 @@ prog:SubCommand {
  options = {
   { name = "max", char = 'n', arg="COUNT",
     usage = "Display at most COUNT jobs",
+  },
+  { name = "exclude-complete", char = 'x',
+    usage = "Skip the listing of complete jobs in the kvs"
   }
  },
  description = "List jobs in kvs",
  handler = function (self, arg)
-    local dirs,err = joblist_from_args { self = self, args = arg }
+    local dirs,err = joblist_from_args { self = self, args = arg,
+                                         active_only = self.opt.x }
     if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
@@ -447,8 +451,12 @@ prog:SubCommand {
  },
  description = "List FLUX_URI for jobs that are Flux instances",
  handler = function (self, arg)
-    local dirs, err = joblist_from_args { self = self,
-                                          args = arg }
+    -- Only include running jobs:
+    local states = { include = { running = true } }
+    local dirs,err = joblist_from_args { self = self,
+                                         args = arg,
+                                         states = states,
+                                         active_only = true }
     if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %-40s %-.13s\n";
@@ -653,8 +661,15 @@ prog:SubCommand {
 
     ---
     -- Gather LWJ path list
-    --
-    local dirs = wreck.joblist{ flux = f } or {}
+    -- Only include complete jobs
+    local states = { include = { complete = true,
+                                 failed = true
+                               }
+                   }
+    local dirs = wreck.joblist{ flux = f,
+                                kvs_only = true,
+                                states = states
+                              }  or {}
     if verbose then
         self:log ("%4.03fs: got lwj list (%d entries)\n", tt:get0(), #dirs)
     end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -53,7 +53,8 @@ end
 
 
 local function kvs_path (id, fmt, ...)
-    local p = assert (wreck.id_to_path { flux = f, jobid = id })
+    local id = assert (tonumber (id))
+    local p, err = assert (wreck.id_to_path { flux = f, jobid = id })
     if fmt then
         p = p .. "." .. string.format (fmt, ...)
     end

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -392,6 +392,7 @@ local function joblist_from_args (arg)
     local args = arg.args
 
     local max = tonumber (self.opt.n) or 25
+    if max <= 0 then max = math.huge end
     if #args == 0 then
         return wreck.joblist{ flux = f,
                               max = max,

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -386,10 +386,17 @@ local function bracketify (args)
     return (r)
 end
 
-local function joblist_from_args (self, args)
+local function joblist_from_args (arg)
+    local self = arg.self
+    local args = arg.args
+
     local max = tonumber (self.opt.n) or 25
     if #args == 0 then
-        return wreck.joblist{ flux = f, max = max }
+        return wreck.joblist{ flux = f,
+                              max = max,
+                              states = arg.states,
+                              active_only = arg.active_only,
+                              kvs_only = arg.kvs_only  }
     end
     -- otherwise use dirs on cmdline
     local hl,err = hostlist.union (unpack (bracketify (args)))
@@ -407,7 +414,7 @@ prog:SubCommand {
  },
  description = "List jobs in kvs",
  handler = function (self, arg)
-    local dirs,err = joblist_from_args (self, arg)
+    local dirs,err = joblist_from_args { self = self, args = arg }
     if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
@@ -440,7 +447,8 @@ prog:SubCommand {
  },
  description = "List FLUX_URI for jobs that are Flux instances",
  handler = function (self, arg)
-    local dirs,err = joblist_from_args (self, arg)
+    local dirs, err = joblist_from_args { self = self,
+                                          args = arg }
     if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %-40s %-.13s\n";
@@ -478,7 +486,7 @@ prog:SubCommand {
  },
  description = "List timings of jobs in kvs",
  handler = function (self, arg) 
-    local dirs,err = joblist_from_args (self, arg)
+    local dirs,err = joblist_from_args {self = self, args = arg}
     if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %12s %12s %12s %12s %12s\n"

--- a/src/modules/wreck/test/wreck_job.c
+++ b/src/modules/wreck/test/wreck_job.c
@@ -2,6 +2,7 @@
 #include "config.h"
 #endif
 #include <czmq.h>
+#include <jansson.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/modules/wreck/wreck_job.h"
@@ -34,13 +35,30 @@ void basic (void)
         "wreck_job_set_aux calls destructor when aux overwritten");
     wreck_job_destroy (job);
     ok (free_fun_count == 2,
-        "wreck_job_destry calls aux destructor");
+        "wreck_job_destroy calls aux destructor");
+}
+
+static int count_entries (const char *json_str)
+{
+    json_t *obj = NULL;
+    json_t *array = NULL;
+    int n = 0;
+
+    if (!json_str || !(obj = json_loads (json_str, 0, NULL))
+                  || json_unpack (obj, "{s:o}", "jobs", &array) < 0)
+        BAIL_OUT ("JSON parse error");
+    n = json_array_size (array);
+    json_decref (obj);
+    return n;
 }
 
 void hash (void)
 {
     zhash_t *h = zhash_new ();
     struct wreck_job *job;
+    char *s = NULL;
+    json_t *obj = NULL;
+    json_t *array = NULL;
 
     if (!h)
         BAIL_OUT ("zhash_new failed");
@@ -49,6 +67,7 @@ void hash (void)
     if (!job)
         BAIL_OUT ("wreck_job_create failed");
     job->id = 42;
+    wreck_job_set_state (job, "submitted");
     ok (wreck_job_insert (job, h) == 0 && zhash_size (h) == 1,
         "wreck_job_insert 42 works");
 
@@ -56,6 +75,7 @@ void hash (void)
     if (!job)
         BAIL_OUT ("wreck_job_create failed");
     job->id = 43;
+    wreck_job_set_state (job, "complete");
     ok (wreck_job_insert (job, h) == 0 && zhash_size (h) == 2,
         "wreck_job_insert 43 works");
 
@@ -74,10 +94,131 @@ void hash (void)
     ok (job == NULL && errno == ENOENT,
         "wreck_job_lookup 2 fails with ENOENT");
 
+    /* List has two entries, one "complete", one "submitted".
+     */
+    s = wreck_job_list (h, 0, NULL, NULL);
+    ok (s != NULL && (obj = json_loads (s, 0, NULL)) && json_is_object (obj),
+        "wreck_job_list produces a JSON object");
+    diag ("%s", s ? s : "(null)");
+    ok (json_unpack (obj, "{s:o}", "jobs", &array) == 0,
+        "JSON object has one member");
+    ok (json_is_array (array) && json_array_size (array) == 2,
+        "member is array with expected size");
+    json_decref (obj);
+    free (s);
+
+    /* 'max' can limit number of entries returned.
+     */
+    s = wreck_job_list (h, 1, NULL, NULL);
+    ok (count_entries (s) == 1,
+        "wreck_job_list max=1 limits entries to 1");
+    free (s);
+
+    /* If 'include' and no match (and no 'exclude'), zero entries returned .
+     */
+    s = wreck_job_list (h, 0, "badstate", NULL);
+    ok (count_entries (s) == 0,
+        "wreck_job_list include=badstate returns 0 entries");
+    free (s);
+
+    /* If 'exclude' and no match (and no 'include'), all entries returned
+     */
+    s = wreck_job_list (h, 0, NULL, "badstate");
+    ok (count_entries (s) == 2,
+        "wreck_job_list exclude=badstate returns 2 entries");
+    free (s);
+
+    /* If 'include' and one match (and no 'exclude'), 1 of 2 entries returned
+     */
+    s = wreck_job_list (h, 0, "complete", NULL);
+    ok (count_entries (s) == 1,
+        "wreck_job_list include=complete returns 1 entry");
+    free (s);
+
+    /* If 'exclude' and one match (and no 'include'), 1 of 2 entries returned
+     */
+    s = wreck_job_list (h, 0, NULL, "complete");
+    ok (count_entries (s) == 1,
+        "wreck_job_list exclude=complete returns 1 entry");
+    free (s);
+
+    /* If 'include' and all match (and no 'exclude'), all entries returned
+     */
+    s = wreck_job_list (h, 0, "complete,submitted", NULL);
+    ok (count_entries (s) == 2,
+        "wreck_job_list include=complete,submitted returns 2 entries");
+    free (s);
+
+    /* If 'exclude' and all match (and no 'include'), zero entries returned
+     */
+    s = wreck_job_list (h, 0, NULL, "complete,submitted");
+    ok (count_entries (s) == 0,
+        "wreck_job_list exclude=complete,submitted returns 0 entries");
+    free (s);
+
     free_fun_count = 0;
     zhash_destroy (&h);
     ok (free_fun_count == 2,
         "zhash_destroy frees jobs");
+}
+
+void corner (void)
+{
+    zhash_t *hash;
+    struct wreck_job *job;
+    const char *s;
+
+    if (!(hash = zhash_new()))
+        BAIL_OUT ("zhash_new failed");
+    if (!(job = wreck_job_create ()))
+        BAIL_OUT ("wreck_job_create failed)");
+
+    lives_ok ({wreck_job_destroy (NULL);},
+        "wreck_job_destroy (job=NULL) doesn't crash");
+
+    lives_ok ({wreck_job_set_state (NULL, "completed");},
+        "wreck_job_set_state (job=NULL doesn't crash");
+    lives_ok ({wreck_job_set_state (job, NULL);},
+        "wreck_job_set_state (state=NULL) doesn't crash");
+    lives_ok ({wreck_job_set_state (job, "0123456789abcdef");},
+        "wreck_job_set_state (state=too long) doesn't crash");
+
+    s = wreck_job_get_state (NULL);
+    ok (s != NULL && strlen (s) == 0,
+        "wreck_job_get_state (job=NULL) returns empty string");
+
+    errno = 0;
+    ok (wreck_job_insert (NULL, hash) < 0 && errno == EINVAL,
+        "wreck_job_insert (job=NULL) fails with EINVAL");
+    errno = 0;
+    job->id = 42;
+    ok (wreck_job_insert (job, NULL) < 0 && errno == EINVAL,
+        "wreck_job_insert (hash=NULL) fails with EINVAL");
+
+    errno = 0;
+    ok (wreck_job_lookup (-1, hash) == NULL && errno == EINVAL,
+        "wreck_job_lookup (id=-1) fails with EINVAL");
+    errno = 0;
+    ok (wreck_job_lookup (0, hash) == NULL && errno == EINVAL,
+        "wreck_job_lookup (id=0) fails with EINVAL");
+
+    errno = 0;
+    ok (wreck_job_lookup (1, NULL) == NULL && errno == EINVAL,
+        "wreck_job_lookup (hash=NULL) fails with EINVAL");
+
+    lives_ok ({wreck_job_delete (1, NULL);},
+        "wreck_job_delete (job=NULL) doesn't crash");
+    lives_ok ({wreck_job_set_aux (NULL, NULL, NULL);},
+        "wreck_job_set_aux (job=NULL) doesn't crash");
+    lives_ok ({wreck_job_get_aux (NULL);},
+        "wreck_job_get_aux (job=NULL) doesn't crash");
+
+    errno = 0;
+    ok (wreck_job_list (NULL, 0, NULL, NULL) == NULL && errno == EINVAL,
+        "wreck_job_list (hash=NULL) fails with EINVAL");
+
+    zhash_destroy (&hash);
+    wreck_job_destroy (job);
 }
 
 int main (int argc, char *argv[])
@@ -86,6 +227,7 @@ int main (int argc, char *argv[])
 
     basic ();
     hash ();
+    corner ();
 
     done_testing ();
     return (0);

--- a/src/modules/wreck/wreck_job.c
+++ b/src/modules/wreck/wreck_job.c
@@ -25,9 +25,12 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <time.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
+#include <jansson.h>
+#include <argz.h>
 
 #include "wreck_job.h"
 
@@ -63,18 +66,24 @@ struct wreck_job *wreck_job_create (void)
 
 void wreck_job_set_state (struct wreck_job *job, const char *status)
 {
-    assert (strlen (status) < sizeof (job->state));
-    strcpy (job->state, status);
+    if (job && status != NULL && strlen (status) < sizeof (job->state)) {
+        strcpy (job->state, status);
+        clock_gettime (CLOCK_MONOTONIC, &job->mtime);
+    }
 }
 
 const char *wreck_job_get_state (struct wreck_job *job)
 {
-    return job->state;
+    return job ? job->state : "";
 }
 
 int wreck_job_insert (struct wreck_job *job, zhash_t *hash)
 {
     hashkey_t key;
+    if (!job || !hash) {
+        errno = EINVAL;
+        return -1;
+    }
     if (zhash_lookup (hash, idkey (key, job->id)) != NULL) {
         errno = EEXIST;
         return -1;
@@ -89,6 +98,10 @@ struct wreck_job *wreck_job_lookup (int64_t id, zhash_t *hash)
     hashkey_t key;
     struct wreck_job *job;
 
+    if (id <= 0 || !hash) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(job = zhash_lookup (hash, idkey (key, id)))) {
         errno = ENOENT;
         return NULL;
@@ -99,20 +112,142 @@ struct wreck_job *wreck_job_lookup (int64_t id, zhash_t *hash)
 void wreck_job_delete (int64_t id, zhash_t *hash)
 {
     hashkey_t key;
-    zhash_delete (hash, idkey (key, id));
+    if (id > 0 && hash != NULL)
+        zhash_delete (hash, idkey (key, id));
 }
 
 void wreck_job_set_aux (struct wreck_job *job, void *item, flux_free_f destroy)
 {
-    if (job->aux_destroy)
-        job->aux_destroy (job->aux);
-    job->aux = item;
-    job->aux_destroy = destroy;
+    if (job != NULL) {
+        if (job->aux_destroy)
+            job->aux_destroy (job->aux);
+        job->aux = item;
+        job->aux_destroy = destroy;
+    }
 }
 
 void *wreck_job_get_aux (struct wreck_job *job)
 {
-    return job->aux;
+    return job ? job->aux : NULL;
+}
+
+/* Sort jobs in reverse mtime order.
+ * This has the zlist_compare_fn footprint and can be used with zlist_sort().
+ */
+static int compare_job_mtime (struct wreck_job *j1, struct wreck_job *j2)
+{
+    if (j1->mtime.tv_sec < j2->mtime.tv_sec)
+        return 1;
+    if (j1->mtime.tv_sec > j2->mtime.tv_sec)
+        return -1;
+    if (j1->mtime.tv_nsec < j2->mtime.tv_nsec)
+        return 1;
+    if (j1->mtime.tv_nsec > j2->mtime.tv_nsec)
+        return -1;
+    return 0;
+}
+
+/* If 'key' is one of the strings in an argz vector, return true.
+ */
+static bool findz (const char *argz, size_t argz_len, const char *key)
+{
+    const char *entry = NULL;
+    if (argz && key) {
+        while ((entry = argz_next (argz, argz_len, entry)) != NULL)
+            if (!strcmp (key, entry))
+                return true;
+    }
+    return false;
+}
+
+/* If 'key' survives black/white list filtering, return true.
+ */
+static bool bw_test (const char *key, const char *b, size_t b_len,
+                                      const char *w, size_t w_len)
+{
+    if (b && findz (b, b_len, key))
+        return false;
+    if (w && !findz (w, w_len, key))
+        return false;
+    return true;
+}
+
+char *wreck_job_list (zhash_t *hash, int max, const char *include_states,
+                                              const char *exclude_states)
+{
+    json_t *array = NULL;
+    json_t *obj = NULL;
+    zlist_t *joblist = NULL;
+    char *json_str;
+    struct wreck_job *job;
+    char *white = NULL;
+    size_t white_len = 0;
+    char *black = NULL;
+    size_t black_len = 0;
+    int saved_errno;
+
+    if (!hash) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (include_states) {
+        if (argz_create_sep (include_states, ',', &white, &white_len) != 0)
+            goto nomem;
+    }
+    if (exclude_states) {
+        if (argz_create_sep (exclude_states, ',', &black, &black_len) != 0)
+            goto nomem;
+    }
+    if (!(joblist = zlist_new ()))
+        goto nomem;
+    if (!(array = json_array ()))
+        goto nomem;
+    job = zhash_first (hash);
+    while (job != NULL) {
+        if (bw_test (job->state, black, black_len, white, white_len)) {
+            if (zlist_append (joblist, job) < 0)
+                goto nomem;
+        }
+        job = zhash_next (hash);
+    }
+    zlist_sort (joblist, (zlist_compare_fn *)compare_job_mtime);
+    job = zlist_first (joblist);
+    while (job != NULL) {
+        json_t *entry;
+        if (!(entry = json_pack ("{s:I s:s s:s}",
+                            "jobid", job->id,
+                            "kvs_path", job->kvs_path ? job->kvs_path : "",
+                            "state", job->state)))
+            goto nomem;
+        if (json_array_append_new (array, entry) < 0) {
+            json_decref (entry);
+            goto nomem;
+        }
+        if (max > 0 && json_array_size (array) == max)
+            break;
+        job = zlist_next (joblist);
+    }
+    if (!(obj = json_pack ("{s:O}", "jobs", array)))
+        goto nomem;
+    if (!(json_str = json_dumps (obj, JSON_COMPACT)))
+        goto error;
+    zlist_destroy (&joblist);
+    json_decref (array);
+    json_decref (obj);
+    free (black);
+    free (white);
+    return json_str;
+nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    zlist_destroy (&joblist);
+    json_decref (array);
+    json_decref (obj);
+    free (black);
+    free (white);
+    errno = saved_errno;
+    return NULL;
 }
 
 /*

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -444,12 +444,34 @@ test_expect_success 'flux-wreck: ls RANGE ignores missing jobids' '
 	flux kvs move tmp $LWJ &&
 	test $(cat ls-range.out | wc -l) = 3
 '
+test_expect_success 'flux-wreck: ls lists most recent "active" job first' '
+	flux wreckrun -d sleep 100 &&
+	KILL=$(last_job_id) &&
+	flux wreckrun -d sleep 100 &&
+	LASTID=$(last_job_id) &&
+	flux wreckrun hostname && flux wreckrun hostname &&
+	flux wreck ls --max=1 > ls-active.out &&
+	flux wreck kill $KILL &&
+	flux wreck kill $LASTID &&
+	test_debug "echo expecting $LASTID" &&
+	test_debug "cat ls-active.out" &&
+	test $(cat ls-active.out | wc -l) = 2 &&
+	tail -1 ls-active.out | grep ^\ *$LASTID
+'
 test_expect_success 'flux-wreck: purge works' '
 	flux wreck purge &&
 	flux wreck purge -t 2 -R &&
 	flux wreck ls &&
 	COUNT=$(flux wreck ls | grep -v NTASKS | wc -l) &&
 	test "$COUNT" = 2
+'
+test_expect_success 'flux-wreck: purge excludes active jobs' '
+	flux wreckrun -d sleep 100 &&
+	flux wreck purge -v -t 0 -R &&
+	flux wreck kill $(last_job_id) &&
+	flux wreck ls &&
+	COUNT=$(flux wreck ls | grep -v NTASKS | wc -l) &&
+	test "$COUNT" = 1
 '
 
 flux module list | grep -q sched || test_set_prereq NO_SCHED

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -439,8 +439,9 @@ test_expect_success 'flux-wreck: ls RANGE ignores missing jobids' '
 	LASTID=$(last_job_id) &&
 	LWJ=$(last_job_path) &&
 	flux wreckrun hostname &&
-	flux kvs unlink -R $LWJ &&
+	flux kvs move $LWJ tmp &&
 	flux wreck ls $((${LASTID}-1))-$((${LASTID}+1)) > ls-range.out &&
+	flux kvs move tmp $LWJ &&
 	test $(cat ls-range.out | wc -l) = 3
 '
 test_expect_success 'flux-wreck: purge works' '


### PR DESCRIPTION
This PR adds a bit of code to the job module to track active jobs.

It listens for all job state transitions, enters jobs into a hash when they first appear, and removes them when the terminal "complete" or "failed" states are reached.  The hash exists on all ranks.

There's a simple `job.list` request that returns a sorted array of jobs including id, kvs_path, and state, e.g.

```json
[
  {"jobid":1, "kvs_path":"lwj.0.0.1", "state":"running"},
  {"jobid":2, "kvs_path":"lwj.0.0.2", "state":"starting"},
  {"jobid":3, "kvs_path":"lwj.0.0.3", "state":"submitted"}
]
```

Next step is to add an option to `flux wreck ls` to show only active jobs.  The addition of that command would address #1456.