### PR TITLE
libflux/flog: sanitize log messages containing line breaks

### DIFF
--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -141,6 +141,37 @@ int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
     return 0;
 }
 
+char *stdlog_split_message (const char *buf, int *len, const char *sep)
+{
+    struct stdlog_header hdr;
+    const char *msg;
+    int msglen;
+    int off;
+    char *xtra;
+    int xtra_len;
+
+    if (stdlog_decode (buf, *len, &hdr, NULL, NULL, &msg, &msglen) < 0)
+        return NULL;
+    for (off = 0; off < msglen; off++) {
+        if (strchr (sep, msg[off]))
+            break;
+    }
+    xtra_len = msglen - off;
+    if (xtra_len == 0)
+        return NULL;
+    if (!(xtra = malloc (xtra_len + 1)))
+        return NULL;
+    memcpy (xtra, msg + off, xtra_len);
+    xtra[xtra_len] = '\0';
+    *len -= xtra_len; // truncate original (N.B. message is last, no \0 term)
+    while (xtra_len > 0 && strchr (sep, xtra[0]))
+        memmove (xtra, xtra + 1, xtra_len--); // drop leading separator(s)
+    if (xtra_len == 0) {
+        free (xtra);
+        return NULL;
+    }
+    return xtra;
+}
 
 int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
                      const char *sd, const char *fmt, va_list ap)

--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -166,6 +166,12 @@ int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
         n = len - m;
     for (i = 0; i < n; i++)
         buf[m + i] &= 0x7f; // ensure only ascii chars are logged
+    for (i = n - 1; i >= 0; i--) {
+        if (buf[m + i] != '\r' && buf[m + i] != '\n')
+            break;
+        buf[m + i] = '\0';  // drop trailing \r, \n
+        rc--;
+    }
     return rc;
 }
 

--- a/src/common/libutil/stdlog.h
+++ b/src/common/libutil/stdlog.h
@@ -45,6 +45,14 @@ int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
 int stdlog_encodef (char *buf, int len, struct stdlog_header *hdr,
                     const char *sd, const char *fmt, ...);
 
+/* If encoded stdlog message in buf, *len contains chars from 'sep'
+ * (in the message part), truncate the original message and return
+ * buffer containing the rest, with NULL terminator.
+ * Returns NULL if no 'sep' chars or on alloc failure.
+ * If non-NULL, caller must free returned value.
+ */
+char *stdlog_split_message (const char *buf, int *len, const char *sep);
+
 void stdlog_init (struct stdlog_header *hdr);
 
 

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -72,7 +72,20 @@ int main(int argc, char** argv)
         "stdlog_decode decoded structured data");
     ok (msglen == strlen (STDLOG_NILVALUE) && strncmp (msg, STDLOG_NILVALUE, msglen) == 0,
         "stdlog_decode decoded message");
-    
+
+    /* Check that trailing \n or \r in message are dropped
+     */
+    stdlog_init (&hdr);
+    len = stdlog_encode (buf, sizeof (buf), &hdr,
+                         STDLOG_NILVALUE,
+                         "Hello whorl\n\r\n");
+    ok (len >= 0,
+        "stdlog_encode worked with message");
+    diag ("%.*s", len, buf);
+    n = stdlog_decode (buf, len, &hdr, &sd, &sdlen, &msg, &msglen);
+    ok (n == 0 && strncmp (msg, "Hello whorl", msglen) == 0,
+        "trailing cr/lf chars were truncated");
+
     int i = 0;
     while (valid[i] != NULL) {
         n = stdlog_decode (valid[i], strlen (valid[i]), &hdr, &sd, &sdlen, &msg, &msglen);


### PR DESCRIPTION
This PR sanitizes log messages that have trailing newlines or contain multiple lines.  Any trailing CR or LF characters are stripped, and multiple lines are split into separate log messages.