### PR TITLE
kvs: add RFC 18 eventlog support

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -167,6 +167,20 @@ display the namespace owner.  If '-s' is specified, display the root
 sequence number.  If '-w' is specified, display the current root,
 then a new value each time it is updated, up to 'count', if specified.
 
+*eventlog get* [-w] [-c count] [-u] 'key'::
+Display the contents of an RFC 18 KVS eventlog referred to by 'key'.
+If '-u' is specified, display the log in raw form, otherwise format the
+dates as ISO 8601.  If '-w' is specified, after the existing contents
+have been displayed, the eventlog is monitored and updates are
+displayed as they are committed.  This runs until the program is
+interrupted or an error occurs, unless the number of events is limited
+with the '-c' option.
+
+*eventlog append* [-t SECONDS] 'key' 'name' ['context ...']::
+Append an event to an RFC 18 KVS eventlog referred to by 'key'.
+The event 'name' and optional 'context' are specified on the command line.
+The timestamp may optionally be specified with '-t' as decimal seconds since
+the UNIX epoch (UTC), otherwise the current wall clock is used.
 
 AUTHOR
 ------

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -52,6 +52,7 @@ MAN3_FILES_PRIMARY = \
 	flux_kvs_namespace_list.3 \
 	flux_kvs_set_namespace.3 \
 	flux_kvs_getroot.3 \
+	flux_kvs_eventlog_create.3 \
 	idset_create.3
 
 # These files are generated as roff .so includes of a primary page.
@@ -177,6 +178,13 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_namespace_itr_rewind.3 \
 	flux_kvs_namespace_itr_destroy.3 \
 	flux_kvs_get_namespace.3 \
+	flux_kvs_eventlog_destroy.3 \
+	flux_kvs_eventlog_encode.3 \
+	flux_kvs_eventlog_decode.3 \
+	flux_kvs_eventlog_update.3 \
+	flux_kvs_eventlog_append.3 \
+	flux_kvs_eventlog_first.3 \
+	flux_kvs_eventlog_next.3 \
 	idset_destroy.3 \
 	idset_encode.3 \
 	idset_decode.3
@@ -322,6 +330,13 @@ flux_kvs_namespace_itr_next.3: flux_kvs_namespace_list.3
 flux_kvs_namespace_itr_rewind.3: flux_kvs_namespace_list.3
 flux_kvs_namespace_itr_destroy.3: flux_kvs_namespace_list.3
 flux_kvs_get_namespace.3: flux_kvs_set_namespace.3
+flux_kvs_eventlog_destroy.3: flux_kvs_eventlog_create.3
+flux_kvs_eventlog_encode.3: flux_kvs_eventlog_create.3
+flux_kvs_eventlog_decode.3: flux_kvs_eventlog_create.3
+flux_kvs_eventlog_update.3: flux_kvs_eventlog_create.3
+flux_kvs_eventlog_append.3: flux_kvs_eventlog_create.3
+flux_kvs_eventlog_first.3: flux_kvs_eventlog_create.3
+flux_kvs_eventlog_next.3: flux_kvs_eventlog_create.3
 idset_destroy.3: idset_create.3
 idset_encode.3: idset_create.3
 idset_decode.3: idset_create.3

