### PR TITLE
libflux: extend flux_future_t with composite types

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -43,6 +43,8 @@ MAN3_FILES_PRIMARY = \
 	flux_log.3 \
 	flux_future_get.3 \
 	flux_future_create.3 \
+	flux_future_wait_all_create.3 \
+	flux_future_and_then.3 \
 	flux_kvs_lookup.3 \
 	flux_kvs_commit.3 \
 	flux_kvs_txn_create.3 \
@@ -132,6 +134,16 @@ MAN3_FILES_SECONDARY = \
 	flux_future_aux_get.3 \
 	flux_future_set_flux.3 \
 	flux_future_get_flux.3 \
+	flux_future_wait_all_create.3 \
+	flux_future_wait_any_create.3 \
+	flux_future_push.3 \
+	flux_future_first_child.3 \
+	flux_future_next_child.3 \
+	flux_future_get_child.3 \
+	flux_future_and_then.3 \
+	flux_future_or_then.3 \
+	flux_future_continue.3 \
+	flux_future_continue_error.3 \
 	flux_rpc_pack.3 \
 	flux_rpc_raw.3 \
 	flux_rpc_get.3 \

--- a/doc/man3/flux_future_and_then.adoc
+++ b/doc/man3/flux_future_and_then.adoc
@@ -1,0 +1,112 @@
+flux_future_and_then(3)
+=======================
+:doctype: manpage
+
+
+NAME
+----
+flux_future_and_then, flux_future_or_then, flux_future_continue, flux_future_continue_error - functions for sequential composition of futures
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_future_and_then (flux_future_t *f,
+                                      flux_continuation_f cb, void *arg);
+ flux_future_t *flux_future_or_then (flux_future_t *f,
+                                     flux_continuation_f cb, void *arg);
+
+ int flux_future_continue (flux_future_t *prev, flux_future_t *f);
+ void flux_future_continue_error (flux_future_t *prev, int errnum);
+
+
+
+DESCRIPTION
+-----------
+
+See `flux_future_get(3)` for general functions that operate on futures,
+and `flux_future_create(3)` for a description of the `flux_future_t`
+base type. This page covers functions for the sequential composition of
+futures, i.e. chains of dependent futures.
+
+`flux_future_and_then(3)` is similar to `flux_future_then(3)`, but
+returns a future that may later be "continued" from the continuation
+callback `cb`. The provided continuation callback `cb` is only 
+executed when the future argument `f` is fulfilled successfully. On
+error, the error from `f` is automatically propagated to the "next"
+future in the chain (returned by the function).
+
+`flux_future_and_then()` is useful when a series of asynchronous
+operations, each returning a `flux_future_t`, depend on the result
+of a previous operation. That is, `flux_future_and_then()` returns a
+placeholder future for an eventual future that can't be created until
+the continuation `cb` is run. The returned future can then be
+used as a synchronization handle or even passed to another
+`flux_future_and_then()` in the chain. The callback `cb` *must* call
+either `flux_future_continue(3)` or `flux_future_continue_error(3)`
+to pass a result to the next future in the chain, otherwise the last
+future in the chain can never be fulfilled.
+
+`flux_future_or_then(3)` is like `flux_future_and_then()`, except
+the continuation callback `cb` is run when the future `f` is fulfilled
+with an error. This function is useful for recovery or other error
+handling (other than the default behavior of propagating an error
+down the chain to the final result). The `flux_future_or_then()`
+callback offers a chance to successfully fulfill the "next" future
+in the chain, even when the "previous" future was fulfilled with
+an error.
+
+As with `flux_future_and_then()` it is important that the continuation
+`cb` function for `flux_future_or_then()` calls `flux_future_continue()`
+or `flux_future_continue_error()` to avoid breaking the chain.
+
+`flux_future_continue(3)` continues the next future embedded in `prev`
+(created by `flux_future_and_then()` or `flux_future_or_then()` with
+the eventual result of the provided future `f`. This allows a future
+that was not created until the context of the callback to continue
+a sequential chain of futures created earlier.
+
+`flux_future_continue_error(3)` is like `flux_future_continue()`
+but immediately fulfills the next future in the chain with an error.
+
+RETURN VALUE
+------------
+
+`flux_future_and_then()` and `flux_future_or_then()` return a `flux_future_t`
+on success, or NULL on error. If both functions are called on the same
+future, the returned `flux_future_t` from each will be the same object.
+
+`flux_future_continue()` returns 0 on success, or -1 on error with errno
+set.
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+EINVAL::
+Invalid argument.
+
+ENOENT::
+The requested object is not found.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_future_get(3), flux_future_create(3)

--- a/doc/man3/flux_future_wait_all_create.adoc
+++ b/doc/man3/flux_future_wait_all_create.adoc
@@ -1,0 +1,126 @@
+flux_future_wait_all_create(3)
+==============================
+:doctype: manpage
+
+
+NAME
+----
+flux_future_wait_all_create, flux_future_wait_any_create, flux_future_push, flux_future_first_child, flux_future_next_child, flux_future_get_child - functions for future composition
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_future_wait_all_create (void);
+ flux_future_t *flux_future_wait_any_create (void);
+ 
+ int flux_future_push (flux_future_t *cf, const char *name, flux_future_t *f);
+
+ const char *flux_future_first_child (flux_future_t *cf);
+ const char *flux_future_next_child (flux_future_t *cf);
+ flux_future_t *flux_future_get_child (flux_future_t *cf, const char *name);
+
+
+DESCRIPTION
+-----------
+
+See `flux_future_get(3)` for general functions that operate on futures,
+and `flux_future_create(3)` for a description of the `flux_future_t`
+base type. This page covers functions used for composing futures into
+composite types using containers that allow waiting on all or any of a
+set of child futures.
+
+`flux_future_wait_all_create(3)` creates a future that is an empty
+container for other futures, which can subsequently be pushed into
+the container using `flux_future_push(3)`. The returned future will
+be automatically fulfilled when *all* children futures have been
+fulfilled.  The caller may then use `flux_future_first_child(3)`,
+`flux_future_next_child(3)`, and/or `flux_future_get_child(3)` and
+expect that `flux_future_get(3)` will not block for any of these child
+futures. This function is useful to synchronize on a series of futures
+that may be run in parallel.
+
+`flux_future_wait_any_create(3)` creates a composite future that will be
+fulfilled once *any* one of its children are fulfilled. Once the composite
+future is fulfilled, the caller will need to traverse the child futures
+to determine which was fulfilled. This function is useful to synchronize
+on work where any one of several results is sufficient to continue.
+
+`flux_future_push(3)` places a new child future `f` into a future
+composite created by either `flux_future_wait_all_create(3)` or
+`flux_future_wait_any_create(3)`. A `name` is provided for the child so
+that the child future can be easily differentiated from other futures
+inside the container once the composite future is fulfilled.
+
+Once a `flux_future_t` is pushed onto a composite future with
+`flux_future_push(3)`, the memory for the child future is "adopted" by
+the new parent. Thus, calling `flux_future_destroy(3)` on the parent
+composite will destroy all children. Therefore, child futures that
+have been the target of `flux_future_push(3)` should *not* have
+flux_future_destroy(3)` called upon them to avoid double-free.
+
+`flux_future_first_child(3)` and `flux_future_next_child(3)` are used to
+iterate over child future names in a composite future created with either
+`flux_future_wait_all_create(3)` or `flux_future_wait_any_create(3)`. The
+`flux_future_t` corresponding to the returned _name_ can be then
+fetched with `flux_future_get_child(3)`. `flux_future_next_child` will
+return a `NULL` once all children have been iterated.
+
+
+`flux_future_get_child(3)` retrieves a child future from a composite
+by name.
+
+
+
+RETURN VALUE
+------------
+
+`flux_future_wait_any_create()` and `flux_future_wait_all_create()` return
+a future on success.  On error, NULL is returned and errno is set appropriately.
+
+`flux_future_push()` returns zero on success.  On error, -1 is
+returned and errno is set appropriately.
+
+`flux_future_first_child()` returns the name of the first child future in
+the targeted composite in no given order. If the composite is empty,
+a NULL is returned.
+
+`flux_future_next_child()` returns the name of the next child future in the
+targeted composite in no given order. If the last child has already been
+returned then this function returns NULL.
+
+`flux_future_get_child()` returns a `flux_future_t` corresponding to the
+child future with the supplied string `name` parameter. If no future with
+that name is a child of the composite, then the function returns NULL.
+
+ERRORS
+------
+
+ENOMEM::
+Out of memory.
+
+EINVAL::
+Invalid argument.
+
+ENOENT::
+The requested object is not found.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_future_get(3), flux_future_create(3)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -128,6 +128,7 @@ TESTS = test_module.t \
 	test_tagpool.t \
 	test_security.t \
 	test_future.t \
+	test_composite_future.t \
 	test_reactor.t \
 	test_buffer.t
 
@@ -189,6 +190,10 @@ test_security_t_LDADD = $(test_ldadd) $(LIBDL)
 test_future_t_SOURCES = test/future.c
 test_future_t_CPPFLAGS = $(test_cppflags)
 test_future_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_composite_future_t_SOURCES = test/composite_future.c
+test_composite_future_t_CPPFLAGS = $(test_cppflags)
+test_composite_future_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_buffer_t_SOURCES = test/buffer.c
 test_buffer_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -109,6 +109,7 @@ libflux_la_SOURCES = \
 	keepalive.c \
 	content.c \
 	future.c \
+	composite_future.c \
 	barrier.c \
 	buffer_private.h \
 	buffer.c

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -209,6 +209,192 @@ const char *flux_future_next_child (flux_future_t *f)
     return (zhash_cursor (cf->children));
 }
 
+/*  Chained futures support: */
+
+struct continuation_info {
+    flux_continuation_f cb;
+    void *arg;
+};
+
+struct chained_future {
+    flux_future_t *next;
+    flux_future_t *prev;
+    struct continuation_info and_then;
+    struct continuation_info or_then;
+};
+
+/*
+ *  Continuation for chained futures: fulfill future `next` immediately
+ *   with the result from `f`. Since a result freed by destruction of
+ *   `f` will now be placed into `next`, the `next` future must steal
+ *   a reference to `f`, thus we place `f` in the aux hash.
+ */
+static void fulfill_next (flux_future_t *f, flux_future_t *next)
+{
+    void *result;
+    /*  Tie destruction of future `f` to future `next` since we
+     *   are fulfilling `next` via `f`
+     */
+    flux_future_aux_set (next, NULL, f, (flux_free_f) flux_future_destroy);
+
+    if (flux_future_get (f, &result) < 0)
+        flux_future_fulfill_error (next, errno);
+    else
+        flux_future_fulfill (next, result, NULL);
+}
+
+/*  Callback for chained continuations. Obtains the result of the completed
+ *   "previous" future, then calls the appropriate "and_then" or "or_then"
+ *   callback, or fulfill the "next" future with an error automatically.
+ */
+static void chained_continuation (flux_future_t *prev, void *arg)
+{
+    struct chained_future *cf = arg;
+
+    if (flux_future_get (prev, NULL) < 0) {
+        /*  Handle "or" callback if set and return immediately */
+        if (cf->or_then.cb)
+            return (*cf->or_then.cb) (prev, cf->or_then.arg);
+    }
+    else if (cf->and_then.cb)
+        return (*cf->and_then.cb) (prev, cf->and_then.arg);
+
+    /* Neither and-then nor or-then callback was used, auto-fulfill cf->next
+     *  using the result of prev:
+     */
+    fulfill_next (prev, cf->next);
+}
+
+/*  Initialization for a chained future. Get current reactor for this
+ *   context and install it in "previous" future, _then_ set the "then"
+ *   callback for that future to `chained_continuation()` which will
+ *   call take the appropriate action for the result.
+ */
+static void chained_future_init (flux_future_t *f, void *arg)
+{
+    flux_reactor_t *r;
+    struct chained_future *cf = arg;
+    if (cf == NULL || cf->prev == NULL || cf->next == NULL
+        || !(r = flux_future_get_reactor (f))) {
+        errno = EINVAL;
+        goto error;
+    }
+    flux_future_set_reactor (cf->prev, r);
+    if (flux_future_then (cf->prev, -1., chained_continuation, cf) < 0)
+        goto error;
+    return;
+error:
+    /* Initialization failed. Fulfill f with error to indicate the failure,
+     *  and pass the error up the chain to cf->next, since that is likely the
+     *  future which has callbacks registered on it.
+     */
+    flux_future_fulfill_error (f, errno);
+    fulfill_next (f, cf->next);
+}
+
+
+/*  Allocate a chained future structure */
+static struct chained_future *chained_future_alloc (void)
+{
+    struct chained_future *cf = calloc (1, sizeof (*cf));
+    if (cf == NULL)
+        return NULL;
+    if (!(cf->next = flux_future_create (chained_future_init, (void *)cf))) {
+        free (cf);
+        return (NULL);
+    }
+    return (cf);
+}
+
+static void chained_future_destroy (struct chained_future *cf)
+{
+    free (cf);
+}
+
+/*  Create a chained future on `f` by embedding a chained future
+ *   structure as "flux::chained" in the aux hash.
+ *
+ *  The future `f` doesn't "own" the memory for cf->next,
+ *   since this next future in the chain may be passed to the user
+ *   or another continuation etc.
+ */
+static struct chained_future *chained_future_create (flux_future_t *f)
+{
+    struct chained_future *cf = flux_future_aux_get (f, "flux::chained");
+    if (cf == NULL && (cf = chained_future_alloc ())) {
+        if (flux_future_aux_set (f, "flux::chained",
+                                 (void *) cf,
+                                 (flux_free_f) chained_future_destroy) < 0) {
+            chained_future_destroy (cf);
+            return (NULL);
+        }
+    }
+    cf->prev = f;
+    return (cf);
+}
+
+static struct chained_future *chained_future_get (flux_future_t *f)
+{
+    return (flux_future_aux_get (f, "flux::chained"));
+}
+
+/* "Continue" the chained "next" future embedded in `prev` with the
+ *  future `f` by setting the continuation of `f` to fulfill "next".
+ *
+ * Steals ownership of `f` so that its destruction can be tied to
+ *  next.
+ */
+int flux_future_continue (flux_future_t *prev, flux_future_t *f)
+{
+    struct chained_future *cf = chained_future_get (prev);
+    if (cf == NULL || !cf->next) {
+        errno = EINVAL;
+        return -1;
+    }
+    /*  Ensure that the reactor for f matches the current reactor context
+     *   for the previous future `prev`:
+     */
+    flux_future_set_reactor (f, flux_future_get_reactor (prev));
+
+    /*  Set the "next" future in the chain (prev->next) to be fulfilled
+     *   by the future `f` once it is fulfilled.
+     */
+    return flux_future_then (f, -1.,
+                             (flux_continuation_f) fulfill_next,
+                             cf->next);
+}
+
+/* "Continue" the chained "next" future embedded in `prev` with an error
+ */
+void flux_future_continue_error (flux_future_t *prev, int errnum)
+{
+    struct chained_future *cf = chained_future_get (prev);
+    if (cf && cf->next)
+        flux_future_fulfill_error (cf->next, errnum);
+}
+
+flux_future_t *flux_future_and_then (flux_future_t *prev,
+                                     flux_continuation_f next_cb, void *arg)
+{
+    struct chained_future *cf = chained_future_create (prev);
+    if (!cf)
+        return NULL;
+    cf->and_then.cb = next_cb;
+    cf->and_then.arg = arg;
+    return (cf->next);
+}
+
+flux_future_t *flux_future_or_then (flux_future_t *prev,
+                                    flux_continuation_f or_cb, void *arg)
+{
+    struct chained_future *cf = chained_future_create (prev);
+    if (!cf)
+        return NULL;
+    cf->or_then.cb = or_cb;
+    cf->or_then.arg = arg;
+    return (cf->next);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -1,0 +1,214 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+
+#include "future.h"
+
+/*  Type-specific data for a composite future:
+ */
+struct composite_future {
+    unsigned int any:1;  /* true if this future is a "wait any" type */
+    zhash_t *children;   /* hash of child futures by name            */
+};
+
+static void composite_future_destroy (struct composite_future *f)
+{
+    if (f) {
+        if (f->children)
+            zhash_destroy (&f->children);
+        free (f);
+    }
+}
+
+static struct composite_future * composite_future_create (void)
+{
+    struct composite_future *cf = calloc (1, sizeof (*cf));
+    if (cf == NULL)
+        return NULL;
+    if (!(cf->children = zhash_new ())) {
+        free (cf);
+        return (NULL);
+    }
+    return (cf);
+}
+
+/*  Return the embedded composite_future data from future `f`
+ */
+static struct composite_future * composite_get (flux_future_t *f)
+{
+    return flux_future_aux_get (f, "flux::composite");
+}
+
+/*
+ *  Return true if all futures in this composite are ready
+ */
+static bool wait_all_is_ready (struct composite_future *cf)
+{
+    flux_future_t *f = zhash_first (cf->children);
+    while (f) {
+        if (!flux_future_is_ready (f))
+            return (false);
+        f = zhash_next (cf->children);
+    }
+    return (true);
+}
+
+/*  Continuation for children of a composition future -- simply check
+ *   to see if the parent composite is "ready" and fulfill it if so.
+ */
+static void child_cb (flux_future_t *f, void *arg)
+{
+    flux_future_t *parent = arg;
+    struct composite_future *cf = composite_get (parent);
+    if (!arg || !cf)
+        return;
+    /*
+     *  Fulfill the composite future if "wait any" is set, or all child
+     *   futures are fulfilled:
+     */
+    if (cf->any || wait_all_is_ready (cf))
+        flux_future_fulfill (parent, NULL, NULL);
+}
+
+/*  Initialization callback for a composite future. Register then
+ *   continuations for all child futures on active reactor.
+ */
+void composite_future_init (flux_future_t *f, void *arg)
+{
+    flux_reactor_t *r;
+    flux_future_t *child;
+    struct composite_future *cf = arg;
+    if (cf == NULL) {
+        errno = EINVAL;
+        goto error;
+    }
+    /*
+     *  Get the current reactor for the context of this composite future,
+     *   and install it on all child futures so that the composite future's
+     *   'then' *or* 'now' context becomes a 'then' context for all children.
+     */
+    r = flux_future_get_reactor (f);
+    child = zhash_first (cf->children);
+    while (child) {
+        flux_future_set_reactor (child, r);
+        if (flux_future_then (child, -1., child_cb, (void *) f) < 0)
+            goto error;
+        child = zhash_next (cf->children);
+    }
+    return;
+error:
+    flux_future_fulfill_error (f, errno);
+}
+
+/*
+ *  Construct a composite future.
+ *  If the wait_any flag is 1 then make this a "wait any" composite.
+ */
+static flux_future_t *future_create_composite (int wait_any)
+{
+    struct composite_future *cf = composite_future_create ();
+    flux_future_t *f = flux_future_create (composite_future_init, (void *) cf);
+    if (!f || !cf || flux_future_aux_set (f, "flux::composite", cf,
+                         (flux_free_f) composite_future_destroy) < 0) {
+        composite_future_destroy (cf);
+        flux_future_destroy (f);
+        return (NULL);
+    }
+    cf->any = wait_any;
+    return (f);
+}
+
+/*  Constructor for "wait_all" composite future.
+ */
+flux_future_t *flux_future_wait_all_create (void)
+{
+    return future_create_composite (0);
+}
+
+/*  Constructor for "wait_any" composite future
+ */
+flux_future_t *flux_future_wait_any_create (void)
+{
+    return future_create_composite (1);
+}
+
+int flux_future_push (flux_future_t *f, const char *name, flux_future_t *child)
+{
+    struct composite_future *cf = NULL;
+
+    if (!f || !name || !child || !(cf = composite_get (f))) {
+        errno = EINVAL;
+        return (-1);
+    }
+    if (zhash_insert (cf->children, name, child) < 0)
+        return (-1);
+    zhash_freefn (cf->children, name, (flux_free_f) flux_future_destroy);
+    if (flux_future_aux_set (child, "flux::parent", f, NULL) < 0) {
+        zhash_delete (cf->children, name);
+        return (-1);
+    }
+    return (0);
+}
+
+flux_future_t *flux_future_get_child (flux_future_t *f, const char *name)
+{
+    struct composite_future *cf = NULL;
+    if (!f || !name || !(cf = composite_get (f))) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    return zhash_lookup (cf->children, name);
+}
+
+const char *flux_future_first_child (flux_future_t *f)
+{
+    struct composite_future *cf = NULL;
+    if (!f || !(cf = composite_get (f))) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    if (!zhash_first (cf->children))
+        return (NULL);
+    return (zhash_cursor (cf->children));
+}
+
+const char *flux_future_next_child (flux_future_t *f)
+{
+    struct composite_future *cf = NULL;
+    if (!f || !(cf = composite_get (f))) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    if (!zhash_next (cf->children))
+        return (NULL);
+    return (zhash_cursor (cf->children));
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -379,6 +379,16 @@ int flux_future_wait_for (flux_future_t *f, double timeout)
     return 0;
 }
 
+
+/* Return true if future is fulfilled and flux_future_get() will not block.
+ */
+bool flux_future_is_ready (flux_future_t *f)
+{
+    if (f && flux_future_wait_for (f, 0.) == 0)
+        return true;
+    return false;
+}
+
 /* Block until future is fulfilled if not already.
  * Then return either result or error depending on how it was fulfilled.
  */

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -430,10 +430,6 @@ int flux_future_then (flux_future_t *f, double timeout,
         f->init (f, f->init_arg); // might set error
         f->then->init_called = true;
     }
-    if (f->result_errnum_valid) {
-        errno = f->result_errnum;
-        return -1;
-    }
     return 0;
 }
 

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -64,6 +64,39 @@ const char * flux_future_next_child (flux_future_t *cf);
 
 flux_future_t *flux_future_get_child (flux_future_t *cf, const char *name);
 
+/* Future chaining
+ */
+
+/* Similar to flux_future_then(3), but return a future that can subsequently
+ *  be "continued" from the continuation function `cb` via
+ *  flux_future_continue(3) upon successful fulfillment of future `f`.
+ *
+ * The continuation `cb` is only called on success of future `f`. If `f`
+ *  is fulfilled with an error, then that error is immediately passed
+ *  to  future returned by this function, unless `flux_future_or_then(3)`
+ *  has been used.
+ */
+flux_future_t *flux_future_and_then (flux_future_t *f,
+                                     flux_continuation_f cb, void *arg);
+
+/* Like flux_future_and_then(3), but run the continuation `cb` when
+ *  future `f` is fulfilled with an error.
+ */
+flux_future_t *flux_future_or_then (flux_future_t *f,
+                                    flux_continuation_f cb, void *arg);
+
+/* Set the next future for the chained future `prev` to `f`.
+ *  This function steals a reference to `f` and thus flux_future_destroy()
+ *  should not be called on `f`.
+ *
+ */
+int flux_future_continue (flux_future_t *prev, flux_future_t *f);
+
+/*  Set the next future for the chained future `prev` to be fulfilled
+ *   with an error `errnum`.
+ */
+void flux_future_continue_error (flux_future_t *prev, int errnum);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -23,6 +23,8 @@ int flux_future_then (flux_future_t *f, double timeout,
 
 int flux_future_wait_for (flux_future_t *f, double timeout);
 
+bool flux_future_is_ready (flux_future_t *f);
+
 void flux_future_reset (flux_future_t *f);
 
 void flux_future_destroy (flux_future_t *f);

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -52,6 +52,18 @@ flux_t *flux_future_get_flux (flux_future_t *f);
 void flux_future_set_reactor (flux_future_t *f, flux_reactor_t *r);
 flux_reactor_t *flux_future_get_reactor (flux_future_t *f);
 
+/* Composite future implementation
+ */
+flux_future_t *flux_future_wait_all_create (void);
+flux_future_t *flux_future_wait_any_create (void);
+
+int flux_future_push (flux_future_t *cf, const char *name, flux_future_t *f);
+
+const char * flux_future_first_child (flux_future_t *cf);
+const char * flux_future_next_child (flux_future_t *cf);
+
+flux_future_t *flux_future_get_child (flux_future_t *cf, const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -1,0 +1,168 @@
+#include <czmq.h>
+
+#include "src/common/libflux/reactor.h"
+#include "src/common/libflux/future.h"
+#include "src/common/libtap/tap.h"
+
+static bool init_and_fulfill_called = false;
+static bool init_no_fulfill_called = false;
+
+static void reset_static_sentinels (void)
+{
+    init_and_fulfill_called = false;
+    init_no_fulfill_called = false;
+}
+
+static void init_and_fulfill (flux_future_t *f, void *arg)
+{
+    init_and_fulfill_called = true;
+    flux_future_fulfill (f, NULL, NULL);
+}
+
+static void init_no_fulfill (flux_future_t *f, void *arg)
+{
+    init_no_fulfill_called = true;
+}
+
+static void test_composite_basic_any (flux_reactor_t *r)
+{
+    flux_future_t *any = flux_future_wait_any_create ();
+    flux_future_t *f1 = flux_future_create (init_no_fulfill, NULL);
+    flux_future_t *f2 = flux_future_create (init_and_fulfill, NULL);
+    const char *s = NULL;
+    const char *p = NULL;
+    int rc;
+
+    if (!any || !f1 || !f2)
+        BAIL_OUT ("Error creating test futures");
+
+    flux_future_set_reactor (any, r);
+
+    ok (flux_future_push (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_future_push (NULL, NULL, NULL) returns EINVAL");
+    ok (flux_future_push (any, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_future_push (any, NULL, NULL) returns EINVAL");
+    ok (flux_future_push (any, NULL, f1) < 0 && errno == EINVAL,
+        "flux_future_push (any, NULL, f1) returns EINVAL");
+    ok (flux_future_push (f1, "any", any) < 0 && errno == EINVAL,
+        "flux_future_push on non-composite future returns EINVAL");
+
+    ok (flux_future_first_child (any) == NULL,
+        "flux_future_first_child with no children returns NULL");
+    ok (flux_future_get_child (any, "foo") == NULL,
+        "flux_future_get_child (any, 'foo') == NULL");
+    rc = flux_future_push (any, "f1", f1);
+    ok (rc == 0,
+        "flux_future_push (any, 'f1', f1) == %d", rc);
+    ok (flux_future_get_child (any, "f1") == f1,
+        "flux_future_get_child (any, 'f1') == f1");
+
+    s = flux_future_first_child (any);
+    ok ((s != NULL) && !strcmp (s, "f1"),
+        "flux_future_first_child() == 'f1'");
+
+    ok (flux_future_push (any, "f2", f2) == 0,
+        "flux_future_push (any, 'f2', f2)");
+
+    s = flux_future_first_child (any);
+    ok (s != NULL && (!strcmp (s, "f1") || !strcmp (s, "f2")),
+        "flux_future_first_child (any) returns one of two children");
+    p = flux_future_next_child (any);
+    ok ((p != NULL) && (!strcmp (p, "f1") || !strcmp (p, "f2"))
+        && (strcmp (p, s) != 0),
+        "flux_future_next_child (any) returns different child (%s)", s);
+    ok (flux_future_next_child (any) == NULL,
+        "flux_future_next_child (any) == NULL signifies end of list");
+
+    ok (!flux_future_is_ready (any),
+        "flux_future_is_ready (any) == false");
+
+    ok (flux_future_wait_for (any, 0.1) == 0,
+        "flux_future_wait_for() returns success");
+    ok (init_and_fulfill_called && init_no_fulfill_called,
+        "initializers for both futures called synchronously");
+    ok (flux_future_get (any, NULL) == 0,
+        "flux_future_get on composite returns success");
+    ok (!flux_future_is_ready (f1),
+        "future f1 is not ready");
+    ok (flux_future_is_ready (f2),
+        "future f2 is ready");
+
+    flux_future_destroy (any);
+}
+
+static void test_composite_basic_all (flux_reactor_t *r)
+{
+    flux_future_t *all = flux_future_wait_all_create ();
+    flux_future_t *f1 = flux_future_create (init_no_fulfill, NULL);
+    flux_future_t *f2 = flux_future_create (init_and_fulfill, NULL);
+    const char *s = NULL;
+    int rc;
+
+    if (!all || !f1 || !f2)
+        BAIL_OUT ("Error creating test futures");
+
+    reset_static_sentinels ();
+
+    flux_future_set_reactor (all, r);
+
+    rc = flux_future_push (all, "f1", f1);
+    ok (rc == 0,
+        "flux_future_push (all, 'f1', f1) == %d", rc);
+    ok (flux_future_get_child (all, "f1") == f1,
+        "flux_future_get_child (all, 'f1') == f1");
+
+    s = flux_future_first_child (all);
+    ok ((s != NULL) && !strcmp (s, "f1"),
+        "flux_future_first_child() == 'f1'");
+
+    ok (flux_future_push (all, "f2", f2) == 0,
+        "flux_future_push (all, 'f2', f2)");
+
+    ok (!flux_future_is_ready (all),
+        "flux_future_is_ready (all) == false");
+
+    ok (flux_future_wait_for (all, 0.1) < 0 && errno == ETIMEDOUT,
+        "flux_future_wait_for() returns ETIMEDOUT");
+
+    ok (init_and_fulfill_called && init_no_fulfill_called,
+        "initializers for both futures called synchronously");
+
+    ok (!flux_future_is_ready (all),
+        "wait_all future still not ready");
+
+    flux_future_fulfill (f1, NULL, NULL);
+
+    ok (flux_future_wait_for (all, 0.1) == 0,
+        "flux_future_wait_for() now returns success");
+
+    ok (flux_future_get (all, NULL) == 0,
+        "flux_future_get on wait_all composite returns success");
+
+    flux_future_destroy (all);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_reactor_t *reactor;
+
+    plan (NO_PLAN);
+
+    ok ((reactor = flux_reactor_create (0)) != NULL,
+        "created reactor");
+    if (!reactor)
+        BAIL_OUT ("can't continue without reactor");
+
+    test_composite_basic_any (reactor);
+    test_composite_basic_all (reactor);
+
+    flux_reactor_destroy (reactor);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -1,4 +1,6 @@
+#define _GNU_SOURCE
 #include <czmq.h>
+#include <stdio.h>
 
 #include "src/common/libflux/reactor.h"
 #include "src/common/libflux/future.h"
@@ -308,6 +310,221 @@ static void test_basic_chained (flux_reactor_t *r)
     flux_future_destroy (f3);
 }
 
+void timeout_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    flux_future_t *f = arg;
+    flux_future_fulfill (f, NULL, NULL);
+}
+
+void timeout_init (flux_future_t *f, void *arg)
+{
+    flux_reactor_t *r = flux_future_get_reactor (f);
+    double *dptr = arg;
+    flux_watcher_t *w;
+    if (!(w = flux_timer_watcher_create (r, *dptr, 0., timeout_cb, f)))
+        goto error;
+    /* no longer need memory for stashed argument */
+    free (dptr);
+    if (flux_future_aux_set (f, "watcher", w,
+                             (flux_free_f) flux_watcher_destroy) < 0) {
+        flux_watcher_destroy (w);
+        goto error;
+    }
+    flux_watcher_start (w);
+    return;
+error:
+    flux_future_fulfill_error (f, errno);
+}
+
+static void flux_future_timeout_clear (flux_future_t *f)
+{
+    flux_watcher_t *w = flux_future_aux_get (f, "watcher");
+    ok (w != NULL, "timeout stop: got timer watcher");
+    if (w)
+        flux_watcher_stop (w);
+}
+
+static flux_future_t *flux_future_timeout (double s)
+{
+    double *dptr = calloc (1, sizeof (*dptr));
+    if (dptr == NULL)
+        return (NULL);
+    *dptr = s;
+    return flux_future_create (timeout_init, (void *) dptr);
+}
+
+static int async_check_rc = -1;
+void async_check (flux_future_t *fc, void *arg)
+{
+    flux_future_t *f;
+    ok (flux_future_is_ready (fc) == true,
+        "async: composite future is ready");
+    ok ((f = flux_future_get_child (fc, "f1")) != NULL,
+        "async: retrieved handle child future");
+    ok (flux_future_get (f, NULL) == 0,
+        "async: flux_future_get on child successful");
+    ok ((f = flux_future_get_child (fc, "timeout")) != NULL,
+        "async: retrieved handle to timeout future");
+    ok (flux_future_get (f, NULL) == 0,
+        "async: timeout future fulfilled");
+    async_check_rc = 0;
+}
+
+void test_composite_all_async (void)
+{
+    flux_reactor_t *r;
+    flux_future_t *f, *fc;
+
+    r = flux_reactor_create (0);
+    if (!r)
+        BAIL_OUT ("flux_reactor_create failed");
+    if (!(fc = flux_future_wait_all_create ()))
+        BAIL_OUT ("flux_future_wait_all_create failed");
+    if (!(f = flux_future_create (init_and_fulfill, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    ok (flux_future_push (fc, "f1", f) == 0,
+        "flux_future_push success");
+
+    if (!(f = flux_future_timeout (0.1)))
+        BAIL_OUT ("flux_future_timeout failed");
+
+    ok (flux_future_push (fc, "timeout", f) == 0,
+        "flux_future_push timeout success");
+
+    flux_future_set_reactor (fc, r);
+    ok (flux_future_then (fc, 1., async_check, NULL) == 0,
+        "flux_future_then worked");
+    ok (flux_future_is_ready (fc) == 0,
+        "flux_future_is_ready returns false");
+    ok (flux_reactor_run (r, 0) == 0,
+        "flux_reactor_run returned");
+    ok (async_check_rc == 0,
+        "asynchronous callback called");
+
+    flux_future_destroy (fc);
+    flux_reactor_destroy (r);
+}
+
+static int async_any_check_rc = -1;
+void async_any_check (flux_future_t *fc, void *arg)
+{
+    flux_future_t *f;
+    ok (flux_future_is_ready (fc) == true,
+        "async: composite future is ready");
+    ok ((f = flux_future_get_child (fc, "f1")) != NULL,
+        "async: retrieved handle child future");
+    ok (flux_future_get (f, NULL) == 0,
+        "async: flux_future_get on child successful");
+    ok ((f = flux_future_get_child (fc, "timeout")) != NULL,
+        "async: retrieved handle to timeout future");
+    ok (flux_future_is_ready (f) == false,
+        "async: timeout future not yet fulfilled");
+    flux_future_timeout_clear (f);
+    async_any_check_rc = 0;
+    /* Required so we pop out of reactor since we will still have
+     *  active watchers */
+    flux_reactor_stop (flux_future_get_reactor (f));
+}
+
+void test_composite_any_async (void)
+{
+    flux_reactor_t *r;
+    flux_future_t *f, *fc;
+
+    r = flux_reactor_create (0);
+    if (!r)
+        BAIL_OUT ("flux_reactor_create failed");
+    if (!(fc = flux_future_wait_any_create ()))
+        BAIL_OUT ("flux_future_wait_any_create failed");
+    if (!(f = flux_future_create (init_and_fulfill, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    ok (flux_future_push (fc, "f1", f) == 0,
+        "flux_future_push success");
+
+    if (!(f = flux_future_timeout (1.0)))
+        BAIL_OUT ("flux_future_timeout failed");
+
+    ok (flux_future_push (fc, "timeout", f) == 0,
+        "flux_future_push timeout success");
+
+    flux_future_set_reactor (fc, r);
+    ok (flux_future_then (fc, -1., async_any_check, NULL) == 0,
+        "flux_future_then worked");
+    ok (flux_future_is_ready (fc) == 0,
+        "flux_future_is_ready returns false");
+    int count = flux_reactor_run (r, 0);
+    ok (count >= 0,
+        "flux_reactor_run returned %d", count);
+    ok (async_any_check_rc == 0,
+        "asynchronous callback called");
+
+    flux_future_destroy (fc);
+    flux_reactor_destroy (r);
+}
+
+void f_strdup_init (flux_future_t *f, void *arg)
+{
+    char *result = strdup ((char *) arg);
+    flux_future_fulfill (f, result, free);
+}
+
+void f_strcat (flux_future_t *prev, void *arg)
+{
+    char *result = NULL;
+    char *next = NULL;
+    char *append = arg;
+    flux_future_t *f;
+
+    ok (flux_future_get (prev, (void *)&result) == 0,
+        "flux_future_get (prev) worked");
+    if (asprintf (&next, "%s%s", result, append) < 0)
+        BAIL_OUT ("f_strcat: asprintf: %s", strerror (errno));
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("f_strcat: flux_future_create: %s", strerror (errno));
+    flux_future_fulfill (f, next, free);
+    ok (flux_future_continue (prev, f) == 0,
+        "f_strcat: flux_future_continue worked");
+    flux_future_destroy (prev);
+}
+
+void chained_async_cb (flux_future_t *f, void *arg)
+{
+    char *result;
+    const char *expected = arg;
+    ok (flux_future_is_ready (f),
+        "chained_async_cb: future is ready");
+    ok (flux_future_get (f, (void *) &result) == 0,
+        "chained_async_cb: flux_future_get worked");
+    is (result, expected,
+        "chained_async_cb: got expected result");
+    flux_future_destroy (f);
+}
+
+void test_chained_async ()
+{
+    flux_reactor_t *r;
+    flux_future_t *f;
+
+    r = flux_reactor_create (0);
+    if (!r)
+        BAIL_OUT ("flux_reactor_create failed");
+    if (!(f = flux_future_create (f_strdup_init, "Hello")))
+        BAIL_OUT ("flux_future_create failed");
+    if (!(f = flux_future_and_then (f, f_strcat, ", ")))
+        BAIL_OUT ("flux_future_create failed");
+    if (!(f = flux_future_and_then (f, f_strcat, "World.")))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_set_reactor (f, r);
+    ok (flux_future_then (f, -1., chained_async_cb, "Hello, World.") == 0,
+        "chained async: flux_future_then worked");
+    ok (flux_reactor_run (r, 0) == 0,
+        "chained async: reactor exited");
+    flux_reactor_destroy (r);
+}
+
 int main (int argc, char *argv[])
 {
     flux_reactor_t *reactor;
@@ -322,6 +539,9 @@ int main (int argc, char *argv[])
     test_composite_basic_any (reactor);
     test_composite_basic_all (reactor);
     test_basic_chained (reactor);
+    test_composite_all_async ();
+    test_composite_any_async ();
+    test_chained_async ();
 
     flux_reactor_destroy (reactor);
 

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -95,13 +95,15 @@ void test_simple (void)
     ok (flux_future_aux_set (f, NULL, "bar", aux_destroy) == 0,
         "flux_future_aux_set with NULL key works");
 
-    /* wait_for/get - no future_init; artificially call fulfill */
+    /* is_ready/wait_for/get - no future_init; artificially call fulfill */
     errno = 0;
     ok (flux_future_wait_for (NULL, 0.) < 0 && errno == EINVAL,
         "flux_future_wait_for w/ NULL future returns EINVAL");
     errno = 0;
     ok (flux_future_wait_for (f, 0.) < 0 && errno == ETIMEDOUT,
         "flux_future_wait_for initially times out");
+    ok (!flux_future_is_ready (f),
+        "flux_future_is_ready returns false");
     errno = 0;
     void *result = NULL;
     result_destroy_called = 0;
@@ -109,6 +111,8 @@ void test_simple (void)
     flux_future_fulfill (f, "Hello", result_destroy);
     ok (flux_future_wait_for (f, 0.) == 0,
         "flux_future_wait_for succedes after result is set");
+    ok (flux_future_is_ready (f),
+        "flux_future_is_ready returns true after result is set");
     ok (flux_future_get (f, &result) == 0
         && result != NULL && !strcmp (result, "Hello"),
         "flux_future_get returns correct result");


### PR DESCRIPTION
As described in #1550, this PR adds a first stab at support for composable `flux_future_t` to the API. The testing here so far is minimal, I wanted to make sure the interface was ok before proceeding further.

This doesn't go as far as the proposal in #1550 -- instead of turning `flux_future_t` into a composite type, it extends the interface with two composite containers (which are also of type `flux_future_t`), "wait all" and "wait any", which are created with specific constructors:

```C
flux_future_t *flux_future_wait_all_create (void);
flux_future_t *flux_future_wait_any_create (void);
```
The constructors "extend" the base type by adding composite specific data to the `flux_future_t` `aux` hash. The "type" is checked simply by ensuring the `flux::composite` entry exists. The current code also adds a `parent` entry to each child to point back to the child future's parent, but that is unused in the implementation so I may remove it.

Children are pushed onto the containers with `flux_future_push()` and are then owned by the container (at "init" time the container will install `then` callbacks for each child so it can check for fulfillment, and the child futures will be auto-destructed on destruction of the parent). Each child is pushed with a name so that a caller can keep track of which child future is which after the future is fulfilled. Simple calls are provided for traversing children of the composite and fetching them:

```C
const char * flux_future_first_child (flux_future_t *cf);
const char * flux_future_next_child (flux_future_t *cf);

flux_future_t *flux_future_get_child (flux_future_t *cf, const char *name);
```

Once a composite future is fulfilled, it is expected that the creator of the composite future will traverse all children and call `flux_future_get()` on each to gather results (or find which future is ready in the case of `wait_any`). In many cases a custom `flux_future_get_*` would be provided to do this on behalf of the user, who in some cases might not even need to be aware they are waiting on a composite future.

The unit tests so far only test basic functionality and only in synchronous mode. Tests should also be added to ensure that composite futures work as children of other composite futures.

