### PR TITLE
libidset: public lib for numerically sorted, non-negative integer sets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -303,6 +303,7 @@ AC_CONFIG_FILES( \
   src/common/libsubprocess/Makefile \
   src/common/libcompat/Makefile \
   src/common/liboptparse/Makefile \
+  src/common/libidset/Makefile \
   src/common/libjobspec/Makefile \
   src/common/libjobspec/flux-jobspec.pc \
   src/common/libtomlc99/Makefile \
@@ -334,6 +335,7 @@ AC_CONFIG_FILES( \
   etc/flux-core.pc \
   etc/flux-pmi.pc \
   etc/flux-optparse.pc \
+  etc/flux-idset.pc \
   etc/flux.service \
   doc/Makefile \
   doc/man1/Makefile \

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -47,7 +47,8 @@ MAN3_FILES_PRIMARY = \
 	flux_kvs_txn_create.3 \
 	flux_kvs_namespace_create.3 \
 	flux_kvs_namespace_list.3 \
-	flux_kvs_set_namespace.3
+	flux_kvs_set_namespace.3 \
+	idset_create.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -148,7 +149,10 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_namespace_itr_next.3 \
 	flux_kvs_namespace_itr_rewind.3 \
 	flux_kvs_namespace_itr_destroy.3 \
-	flux_kvs_get_namespace.3
+	flux_kvs_get_namespace.3 \
+	idset_destroy.3 \
+	idset_encode.3 \
+	idset_decode.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -270,6 +274,9 @@ flux_kvs_namespace_itr_next.3: flux_kvs_namespace_list.3
 flux_kvs_namespace_itr_rewind.3: flux_kvs_namespace_list.3
 flux_kvs_namespace_itr_destroy.3: flux_kvs_namespace_list.3
 flux_kvs_get_namespace.3: flux_kvs_set_namespace.3
+idset_destroy.3: idset_create.3
+idset_encode.3: idset_create.3
+idset_decode.3: idset_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -1,0 +1,119 @@
+idset_create(3)
+===============
+:doctype: manpage
+
+
+NAME
+----
+idset_create, idset_destroy, idset_encode, idset_decode - Manipulate numerically sorted sets of non-negative integers
+
+
+SYNOPSIS
+--------
+#include <flux/idset.h>
+
+struct idset *idset_create (size_t slots, int flags);
+
+void idset_destroy (struct idset *idset);
+
+char *idset_encode (const struct idset *idset, int flags);
+
+struct idset *idset_decode (const char *s);
+
+USAGE
+-----
+
+cc [flags] files -lflux-idset [libraries]
+
+DESCRIPTION
+-----------
+
+An idset is a set of numerically sorted, non-negative integers.
+It is internally represented as a Van Embde Boas (or vEB) tree.
+Functionally it behaves like a bitmap, and has space efficiency
+comparable to a bitmap, but performs operations (insert, delete,
+lookup, findNext, findPrevious) in O(log(m)) time, where pow (2,m)
+is the number of slots in the idset.
+
+`idset_create()` creates an idset.  'slots' specifies the highest
+numbered 'id' it can hold, plus one.  The size is fixed unless
+'flags' specify otherwise (see FLAGS below).
+
+`idset_destroy()` destroys an idset.
+
+`idset_decode ()` creates an idset from a string 's'.  The string may
+have been produced by `idset_encode()`.  It must consist of comma-separated
+non-negative integer id's, and may also contain hyphenated ranges.
+If enclosed in square brackets, the brackets are ignored.  Some examples
+of valid input strings are:
+
+  1,2,5,4
+
+  1-4,7,9-10
+
+  42
+
+  [99-101]
+
+`idset_encode()` creates a string from 'idset'.  The string contains
+a comma-separated list of id's, potentially modified by 'flags'
+(see FLAGS below).
+
+FLAGS
+-----
+
+IDSET_FLAG_AUTOGROW::
+Valid for `idset_create()` only.  If set, the idset will grow to
+accommodate any id inserted into it. The internal vEB tree is doubled
+in size until until the new id can be inserted.  Resizing is a costly
+operation that requires all id's in the old tree to be inserted into
+the new one.
+
+IDSET_FLAG_BRACKETS::
+Valid for `idset_encode()` only.  If set, the encoded string will be
+enclosed in brackets, unless the idset is a singleton (contains only
+one id).
+
+IDSET_FLAG_RANGE::
+Valid for `idset_encode()` only.  If set, any consecutive id's are
+compressed into hyphenated ranges in the encoded string.
+
+RETURN VALUE
+------------
+
+`idset_create()` and `idset_encode()` return an idset on success
+which must be freed with `idset_destroy()`.  On error, NULL is
+returned with errno set.
+
+`idset_decode()` returns a string on success which must be freed
+with `free()`.  On error, NULL is returned with errno set.
+
+ERRORS
+------
+
+EINVAL::
+One or more arguments were invalid.
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux-dmesg(1), flux-logger(1),
+https://tools.ietf.org/html/rfc5424[RFC 5424 The Syslog Protocol]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -411,3 +411,11 @@ EOVERFLOW
 itr
 JOBIDS
 ns
+Embde
+idset
+AUTOGROW
+findNext
+findPrevious
+vEB
+lflux
+resizing

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -35,7 +35,7 @@ clean-local:
 	-rm -rf flux
 
 if WITH_PKG_CONFIG
-pkgconfig_DATA = flux-core.pc flux-pmi.pc flux-optparse.pc
+pkgconfig_DATA = flux-core.pc flux-pmi.pc flux-optparse.pc flux-idset.pc
 endif
 
 EXTRA_DIST = \

--- a/etc/flux-idset.pc.in
+++ b/etc/flux-idset.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: flux-core
+Description: Flux Resource Manager ID Set Library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lflux-idset
+Cflags: -I${includedir}

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -11,6 +11,7 @@ SUBDIRS = libtap \
 	  libsubprocess \
 	  libcompat \
 	  liboptparse \
+	  libidset \
 	  libtomlc99 \
 	  libkz
 
@@ -41,7 +42,7 @@ libflux_internal_la_LIBADD = \
 	$(LIBDL) $(LIBRT)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
-lib_LTLIBRARIES = libflux-core.la libflux-optparse.la
+lib_LTLIBRARIES = libflux-core.la libflux-optparse.la libflux-idset.la
 if ENABLE_JOBSPEC
 lib_LTLIBRARIES += libflux-jobspec.la
 endif
@@ -65,6 +66,15 @@ libflux_optparse_la_LIBADD = \
 	$(ZMQ_LIBS) $(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libflux-optparse.map \
+	-shared -export-dynamic --disable-static \
+	$(san_ld_zdef_flag)
+
+libflux_idset_la_SOURCES =
+libflux_idset_la_LIBADD = \
+	$(builddir)/libidset/libidset.la \
+	$(builddir)/libutil/veb.lo
+libflux_idset_la_LDFLAGS = \
+        -Wl,--version-script=$(srcdir)/libflux-idset.map \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
 
@@ -93,4 +103,9 @@ libpmi2_la_LDFLAGS = \
 	$(san_ld_zdef_flag)
 
 
-EXTRA_DIST = libflux-core.map libflux-optparse.map libpmi.map libpmi2.map
+EXTRA_DIST = \
+	libflux-core.map \
+	libflux-optparse.map \
+	libflux-idset.map \
+	libpmi.map \
+	libpmi2.map

--- a/src/common/libflux-idset.map
+++ b/src/common/libflux-idset.map
@@ -1,0 +1,5 @@
+{ global:
+    idset_*;
+    local: *;
+};
+

--- a/src/common/libidset/Makefile.am
+++ b/src/common/libidset/Makefile.am
@@ -1,0 +1,20 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(ZMQ_CFLAGS)
+
+noinst_LTLIBRARIES = libidset.la
+fluxinclude_HEADERS = idset.h
+libidset_la_SOURCES = idset.c
+
+libidset_la_CPPFLAGS = \
+	$(AM_CPPFLAGS)
+libidset_la_LDFLAGS = \
+	-avoid-version -module -shared -export-dynamic \
+	$(AM_LDFLAGS)

--- a/src/common/libidset/Makefile.am
+++ b/src/common/libidset/Makefile.am
@@ -18,3 +18,19 @@ libidset_la_CPPFLAGS = \
 libidset_la_LDFLAGS = \
 	-avoid-version -module -shared -export-dynamic \
 	$(AM_LDFLAGS)
+
+
+TESTS = test_idset.t
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_idset_t_SOURCES = test/idset.c
+test_idset_t_CPPFLAGS = $(AM_CPPFLAGS)
+test_idset_t_LDADD = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libidset/libidset.la \
+	$(top_builddir)/src/common/libutil/libutil.la

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -1,0 +1,333 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* idset - a set of numerically sorted, non-negative integers */
+
+/* Implemented as a wrapper around a Van Emde Boas tree.
+ * T.D is data; T.M is size
+ * All ops are O(log m), for key bitsize m: 2^m == T.M.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "src/common/libutil/veb.h"
+
+#include "idset.h"
+
+#define IDSET_MAGIC 0xf00f0ee1
+struct idset {
+    int magic;
+    Veb T;
+    int flags;
+};
+
+#define ENCODE_CHUNK 1024
+
+struct idset *idset_create (size_t slots, int flags)
+{
+    struct idset *idset;
+
+    if (slots == 0 || (flags & ~IDSET_FLAG_AUTOGROW) != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(idset = malloc (sizeof (*idset))))
+        return NULL;
+    idset->magic = IDSET_MAGIC;
+    idset->T = vebnew (slots, 0);
+    if (!idset->T.D) {
+        free (idset);
+        errno = ENOMEM;
+        return NULL;
+    }
+    idset->flags = flags;
+    return idset;
+}
+
+void idset_destroy (struct idset *idset)
+{
+    if (idset) {
+        idset->magic = ~IDSET_MAGIC;
+        free (idset->T.D);
+        free (idset);
+    }
+}
+
+/* Format a string like printf, then append it to *s.
+ * The allocated size of '*s' is '*sz'.
+ * The current string length of '*s' is '*len'.
+ * Grow *s by ENCODE_CHUNK to allow new string to be appended.
+ * Returns 0 on success, -1 on failure with errno = ENOMEM.
+ */
+static int catprintf (char **s, int *sz, int *len, const char *fmt, ...)
+{
+    va_list ap;
+    char *ns;
+    int nlen;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = vasprintf (&ns, fmt, ap);
+    va_end (ap);
+    if (rc < 0)
+        return -1;
+    nlen = strlen (ns);
+
+    while (*len + nlen + 1 > *sz) {
+        int nsz = *sz + ENCODE_CHUNK;
+        char *p;
+        if (!(p = realloc (*s, nsz)))
+            goto error;
+        if (*s == NULL)
+            *p = '\0';
+        *s = p;
+        *sz = nsz;
+    }
+    strcat (*s, ns);
+    *len += nlen;
+    free (ns);
+    return 0;
+error:
+    free (ns);
+    errno = ENOMEM;
+    return -1;
+}
+
+static int catrange (char **s, int *sz, int *len,
+                     int lo, int hi, const char *sep)
+{
+    int rc;
+    if (lo == hi)
+        rc = catprintf (s, sz, len, "%d%s", lo, sep);
+    else
+        rc = catprintf (s, sz, len, "%d-%d%s", lo, hi, sep);
+    return rc;
+}
+
+static int encode_ranged (const struct idset *idset,
+                          char **s, int *sz, int *len)
+{
+    int count = 0;
+    int id;
+    int lo = 0;
+    int hi = 0;
+    bool first = true;
+
+    lo = hi = id = vebsucc (idset->T, 0);
+    while (id < idset->T.M) {
+        int next = vebsucc (idset->T, id + 1);;
+        bool last = (next == idset->T.M);
+
+        if (first)                  // first iteration
+            first = false;
+        else if (id == hi + 1)      // id is in range
+            hi++;
+        else {                      // id is NOT in range
+            if (catrange (s, sz, len, lo, hi, ",") < 0)
+                return -1;
+            lo = hi = id;
+        }
+        if (last) {                 // last iteration
+            if (catrange (s, sz, len, lo, hi, last ? "" : ",") < 0)
+                return -1;
+        }
+        count++;
+        id = next;
+    }
+    return count;
+}
+
+static int encode_simple (const struct idset *idset,
+                          char **s, int *sz, int *len)
+{
+    int count = 0;
+    int id;
+
+    id = vebsucc (idset->T, 0);
+    while (id != idset->T.M) {
+        int next = vebsucc (idset->T, id + 1);
+        char *sep = next == idset->T.M ? "" : ",";
+        if (catprintf (s, sz, len, "%d%s", id, sep) < 0)
+            return -1;
+        count++;
+        id = next;
+    }
+    return count;
+}
+
+char *idset_encode (const struct idset *idset, int flags)
+{
+    char *str = NULL;
+    int strsz = 0;
+    int strlength = 0;
+    int count;
+
+    if (!idset || idset->magic != IDSET_MAGIC
+               || (flags & ~(IDSET_FLAG_BRACKETS | IDSET_FLAG_RANGE)) != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if ((flags & IDSET_FLAG_BRACKETS)) {    // add open brace, if requested
+        if (catprintf (&str, &strsz, &strlength, "[") < 0)
+            goto error;
+    }
+    if ((flags & IDSET_FLAG_RANGE))
+        count = encode_ranged (idset, &str, &strsz, &strlength);
+    else
+        count = encode_simple (idset, &str, &strsz, &strlength);
+    if (count < 0)
+        goto error;
+    if ((flags & IDSET_FLAG_BRACKETS) && count > 1) { // add close brace
+        if (catprintf (&str, &strsz, &strlength, "]") < 0)
+            goto error;
+    }
+    if (!str) {
+        if (!(str = strdup ("")))
+            goto error;
+    }
+    if (count <= 1 && str[0] == '[')        // no braces for singletons
+        memmove (str, str + 1, strlength);  // moves '\0' too
+    return str;
+error:
+    free (str);
+    errno = ENOMEM;
+    return NULL;
+}
+
+/* Grow idset to next power of 2 size that has at least 'slots' slots.
+ * Return 0 on success, -1 on failure with errno == ENOMEM.
+ */
+static int idset_grow (struct idset *idset, int slots)
+{
+    int newsize = idset->T.M;
+    Veb T;
+    int id;
+
+    while (newsize <= slots)
+        newsize <<= 1;
+
+    if (newsize > idset->T.M) {
+        T = vebnew (newsize, 0);
+        if (!T.D)
+            return -1;
+
+        id = vebsucc (idset->T, 0);
+        while (id < idset->T.M) {
+            vebput (T, id);
+            id = vebsucc (idset->T, id + 1);
+        }
+        free (idset->T.D);
+        idset->T = T;
+    }
+    return 0;
+}
+
+static int idset_set (struct idset *idset, int id)
+{
+    if (idset_grow (idset, id + 1) < 0)
+        return -1;
+    vebput (idset->T, id);
+    return 0;
+}
+
+static int parse_range (const char *s, int *hi, int *lo)
+{
+    char *endptr;
+    int h, l;
+
+    h = l = strtoul (s, &endptr, 10);
+    if (endptr == s || (*endptr != '\0' && *endptr != '-'))
+        return -1;
+    if (*endptr == '-') {
+        s = endptr + 1;
+        h = strtoul (s, &endptr, 10);
+        if (endptr == s || *endptr != '\0')
+            return -1;
+    }
+    *hi = h;
+    *lo = l;
+    return 0;
+}
+
+static char *trim_brackets (char *s)
+{
+    char *p = s;
+    if (*p == '[')
+        p++;
+    int len = strlen (p);
+    if (len > 0 && p[len - 1] == ']')
+        p[len - 1] = '\0';
+    return p;
+}
+
+struct idset *idset_decode (const char *str)
+{
+    struct idset *idset;
+    char *cpy = NULL;
+    char *tok, *saveptr, *a1;
+    int saved_errno;
+
+    if (!str) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(idset = idset_create (1024, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+    if (!(cpy = strdup (str)))
+        goto error;
+    a1 = trim_brackets (cpy);
+    saveptr = NULL;
+    while ((tok = strtok_r (a1, ",", &saveptr))) {
+        int hi, lo, i;
+        if (parse_range (tok, &hi, &lo) < 0)
+            goto inval;
+        for (i = hi; i >= lo; i--) {
+            if (idset_set (idset, i) < 0)
+                goto error;
+        }
+        a1 = NULL;
+    }
+    free (cpy);
+    return idset;
+inval:
+    errno = EINVAL;
+error:
+    saved_errno = errno;
+    idset_destroy (idset);
+    free (cpy);
+    errno = saved_errno;
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -1,0 +1,38 @@
+#ifndef _IDSET_H
+#define _IDSET_H
+
+#include <sys/types.h>
+
+/* An idset is a numerically sorted set of non-negative integers  (0,1,2,3...).
+ */
+
+enum idset_flags {
+    IDSET_FLAG_AUTOGROW = 1, // allow idset to automatically grow beyond 'slots'
+    IDSET_FLAG_BRACKETS = 2, // encode non-singleton idset with brackets
+    IDSET_FLAG_RANGE = 4,    // encode with ranges ("2,3,4,8" -> "2-4,8")
+};
+
+/* Create/destroy an idset.
+ * Set the initial number of slots to 'slots'.
+ * 'flags' may include IDSET_FLAG_AUTOGROW.
+ * Returns idset on success, or NULL on failure with errno set.
+ */
+struct idset *idset_create (size_t slots, int flags);
+void idset_destroy (struct idset *idset);
+
+/* Encode 'idset' to a string, which the caller must free.
+ * 'flags' may include IDSET_FLAG_BRACKETS, IDSET_FLAG_RANGE.
+ * Returns string on success, or NULL on failure with errno set.
+ */
+char *idset_encode (const struct idset *idset, int flags);
+
+/* Decode string 's' to an idset.
+ * Returns idset on success, or NULL on failure with errno set.
+ */
+struct idset *idset_decode (const char *s);
+
+#endif /* !_IDSET_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -1,0 +1,159 @@
+#include <errno.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libidset/idset.h"
+
+struct inout {
+    const char *in;
+    int flags;
+    const char *out;
+};
+
+struct inout test_inputs[] = {
+    { "2",              0,          "2" },
+    { "7-9",            0,          "7,8,9" },
+    { "1,7-9",          0,          "1,7,8,9" },
+    { "1,7-9,16",       0,          "1,7,8,9,16" },
+    { "1,7-9,14,16",    0,          "1,7,8,9,14,16" },
+    { "1-3,7-9,14,16",  0,          "1,2,3,7,8,9,14,16" },
+    { "3,2,4,5",        0,          "2,3,4,5" },
+    { "",               0,          ""},
+    { "1048576",        0,          "1048576"},
+
+    { "[2]",            0,          "2" },
+    { "[7-9]",          0,          "7,8,9" },
+    { "[3,2,4,5]",      0,          "2,3,4,5" },
+    { "[]",             0,          ""},
+
+    { "2",              IDSET_FLAG_RANGE,  "2" },
+    { "7-9",            IDSET_FLAG_RANGE,  "7-9" },
+    { "1,7-9",          IDSET_FLAG_RANGE,  "1,7-9" },
+    { "1,7-9,16",       IDSET_FLAG_RANGE,  "1,7-9,16" },
+    { "1,7-9,14,16",    IDSET_FLAG_RANGE,  "1,7-9,14,16" },
+    { "1-3,7-9,14,16",  IDSET_FLAG_RANGE,  "1-3,7-9,14,16" },
+    { "3,2,4,5",        IDSET_FLAG_RANGE,  "2-5" },
+    { "",               IDSET_FLAG_RANGE,  ""},
+
+    { "2",             IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "2" },
+    { "7-9",           IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[7-9]" },
+    { "1,7-9",         IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1,7-9]" },
+    { "1,7-9,16",      IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1,7-9,16]" },
+    { "1,7-9,14,16",   IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1,7-9,14,16]" },
+    { "1-3,7-9,14,16", IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1-3,7-9,14,16]"},
+    { "3,2,4,5",       IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[2-5]" },
+    { "",              IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, ""},
+
+    { NULL, 0, NULL },
+};
+
+void test_basic (void)
+{
+    struct idset *idset;
+
+    idset = idset_create (100, 0);
+    ok (idset != NULL,
+        "idset_create works");
+
+    idset_destroy (idset);
+}
+
+void test_codec (void)
+{
+    struct inout *ip;
+
+    for (ip = &test_inputs[0]; ip->in != NULL; ip++) {
+        struct idset *idset;
+        char *s;
+
+        idset = idset_decode (ip->in);
+        ok (idset != NULL,
+            "idset_decode '%s' works", ip->in);
+        s = idset_encode (idset, ip->flags);
+        bool match = (s == NULL && ip->out == NULL)
+                  || (s && ip->out && !strcmp (s, ip->out));
+        ok (match == true,
+            "idset_encode flags=0x%x '%s' works",
+            ip->flags, ip->out ? ip->out : "NULL");
+        if (!match)
+            diag ("%s", s ? s : "NULL");
+        free (s);
+        idset_destroy (idset);
+    }
+}
+
+/* Try a big one to cover encode buffer growth */
+void test_codec_large (void)
+{
+    struct idset *idset;
+    char *s;
+
+    idset = idset_decode ("0-1023");
+    ok (idset != NULL,
+        "idset_decode '0-1023' works");
+    s = idset_encode (idset, 0);
+    int count = 0;
+    if (s) {
+        char *a1 = s;
+        char *tok;
+        char *saveptr;
+        while ((tok = strtok_r (a1, ",", &saveptr))) {
+            int i = strtol (tok, NULL, 10);
+            if (i != count)
+                break;
+            count++;
+            a1 = NULL;
+        }
+    }
+    ok (count == 1024,
+        "idset_encode flags=0x0 '0,2,3,...,1023' works");
+    if (count != 1024)
+        diag ("count=%d", count);
+    free (s);
+    idset_destroy (idset);
+}
+
+void test_badparam (void)
+{
+    struct idset *idset;
+
+    if (!(idset = idset_create (100, 0)))
+        BAIL_OUT ("idset_create failed");
+
+    errno = 0;
+    ok (idset_create (0, 0) == NULL && errno == EINVAL,
+        "idset_create(slots=0) fails with EINVAL");
+    errno = 0;
+    ok (idset_create (1000, IDSET_FLAG_BRACKETS) == NULL && errno == EINVAL,
+        "idset_create(flags=wrong) fails with EINVAL");
+
+
+    errno = 0;
+    ok (idset_encode (NULL, 0) == NULL && errno == EINVAL,
+        "idset_encode(idset=NULL) fails with EINVAL");
+    errno = 0;
+    ok (idset_encode (idset, IDSET_FLAG_AUTOGROW) == NULL && errno == EINVAL,
+        "idset_encode(flags=wrong) fails with EINVAL");
+    errno = 0;
+    ok (idset_decode (NULL) == NULL && errno == EINVAL,
+        "idset_decode(s=NULL) fails with EINVAL");
+
+    idset_destroy (idset);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_basic ();
+    test_badparam ();
+    test_codec ();
+    test_codec_large ();
+
+    done_testing ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
As discussed in #1496, this adds a new library that contains a minimal subset of the libutil/nodeset class, cleaned up and reworked for public consumption.

@dongahn, you might give this a try in flux-framework/flux-sched#330, e.g.
```c
#include <flux/idset.h>

struct idset *idset = idset_decode (s_in);
if (!idset)
    // handle error
char *s_out = idset_encode (idset, IDSET_FLAG_RANGE);
if (!s_out)
    // handle error
// do something with s_out, a range-compressed version of s_in
free (s_out);
idset_destroy (idset);
```