### PR TITLE
libflux: add flux_event_publish() interface

### DIFF
--- a/doc/man1/flux-event.adoc
+++ b/doc/man1/flux-event.adoc
@@ -28,13 +28,16 @@ A subscription to the empty string matches all events.
 
 COMMANDS
 --------
-*pub* [-r] [-l] 'topic' ['payload']::
+*pub*  [-r] [-l] [-s] [-p] 'topic' ['payload']::
 Publish an event with optional payload.  If payload is specified,
 it is interpreted as raw if the '-r' option is used, otherwise it is
 interpreted as JSON.  If the payload spans multiple arguments,
 the arguments are concatenated with one space between them.
+If '-s' is specified, wait for the event's sequence number to be
+assigned before exiting.
 If '-l' is specified, subscribe to the published event and wait for
-it to be received before exiting.
+it to be received before exiting.  '-p' causes the privacy flag to
+be set on the published event.
 
 *sub* '[-c N]' ['topic'] ['topic'...]::
 Subscribe to events matching the topic string(s) provided on the

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -9,6 +9,7 @@ MAN3_FILES_PRIMARY = \
 	flux_flags_set.3 \
 	flux_fatal_set.3 \
 	flux_event_subscribe.3 \
+	flux_event_publish.3 \
 	flux_pollevents.3 \
 	flux_msg_encode.3 \
 	flux_msg_sendfd.3 \
@@ -61,6 +62,9 @@ MAN3_FILES_SECONDARY = \
 	flux_fatal_error.3 \
 	FLUX_FATAL.3 \
 	flux_event_unsubscribe.3 \
+	flux_event_publish_pack.3 \
+	flux_event_publish_raw.3 \
+	flux_event_publish_get_seq.3 \
 	flux_pollfd.3 \
 	flux_msg_decode.3 \
 	flux_msg_recvfd.3 \
@@ -185,6 +189,9 @@ flux_flags_get.3: flux_flags_set.3
 flux_fatal_error.3: flux_fatal_set.3
 FLUX_FATAL.3: flux_fatal_set.3
 flux_event_unsubscribe.3: flux_event_subscribe.3
+flux_event_publish_pack.3: flux_event_publish.3
+flux_event_publish_raw.3: flux_event_publish.3
+flux_event_publish_get_seq.3: flux_event_publish.3
 flux_pollfd.3: flux_pollevents.3
 flux_msg_decode.3: flux_msg_encode.3
 flux_msg_recvfd.3: flux_msg_sendfd.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -119,6 +119,7 @@ MAN3_FILES_SECONDARY = \
 	flux_vlog.3 \
 	flux_log_set_appname.3 \
 	flux_log_set_procid.3 \
+	flux_future_then.3 \
 	flux_future_wait_for.3 \
 	flux_future_reset.3 \
 	flux_future_destroy.3 \

--- a/doc/man3/flux_event_publish.adoc
+++ b/doc/man3/flux_event_publish.adoc
@@ -1,0 +1,118 @@
+flux_event_publish(3)
+=====================
+:doctype: manpage
+
+
+NAME
+----
+flux_event_publish, flux_event_publish_pack, flux_event_publish_raw, flux_event_publish_get_seq - publish events
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_event_publish (flux_t *h,
+                                    const char *topic, int flags,
+                                    const char *json_str);
+ 
+ flux_future_t *flux_event_publish_pack (flux_t *h,
+                                         const char *topic, int flags,
+                                         const char *fmt, ...);
+ 
+ flux_future_t *flux_event_publish_raw (flux_t *h,
+                                        const char *topic, int flags,
+                                        const void *data, int len);
+ 
+ int flux_event_publish_get_seq (flux_future_t *f, int *seq);
+
+DESCRIPTION
+-----------
+
+`flux_event_publish()` sends an event message with topic string _topic_,
+_flags_ as described below, and optional payload _json_str_, a string-encoded
+JSON object or NULL indicating no payload.  The returned future is
+fulfilled once the event is accepted by the broker and assigned a
+global sequence number.
+
+`flux_event_publish_pack()` is similar, except the JSON payload
+is constructed using `json_pack()` style arguments (see below).
+
+`flux_event_publish_raw()` is similar, except the payload is raw _data_
+of length _len_.
+
+`flux_event_publish_get_seq()` may be used to retrieve the sequence
+number assigned to the message once the future is fulfilled.
+
+
+CONFIRMATION SEMANTICS
+----------------------
+
+All Flux events are "open loop" in the sense that publishers get no
+confirmation that subscribers have received a message.  However,
+the above functions do confirm, upon fulfillment of the returned future,
+that the published event has been received by the broker and assigned
+a global sequence number.
+
+Gaps in the sequence trigger the logging of errors currently, and in
+the future will trigger recovery of lost events, so these confirmations
+do indicate that Flux's best effort at event propagation is under way.
+
+If this level of confirmation is not required, one may encode
+an event message directly using `flux_event_encode(3)` and related
+functions and send it directly with `flux_send(3)`.
+
+
+FLAGS
+-----
+
+The _flags_ argument in the above functions must be zero, or the
+logical OR of the following values:
+
+FLUX_MSGFLAG_PRIVATE::
+Indicates that the event should only be visible to the instance owner
+and the sender.
+
+
+
+include::JSON_PACK.adoc[]
+
+
+RETURN VALUE
+------------
+
+These functions return a future on success.  On error, NULL is returned,
+and errno is set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+Some arguments were invalid.
+
+ENOMEM::
+Out of memory.
+
+EPROTO::
+A protocol error was encountered.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux_event_decode(3), flux_event_subscribe(3)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -423,3 +423,4 @@ HOSTLIST
 hostlist
 hostnames
 unfulfills
