### PR TITLE
common/subprocess: Do not append _FD to channels

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -350,7 +350,7 @@ void channel_cb (flux_subprocess_t *p, const char *stream)
     int rc, lenp;
 
     assert (cli);
-    assert (!strcmp (stream, "PMI"));
+    assert (!strcmp (stream, "PMI_FD"));
 
     if (!(ptr = flux_subprocess_read_line (p, stream, &lenp)))
         log_err_exit ("%s: flux_subprocess_read_line", __FUNCTION__);
@@ -388,7 +388,7 @@ char *create_scratch_dir (const char *session_id)
 static int pmi_response_send (void *client, const char *buf)
 {
     struct client *cli = client;
-    return flux_subprocess_write (cli->p, "PMI", buf, strlen (buf));
+    return flux_subprocess_write (cli->p, "PMI_FD", buf, strlen (buf));
 }
 
 static void pmi_debug_trace (void *client, const char *buf)
@@ -503,7 +503,7 @@ struct client *client_create (const char *broker_path, const char *scratch_dir,
     }
     free (argz);
 
-    if (flux_cmd_add_channel (cli->cmd, "PMI") < 0)
+    if (flux_cmd_add_channel (cli->cmd, "PMI_FD") < 0)
         log_err_exit ("flux_cmd_add_channel");
     if (flux_cmd_setenvf (cli->cmd, 1, "PMI_RANK", "%d", rank) < 0)
         log_err_exit ("flux_cmd_setenvf");

--- a/src/common/subprocess/local.c
+++ b/src/common/subprocess/local.c
@@ -244,7 +244,7 @@ static int channel_local_setup (flux_subprocess_t *p,
     }
 
     if (channel_flags & CHANNEL_FD) {
-        if (asprintf (&e, "%s_FD", name) < 0) {
+        if (asprintf (&e, "%s", name) < 0) {
             flux_log_error (p->h, "asprintf");
             goto error;
         }

--- a/src/common/subprocess/subprocess.h
+++ b/src/common/subprocess/subprocess.h
@@ -177,9 +177,9 @@ const char *flux_cmd_getcwd (const flux_cmd_t *cmd);
  *   and read from it via flux_subprocess_read(), which is typically
  *   called from a callback set in 'on_channel_out'.
  *
- *  The `name` argument is also used as the name of an environment variable
+ *  The `name` argument is also used as the name of the environment variable
  *   in the subprocess environment that is set to the file descriptor number
- *   of the process side of the socketpair. E.g. name = "FLUX_PMI" would
+ *   of the process side of the socketpair. E.g. name = "FLUX_PMI_FD" would
  *   result in the environment variable "FLUX_PMI_FD=N" set in the process
  *   environment.
  */

--- a/src/common/subprocess/test/subprocess.c
+++ b/src/common/subprocess/test/subprocess.c
@@ -1287,8 +1287,8 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strncmp (ptr, "FOO_FD=", 7),
-            "environment variable FOO_FD created in subprocess");
+        ok (!strncmp (ptr, "FOO=", 4),
+            "environment variable FOO created in subprocess");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);

--- a/src/common/subprocess/test/test_echo.c
+++ b/src/common/subprocess/test/test_echo.c
@@ -94,7 +94,7 @@ main (int argc, char *argv[])
         const char *fdstr;
         char channelstr[1024];
 
-        sprintf (channelstr, "%s_FD", channel_name);
+        sprintf (channelstr, "%s", channel_name);
 
         if (!(fdstr = getenv (channelstr))) {
             perror ("getenv");

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -118,7 +118,7 @@ test_expect_success 'basic rexec stdin / stdout long lines' '
 # pipe in /dev/null, we don't care about stdin for this test
 test_expect_success 'rexec check channel FD created' '
 	${FLUX_BUILD_DIR}/t/rexec/rexec -i TEST_CHANNEL /usr/bin/env < /dev/null > output 2>&1 &&
-        grep "TEST_CHANNEL_FD=" output
+        grep "TEST_CHANNEL=" output
 '
 
 # rexec does not close TEST_CHANNEL, so we tell test_echo max


### PR DESCRIPTION
Do not append the string "_FD" to the channel environment variables
created for subprocesses.  Instead, use the channel name itself.
If the caller wishes for the environment variable to have "_FD"
at the end, they should name their channel with "_FD" at the end.