### PR TITLE
add support for asciidoctor as manpage generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ python-devel >= 2.7
 python-cffi >= 1.1
 # for man pages
 asciidoc
+# or
+asciidoctor >= 1.5.7
 ```
 
 If you want to build the MPI-based test programs, make sure that

--- a/configure.ac
+++ b/configure.ac
@@ -66,8 +66,10 @@ AC_ARG_ENABLE([docs],
 	      AS_HELP_STRING([--disable-docs], [disable building docs]))
 AS_IF([test "x$enable_docs" != "xno"], [
   AC_CHECK_PROG(A2X,[a2x],[a2x])
+  AC_CHECK_PROG(ADOC,[asciidoctor],[asciidoctor])
 ])
-AM_CONDITIONAL([ENABLE_DOCS], [test "$A2X" = "a2x" ])
+AM_CONDITIONAL([ENABLE_DOCS], [test "$A2X" = "a2x" || test "$ADOC" = "asciidoctor"])
+AM_CONDITIONAL([ENABLE_ADOC], [test "$ADOC" = "asciidoctor"])
 AC_CHECK_PROG(ASPELL,[aspell],[aspell])
 
 ##
@@ -371,7 +373,7 @@ AC_CONFIG_LINKS([ \
 AC_OUTPUT
 
 AS_IF([test "x$enable_docs" != "xno"], [
-  if test "$A2X" != "a2x"; then
+  if test "$A2X" != "a2x" && test "$ADOC" != "asciidoctor"; then
     AC_MSG_WARN([No asciidoc formatter found. Manual pages will not be generated.])
   fi
 ])

--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -50,12 +50,21 @@ STDERR_DEVNULL = $(stderr_devnull_$(V))
 stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
+if ENABLE_ADOC
+.adoc.1:
+	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
+	    --attribute manversion=$(PACKAGE_VERSION) \
+	    --attribute manmanual="Flux Command Reference" \
+	    --destination-dir $(builddir) \
+	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
+else
 .adoc.1:
 	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
 	    --attribute manmanual="Flux Command Reference" \
 	    --destination-dir=$(builddir) \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
+endif
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc NODESET.adoc
 

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -194,12 +194,21 @@ STDERR_DEVNULL = $(stderr_devnull_$(V))
 stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
+if ENABLE_ADOC
+.adoc.3:
+	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
+	    --attribute manversion=$(PACKAGE_VERSION) \
+	    --attribute manmanual="Flux Programming Reference" \
+	    --destination-dir $(builddir) \
+	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
+else
 .adoc.3:
 	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
 	    --attribute manmanual="Flux Programming Reference" \
 	    --destination-dir=$(builddir) \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
+endif
 
 
 flux_clone.3: flux_open.3

--- a/doc/man7/Makefile.am
+++ b/doc/man7/Makefile.am
@@ -19,14 +19,14 @@ if ENABLE_ADOC
 .adoc.7:
 	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
-	    --attribute manmanual="Flux Command Reference" \
+	    --attribute manmanual="Flux Miscellaneous Reference" \
 	    --destination-dir $(builddir) \
 	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
 else
 .adoc.7:
 	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
-	    --attribute manmanual="Flux Command Reference" \
+	    --attribute manmanual="Flux Miscellaneous Reference" \
 	    --destination-dir=$(builddir) \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
 endif

--- a/doc/man7/Makefile.am
+++ b/doc/man7/Makefile.am
@@ -15,12 +15,21 @@ STDERR_DEVNULL = $(stderr_devnull_$(V))
 stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
+if ENABLE_ADOC
+.adoc.7:
+	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
+	    --attribute manversion=$(PACKAGE_VERSION) \
+	    --attribute manmanual="Flux Command Reference" \
+	    --destination-dir $(builddir) \
+	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
+else
 .adoc.7:
 	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
 	    --attribute manmanual="Flux Command Reference" \
 	    --destination-dir=$(builddir) \
 	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
+endif
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 


### PR DESCRIPTION
This adds support for an alternate asciidoc translator.  The unwritten docbook deps on a2x have been giving me heartburn on building a base docker image, this has a lot fewer deps (ruby, and... ruby AFAIK).  May want to wait for the PR with a docker-based travis conf, which will be coming shortly.

fixes #873 
Commit message with explanation below:

This allows asciidoctor to be used in place of a2x, which removes the
dependency on goodness-knows what docbook package our a2x generator
depends on that isn't in either our dependency list or theirs.  This
exists primarily because after making three versions of a docker image
trying to get one that could build the docs the other way, this works
faster, with less deps, and seemingly the same result.