### PR TITLE
modules/cron: misc cleanup

### DIFF
--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -70,7 +70,7 @@ struct cron_ctx {
 static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg);
 static void cron_entry_destroy (cron_entry_t *e);
 static int cron_entry_stop (cron_entry_t *e);
-static void cron_entry_completion_handler (flux_t *h, cron_task_t *t,
+static void cron_entry_finished_handler (flux_t *h, cron_task_t *t,
     void *arg);
 static void cron_entry_io_cb (flux_t *h, cron_task_t *t, void *arg,
     bool is_stderr, const char *data, int datalen, bool eof);
@@ -105,8 +105,8 @@ static int cron_entry_run_task (cron_entry_t *e)
     flux_t *h = e->ctx->h;
     if (cron_task_run (e->task, e->rank, e->command, e->cwd, e->env) < 0) {
         flux_log_error (h, "cron-%ju: cron_task_run", e->id);
-        /* Run "completion" handler since this task is done */
-        cron_entry_completion_handler (h, e->task, e);
+        /* Run "finished" handler since this task is done */
+        cron_entry_finished_handler (h, e->task, e);
         return (-1);
     }
     e->stats.lastrun = get_timestamp ();
@@ -130,7 +130,7 @@ int cron_entry_schedule_task (cron_entry_t *e)
                   e->id, e->name);
         return (0);
     }
