### PR TITLE
kvs: add kvs-watch module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,7 @@ AC_CONFIG_FILES( \
   src/modules/Makefile \
   src/modules/connector-local/Makefile \
   src/modules/kvs/Makefile \
+  src/modules/kvs-watch/Makefile \
   src/modules/content-sqlite/Makefile \
   src/modules/barrier/Makefile \
   src/modules/wreck/Makefile \

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -157,6 +157,13 @@ of synchronization between peers is:  node A puts a value, commits it,
 reads version, sends version to node B.  Node B waits for version, gets
 value.
 
+*getroot* [-w] [-c count] [-s | -o | -b]::
+Retrieve the current KVS root, displaying it as an RFC 11 dirref object.
+If '-b' is specified, display it as a blobref.  If '-o' is specified,
+display the namespace owner.  If '-s' is specified, display the root
+sequence number.  If '-w' is specified, display the current root,
+then a new value each time it is updated, up to 'count', if specified.
+
 
 AUTHOR
 ------

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -51,6 +51,7 @@ MAN3_FILES_PRIMARY = \
 	flux_kvs_namespace_create.3 \
 	flux_kvs_namespace_list.3 \
 	flux_kvs_set_namespace.3 \
+	flux_kvs_getroot.3 \
 	idset_create.3
 
 # These files are generated as roff .so includes of a primary page.
@@ -156,6 +157,11 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_lookup_get_dir.3 \
 	flux_kvs_lookup_get_treeobj.3 \
 	flux_kvs_lookup_get_symlink.3 \
+	flux_kvs_getroot_get_treeobj.3 \
+	flux_kvs_getroot_get_blobref.3 \
+	flux_kvs_getroot_get_sequence.3 \
+	flux_kvs_getroot_get_owner.3 \
+	flux_kvs_getroot_cancel.3 \
 	flux_kvs_fence.3 \
 	flux_kvs_txn_destroy.3 \
 	flux_kvs_txn_put.3 \
@@ -286,6 +292,11 @@ flux_kvs_lookup_get_raw.3: flux_kvs_lookup.3
 flux_kvs_lookup_get_dir.3: flux_kvs_lookup.3
 flux_kvs_lookup_treeobj.3: flux_kvs_lookup.3
 flux_kvs_lookup_symlink.3: flux_kvs_lookup.3
+flux_kvs_getroot_get_treeobj.3: flux_kvs_getroot.3
+flux_kvs_getroot_get_blobref.3: flux_kvs_getroot.3
+flux_kvs_getroot_get_sequence.3: flux_kvs_getroot.3
+flux_kvs_getroot_get_owner.3: flux_kvs_getroot.3
+flux_kvs_getroot_cancel.3: flux_kvs_getroot.3
 flux_kvs_fence.3: flux_kvs_commit.3
 flux_kvs_txn_destroy.3: flux_kvs_txn_create.3
 flux_kvs_txn_put.3: flux_kvs_txn_create.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -284,7 +284,6 @@ flux_rpc_raw.3: flux_rpc.3
 flux_rpc_get.3: flux_rpc.3
 flux_rpc_get_unpack.3: flux_rpc.3
 flux_rpc_get_raw.3: flux_rpc.3
-flux_rpc_get_error.3: flux_rpc.3
 flux_kvs_lookupat.3: flux_kvs_lookup.3
 flux_kvs_lookup_get.3: flux_kvs_lookup.3
 flux_kvs_lookup_get_unpack.3: flux_kvs_lookup.3

--- a/doc/man3/flux_kvs_getroot.adoc
+++ b/doc/man3/flux_kvs_getroot.adoc
@@ -1,0 +1,125 @@
+flux_kvs_getroot(3)
+===================
+:doctype: manpage
+
+
+NAME
+----
+flux_kvs_getroot, flux_kvs_getroot_get_treeobj, flux_kvs_getroot_get_blobref, flux_kvs_getroot_get_sequence, flux_kvs_getroot_get_owner, flux_kvs_getroot_cancel - look up KVS root hash
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_kvs_getroot (flux_t *h,
+                                  const char *ns,
+                                  int flags);
+
+ int flux_kvs_getroot_get_treeobj (flux_future_t *f,
+                                   const char **treeobj);
+
+ int flux_kvs_getroot_get_blobref (flux_future_t *f,
+                                   const char **blobref);
+
+ int flux_kvs_getroot_get_sequence (flux_future_t *f,
+                                    int *seq);
+
+ int flux_kvs_getroot_get_owner (flux_future_t *f,
+                                 uint32_t *owner);
+
+ int flux_kvs_getroot_cancel (flux_future_t *f);
+
+
+DESCRIPTION
+-----------
+
+`flux_kvs_getroot()` sends a request via handle _h_ to the `kvs` or `kvs-watch`
+service to look up the current root hash for namespace _ns_.  A `flux_future_t`
+object is returned, which acts as handle for synchronization and container
+for the response.  _flags_ modifies the request as described below.
+
+Upon future fulfillment, these functions can decode the result:
+
+`flux_kvs_getroot_get_treeobj()` obtains the root hash in the form
+of an RFC 11 _dirref_ treeobj, suitable to be passed to `flux_kvs_lookupat(3)`.
+
+`flux_kvs_getroot_get_blobref()` obtains the RFC 10 blobref, suitable to
+be passed to `flux_content_load(3)`.
+
+`flux_kvs_getroot_get_sequence()` retrieves the monotonic sequence number
+for the root.
+
+`flux_kvs_getroot_get_owner()` retrieves the namespace owner.
+
+If the `FLUX_KVS_WATCH` flag is used, the current root is returned immediately.
+Thereafter, a new response is returned each time the root is updated.
+`flux_future_reset()` must be called after each response to destroy the
+current result value and re-arm the future.  The stream of responses may
+be stopped at any time with `flux_kvs_getroot_cancel()`, after which
+the caller should wait for the future to be fulfilled with an ENODATA error.
+After an error, the future may be safely destroyed.
+
+
+FLAGS
+-----
+
+The following are valid bits in the _flags_ mask passed as an argument
+to `flux_kvs_lookup()`:
+
+FLUX_KVS_WATCH::
+The current root is returned immediately.  Thereafter, a new response is
+returned each time the root is updated, as described above.
+
+
+RETURN VALUE
+------------
+
+`flux_kvs_getroot()` returns a `flux_future_t` on success, or NULL on
+failure with errno set appropriately.
+
+The other functions return zero on success, or -1 on failure with errno
+set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+One of the arguments was invalid.
+
+ENOMEM::
+Out of memory.
+
+EPROTO::
+A request was malformed.
+
+ENOSYS::
+The kvs or kvs-watch module is not loaded.
+
+EPERM::
+The requesting user is not permitted to access the requested namespace.
+
+ENODATA::
+A stream of responses has been terminated by a call to
+`flux_kvs_getroot_cancel()`.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_kvs_lookup (3), flux_future_get (3), flux_content_load (3).

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -5,7 +5,7 @@ flux_rpc(3)
 
 NAME
 ----
-flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw, flux_rpc_get_error - perform a remote procedure call to a Flux service
+flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw - perform a remote procedure call to a Flux service
 
 
 SYNOPSIS

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -442,3 +442,5 @@ epilog
 gpubind
 gpus
 fulfillments
+enodata
+getroot

--- a/etc/rc1
+++ b/etc/rc1
@@ -6,6 +6,7 @@ flux module load -r all barrier
 flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
+flux module load -r all kvs-watch
 flux module load -r all aggregator
 
 flux module load -r all resource-hwloc & pids="$pids $!"

--- a/etc/rc3
+++ b/etc/rc3
@@ -22,6 +22,7 @@ flux module remove -r 0 cron
 flux module remove -r all job
 flux module remove -r all resource-hwloc
 flux module remove -r all aggregator
+flux module remove -r all kvs-watch
 flux module remove -r all kvs
 flux module remove -r all barrier
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -324,6 +324,12 @@ flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
     return f;
 }
 
