### PR TITLE
libpmi: add ability to bootstrap Flux using pmix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ compiler:
 matrix:
   include:
     - compiler: gcc
-      env: COVERAGE=t ARGS="--enable-caliper --enable-pylint"
+      env: COVERAGE=t ARGS="--with-pmix --enable-caliper --enable-pylint"
     - compiler: gcc
       env: T_INSTALL=t
     - compiler: clang
-      env: CPPCHECK=t ARGS=--enable-sanitizer CC=clang-3.8 CXX=clang++-3.8
+      env: CPPCHECK=t ARGS="--with-pmix --enable-sanitizer" CC=clang-3.8 CXX=clang++-3.8
     - compiler: gcc
-      env: CC=gcc-4.9 chain_lint=t
+      env: CC=gcc-4.9 ARGS="--with-pmix" chain_lint=t
     - compiler: clang
-      env: ARGS=--enable-caliper CC=clang-3.8 CXX=clang++-3.8
+      env: ARGS="--with-pmix --enable-caliper" CC=clang-3.8 CXX=clang++-3.8
       
 cache:
   directories:
@@ -51,6 +51,7 @@ addons:
       - valgrind
       - libyaml-cpp-dev
       - libboost-dev # for yaml-cpp 0.5.1. >=0.5.2 no longer need boost
+      - libevent-dev # pmix needs this
 
   coverity_scan:
     project:

--- a/config/x_ac_pmix.m4
+++ b/config/x_ac_pmix.m4
@@ -1,0 +1,16 @@
+# If configured "--with-pmix" locate libpmix.so.
+# It is a hard failure if pmix is requested but cannot be found.
+# The default is to build Flux without libpmix support.
+#
+AC_DEFUN([X_AC_PMIX], [
+    AC_ARG_WITH([pmix],
+        AS_HELP_STRING([--with-pmix], [Enable Flux bootstrap with PMIx]))
+    AS_IF([test "x$with_pmix" = "xyes"], [
+        X_AC_CHECK_COND_LIB(pmix, PMIx_Init)
+        AS_VAR_IF([ac_cv_lib_pmix_PMIx_Init],[yes],,[
+            AC_MSG_ERROR([no suitable PMIX library found])
+        ])
+    ])
+    AM_CONDITIONAL([HAVE_LIBPMIX], [test "x$with_pmix" = "xyes"])
+  ]
+)

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,7 @@ X_AC_JANSSON
 X_AC_YAMLCPP
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
+X_AC_PMIX
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 AX_VALGRIND_H

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -53,7 +53,9 @@ flux_broker_SOURCES = \
 
 flux_broker_LDADD = \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-internal.la 
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libpmi/libpmi.la \
+	$(LIBPMIX)
 
 broker_ldflags = 
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -86,6 +86,7 @@ endif
 
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \
+	$(top_builddir)/src/common/libpmi/libpmi.la \
 	$(LIBUTIL)
 
 #

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -31,7 +31,6 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libutil/libutil.la \
 	$(builddir)/libev/libev.la \
 	$(builddir)/libminilzo/libminilzo.la \
-	$(builddir)/libpmi/libpmi.la \
 	$(builddir)/libkz/libkz.la \
 	$(builddir)/libsubprocess/libsubprocess.la \
 	$(builddir)/libcompat/libcompat.la \
@@ -84,7 +83,7 @@ endif
 libpmi_la_SOURCES =
 libpmi_la_LIBADD = \
 	$(builddir)/libpmi/libpmi.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL)
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL) $(LIBPMIX)
 libpmi_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libpmi.map \
 	-Wl,--defsym=flux_pmi_library=1 \
@@ -94,7 +93,7 @@ libpmi_la_LDFLAGS = \
 libpmi2_la_SOURCES =
 libpmi2_la_LIBADD = \
 	$(builddir)/libpmi/libpmi.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL)
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL) $(LIBPMIX)
 libpmi2_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libpmi2.map \
 	-shared -export-dynamic --disable-static \

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -45,6 +45,7 @@ fluxinclude_HEADERS = \
 TESTS = test_keyval.t \
 	test_simple.t \
 	test_single.t \
+	test_wrap.t \
 	test_clique.t
 
 test_ldadd = \
@@ -81,6 +82,11 @@ test_simple_t_LDADD = $(test_ldadd)
 test_single_t_SOURCES = test/single.c
 test_single_t_CPPFLAGS = $(test_cppflags)
 test_single_t_LDADD = $(test_ldadd)
+
+test_wrap_t_SOURCES = test/wrap.c
+test_wrap_t_CPPFLAGS = $(test_cppflags) \
+    -DINTREE_PMI_LIBRARY_PATH=\"$(abs_top_builddir)/src/common/.libs/libpmi.so\"
+test_wrap_t_LDADD = $(test_ldadd)
 
 test_clique_t_SOURCES = test/clique.c
 test_clique_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -29,7 +29,8 @@ libpmi_la_SOURCES = \
 	dgetline.c \
 	dgetline.h \
 	clique.c \
-	clique.h
+	clique.h \
+	pmi_operations.h
 
 fluxinclude_HEADERS = \
 	pmi.h \

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -32,6 +32,12 @@ libpmi_la_SOURCES = \
 	clique.h \
 	pmi_operations.h
 
+if HAVE_LIBPMIX
+libpmi_la_SOURCES += \
+	pmix_client.c \
+	pmix_client.h
+endif
+
 fluxinclude_HEADERS = \
 	pmi.h \
 	pmi2.h
@@ -48,7 +54,8 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libev/libev.la \
-	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) $(LIBDL) $(LIBMUNGE)
+	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) \
+	$(LIBRT) $(LIBDL) $(LIBMUNGE) $(LIBPMIX)
 
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -35,6 +35,7 @@
 #include "pmi.h"
 #include "pmi_strerror.h"
 #include "simple_client.h"
+#include "pmix_client.h"
 #include "wrap.h"
 #include "single.h"
 #include "clique.h"
@@ -81,6 +82,15 @@ int PMI_Init (int *spawned)
         if (!(ctx.impl = pmi_simple_client_create (&ctx.ops)))
             goto done;
     }
