### PR TITLE
Support queue of future fulfillments in flux futures + other structural improvements

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -149,7 +149,6 @@ MAN3_FILES_SECONDARY = \
 	flux_rpc_get.3 \
 	flux_rpc_get_unpack.3 \
 	flux_rpc_get_raw.3 \
-	flux_rpc_get_error.3 \
 	flux_kvs_lookupat.3 \
 	flux_kvs_lookup_get.3 \
 	flux_kvs_lookup_get_unpack.3 \

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -22,6 +22,8 @@ SYNOPSIS
 
  void flux_future_fulfill_error (flux_future_t *f, int errnum);
 
+ void flux_future_fatal_error (flux_future_t *f, int errnum);
+
  void *flux_future_aux_get (flux_future_t *f, const char *name);
 
  int flux_future_aux_set (flux_future_t *f, const char *name,
@@ -56,18 +58,20 @@ function that is called lazily by the future implementation to perform
 class-specific reactor setup, such as installing watchers and message
 handlers.
 
-`flux_future_create()` creates a future and registers the class-specific
-initialization callback _cb_, and an opaque argument _arg_ that will be
-passed to _cb_.  The purpose of the initialization callback is to set up
-class-specific watchers on a reactor obtained with `flux_future_get_reactor()`,
-or message handlers on a flux_t handle obtained with `flux_future_get_flux()`,
-or both.  `flux_future_get_reactor()` and `flux_future_get_flux()` return
+`flux_future_create()` creates a future and registers the
+class-specific initialization callback _cb_, and an opaque argument
+_arg_ that will be passed to _cb_.  The purpose of the initialization
+callback is to set up class-specific watchers on a reactor obtained
+with `flux_future_get_reactor()`, or message handlers on a flux_t
+handle obtained with `flux_future_get_flux()`, or both.
+`flux_future_get_reactor()` and `flux_future_get_flux()` return
 different results depending on whether the initialization callback is
-triggered by a user calling `flux_future_then()` or `flux_future_wait_for()`.
-The function may be triggered in one or both contexts, at most once for each.
-The watchers or message handlers must eventually call `flux_future_fulfill()`
-or `flux_future_fulfill_error()` to fulfill the future.  See REACTOR CONTEXTS
-below for more information.
+triggered by a user calling `flux_future_then()` or
+`flux_future_wait_for()`.  The function may be triggered in one or
+both contexts, at most once for each.  The watchers or message
+handlers must eventually call `flux_future_fulfill()`,
+`flux_future_fulfill_error()`, or `flux_future_fatal_error()` to
+fulfill the future.  See REACTOR CONTEXTS below for more information.
 
 `flux_future_fulfill()` fulfills the future, assigning an opaque
 _result_ value with optional destructor _free_fn_ to the future.
@@ -78,6 +82,11 @@ as needed until the future is destroyed.
 `flux_future_fulfill_error()` fulfills the future, assigning an _errnum_
 value.  After the future is fulfilled with an error, `flux_future_get()`
 will return -1 with errno set to _errnum_.
+
+`flux_future_fatal_error()` fulfills the future, assigning an _errnum_
+value.  Unlike `flux_future_fulfill_error()` this fulfillment can only
+be called once and takes precedence over all other fulfillments.  It
+is used for catastrophic error paths in future fulfillment.
 
 `flux_future_aux_set()` attaches an object _aux_, with optional destructor
 _destroy_, to the future under an optional _name_.  `flux_future_aux_get()`

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -20,9 +20,11 @@ SYNOPSIS
  void flux_future_fulfill (flux_future_t *f,
                            void *result, flux_free_f free_fn);
 
- void flux_future_fulfill_error (flux_future_t *f, int errnum);
+ void flux_future_fulfill_error (flux_future_t *f, int errnum,
+                                 const char *errstr);
 
- void flux_future_fatal_error (flux_future_t *f, int errnum);
+ void flux_future_fatal_error (flux_future_t *f, int errnum,
+                               const char *errstr);
 
  void *flux_future_aux_get (flux_future_t *f, const char *name);
 
@@ -79,14 +81,16 @@ A NULL _result_ is valid and also fulfills the future.  The _result_
 is contained within the future and can be accessed with `flux_future_get()`
 as needed until the future is destroyed.
 
-`flux_future_fulfill_error()` fulfills the future, assigning an _errnum_
-value.  After the future is fulfilled with an error, `flux_future_get()`
-will return -1 with errno set to _errnum_.
+`flux_future_fulfill_error()` fulfills the future, assigning an
+_errnum_ value and an optional error string.  After the future is
+fulfilled with an error, `flux_future_get()` will return -1 with errno
+set to _errnum_.
 
 `flux_future_fatal_error()` fulfills the future, assigning an _errnum_
-value.  Unlike `flux_future_fulfill_error()` this fulfillment can only
-be called once and takes precedence over all other fulfillments.  It
-is used for catastrophic error paths in future fulfillment.
+value and an optional error string.  Unlike
+`flux_future_fulfill_error()` this fulfillment can only be called once
+and takes precedence over all other fulfillments.  It is used for
+catastrophic error paths in future fulfillment.
 
 `flux_future_aux_set()` attaches an object _aux_, with optional destructor
 _destroy_, to the future under an optional _name_.  `flux_future_aux_get()`

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -86,6 +86,11 @@ _errnum_ value and an optional error string.  After the future is
 fulfilled with an error, `flux_future_get()` will return -1 with errno
 set to _errnum_.
 
+Both `flux_future_fulfill()` and `flux_future_fulfill_error()` can be
+called multiple times to queue multiple results or errors.  When
+callers access future results via `flux_future_get()`, results or
+errors will be returned in FIFO order.
+
 `flux_future_fatal_error()` fulfills the future, assigning an _errnum_
 value and an optional error string.  Unlike
 `flux_future_fulfill_error()` this fulfillment can only be called once

--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -25,6 +25,7 @@ SYNOPSIS
 
  void flux_future_destroy (flux_future_t *f);
 
+ const char *flux_future_error_string (flux_future_t *f);
 
 OVERVIEW
 --------
@@ -77,6 +78,9 @@ another `flux_future_then()`, if desired.
 `flux_future_destroy()` destroys a future, including any result contained
 within.
 
+When flux futures are fulfilled with errors, they can optionally
+include an error string for callers.  `flux_future_error_string()`
+returns the error string if one is available.
 
 RETURN VALUE
 ------------

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -31,8 +31,6 @@ SYNOPSIS
  int flux_rpc_get_raw (flux_future_t *f,
                        const void **data, int *len);
 
- const char *flux_rpc_get_error (flux_future_t *f);
-
 DESCRIPTION
 -----------
 
@@ -54,12 +52,6 @@ decode the RPC result.  Internally, they call `flux_future_get()`
 to access the response message stored in the future.  If the response
 message has not yet been received, these functions block until it is,
 or an error occurs.
-
-`flux_rpc_get_error()` returns an error string explaining the reason
-for a failure.  Its return value is never NULL.  If the remote service
-included a textual error string in the response, that is returned.
-Otherwise flux_strerror(3) provides the string based on the error
-number received in the response.
 
 
 REQUEST OPTIONS

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -441,3 +441,4 @@ distrib
 epilog
 gpubind
 gpus
+fulfillments

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -122,7 +122,7 @@ void composite_future_init (flux_future_t *f, void *arg)
     }
     return;
 error:
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 
 /*
@@ -238,7 +238,7 @@ static void fulfill_next (flux_future_t *f, flux_future_t *next)
     flux_future_aux_set (next, NULL, f, (flux_free_f) flux_future_destroy);
 
     if (flux_future_get (f, &result) < 0)
-        flux_future_fulfill_error (next, errno);
+        flux_future_fulfill_error (next, errno, NULL);
     else
         flux_future_fulfill (next, result, NULL);
 }
@@ -288,7 +288,7 @@ error:
      *  and pass the error up the chain to cf->next, since that is likely the
      *  future which has callbacks registered on it.
      */
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
     fulfill_next (f, cf->next);
 }
 
