### PR TITLE
pmi: async kvs_get support for simple PMI server

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -386,13 +386,12 @@ int pmi_kvs_put (void *arg, const char *kvsname,
     return 0;
 }
 
-int pmi_kvs_get (void *arg, const char *kvsname,
-                 const char *key, char *val, int len)
+int pmi_kvs_get (void *arg, void *client, const char *kvsname,
+                 const char *key)
 {
     char *v = zhash_lookup (ctx.pmi.kvs, key);
-    if (!v || strlen (v) >= len)
-        return -1;
-    strcpy (val, v);
+    if (pmi_simple_server_kvs_get_complete (ctx.pmi.srv, client, v) < 0)
+        log_err_exit ("pmi_simple_server_kvs_get_complete");
     return 0;
 }
 

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -21,8 +21,7 @@ struct pmi_simple_server;
 struct pmi_simple_ops {
     int (*kvs_put)(void *arg, const char *kvsname,
                    const char *key, const char *val);
-    int (*kvs_get)(void *arg, const char *kvsname,
-                   const char *key, char *val, int len);
+    int (*kvs_get)(void *arg, void *cli, const char *kvsname, const char *key);
     int (*barrier_enter)(void *arg);
     int (*response_send)(void *client, const char *buf);
     void (*debug_trace)(void *client, const char *buf);
@@ -53,6 +52,11 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
 /* Finalize a barrier.  Set rc to 0 for success, -1 for failure.
  */
 int pmi_simple_server_barrier_complete (struct pmi_simple_server *pmi, int rc);
+
+/* Finalize a kvs_get.
+ */
+int pmi_simple_server_kvs_get_complete (struct pmi_simple_server *pmi,
+                                        void *client, const char *val);
 
 #endif /* ! _FLUX_CORE_PMI_SIMPLE_SERVER_H */
 

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -35,19 +35,14 @@ static int s_kvs_put (void *arg, const char *kvsname, const char *key,
     return rc;
 }
 
-static int s_kvs_get (void *arg, const char *kvsname, const char *key,
-                 char *val, int len)
+static int s_kvs_get (void *arg, void *client,
+                      const char *kvsname, const char *key)
 {
     diag ("%s: %s::%s", __FUNCTION__, kvsname, key);
     struct context *ctx = arg;
     char *v = zhash_lookup (ctx->kvs, key);
-    int rc = -1;
-
-    if (v && strlen (v) < len) {
-        strcpy (val, v);
-        rc = 0;
-    }
-    return rc;
+    pmi_simple_server_kvs_get_complete (ctx->pmi, client, v);
+    return 0;
 }
 
 static int s_send_response (void *client, const char *buf)


### PR DESCRIPTION
As discussed in #1606, split the simple PMI kvs_get operation into  `kvs_get` and `kvs_get_complete` calls so that an implementation may utilize asynchronous calls when available.

Switch all call sites to the new kvs_get prototype, and use async version in wrexexcd's implementation to (hopefully) mitigate serialization when wrexecd is managing many local tasks.

Fixes #1609