### PR TITLE
libflux: add flux_future_reset()

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -116,6 +116,7 @@ MAN3_FILES_SECONDARY = \
 	flux_log_set_appname.3 \
 	flux_log_set_procid.3 \
 	flux_future_wait_for.3 \
+	flux_future_reset.3 \
 	flux_future_destroy.3 \
 	flux_future_get.3 \
 	flux_future_fulfill.3 \
@@ -238,6 +239,7 @@ flux_content_store_get.3: flux_content_load.3
 flux_vlog.3: flux_log.3
 flux_log_set_appname.3: flux_log.3
 flux_log_set_procid.3: flux_log.3
+flux_future_reset.3: flux_future_get.3
 flux_future_destroy.3: flux_future_get.3
 flux_future_wait_for.3: flux_future_get.3
 flux_future_then.3: flux_future_get.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -40,7 +40,7 @@ MAN3_FILES_PRIMARY = \
 	flux_request_encode.3 \
 	flux_content_load.3 \
 	flux_log.3 \
-	flux_future_then.3 \
+	flux_future_get.3 \
 	flux_future_create.3 \
 	flux_kvs_lookup.3 \
 	flux_kvs_commit.3 \
@@ -238,9 +238,9 @@ flux_content_store_get.3: flux_content_load.3
 flux_vlog.3: flux_log.3
 flux_log_set_appname.3: flux_log.3
 flux_log_set_procid.3: flux_log.3
-flux_future_destroy.3: flux_future_then.3
-flux_future_wait_for.3: flux_future_then.3
-flux_future_get.3: flux_future_then.3
+flux_future_destroy.3: flux_future_get.3
+flux_future_wait_for.3: flux_future_get.3
+flux_future_then.3: flux_future_get.3
 flux_future_fulfill.3: flux_future_create.3
 flux_future_fulfill_error.3: flux_future_create.3
 flux_future_aux_set.3: flux_future_create.3

--- a/doc/man3/flux_content_load.adoc
+++ b/doc/man3/flux_content_load.adoc
@@ -132,6 +132,6 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 ---------
-flux_rpc(3), flux_future_then(3)
+flux_rpc(3), flux_future_get(3)
 
 https://github.com/flux-framework/rfc/blob/master/spec_10.adoc[RFC 10: Content Storage Service]

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -39,12 +39,14 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
+See `flux_future_get(3)` for general functions that operate on futures.
+This page covers functions primarily used when building classes that
+return futures.
+
 A Flux future represents some activity that may be completed with reactor
 watchers and/or message handlers.  It is intended to be returned by other
 classes as a handle for synchronization and a container for results.
 This page describes the future interfaces used by such classes.
-Class users and users seeking an introduction to Flux futures are referred
-to `flux_future_then(3)`.
 
 A class that returns a future usually provides a creation function
 that internally calls `flux_future_create()`, and may provide functions
@@ -182,4 +184,4 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 ---------
-flux_future_create(3), flux_clone(3)
+flux_future_get(3), flux_clone(3)

--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -5,7 +5,7 @@ flux_future_get(3)
 
 NAME
 ----
-flux_future_get, flux_future_then, flux_future_wait_for, flux_future_destroy - synchronize an activity
+flux_future_get, flux_future_then, flux_future_wait_for, flux_future_reset, flux_future_destroy - synchronize an activity
 
 
 SYNOPSIS
@@ -20,6 +20,8 @@ SYNOPSIS
                        flux_continuation_f cb, void *arg);
 
  int flux_future_wait_for (flux_future_t *f, double timeout);
+
+ void flux_future_reset (flux_future_t *f);
 
  void flux_future_destroy (flux_future_t *f);
 
@@ -58,13 +60,13 @@ derived from that).
 
 The continuation will normally use `flux_future_get()` or a class-specific
 access function to obtain the result from the future container without
-blocking.  `flux_future_then()` may only be called once on a given future.
-It is not an error to set up a continuation on a future that has already
-been fulfilled.  If _timeout_ is non-negative, the future must be fulfilled
-within the specified amount of time or the timeout fulfills it with an error
-(errno set to ETIMEDOUT).  The reactor must be run or re-entered in order
-for the timer and the future activity to make progress.  It is safe to
-destroy the future from within the continuation callback.
+blocking.  The continuation may call `flux_future_destroy()` or
+`flux_future_reset()`.  It is not an error to set up a continuation on
+a future that has already been fulfilled.  If _timeout_ is non-negative,
+the future must be fulfilled within the specified amount of time or the
+timeout fulfills it with an error (errno set to ETIMEDOUT).  The reactor
+must be run or re-entered in order for the timer and the future activity
+to make progress.
 
 `flux_future_wait_for()` blocks until the future is fulfilled, or _timeout_
 (if non-negative) expires.  This function may be called multiple times,