@@ -370,7 +370,7 @@ void flux_future_continue_error (flux_future_t *prev, int errnum)
 {
     struct chained_future *cf = chained_future_get (prev);
     if (cf && cf->next)
-        flux_future_fulfill_error (cf->next, errnum);
+        flux_future_fulfill_error (cf->next, errnum, NULL);
 }
 
 flux_future_t *flux_future_and_then (flux_future_t *prev,

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -74,6 +74,7 @@ struct flux_future {
     void *init_arg;
     struct now_context *now;
     struct then_context *then;
+    zlist_t *queue;
 };
 
 static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
@@ -213,17 +214,22 @@ static void then_context_clear_timer (struct then_context *then)
         flux_watcher_stop (then->timer);
 }
 
+static void init_result (struct future_result *fs)
+{
+    fs->is_error = false;
+    fs->errnum = 0;
+    fs->errnum_string = NULL;
+    fs->value = NULL;
+    fs->value_free = NULL;
+}
+
 static void clear_result (struct future_result *fs)
 {
     if (fs->value && fs->value_free)
         fs->value_free (fs->value);
-    fs->is_error = false;
-    fs->errnum = 0;
     if (fs->errnum_string)
         free (fs->errnum_string);
-    fs->errnum_string = NULL;
-    fs->value = NULL;
-    fs->value_free = NULL;
+    init_result (fs);
 }
 
 static void set_result_value (struct future_result *fs, void *value,
@@ -249,6 +255,51 @@ static int set_result_errnum (struct future_result *fs, int errnum,
     return 0;
 }
 
+static void move_result (struct future_result *dst, struct future_result *src)
+{
+    dst->is_error = src->is_error;
+    dst->errnum = src->errnum;
+    dst->errnum_string = src->errnum_string;
+    dst->value = src->value;
+    dst->value_free = src->value_free;
+    init_result (src);
+}
+
+static void future_result_destroy (void *data)
+{
+    struct future_result *fs = data;
+    if (fs) {
+        clear_result (fs);
+        free (fs);
+    }
+}
+
+static struct future_result *future_result_value_create (void *value,
+                                                         flux_free_f value_free)
+{
+    struct future_result *fs = calloc (1, sizeof (*fs));
+    if (!fs)
+        return NULL;
+    set_result_value (fs, value, value_free);
+    return fs;
+}
+
+static struct future_result *future_result_errnum_create (int errnum,
+                                                          const char *errstr)
+{
+    struct future_result *fs = calloc (1, sizeof (*fs));
+    if (!fs)
+        return NULL;
+    if (set_result_errnum (fs, errnum, errstr) < 0) {
+        int save_errno = errno;
+        clear_result (fs);
+        free (fs);
+        errno = save_errno;
+        return NULL;
+    }
+    return fs;
+}
+
 /* Destroy a future.
  */
 void flux_future_destroy (flux_future_t *f)
@@ -260,6 +311,7 @@ void flux_future_destroy (flux_future_t *f)
         free (f->fatal_errnum_string);
         now_context_destroy (f->now);
         then_context_destroy (f->then);
+        zlist_destroy (&f->queue);
         free (f);
     }
     errno = saved_errno;