+#if HAVE_LIBPMIX
+    /* If PMIX_SERVER_* is set, pmix service is offered.
+     * Use the pmix client.
+     */
+    else if (getenv ("PMIX_SERVER_URI") || getenv ("PMIX_SERVER_URI2")) {
+        if (!(ctx.impl = pmix_client_create (&ctx.ops)))
+            goto done;
+    }
+#endif
     /* If PMI_LIBRARY is set, we are directed to open a specific library.
      */
     else if ((library = getenv ("PMI_LIBRARY"))) {

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -95,7 +95,7 @@ int PMI_Init (int *spawned)
      */
     else if ((library = getenv ("PMI_LIBRARY"))) {
         DPRINTF ("%s: PMI_LIBRARY is set, use %s\n", __FUNCTION__, library);
-        if (!(ctx.impl = pmi_wrap_create (library, &ctx.ops)))
+        if (!(ctx.impl = pmi_wrap_create (library, &ctx.ops, false)))
             goto done;
     }
 
@@ -104,7 +104,7 @@ int PMI_Init (int *spawned)
      * If that fails, fall through to singleton.
      */
     else if (!getenv ("FLUX_PMI_SINGLETON")
-                        && (ctx.impl = pmi_wrap_create (NULL, &ctx.ops))) {
+                    && (ctx.impl = pmi_wrap_create (NULL, &ctx.ops, false))) {
     }
     /* Singleton.
      */

--- a/src/common/libpmi/pmi_operations.h
+++ b/src/common/libpmi/pmi_operations.h
@@ -1,0 +1,51 @@
+#ifndef _FLUX_CORE_PMI_OPERATIONS_H
+#define _FLUX_CORE_PMI_OPERATIONS_H
+
+#include "src/common/libpmi/pmi.h"
+
+struct pmi_operations {
+    int (*init) (void *impl, int *spawned);
+    int (*initialized) (void *impl, int *initialized);
+    int (*finalize) (void *impl);
+    int (*get_size) (void *impl, int *size);
+    int (*get_rank) (void *impl, int *rank);
+    int (*get_appnum) (void *impl, int *appnum);
+    int (*get_universe_size) (void *impl, int *universe_size);
+    int (*publish_name) (void *impl, const char *service_name,
+                         const char *port);
+    int (*unpublish_name) (void *impl, const char *service_name);
+    int (*lookup_name) (void *impl, const char *service_name, char *port);
+    int (*barrier) (void *impl);
+    int (*abort) (void *impl, int exit_code, const char *error_msg);
+    int (*kvs_get_my_name) (void *impl, char *kvsname, int length);
+    int (*kvs_get_name_length_max) (void *impl, int *length);
+    int (*kvs_get_key_length_max) (void *impl, int *length);
+    int (*kvs_get_value_length_max) (void *impl, int *length);
+    int (*kvs_put) (void *impl, const char *kvsname,
+                    const char *key, const char *value);
+    int (*kvs_commit) (void *impl, const char *kvsname);
+    int (*kvs_get) (void *impl, const char *kvsname,
+                    const char *key, char *value, int len);
+    int (*get_clique_size) (void *impl, int *size);
+    int (*get_clique_ranks) (void *impl, int ranks[], int length);
+
+    int (*spawn_multiple) (void *impl,
+                           int count,
+                           const char *cmds[],
+                           const char **argvs[],
+                           const int maxprocs[],
+                           const int info_keyval_sizesp[],
+                           const PMI_keyval_t *info_keyval_vectors[],
+                           int preput_keyval_size,
+                           const PMI_keyval_t preput_keyval_vector[],
+                           int errors[]);
+
+    void (*destroy) (void *impl);
+};
+
+
+#endif /* _FLUX_CORE_PMI_OPERATIONS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/pmix_client.c
+++ b/src/common/libpmi/pmix_client.c
@@ -1,0 +1,594 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* pmix_client.c - bootstrap with PMIx */
+
+/* The main purpose of this code is to allow Flux to be launched by LSF
+ * on IBM spectrum_mpi system that provides libpmix.so but (currently) doesn't
+ * distribute its PMI-1 compatability library.
+ *
+ * As such, this code borrows from pmix/src/client/pmi1.c, which was
+ * licensed under a 3-clause BSD license and:
+ *
+ *   Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ *   Copyright (c) 2014      Research Organization for Information Science
+ *                           and Technology (RIST). All rights reserved.
+ *   Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                           All rights reserved.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+
+#include "pmi.h"
+
+#include "pmix_client.h"
+
+#define KVS_VAL_MAX 4096
+
+static pmix_status_t convert_int (int *value, pmix_value_t *kv);
+static int convert_err (pmix_status_t rc);
+
+struct pmix_client {
+    pmix_proc_t myproc;
+    int init;
+};
+
+static int pmix_client_init (void *impl, int *spawned)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+    pmix_info_t info[1];
+    bool val_optional = 1;
+
+    if ((rc = PMIx_Init (&pmi->myproc, NULL, 0)) != PMIX_SUCCESS)
+        return PMI_ERR_INIT;
+
+    /* getting internal key requires special rank value */
+    proc = pmi->myproc;
+    proc.rank = PMIX_RANK_UNDEF;
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT (&info[0]);
+    PMIX_INFO_LOAD (&info[0], PMIX_OPTIONAL, &val_optional, PMIX_BOOL);
+
+    if (spawned) {
+        /* get the spawned flag */
+        if (PMIx_Get (&proc, PMIX_SPAWNED, info, 1, &val) == PMIX_SUCCESS) {
+            rc = convert_int (spawned, val);
+            PMIX_VALUE_RELEASE(val);
+            if (rc != PMIX_SUCCESS)
+                goto error;
+        }
+        /* if not found, default to not spawned */
+        else {
+            *spawned = 0;
+        }
+    }
+    pmi->init = 1;
+    rc = PMIX_SUCCESS;
+error:
+    PMIX_INFO_DESTRUCT (&info[0]);
+    return convert_err (rc);
+}
+
+static int pmix_client_initialized (void *impl, int *initialized)
+{
+    if (!initialized)
+        return PMI_ERR_INVALID_ARG;
+    *initialized = PMIx_Initialized();
+    return PMI_SUCCESS;
+}
+
+static int pmix_client_finalize (void *impl)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    pmi->init = 0;
+    rc = PMIx_Finalize (NULL, 0);
+    return convert_err (rc);
+}
+
+static int pmix_client_get_size (void *impl, int *size)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optional = 1;
+    pmix_proc_t proc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT (&info[0]);
+    PMIX_INFO_LOAD (&info[0], PMIX_OPTIONAL, &val_optional, PMIX_BOOL);
+
+    proc = pmi->myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+    rc = PMIx_Get (&proc, PMIX_JOB_SIZE, info, 1, &val);
+    if (rc == PMIX_SUCCESS) {
+        rc = convert_int (size, val);
+        PMIX_VALUE_RELEASE (val);
+    }
+    PMIX_INFO_DESTRUCT (&info[0]);
+    return convert_err (rc);
+}
+
+static int pmix_client_get_rank (void *impl, int *rank)
+{
+    struct pmix_client *pmi = impl;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!rank)
+        return PMI_ERR_INVALID_ARG;
+    *rank = pmi->myproc.rank;
+    return PMI_SUCCESS;
+}
+
+static int pmix_client_get_appnum (void *impl, int *appnum)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optional = 1;
+    pmix_proc_t proc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!appnum)
+        return PMI_ERR_INVALID_ARG;
+    proc = pmi->myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT (&info[0]);
+    PMIX_INFO_LOAD (&info[0], PMIX_OPTIONAL, &val_optional, PMIX_BOOL);
+    rc = PMIx_Get (&proc, PMIX_APPNUM, info, 1, &val);
+    if (rc == PMIX_SUCCESS) {
+        rc = convert_int (appnum, val);
+        PMIX_VALUE_RELEASE (val);
+    }
+    /* this is optional value, set to 0 */
+    else if (rc == PMIX_ERR_NOT_FOUND) {
+        *appnum = 0;
+        rc = PMIX_SUCCESS;
+    }
+    PMIX_INFO_DESTRUCT (&info[0]);
+    return convert_err (rc);
+}
+
+static int pmix_client_get_universe_size (void *impl, int *universe_size)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_info_t info[1];
+    bool  val_optional = 1;
+    pmix_proc_t proc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!universe_size)
+        return PMI_ERR_INVALID_ARG;
+    proc = pmi->myproc;
+    proc.rank = PMIX_RANK_WILDCARD;
+    /* set controlling parameters
+     * PMIX_OPTIONAL - expect that these keys should be available on startup
+     */
+    PMIX_INFO_CONSTRUCT (&info[0]);
+    PMIX_INFO_LOAD (&info[0], PMIX_OPTIONAL, &val_optional, PMIX_BOOL);
+
+    rc = PMIx_Get (&proc, PMIX_UNIV_SIZE, info, 1, &val);
+    if (rc == PMIX_SUCCESS) {
+        rc = convert_int (universe_size, val);
+        PMIX_VALUE_RELEASE (val);
+    }
+
+    PMIX_INFO_DESTRUCT (&info[0]);
+    return convert_err (rc);
+}
+
+static int pmix_client_publish_name (void *impl, const char *service_name,
+                                     const char *port)
+{
+    return PMI_FAIL;
+}
+
+static int pmix_client_unpublish_name (void *impl, const char *service_name)
+{
+    return PMI_FAIL;
+}
+
+static int pmix_client_lookup_name (void *impl, const char *service_name,
+                                    char *port)
+{
+    return PMI_FAIL;
+}
+
+static int pmix_client_barrier (void *impl)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_info_t buf;
+    int ninfo = 0;
+    pmix_info_t *info = NULL;
+    bool val = 1;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    info = &buf;
+    PMIX_INFO_CONSTRUCT (info);
+    PMIX_INFO_LOAD (info, PMIX_COLLECT_DATA, &val, PMIX_BOOL);
+    ninfo = 1;
+    rc = PMIx_Fence (NULL, 0, info, ninfo);
+    PMIX_INFO_DESTRUCT (info);
+    return convert_err (rc);
+}
+
+static int pmix_client_abort (void *impl, int exit_code, const char *error_msg)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    rc = PMIx_Abort (exit_code, error_msg, NULL, 0);
+    return convert_err (rc);
+}
+
+static int pmix_client_kvs_get_my_name (void *impl, char *kvsname, int length)
+{
+    struct pmix_client *pmi = impl;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!kvsname)
+        return PMI_ERR_INVALID_ARG;
+    if (length < strlen (pmi->myproc.nspace) + 1)
+        return PMI_ERR_INVALID_LENGTH;
+    strcmp (kvsname, pmi->myproc.nspace);
+    return PMI_SUCCESS;
+}
+
+static int pmix_client_kvs_get_name_length_max (void *impl, int *length)
+{
+    struct pmix_client *pmi = impl;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    *length = PMIX_MAX_NSLEN;
+    return PMI_SUCCESS;
+}
+
+static int pmix_client_kvs_get_key_length_max (void *impl, int *length)
+{
+    struct pmix_client *pmi = impl;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    *length = PMIX_MAX_KEYLEN;
+    return PMI_SUCCESS;
+}
+
+static int pmix_client_kvs_get_value_length_max (void *impl, int *length)
+{
+    struct pmix_client *pmi = impl;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    *length = KVS_VAL_MAX;
+    return PMI_SUCCESS;
+}
+
+static int pmix_client_kvs_put (void *impl, const char *kvsname,
+                                const char *key, const char *value)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_value_t val;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!kvsname || strlen (kvsname) > PMIX_MAX_NSLEN)
+        return PMI_ERR_INVALID_LENGTH;
+    if (!key || strlen (key) > PMIX_MAX_KEYLEN)
+        return PMI_ERR_INVALID_KEY;
+    if (!value || strlen (value) > KVS_VAL_MAX)
+        return PMI_ERR_INVALID_VAL;
+    val.type = PMIX_STRING;
+    val.data.string = (char *)value;
+    rc = PMIx_Put (PMIX_GLOBAL, key, &val);
+    return convert_err (rc);
+}
+
+static int pmix_client_kvs_commit (void *impl, const char *kvsname)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!kvsname || strlen (kvsname) > PMIX_MAX_NSLEN)
+        return PMI_ERR_INVALID_LENGTH;
+    rc = PMIx_Commit ();
+    return convert_err (rc);
+}
+
+static int pmix_client_kvs_get (void *impl, const char *kvsname,
+                                const char *key, char *value, int len)
+{
+    struct pmix_client *pmi = impl;
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_proc_t proc;
+
+    if (!pmi->init)
+        return PMI_FAIL;
+    if (!kvsname || strlen (kvsname) > PMIX_MAX_NSLEN)
+        return PMI_ERR_INVALID_LENGTH;
+    if (!key || strlen (key) > PMIX_MAX_KEYLEN)
+        return PMI_ERR_INVALID_KEY;
+    if (!value)
+        return PMI_ERR_INVALID_VAL;
+
+    /* PMI-1 expects resource manager to set
+     * process mapping in ANL notation. */
+    if (!strcmp(key, "PMI_process_mapping")) {
+        /* we are looking in the job-data. If there is nothing there
+         * we don't want to look in rank's data, thus set rank to widcard */
+        proc = pmi->myproc;
+        proc.rank = PMIX_RANK_WILDCARD;
+        if (PMIx_Get(&proc, PMIX_ANL_MAP, NULL, 0, &val) == PMIX_SUCCESS &&
+                                            val && val->type == PMIX_STRING) {
+            strncpy (value, val->data.string, len);
+            PMIX_VALUE_FREE(val, 1);
+            return PMI_SUCCESS;
+        }
+        else {
+            return PMI_FAIL;
+        }
+    }
+
+    /* retrieve the data from PMIx - since we don't have a rank,
+     * we indicate that by passing the UNDEF value */
+    (void)strncpy (proc.nspace, kvsname, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_UNDEF;
+
+    rc = PMIx_Get (&proc, key, NULL, 0, &val);
+    if (rc == PMIX_SUCCESS && val) {
+        if (val->type != PMIX_STRING) {
+            rc = PMIX_ERROR;
+        } else if (val->data.string) {
+            (void)strncpy (value, val->data.string, len);
+        }
+        PMIX_VALUE_RELEASE (val);
+    }
+    return convert_err(rc);
+}
+
+static int pmix_client_spawn_multiple (void *impl,
+                                       int count,
+                                       const char *cmds[],
+                                       const char **argvs[],
+                                       const int maxprocs[],
+                                       const int info_keyval_sizesp[],
+                                       const PMI_keyval_t *info_keyval_vectors[],
+                                       int preput_keyval_size,
+                                       const PMI_keyval_t preput_keyval_vector[],
+                                       int errors[])
+{
+    return PMI_FAIL;
+}
+
+static void pmix_client_destroy (void *impl)
+{
+    struct pmix_client *pmi = impl;
+
+    free (pmi);
+}
+
+static struct pmi_operations pmix_client_operations = {
+    .init                       = pmix_client_init,
+    .initialized                = pmix_client_initialized,
+    .finalize                   = pmix_client_finalize,
+    .get_size                   = pmix_client_get_size,
+    .get_rank                   = pmix_client_get_rank,
+    .get_appnum                 = pmix_client_get_appnum,
+    .get_universe_size          = pmix_client_get_universe_size,
+    .publish_name               = pmix_client_publish_name,
+    .unpublish_name             = pmix_client_unpublish_name,
+    .lookup_name                = pmix_client_lookup_name,
+    .barrier                    = pmix_client_barrier,
+    .abort                      = pmix_client_abort,
+    .kvs_get_my_name            = pmix_client_kvs_get_my_name,
+    .kvs_get_name_length_max    = pmix_client_kvs_get_name_length_max,
+    .kvs_get_key_length_max     = pmix_client_kvs_get_key_length_max,
+    .kvs_get_value_length_max   = pmix_client_kvs_get_value_length_max,
+    .kvs_put                    = pmix_client_kvs_put,
+    .kvs_commit                 = pmix_client_kvs_commit,
+    .kvs_get                    = pmix_client_kvs_get,
+    .get_clique_size            = NULL,
+    .get_clique_ranks           = NULL,
+    .spawn_multiple             = pmix_client_spawn_multiple,
+    .destroy                    = pmix_client_destroy,
+};
+
+void *pmix_client_create (struct pmi_operations **ops)
+{
+    struct pmix_client *pmi = calloc (1, sizeof (*pmi));
+
+    if (!pmi)
+        return NULL;
+    *ops = &pmix_client_operations;
+    return pmi;
+}
+
+
+/***   UTILITY FUNCTIONS   ***/
+/* internal function */
+static pmix_status_t convert_int(int *value, pmix_value_t *kv)
+{
+    switch (kv->type) {
+    case PMIX_INT:
+        *value = kv->data.integer;
+        break;
+    case PMIX_INT8:
+        *value = kv->data.int8;
+        break;
+    case PMIX_INT16:
+        *value = kv->data.int16;
+        break;
+    case PMIX_INT32:
+        *value = kv->data.int32;
+        break;
+    case PMIX_INT64:
+        *value = kv->data.int64;
+        break;
+    case PMIX_UINT:
+        *value = kv->data.uint;
+        break;
+    case PMIX_UINT8:
+        *value = kv->data.uint8;
+        break;
+    case PMIX_UINT16:
+        *value = kv->data.uint16;
+        break;
+    case PMIX_UINT32:
+        *value = kv->data.uint32;
+        break;
+    case PMIX_UINT64:
+        *value = kv->data.uint64;
+        break;
+    case PMIX_BYTE:
+        *value = kv->data.byte;
+        break;
+    case PMIX_SIZE:
+        *value = kv->data.size;
+        break;
+    case PMIX_BOOL:
+        *value = kv->data.flag;
+        break;
+    default:
+        /* not an integer type */
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return PMIX_SUCCESS;
+}
+
+static int convert_err(pmix_status_t rc)
+{
+    switch (rc) {
+    case PMIX_ERR_INVALID_SIZE:
+        return PMI_ERR_INVALID_SIZE;
+
+    case PMIX_ERR_INVALID_KEYVALP:
+        return PMI_ERR_INVALID_KEYVALP;
+
+    case PMIX_ERR_INVALID_NUM_PARSED:
+        return PMI_ERR_INVALID_NUM_PARSED;
+
+    case PMIX_ERR_INVALID_ARGS:
+        return PMI_ERR_INVALID_ARGS;
+
+    case PMIX_ERR_INVALID_NUM_ARGS:
+        return PMI_ERR_INVALID_NUM_ARGS;
+
+    case PMIX_ERR_INVALID_LENGTH:
+        return PMI_ERR_INVALID_LENGTH;
+
+    case PMIX_ERR_INVALID_VAL_LENGTH:
+        return PMI_ERR_INVALID_VAL_LENGTH;
+
+    case PMIX_ERR_INVALID_VAL:
+        return PMI_ERR_INVALID_VAL;
+
+    case PMIX_ERR_INVALID_KEY_LENGTH:
+        return PMI_ERR_INVALID_KEY_LENGTH;
+
+    case PMIX_ERR_INVALID_KEY:
+        return PMI_ERR_INVALID_KEY;
+
+    case PMIX_ERR_INVALID_ARG:
+        return PMI_ERR_INVALID_ARG;
+
+    case PMIX_ERR_NOMEM:
+        return PMI_ERR_NOMEM;
+
+    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+    case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
+    case PMIX_ERR_LOST_PEER_CONNECTION:
+    case PMIX_ERR_LOST_CONNECTION_TO_CLIENT:
+    case PMIX_ERR_NOT_SUPPORTED:
+    case PMIX_ERR_NOT_FOUND:
+    case PMIX_ERR_SERVER_NOT_AVAIL:
+    case PMIX_ERR_INVALID_NAMESPACE:
+    case PMIX_ERR_DATA_VALUE_NOT_FOUND:
+    case PMIX_ERR_OUT_OF_RESOURCE:
+    case PMIX_ERR_RESOURCE_BUSY:
+    case PMIX_ERR_BAD_PARAM:
+    case PMIX_ERR_IN_ERRNO:
+    case PMIX_ERR_UNREACH:
+    case PMIX_ERR_TIMEOUT:
+    case PMIX_ERR_NO_PERMISSIONS:
+    case PMIX_ERR_PACK_MISMATCH:
+    case PMIX_ERR_PACK_FAILURE:
+    case PMIX_ERR_UNPACK_FAILURE:
+    case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
+    case PMIX_ERR_TYPE_MISMATCH:
+    case PMIX_ERR_PROC_ENTRY_NOT_FOUND:
+    case PMIX_ERR_UNKNOWN_DATA_TYPE:
+    case PMIX_ERR_WOULD_BLOCK:
+    case PMIX_EXISTS:
+    case PMIX_ERROR:
+        return PMI_FAIL;
+
+    case PMIX_ERR_INIT:
+        return PMI_ERR_INIT;
+
+    case PMIX_SUCCESS:
+        return PMI_SUCCESS;
+    default:
+        return PMI_FAIL;
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/pmix_client.h
+++ b/src/common/libpmi/pmix_client.h
@@ -1,0 +1,13 @@
+#ifndef _FLUX_CORE_PMI_PMIX_CLIENT_H
+#define _FLUX_CORE_PMI_PMIX_CLIENT_H
+
+#include "src/common/libpmi/pmi_operations.h"
+
+void *pmix_client_create (struct pmi_operations **ops);
+
+
+#endif /* _FLUX_CORE_PMI_PMIX_CLIENT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -51,8 +51,9 @@ struct pmi_simple_client {
     int buflen;
 };
 
-int pmi_simple_client_init (struct pmi_simple_client *pmi, int *spawned)
+static int pmi_simple_client_init (void *impl, int *spawned)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     unsigned int vers, subvers;
     char buf[SIMPLE_MAX_PROTO_LINE];
@@ -102,15 +103,16 @@ done:
     return result;
 }
 
-int pmi_simple_client_initialized (struct pmi_simple_client *pmi,
-                                   int *initialized)
+static int pmi_simple_client_initialized (void *impl, int *initialized)
 {
+    struct pmi_simple_client *pmi = impl;
     *initialized = pmi->initialized;
     return PMI_SUCCESS;
 }
 
-int pmi_simple_client_finalize (struct pmi_simple_client *pmi)
+static int pmi_simple_client_finalize (void *impl)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -129,24 +131,27 @@ done:
     return result;
 }
 
-int pmi_simple_client_get_size (struct pmi_simple_client *pmi, int *size)
+static int pmi_simple_client_get_size (void *impl, int *size)
 {
+    struct pmi_simple_client *pmi = impl;
     if (!pmi->initialized)
         return PMI_FAIL;
     *size = pmi->size;
     return PMI_SUCCESS;
 }
 
-int pmi_simple_client_get_rank (struct pmi_simple_client *pmi, int *rank)
+static int pmi_simple_client_get_rank (void *impl, int *rank)
 {
+    struct pmi_simple_client *pmi = impl;
     if (!pmi->initialized)
         return PMI_FAIL;
     *rank = pmi->rank;
     return PMI_SUCCESS;
 }
 
-int pmi_simple_client_get_appnum (struct pmi_simple_client *pmi, int *appnum)
+static int pmi_simple_client_get_appnum (void *impl, int *appnum)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -169,9 +174,9 @@ done:
     return result;
 }
 
