### PR TITLE
Fix GCC 8 output truncation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - compiler: clang
       env: LUA_VERSION=5.1 CPPCHECK=t ARGS="--with-flux-security --with-pmix --enable-sanitizer" CC=clang-3.8 CXX=clang++-3.8
     - compiler: gcc
-      env: LUA_VERSION=5.2 CC=gcc-4.9 ARGS="--with-flux-security --with-pmix" chain_lint=t
+      env: LUA_VERSION=5.2 CC=gcc-8 CXX=g++-8 ARGS="--with-flux-security --with-pmix" chain_lint=t
     - compiler: clang
       env: LUA_VERSION=5.2 ARGS="--with-flux-security --with-pmix --enable-caliper" CC=clang-3.8 CXX=clang++-3.8
       
@@ -35,8 +35,8 @@ addons:
       - cmake
       - cmake-data
       - clang-3.8
-      - gcc-4.9
-      - g++-4.9
+      - gcc-8
+      - g++-8
       - libmunge-dev
       - uuid-dev
       - aspell

--- a/src/common/libflux/test/security.c
+++ b/src/common/libflux/test/security.c
@@ -444,7 +444,10 @@ void test_curve (void)
     zcert_apply (rogue_cert, rogue);
     /* read server public key from file */
     char server_file[PATH_MAX];
-    snprintf (server_file, sizeof (server_file), "%s/curve/server", path);
+    int n;
+    n = snprintf (server_file, sizeof (server_file), "%s/curve/server", path);
+    if ((n < 0) || (n >= sizeof (server_file)))
+        BAIL_OUT ("snprintf failed in creation of server_file");
     zcert_t *server_cert = zcert_load (server_file);
     if (!server_cert)
         BAIL_OUT ("zcert_load %s: %s", server_file, zmq_strerror (errno));

--- a/src/common/libutil/macros.h
+++ b/src/common/libutil/macros.h
@@ -3,5 +3,6 @@
 
 #define REAL_STRINGIFY(X) #X
 #define STRINGIFY(X) REAL_STRINGIFY (X)
+#define SIZEOF_FIELD(type, field) sizeof (((type *)0)->field)
 
 #endif

--- a/src/common/libutil/test/cf.c
+++ b/src/common/libutil/test/cf.c
@@ -424,6 +424,7 @@ void test_update_file (void)
 void test_update_glob (void)
 {
     int rc;
+    int len;
     const char *tmpdir = getenv ("TMPDIR");
     char dir[PATH_MAX + 1];
     char path1[PATH_MAX + 1];
@@ -448,7 +449,9 @@ void test_update_glob (void)
     if (!(cf = cf_create ()))
         BAIL_OUT ("cf_create: %s", strerror (errno));
 
-    snprintf (p, sizeof (p), "%s/*.toml", dir);
+    len = snprintf (p, sizeof (p), "%s/*.toml", dir);
+    if ((len < 0) || (len >= sizeof (p)))
+        BAIL_OUT ("snprintf failed in creating toml file path");
 
     ok (cf_update_glob (cf, p, &error) == 3, 
         "cf_update_glob successfully parsed 3 files");

--- a/src/common/libutil/test/cleanup.c
+++ b/src/common/libutil/test/cleanup.c
@@ -18,18 +18,22 @@ int main(int argc, char** argv)
     char dir[PATH_MAX];
     char dir2[PATH_MAX];
     struct stat sb;
-    int fd;
+    int fd, len;
 
     plan (NO_PLAN);
 
     /* Independent file and dir
      */
-    snprintf (file, sizeof (file), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    len = snprintf (file, sizeof (file), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (file)))
+        BAIL_OUT ("snprintf failed creating tmp file path");
     if (!(fd = mkstemp (file)))
         BAIL_OUT ("could not create tmp file");
     close (fd);
 
-    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    len = snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (dir)))
+        BAIL_OUT ("snprintf failed creating tmp directory");
     if (!mkdtemp (dir))
         BAIL_OUT ("could not create tmp directory");
 
@@ -43,11 +47,15 @@ int main(int argc, char** argv)
 
     /* This time put file inside directory
      */
-    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    len = snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (dir)))
+        BAIL_OUT ("snprintf failed creating tmp directory");
     if (!mkdtemp (dir))
         BAIL_OUT ("could not create tmp directory");
 
-    snprintf (file, sizeof (file), "%s/file", dir);
+    len = snprintf (file, sizeof (file), "%s/file", dir);
+    if ((len < 0) || (len >= sizeof (file)))
+        BAIL_OUT ("snprintf failed creating tmp file path");
     if (!(fd = open (file, O_CREAT, 0644)))
         BAIL_OUT ("could not create tmp file");
     close (fd);