@@ -276,10 +328,22 @@ flux_future_t *flux_future_create (flux_future_init_f cb, void *arg)
     }
     f->init = cb;
     f->init_arg = arg;
+    f->queue = NULL;
     return f;
 error:
     flux_future_destroy (f);
     return NULL;
+}
+
+static void post_fulfill (flux_future_t *f)
+{
+    now_context_clear_timer (f->now);
+    then_context_clear_timer (f->then);
+    if (f->now)
+        flux_reactor_stop (f->now->r);
+    /* in "then" context, the main reactor prepare/check/idle watchers
+     * will run continuation in the next reactor loop for fairness.
+     */
 }
 
 /* Reset (unfulfill) a future.
@@ -291,6 +355,13 @@ void flux_future_reset (flux_future_t *f)
         f->result_valid = false;
         if (f->then)
             then_context_start (f->then);
+        if (f->queue && zlist_size (f->queue) > 0) {
+            struct future_result *fs = zlist_pop (f->queue);
+            move_result (&f->result, fs);
+            f->result_valid = true;
+            future_result_destroy (fs);
+            post_fulfill (f);
+        }
     }
 }
 
@@ -531,15 +602,27 @@ int flux_future_aux_set (flux_future_t *f, const char *name,
     return 0;
 }
 
-static void post_fulfill (flux_future_t *f)
+static void fulfill_internal_error (flux_future_t *f,
+                                    void *result,
+                                    flux_free_f free_fn,
+                                    int errnum)
 {
-    now_context_clear_timer (f->now);
-    then_context_clear_timer (f->then);
-    if (f->now)
-        flux_reactor_stop (f->now->r);
-    /* in "then" context, the main reactor prepare/check/idle watchers
-     * will run continuation in the next reactor loop for fairness.
-     */
+    if (result && free_fn)
+        free_fn (result);
+    flux_future_fatal_error (f, errnum, NULL);
+}
+
+static int queue_result (flux_future_t *f, struct future_result *fs)
+{
+    if (!f->queue) {
+        if (!(f->queue = zlist_new ())) {
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+    zlist_append (f->queue, fs);
+    zlist_freefn (f->queue, fs, future_result_destroy, true);
+    return 0;
 }
 
 void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn)
@@ -547,9 +630,22 @@ void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn)
     if (f) {
         if (f->fatal_errnum_valid)
             return;
-        clear_result (&f->result);
-        set_result_value (&f->result, result, free_fn);
-        f->result_valid = true;
+        if (f->result_valid) {
+            struct future_result *fs;
+            if (!(fs = future_result_value_create (result, free_fn))) {
+                fulfill_internal_error (f, result, free_fn, errno);
+                return;
+            }
+            if (queue_result (f, fs) < 0) {
+                fulfill_internal_error (f, result, free_fn, errno);
+                future_result_destroy (fs);
+                return;
+            }
+        }
+        else {
+            set_result_value (&f->result, result, free_fn);
+            f->result_valid = true;
+        }
         post_fulfill (f);
     }
 }
