### PR TITLE
common/libsubprocess: Fix comment typos

### DIFF
--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -169,7 +169,7 @@ done:
 
 /*
  *  Default handler for stdout/err: send output directly into
- *   stderr of caller...
+ *   stdout/err of caller...
  */
 static int send_output_to_stream (const char *name, const char *json_str)
 {

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -189,7 +189,7 @@ int main (int ac, char **av)
     is (subprocess_state_string (p), "Waiting", "subprocess is Waiting");
     ok (subprocess_pid (p) > 0, "subprocess_pid() is valid");
 
-    ok (subprocess_exec (p) == 0, "subprocess_run");
+    ok (subprocess_exec (p) == 0, "subprocess_exec");
     is (subprocess_state_string (p), "Running", "subprocess is Running");
     q = subprocess_manager_wait (sm);
     ok (q != NULL, "subprocess_manager_wait");


### PR DESCRIPTION
Just a few comment typos I ran across