### PR TITLE
wreck: set CUDA_VISIBLE_DEVICES when gpus are in R_lite

### DIFF
--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -38,6 +38,7 @@ local lwj_options = {
     ['no-pmi-server'] =         "Do not start simple-pmi server",
     ['trace-pmi-server'] =      "Log simple-pmi server protocol exchange",
     ['cpu-affinity'] =          "Set default cpu-affinity to assigned cores",
+    ['gpubind'] =               "Control CUDA_VISIBLE_DEVICES [=per-task,off]",
     ['mpi'] =                   "Set hint for type of MPI, e.g. -o mpi=spectrum "
 }
 

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -91,12 +91,17 @@ local function alloc_tasks (f, wreck, lwj)
         end
     end
     for i, ntasks in ipairs (counts) do
+        local gpus_per_task = tonumber (wreck.opts.g or 0)
         local rank = i - 1
         local corelist = "0"
+        local gpulist = nil
+        if gpus_per_task > 0 then
+            gpulist = "0-".. (ntasks * gpus_per_task) - 1
+        end
         if ntasks > 1 then
             corelist = corelist .. "-" .. ntasks - 1
         end
-        table.insert (Rlite, { rank = rank, children = { core = corelist } })
+        table.insert (Rlite, { rank = rank, children = { core = corelist, gpu = gpulist } })
         if not r[ntasks] then r[ntasks] = {} end
         table.insert (r[ntasks], rank)
     end

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -84,8 +84,9 @@ dist_wreckscripts_SCRIPTS = \
 	lua.d/mvapich.lua \
 	lua.d/pmi-mapping.lua \
 	lua.d/intel_mpi.lua \
-        lua.d/openmpi.lua \
-        lua.d/spectrum.lua
+	lua.d/openmpi.lua \
+	lua.d/spectrum.lua \
+	lua.d/cuda_devices.lua
    
 # XXX: Hack below to force rebuild of unbuilt wrexecd dependencies
 #

--- a/src/modules/wreck/lua.d/cuda_devices.lua
+++ b/src/modules/wreck/lua.d/cuda_devices.lua
@@ -1,0 +1,75 @@
+local gpubind = wreck:getopt ("gpubind")
+if gpubind == "no" or gpubind == "off" then
+    return
+end
+
+-- Set CUDA_VISIBLE_DEVICES for all tasks on any rank with one or
+--  more "gpu" resources
+
+local gpuinfo = {}
+function gpuinfo_create (wreck, gpus)
+    local g = {}
+    -- Use affinity.cpuset as a convenience to parse the GPU list, which
+    --  is in nodeset form (e.g. "0-1" or "0,2-5", etc.)
+    --
+    local gset, err = require 'flux.affinity'.cpuset.new (gpus)
+    if not gset then
+        wreck:log_error ("Unable to parse GPU list [%s]: %s", gpus, err)
+        return nil
+    end
+    local g = {
+        gpuids = gset:expand (),
+        ngpus  = gset:count (),
+        ntasks = wreck.tasks_per_node [wreck.nodeid]
+    }
+
+    -- If per-task binding is requested, ensure ngpus is evenly divisible
+    --  into ntasks:
+    if gpubind == "per-task" and g.ngpus % g.ntasks == 0 then
+        g.ngpus_per_task = g.ngpus/g.ntasks
+    end
+    return g
+end
+
+function rexecd_init ()
+    -- NB: Lua arrays are indexed starting at 1, so this rank's index
+    --  into R_lite rank array is nodeid + 1:
+    --
+    local index = wreck.nodeid + 1
+
+    -- Grab local resources structure from kvs for this nodeid:
+    --
+    local Rlocal = wreck.kvsdir.R_lite[index].children
+
+    -- If a gpu resource list is set for this rank, then expand it and
+    --  set CUDA_VISIBLE_DEVICES to the result:
+    --
+    local gpus = Rlocal.gpu
+    if not gpus then return end
+
+    gpuinfo = gpuinfo_create (wreck, gpus)
+    -- If ngpus_per_task is not set, then set CUDA_VISIBLE_DEVICES the same
+    --  for all tasks:
+    if not gpuinfo.ngpus_per_task then
+        local ids = table.concat (gpuinfo.gpuids, ",")
+        wreck.environ ["CUDA_VISIBLE_DEVICES"] = ids
+    end
+    -- Always set CUDA_DEVICE_ORDER=PCI_BUS_ID to ensure CUDA ids match
+    --  IDs known to flux scheduler.
+    wreck.environ ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+end
+
+function rexecd_task_init ()
+    -- If ngpus_per_task is set, then select that many GPUs from the gpuids
+    --  list assigned to this rank for the current task:
+    if not gpuinfo.ngpus_per_task then return end
+
+    local basis = gpuinfo.ngpus_per_task * wreck.taskid
+    local t = {}
+    for i = 1,gpuinfo.ngpus_per_task do
+        table.insert (t, gpuinfo.gpuids [basis + i])
+    end
+    wreck.environ ["CUDA_VISIBLE_DEVICES"] = table.concat (t, ",")
+end
+
+-- vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
I thought I'd throw the current version of the CUDA_VISIBLE_DEVICES plugin into a PR.
This version also sets CUDA_DEVICE_ORDER as @dongahn instructs in #1598.

The per-task behavior can be requested with `-o gpubind=per-task` and the plugin can be disabled with `-o gpubind=off`.

Probably should figure out some way to test this in CI, but we first need a way to simulate gpu resources I guess...