@@ -560,12 +656,26 @@ void flux_future_fulfill_error (flux_future_t *f, int errnum,
     if (f) {
         if (f->fatal_errnum_valid)
             return;
-        clear_result (&f->result);
-        if (set_result_errnum (&f->result, errnum, errstr) < 0) {
-            flux_future_fatal_error (f, errno, NULL);
-            return;
+        if (f->result_valid) {
+            struct future_result *fs;
+            if (!(fs = future_result_errnum_create (errnum, errstr))) {
+                fulfill_internal_error (f, NULL, NULL, errno);
+                return;
+            }
+            if (queue_result (f, fs) < 0) {
+                fulfill_internal_error (f, NULL, NULL, errno);
+                future_result_destroy (fs);
+                return;
+            }
         }
-        f->result_valid = true;
+        else {
+            clear_result (&f->result);
+            if (set_result_errnum (&f->result, errnum, errstr) < 0) {
+                flux_future_fatal_error (f, errno, NULL);
+                return;
+            }
+            f->result_valid = true;
+        }
         post_fulfill (f);
     }
 }

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -44,9 +44,11 @@ flux_future_t *flux_future_create (flux_future_init_f cb, void *arg);
 int flux_future_get (flux_future_t *f, void *result);
 
 void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn);
-void flux_future_fulfill_error (flux_future_t *f, int errnum);
+void flux_future_fulfill_error (flux_future_t *f, int errnum, const char *errstr);
 
