### PR TITLE
Add queue to flux future fulfillments

### DIFF
--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -122,7 +122,7 @@ static int internal_content_dropcache (optparse_t *p, int ac, char *av[])
         log_err_exit ("flux_open");
     if (!(f = flux_rpc (h, "content.dropcache", NULL, FLUX_NODEID_ANY, 0)))
         log_err_exit ("content.dropcache");
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         log_err_exit ("content.dropcache");
     flux_future_destroy (f);
     flux_close (h);

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -36,7 +36,7 @@ static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])
         log_err_exit ("flux_open");
     if (!(f = flux_rpc_pack (h, "heaptrace.start", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "filename", av[ac - 1]))
-            || flux_future_get (f, NULL) < 0)
+            || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("heaptrace.start");
     flux_future_destroy (f);
     flux_close (h);

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -263,7 +263,7 @@ static void config_hwloc_paths (flux_t *h, const char *dirpath)
     }
     if (!(f = flux_kvs_commit (h, 0, txn)))
         log_err_exit ("flux_kvs_commit request");
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit response");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -406,7 +406,7 @@ int cmd_namespace_create (optparse_t *p, int argc, char **argv)
         const char *name = argv[i];
         int flags = 0;
         if (!(f = flux_kvs_namespace_create (h, name, owner, flags))
-            || flux_future_get (f, NULL) < 0)
+            || flux_rpc_get (f, NULL) < 0)
             log_err_exit ("%s", name);
         flux_future_destroy (f);
     }
@@ -427,7 +427,7 @@ int cmd_namespace_remove (optparse_t *p, int argc, char **argv)
     for (i = optindex; i < argc; i++) {
         const char *name = argv[i];
         if (!(f = flux_kvs_namespace_remove (h, name))
-            || flux_future_get (f, NULL) < 0)
+            || flux_rpc_get (f, NULL) < 0)
             log_err_exit ("%s", name);
         flux_future_destroy (f);
     }
