### PR TITLE
[cleanup] partial migration from json-c to jansson

### DIFF
--- a/doc/man3/tmrpc_then.c
+++ b/doc/man3/tmrpc_then.c
@@ -1,36 +1,28 @@
+#include <inttypes.h>
 #include <flux/core.h>
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/log.h"
 
 void get_rank (flux_mrpc_t *mrpc, void *arg)
 {
-    const char *json_str;
-    json_object *o;
     const char *rank;
     uint32_t nodeid;
 
     if (flux_mrpc_get_nodeid (mrpc, &nodeid) < 0)
         log_err_exit ("flux_mrpc_get_nodeid");
-    if (flux_mrpc_get (mrpc, &json_str) < 0)
+    if (flux_mrpc_get_unpack (mrpc, "{s:s}", "value", &rank) < 0)
         log_err_exit ("flux_mrpc_get");
-    if (!json_str
-        || !(o = Jfromstr (json_str))
-        || !Jget_str (o, "value", &rank))
-        log_msg_exit ("response protocol error");
     printf ("[%" PRIu32 "] rank is %s\n", nodeid, rank);
-    Jput (o);
 }
 
 int main (int argc, char **argv)
 {
     flux_t *h;
     flux_mrpc_t *mrpc;
-    json_object *o = Jnew();
 
-    Jadd_str (o, "name", "rank");
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
-    if (!(mrpc = flux_mrpc (h, "attr.get", Jtostr (o), "all", 0)))
+    if (!(mrpc = flux_mrpc_pack (h, "attr.get", "all", 0,
+				 "{s:s}", "name", "rank")))
         log_err_exit ("flux_mrpc");
     if (flux_mrpc_then (mrpc, get_rank, NULL) < 0)
         log_err_exit ("flux_mrpc_then");
@@ -39,6 +31,5 @@ int main (int argc, char **argv)
 
     flux_mrpc_destroy (mrpc);
     flux_close (h);
-    Jput (o);
     return (0);
 }

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -33,7 +33,6 @@
 #include <inttypes.h>
 
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/shortjson.h"
 
 
 #define OPTIONS "+hr:"

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -40,7 +40,6 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/environment.h"
 
 #include "cmdhelp.h"

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -1,7 +1,6 @@
 #include <argz.h>
 #include <flux/core.h>
 
-#include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libtap/tap.h"
 

--- a/src/common/libsubprocess/test/loop.c
+++ b/src/common/libsubprocess/test/loop.c
@@ -29,8 +29,6 @@
 #include <czmq.h>
 #include <flux/core.h>
 
-#include "src/common/libjson-c/json.h"
-
 #include "tap.h"
 #include "subprocess.h"
 

--- a/src/common/libsubprocess/test/socketpair.c
+++ b/src/common/libsubprocess/test/socketpair.c
@@ -29,7 +29,6 @@
 #include <czmq.h>
 #include <flux/core.h>
 
-#include "src/common/libjson-c/json.h"
 #include "tap.h"
 #include "subprocess.h"
 

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -25,7 +25,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
-#include "src/common/libjson-c/json.h"
 
 #include "tap.h"
 #include "subprocess.h"

--- a/src/common/libsubprocess/test/zio.c
+++ b/src/common/libsubprocess/test/zio.c
@@ -32,7 +32,6 @@
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
-#include "src/common/libjson-c/json.h"
 
 #include "zio.h"
 

--- a/src/common/libutil/tstat.c
+++ b/src/common/libutil/tstat.c
@@ -27,7 +27,6 @@
 #endif
 #include <math.h>
 
-#include "shortjson.h"
 #include "tstat.h"
 #include "log.h"
 

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -44,7 +44,7 @@ static t_req_ctx_t *getctx (flux_t *h)
         ctx->clog_requests = zlist_new ();
         if (!ctx->clog_requests || !ctx->ping_requests) {
             saved_errno = ENOMEM;
-            goto error; 
+            goto error;
         }
         if (flux_get_rank (h, &ctx->rank) < 0) {
             saved_errno = errno;


### PR DESCRIPTION
This PR converts a number of residual users of json-c over to jansson.  This is mostly the small stuff.

I skipped wreck/job.c because I think @grondo has already fixed that one offline.

The remaining areas in flux-core that still use json-c are:
* ./src/modules/wreck/wrexecd.c
* ./src/modules/aggregator/aggregator.c
* ./src/common/libjsc/jstatctl.c
* ./src/bindings/lua/flux-lua.c
* ./src/bindings/lua/json-lua.c
