### PR TITLE
commands: relax run-from-build-tree detection

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -270,9 +270,10 @@ char *dir_self (void)
 
 bool flux_is_installed (void)
 {
+    const char *conf_bindir = flux_conf_get ("bindir", CONF_FLAG_INTREE);
     char *selfdir = dir_self ();
     char *bindir = NULL;
-    bool ret = false;
+    bool ret = true;
     /*
      *  Calling realpath(3) with NULL second arg is safe since POSIX.1-2008.
      *   (Equivalent to glibc's canonicalize_path_name(3))
@@ -280,10 +281,11 @@ bool flux_is_installed (void)
      *  If realpath(3) returns ENOENT, then BINDIR doesn't exist and flux
      *   clearly can't be from the installed path:
      */
-    if (!(bindir = realpath (X_BINDIR, NULL)) && (errno != ENOENT))
-        log_err_exit ("realpath (%s)", X_BINDIR);
+
+    if (!(bindir = realpath (conf_bindir, NULL)) && (errno != ENOENT))
+        log_err_exit ("realpath (%s)", conf_bindir);
     else if (bindir && !strcmp (selfdir, bindir))
-        ret = true;
+        ret = false;
     free (selfdir);
     free (bindir);
     return ret;

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -25,7 +25,8 @@ installed_conf_cppflags = \
 	-DINSTALLED_WREXECD_PATH=\"$(fluxlibexecdir)/wrexecd\" \
 	-DINSTALLED_CMDHELP_PATTERN=\"${datadir}/flux/help.d/*.json\" \
 	-DINSTALLED_NO_DOCS_PATH=\"${datadir}/flux/.nodocs\" \
-	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\"
+	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\" \
+	-DINSTALLED_BINDIR=\"$(fluxcmddir)\"
 
 intree_conf_cppflags = \
 	-DINTREE_MODULE_PATH=\"$(abs_top_builddir)/src/modules\" \
@@ -43,7 +44,8 @@ intree_conf_cppflags = \
 	-DINTREE_WREXECD_PATH=\"$(abs_top_builddir)/src/modules/wreck/wrexecd\" \
 	-DINTREE_CMDHELP_PATTERN=\"${abs_top_builddir}/etc/flux/help.d/*.json\" \
 	-DINTREE_KEYDIR=\"${abs_top_builddir}/etc/flux\" \
-	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\"
+	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\" \
+	-DINTREE_BINDIR=\"${abs_top_builddir}/src/cmd\"
 
 
 fluxcoreinclude_HEADERS = \

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -55,6 +55,7 @@ static struct config default_config[] = {
     { "keydir",         NULL,                       INTREE_KEYDIR },
     { "no_docs_path",   INSTALLED_NO_DOCS_PATH,     INTREE_NO_DOCS_PATH },
     { "rundir",         INSTALLED_RUNDIR,           NULL },
+    { "bindir",         INSTALLED_BINDIR,           INTREE_BINDIR },
     { NULL, NULL, NULL },
 };
 


### PR DESCRIPTION
Instead of comparing `/proc/self/exe` to `$prefix/bin`, compare to `${abs_top_builddir}/src/cmd}`.

This may help when running flux under spindle, where the installed flux executable is relocated from its installed path.

The problem is discussed in #1514.