-int pmi_simple_client_get_universe_size (struct pmi_simple_client *pmi,
-                                         int *universe_size)
+static int pmi_simple_client_get_universe_size (void *impl, int *universe_size)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -194,26 +199,28 @@ done:
     return result;
 }
 
-int pmi_simple_client_publish_name (struct pmi_simple_client *pmi,
-                                    const char *service_name, const char *port)
+static int pmi_simple_client_publish_name (void *impl,
+                                           const char *service_name,
+                                           const char *port)
 {
     return PMI_FAIL;
 }
 
-int pmi_simple_client_unpublish_name (struct pmi_simple_client *pmi,
-                                      const char *service_name)
+static int pmi_simple_client_unpublish_name (void *impl,
+                                             const char *service_name)
 {
     return PMI_FAIL;
 }
 
-int pmi_simple_client_lookup_name (struct pmi_simple_client *pmi,
-                                   const char *service_name, char *port)
+static int pmi_simple_client_lookup_name (void *impl,
+                                          const char *service_name, char *port)
 {
     return PMI_FAIL;
 }
 
-int pmi_simple_client_barrier (struct pmi_simple_client *pmi)
+static int pmi_simple_client_barrier (void *impl)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -234,15 +241,16 @@ done:
     return result;
 }
 
-int pmi_simple_client_abort (struct pmi_simple_client *pmi,
-                             int exit_code, const char *error_msg)
+static int pmi_simple_client_abort (void *impl,
+                                    int exit_code, const char *error_msg)
 {
     return PMI_FAIL;
 }
 
