### PR TITLE
common/libflux: Add flux_buffer data structure

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -71,7 +71,8 @@ fluxcoreinclude_HEADERS = \
 	heartbeat.h \
 	content.h \
 	future.h \
-	barrier.h
+	barrier.h \
+	buffer.h
 
 noinst_LTLIBRARIES = \
 	libflux.la
@@ -102,7 +103,8 @@ libflux_la_SOURCES = \
 	keepalive.c \
 	content.c \
 	future.c \
-	barrier.c
+	barrier.c \
+	buffer.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \
@@ -118,7 +120,8 @@ TESTS = test_module.t \
 	test_tagpool.t \
 	test_security.t \
 	test_future.t \
-	test_reactor.t
+	test_reactor.t \
+	test_buffer.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
@@ -179,3 +182,7 @@ test_security_t_LDADD = $(test_ldadd) $(LIBDL)
 test_future_t_SOURCES = test/future.c
 test_future_t_CPPFLAGS = $(test_cppflags)
 test_future_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_buffer_t_SOURCES = test/buffer.c
+test_buffer_t_CPPFLAGS = $(test_cppflags)
+test_buffer_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/buffer.c
+++ b/src/common/libflux/buffer.c
@@ -1,0 +1,277 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include "buffer.h"
+
+#include "src/common/liblsd/cbuf.h"
+
+#define FLUX_BUFFER_MAGIC 0xeb4feb4f
+
+struct flux_buffer {
+    int magic;
+    cbuf_t cbuf;
+    void *buf;                  /* internal buffer for user reads */
+    int buflen;
+};
+
+flux_buffer_t *flux_buffer_create (int size)
+{
+    flux_buffer_t *fb = NULL;
+
+    if (size <= 0) {
+        errno = EINVAL;
+        goto cleanup;
+    }
+
+    if (!(fb = calloc (1, sizeof (*fb)))) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+
+    fb->magic = FLUX_BUFFER_MAGIC;
+
+    if (!(fb->cbuf = cbuf_create (size, size)))
+        goto cleanup;
+
+    if (cbuf_opt_set (fb->cbuf, CBUF_OPT_OVERWRITE, CBUF_NO_DROP) < 0)
+        goto cleanup;
+
+    /* +1 for possible NUL on line reads */
+    fb->buflen = size + 1;
+
+    if (!(fb->buf = malloc (fb->buflen))) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+
+    return fb;
+
+cleanup:
+    flux_buffer_destroy (fb);
+    return NULL;
+}
+
+void flux_buffer_destroy (void *data)
+{
+    flux_buffer_t *fb = data;
+    if (fb && fb->magic == FLUX_BUFFER_MAGIC) {
+        fb->magic = ~FLUX_BUFFER_MAGIC;
+        cbuf_destroy (fb->cbuf);
+        free (fb->buf);
+        free (fb);
+    }
+}
+
+int flux_buffer_bytes (flux_buffer_t *fb)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_used (fb->cbuf);
+}
+
+int flux_buffer_drop (flux_buffer_t *fb, int len)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_drop (fb->cbuf, len);
+}
+
+const void *flux_buffer_peek (flux_buffer_t *fb, int len, int *lenp)
+{
+    int ret;
+
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (len < 0)
+        len = cbuf_used (fb->cbuf);
+
+    if (len > fb->buflen)
+        len = fb->buflen;
+
+    if ((ret = cbuf_peek (fb->cbuf, fb->buf, len)) < 0)
+        return NULL;
+
+    if (lenp)
+        (*lenp) = ret;
+
+    return fb->buf;
+}
+
+const void *flux_buffer_read (flux_buffer_t *fb, int len, int *lenp)
+{
+    int ret;
+
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (len < 0)
+        len = cbuf_used (fb->cbuf);
+
+    if (len > fb->buflen)
+        len = fb->buflen;
+
+    if ((ret = cbuf_read (fb->cbuf, fb->buf, len)) < 0)
+        return NULL;
+
+    if (lenp)
+        (*lenp) = ret;
+
+    return fb->buf;
+}
+
+int flux_buffer_write (flux_buffer_t *fb, const void *data, int len)
+{
+    if (!fb
+        || fb->magic != FLUX_BUFFER_MAGIC
+        || !data
+        || len < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_write (fb->cbuf, (void *)data, len, NULL);
+}
+
+int flux_buffer_lines (flux_buffer_t *fb)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_lines_used (fb->cbuf);
+}
+
+int flux_buffer_drop_line (flux_buffer_t *fb)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_drop_line (fb->cbuf, fb->buflen, 1);
+}
+
+const void *flux_buffer_peek_line (flux_buffer_t *fb, int *lenp)
+{
+    int ret;
+
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if ((ret = cbuf_peek_line (fb->cbuf, fb->buf, fb->buflen, 1)) < 0)
+        return NULL;
+
+    if (lenp)
+        (*lenp) = ret;
+
+    return fb->buf;
+}
+
+const void *flux_buffer_read_line (flux_buffer_t *fb, int *lenp)
+{
+    int ret;
+
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if ((ret = cbuf_read_line (fb->cbuf, fb->buf, fb->buflen, 1)) < 0)
+        return NULL;
+
+    if (lenp)
+        (*lenp) = ret;
+
+    return fb->buf;
+}
+
+int flux_buffer_write_line (flux_buffer_t *fb, const char *data)
+{
+    if (!fb
+        || fb->magic != FLUX_BUFFER_MAGIC
+        || !data) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_write_line (fb->cbuf, (char *)data, NULL);
+}
+
+int flux_buffer_peek_to_fd (flux_buffer_t *fb, int fd, int len)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_peek_to_fd (fb->cbuf, fd, len);
+}
+
+int flux_buffer_read_to_fd (flux_buffer_t *fb, int fd, int len)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_read_to_fd (fb->cbuf, fd, len);
+}
+
+int flux_buffer_write_from_fd (flux_buffer_t *fb, int fd, int len)
+{
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return cbuf_write_from_fd (fb->cbuf, fd, len, NULL);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/buffer.h
+++ b/src/common/libflux/buffer.h
@@ -1,0 +1,82 @@
+#ifndef FLUX_BUFFER_H
+#define FLUX_BUFFER_H
+
+typedef struct flux_buffer flux_buffer_t;
+
+/* Create buffer.
+ */
+flux_buffer_t *flux_buffer_create (int size);
+
+void flux_buffer_destroy (void *fb);
+
+/* Returns the number of bytes current stored in flux_buffer */
+int flux_buffer_bytes (flux_buffer_t *fb);
+
+/* Drop up to [len] bytes of data in the buffer. Set [len] to -1
+ * to drop all data.  Returns number of bytes dropped on success.
+ */
+int flux_buffer_drop (flux_buffer_t *fb, int len);
+
+/* Read up to [len] bytes of data in the buffer without consuming it.
+ * Pointer to buffer is returned to user and optionally length read
+ * can be returned to user in [lenp].  User shall not free returned
+ * pointer.  Set [len] to -1 to read all data.
+ */
+const void *flux_buffer_peek (flux_buffer_t *fb, int len, int *lenp);
+
+/* Read up to [len] bytes of data in the buffer and mark data as
+ * consumed.  Pointer to buffer is returned to user and optionally
+ * length read can be returned to user in [lenp].  User shall not free
+ * returned pointer.  Set [len] to -1 to read all data.
+ */
+const void *flux_buffer_read (flux_buffer_t *fb, int len, int *lenp);
+
+/* Write [len] bytes of data into the buffer.  Returns number of bytes
+ * written on success.
+ */
+int flux_buffer_write (flux_buffer_t *fb, const void *data, int len);
+
+/* Determines lines available for peeking/reading.  Returns -1
+ * on error, >= 0 for lines available */
+int flux_buffer_lines (flux_buffer_t *fb);
+
+/* Drop a line in the buffer.  Returns number of bytes dropped on
+ * success. */
+int flux_buffer_drop_line (flux_buffer_t *fb);
+
+/* Read a line in the buffer without consuming it.  Return buffer will
+ * include newline.  Optionally return length of data returned in
+ * [lenp].  Return NULL on error or no line present.
+ */
+const void *flux_buffer_peek_line (flux_buffer_t *fb, int *lenp);
+
+/* Read a line in the buffer and mark data as consumed.  Return buffer
+ * will include newline.  Optionally return length of data returned in
+ * [lenp].  Return NULL on error or no line present.
+ */
+const void *flux_buffer_read_line (flux_buffer_t *fb, int *lenp);
+
+/* Write NUL terminated string data into the buffer and appends a
+ * newline.  Returns number of bytes written on success.
+ */
+int flux_buffer_write_line (flux_buffer_t *fb, const char *data);
+
+/* Read up to [len] bytes from buffer to file descriptor [fd] without
+ * consuming data.  Set [len] to -1 to read all data.  Returns number
+ * of bytes read or -1 on error. */
+int flux_buffer_peek_to_fd (flux_buffer_t *fb, int fd, int len);
+
+/* Read up to [len] bytes from buffer to file descriptor [fd] and mark
+ * data as consumed.  Set [len] to -1 to read all data.  Returns
+ * number of bytes read or -1 on error. */
+int flux_buffer_read_to_fd (flux_buffer_t *fb, int fd, int len);
+
+/* Write up to [len] bytes to buffer from file descriptor [fd].  Set
+ * [len] to -1 to read an appropriate chunk size.  Returns number of
+ * bytes written on success.
+ */
+int flux_buffer_write_from_fd (flux_buffer_t *fb, int fd, int len);
+
+/* FUTURE: append, prepend, printf, add_flux_buffer, etc. */
+
+#endif /* !_FLUX_BUFFER_H */

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -25,6 +25,7 @@
 #include "content.h"
 #include "future.h"
 #include "barrier.h"
+#include "buffer.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/test/buffer.c
+++ b/src/common/libflux/test/buffer.c
@@ -1,0 +1,410 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "src/common/libflux/buffer.h"
+#include "src/common/libtap/tap.h"
+
+#define FLUX_BUFFER_TEST_MAXSIZE 1048576
+
+void basic (void)
+{
+    flux_buffer_t *fb;
+    int pipefds[2];
+    char buf[1024];
+    const char *ptr;
+    int len;
+
+    ok (pipe (pipefds) == 0,
+        "pipe succeeded");
+
+    ok ((fb = flux_buffer_create (FLUX_BUFFER_TEST_MAXSIZE)) != NULL,
+        "flux_buffer_create works");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes initially returns 0");
+
+    /* write & peek tests */
+
+    ok (flux_buffer_write (fb, "foo", 3) == 3,
+        "flux_buffer_write works");
+
+    ok (flux_buffer_bytes (fb) == 3,
+        "flux_buffer_bytes returns length of bytes written");
+
+    ok ((ptr = flux_buffer_peek (fb, 2, &len)) != NULL
+        && len == 2,
+        "flux_buffer_peek with specific length works");
+
+    ok (!memcmp (ptr, "fo", 2),
+        "flux_buffer_peek returns exepected data");
+
+    ok ((ptr = flux_buffer_peek (fb, -1, &len)) != NULL
+        && len == 3,
+        "flux_buffer_peek with length -1 works");
+
+    ok (!memcmp (ptr, "foo", 3),
+        "flux_buffer_peek returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 3,
+        "flux_buffer_bytes returns unchanged length after peek");
+
+    ok (flux_buffer_drop (fb, 2) == 2,
+        "flux_buffer_drop works");
+
+    ok (flux_buffer_bytes (fb) == 1,
+        "flux_buffer_bytes returns length of remaining bytes written");
+
+    ok (flux_buffer_drop (fb, -1) == 1,
+        "flux_buffer_drop drops remaining bytes");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes returns 0 with all bytes dropped");
+
+    /* write and read tests */
+
+    ok (flux_buffer_write (fb, "foo", 3) == 3,
+        "flux_buffer_write works");
+
+    ok (flux_buffer_bytes (fb) == 3,
+        "flux_buffer_bytes returns length of bytes written");
+
+    ok ((ptr = flux_buffer_read (fb, 2, &len)) != NULL
+        && len == 2,
+        "flux_buffer_read with specific length works");
+
+    ok (!memcmp (ptr, "fo", 2),
+        "flux_buffer_read returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 1,
+        "flux_buffer_bytes returns new length after read");
+
+    ok ((ptr = flux_buffer_read (fb, -1, &len)) != NULL
+        && len == 1,
+        "flux_buffer_peek with length -1 works");
+
+    ok (!memcmp (ptr, "o", 1),
+        "flux_buffer_peek returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes returns 0 with all bytes read");
+
+    /* write_line & peek_line tests */
+
+    ok (flux_buffer_lines (fb) == 0,
+        "flux_buffer_lines returns 0 on no line");
+
+    ok (flux_buffer_write_line (fb, "foo") == 4,
+        "flux_buffer_write_line works");
+
+    ok (flux_buffer_bytes (fb) == 4,
+        "flux_buffer_bytes returns length of bytes written");
+
+    ok (flux_buffer_lines (fb) == 1,
+        "flux_buffer_lines returns 1 on line written");
+
+    ok ((ptr = flux_buffer_peek_line (fb, &len)) != NULL
+        && len == 4,
+        "flux_buffer_peek_line works");
+
+    ok (!memcmp (ptr, "foo\n", 4),
+        "flux_buffer_peek_line returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 4,
+        "flux_buffer_bytes returns unchanged length after peek_line");
+
+    ok (flux_buffer_drop_line (fb) == 4,
+        "flux_buffer_drop_line works");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes returns 0 after drop_line");
+
+    ok (flux_buffer_lines (fb) == 0,
+        "flux_buffer_lines returns 0 after drop_line");
+
+    /* write_line & read_line tests */
+
+    ok (flux_buffer_lines (fb) == 0,
+        "flux_buffer_lines returns 0 on no line");
+
+    ok (flux_buffer_write_line (fb, "foo") == 4,
+        "flux_buffer_write_line works");
+
+    ok (flux_buffer_bytes (fb) == 4,
+        "flux_buffer_bytes returns length of bytes written");
+
+    ok (flux_buffer_lines (fb) == 1,
+        "flux_buffer_lines returns 1 on line written");
+
+    ok ((ptr = flux_buffer_read_line (fb, &len)) != NULL
+        && len == 4,
+        "flux_buffer_peek_line works");
+
+    ok (!memcmp (ptr, "foo\n", 4),
+        "flux_buffer_peek_line returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes returns 0 after read_line");
+
+    ok (flux_buffer_lines (fb) == 0,
+        "flux_buffer_lines returns 0 after read_line");
+
+    /* peek_to_fd tests */
+
+    ok (flux_buffer_write (fb, "foo", 3) == 3,
+        "flux_buffer_write works");
+
+    ok (flux_buffer_peek_to_fd (fb, pipefds[1], 2) == 2,
+        "flux_buffer_peek_to_fd specific length works");
+
+    memset (buf, '\0', 1024);
+    ok (read (pipefds[0], buf, 1024) == 2,
+        "read correct number of bytes");
+
+    ok (memcmp (buf, "fo", 2) == 0,
+        "read returned correct data");
+
+    ok (flux_buffer_bytes (fb) == 3,
+        "flux_buffer_bytes returns correct length after peek");
+
+    ok (flux_buffer_peek_to_fd (fb, pipefds[1], -1) == 3,
+        "flux_buffer_peek_to_fd length -1 works");
+
+    memset (buf, '\0', 1024);
+    ok (read (pipefds[0], buf, 1024) == 3,
+        "read correct number of bytes");
+
+    ok (memcmp (buf, "foo", 3) == 0,
+        "read returned correct data");
+
+    ok (flux_buffer_bytes (fb) == 3,
+        "flux_buffer_bytes returns correct length after peek");
+
+    ok (flux_buffer_drop (fb, -1) == 3,
+        "flux_buffer_drop drops remaining bytes");
+
+    /* read_to_fd tests */
+
+    ok (flux_buffer_write (fb, "foo", 3) == 3,
+        "flux_buffer_write works");
+
+    ok (flux_buffer_read_to_fd (fb, pipefds[1], 2) == 2,
+        "flux_buffer_read_to_fd specific length works");
+
+    memset (buf, '\0', 1024);
+    ok (read (pipefds[0], buf, 1024) == 2,
+        "read correct number of bytes");
+
+    ok (memcmp (buf, "fo", 2) == 0,
+        "read returned correct data");
+
+    ok (flux_buffer_bytes (fb) == 1,
+        "flux_buffer_bytes returns correct length after read");
+
+    ok (flux_buffer_read_to_fd (fb, pipefds[1], -1) == 1,
+        "flux_buffer_read_to_fd length -1 works");
+
+    memset (buf, '\0', 1024);
+    ok (read (pipefds[0], buf, 1024) == 1,
+        "read correct number of bytes");
+
+    ok (memcmp (buf, "o", 1) == 0,
+        "read returned correct data");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes returns correct length after read");
+
+    /* write_from_fd and read tests */
+
+    ok (write (pipefds[1], "foo", 3) == 3,
+        "write to pipe works");
+
+    ok (flux_buffer_write_from_fd (fb, pipefds[0], -1) == 3,
+        "flux_buffer_write_from_fd works");
+
+    ok ((ptr = flux_buffer_read (fb, 2, &len)) != NULL
+        && len == 2,
+        "flux_buffer_read with specific length works");
+
+    ok (!memcmp (ptr, "fo", 2),
+        "flux_buffer_read returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 1,
+        "flux_buffer_bytes returns new length after read");
+
+    ok ((ptr = flux_buffer_read (fb, -1, &len)) != NULL
+        && len == 1,
+        "flux_buffer_peek with length -1 works");
+
+    ok (!memcmp (ptr, "o", 1),
+        "flux_buffer_peek returns exepected data");
+
+    ok (flux_buffer_bytes (fb) == 0,
+        "flux_buffer_bytes returns 0 with all bytes read");
+
+    flux_buffer_destroy (fb);
+    close (pipefds[0]);
+    close (pipefds[1]);
+}
+
+void corner_case (void)
+{
+    flux_buffer_t *fb;
+
+    ok (flux_buffer_create (-1) == NULL
+        && errno == EINVAL,
+        "flux_buffer_create fails on bad input -1");
+
+    ok (flux_buffer_create (0) == NULL
+        && errno == EINVAL,
+        "flux_buffer_create fails on bad input 0");
+
+    /* all functions fail on NULL fb pointer */
+    ok (flux_buffer_bytes (NULL) < 0
+        && errno == EINVAL,
+        "flux_buffer_bytes fails on NULL pointer");
+    ok (flux_buffer_drop (NULL, -1) < 0
+        && errno == EINVAL,
+        "flux_buffer_drop fails on NULL pointer");
+    ok (flux_buffer_peek (NULL, -1, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_peek fails on NULL pointer");
+    ok (flux_buffer_read (NULL, -1, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_read fails on NULL pointer");
+    ok (flux_buffer_write (NULL, NULL, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_write fails on NULL pointer");
+    ok (flux_buffer_lines (NULL) < 0
+        && errno == EINVAL,
+        "flux_buffer_lines fails on NULL pointer");
+    ok (flux_buffer_drop_line (NULL) < 0
+        && errno == EINVAL,
+        "flux_buffer_drop_line fails on NULL pointer");
+    ok (flux_buffer_peek_line (NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_peek_line fails on NULL pointer");
+    ok (flux_buffer_read_line (NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_read_line fails on NULL pointer");
+    ok (flux_buffer_write_line (NULL, "foo") < 0
+        && errno == EINVAL,
+        "flux_buffer_write_line fails on NULL pointer");
+    ok (flux_buffer_peek_to_fd (NULL, 0, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_peek_to_fd fails on NULL pointer");
+    ok (flux_buffer_read_to_fd (NULL, 0, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_read_to_fd fails on NULL pointer");
+    ok (flux_buffer_write_from_fd (NULL, 0, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_write_from_fd fails on NULL pointer");
+
+    ok ((fb = flux_buffer_create (FLUX_BUFFER_TEST_MAXSIZE)) != NULL,
+        "flux_buffer_create works");
+
+    /* write corner case tests */
+
+    ok (flux_buffer_write (fb, NULL, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_write fails on bad input");
+    ok (flux_buffer_write (fb, "foo", -1) < 0
+        && errno == EINVAL,
+        "flux_buffer_write fails on bad input");
+    ok (flux_buffer_write_line (fb, NULL) < 0
+        && errno == EINVAL,
+        "flux_buffer_write_line fails on bad input");
+    ok (flux_buffer_write_from_fd (fb, -1, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_write_from_fd fails on bad input");
+
+    /* flux_buffer_destroy works with NULL */
+    flux_buffer_destroy (NULL);
+
+    flux_buffer_destroy (fb);
+
+    /* all functions fail on destroyed fb pointer */
+    ok (flux_buffer_bytes (fb) < 0
+        && errno == EINVAL,
+        "flux_buffer_bytes fails on destroyed fb pointer");
+    ok (flux_buffer_drop (fb, -1) < 0
+        && errno == EINVAL,
+        "flux_buffer_drop fails on destroyed fb pointer");
+    ok (flux_buffer_peek (fb, -1, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_peek fails on destroyed fb pointer");
+    ok (flux_buffer_read (fb, -1, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_read fails on destroyed fb pointer");
+    ok (flux_buffer_write (fb, NULL, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_write fails on destroyed fb pointer");
+    ok (flux_buffer_lines (fb) < 0
+        && errno == EINVAL,
+        "flux_buffer_lines fails on destroyed fb pointer");
+    ok (flux_buffer_drop_line (fb) < 0
+        && errno == EINVAL,
+        "flux_buffer_drop_line fails on destroyed fb pointer");
+    ok (flux_buffer_peek_line (fb, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_peek_line fails on destroyed fb pointer");
+    ok (flux_buffer_read_line (fb, NULL) == NULL
+        && errno == EINVAL,
+        "flux_buffer_read_line fails on destroyed fb pointer");
+    ok (flux_buffer_write_line (fb, "foo") < 0
+        && errno == EINVAL,
+        "flux_buffer_write_line fails on destroyed fb pointer");
+    ok (flux_buffer_peek_to_fd (fb, 0, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_peek_to_fd fails destroyed fb pointer");
+    ok (flux_buffer_read_to_fd (fb, 0, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_read_to_fd fails destroyed fb pointer");
+    ok (flux_buffer_write_from_fd (fb, 0, 0) < 0
+        && errno == EINVAL,
+        "flux_buffer_write_from_fd fails on destroyed fb pointer");
+}
+
+void full_buffer (void)
+{
+    flux_buffer_t *fb;
+
+    ok ((fb = flux_buffer_create (4)) != NULL,
+        "flux_buffer_create works");
+
+    ok (flux_buffer_write (fb, "1234", 4) == 4,
+        "flux_buffer_write success");
+
+    ok (flux_buffer_write (fb, "5", 1) < 0
+        && errno == ENOSPC,
+        "flux_buffer_write fails with ENOSPC if exceeding buffer size");
+
+    ok (flux_buffer_drop (fb, -1) == 4,
+        "flux_buffer_drop works");
+
+    ok (flux_buffer_write_line (fb, "1234") < 0
+        && errno == ENOSPC,
+        "flux_buffer_write_line fails with ENOSPC if exceeding buffer size");
+
+    flux_buffer_destroy (fb);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic ();
+    corner_case ();
+    full_buffer ();
+
+    done_testing();
+
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
Add basic buffer data structure.  This data structure is a loose
wrapper around liblsd/cbuf, providing a public flux buffer data
structure for use for buffer related APIs in the future.