### PR TITLE
libflux: add flux_event_encode_raw(), flux_event_decode_raw()

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -142,7 +142,6 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_txn_unlink.3 \
 	flux_kvs_txn_symlink.3 \
 	flux_kvs_txn_put_raw.3 \
-	# flux_kvs_txn_put_treeobj.3 \
 	flux_kvs_namespace_remove.3 \
 	flux_kvs_namespace_itr_next.3 \
 	flux_kvs_namespace_itr_rewind.3 \
@@ -261,7 +260,7 @@ flux_kvs_txn_mkdir.3: flux_kvs_txn_create.3
 flux_kvs_txn_unlink.3: flux_kvs_txn_create.3
 flux_kvs_txn_symlink.3: flux_kvs_txn_create.3
 flux_kvs_txn_put_raw.3: flux_kvs_txn_create.3
-# flux_kvs_txn_put_treeobj.3: flux_kvs_txn_create.3
+# N.B. exceeds max 8 stubs  flux_kvs_txn_put_treeobj.3: flux_kvs_txn_create.3
 flux_kvs_namespace_remove.3: flux_kvs_namespace_create.3
 flux_kvs_namespace_itr_next.3: flux_kvs_namespace_list.3
 flux_kvs_namespace_itr_rewind.3: flux_kvs_namespace_list.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -104,6 +104,8 @@ MAN3_FILES_SECONDARY = \
 	flux_event_unpack.3 \
 	flux_event_encode.3 \
 	flux_event_pack.3 \
+	flux_event_encode_raw.3 \
+	flux_event_decode_raw.3 \
 	flux_response_decode_raw.3 \
 	flux_request_encode_raw.3 \
 	flux_content_load_get.3 \
@@ -222,6 +224,8 @@ flux_request_decode_raw.3: flux_request_decode.3
 flux_event_unpack.3: flux_event_decode.3
 flux_event_encode.3: flux_event_decode.3
 flux_event_pack.3: flux_event_decode.3
+flux_event_encode_raw.3: flux_event_decode.3
+flux_event_decode_raw.3: flux_event_decode.3
 flux_response_decode_raw.3: flux_response_decode.3
 flux_request_encode_raw.3: flux_request_encode.3
 flux_content_load_get.3: flux_content_load.3

--- a/doc/man3/flux_event_decode.adoc
+++ b/doc/man3/flux_event_decode.adoc
@@ -5,7 +5,7 @@ flux_event_decode(3)
 
 NAME
 ----
-flux_event_decode, flux_event_unpack, flux_event_encode, flux_event_pack - encode/decode a Flux event message
+flux_event_decode, flux_event_decode_raw, flux_event_unpack, flux_event_encode, flux_event_encode_raw, flux_event_pack - encode/decode a Flux event message
 
 
 SYNOPSIS
@@ -16,12 +16,19 @@ SYNOPSIS
                         const char **topic,
                         const char **json_str);
 
+ int flux_event_decode_raw (const flux_msg_t *msg,
+                            const char **topic,
+                            const void **data, int *len);
+
  int flux_event_unpack (const flux_msg_t *msg,
                         const char **topic,
                         const char *fmt, ...);
 
  flux_msg_t *flux_event_encode (const char *topic,
                                 const char *json_str);
+
+ flux_msg_t *flux_event_encode_raw (const char *topic,
+                                    const void *data, int len);
 
  flux_msg_t *flux_event_pack (const char *topic,
                               const char *fmt, ...);
@@ -39,6 +46,10 @@ _json_str_, if non-NULL, will be set to the message's JSON payload. If
 no payload exists, _json_str_ is set to NULL.  The storage for this
 string belongs to _msg_ and should not be freed.
 
+`flux_event_decode_raw()` decodes an event message with a raw payload,
+setting _data_ and _len_ to the payload data and length.  The storage for
+the raw payload belongs to _msg_ and should not be freed.
+
 `flux_event_unpack()` decodes a Flux event message with a JSON payload as
 above, parsing the payload using variable arguments with a format string
 in the style of jansson's `json_unpack()` (used internally). Decoding fails
@@ -47,6 +58,10 @@ if the message doesn't have a JSON payload.
 `flux_event_encode()` encodes a Flux event message with topic string _topic_
 and optional JSON payload _json_str_.  The newly constructed message that
 is returned must be destroyed with `flux_msg_destroy()`.
+
+`flux_event_encode_raw()` encodes a Flux event message with topic
+string _topic_.  If _data_ is non-NULL, its contents will be used as
+the message payload, and the payload type set to raw.
 
 `flux_event_pack()` encodes a Flux event message with a JSON payload as
 above, encoding the payload using variable arguments with a format string

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -34,6 +34,20 @@ flux_msg_t *flux_event_encode (const char *topic, const char *json_str);
  */
 flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...);
 
+/* Encode an event message with optional raw payload.
+ */
+flux_msg_t *flux_event_encode_raw (const char *topic,
+                                   const void *data, int len);
+
+/* Decode an event message, with optional raw payload.
+ * If topic is non-NULL, assign the event topic string.
+ * Data and len must be non-NULL and will be assigned the payload and length.
+ * If there is no payload, they will be assigned NULL and zero.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_event_decode_raw (const flux_msg_t *msg, const char **topic,
+                           const void **data, int *len);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR fills in some gaps noted in #1474, adding:

Functions for encoding/decoding events with raw payloads:
```c
/* Encode an event message with optional raw payload.
 */
flux_msg_t *flux_event_encode_raw (const char *topic,
                                   const void *data, int len);

/* Decode an event message, with optional raw payload.
 * If topic is non-NULL, assign the event topic string.
 * Data and len must be non-NULL and will be assigned the payload and length.
 * If there is no payload, they will be assigned NULL and zero.
 * Returns 0 on success, or -1 on failure with errno set.
 */
int flux_event_decode_raw (const flux_msg_t *msg, const char **topic,
                           const void **data, int *len);
```

Functions for encoding and sending events in one go:
```c
/* Send an event message with no confirmation of acceptance by broker.
 * Flags may include FLUX_MSGFLAG_PRIVATE to restrict access to instance owner.
 * If json_str is non-NULL, it is copied to the message payload.
 * Returns 0 on success, or -1 on failure with errno set.
 */
int flux_publish (flux_t *h, int flags, const char *topic,
                  const char *json_str);

/* Same as flux_publish() except payload is encoded using jansson pack
 * style variable arguments.
 */
int flux_publish_pack (flux_t *h, int flags, const char *topic,
                       const char *fmt, ...);

/* Same as flux_publish() except payload is raw.
 */
int flux_publish_raw (flux_t *h, int flags, const char *topic,
                      const void *data, int len);
```

Man pages and unit tests are updated accordingly.

Some users are converted.

It does not address the need for API function(s) for the `cmb.pub` RPC, so it does not finish #1474.  I thought that was appropriate for another PR.

I still need to add some tests for publishing raw events.