-int pmi_simple_client_kvs_get_my_name (struct pmi_simple_client *pmi,
-                                       char *kvsname, int length)
+static int pmi_simple_client_kvs_get_my_name (void *impl,
+                                              char *kvsname, int length)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -265,37 +273,38 @@ done:
     return result;
 }
 
-int pmi_simple_client_kvs_get_name_length_max (struct pmi_simple_client *pmi,
-                                               int *length)
+static int pmi_simple_client_kvs_get_name_length_max (void *impl, int *length)
 {
+    struct pmi_simple_client *pmi = impl;
     if (!pmi->initialized)
         return PMI_FAIL;
     *length = pmi->kvsname_max;
     return PMI_SUCCESS;
 }
 
-int pmi_simple_client_kvs_get_key_length_max (struct pmi_simple_client *pmi,
-                                              int *length)
+static int pmi_simple_client_kvs_get_key_length_max (void *impl, int *length)
 {
+    struct pmi_simple_client *pmi = impl;
     if (!pmi->initialized)
         return PMI_FAIL;
     *length = pmi->keylen_max;
     return PMI_SUCCESS;
 }
 
-int pmi_simple_client_kvs_get_value_length_max (struct pmi_simple_client *pmi,
-                                                int *length)
+static int pmi_simple_client_kvs_get_value_length_max (void *impl, int *length)
 {
+    struct pmi_simple_client *pmi = impl;
     if (!pmi->initialized)
         return PMI_FAIL;
     *length = pmi->vallen_max;
     return PMI_SUCCESS;
 }
 
-int pmi_simple_client_kvs_put (struct pmi_simple_client *pmi,
-                               const char *kvsname, const char *key,
-                               const char *value)
+static int pmi_simple_client_kvs_put (void *impl,
+                                      const char *kvsname, const char *key,
+                                      const char *value)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -317,16 +326,16 @@ done:
     return result;
 }
 
-int pmi_simple_client_kvs_commit (struct pmi_simple_client *pmi,
-                                  const char *kvsname)
+static int pmi_simple_client_kvs_commit (void *impl, const char *kvsname)
 {
     return PMI_SUCCESS; /* a no-op here */
 }
 
-int pmi_simple_client_kvs_get (struct pmi_simple_client *pmi,
-                               const char *kvsname,
-                               const char *key, char *value, int len)
+static int pmi_simple_client_kvs_get (void *impl,
+                                      const char *kvsname,
+                                      const char *key, char *value, int len)
 {
+    struct pmi_simple_client *pmi = impl;
     int result = PMI_FAIL;
     int rc;
 
@@ -349,22 +358,23 @@ done:
     return result;
 }
 
-int pmi_simple_client_spawn_multiple (struct pmi_simple_client *pmi,
-                                      int count,
-                                      const char *cmds[],
-                                      const char **argvs[],
-                                      const int maxprocs[],
-                                      const int info_keyval_sizesp[],
-                                      const PMI_keyval_t *info_keyval_vectors[],
-                                      int preput_keyval_size,
-                                      const PMI_keyval_t preput_keyval_vector[],
-                                      int errors[])
+static int pmi_simple_client_spawn_multiple (void *impl,
+                                             int count,
+                                             const char *cmds[],
+                                             const char **argvs[],
+                                             const int maxprocs[],
+                                             const int info_keyval_sizesp[],
+                                             const PMI_keyval_t *info_keyval_vectors[],
+                                             int preput_keyval_size,
+                                             const PMI_keyval_t preput_keyval_vector[],
+                                             int errors[])
 {
     return PMI_FAIL;
 }
 
-void pmi_simple_client_destroy (struct pmi_simple_client *pmi)
+static void pmi_simple_client_destroy (void *impl)
 {
+    struct pmi_simple_client *pmi = impl;
     if (pmi) {
         if (pmi->fd != -1)
             (void)close (pmi->fd);
@@ -374,7 +384,33 @@ void pmi_simple_client_destroy (struct pmi_simple_client *pmi)
     }
 }
 
