### PR TITLE
wreck/lua: fix crash due to Lua stack overflow

### DIFF
--- a/src/modules/wreck/luastack.c
+++ b/src/modules/wreck/luastack.c
@@ -361,6 +361,10 @@ int lua_script_call (lua_script_t s, const char *name)
 {
     struct lua_State *L = lua_script_state (s);
 
+    /* Clear Lua stack before calling into each script to avoid
+     *  potential for stack overflow.
+     */
+    lua_settop (L, 0);
     lua_script_getglobal (s, name);
 
     if (lua_isnil (L, -1)) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -9,8 +9,12 @@ AM_CPPFLAGS = \
         -I$(top_srcdir) -I$(top_srcdir)/src/include \
         $(ZMQ_CFLAGS)
 
+#  If LUA_PATH is already set, ensure ./?.lua appears in LUA_PATH so that
+#   fluxometer.lua is found. O/w, if LUA_PATH is *not* set, ./?.lua already
+#   appears in the default LUA_PATH, so do nothing.
+#
 AM_TESTS_ENVIRONMENT = \
-	export LUA_PATH="$(builddir)/?.lua;$$LUA_PATH";
+	test -n "$$LUA_PATH" && export LUA_PATH="$(builddir)/?.lua;$$LUA_PATH";
 
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \


### PR DESCRIPTION
Problem: The Lua stack is not reset anywhere in luastack.c when
loading and running Lua wrexecd plugins. We got away with this
when each script was run in its own lua_thread (coroutine), because
the stacks were not shared between scripts, but when the use of
coroutines was removed, the stack growth was large enough to cause
crashes in some tests that ran many tasks.

Fix the bug by resetting the Lua stack before executing a callback
function in each lua script.

Fixes #1592