+MSGFLAG

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -47,7 +47,9 @@ flux_broker_SOURCES = \
 	boot_config.h \
 	boot_config.c \
 	boot_pmi.h \
-	boot_pmi.c
+	boot_pmi.c \
+	publisher.h \
+	publisher.c
 
 flux_broker_LDADD = \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -1,0 +1,239 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* publisher.c - event publishing service on rank 0 */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/base64.h"
+
+#include "publisher.h"
+
+struct sender {
+    publisher_send_f send;
+    void *arg;
+    char name[32];
+};
+
+struct publisher {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    int seq;
+    zlist_t *senders;
+};
+
+void publisher_destroy (struct publisher *pub)
+{
+    if (pub) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (pub->handlers);
+        if (pub->senders) {
+            struct sender *sender;
+            while ((sender = zlist_pop (pub->senders)))
+                free (sender);
+            zlist_destroy (&pub->senders);
+        }
+        free (pub);
+        errno = saved_errno;
+    }
+}
+
+struct publisher *publisher_create (void)
+{
+    struct publisher *pub;
+
+    if (!(pub = calloc (1, sizeof (*pub))))
+        return NULL;
+    if (!(pub->senders = zlist_new ())) {
+        publisher_destroy (pub);
+        return NULL;
+    }
+    return pub;
+}
+
+static flux_msg_t *encode_event (const char *topic, int flags,
+                                 uint32_t rolemask, uint32_t userid,
+                                 uint32_t seq, const char *src)
+{
+    flux_msg_t *msg;
+    void *dst = NULL;
+    int saved_errno;
+
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_EVENT)))
+        goto error;
+    if (flux_msg_set_topic (msg, topic) < 0)
+        goto error;
+    if (flux_msg_set_userid (msg, userid) < 0)
+        goto error;
+    if (flux_msg_set_rolemask (msg, rolemask) < 0)
+        goto error;
+    if (flux_msg_set_seq (msg, seq) < 0)
+        goto error;
+    if ((flags & FLUX_MSGFLAG_PRIVATE)) {
+        if (flux_msg_set_private (msg) < 0)
+            goto error;
+    }
+    if (src) { // optional payload
+        int srclen = strlen (src);
+        int dstlen = base64_decode_length (srclen);
+
+        if (!(dst = malloc (dstlen)))
+            goto error;
+        if (base64_decode_block (dst, &dstlen, src, srclen) < 0) {
+            errno = EPROTO;
+            goto error;
+        }
+        if (flux_msg_set_payload (msg, (flags & FLUX_MSGFLAG_JSON),
+                                  dst, dstlen) < 0) {
+            if (errno == EINVAL)
+                errno = EPROTO;
+            goto error;
+        }
+    }
+    free (dst);
+    return msg;
+error:
+    saved_errno = errno;
+    free (dst);
+    flux_msg_destroy (msg);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* Broadcast event using all senders.
+ * Log failure, but don't abort the event at this point.
+ */
+static void send_event (struct publisher *pub, const flux_msg_t *msg)
+{
+    struct sender *sender;
+
+    sender = zlist_first (pub->senders);
+    while (sender != NULL) {
+        if (sender->send (sender->arg, msg) < 0)
+            flux_log_error (pub->h, "%s: sender=%s",
+                            __FUNCTION__, sender->name);
+        sender = zlist_next (pub->senders);
+    }
+}
+
+void pub_cb (flux_t *h, flux_msg_handler_t *mh,
+             const flux_msg_t *msg, void *arg)
+{
+    struct publisher *pub = arg;
+    const char *topic;
+    const char *payload = NULL; // optional
+    int flags;
+    uint32_t rolemask, userid;
+    flux_msg_t *event = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:i s?:s}",
+                                        "topic", &topic,
+                                        "flags", &flags,
+                                        "payload", &payload) < 0)
+        goto error;
+    if ((flags & ~(FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_JSON)) != 0
+                            || (!payload && (flags & FLUX_MSGFLAG_JSON))) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+    if (!(event = encode_event (topic, flags, rolemask, userid,
+                                ++pub->seq, payload)))
+        goto error_restore_seq;
+    send_event (pub, event);
+    if (flux_respond_pack (h, msg, "{s:i}", "seq", pub->seq) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_msg_destroy (event);
+    return;
+error_restore_seq:
+    pub->seq--;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_msg_destroy (event);
+}
+
+int publisher_send (struct publisher *pub, const flux_msg_t *msg)
+{
+    flux_msg_t *cpy;
+
+    if (!(cpy = flux_msg_copy (msg, true)))
+        return -1;
+    if (flux_msg_clear_route (cpy) < 0)
+        goto error;
+    if (flux_msg_set_seq (cpy, ++pub->seq) < 0)
+        goto error_restore_seq;
+    send_event (pub, cpy);
+    flux_msg_destroy (cpy);
+    return 0;
+error_restore_seq:
+    pub->seq--;
+error:
+    flux_msg_destroy (cpy);
+    return -1;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "event.pub",  pub_cb, FLUX_ROLE_USER },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+
+int publisher_set_flux (struct publisher *pub, flux_t *h)
+{
+    pub->h = h;
+    if (flux_msg_handler_addvec (h, htab, pub, &pub->handlers) < 0)
+        return -1;
+    return 0;
+}
+
+int publisher_set_sender (struct publisher *pub, const char *name,
+                          publisher_send_f cb, void *arg)
+{
+    struct sender *sender;
+
+    if (!(sender = calloc (1, sizeof (*sender))))
+        return -1;
+    sender->send = cb;
+    sender->arg = arg;
+    (void)snprintf (sender->name, sizeof (sender->name), "%s", name);
+    if (zlist_append (pub->senders, sender) < 0) {
+        free (sender);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/publisher.h
+++ b/src/broker/publisher.h
@@ -1,0 +1,26 @@
+#ifndef _BROKER_PUBLISHER_H
+#define _BROKER_PUBLISHER_H
+
+typedef int (*publisher_send_f)(void *arg, const flux_msg_t *msg);
+
+struct publisher *publisher_create (void);
+void publisher_destroy (struct publisher *pub);
+
+int publisher_set_flux (struct publisher *pub, flux_t *h);
+
+/* Add a sender.  All senders are called when an event is published.
+ * If a sender returns -1, an error will be logged but sending will continue.
+ * Senders should return 0 on success.
+ */
+int publisher_set_sender (struct publisher *pub, const char *name,
+                          publisher_send_f cb, void *arg);
+
+/* Publish an encoded event message, assigning sequence number.
+ */
+int publisher_send (struct publisher *pub, const flux_msg_t *msg);
+
+#endif /* !_BROKER_PUBLISHER_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -173,6 +173,9 @@ static struct optparse_option pub_opts[] = {
     { .name = "loopback", .key = 'l', .has_arg = 0,
       .usage = "Wait for published event to be received before exiting.",
     },
+    { .name = "private", .key = 'p', .has_arg = 0,
+      .usage = "Set privacy flag on published event.",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -211,6 +214,9 @@ static int event_pub (optparse_t *p, int argc, char **argv)
         if (optparse_hasopt (p, "raw"))
             payloadsz = strlen (payload);
     }
+
+    if (optparse_hasopt (p, "private"))
+        flags |= FLUX_MSGFLAG_PRIVATE;
 
     if (optparse_hasopt (p, "loopback")) {
         if (flux_event_subscribe (h, topic) < 0)

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -92,6 +92,77 @@ static bool match_payload_raw (const void *p1, int p1sz,
     return !memcmp (p1, p2, p1sz);
 }
 
+static int publish_raw_sync (flux_t *h, const char *topic, int flags,
+                             char *payload, int payloadsz)
+{
+    flux_future_t *f;
+    int seq;
+    int rc = -1;
+    if (!(f = flux_event_publish_raw (h, topic, flags, payload, payloadsz)))
+        goto done;
+    if (flux_event_publish_get_seq (f, &seq) < 0)
+        goto done;
+    printf ("seq=%d\n", seq);
+    rc = 0;
+done:
+    flux_future_destroy (f);
+    return rc;
+}
+
+static int publish_raw (flux_t *h, const char *topic, int flags,
+                        char *payload, int payloadsz)
+{
+    flux_msg_t *msg;
+    int rc = -1;
+
+    if (!(msg = flux_event_encode_raw (topic, payload, payloadsz)))
+        goto done;
+    if ((flags & FLUX_MSGFLAG_PRIVATE) && flux_msg_set_private (msg) < 0)
+        goto done;
+    if (flux_send (h, msg, 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_msg_destroy (msg);
+    return rc;
+}
+
+static int publish_json_sync (flux_t *h, const char *topic, int flags,
+                              char *payload)
+{
+    flux_future_t *f;
+    int seq;
+    int rc = -1;
+
+    if (!(f = flux_event_publish (h, topic, 0, payload)))
+        goto done;
+    if (flux_event_publish_get_seq (f, &seq) < 0)
+        goto done;
+    printf ("seq=%d\n", seq);
+done:
+    flux_future_destroy (f);
+    rc = 0;
+    return rc;
+}
+
+static int publish_json (flux_t *h, const char *topic, int flags,
+                         char *payload)
+{
+    flux_msg_t *msg;
+    int rc = -1;
+
+    if (!(msg = flux_event_encode (topic, payload)))
+        goto done;
+    if ((flags & FLUX_MSGFLAG_PRIVATE) && flux_msg_set_private (msg) < 0)
+        goto done;
+    if (flux_send (h, msg, 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_msg_destroy (msg);
+    return rc;
+}
+
 static struct optparse_option pub_opts[] = {
     { .name = "raw", .key = 'r', .has_arg = 0,
       .usage = "Interpret event payload as raw.",
@@ -119,6 +190,9 @@ static int event_pub (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     char *topic;
     char *payload = NULL;
+    int payloadsz = 0;
+    int flags = 0;
+    int rc;
 
     if (optindex == argc) {
         optparse_print_usage (p);
@@ -134,6 +208,8 @@ static int event_pub (optparse_t *p, int argc, char **argv)
         if ((e = argz_create (argv + optindex, &payload, &len)) != 0)
             log_errn_exit (e, "argz_create");
         argz_stringify (payload, len, ' ');
+        if (optparse_hasopt (p, "raw"))
+            payloadsz = strlen (payload);
     }
 
     if (optparse_hasopt (p, "loopback")) {
@@ -142,83 +218,44 @@ static int event_pub (optparse_t *p, int argc, char **argv)
     }
 
     if (optparse_hasopt (p, "raw")) {
-        int payloadsz = payload ? strlen (payload) : 0;
-        if (optparse_hasopt (p, "synchronous")) {
-            flux_future_t *f;
-            int seq;
-            if (!(f = flux_event_publish_raw (h, topic, 0, payload, payloadsz)))
-                log_err_exit ("flux_event_publish_raw");
-            if (flux_event_publish_get_seq (f, &seq) < 0)
-                log_err_exit ("flux_event_publish_get_seq");
-            printf ("seq=%d\n", seq);
-            flux_future_destroy (f);
-        }
-        else {
-            flux_msg_t *msg;
-            if (!(msg = flux_event_encode_raw (topic, payload, payloadsz)))
-                log_err_exit ("flux_event_encode_raw");
-            if (flux_send (h, msg, 0) < 0)
-                log_err_exit ("flux_send");
-            flux_msg_destroy (msg);
-        }
-        if (optparse_hasopt (p, "loopback")) {
-            flux_msg_t *msg;
-            const void *data;
-            int len;
-            struct flux_match match = FLUX_MATCH_EVENT;
-            bool received = false;
-            match.topic_glob = topic;
+        if (optparse_hasopt (p, "synchronous"))
+            rc = publish_raw_sync (h, topic, flags, payload, payloadsz);
+        else
+            rc = publish_raw (h, topic, flags, payload, payloadsz);
+    }
+    else {
+        if (optparse_hasopt (p, "synchronous"))
+            rc = publish_json_sync (h, topic, flags, payload);
+        else
+            rc = publish_json (h, topic, flags, payload);
+    }
+    if (rc < 0)
+        log_err_exit ("publish failed");
 
-            while (!received) {
-                if (!(msg = flux_recv (h, match, 0)))
-                    log_err_exit ("flux_recv error");
+    if (optparse_hasopt (p, "loopback")) {
+        flux_msg_t *msg;
+        struct flux_match match = FLUX_MATCH_EVENT;
+        bool received = false;
+        match.topic_glob = topic;
+
+        while (!received) {
+            if (!(msg = flux_recv (h, match, 0)))
+                log_err_exit ("flux_recv error");
+            if (optparse_hasopt (p, "raw")) {
+                const void *data;
+                int len;
                 if ((flux_event_decode_raw (msg, NULL, &data, &len) == 0
                         && match_payload_raw (payload, payloadsz, data, len)))
                     received = true;
-                flux_msg_destroy (msg);
             }
-        }
-    }
-    else {
-        if (optparse_hasopt (p, "synchronous")) {
-            flux_future_t *f;
-            int seq;
-            if (!(f = flux_event_publish (h, topic, 0, payload)))
-                log_err_exit ("flux_event_publish");
-            if (flux_event_publish_get_seq (f, &seq) < 0)
-                log_err_exit ("flux_event_publish_get_seq");
-            printf ("seq=%d\n", seq);
-            flux_future_destroy (f);
-        }
-        else {
-            flux_msg_t *msg;
-            if (!(msg = flux_event_encode (topic, payload)))
-                log_err_exit ("flux_event_encode");
-            if (flux_send (h, msg, 0) < 0)
-                log_err_exit ("flux_send");
+            else {
+                const char *json_str;
+                if ((flux_event_decode (msg, NULL, &json_str) == 0
+                        && match_payload (payload, json_str)))
+                    received = true;
+            }
             flux_msg_destroy (msg);
         }
-        if (optparse_hasopt (p, "loopback")) {
-            flux_msg_t *recvmsg;
-            const char *data;
-            struct flux_match match = FLUX_MATCH_EVENT;
-            bool received = false;
-            match.topic_glob = topic;
-
-            while (!received) {
-                if (!(recvmsg = flux_recv (h, match, 0)))
-                    log_err_exit ("flux_recv error");
-                if ((flux_event_decode (recvmsg, NULL, &data) == 0
-                        && match_payload (payload, data)))
-                    received = true;
-                flux_msg_destroy (recvmsg);
-            }
-        }
-    }
-
-    if (optparse_hasopt (p, "loopback")) {
-        if (flux_event_unsubscribe (h, topic) < 0)
-            log_err_exit ("flux_event_unsubscribe");
     }
 
     free (payload);

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -2,10 +2,15 @@
 #define _FLUX_CORE_EVENT_H
 
 #include "message.h"
+#include "future.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+enum event_flags {
+    FLUX_EVENT_PRIVATE = 1,
+};
 
 /* Decode an event message.
  * If topic is non-NULL, assign the event topic string.
@@ -47,6 +52,27 @@ flux_msg_t *flux_event_encode_raw (const char *topic,
  */
 int flux_event_decode_raw (const flux_msg_t *msg, const char **topic,
                            const void **data, int *len);
+
+/* Publish an event.
+ * The future is fulfilled once the event has been assigned a sequence number,
+ * and does not indicate that the event has yet reached all subscribers.
+ */
+flux_future_t *flux_event_publish (flux_t *h,
+                                   const char *topic, int flags,
+                                   const char *json_str);
+
+flux_future_t *flux_event_publish_pack (flux_t *h,
+                                        const char *topic, int flags,
+                                        const char *fmt, ...);
+
+flux_future_t *flux_event_publish_raw (flux_t *h,
+                                       const char *topic, int flags,
+                                       const void *data, int len);
+
+/* Obtain the event sequence number from the fulfilled
+ * flux_event_publish() future.
+ */
+int flux_event_publish_get_seq (flux_future_t *f, int *seq);
 
 #ifdef __cplusplus
 }

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1151,7 +1151,7 @@ int flux_msg_get_json (const flux_msg_t *msg, const char **s)
     } else {
         if (!buf || size == 0 || !(flags & FLUX_MSGFLAG_JSON)
                               || buf[size - 1] != '\0'
-                              || buf[0] != '{') {
+                              || buf[0] != '{' || buf[size - 2] != '}') {
             errno = EPROTO;
             goto done;
         }

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -424,11 +424,7 @@ int flux_msg_get_type (const flux_msg_t *msg, int *type)
     return 0;
 }
 
-/* There is no reason to expose flux_msg_set/get_flags()
- * outside of this module for now.
- */
-
-static int flux_msg_set_flags (flux_msg_t *msg, uint8_t fl)
+int flux_msg_set_flags (flux_msg_t *msg, uint8_t fl)
 {
     zframe_t *zf = zmsg_last (msg->zmsg);
     if (!zf || proto_set_flags (zframe_data (zf), zframe_size (zf), fl) < 0) {
@@ -438,7 +434,7 @@ static int flux_msg_set_flags (flux_msg_t *msg, uint8_t fl)
     return 0;
 }
 
-static int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *fl)
+int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *fl)
 {
     zframe_t *zf = zmsg_last (msg->zmsg);
     if (!zf || proto_get_flags (zframe_data (zf), zframe_size (zf), fl) < 0) {

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -169,6 +169,14 @@ int flux_msg_set_payload (flux_msg_t *msg, int flags,
                           const void *buf, int size);
 bool flux_msg_has_payload (const flux_msg_t *msg);
 
+/* Get/set flags
+ * Users should avoid using flux_msg_set_flags(), and instead use the
+ * higher level functions that manipulate message flags.  It is exposed
+ * mainly for testing.
+ */
+int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *flags);
+int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags);
+
 /* Get/set JSON payload.
  * flux_msg_set_json() accepts a NULL json_str (no payload).
  * flux_msg_get_json() will set json_str to NULL if there is no payload

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -45,4 +45,36 @@ test_expect_success 'publish event with raw payload (loopback)' '
 	run_timeout 5 flux event pub -l -r foo.bar foo
 '
 
+test_expect_success 'publish private event with JSON payload (loopback)' '
+	run_timeout 5 flux event pub -l foo.bar {}
+'
+
+test_expect_success 'publish private event with raw payload (loopback)' '
+	run_timeout 5 flux event pub -p -l -r foo.bar foo
+'
+
+test_expect_success 'publish event with no payload (synchronous)' '
+	run_timeout 5 flux event pub -s foo.bar
+'
+
+test_expect_success 'publish event with JSON payload (synchronous)' '
+	run_timeout 5 flux event pub -s foo.bar {}
+'
+
+test_expect_success 'publish event with raw payload (synchronous)' '
+	run_timeout 5 flux event pub -s -r foo.bar foo
+'
+
+test_expect_success 'publish private event with JSON payload (synchronous)' '
+	run_timeout 5 flux event pub -p -s foo.bar {}
+'
+
+test_expect_success 'publish private event with raw payload (synchronous)' '
+	run_timeout 5 flux event pub -p -s -r foo.bar foo
+'
+
+test_expect_success 'publish private event with no payload (synchronous,loopback)' '
+	run_timeout 5 flux event pub -p -s -l foo.bar
+'
+
 test_done


### PR DESCRIPTION
This PR adds functions for "synchronous" event publication.  That is, they encapsulate an event in a request message and send it as an RPC to a broker service that assigns a sequence number to it,  then responds to the RPC in parallel with the event propagation.

This was added in a more ad-hoc way recently, with the `cmb.pub` broker service.  That is replaced here  with a more elaborate `event.pub` service that breaks event publishing out from broker.c to  `publisher.[ch]`.  The new implementation adds a couple of missing features, like raw payloads and privacy flag.

The following missing API functions were added:
```c
/* Publish an event.
 * The future is fulfilled once the event has been assigned a sequence number,
 * and does not indicate that the event has yet reached all subscribers.
 */
flux_future_t *flux_event_publish (flux_t *h,
                                   const char *topic, int flags,
                                   const char *json_str);

flux_future_t *flux_event_publish_pack (flux_t *h,
                                        const char *topic, int flags,
                                        const char *fmt, ...);

flux_future_t *flux_event_publish_raw (flux_t *h,
                                       const char *topic, int flags,
                                       const void *data, int len);

/* Obtain the event sequence number from the fulfilled
 * flux_event_publish() future.
 */
int flux_event_publish_get_seq (flux_future_t *f, int *seq);
```

The job module was switched from the ad-hoc `cmb.pub` interface to this one.

`flux-event(1)` was extended to optionally use the above interface (`flux event pub -s ...`).

Man pages and unit tests were (minimally) updated.