### PR TITLE
libflux: allow error string in RPC response

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -103,6 +103,7 @@ MAN3_FILES_SECONDARY = \
 	flux_stat_watcher_get_rstat.3 \
 	flux_respond_raw.3 \
 	flux_respond_pack.3 \
+	flux_respond_error.3 \
 	flux_reactor_now_update.3 \
 	flux_request_unpack.3 \
 	flux_request_decode_raw.3 \
@@ -232,6 +233,7 @@ flux_signal_watcher_get_signum.3: flux_signal_watcher_create.3
 flux_stat_watcher_get_rstat.3: flux_stat_watcher_create.3
 flux_respond_raw.3: flux_respond.3
 flux_respond_pack.3: flux_respond.3
+flux_respond_error.3: flux_respond.3
 flux_reactor_now_update.3: flux_reactor_now.3
 flux_request_unpack.3: flux_request_decode.3
 flux_request_decode_raw.3: flux_request_decode.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -137,6 +137,7 @@ MAN3_FILES_SECONDARY = \
 	flux_rpc_get.3 \
 	flux_rpc_get_unpack.3 \
 	flux_rpc_get_raw.3 \
+	flux_rpc_get_error.3 \
 	flux_kvs_lookupat.3 \
 	flux_kvs_lookup_get.3 \
 	flux_kvs_lookup_get_unpack.3 \
@@ -266,6 +267,7 @@ flux_rpc_raw.3: flux_rpc.3
 flux_rpc_get.3: flux_rpc.3
 flux_rpc_get_unpack.3: flux_rpc.3
 flux_rpc_get_raw.3: flux_rpc.3
+flux_rpc_get_error.3: flux_rpc.3
 flux_kvs_lookupat.3: flux_kvs_lookup.3
 flux_kvs_lookup_get.3: flux_kvs_lookup.3
 flux_kvs_lookup_get_unpack.3: flux_kvs_lookup.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -112,6 +112,7 @@ MAN3_FILES_SECONDARY = \
 	flux_event_encode_raw.3 \
 	flux_event_decode_raw.3 \
 	flux_response_decode_raw.3 \
+	flux_response_decode_error.3 \
 	flux_request_encode_raw.3 \
 	flux_content_load_get.3 \
 	flux_content_store.3 \
@@ -240,6 +241,7 @@ flux_event_pack.3: flux_event_decode.3
 flux_event_encode_raw.3: flux_event_decode.3
 flux_event_decode_raw.3: flux_event_decode.3
 flux_response_decode_raw.3: flux_response_decode.3
+flux_response_decode_error.3: flux_response_decode.3
 flux_request_encode_raw.3: flux_request_encode.3
 flux_content_load_get.3: flux_content_load.3
 flux_content_store.3: flux_content_load.3

--- a/doc/man3/flux_event_decode.adoc
+++ b/doc/man3/flux_event_decode.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
 
  int flux_event_decode (const flux_msg_t *msg,
                         const char **topic,
-                        const char **json_str);
+                        const char **s);
 
  int flux_event_decode_raw (const flux_msg_t *msg,
                             const char **topic,
@@ -25,7 +25,7 @@ SYNOPSIS
                         const char *fmt, ...);
 
  flux_msg_t *flux_event_encode (const char *topic,
-                                const char *json_str);
+                                const char *s);
 
  flux_msg_t *flux_event_encode_raw (const char *topic,
                                     const void *data, int len);
@@ -42,9 +42,9 @@ DESCRIPTION
 _topic_, if non-NULL, will be set to the message's topic string. The storage
 for this string belongs to _msg_ and should not be freed.
 
-_json_str_, if non-NULL, will be set to the message's JSON payload. If
-no payload exists, _json_str_ is set to NULL.  The storage for this
-string belongs to _msg_ and should not be freed.
+_s_, if non-NULL, will be set to the message's NULL-terminated string payload.
+If no payload exists, it is set to NULL.  The storage for this string belongs
+to _msg_ and should not be freed.
 
 `flux_event_decode_raw()` decodes an event message with a raw payload,
 setting _data_ and _len_ to the payload data and length.  The storage for
@@ -56,8 +56,8 @@ in the style of jansson's `json_unpack()` (used internally). Decoding fails
 if the message doesn't have a JSON payload.
 
 `flux_event_encode()` encodes a Flux event message with topic string _topic_
-and optional JSON payload _json_str_.  The newly constructed message that
-is returned must be destroyed with `flux_msg_destroy()`.
+and optional NULL-terminated string payload _s_.  The newly constructed
+message that is returned must be destroyed with `flux_msg_destroy()`.
 
 `flux_event_encode_raw()` encodes a Flux event message with topic
 string _topic_.  If _data_ is non-NULL, its contents will be used as

--- a/doc/man3/flux_event_publish.adoc
+++ b/doc/man3/flux_event_publish.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
 
  flux_future_t *flux_event_publish (flux_t *h,
                                     const char *topic, int flags,
-                                    const char *json_str);
+                                    const char *s);
 
  flux_future_t *flux_event_publish_pack (flux_t *h,
                                          const char *topic, int flags,
@@ -30,8 +30,8 @@ DESCRIPTION
 -----------
 
 `flux_event_publish()` sends an event message with topic string _topic_,
-_flags_ as described below, and optional payload _json_str_, a string-encoded
-JSON object or NULL indicating no payload.  The returned future is
+_flags_ as described below, and optional payload _s_, a NULL-terminated
+string, or NULL indicating no payload.  The returned future is
 fulfilled once the event is accepted by the broker and assigned a
 global sequence number.
 

--- a/doc/man3/flux_event_publish.adoc
+++ b/doc/man3/flux_event_publish.adoc
@@ -15,15 +15,15 @@ SYNOPSIS
  flux_future_t *flux_event_publish (flux_t *h,
                                     const char *topic, int flags,
                                     const char *json_str);
- 
+
  flux_future_t *flux_event_publish_pack (flux_t *h,
                                          const char *topic, int flags,
                                          const char *fmt, ...);
- 
+
  flux_future_t *flux_event_publish_raw (flux_t *h,
                                         const char *topic, int flags,
                                         const void *data, int len);
- 
+
  int flux_event_publish_get_seq (flux_future_t *f, int *seq);
 
 DESCRIPTION

--- a/doc/man3/flux_mrpc.adoc
+++ b/doc/man3/flux_mrpc.adoc
@@ -12,13 +12,13 @@ SYNOPSIS
 --------
 #include <flux/core.h>
 
-flux_mrpc_t *flux_mrpc (flux_t *h, const char *topic, const char *json_str,
+flux_mrpc_t *flux_mrpc (flux_t *h, const char *topic, const char *s,
                         const char *nodeset, int flags);
 
 flux_mrpc_t *flux_mrpc_pack (flux_t *h, const char *topic, const char *nodeset,
                              int flags, const char *fmt, ...);
 
-int flux_mrpc_get (flux_mrpc_t *mrpc, const char **json_str);
+int flux_mrpc_get (flux_mrpc_t *mrpc, const char **s);
 
 int flux_mrpc_get_unpack (flux_mrpc_t *mrpc, const char *fmt, ...);
 

--- a/doc/man3/flux_request_decode.adoc
+++ b/doc/man3/flux_request_decode.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
 
  int flux_request_decode (const flux_msg_t *msg,
                           const char **topic,
-                          const char **json_str);
+                          const char **s);
 
  int flux_request_unpack (const flux_msg_t *msg,
                           const char **topic,
@@ -32,9 +32,9 @@ DESCRIPTION
 _topic_, if non-NULL, will be set the message's topic string. The storage
 for this string belongs to _msg_ and should not be freed.
 
-_json_str_, if non-NULL, will be set to the message's JSON payload.
-If no payload exists, _json_str_ is set to NULL.  The storage for this
-string belongs to _msg_ and should not be freed.
+_s_, if non-NULL, will be set to the message's NULL-terminated string payload.
+If no payload exists, it is set to NULL.  The storage for this string belongs
+to _msg_ and should not be freed.
 
 `flux_request_unpack()` decodes a request message with a JSON payload as
 above, parsing the payload using variable arguments with a format string

--- a/doc/man3/flux_request_encode.adoc
+++ b/doc/man3/flux_request_encode.adoc
@@ -13,7 +13,7 @@ SYNOPSIS
  #include <flux/core.h>
 
  flux_msg_t *flux_request_encode (const char *topic,
-                                  const char *json_str);
+                                  const char *s);
 
  flux_msg_t *flux_request_encode_raw (const char *topic,
                                       void *data, int len);
@@ -22,7 +22,7 @@ DESCRIPTION
 -----------
 
 `flux_request_encode()` encodes a request message with topic string
-_topic_ and optional JSON payload _json_str_.  The newly constructed
+_topic_ and optional NULL terminated string payload _s_.  The newly constructed
 message that is returned must be destroyed with `flux_msg_destroy()`.
 
 `flux_request_encode_raw()` encodes a request message with topic
@@ -41,7 +41,7 @@ ERRORS
 ------
 
 EINVAL::
-The _topic_ argument was NULL or _json_str_ is not a json object.
+The _topic_ argument was NULL or _s_ is not NULL terminated.
 
 ENOMEM::
 Memory was unavailable.

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -13,7 +13,7 @@ SYNOPSIS
  #include <flux/core.h>
 
  int flux_respond (flux_t *h, const flux_msg_t *request,
-                   int errnum, const char *json_str);
+                   int errnum, const char *s);
 
  int flux_respond_pack (flux_t *h, const flux_msg_t *request,
                         const char *fmt, ...);
@@ -33,7 +33,7 @@ If _errnum_ is non-zero, an error is returned to the sender such that
 `flux_rpc_get(3)` or `flux_rpc_get_raw(3)` will fail, with the system
 errno set to _errnum_.  Any payload arguments are ignored in this case.
 
-If _json_str_ is non-NULL, `flux_respond()` will send it as the response
+If _s_ is non-NULL, `flux_respond()` will send it as the response
 payload, otherwise there will be no payload.  Similarly, if _data_ is
 non-NULL, `flux_respond_raw()` will send it as the response payload.
 

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -5,7 +5,7 @@ flux_respond(3)
 
 NAME
 ----
-flux_respond, flux_respond_pack, flux_respond_raw - respond to a request
+flux_respond, flux_respond_pack, flux_respond_raw, flux_respond_error - respond to a request
 
 
 SYNOPSIS
