### PR TITLE
libidset: internal cleanup

### DIFF
--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -52,18 +52,18 @@ struct idset {
 
 #define ENCODE_CHUNK 1024
 
-struct idset *idset_create (size_t slots, int flags)
+struct idset *idset_create (size_t size, int flags)
 {
     struct idset *idset;
 
-    if (slots == 0 || (flags & ~IDSET_FLAG_AUTOGROW) != 0) {
+    if (size == 0 || (flags & ~IDSET_FLAG_AUTOGROW) != 0) {
         errno = EINVAL;
         return NULL;
     }
     if (!(idset = malloc (sizeof (*idset))))
         return NULL;
     idset->magic = IDSET_MAGIC;
-    idset->T = vebnew (slots, 0);
+    idset->T = vebnew (size, 0);
     if (!idset->T.D) {
         free (idset);
         errno = ENOMEM;
@@ -224,16 +224,16 @@ error:
     return NULL;
 }
 
-/* Grow idset to next power of 2 size that has at least 'slots' slots.
+/* Grow idset to next power of 2 size that has at least 'size' slots.
  * Return 0 on success, -1 on failure with errno == ENOMEM.
  */
-static int idset_grow (struct idset *idset, int slots)
+static int idset_grow (struct idset *idset, int size)
 {
     int newsize = idset->T.M;
     Veb T;
     int id;
 
-    while (newsize <= slots)
+    while (newsize <= size)
         newsize <<= 1;
 
     if (newsize > idset->T.M) {

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -52,6 +52,7 @@ struct idset {
 };
 
 #define ENCODE_CHUNK 1024
+#define DECODE_SIZE  1024 // initial idset size for idset_decode()
 
 struct idset *idset_create (size_t size, int flags)
 {
@@ -319,7 +320,7 @@ struct idset *idset_decode (const char *str)
         errno = EINVAL;
         return NULL;
     }
-    if (!(idset = idset_create (1024, IDSET_FLAG_AUTOGROW)))
+    if (!(idset = idset_create (DECODE_SIZE, IDSET_FLAG_AUTOGROW)))
         return NULL;
     if (!(cpy = strdup (str)))
         goto error;

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -329,6 +329,10 @@ struct idset *idset_decode (const char *str)
         unsigned int hi, lo, i;
         if (parse_range (tok, &hi, &lo) < 0)
             goto inval;
+        /* Count backwards so that idset_set() can grow the
+         * idset to the maximum size on the first access,
+         * rather than possibly doing it multiple times.
+         */
         for (i = hi; i >= lo && i != UINT_MAX; i--) {
             if (idset_set (idset, i) < 0)
                 goto error;

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -135,6 +135,9 @@ static int catrange (char **s, size_t *sz, size_t *len,
     return rc;
 }
 
+/* Return value: count of id's in set, or -1 on failure.
+ * N.B. if count is more than INT_MAX, return value is INT_MAX.
+ */
 static int encode_ranged (const struct idset *idset,
                           char **s, size_t *sz, size_t *len)
 {
@@ -162,12 +165,16 @@ static int encode_ranged (const struct idset *idset,
             if (catrange (s, sz, len, lo, hi, last ? "" : ",") < 0)
                 return -1;
         }
-        count++;
+        if (count < INT_MAX)
+            count++;
         id = next;
     }
     return count;
 }
 
+/* Return value: count of id's in set, or -1 on failure.
+ * N.B. if count is more than INT_MAX, return value is INT_MAX.
+ */
 static int encode_simple (const struct idset *idset,
                           char **s, size_t *sz, size_t *len)
 {
@@ -180,7 +187,8 @@ static int encode_simple (const struct idset *idset,
         char *sep = next == idset->T.M ? "" : ",";
         if (catprintf (s, sz, len, "%d%s", id, sep) < 0)
             return -1;
-        count++;
+        if (count < INT_MAX)
+            count++;
         id = next;
     }
     return count;

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -32,6 +32,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <sys/param.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
@@ -264,15 +265,18 @@ static int parse_range (const char *s, int *hi, int *lo)
 {
     char *endptr;
     int h, l;
+    unsigned long n;
 
-    h = l = strtoul (s, &endptr, 10);
-    if (endptr == s || (*endptr != '\0' && *endptr != '-'))
+    n = strtoul (s, &endptr, 10);
+    if (n >= UINT_MAX || endptr == s || (*endptr != '\0' && *endptr != '-'))
         return -1;
+    h = l = n;
     if (*endptr == '-') {
         s = endptr + 1;
-        h = strtoul (s, &endptr, 10);
-        if (endptr == s || *endptr != '\0')
+        n = strtoul (s, &endptr, 10);
+        if (n >= UINT_MAX || endptr == s || *endptr != '\0')
             return -1;
+        h = n;
     }
     *hi = h;
     *lo = l;

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -89,11 +89,11 @@ void idset_destroy (struct idset *idset)
  * Returns 0 on success, -1 on failure with errno = ENOMEM.
  */
 static int __attribute__ ((format (printf, 4, 5)))
-catprintf (char **s, int *sz, int *len, const char *fmt, ...)
+catprintf (char **s, size_t *sz, size_t *len, const char *fmt, ...)
 {
     va_list ap;
     char *ns;
-    int nlen;
+    size_t nlen;
     int rc;
 
     va_start (ap, fmt);
@@ -104,7 +104,7 @@ catprintf (char **s, int *sz, int *len, const char *fmt, ...)
     nlen = strlen (ns);
 
     while (*len + nlen + 1 > *sz) {
-        int nsz = *sz + ENCODE_CHUNK;
+        size_t nsz = *sz + ENCODE_CHUNK;
         char *p;
         if (!(p = realloc (*s, nsz)))
             goto error;
@@ -123,7 +123,7 @@ error:
     return -1;
 }
 
-static int catrange (char **s, int *sz, int *len,
+static int catrange (char **s, size_t *sz, size_t *len,
                      int lo, int hi, const char *sep)
 {
     int rc;
@@ -135,7 +135,7 @@ static int catrange (char **s, int *sz, int *len,
 }
 
 static int encode_ranged (const struct idset *idset,
-                          char **s, int *sz, int *len)
+                          char **s, size_t *sz, size_t *len)
 {
     int count = 0;
     int id;
@@ -168,7 +168,7 @@ static int encode_ranged (const struct idset *idset,
 }
 
 static int encode_simple (const struct idset *idset,
-                          char **s, int *sz, int *len)
+                          char **s, size_t *sz, size_t *len)
 {
     int count = 0;
     int id;
@@ -188,8 +188,8 @@ static int encode_simple (const struct idset *idset,
 char *idset_encode (const struct idset *idset, int flags)
 {
     char *str = NULL;
-    int strsz = 0;
-    int strlength = 0;
+    size_t strsz = 0;
+    size_t strlength = 0;
     int count;
 
     if (!idset || idset->magic != IDSET_MAGIC
@@ -284,7 +284,7 @@ static char *trim_brackets (char *s)
     char *p = s;
     if (*p == '[')
         p++;
-    int len = strlen (p);
+    size_t len = strlen (p);
     if (len > 0 && p[len - 1] == ']')
         p[len - 1] = '\0';
     return p;

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -88,7 +88,8 @@ void idset_destroy (struct idset *idset)
  * Grow *s by ENCODE_CHUNK to allow new string to be appended.
  * Returns 0 on success, -1 on failure with errno = ENOMEM.
  */
-static int catprintf (char **s, int *sz, int *len, const char *fmt, ...)
+static int __attribute__ ((format (printf, 4, 5)))
+catprintf (char **s, int *sz, int *len, const char *fmt, ...)
 {
     va_list ap;
     char *ns;

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -242,7 +242,7 @@ static int idset_grow (struct idset *idset, size_t size)
     Veb T;
     unsigned int id;
 
-    while (newsize <= size)
+    while (newsize < size)
         newsize <<= 1;
 
     if (newsize > idset->T.M) {

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -278,8 +278,14 @@ static int parse_range (const char *s, unsigned int *hi, unsigned int *lo)
             return -1;
         h = n;
     }
-    *hi = h;
-    *lo = l;
+    if (h >= l) {
+        *hi = h;
+        *lo = l;
+    }
+    else {
+        *hi = l;
+        *lo = h;
+    }
     return 0;
 }
 

--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -7,17 +7,17 @@
  */
 
 enum idset_flags {
-    IDSET_FLAG_AUTOGROW = 1, // allow idset to automatically grow beyond 'slots'
+    IDSET_FLAG_AUTOGROW = 1, // allow idset size to automatically grow
     IDSET_FLAG_BRACKETS = 2, // encode non-singleton idset with brackets
     IDSET_FLAG_RANGE = 4,    // encode with ranges ("2,3,4,8" -> "2-4,8")
 };
 
 /* Create/destroy an idset.
- * Set the initial number of slots to 'slots'.
+ * Set the initial size to 'size' (max id is size - 1)
  * 'flags' may include IDSET_FLAG_AUTOGROW.
  * Returns idset on success, or NULL on failure with errno set.
  */
-struct idset *idset_create (size_t slots, int flags);
+struct idset *idset_create (size_t size, int flags);
 void idset_destroy (struct idset *idset);
 
 /* Encode 'idset' to a string, which the caller must free.

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -93,9 +93,9 @@ void test_codec_large (void)
     struct idset *idset;
     char *s;
 
-    idset = idset_decode ("0-1023");
+    idset = idset_decode ("0-5000");
     ok (idset != NULL,
-        "idset_decode '0-1023' works");
+        "idset_decode '0-5000' works");
     s = idset_encode (idset, 0);
     int count = 0;
     if (s) {
@@ -110,9 +110,9 @@ void test_codec_large (void)
             a1 = NULL;
         }
     }
-    ok (count == 1024,
-        "idset_encode flags=0x0 '0,2,3,...,1023' works");
-    if (count != 1024)
+    ok (count == 5001,
+        "idset_encode flags=0x0 '0,2,3,...,5000' works");
+    if (count != 5001)
         diag ("count=%d", count);
     free (s);
     idset_destroy (idset);

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -14,6 +14,7 @@ struct inout {
 struct inout test_inputs[] = {
     { "2",              0,          "2" },
     { "7-9",            0,          "7,8,9" },
+    { "9-7",            0,          "7,8,9" },
     { "1,7-9",          0,          "1,7,8,9" },
     { "1,7-9,16",       0,          "1,7,8,9,16" },
     { "1,7-9,14,16",    0,          "1,7,8,9,14,16" },
@@ -24,11 +25,13 @@ struct inout test_inputs[] = {
 
     { "[2]",            0,          "2" },
     { "[7-9]",          0,          "7,8,9" },
+    { "[9-7]",          0,          "7,8,9" },
     { "[3,2,4,5]",      0,          "2,3,4,5" },
     { "[]",             0,          ""},
 
     { "2",              IDSET_FLAG_RANGE,  "2" },
     { "7-9",            IDSET_FLAG_RANGE,  "7-9" },
+    { "9-7",            IDSET_FLAG_RANGE,  "7-9" },
     { "1,7-9",          IDSET_FLAG_RANGE,  "1,7-9" },
     { "1,7-9,16",       IDSET_FLAG_RANGE,  "1,7-9,16" },
     { "1,7-9,14,16",    IDSET_FLAG_RANGE,  "1,7-9,14,16" },
@@ -38,6 +41,7 @@ struct inout test_inputs[] = {
 
     { "2",             IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "2" },
     { "7-9",           IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[7-9]" },
+    { "9-7",           IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[7-9]" },
     { "1,7-9",         IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1,7-9]" },
     { "1,7-9,16",      IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1,7-9,16]" },
     { "1,7-9,14,16",   IDSET_FLAG_RANGE|IDSET_FLAG_BRACKETS, "[1,7-9,14,16]" },


### PR DESCRIPTION
This was the beginning of a larger PR to migrate the remainder of `libutil/nodeset` functionality to a public API `libidset`.  Recall this was started in #1498 but the bulk of the work deferred.

After a discussion of priorities wtih @grondo this morning, I decided to work on something else, but this groundwork actually can stand alone as cleanup, so I thought I'd go ahead and submit it as its own PR.