@@ -62,11 +70,15 @@ int main(int argc, char** argv)
 
     /* Same but reverse push order
      */
-    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    len = snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (dir)))
+        BAIL_OUT ("snprintf failed creating tmp directory");
     if (!mkdtemp (dir))
         BAIL_OUT ("could not create tmp directory");
 
-    snprintf (file, sizeof (file), "%s/file", dir);
+    len = snprintf (file, sizeof (file), "%s/file", dir);
+    if ((len < 0) || (len >= sizeof (file)))
+        BAIL_OUT ("snprintf failed creating tmp file path");
     if (!(fd = open (file, O_CREAT, 0644)))
         BAIL_OUT ("could not create tmp file");
     close (fd);
@@ -83,11 +95,15 @@ int main(int argc, char** argv)
 
     /* Same but recursive removal
      */
-    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    len = snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (dir)))
+        BAIL_OUT ("snprintf failed creating tmp directory");
     if (!mkdtemp (dir))
         BAIL_OUT ("could not create tmp directory");
 
-    snprintf (file, sizeof (file), "%s/file", dir);
+    len = snprintf (file, sizeof (file), "%s/file", dir);
+    if ((len < 0) || (len >= sizeof (file)))
+        BAIL_OUT ("snprintf failed creating tmp file path");
     if (!(fd = open (file, O_CREAT, 0644)))
         BAIL_OUT ("could not create tmp file");
     close (fd);
@@ -102,14 +118,20 @@ int main(int argc, char** argv)
 
     /* Try couple levels deep
      */
-    snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    len = snprintf (dir, sizeof (dir), "%s/cleanup_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (dir)))
+        BAIL_OUT ("snprintf failed creating tmp dir path");
     if (!mkdtemp (dir))
         BAIL_OUT ("could not create tmp directory");
-    snprintf (dir2, sizeof (dir), "%s/dir", dir);
+    len = snprintf (dir2, sizeof (dir2), "%s/dir", dir);
+    if ((len < 0) || (len >= sizeof (dir2)))
+        BAIL_OUT ("snprintf failed creating tmp dir path");
     if (mkdir (dir2, 0755) < 0)
         BAIL_OUT ("mkdir failed");
 
-    snprintf (file, sizeof (file), "%s/file", dir2);
+    len = snprintf (file, sizeof (file), "%s/file", dir2);
+    if ((len < 0) || (len >= sizeof (file)))
+        BAIL_OUT ("snprintf failed creating tmp file path");
     if (!(fd = open (file, O_CREAT, 0644)))
         BAIL_OUT ("could not create tmp file");
     close (fd);

--- a/src/common/libutil/test/unlink.c
+++ b/src/common/libutil/test/unlink.c
@@ -17,12 +17,12 @@ int main(int argc, char** argv)
     char path2[PATH_MAX];
     int n;
     struct stat sb;
-    int fd;
+    int fd, len;
 
     plan (NO_PLAN);
 
-    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
-    if (!mkdtemp (path))
+    len = snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (path)) || !mkdtemp (path))
         BAIL_OUT ("could not create tmp directory");
 
     n = unlink_recursive (path);
@@ -31,11 +31,11 @@ int main(int argc, char** argv)
         "cleaned up directory containing nothing");
 
 
-    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
-    if (!mkdtemp (path))
+    len = snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (path)) || !mkdtemp (path))
         BAIL_OUT ("could not create tmp directory");
-    snprintf (path2, sizeof (path2), "%s/a", path);
-    if (mkdir (path2, 0777) < 0)
+    len = snprintf (path2, sizeof (path2), "%s/a", path);
+    if ((len < 0) || (len >= sizeof (path2)) || mkdir (path2, 0777) < 0)
         BAIL_OUT ("could not create subdirectory");
     n = unlink_recursive (path);
     errno = 0;
@@ -43,31 +43,34 @@ int main(int argc, char** argv)
         "cleaned up directory containing 1 dir");
 
 
-    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
-    if (!mkdtemp (path))
+    len = snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (path)) || !mkdtemp (path))
         BAIL_OUT ("could not create tmp directory");
-    snprintf (path2, sizeof (path2), "%s/a", path);
-    if (mkdir (path2, 0777) < 0)
+    len = snprintf (path2, sizeof (path2), "%s/a", path);
+    if ((len < 0) || (len >= sizeof (path2)) || mkdir (path2, 0777) < 0)
         BAIL_OUT ("could not create subdirectory");
