### PR TITLE
test: fix off by one bug in t2000-wreck.t cpu-affinity=per-task test

### DIFF
--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -232,7 +232,7 @@ test_expect_success 'wreckrun: job with more nodes than tasks fails' '
 	test "$(flux kvs get --json ${LWJ}.state)" = "failed"
 '
 cpus_allowed=${SHARNESS_TEST_SRCDIR}/scripts/cpus-allowed.lua
-if test $($cpus_allowed count) -gt 0; then
+if test $($cpus_allowed count) -gt 1; then
     test_set_prereq MULTICORE
     # Note: Normalize format of cpu0 thread siblings using cpus-allowed script
     #  so that comparison of output works in MULTICORE tests below


### PR DESCRIPTION
Problem:  the wreck cpu-affinity=per-task test
fails on systems with only one CPU.

The MULTICORE prereq is set if "scripts/cpus-allowed.lua
count" -gt 0.  It should be -gt 1.

Fixes #1635