@@ -75,6 +77,13 @@ make progress while `flux_future_wait_for()` is executing, unless _timeout_
 is zero, in which case the function times out immediately if the future
 has not already been fulfilled.  While `flux_future_wait_for()` is executing,
 unrelated reactor watchers and message handlers are not active.
+
+`flux_future_reset()` unfulfills a future, invalidating any result stored
+in the container, and preparing it to be fulfilled once again.  If a
+continuation was registered, it remains in effect for the next fulfillment,
+however any timeout will have been cleared by the current fulfillment
+and must be re-established by following the `flux_future_reset()` with
+another `flux_future_then()`, if desired. 
 
 `flux_future_destroy()` destroys a future, including any result contained
 within.

--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -49,34 +49,23 @@ DESCRIPTION
 future is not yet fulfilled, it calls `flux_future_wait_for()` internally
 with a negative _timeout_, causing it to block until the future is fulfilled.
 A pointer to the result is assigned to _result_ (caller must NOT free),
-or -1 is returned if the future was fulfilled with an error.  Often this
-function is wrapped with a class-specific result access function.
+or -1 is returned if the future was fulfilled with an error.
 
 `flux_future_then()` sets up a continuation callback _cb_ that is called
 with opaque argument _arg_ once the future is fulfilled.  The continuation
-is registered on the reactor passed to a class-specific create function
-(some create functions accept a flux_t handle, and the reactor is
-derived from that).
-
-The continuation will normally use `flux_future_get()` or a class-specific
-access function to obtain the result from the future container without
-blocking.  The continuation may call `flux_future_destroy()` or
-`flux_future_reset()`.  It is not an error to set up a continuation on
-a future that has already been fulfilled.  If _timeout_ is non-negative,
-the future must be fulfilled within the specified amount of time or the
-timeout fulfills it with an error (errno set to ETIMEDOUT).  The reactor
-must be run or re-entered in order for the timer and the future activity
-to make progress.
+will normally use `flux_future_get()` or a class-specific access function
+to obtain the result from the future container without blocking.  The
+continuation may call `flux_future_destroy()` or `flux_future_reset()`.
+If _timeout_ is non-negative, the future must be fulfilled within the
+specified amount of time or the timeout fulfills it with an error (errno
+set to ETIMEDOUT).
 
 `flux_future_wait_for()` blocks until the future is fulfilled, or _timeout_
 (if non-negative) expires.  This function may be called multiple times,
 with different values for _timeout_.  If the timeout expires before
 the future is fulfilled, an error is returned (errno set to ETIMEDOUT)
-but the future remains unfulfilled.  The timer and the future activity can
-make progress while `flux_future_wait_for()` is executing, unless _timeout_
-is zero, in which case the function times out immediately if the future
-has not already been fulfilled.  While `flux_future_wait_for()` is executing,
-unrelated reactor watchers and message handlers are not active.
+but the future remains unfulfilled.  If _timeout_ is zero, function times
+out immediately if the future has not already been fulfilled.
 
 `flux_future_reset()` unfulfills a future, invalidating any result stored
 in the container, and preparing it to be fulfilled once again.  If a

--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -1,33 +1,31 @@
-flux_future_then(3)
-===================
+flux_future_get(3)
+==================
 :doctype: manpage
 
 
 NAME
 ----
-flux_future_then, flux_future_wait_for, flux_future_get, flux_future_destroy - synchronize an activity
+flux_future_get, flux_future_then, flux_future_wait_for, flux_future_destroy - synchronize an activity
 
 
 SYNOPSIS
 --------
  #include <flux/core.h>
 
- typedef struct flux_future flux_future_t;
-
  typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);
+
+ int flux_future_get (flux_future_t *f, void *result);
 
  int flux_future_then (flux_future_t *f, double timeout,
                        flux_continuation_f cb, void *arg);
 
  int flux_future_wait_for (flux_future_t *f, double timeout);
 
- int flux_future_get (flux_future_t *f, void *result);
-
  void flux_future_destroy (flux_future_t *f);
 
 
