### PR TITLE
libpmi: drop PMIX heuristic

### DIFF
--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -100,22 +100,6 @@ int PMI_Init (int *spawned)
         ctx.type = IMPL_SIMPLE;
         goto done;
     }
-    /* If PMIX_SERVER_URI is set, this indicates PMIx service is offered.
-     * Use it via the PMI v1 API provided in libpmix.so.
-     */
-    if (getenv ("PMIX_SERVER_URI")) {
-        DPRINTF ("%s: PMIX_SERVER_URI is set, use libpmix.so\n", __FUNCTION__);
-        if (!(ctx.wrap = pmi_wrap_create ("libpmix.so")))
-            goto done;
-        result = pmi_wrap_init (ctx.wrap, spawned);
-        if (result != PMI_SUCCESS) {
-            pmi_wrap_destroy (ctx.wrap);
-            ctx.wrap = NULL;
-            goto done;
-        }
-        ctx.type = IMPL_WRAP;
-        goto done;
-    }
     /* If PMI_LIBRARY is set, we are directed to open a specific library.
      */
     if ((library = getenv ("PMI_LIBRARY"))) {


### PR DESCRIPTION
Problem: The logic that dlopens libpmix.so, expecting to
find PMI-1 symbols there if PMIX_SERVER_URI is set in
the environment no longer works since PMI-1 symbols
were moved to a separate compatibility library.

On the LSF/jsrun based IBM system where PMIX is the native
PMI, we have requested that IBM supply the libpmi.so compatability
library.  Once they do, flux should be able to find it in the
usual way.

Meanwhile delete the PMIX heuristic.

Fixes #918