### PR TITLE
libflux: add flux_buffer_write_watcher_close()

### DIFF
--- a/src/common/libflux/ev_buffer_write.h
+++ b/src/common/libflux/ev_buffer_write.h
@@ -17,6 +17,9 @@ struct ev_buffer_write {
     flux_buffer_t     *fb;
     struct ev_loop    *loop;
     bool              start;    /* flag, if user started reactor */
+    bool              eof;      /* flag, eof written             */
+    bool              closed;   /* flag, fd has been closed      */
+    int               close_errno;  /* errno from close          */
     void              *data;
 };
 
@@ -28,5 +31,5 @@ int ev_buffer_write_init (struct ev_buffer_write *ebw,
 void ev_buffer_write_cleanup (struct ev_buffer_write *ebw);
 void ev_buffer_write_start (struct ev_loop *loop, struct ev_buffer_write *ebw);
 void ev_buffer_write_stop (struct ev_loop *loop, struct ev_buffer_write *ebw);
-
+void ev_buffer_write_wakeup (struct ev_buffer_write *ebw);
 #endif /* !_EV_BUFFER_WRITE_H */

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -563,6 +563,39 @@ flux_buffer_t *flux_buffer_write_watcher_get_buffer (flux_watcher_t *w)
     return NULL;
 }
 
+int flux_buffer_write_watcher_close (flux_watcher_t *w)
+{
+    struct ev_buffer_write *evw;
+    if (!w) {
+        errno = EINVAL;
+        return (-1);
+    }
+    evw = w->data;
+    if (evw->eof) {
+        errno = EINPROGRESS;
+        return (-1);
+    }
+    if (evw->closed) {
+        errno = EINVAL;
+        return (-1);
+    }
+    evw->eof = true;
+    flux_buffer_readonly (evw->fb);
+    ev_buffer_write_wakeup (evw);
+    return (0);
+}
+
+int flux_buffer_write_watcher_is_closed (flux_watcher_t *w, int *errp)
+{
+    if (w) {
+        struct ev_buffer_write *evw = w->data;
+        if (evw->closed && errp != NULL)
+            *errp = evw->close_errno;
+        return (evw->closed);
+    }
+    return (0);
+}
+
 /* 0MQ sockets
  */
 

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -91,12 +91,26 @@ flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
 
 flux_buffer_t *flux_buffer_read_watcher_get_buffer (flux_watcher_t *w);
 
-/* 'cb' is used only for FLUX_POLLERR */
+/* 'cb' only called after fd closed (FLUX_POLLOUT) or error (FLUX_POLLERR) */
 flux_watcher_t *flux_buffer_write_watcher_create (flux_reactor_t *r, int fd,
                                                   int size, flux_watcher_f cb,
                                                   int flags, void *arg);
 
 flux_buffer_t *flux_buffer_write_watcher_get_buffer (flux_watcher_t *w);
+
+/* "write" EOF to buffer write watcher 'w'. The underlying fd will be closed
+ *  once the buffer is emptied. The underlying flux_buffer_t will be marked
+ *  readonly and subsequent flux_buffer_write* calls will return EROFS.
+ *
+ *  Once close(2) completes, the watcher callback is called with FLUX_POLLOUT.
+ *  Use flux_buffer_write_watcher_is_closed() to check for errors.
+ *
+ * Returns 0 on success, -1 on error with errno set.
+ */
+int flux_buffer_write_watcher_close (flux_watcher_t *w);
+
+/* Returns 1 if write watcher is closed, errnum from close in close_err */
+int flux_buffer_write_watcher_is_closed (flux_watcher_t *w, int *close_err);
 
 /* zmq socket
  */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -203,7 +203,8 @@ check_PROGRAMS = \
 	module/basic \
 	request/treq \
 	barrier/tbarrier \
-	wreck/rcalc
+	wreck/rcalc \
+	reactor/reactorcat
 
 check_LTLIBRARIES = \
 	module/parent.la \