-struct pmi_simple_client *pmi_simple_client_create (void)
+static struct pmi_operations pmi_simple_operations = {
+    .init                       = pmi_simple_client_init,
+    .initialized                = pmi_simple_client_initialized,
+    .finalize                   = pmi_simple_client_finalize,
+    .get_size                   = pmi_simple_client_get_size,
+    .get_rank                   = pmi_simple_client_get_rank,
+    .get_appnum                 = pmi_simple_client_get_appnum,
+    .get_universe_size          = pmi_simple_client_get_universe_size,
+    .publish_name               = pmi_simple_client_publish_name,
+    .unpublish_name             = pmi_simple_client_unpublish_name,
+    .lookup_name                = pmi_simple_client_lookup_name,
+    .barrier                    = pmi_simple_client_barrier,
+    .abort                      = pmi_simple_client_abort,
+    .kvs_get_my_name            = pmi_simple_client_kvs_get_my_name,
+    .kvs_get_name_length_max    = pmi_simple_client_kvs_get_name_length_max,
+    .kvs_get_key_length_max     = pmi_simple_client_kvs_get_key_length_max,
+    .kvs_get_value_length_max   = pmi_simple_client_kvs_get_value_length_max,
+    .kvs_put                    = pmi_simple_client_kvs_put,
+    .kvs_commit                 = pmi_simple_client_kvs_commit,
+    .kvs_get                    = pmi_simple_client_kvs_get,
+    .get_clique_size            = NULL,
+    .get_clique_ranks           = NULL,
+    .spawn_multiple             = pmi_simple_client_spawn_multiple,
+    .destroy                    = pmi_simple_client_destroy,
+};
+
+void *pmi_simple_client_create (struct pmi_operations **ops)
 {
     struct pmi_simple_client *pmi = calloc (1, sizeof (*pmi));
     const char *s;
@@ -393,6 +429,7 @@ struct pmi_simple_client *pmi_simple_client_create (void)
     pmi->spawned = 0;
     if ((s = getenv ("PMI_SPAWNED")))
         pmi->spawned = strtol (s, NULL, 10);
+    *ops = &pmi_simple_operations;
     return pmi;
 error:
     pmi_simple_client_destroy (pmi);

--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -244,7 +244,10 @@ done:
 static int pmi_simple_client_abort (void *impl,
                                     int exit_code, const char *error_msg)
 {
-    return PMI_FAIL;
+    fprintf (stderr, "PMI_Abort: %s\n", error_msg);
+    exit (exit_code);
+    /*NOTREACHED*/
+    return PMI_SUCCESS;
 }
 
 static int pmi_simple_client_kvs_get_my_name (void *impl,

--- a/src/common/libpmi/simple_client.h
+++ b/src/common/libpmi/simple_client.h
@@ -1,58 +1,9 @@
 #ifndef _FLUX_CORE_PMI_SIMPLE_CLIENT_H
 #define _FLUX_CORE_PMI_SIMPLE_CLIENT_H
 
-#include "src/common/libpmi/pmi.h"
+#include "src/common/libpmi/pmi_operations.h"
 
-struct pmi_simple_client;
-
-int pmi_simple_client_init (struct pmi_simple_client *pmi, int *spawned);
-int pmi_simple_client_initialized (struct pmi_simple_client *pmi,
-                                   int *initialized);
-int pmi_simple_client_finalize (struct pmi_simple_client *pmi);
-int pmi_simple_client_get_size (struct pmi_simple_client *pmi, int *size);
-int pmi_simple_client_get_rank (struct pmi_simple_client *pmi, int *rank);
-int pmi_simple_client_get_appnum (struct pmi_simple_client *pmi, int *appnum);
-int pmi_simple_client_get_universe_size (struct pmi_simple_client *pmi,
-                                         int *universe_size);
-int pmi_simple_client_publish_name (struct pmi_simple_client *pmi,
-                                    const char *service_name, const char *port);
-int pmi_simple_client_unpublish_name (struct pmi_simple_client *pmi,
-                                      const char *service_name);
-int pmi_simple_client_lookup_name (struct pmi_simple_client *pmi,
-                                   const char *service_name, char *port);
-int pmi_simple_client_barrier (struct pmi_simple_client *pmi);
-int pmi_simple_client_abort (struct pmi_simple_client *pmi,
-                             int exit_code, const char *error_msg);
-int pmi_simple_client_kvs_get_my_name (struct pmi_simple_client *pmi,
-                                       char *kvsname, int length);
-int pmi_simple_client_kvs_get_name_length_max (struct pmi_simple_client *pmi,
-                                               int *length);
-int pmi_simple_client_kvs_get_key_length_max (struct pmi_simple_client *pmi,
-                                              int *length);
-int pmi_simple_client_kvs_get_value_length_max (struct pmi_simple_client *pmi,
-                                                int *length);
-int pmi_simple_client_kvs_put (struct pmi_simple_client *pmi,
-                               const char *kvsname, const char *key,
-                               const char *value);
-int pmi_simple_client_kvs_commit (struct pmi_simple_client *pmi,
-                                  const char *kvsname);
-int pmi_simple_client_kvs_get (struct pmi_simple_client *pmi,
-                               const char *kvsname,
-                               const char *key, char *value, int len);
-
-int pmi_simple_client_spawn_multiple (struct pmi_simple_client *pmi,
-                                      int count,
-                                      const char *cmds[],
-                                      const char **argvs[],
-                                      const int maxprocs[],
-                                      const int info_keyval_sizesp[],
-                                      const PMI_keyval_t *info_keyval_vectors[],
-                                      int preput_keyval_size,
-                                      const PMI_keyval_t preput_keyval_vector[],
-                                      int errors[]);
-
-void pmi_simple_client_destroy (struct pmi_simple_client *pmi);
-struct pmi_simple_client *pmi_simple_client_create (void);
+void *pmi_simple_client_create (struct pmi_operations **ops);
 
 
 #endif /* _FLUX_CORE_PMI_SIMPLE_CLIENT_H */

--- a/src/common/libpmi/single.h
+++ b/src/common/libpmi/single.h
@@ -1,59 +1,9 @@
 #ifndef _FLUX_CORE_PMI_SINGLE_H
 #define _FLUX_CORE_PMI_SINGLE_H
 
-#include "src/common/libpmi/pmi.h"
+#include "src/common/libpmi/pmi_operations.h"
 
-struct pmi_single;
-
-int pmi_single_init (struct pmi_single *pmi, int *spawned);
-int pmi_single_initialized (struct pmi_single *pmi,
-                                   int *initialized);
-int pmi_single_finalize (struct pmi_single *pmi);
-int pmi_single_get_size (struct pmi_single *pmi, int *size);
-int pmi_single_get_rank (struct pmi_single *pmi, int *rank);
-int pmi_single_get_appnum (struct pmi_single *pmi, int *appnum);
-int pmi_single_get_universe_size (struct pmi_single *pmi,
-                                         int *universe_size);
-int pmi_single_publish_name (struct pmi_single *pmi,
-                                    const char *service_name, const char *port);
-int pmi_single_unpublish_name (struct pmi_single *pmi,
-                                      const char *service_name);
-int pmi_single_lookup_name (struct pmi_single *pmi,
-                                   const char *service_name, char *port);
-int pmi_single_barrier (struct pmi_single *pmi);
-int pmi_single_abort (struct pmi_single *pmi,
-                             int exit_code, const char *error_msg);
-int pmi_single_kvs_get_my_name (struct pmi_single *pmi,
-                                       char *kvsname, int length);
-int pmi_single_kvs_get_name_length_max (struct pmi_single *pmi,
-                                               int *length);
-int pmi_single_kvs_get_key_length_max (struct pmi_single *pmi,
-                                              int *length);
-int pmi_single_kvs_get_value_length_max (struct pmi_single *pmi,
-                                                int *length);
-int pmi_single_kvs_put (struct pmi_single *pmi,
-                               const char *kvsname, const char *key,
-                               const char *value);
-int pmi_single_kvs_commit (struct pmi_single *pmi,
-                                  const char *kvsname);
-int pmi_single_kvs_get (struct pmi_single *pmi,
-                               const char *kvsname,
-                               const char *key, char *value, int len);
-
-int pmi_single_spawn_multiple (struct pmi_single *pmi,
-                                      int count,
-                                      const char *cmds[],
-                                      const char **argvs[],
-                                      const int maxprocs[],
-                                      const int info_keyval_sizesp[],
-                                      const PMI_keyval_t *info_keyval_vectors[],
-                                      int preput_keyval_size,
-                                      const PMI_keyval_t preput_keyval_vector[],
-                                      int errors[]);
-
-void pmi_single_destroy (struct pmi_single *pmi);
-struct pmi_single *pmi_single_create (void);
-
+void *pmi_single_create (struct pmi_operations **ops);
 
 #endif /* _FLUX_CORE_PMI_SINGLE_H */
 

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -139,6 +139,7 @@ int main (int argc, char *argv[])
     char *name = NULL, *val = NULL, *val2 = NULL, *val3 = NULL;
     char *key = NULL;
     int rc;
+    char port[1024];
 
     plan (NO_PLAN);
 
@@ -257,6 +258,26 @@ int main (int argc, char *argv[])
     rig_barrier_exit_failure = 0;
     ok (ops->barrier (cli) == PMI_SUCCESS,
         "pmi_simple_client_barrier OK (rigged errors cleared)");
+
+    /* unimplemented stuff
+     */
+    rc = ops->publish_name (cli, "foo", "42");
+    ok (rc == PMI_FAIL,
+        "pmi_simple_publish_name fails with PMI_FAIL");
+    rc = ops->unpublish_name (cli, "foo");
+    ok (rc == PMI_FAIL,
+        "pmi_simple_unpublish_name fails with PMI_FAIL");
+    rc = ops->lookup_name (cli, "foo", port);
+    ok (rc == PMI_FAIL,
+        "pmi_simple_lookup_name fails with PMI_FAIL");
+
+    rc = ops->spawn_multiple (cli, 0, NULL, NULL, NULL, NULL, NULL,
+                              0, NULL, NULL);
+    ok (rc == PMI_FAIL,
+        "pmi_simple_spawn_multiple fails with PMI_FAIL");
+
+    dies_ok ({ops->abort (cli, 0, "a test message");},
+        "pmi_simple_abort exits program");
 
     /* finalize
      */

--- a/src/common/libpmi/test/single.c
+++ b/src/common/libpmi/test/single.c
@@ -11,6 +11,7 @@ int main (int argc, char *argv[])
     int rc, spawned, initialized, rank, size, appnum;
     int kvsname_length, kvskey_length, kvsval_length;
     char *kvsname, *kvsval;
+    char port[1024];
 
     plan (NO_PLAN);
 
@@ -87,6 +88,24 @@ int main (int argc, char *argv[])
     rc = ops->kvs_put (pmi, kvsname, "foo", "bar");
     ok (rc == PMI_ERR_INVALID_KEY,
         "pmi_single_kvs_put on duplicate key fails w/PMI_ERR_INVALID_KEY");
+
+    rc = ops->publish_name (pmi, "foo", "42");
+    ok (rc == PMI_FAIL,
+        "pmi_single_publish_name fails with PMI_FAIL");
+    rc = ops->unpublish_name (pmi, "foo");
+    ok (rc == PMI_FAIL,
+        "pmi_single_unpublish_name fails with PMI_FAIL");
+    rc = ops->lookup_name (pmi, "foo", port);
+    ok (rc == PMI_FAIL,
+        "pmi_single_lookup_name fails with PMI_FAIL");
+
+    rc = ops->spawn_multiple (pmi, 0, NULL, NULL, NULL, NULL, NULL,
+                              0, NULL, NULL);
+    ok (rc == PMI_FAIL,
+        "pmi_single_spawn_multiple fails with PMI_FAIL");
+
+    dies_ok ({ops->abort (pmi, 0, "a test message");},
+        "pmi_single_abort exits program");
 
     rc = ops->finalize (pmi);
     ok (rc == PMI_SUCCESS,

--- a/src/common/libpmi/test/single.c
+++ b/src/common/libpmi/test/single.c
@@ -6,94 +6,95 @@
 
 int main (int argc, char *argv[])
 {
-    struct pmi_single *pmi;
+    void *pmi;
+    struct pmi_operations *ops;
     int rc, spawned, initialized, rank, size, appnum;
     int kvsname_length, kvskey_length, kvsval_length;
     char *kvsname, *kvsval;
 
     plan (NO_PLAN);
 
-    pmi = pmi_single_create ();
+    pmi = pmi_single_create (&ops);
     ok (pmi != NULL,
         "pmi_single_create works");
     spawned = -1;
-    rc = pmi_single_init (pmi, &spawned);
+    rc = ops->init (pmi, &spawned);
     ok (rc == PMI_SUCCESS && spawned == 0,
         "pmi_single_init works, spawned = 0");
     initialized = -1;
-    rc = pmi_single_initialized (pmi, &initialized);
+    rc = ops->initialized (pmi, &initialized);
     ok (rc == PMI_SUCCESS && initialized != 0,
         "pmi_single_initialized works, initialized true");
     size = -1;
-    rc = pmi_single_get_size (pmi, &size);
+    rc = ops->get_size (pmi, &size);
     ok (rc == PMI_SUCCESS && size == 1,
         "pmi_single_get_size works, size == 1");
     rank = -1;
-    rc = pmi_single_get_rank (pmi, &rank);
+    rc = ops->get_rank (pmi, &rank);
     ok (rc == PMI_SUCCESS && rank == 0,
         "pmi_single_get_rank works, rank == 0");
     appnum = -2;
-    rc = pmi_single_get_appnum (pmi, &appnum);
+    rc = ops->get_appnum (pmi, &appnum);
     ok (rc == PMI_SUCCESS && appnum >= 0,
         "pmi_single_get_appnum works, appnum positive number");
     size = -1;
-    rc = pmi_single_get_universe_size (pmi, &size);
+    rc = ops->get_universe_size (pmi, &size);
     ok (rc == PMI_SUCCESS && size == 1,
         "pmi_single_get_universe_size works, size == 1");
 
     kvsname_length = -1;
-    rc = pmi_single_kvs_get_name_length_max (pmi, &kvsname_length);
+    rc = ops->kvs_get_name_length_max (pmi, &kvsname_length);
     ok (rc == PMI_SUCCESS && kvsname_length > 0,
         "pmi_single_kvs_get_name_length_max works");
     diag ("kvsname_length: %d", kvsname_length);
 
     kvsname = xzmalloc (kvsname_length);
-    rc = pmi_single_kvs_get_my_name (pmi, kvsname, kvsname_length);
+    rc = ops->kvs_get_my_name (pmi, kvsname, kvsname_length);
     ok (rc == PMI_SUCCESS && strlen (kvsname) > 0,
         "pmi_single_kvs_get_my_name works");
     diag ("kvsname: %s", kvsname);
 
     kvskey_length = -1;
-    rc = pmi_single_kvs_get_key_length_max (pmi, &kvskey_length);
+    rc = ops->kvs_get_key_length_max (pmi, &kvskey_length);
     ok (rc == PMI_SUCCESS && kvskey_length > 0,
         "pmi_single_kvs_get_key_length_max works");
     diag ("kvskey_length: %d", kvskey_length);
 
     kvsval_length = -1;
-    rc = pmi_single_kvs_get_value_length_max (pmi, &kvsval_length);
+    rc = ops->kvs_get_value_length_max (pmi, &kvsval_length);
     ok (rc == PMI_SUCCESS && kvsval_length > 0,
         "pmi_single_kvs_get_value_length_max works");
     diag ("kvsval_length: %d", kvsval_length);
 
     kvsval = xzmalloc (kvsval_length);
-    rc = pmi_single_kvs_get (pmi, kvsname, "noexist", kvsval, kvsval_length);
+    rc = ops->kvs_get (pmi, kvsname, "noexist", kvsval, kvsval_length);
     ok (rc == PMI_ERR_INVALID_KEY,
         "pmi_single_kvs_get unknown fails w/PMI_ERR_INVALID_KEY");
 
-    rc = pmi_single_kvs_put (pmi, kvsname, "foo", "bar");
+    rc = ops->kvs_put (pmi, kvsname, "foo", "bar");
     ok (rc == PMI_SUCCESS,
         "pmi_single_kvs_put works");
-    rc = pmi_single_kvs_commit (pmi, kvsname);
+    rc = ops->kvs_commit (pmi, kvsname);
     ok (rc == PMI_SUCCESS,
         "pmi_single_kvs_commit works");
-    rc = pmi_single_barrier (pmi);
+    rc = ops->barrier (pmi);
     ok (rc == PMI_SUCCESS,
         "pmi_single_barrier works");
-    rc = pmi_single_kvs_get (pmi, kvsname, "foo", kvsval, kvsval_length);
+    rc = ops->kvs_get (pmi, kvsname, "foo", kvsval, kvsval_length);
     ok (rc == PMI_SUCCESS && !strcmp (kvsval, "bar"),
         "pmi_single_kvs_get works ");
 
-    rc = pmi_single_kvs_put (pmi, kvsname, "foo", "bar");
+    rc = ops->kvs_put (pmi, kvsname, "foo", "bar");
     ok (rc == PMI_ERR_INVALID_KEY,
         "pmi_single_kvs_put on duplicate key fails w/PMI_ERR_INVALID_KEY");
 
-    rc = pmi_single_finalize (pmi);
+    rc = ops->finalize (pmi);
     ok (rc == PMI_SUCCESS,
         "pmi_single_finalize works");
 
     free (kvsval);
     free (kvsname);
-    pmi_single_destroy (pmi);
+    ops->destroy (pmi);
     done_testing ();
     return 0;
 }

--- a/src/common/libpmi/test/wrap.c
+++ b/src/common/libpmi/test/wrap.c
@@ -1,0 +1,147 @@
+#include <czmq.h>
+#include <string.h>
+#include "src/common/libpmi/wrap.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/xzmalloc.h"
+
+int main (int argc, char *argv[])
+{
+    void *pmi;
+    struct pmi_operations *ops;
+    int rc, spawned, initialized, rank, size, appnum;
+    int kvsname_length, kvskey_length, kvsval_length;
+    char *kvsname, *kvsval;
+    char port[1024];
+
+    plan (NO_PLAN);
+
+    /* Tricky:
+     * Instantiate the 'wrap' pmi client for testing, instructing it to
+     * dlopen() the Flux PMI library with its recursion safety check disabled.
+     * Set FLUX_PMI_SINGLETON so the Flux PMI library uses the singleton
+     * implementation.
+     */
+    if (unsetenv ("PMI_FD") < 0
+            || unsetenv ("PMIX_SERVER_URI") < 0
+            || unsetenv ("PMIX_SERVER_URI2") < 0
+            || unsetenv ("PMI_LIBRARY") < 0
+            || setenv ("FLUX_PMI_SINGLETON", "1", 1) < 0)
+        BAIL_OUT ("Environment setup failed");
+
+    pmi = pmi_wrap_create (INTREE_PMI_LIBRARY_PATH, &ops, false);
+    ok (pmi == NULL,
+        "pmi_wrap_create recursion safety check works");
+
+    pmi = pmi_wrap_create ("/noexist", &ops, false);
+    ok (pmi == NULL,
+        "pmi_wrap_create fails on wrong library path");
+
+    pmi = pmi_wrap_create (INTREE_PMI_LIBRARY_PATH, &ops, true);
+    ok (pmi != NULL,
+        "pmi_wrap_create works on Flux libpmi.so with safety check disabled");
+    if (!pmi)
+        BAIL_OUT ("failed to instantiate 'wrap' client");
+    spawned = -1;
+    rc = ops->init (pmi, &spawned);
+    ok (rc == PMI_SUCCESS && spawned == 0,
+        "pmi_wrap_init works, spawned = 0");
+    initialized = -1;
+    rc = ops->initialized (pmi, &initialized);
+    ok (rc == PMI_SUCCESS && initialized != 0,
+        "pmi_wrap_initialized works, initialized true");
+    size = -1;
+    rc = ops->get_size (pmi, &size);
+    ok (rc == PMI_SUCCESS && size == 1,
+        "pmi_wrap_get_size works, size == 1");
+    rank = -1;
+    rc = ops->get_rank (pmi, &rank);
+    ok (rc == PMI_SUCCESS && rank == 0,
+        "pmi_wrap_get_rank works, rank == 0");
+    appnum = -2;
+    rc = ops->get_appnum (pmi, &appnum);
+    ok (rc == PMI_SUCCESS && appnum >= 0,
+        "pmi_wrap_get_appnum works, appnum positive number");
+    size = -1;
+    rc = ops->get_universe_size (pmi, &size);
+    ok (rc == PMI_SUCCESS && size == 1,
+        "pmi_wrap_get_universe_size works, size == 1");
+
+    kvsname_length = -1;
+    rc = ops->kvs_get_name_length_max (pmi, &kvsname_length);
+    ok (rc == PMI_SUCCESS && kvsname_length > 0,
+        "pmi_wrap_kvs_get_name_length_max works");
+    diag ("kvsname_length: %d", kvsname_length);
+
+    kvsname = xzmalloc (kvsname_length);
+    rc = ops->kvs_get_my_name (pmi, kvsname, kvsname_length);
+    ok (rc == PMI_SUCCESS && strlen (kvsname) > 0,
+        "pmi_wrap_kvs_get_my_name works");
+    diag ("kvsname: %s", kvsname);
+
+    kvskey_length = -1;
+    rc = ops->kvs_get_key_length_max (pmi, &kvskey_length);
+    ok (rc == PMI_SUCCESS && kvskey_length > 0,
+        "pmi_wrap_kvs_get_key_length_max works");
+    diag ("kvskey_length: %d", kvskey_length);
+
+    kvsval_length = -1;
+    rc = ops->kvs_get_value_length_max (pmi, &kvsval_length);
+    ok (rc == PMI_SUCCESS && kvsval_length > 0,
+        "pmi_wrap_kvs_get_value_length_max works");
+    diag ("kvsval_length: %d", kvsval_length);
+
+    kvsval = xzmalloc (kvsval_length);
+    rc = ops->kvs_get (pmi, kvsname, "noexist", kvsval, kvsval_length);
+    ok (rc == PMI_ERR_INVALID_KEY,
+        "pmi_wrap_kvs_get unknown fails w/PMI_ERR_INVALID_KEY");
+
+    rc = ops->kvs_put (pmi, kvsname, "foo", "bar");
+    ok (rc == PMI_SUCCESS,
+        "pmi_wrap_kvs_put works");
+    rc = ops->kvs_commit (pmi, kvsname);
+    ok (rc == PMI_SUCCESS,
+        "pmi_wrap_kvs_commit works");
+    rc = ops->barrier (pmi);
+    ok (rc == PMI_SUCCESS,
+        "pmi_wrap_barrier works");
+    rc = ops->kvs_get (pmi, kvsname, "foo", kvsval, kvsval_length);
+    ok (rc == PMI_SUCCESS && !strcmp (kvsval, "bar"),
+        "pmi_wrap_kvs_get works ");
+
+    rc = ops->kvs_put (pmi, kvsname, "foo", "bar");
+    ok (rc == PMI_ERR_INVALID_KEY,
+        "pmi_wrap_kvs_put on duplicate key fails w/PMI_ERR_INVALID_KEY");
+
+    rc = ops->publish_name (pmi, "foo", "42");
+    ok (rc == PMI_FAIL,
+        "pmi_wrap_publish_name fails with PMI_FAIL");
+    rc = ops->unpublish_name (pmi, "foo");
+    ok (rc == PMI_FAIL,
+        "pmi_wrap_unpublish_name fails with PMI_FAIL");
+    rc = ops->lookup_name (pmi, "foo", port);
+    ok (rc == PMI_FAIL,
+        "pmi_wrap_lookup_name fails with PMI_FAIL");
+
+    rc = ops->spawn_multiple (pmi, 0, NULL, NULL, NULL, NULL, NULL,
+                              0, NULL, NULL);
+    ok (rc == PMI_FAIL,
+        "pmi_wrap_spawn_multiple fails with PMI_FAIL");
+
+    dies_ok ({ops->abort (pmi, 0, "a test message");},
+        "pmi_wrap_abort exits program");
+
+
+    rc = ops->finalize (pmi);
+    ok (rc == PMI_SUCCESS,
+        "pmi_wrap_finalize works");
+
+    free (kvsval);
+    free (kvsname);
+    ops->destroy (pmi);
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/wrap.c
+++ b/src/common/libpmi/wrap.c
@@ -43,149 +43,171 @@ struct pmi_wrap {
     void *dso;
 };
 
-int pmi_wrap_init (struct pmi_wrap *pmi, int *spawned)
+static int pmi_wrap_init (void *impl, int *spawned)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Init");
     return f ? f (spawned) : PMI_FAIL;
 }
 
-int pmi_wrap_initialized (struct pmi_wrap *pmi, int *initialized)
+static int pmi_wrap_initialized (void *impl, int *initialized)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Initialized");
     return f ? f (initialized) : PMI_FAIL;
 }
 
-int pmi_wrap_finalize (struct pmi_wrap *pmi)
+static int pmi_wrap_finalize (void *impl)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(void) = dlsym (pmi->dso, "PMI_Finalize");
     return f ? f () : PMI_FAIL;
 }
 
-int pmi_wrap_get_size (struct pmi_wrap *pmi, int *size)
+static int pmi_wrap_get_size (void *impl, int *size)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Get_size");
     return f ? f (size) : PMI_FAIL;
 }
 
