### PR TITLE
testsuite: add timeout to valgrind test, add missing test to EXTRA_DIST

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -124,7 +124,7 @@ docker run --rm \
     -e USER \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
-    ${INTERACTIVE:+--tty --interactive} \
+    --tty \
     travis-builder:${IMAGE} \
     ${INTERACTIVE:-./src/test/travis_run.sh ${CONFIGURE_ARGS}} \
     || die "docker run failed"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -208,6 +208,7 @@ check_SCRIPTS = \
         issues/t0441-kvs-put-get.sh \
         issues/t0505-msg-handler-reg.lua \
         issues/t0821-kvs-segfault.sh \
+	issues/t0704-mpirun-rank.sh \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -34,6 +34,7 @@ BROKER=${FLUX_BUILD_DIR}/src/broker/flux-broker
 FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
 
 test_expect_success 'valgrind reports no new errors on single broker run' '
+	run_timeout 120 \
 	libtool e flux ${VALGRIND} \
 		--tool=memcheck \
 		--leak-check=full \


### PR DESCRIPTION
As discussed in #1699, this PR adds a timeout to the t5000-valgrind.t test (2 minutes, should be plenty of time I think, but we could make it longer). Also, this PR adds the missing issues test to EXTRA_DIST, and small output fix for docker-run-checks.