@@ -397,3 +398,8 @@ wreck_sched_dummy_la_CPPFLAGS = $(test_cppflags)
 wreck_sched_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
 wreck_sched_dummy_la_LIBADD = \
         $(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+reactor_reactorcat_SOURCES = reactor/reactorcat.c
+reactor_reactorcat_CPPFLAGS = $(test_cppflags)
+reactor_reactorcat_LDADD = \
+	 $(test_ldadd) $(LIBDL) $(LIBUTIL)

--- a/t/reactor/reactorcat.c
+++ b/t/reactor/reactorcat.c
@@ -1,0 +1,98 @@
+
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+#include <flux/core.h>
+
+static int total_bytes = 0;
+
+static void die (const char *fmt, ...)
+{
+    va_list ap;
+    va_start (ap, fmt);
+    vfprintf (stderr, fmt, ap);
+    va_end (ap);
+    exit (1);
+}
+
+static void write_cb (flux_reactor_t *r, flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    int errnum;
+    if (revents & FLUX_POLLERR)
+        die ("got POLLERR on stdout. Aborting\n");
+
+    if (flux_buffer_write_watcher_is_closed (w, &errnum)) {
+        if (errnum)
+            fprintf (stderr, "error: close: %s\n", strerror (errnum));
+        flux_watcher_stop (w);
+    }
+}
+
+static void read_cb (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    const void *data;
+    int len, n = 0;
+    flux_watcher_t *writer = arg;
+    flux_buffer_t *wfb = NULL;
+    flux_buffer_t *rfb = NULL;;
+
+    if (!(wfb = flux_buffer_write_watcher_get_buffer (writer))
+        || !(rfb = flux_buffer_read_watcher_get_buffer (w)))
+        die ("failed to get read/write buffers from watchers!\n");
+
+    if (!(data = flux_buffer_peek (rfb, -1, &len)))
+        die ("flux_buffer_peek: %s\n", strerror (errno));
+
+    if ((len > 0) && ((n = flux_buffer_write (wfb, data, len)) < 0))
+        die ("flux_buffer_write: %s\n", strerror (errno));
+    else if (len == 0) {
+        /* Propagate EOF to writer, stop reader */
+        flux_buffer_write_watcher_close (writer);
+        flux_watcher_stop (w);
+    }
+
+    /* Drop data in read buffer that was successfully written to writer */
+    flux_buffer_drop (rfb, n);
+    total_bytes += n;
+}
+
+int main (int argc, char *argv[])
+{
+    int rc;
+    flux_watcher_t *rw, *ww;
+    flux_reactor_t *r;
+
+    if (!(r = flux_reactor_create (0)))
+        die ("flux_reactor_create failed\n");
+
+    ww = flux_buffer_write_watcher_create (r, STDOUT_FILENO, 4096,
+                                           write_cb, 0, NULL);
+    rw = flux_buffer_read_watcher_create (r, STDIN_FILENO, 4096,
+                                          read_cb, 0, (void *) ww);
+    if (!rw || !ww)
+        die ("flux buffer watcher create failed\n");
+
+    flux_watcher_start (rw);
+    flux_watcher_start (ww);
+
+    if ((rc = flux_reactor_run (r, 0)) < 0)
+        die ("flux_reactor_run() returned nonzero\n");
+
+    fprintf (stderr, "debug: %d bytes transferred.\n", total_bytes);
+
+    flux_watcher_destroy (rw);
+    flux_watcher_destroy (ww);
+    flux_reactor_destroy (r);
+
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -378,4 +378,13 @@ test_expect_success 'passing NULL to flux_log functions logs to stderr (#1191)' 
         grep "err: world: No such file or directory" std.err
 '
 
+reactorcat=${SHARNESS_TEST_DIRECTORY}/reactor/reactorcat
+test_expect_success 'reactor: reactorcat example program works' '
+	dd if=/dev/urandom bs=1024 count=4 >reactorcat.in &&
+	$reactorcat <reactorcat.in >reactorcat.out &&
+	test_cmp reactorcat.in reactorcat.out &&
+	$reactorcat </dev/null >reactorcat.devnull.out &&
+	test -f reactorcat.devnull.out &&
+	test_must_fail test -s reactorcat.devnull.out
+'
 test_done


### PR DESCRIPTION
As discussed in #1546, add a simple method for scheduling a call to `close(2)` once buffer has been emptied for flux buffer write watchers. This is basically the simplest approach for now while we continue to discuss alternatives.

Also added is the `reactorcat` test case, which implements something like `cat(1)` with the Flux reactor and buffer watchers.

Still need to add unit tests and a sharness test driver for `reactorcat`.

Fixes #1546