### PR TITLE
Experimental: add --wrap=arg0,arg1,... option to flux-start

### DIFF
--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -65,6 +65,10 @@ If a DIR is not set with this option, a unique temporary directory will
 be created for the lifetime of the instance and removed when the
 instance is destroyed.
 
+*--wrap*='ARGS,...'::
+Wrap broker execution in a comma-separated list of arguments. This is
+useful for running flux-broker directly under debuggers or valgrind.
+
 
 EXAMPLES
 --------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -425,3 +425,4 @@ hostnames
 unfulfills
 MSGFLAG
 errstr
+valgrind

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -118,6 +118,11 @@ static struct optparse_option opts[] = {
       .cb = no_caliper_fatal_err, /* Emit fatal err if not built w/ Caliper */
 #endif /* !HAVE_CALIPER */
     },
+    { .group = 1,
+      .name = "wrap", .has_arg = 1, .arginfo = "ARGS,...",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Wrap broker execution in comma-separated arguments"
+    },
     OPTPARSE_TABLE_END,
 };
 
@@ -415,6 +420,7 @@ int exec_broker (const char *cmd_argz, size_t cmd_argz_len,
     char *argz = NULL;
     size_t argz_len = 0;
 
+    add_args_list (&argz, &argz_len, ctx.opts, "wrap");
     if (argz_add (&argz, &argz_len, broker_path) != 0)
         goto nomem;
 
@@ -460,6 +466,7 @@ struct client *client_create (const char *broker_path, const char *scratch_dir,
     subprocess_set_context (cli->p, "cli", cli);
     subprocess_add_hook (cli->p, SUBPROCESS_COMPLETE, child_exit);
     subprocess_add_hook (cli->p, SUBPROCESS_STATUS, child_report);
+    add_args_list (&argz, &argz_len, ctx.opts, "wrap");
     argz_add (&argz, &argz_len, broker_path);
     char *run_dir = xasprintf ("%s/%d", scratch_dir, rank);
     if (mkdir (run_dir, 0755) < 0)

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -414,16 +414,11 @@ int exec_broker (const char *cmd_argz, size_t cmd_argz_len,
 {
     char *argz = NULL;
     size_t argz_len = 0;
-    const char *arg;
 
     if (argz_add (&argz, &argz_len, broker_path) != 0)
         goto nomem;
 
-    optparse_getopt_iterator_reset (ctx.opts, "broker-opts");
-    while ((arg = optparse_getopt_next (ctx.opts, "broker-opts"))) {
-        if (argz_add (&argz, &argz_len, arg) != 0)
-            goto nomem;
-    }
+    add_args_list (&argz, &argz_len, ctx.opts, "broker-opts");
     if (cmd_argz) {
         if (argz_append (&argz, &argz_len, cmd_argz, cmd_argz_len) != 0)
             goto nomem;

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -391,7 +391,7 @@ int pmi_kvs_get (void *arg, const char *kvsname,
     return 0;
 }
 
-int execvp_argz (const char *cmd_argz, char *argz, size_t argz_len)
+int execvp_argz (char *argz, size_t argz_len)
 {
     char **av = malloc (sizeof (char *) * (argz_count (argz, argz_len) + 1));
     if (!av) {
@@ -399,7 +399,7 @@ int execvp_argz (const char *cmd_argz, char *argz, size_t argz_len)
         return -1;
     }
     argz_extract (argz, argz_len, av);
-    execvp (cmd_argz, av);
+    execvp (av[0], av);
     free (av);
     return -1;
 }
@@ -433,7 +433,7 @@ int exec_broker (const char *cmd_argz, size_t cmd_argz_len,
         free (cpy);
     }
     if (!optparse_hasopt (ctx.opts, "noexec")) {
-        if (execvp_argz (broker_path, argz, argz_len) < 0)
+        if (execvp_argz (argz, argz_len) < 0)
             goto error;
     }
     free (argz);

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -102,11 +102,22 @@ test_under_flux() {
         unset FLUX_RC1_PATH
         unset FLUX_RC3_PATH
     fi
+    if test -n "$FLUX_TEST_VALGRIND" ; then
+        VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
+        valgrind="--wrap=libtool,e"
+        valgrind="$valgrind,valgrind,--leak-check=full"
+        valgrind="$valgrind,--trace-children=no,--child-silent-after-fork=yes"
+        valgrind="$valgrind,--leak-resolution=med,--error-exitcode=1"
+        valgrind="$valgrind,--suppressions=${VALGRIND_SUPPRESSIONS}"
+    fi
 
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --bootstrap=selfpmi --size=${size} ${logopts} ${timeout} \
+      exec flux start --bootstrap=selfpmi --size=${size} \
+                      ${logopts} \
+                      ${timeout} \
+                      ${valgrind} \
                      "sh $0 ${flags}"
 }
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -97,6 +97,22 @@ test_expect_success 'flux-start in subprocess/pmi mode works as initial program'
 test_expect_success 'flux-start init.rc2_timeout attribute works' "
 	test_expect_code 143 flux start ${ARGS} -o,-Sinit.rc2_timeout=0.1 sleep 5
 "
+test_expect_success 'flux-start --wrap option works' '
+	broker_path=$(flux start -vX 2>&1 | sed "s/^flux-start: *//g") &&
+	echo broker_path=${broker_path} &&
+	test -n "${broker_path}" &&
+	flux start --wrap=/bin/echo,start: arg0 arg1 arg2 > wrap.output &&
+	test_debug "cat wrap.output" &&
+	cat >wrap.expected <<-EOF &&
+	start: ${broker_path} arg0 arg1 arg2
+	EOF
+	test_cmp wrap.expected wrap.output
+'
+test_expect_success 'flux-start --wrap option works with --size' '
+	flux start --size=2 -vX --wrap=test-wrap > wrap2.output 2>&1 &&
+	test_debug "cat wrap2.output" &&
+	test "$(grep -c test-wrap wrap2.output)" = "2"
+'
 
 test_expect_success 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&


### PR DESCRIPTION
This is an experimental PR that adds a `--wrap` option to `flux-start` that wraps `flux-broker` execution in arbitrary arguments. Posting here for any comments. If we move forward with this, I'd just need to add some tests and cleanup a bit.

The main use case for `--wrap` is to run valgrind on flux brokers in a test session without all the `--trace-children=yes --trace-children-skip=pattern` shenanigans.

e.g.
```console
t$ src/cmd/flux start -s4 -vX --wrap=libtool,--mode=execute,valgrind,--leak-check=full,--suppressions=t/valgrind/valgrind.supp flux getattr rank
flux-start: warning: setting --bootstrap=selfpmi due to --size option
flux-start: 0: libtool --mode=execute valgrind --leak-check=full --suppressions=t/valgrind/valgrind.supp /g/g0/grondo/git/flux-core.git/src/broker/flux-broker --setattr=broker.rundir=/var/tmp/grondo/flux-190781-T5W4Wy/0 --setattr=tbon.endpoint=ipc://%B/req flux getattr rank
flux-start: 1: libtool --mode=execute valgrind --leak-check=full --suppressions=t/valgrind/valgrind.supp /g/g0/grondo/git/flux-core.git/src/broker/flux-broker --setattr=broker.rundir=/var/tmp/grondo/flux-190781-T5W4Wy/1 --setattr=tbon.endpoint=ipc://%B/req
flux-start: 2: libtool --mode=execute valgrind --leak-check=full --suppressions=t/valgrind/valgrind.supp /g/g0/grondo/git/flux-core.git/src/broker/flux-broker --setattr=broker.rundir=/var/tmp/grondo/flux-190781-T5W4Wy/2 --setattr=tbon.endpoint=ipc://%B/req
flux-start: 3: libtool --mode=execute valgrind --leak-check=full --suppressions=t/valgrind/valgrind.supp /g/g0/grondo/git/flux-core.git/src/broker/flux-broker --setattr=broker.rundir=/var/tmp/grondo/flux-190781-T5W4Wy/3 --setattr=tbon.endpoint=ipc://%B/req
```

In addition, this PR adds an enhancement to sharness `test_under_flux` to run the session under valgrind if `FLUX_TEST_VALGRIND` is set. Therefore, an entire sharness test can be executed under valgrind by running
```console
$ FLUX_TEST_VALGRIND=t ./t2100-aggregate.t
flux-start: 0: libtool e valgrind --leak-check=full --trace-children=no --child-silent-after-fork=yes --leak-resolution=med --error-exitcode=1 --suppressions=/g/g0/grondo/git/flux-core.git/t/valgrind/valgrind.supp /g/g0/grondo/git/flux-core.git/src/broker/flux-broker --setattr=broker.rundir=/var/tmp/grondo/flux-190811-uHVOPd/0 --setattr=tbon.endpoint=ipc://%B/req -Slog-filename=t2100-aggregate.broker.log -Slog-forward-level=7 -Sinit.rc2_timeout=300 sh ./t2100-aggregate.t 
[snp]
==190883== Command: /g/g0/grondo/git/flux-core.git/src/broker/.libs/lt-flux-broker --setattr=broker.rundir=/var/tmp/grondo/flux-190811-uHVOPd/7 --setattr=tbon.endpoint=ipc://%B/req -Slog-filename=t2100-aggregate.broker.log -Slog-forward-level=7 -Sinit.rc2_timeout=300
==190883== 
ok 1 - have aggregator module
ok 2 - flux-aggreagate: works
ok 3 - flux-aggreagate: works for floating-point numbers
ok 4 - flux-aggreagate: works for strings
ok 5 - flux-aggreagate: works for arrays
ok 6 - flux-aggreagate: works for objects
2018-05-31T14:37:12.792982Z aggregator.err[0]: sink: refusing to sink to rootdir
2018-05-31T14:37:12.804185Z aggregator.err[0]: sink: refusing to sink to rootdir
2018-05-31T14:37:12.804649Z aggregator.err[0]: sink: aborting aggregate .
ok 7 - flux-aggregate: abort works
ok 8 - flux-aggregate: different value per rank
ok 9 - flux-aggregate: different fp value per rank
ok 10 - flux-aggregate: --timeout=0. - immediate forward
ok 11 - flux-aggregate: --fwd-count works
# passed all 11 test(s)
1..11
==190865== 
==190865== HEAP SUMMARY:
==190865==     in use at exit: 19,755 bytes in 53 blocks
==190865==   total heap usage: 203,266 allocs, 203,213 frees, 37,181,484 bytes allocated
==190865== 
==190876== 
==190876== HEAP SUMMARY:
==190876==     in use at exit: 16,567 bytes in 43 blocks
==190876==   total heap usage: 44,456 allocs, 44,413 frees, 21,059,084 bytes allocated
==190876== 
==190883== 
==190883== HEAP SUMMARY:
==190883==     in use at exit: 16,567 bytes in 43 blocks
==190883==   total heap usage: 45,011 allocs, 44,968 frees, 21,083,525 bytes allocated
==190883== 
==190865== 24 bytes in 1 blocks are definitely lost in loss record 1 of 13
==190865==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==190865==    by 0x52BF77D: json_integer (in /usr/lib64/libjansson.so.4.10.0)
==190865==    by 0x52BC370: ??? (in /usr/lib64/libjansson.so.4.10.0)
==190865==    by 0x52BC169: ??? (in /usr/lib64/libjansson.so.4.10.0)
==190865==    by 0x52BC169: ??? (in /usr/lib64/libjansson.so.4.10.0)
==190865==    by 0x52BC4F5: ??? (in /usr/lib64/libjansson.so.4.10.0)
==190865==    by 0x52BC692: json_loads (in /usr/lib64/libjansson.so.4.10.0)
==190865==    by 0x4E55A4C: flux_msg_vunpack (message.c:1169)
==190865==    by 0x4E55B26: flux_msg_unpack (message.c:1190)
==190865==    by 0xC22FF96: push_cb (aggregator.c:604)
==190865==    by 0x4E51639: call_handler (msg_handler.c:302)
==190865==    by 0x4E51785: dispatch_message (msg_handler.c:326)
==190865==    by 0x4E51785: handle_cb (msg_handler.c:392)
==190865== 
==190865== LEAK SUMMARY:
==190865==    definitely lost: 24 bytes in 1 blocks
==190865==    indirectly lost: 0 bytes in 0 blocks
==190865==      possibly lost: 0 bytes in 0 blocks
==190865==    still reachable: 19,731 bytes in 52 blocks
==190865==         suppressed: 0 bytes in 0 blocks
==190865== Reachable blocks (those to which a pointer was found) are not shown.
==190865== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190865== 
==190865== For counts of detected and suppressed errors, rerun with: -v
==190865== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
==190868== 
==190868== HEAP SUMMARY:
==190868==     in use at exit: 16,567 bytes in 43 blocks
==190868==   total heap usage: 63,130 allocs, 63,087 frees, 23,235,826 bytes allocated
==190868== 
==190872== 
==190872== HEAP SUMMARY:
==190872==     in use at exit: 16,567 bytes in 43 blocks
==190872==   total heap usage: 44,452 allocs, 44,409 frees, 21,058,761 bytes allocated
==190872== 
==190876== LEAK SUMMARY:
==190876==    definitely lost: 0 bytes in 0 blocks
==190876==    indirectly lost: 0 bytes in 0 blocks
==190876==      possibly lost: 0 bytes in 0 blocks
==190876==    still reachable: 16,567 bytes in 43 blocks
==190876==         suppressed: 0 bytes in 0 blocks
==190876== Reachable blocks (those to which a pointer was found) are not shown.
==190876== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190876== 
==190876== For counts of detected and suppressed errors, rerun with: -v
==190876== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==190867== 
==190867== HEAP SUMMARY:
==190867==     in use at exit: 16,567 bytes in 43 blocks
==190867==   total heap usage: 77,112 allocs, 77,069 frees, 25,116,820 bytes allocated
==190867== 
==190868== LEAK SUMMARY:
==190868==    definitely lost: 0 bytes in 0 blocks
==190868==    indirectly lost: 0 bytes in 0 blocks
==190868==      possibly lost: 0 bytes in 0 blocks
==190868==    still reachable: 16,567 bytes in 43 blocks
==190868==         suppressed: 0 bytes in 0 blocks
==190868== Reachable blocks (those to which a pointer was found) are not shown.
==190868== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190868== 
==190868== For counts of detected and suppressed errors, rerun with: -v
==190868== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==190883== LEAK SUMMARY:
==190883==    definitely lost: 0 bytes in 0 blocks
==190883==    indirectly lost: 0 bytes in 0 blocks
==190883==      possibly lost: 0 bytes in 0 blocks
==190883==    still reachable: 16,567 bytes in 43 blocks
==190883==         suppressed: 0 bytes in 0 blocks
==190883== Reachable blocks (those to which a pointer was found) are not shown.
==190883== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190883== 
==190883== For counts of detected and suppressed errors, rerun with: -v
==190883== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==190872== LEAK SUMMARY:
==190872==    definitely lost: 0 bytes in 0 blocks
==190872==    indirectly lost: 0 bytes in 0 blocks
==190872==      possibly lost: 0 bytes in 0 blocks
==190872==    still reachable: 16,567 bytes in 43 blocks
==190872==         suppressed: 0 bytes in 0 blocks
==190872== Reachable blocks (those to which a pointer was found) are not shown.
==190872== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190872== 
==190872== For counts of detected and suppressed errors, rerun with: -v
==190872== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==190866== 
==190866== HEAP SUMMARY:
==190866==     in use at exit: 16,567 bytes in 43 blocks
==190866==   total heap usage: 93,147 allocs, 93,104 frees, 26,961,555 bytes allocated
==190866== 
==190867== LEAK SUMMARY:
==190867==    definitely lost: 0 bytes in 0 blocks
==190867==    indirectly lost: 0 bytes in 0 blocks
==190867==      possibly lost: 0 bytes in 0 blocks
==190867==    still reachable: 16,567 bytes in 43 blocks
==190867==         suppressed: 0 bytes in 0 blocks
==190867== Reachable blocks (those to which a pointer was found) are not shown.
==190867== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190867== 
==190867== For counts of detected and suppressed errors, rerun with: -v
==190867== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==190866== LEAK SUMMARY:
==190866==    definitely lost: 0 bytes in 0 blocks
==190866==    indirectly lost: 0 bytes in 0 blocks
==190866==      possibly lost: 0 bytes in 0 blocks
==190866==    still reachable: 16,567 bytes in 43 blocks
==190866==         suppressed: 0 bytes in 0 blocks
==190866== Reachable blocks (those to which a pointer was found) are not shown.
==190866== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190866== 
==190866== For counts of detected and suppressed errors, rerun with: -v
==190866== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
flux-start: 0 (pid 190865) exited with rc=1
==190870== 
==190870== HEAP SUMMARY:
==190870==     in use at exit: 16,567 bytes in 43 blocks
==190870==   total heap usage: 44,439 allocs, 44,396 frees, 21,059,836 bytes allocated
==190870== 
==190870== LEAK SUMMARY:
==190870==    definitely lost: 0 bytes in 0 blocks
==190870==    indirectly lost: 0 bytes in 0 blocks
==190870==      possibly lost: 0 bytes in 0 blocks
==190870==    still reachable: 16,567 bytes in 43 blocks
==190870==         suppressed: 0 bytes in 0 blocks
==190870== Reachable blocks (those to which a pointer was found) are not shown.
==190870== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==190870== 
==190870== For counts of detected and suppressed errors, rerun with: -v
==190870== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
