### PR TITLE
travis-ci: quiet tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
 
 env:
   global:
+   - TAP_DRIVER_QUIET=1
    - DOCKERREPO=fluxrm/flux-core
    - DOCKER_USERNAME=travisflux
    - secure: "Uga2i1Yu0PvWMFzOYvM9yxnAMDTgY17ZqeFlIN8MV3uoTCy6y61GULrMkKuhuI1sUfyugpFWVKIJo5jwTpsfG84f3o9lUTRgLPpTA2Xls8A/rmurF/QacVv6hZ2Zs2LQVlrM8BkT36TpT2NfWW2D2238kovqz3l5gIZKMClMvyk="

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -123,6 +123,7 @@ docker run --rm \
     -e JOBS \
     -e USER \
     -e TRAVIS \
+    -e TAP_DRIVER_QUIET \
     ${INTERACTIVE:+--tty --interactive} \
     travis-builder:${IMAGE} \
     ${INTERACTIVE:-./src/test/travis_run.sh ${CONFIGURE_ARGS}} \


### PR DESCRIPTION
This is an experimental PR to quiet the output from `make check` in travis (and elsewhere).
It is experimental because it adds code to `tap-driver.sh` and I'm not sure that's a good idea.

The main change is the addition of a quiet mode for `tap-driver.sh` which suppresses output for each line of TAP, instead issuing a one-line summary for each test. This dramatically reduces the output in travis from about 11.5K lines to 5500 lines. The new output looks like:

```
        shmem/backtoback.t: PASS: N=10  PASS=10  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
                loop/log.t: PASS: N=3   PASS=3   FAIL=0 SKIP=0 XPASS=0 XFAIL=0
             loop/handle.t: PASS: N=33  PASS=33  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
                 rpc/rpc.t: PASS: N=79  PASS=79  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
           loop/dispatch.t: PASS: N=53  PASS=53  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
           rolemask/loop.t: PASS: N=46  PASS=46  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
            loop/reactor.t: PASS: N=11  PASS=11  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
                rpc/mrpc.t: PASS: N=81  PASS=81  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
             loop/reduce.t: PASS: N=62  PASS=62  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
          t0000-sharness.t: PASS: N=27  PASS=21  FAIL=0 SKIP=5 XPASS=0 XFAIL=1
              t0008-attr.t: PASS: N=7   PASS=7   FAIL=0 SKIP=0 XPASS=0 XFAIL=0
           t0002-request.t: PASS: N=20  PASS=20  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
             t0009-dmesg.t: PASS: N=11  PASS=11  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
     t0010-generic-utils.t: PASS: N=4   PASS=4   FAIL=0 SKIP=0 XPASS=0 XFAIL=0
     t0016-cron-faketime.t: SKIP: N=1   PASS=0   FAIL=0 SKIP=1 XPASS=0 XFAIL=0
            t0003-module.t: PASS: N=44  PASS=44  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
             t0004-event.t: PASS: N=14  PASS=14  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
       t0013-config-file.t: PASS: N=13  PASS=13  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
             t0005-rexec.t: PASS: N=24  PASS=24  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
              t0005-exec.t: PASS: N=27  PASS=27  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
          t0017-security.t: PASS: N=39  PASS=39  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
              t0007-ping.t: PASS: N=33  PASS=33  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
          t0014-runlevel.t: PASS: N=8   PASS=8   FAIL=0 SKIP=0 XPASS=0 XFAIL=0
    t0012-content-sqlite.t: PASS: N=26  PASS=25  FAIL=0 SKIP=1 XPASS=0 XFAIL=0
              t0015-cron.t: PASS: N=27  PASS=27  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
     t0011-content-cache.t: PASS: N=17  PASS=16  FAIL=0 SKIP=1 XPASS=0 XFAIL=0
         t1002-kvs-watch.t: PASS: N=16  PASS=16  FAIL=0 SKIP=0 XPASS=0 XFAIL=0
```

Quiet mode is enabled with `TAP_DRIVER_QUIET=1` in the environment before testing.