@@ -685,7 +685,7 @@ int cmd_put (optparse_t *p, int argc, char **argv)
         free (key);
     }
     if (!(f = flux_kvs_commit (h, commit_flags, txn))
-                                        || flux_future_get (f, NULL) < 0)
+                                        || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -755,7 +755,7 @@ int cmd_unlink (optparse_t *p, int argc, char **argv)
                 log_err_exit ("%s", argv[i]);
         }
     }
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -781,7 +781,7 @@ int cmd_link (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_kvs_txn_create");
     if (flux_kvs_txn_symlink (txn, 0, argv[optindex + 1], argv[optindex]) < 0)
         log_err_exit ("%s", argv[optindex + 1]);
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -838,7 +838,7 @@ int cmd_mkdir (optparse_t *p, int argc, char **argv)
         if (flux_kvs_txn_mkdir (txn, 0, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -1522,7 +1522,7 @@ int cmd_copy (optparse_t *p, int argc, char **argv)
         log_err_exit( "flux_kvs_txn_put_treeobj");
     flux_future_destroy (f);
 
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_kvs_txn_destroy (txn);
     flux_future_destroy (f);
@@ -1556,7 +1556,7 @@ int cmd_move (optparse_t *p, int argc, char **argv)
         log_err_exit( "flux_kvs_txn_unlink");
     flux_future_destroy (f);
 
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_kvs_txn_destroy (txn);
     flux_future_destroy (f);

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -643,7 +643,7 @@ int cmd_stats (optparse_t *p, int argc, char **argv)
         topic = xasprintf ("%s.stats.clear", service);
         if (!(f = flux_rpc (h, topic, NULL, nodeid, 0)))
             log_err_exit ("%s", topic);
-        if (flux_future_get (f, NULL) < 0)
+        if (flux_rpc_get (f, NULL) < 0)
             log_err_exit ("%s", topic);
     } else if (optparse_hasopt (p, "clear-all")) {
         topic = xasprintf ("%s.stats.clear", service);

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -135,7 +135,7 @@ static int attr_set_rpc (attr_ctx_t *ctx, const char *name, const char *val)
 #endif
     if (!f)
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     if (val) {
         if (!(attr = attr_create (val, 0)))

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -124,7 +124,7 @@ static int log_rpc (flux_t *h, const char *buf, int len, int flags)
         goto done;
     if ((flags & FLUX_RPC_NORESPONSE))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -238,7 +238,7 @@ static int dmesg_clear (flux_t *h, int seq)
     if (!(f = flux_rpc_pack (h, "log.clear", FLUX_NODEID_ANY, 0,
                              "{s:i}", "seq", seq)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -325,7 +325,7 @@ int flux_rmmod (flux_t *h, uint32_t nodeid, const char *name)
         goto done;
     if (!(f = flux_rpc (h, topic, json_str, nodeid, 0)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -397,7 +397,7 @@ int flux_insmod (flux_t *h, uint32_t nodeid, const char *path,
     json_str = flux_insmod_json_encode (path, argc, argv);
     if (!(f = flux_rpc (h, topic, json_str, nodeid, 0)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -239,7 +239,7 @@ static int jobid_exist (flux_t *h, int64_t jobid)
         if (!(path = jscctx_jobid_path (ctx, jobid)))
             goto done;
         if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, path))
-                                    || flux_future_get (f, NULL) < 0)
+                                    || flux_rpc_get (f, NULL) < 0)
             goto done;
     }
     rc = 0;
@@ -482,7 +482,7 @@ static int update_state (flux_t *h, int64_t jobid, json_t *jcb)
         goto done;
     if (flux_kvs_txn_pack (txn, 0, key, "s", jsc_job_num2state (state)) < 0)
         goto done;
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         goto done;
     if (send_state_event (h, state, jobid) < 0)
         goto done;
@@ -535,7 +535,7 @@ static int update_rdesc (flux_t *h, int64_t jobid, json_t *jcb)
         goto done;
     if (flux_kvs_txn_pack (txn, 0, key, "I", ncores) < 0)
         goto done;
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -561,7 +561,7 @@ static int update_rdl (flux_t *h, int64_t jobid, json_t *jcb)
         goto done;
     if (flux_kvs_txn_pack (txn, 0, key, "O", rdl) < 0)
         goto done;
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -587,7 +587,7 @@ static int update_r_lite (flux_t *h, int64_t jobid, json_t *jcb)
         goto done;
     if (flux_kvs_txn_pack (txn, 0, key, "O", r_lite) < 0)
         goto done;
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -222,7 +222,7 @@ int flux_kvs_wait_version (flux_t *h, int version)
         goto done;
     /* N.B. response contains (rootseq, rootref) but we don't need it.
      */
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     ret = 0;
 done:
@@ -237,7 +237,7 @@ int flux_kvs_dropcache (flux_t *h)
 
     if (!(f = flux_rpc (h, "kvs.dropcache", NULL, FLUX_NODEID_ANY, 0)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -190,7 +190,7 @@ int flux_kvs_commit_anon (flux_t *h, int flags)
         return -1;
     if (!(f = flux_kvs_commit (h, flags, txn))) /* no-op if NULL txn */
         return -1;
-    rc = flux_future_get (f, NULL);
+    rc = flux_rpc_get (f, NULL);
     saved_errno = errno;
     flux_future_destroy (f);
     clear_default_txn (h);
@@ -208,7 +208,7 @@ int flux_kvs_fence_anon (flux_t *h, const char *name, int nprocs, int flags)
         return -1;
     if (!(f = flux_kvs_fence (h, flags, name, nprocs, txn)))
         return -1;
-    rc = flux_future_get (f, NULL);
+    rc = flux_rpc_get (f, NULL);
     saved_errno = errno;
     flux_future_destroy (f);
     clear_default_txn (h);

--- a/src/common/libkvs/kvs_classic.h
+++ b/src/common/libkvs/kvs_classic.h
@@ -40,7 +40,7 @@ int flux_kvs_mkdir (flux_t *h, const char *key)
                     __attribute__ ((deprecated));
 
 /* flux_kvs_commit_anon() and flux_kvs_fence_anon() combine a flux_kvs_commit()
- * and a flux_future_get() call in one function, thus they block the calling
+ * and a flux_rpc_get() call in one function, thus they block the calling
  * thread while RPC's complete.  These functions operate only on the
  * anonymous transaction (see above).
  */

--- a/src/common/libkvs/kvs_watch.c
+++ b/src/common/libkvs/kvs_watch.c
@@ -157,7 +157,7 @@ int flux_kvs_unwatch (flux_t *h, const char *key)
                              "key", key,
                              "namespace", namespace)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     /* Delete all watchers for the specified key.
      */
@@ -324,6 +324,9 @@ static int kvs_watch_rpc_get_matchtag (flux_future_t *f, uint32_t *matchtag)
     const flux_msg_t *msg;
 
     if (flux_future_get (f, &msg) < 0)
+        return -1;
+    /* check if error in the response */
+    if (flux_response_decode (msg, NULL, NULL) < 0)
         return -1;
     if (flux_msg_get_matchtag (msg, &tag) < 0)
         return -1;

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -160,7 +160,7 @@ static int op_event (void *impl, const char *topic, const char *msg_topic)
     if (!(f = flux_rpc_pack (c->h, msg_topic, FLUX_NODEID_ANY, 0,
                              "{s:s}", "topic", topic)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -142,7 +142,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     if (!(f = flux_rpc_pack (ctx->h, "cmb.sub", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -160,7 +160,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     if (!(f = flux_rpc_pack (ctx->h, "cmb.unsub", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -141,7 +141,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     if (!(f = flux_rpc_pack (c->h, "local.sub", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:
@@ -159,7 +159,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     if (!(f = flux_rpc_pack (c->h, "local.unsub", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -343,7 +343,7 @@ static void sink_continuation (flux_future_t *f, void *arg)
     flux_t *h = flux_future_get_flux (f);
     struct aggregate *ag = arg;
 
-    int rc = flux_future_get (f, NULL);
+    int rc = flux_rpc_get (f, NULL);
     flux_future_destroy (f);
     if (rc < 0) {
         /*  Schedule a retry, if  succesful return immediately, otherwise

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -417,7 +417,7 @@ int register_backing_store (flux_t *h, bool value, const char *name)
                              "backing", value,
                              "name", name)))
         goto done;
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_rpc_get (f, NULL) < 0)
         goto done;
     rc = 0;
 done:

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -399,7 +399,7 @@ static int load_hwloc (flux_t *h, resource_ctx_t *ctx)
         flux_log_error (h, "%s: flux_kvs_txn_pack", __FUNCTION__);
         goto done;
     }
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0) {
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0) {
         flux_log_error (h, "%s: flux_kvs_commit", __FUNCTION__);
         goto done;
     }

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1289,8 +1289,8 @@ static int aggregator_push_task_exit (struct task_info *t)
         rc = -1;
     }
 
-    if (f && flux_future_get (f, NULL) < 0) {
-        flux_log_error (h, "flux_future_get");
+    if (f && flux_rpc_get (f, NULL) < 0) {
+        flux_log_error (h, "flux_rpc_get");
         rc = -1;
     }
     flux_future_destroy (f);
@@ -2142,7 +2142,7 @@ static void wreck_barrier_next (struct prog_ctx *ctx)
 static void wreck_barrier_complete (flux_future_t *f, void *arg)
 {
     struct prog_ctx *ctx = arg;
-    int rc = flux_future_get (f, NULL);
+    int rc = flux_rpc_get (f, NULL);
     pmi_simple_server_barrier_complete (ctx->pmi, rc);
     flux_future_destroy (f);
     wreck_barrier_next (ctx);

--- a/t/barrier/tbarrier.c
+++ b/t/barrier/tbarrier.c
@@ -105,7 +105,7 @@ int main (int argc, char *argv[])
             else
                 log_err_exit ("flux_barrier");
         }
-        if (flux_future_get (f, NULL) < 0)
+        if (flux_rpc_get (f, NULL) < 0)
             log_err_exit ("barrier completion failed");
         if (!quiet)
             printf ("barrier name=%s nprocs=%d time=%0.3f ms\n",

--- a/t/kvs/commit.c
+++ b/t/kvs/commit.c
@@ -115,12 +115,12 @@ void *thread (void *arg)
         if (fopt) {
             if (!(f = flux_kvs_fence (t->h, flags, fence_name,
                                                    fence_nprocs, txn))
-                    || flux_future_get (f, NULL) < 0)
+                    || flux_rpc_get (f, NULL) < 0)
                 log_err_exit ("flux_kvs_fence");
             flux_future_destroy (f);
         } else {
             if (!(f = flux_kvs_commit (t->h, flags, txn))
-                    || flux_future_get (f, NULL) < 0)
+                    || flux_rpc_get (f, NULL) < 0)
                 log_err_exit ("flux_kvs_commit");
             flux_future_destroy (f);
         }

--- a/t/kvs/dtree.c
+++ b/t/kvs/dtree.c
@@ -99,7 +99,7 @@ int main (int argc, char *argv[])
             log_err_exit ("flux_kvs_txn_create");
         if (flux_kvs_txn_mkdir (txn, 0, prefix) < 0)
             log_err_exit ("flux_kvs_txn_mkdir %s", prefix);
-        if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
             log_err_exit ("flux_kvs_commit");
         flux_future_destroy (f);
         flux_kvs_txn_destroy (txn);
@@ -121,7 +121,7 @@ int main (int argc, char *argv[])
         if (!(txn = flux_kvs_txn_create ()))
             log_err_exit ("flux_kvs_txn_create");
         dtree (txn, prefix, width, height);
-        if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
            log_err_exit ("flux_kvs_commit");
         flux_future_destroy (f);
         flux_kvs_txn_destroy (txn);

--- a/t/kvs/fence_invalid.c
+++ b/t/kvs/fence_invalid.c
@@ -113,8 +113,8 @@ int main (int argc, char *argv[])
         goto done;
     }
 
-    if (flux_future_get (f2, NULL) < 0) {
-        printf ("flux_future_get: %s\n", flux_strerror (errno));
+    if (flux_rpc_get (f2, NULL) < 0) {
+        printf ("flux_rpc_get: %s\n", flux_strerror (errno));
         goto done;
     }
 

--- a/t/kvs/fence_namespace_remove.c
+++ b/t/kvs/fence_namespace_remove.c
@@ -98,7 +98,7 @@ int main (int argc, char *argv[])
     }
 
     /* nprocs = 2, but we call flux_kvs_fence only once, so the
-     * flux_future_get() below should hang until an error occurs
+     * flux_rpc_get() below should hang until an error occurs
      */
 
     if (!(f = flux_kvs_fence (h, 0, fence_name, 2, txn))) {
@@ -106,8 +106,8 @@ int main (int argc, char *argv[])
         goto done;
     }
 
-    if (flux_future_get (f, NULL) < 0) {
-        printf ("flux_future_get: %s\n", flux_strerror (errno));
+    if (flux_rpc_get (f, NULL) < 0) {
+        printf ("flux_rpc_get: %s\n", flux_strerror (errno));
         goto done;
     }
 

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -122,7 +122,7 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_kvs_txn_create");
     if (flux_kvs_txn_unlink (txn, 0, prefix) < 0)
         log_err_exit ("flux_kvs_txn_unlink");
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -147,7 +147,7 @@ int main (int argc, char *argv[])
              monotime_since (t0)/1000, count, size);
 
     monotime (&t0);
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);

--- a/t/kvs/transactionmerge.c
+++ b/t/kvs/transactionmerge.c
@@ -150,7 +150,7 @@ void *watchthread (void *arg)
         log_err_exit ("flux_kvs_txn_create");
     if (flux_kvs_txn_unlink (txn, 0, key) < 0)
         log_err_exit ("flux_kvs_txn_unlink");
-    if (!(f = flux_kvs_commit (t->h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (t->h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -198,7 +198,7 @@ void *committhread (void *arg)
     if (flux_kvs_txn_pack (txn, 0, key, "i", t->n) < 0)
         log_err_exit ("%s", key);
     if (!(f = flux_kvs_commit (t->h, nopt ? FLUX_KVS_NO_MERGE : 0, txn))
-            || flux_future_get (f, NULL) < 0)
+            || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
 
     flux_future_destroy (f);

--- a/t/kvs/watch.c
+++ b/t/kvs/watch.c
@@ -234,7 +234,7 @@ void test_mt (int argc, char **argv)
     key_stable = xasprintf ("%s-stable", key);
     if (flux_kvs_txn_pack (txn, 0, key_stable, "i", 0) < 0)
         log_err_exit ("flux_kvs_txn_pack %s", key);
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -254,7 +254,7 @@ void test_mt (int argc, char **argv)
             log_err_exit ("flux_kvs_txn_create");
         if (flux_kvs_txn_pack (txn, 0, key, "i", i) < 0)
             log_err_exit ("flux_kvs_txn_pack %s", key);
-        if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+        if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
             log_err_exit ("flux_kvs_commit");
         flux_future_destroy (f);
         flux_kvs_txn_destroy (txn);
@@ -315,7 +315,7 @@ static int selfmod_watch_cb (const char *key, const char *json_str, void *arg, i
         log_err_exit ("flux_kvs_txn_create");
     if (flux_kvs_txn_pack (txn, 0, key, "i", val + 1) < 0)
         log_err_exit ("%s: flux_kvs_txn_pack", __FUNCTION__);
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("%s: flux_kvs_commit", __FUNCTION__);
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -342,7 +342,7 @@ void test_selfmod (int argc, char **argv)
         log_err_exit ("flux_kvs_txn_create");
     if (flux_kvs_txn_pack (txn, 0, key, "i", -1) < 0)
         log_err_exit ("flux_kvs_txn_pack");
-    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, 0, txn)) || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -383,7 +383,7 @@ static void unwatch_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     if (flux_kvs_txn_pack (txn, 0, ctx->key, "i", count++) < 0)
         log_err_exit ("%s: flux_kvs_txn_pack", __FUNCTION__);
     if (!(f = flux_kvs_commit (ctx->h, 0, txn))
-                || flux_future_get (f, NULL) < 0)
+                || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("%s: flux_kvs_commit", __FUNCTION__);
     flux_kvs_txn_destroy (txn);
     flux_future_destroy (f);

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -139,7 +139,7 @@ void test_null (flux_t *h, uint32_t nodeid)
     flux_future_t *f;
 
     if (!(f = flux_rpc (h, "req.null", NULL, nodeid, 0))
-             || flux_future_get (f, NULL) < 0)
+             || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("req.null");
     flux_future_destroy (f);
 }
@@ -164,7 +164,7 @@ void test_err (flux_t *h, uint32_t nodeid)
 
     if (!(f = flux_rpc (h, "req.err", NULL, nodeid, 0)))
         log_err_exit ("error sending request");
-    if (flux_future_get (f, NULL) == 0)
+    if (flux_rpc_get (f, NULL) == 0)
         log_msg_exit ("%s: succeeded when should've failed", __FUNCTION__);
     if (errno != 42)
         log_msg_exit ("%s: got errno %d instead of 42", __FUNCTION__, errno);
@@ -189,7 +189,7 @@ void test_sink (flux_t *h, uint32_t nodeid)
     flux_future_t *f;
 
     if (!(f = flux_rpc_pack (h, "req.sink", nodeid, 0, "{s:f}", "pi", 3.14))
-             || flux_future_get (f, NULL) < 0)
+             || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("%s", __FUNCTION__);
     flux_future_destroy (f);
 }
@@ -325,7 +325,7 @@ void test_flush (flux_t *h, uint32_t nodeid)
 {
     flux_future_t *f;
     if (!(f = flux_rpc (h, "req.flush", NULL, nodeid, 0))
-             || flux_future_get (f, NULL) < 0)
+             || flux_rpc_get (f, NULL) < 0)
         log_err_exit ("req.flush");
     flux_future_destroy (f);
 }

--- a/t/rolemask/loop.c
+++ b/t/rolemask/loop.c
@@ -146,7 +146,7 @@ static void check_rpc_default_policy (flux_t *h)
     ok (rc >= 0,
         "default-creds: reactor successfully handled one event");
     ok (testrpc1_called == true
-        && flux_future_get (f, NULL) == 0,
+        && flux_rpc_get (f, NULL) == 0,
         "default-creds: handler was called and returned success response");
     flux_future_destroy (f);
 
@@ -170,7 +170,7 @@ static void check_rpc_default_policy (flux_t *h)
         "random-creds: reactor successfully handled one event");
     errno = 0;
     ok (testrpc1_called == false
-        && flux_future_get (f, NULL) == -1 && errno == EPERM,
+        && flux_rpc_get (f, NULL) == -1 && errno == EPERM,
         "random-creds: handler was NOT called and dispatcher returned EPERM response");
     flux_future_destroy (f);
     ok (cred_set (h, &saved) == 0,
@@ -202,7 +202,7 @@ static void check_rpc_open_policy (flux_t *h)
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
     ok (rc >= 0,
         "default-creds: reactor successfully handled one event");
-    ok (testrpc1_called == true && flux_future_get (f, NULL) == 0,
+    ok (testrpc1_called == true && flux_rpc_get (f, NULL) == 0,
         "default-creds: handler was called and returned success response");
     flux_future_destroy (f);
 
@@ -224,7 +224,7 @@ static void check_rpc_open_policy (flux_t *h)
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
     ok (rc >= 0,
         "random-creds: reactor successfully handled one event");
-    ok (testrpc1_called == true && flux_future_get (f, NULL) == 0,
+    ok (testrpc1_called == true && flux_rpc_get (f, NULL) == 0,
         "random-creds: handler was called and returned success response");
     flux_future_destroy (f);
     ok (cred_set (h, &saved) == 0,
@@ -262,7 +262,7 @@ static void check_rpc_targetted_policy (flux_t *h)
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
     ok (rc >= 0,
         "default-creds: reactor successfully handled one event");
-    ok (testrpc1_called == true && flux_future_get (f, NULL) == 0,
+    ok (testrpc1_called == true && flux_rpc_get (f, NULL) == 0,
         "default-creds: handler was called and returned success response");
     flux_future_destroy (f);
 
@@ -281,7 +281,7 @@ static void check_rpc_targetted_policy (flux_t *h)
     rc = flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
     ok (rc >= 0,
         "target-creds: reactor successfully handled one event");
-    ok (testrpc1_called == true && flux_future_get (f, NULL) == 0,
+    ok (testrpc1_called == true && flux_rpc_get (f, NULL) == 0,
         "target-creds: handler was called and returned success response");
     flux_future_destroy (f);
 
@@ -302,7 +302,7 @@ static void check_rpc_targetted_policy (flux_t *h)
         "nontarget-creds: reactor successfully handled one event");
     errno = 0;
     ok (testrpc1_called == false
-        && flux_future_get (f, NULL) == -1 && errno == EPERM,
+        && flux_rpc_get (f, NULL) == -1 && errno == EPERM,
         "nontarget-creds: handler was NOT called and dispatcher returned EPERM response");
     flux_future_destroy (f);
 

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -267,8 +267,8 @@ void test_error (flux_t *h)
     ok (f != NULL,
         "flux_rpc_pack sent request to rpctest.echoerr service");
     errno = 0;
-    ok (flux_future_get (f, NULL) < 0 && errno == 69,
-        "flux_future_get failed with expected errno");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == 69,
+        "flux_rpc_get failed with expected errno");
     errno = 0;
     ok (flux_rpc_get (f, NULL) < 0 && errno == 69,
         "flux_rpc_get failed with expected errno");
@@ -285,8 +285,8 @@ void test_error (flux_t *h)
     ok (f != NULL,
         "flux_rpc_pack sent request to rpctest.echoerr service (no errstr)");
     errno = 0;
-    ok (flux_future_get (f, NULL) < 0 && errno == ENOTDIR,
-        "flux_future_get failed with expected errno");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOTDIR,
+        "flux_rpc_get failed with expected errno");
     errno = 0;
     ok (flux_rpc_get (f, NULL) < 0 && errno == ENOTDIR,
         "flux_rpc_get failed with expected errno");
@@ -301,8 +301,8 @@ void test_error (flux_t *h)
     f = flux_rpc (h, "rpctest.echo", "Nerp", FLUX_NODEID_ANY, 0);
     ok (f != NULL,
         "flux_rpc sent request to rpctest.echo");
-    ok (flux_future_get (f, NULL) == 0,
-        "flux_future_get returned success");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "flux_rpc_get returned success");
     ok (flux_rpc_get (f, &s) == 0 && s != NULL && !strcmp (s, "Nerp"),
         "flux_rpc_get worked and retrieved payload");
     errstr = flux_rpc_get_error (f);

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -303,12 +303,12 @@ test_expect_success 'kvs: clear stats globally' '
 
 test_expect_success 'kvs: test invalid fence arguments on rank 0' '
         ${FLUX_BUILD_DIR}/t/kvs/fence_invalid invalidtest1 > invalid_output &&
-        grep "flux_future_get: Invalid argument" invalid_output
+        grep "flux_rpc_get: Invalid argument" invalid_output
 '
 
 test_expect_success 'kvs: test invalid fence arguments on rank 1' '
         flux exec -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_invalid invalidtest2" > invalid_output &&
-        grep "flux_future_get: Invalid argument" invalid_output
+        grep "flux_rpc_get: Invalid argument" invalid_output
 '
 
 test_done

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -623,7 +623,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence gets ENOTSUP when names
         wait_fencecount_nonzero 0 $NAMESPACETMP-REMOVE-FENCE0 &&
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE0 &&
         wait $watchpid &&
-        grep "flux_future_get: Operation not supported" fence_out
+        grep "flux_rpc_get: Operation not supported" fence_out
 '
 
 
@@ -639,7 +639,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence on rank 1 gets ENOTSUP 
         wait_fencecount_nonzero 1 $NAMESPACETMP-REMOVE-FENCE1 &&
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE1 &&
         wait $watchpid &&
-        grep "flux_future_get: Operation not supported" fence_out
+        grep "flux_rpc_get: Operation not supported" fence_out
 '
 
 #


### PR DESCRIPTION
Per discussion in #1589, initial implementation to add queue into flux futures to allow multiple future fulfillments so that prior fulfillments are not lost.

This PR handles the discussed implementation strategy summarized by @garlick's post:

>    - flux_future_fulfill() can continue to return void. On zlist_append() error, fulfill with error and call fulfill destructor. Error will be handled by flux_future_get() where the most context is available.
>    - No need to queue errors.
>    - RPC implementation should not try to parse response in response_cb(). Instead, unconditionally fulfill future with response message and let flux_rpc_get() decode the message and return error.
>    - Textual error response needs to be handled differently (e.g. flux_rpc_get_error() should decode the message in the future, not reference aux hash)
>    - There may be a few places in flux-core where we (I probably) have called flux_future_get() where flux_rpc_get() will now need to be called in order to catch errors.

But there is active discussion in #1589, so perhaps things will be changed OR we decide those issues are for another issue.  So perhaps this PR will change greatly.