-int pmi_wrap_get_rank (struct pmi_wrap *pmi, int *rank)
+static int pmi_wrap_get_rank (void *impl, int *rank)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Get_rank");
     return f ? f (rank) : PMI_FAIL;
 }
 
-int pmi_wrap_get_universe_size (struct pmi_wrap *pmi, int *size)
+static int pmi_wrap_get_universe_size (void *impl, int *size)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Get_universe_size");
     return f ? f (size) : PMI_FAIL;
 }
 
-int pmi_wrap_get_appnum (struct pmi_wrap *pmi, int *appnum)
+static int pmi_wrap_get_appnum (void *impl, int *appnum)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Get_appnum");
     return f ? f (appnum) : PMI_FAIL;
 }
 
-int pmi_wrap_barrier (struct pmi_wrap *pmi)
+static int pmi_wrap_barrier (void *impl)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(void) = dlsym (pmi->dso, "PMI_Barrier");
     return f ? f () : PMI_FAIL;
 }
 
-int pmi_wrap_abort (struct pmi_wrap *pmi, int exit_code, const char *error_msg)
+static int pmi_wrap_abort (void *impl, int exit_code, const char *error_msg)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int, const char *) = dlsym (pmi->dso, "PMI_Abort");
     return f ? f (exit_code, error_msg) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_get_my_name (struct pmi_wrap *pmi, char *kvsname, int length)
