### PR TITLE
re-define flux_subprocess_destroy prototype

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -215,6 +215,12 @@ static void signal_cb (int signum)
     }
 }
 
+void subprocess_destroy (void *arg)
+{
+    flux_subprocess_t *p = arg;
+    flux_subprocess_destroy (p);
+}
+
 int main (int argc, char *argv[])
 {
     const char *optargp;
@@ -302,7 +308,7 @@ int main (int argc, char *argv[])
             log_err_exit ("flux_rexec");
         if (zlist_append (subprocesses, p) < 0)
             log_err_exit ("zlist_append");
-        if (!zlist_freefn (subprocesses, p, flux_subprocess_destroy, true))
+        if (!zlist_freefn (subprocesses, p, subprocess_destroy, true))
             log_err_exit ("zlist_freefn");
     }
 

--- a/src/common/subprocess/subprocess.c
+++ b/src/common/subprocess/subprocess.c
@@ -937,12 +937,6 @@ void flux_subprocess_unref (flux_subprocess_t *p)
     }
 }
 
-void flux_subprocess_destroy (void *arg)
-{
-    flux_subprocess_t *p = arg;
-    flux_subprocess_unref (p);
-}
-
 flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p)
 {
     if (!p || p->magic != SUBPROCESS_MAGIC) {

--- a/src/common/subprocess/subprocess.h
+++ b/src/common/subprocess/subprocess.h
@@ -310,7 +310,7 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signo);
  */
 void flux_subprocess_ref (flux_subprocess_t *p);
 void flux_subprocess_unref (flux_subprocess_t *p);
-void flux_subprocess_destroy (void *arg);
+#define flux_subprocess_destroy(x) flux_subprocess_unref(x)
 
 /*  Return current state value of subprocess.  Note this may differ
  *  than state returned in on_state_change callback, as a subprocess

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -121,7 +121,7 @@ test_expect_success 'rexec check channel FD created' '
         grep "TEST_CHANNEL_FD=" output
 '
 
-# execbasic does not close TEST_CHANNEL, so we tell test_echo max
+# rexec does not close TEST_CHANNEL, so we tell test_echo max
 # bytes we're feeding in
 test_expect_success 'rexec channel input' '
 	echo -n "foobar" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i TEST_CHANNEL ${TEST_SUBPROCESS_DIR}/test_echo -c TEST_CHANNEL -P -O -b 6 > output 2>&1 &&
@@ -129,7 +129,7 @@ test_expect_success 'rexec channel input' '
         test_cmp expected output
 '
 
-# execbasic does not close TEST_CHANNEL, so we tell test_echo max
+# rexec does not close TEST_CHANNEL, so we tell test_echo max
 # bytes we're feeding in
 test_expect_success 'rexec channel input and output' '
 	echo -n "foobaz" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i TEST_CHANNEL ${TEST_SUBPROCESS_DIR}/test_echo -c TEST_CHANNEL -P -C -b 6 > output 2>&1 &&
@@ -137,7 +137,7 @@ test_expect_success 'rexec channel input and output' '
         test_cmp expected output
 '
 
-# execbasic does not close TEST_CHANNEL, so we tell test_echo max
+# rexec does not close TEST_CHANNEL, so we tell test_echo max
 # bytes we're feeding in
 test_expect_success 'rexec channel input and output multiple lines' '
 	/bin/echo -en "foo\nbar\nbaz\n" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i TEST_CHANNEL ${TEST_SUBPROCESS_DIR}/test_echo -c TEST_CHANNEL -C -n -b 6 > output 2>&1 &&


### PR DESCRIPTION
Per a discussion in #1564, re-define ```flux_subprocess_destroy()``` as a convenience that calls ```flux_subprocess_unref()```.  Also, includes a dumb typo fix I found.