### PR TITLE
kvs: implement lightweight key watch and API

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -68,13 +68,16 @@ Remove a kvs namespace.
 *namespace-list*::
 List all current namespaces and info on each namespace.
 
-*get* [-j|-r|-t] [-a treeobj] 'key' ['key...']::
+*get* [-j|-r|-t] [-a treeobj] [-l] [-w] [-c count] 'key' ['key...']::
 Retrieve the value stored under 'key'.  If nothing has been stored under
 'key', display an error message.  If no options, value is displayed with
-a newline appended (if value length is nonzero).  If '-j', value is
-interpreted as encoded JSON and formatted accordingly.  If '-r', value
-is displayed without a newline.  If '-t', the RFC 11 object is displayed.
-'-a treeobj' causes the lookup to be relative to an RFC 11 snapshot reference.
+a newline appended (if value length is nonzero).  If '-l', a 'key=' prefix is
+added. If '-j', value is interpreted as encoded JSON and formatted accordingly.
+If '-r', value is displayed without a newline.  If '-t', the RFC 11 object
+is displayed.  '-a treeobj' causes the lookup to be relative to an RFC 11
+snapshot reference.  If '-w', after the initial value, display the
+new value each time the key changes until interrupted, or if '-c count'
+is specified, until 'count' values have been displayed.
 
 *put* [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  If it already has a value,

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -147,6 +147,7 @@ MAN3_FILES_SECONDARY = \
 	flux_future_continue_error.3 \
 	flux_rpc_pack.3 \
 	flux_rpc_raw.3 \
+	flux_rpc_message.3 \
 	flux_rpc_get.3 \
 	flux_rpc_get_unpack.3 \
 	flux_rpc_get_raw.3 \
@@ -290,6 +291,7 @@ flux_future_set_flux.3: flux_future_create.3
 flux_future_get_flux.3: flux_future_create.3
 flux_rpc_pack.3: flux_rpc.3
 flux_rpc_raw.3: flux_rpc.3
+flux_rpc_message.3: flux_rpc.3
 flux_rpc_get.3: flux_rpc.3
 flux_rpc_get_unpack.3: flux_rpc.3
 flux_rpc_get_raw.3: flux_rpc.3

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -33,6 +33,8 @@ SYNOPSIS
 
  const char *flux_kvs_lookup_get_key (flux_future_t *f);
 
+ int flux_kvs_lookup_cancel (flux_future_t *f);
+
 
 DESCRIPTION
 -----------
@@ -92,6 +94,10 @@ The result is parsed and symlink target is assigned to _target_.
 `flux_kvs_lookup_get_key()` accesses the key argument from the original
 lookup.
 
+`flux_kvs_lookup_cancel()` cancels a stream of lookup responses requested
+with FLUX_KVS_WATCH (see below).  The future will be fulfilled with
+an ENODATA error once the cancel request is received and processed.
+
 These functions may be used asynchronously.  See `flux_future_then(3)` for
 details.
 
@@ -117,6 +123,14 @@ be converted to a "val" object, and a "dirref" will not be converted
 to a "dir" object.  This is useful for obtaining a snapshot reference
 that can be passed to `flux_kvs_lookupat()`.
 
+FLUX_KVS_WATCH::
+After the initial response, continue to send responses to the lookup
+request each time _key_ is mentioned verbatim in a committed transaction.
+Responses continue until the namespace is removed, the key is removed,
+the lookup is canceled with `flux_kvs_lookup_cancel()`, or an error
+occurs.  `flux_future_reset()` should be used to consume a response
+and prepare for the next one.
+
 
 RETURN VALUE
 ------------
@@ -126,8 +140,9 @@ RETURN VALUE
 
 `flux_kvs_lookup_get()`, `flux_kvs_lookup_get_unpack()`,
 `flux_kvs_lookup_get_raw()`, `flux_kvs_lookup_get_dir()`,
-`flux_kvs_lookup_get_treeobj()`, and `flux_kvs_lookup_get_symlink()`
-return 0 on success, or -1 on failure with errno set appropriately.
+`flux_kvs_lookup_get_treeobj()`, `flux_kvs_lookup_get_symlink()`,
+and `flux_kvs_lookup_cancel()` return 0 on success, or -1 on failure with
+errno set appropriately.
 
 `flux_kvs_lookup_get_key()` returns key on success, or NULL with errno
 set to EINVAL if its future argument did not come from a KVS lookup.
@@ -162,6 +177,15 @@ The KVS module is not loaded.
 
 ENOTSUP::
 An unknown namespace was requested.
+
+ENODATA::
+A stream of responses requested with FLUX_KVS_WATCH was terminated
+with `flux_kvs_lookup_cancel()`.
+
+EPERM::
+The user does not have instance owner capability, and a lookup was attempted
+against a KVS namespace owned by another user.
+
 
 AUTHOR
 ------

--- a/doc/man3/flux_rpc.adoc
+++ b/doc/man3/flux_rpc.adoc
@@ -5,7 +5,7 @@ flux_rpc(3)
 
 NAME
 ----
-flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw - perform a remote procedure call to a Flux service
+flux_rpc, flux_rpc_pack, flux_rpc_raw, flux_rpc_message, flux_rpc_get, flux_rpc_get_unpack, flux_rpc_get_raw - perform a remote procedure call to a Flux service
 
 
 SYNOPSIS
@@ -24,6 +24,10 @@ SYNOPSIS
                               const void *data, int len,
                               uint32_t nodeid, int flags);
 