-void flux_future_fatal_error (flux_future_t *f, int errnum);
+void flux_future_fatal_error (flux_future_t *f, int errnum, const char *errstr);
+
+const char *flux_future_error_string (flux_future_t *f);
 
 void flux_future_set_flux (flux_future_t *f, flux_t *h);
 flux_t *flux_future_get_flux (flux_future_t *f);

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -46,6 +46,8 @@ int flux_future_get (flux_future_t *f, void *result);
 void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn);
 void flux_future_fulfill_error (flux_future_t *f, int errnum);
 
+void flux_future_fatal_error (flux_future_t *f, int errnum);
+
 void flux_future_set_flux (flux_future_t *f, flux_t *h);
 flux_t *flux_future_get_flux (flux_future_t *f);
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -186,7 +186,7 @@ static void response_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 error:
     saved_errno = errno;
-    flux_future_fulfill_error (f, saved_errno);
+    flux_future_fulfill_error (f, saved_errno, NULL);
     /* If error response contains an error string payload,
      * save it in the future aux hash.  If unlikely ENOMEM errors occur,
      * silently discard the error string.
@@ -220,7 +220,7 @@ static void initialize_cb (flux_future_t *f, void *arg)
     flux_msg_handler_start (mh);
     return;
 error:
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 
 static flux_future_t *flux_rpc_msg (flux_t *h,

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -144,21 +144,6 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...)
     return rc;
 }
 
-const char *flux_rpc_get_error (flux_future_t *f)
-{
-    int errnum = 0;
-    const char *errstr = NULL;
-
-    if (flux_future_get (f, NULL) < 0) {
-        errnum = errno;
-        errstr = flux_future_error_string (f);
-    }
-    if (errstr)
-        return errstr;
-    else
-        return flux_strerror (errnum);
-}
-
 /* Message handler for response.
  * Parse the response message here so one could call flux_future_get()
  * instead of flux_rpc_get() to test result of RPC with no response payload.

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -28,14 +28,6 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
 
-/* Get a human-readable error message for fulfilled RPC.
- * The result is always a valid string:
- * If the RPC did not fail, flux_strerror (0) is returned.
- * If the RPC failed, but did not include an error message payload,
- * flux_strerror (errnum) is returned.
- */
-const char *flux_rpc_get_error (flux_future_t *f);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -242,7 +242,7 @@ static void test_basic_chained (flux_reactor_t *r)
     ok (!flux_future_is_ready (f3) && !flux_future_is_ready (f2),
         "chained: chained future not yet ready");
 
