### PR TITLE
resource: Add IO_DEVICES to pick up GPUs through hwloc

### DIFF
--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -70,6 +70,9 @@ static int ctx_hwloc_init (flux_t *h, resource_ctx_t *ctx)
         flux_log_error (h, "flux_topology_init");
         goto done;
     }
+    if (hwloc_topology_set_flags (ctx->topology,
+                                  HWLOC_TOPOLOGY_FLAG_IO_DEVICES) < 0)
+        flux_log (h, LOG_ERR, "hwloc_topology_set_flags FLAG_IO_DEVICES failed");
     if (hwloc_topology_ignore_type (ctx->topology, HWLOC_OBJ_CACHE) < 0)
         flux_log (h, LOG_ERR, "hwloc_topology_ignore_type OBJ_CACHE failed");
     if (hwloc_topology_ignore_type (ctx->topology, HWLOC_OBJ_GROUP) < 0)


### PR DESCRIPTION
This PR makes IO hierarchy visible to the scheduler. The sched-side change is in https://github.com/flux-framework/flux-sched/pull/354.

Because this will generally increase the overhead of resource-hwloc module, I can wrap this with an option if desired. Let me know if that's the case. 