-    snprintf (path2, sizeof (path2), "%s/b", path);
-    if ((fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
+    len = snprintf (path2, sizeof (path2), "%s/b", path);
+    if ((len < 0) || (len >= sizeof (path2))
+        || (fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
         BAIL_OUT ("could not create subdirectory");
     n = unlink_recursive (path);
     errno = 0;
     ok (n == 3 && stat (path, &sb) < 0 && errno == ENOENT,
         "cleaned up directory containing 1 dir (empty) + 1 file ");
 
-    snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
-    if (!mkdtemp (path))
+    len = snprintf (path, sizeof (path), "%s/unlink_test.XXXXXX", tmp ? tmp : "/tmp");
+    if ((len < 0) || (len >= sizeof (path)) || !mkdtemp (path))
         BAIL_OUT ("could not create tmp directory");
-    snprintf (path2, sizeof (path2), "%s/a", path);
-    if (mkdir (path2, 0777) < 0)
+    len = snprintf (path2, sizeof (path2), "%s/a", path);
+    if ((len < 0) || (len >= sizeof (path2)) || mkdir (path2, 0777) < 0)
         BAIL_OUT ("could not create subdirectory");
-    snprintf (path2, sizeof (path2), "%s/b", path);
-    if ((fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
+    len = snprintf (path2, sizeof (path2), "%s/b", path);
+    if ((len < 0) || (len >= sizeof (path2))
+        || (fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
         BAIL_OUT ("could not create subdirectory");
-    snprintf (path2, sizeof (path2), "%s/a/a", path);
-    if ((fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
+    len = snprintf (path2, sizeof (path2), "%s/a/a", path);
+    if ((len < 0) || (len >= sizeof (path2))
+       || (fd = open (path2, O_CREAT | O_RDWR, 0666)) < 0 || close (fd) < 0)
         BAIL_OUT ("could not create file in subdirectory");
     n = unlink_recursive (path);
     errno = 0;

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -39,6 +39,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/macros.h"
 
 #define CTX_MAGIC   0xf434aaab
 typedef struct {
@@ -258,7 +259,7 @@ static int connect_sock_with_retry (int fd, const char *file, int retries)
 flux_t *connector_init (const char *path, int flags)
 {
     local_ctx_t *c = NULL;
-    char sockfile[PATH_MAX + 1];
+    char sockfile [SIZEOF_FIELD (struct sockaddr_un, sun_path)];
     int n;
     int retries = env_getint ("FLUX_LOCAL_CONNECTOR_RETRY_COUNT", 5);
 

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -44,7 +44,7 @@ declare -A extra_make_opts=(\
 )
 
 declare -A extra_cmake_opts=(\
-["Caliper"]="-DCMAKE_C_COMPILER=/usr/bin/gcc-4.9 -DCMAKE_CXX_COMPILER=g++-4.9"
+["Caliper"]="-DCMAKE_C_COMPILER=/usr/bin/gcc-8 -DCMAKE_CXX_COMPILER=g++-8"
 )
 
 #


### PR DESCRIPTION
This PR fixes the GCC 8 warning mentioned in #1633 by sizing the `sockfile` buffer in `connector_init` to the size of the `addr.sun_path` instead of PATH_MAX+1, since Unix domain socket pathname length would seem to be constrained to the sun_path array size, not PATH_MAX.

Other GCC 8 warnings came from the use of snprintf() in tests where source and destination buffers are the same length.  Checking the return code from snprintf() for truncation suppressed these warnings as suggested by @trws.

I also tried to update the "newer" GCC in travis-ci from 4.9 to 8.1, but ran into an error linking against libjobspec, which I do not pretend to understand:
```
  CXXLD    job-ingest.la
libtool: warning: '/lib64/libmunge.la' seems to be moved
../../../src/common/libjobspec/.libs/libjobspec.a(libjobspec_la-jobspec.o): In function `YAML::Node::Scalar[abi:cxx11]() const [clone .isra.151]':
/usr/include/yaml-cpp/node/impl.h:158: undefined reference to `YAML::detail::node_data::empty_scalar[abi:cxx11]'
../../../src/common/libjobspec/.libs/libjobspec.a(libjobspec_la-jobspec.o): In function `Flux::Jobspec::Jobspec::Jobspec(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)':
/g/g0/grondo/git/flux-core.git/src/common/libjobspec/jobspec.cpp:400: undefined reference to `YAML::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
```
So for now, the GCC8 build adds `--disable-jobspec`

Along the way some other issues popped up and were fixed:
 * In travis-ci the `ARGS` meant to be passed through to `configure` in `make distcheck` were not, so all our builds were using default `./configure`. `DISTCHECK_CONFIGURE_FLAGS=$ARGS` is now used to pass these flags to the inner configure. (oops!)
 * For built dependencies in `travis-dep-builder.sh`, the system compiler was forced by overriding CC=gcc, but this wasn't done for CXX. Fixed.
 * I started hitting #1638 in travis, so that fix was applied to this PR.
