### PR TITLE
Remove last references to json-c, simplify/update README.md

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,6 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"common/liblsd/*" \
 	"common/libutil/sds.*" \
 	"common/libminilzo/*" \
-	"common/libjson-c/*" \
 	"common/liboptparse/getopt*"
 
 CODE_COVERAGE_LCOV_OPTIONS =

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,6 @@ coverage:
  - ".*/tests/.*"
  - ".*/man3/*.c"
  - ".*/common/libtap/.*"
- - ".*/common/libjson-c/.*"
  - ".*/common/liblsd/.*"
  - ".*/common/libev/.*"
  - ".*/common/liboptparse/getopt*"


### PR DESCRIPTION
This PR removes json-c references in `README.md` and codecov.io and check-code-coverage ignore lists.

While I was in there, I quickly simplified and updated the `README.md` to modernize it. I probably didn't do a complete job, but didn't want to spend too much time on it presently. If someone else wants to make another/alternate pass, that would be fine with me.