@@ -21,17 +21,21 @@ SYNOPSIS
  int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                        int errnum, const void *data, int length);
 
+ int flux_respond_error (flux_t *h, const flux_msg_t *request,
+                         int errnum, const char *fmt, ...);
 
 DESCRIPTION
 -----------
 
-`flux_respond()`, `flux_respond_pack()`, and `flux_respond_raw()` encode
-and send a response message on handle _h_, deriving topic string,
-matchtag, and route stack from the provided _request_.
+`flux_respond()`, `flux_respond_pack()`, `flux_respond_raw()`, and
+`flux_respond_error()`  encode and send a response message on handle _h_,
+deriving topic string, matchtag, and route stack from the provided
+_request_.
 
-If _errnum_ is non-zero, an error is returned to the sender such that
-`flux_rpc_get(3)` or `flux_rpc_get_raw(3)` will fail, with the system
-errno set to _errnum_.  Any payload arguments are ignored in this case.
+`flux_respond()` can operate in two modes.  If _errnum_ is non-zero,
+an error is returned to the sender such that `flux_rpc_get(3)` or
+variants will fail, with the system errno set to _errnum_.  Any payload
+arguments are ignored in this case.
 
 If _s_ is non-NULL, `flux_respond()` will send it as the response
 payload, otherwise there will be no payload.  Similarly, if _data_ is
@@ -41,6 +45,11 @@ non-NULL, `flux_respond_raw()` will send it as the response payload.
 building the payload using variable arguments with a format string in
 the style of jansson's `json_pack()` (used internally).
 
+`flux_respond_error()` returns an error response to the sender.
+_errnum_ must be non-zero.  If _fmt_ is non-NULL, an error string
+payload is included in the response, constructed using printf(3)-style
+arguments.  The error string may be used to provide a more
+detailed error message than can be conveyed via _errnum_.
 
 include::JSON_PACK.adoc[]
 

--- a/doc/man3/flux_response_decode.adoc
+++ b/doc/man3/flux_response_decode.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
 
  int flux_response_decode (const flux_msg_t *msg,
                            const char **topic,
-                           const char **json_str);
+                           const char **s);
 
  int flux_response_decode_raw (const flux_msg_t *msg,
                                const char **topic,
@@ -28,8 +28,8 @@ DESCRIPTION
 _topic_, if non-NULL, will be set to the message's topic string. The
 storage for this string belongs to _msg_ and should not be freed.
 
-_json_str_, if non-NULL, will be set to the message's JSON payload.
-If no payload exists, _json_str_ is set to NULL.  The storage for this
+_s_, if non-NULL, will be set to the message's NULL-terminated string payload.
+If no payload exists, it is set to NULL.  The storage for this
 string belongs to _msg_ and should not be freed.
 
 `flux_response_decode_raw()` decodes a response message with a raw payload,

--- a/doc/man3/flux_response_decode.adoc
+++ b/doc/man3/flux_response_decode.adoc
@@ -5,7 +5,7 @@ flux_response_decode(3)
 
 NAME
 ----
-flux_response_decode, flux_response_decode_raw - decode a Flux response message
+flux_response_decode, flux_response_decode_raw, flux_response_decode_error - decode a Flux response message
 
 
 SYNOPSIS
@@ -19,6 +19,10 @@ SYNOPSIS
  int flux_response_decode_raw (const flux_msg_t *msg,
                                const char **topic,
                                const void **data, int *len);
+
+ int flux_response_decode_error (const flux_msg_t *msg,
+                                 const char *errstr);
+
 
 DESCRIPTION
 -----------
@@ -35,6 +39,10 @@ string belongs to _msg_ and should not be freed.
 `flux_response_decode_raw()` decodes a response message with a raw payload,
 setting _data_ and _len_ to the payload data and length. The storage for
 the raw payload belongs to _msg_ and should not be freed.
+
+`flux_response_decode_error()` decodes an optional error string included
+with an error response.  This fails if the response is not an error,
+or does not include an error string payload.
 
 
 RETURN VALUE
@@ -53,6 +61,10 @@ The _msg_ argument was NULL.
 EPROTO::
 Message decoding failed, such as due to incorrect message type,
 missing topic string, etc..
+
+ENOENT::
+`flux_response_decode_error()` was called on a message with no
+error response payload.
 
 
 AUTHOR

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -5,7 +5,7 @@ flux_rpc(3)
 
 NAME
 ----
-flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw - perform a remote procedure call to a Flux service
+flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw, flux_rpc_get_error - perform a remote procedure call to a Flux service
 
 
 SYNOPSIS
@@ -31,6 +31,7 @@ SYNOPSIS
  int flux_rpc_get_raw (flux_future_t *f,
                        const void **data, int *len);
 
+ const char *flux_rpc_get_error (flux_future_t *f);
 
 DESCRIPTION
 -----------
@@ -53,6 +54,12 @@ decode the RPC result.  Internally, they call `flux_future_get()`
 to access the response message stored in the future.  If the response
 message has not yet been received, these functions block until it is,
 or an error occurs.
+
+`flux_rpc_get_error()` returns an error string explaining the reason
+for a failure.  Its return value is never NULL.  If the remote service
+included a textual error string in the response, that is returned.
+Otherwise flux_strerror(3) provides the string based on the error
+number received in the response.
 
 
 REQUEST OPTIONS

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -13,7 +13,7 @@ SYNOPSIS
  #include <flux/core.h>
 
  flux_future_t *flux_rpc (flux_t *h, const char *topic,
-                          const char *json_str,
+                          const char *s,
                           uint32_t nodeid, int flags);
 
  flux_future_t *flux_rpc_pack (flux_t *h, const char *topic,
@@ -24,7 +24,7 @@ SYNOPSIS
                               const void *data, int len,
                               uint32_t nodeid, int flags);
 
- int flux_rpc_get (flux_future_t *f, const char **json_str);
+ int flux_rpc_get (flux_future_t *f, const char **s);
 
  int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
@@ -61,11 +61,11 @@ REQUEST OPTIONS
 The request message is encoded and sent with or without a payload
 using one of the three `flux_rpc()` variants.
 
-`flux_rpc()` attaches _json_str_, a serialized JSON string, as request
+`flux_rpc()` attaches _s_, a NULL terminated string, as request
 payload.  If NULL, the request is encoded without a payload.
 
-`flux_rpc_pack()` attaches a JSON payload encoded using Jansson
-`json_pack()` style arguments (see below).
+`flux_rpc_pack()` attaches a JSON payload encoded as a NULL terminated
+string using Jansson `json_pack()` style arguments (see below).
 
 `flux_rpc_raw()` attaches a raw payload _data_ of length _len_, in bytes.
 If _data_ is NULL, the request is encoded without a payload.
@@ -100,13 +100,13 @@ with an error.  Otherwise it is fulfilled with the response message.
 If there was an error, `flux_future_get()` or the `flux_rpc_get()` variants
 return an error.
 
-`flux_rpc_get()` sets _json_str_ (if non-NULL) to the serialized JSON
-payload contained in the RPC response.  If there was no payload, _json_str_
+`flux_rpc_get()` sets _s_ (if non-NULL) to the NULL-terminated string
+payload contained in the RPC response.  If there was no payload, _s_
 is set to NULL.
 
-`flux_rpc_get_unpack()` decodes the JSON payload using Jansson `json_unpack()`
-style arguments (see below).  It is an error if there is no payload, or if
-the payload is not JSON.
+`flux_rpc_get_unpack()` decodes the NULL-terminated string payload as JSON
+using Jansson `json_unpack()` style arguments (see below).  It is an error
+if there is no payload, or if the payload is not JSON.
 
 `flux_rpc_get_raw()` assigns the raw payload of the RPC response message
 to _data_ and its length to _len_.  If there is no payload, this function

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -424,3 +424,4 @@ hostlist
 hostnames
 unfulfills
 MSGFLAG
+errstr

--- a/src/bindings/lua/tests/zmsg-test.c
+++ b/src/bindings/lua/tests/zmsg-test.c
@@ -47,12 +47,9 @@ flux_msg_t *l_cmb_zmsg_encode (lua_State *L)
 	if ((json_str == NULL) || (tag == NULL))
 		return NULL;
 
-    flux_msg_t *msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
-    if (!msg || flux_msg_set_topic (msg, tag) < 0
-              || flux_msg_set_json (msg, json_str) < 0) {
-        flux_msg_destroy (msg);
+    flux_msg_t *msg = flux_request_encode (tag, json_str);
+    if (!msg)
         return NULL;
-    }
     free (json_str);
     return (msg);
 }