+uint32_t flux_rpc_get_matchtag (flux_future_t *f)
+{
+    struct flux_rpc *rpc = flux_future_aux_get (f, "flux::rpc");
+    return rpc ? rpc->matchtag : FLUX_MATCHTAG_NONE;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -28,6 +28,10 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
 
+/* Accessor for RPC matchtag (see RFC 6).
+ */
+uint32_t flux_rpc_get_matchtag (flux_future_t *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -14,6 +14,7 @@ noinst_LTLIBRARIES = libkvs.la
 libkvs_la_SOURCES = \
 	kvs.c \
 	kvs_lookup.c \
+	kvs_getroot.c \
 	kvs_dir.c \
 	kvs_dir_private.h \
 	kvs_classic.c \
@@ -27,6 +28,7 @@ libkvs_la_SOURCES = \
 fluxcoreinclude_HEADERS = \
 	kvs.h \
 	kvs_lookup.h \
+	kvs_getroot.h \
 	kvs_dir.h \
 	kvs_watch.h \
 	kvs_classic.h \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -42,6 +42,7 @@ TESTS = \
 	test_kvs_dir.t \
 	test_kvs_commit.t \
 	test_kvs_watch.t \
+	test_kvs_getroot.t \
 	test_treeobj.t
 
 check_PROGRAMS = \
@@ -88,6 +89,10 @@ test_kvs_commit_t_LDADD = $(test_ldadd) $(LIBDL)
 test_kvs_watch_t_SOURCES = test/kvs_watch.c
 test_kvs_watch_t_CPPFLAGS = $(test_cppflags)
 test_kvs_watch_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_kvs_getroot_t_SOURCES = test/kvs_getroot.c
+test_kvs_getroot_t_CPPFLAGS = $(test_cppflags)
+test_kvs_getroot_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_treeobj_t_SOURCES = test/treeobj.c
 test_treeobj_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -5,6 +5,7 @@
 
 #include "kvs_dir.h"
 #include "kvs_lookup.h"
+#include "kvs_getroot.h"
 #include "kvs_classic.h"
 #include "kvs_watch.h"
 #include "kvs_txn.h"

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -19,6 +19,7 @@ extern "C" {
 enum kvs_op {
     FLUX_KVS_READDIR = 1,
     FLUX_KVS_READLINK = 2,
+    FLUX_KVS_WATCH = 4,
     FLUX_KVS_TREEOBJ = 16,
     FLUX_KVS_APPEND = 32,
 };

--- a/src/common/libkvs/kvs_getroot.c
+++ b/src/common/libkvs/kvs_getroot.c
@@ -1,0 +1,220 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "kvs_getroot.h"
+#include "treeobj.h"
+
+static const char *auxkey = "flux::getroot_ctx";
+
+struct getroot_ctx {
+    int rootseq;        /* seq no of cached treeobj */
+    char *treeobj;      /* cached treeobj */
+    int flags;          /* original flux_kvs_getroot() flags */
+};
+
+static void free_ctx (struct getroot_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        free (ctx->treeobj);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct getroot_ctx *alloc_ctx (void)
+{
+    struct getroot_ctx *ctx;
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    return ctx;
+}
+
+static int validate_getroot_flags (int flags)
+{
+    switch (flags) {
+        case 0:
+        case FLUX_KVS_WATCH:
+            return 0;
+        default:
+            return -1;
+    }
+}
+
+flux_future_t *flux_kvs_getroot (flux_t *h, const char *namespace, int flags)
+{
+    flux_future_t *f;
+    const char *topic = "kvs.getroot";
+    struct getroot_ctx *ctx;
+
+    if (!h || validate_getroot_flags (flags) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ctx = alloc_ctx ()))
+        return NULL;
+    ctx->flags = flags;
+    if ((flags & FLUX_KVS_WATCH)) {
+        topic = "kvs-watch.getroot";
+        flags &= ~(FLUX_KVS_WATCH);
+    }
+    if (!namespace && !(namespace = flux_kvs_get_namespace (h)))
+        goto error;
+    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0, "{s:s}",
+                             "namespace", namespace)))
+        goto error;
+    if (flux_future_aux_set (f, auxkey, ctx, (flux_free_f)free_ctx) < 0)
+        goto error_future;
+    return f;
+
+error_future:
+    flux_future_destroy (f);
+error:
+    free_ctx (ctx);
+    return NULL;
+}
+
+static int decode_response (flux_future_t *f, const char **rootrefp,
+                            int *rootseqp, uint32_t *ownerp)
+{
+    const char *rootref;
+    int rootseq;
+    int owner;
+    int flags;
+
+    if (flux_rpc_get_unpack (f, "{s:s s:i s:i s:i}",
+                             "rootref", &rootref,
+                             "rootseq", &rootseq,
+                             "owner", &owner,
+                             "flags", &flags) < 0)
+        return -1;
+    if (rootrefp)
+        *rootrefp = rootref;
+    if (rootseqp)
+        *rootseqp = rootseq;
+    if (ownerp)
+        *ownerp = (uint32_t)owner;
+    return 0;
+}
+
+int flux_kvs_getroot_get_blobref (flux_future_t *f, const char **blobref)
+{
+    if (!f || !blobref) {
+        errno = EINVAL;
+        return -1;
+    }
+    return decode_response (f, blobref, NULL, NULL);
+}
+
+int flux_kvs_getroot_get_sequence (flux_future_t *f, int *rootseq)
+{
+    if (!f || !rootseq) {
+        errno = EINVAL;
+        return -1;
+    }
+    return decode_response (f, NULL, rootseq, NULL);
+}
+
+int flux_kvs_getroot_get_owner (flux_future_t *f, uint32_t *owner)
+{
+    if (!f || !owner) {
+        errno = EINVAL;
+        return -1;
+    }
+    return decode_response (f, NULL, NULL, owner);
+}
+
+/* Use cached value of ctx->treeobj, unless stored response no longer
+ * contains ctx->rootseq.
+ */
+int flux_kvs_getroot_get_treeobj (flux_future_t *f, const char **treeobj)
+{
+    struct getroot_ctx *ctx;
+    int rootseq;
+    const char *rootref;
+
+    if (!f || !treeobj) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((!(ctx = flux_future_aux_get (f, auxkey)))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (decode_response (f, &rootref, &rootseq, NULL) < 0)
+        return -1;
+    if (!ctx->treeobj || ctx->rootseq != rootseq) {
+        json_t *o;
+        if (!(o = treeobj_create_dirref (rootref)))
+            return -1;
+        free (ctx->treeobj);
+        if (!(ctx->treeobj = treeobj_encode (o))) {
+            json_decref (o);
+            errno = ENOMEM;
+            return -1;
+        }
+        json_decref (o);
+        ctx->rootseq = rootseq;
+    }
+    *treeobj = ctx->treeobj;
+    return 0;
+}
+
+/* This only applies with FLUX_KVS_WATCH.
+ * Causes a stream of getroot responses to end with an ENODATA response.
+ */
+int flux_kvs_getroot_cancel (flux_future_t *f)
+{
+    struct getroot_ctx *ctx;
+    flux_future_t *f2;
+
+    if (!f || !(ctx = flux_future_aux_get (f, auxkey))
+           || !(ctx->flags & FLUX_KVS_WATCH)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f2 = flux_rpc_pack (flux_future_get_flux (f),
+                              "kvs-watch.cancel",
+                              FLUX_NODEID_ANY,
+                              FLUX_RPC_NORESPONSE,
+                              "{s:i}",
+                              "matchtag", (int)flux_rpc_get_matchtag (f))))
+        return -1;
+    flux_future_destroy (f2);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/kvs_getroot.h
+++ b/src/common/libkvs/kvs_getroot.h
@@ -1,0 +1,42 @@
+#ifndef _FLUX_CORE_KVS_GETROOT_H
+#define _FLUX_CORE_KVS_GETROOT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Request the current KVS root hash for namespace 'ns'.
+ * If flags = FLUX_KVS_WATCH, a response is sent each time the root
+ * hash changes.  In that case, the user must call flux_future_reset()
+ * after consuming the response to re-arm the future for the next response.
+ */
+flux_future_t *flux_kvs_getroot (flux_t *h, const char *ns, int flags);
+
+/* Decode KVS root hash response.
+ *
+ * treeobj - get the hash as an RFC 11 "dirref" object.
+ * blobref - get the raw hash as a n RFC 10 "blobref".
+ * sequence - get the commit sequence number
+ * owner - get the userid of the namespace owner
+ */
+int flux_kvs_getroot_get_treeobj (flux_future_t *f, const char **treeobj);
+int flux_kvs_getroot_get_blobref (flux_future_t *f, const char **blobref);
+int flux_kvs_getroot_get_sequence (flux_future_t *f, int *seq);
+int flux_kvs_getroot_get_owner (flux_future_t *f, uint32_t *owner);
+
+/* Cancel a FLUX_KVS_WATCH "stream".
+ * Once the cancel request is processed, an ENODATA error response is sent,
+ * thus the user should continue to reset and consume responses until an
+ * error occurs, after which it is safe to destroy the future.
+ */
+int flux_kvs_getroot_cancel (flux_future_t *f);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_KVS_GETROOT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/test/kvs_getroot.c
+++ b/src/common/libkvs/test/kvs_getroot.c
@@ -1,0 +1,82 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libflux/flux.h"
+#include "kvs_getroot.h"
+#include "src/common/libtap/tap.h"
+
+void errors (void)
+{
+    flux_t *h = (flux_t *)(uintptr_t)42; // fake but non-NULL
+    flux_future_t *f;
+    const char *s;
+    int i;
+    uint32_t u32;
+
+    /* check simple error cases */
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    errno = 0;
+    ok (flux_kvs_getroot (NULL, "foo", 0) == NULL && errno == EINVAL,
+        "flux_kvs_getroot h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot (h, "foo", 0xff) == NULL && errno == EINVAL,
+        "flux_kvs_getroot flags=(inval) fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_blobref (NULL, &s) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_blobref f=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_blobref (f, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_blobref blobref=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_sequence (NULL, &i) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_sequence f=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_sequence (f, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_sequence sequence=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_owner (NULL, &u32) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_owner f=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_owner (f, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_owner owner=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_treeobj (NULL, &s) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_treeobj f=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_treeobj (f, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_treeobj treeobj=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_get_treeobj (f, &s) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_get_treeobj f=(non-getroot) fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_cancel (NULL) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_cancel f=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_getroot_cancel (f) < 0 && errno == EINVAL,
+        "flux_kvs_getroot_cancel f=(non-getroot) fails with EINVAL");
+
+    flux_future_destroy (f);
+}
+
+int main (int argc, char *argv[])
+{
+
+    plan (NO_PLAN);
+
+    errors ();
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS = \
  barrier \
  connector-local \
  kvs \
+ kvs-watch \
  content-sqlite \
  wreck \
  resource-hwloc \

--- a/src/modules/kvs-watch/Makefile.am
+++ b/src/modules/kvs-watch/Makefile.am
@@ -1,0 +1,24 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+
+fluxmod_LTLIBRARIES = kvs-watch.la
+
+kvs_watch_la_SOURCES = \
+	kvs-watch.c
+
+
+kvs_watch_la_LDFLAGS = $(fluxmod_ldflags) -module
+kvs_watch_la_LIBADD = $(fluxmod_libadd) \
+	$(top_builddir)/src/common/libkvs/libkvs.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS)

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -1,0 +1,658 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* kvs-watcher - track KVS changes */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/blobref.h"
+
+/* State for one getroot watcher.
+ */
+struct watcher {
+    flux_msg_t *request;        // getroot request message
+    int rootseq;                // last root sequence number sent
+    bool auth;                  // true if authorized to watch namespace
+    bool cancelled;             // true if watcher has been cancelled
+    bool mute;                  // true if response should be suppressed
+};
+
+/* Current KVS root.
+ */
+struct commit {
+    char *rootref;              // current root blobref
+    int rootseq;                // current root sequence number
+    json_t *keys;               // keys changed by commit
+};                              //  (empty if data originates from getroot RPC)
+
+/* State for monitoring a KVS namespace.
+ */
+struct namespace {
+    char *name;                 // namespace name, hash key for ctx->namespaces
+    uint32_t owner;             // namespace owner (userid)
+    struct commit *commit;      // current commit data
+    int errnum;                 // if non-zero, error pending for all watchers
+    struct watch_ctx *ctx;      // back-pointer to watch_ctx
+    zlist_t *watchers;          // list of watchers of this namespace
+    char *topic;                // topic string for setroot subscription
+    bool subscribed;            // setroot (ns->topic) subscription active
+};
+
+/* Module state.
+ */
+struct watch_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    zhash_t *namespaces;        // hash of monitored namespaces
+    int subscriptions;          // count of setroot subscrpitions
+};
+
+
+static void watcher_destroy (struct watcher *w)
+{
+    if (w) {
+        int saved_errno = errno;
+        flux_msg_destroy (w->request);
+        free (w);
+        errno = saved_errno;
+    }
+}
+
+static struct watcher *watcher_create (const flux_msg_t *msg)
+{
+    struct watcher *w;
+
+    if (!(w = calloc (1, sizeof (*w))))
+        return NULL;
+    if (!(w->request = flux_msg_copy (msg, true))) {
+        watcher_destroy (w);
+        return NULL;
+    }
+    w->rootseq = -1;
+    return w;
+}
+
+static void commit_destroy (struct commit *commit)
+{
+    if (commit) {
+        int saved_errno = errno;
+        free (commit->rootref);
+        if (commit->keys)
+            json_decref (commit->keys);
+        free (commit);
+        errno = saved_errno;
+    }
+}
+
+static struct commit *commit_create (const char *rootref, int rootseq,
+                                     json_t *keys)
+{
+    struct commit *commit = calloc (1, sizeof (*commit));
+    if (!commit)
+        return NULL;
+    if (!(commit->rootref = strdup (rootref))) {
+        commit_destroy (commit);
+        return NULL;
+    }
+    commit->keys = json_incref (keys);
+    commit->rootseq = rootseq;
+    return commit;
+}
+
+static void namespace_destroy (struct namespace *ns)
+{
+    if (ns) {
+        int saved_errno = errno;
+        commit_destroy (ns->commit);
+        if (ns->watchers) {
+            struct watcher *w;
+            while ((w = zlist_pop (ns->watchers)))
+                watcher_destroy (w);
+            zlist_destroy (&ns->watchers);
+        }
+        if (ns->subscribed) {
+            (void)flux_event_unsubscribe (ns->ctx->h, ns->topic);
+            if (--(ns->ctx->subscriptions) == 0)
+                (void)flux_event_unsubscribe (ns->ctx->h,
+                                              "kvs.namespace-remove");
+        }
+        free (ns->topic);
+        free (ns->name);
+        free (ns);
+        errno = saved_errno;
+    }
+}
+
+static struct namespace *namespace_create (struct watch_ctx *ctx,
+                                           const char *namespace)
+{
+    struct namespace *ns = calloc (1, sizeof (*ns));
+    if (!ns)
+        return NULL;
+    if (!(ns->watchers = zlist_new ()))
+        goto error;
+    if (!(ns->name = strdup (namespace)))
+        goto error;
+    if (asprintf (&ns->topic, "kvs.setroot-%s", namespace) < 0)
+        goto error;
+    ns->owner = FLUX_USERID_UNKNOWN;
+    ns->ctx = ctx;
+    if (flux_event_subscribe (ctx->h, ns->topic) < 0)
+        goto error;
+    ns->subscribed = true;
+    if (ctx->subscriptions++ == 0) {
+        if (flux_event_subscribe (ctx->h, "kvs.namespace-remove") < 0)
+            goto error;
+    }
+    return ns;
+error:
+    namespace_destroy (ns);
+    return NULL;
+}
+
+/* Verify that a getroot request 'msg' is authorized to access 'ns'.
+ * The instance owner or namespace owner are permitted (return 0).
+ * All others are denied (return -1, errno == EPERM).
+ */
+static int authenticate (struct namespace *ns, const flux_msg_t *msg)
+{
+    uint32_t rolemask;
+    uint32_t userid;
+
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+        return -1;
+    if ((rolemask & FLUX_ROLE_OWNER))
+        return 0;
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        return -1;
+    if (ns->owner != FLUX_USERID_UNKNOWN && userid == ns->owner)
+        return 0;
+    errno = EPERM;
+    return -1;
+}
+
+/* Respond to watcher request, if appropriate.
+ * De-list and destroy watcher from namespace on error.
+ * De-hash and destroy namespace if watchers list becomes empty.
+ */
+static void watcher_respond (struct namespace *ns, struct watcher *w)
+{
+    if (w->cancelled) {
+        errno = ENODATA;
+        goto error_respond;
+    }
+    if (ns->errnum != 0) {
+        errno = ns->errnum;
+        goto error_respond;
+    }
+    if (ns->commit && ns->commit->rootseq > w->rootseq) {
+        if (!w->auth && authenticate (ns, w->request) < 0) {
+            flux_log (ns->ctx->h, LOG_DEBUG, "%s: auth failure", __FUNCTION__);
+            goto error_respond;
+        }
+        w->auth = true;
+        if (!w->mute) {
+            if (flux_respond_pack (ns->ctx->h, w->request, "{s:s s:i s:i s:i}",
+                                   "rootref", ns->commit->rootref,
+                                   "rootseq", ns->commit->rootseq,
+                                   "owner", ns->owner,
+                                   "flags", 0) < 0) {
+                flux_log_error (ns->ctx->h, "%s: flux_respond", __FUNCTION__);
+                goto error;
+            }
+        }
+        w->rootseq = ns->commit->rootseq;
+    }
+    return;
+error_respond:
+    if (!w->mute) {
+        if (flux_respond_error (ns->ctx->h, w->request, errno, NULL) < 0)
+            flux_log_error (ns->ctx->h, "%s: flux_respond_error", __FUNCTION__);
+    }
+error:
+    zlist_remove (ns->watchers, w);
+    watcher_destroy (w);
+    if (zlist_size (ns->watchers) == 0)
+        zhash_delete (ns->ctx->namespaces, ns->name);
+}
+
+/* Respond to all watchers for a namespace, as appropriate.
+ * See watcher_respond().
+ */
+static void watcher_respond_ns (struct namespace *ns)
+{
+    zlist_t *l;
+    struct watcher *w;
+
+    if ((l = zlist_dup (ns->watchers))) {
+        w = zlist_first (l);
+        while (w) {
+            watcher_respond (ns, w);
+            w = zlist_next (l);
+        }
+        zlist_destroy (&l);
+    }
+    else
+        flux_log_error (ns->ctx->h, "%s: zlist_dup", __FUNCTION__);
+}
+
+/* Cancel this watcher 'w' if it matches (sender, matchtag).
+ * matchtag=FLUX_MATCHTAG_NONE matches any matchtag.
+ * If 'mute' is true, suppress response.
+ */
+static void watcher_cancel (struct namespace *ns, struct watcher *w,
+                            const char *sender, uint32_t matchtag,
+                            bool mute)
+{
+    uint32_t t;
+    char *s;
+
+    if (matchtag != FLUX_MATCHTAG_NONE
+            && (flux_msg_get_matchtag (w->request, &t) < 0 || matchtag != t))
+        return;
+    if (flux_msg_get_route_first (w->request, &s) < 0)
+        return;
+    if (!strcmp (sender, s)) {
+        w->cancelled = true;
+        w->mute = mute;
+        watcher_respond (ns, w);
+    }
+    free (s);
+}
+
+/* Cancel all namespace watchers that match (sender, matchtag).
+ * If 'mute' is true, suppress response.
+ */
+static void watcher_cancel_ns (struct namespace *ns,
+                               const char *sender, uint32_t matchtag,
+                               bool mute)
+{
+    zlist_t *l;
+    struct watcher *w;
+
+    if ((l = zlist_dup (ns->watchers))) {
+        w = zlist_first (l);
+        while (w) {
+            watcher_cancel (ns, w, sender, matchtag, mute);
+            w = zlist_next (l);
+        }
+        zlist_destroy (&l);
+    }
+    else
+        flux_log_error (ns->ctx->h, "%s: zlist_dup", __FUNCTION__);
+}
+
+/* Cancel all watchers that match (sender, matchtag).
+ * If 'mute' is true, suppress response.
+ */
+static void watcher_cancel_all (struct watch_ctx *ctx,
+                                const char *sender, uint32_t matchtag,
+                                bool mute)
+{
+    zlist_t *l;
+    char *name;
+    struct namespace *ns;
+
+    if ((l = zhash_keys (ctx->namespaces))) {
+        name = zlist_first (l);
+        while (name) {
+            ns = zhash_lookup (ctx->namespaces, name);
+            watcher_cancel_ns (ns, sender, matchtag, mute);
+            name = zlist_next (l);
+        }
+        zlist_destroy (&l);
+    }
+    else
+        flux_log_error (ctx->h, "%s: zhash_keys", __FUNCTION__);
+}
+
+/* kvs.namespace-remove event
+ * A namespace has been removed.  All watchers should receive ENODATA.
+ */
+static void remove_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct watch_ctx *ctx = arg;
+    const char *namespace;
+    struct namespace *ns;
+
+    if (flux_event_unpack (msg, NULL, "{s:s}", "namespace", &namespace) < 0) {
+        flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
+        return;
+    }
+    if ((ns = zhash_lookup (ctx->namespaces, namespace))) {
+        ns->errnum = ENODATA;
+        watcher_respond_ns (ns);
+    }
+}
+
+/* kvs.setroot event
+ * Update namespace with new commit info.
+ * Subscribe/unsubscribe is tied to 'struct namespace' create/destroy.
+ */
+static void setroot_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct watch_ctx *ctx = arg;
+    struct namespace *ns;
+    const char *namespace;
+    int rootseq;
+    const char *rootref;
+    int owner;
+    json_t *keys;
+    struct commit *commit;
+
+    if (flux_event_unpack (msg, NULL, "{s:s s:i s:s s:i s:o}",
+                           "namespace", &namespace,
+                           "rootseq", &rootseq,
+                           "rootref", &rootref,
+                           "owner", &owner,
+                           "keys", &keys) < 0) {
+        flux_log_error (h, "%s: flux_event_decode", __FUNCTION__);
+        return;
+    }
+    if (!(ns = zhash_lookup (ctx->namespaces, namespace))
+            || (ns->commit && rootseq <= ns->commit->rootseq))
+        return;
+    if (!(commit = commit_create (rootref, rootseq, keys))) {
+        flux_log_error (h, "%s: error creating commit", __FUNCTION__);
+        ns->errnum = errno;
+        goto done;;
+    }
+    commit_destroy (ns->commit);
+    ns->commit = commit;
+    if (ns->owner == FLUX_USERID_UNKNOWN)
+        ns->owner = owner;
+done:
+    watcher_respond_ns (ns);
+}
+
+/* kvs.getroot response
+ * Discard result if namespace has already begun receiving setroot events.
+ * N.B. commit->keys is empty in this case, in contrast setroot_cb().
+ */
+static void getroot_continuation (flux_future_t *f, void *arg)
+{
+    struct namespace *ns = arg;
+    const char *rootref;
+    int rootseq;
+    uint32_t owner;
+    struct commit *commit;
+
+    if (ns->commit) {
+        flux_future_destroy (f);
+        return;
+    }
+    if (flux_kvs_getroot_get_sequence (f, &rootseq) < 0
+            || flux_kvs_getroot_get_blobref (f, &rootref) < 0
+            || flux_kvs_getroot_get_owner (f, &owner) < 0) {
+        flux_log_error (ns->ctx->h, "%s: kvs_getroot", __FUNCTION__);
+        ns->errnum = errno;
+        goto done;
+    }
+    if (!(commit = commit_create (rootref, rootseq, NULL))) {
+        flux_log_error (ns->ctx->h, "%s: commit_create", __FUNCTION__);
+        ns->errnum = errno;
+        goto done;
+    }
+    ns->commit = commit;
+    ns->owner = owner;
+done:
+    watcher_respond_ns (ns);
+    flux_future_destroy (f);
+}
+
+/* kvs-watch.getroot request
+ */
+static void getroot_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct watch_ctx *ctx = arg;
+    const char *namespace;
+    struct watcher *w;
+    struct namespace *ns;
+    flux_future_t *f;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "namespace", &namespace) < 0)
+        goto error;
+    /* Create 'ns' if not already monitoring this namespace, and
+     * send a getroot RPC to the kvs so first response need not wait
+     * for the next commit to occur in the arbitrarily distant future.
+     */
+    if (!(ns = zhash_lookup (ctx->namespaces, namespace))) {
+        if (!(ns = namespace_create (ctx, namespace)))
+            goto error;
+        if (zhash_insert (ctx->namespaces, namespace, ns) < 0) {
+            namespace_destroy (ns);
+            goto error;
+        }
+        zhash_freefn (ctx->namespaces, namespace,
+                      (zhash_free_fn *)namespace_destroy);
+        if (!(f = flux_kvs_getroot (ctx->h, namespace, 0))) {
+            zhash_delete (ctx->namespaces, namespace);
+            goto error;
+        }
+        if (flux_future_then (f, -1., getroot_continuation, ns) < 0) {
+            zhash_delete (ctx->namespaces, namespace);
+            goto error;
+        }
+    }
+    /* Thread a new watcher 'w' onto ns->watchers.
+     * If there is already a commit result available, send first response now,
+     * otherwise response will be sent upon getroot RPC response
+     * or setroot event.
+     */
+    if (!(w = watcher_create (msg)))
+        goto error;
+    if (zlist_append (ns->watchers, w) < 0) {
+        watcher_destroy (w);
+        errno = ENOMEM;
+        goto error;
+    }
+    if (ns->commit)
+        watcher_respond (ns, w);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* kvs-watch.cancel request
+ * The user called flux_kvs_getroot_cancel() which expects no response.
+ * The enclosed matchtag and the cancel sender are used to find the
+ * watcher that is to be cancelled.  The watcher will receive an ENODATA
+ * response message.
+ */
+static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct watch_ctx *ctx = arg;
+    uint32_t matchtag;
+    char *sender;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    watcher_cancel_all (ctx, sender, matchtag, false);
+    free (sender);
+}
+
+/* kvs-watch.disconnect request
+ * This is sent automatically upon local connector disconnect.
+ * The disconnect sender is used to find any watchers to be cancelled.
+ */
+static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
+                           const flux_msg_t *msg, void *arg)
+{
+    struct watch_ctx *ctx = arg;
+    char *sender;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        flux_log_error (h, "%s: flux_request_decode", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    watcher_cancel_all (ctx, sender, FLUX_MATCHTAG_NONE, true);
+    free (sender);
+}
+
+/* kvs-watch.stats.get request
+ */
+static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct watch_ctx *ctx = arg;
+    struct namespace *ns;
+    json_t *stats;
+    int watchers = 0;
+
+    if (!(stats = json_object()))
+        goto nomem;
+    ns = zhash_first (ctx->namespaces);
+    while (ns) {
+        json_t *o = json_pack ("{s:i s:i s:s s:i}",
+                               "owner", (int)ns->owner,
+                               "rootseq", ns->commit ? ns->commit->rootseq
+                                                     : -1,
+                               "rootref", ns->commit ? ns->commit->rootref
+                                                     : "(null)",
+                               "watchers", (int)zlist_size (ns->watchers));
+        if (!o)
+            goto nomem;
+        if (json_object_set_new (stats, ns->name, o) < 0) {
+            json_decref (o);
+            goto nomem;
+        }
+        watchers += zlist_size (ns->watchers);
+        ns = zhash_next (ctx->namespaces);
+    }
+    if (flux_respond_pack (h, msg, "{s:i s:i s:O}",
+                           "watchers", watchers,
+                           "namespace-count", (int)zhash_size (ctx->namespaces),
+                           "namespaces", stats) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    json_decref (stats);
+    return;
+nomem:
+    if (flux_respond_error (h, msg, ENOMEM, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    json_decref (stats);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { .typemask     = FLUX_MSGTYPE_EVENT,
+      .topic_glob   = "kvs.namespace-remove",
+      .cb           = remove_cb,
+      .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_EVENT,
+      .topic_glob   = "kvs.setroot-*",
+      .cb           = setroot_cb,
+      .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "kvs-watch.stats.get",
+      .cb           = stats_cb,
+      .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "kvs-watch.getroot",
+      .cb           = getroot_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "kvs-watch.cancel",
+      .cb           = cancel_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "kvs-watch.disconnect",
+      .cb           = disconnect_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void watch_ctx_destroy (struct watch_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        zhash_destroy (&ctx->namespaces);
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct watch_ctx *watch_ctx_create (flux_t *h)
+{
+    struct watch_ctx *ctx = calloc (1, sizeof (*ctx));
+    if (!ctx)
+        return NULL;
+    ctx->h = h;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (!(ctx->namespaces = zhash_new ()))
+        goto error;
+    return ctx;
+error:
+    watch_ctx_destroy (ctx);
+    return NULL;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct watch_ctx *ctx;
+    int rc = -1;
+
+    if (!(ctx = watch_ctx_create (h))) {
+        flux_log_error (h, "initialization error");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    watch_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("kvs-watch");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -837,13 +837,15 @@ static int setroot_event_send (kvs_ctx_t *ctx, struct kvsroot *root,
         goto done;
     }
 
-    if (!(msg = flux_event_pack (setroot_topic, "{ s:s s:i s:s s:O s:O s:O}",
+    if (!(msg = flux_event_pack (setroot_topic,
+                                 "{ s:s s:i s:s s:O s:O s:O s:i}",
                                  "namespace", root->namespace,
                                  "rootseq", root->seq,
                                  "rootref", root->ref,
                                  "names", names,
                                  "rootdir", root_dir,
-                                 "keys", keys))) {
+                                 "keys", keys,
+                                 "owner", root->owner))) {
         saved_errno = errno;
         flux_log_error (ctx->h, "%s: flux_event_pack", __FUNCTION__);
         goto done;

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -48,6 +48,7 @@ int kvstxn_set_aux_errnum (kvstxn_t *kt, int errnum);
 bool kvstxn_fallback_mergeable (kvstxn_t *kt);
 
 json_t *kvstxn_get_ops (kvstxn_t *kt);
+json_t *kvstxn_get_keys (kvstxn_t *kt);
 json_t *kvstxn_get_names (kvstxn_t *kt);
 int kvstxn_get_flags (kvstxn_t *kt);
 

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -215,9 +215,10 @@ void basic_kvstxn_mgr_tests (void)
                                          0)) != NULL,
          "kvsroot_mgr_create_root works");
 
-    ops = json_array ();
-    /* not a real operation */
-    json_array_append_new (ops, json_string ("foo"));
+    ops = json_pack ("[{s:s s:i s:n}]",
+                     "key", "a.b.c",
+                     "flags", 0,
+                     "dirent");
 
     ok (kvstxn_mgr_add_transaction (root->ktm,
                                     "foo",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
 	t1003-kvs-stress.t \
 	t1004-kvs-namespace.t \
 	t1005-kvs-security.t \
+	t1006-kvs-getroot.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -146,6 +147,7 @@ check_SCRIPTS = \
 	t1003-kvs-stress.t \
 	t1004-kvs-namespace.t \
 	t1005-kvs-security.t \
+	t1006-kvs-getroot.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/rc/rc1-kvs
+++ b/t/rc/rc1-kvs
@@ -3,3 +3,4 @@
 flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
+flux module load -r all kvs-watch

--- a/t/rc/rc1-wreck
+++ b/t/rc/rc1-wreck
@@ -5,6 +5,7 @@ pids=""
 flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
+flux module load -r all kvs-watch
 
 flux module load -r all barrier
 flux module load -r all aggregator

--- a/t/rc/rc3-kvs
+++ b/t/rc/rc3-kvs
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+flux module remove -r all kvs-watch
 flux module remove -r all -x 0 kvs
 flux module remove -r 0 kvs
 flux module remove -r 0  content-sqlite

--- a/t/rc/rc3-wreck
+++ b/t/rc/rc3-wreck
@@ -4,6 +4,7 @@ flux module remove -r all job
 flux module remove -r all aggregator
 flux module remove -r all barrier
 
+flux module remove -r all kvs-watch
 flux module remove -r all -x 0 kvs
 flux module remove -r 0 kvs
 flux module remove -r 0  content-sqlite

--- a/t/t1006-kvs-getroot.t
+++ b/t/t1006-kvs-getroot.t
@@ -1,0 +1,156 @@
+#!/bin/sh
+
+test_description='Test KVS getroot [--watch]'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 kvs
+
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+test_expect_success 'flux kvs getroot returns valid dirref object' '
+	flux kvs put test.a=42 &&
+	DIRREF=$(flux kvs getroot) &&
+	flux kvs put test.a=43 &&
+	flux kvs get --at "$DIRREF" test.a >get.out &&
+	echo 42 >get.exp &&
+	test_cmp get.exp get.out
+'
+
+test_expect_success 'flux kvs getroot --blobref returns valid blobref' '
+	BLOBREF=$(flux kvs getroot --blobref) &&
+	flux content load $BLOBREF >/dev/null
+'
+
+test_expect_success 'flux kvs getroot --watch --count=1 --blobref also works' '
+	BLOBREF=$(flux kvs getroot --watch --count=1 --blobref) &&
+	flux content load $BLOBREF >/dev/null
+'
+
+test_expect_success 'flux kvs getroot --sequence returns increasing rootseq' '
+	SEQ=$(flux kvs getroot --sequence) &&
+	flux kvs put test.b=hello &&
+	SEQ2=$(flux kvs getroot --sequence) &&
+	test $SEQ -lt $SEQ2
+'
+
+test_expect_success 'flux kvs getroot --owner returns instance owner' '
+	OWNER=$(flux kvs getroot --owner) &&
+	test $OWNER -eq $(id -u)
+'
+
+test_expect_success 'flux kvs getroot works on alt namespace' '
+	flux kvs namespace-create testns1 &&
+	SEQ=$(flux kvs --namespace=testns1 getroot --sequence) &&
+	test $SEQ -eq 0 &&
+	flux kvs --namespace=testns1 put test.c=moop &&
+	SEQ2=$(flux kvs --namespace=testns1 getroot --sequence) &&
+	test $SEQ -lt $SEQ2 &&
+	flux kvs namespace-remove testns1
+'
+
+# Check that stdin contains an integer on each line that
+# is one more than the integer on the previous line.
+test_monotonicity() {
+	local item
+	local prev=0
+	while read item; do
+		test $prev -gt 0 && test $item -ne $(($prev+1)) && return 1
+		prev=$item
+	done
+	return 0
+}
+
+test_expect_success NO_CHAIN_LINT 'flux kvs getroot --watch yields monotonic sequence' '
+	flux kvs getroot --watch --count=20 --sequence >seq.out &
+	pid=$! &&
+	for i in $(seq 1 20); \
+	    do flux kvs put --no-merge test.c=$i; \
+	done &&
+	$waitfile --count=20 --timeout=10 --pattern="[0-9]+" seq.out &&
+	wait $pid &&
+	test_monotonicity <seq.out
+'
+
+test_expect_success 'kvs-watch stats reports no watchers when there are no watchers' '
+	count=$(flux module stats --parse=watchers kvs-watch) &&
+	test $count -eq 0
+'
+
+test_expect_success 'kvs-watch stats reports no namespaces when there are no watchers' '
+	count=$(flux module stats --parse=namespace-count kvs-watch) &&
+	test $count -eq 0
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs-watch stats reports active watcher' '
+	flux kvs getroot --watch --count=2 --sequence >seq2.out &
+	pid=$! &&
+	$waitfile --count=1 --timeout=10 --pattern="[0-9]+" seq2.out &&
+	count=$(flux module stats --parse=watchers kvs-watch) &&
+	test $count -eq 1 &&
+	count=$(flux module stats --parse=namespace-count kvs-watch) &&
+	test $count -eq 1 &&
+	flux kvs put --no-merge test.d=foo &&
+	wait $pid
+'
+
+test_expect_success NO_CHAIN_LINT 'kvs-watch namespace removal terminates stream' '
+	flux kvs namespace-create meep &&
+	flux kvs --namespace=meep getroot --watch >seq3.out &
+	pid=$! &&
+	$waitfile --timeout=10 seq3.out &&
+	flux kvs namespace-remove meep &&
+	wait $pid
+'
+
+# Security checks
+
+test_expect_success 'flux kvs getroot [--watch] denies guest access to primary ns' '
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
+		flux kvs getroot &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
+		flux kvs getroot --watch --count=1
+'
+
+test_expect_success 'flux kvs getroot [--watch] allows owner userid' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+		flux kvs getroot &&
+	FLUX_HANDLE_ROLEMASK=0x2 \
+		flux kvs getroot --watch --count=1
+'
+
+test_expect_success 'flux kvs getroot [--watch] allows FLUX_ROLE_OWNER' '
+	FLUX_HANDLE_ROLEMASK=0x1 FLUX_HANDLE_USERID=9999 \
+		flux kvs getroot &&
+	FLUX_HANDLE_ROLEMASK=0x1 FLUX_HANDLE_USERID=9999 \
+		flux kvs getroot --watch --count=1
+'
+
+test_expect_success 'flux kvs getroot [--watch] allows guest access to its ns' '
+	flux kvs namespace-create --owner=9999 testns2 &&
+	FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
+		flux kvs --namespace=testns2 getroot &&
+	FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
+		flux kvs --namespace=testns2 getroot --watch --count=1 &&
+	flux kvs namespace-remove testns2
+'
+
+test_expect_success 'flux kvs getroot [--watch] denies guest access to anothers ns' '
+	flux kvs namespace-create --owner=9999 testns3 &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9998 \
+		flux kvs --namespace=testns3 getroot &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9998 \
+		flux kvs --namespace=testns3 getroot --watch --count=1 &&
+	flux kvs namespace-remove testns3
+'
+
+test_expect_success 'flux kvs getroot [--watch] allows owner access to guest ns' '
+	flux kvs namespace-create --owner=9999 testns4 &&
+	FLUX_HANDLE_ROLEMASK=0x1 FLUX_HANDLE_USERID=9998 \
+		flux kvs --namespace=testns4 getroot &&
+	FLUX_HANDLE_ROLEMASK=0x1 FLUX_HANDLE_USERID=9998 \
+		flux kvs --namespace=testns4 getroot --watch --count=1 &&
+	flux kvs namespace-remove testns4
+'
+
+test_done


### PR DESCRIPTION
(N.B. just realized I didn't finish reworking commit messages - please hold off on any detailed review)

This PR is a precursor to reworking the KVS watch mechanism.  It adds a new module `kvs-watch` that currently only supports "watching" the root hash of a namespace. (I thought this was complicated enough for a PR, and the generic watch could wait for another PR).

This PR adds the following API:
```c
/* Request the current KVS root hash for namespace 'ns'.
 * If flags = FLUX_KVS_WATCH, a response is sent each time the root
 * hash changes.  In that case, the user must call flux_future_reset()
 * after consuming the response to re-arm the future for the next response.
 */
flux_future_t *flux_kvs_getroot (flux_t *h, const char *ns, int flags);

/* Decode KVS root hash response.
 *
 * treeobj - get the hash as an RFC 11 "dirref" object.
 * blobref - get the raw hash as a n RFC 10 "blobref".
 * sequence - get the commit sequence number
 * owner - get the userid of the namespace owner
 */
int flux_kvs_getroot_get_treeobj (flux_future_t *f, const char **treeobj);
int flux_kvs_getroot_get_blobref (flux_future_t *f, const char **blobref);
int flux_kvs_getroot_get_sequence (flux_future_t *f, int *seq);
int flux_kvs_getroot_get_owner (flux_future_t *f, uint32_t *owner);

/* Cancel a FLUX_KVS_WATCH "stream".
 * Once the cancel request is processed, an ENODATA error response is sent,
 * thus the user should continue to reset and consume responses until an
 * error occurs, after which it is safe to destroy the future.
 */
int flux_kvs_getroot_cancel (flux_future_t *f);
```

My plan for regular watch API is to simply allow the FLUX_KVS_WATCH flag to be passed to `flux_kvs_lookup()`.

I added a new `flux kvs getroot` subcommand, a man page, and a sharness test.

Also, since `flux_kvs_get_version()` is a synchronous RPC interface that accomplishes the same thing as `flux_kvs_getroot()` + `flux_kvs_getroot_get_sequence()`, and had no users except tests, I went ahead and eliminated the former and also the `flux kvs version` subcommand, and updated tests accordingly.