### PR TITLE
modules/job: Fix fallthrough error case bug

### DIFF
--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -584,6 +584,7 @@ static void cmb_exec_cb (flux_future_t *f, void *arg)
                               "status", &status, "pid", &pid) < 0) {
         flux_log_error (h, "cmb_exec_cb: flux_msg_unpack");
         flux_future_destroy (f);
+        return;
     }
 
     if (type && strcmp (type, "io") == 0)


### PR DESCRIPTION
Simple fallthrough bug I found.  By not returning on error, the code continued on in the "good path".