+ flux_future_t *flux_rpc_message (flux_t *h,
+                                  const flux_msg_t *msg,
+                                  uint32_t nodeid, int flags);
+
  int flux_rpc_get (flux_future_t *f, const char **s);
 
  int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
@@ -41,6 +45,10 @@ via Flux broker handle _h_ to a Flux service identified by _topic_
 and _nodeid_.  A `flux_future_t` object is returned which acts as a handle
 for synchronization and a container for the response message which in
 turn contains the RPC result.
+
+A lower-level variant of `flux_rpc()`, `flux_rpc_message()` accepts a
+pre-created request message, assigning _nodeid_ and matchtag according
+to _flags_.
 
 `flux_future_then(3)` may be used to register a reactor callback
 (continuation) to be called once the response has been received.

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -257,6 +257,29 @@ error:
     return NULL;
 }
 
+flux_future_t *flux_rpc_message (flux_t *h,
+                                 const flux_msg_t *msg,
+                                 uint32_t nodeid,
+                                 int flags)
+{
+    flux_msg_t *cpy;
+    flux_future_t *f;
+
+    if (!h || !msg || (flags != 0 && flags != FLUX_RPC_NORESPONSE)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(cpy = flux_msg_copy (msg, true)))
+        return NULL;
+    if (!(f = flux_rpc_message_nocopy (h, cpy, nodeid, flags)))
+        goto error;
+    flux_msg_destroy (cpy);
+    return f;
+error:
+    flux_msg_destroy (cpy);
+    return NULL;
+}
+
 flux_future_t *flux_rpc (flux_t *h,
                          const char *topic,
                          const char *s,

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -205,10 +205,10 @@ error:
     flux_future_fulfill_error (f, errno, NULL);
 }
 