+static int pmi_wrap_kvs_get_my_name (void *impl, char *kvsname, int length)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(char *, int) = dlsym (pmi->dso, "PMI_KVS_Get_my_name");
     return f ? f (kvsname, length) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_get_name_length_max (struct pmi_wrap *pmi, int *length)
+static int pmi_wrap_kvs_get_name_length_max (void *impl, int *length)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_KVS_Get_name_length_max");
     return f ? f (length) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_get_key_length_max (struct pmi_wrap *pmi, int *length)
+static int pmi_wrap_kvs_get_key_length_max (void *impl, int *length)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_KVS_Get_key_length_max");
     return f ? f (length) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_get_value_length_max (struct pmi_wrap *pmi, int *length)
+static int pmi_wrap_kvs_get_value_length_max (void *impl, int *length)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_KVS_Get_value_length_max");
     return f ? f (length) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_put (struct pmi_wrap *pmi, const char *kvsname,
-                      const char *key, const char *value)
+static int pmi_wrap_kvs_put (void *impl, const char *kvsname,
+                             const char *key, const char *value)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(const char *, const char *, const char *) = dlsym (pmi->dso,
                                                                 "PMI_KVS_Put");
     return f ? f (kvsname, key, value) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_commit (struct pmi_wrap *pmi, const char *kvsname)
+static int pmi_wrap_kvs_commit (void *impl, const char *kvsname)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(const char *) = dlsym (pmi->dso, "PMI_KVS_Commit");
     return f ? f (kvsname) : PMI_FAIL;
 }
 
-int pmi_wrap_kvs_get (struct pmi_wrap *pmi, const char *kvsname,
-                      const char *key, char *value, int len)
+static int pmi_wrap_kvs_get (void *impl, const char *kvsname,
+                             const char *key, char *value, int len)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(const char *, const char *, char *, int) = dlsym (pmi->dso,
                                                                "PMI_KVS_Get");
     return f ? f (kvsname, key, value, len) : PMI_FAIL;
 }
 
-int pmi_wrap_get_clique_size (struct pmi_wrap *pmi, int *size)
+static int pmi_wrap_get_clique_size (void *impl, int *size)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *) = dlsym (pmi->dso, "PMI_Get_clique_size");
     return f ? f (size) : PMI_FAIL;
 }
 
-int pmi_wrap_get_clique_ranks (struct pmi_wrap *pmi, int *ranks, int length)
+static int pmi_wrap_get_clique_ranks (void *impl, int *ranks, int length)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int *, int) = dlsym (pmi->dso, "PMI_Get_clique_ranks");
     return f ? f (ranks, length) : PMI_FAIL;
 }
 
-int pmi_wrap_publish_name (struct pmi_wrap *pmi,
-                           const char *service_name, const char *port)
+static int pmi_wrap_publish_name (void *impl,
+                                  const char *service_name, const char *port)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(const char *, const char *) = dlsym (pmi->dso, "PMI_Publish_name");
     return f ? f (service_name, port) : PMI_FAIL;
 }
 
-int pmi_wrap_unpublish_name (struct pmi_wrap *pmi, const char *service_name)
+static int pmi_wrap_unpublish_name (void *impl, const char *service_name)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(const char *) = dlsym (pmi->dso, "PMI_Unpublish_name");
     return f ? f (service_name) : PMI_FAIL;
 }
 
-int pmi_wrap_lookup_name (struct pmi_wrap *pmi,
-                          const char *service_name, char *port)
+static int pmi_wrap_lookup_name (void *impl,
+                                 const char *service_name, char *port)
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(const char *, const char *) = dlsym (pmi->dso, "PMI_Lookup_name");
     return f ? f (service_name, port) : PMI_FAIL;
 }
 
-int pmi_wrap_spawn_multiple (struct pmi_wrap *pmi,
-                             int count,
-                             const char *cmds[],
-                             const char **argvs[],
-                             const int maxprocs[],
-                             const int info_keyval_sizesp[],
-                             const PMI_keyval_t *info_keyval_vectors[],
-                             int preput_keyval_size,
-                             const PMI_keyval_t preput_keyval_vector[],
-                             int errors[])
+static int pmi_wrap_spawn_multiple (void *impl,
+                                    int count,
+                                    const char *cmds[],
+                                    const char **argvs[],
+                                    const int maxprocs[],
+                                    const int info_keyval_sizesp[],
+                                    const PMI_keyval_t *info_keyval_vectors[],
+                                    int preput_keyval_size,
+                                    const PMI_keyval_t preput_keyval_vector[],
+                                    int errors[])
 {
+    struct pmi_wrap *pmi = impl;
     int (*f)(int, const char **, const char ***, const int *, const int *,
              const PMI_keyval_t **, int, const PMI_keyval_t *, int *);
     if ((f = dlsym (pmi->dso, "PMI_Lookup_name")))
@@ -320,8 +342,9 @@ error:
 }
 
 