--- a/doc/man3/flux_kvs_eventlog_create.adoc
+++ b/doc/man3/flux_kvs_eventlog_create.adoc
@@ -1,0 +1,139 @@
+flux_kvs_eventlog_create(3)
+===========================
+:doctype: manpage
+
+
+NAME
+----
+flux_kvs_eventlog_create, flux_kvs_eventlog_destroy, flux_kvs_eventlog_encode, flux_kvs_eventlog_decode, flux_kvs_eventlog_update, flux_kvs_eventlog_append, flux_kvs_eventlog_first, flux_kvs_eventlog_next - manipulate RFC 18 KVS eventlogs
+
+
+SYNOPSIS
+--------
+
+ struct flux_kvs_eventlog *flux_kvs_eventlog_create (void);
+
+ void flux_kvs_eventlog_destroy (struct flux_kvs_eventlog *eventlog);
+
+ char *flux_kvs_eventlog_encode (const struct flux_kvs_eventlog *eventlog);
+
+ struct flux_kvs_eventlog *flux_kvs_eventlog_decode (const char *s);
+
+ int flux_kvs_eventlog_update (struct flux_kvs_eventlog *eventlog,
+                               const char *s);
+
+ int flux_kvs_eventlog_append (struct flux_kvs_eventlog *eventlog,
+                               const char *s);
+
+ const char *flux_kvs_eventlog_first (struct flux_kvs_eventlog *eventlog);
+
+ const char *flux_kvs_eventlog_next (struct flux_kvs_eventlog *eventlog);
+
+ int flux_kvs_event_decode (const char *s,
+                            double *timestamp,
+                            flux_kvs_event_name_t name,
+                            flux_kvs_event_context_t context);
+
+ char *flux_kvs_event_encode (const char *name, const char *context);
+
+ char *flux_kvs_event_encode_timestamp (double timestamp,
+                                       const char *name,
+                                       const char *context);
+
+
+
+DESCRIPTION
+-----------
+
+An RFC 18 KVS eventlog consists of single line log entries of the form:
+
+  timestamp name [context ...]\n
+
+Where 'timestamp' is seconds since the UNIX epoch (UTC), in decimal form;
+'name' is a 64 character or less event name, and 'context' is an optional
+256 character or less free form string.  Each event is terminated by a newline
+character.
+
+Raw event strings can be atomically appended to an eventlog stored in the KVS
+using `flux_kvs_txn_put()` with the the 'FLUX_KVS_APPEND' flag.
+The eventlog can be accessed with `flux_kvs_lookup()`, optionally with
+the 'FLUX_KVS_WATCH' flag.
+
+`flux_kvs_eventlog_create()` creates an empty eventlog object in memory,
+and `flux_kvs_eventlog_destroy()` disposes of it.
+
+`flux_kvs_eventlog_decode()` creates an eventlog object from raw RFC 18
+eventlog data in string form, such as would be returned by
+`flux_kvs_lookup_get()`.  The caller must free the returned object.
+`flux_kvs_eventlog_encode()` performs the opposite function; again, the
+caller must free the returned string.
+
+`flux_kvs_eventlog_update()` updates an eventlog object with a new snapshot
+of the raw log, such as might be returned from `flux_kvs_lookup_get()`.
+This function does not change the iterator cursor.
+
+`flux_kvs_eventlog_append()` appends a single raw event to the eventlog.
+
+The events in an eventlog object may be accessed in raw form  with the
+iterators `flux_kvs_eventlog_first()` and `flux_kvs_eventlog_next()`.
+These functions return NULL when the end of the log has been reached.
+Pointers returned by these functions remain valid until the object
+is destroyed.
+
+`flux_kvs_event_decode()` decodes a raw event, copying the timestamp,
+name, and context fields to the supplied storage.  A field may be
+ignored by setting the corresponding parameter to zero.  If the optional
+context is not present, the supplied storage will be filled with the
+empty string.
+
+`flux_kvs_event_encode()` creates a raw event from the supplied fields.
+The timestamp is assigned the current wallclock time. The caller must
+free the returned event string.  `flux_kvs_event_encode_timestamp()` is
+the same except the timestamp value may be explicitly set.
+
+RETURN VALUE
+------------
+
+`flux_kvs_eventlog_create()` and `flux_kvs_eventlog_decode()` return
+an eventlog object on success, or NULL on failure with errno set.
+
+`flux_kvs_eventlog_encode()`, `flux_kvs_event_encode()`, and
+`flux_kvs_event_encode_timestamp()` return encoded strings on success,
+or NULL on failure with errno set.
+
+`flux_kvs_eventlog_update()`, `flux_kvs_eventlog_append()`, and
+`flux_kvs_event_decode()` return 0 on success, or -1 on failure
+with errno set.
+
+`flux_kvs_eventlog_first()` and `flux_kvs_eventlog_next()` return
+a const pointer to a raw event, or NULL if the internal cursor has
+reached the end of the log.
+
+ERRORS
+------
+
+EINVAL::
+One of the arguments was invalid.
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_kvs_lookup (3), flux_kvs_txn_create (3)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -444,3 +444,4 @@ gpus
 fulfillments
 enodata
 getroot
+eventlog

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -445,3 +445,4 @@ fulfillments
 enodata
 getroot
 eventlog
+eventlogs

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -23,7 +23,8 @@ libkvs_la_SOURCES = \
 	kvs_txn.c \
 	kvs_txn_private.h \
 	treeobj.h \
-	treeobj.c
+	treeobj.c \
+	kvs_eventlog.c
 
 fluxcoreinclude_HEADERS = \
 	kvs.h \
@@ -33,7 +34,8 @@ fluxcoreinclude_HEADERS = \
 	kvs_watch.h \
 	kvs_classic.h \
 	kvs_txn.h \
-	kvs_commit.h
+	kvs_commit.h \
+	kvs_eventlog.h
 
 TESTS = \
 	test_kvs.t \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -45,7 +45,8 @@ TESTS = \
 	test_kvs_commit.t \
 	test_kvs_watch.t \
 	test_kvs_getroot.t \