@@ -63,7 +60,7 @@ static int l_zi_resp_cb (lua_State *L,
     flux_msg_t **old = zmsg_info_zmsg (zi);
     flux_msg_t **msg = malloc (sizeof (*msg));
     *msg = flux_msg_copy (*old, true);
-    if (flux_msg_set_json (*msg, json_str) < 0) {
+    if (flux_msg_set_string (*msg, json_str) < 0) {
         flux_msg_destroy (*msg);
         free (msg);
         return lua_pusherror (L, "flux_msg_set_json: %s", strerror (errno));

--- a/src/bindings/lua/tests/zmsg-test.c
+++ b/src/bindings/lua/tests/zmsg-test.c
@@ -109,7 +109,7 @@ static int l_cmb_zmsg_create_response_with_error (lua_State *L)
         return lua_pusherror (L, "flux_msg_set_topic: %s", strerror (errno));
     if (flux_msg_set_errnum (msg, errnum) < 0)
         return lua_pusherror (L, "flux_msg_set_errnum: %s", strerror (errno));
-    if (flux_msg_set_payload (msg, 0, NULL, 0))
+    if (flux_msg_set_payload (msg, NULL, 0))
         return lua_pusherror (L, "flux_msg_set_payload: %s", strerror (errno));
 
     zi = zmsg_info_create (&msg, FLUX_MSGTYPE_RESPONSE);

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -70,7 +70,7 @@ struct zmsg_info * zmsg_info_create (flux_msg_t **msg, int typemask)
     if ((flux_msg_get_topic (*msg, &topic) < 0)
         || !(zi->tag = strdup (topic))
         || !(zi->msg = flux_msg_copy (*msg, true))
-        || (flux_msg_get_json (zi->msg, &json_str) < 0)) {
+        || (flux_msg_get_string (zi->msg, &json_str) < 0)) {
         zmsg_info_destroy (zi);
         return (NULL);
     }

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -74,7 +74,7 @@ class Message(WrapperPimpl):
     def payload_str(self):
         string = ffi.new('char *[1]')
         if self.pimpl.has_payload():
-            self.pimpl.get_json(ffi.cast('char**', string))
+            self.pimpl.get_string(ffi.cast('char**', string))
             return ffi.string(string[0])
         else:
             return None

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -109,8 +109,7 @@ static flux_msg_t *encode_event (const char *topic, int flags,
             errno = EPROTO;
             goto error;
         }
-        if (flux_msg_set_payload (msg, (flags & FLUX_MSGFLAG_JSON),
-                                  dst, dstlen) < 0) {
+        if (flux_msg_set_payload (msg, dst, dstlen) < 0) {
             if (errno == EINVAL)
                 errno = EPROTO;
             goto error;
@@ -157,8 +156,7 @@ void pub_cb (flux_t *h, flux_msg_handler_t *mh,
                                         "flags", &flags,
                                         "payload", &payload) < 0)
         goto error;
-    if ((flags & ~(FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_JSON)) != 0
-                            || (!payload && (flags & FLUX_MSGFLAG_JSON))) {
+    if ((flags & ~(FLUX_MSGFLAG_PRIVATE)) != 0) {
         errno = EPROTO;
         goto error;
     }

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -509,7 +509,8 @@ static bool internal_request (client_t *c, const flux_msg_t *msg)
 
     /* Respond to client
      */
-    if (!(rmsg = flux_response_encode (topic, rc < 0 ? errno : 0, NULL))
+    if (!(rmsg = flux_response_encode (topic, NULL))
+                    || flux_msg_set_errnum (rmsg, rc < 0 ? errno : 0) < 0
                     || flux_msg_set_matchtag (rmsg, matchtag) < 0
                     || flux_msg_set_rolemask (rmsg, FLUX_ROLE_OWNER) < 0)
         flux_log_error (c->ctx->h, "%s: encoding response", __FUNCTION__);

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -86,7 +86,6 @@ int flux_event_decode_raw (const flux_msg_t *msg, const char **topicp,
     const char *topic;
     const void *data = NULL;
     int len = 0;
-    int flags;
     int rc = -1;
 
     if (!datap || !lenp) {
@@ -95,7 +94,7 @@ int flux_event_decode_raw (const flux_msg_t *msg, const char **topicp,
     }
     if (event_decode (msg, &topic) < 0)
         goto done;
-    if (flux_msg_get_payload (msg, &flags, &data, &len) < 0) {
+    if (flux_msg_get_payload (msg, &data, &len) < 0) {
         if (errno != EPROTO)
             goto done;
         errno = 0;
@@ -177,7 +176,7 @@ flux_msg_t *flux_event_encode_raw (const char *topic,
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
         goto error;
-    if (data && flux_msg_set_payload (msg, 0, data, len) < 0)
+    if (data && flux_msg_set_payload (msg, data, len) < 0)
         goto error;
     return msg;
 error:
@@ -252,10 +251,8 @@ flux_future_t *flux_event_publish (flux_t *h,
         errno = EINVAL;
         return NULL;
     }
-    if (json_str) {
-        flags |= FLUX_MSGFLAG_JSON;
+    if (json_str)
         len = strlen (json_str) + 1;
-    }
     return wrap_event_rpc (h, topic, flags, json_str, len);
 }
 
@@ -285,7 +282,7 @@ flux_future_t *flux_event_publish_pack (flux_t *h,
         return NULL;
     }
     json_decref (o);
-    if (!(f = wrap_event_rpc (h,  topic, flags | FLUX_MSGFLAG_JSON,
+    if (!(f = wrap_event_rpc (h,  topic, flags,
                               json_str, strlen (json_str) + 1))) {
         int saved_errno = errno;
         free (json_str);

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -62,19 +62,20 @@ done:
 }
 
 
-int flux_event_decode (const flux_msg_t *msg, const char **topic, const char **json_str)
+int flux_event_decode (const flux_msg_t *msg, const char **topicp,
+                       const char **sp)
 {
-    const char *ts, *js;
+    const char *topic, *s;
     int rc = -1;
 
-    if (event_decode (msg, &ts) < 0)
+    if (event_decode (msg, &topic) < 0)
         goto done;
-    if (flux_msg_get_json (msg, &js) < 0)
+    if (flux_msg_get_string (msg, &s) < 0)
         goto done;
-    if (topic)
-        *topic = ts;
-    if (json_str)
-        *json_str = js;
+    if (topicp)
+        *topicp = topic;
+    if (sp)
+        *sp = s;
     rc = 0;
 done:
     return rc;
@@ -157,12 +158,12 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_event_encode (const char *topic, const char *json_str)
+flux_msg_t *flux_event_encode (const char *topic, const char *s)
 {
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
         goto error;
-    if (json_str && flux_msg_set_json (msg, json_str) < 0)
+    if (s && flux_msg_set_string (msg, s) < 0)
         goto error;
     return msg;
 error:

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -12,34 +12,34 @@ enum event_flags {
     FLUX_EVENT_PRIVATE = 1,
 };
 
-/* Decode an event message.
+/* Decode an event message with optional string payload.
  * If topic is non-NULL, assign the event topic string.
- * If json_str is non-NULL, assign the payload or set to NULL if none
+ * If s is non-NULL, assign string payload or set to NULL if none
  * exists.  Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_event_decode (const flux_msg_t *msg, const char **topic,
-                       const char **json_str);
+                       const char **s);
 
-/* Decode an event message with json payload.  These functions use
+/* Decode an event message with required JSON payload.  These functions use
  * jansson unpack style variable arguments for decoding the JSON object
  * payload directly.  Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_event_unpack (const flux_msg_t *msg, const char **topic,
                        const char *fmt, ...);
 
-/* Encode an event message.
- * If json_str is non-NULL, it is copied to the message payload.
+/* Encode an event message with optinal string payload.
+ * If s is non-NULL, it is copied to the message payload.
  * Returns message or NULL on failure with errno set.
  */
-flux_msg_t *flux_event_encode (const char *topic, const char *json_str);
+flux_msg_t *flux_event_encode (const char *topic, const char *s);
 
-/* Encode an event message with json payload.  These functions use
+/* Encode an event message with JSON payload.  These functions use
  * jansson pack style variable arguments for encoding the JSON object
  * payload directly.  Returns message or NULL on failure with errno set.
  */
 flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...);
 
-/* Encode an event message with optional raw payload.
+/* Encode an event message with raw payload.
  */
 flux_msg_t *flux_event_encode_raw (const char *topic,
                                    const void *data, int len);
@@ -53,18 +53,22 @@ flux_msg_t *flux_event_encode_raw (const char *topic,
 int flux_event_decode_raw (const flux_msg_t *msg, const char **topic,
                            const void **data, int *len);
 
-/* Publish an event.
+/* Publish an event with optional string payload.
  * The future is fulfilled once the event has been assigned a sequence number,
  * and does not indicate that the event has yet reached all subscribers.
  */
 flux_future_t *flux_event_publish (flux_t *h,
                                    const char *topic, int flags,
-                                   const char *json_str);
+                                   const char *s);
 
+/* Publish an event with JSON payload.
+ */
 flux_future_t *flux_event_publish_pack (flux_t *h,
                                         const char *topic, int flags,
                                         const char *fmt, ...);
 
+/* Publish an event with optinal raw paylaod.
+ */
 flux_future_t *flux_event_publish_raw (flux_t *h,
                                        const char *topic, int flags,
                                        const void *data, int len);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -27,7 +27,6 @@ enum {
 enum {
     FLUX_MSGFLAG_TOPIC      = 0x01,	/* message has topic string */
     FLUX_MSGFLAG_PAYLOAD    = 0x02,	/* message has payload */
-    FLUX_MSGFLAG_JSON       = 0x04,	/* message payload is JSON */
     FLUX_MSGFLAG_ROUTE      = 0x08,	/* message is routable */
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
     FLUX_MSGFLAG_PRIVATE    = 0x20, /* private to instance owner and sender */
@@ -161,12 +160,9 @@ int flux_msg_get_topic (const flux_msg_t *msg, const char **topic);
  * The new payload will be copied (caller retains ownership).
  * Any old payload is deleted.
  * flux_msg_get_payload returns pointer to msg-owned buf.
- * Flags can be 0 or FLUX_MSGFLAG_JSON (hint for decoding).
  */
-int flux_msg_get_payload (const flux_msg_t *msg, int *flags,
-                          const void **buf, int *size);
-int flux_msg_set_payload (flux_msg_t *msg, int flags,
-                          const void *buf, int size);
+int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, int *size);
+int flux_msg_set_payload (flux_msg_t *msg, const void *buf, int size);
 bool flux_msg_has_payload (const flux_msg_t *msg);
 
 /* Get/set flags

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -173,17 +173,21 @@ bool flux_msg_has_payload (const flux_msg_t *msg);
 int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *flags);
 int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags);
 
-/* Get/set JSON payload.
- * flux_msg_set_json() accepts a NULL json_str (no payload).
- * flux_msg_get_json() will set json_str to NULL if there is no payload
+/* Get/set string payload.
+ * flux_msg_set_string() accepts a NULL 's' (no payload).
+ * flux_msg_get_string() will set 's' to NULL if there is no payload
+ * N.B. the raw paylaod includes C string \0 terminator.
+ */
+int flux_msg_set_string (flux_msg_t *msg, const char *);
+int flux_msg_get_string (const flux_msg_t *msg, const char **s);
+
+/* Get/set JSON payload (encoded as string)
  * pack/unpack functions use jansson pack/unpack style arguments for
  * encoding/decoding the JSON object payload directly from/to its members.
  */
-int flux_msg_set_json (flux_msg_t *msg, const char *json_str);
 int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap);
 
-int flux_msg_get_json (const flux_msg_t *msg, const char **json_str);
 int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vunpack (const flux_msg_t *msg, const char *fmt, va_list ap);
 

--- a/src/common/libflux/mrpc.c
+++ b/src/common/libflux/mrpc.c
@@ -228,14 +228,14 @@ done:
     return rc;
 }
 
-int flux_mrpc_get (flux_mrpc_t *mrpc, const char **json_str)
+int flux_mrpc_get (flux_mrpc_t *mrpc, const char **s)
 {
     int rc = -1;
 
     assert (mrpc->magic == MRPC_MAGIC);
     if (mrpc_get (mrpc) < 0)
         goto done;
-    if (flux_response_decode (mrpc->rx_msg, NULL, json_str) < 0)
+    if (flux_response_decode (mrpc->rx_msg, NULL, s) < 0)
         goto done;
     rc = 0;
 done:
@@ -259,17 +259,12 @@ done:
 static int flux_mrpc_vget_unpack (flux_mrpc_t *mrpc, const char *fmt, va_list ap)
 {
     int rc = -1;
-    const char *json_str;
 
     assert (mrpc->magic == MRPC_MAGIC);
     if (mrpc_get (mrpc) < 0)
         goto done;
-    if (flux_response_decode (mrpc->rx_msg, NULL, &json_str) < 0)
+    if (flux_response_decode (mrpc->rx_msg, NULL, NULL) < 0)
         goto done;
-    if (!json_str) {
-        errno = EPROTO;
-        goto done;
-    }
     if (flux_msg_vunpack (mrpc->rx_msg, fmt, ap) < 0)
         goto done;
     rc = 0;
@@ -490,14 +485,14 @@ error:
 
 flux_mrpc_t *flux_mrpc (flux_t *h,
                         const char *topic,
-                        const char *json_str,
+                        const char *s,
                         const char *nodeset,
                         int flags)
 {
     flux_msg_t *msg;
     flux_mrpc_t *rc = NULL;
 
-    if (!(msg = flux_request_encode (topic, json_str)))
+    if (!(msg = flux_request_encode (topic, s)))
         goto done;
     rc = mrpc (h, nodeset, flags, msg);
 done:

--- a/src/common/libflux/mrpc.h
+++ b/src/common/libflux/mrpc.h
@@ -20,7 +20,7 @@ typedef void (*flux_mrpc_continuation_f)(flux_mrpc_t *mrpc, void *arg);
  * shorthand for a single rpc sent to FLUX_NODEID_UPSTREAM.  On
  * failure return NULL with errno set.
  */
-flux_mrpc_t *flux_mrpc (flux_t *h, const char *topic, const char *json_str,
+flux_mrpc_t *flux_mrpc (flux_t *h, const char *topic, const char *s,
                         const char *nodeset, int flags);
 
 /* Variant of flux_mrpc that encodes a json payload using jansson
@@ -38,11 +38,11 @@ void flux_mrpc_destroy (flux_mrpc_t *mrpc);
 bool flux_mrpc_check (flux_mrpc_t *mrpc);
 
 /* Wait for a response if necessary, then decode it.
- * Any returned 'json_str' payload is invalidated by
+ * Any returned 's' payload is invalidated by
  * flux_mrpc_destroy() or flux_mrpc_next().
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_mrpc_get (flux_mrpc_t *mrpc, const char **json_str);
+int flux_mrpc_get (flux_mrpc_t *mrpc, const char **s);
 
 /* Variant of flux_mrpc_get that decodes json payload using
  * jansson pack/unpack format strings.  Returned items are

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -89,7 +89,7 @@ int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
     }
     if (request_decode (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload (msg, NULL, &d, &l) < 0) {
+    if (flux_msg_get_payload (msg, &d, &l) < 0) {
         if (errno != EPROTO)
             goto done;
         errno = 0;
@@ -177,7 +177,7 @@ flux_msg_t *flux_request_encode_raw (const char *topic,
 
     if (!msg)
         goto error;
-    if (data && flux_msg_set_payload (msg, 0, data, len) < 0)
+    if (data && flux_msg_set_payload (msg, data, len) < 0)
         goto error;
     return msg;
 error:

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -56,20 +56,20 @@ done:
     return rc;
 }
 
-int flux_request_decode (const flux_msg_t *msg, const char **topic,
-                         const char **json_str)
+int flux_request_decode (const flux_msg_t *msg, const char **topicp,
+                         const char **sp)
 {
-    const char *ts, *js;
+    const char *topic, *s;
     int rc = -1;
 
-    if (request_decode (msg, &ts) < 0)
+    if (request_decode (msg, &topic) < 0)
         goto done;
-    if (flux_msg_get_json (msg, &js) < 0)
+    if (flux_msg_get_string (msg, &s) < 0)
         goto done;
-    if (topic)
-        *topic = ts;
-    if (json_str)
-        *json_str = js;
+    if (topicp)
+        *topicp = topic;
+    if (sp)
+        *sp = s;
     rc = 0;
 done:
     return rc;
@@ -156,13 +156,13 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_request_encode (const char *topic, const char *json_str)
+flux_msg_t *flux_request_encode (const char *topic, const char *s)
 {
     flux_msg_t *msg = request_encode (topic);
 
     if (!msg)
         goto error;
-    if (json_str && flux_msg_set_json (msg, json_str) < 0)
+    if (s && flux_msg_set_string (msg, s) < 0)
         goto error;
     return msg;
 error:

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -7,15 +7,15 @@
 extern "C" {
 #endif
 
-/* Decode a request message with optional json payload.
+/* Decode a request message with optional string payload.
  * If topic is non-NULL, assign the request topic string.
- * If json_str is non-NULL, assign the payload or set to NULL if none
+ * If s is non-NULL, assign the string payload or set to NULL if none
  * exists.  Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_request_decode (const flux_msg_t *msg, const char **topic,
-                         const char **json_str);
+                         const char **s);
 
-/* Decode a request message with json payload.  These functions use
+/* Decode a request message with required json payload.  These functions use
  * jansson unpack style variable arguments for decoding the JSON object
  * payload directly.  Returns 0 on success, or -1 on failure with errno set.
  */
@@ -31,12 +31,12 @@ int flux_request_unpack (const flux_msg_t *msg, const char **topic,
 int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
                              const void **data, int *len);
 
-/* Encode a request message.
- * If json_str is non-NULL, assign the json payload.
+/* Encode a request message with optional string payload.
+ * If s is non-NULL, assign the string payload.
  */
-flux_msg_t *flux_request_encode (const char *topic, const char *json_str);
+flux_msg_t *flux_request_encode (const char *topic, const char *s);
 
-/* Encode a request message.
+/* Encode a request message with optional raw payload.
  * If data is non-NULL, assign the raw payload.
  * Otherwise there will be no payload.
  */

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -113,6 +113,38 @@ done:
     return rc;
 }
 
+int flux_response_decode_error (const flux_msg_t *msg, const char **errstr)
+{
+    int type;
+    int errnum;
+    const char *s = NULL;
+
+    if (!msg || !errstr) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_msg_get_type (msg, &type) < 0)
+        return -1;
+    if (type != FLUX_MSGTYPE_RESPONSE) {
+        errno = EPROTO;
+        return -1;
+    }
+    if (flux_msg_get_errnum (msg, &errnum) < 0)
+        return -1;
+    if (errnum == 0) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (flux_msg_get_string (msg, &s) < 0)
+        return -1;
+    if (s == NULL) {
+        errno = ENOENT;
+        return -1;
+    }
+    *errstr = s;
+    return 0;
+}
+
 static flux_msg_t *response_encode (const char *topic, int errnum)
 {
     flux_msg_t *msg = NULL;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -204,6 +204,25 @@ error:
     return NULL;
 }
 
+flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
+                                        const char *errstr)
+{
+    flux_msg_t *msg;
+
+    if (errnum == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(msg = response_encode (topic, errnum)))
+        goto error;
+    if (errstr && flux_msg_set_string (msg, errstr) < 0)
+        goto error;
+    return msg;
+error:
+    flux_msg_destroy (msg);
+    return NULL;
+}
+
 static flux_msg_t *derive_response (flux_t *h, const flux_msg_t *request,
                                     int errnum)
 {

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -91,7 +91,6 @@ int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
     const char *ts;
     const void *d = NULL;
     int l = 0;
-    int flags = 0;
     int rc = -1;
 
     if (!data || !len) {
@@ -100,7 +99,7 @@ int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
     }
     if (response_decode (msg, &ts) < 0)
         goto done;
-    if (flux_msg_get_payload (msg, &flags, &d, &l) < 0) {
+    if (flux_msg_get_payload (msg, &d, &l) < 0) {
         if (errno != EPROTO)
             goto done;
         errno = 0;
@@ -166,7 +165,7 @@ flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
         errno = EINVAL;
         goto error;
     }
-    if (data && flux_msg_set_payload (msg, 0, data, len) < 0)
+    if (data && flux_msg_set_payload (msg, data, len) < 0)
         goto error;
     return msg;
 error:
@@ -254,7 +253,7 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
     flux_msg_t *msg = derive_response (h, request, errnum);
     if (!msg)
         goto fatal;
-    if (!errnum && data && flux_msg_set_payload (msg, 0, data, len) < 0)
+    if (!errnum && data && flux_msg_set_payload (msg, data, len) < 0)
         goto fatal;
     if (flux_send (h, msg, 0) < 0)
         goto fatal;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -287,12 +287,12 @@ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
 }
 
 int flux_respond_raw (flux_t *h, const flux_msg_t *request,
-                      int errnum, const void *data, int len)
+                      const void *data, int len)
 {
-    flux_msg_t *msg = derive_response (h, request, errnum);
+    flux_msg_t *msg = derive_response (h, request, 0);
     if (!msg)
         goto error;
-    if (!errnum && data && flux_msg_set_payload (msg, data, len) < 0)
+    if (data && flux_msg_set_payload (msg, data, len) < 0)
         goto error;
     if (flux_send (h, msg, 0) < 0)
         goto error;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -167,16 +167,12 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s)
+flux_msg_t *flux_response_encode (const char *topic, const char *s)
 {
     flux_msg_t *msg;
 
-    if (!(msg = response_encode (topic, errnum)))
+    if (!(msg = response_encode (topic, 0)))
         goto error;
-    if ((errnum != 0 && s != NULL)) {
-        errno = EINVAL;
-        goto error;
-    }
     if (s && flux_msg_set_string (msg, s) < 0)
         goto error;
     return msg;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -222,22 +222,21 @@ static flux_msg_t *derive_response (flux_t *h, const flux_msg_t *request,
 
     if (!request) {
         errno = EINVAL;
-        goto fatal;
+        goto error;
     }
     if (!(msg = flux_msg_copy (request, false)))
-        goto fatal;
+        goto error;
     if (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) < 0)
-        goto fatal;
+        goto error;
     if (flux_msg_set_userid (msg, FLUX_USERID_UNKNOWN) < 0)
-        goto fatal;
+        goto error;
     if (flux_msg_set_rolemask (msg, FLUX_ROLE_NONE) < 0)
-        goto fatal;
+        goto error;
     if (errnum && flux_msg_set_errnum (msg, errnum) < 0)
-        goto fatal;
+        goto error;
     return msg;
-fatal:
+error:
     flux_msg_destroy (msg);
-    FLUX_FATAL (h);
     return NULL;
 }
 
@@ -246,16 +245,15 @@ int flux_respond (flux_t *h, const flux_msg_t *request,
 {
     flux_msg_t *msg = derive_response (h, request, errnum);
     if (!msg)
-        goto fatal;
-    if (!errnum && s&& flux_msg_set_string (msg, s) < 0)
-        goto fatal;
+        goto error;
+    if (!errnum && s && flux_msg_set_string (msg, s) < 0)
+        goto error;
     if (flux_send (h, msg, 0) < 0)
-        goto fatal;
+        goto error;
     flux_msg_destroy (msg);
     return 0;
-fatal:
+error:
     flux_msg_destroy (msg);
-    FLUX_FATAL (h);
     return -1;
 }
 
@@ -264,16 +262,15 @@ static int flux_respond_vpack (flux_t *h, const flux_msg_t *request,
 {
     flux_msg_t *msg = derive_response (h, request, 0);
     if (!msg)
-        goto fatal;
+        goto error;
     if (flux_msg_vpack (msg, fmt, ap) < 0)
-        goto fatal;
+        goto error;
     if (flux_send (h, msg, 0) < 0)
-        goto fatal;
+        goto error;
     flux_msg_destroy (msg);
     return 0;
-fatal:
+error:
     flux_msg_destroy (msg);
-    FLUX_FATAL (h);
     return -1;
 }
 
@@ -294,16 +291,15 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
 {
     flux_msg_t *msg = derive_response (h, request, errnum);
     if (!msg)
-        goto fatal;
+        goto error;
     if (!errnum && data && flux_msg_set_payload (msg, data, len) < 0)
-        goto fatal;
+        goto error;
     if (flux_send (h, msg, 0) < 0)
-        goto fatal;
+        goto error;
     flux_msg_destroy (msg);
     return 0;
-fatal:
+error:
     flux_msg_destroy (msg);
-    FLUX_FATAL (h);
     return -1;
 }
 

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -185,17 +185,13 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
+flux_msg_t *flux_response_encode_raw (const char *topic,
                                       const void *data, int len)
 {
     flux_msg_t *msg;
 
-    if (!(msg = response_encode (topic, errnum)))
+    if (!(msg = response_encode (topic, 0)))
         goto error;
-    if ((errnum != 0 && data != NULL)) {
-        errno = EINVAL;
-        goto error;
-    }
     if (data && flux_msg_set_payload (msg, data, len) < 0)
         goto error;
     return msg;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -65,21 +65,21 @@ done:
     return rc;
 }
 
-int flux_response_decode (const flux_msg_t *msg, const char **topic,
-                          const char **json_str)
+int flux_response_decode (const flux_msg_t *msg, const char **topicp,
+                          const char **sp)
 {
-    const char *ts, *js;
+    const char *topic, *s;
     int rc = -1;
 
-    if (response_decode (msg, &ts) < 0)
+    if (response_decode (msg, &topic) < 0)
         goto done;
-    if (json_str) {
-        if (flux_msg_get_json (msg, &js) < 0)
+    if (sp) {
+        if (flux_msg_get_string (msg, &s) < 0)
             goto done;
-        *json_str = js;
+        *sp = s;
     }
-    if (topic)
-        *topic = ts;
+    if (topicp)
+        *topicp = topic;
     rc = 0;
 done:
     return rc;
@@ -135,18 +135,17 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_response_encode (const char *topic, int errnum,
-                                  const char *json_str)
+flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s)
 {
     flux_msg_t *msg;
 
     if (!(msg = response_encode (topic, errnum)))
         goto error;
-    if ((errnum != 0 && json_str != NULL)) {
+    if ((errnum != 0 && s != NULL)) {
         errno = EINVAL;
         goto error;
     }
-    if (json_str && flux_msg_set_json (msg, json_str) < 0)
+    if (s && flux_msg_set_string (msg, s) < 0)
         goto error;
     return msg;
 error:
@@ -200,12 +199,12 @@ fatal:
 }
 
 int flux_respond (flux_t *h, const flux_msg_t *request,
-                  int errnum, const char *json_str)
+                  int errnum, const char *s)
 {
     flux_msg_t *msg = derive_response (h, request, errnum);
     if (!msg)
         goto fatal;
-    if (!errnum && json_str && flux_msg_set_json (msg, json_str) < 0)
+    if (!errnum && s&& flux_msg_set_string (msg, s) < 0)
         goto fatal;
     if (flux_send (h, msg, 0) < 0)
         goto fatal;

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -8,9 +8,9 @@
 extern "C" {
 #endif
 
-/* Decode a response message, with optional json payload.
+/* Decode a response message, with optional string payload.
  * If topic is non-NULL, assign the response topic string.
- * If json_str is non-NULL, assign the payload if one exists or set to
+ * If s is non-NULL, assign the string payload if one exists or set to
  * NULL is none exists.  If response includes a nonzero errnum, errno
  * is set to the errnum value and -1 is returned with no assignments
  * to topic or json_str.  Returns 0 on success, or -1 on failure with
@@ -30,19 +30,22 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
 int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
                               const void **data, int *len);
 
-flux_msg_t *flux_response_encode (const char *topic, int errnum,
-                                  const char *json_str);
+/* Encode a message with optional string payload.
+ */
+flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s);
+
 /* Encode a response message with optional raw payload.
  */
 flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
                                       const void *data, int len);
 
-/* Create a response to the provided request message with optional json payload.
+/* Create a response to the provided request message with optional
+ * string payload.
  * If errnum is nonzero, payload argument is ignored.
  * All errors in this function are fatal - see flux_fatal_set().
  */
 int flux_respond (flux_t *h, const flux_msg_t *request,
-                  int errnum, const char *json_str);
+                  int errnum, const char *s);
 
 /* Create a response to the provided request message with json payload, using
  * jansson pack style variable arguments for encoding the JSON object

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -13,11 +13,11 @@ extern "C" {
  * If s is non-NULL, assign the string payload if one exists or set to
  * NULL is none exists.  If response includes a nonzero errnum, errno
  * is set to the errnum value and -1 is returned with no assignments
- * to topic or json_str.  Returns 0 on success, or -1 on failure with
+ * to topic or s.  Returns 0 on success, or -1 on failure with
  * errno set.
  */
 int flux_response_decode (const flux_msg_t *msg, const char **topic,
-                          const char **json_str);
+                          const char **s);
 
 /* Decode a response message, with optional raw payload.
  * If topic is non-NULL, assign the response topic string.

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -30,6 +30,13 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
 int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
                               const void **data, int *len);
 
+/* If failed response includes an error string payload, assign to 'errstr',
+ * otherwise fail.
+ * Returns 0 on success, or -1 on failure with errno set.
+ */
+int flux_response_decode_error (const flux_msg_t *msg, const char **errstr);
+
+
 /* Encode a message with optional string payload.
  */
 flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s);

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -38,9 +38,8 @@ int flux_response_decode_error (const flux_msg_t *msg, const char **errstr);
 
 
 /* Encode a message with optional string payload 's'.
- * If errnum != 0, payload 's' must be NULL.
  */
-flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s);
+flux_msg_t *flux_response_encode (const char *topic, const char *s);
 
 /* Encode a response message with optional raw payload.
  */

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -24,7 +24,7 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
  * Data and len must be non-NULL and will be assigned the payload and length.
  * If there is no payload, they will be assigned NULL and zero.
  * If response includes a nonzero errnum, errno is set to the errnum value
- * and -1 is returned with no assignments to topic or json_str.
+ * and -1 is returned with no assignments to topic, data, or len.
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
@@ -37,13 +37,14 @@ int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
 int flux_response_decode_error (const flux_msg_t *msg, const char **errstr);
 
 
-/* Encode a message with optional string payload.
+/* Encode a message with optional string payload 's'.
+ * If errnum != 0, payload 's' must be NULL.
  */
 flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s);
 
 /* Encode a response message with optional raw payload.
  */
-flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
+flux_msg_t *flux_response_encode_raw (const char *topic,
                                       const void *data, int len);
 
 /* Encode an error response with 'errnum' (must be nonzero) and

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -76,6 +76,14 @@ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
 int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       int errnum, const void *data, int len);
 
+/* Create an error response to the provided request message with optional
+ * printf-style error string payload if 'fmt' is non-NULL.
+ */
+int flux_respond_error (flux_t *h, const flux_msg_t *request,
+                        int errnum, const char *fmt, ...)
+                        __attribute__ ((format (printf, 4, 5)));
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -68,10 +68,9 @@ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
 
 
 /* Create a response to the provided request message with optional raw payload.
- * If errnum is nonzero, payload argument is ignored.
  */
 int flux_respond_raw (flux_t *h, const flux_msg_t *request,
-                      int errnum, const void *data, int len);
+                      const void *data, int len);
 
 /* Create an error response to the provided request message with optional
  * printf-style error string payload if 'fmt' is non-NULL.

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -46,6 +46,12 @@ flux_msg_t *flux_response_encode (const char *topic, int errnum, const char *s);
 flux_msg_t *flux_response_encode_raw (const char *topic, int errnum,
                                       const void *data, int len);
 
+/* Encode an error response with 'errnum' (must be nonzero) and
+ * if non-NULL, an error string payload.
+ */
+flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
+                                        const char *errstr);
+
 /* Create a response to the provided request message with optional
  * string payload.
  * If errnum is nonzero, payload argument is ignored.

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -55,7 +55,6 @@ flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
 /* Create a response to the provided request message with optional
  * string payload.
  * If errnum is nonzero, payload argument is ignored.
- * All errors in this function are fatal - see flux_fatal_set().
  */
 int flux_respond (flux_t *h, const flux_msg_t *request,
                   int errnum, const char *s);
@@ -63,7 +62,6 @@ int flux_respond (flux_t *h, const flux_msg_t *request,
 /* Create a response to the provided request message with json payload, using
  * jansson pack style variable arguments for encoding the JSON object
  * payload directly.
- * All errors in this function are fatal - see flux_fatal_set().
  */
 int flux_respond_pack (flux_t *h, const flux_msg_t *request,
                        const char *fmt, ...);
@@ -71,7 +69,6 @@ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
 
 /* Create a response to the provided request message with optional raw payload.
  * If errnum is nonzero, payload argument is ignored.
- * All errors in this function are fatal - see flux_fatal_set().
  */
 int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       int errnum, const void *data, int len);

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -44,8 +44,7 @@
 #include "rpc.h"
 #include "reactor.h"
 #include "msg_handler.h"
-
-#include "src/common/libutil/nodeset.h"
+#include "flog.h"
 
 struct flux_rpc {
     flux_t *h;
@@ -145,6 +144,21 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...)
     return rc;
 }
 
+const char *flux_rpc_get_error (flux_future_t *f)
+{
+    int errnum = 0;
+    const char *errstr = NULL;
+
+    if (flux_future_get (f, NULL) < 0) {
+        errnum = errno;
+        errstr = flux_future_aux_get (f, "flux::rpc_errstr");
+    }
+    if (errstr)
+        return errstr;
+    else
+        return flux_strerror (errnum);
+}
+
 /* Message handler for response.
  * Parse the response message here so one could call flux_future_get()
  * instead of flux_rpc_get() to test result of RPC with no response payload.
@@ -156,6 +170,7 @@ static void response_cb (flux_t *h, flux_msg_handler_t *mh,
     flux_future_t *f = arg;
     flux_msg_t *cpy;
     int saved_errno;
+    const char *errstr;
 
 #if HAVE_CALIPER
     cali_begin_string_byname ("flux.message.rpc", "single");
@@ -172,6 +187,15 @@ static void response_cb (flux_t *h, flux_msg_handler_t *mh,
 error:
     saved_errno = errno;
     flux_future_fulfill_error (f, saved_errno);
+    /* If error response contains an error string payload,
+     * save it in the future aux hash.  If unlikely ENOMEM errors occur,
+     * silently discard the error string.
+     */
+    if (flux_response_decode_error (msg, &errstr) == 0) {
+        char *cpy = strdup (errstr);
+        if (cpy && flux_future_aux_set (f, "flux::rpc_errstr", cpy, free) < 0)
+            free (cpy);
+    }
 }
 
 /* Callback to initialize future in main or alternate reactor contexts.

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -91,14 +91,14 @@ error:
     return NULL;
 }
 
-int flux_rpc_get (flux_future_t *f, const char **json_str)
+int flux_rpc_get (flux_future_t *f, const char **s)
 {
     const flux_msg_t *msg;
     int rc = -1;
 
     if (flux_future_get (f, &msg) < 0)
         goto done;
-    if (flux_response_decode (msg, NULL, json_str) < 0)
+    if (flux_response_decode (msg, NULL, s) < 0)
         goto done;
     rc = 0;
 done:
@@ -253,13 +253,13 @@ error:
 
 flux_future_t *flux_rpc (flux_t *h,
                          const char *topic,
-                         const char *json_str,
+                         const char *s,
                          uint32_t nodeid,
                          int flags)
 {
     flux_msg_t *msg = NULL;
     flux_future_t *f = NULL;
-    if (!(msg = flux_request_encode (topic, json_str)))
+    if (!(msg = flux_request_encode (topic, s)))
         goto done;
     if (!(f = flux_rpc_msg (h, nodeid, flags, msg)))
         goto done;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -28,6 +28,14 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
 
+/* Get a human-readable error message for fulfilled RPC.
+ * The result is always a valid string:
+ * If the RPC did not fail, flux_strerror (0) is returned.
+ * If the RPC failed, but did not include an error message payload,
+ * flux_strerror (errnum) is returned.
+ */
+const char *flux_rpc_get_error (flux_future_t *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -12,7 +12,7 @@ enum {
     FLUX_RPC_NORESPONSE = 1,
 };
 
-flux_future_t *flux_rpc (flux_t *h, const char *topic, const char *json_str,
+flux_future_t *flux_rpc (flux_t *h, const char *topic, const char *s,
                          uint32_t nodeid, int flags);
 
 flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
@@ -22,7 +22,7 @@ flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
                              const void *data, int len,
                              uint32_t nodeid, int flags);
 
-int flux_rpc_get (flux_future_t *f, const char **json_str);
+int flux_rpc_get (flux_future_t *f, const char **s);
 
 int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -125,7 +125,6 @@ void check_payload_json (void)
     const char *s;
     flux_msg_t *msg;
     const char *json_str = "{\"foo\"=42}";
-    uint8_t flags;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
        "flux_msg_create works");
@@ -148,31 +147,22 @@ void check_payload_json (void)
     /* Sneak in a malformed JSON payloads and test decoding.
      * 1) array
      */
-    if (flux_msg_set_payload (msg, 0, "[1,2,3]", 8) < 0)
+    if (flux_msg_set_payload (msg, "[1,2,3]", 8) < 0)
         BAIL_OUT ("flux_msg_set_payload failed");
-    if (flux_msg_get_flags (msg, &flags) < 0
-            || flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_JSON) < 0)
-        BAIL_OUT ("flux_msg_set_flags failed");
     errno = 0;
     ok (flux_msg_get_json (msg, &s) < 0 && errno == EPROTO,
         "flux_msg_get_json array fails with EPROTO");
     /* 2) bare value
      */
-    if (flux_msg_set_payload (msg, 0, "3.14", 5) < 0)
+    if (flux_msg_set_payload (msg, "3.14", 5) < 0)
         BAIL_OUT ("flux_msg_set_payload failed");
-    if (flux_msg_get_flags (msg, &flags) < 0
-            || flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_JSON) < 0)
-        BAIL_OUT ("flux_msg_set_flags failed");
     errno = 0;
     ok (flux_msg_get_json (msg, &s) < 0 && errno == EPROTO,
         "flux_msg_get_json scalar fails with EPROTO");
     /* 3) malformed object (no trailing })
      */
-    if (flux_msg_set_payload (msg, 0, "{\"a\":42", 8) < 0)
+    if (flux_msg_set_payload (msg, "{\"a\":42", 8) < 0)
         BAIL_OUT ("flux_msg_set_payload failed");
-    if (flux_msg_get_flags (msg, &flags) < 0
-            || flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_JSON) < 0)
-        BAIL_OUT ("flux_msg_set_flags failed");
     errno = 0;
     ok (flux_msg_get_json (msg, &s) < 0 && errno == EPROTO,
         "flux_msg_get_json malformed object fails with EPROTO");
@@ -254,38 +244,37 @@ void check_payload (void)
     const void *buf;
     void *pay[1024];
     int plen = sizeof (pay), len;
-    int flags;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
        "flux_msg_create works");
     errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) < 0 && errno == EPROTO,
+    ok (flux_msg_get_payload (msg, &buf, &len) < 0 && errno == EPROTO,
        "flux_msg_get_payload fails with EPROTO on msg w/o payload");
     errno = 0;
-    ok (flux_msg_set_payload (msg, 0, NULL, 0) == 0 && errno == 0,
+    ok (flux_msg_set_payload (msg, NULL, 0) == 0 && errno == 0,
         "flux_msg_set_payload NULL works with no payload");
     errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) < 0 && errno == EPROTO,
+    ok (flux_msg_get_payload (msg, &buf, &len) < 0 && errno == EPROTO,
        "flux_msg_get_payload still fails");
 
     errno = 0;
     memset (pay, 42, plen);
-    ok (flux_msg_set_payload (msg, 0, pay, plen) == 0
+    ok (flux_msg_set_payload (msg, pay, plen) == 0
         && flux_msg_frames (msg) == 2,
        "flux_msg_set_payload works");
 
-    len = 0; buf = NULL; flags =0; errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) == 0
-        && buf && len == plen && flags == 0 && errno == 0,
+    len = 0; buf = NULL; errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0
+        && buf && len == plen && errno == 0,
        "flux_msg_get_payload works");
     cmp_mem (buf, pay, len,
        "and we got back the payload we set");
 
     ok (flux_msg_set_topic (msg, "blorg") == 0 && flux_msg_frames (msg) == 3,
        "flux_msg_set_topic works");
-    len = 0; buf = NULL; flags = 0; errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) == 0
-        && buf && len == plen && flags == 0 && errno == 0,
+    len = 0; buf = NULL; errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0
+        && buf && len == plen && errno == 0,
        "flux_msg_get_payload works with topic");
     cmp_mem (buf, pay, len,
        "and we got back the payload we set");