-static flux_future_t *flux_rpc_msg (flux_t *h,
-                                    uint32_t nodeid,
-                                    int flags,
-                                    flux_msg_t *msg)
+static flux_future_t *flux_rpc_message_nocopy (flux_t *h,
+                                               flux_msg_t *msg,
+                                               uint32_t nodeid,
+                                               int flags)
 {
     struct flux_rpc *rpc = NULL;
     flux_future_t *f;
@@ -267,7 +267,7 @@ flux_future_t *flux_rpc (flux_t *h,
     flux_future_t *f = NULL;
     if (!(msg = flux_request_encode (topic, s)))
         goto done;
-    if (!(f = flux_rpc_msg (h, nodeid, flags, msg)))
+    if (!(f = flux_rpc_message_nocopy (h, msg, nodeid, flags)))
         goto done;
 done:
     flux_msg_destroy (msg);
@@ -286,7 +286,7 @@ flux_future_t *flux_rpc_raw (flux_t *h,
 
     if (!(msg = flux_request_encode_raw (topic, data, len)))
         goto done;
-    if (!(f = flux_rpc_msg (h, nodeid, flags, msg)))
+    if (!(f = flux_rpc_message_nocopy (h, msg, nodeid, flags)))
         goto done;
 done:
     flux_msg_destroy (msg);
@@ -306,7 +306,7 @@ static flux_future_t *flux_rpc_vpack (flux_t *h,
         goto done;
     if (flux_msg_vpack (msg, fmt, ap) < 0)
         goto done;
-    f = flux_rpc_msg (h, nodeid, flags, msg);
+    f = flux_rpc_message_nocopy (h, msg, nodeid, flags);
 done:
     flux_msg_destroy (msg);
     return f;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -22,6 +22,9 @@ flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
                              const void *data, int len,
                              uint32_t nodeid, int flags);
 
+flux_future_t *flux_rpc_message (flux_t *h, const flux_msg_t *msg,
+                                 uint32_t nodeid, int flags);
+
 int flux_rpc_get (flux_future_t *f, const char **s);
 
 int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -197,14 +197,23 @@ static int decode_treeobj (flux_future_t *f, json_t **treeobj)
     return 0;
 }
 
-int flux_kvs_lookup_get (flux_future_t *f, const char **value)
+static struct lookup_ctx *get_lookup_ctx (flux_future_t *f)
 {
     struct lookup_ctx *ctx;
 
     if (!(ctx = flux_future_aux_get (f, auxkey))) {
         errno = EINVAL;
-        return -1;
+        return NULL;
     }
+    return ctx;
+}
+
+int flux_kvs_lookup_get (flux_future_t *f, const char **value)
+{
+    struct lookup_ctx *ctx;
+
+    if (!(ctx = get_lookup_ctx (f)))
+        return -1;
     if (!(ctx->treeobj)) {
         if (decode_treeobj (f, &ctx->treeobj) < 0)
             return -1;
@@ -225,10 +234,8 @@ int flux_kvs_lookup_get_treeobj (flux_future_t *f, const char **treeobj)
 {
     struct lookup_ctx *ctx;
 
-    if (!(ctx = flux_future_aux_get (f, auxkey))) {
-        errno = EINVAL;
+    if (!(ctx = get_lookup_ctx (f)))
         return -1;
-    }
     if (!(ctx->treeobj)) {
         if (decode_treeobj (f, &ctx->treeobj) < 0)
             return -1;
@@ -248,10 +255,8 @@ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...)
     va_list ap;
     int rc;
 
-    if (!(ctx = flux_future_aux_get (f, auxkey))) {
-        errno = EINVAL;
+    if (!(ctx = get_lookup_ctx (f)))
         return -1;
-    }
     if (!(ctx->treeobj)) {
         if (decode_treeobj (f, &ctx->treeobj) < 0)
             return -1;
@@ -281,10 +286,8 @@ int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len)
 {
     struct lookup_ctx *ctx;
 
-    if (!(ctx = flux_future_aux_get (f, auxkey))) {
-        errno = EINVAL;
+    if (!(ctx = get_lookup_ctx (f)))
         return -1;
-    }
     if (!(ctx->treeobj)) {
         if (decode_treeobj (f, &ctx->treeobj) < 0)
             return -1;
@@ -306,10 +309,8 @@ int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dirp)
 {
     struct lookup_ctx *ctx;
 
-    if (!(ctx = flux_future_aux_get (f, auxkey))) {
-        errno = EINVAL;
+    if (!(ctx = get_lookup_ctx (f)))
         return -1;
-    }
     if (!(ctx->treeobj)) {
         if (decode_treeobj (f, &ctx->treeobj) < 0)
             return -1;
@@ -330,10 +331,8 @@ int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target)
     json_t *str;
     const char *s;
 
-    if (!(ctx = flux_future_aux_get (f, auxkey))) {
-        errno = EINVAL;
+    if (!(ctx = get_lookup_ctx (f)))
         return -1;
-    }
     if (!(ctx->treeobj)) {
         if (decode_treeobj (f, &ctx->treeobj) < 0)
             return -1;
@@ -356,10 +355,8 @@ const char *flux_kvs_lookup_get_key (flux_future_t *f)
 {
     struct lookup_ctx *ctx;
 
-    if (!(ctx = flux_future_aux_get (f, auxkey))) {
-        errno = EINVAL;
+    if (!(ctx = get_lookup_ctx (f)))
         return NULL;
-    }
     return ctx->key;
 }
 

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -18,6 +18,13 @@ int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target);
 
 const char *flux_kvs_lookup_get_key (flux_future_t *f);
 
+/* Cancel a FLUX_KVS_WATCH "stream".
+ * Once the cancel request is processed, an ENODATA error response is sent,
+ * thus the user should continue to reset and consume responses until an
+ * error occurs, after which it is safe to destroy the future.
+ */
+int flux_kvs_lookup_cancel (flux_future_t *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libkvs/test/kvs_lookup.c
+++ b/src/common/libkvs/test/kvs_lookup.c
@@ -39,11 +39,21 @@ void errors (void)
     ok (flux_kvs_lookup_get_key (NULL) == NULL && errno == EINVAL,
         "flux_kvs_lookup_get_key future=NULL fails with EINVAL");
 
+    errno = 0;
+    ok (flux_kvs_lookup_cancel (NULL) == -1 && errno == EINVAL,
+        "flux_kvs_lookup_cancel future=NULL fails with EINVAL");
+
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
+
     errno = 0;
     ok (flux_kvs_lookup_get_key (f) == NULL && errno == EINVAL,
         "flux_kvs_lookup_get_key future=(wrong type) fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_lookup_cancel (f) == -1 && errno == EINVAL,
+        "flux_kvs_lookup_cancel future=(wrong type) fails with EINVAL");
+
     flux_future_destroy (f);
 }
 

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -593,7 +593,8 @@ static void getroot_continuation (flux_future_t *f, void *arg)
     if (flux_kvs_getroot_get_sequence (f, &rootseq) < 0
             || flux_kvs_getroot_get_blobref (f, &rootref) < 0
             || flux_kvs_getroot_get_owner (f, &owner) < 0) {
-        flux_log_error (ns->ctx->h, "%s: kvs_getroot", __FUNCTION__);
+        if (errno != ENOTSUP && errno != EPERM)
+            flux_log_error (ns->ctx->h, "%s: kvs_getroot", __FUNCTION__);
         ns->errnum = errno;
         goto done;
     }

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -514,7 +514,7 @@ static void watcher_cancel_all (struct watch_ctx *ctx,
 }
 
 /* kvs.namespace-remove event
- * A namespace has been removed.  All watchers should receive ENODATA.
+ * A namespace has been removed.  All watchers should receive ENOENT.
  */
 static void remove_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
@@ -528,7 +528,7 @@ static void remove_cb (flux_t *h, flux_msg_handler_t *mh,
         return;
     }
     if ((ns = zhash_lookup (ctx->namespaces, namespace))) {
-        ns->errnum = ENODATA;
+        ns->errnum = ENOENT;
         watcher_respond_ns (ns);
     }
 }

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -483,6 +483,25 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+static void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    const char *namespace;
+    const char *key;
+    int flags;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:s s:i}",
+                             "namespace", &namespace,
+                             "key", &key,
+                             "flags", &flags) < 0)
+        goto error;
+    /* FIXME: */
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
 /* kvs-watch.cancel request
  * The user called flux_kvs_getroot_cancel() which expects no response.
  * The enclosed matchtag and the cancel sender are used to find the
@@ -592,6 +611,11 @@ static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "kvs-watch.getroot",
       .cb           = getroot_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "kvs-watch.lookup",
+      .cb           = lookup_cb,
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -226,6 +226,7 @@ check_PROGRAMS = \
 	kvs/transactionmerge \
 	kvs/fence_namespace_remove \
 	kvs/fence_invalid \
+	kvs/commit_order \
 	module/basic \
 	request/treq \
 	barrier/tbarrier \
@@ -372,6 +373,11 @@ kvs_fence_namespace_remove_LDADD = \
 kvs_fence_invalid_SOURCES = kvs/fence_invalid.c
 kvs_fence_invalid_CPPFLAGS = $(test_cppflags)
 kvs_fence_invalid_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_commit_order_SOURCES = kvs/commit_order.c
+kvs_commit_order_CPPFLAGS = $(test_cppflags)
+kvs_commit_order_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 kvs_watch_disconnect_SOURCES = kvs/watch_disconnect.c

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -64,6 +64,7 @@ TESTS = \
 	t1004-kvs-namespace.t \
 	t1005-kvs-security.t \
 	t1006-kvs-getroot.t \
+	t1007-kvs-lookup-watch.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -160,6 +161,7 @@ check_SCRIPTS = \
 	t1004-kvs-namespace.t \
 	t1005-kvs-security.t \
 	t1006-kvs-getroot.t \
+	t1007-kvs-lookup-watch.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/kvs/commit_order.c
+++ b/t/kvs/commit_order.c
@@ -1,0 +1,217 @@
+/* commit_order.c - ensure watch responses are returned in commit order */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <getopt.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+static bool verbose;
+static int totcount = 1000;
+static int max_queue_depth = 16;
+static const char *key;
+
+static int txcount;         // count of commit requests
+static int rxcount;         // count of commit responses
+static int wrxcount;        // count of lookup/watch responses
+static flux_watcher_t *w_prep;
+static flux_watcher_t *w_check;
+static flux_watcher_t *w_idle;
+
+void watch_continuation (flux_future_t *f, void *arg);
+void commit_continuation (flux_future_t *f, void *arg);
+flux_future_t *commit_int (flux_t *h, const char *k, int v);
+void prep (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg);
+void check (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg);
+
+#define OPTIONS "hvc:f:n:"
+static const struct option longopts[] = {
+    {"help",            no_argument,        0, 'h'},
+    {"verbose",         no_argument,     0, 'v'},
+    {"count",           required_argument,  0, 'c'},
+    {"fanout",          required_argument,  0, 'f'},
+    {"namespace",       required_argument,  0, 'n'},
+    { 0, 0, 0, 0 },
+};
+
+void usage (void)
+{
+    fprintf (stderr,
+"Usage: commit_order [--verbose] [--namespace=NAME] [--count=N] [--fanout=N] key\n"
+);
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_reactor_t *r;
+    int last = -1;
+    int ch;
+    char *ns = NULL;
+    flux_future_t *f;
+
+    log_init ("commit_order");
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'h': /* --help */
+                usage ();
+                break;
+            case 'v': /* --verbose */
+                verbose = true;
+                break;
+            case 'c': /* --count N */
+                totcount = strtoul (optarg, NULL, 10);
+                break;
+            case 'f': /* --fanout N */
+                max_queue_depth = strtoul (optarg, NULL, 10);
+                break;
+            case 'n': /* --namespace=NAME */
+                if (!(ns = strdup (optarg)))
+                    log_err_exit ("out of memory");
+                break;
+            default:
+                usage ();
+                break;
+        }
+    }
+    if (optind != argc - 1)
+        usage ();
+    key = argv[optind++];
+    if (totcount < 1 || max_queue_depth < 1)
+        usage ();
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    if (!(r = flux_get_reactor (h)))
+        log_err_exit ("flux_get_reactor");
+    if (ns) {
+        if (flux_kvs_set_namespace (h, ns) < 0)
+            log_err_exit ("flux_kvs_set_namespace");
+    }
+    /* One synchronous put before watch request, so that
+     * watch request doesn't fail with ENOENT.
+     */
+    f = commit_int (h, key, txcount++);
+    commit_continuation (f, NULL); // destroys f, increments rxcount
+
+    /* Configure watcher
+     * Wait for one response before unleashing async puts, to ensure
+     * that first value is captured.
+     */
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_WATCH, key)))
+        log_err_exit ("flux_kvs_lookup");
+    watch_continuation (f, &last); // resets f, increments wrxcount
+    if (flux_future_then (f, -1., watch_continuation, &last) < 0)
+        log_err_exit ("flux_future_then");
+
+    /* Configure mechanism to keep max_queue_depth (--fanout) put RPCs
+     * outstanding until totcount (--count) reached.
+     */
+    if (!(w_prep = flux_prepare_watcher_create (r, prep, NULL)))
+        log_err_exit ("flux_prepare_watcher_create");
+    if (!(w_check = flux_check_watcher_create (r, check, h)))
+        log_err_exit ("flux_check_watcher_create");
+    if (!(w_idle = flux_idle_watcher_create (r, NULL, NULL)))
+        log_err_exit ("flux_idle_watcher_create");
+    flux_watcher_start (w_prep);
+    flux_watcher_start (w_check);
+
+    /* Run until work is exhausted.
+     */
+    if (flux_reactor_run (r, 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    flux_watcher_destroy (w_prep);
+    flux_watcher_destroy (w_check);
+    flux_watcher_destroy (w_idle);
+
+    free (ns);
+    flux_close (h);
+    log_fini ();
+    return 0;
+}
+
+void watch_continuation (flux_future_t *f, void *arg)
+{
+    int *last = arg;
+    int i;
+
+    if (flux_kvs_lookup_get_unpack (f, "i", &i) < 0) {
+        if (errno == ENODATA) {
+            flux_future_destroy (f); // ENODATA (like EOF on response stream)
+            if (verbose)
+                printf ("< ENODATA\n");
+        }
+        else
+            log_err_exit ("flux_lookup_get_unpack");
+        return;
+    }
+    if (verbose)
+        printf ("< %s=%d\n", key, i);
+    if (i != *last + 1)
+        log_msg_exit ("%s: got %d, expected %d", __FUNCTION__, i, *last + 1);
+    if (++wrxcount == totcount)
+        flux_kvs_lookup_cancel (f);
+    *last = i;
+
+    flux_future_reset (f);
+}
+
+void commit_continuation (flux_future_t *f, void *arg)
+{
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_commit");
+    rxcount++;
+
+    flux_future_destroy (f);
+}
+
+flux_future_t *commit_int (flux_t *h, const char *k, int v)
+{
+    flux_kvs_txn_t *txn;
+    flux_future_t *f;
+
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+    if (flux_kvs_txn_pack (txn, 0, k, "i", v) < 0)
+        log_err_exit ("flux_kvs_txn_pack");
+    if (!(f = flux_kvs_commit (h, FLUX_KVS_NO_MERGE, txn)))
+        log_err_exit ("flux_kvs_commit");
+    flux_kvs_txn_destroy (txn);
+    if (verbose)
+        printf("> %s=%d\n", k, v);
+    return f;
+}
+
+void prep (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    if (txcount == totcount) {
+        flux_watcher_stop (w_prep);
+        flux_watcher_stop (w_check);
+    }
+    else if ((txcount - rxcount) < max_queue_depth)
+        flux_watcher_start (w_idle); // keeps loop from blocking
+}
+
+void check (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    flux_t *h = arg;
+
+    flux_watcher_stop (w_idle);
+
+    if (txcount < totcount && (txcount - rxcount) < max_queue_depth) {
+        flux_future_t *f;
+
+        f = commit_int (h, key, txcount++);
+        if (flux_future_then (f, -1.0, commit_continuation, NULL) < 0)
+            log_err_exit ("flux_future_then");
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -976,4 +976,13 @@ test_expect_success NO_CHAIN_LINT 'kvs: version and wait' '
         test_expect_code 0 wait $kvswaitpid
 '
 
+#
+# Other get options
+#
+
+test_expect_success 'kvs: get --label works' '
+	flux kvs put test.ZZZ=42 &&
+	flux kvs get --label test.ZZZ |grep test.ZZZ=42
+'
+
 test_done

--- a/t/t1006-kvs-getroot.t
+++ b/t/t1006-kvs-getroot.t
@@ -100,7 +100,7 @@ test_expect_success NO_CHAIN_LINT 'kvs-watch namespace removal terminates stream
 	pid=$! &&
 	$waitfile --timeout=10 seq3.out &&
 	flux kvs namespace-remove meep &&
-	wait $pid
+	! wait $pid
 '
 
 # Security checks

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -1,0 +1,140 @@
+#!/bin/sh
+
+test_description='Test KVS get --watch'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 kvs
+
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+commit_order=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+test_expect_success 'flux kvs get --watch --count=1 works' '
+	flux kvs put test.a=42 &&
+	run_timeout 2 flux kvs get --watch --count=1 test.a >get.out &&
+	echo 42 >get.exp &&
+	test_cmp get.exp get.out
+'
+
+test_expect_success 'flux kvs get --watch works on alt namespace' '
+	flux kvs namespace-create testns1 &&
+	flux kvs --namespace=testns1 put test.b=foo &&
+	run_timeout 2 flux kvs --namespace=testns1 get --watch --count=1 test.b >getns.out &&
+	echo foo >getns.exp &&
+	test_cmp getns.exp getns.out &&
+	flux kvs namespace-remove testns1
+'
+
+# Check that stdin contains an integer on each line that
+# is one more than the integer on the previous line.
+test_monotonicity() {
+        local item
+        local prev=0
+        while read item; do
+                test $prev -gt 0 && test $item -ne $(($prev+1)) && return 1
+                prev=$item
+        done
+        return 0
+}
+
+test_expect_success NO_CHAIN_LINT 'flux kvs get --watch returns commit order' '
+	flux kvs put test.c=1 &&
+	flux kvs get --watch --count=20 test.c >seq.out &
+	pid=$! &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="[0-9]+" seq.out >/dev/null &&
+	for i in $(seq 2 20); \
+	    do flux kvs put --no-merge test.c=$i; \
+	done &&
+	$waitfile --count=20 --timeout=10 --pattern="[0-9]+" seq.out &&
+	wait $pid &&
+	test_monotonicity <seq.out
+'
+
+test_expect_success 'kvs/commit_order test works (similar to above, with higher concurrency)' '
+	$FLUX_BUILD_DIR/t/kvs/commit_order -f 16 -c 1024 test.d
+'
+
+test_expect_success 'flux kvs get --watch fails on nonexistent key' '
+	test_must_fail flux kvs get --watch --count=1 test.noexist
+'
+
+test_expect_success 'flux kvs get --watch fails on nonexistent namespace' '
+	test_must_fail flux kvs --namespace=noexist \
+		get --watch --count=1 test.noexist
+'
+
+test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by key removal' '
+	flux kvs put test.e=1 &&
+	flux kvs get --watch test.e >seq2.out &
+	pid=$! &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="[0-9]+" seq2.out >/dev/null &&
+	flux kvs unlink test.e &&
+	! wait $pid
+'
+
+test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by namespace removal' '
+	flux kvs namespace-create testns2 &&
+	flux kvs --namespace=testns2 put meep=1 &&
+	flux kvs --namespace=testns2 get --watch meep >seq4.out &
+	pid=$! &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="[0-9]+" seq4.out >/dev/null &&
+	flux kvs namespace-remove testns2 &&
+	! wait $pid
+'
+
+test_expect_success NO_CHAIN_LINT 'flux kvs get --watch sees duplicate commited values' '
+	flux kvs put test.f=1 &&
+
+	flux kvs get --count=20 --watch test.f >seq3.out &
+	pid=$! &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="[0-9]+" seq3.out >/dev/null &&
+	for i in $(seq 2 20); \
+	    do flux kvs put --no-merge test.f=1; \
+	done &&
+	$waitfile --count=20 --timeout=10 --pattern="[0-9]+" seq3.out &&
+	wait $pid
+'
+
+# Security checks
+
+test_expect_success 'flux kvs get --watch denies guest access to primary namespace' '
+	flux kvs put test.g=42 &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
+		flux kvs get --watch --count=1 test.g
+'
+
+test_expect_success 'flux kvs get --watch allows owner userid' '
+	flux kvs put test.h=43 &&
+	FLUX_HANDLE_ROLEMASK=0x2 \
+		flux kvs get --watch --count=1 test.h
+'
+
+test_expect_success 'flux kvs get --watch allows guest access to its ns' '
+	flux kvs namespace-create --owner=9999 testns3 &&
+	flux kvs --namespace=testns3 put test.i=69 &&
+	FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
+		flux kvs --namespace=testns3 get --watch --count=1 test.i &&
+	flux kvs namespace-remove testns3
+'
+
+test_expect_success 'flux kvs get --watch denies guest access to anothers ns' '
+	flux kvs namespace-create --owner=9999 testns4 &&
+	flux kvs --namespace=testns4 put test.j=102 &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9998 \
+		flux kvs --namespace=testns4 get --watch --count=1 test.j &&
+	flux kvs namespace-remove testns4
+'
+
+test_expect_success 'flux kvs get --watch allows owner access to guest ns' '
+	flux kvs namespace-create --owner=9999 testns5 &&
+	flux kvs --namespace=testns5 put test.k=100 &&
+	! FLUX_HANDLE_ROLEMASK=0x1 FLUX_HANDLE_USERID=9998 \
+		flux kvs --namespace=testns4 get --watch --count=1 test.k &&
+	flux kvs namespace-remove testns4
+'
+
+test_done


### PR DESCRIPTION
This PR finishes the alternate KVS watch API, based on passing a FLUX_KVS_WATCH flag to `flux_kvs_lookup()`; and the lightweight `kvs-watch` service, which only checks watched keys when they are mentioned in a commit.   This strategy was discussed in #1556.

N.B. this PR falls short of implementing the "bulk" watch described in #1631 - this is for another PR.

In addition to the API and `kvs-watch` modifications, the `flux kvs get` subcommand now has a `--watch` and related options.

Still TODO:  doc updates and sharness test(s).