### PR TITLE
jsc: add missing "s:i" parameter to event unpack in `get_submit_jcb`

### DIFF
--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -1128,7 +1128,7 @@ static json_object *get_submit_jcb (flux_t *h, const flux_msg_t *msg, int64_t nj
     char *key = xasprintf ("%"PRId64, nj);
     jscctx_t *ctx = getctx (h);
 
-    if (flux_event_unpack (msg, NULL, "{ s:i s:i s:i s:i }",
+    if (flux_event_unpack (msg, NULL, "{ s:i s:i s:i s:i s:i }",
                            "ntasks", &ntasks,
                            "nnodes", &nnodes,
                            "ncores", &ncores,


### PR DESCRIPTION
The job submission flux event that was being unpacked in
`get_submit_jcb` had a missing "s:i" parameter.  Without this
parameter, the walltime of all jobs was staying at 0.

Fixes the errors that manifested in the easy backfilling testcase failure
seen in flux-sched/pull/313