### PR TITLE
libjsc: fix leaks detected by valgrind

### DIFF
--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -121,6 +121,7 @@ static void freectx (void *arg)
     lru_cache_destroy (ctx->kvs_paths);
     zlist_destroy (&(ctx->callbacks));
     flux_msg_handler_delvec (ctx->handlers);
+    free (ctx);
 }
 
 static jscctx_t *getctx (flux_t *h)
@@ -1171,6 +1172,7 @@ static json_object *get_reserve_jcb (flux_t *h, int64_t nj)
                   __FUNCTION__);
         goto done;
     }
+    free (key);
     return jcb;
 
 done:
@@ -1226,6 +1228,7 @@ static json_object *get_submit_jcb (flux_t *h, const flux_msg_t *msg, int64_t nj
         goto error;
     }
 
+    free (key);
     return jcb;
 
 error:


### PR DESCRIPTION
Fix a few minor leaks in jstatctl.c found when running valgrind
with flux-sched sched module loaded:
 * ` get_reserve_jcb` and `get_submit_jcb`: free result of xasprintf()
 * `freectx`: add missing free() for `ctx`