### PR TITLE
wreck:  flush PMI server response before closing zio

### DIFF
--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -45,7 +45,7 @@ void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
 
 /* Put null-terminated request with sending client reference to protocol
  * engine.  The request should end with a newline.
- * Return 0 on success, -1 on failure.
+ * Returns 1 indicating finalized / close fd, 0 on success, -1 on failure.
  */
 int pmi_simple_server_request (struct pmi_simple_server *pmi,
                                const char *buf, void *client);

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -395,8 +395,12 @@ static void wreck_pmi_close (struct task_info *t)
     if (t->pmi_zio)
         zio_destroy (t->pmi_zio);
     t->pmi_zio = NULL;
-    if (t->pmi_client)
+    if (t->pmi_client) {
+        /* flush any lingering data before destroying */
+        if (zio_flush (t->pmi_client) < 0)
+            wlog_err (t->ctx, "zio_flush: %s", flux_strerror (errno));
         zio_destroy (t->pmi_client);
+    }
     t->pmi_client = NULL;
 }
 


### PR DESCRIPTION
Per discussion in #1523, fix corner case if data is buffered and not sent immediately.

Also fix a tiny documentation miss.