### PR TITLE
system instance: fix default socket path, config file parsing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,9 @@ AC_CONFIG_SRCDIR([NEWS])
 AC_CANONICAL_SYSTEM
 ##
 # If runstatedir not explicitly set on command line, use '/run' as default
+# N.B. runstatedir is not set at all in autoconf < 2.70.
 ##
-if test "$runstatedir" = '${localstatedir}/run'; then
+if test "$runstatedir" = '${localstatedir}/run' || test -z "$runstatedir"; then
    AC_SUBST([runstatedir],[/run])
 fi
 X_AC_EXPAND_INSTALL_DIRS

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -103,6 +103,8 @@ static int find_local_cf_endpoint (const cf_t *cf, int size)
             if (fnmatch (pat, s, 0) == 0)
                 break;
         }
+        if (entry != NULL) // found a match in 'addrs'
+            break;
     }
     free (addrs);
     if (i == size) {


### PR DESCRIPTION
This PR fixes two issues that came up during initial system instance testing on the `upgrade` cluster.