### PR TITLE
cmd/flux: ensure selfdir always at front of PATH, and fix issue when builddir is inaccessible

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -282,7 +282,9 @@ bool flux_is_installed (void)
      *   clearly can't be from the installed path:
      */
 
-    if (!(bindir = realpath (conf_bindir, NULL)) && (errno != ENOENT))
+    if (!(bindir = realpath (conf_bindir, NULL))
+       && (errno != ENOENT)
+       && (errno != EACCES))
         log_err_exit ("realpath (%s)", conf_bindir);
     else if (bindir && !strcmp (selfdir, bindir))
         ret = false;

--- a/src/common/libutil/environment.c
+++ b/src/common/libutil/environment.c
@@ -163,13 +163,20 @@ static void environment_push_inner (struct environment *e,
         argz_create_sep (value, item->sep, &split_value, &split_value_len);
         char *entry = 0;
         while((entry = argz_next (split_value, split_value_len, entry))) {
-            if ((!strlen(entry)) || find_env_item(item, entry))
+            char *found;
+            if ((!strlen(entry)))
                 continue;
-            if (before) {
+            /*
+             * If an existing entry is found matching this entry, and
+             *  the `before` flag is set, then delete the existing entry so
+             *  it is effectively pushed to the front (without duplication)
+             */
+            if ((found = find_env_item (item, entry)) && before)
+                argz_delete (&item->argz, &item->argz_len, found);
+            if (before)
                 argz_insert (&item->argz, &item->argz_len, item->argz, entry);
-            } else {
+            else if (found == NULL)
                 argz_add(&item->argz, &item->argz_len, entry);
-            }
         }
         free(split_value);
     } else {

--- a/t/t1102-cmddriver.t
+++ b/t/t1102-cmddriver.t
@@ -87,7 +87,11 @@ test_expect_success READLINK 'cmddriver adds its own path to PATH if called with
 	fluxdir=\$(dirname \$fluxcmd) &&
 	PATH='/bin:/usr/bin' \$fluxcmd env sh -c 'echo \$PATH' | grep ^\$fluxdir
 "
-
+test_expect_success READLINK 'cmddriver moves its own path to the front of PATH' "
+	fluxcmd=\$(readlink -f \$(which flux)) &&
+	fluxdir=\$(dirname \$fluxcmd) &&
+	PATH=/bin:\$fluxdir \$fluxcmd env sh -c 'echo \$PATH' | grep ^\$fluxdir
+"
 test_expect_success 'FLUX_*_PREPEND environment variables work' '
 	( FLUX_CONNECTOR_PATH_PREPEND=/foo \
 	  flux /usr/bin/printenv | grep "FLUX_CONNECTOR_PATH=/foo" &&


### PR DESCRIPTION
This pulls off the cmd/flux fixes from #1670 into their own PR. These fixes were more general than just testsuite changes required for the docker environment.