@@ -297,39 +286,39 @@ void check_payload (void)
     ok (flux_msg_push_route (msg, "id1") == 0 && flux_msg_frames (msg) == 4,
         "flux_msg_push_route works");
 
-    len = 0; buf = NULL; flags =0; errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) == 0
-        && buf && len == plen && flags == 0 && errno == 0,
+    len = 0; buf = NULL; errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0
+        && buf && len == plen && errno == 0,
        "flux_msg_get_payload still works, with routes");
     cmp_mem (buf, pay, len,
        "and we got back the payload we set");
 
     ok (flux_msg_set_topic (msg, "blorg") == 0 && flux_msg_frames (msg) == 5,
        "flux_msg_set_topic works");
-    len = 0; buf = NULL; flags = 0; errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) == 0
-        && buf && len == plen && flags == 0 && errno == 0,
+    len = 0; buf = NULL; errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0
+        && buf && len == plen && errno == 0,
        "flux_msg_get_payload works, with topic and routes");
     cmp_mem (buf, pay, len,
        "and we got back the payload we set");
 
     errno = 0;
-    ok (flux_msg_set_payload (msg, 0, buf, len - 1) < 0 && errno == EINVAL,
+    ok (flux_msg_set_payload (msg, buf, len - 1) < 0 && errno == EINVAL,
         "flux_msg_set_payload detects reuse of payload fragment and fails with EINVAL");
 
-    ok (flux_msg_set_payload (msg, 0, buf, len) == 0,
+    ok (flux_msg_set_payload (msg, buf, len) == 0,
         "flux_msg_set_payload detects payload echo and works");
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) == 0
-        && buf && len == plen && flags == 0,
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0
+        && buf && len == plen,
        "flux_msg_get_payload works");
     cmp_mem (buf, pay, len,
        "and we got back the payload we set");
 
     errno = 0;