-	test_treeobj.t
+	test_treeobj.t \
+	test_kvs_eventlog.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -99,3 +100,7 @@ test_kvs_getroot_t_LDADD = $(test_ldadd) $(LIBDL)
 test_treeobj_t_SOURCES = test/treeobj.c
 test_treeobj_t_CPPFLAGS = $(test_cppflags)
 test_treeobj_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_kvs_eventlog_t_SOURCES = test/kvs_eventlog.c
+test_kvs_eventlog_t_CPPFLAGS = $(test_cppflags)
+test_kvs_eventlog_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -10,6 +10,7 @@
 #include "kvs_watch.h"
 #include "kvs_txn.h"
 #include "kvs_commit.h"
+#include "kvs_eventlog.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/libkvs/kvs_eventlog.c
+++ b/src/common/libkvs/kvs_eventlog.c
@@ -1,0 +1,379 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2 of the
+ *  license, or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <czmq.h>
+#include <argz.h>
+
+#include "kvs_eventlog.h"
+
+#define MAX_KVS_EVENT_NAME  (sizeof (flux_kvs_event_name_t) - 1)
+#define MAX_KVS_EVENT_CONTEXT (sizeof (flux_kvs_event_context_t) - 1)
+
+/* eventlog is a list of RFC 18 events.
+ * Once appended to the list, pointers to the events can be accessed by users
+ * with the guarantee that they remain valid until the eventlog is destroyed.
+ */
+struct flux_kvs_eventlog {
+    zlist_t *events; // zlist cursor reserved for internal use
+    int cursor;
+};
+
+
+void flux_kvs_eventlog_destroy (struct flux_kvs_eventlog *eventlog)
+{
+    if (eventlog) {
+        int saved_errno = errno;
+        if (eventlog->events) {
+            char *s;
+            while ((s = zlist_pop (eventlog->events)))
+                free (s);
+            zlist_destroy (&eventlog->events);
+        }
+        free (eventlog);
+        errno = saved_errno;
+    }
+}
+
+struct flux_kvs_eventlog *flux_kvs_eventlog_create (void)
+{
+    struct flux_kvs_eventlog *eventlog;
+
+    if (!(eventlog = calloc (1, sizeof (*eventlog))))
+        return NULL;
+    if (!(eventlog->events = zlist_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return eventlog;
+error:
+    flux_kvs_eventlog_destroy (eventlog);
+    return NULL;
+}
+
+/* Determine the buffer size (including terminating \0) needed
+ * to encode 'eventlog'.
+ */
+static size_t eventlog_encode_size (const struct flux_kvs_eventlog *eventlog)
+{
+    char *event;
+    size_t size = 0;
+
+    event = zlist_first (eventlog->events);
+    while ((event)) {
+        size += strlen (event);
+        event = zlist_next (eventlog->events);
+    }
+    return size + 1; // plus \0 terminator
+}
+
+char *flux_kvs_eventlog_encode (const struct flux_kvs_eventlog *eventlog)
+{
+    char *cpy;
+    char *event;
+    size_t size;
+    size_t used = 0;
+
+    if (!eventlog) {
+        errno = EINVAL;
+        return NULL;
+    }
+    size = eventlog_encode_size (eventlog);
+    if (!(cpy = calloc (1, size)))
+        return NULL;
+    event = zlist_first (eventlog->events);
+    while (event) {
+        int n;
+        n = snprintf (cpy + used, size - used, "%s", event);
+        assert (n < size - used);
+        used += n;
+        event = zlist_next (eventlog->events);
+    }
+    return cpy;
+}
+
+/* 'pp' is an in/out parameter pointing to input buffer.
+ * Set 'tok' to next \n-terminated token, and 'toklen' to its length.
+ * Advance 'pp' past token.  Returns false when input is exhausted.
+ */
+static bool eventlog_parse_next (const char **pp, const char **tok,
+                                 size_t *toklen)
+{
+    char *term;
+
+    if (!(term = strchr (*pp, '\n')))
+        return false;
+    *tok = *pp;
+    *toklen = term - *pp + 1;
+    *pp = term + 1;
+    return true;
+}
+
+/* Return true if 'tok' contains a valid RFC 18 event
+ */
+static bool event_validate (const char *tok, size_t toklen)
+{
+    char *s;
+    int rc;
+
+    if (!(s = strndup (tok, toklen)))
+        return false;
+    rc = flux_kvs_event_decode (s, NULL, NULL, NULL);
+    free (s);
+    if (rc < 0)
+        return false;
+    return true;
+}
+
+int flux_kvs_eventlog_update (struct flux_kvs_eventlog *eventlog,
+                              const char *s)
+{
+    const char *input;
+    const char *tok;
+    size_t toklen;
+    char *event;
+
+    if (!eventlog || !s)
+        goto error_inval;
+    input = s;
+    event = zlist_first (eventlog->events);
+    while (eventlog_parse_next (&input, &tok, &toklen)) {
+        if (event) {
+            if (toklen != strlen (event) || strncmp (event, tok, toklen) != 0)
+                goto error_inval;
+            event = zlist_next (eventlog->events);
+        }
+        else {
+            char *cpy;
+            if (!event_validate (tok, toklen))
+                goto error_inval;
+            if (!(cpy = strndup (tok, toklen)))
+                goto error;
+            if (zlist_append (eventlog->events, cpy) < 0) {
+                free (cpy);
+                errno = ENOMEM;
+                goto error;
+            }
+        }
+    }
+    if (*input != '\0')
+        goto error_inval;
+    return 0;
+error_inval:
+    errno = EINVAL;
+error:
+    return -1;
+}
+
+struct flux_kvs_eventlog *flux_kvs_eventlog_decode (const char *s)
+{
+    struct flux_kvs_eventlog *eventlog;
+
+    if (!(eventlog = flux_kvs_eventlog_create ()))
+        return NULL;
+    if (flux_kvs_eventlog_update (eventlog, s) < 0) {
+        flux_kvs_eventlog_destroy (eventlog);
+        return NULL;
+    }
+    return eventlog;
+}
+
+/* Return the nth (zero-origin) element of 'l', or NULL if it doesn't exist.
+ */
+static void *get_zlist_nth (zlist_t *l, int n)
+{
+    void *item;
+    int count = 0;
+    if (!l)
+        return NULL;
+    item = zlist_first (l);
+    while (item && count++ < n)
+        item = zlist_next (l);
+    return item;
+}
+
+const char *flux_kvs_eventlog_next (struct flux_kvs_eventlog *eventlog)
+{
+    char *event;
+
+    if (!eventlog)
+        return NULL;
+    if ((event = get_zlist_nth (eventlog->events, eventlog->cursor)))
+        eventlog->cursor++;
+    return event;
+}
+
+const char *flux_kvs_eventlog_first (struct flux_kvs_eventlog *eventlog)
+{
+    if (!eventlog)
+        return NULL;
+    eventlog->cursor = 0;
+    return flux_kvs_eventlog_next (eventlog);
+}
+
+int flux_kvs_eventlog_append (struct flux_kvs_eventlog *eventlog,
+                              const char *s)
+{
+    char *cpy;
+
+    if (!eventlog || !s || !event_validate (s, strlen (s))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (s)))
+        goto error_nomem;
+    if (zlist_append (eventlog->events, cpy) < 0)
+        goto error_nomem;
+    return 0;
+error_nomem:
+    free (cpy);
+    errno = ENOMEM;
+    return -1;
+}
+
+static const char *strnchr (const char *s, int c, size_t size)
+{
+    int i;
+    for (i = 0; i < size; i++)
+        if (s[i] == c)
+            return &s[i];
+    return NULL;
+}
+
+int flux_kvs_event_decode (const char *s,
+                           double *timestamp,
+                           flux_kvs_event_name_t name,
+                           flux_kvs_event_context_t context)
+{
+    const char *input;
+    double t;
+    char *cp;
+    size_t toklen;
+
+    if (!s)
+        goto error_inval;
+    input = s;
+
+    /* time */
+    if (!isdigit (*input))
+        goto error_inval;
+    errno = 0;
+    t = strtod (input, &cp);
+    if (errno != 0 || *cp != ' ' || t <= 0)
+        goto error_inval;
+    if (timestamp)
+        *timestamp = t;
+    input = cp + 1;
+
+    /* name */
+    if (!(cp = strchr (input, ' ')) && !(cp = strchr (input, '\n')))
+        goto error_inval;
+    if ((toklen = cp - input) > MAX_KVS_EVENT_NAME || toklen == 0)
+        goto error_inval;
+    if (strnchr (input, '\n', toklen))
+        goto error_inval;
+    if (name) {
+        memcpy (name, input, toklen);
+        name[toklen] = '\0';
+    }
+    input = cp + 1;
+
+    /* context (optional) */
+    if (*cp == '\n') {
+        if (context)
+            context[0] = '\0';
+    }
+    else {
+        if (!(cp = strchr (input, '\n')))
+            goto error_inval;
+        if ((toklen = cp - input) > MAX_KVS_EVENT_CONTEXT)
+            goto error_inval;
+        if (context) {
+            memcpy (context, input, toklen);
+            context[toklen] = '\0';
+        }
+        input = cp + 1;
+    }
+
+    if (*input != '\0')
+        goto error_inval;
+    return 0;
+error_inval:
+    errno = EINVAL;
+    return -1;
+}
+
+char *flux_kvs_event_encode_timestamp (double timestamp, const char *name,
+                                       const char *context)
+{
+    char *s;
+    int namelen;
+
+    if (!name || timestamp <= 0.
+              || (namelen = strlen (name)) > MAX_KVS_EVENT_NAME
+              || namelen == 0
+              || strchr (name, ' ') != NULL
+              || strchr (name, '\n') != NULL
+              || (context && (strchr (context, '\n') != NULL
+                            || strlen (context) > MAX_KVS_EVENT_CONTEXT))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (asprintf (&s, "%.6f %s%s%s\n",
+                  timestamp,
+                  name,
+                  context ? " " : "",
+                  context ? context : "") < 0)
+        return NULL;
+    return s;
+}
+
+static int get_timestamp_now (double *timestamp)
+{
+    struct timespec ts;
+    if (clock_gettime (CLOCK_REALTIME, &ts) < 0)
+        return -1;
+    *timestamp = (1E-9 * ts.tv_nsec) + ts.tv_sec;
+    return 0;
+}
+
+
+char *flux_kvs_event_encode (const char *name, const char *context)
+{
+    double timestamp;
+
+    if (get_timestamp_now (&timestamp) < 0)
+        return NULL;
+    return flux_kvs_event_encode_timestamp (timestamp, name, context);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/kvs_eventlog.h
+++ b/src/common/libkvs/kvs_eventlog.h
@@ -1,0 +1,65 @@
+#ifndef _FLUX_CORE_KVS_EVENTLOG_H
+#define _FLUX_CORE_KVS_EVENTLOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* RFC 18 KVS Event Log
+ *
+ * Events are of the form:
+ *   "timestamp name [context ...]\n"
+ */
+
+typedef char flux_kvs_event_name_t[65];
+typedef char flux_kvs_event_context_t[257];
+
+/* Create/destroy an eventlog
+ */
+struct flux_kvs_eventlog *flux_kvs_eventlog_create (void);
+void flux_kvs_eventlog_destroy (struct flux_kvs_eventlog *eventlog);
+
+/* Encode/decode an eventlog to/from a string (caller must free)
+ */
+char *flux_kvs_eventlog_encode (const struct flux_kvs_eventlog *eventlog);
+struct flux_kvs_eventlog *flux_kvs_eventlog_decode (const char *s);
+
+/* Update an eventlog with new encoded snapshot 's'.
+ */
+int flux_kvs_eventlog_update (struct flux_kvs_eventlog *eventlog,
+                              const char *s);
+
+/* Append an encoded event to eventlog.
+ */
+int flux_kvs_eventlog_append (struct flux_kvs_eventlog *eventlog,
+                              const char *s);
+
+/* Iterator for events.
+ */
+const char *flux_kvs_eventlog_first (struct flux_kvs_eventlog *eventlog);
+const char *flux_kvs_eventlog_next (struct flux_kvs_eventlog *eventlog);
+
+/* Encode/decode an event.
+ * flux_kvs_event_encode() sets timestamp to current wallclock.
+ * flux_kvs_event_encode_timestmap() allows timestamp to be set to any value.
+ * Caller must free return value of flux_kvs_event_encode().
+ */
+int flux_kvs_event_decode (const char *s,
+                           double *timestamp,
+                           flux_kvs_event_name_t name,
+                           flux_kvs_event_context_t context);
+char *flux_kvs_event_encode (const char *name, const char *context);
+char *flux_kvs_event_encode_timestamp (double timestamp,
+                                       const char *name,
+                                       const char *context);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_KVS_EVENTLOG_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/test/kvs_eventlog.c
+++ b/src/common/libkvs/test/kvs_eventlog.c
@@ -1,0 +1,284 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "kvs.h"
+#include "src/common/libtap/tap.h"
+
+const char *badevent[] = {
+    "1 foo",
+    "1 foo bar",
+    "1 foo bar bar",
+    "x foo\n",
+    "foo\n",
+    "1 foo\nbar\n",
+    "1\nfoo bar\n",
+    "1\n foo\n",
+    "\n1 foo\n",
+    "1\n",
+    "1 \n",
+    "1  \n",
+    "\n",
+    "1 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n",
+    "",
+    NULL,
+};
+
+const char *badlog[] = {
+    "\n",
+    "1 foo",
+    "1 foo\n\n",
+    "\n1 foo\n",
+    "1\n1\n",
+    NULL,
+};
+
+const char *long_context = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+/* make output double the size of input to be safe */
+char *printable (char *output, const char *input)
+{
+    const char *ip;
+    char *op;
+
+    for (ip = input, op = output; *ip != '\0'; ip++, op++) {
+        switch (*ip) {
+            case '\n':
+                *op++ = '\\';
+                *op = 'n';
+                break;
+            case '\r':
+                *op++ = '\\';
+                *op = 'r';
+                break;
+            default:
+                *op = *ip;
+        }
+    }
+    *op = '\0';
+    return output;
+}
+
+void basic_check (struct flux_kvs_eventlog *log, bool first, bool xeof,
+                  double xtimestamp, const char *xname, const char *xcontext)
+{
+    const char *s;
+    int rc;
+    double timestamp;
+    flux_kvs_event_name_t name;
+    flux_kvs_event_context_t context;
+
+    name[0] = '\0';
+    context[0] = '\0';
+
+    if (first)
+        s = flux_kvs_eventlog_first (log);
+    else
+        s = flux_kvs_eventlog_next (log);
+    if (xeof) {
+        ok (s == NULL,
+            "flux_kvs_eventlog_%s = NULL", first ? "first" : "next");
+    }
+    else {
+        ok (s != NULL,
+            "flux_kvs_eventlog_%s != NULL", first ? "first" : "next");
+        rc = flux_kvs_event_decode (s, &timestamp, name, context);
+        ok (rc == 0
+            && timestamp == xtimestamp
+            && (!xname || !strcmp (name, xname))
+            && (!xcontext || !strcmp (context, xcontext)),
+            "flux_kvs_event_decode time=%llu name=%s context=%s",
+            (unsigned long long)xtimestamp, xname, xcontext);
+    }
+}
+
+void basic (void)
+{
+    const char *test1 = "42.123 foo\n44.0 bar quick brown fox\n";
+    const char *test2 = "42.123 foo\n44.0 bar quick brown fox\n50 meep\n";
+    const char *test3 = "999.2 duh baz\n";
+    struct flux_kvs_eventlog *log;
+    char *s;
+
+    /* simple create/destroy */
+    log = flux_kvs_eventlog_create ();
+    ok (log != NULL,
+        "flux_kvs_eventlog_create works");
+    flux_kvs_eventlog_destroy (log);
+
+    /* create log from data and iterate */
+    log = flux_kvs_eventlog_decode (test1);
+    ok (log != NULL,
+        "flux_kvs_eventlog_decode works on 2 entry log: [foo, bar]");
+
+    basic_check (log, true, false, 42.123, "foo", "");
+    basic_check (log, false, false, 44.0, "bar", "quick brown fox");
+    basic_check (log, false, true, 0, NULL, NULL);
+
+    /* encode and compare to input */
+    s = flux_kvs_eventlog_encode (log);
+    ok (s != NULL && !strcmp (s, test1),
+        "flux_kvs_eventlog_encode output = decode input");
+    free (s);
+
+    /* update and iterate */
+    ok (flux_kvs_eventlog_update (log, test2) == 0,
+        "flux_kvs_eventlog_update works adding 1 entry: [foo, bar, meep]");
+
+    basic_check (log, false, false, 50, "meep", "");
+    basic_check (log, false, true, 0, NULL, NULL);
+
+    /* append and iterate */
+    ok (flux_kvs_eventlog_append (log, test3) == 0,
+        "flux_kvs_eventlog_append works adding 1 entry: [foo, bar, meep, duh]");
+
+    basic_check (log, false, false, 999.2, "duh", "baz");
+    basic_check (log, false, true, 0, NULL, NULL);
+
+    flux_kvs_eventlog_destroy (log);
+}
+
+void bad_input (void)
+{
+    struct flux_kvs_eventlog *log;
+    char *s;
+    int i;
+
+    lives_ok ({flux_kvs_eventlog_destroy (NULL);},
+              "flux_kvs_eventlog_destroy log=NULL doesn't crash");
+
+    /* empty logs */
+    errno = 0;
+    ok (flux_kvs_eventlog_decode (NULL) == NULL && errno == EINVAL,
+        "flux_kvs_eventlog_decode log=NULL fails with EINVAL");
+    log = flux_kvs_eventlog_decode ("");
+    ok (log != NULL && flux_kvs_eventlog_first (log) == NULL,
+        "flux_kvs_eventlog_decode log=\"\" creates valid empty log");
+    errno = 0;
+    ok (flux_kvs_eventlog_update (log, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_eventlog_update s=NULL fails with EINVAL");
+    ok (flux_kvs_eventlog_update (log, "") == 0
+        && flux_kvs_eventlog_first (log) == NULL,
+        "flux_kvs_eventlog_update s=\"\" works, log still empty");
+    s = flux_kvs_eventlog_encode (log);
+    ok (s != NULL && !strcmp (s, ""),
+        "flux_kvs_eventlog_encode returns \"\"");
+    free (s);
+    flux_kvs_eventlog_destroy (log);
+
+    /* append */
+    log = flux_kvs_eventlog_create ();
+    if (!log)
+        BAIL_OUT ("flux_kvs_eventlog_create failed");
+    errno = 0;
+    ok (flux_kvs_eventlog_append (NULL, "0 foo\n") < 0 && errno == EINVAL,
+        "flux_kvs_eventlog_append log=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_eventlog_append (log, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_eventlog_append event=NULL fails with EINVAL");
+
+    /* first/next */
+    ok (flux_kvs_eventlog_first (NULL) == NULL,
+        "flux_kvs_eventlog_first log=NULL returns NULL");
+    ok (flux_kvs_eventlog_next (NULL) == NULL,
+        "flux_kvs_eventlog_next log=NULL returns NULL");
+
+    errno = 0;
+    ok (flux_kvs_event_decode (NULL, NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_kvs_event_decode log=NULL fails with EINVAL");
+
+    /* decode bad events */
+    for (i = 0; badevent[i] != NULL; i++) {
+        char buf[80];
+        errno = 0;
+        ok (flux_kvs_event_decode (badevent[i], NULL, NULL, NULL) < 0
+            && errno == EINVAL,
+            "flux_kvs_event_decode event=\"%s\" fails with EINVAL",
+            printable (buf, badevent[i]));
+        errno = 0;
+        ok (flux_kvs_eventlog_append (log, badevent[i]) < 0
+            && errno == EINVAL,
+            "flux_kvs_eventlog_append event=\"%s\" fails with EINVAL",
+            printable (buf, badevent[i]));
+    }
+
+    /* decode bad logs */
+    for (i = 0; badlog[i] != NULL; i++) {
+        char buf[512];
+        errno = 0;
+        ok (flux_kvs_eventlog_decode (badlog[i]) == NULL && errno == EINVAL,
+            "flux_kvs_eventlog_decode log=\"%s\" fails with EINVAL",
+            printable (buf, badlog[i]));
+    }
+
+    errno = 0;
+    ok (flux_kvs_eventlog_encode (NULL) == NULL && errno == EINVAL,
+        "flux_kvs_eventlog_encode log=NULL fails with EINVAL");
+}
+
+void event (void)
+{
+    char *s;
+
+    s = flux_kvs_event_encode_timestamp (1., "foo", NULL);
+    ok (s != NULL,
+        "flux_kvs_event_encode_timestamp context=NULL works");
+    free (s);
+
+    s = flux_kvs_event_encode_timestamp (1., "foo", "foo");
+    ok (s != NULL,
+        "flux_kvs_event_encode_timestamp context=\"foo\" works");
+    free (s);
+
+    s = flux_kvs_event_encode ("foo", "foo");
+    ok (s != NULL,
+        "flux_kvs_event_encode_timestamp works");
+    free (s);
+
+    errno = 0;
+    ok (flux_kvs_event_encode_timestamp (-1., "foo", NULL) == NULL
+        && errno == EINVAL,
+        "flux_kvs_event_encode_timestamp timestamp=(-1) fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_event_encode_timestamp (1., "", NULL) == NULL
+        && errno == EINVAL,
+        "flux_kvs_event_encode_timestamp name=\"\" fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_event_encode_timestamp (1., "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", NULL) == NULL
+        && errno == EINVAL,
+        "flux_kvs_event_encode_timestamp name=(too long) fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_event_encode_timestamp (1., "a a", NULL) == NULL
+        && errno == EINVAL,
+        "flux_kvs_event_encode_timestamp name=\"a a\" fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_event_encode_timestamp (1., "a", "foo\n") == NULL
+        && errno == EINVAL,
+        "flux_kvs_event_encode_timestamp context=\"foo\\n\" fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_event_encode_timestamp (1., "a", long_context) == NULL
+        && errno == EINVAL,
+        "flux_kvs_event_encode_timestamp context=(too long) fails with EINVAL");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic ();
+    bad_input ();
+    event ();
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -65,6 +65,7 @@ TESTS = \
 	t1005-kvs-security.t \
 	t1006-kvs-getroot.t \
 	t1007-kvs-lookup-watch.t \
+	t1008-kvs-eventlog.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -162,6 +163,7 @@ check_SCRIPTS = \
 	t1005-kvs-security.t \
 	t1006-kvs-getroot.t \
 	t1007-kvs-lookup-watch.t \
+	t1008-kvs-eventlog.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -7,7 +7,6 @@ test_description='Test KVS get --watch'
 test_under_flux 4 kvs
 
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
-commit_order=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 
 test_expect_success 'flux kvs get --watch --count=1 works' '
 	flux kvs put test.a=42 &&

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+test_description='Test kvs eventlog get|append'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 kvs
+
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+test_expect_success 'flux kvs eventlog append --timestamp works' '
+	flux kvs eventlog append --timestamp=1 test.a name some context &&
+	flux kvs eventlog get --unformatted test.a >get_a.out &&
+	echo "1.000000 name some context" >get_a.exp &&
+	test_cmp get_a.exp get_a.out
+'
+
+test_expect_success 'flux kvs eventlog append works' '
+	flux kvs eventlog append test.b foo &&
+	flux kvs eventlog get test.b >get_b.out &&
+	grep -q foo get_b.out
+'
+
+test_expect_success 'flux kvs eventlog get --watch --count=N works' '
+	flux kvs eventlog append --timestamp=42 test.c foo &&
+	flux kvs eventlog append --timestamp=43 test.c bar &&
+	run_timeout 2 flux kvs eventlog \
+		get --watch --unformatted --count=2 test.c >get_c.out &&
+	echo "42.000000 foo" >get_c.exp &&
+	echo "43.000000 bar" >>get_c.exp &&
+	test_cmp get_c.exp get_c.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --watch returns append order' '
+	flux kvs eventlog append --timestamp=1 test.d foo bar &&
+	echo "1.000000 foo bar" >get_d.exp
+	flux kvs eventlog get --unformatted --watch --count=20 test.d >get_d.out &
+	pid=$! &&
+	for i in $(seq 2 20); do \
+		flux kvs eventlog append --timestamp=$i test.d foo bar; \
+		echo "$i.000000 foo bar" >>get_d.exp; \
+	done &&
+	wait $pid &&
+	test_cmp get_d.exp get_d.out
+'
+test_done


### PR DESCRIPTION
This is a small class for manipulating RFC 18 KVS eventlogs, as discussed in #1654.

@grondo's idea of keeping this decoupled from futures and KVS transactions was a great one.  This is completely standalone and can be covered well with unit tests.

I added a `flux kvs eventlog append|get` subcommand that allows events to be appended to an eventlog, and the logs to be dumped and also watched.  The get implementation illustrates how the iterators can be used with `flux_kvs_eventlog_update()` in a continuation to "consume" only the new eventlog entries.

This still needs a man page but any feedback on the API would be useful at this point.

One thing I waffled on was the static buffer typedefs for event name and context.  The RFC didn't establish any maximum field widths for this, but I assumed 16 and 256, respectively here to avoid mallocs during parsing.  Either the RFC needs  to be updated or this needs to change.

Commit messages contain additional commentary.

Here's the current proposed API:
```c
/* RFC 18 KVS Event Log
 *
 * Events are of the form:
 *   "timestamp name [context ...]\n"
 */
typedef char flux_kvs_event_name_t[17];
typedef char flux_kvs_event_context_t[257];

/* Create/destroy an eventlog
 */
struct flux_kvs_eventlog *flux_kvs_eventlog_create (void);
void flux_kvs_eventlog_destroy (struct flux_kvs_eventlog *eventlog);

/* Encode/decode an eventlog to/from a string (caller must free)
 */
char *flux_kvs_eventlog_encode (const struct flux_kvs_eventlog *eventlog);
struct flux_kvs_eventlog *flux_kvs_eventlog_decode (const char *s);

/* Update an eventlog with new encoded snapshot 's'.
 */
int flux_kvs_eventlog_update (struct flux_kvs_eventlog *eventlog,
                              const char *s);

/* Append an encoded event to eventlog.
 */
int flux_kvs_eventlog_append (struct flux_kvs_eventlog *eventlog,
                              const char *s);

/* Iterator for events.
 */
const char *flux_kvs_eventlog_first (struct flux_kvs_eventlog *eventlog);
const char *flux_kvs_eventlog_next (struct flux_kvs_eventlog *eventlog);

/* Encode/decode an event.
 * flux_kvs_event_encode() sets timestamp to current wallclock.
 * flux_kvs_event_encode_timestmap() allows timestamp to be set to any value.
 * Caller must free return value of flux_kvs_event_encode().
 */
int flux_kvs_event_decode (const char *s,
                           double *timestamp,
                           flux_kvs_event_name_t name,
                           flux_kvs_event_context_t context);
char *flux_kvs_event_encode (const char *name, const char *context);
char *flux_kvs_event_encode_timestamp (double timestamp,
                                       const char *name,
                                       const char *context);
```

