### PR TITLE
wreck: support `-o mpi=TYPE`

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -38,6 +38,7 @@ local lwj_options = {
     ['no-pmi-server'] =         "Do not start simple-pmi server",
     ['trace-pmi-server'] =      "Log simple-pmi server protocol exchange",
     ['cpu-affinity'] =          "Set default cpu-affinity to assigned cores",
+    ['mpi'] =                   "Set hint for type of MPI, e.g. -o mpi=spectrum "
 }
 
 local default_opts = {

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1592,6 +1592,18 @@ static int l_wreck_tasks_per_node (struct prog_ctx *ctx, lua_State *L)
     return (1);
 }
 
+static int l_wreck_getopt (lua_State *L)
+{
+    struct prog_ctx *ctx = l_get_prog_ctx (L, 1);
+    const char *opt = lua_tostring (L, 2);
+    const char *val = NULL;
+    if (opt && (val = prog_ctx_getopt (ctx, opt)))
+        lua_pushstring (L, val);
+    else
+        lua_pushnil (L);
+    return (1);
+}
+
 static int l_wreck_index (lua_State *L)
 {
     struct task_info *t;
@@ -1650,6 +1662,10 @@ static int l_wreck_index (lua_State *L)
             ctx->envref = luaL_ref (L, LUA_REGISTRYINDEX);
         }
         lua_rawgeti (L, LUA_REGISTRYINDEX, ctx->envref);
+        return (1);
+    }
+    if (strcmp (key, "getopt") == 0) {
+        lua_pushcfunction (L, l_wreck_getopt);
         return (1);
     }
     if (strcmp (key, "argv") == 0) {


### PR DESCRIPTION
Add support for optionally giving a hint about the MPI type being used in a job with an `-o mpi=TYPE` option.

Also adds a method for wreck/lua plugins to check for options set with `-o` via `wreck:getopt()`, e.g. an MPI Lua plugin could be optionally enabled by adding something like
```lua
if wreck:getopt ("mpi") ~= "spectrum" then return end
```

to the top of the file.

Still need to add at least one sanity test, but opening the PR early to ensure the general approach is acceptable.