-    ok (flux_msg_set_payload (msg, 0, NULL, 0) == 0 && errno == 0,
+    ok (flux_msg_set_payload (msg, NULL, 0) == 0 && errno == 0,
         "flux_msg_set_payload NULL works");
     errno = 0;
-    ok (flux_msg_get_payload (msg, &flags, &buf, &len) < 0 && errno == EPROTO,
+    ok (flux_msg_get_payload (msg, &buf, &len) < 0 && errno == EPROTO,
        "flux_msg_get_payload now fails with EPROTO");
 
     flux_msg_destroy (msg);
@@ -631,7 +620,7 @@ void check_copy (void)
     flux_msg_t *msg, *cpy;
     int type;
     const char *topic;
-    int cpylen, flags;
+    int cpylen;
     const char buf[] = "xxxxxxxxxxxxxxxxxx";
     const void *cpybuf;
 
@@ -654,14 +643,14 @@ void check_copy (void)
         "added route delim");
     ok (flux_msg_set_topic (msg, "foo") == 0,
         "set topic string");
-    ok (flux_msg_set_payload (msg, 0, buf, sizeof (buf)) == 0,
+    ok (flux_msg_set_payload (msg, buf, sizeof (buf)) == 0,
         "added payload");
     ok ((cpy = flux_msg_copy (msg, true)) != NULL,
         "flux_msg_copy works");
     type = -1;
     ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
              && flux_msg_has_payload (cpy)
-             && flux_msg_get_payload (cpy, &flags, &cpybuf, &cpylen) == 0
+             && flux_msg_get_payload (cpy, &cpybuf, &cpylen) == 0
              && cpylen == sizeof (buf) && memcmp (cpybuf, buf, cpylen) == 0
              && flux_msg_get_route_count (cpy) == 0
              && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
@@ -710,7 +699,7 @@ void check_print (void)
         "enabled routing");
     ok (flux_msg_push_route (msg, "id1") == 0,
         "added one route");
-    ok (flux_msg_set_payload (msg, 0, buf, strlen (buf)) == 0,
+    ok (flux_msg_set_payload (msg, buf, strlen (buf)) == 0,
         "added payload");
     lives_ok ({flux_msg_fprint (f, msg);},
         "flux_msg_fprint doesn't segfault on fully loaded request");
@@ -734,17 +723,8 @@ void check_params (void)
     if (!(msg = flux_msg_create (FLUX_MSGTYPE_EVENT)))
         BAIL_OUT ("flux_msg_create failed");
     errno = 0;
-    ok (flux_msg_set_payload (NULL, 0, NULL, 0) < 0 && errno == EINVAL,
+    ok (flux_msg_set_payload (NULL, NULL, 0) < 0 && errno == EINVAL,
         "flux_msg_set_payload msg=NULL fails with EINVAL");
-
-    errno = 0;
-    ok (flux_msg_set_payload (msg, 0xff, NULL, 0) < 0 && errno == EINVAL,
-        "flux_msg_set_payload flags=0xff fails with EINVAL");
-
-    errno = 0;
-    ok (flux_msg_set_payload (msg, FLUX_MSGFLAG_JSON, NULL, 0) < 0
-        && errno == EINVAL,
-        "flux_msg_set_payload flags=JSON, buf=NULL fails with EINVAL");
 
     flux_msg_destroy (msg);
 }

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -19,7 +19,7 @@ int main (int argc, char *argv[])
 
     /* no topic is an error */
     errno = 0;
-    ok ((msg = flux_response_encode (NULL, 0, json_str)) == NULL
+    ok ((msg = flux_response_encode (NULL, json_str)) == NULL
         && errno == EINVAL,
         "flux_response_encode returns EINVAL with no topic string");
     errno = 0;
@@ -27,14 +27,8 @@ int main (int argc, char *argv[])
         && errno == EINVAL,
         "flux_response_encode_raw returns EINVAL with no topic string");
 
-    /* both errnum and payload is an error */
-    errno = 0;
-    ok ((msg = flux_response_encode ("foo.bar", 1, json_str)) == NULL
-        && errno == EINVAL,
-        "flux_response_encode returns EINVAL with both payload and errnum");
-
     /* without payload */
-    ok ((msg = flux_response_encode ("foo.bar", 0, NULL)) != NULL,
+    ok ((msg = flux_response_encode ("foo.bar", NULL)) != NULL,
         "flux_response_encode works with NULL payload");
 
     topic = NULL;
@@ -65,7 +59,7 @@ int main (int argc, char *argv[])
     flux_msg_destroy (msg);
 
     /* with json payload */
-    ok ((msg = flux_response_encode ("foo.bar", 0, json_str)) != NULL,
+    ok ((msg = flux_response_encode ("foo.bar", json_str)) != NULL,
         "flux_response_encode works with payload");
 
     s = NULL;
@@ -89,8 +83,8 @@ int main (int argc, char *argv[])
     flux_msg_destroy (msg);
 
     /* with error */
-    ok ((msg = flux_response_encode ("foo.bar", 42, NULL)) != NULL,
-        "flux_response_encode works with errnum");
+    ok ((msg = flux_response_encode_error ("foo.bar", 42, NULL)) != NULL,
+        "flux_response_encode_error works with errnum");
     s = NULL;
     errno = 0;
     ok (flux_response_decode (msg, NULL, NULL) < 0

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -23,7 +23,7 @@ int main (int argc, char *argv[])
         && errno == EINVAL,
         "flux_response_encode returns EINVAL with no topic string");
     errno = 0;
-    ok ((msg = flux_response_encode_raw (NULL, 0, data, len)) == NULL
+    ok ((msg = flux_response_encode_raw (NULL, data, len)) == NULL
         && errno == EINVAL,
         "flux_response_encode_raw returns EINVAL with no topic string");
 
@@ -32,10 +32,6 @@ int main (int argc, char *argv[])
     ok ((msg = flux_response_encode ("foo.bar", 1, json_str)) == NULL
         && errno == EINVAL,
         "flux_response_encode returns EINVAL with both payload and errnum");
-    errno = 0;
-    ok ((msg = flux_response_encode_raw ("foo.bar", 1, data, len)) == NULL
-        && errno == EINVAL,
-        "flux_response_encode_raw returns EINVAL with both payload and errnum");
 
     /* without payload */
     ok ((msg = flux_response_encode ("foo.bar", 0, NULL)) != NULL,
@@ -53,7 +49,7 @@ int main (int argc, char *argv[])
     flux_msg_destroy (msg);
 
     /* without payload (raw) */
-    ok ((msg = flux_response_encode_raw ("foo.bar", 0, NULL, 0)) != NULL,
+    ok ((msg = flux_response_encode_raw ("foo.bar", NULL, 0)) != NULL,
         "flux_response_encode_raw works with NULL payload");
 
     topic = NULL;
@@ -82,7 +78,7 @@ int main (int argc, char *argv[])
     flux_msg_destroy (msg);
 
     /* with raw payload */
-    ok ((msg = flux_response_encode_raw ("foo.bar", 0, data, len)) != NULL,
+    ok ((msg = flux_response_encode_raw ("foo.bar", data, len)) != NULL,
         "flux_response_encode_raw works with payload");
 
     d = NULL;
@@ -100,17 +96,6 @@ int main (int argc, char *argv[])
     ok (flux_response_decode (msg, NULL, NULL) < 0
         && errno == 42,
         "flux_response_decode fails with encoded errnum");
-    flux_msg_destroy (msg);
-
-    /* with error (raw) */
-    ok ((msg = flux_response_encode_raw ("foo.bar", 42, NULL, 0)) != NULL,
-        "flux_response_encode_raw works with errnum");
-    d = NULL;
-    l = 0;
-    errno = 0;
-    ok (flux_response_decode_raw (msg, NULL, &d, &l) < 0
-        && errno == 42 && d == NULL && l == 0,
-        "flux_response_decode_raw fails with encoded errnum");
     flux_msg_destroy (msg);
 
     done_testing();

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -637,9 +637,19 @@ static bool internal_request (client_t *c, const flux_msg_t *msg)
         return false; // no match - forward to broker
 
 done_respond:
-    if (!(rmsg = flux_response_encode (topic, rc < 0 ? errno : 0, NULL))) {
-        flux_log_error (c->ctx->h, "%s: flux_response_encode", __FUNCTION__);
-        goto done;
+    if (rc < 0) {
+        if (!(rmsg = flux_response_encode_error (topic, errno, NULL))) {
+            flux_log_error (c->ctx->h, "%s: flux_response_encode_error",
+                            __FUNCTION__);
+            goto done;
+        }
+    }
+    else {
+        if (!(rmsg = flux_response_encode (topic, NULL))) {
+            flux_log_error (c->ctx->h, "%s: flux_response_encode",
+                            __FUNCTION__);
+            goto done;
+        }
     }
     if (flux_msg_set_rolemask (rmsg, FLUX_ROLE_OWNER) < 0) {
         flux_log_error (c->ctx->h, "%s: flux_response_set_rolemask",

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -317,8 +317,14 @@ void load_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     rc = 0;
 done:
-    if (flux_respond_raw (h, msg, rc < 0 ? errno : 0, data, size) < 0)
-        flux_log_error (h, "load: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "load: flux_respond_error");
+    }
+    else {
+        if (flux_respond_raw (h, msg, data, size) < 0)
+            flux_log_error (h, "load: flux_respond_raw");
+    }
     (void )sqlite3_reset (ctx->load_stmt);
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }
@@ -388,9 +394,14 @@ void store_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     rc = 0;
 done:
-    if (flux_respond_raw (h, msg, rc < 0 ? errno : 0,
-                                        blobref, strlen (blobref) + 1) < 0)
-        flux_log_error (h, "store: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "store: flux_respond_error");
+    }
+    else {
+        if (flux_respond_raw (h, msg, blobref, strlen (blobref) + 1) < 0)
+            flux_log_error (h, "store: flux_respond_raw");
+    }
     (void) sqlite3_reset (ctx->store_stmt);
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -141,7 +141,7 @@ static int io_handler (flux_t *h, cron_task_t *t, const flux_msg_t *msg)
     bool is_stderr = false;
     int len;
 
-    if (flux_msg_get_json (msg, &json_str) < 0)
+    if (flux_msg_get_string (msg, &json_str) < 0)
         return -1;
 
     if ((len = zio_json_decode (json_str, &data, &eof)) < 0) {

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -546,7 +546,7 @@ static void spawn_io_cb (flux_t *h, struct wreck_job *job,
     int level = LOG_INFO;
     int len;
 
-    if (flux_msg_get_json (msg, &json_str) < 0)
+    if (flux_msg_get_string (msg, &json_str) < 0)
         return;
 
     if ((len = zio_json_decode (json_str, &data, NULL)) < 0) {

--- a/t/loop/dispatch.c
+++ b/t/loop/dispatch.c
@@ -75,7 +75,7 @@ void test_fastpath (flux_t *h)
         "allocated matchtag");
     ok ((mh = flux_msg_handler_create (h, m, cb, NULL)) != NULL,
         "created handler for response");
-    ok ((msg = flux_response_encode ("foo", 0, NULL)) != NULL,
+    ok ((msg = flux_response_encode ("foo", NULL)) != NULL,
         "encoded response message");
     ok (flux_msg_set_matchtag (msg, m.matchtag) == 0,
         "set matchtag in response");
@@ -157,7 +157,7 @@ void test_cloned_dispatch (flux_t *orig)
     ok ((mh2 = flux_msg_handler_create (h, m, cb, NULL)) != NULL,
         "created handler for response");
     flux_msg_handler_start (mh2);
-    ok ((msg = flux_response_encode ("foo", 0, NULL)) != NULL,
+    ok ((msg = flux_response_encode ("foo", NULL)) != NULL,
         "encoded response message");
     ok (flux_msg_set_matchtag (msg, m.matchtag) == 0,
         "set matchtag in response");
@@ -170,7 +170,7 @@ void test_cloned_dispatch (flux_t *orig)
     m2.matchtag = flux_matchtag_alloc (h, 0);
     ok (m2.matchtag != FLUX_MATCHTAG_NONE,
         "allocated matchtag (%d)", m2.matchtag); // 2
-    ok ((msg = flux_response_encode ("bar", 0, NULL)) != NULL,
+    ok ((msg = flux_response_encode ("bar", NULL)) != NULL,
         "encoded response message");
     ok (flux_msg_set_matchtag (msg, m2.matchtag) == 0,
         "set matchtag in response");

--- a/t/lua/t0003-events.t
+++ b/t/lua/t0003-events.t
@@ -67,7 +67,7 @@ local response, err = f:rpc ("event.pub", request);
 is (err, nil, "event.pub: works with payload")
 
 -- good request, with JSON "{}\0"
-local request = { topic = "foo", flags = 4, payload = "e30A" }
+local request = { topic = "foo", flags = 0, payload = "e30A" }
 local response, err = f:rpc ("event.pub", request);
 is (err, nil, "event.pub: works with json payload")
 

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -302,7 +302,7 @@ void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
                   topic);
         goto error;
     }
-    if (flux_msg_get_payload (msg, &flags, &buf, &size) == 0) {
+    if (flux_msg_get_payload (msg, &buf, &size) == 0) {
         flux_log (h, LOG_ERR, "%s: unexpected payload size %d", __FUNCTION__,
                   size);
         goto error;

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -67,10 +67,14 @@ void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_request_decode_raw (msg, NULL, &d, &l) < 0) {
         errnum = errno;
-        goto done;
+        goto error;
     }
-done:
-    (void)flux_respond_raw (h, msg, errnum, d, l);
+    if (flux_respond_raw (h, msg, d, l) < 0)
+        BAIL_OUT ("flux_respond_raw: %s", flux_strerror (errno));
+    return;
+error:
+    if (flux_respond_error (h, msg, errnum, NULL) < 0)
+        BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
 }
 
 /* no-payload response */

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -62,6 +62,31 @@ error:
         BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
 }
 
+/* request payload sets error response content */
+void rpctest_echo_error_cb (flux_t *h, flux_msg_handler_t *mh,
+                            const flux_msg_t *msg, void *arg)
+{
+    int errnum;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:i s?:s}",
+                             "errnum", &errnum, "errstr", &errstr) < 0)
+        goto error;
+    if (errstr) {
+        if (flux_respond_error (h, msg, errnum, "Error: %s", errstr) < 0)
+            BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
+    }
+    else {
+        if (flux_respond_error (h, msg, errnum, NULL) < 0)
+            BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
+}
+
+
 /* raw request payload echoed in response */
 void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
@@ -136,6 +161,7 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,   "rpctest.hello",   rpctest_hello_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,   "rpcftest.hello",  rpcftest_hello_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,   "rpctest.echo",    rpctest_echo_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "rpctest.echoerr", rpctest_echo_error_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,   "rpctest.rawecho", rpctest_rawecho_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,   "rpctest.nodeid",  rpctest_nodeid_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,   "rpctest.multi",   rpctest_multi_cb, 0 },
@@ -224,6 +250,65 @@ void test_basic (flux_t *h)
     flux_future_destroy (r);
 
     diag ("completed synchronous rpc test");
+}
+
+void test_error (flux_t *h)
+{
+    flux_future_t *f;
+    const char *errstr;
+    const char *s;
+
+    /* Error response with error message payload.
+     */
+    f = flux_rpc_pack (h, "rpctest.echoerr", FLUX_NODEID_ANY, 0,
+                       "{s:i s:s}",
+                       "errnum", 69,
+                       "errstr", "Hello world");
+    ok (f != NULL,
+        "flux_rpc_pack sent request to rpctest.echoerr service");
+    errno = 0;
+    ok (flux_future_get (f, NULL) < 0 && errno == 69,
+        "flux_future_get failed with expected errno");
+    errno = 0;
+    ok (flux_rpc_get (f, NULL) < 0 && errno == 69,
+        "flux_rpc_get failed with expected errno");
+    errstr = flux_rpc_get_error (f);
+    ok (errstr != NULL && !strcmp (errstr, "Error: Hello world"),
+        "flux_rpc_get_error returned expected error string");
+    flux_future_destroy (f);
+
+    /* Error response with no error message payload.
+     */
+    f = flux_rpc_pack (h, "rpctest.echoerr", FLUX_NODEID_ANY, 0,
+                       "{s:i}",
+                       "errnum", ENOTDIR);
+    ok (f != NULL,
+        "flux_rpc_pack sent request to rpctest.echoerr service (no errstr)");
+    errno = 0;
+    ok (flux_future_get (f, NULL) < 0 && errno == ENOTDIR,
+        "flux_future_get failed with expected errno");
+    errno = 0;
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOTDIR,
+        "flux_rpc_get failed with expected errno");
+    errstr = flux_rpc_get_error (f);
+    ok (errstr != NULL && !strcmp (errstr, flux_strerror (ENOTDIR)),
+        "flux_rpc_get_error returned canned error string");
+    flux_future_destroy (f);
+
+    /* Success response with payload.
+     * Ensure flux_rpc_get_error() doesn't return the payload!
+     */
+    f = flux_rpc (h, "rpctest.echo", "Nerp", FLUX_NODEID_ANY, 0);
+    ok (f != NULL,
+        "flux_rpc sent request to rpctest.echo");
+    ok (flux_future_get (f, NULL) == 0,
+        "flux_future_get returned success");
+    ok (flux_rpc_get (f, &s) == 0 && s != NULL && !strcmp (s, "Nerp"),
+        "flux_rpc_get worked and retrieved payload");
+    errstr = flux_rpc_get_error (f);
+    ok (errstr != NULL && !strcmp (errstr, flux_strerror (0)),
+        "flux_rpc_get_error returned canned Success string");
+    flux_future_destroy (f);
 }
 
 void test_encoding (flux_t *h)
@@ -564,6 +649,7 @@ int main (int argc, char *argv[])
 
     test_service (h);
     test_basic (h);
+    test_error (h);
     test_encoding (h);
     test_then (h);
     test_multi_response (h);


### PR DESCRIPTION
As discussed in #796, this PR adds the capability to return an error string in an RPC response, adding these API functions:

**response.h**
```c
// mainly used in unit tests like other similar functions
int flux_response_decode_error (const flux_msg_t *msg, const char *errstr);
flux_msg_t *flux_response_encode_error (const char *topic, int errnum, const char *errstr);

// respond with error:  errnum != 0 required, errstr != NULL optional
int flux_respond_error (flux_t *h, const flux_msg_t *msg, int errnum, const char *errstr);
```

**rpc.h**
```c
// Get error message from fulfilled RPC future
// Never NULL - if no error string in response, returns flux_strerror (errnum)
const char *flux_rpc_get_error (flux_future_t *f);
```

So one might write RPC client code that looks like this:
```c
if (!(f = flux_rpc (h, ....)))
    fatal ("flux_rpc failed");
if (flux_rpc_get (f, "foo.method", ...) < 0)
    fatal ("foo.method: %s", flux_rpc_get_error (f))
...
```

In addition, relax some API calls that take "JSON strings" to allow any string, for flexibility (ostensibly to add error string payload to response, but this seemed like a good general improvement):
* Rename `flux_msg_set_json()` to `flux_msg_set_string()`
* Rename `flux_msg_get_json()` to `flux_msg_get_string()`
* Drop FLUX_MSGFLAG_JSON flag as proposed in flux-framework/rfc#123
* Change various message payload accessors to use "NULL terminated strings" instead of "JSON strings" (mostly cosmetic)

Finally, I thought now that we have `flux_respond_error()`, there was no need to have `flux_respond()` and `flux_respond_raw()` perform double duty, accepting both errnum and a payload, and ignoring the payload if errnum != 0.  I did remove `errnum` from `flux_respond_raw` which has few users, but `flux_respond()` has many users and I thought I'd better open an issue and get feedback, and do that in a separate PR if we think that's a good idea.

Todo: add new functions to man pages, revisit testing, probably some PR comment improvement.