### PR TITLE
common/libflux: Add buffer readonly setting

### DIFF
--- a/src/common/libflux/buffer.h
+++ b/src/common/libflux/buffer.h
@@ -18,6 +18,18 @@ int flux_buffer_bytes (flux_buffer_t *fb);
 /* Returns the number of bytes of space available in flux_buffer */
 int flux_buffer_space (flux_buffer_t *fb);
 
+/* Manage "readonly" status
+ * - flux_buffer_readonly() makes it so writes are no longer allowed
+ *   to the buffer.  Reads are allowed until the buffer is empty.
+ *   Changing a buffer to "readonly" can only be called once and
+ *   cannot be disabled.  This is a convenience status can be used to
+ *   indicate to users that the buffer is no longer usable.
+ * - flux_buffer_is_readonly() returns > 0 if a buffer is readonly, 0
+ *   if not, and -1 on error.
+ */
+int flux_buffer_readonly (flux_buffer_t *fb);
+int flux_buffer_is_readonly (flux_buffer_t *fb);
+
 /* Drop up to [len] bytes of data in the buffer. Set [len] to -1
  * to drop all data.  Returns number of bytes dropped on success.
  */


### PR DESCRIPTION
As discussed in #1546 and #1547, this adds a "drain" flag that indicates users are allowed to finish reading everything in the buffer, but can no longer write to it.  It should be useful in #1547 to indicate to users that a buffer is closed and no longer available for writing.

Note that I decided to use the word "drain" for this setting.  It's the best word I could come up with given the usage.  Terms like "close" or "complete" didn't seem quite right.  Open to suggestions of a different word.

Also, the errno I chose to return when a user attempts to write to the buffer when drain is set, is EROFS, i.e. read only file system.  Not the most perfect errno, but I couldn't think of a better one.  