-void pmi_wrap_destroy (struct pmi_wrap *pmi)
+static void pmi_wrap_destroy (void *impl)
 {
+    struct pmi_wrap *pmi = impl;
     if (pmi) {
         if (pmi->dso)
             dlclose (pmi->dso);
@@ -329,11 +352,37 @@ void pmi_wrap_destroy (struct pmi_wrap *pmi)
     }
 }
 
+static struct pmi_operations pmi_wrap_operations = {
+    .init                       = pmi_wrap_init,
+    .initialized                = pmi_wrap_initialized,
+    .finalize                   = pmi_wrap_finalize,
+    .get_size                   = pmi_wrap_get_size,
+    .get_rank                   = pmi_wrap_get_rank,
+    .get_appnum                 = pmi_wrap_get_appnum,
+    .get_universe_size          = pmi_wrap_get_universe_size,
+    .publish_name               = pmi_wrap_publish_name,
+    .unpublish_name             = pmi_wrap_unpublish_name,
+    .lookup_name                = pmi_wrap_lookup_name,
+    .barrier                    = pmi_wrap_barrier,
+    .abort                      = pmi_wrap_abort,
+    .kvs_get_my_name            = pmi_wrap_kvs_get_my_name,
+    .kvs_get_name_length_max    = pmi_wrap_kvs_get_name_length_max,
+    .kvs_get_key_length_max     = pmi_wrap_kvs_get_key_length_max,
+    .kvs_get_value_length_max   = pmi_wrap_kvs_get_value_length_max,
+    .kvs_put                    = pmi_wrap_kvs_put,
+    .kvs_commit                 = pmi_wrap_kvs_commit,
+    .kvs_get                    = pmi_wrap_kvs_get,
+    .get_clique_size            = pmi_wrap_get_clique_size,
+    .get_clique_ranks           = pmi_wrap_get_clique_ranks,
+    .spawn_multiple             = pmi_wrap_spawn_multiple,
+    .destroy                    = pmi_wrap_destroy,
+};
+
 /* Notes:
  * - Use RTLD_GLOBAL due to issue #432
  */
 
-struct pmi_wrap *pmi_wrap_create (const char *libname)
+void *pmi_wrap_create (const char *libname, struct pmi_operations **ops)
 {
     struct pmi_wrap *pmi = calloc (1, sizeof (*pmi));
     const char *s;
@@ -374,6 +423,7 @@ struct pmi_wrap *pmi_wrap_create (const char *libname)
     if (!pmi->dso)
         goto error;
     liblist_destroy (libs);
+    *ops = &pmi_wrap_operations;
     return pmi;
 error:
     pmi_wrap_destroy (pmi);

--- a/src/common/libpmi/wrap.c
+++ b/src/common/libpmi/wrap.c
@@ -382,7 +382,8 @@ static struct pmi_operations pmi_wrap_operations = {
  * - Use RTLD_GLOBAL due to issue #432
  */
 
-void *pmi_wrap_create (const char *libname, struct pmi_operations **ops)
+void *pmi_wrap_create (const char *libname, struct pmi_operations **ops,
+                       bool allow_self_wrap)
 {
     struct pmi_wrap *pmi = calloc (1, sizeof (*pmi));
     const char *s;
@@ -408,7 +409,7 @@ void *pmi_wrap_create (const char *libname, struct pmi_operations **ops)
                              __FUNCTION__, name);
             }
         }
-        else if (dlsym (pmi->dso, "flux_pmi_library")) {
+        else if (!allow_self_wrap && dlsym (pmi->dso, "flux_pmi_library")) {
             if (debug)
                 fprintf (stderr, "%s: skipping %s\n", __FUNCTION__, name);
             dlclose (pmi->dso);

--- a/src/common/libpmi/wrap.h
+++ b/src/common/libpmi/wrap.h
@@ -1,9 +1,11 @@
 #ifndef _FLUX_CORE_PMI_WRAP_H
 #define _FLUX_CORE_PMI_WRAP_H
 
+#include <stdbool.h>
 #include "src/common/libpmi/pmi_operations.h"
 
-void *pmi_wrap_create (const char *libname, struct pmi_operations **ops);
+void *pmi_wrap_create (const char *libname, struct pmi_operations **ops,
+                       bool allow_self_wrap);
 
 #endif /* _FLUX_CORE_PMI_WRAP_H */
 

--- a/src/common/libpmi/wrap.h
+++ b/src/common/libpmi/wrap.h
@@ -1,52 +1,11 @@
-#ifndef _FLUX_CORE_PMI_DLOPEN_WRAPPER_H
-#define _FLUX_CORE_PMI_DLOPEN_WRAPPER_H
+#ifndef _FLUX_CORE_PMI_WRAP_H
+#define _FLUX_CORE_PMI_WRAP_H
 
-#include "src/common/libpmi/pmi.h"
+#include "src/common/libpmi/pmi_operations.h"
 
-struct pmi_wrap;
+void *pmi_wrap_create (const char *libname, struct pmi_operations **ops);
 
-int pmi_wrap_init (struct pmi_wrap *pmi, int *spawned);
-int pmi_wrap_initialized (struct pmi_wrap *pmi, int *initialized);
-int pmi_wrap_finalize (struct pmi_wrap *pmi);
-int pmi_wrap_get_size (struct pmi_wrap *pmi, int *size);
-int pmi_wrap_get_rank (struct pmi_wrap *pmi, int *rank);
-int pmi_wrap_get_appnum (struct pmi_wrap *pmi, int *appnum);
-int pmi_wrap_get_universe_size (struct pmi_wrap *pmi, int *universe_size);
-int pmi_wrap_publish_name (struct pmi_wrap *pmi,
-                           const char *service_name, const char *port);
-int pmi_wrap_unpublish_name (struct pmi_wrap *pmi, const char *service_name);
-int pmi_wrap_lookup_name (struct pmi_wrap *pmi,
-                          const char *service_name, char *port);
-int pmi_wrap_barrier (struct pmi_wrap *pmi);
-int pmi_wrap_abort (struct pmi_wrap *pmi, int exit_code, const char *error_msg);
-int pmi_wrap_kvs_get_my_name (struct pmi_wrap *pmi, char *kvsname, int length);
-int pmi_wrap_kvs_get_name_length_max (struct pmi_wrap *pmi, int *length);
-int pmi_wrap_kvs_get_key_length_max (struct pmi_wrap *pmi, int *length);
-int pmi_wrap_kvs_get_value_length_max (struct pmi_wrap *pmi, int *length);
-int pmi_wrap_kvs_put (struct pmi_wrap *pmi, const char *kvsname,
-                      const char *key, const char *value);
-int pmi_wrap_kvs_commit (struct pmi_wrap *pmi, const char *kvsname);
-int pmi_wrap_kvs_get (struct pmi_wrap *pmi, const char *kvsname,
-                      const char *key, char *value, int len);
-int pmi_wrap_get_clique_size (struct pmi_wrap *pmi, int *size);
-int pmi_wrap_get_clique_ranks (struct pmi_wrap *pmi, int ranks[], int length);
-
-int pmi_wrap_spawn_multiple (struct pmi_wrap *pmi,
-                             int count,
-                             const char *cmds[],
-                             const char **argvs[],
-                             const int maxprocs[],
-                             const int info_keyval_sizesp[],
-                             const PMI_keyval_t *info_keyval_vectors[],
-                             int preput_keyval_size,
-                             const PMI_keyval_t preput_keyval_vector[],
-                             int errors[]);
-
-void pmi_wrap_destroy (struct pmi_wrap *pmi);
-struct pmi_wrap *pmi_wrap_create (const char *libname);
-
-
-#endif /* _FLUX_CORE_PMI_DLOPEN_WRAPPER_H */
+#endif /* _FLUX_CORE_PMI_WRAP_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -42,6 +42,7 @@ wrexecd_SOURCES = \
 wrexecd_libs = \
 	$(top_builddir)/src/bindings/lua/libfluxlua.la \
 	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libpmi/libpmi.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -15,6 +15,7 @@ https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz
 https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz \
 http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz \
 http://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.1.tar.gz \
+https://github.com/pmix/pmix/releases/download/v3.0.0/pmix-3.0.0.tar.gz \
 http://www.digip.org/jansson/releases/jansson-2.9.tar.gz \
 http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz \
 https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \


### PR DESCRIPTION
This PR adds code to Flux to enable it to bootstrap from PMIx, if built `--with-pmix`.  I used the pmix PMI-1 compat library as a guide and pulled the code into flux-core's libpmi.  The broker will use it to bootstrap if it finds PMIX_SERVER_URI or _URI2 set as discussed in #1555

This recipe works to build it on sierra:
```
$ LDFLAGS="-L/opt/ibm/spectrum_mpi/lib" \
CPPFLAGS="-I/opt/ibm/spectrum_mpi/include" \
./configure --with-pmix --disable-jobspec
$ make -j8
$ make -j8 check
```

I'm having some difficulty running _anything_ on sierra at the moment but I'll get back to it and hopefully spin up some tests on monday.  @dongahn provided some nice bsub/jsrun runes for me to cut and paste from in #1555 (thanks!)

I did notice that on my desktop, libpmix links against hwloc, and the hwloc on my system must link against cuda, because suddenly, but only when built against pmix, the valgrind test began failing with memory lost in the cuda library, so I'll need to run that down also.

Oh also, I had kind of stupidly implemented the different PMI client options as a case statement in each function, so there is a refactoring patch in here too to make the approach a little more scaleable.