-    if (!(e->task = cron_task_new (h, cron_entry_completion_handler, e))) {
+    if (!(e->task = cron_task_new (h, cron_entry_finished_handler, e))) {
         flux_log_error (h, "cron_task_create");
         return -1;
     }
@@ -164,14 +164,14 @@ static void cron_entry_io_cb (flux_t *h, cron_task_t *t, void *arg,
  *  entry e. If the list has grown past completed-task-size, then drop the
  *  tail task on the list.
  */
-int cron_entry_push_completed_task (cron_entry_t *e, struct cron_task *t)
+int cron_entry_push_finished_task (cron_entry_t *e, struct cron_task *t)
 {
-    if (zlist_push (e->completed_tasks, t) < 0)
+    if (zlist_push (e->finished_tasks, t) < 0)
         return (-1);
-    if (zlist_size (e->completed_tasks) > e->task_history_count) {
-        struct cron_task *tdel = zlist_tail (e->completed_tasks);
+    if (zlist_size (e->finished_tasks) > e->task_history_count) {
+        struct cron_task *tdel = zlist_tail (e->finished_tasks);
         if (tdel) {
-            zlist_remove (e->completed_tasks, tdel);
+            zlist_remove (e->finished_tasks, tdel);
             cron_task_destroy (tdel);
         }
     }
@@ -190,7 +190,7 @@ static void cron_entry_failure (cron_entry_t *e)
     }
 }
 
-static void cron_entry_completion_handler (flux_t *h, cron_task_t *t, void *arg)
+static void cron_entry_finished_handler (flux_t *h, cron_task_t *t, void *arg)
 {
     cron_entry_t *e = arg;
 
@@ -215,7 +215,7 @@ static void cron_entry_completion_handler (flux_t *h, cron_task_t *t, void *arg)
      *   drop a task if needed. Reset e->task to NULL since there
      *   is currently no active task.
      */
-    if (cron_entry_push_completed_task (e, t) < 0)
+    if (cron_entry_push_finished_task (e, t) < 0)
         return;
     e->task = NULL;
 
@@ -317,13 +317,13 @@ static void cron_entry_destroy (cron_entry_t *e)
     if (e->env)
         json_decref (e->env);
 
-    if (e->completed_tasks) {
-        t = zlist_first (e->completed_tasks);
+    if (e->finished_tasks) {
+        t = zlist_first (e->finished_tasks);
         while (t) {
             cron_task_destroy (t);
-            t = zlist_next (e->completed_tasks);
+            t = zlist_next (e->finished_tasks);
         }
-        zlist_destroy (&e->completed_tasks);
+        zlist_destroy (&e->finished_tasks);
     }
 
     free (e);
@@ -478,7 +478,7 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg)
 
     /* List for all completed tasks up to task-history-count
      */
-    if (!(e->completed_tasks = zlist_new ())) {
+    if (!(e->finished_tasks = zlist_new ())) {
         saved_errno = errno;
         flux_log_error (h, "cron_entry_create: zlist_new");
         goto out_err;
@@ -652,11 +652,11 @@ static json_t *cron_entry_to_json (cron_entry_t *e)
     if (e->task && (to = cron_task_to_json (e->task)))
         json_array_append_new (tasks, to);
 
-    t = zlist_first (e->completed_tasks);
+    t = zlist_first (e->finished_tasks);
     while (t) {
         if ((to = cron_task_to_json (t)))
             json_array_append_new (tasks, to);
-        t = zlist_next (e->completed_tasks);
+        t = zlist_next (e->finished_tasks);
     }
 
     json_object_set_new (o, "tasks", tasks);

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -73,7 +73,7 @@ static int cron_entry_stop (cron_entry_t *e);
 static void cron_entry_finished_handler (flux_t *h, cron_task_t *t,
     void *arg);
 static void cron_entry_io_cb (flux_t *h, cron_task_t *t, void *arg,
-    bool is_stderr, const char *data, int datalen, bool eof);
+    bool is_stderr, const char *data, int datalen);
 static int cron_entry_run_task (cron_entry_t *e);
 static int cron_entry_defer (cron_entry_t *e);
 
@@ -152,7 +152,7 @@ int cron_entry_schedule_task (cron_entry_t *e)
 /**************************************************************************/
 
 static void cron_entry_io_cb (flux_t *h, cron_task_t *t, void *arg,
-    bool is_stderr, const char *data, int datalen, bool eof)
+    bool is_stderr, const char *data, int datalen)
 {
     cron_entry_t *e = arg;
     int level = is_stderr ? LOG_ERR : LOG_INFO;

--- a/src/modules/cron/entry.h
+++ b/src/modules/cron/entry.h
@@ -88,7 +88,7 @@ struct cron_entry {
     void *                 data;            /* Entry type specific data      */
 
     struct cron_task *  task;               /* Currently executing task      */
-    zlist_t          *  completed_tasks;    /* List of completed tasks       */
+    zlist_t          *  finished_tasks;     /* List of finished tasks       */
     int                 task_history_count; /* Max # of tasks in history     */
     int                 stop_on_failure;    /* Stop cron entry after failure */
 

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -65,8 +65,6 @@ struct cron_task {
     unsigned int      timedout:1;
     unsigned int        exited:1;
     unsigned int     completed:1;
-    unsigned int stderr_closed:1;
-    unsigned int stdout_closed:1;
 
     cron_task_io_f       io_cb;
     cron_task_state_f    state_cb;
@@ -117,8 +115,6 @@ static bool cron_task_completed (cron_task_t *t)
     if (t->rexec_failed)
         return true;
     if (t->exec_failed)
-        return true;
-    if (t->exited && t->stderr_closed && t->stdout_closed)
         return true;
     if (t->completed)
         return true;
@@ -281,13 +277,6 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
 
     if (t->io_cb && lenp)
         (*t->io_cb) (t->h, t, t->arg, is_stderr, ptr, lenp, eof);
-
-    if (eof) {
-        if (is_stderr)
-            t->stderr_closed = 1;
-        else
-            t->stdout_closed = 1;
-    }
 }
 
 int cron_task_kill (cron_task_t *t, int sig)

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -252,7 +252,6 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr = NULL;
     int lenp;
     bool is_stderr = false;
-    bool eof = false;
 
     assert (t);
 
@@ -271,12 +270,10 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
                             __FUNCTION__);
             return;
         }
-        if (!lenp)
-            eof = true;
     }
 
     if (t->io_cb && lenp)
-        (*t->io_cb) (t->h, t, t->arg, is_stderr, ptr, lenp, eof);
+        (*t->io_cb) (t->h, t, t->arg, is_stderr, ptr, lenp);
 }
 
 int cron_task_kill (cron_task_t *t, int sig)

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -314,14 +314,6 @@ static flux_cmd_t *exec_cmd_create (struct cron_task *t,
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_argv_append");
         goto error;
     }
-    if (!cwd) {
-        /* flux_rexec() requires a cwd */
-        if (!(tmp_cwd = get_current_dir_name ())) {
-            flux_log_error (t->h, "exec_cmd_create: get_get_current_dir_name");
-            goto error;
-        }
-        cwd = tmp_cwd;
-    }
     if (flux_cmd_setcwd (cmd, cwd) < 0) {
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_setcwd");
         goto error;

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -63,6 +63,7 @@ struct cron_task {
     unsigned int       running:1;
     unsigned int      timedout:1;
     unsigned int        exited:1;
+    unsigned int     completed:1;
     unsigned int stderr_closed:1;
     unsigned int stdout_closed:1;
 
@@ -115,6 +116,8 @@ static bool cron_task_completed (cron_task_t *t)
     if (t->rexec_failed)
         return true;
     if (t->exited && t->stderr_closed && t->stdout_closed)
+        return true;
+    if (t->completed)
         return true;
     return false;
 }
@@ -190,6 +193,7 @@ static void completion_cb (flux_subprocess_t *p)
 
     assert (t);
 
+    t->completed = 1;
     cron_task_handle_completion (p, t);
 }
 

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -35,8 +35,7 @@ typedef struct cron_task cron_task_t;
 /*  io callback fn for cron task
  */
 typedef void (*cron_task_io_f) (flux_t *h, cron_task_t *t, void *arg,
-                                bool is_stderr, const char *data, int datalen,
-                                bool eof);
+                                bool is_stderr, const char *data, int datalen);
 
 /*  task state change handler for cron task, check state with
  *   cron_task_state().

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -46,13 +46,13 @@ typedef void (*cron_task_state_f) (flux_t *h, cron_task_t *t, void *arg);
 /*  task completion handler, the only required handler for cron task,
  *   called when task and its I/O have completed.
  */
-typedef void (*cron_task_complete_f) (flux_t *h, cron_task_t *t, void *arg);
+typedef void (*cron_task_finished_f) (flux_t *h, cron_task_t *t, void *arg);
 
 /*  create a new cron task using flux handle `h`. Completion handler
  *   `cb` will be called when cron task has fully completed. All callbacks
  *   will be passed context `arg`.
  */
-cron_task_t *cron_task_new (flux_t *h, cron_task_complete_f cb, void *arg);
+cron_task_t *cron_task_new (flux_t *h, cron_task_finished_f cb, void *arg);
 
 /*  destroy cron task `t`
  */


### PR DESCRIPTION
In #1564, ```modules/cron``` was converted to use the new subprocess library.   While everything works, some code seems wrong/out of place/wrong style given differences between the old and new subprocess library.  This PR cleans up / adjusts ```modules/cron``` accordingly.
