### PR TITLE
 wreck: add wreck plugin for spectrum MPI 

### DIFF
--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -84,7 +84,8 @@ dist_wreckscripts_SCRIPTS = \
 	lua.d/mvapich.lua \
 	lua.d/pmi-mapping.lua \
 	lua.d/intel_mpi.lua \
-	lua.d/openmpi.lua
+        lua.d/openmpi.lua \
+        lua.d/spectrum.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/lua.d/spectrum.lua
+++ b/src/modules/wreck/lua.d/spectrum.lua
@@ -1,0 +1,49 @@
+-- Set environment specific to spectrum_mpi (derived from openmpi)
+--
+
+if wreck:getopt ("mpi") ~= "spectrum" then return end
+
+local posix = require 'posix'
+
+function prepend_path (env_var, path)
+    local env = wreck.environ
+    if env[env_var] == nil then
+       suffix = ''
+    else
+       suffix = ':'..env[env_var]
+    end
+    env[env_var] = path..suffix
+end
+
+function rexecd_init ()
+    local env = wreck.environ
+    local f = wreck.flux
+    local rundir = f:getattr ('broker.rundir')
+
+    -- Avoid shared memory segment name collisions
+    -- when flux instance runs >1 broker per node.
+    env['OMPI_MCA_orte_tmpdir_base'] = rundir
+
+    -- Assumes the installation paths of Spectrum MPI on LLNL's Sierra
+    env['OMPI_MCA_osc'] = "pt2pt"
+    env['OMPI_MCA_pml'] = "yalla"
+    env['OMPI_MCA_btl'] = "self"
+    env['MPI_ROOT'] = "/opt/ibm/spectrum_mpi"
+    env['OPAL_LIBDIR'] = "/opt/ibm/spectrum_mpi/lib"
+    env['OMPI_MCA_coll_hcoll_enable'] = '0'
+
+    env['PMIX_SERVER_URI'] = nil
+    env['PMIX_SERVER_URI2'] = nil
+
+    -- Help find libcollectives.so
+    prepend_path ('LD_LIBRARY_PATH', '/opt/ibm/spectrum_mpi/lib/pami_port')
+    prepend_path ('LD_PRELOAD', '/opt/ibm/spectrum_mpi/lib/libpami_cudahook.so')
+end
+
+function rexecd_task_init ()
+    -- Approximately `ulimit -Ss 10240`
+    -- Used to silence IBM MCM warnings
+    posix.setrlimit ("stack", 10485760)
+end
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -79,6 +79,7 @@ TESTS = \
 	t2009-hostlist.t \
 	t2100-aggregate.t \
 	t3000-mpi-basic.t \
+        t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	lua/t0001-send-recv.t \
@@ -162,6 +163,7 @@ check_SCRIPTS = \
 	t2009-hostlist.t \
 	t2100-aggregate.t \
 	t3000-mpi-basic.t \
+        t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
         issues/t0441-kvs-put-get.sh \

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+
+test_description="Test that Flux's MPI personalities work"
+
+. `dirname $0`/sharness.sh
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE} wreck
+echo "# $0: flux session size will be ${SIZE}"
+
+# Usage: run_program timeout ntasks nnodes
+run_program() {
+        local timeout=$1
+        local ntasks=$2
+        local nnodes=$3
+        shift 3
+        run_timeout $timeout flux wreckrun $OPTS \
+                    -n${ntasks} -N${nnodes} $*
+}
+
+test_expect_success "intel mpi rewrites I_MPI_MPI_LIBRARY" '
+  export I_MPI_PMI_LIBRARY="foobar" \
+  && run_program 5 ${SIZE} ${SIZE} printenv I_MPI_PMI_LIBRARY \
+     | tee intel-mpi.set \
+  && test "$(uniq intel-mpi.set)" = "$(flux getattr conf.pmi_library_path)"
+'
+
+test_expect_success "intel mpi only rewrites when necessary" '
+   run_program 5 ${SIZE} ${SIZE} printenv $I_MPI_PMI_LIBRARY \
+	| tee intel-mpi.unset \
+    && test "$(wc -l intel-mpi.unset | cut -f 1 -d " ")" = "0"
+'
+
+OPTS="-o mpi=spectrum"
+test_expect_success "spectrum mpi sets MPI_ROOT" '
+  run_program 5 ${SIZE} ${SIZE} printenv MPI_ROOT \
+        | tee spectrum-mpi.env \
+    && test "$(uniq spectrum-mpi.env)" = "/opt/ibm/spectrum_mpi"
+'
+
+OPTS="-o mpi=spectrum"
+test_expect_success "spectrum mpi sets the soft stack limit" '
+  run_timeout 5 flux wreckrun -n ${SIZE} -N ${SIZE} $OPTS bash -c "ulimit -s" \
+        | tee spectrum-mpi.ulimit \
+        && test "$(uniq spectrum-mpi.ulimit)" = "10240"
+'
+
+test_done


### PR DESCRIPTION
Add support for spectrum MPI on Sierra via optional wreck plugin.
Activated by calling `wreckrun` or `submit` with `-o mpi=spectrum`.

Credit goes to @grondo and @garlick.

Closes #1584 
Closes #1382 