-DESCRIPTION
------------
+OVERVIEW
+--------
 
 A Flux future represents some activity that may be completed with reactor
 watchers and/or message handlers.  It is both a handle for synchronization
@@ -41,6 +39,16 @@ Generally other Flux classes return futures, and may provide class-specific
 access function for results. The functions described in this page can be
 used to access, synchronize, and destroy futures returned from any such class.
 Authors of classes that return futures are referred to `flux_future_create(3)`.
+
+DESCRIPTION
+-----------
+
+`flux_future_get()` accesses the result of a fulfilled future.  If the
+future is not yet fulfilled, it calls `flux_future_wait_for()` internally
+with a negative _timeout_, causing it to block until the future is fulfilled.
+A pointer to the result is assigned to _result_ (caller must NOT free),
+or -1 is returned if the future was fulfilled with an error.  Often this
+function is wrapped with a class-specific result access function.
 
 `flux_future_then()` sets up a continuation callback _cb_ that is called
 with opaque argument _arg_ once the future is fulfilled.  The continuation
@@ -67,13 +75,6 @@ make progress while `flux_future_wait_for()` is executing, unless _timeout_
 is zero, in which case the function times out immediately if the future
 has not already been fulfilled.  While `flux_future_wait_for()` is executing,
 unrelated reactor watchers and message handlers are not active.
-
-`flux_future_get()` accesses the result of a fulfilled future.  If the
-future is not yet fulfilled, it calls `flux_future_wait_for()` internally
-with a negative _timeout_, causing it to block until the future is fulfilled.
-A pointer to the result is assigned to _result_ (caller must NOT free),
-or -1 is returned if the future was fulfilled with an error.  Often this
-function is wrapped with a class-specific result access function.
 
 `flux_future_destroy()` destroys a future, including any result contained
 within.

--- a/doc/man3/flux_future_then.adoc
+++ b/doc/man3/flux_future_then.adoc
@@ -19,7 +19,7 @@ SYNOPSIS
  int flux_future_then (flux_future_t *f, double timeout,
                        flux_continuation_f cb, void *arg);
 
- int bool flux_future_wait_for (flux_future_t *f, double timeout);
+ int flux_future_wait_for (flux_future_t *f, double timeout);
 
  int flux_future_get (flux_future_t *f, void *result);
 
@@ -85,10 +85,6 @@ RETURN VALUE
 `flux_future_then()`, `flux_future_get()`, and `flux_future_wait_for()`
 return zero on success.  On error, -1 is returned, and errno is set
 appropriately.
-
-`flux_future_check()` returns a boolean result.  If an error occurs,
-it returns true.  A subsequent call to `flux_future_get()` returns
--1 with errno set to the error that occurred during the check.
 
 
 ERRORS

--- a/doc/man3/flux_kvs_commit.adoc
+++ b/doc/man3/flux_kvs_commit.adoc
@@ -116,4 +116,4 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 ---------
-flux_future_then(3), flux_kvs_txn_create(3), flux_kvs_set_namespace(3)
+flux_future_get(3), flux_kvs_txn_create(3), flux_kvs_set_namespace(3)

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -190,7 +190,7 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 ---------
-flux_future_then(3)
+flux_future_get(3)
 
 https://github.com/flux-framework/rfc/blob/master/spec_6.adoc[RFC 6: Flux
 Remote Procedure Call Protocol]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -422,3 +422,4 @@ resizing
 HOSTLIST
 hostlist
 hostnames
+unfulfills

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -23,6 +23,8 @@ int flux_future_then (flux_future_t *f, double timeout,
 
 int flux_future_wait_for (flux_future_t *f, double timeout);
 
+void flux_future_reset (flux_future_t *f);
+
 void flux_future_destroy (flux_future_t *f);
 
 void *flux_future_aux_get (flux_future_t *f, const char *name);


### PR DESCRIPTION
This PR adds `flux_future_reset()`, to "unfulfill" a future.

The driving use case was RPC with multiple response messages.  One can now do this:
```c
flux_future_t *f = flux_rpc (...)
do {
    flux_rpc_get (f, ...);
    flux_future_reset (f);
} while (condition);
flux_future_destroy (f);
```
or in a continuation, one can conditionally call either `flux_future_reset()` or `flux_future_destroy()` before returning.  If reset, the continuation will be called on the next fulfillment (RPC response, or whatever).

Added unit tests and updated man pages.  I reworked the "user" man page a bit for better readability also.

I'd say test coverage might be a little light here, so I'll see how that goes and possibly add more tests.