### PR TITLE
job-ingest: create eventlog

### DIFF
--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -60,6 +60,13 @@ test_expect_success 'job-ingest: submitter userid stored in KVS' '
 	test $jobuserid -eq $myuserid
 '
 
+test_expect_success 'job-ingest: eventlog created with submit entry' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog get ${kvsdir}.eventlog >eventlog &&
+	grep -q " submit" eventlog
+'
+
 test_expect_success 'job-ingest: valid jobspecs accepted' '
 	test_valid ${JOBSPEC}/valid/*
 '


### PR DESCRIPTION
As discussed in #1680, the job eventlog needs to be created in the KVS before the user gets a response from `flux_job_submit()` so they can immediately "wait" on the eventlog with `flux_kvs_lookup (FLUX_KVS_WATCH)` or a TBD `flux_job_wait()` function.

This PR simply creates the eventlog with other RFC 16 job schema entries at ingest time.

The ingest sharness test is amended to check for it.