-    flux_future_fulfill_error (f, 42);
+    flux_future_fulfill_error (f, 42, NULL);
     ok (flux_future_wait_for (f3, 0.1) == 0,
         "chained: flux_future_wait_for step3 returns 0");
     ok (flux_future_get (f3, NULL) < 0 && errno == 42,
@@ -297,7 +297,7 @@ static void test_basic_chained (flux_reactor_t *r)
     ok (!flux_future_is_ready (f3) && !flux_future_is_ready (f2),
         "chained (or-then): chained future not yet ready");
 
-    flux_future_fulfill_error (f, 42);
+    flux_future_fulfill_error (f, 42, NULL);
 
     ok (flux_future_wait_for (f3, 0.1) == 0,
         "chained (or-then): flux_future_wait_for step3 returns 0");
@@ -333,7 +333,7 @@ void timeout_init (flux_future_t *f, void *arg)
     flux_watcher_start (w);
     return;
 error:
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 
 static void flux_future_timeout_clear (flux_future_t *f)

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -238,7 +238,7 @@ void simple_init (flux_future_t *f, void *arg)
     flux_watcher_start (w);
     return;
 error:
-   flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 
 void test_init_now (void)
@@ -347,7 +347,7 @@ void mumble_init (flux_future_t *f, void *arg)
     flux_watcher_start (w);
     return;
 error:
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 
 flux_future_t *mumble_create (void)
@@ -450,7 +450,7 @@ void incept_mumble_contin (flux_future_t *f, void *arg)
         flux_future_fulfill (incept_f, xstrdup ("Blorg"), free);
     return;
 error:
-    flux_future_fulfill_error (incept_f, errno);
+    flux_future_fulfill_error (incept_f, errno, NULL);
 }
 void incept_init (flux_future_t *f, void *arg)
 {
@@ -465,7 +465,7 @@ void incept_init (flux_future_t *f, void *arg)
         goto error;
     return;
 error:
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 flux_future_t *incept_create (void)
 {
@@ -561,7 +561,7 @@ void walk_mumble_contin (flux_future_t *f, void *arg)
     diag ("%s: count=%d", __FUNCTION__, walk->count);
     return;
 error:
-    flux_future_fulfill_error (walk_f, errno);
+    flux_future_fulfill_error (walk_f, errno, NULL);
 }
 void walk_init (flux_future_t *f, void *arg)
 {
@@ -584,7 +584,7 @@ void walk_init (flux_future_t *f, void *arg)
     }
     return;
 error:
-    flux_future_fulfill_error (f, errno);
+    flux_future_fulfill_error (f, errno, NULL);
 }
 flux_future_t *walk_create (int count)
 {
@@ -706,8 +706,8 @@ void test_fatal_error (void)
         BAIL_OUT ("flux_future_create failed");
 
     flux_future_fulfill (f, "Hello", NULL);
-    flux_future_fatal_error (f, EPERM);
-    flux_future_fatal_error (f, ENOENT); /* test EPERM is not overwritten */
+    flux_future_fatal_error (f, EPERM, NULL);
+    flux_future_fatal_error (f, ENOENT, NULL); /* test EPERM is not overwritten */
 
     ok (flux_future_get (f, NULL) < 0
         && errno == EPERM,
@@ -718,9 +718,9 @@ void test_fatal_error (void)
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
 
-    flux_future_fulfill_error (f, EACCES);
-    flux_future_fatal_error (f, EPERM);
-    flux_future_fatal_error (f, ENOENT); /* test EPERM is not overwritten */
+    flux_future_fulfill_error (f, EACCES, NULL);
+    flux_future_fatal_error (f, EPERM, NULL);
+    flux_future_fatal_error (f, ENOENT, NULL); /* test EPERM is not overwritten */
 
     ok (flux_future_get (f, NULL) < 0
         && errno == EPERM,
@@ -731,7 +731,7 @@ void test_fatal_error (void)
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
 
-    flux_future_fatal_error (f, EPERM);
+    flux_future_fatal_error (f, EPERM, NULL);
     flux_future_fulfill (f, "Hello", NULL);
 
     ok (flux_future_get (f, NULL) < 0
@@ -743,12 +743,79 @@ void test_fatal_error (void)
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
 
-    flux_future_fatal_error (f, EPERM);
-    flux_future_fulfill_error (f, EACCES);
+    flux_future_fatal_error (f, EPERM, NULL);
+    flux_future_fulfill_error (f, EACCES, NULL);
 
     ok (flux_future_get (f, NULL) < 0
         && errno == EPERM,
         "flux_future_get returns fatal error EPERM, later fulfillment ignored");
+
+    flux_future_destroy (f);
+}
+
+void test_error_string (void)
+{
+    flux_future_t *f;
+    const char *str;
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fulfill (f, "Hello", NULL);
+
+    ok (flux_future_get (f, NULL) == 0
+        && flux_future_error_string (f) == NULL,
+        "flux_future_error_string returns NULL when future fulfilled");
+
+    flux_future_destroy (f);
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fulfill_error (f, ENOENT, NULL);
+
+    ok (flux_future_get (f, NULL) < 0
+        && errno == ENOENT
+        && flux_future_error_string (f) == NULL,
+        "flux_future_error_string returns NULL when no error string set");
+
+    flux_future_destroy (f);
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fulfill_error (f, ENOENT, "foobar");
+
+    ok (flux_future_get (f, NULL) < 0
+        && errno == ENOENT
+        && (str = flux_future_error_string (f)) != NULL
+        && !strcmp (str, "foobar"),
+        "flux_future_error_string returns correct string when error string set");
+
+    flux_future_destroy (f);
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fatal_error (f, ENOENT, NULL);
+
+    ok (flux_future_get (f, NULL) < 0
+        && errno == ENOENT
+        && flux_future_error_string (f) == NULL,
+        "flux_future_error_string returns NULL when no fatal error string set");
+
+    flux_future_destroy (f);
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fatal_error (f, ENOENT, "boobaz");
+
+    ok (flux_future_get (f, NULL) < 0
+        && errno == ENOENT
+        && (str = flux_future_error_string (f)) != NULL
+        && !strcmp (str, "boobaz"),
+        "flux_future_error_string returns correct fatal error string when error string set");
 
     flux_future_destroy (f);
 }
@@ -771,6 +838,8 @@ int main (int argc, char *argv[])
     test_reset ();
 
     test_fatal_error ();
+
+    test_error_string ();
 
     done_testing();
     return (0);

--- a/t/rpc/rpc.c
+++ b/t/rpc/rpc.c
@@ -256,7 +256,6 @@ void test_error (flux_t *h)
 {
     flux_future_t *f;
     const char *errstr;
-    const char *s;
 
     /* Error response with error message payload.
      */
@@ -272,7 +271,7 @@ void test_error (flux_t *h)
     errno = 0;
     ok (flux_rpc_get (f, NULL) < 0 && errno == 69,
         "flux_rpc_get failed with expected errno");
-    errstr = flux_rpc_get_error (f);
+    errstr = flux_future_error_string (f);
     ok (errstr != NULL && !strcmp (errstr, "Error: Hello world"),
         "flux_rpc_get_error returned expected error string");
     flux_future_destroy (f);
@@ -290,24 +289,9 @@ void test_error (flux_t *h)
     errno = 0;
     ok (flux_rpc_get (f, NULL) < 0 && errno == ENOTDIR,
         "flux_rpc_get failed with expected errno");
-    errstr = flux_rpc_get_error (f);
-    ok (errstr != NULL && !strcmp (errstr, flux_strerror (ENOTDIR)),
-        "flux_rpc_get_error returned canned error string");
-    flux_future_destroy (f);
-
-    /* Success response with payload.
-     * Ensure flux_rpc_get_error() doesn't return the payload!
-     */
-    f = flux_rpc (h, "rpctest.echo", "Nerp", FLUX_NODEID_ANY, 0);
-    ok (f != NULL,
-        "flux_rpc sent request to rpctest.echo");
-    ok (flux_future_get (f, NULL) == 0,
-        "flux_future_get returned success");
-    ok (flux_rpc_get (f, &s) == 0 && s != NULL && !strcmp (s, "Nerp"),
-        "flux_rpc_get worked and retrieved payload");
-    errstr = flux_rpc_get_error (f);
-    ok (errstr != NULL && !strcmp (errstr, flux_strerror (0)),
-        "flux_rpc_get_error returned canned Success string");
+    errstr = flux_future_error_string (f);
+    ok (errstr == NULL,
+        "flux_future_error_string returned NULL, no error string set");
     flux_future_destroy (f);
 }
 


### PR DESCRIPTION
The PR handles the issues discussed in #1589.  A summary.

- Refactor futures so that values (e.g. msgs) and errors are both valid fulfillments (or "results") of a future.
- Support the concept of a "fatal error" in futures, in which such an error takes precedence over any other results in a future.  This is set via the ```flux_future_fatal_error()``` function.  This allows  catastrophic errors to be set and reported to a user.
- Support an optional "error string" in any error fulfilled in a future.  This error string can give additional information to a user on where an error came from.  For example, if an EPROTO error occured, an error string of "client" or "server" could be set to differentiate where it occurred from.  The string can be retrieved with ```flux_future_error_string()```.
  - Due to the "error string" support, remove ```flux_rpc_get_error()```.
- Support a queue in each future that allows multiple "results" to be queued and returned to the user in FIFO order.  This allows multiple messages, errors, etc. to be returned to a user.  The queue implementation also solves any race issues that may occur if the fulfiller of a future is faster than the reader of a future.
