### PR TITLE
build: prefer asciidoc (a2x) over asciidoctor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,11 +65,17 @@ AC_PROG_AWK
 AC_ARG_ENABLE([docs],
 	      AS_HELP_STRING([--disable-docs], [disable building docs]))
 AS_IF([test "x$enable_docs" != "xno"], [
-  AC_CHECK_PROG(A2X,[a2x],[a2x])
-  AC_CHECK_PROG(ADOC,[asciidoctor],[asciidoctor])
+  AC_CHECK_PROGS(ADOC, [a2x asciidoctor],[not-found])
+  AS_IF([test "$ADOC" == "a2x"], [
+	ADOC_FORMAT_OPT="--format"
+	AC_SUBST([ADOC_FORMAT_OPT])
+  ])
+  AS_IF([test "$ADOC" == "asciidoctor"], [
+	ADOC_FORMAT_OPT="--backend"
+	AC_SUBST([ADOC_FORMAT_OPT])
+  ])
 ])
-AM_CONDITIONAL([ENABLE_DOCS], [test "$A2X" = "a2x" || test "$ADOC" = "asciidoctor"])
-AM_CONDITIONAL([ENABLE_ADOC], [test "$ADOC" = "asciidoctor"])
+AM_CONDITIONAL([ENABLE_DOCS], [test "$ADOC" != "not-found"])
 AC_CHECK_PROG(ASPELL,[aspell],[aspell])
 
 ##
@@ -373,7 +379,7 @@ AC_CONFIG_LINKS([ \
 AC_OUTPUT
 
 AS_IF([test "x$enable_docs" != "xno"], [
-  if test "$A2X" != "a2x" && test "$ADOC" != "asciidoctor"; then
+  if test "$ADOC" == "not-found"; then
     AC_MSG_WARN([No asciidoc formatter found. Manual pages will not be generated.])
   fi
 ])

--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -50,21 +50,12 @@ STDERR_DEVNULL = $(stderr_devnull_$(V))
 stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
-if ENABLE_ADOC
 .adoc.1:
 	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
-	    --attribute manversion=$(PACKAGE_VERSION) \
-	    --attribute manmanual="Flux Command Reference" \
-	    --destination-dir $(builddir) \
-	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
-else
-.adoc.1:
-	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
-	    --attribute manversion=$(PACKAGE_VERSION) \
-	    --attribute manmanual="Flux Command Reference" \
-	    --destination-dir=$(builddir) \
-	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
-endif
+	--attribute manversion=$(PACKAGE_VERSION) \
+	--attribute manmanual="Flux Command Reference" \
+	--destination-dir $(builddir) \
+	--doctype manpage $(ADOC_FORMAT_OPT) manpage $< $(STDERR_DEVNULL)
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc NODESET.adoc
 

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -203,22 +203,12 @@ STDERR_DEVNULL = $(stderr_devnull_$(V))
 stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
-if ENABLE_ADOC
 .adoc.3:
 	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
 	    --attribute manmanual="Flux Programming Reference" \
 	    --destination-dir $(builddir) \
-	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
-else
-.adoc.3:
-	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
-	    --attribute manversion=$(PACKAGE_VERSION) \
-	    --attribute manmanual="Flux Programming Reference" \
-	    --destination-dir=$(builddir) \
-	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
-endif
-
+	    --doctype manpage $(ADOC_FORMAT_OPT) manpage $< $(STDERR_DEVNULL)
 
 flux_clone.3: flux_open.3
 flux_close.3: flux_open.3

--- a/doc/man7/Makefile.am
+++ b/doc/man7/Makefile.am
@@ -15,21 +15,12 @@ STDERR_DEVNULL = $(stderr_devnull_$(V))
 stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
 stderr_devnull_0 = 2>/dev/null
 
-if ENABLE_ADOC
 .adoc.7:
 	$(AM_V_GEN)$(ADOC) --attribute mansource=$(PACKAGE_NAME) \
 	    --attribute manversion=$(PACKAGE_VERSION) \
 	    --attribute manmanual="Flux Miscellaneous Reference" \
 	    --destination-dir $(builddir) \
-	    --doctype manpage --backend manpage $< $(STDERR_DEVNULL)
-else
-.adoc.7:
-	$(AM_V_GEN)$(A2X) --attribute mansource=$(PACKAGE_NAME) \
-	    --attribute manversion=$(PACKAGE_VERSION) \
-	    --attribute manmanual="Flux Miscellaneous Reference" \
-	    --destination-dir=$(builddir) \
-	    --doctype manpage --format manpage $< $(STDERR_DEVNULL)
-endif
+	    --doctype manpage $(ADOC_FORMAT_OPT) manpage $< $(STDERR_DEVNULL)
 
 EXTRA_DIST = $(ADOC_FILES) COPYRIGHT.adoc
 


### PR DESCRIPTION
Problem: only recent version of asciidoctor handle man
page stubs properly, but if both asciidoctor and asciidoc
are installed, the former will be used.

Change config logic to prefer a2x if both are installed.

Also, simpifly the doc/man*/Makefile.am files by setting
$(ADOC) to either asciidoc or a2x, and setting
$(ADOC_FORMAT_OPT) to either --backend or --format, so that
a single command line can be used for both formatters.

Fixes #1672