### PR TITLE
common/libutil: Remove blobref_t type

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -535,7 +535,7 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
     const void *data;
     int len;
     struct cache_entry *e = NULL;
-    blobref_t blobref;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
     int rc = -1;
 
     if (flux_request_decode_raw (msg, NULL, &data, &len) < 0)
@@ -544,7 +544,8 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
         errno = EFBIG;
         goto done;
     }
-    if (blobref_hash (cache->hash_name, (uint8_t *)data, len, blobref) < 0)
+    if (blobref_hash (cache->hash_name, (uint8_t *)data, len, blobref,
+                      sizeof (blobref)) < 0)
         goto done;
 
     if (!(e = lookup_entry (cache, blobref))) {

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -516,7 +516,7 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
                                    void *data, int len)
 {
     json_t *valref = NULL;
-    blobref_t blobref;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
     int blob_len;
 
     if (!(valref = treeobj_create_valref (NULL)))
@@ -525,7 +525,8 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
         blob_len = len;
         if (maxblob > 0 && len > maxblob)
             blob_len = maxblob;
-        if (blobref_hash (hashtype, data, blob_len, blobref) < 0)
+        if (blobref_hash (hashtype, data, blob_len, blobref,
+                          sizeof (blobref)) < 0)
             goto error;
         if (treeobj_append_blobref (valref, blobref) < 0)
             goto error;

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -168,13 +168,14 @@ inval:
 
 static int hashtostr (struct blobhash *bh,
                       const void *hash, int len,
-                      blobref_t blobref)
+                      char *blobref, int blobref_len)
 {
-    int size = sizeof (blobref_t);
     uint8_t *ihash = (uint8_t *)hash;
     int i;
 
-    if (len != bh->hashlen || size < bh->hashlen*2 + strlen (bh->name) + 2) {
+    if (len != bh->hashlen
+        || !blobref
+        || blobref_len < bh->hashlen*2 + strlen (bh->name) + 2) {
         errno = EINVAL;
         return -1;
     }
@@ -191,7 +192,7 @@ static int hashtostr (struct blobhash *bh,
 
 int blobref_hashtostr (const char *hashtype,
                        const void *hash, int len,
-                       blobref_t blobref)
+                       void *blobref, int blobref_len)
 {
     struct blobhash *bh;
 
@@ -199,13 +200,13 @@ int blobref_hashtostr (const char *hashtype,
         errno = EINVAL;
         return -1;
     }
-    return hashtostr (bh, hash, len, blobref);
+    return hashtostr (bh, hash, len, blobref, blobref_len);
 }
 
 
 int blobref_hash (const char *hashtype,
                   const void *data, int len,
-                  blobref_t blobref)
+                  void *blobref, int blobref_len)
 {
     struct blobhash *bh;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
@@ -215,7 +216,7 @@ int blobref_hash (const char *hashtype,
         return -1;
     }
     bh->hashfun (data, len, hash, bh->hashlen);
-    return hashtostr (bh, hash, bh->hashlen, blobref);
+    return hashtostr (bh, hash, bh->hashlen, blobref, blobref_len);
 }
 
 int blobref_validate (const char *blobref)

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -6,8 +6,6 @@
 
 #include <stdint.h>
 
-typedef char blobref_t[BLOBREF_MAX_STRING_SIZE];
-
 /* Convert a blobref string to hash digest.
  * The hash algorithm is selected by the blobref prefix.
  * Returns hash length on success, or -1 on error, with errno set.
@@ -20,7 +18,7 @@ int blobref_strtohash (const char *blobref, void *hash, int size);
  */
 int blobref_hashtostr (const char *hashtype,
                        const void *hash, int len,
-                       blobref_t blobref);
+                       void *blobref, int blobref_len);
 
 /* Compute hash over data and return null-terminated blobref string in
  * 'blobref'.  The hash algorithm is selected by 'hashtype', e.g. "sha1".
@@ -28,7 +26,7 @@ int blobref_hashtostr (const char *hashtype,
  */
 int blobref_hash (const char *hashtype,
                   const void *data, int len,
-                  blobref_t blobref);
+                  void *blobref, int blobref_len);
 
 /* Check validity of blobref string.
  */

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -21,8 +21,8 @@ const char *goodref[] = {
 
 int main(int argc, char** argv)
 {
-    blobref_t ref;
-    blobref_t ref2;
+    char ref[BLOBREF_MAX_STRING_SIZE];
+    char ref2[BLOBREF_MAX_STRING_SIZE];
     uint8_t digest[BLOBREF_MAX_DIGEST_SIZE];
     uint8_t data[1024];
 
@@ -32,9 +32,17 @@ int main(int argc, char** argv)
 
     /* invalid args */
     errno = 0;
-    ok (blobref_hash ("nerf", data, sizeof (data), ref) < 0
+    ok (blobref_hash ("nerf", data, sizeof (data), ref, sizeof (ref)) < 0
         && errno == EINVAL,
         "blobref_hash fails EINVAL with unknown hash name");
+    errno = 0;
+    ok (blobref_hash ("sha1", data, sizeof (data), NULL, 0) < 0
+        && errno == EINVAL,
+        "blobref_hash fails EINVAL with NULL ref pointer");
+    errno = 0;
+    ok (blobref_hash ("sha1", data, sizeof (data), ref, 1) < 0
+        && errno == EINVAL,
+        "blobref_hash fails EINVAL with invalid ref length");
 
     errno = 0;
     ok (blobref_strtohash (badref[0], digest, sizeof (digest)) < 0
@@ -59,41 +67,55 @@ int main(int argc, char** argv)
 
     memset (digest, 6, sizeof (digest));
     errno = 0;
-    ok (blobref_hashtostr ("nerf", digest, SHA1_DIGEST_SIZE, ref) < 0
+    ok (blobref_hashtostr ("nerf", digest, SHA1_DIGEST_SIZE, ref,
+                           sizeof (ref)) < 0
         && errno == EINVAL,
         "blobref_hashtostr fails EINVAL with unknown hash");
     errno = 0;
-    ok (blobref_hashtostr ("sha1", digest, SHA256_BLOCK_SIZE, ref) < 0
+    ok (blobref_hashtostr ("sha1", digest, SHA256_BLOCK_SIZE, ref,
+                           sizeof (ref)) < 0
         && errno == EINVAL,
         "blobref_hashtostr fails EINVAL with wrong digest size for hash");
+    errno = 0;
+    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, NULL,
+                           sizeof (ref)) < 0
+        && errno == EINVAL,
+        "blobref_hashtostr fails EINVAL with NULL ref pointer");
+    errno = 0;
+    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref,
+                           1) < 0
+        && errno == EINVAL,
+        "blobref_hashtostr fails EINVAL with invalid ref length");
 
     /* sha1 */
-    ok (blobref_hash ("sha1", NULL, 0, ref) == 0,
+    ok (blobref_hash ("sha1", NULL, 0, ref, sizeof (ref)) == 0,
         "blobref_hash sha1 handles zero length data");
     diag ("%s", ref);
-    ok (blobref_hash ("sha1", data, sizeof (data), ref) == 0,
+    ok (blobref_hash ("sha1", data, sizeof (data), ref, sizeof (ref)) == 0,
         "blobref_hash sha1 works");
     diag ("%s", ref);
 
     ok (blobref_strtohash (ref, digest, sizeof (digest)) == SHA1_DIGEST_SIZE,
         "blobref_strtohash returns expected size hash");
-    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref2) == 0,
+    ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref2,
+                           sizeof (ref2)) == 0,
         "blobref_hashtostr back again works");
     diag ("%s", ref2);
     ok (strcmp (ref, ref2) == 0,
         "and blobrefs match");
 
     /* sha256 */
-    ok (blobref_hash ("sha256", NULL, 0, ref) == 0,
+    ok (blobref_hash ("sha256", NULL, 0, ref, sizeof (ref)) == 0,
         "blobref_hash sha256 handles zero length data");
     diag ("%s", ref);
-    ok (blobref_hash ("sha256", data, sizeof (data), ref) == 0,
+    ok (blobref_hash ("sha256", data, sizeof (data), ref, sizeof (ref)) == 0,
         "blobref_hash sha256 works");
     diag ("%s", ref);
 
     ok (blobref_strtohash (ref, digest, sizeof (digest)) == SHA256_BLOCK_SIZE,
         "blobref_strtohash returns expected size hash");
-    ok (blobref_hashtostr ("sha256", digest, SHA256_BLOCK_SIZE, ref2) == 0,
+    ok (blobref_hashtostr ("sha256", digest, SHA256_BLOCK_SIZE, ref2,
+                           sizeof (ref2)) == 0,
         "blobref_hashtostr back again works");
     diag ("%s", ref2);
     ok (strcmp (ref, ref2) == 0,

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -336,7 +336,7 @@ void store_cb (flux_t *h, flux_msg_handler_t *mh,
     const void *data;
     int size, hash_len;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
-    blobref_t blobref = "-";
+    char blobref[BLOBREF_MAX_STRING_SIZE] = "-";
     int uncompressed_size = -1;
     int rc = -1;
     int old_state;
@@ -351,7 +351,8 @@ void store_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EFBIG;
         goto done;
     }
-    if (blobref_hash (ctx->hashfun, (uint8_t *)data, size, blobref) < 0)
+    if (blobref_hash (ctx->hashfun, (uint8_t *)data, size, blobref,
+                      sizeof (blobref)) < 0)
         goto done;
     if ((hash_len = blobref_strtohash (blobref, hash, sizeof (hash))) < 0)
         goto done;

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -263,7 +263,7 @@ void kvsroot_setroot (kvsroot_mgr_t *krm, struct kvsroot *root,
     if (!root || !root_ref)
         return;
 
-    assert (strlen (root_ref) < sizeof (blobref_t));
+    assert (strlen (root_ref) < sizeof (root->ref));
 
     strcpy (root->ref, root_ref);
     root->seq = root_seq;

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -16,7 +16,7 @@ struct kvsroot {
     char *namespace;
     uint32_t owner;
     int seq;
-    blobref_t ref;
+    char ref[BLOBREF_MAX_STRING_SIZE];
     kvstxn_mgr_t *ktm;
     treq_mgr_t *trm;
     waitqueue_t *watchlist;

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -5,7 +5,6 @@
 #include <czmq.h>
 
 #include "cache.h"
-#include "src/common/libutil/blobref.h"
 
 typedef struct kvstxn_mgr kvstxn_mgr_t;
 typedef struct kvstxn kvstxn_t;
@@ -85,7 +84,7 @@ const char *kvstxn_get_newroot_ref (kvstxn_t *kt);
  */
 kvstxn_process_t kvstxn_process (kvstxn_t *kt,
                                  int current_epoch,
-                                 const blobref_t rootdir_ref);
+                                 const char *rootdir_ref);
 
 /* on stall, iterate through all missing refs that the caller should
  * load into the cache

--- a/t/kvs/blobref.c
+++ b/t/kvs/blobref.c
@@ -18,7 +18,7 @@ int main (int argc, char *argv[])
     uint8_t *data;
     int size;
     char *hashtype;
-    blobref_t blobref;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
 
     if (argc != 2) {
         fprintf (stderr, "Usage: cat file | blobref hashtype\n");
@@ -29,7 +29,7 @@ int main (int argc, char *argv[])
     if ((size = read_all (STDIN_FILENO, (void **)&data)) < 0)
         log_err_exit ("read");
 
-    if (blobref_hash (hashtype, data, size, blobref) < 0)
+    if (blobref_hash (hashtype, data, size, blobref, sizeof (blobref)) < 0)
         log_err_exit ("blobref_hash");
     printf ("%s\n", blobref);
     return 0;


### PR DESCRIPTION
Per RFC7, typedefs should not point to fixed length arrays.  So remove
blobref_t typedef globally.  Adjust functions to take a char array
and an array length parameter.

Fixes #1692