### PR TITLE
Rename flux_subprocess_output()

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -142,7 +142,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     int lenp;
 
     if (!(ptr = flux_subprocess_read_line (p, stream, &lenp)))
-        log_err_exit ("flux_subprocess_output: read_line");
+        log_err_exit ("flux_subprocess_read_line");
 
     /* if process exited, read remaining stuff or EOF, otherwise
      * wait for future newline */
@@ -150,7 +150,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
         && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
 
         if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp)))
-            log_err_exit ("flux_subprocess_output: read_line");
+            log_err_exit ("flux_subprocess_read");
     }
 
     if (lenp) {

--- a/src/common/subprocess/subprocess.c
+++ b/src/common/subprocess/subprocess.c
@@ -319,7 +319,11 @@ int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,
     return server_terminate_by_uuid (s, id);
 }
 
-void flux_subprocess_output (flux_subprocess_t *p, const char *stream)
+/*
+ * Convenience Functions:
+ */
+
+void flux_standard_output (flux_subprocess_t *p, const char *stream)
 {
     /* everything except stderr goes to stdout */
     FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
@@ -327,7 +331,7 @@ void flux_subprocess_output (flux_subprocess_t *p, const char *stream)
     int lenp;
 
     if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
-        log_err ("flux_subprocess_output: read_line");
+        log_err ("flux_standard_output: read_line");
         return;
     }
 
@@ -336,7 +340,7 @@ void flux_subprocess_output (flux_subprocess_t *p, const char *stream)
     if (!lenp
         && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
         if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
-            log_err ("flux_subprocess_output: read_line");
+            log_err ("flux_standard_output: read_line");
             return;
         }
     }

--- a/src/common/subprocess/subprocess.h
+++ b/src/common/subprocess/subprocess.h
@@ -105,12 +105,17 @@ void flux_subprocess_server_stop (flux_subprocess_server_t *s);
 int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,
                                               const char *id);
 
-/*  General output callback that will send output from the subprocess
- *  to stdout or stderr.  Set to `on_stdout` and/or `on_stderr` in
- *  flux_subprocess_ops_t.  Can also be used for 'on_channel_out'
- *  callback, sending all output to stdout.
+/*
+ * Convenience Functions:
  */
-void flux_subprocess_output (flux_subprocess_t *p, const char *stream);
+
+/*  General output callback that will send output from the subprocess
+ *  to stdout or stderr.  Set the `on_stdout` and/or `on_stderr`
+ *  callbacks in flux_subprocess_ops_t and this function will output
+ *  to stdout/stderr respectively.  You can also set 'on_channel_out'
+ *  to this function, which will send all channel output to stdout.
+ */
+void flux_standard_output (flux_subprocess_t *p, const char *stream);
 
 /*
  *  Commands:

--- a/src/common/subprocess/test/subprocess.c
+++ b/src/common/subprocess/test/subprocess.c
@@ -416,8 +416,8 @@ void test_basic_default_output (flux_reactor_t *r)
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
-        .on_stdout = flux_subprocess_output,
-        .on_stderr = flux_subprocess_output
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
     p = flux_local_exec (r, 0, cmd, &ops);
@@ -1375,7 +1375,7 @@ void test_channel_fd_in (flux_reactor_t *r)
         .on_completion = completion_cb,
         .on_channel_out = NULL,
         .on_stdout = channel_in_cb,
-        .on_stderr = flux_subprocess_output
+        .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
     channel_in_cb_count = 0;
@@ -1441,8 +1441,8 @@ void test_channel_fd_in_and_out (flux_reactor_t *r)
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
         .on_channel_out = channel_in_and_out_cb,
-        .on_stdout = flux_subprocess_output,
-        .on_stderr = flux_subprocess_output
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
     channel_in_and_out_cb_count = 0;
@@ -1527,8 +1527,8 @@ void test_channel_multiple_lines (flux_reactor_t *r)
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
         .on_channel_out = channel_multiple_lines_cb,
-        .on_stdout = flux_subprocess_output,
-        .on_stderr = flux_subprocess_output
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
     multiple_lines_channel_cb_count = 0;
@@ -1609,9 +1609,9 @@ void test_bufsize (flux_reactor_t *r)
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
-        .on_channel_out = flux_subprocess_output,
-        .on_stdout = flux_subprocess_output,
-        .on_stderr = flux_subprocess_output
+        .on_channel_out = flux_standard_output,
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
     p = flux_local_exec (r, 0, cmd, &ops);
@@ -1642,9 +1642,9 @@ void test_bufsize_error (flux_reactor_t *r)
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
-        .on_channel_out = flux_subprocess_output,
-        .on_stdout = flux_subprocess_output,
-        .on_stderr = flux_subprocess_output
+        .on_channel_out = flux_standard_output,
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output
     };
     p = flux_local_exec (r, 0, cmd, &ops);
     ok (p == NULL

--- a/t/rexec/rexec.c
+++ b/t/rexec/rexec.c
@@ -114,8 +114,8 @@ int main (int argc, char *argv[])
         .on_completion = completion_cb,
         .on_state_change = state_cb,
         .on_channel_out = NULL,
-        .on_stdout = flux_subprocess_output,
-        .on_stderr = flux_subprocess_output,
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output,
     };
     const char *optargp;
     int optindex;
@@ -153,7 +153,7 @@ int main (int argc, char *argv[])
             && strcmp (optargp, "STDERR")) {
             if (flux_cmd_add_channel (cmd, optargp) < 0)
                 log_err_exit ("flux_cmd_add_channel");
-            ops.on_channel_out = flux_subprocess_output;
+            ops.on_channel_out = flux_standard_output;
         }
     }
 


### PR DESCRIPTION
Rename ```flux_subprocess_output()``` to ```flux_standard_output()```.  The prefix ```flux_subprocess``` can suggest the function is part of the core subprocess API, but it is simply a convenience function.

Also fix some error message outputs I found.