### PR TITLE
flux_future_get: void * -> const void **

### DIFF
--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -14,7 +14,7 @@ SYNOPSIS
 
  typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);
 
- int flux_future_get (flux_future_t *f, void *result);
+ int flux_future_get (flux_future_t *f, const void **result);
 
  int flux_future_then (flux_future_t *f, double timeout,
                        flux_continuation_f cb, void *arg);

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -237,7 +237,7 @@ static void fulfill_next (flux_future_t *f, flux_future_t *next)
      */
     flux_future_aux_set (next, NULL, f, (flux_free_f) flux_future_destroy);
 
-    if (flux_future_get (f, &result) < 0)
+    if (flux_future_get (f, (const void **)&result) < 0)
         flux_future_fulfill_error (next, errno, NULL);
     else
         flux_future_fulfill (next, result, NULL);

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -500,7 +500,7 @@ bool flux_future_is_ready (flux_future_t *f)
 /* Block until future is fulfilled if not already.
  * Then return either result or error depending on how it was fulfilled.
  */
-int flux_future_get (flux_future_t *f, void *result)
+int flux_future_get (flux_future_t *f, const void **result)
 {
     if (flux_future_wait_for (f, -1.0) < 0) // no timeout
         return -1;
@@ -515,7 +515,7 @@ int flux_future_get (flux_future_t *f, void *result)
         }
         else {
             if (result)
-                *(void **)result = f->result.value;
+                (*result) = f->result.value;
         }
     }
     return 0;

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -41,7 +41,7 @@ typedef void (*flux_future_init_f)(flux_future_t *f, void *arg);
 
 flux_future_t *flux_future_create (flux_future_init_f cb, void *arg);
 
-int flux_future_get (flux_future_t *f, void *result);
+int flux_future_get (flux_future_t *f, const void **result);
 
 void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn);
 void flux_future_fulfill_error (flux_future_t *f, int errnum, const char *errstr);

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -95,7 +95,7 @@ int flux_rpc_get (flux_future_t *f, const char **s)
     const flux_msg_t *msg;
     int rc = -1;
 
-    if (flux_future_get (f, &msg) < 0)
+    if (flux_future_get (f, (const void **)&msg) < 0)
         goto done;
     if (flux_response_decode (msg, NULL, s) < 0)
         goto done;
@@ -109,7 +109,7 @@ int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len)
     const flux_msg_t *msg;
     int rc = -1;
 
-    if (flux_future_get (f, &msg) < 0)
+    if (flux_future_get (f, (const void **)&msg) < 0)
         goto done;
     if (flux_response_decode_raw (msg, NULL, data, len) < 0)
         goto done;
@@ -123,7 +123,7 @@ static int flux_rpc_get_vunpack (flux_future_t *f, const char *fmt, va_list ap)
     const flux_msg_t *msg;
     int rc = -1;
 
-    if (flux_future_get (f, &msg) < 0)
+    if (flux_future_get (f, (const void **)&msg) < 0)
         goto done;
     if (flux_msg_vunpack (msg, fmt, ap) < 0)
         goto done;

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -146,10 +146,10 @@ static void test_composite_basic_all (flux_reactor_t *r)
 
 static void step1_or (flux_future_t *f, void *arg)
 {
-    void * result;
+    const void *result;
     char *str = arg;
     /* or_then handler -- future `f` must have been fulfilled with error */
-    ok (flux_future_get (f, &result) < 0,
+    ok (flux_future_get (f, (const void **)&result) < 0,
         "chained: step1 or_then: flux_future_get returns failure");
     strcat (str, "-step1_or");
 
@@ -162,9 +162,9 @@ static void step1_or (flux_future_t *f, void *arg)
 
 static void step2 (flux_future_t *f, void *arg)
 {
-    void * result;
+    const void *result;
     char *str = arg;
-    ok (flux_future_get (f, &result) == 0,
+    ok (flux_future_get (f, (const void **)&result) == 0,
         "chained: step2: flux_future_get returns success");
     strcat (str, "-step2");
     flux_future_t *next = flux_future_create (NULL, NULL);
@@ -175,9 +175,9 @@ static void step2 (flux_future_t *f, void *arg)
 
 static void step2_err (flux_future_t *f, void *arg)
 {
-    void * result;
+    const void *result;
     char *str = arg;
-    ok (flux_future_get (f, &result) == 0,
+    ok (flux_future_get (f, (const void **)&result) == 0,
         "chained: step2: flux_future_get returns success");
     strcat (str, "-step2_err");
     flux_future_continue_error (f, 123);
@@ -186,9 +186,9 @@ static void step2_err (flux_future_t *f, void *arg)
 
 static void step3 (flux_future_t *f2, void *arg)
 {
-    void * result;
+    const void *result;
     char *str = arg;
-    ok (flux_future_get (f2, &result) == 0,
+    ok (flux_future_get (f2, (const void **)&result) == 0,
         "chained: step3: flux_future_get returns success");
     strcat (str, "-step3");
     flux_future_t *next = flux_future_create (NULL, NULL);
@@ -472,12 +472,12 @@ void f_strdup_init (flux_future_t *f, void *arg)
 
 void f_strcat (flux_future_t *prev, void *arg)
 {
-    char *result = NULL;
+    const char *result = NULL;
     char *next = NULL;
     char *append = arg;
     flux_future_t *f;
 
-    ok (flux_future_get (prev, (void *)&result) == 0,
+    ok (flux_future_get (prev, (const void **)&result) == 0,
         "flux_future_get (prev) worked");
     if (asprintf (&next, "%s%s", result, append) < 0)
         BAIL_OUT ("f_strcat: asprintf: %s", strerror (errno));
@@ -491,11 +491,11 @@ void f_strcat (flux_future_t *prev, void *arg)
 
 void chained_async_cb (flux_future_t *f, void *arg)
 {
-    char *result;
+    const char *result;
     const char *expected = arg;
     ok (flux_future_is_ready (f),
         "chained_async_cb: future is ready");
-    ok (flux_future_get (f, (void *) &result) == 0,
+    ok (flux_future_get (f, (const void **) &result) == 0,
         "chained_async_cb: flux_future_get worked");
     is (result, expected,
         "chained_async_cb: got expected result");

--- a/src/common/libkvs/kvs_watch.c
+++ b/src/common/libkvs/kvs_watch.c
@@ -323,7 +323,7 @@ static int kvs_watch_rpc_get_matchtag (flux_future_t *f, uint32_t *matchtag)
     uint32_t tag;
     const flux_msg_t *msg;
 
-    if (flux_future_get (f, &msg) < 0)
+    if (flux_future_get (f, (const void **)&msg) < 0)
         return -1;
     if (flux_msg_get_matchtag (msg, &tag) < 0)
         return -1;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -574,7 +574,7 @@ static void cmb_exec_cb (flux_future_t *f, void *arg)
     flux_t *h = flux_future_get_flux (f);
     struct wreck_job *job = arg;
 
-    if (flux_future_get (f, &msg) < 0) {
+    if (flux_future_get (f, (const void **)&msg) < 0) {
         flux_log_error (h, "cmb_exec_cb: flux_future_get");
         flux_future_destroy (f);
         return;


### PR DESCRIPTION
Per #1602, replace ```void *``` parameter with ```const void **``` parameter, so code is consistent to changes done in #1144 and #1212.

I was in the area of this code in PR #1610 and just decided to fix it.  This PR follows PR #1610 and should be merged after it.