### PR TITLE
modules/kvs: fix memory leak in namespace_create()

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2594,6 +2594,8 @@ static int namespace_create (kvs_ctx_t *ctx, const char *namespace,
         goto cleanup_remove_root;
     }
 
+    json_decref (rootdir);
+    free (data);
     return 0;
 
 cleanup_remove_root:


### PR DESCRIPTION
Problem: valgrind test fails when private KVS namespace
is made part of job setup.

Looks like some memory allocated in namespace_create()
that was freed in the error path, was not freed in
the non-error path.  Fix that.

Fixes #1483