### PR TITLE
wreck: ensure cancelled jobs are no longer in active job hash

### DIFF
--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -777,7 +777,9 @@ static void wreck_state_cb (flux_t *h, flux_msg_handler_t *w,
             goto error_destroy;
     }
     wreck_job_set_state (job, topic);
-    if (!strcmp (job->state, "complete") || !strcmp (job->state, "failed"))
+    if ( !strcmp (job->state, "complete")
+      || !strcmp (job->state, "failed")
+      || !strcmp (job->state, "cancelled"))
         wreck_job_delete (id, active_jobs);
     return;
 error_destroy:

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -755,10 +755,10 @@ static void wreck_state_cb (flux_t *h, flux_msg_handler_t *w,
 {
     int64_t id;
     const char *topic;
-    const char *kvs_path;
+    const char *kvs_path = NULL;
     struct wreck_job *job;
 
-    if (flux_event_unpack (msg, &topic, "{s:I s:s}",
+    if (flux_event_unpack (msg, &topic, "{s:I s?s}",
                            "jobid", &id,
                            "kvs_path", &kvs_path) < 0)
         goto error;
@@ -771,7 +771,7 @@ static void wreck_state_cb (flux_t *h, flux_msg_handler_t *w,
         if (!(job = wreck_job_create ()))
             goto error;
         job->id = id;
-        if (!(job->kvs_path = strdup (kvs_path)))
+        if (kvs_path && !(job->kvs_path = strdup (kvs_path)))
             goto error_destroy;
         if (wreck_job_insert (job, active_jobs) < 0)
             goto error_destroy;

--- a/t/t2000-wreck-dummy-sched.t
+++ b/t/t2000-wreck-dummy-sched.t
@@ -44,6 +44,19 @@ test_expect_success 'job.submit-nocreate issues correct event' '
 	test_debug "cat output.createonly" &&
 	test_cmp expected.createonly output.createonly
 '
+test_expect_success 'wreck.state.cancelled event removes job from active list' '
+	flux submit hostname &&
+	state=$(flux kvs get "$(last_job_path).state") &&
+	id=$(last_job_id) &&
+	test_debug "echo state of job${id} is now ${state}" &&
+	flux wreck ls -x > ls-x.before &&
+	test_debug "echo Before: ; cat ls-x.before" &&
+	grep -q "^  *${id} " ls-x.before &&
+	flux event pub wreck.state.cancelled "{\"jobid\": ${id}}" &&
+	flux wreck ls -x > ls-x.after &&
+	test_debug "echo After: ; cat ls-x.after" &&
+	test_must_fail grep "^  *${id} " ls-x.after
+'
 test_expect_success 'unload dummy sched module' '
 	flux module remove sched
 '


### PR DESCRIPTION
This is a partial fix of #1504, once flux-framework/flux-sched#334 is closed then the fix will be complete.

I had to relax the requirement for `kvspath` in the wreck.state payload in `wreck_state_cb`, since the scheduler will not easily have access to the kvs path at the time the job is cancelled. This should not be a problem since kvs_path should not be used when processing the terminal state of a job anyway.