### PR TITLE
add job manager

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,6 +362,7 @@ AC_CONFIG_FILES( \
   src/modules/pymod/Makefile \
   src/modules/userdb/Makefile \
   src/modules/job-ingest/Makefile \
+  src/modules/job-manager/Makefile \
   src/test/Makefile \
   etc/Makefile \
   etc/flux-core.pc \

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1,5 +1,5 @@
 /*****************************************************************************\
- *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
  *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
  *  LLNL-CODE-658032 All rights reserved.
  *
@@ -9,7 +9,10 @@
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the license, or (at your option)
- *  any later version.
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2 of the license,
+ *  or (at your option) any later version.
  *
  *  Flux is distributed in the hope that it will be useful, but WITHOUT
  *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
@@ -32,6 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <jansson.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 #if HAVE_FLUX_SECURITY
@@ -42,10 +46,21 @@
 #include "src/common/libjob/job.h"
 #include "src/common/libutil/read_all.h"
 
+int cmd_list (optparse_t *p, int argc, char **argv);
 int cmd_submitbench (optparse_t *p, int argc, char **argv);
 int cmd_id (optparse_t *p, int argc, char **argv);
 
 static struct optparse_option global_opts[] =  {
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option list_opts[] =  {
+    { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "N",
+      .usage = "Limit output to N jobs",
+    },
+    { .name = "suppress-header", .key = 's', .has_arg = 0,
+      .usage = "Suppress printing of header line",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -86,6 +101,13 @@ static struct optparse_option id_opts[] =  {
 };
 
 static struct optparse_subcommand subcommands[] = {
+    { "list",
+      "[OPTIONS]",
+      "List active jobs",
+      cmd_list,
+      0,
+      list_opts
+    },
     { "submitbench",
       "[OPTIONS] jobspec",
       "Run job(s)",
@@ -161,6 +183,48 @@ int main (int argc, char *argv[])
     optparse_destroy (p);
     log_fini ();
     return (exitval);
+}
+
+int cmd_list (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    int max_entries = optparse_get_int (p, "count", 0);
+    char *attrs = "[\"id\",\"userid\",\"priority\"]";
+    flux_t *h;
+    flux_future_t *f;
+    json_t *jobs;
+    size_t index;
+    json_t *value;
+
+    if (optindex != argc) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_job_list (h, max_entries, attrs)))
+        log_err_exit ("flux_job_list");
+    if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
+        log_err_exit ("flux_job_list");
+    if (!optparse_hasopt (p, "suppress-header"))
+        printf ("%s\t\t%s\t%s\n", "JOBID", "USERID", "PRIORITY");
+    json_array_foreach (jobs, index, value) {
+        flux_jobid_t id;
+        int priority;
+        uint32_t userid;
+        if (json_unpack (value, "{s:I s:i s:i}", "id", &id,
+                                                 "priority", &priority,
+                                                 "userid", &userid) < 0)
+            log_msg_exit ("error parsing job data");
+        printf ("%llu\t%lu\t%d\n", (unsigned long long)id,
+                                   (unsigned long)userid,
+                                   priority);
+    }
+    flux_future_destroy (f);
+    flux_close (h);
+
+   return (0);
 }
 
 struct submitbench_ctx {

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1860,11 +1860,12 @@ static int eventlog_timestr (double timestamp, char *buf, size_t size)
 static void eventlog_prettyprint (FILE *f, const char *s)
 {
     double timestamp;
-    flux_kvs_event_name_t name;
-    flux_kvs_event_context_t context;
+    char name[MAX_KVS_EVENT_NAME + 1];
+    char context[MAX_KVS_EVENT_CONTEXT + 1];
     char buf[64];
 
-    if (flux_kvs_event_decode (s, &timestamp, name, context) < 0)
+    if (flux_kvs_event_decode (s, &timestamp, name, sizeof (name),
+                                              context, sizeof (context)) < 0)
         log_err_exit ("flux_kvs_event_decode");
     if (eventlog_timestr (timestamp, buf, sizeof (buf)) < 0)
         log_msg_exit ("error converting timestamp to ISO 8601");

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -31,7 +31,8 @@
 #include "job.h"
 
 
-flux_future_t *flux_job_submit (flux_t *h, const char *J, int flags)
+flux_future_t *flux_job_submit (flux_t *h, const char *J, int priority,
+                                int flags)
 {
     flux_future_t *f;
 
@@ -40,8 +41,9 @@ flux_future_t *flux_job_submit (flux_t *h, const char *J, int flags)
         return NULL;
     }
     if (!(f = flux_rpc_pack (h, "job-ingest.submit", FLUX_NODEID_ANY, 0,
-                             "{s:s s:i}",
+                             "{s:s s:i s:i}",
                              "J", J,
+                             "priority", priority,
                              "flags", flags)))
         return NULL;
     return f;

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -9,7 +9,10 @@
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the license, or (at your option)
- *  any later version.
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2 of the license,
+ *  or (at your option) any later version.
  *
  *  Flux is distributed in the hope that it will be useful, but WITHOUT
  *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
@@ -27,6 +30,7 @@
 #endif
 
 #include <flux/core.h>
+#include <jansson.h>
 
 #include "job.h"
 
@@ -62,6 +66,29 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *jobid)
         return -1;
     *jobid = id;
     return 0;
+}
+
+flux_future_t *flux_job_list (flux_t *h, int max_entries, const char *json_str)
+{
+    flux_future_t *f;
+    json_t *o = NULL;
+    int saved_errno;
+
+    if (!h || max_entries < 0 || !json_str
+           || !(o = json_loads (json_str, 0, NULL))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, "job-manager.list", FLUX_NODEID_ANY, 0,
+                             "{s:i s:o}",
+                             "max_entries", max_entries,
+                             "attrs", o))) {
+        saved_errno = errno;
+        json_decref (o);
+        errno = saved_errno;
+        return NULL;
+    }
+    return f;
 }
 
 /*

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -9,6 +9,12 @@
 extern "C" {
 #endif
 
+enum job_priority {
+    FLUX_JOB_PRIORITY_MIN = 0,
+    FLUX_JOB_PRIORITY_DEFAULT = 16,
+    FLUX_JOB_PRIORITY_MAX = 31,
+};
+
 typedef uint64_t flux_jobid_t;
 
 /* Submit a job to the system.
@@ -17,7 +23,8 @@ typedef uint64_t flux_jobid_t;
  * Currently the 'flags' parameter must be set to 0.
  * The system assigns a jobid and returns it in the response.
  */
-flux_future_t *flux_job_submit (flux_t *h, const char *J, int flags);
+flux_future_t *flux_job_submit (flux_t *h, const char *J,
+                                int priority, int flags);
 
 /* Parse jobid from response to flux_job_submit() request.
  * Returns 0 on success, -1 on failure with errno set - and an extended

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -1,3 +1,30 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
 #ifndef _FLUX_CORE_JOB_H
 #define _FLUX_CORE_JOB_H
 
@@ -31,6 +58,22 @@ flux_future_t *flux_job_submit (flux_t *h, const char *J,
  * error message may be available with flux_future_error_string().
  */
 int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
+
+/* Request a list of active jobs.
+ * If 'max_entries' > 0, fetch at most that many jobs.
+ * 'json_str' is an encoded JSON array of attribute strings, e.g.
+ * ["id","userid",...] that will be returned in response.
+
+ * Process the response payload with flux_rpc_get() or flux_rpc_get_unpack().
+ * It is a JSON object containing an array of job objects, e.g.
+ * { "jobs":[
+ *   {"id":m, "userid":n},
+ *   {"id":m, "userid":n},
+ *   ...
+ * ])
+ */
+flux_future_t *flux_job_list (flux_t *h, int max_entries,
+                              const char *json_str);
 
 #ifdef __cplusplus
 }

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -12,7 +12,7 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     errno = 0;
-    ok (flux_job_submit (NULL, NULL, 0) == NULL && errno == EINVAL,
+    ok (flux_job_submit (NULL, NULL, 0, 0) == NULL && errno == EINVAL,
         "flux_job_submit with NULL args fails with EINVAL");
 
     errno = 0;

--- a/src/common/libkvs/kvs_eventlog.h
+++ b/src/common/libkvs/kvs_eventlog.h
@@ -11,8 +11,9 @@ extern "C" {
  *   "timestamp name [context ...]\n"
  */
 
-typedef char flux_kvs_event_name_t[65];
-typedef char flux_kvs_event_context_t[257];
+#define MAX_KVS_EVENT_NAME      (64)
+#define MAX_KVS_EVENT_CONTEXT   (256)
+
 
 /* Create/destroy an eventlog
  */
@@ -41,13 +42,13 @@ const char *flux_kvs_eventlog_next (struct flux_kvs_eventlog *eventlog);
 
 /* Encode/decode an event.
  * flux_kvs_event_encode() sets timestamp to current wallclock.
- * flux_kvs_event_encode_timestmap() allows timestamp to be set to any value.
+ * flux_kvs_event_encode_timestamp() allows timestamp to be set to any value.
  * Caller must free return value of flux_kvs_event_encode().
  */
 int flux_kvs_event_decode (const char *s,
                            double *timestamp,
-                           flux_kvs_event_name_t name,
-                           flux_kvs_event_context_t context);
+                           char *name, int name_size,
+                           char *context, int context_size);
 char *flux_kvs_event_encode (const char *name, const char *context);
 char *flux_kvs_event_encode_timestamp (double timestamp,
                                        const char *name,

--- a/src/common/liblsd/Makefile.am
+++ b/src/common/liblsd/Makefile.am
@@ -15,4 +15,7 @@ liblsd_la_SOURCES = \
 	list.c \
 	list.h \
 	cbuf.c \
-	cbuf.h
+	cbuf.h \
+	thread.h \
+	hash.c \
+	hash.h

--- a/src/common/liblsd/Makefile.am
+++ b/src/common/liblsd/Makefile.am
@@ -19,3 +19,24 @@ liblsd_la_SOURCES = \
 	thread.h \
 	hash.c \
 	hash.h
+
+TESTS = \
+	test_hash.t
+
+test_ldadd = \
+	$(top_builddir)/src/common/liblsd/liblsd.la \
+	$(top_builddir)/src/common/libtap/libtap.la
+
+test_cppflags = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
+test_hash_t_SOURCES = test/hash.c
+test_hash_t_CPPFLAGS = $(test_cppflags)
+test_hash_t_LDADD = $(test_ldadd)

--- a/src/common/liblsd/hash.c
+++ b/src/common/liblsd/hash.c
@@ -1,0 +1,485 @@
+/*****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2017 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <https://dun.github.io/munge/>.
+ *
+ *  MUNGE is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.  Additionally for the MUNGE library (libmunge), you
+ *  can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation,
+ *  either version 3 of the License, or (at your option) any later version.
+ *
+ *  MUNGE is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  and GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  and GNU Lesser General Public License along with MUNGE.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *****************************************************************************
+ *  Refer to "hash.h" for documentation on public functions.
+ *****************************************************************************/
+
+
+#if HAVE_CONFIG_H
+#  include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include "hash.h"
+#include "thread.h"
+
+
+/*****************************************************************************
+ *  Constants
+ *****************************************************************************/
+
+#define HASH_DEF_SIZE           1213
+#define HASH_NODE_ALLOC_NUM     1024
+
+
+/*****************************************************************************
+ *  Data Types
+ *****************************************************************************/
+
+struct hash_node {
+    struct hash_node   *next;           /* next node in list                 */
+    void               *data;           /* ptr to hashed item                */
+    const void         *hkey;           /* ptr to hashed item's key          */
+};
+
+struct hash {
+    int                 count;          /* number of items in hash table     */
+    int                 size;           /* num slots allocated in hash table */
+    struct hash_node  **table;          /* hash table array of node ptrs     */
+    hash_cmp_f          cmp_f;          /* key comparison function           */
+    hash_del_f          del_f;          /* item deletion function            */
+    hash_key_f          key_f;          /* key hash function                 */
+#if WITH_PTHREADS
+    pthread_mutex_t     mutex;          /* mutex to protect access to hash   */
+#endif /* WITH_PTHREADS */
+};
+
+
+/*****************************************************************************
+ *  Prototypes
+ *****************************************************************************/
+
+static struct hash_node * hash_node_alloc (void);
+
+static void hash_node_free (struct hash_node *node);
+
+
+/*****************************************************************************
+ *  Variables
+ *****************************************************************************/
+
+static struct hash_node *hash_mem_list = NULL;
+/*
+ *  Singly-linked list for tracking memory allocations from hash_node_alloc()
+ *    for eventual de-allocation via hash_drop_memory().  Each block allocation
+ *    begins with a pointer for chaining these allocations together.  The block
+ *    is broken up into individual hash_node structs and placed on the
+ *    hash_free_list.
+ */
+
+static struct hash_node *hash_free_list = NULL;
+/*
+ *  Singly-linked list of hash_node structs available for use.  These are
+ *    allocated via hash_node_alloc() in blocks of HASH_NODE_ALLOC_NUM.  This
+ *    bulk approach uses less RAM and CPU than allocating/de-allocating objects
+ *    individually as needed.
+ */
+
+#if WITH_PTHREADS
+static pthread_mutex_t hash_free_list_lock = PTHREAD_MUTEX_INITIALIZER;
+/*
+ *  Mutex for protecting access to hash_mem_list and hash_free_list.
+ */
+#endif /* WITH_PTHREADS */
+
+
+/*****************************************************************************
+ *  Functions
+ *****************************************************************************/
+
+hash_t
+hash_create (int size, hash_key_f key_f, hash_cmp_f cmp_f, hash_del_f del_f)
+{
+    hash_t h;
+
+    if (!cmp_f || !key_f) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    if (size <= 0) {
+        size = HASH_DEF_SIZE;
+    }
+    if (!(h = malloc (sizeof (*h)))) {
+        return (NULL);
+    }
+    if (!(h->table = calloc (size, sizeof (struct hash_node *)))) {
+        free (h);
+        return (NULL);
+    }
+    h->count = 0;
+    h->size = size;
+    h->cmp_f = cmp_f;
+    h->del_f = del_f;
+    h->key_f = key_f;
+    lsd_mutex_init (&h->mutex);
+    return (h);
+}
+
+
+void
+hash_destroy (hash_t h)
+{
+    int i;
+    struct hash_node *p, *q;
+
+    if (!h) {
+        errno = EINVAL;
+        return;
+    }
+    lsd_mutex_lock (&h->mutex);
+    for (i = 0; i < h->size; i++) {
+        for (p = h->table[i]; p != NULL; p = q) {
+            q = p->next;
+            if (h->del_f)
+                h->del_f (p->data);
+            hash_node_free (p);
+        }
+    }
+    lsd_mutex_unlock (&h->mutex);
+    lsd_mutex_destroy (&h->mutex);
+    free (h->table);
+    free (h);
+    return;
+}
+
+
+void hash_reset (hash_t h)
+{
+    int i;
+    struct hash_node *p, *q;
+
+    if (!h) {
+        errno = EINVAL;
+        return;
+    }
+    lsd_mutex_lock (&h->mutex);
+    for (i = 0; i < h->size; i++) {
+        for (p = h->table[i]; p != NULL; p = q) {
+            q = p->next;
+            if (h->del_f)
+                h->del_f (p->data);
+            hash_node_free (p);
+        }
+        h->table[i] = NULL;
+    }
+    h->count = 0;
+    lsd_mutex_unlock (&h->mutex);
+    return;
+}
+
+
+int
+hash_is_empty (hash_t h)
+{
+    int n;
+
+    if (!h) {
+        errno = EINVAL;
+        return (0);
+    }
+    lsd_mutex_lock (&h->mutex);
+    n = h->count;
+    lsd_mutex_unlock (&h->mutex);
+    return (n == 0);
+}
+
+
+int
+hash_count (hash_t h)
+{
+    int n;
+
+    if (!h) {
+        errno = EINVAL;
+        return (0);
+    }
+    lsd_mutex_lock (&h->mutex);
+    n = h->count;
+    lsd_mutex_unlock (&h->mutex);
+    return (n);
+}
+
+
+void *
+hash_find (hash_t h, const void *key)
+{
+    unsigned int slot;
+    int cmpval;
+    struct hash_node *p;
+    void *data = NULL;
+
+    if (!h || !key) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    errno = 0;
+    lsd_mutex_lock (&h->mutex);
+    slot = h->key_f (key) % h->size;
+    for (p = h->table[slot]; p != NULL; p = p->next) {
+        cmpval = h->cmp_f (p->hkey, key);
+        if (cmpval < 0) {
+            continue;
+        }
+        if (cmpval == 0) {
+            data = p->data;
+        }
+        break;
+    }
+    lsd_mutex_unlock (&h->mutex);
+    return (data);
+}
+
+
+void *
+hash_insert (hash_t h, const void *key, void *data)
+{
+    unsigned int slot;
+    int cmpval;
+    struct hash_node **pp;
+    struct hash_node *p;
+
+    if (!h || !key || !data) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    lsd_mutex_lock (&h->mutex);
+    slot = h->key_f (key) % h->size;
+    for (pp = &(h->table[slot]); (p = *pp) != NULL; pp = &(p->next)) {
+        cmpval = h->cmp_f (p->hkey, key);
+        if (cmpval < 0) {
+            continue;
+        }
+        if (cmpval == 0) {
+            errno = EEXIST;
+            data = NULL;
+            goto end;
+        }
+        break;
+    }
+    if (!(p = hash_node_alloc ())) {
+        data = NULL;
+        goto end;
+    }
+    p->hkey = key;
+    p->data = data;
+    p->next = *pp;
+    *pp = p;
+    h->count++;
+
+end:
+    lsd_mutex_unlock (&h->mutex);
+    return (data);
+}
+
+
+void *
+hash_remove (hash_t h, const void *key)
+{
+    unsigned int slot;
+    int cmpval;
+    struct hash_node **pp;
+    struct hash_node *p;
+    void *data = NULL;
+
+    if (!h || !key) {
+        errno = EINVAL;
+        return (NULL);
+    }
+    errno = 0;
+    lsd_mutex_lock (&h->mutex);
+    slot = h->key_f (key) % h->size;
+    for (pp = &(h->table[slot]); (p = *pp) != NULL; pp = &(p->next)) {
+        cmpval = h->cmp_f (p->hkey, key);
+        if (cmpval < 0) {
+            continue;
+        }
+        if (cmpval == 0) {
+            data = p->data;
+            *pp = p->next;
+            hash_node_free (p);
+            h->count--;
+        }
+        break;
+    }
+    lsd_mutex_unlock (&h->mutex);
+    return (data);
+}
+
+
+int
+hash_delete_if (hash_t h, hash_arg_f arg_f, void *arg)
+{
+    int i;
+    struct hash_node **pp;
+    struct hash_node *p;
+    int n = 0;
+
+    if (!h || !arg_f) {
+        errno = EINVAL;
+        return (-1);
+    }
+    lsd_mutex_lock (&h->mutex);
+    for (i = 0; i < h->size; i++) {
+        pp = &(h->table[i]);
+        while ((p = *pp) != NULL) {
+            if (arg_f (p->data, p->hkey, arg) > 0) {
+                if (h->del_f)
+                    h->del_f (p->data);
+                *pp = p->next;
+                hash_node_free (p);
+                h->count--;
+                n++;
+            }
+            else {
+                pp = &(p->next);
+            }
+        }
+    }
+    lsd_mutex_unlock (&h->mutex);
+    return (n);
+}
+
+
+int
+hash_for_each (hash_t h, hash_arg_f arg_f, void *arg)
+{
+    int i;
+    struct hash_node *p;
+    int n = 0;
+
+    if (!h || !arg_f) {
+        errno = EINVAL;
+        return (-1);
+    }
+    lsd_mutex_lock (&h->mutex);
+    for (i = 0; i < h->size; i++) {
+        for (p = h->table[i]; p != NULL; p = p->next) {
+            if (arg_f (p->data, p->hkey, arg) > 0) {
+                n++;
+            }
+        }
+    }
+    lsd_mutex_unlock (&h->mutex);
+    return (n);
+}
+
+
+void
+hash_drop_memory (void)
+{
+    struct hash_node *p;
+
+    lsd_mutex_lock (&hash_free_list_lock);
+    while (hash_mem_list != NULL) {
+        p = hash_mem_list;
+        hash_mem_list = p->next;
+        free (p);
+    }
+    hash_free_list = NULL;
+    lsd_mutex_unlock (&hash_free_list_lock);
+    return;
+}
+
+
+/*****************************************************************************
+ *  Hash Functions
+ *****************************************************************************/
+
+unsigned int
+hash_key_string (const char *str)
+{
+    unsigned char *p;
+    unsigned int hval = 0;
+    const unsigned int multiplier = 31;
+
+    for (p = (unsigned char *) str; *p != '\0'; p++) {
+        hval += (multiplier * hval) + *p;
+    }
+    return (hval);
+}
+
+
+/*****************************************************************************
+ *  Internal Functions
+ *****************************************************************************/
+
+static struct hash_node *
+hash_node_alloc (void)
+{
+/*  Allocates a hash node from the freelist.
+ *  Returns a ptr to the object, or NULL if memory allocation fails.
+ */
+    size_t size;
+    struct hash_node *p;
+    int i;
+
+    assert (HASH_NODE_ALLOC_NUM > 0);
+    lsd_mutex_lock (&hash_free_list_lock);
+
+    if (!hash_free_list) {
+        size = sizeof (p) + (HASH_NODE_ALLOC_NUM * sizeof (*p));
+        p = malloc (size);
+
+        if (p != NULL) {
+            p->next = hash_mem_list;
+            hash_mem_list = p;
+            hash_free_list = (struct hash_node *)
+                    ((unsigned char *) p + sizeof (p));
+
+            for (i = 0; i < HASH_NODE_ALLOC_NUM - 1; i++) {
+                hash_free_list[i].next = &hash_free_list[i+1];
+            }
+            hash_free_list[i].next = NULL;
+        }
+    }
+    if (hash_free_list) {
+        p = hash_free_list;
+        hash_free_list = p->next;
+        memset (p, 0, sizeof (*p));
+    }
+    else {
+        errno = ENOMEM;
+    }
+    lsd_mutex_unlock (&hash_free_list_lock);
+    return (p);
+}
+
+
+static void
+hash_node_free (struct hash_node *node)
+{
+/*  De-allocates the object [node], returning it to the freelist.
+ */
+    assert (node != NULL);
+    lsd_mutex_lock (&hash_free_list_lock);
+    node->next = hash_free_list;
+    hash_free_list = node;
+    lsd_mutex_unlock (&hash_free_list_lock);
+    return;
+}

--- a/src/common/liblsd/hash.h
+++ b/src/common/liblsd/hash.h
@@ -1,0 +1,185 @@
+/*****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2017 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <https://dun.github.io/munge/>.
+ *
+ *  MUNGE is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.  Additionally for the MUNGE library (libmunge), you
+ *  can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation,
+ *  either version 3 of the License, or (at your option) any later version.
+ *
+ *  MUNGE is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  and GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  and GNU Lesser General Public License along with MUNGE.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#ifndef HASH_H
+#define HASH_H
+
+
+/*****************************************************************************
+ *  Notes
+ *****************************************************************************/
+/*
+ *  If an item's key is modified after insertion, the hash will be unable to
+ *  locate it if the new key should hash to a different slot in the table.
+ *
+ *  If WITH_PTHREADS is defined, these routines will be thread-safe.
+ */
+
+
+/*****************************************************************************
+ *  Data Types
+ *****************************************************************************/
+
+typedef struct hash * hash_t;
+/*
+ *  Hash table opaque data type.
+ */
+
+typedef unsigned int (*hash_key_f) (const void *key);
+/*
+ *  Function prototype for the hash function responsible for converting
+ *    the data's [key] into an unsigned integer hash value.
+ */
+
+typedef int (*hash_cmp_f) (const void *key1, const void *key2);
+/*
+ *  Function prototype for comparing two keys.
+ *  Returns an integer that is less than zero if [key1] is less than [key2],
+ *    equal to zero if [key1] is equal to [key2], and greater than zero if
+ *    [key1] is greater than [key2].
+ */
+
+typedef void (*hash_del_f) (void *data);
+/*
+ *  Function prototype for de-allocating a data item stored within a hash.
+ *  This function is responsible for freeing all memory associated with
+ *    the [data] item, including any subordinate items.
+ */
+
+typedef int (*hash_arg_f) (void *data, const void *key, void *arg);
+/*
+ *  Function prototype for operating on each element in the hash table.
+ *  The function will be invoked once for each [data] item in the hash,
+ *    with the item's [key] and the specified [arg] being passed in as args.
+ */
+
+
+/*****************************************************************************
+ *  Functions
+ *****************************************************************************/
+
+hash_t hash_create (int size,
+    hash_key_f key_f, hash_cmp_f cmp_f, hash_del_f del_f);
+/*
+ *  Creates and returns a new hash table on success.
+ *    Returns lsd_nomem_error() with errno=ENOMEM if memory allocation fails.
+ *    Returns NULL with errno=EINVAL if [keyf] or [cmpf] is not specified.
+ *  The [size] is the number of slots in the table; a larger table requires
+ *    more memory, but generally provide quicker access times.  If set <= 0,
+ *    the default size is used.
+ *  The [keyf] function converts a key into a hash value.
+ *  The [cmpf] function determines whether two keys are equal.
+ *  The [delf] function de-allocates memory used by items in the hash;
+ *    if set to NULL, memory associated with these items will not be freed
+ *    when the hash is destroyed.
+ */
+
+void hash_destroy (hash_t h);
+/*
+ *  Destroys hash table [h].  If a deletion function was specified when the
+ *    hash was created, it will be called for each item contained within.
+ *  Abadoning a hash without calling hash_destroy() will cause a memory leak.
+ */
+
+void hash_reset (hash_t h);
+/*
+ *  Resets hash table [h] back to an empty state.  If a deletion function was
+ *    specified when the hash was created, it will be called for each item
+ *    contained within.
+ */
+
+int hash_is_empty (hash_t h);
+/*
+ *  Returns non-zero if hash table [h] is empty; o/w, returns zero.
+ */
+
+int hash_count (hash_t h);
+/*
+ *  Returns the number of items in hash table [h].
+ */
+
+void * hash_find (hash_t h, const void *key);
+/*
+ *  Searches for the item corresponding to [key] in hash table [h].
+ *  Returns a ptr to the found item's data on success.
+ *    Returns NULL with errno=0 if no matching item is found.
+ *    Returns NULL with errno=EINVAL if [key] is not specified.
+ */
+
+void * hash_insert (hash_t h, const void *key, void *data);
+/*
+ *  Inserts [data] with the corresponding [key] into hash table [h];
+ *    note that it is permissible for [key] to be set equal to [data].
+ *  Returns a ptr to the inserted item's data on success.
+ *    Returns NULL with errno=EEXIST if [key] already exists in the hash.
+ *    Returns NULL with errno=EINVAL if [key] or [data] is not specified.
+ *    Returns lsd_nomem_error() with errno=ENOMEM if memory allocation fails.
+ */
+
+void * hash_remove (hash_t h, const void *key);
+/*
+ *  Removes the item corresponding to [key] from hash table [h].
+ *  Returns a ptr to the removed item's data on success.
+ *    Returns NULL with errno=0 if no matching item is found.
+ *    Returns NULL with errno=EINVAL if [key] is not specified.
+ */
+
+int hash_delete_if (hash_t h, hash_arg_f argf, void *arg);
+/*
+ *  Conditionally deletes (and de-allocates) items from hash table [h].
+ *  The [argf] function is invoked once for each item in the hash, with
+ *    [arg] being passed in as an argument.  Items for which [argf] returns
+ *    greater-than-zero are deleted.
+ *  Returns the number of items deleted.
+ *    Returns -1 with errno=EINVAL if [argf] is not specified.
+ */
+
+int hash_for_each (hash_t h, hash_arg_f argf, void *arg);
+/*
+ *  Invokes the [argf] function once for each item in hash table [h],
+ *    with [arg] being passed in as an argument.
+ *  Returns the number of items for which [argf] returns greater-than-zero.
+ *    Returns -1 with errno=EINVAL if [argf] is not specified.
+ */
+
+unsigned int hash_key_string (const char *str);
+/*
+ *  A hash_key_f function that hashes the string [str].
+ */
+
+void hash_drop_memory (void);
+/*
+ *  Frees memory that has been internally allocated.  No reference counting is
+ *    performed to determine whether memory regions are still in use.
+ *  This may be useful for explicitly de-allocating memory before program
+ *    termination when checking for memory leaks.
+ *  WARNING: Do not call this routine until ALL hashes have been destroyed.
+ */
+
+
+#endif /* !HASH_H */

--- a/src/common/liblsd/test/hash.c
+++ b/src/common/liblsd/test/hash.c
@@ -1,0 +1,293 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "hash.h"
+
+#include "src/common/libtap/tap.h"
+
+
+/* Dummy comparison for void * */
+static int cmpf (const void *x, const void *y)
+{
+    if (x < y)
+        return (-1);
+    if (x > y)
+        return (1);
+    return (0);
+}
+
+static void sanity_checks ()
+{
+    void *arg;
+    void *x;
+    hash_t h;
+
+    ok (hash_create (0, NULL, NULL, NULL) == NULL && errno == EINVAL,
+        "hash_create with NULL cmp_f and key_f fails with EINVAL");
+
+    h = hash_create (0, (hash_key_f) hash_key_string, cmpf, NULL);
+
+    ok (h != NULL, "hash_create (0, NULL, NULL, NULL) h == %p", h);
+    ok (hash_is_empty (h), "hash_is_empty ()");
+    ok (hash_count (h) == 0, "hash_count () == %d", hash_count (h));
+
+    errno = 0;
+    ok (hash_count (NULL) == 0 && errno == EINVAL,
+        "hash_count on NULL hash returns 0 with errno set");
+    /*  A NULL hash has count == 0, but it's not empty! ;-)
+     */
+    errno = 0;
+    ok (hash_is_empty (NULL) == 0 && errno == EINVAL,
+        "hash_is_empty on NULL hash returns 0 with errno set");
+
+    ok (hash_insert (NULL, "foo", (void *) 0x1) == NULL && errno == EINVAL,
+        "hash_insert to NULL hash fails with EINVAL");
+    ok (hash_insert (h, "foo", NULL) == NULL && errno == EINVAL,
+        "hash_insert of NULL fails with EINVAL");
+    ok (hash_insert (h, NULL, (void *) 0xff) == NULL && errno == EINVAL,
+        "hash_insert of NULL key fails with EINVAL");
+
+    ok (NULL != hash_insert (h, "foo", (void *) 0xafafaf), "hash_insert works");
+    ok (hash_is_empty (h) == 0, "hash_is_empty() == 0");
+    ok (hash_count (h) == 1, "hash_count() == 1");
+
+    ok (hash_insert (h, "foo", (void *) 0x1) == NULL && errno == EEXIST,
+        "hash_insert of duplicate key fails with EEXIST");
+
+    ok ((arg = hash_find (h, NULL)) == NULL && errno == EINVAL,
+        "hash_find of NULL key returns NULL with errno == EINVAL");
+    ok ((arg = hash_find (NULL, "foo")) == NULL && errno == EINVAL,
+        "hash_find on NULL hash returns NULL with errno == EINVAL");
+
+    ok ((arg = hash_find (h, "foo")) != NULL, "hash_find: works");
+    ok (arg == (void *) 0xafafaf, "hash_find: returned data is correct");
+
+    ok (hash_delete_if (h, NULL, NULL) == -1 && errno == EINVAL,
+        "hash_delete_if returns -1 with errno == EINVAL for invalid argf");
+
+    errno = 0;
+    hash_reset (NULL);
+    ok (errno == EINVAL, "hash_reset on NULL hash sets errno == EINVAL");
+
+    ok (hash_for_each (h, NULL, NULL) == -1 && errno == EINVAL,
+        "hash_for_each returns -1 with errno = EINVAL on invalid argf");
+    ok (hash_for_each (NULL, NULL, NULL) == -1 && errno == EINVAL,
+        "hash_for_each returns -1 with errno = EINVAL on NULL hash");
+
+    ok (hash_remove (NULL, "foo") == NULL && errno == EINVAL,
+        "hash_remove of NULL hash fails with EINVAL");
+    ok (hash_remove (h, NULL) == NULL && errno == EINVAL,
+        "hash_remove of NULL key fails with EINVAL");
+
+    ok ((x = hash_remove (h, "foo")) != NULL, "hash_remove: works");
+    ok (x == arg, "hash_remove: returned item's data on success");
+    ok (hash_count (h) == 0, "hash_count is zero after removal");
+    ok (hash_is_empty (h), "hash is empty after removal");
+
+    hash_destroy (NULL);
+    ok (errno == EINVAL, "hash_destroy of NULL hash sets errno to EINVAL");
+
+    hash_destroy (h);
+}
+
+static int foreach (void *data, const void *key, void *arg)
+{
+    if (!key || !data)
+        return (0);
+    return (1);
+}
+
+/* XXX: this list of keys needs to stay global because hash doesn't
+ *      copy keys, and I'm being too lazy to create a container for
+ *      them and manual manage the memory for a test program.
+ */
+static const char *k[] = {
+    "foo", "bar", "baz", "bloop", "bleep", "blurg", NULL
+};
+
+/*  Create fake data for hash item from integer value */
+static void * fake_data (int value)
+{
+    return (void *)(0xfL + (unsigned long) value);
+}
+
+static void hash_calisthenics (const char *prefix, hash_t h)
+{
+    int i;
+    int klen = (sizeof (k) / sizeof (k[0])) - 1;
+
+    ok (hash_for_each (h, (hash_arg_f) foreach, NULL) == hash_count (h),
+        "%s: hash_for_each works", prefix);
+
+    for (i = 0; i < klen; i++) {
+        void *x = hash_find (h, k[i]);
+        ok (x != NULL,
+            "%s: hash_find ('%s') works x=%p", prefix, k[i], x);
+        ok (x == fake_data (i),
+            "%s: hash_find found expected value", prefix);
+    }
+
+    ok ((hash_remove (h, k[1]) == fake_data (1)),
+        "%s: hash_remove of single item works", prefix);
+    ok (hash_count (h) == klen-1,
+        "%s: hash_count is reduced by 1", prefix);
+
+    hash_reset (h);
+
+    ok (hash_count (h) == 0,
+        "%s: hash_count is zero after reset", prefix);
+    ok (hash_is_empty (h),
+        "%s: hash is empty after reset", prefix);
+}
+
+static hash_t do_hash_create (int size, hash_del_f fn)
+{
+    int i;
+    int klen = (sizeof (k) / sizeof (k[0])) - 1;
+    hash_t h = hash_create (size, (hash_key_f) hash_key_string, cmpf, fn);
+    ok (h != NULL, "hash_create (size = %d)", size);
+    if (h == NULL)
+        return NULL;
+
+    for (i = 0; i < klen; i++) {
+        void *result = hash_insert (h, k[i], fake_data (i));
+        if (result == NULL)
+            fail ("size=%d: hash_insert (%s) failed", size, k[i]);
+    }
+
+    ok (hash_count (h) == klen,
+        "size=%d: Successfully inserted %d hash entries", size, klen);
+    return (h);
+}
+
+
+static void test_for_each ()
+{
+    hash_t h = do_hash_create (0, NULL);
+    if (!h)
+        return;
+    hash_calisthenics ("default", h);
+    hash_destroy (h);
+}
+
+static void test_chaining ()
+{
+    /* Force chaining via hash size of 1 */
+    hash_t h = do_hash_create (1, NULL);
+    if (!h)
+        return;
+    hash_calisthenics ("chaining", h);
+    hash_destroy (h);
+}
+
+static int delete_count = 0;
+static void del_f (void *data)
+{
+    delete_count++;
+}
+
+static int cmp_key (void *data, const void *key, void *arg)
+{
+    return (strcmp ((const char *) key, (const char *) arg) == 0);
+}
+
+static void test_delete ()
+{
+    int size;
+
+    /*  Try with default size and size=1 to force chaining */
+    for (size = 0; size <= 1; size++) {
+        int count;
+        hash_t h = do_hash_create (size, del_f);
+        ok (h != NULL, "size %d: hash_create", size);
+        if (h == NULL)
+            return;
+        count = hash_count (h);
+        delete_count = 0;
+        hash_destroy (h);
+        ok (delete_count == count,
+            "size %d: hash_destroy() deleted all items", size);
+
+        /*  Execute same test with hash_reset()  */
+        h = do_hash_create (size, del_f);
+        ok (h != NULL, "size %d: hash_create", size);
+        if (h == NULL)
+            return;
+        count = hash_count (h);
+        delete_count = 0;
+        hash_reset (h);
+        ok (delete_count == count,
+            "size %d: hash_reset() deleted all items", size);
+        ok (hash_is_empty (h), "size %d: hash is empty after reset");
+
+        delete_count = 0;
+        hash_destroy (h);
+        ok (delete_count == 0, "size %d: no items deleted from empty hash");
+
+        /*  Test hash_delete_if */
+        h = do_hash_create (size, del_f);
+        ok (h != NULL, "size %d: hash_create", size);
+        if (h == NULL)
+            return;
+        count = hash_count (h);
+        delete_count = 0;
+        ok (1 == hash_delete_if (h, cmp_key, "bleep"),
+            "size %d: hash_delete_if works", size);
+        ok (delete_count == 1,
+            "size %d: hash_delete_if destroyed 1 item", size);
+        ok (0 == hash_delete_if (h, cmp_key, "bleep"),
+            "size %d: hash_delete_if returns 0 for no matches", size);
+        ok (hash_count (h) == count - 1,
+            "size %d: hash_count reduced by 1");
+        delete_count = 0;
+        hash_destroy (h);
+        ok (delete_count == count - 1,
+            "size %d: remaining items freed by hash_destroy");
+    }
+}
+
+
+int
+main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    sanity_checks ();
+    test_for_each ();
+    test_chaining ();
+    test_delete ();
+
+    hash_drop_memory ();
+
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/liblsd/thread.h
+++ b/src/common/liblsd/thread.h
@@ -1,0 +1,110 @@
+/*****************************************************************************
+ *  Written by Chris Dunlap <cdunlap@llnl.gov>.
+ *  Copyright (C) 2007-2017 Lawrence Livermore National Security, LLC.
+ *  Copyright (C) 2002-2007 The Regents of the University of California.
+ *  UCRL-CODE-155910.
+ *
+ *  This file is part of the MUNGE Uid 'N' Gid Emporium (MUNGE).
+ *  For details, see <https://dun.github.io/munge/>.
+ *
+ *  MUNGE is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option)
+ *  any later version.  Additionally for the MUNGE library (libmunge), you
+ *  can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation,
+ *  either version 3 of the License, or (at your option) any later version.
+ *
+ *  MUNGE is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  and GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  and GNU Lesser General Public License along with MUNGE.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+
+#ifndef LSD_THREAD_H
+#define LSD_THREAD_H
+
+
+#if WITH_PTHREADS
+#  include <errno.h>
+#  include <pthread.h>
+#  include <stdlib.h>
+#endif /* WITH_PTHREADS */
+
+
+/*****************************************************************************
+ *  Macros
+ *****************************************************************************/
+
+#if WITH_PTHREADS
+
+#  ifdef WITH_LSD_FATAL_ERROR_FUNC
+#    undef lsd_fatal_error
+     extern void lsd_fatal_error (char *file, int line, char *mesg);
+#  else /* !WITH_LSD_FATAL_ERROR_FUNC */
+#    ifndef lsd_fatal_error
+#      define lsd_fatal_error(file, line, mesg) (abort ())
+#    endif /* !lsd_fatal_error */
+#  endif /* !WITH_LSD_FATAL_ERROR_FUNC */
+
+#  define lsd_mutex_init(pmutex)                                              \
+     do {                                                                     \
+         int e = pthread_mutex_init (pmutex, NULL);                           \
+         if (e != 0) {                                                        \
+             errno = e;                                                       \
+             lsd_fatal_error (__FILE__, __LINE__, "mutex_init");              \
+             abort ();                                                        \
+         }                                                                    \
+     } while (0)
+
+#  define lsd_mutex_lock(pmutex)                                              \
+     do {                                                                     \
+         int e = pthread_mutex_lock (pmutex);                                 \
+         if (e != 0) {                                                        \
+             errno = e;                                                       \
+             lsd_fatal_error (__FILE__, __LINE__, "mutex_lock");              \
+             abort ();                                                        \
+         }                                                                    \
+     } while (0)
+
+#  define lsd_mutex_unlock(pmutex)                                            \
+     do {                                                                     \
+         int e = pthread_mutex_unlock (pmutex);                               \
+         if (e != 0) {                                                        \
+             errno = e;                                                       \
+             lsd_fatal_error (__FILE__, __LINE__, "mutex_unlock");            \
+             abort ();                                                        \
+         }                                                                    \
+     } while (0)
+
+#  define lsd_mutex_destroy(pmutex)                                           \
+     do {                                                                     \
+         int e = pthread_mutex_destroy (pmutex);                              \
+         if (e != 0) {                                                        \
+             errno = e;                                                       \
+             lsd_fatal_error (__FILE__, __LINE__, "mutex_destroy");           \
+             abort ();                                                        \
+         }                                                                    \
+     } while (0)
+
+#  ifndef NDEBUG
+     int lsd_mutex_is_locked (pthread_mutex_t *pmutex);
+#  endif /* !NDEBUG */
+
+#else /* !WITH_PTHREADS */
+
+#  define lsd_mutex_init(mutex)
+#  define lsd_mutex_lock(mutex)
+#  define lsd_mutex_unlock(mutex)
+#  define lsd_mutex_destroy(mutex)
+#  define lsd_mutex_is_locked(mutex) (1)
+
+#endif /* !WITH_PTHREADS */
+
+
+#endif /* !LSD_THREAD_H */

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -9,7 +9,8 @@ SUBDIRS = \
  cron \
  aggregator \
  userdb \
- job-ingest
+ job-ingest \
+ job-manager
 
 if HAVE_PYTHON
 SUBDIRS += pymod

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -1,0 +1,23 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(ZMQ_CFLAGS)
+
+fluxmod_LTLIBRARIES = job-manager.la
+
+job_manager_la_SOURCES = job-manager.c \
+			 jobdir.h \
+			 jobdir.c
+
+job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
+job_manager_la_LIBADD = $(fluxmod_libadd) \
+		    $(top_builddir)/src/common/libflux-internal.la \
+		    $(top_builddir)/src/common/libflux-core.la \
+		    $(top_builddir)/src/common/libflux-optparse.la \
+		    $(ZMQ_LIBS)

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -276,7 +276,7 @@ static void list_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     if (!(jobs = list_jobs (ctx, userid, rolemask, max_entries, attrs)))
         goto error;
-    if (flux_respond_pack (h, msg, "{s:o}", "jobs", jobs) < 0)
+    if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     json_decref (jobs);
     return;

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -1,0 +1,353 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+#include "src/common/libutil/fluid.h"
+#include "src/common/liblsd/hash.h"
+
+#include "jobdir.h"
+
+struct job_manager_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    struct hash *active_jobs;   // hash by integer id
+    zlistx_t *active_jobs_list; // list of hash entries, in numerical order
+};
+
+struct job {
+    flux_jobid_t id;
+    uint32_t userid;
+    int priority;
+};
+
+/* hash_key_f for active_jobs hash
+ */
+static unsigned int job_hash (flux_jobid_t *key)
+{
+    return *key;
+}
+
+/* hash_cmp_f for active_jobs hash
+ * (compares hash keys)
+ */
+static int job_hash_cmp (flux_jobid_t *key1, flux_jobid_t *key2)
+{
+    if (*key1 == *key2)
+        return 0;
+    return (*key1 < *key2 ? -1 : 1);
+}
+
+
+/* zlistx_comparator_fn for active_jobs_list
+ * (compares elements)
+ */
+#define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
+static int job_cmp (const void *a1, const void *a2)
+{
+    const struct job *j1 = a1;
+    const struct job *j2 = a2;
+    int rc;
+
+    if ((rc = (-1)*NUMCMP (j1->priority, j2->priority)) == 0)
+        rc = NUMCMP (j1->id, j2->id);
+    return rc;
+}
+
+static void job_destroy (struct job *job)
+{
+    if (job) {
+        int saved_errno = errno;
+        free (job);
+        errno = saved_errno;
+    }
+}
+
+static struct job *job_create (flux_jobid_t id, int priority, uint32_t userid)
+{
+    struct job *job;
+
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    job->id = id;
+    job->userid = userid;
+    job->priority = priority;
+    return job;
+}
+
+/* Helper for submit_event_cb() and also callback for jobdir_map().
+ * Inserts 'job' into active_jobs hash and active_jobs_list (pri,FLUID order).
+ * N.B. zlistx_insert uses zlistx comparator function to insert in order,
+ * and low_value=false indicates that search for position begins at end.
+ */
+int add_active_job (flux_jobid_t id, int priority, uint32_t userid, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+    struct job *job;
+
+    if (!(job = job_create (id, priority, userid)))
+        return -1;
+    if (!hash_insert (ctx->active_jobs, &job->id, job)) {
+        job_destroy (job);
+        return (errno == EEXIST ? 0 : -1); // EEXIST is not an error
+    }
+    if (!zlistx_insert (ctx->active_jobs_list, job, false)) {
+        int saved_errno = errno;
+        hash_remove (ctx->active_jobs, &job->id);
+        errno = saved_errno;
+        return -1;
+    }
+    return 0;
+}
+
+/* job-ingest.submit event - add jobs to hash/list
+ */
+static void submit_event_cb (flux_t *h, flux_msg_handler_t *mh,
+                             const flux_msg_t *msg, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+    json_t *jobs;
+    int i;
+
+    if (flux_event_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0) {
+        flux_log_error (h, "%s", __FUNCTION__);
+        return;
+    }
+    for (i = 0; i < json_array_size (jobs); i++) {
+        json_t *el = json_array_get (jobs, i);
+        flux_jobid_t id;
+        uint32_t userid;
+        int priority;
+
+        if (!el || json_unpack (el, "{s:I s:i s:i}", "id", &id,
+                                                     "priority", &priority,
+                                                     "userid", &userid) < 0) {
+            flux_log (h, LOG_ERR, "%s: error decoding job index %d",
+                      __FUNCTION__, i);
+            continue;
+        }
+        if (add_active_job (id, priority, userid, ctx) < 0) {
+            flux_log_error (h, "%s: add job %llu",
+                            __FUNCTION__, (unsigned long long)id);
+            continue;
+        }
+    }
+    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__, i);
+    return;
+}
+
+/* Create a job object for 'job'.
+ * Add requested attributes in 'attrs', to be limited by requestor
+ * creds (userid, rolemask).
+ */
+static json_t *list_job (struct job_manager_ctx *ctx, struct job *job,
+                         json_t *attrs, uint32_t userid, uint32_t rolemask)
+{
+    size_t index;
+    json_t *value;
+    json_t *o;
+    int saved_errno;
+
+    if (!(o = json_object ()))
+        goto error_nomem;
+    json_array_foreach (attrs, index, value) {
+        const char *attr = json_string_value (value);
+        json_t *val = NULL;
+        if (!attr) {
+            errno = EPROTO;
+            goto error;
+        }
+        if (!strcmp (attr, "id")) {
+            val = json_integer (job->id);
+        }
+        else if (!strcmp (attr, "userid")) {
+            val = json_integer (job->userid);
+        }
+        else if (!strcmp (attr, "priority")) {
+            val = json_integer (job->priority);
+        }
+        else {
+            errno = EPROTO;
+            goto error;
+        }
+        if (val == NULL)
+            goto error_nomem;
+        if (json_object_set_new (o, attr, val) < 0) {
+            json_decref (val);
+            goto error_nomem;
+        }
+    }
+    return o;
+error_nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (o);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* Create a JSON array of 'job' objects representing the
+ * job manager's queue of jobs.  If max_entries > 0, then
+ * return only the first max_entries jobs from the head of the queue.
+ */
+static json_t *list_jobs (struct job_manager_ctx *ctx,
+                          uint32_t userid, uint32_t rolemask,
+                          int max_entries, json_t *attrs)
+{
+    json_t *jobs;
+    struct job *job;
+    int saved_errno;
+
+    if (!(jobs = json_array ()))
+        goto error_nomem;
+    job = zlistx_first (ctx->active_jobs_list);
+    while (job) {
+        json_t *o;
+        if (!(o = list_job (ctx, job, attrs, userid, rolemask)))
+            goto error;
+        if (json_array_append_new (jobs, o) < 0) {
+            json_decref (o);
+            goto error_nomem;
+        }
+        if (json_array_size (jobs) == max_entries)
+            break;
+        job = zlistx_next (ctx->active_jobs_list);
+    }
+    return jobs;
+error_nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (jobs);
+    errno = saved_errno;
+    return NULL;
+}
+
+static void list_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+    int max_entries;
+    json_t *jobs;
+    json_t *attrs;
+    uint32_t userid;
+    uint32_t rolemask;
+
+    if (flux_request_unpack (msg, NULL, "{s:i s:o}",
+                                        "max_entries", &max_entries,
+                                        "attrs", &attrs) < 0
+                    || flux_msg_get_userid (msg, &userid) < 0
+                    || flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+    if (max_entries < 0 || !json_is_array (attrs)) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(jobs = list_jobs (ctx, userid, rolemask, max_entries, attrs)))
+        goto error;
+    if (flux_respond_pack (h, msg, "{s:o}", "jobs", jobs) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    json_decref (jobs);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static int walk_kvs_active (flux_t *h, struct job_manager_ctx *ctx)
+{
+    int count;
+
+    if ((count = jobdir_map (h, "job.active", add_active_job, ctx)) < 0)
+        return -1;
+    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__, count);
+    return 0;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT,   "job-ingest.submit", submit_event_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "job-manager.list", list_cb, FLUX_ROLE_USER},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    flux_reactor_t *r = flux_get_reactor (h);
+    int rc = -1;
+    struct job_manager_ctx ctx;
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+    if (!(ctx.active_jobs = hash_create (0, (hash_key_f)job_hash,
+                                        (hash_cmp_f)job_hash_cmp,
+                                        (hash_del_f)job_destroy))) {
+        flux_log_error (h, "list_create");
+        goto done;
+    }
+    if (!(ctx.active_jobs_list = zlistx_new ())) {
+        flux_log_error (h, "zlistx_new");
+        goto done;
+    }
+    zlistx_set_comparator (ctx.active_jobs_list, job_cmp);
+    if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
+        flux_log_error (h, "flux_msghandler_add");
+        goto done;
+    }
+    if (flux_event_subscribe (h, "job-ingest.submit") < 0) {
+        flux_log_error (h, "flux_event_subscribe");
+        goto done;
+    }
+    if (walk_kvs_active (h, &ctx) < 0) {
+        flux_log_error (h, "walk_kvs_active");
+        goto done;
+    }
+    if (flux_reactor_run (r, 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done;
+    }
+    rc = 0;
+done:
+    flux_msg_handler_delvec (ctx.handlers);
+    if (ctx.active_jobs_list)
+        zlistx_destroy (&ctx.active_jobs_list);
+    if (ctx.active_jobs)
+        hash_destroy (ctx.active_jobs);
+    return rc;
+}
+
+MOD_NAME ("job-manager");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/jobdir.c
+++ b/src/modules/job-manager/jobdir.c
@@ -1,0 +1,156 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+#include "src/common/libutil/fluid.h"
+
+#include "jobdir.h"
+
+static int count_char (const char *s, char c)
+{
+    int count = 0;
+    while (*s) {
+        if (*s++ == c)
+            count++;
+    }
+    return count;
+}
+
+static int jobdir_depthfirst_map_one (flux_t *h, const char *key, int dirskip,
+                                      jobdir_map_f cb, void *arg)
+{
+    flux_jobid_t id;
+    char *nkey;
+    flux_future_t *f = NULL;
+    uint32_t userid;
+    int priority;
+    int saved_errno;
+
+    if (strlen (key) <= dirskip) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (fluid_decode (key + dirskip + 1, &id, FLUID_STRING_DOTHEX) < 0)
+        return -1;
+    /* userid */
+    if (asprintf (&nkey, "%s.userid", key) < 0)
+        return -1;
+    if (!(f = flux_kvs_lookup (h, 0, nkey)))
+        goto error;
+    if (flux_kvs_lookup_get_unpack (f, "i", &userid) < 0)
+        goto error;
+    flux_future_destroy (f);
+    free (nkey);
+    f = NULL;
+    nkey = NULL;
+
+    /* priority */
+    if (asprintf (&nkey, "%s.priority", key) < 0)
+        return -1;
+    if (!(f = flux_kvs_lookup (h, 0, nkey)))
+        goto error;
+    if (flux_kvs_lookup_get_unpack (f, "i", &priority) < 0)
+        goto error;
+    if (cb (id, priority, userid, arg) < 0)
+        goto error;
+    flux_future_destroy (f);
+    free (nkey);
+
+    if (cb (id, priority, userid, arg) < 0)
+        goto error;
+    return 1; // processed one
+error:
+    saved_errno = errno;
+    flux_future_destroy (f);
+    free (nkey);
+    errno = saved_errno;
+    return -1;
+}
+
+static int jobdir_depthfirst_map (flux_t *h, const char *key,
+                                  int dirskip, jobdir_map_f cb, void *arg)
+{
+    flux_future_t *f;
+    const flux_kvsdir_t *dir;
+    flux_kvsitr_t *itr;
+    const char *name;
+    int path_level;
+    int count = 0;
+    int rc = -1;
+
+    path_level = count_char (key + dirskip, '.');
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key)))
+        return -1;
+    if (flux_kvs_lookup_get_dir (f, &dir) < 0) {
+        if (errno == ENOENT && path_level == 0)
+            rc = 0;
+        goto done;
+    }
+    if (!(itr = flux_kvsitr_create (dir)))
+        goto done;
+    while ((name = flux_kvsitr_next (itr))) {
+        char *nkey;
+        int n;
+        if (!flux_kvsdir_isdir (dir, name))
+            continue;
+        if (!(nkey = flux_kvsdir_key_at (dir, name)))
+            goto done_destroyitr;
+        if (path_level == 3) // orig 'key' = .A.B.C, thus 'nkey' is complete
+            n = jobdir_depthfirst_map_one (h, nkey, dirskip, cb, arg);
+        else
+            n = jobdir_depthfirst_map (h, nkey, dirskip, cb, arg);
+        if (n < 0) {
+            int saved_errno = errno;
+            free (nkey);
+            errno = saved_errno;
+            goto done_destroyitr;
+        }
+        count += n;
+        free (nkey);
+    }
+    rc = count;
+done_destroyitr:
+    flux_kvsitr_destroy (itr);
+done:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int jobdir_map (flux_t *h, const char *dirname, jobdir_map_f cb, void *arg)
+{
+    return jobdir_depthfirst_map (h, dirname, strlen (dirname), cb, arg);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/jobdir.h
+++ b/src/modules/job-manager/jobdir.h
@@ -1,0 +1,18 @@
+#ifndef _FLUX_JOB_MANAGER_JOBDIR_H
+#define _FLUX_JOB_MANAGER_JOBDIR_H
+
+typedef int (*jobdir_map_f)(flux_jobid_t id, int priority,
+                            uint32_t userid, void *arg);
+
+/* call 'cb' once for each job found in KVS 'dirname', for jobs stored in
+ * FLUID_STRING_DOTHEX (A.B.C.D) form.
+ * Returns number of jobs mapped, or -1 on error.
+ */
+int jobdir_map (flux_t *h, const char *dirname, jobdir_map_f cb, void *arg);
+
+#endif /* !_FLUX_JOB_MANAGER_JOBDIR_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -96,6 +96,7 @@ TESTS = \
 	t2100-aggregate.t \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
+	t2202-job-manager.t \
 	t3000-mpi-basic.t \
         t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \
@@ -201,6 +202,7 @@ check_SCRIPTS = \
 	t2100-aggregate.t \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
+	t2202-job-manager.t \
 	t3000-mpi-basic.t \
         t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -5,3 +5,4 @@ flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 
 flux module load -r all job-ingest
+flux module load -r 0 job-manager

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+flux module remove -r 0 job-manager
 flux module remove -r all job-ingest
 
 flux module remove -r all -x 0 kvs

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -60,6 +60,27 @@ test_expect_success 'job-ingest: submitter userid stored in KVS' '
 	test $jobuserid -eq $myuserid
 '
 
+test_expect_success 'job-ingest: priority stored in KVS' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
+	test $jobpri -eq 16
+'
+
+test_expect_success 'job-ingest: instance owner can submit priority=31' '
+	jobid=$(${SUBMITBENCH} --priority=31 ${JOBSPEC}/valid/basic.yaml) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
+	test $jobpri -eq 31
+'
+
+test_expect_success 'job-ingest: priority range is enforced' '
+	test_must_fail ${SUBMITBENCH} --priority=32 \
+		${JOBSPEC}/valid/basic.yaml &&
+	test_must_fail ${SUBMITBENCH} --priority="-1" \
+		${JOBSPEC}/valid/basic.yaml
+'
+
 test_expect_success 'job-ingest: valid jobspecs accepted' '
 	test_valid ${JOBSPEC}/valid/*
 '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+test_description='Test flux job manager service'
+
+. $(dirname $0)/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+if flux job submitbench --help 2>&1 | grep -q sign-type; then
+    test_set_prereq HAVE_FLUX_SECURITY
+    SUBMITBENCH_OPT_R="--reuse-signature"
+    SUBMITBENCH_OPT_NONE="--sign-type=none"
+fi
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+SUBMITBENCH="flux job submitbench $SUBMITBENCH_OPT_NONE"
+
+# N.B. job submission and job list are eventually consistent
+# Wait here for all jobs submitted to be in the queue before proceeding.
+test_expect_success 'job-manager: submit jobs and list queue' '
+	${SUBMITBENCH} -p0 ${JOBSPEC}/valid/basic.yaml >submit1_p0.out &&
+	${SUBMITBENCH} -p1 ${JOBSPEC}/valid/basic.yaml >submit1_p1.out &&
+	${SUBMITBENCH} -r 100 ${JOBSPEC}/valid/basic.yaml \
+			| sort -n >submit100_p16.out &&
+	${SUBMITBENCH} -p20 ${JOBSPEC}/valid/basic.yaml >submit1_p20.out &&
+	${SUBMITBENCH} -p31 ${JOBSPEC}/valid/basic.yaml >submit1_p31.out &&
+	tries=3 &&
+	while test $tries -gt 0; do \
+		flux job list -s >list.out; \
+		count=$(wc -l <list.out); \
+		test $count -lt 104 || break; \
+		tries=$(($tries-1)); \
+	done &&
+	test $count -eq 104
+'
+
+test_expect_success 'job-manager: flux job list shows priority=31 job first' '
+	head -1 <list.out | cut -f1 >top.out &&
+	test_cmp submit1_p31.out top.out
+'
+
+test_expect_success 'job-manager: flux job list shows priority=0 job last' '
+	tail -1 <list.out | cut -f1 >last.out &&
+	test_cmp submit1_p0.out last.out
+'
+
+test_expect_success 'job-manager: flux job list shows priority=20 job second' '
+	head -2 <list.out | tail -1 | cut -f1 >second.out &&
+	test_cmp submit1_p20.out second.out
+'
+
+test_expect_success 'job-manager: flux job list shows priority=1 job next to last' '
+	tail -2 <list.out | head -1 | cut -f1 >secondlast.out &&
+	test_cmp submit1_p1.out secondlast.out
+'
+
+test_expect_success 'job-manager: flux job list shows expected priorities' '
+	test $(head -1 <list.out | cut -f3) -eq 31 &&
+	test $(tail -1 <list.out | cut -f3) -eq 0 &&
+	test $(head -2 <list.out | tail -1 | cut -f3) -eq 20 &&
+	test $(tail -2 <list.out | head -1 | cut -f3) -eq 1
+'
+
+test_expect_success 'job-manager: flux job list shows expected userid' '
+	test $(head -1 <list.out | cut -f2) -eq $(id -u)
+'
+
+test_expect_success 'job-manager: flux job list --count shows highest priority jobs' '
+	flux job list -s -c 4 >list4.out &&
+	head -4 <list.out >list4.exp &&
+	test_cmp list4.exp list4.out
+'
+
+test_done


### PR DESCRIPTION
This adds the skeleton of a job manager module.

The job manager tracks all active jobs.  It finds out about them through `job-ingest.submit` events from the `job-ingest` module, or if any jobs exist in the KVS when the module is loaded, it pulls them from the KVS.  Internally active jobs are stored in a hash with the jobid as the key.  Jobs are also added to a queue, which is kept in numerical order (roughly the order submitted due to FLUID properties).

I implemented a simple `flux job list` command and a method in the job manager for servicing its requests.  The request sends in a list of attributes and a max number of jobs it wants to get, and the response includes an array of job objects, each of which contains the requested attributes and their values.  The only attributes supported thus far are `id` and `userid`.  If the max number of jobs is set, jobs are taken from the "high priority" (oldest) end of the queue.

Sorry that's all!   I wasn't sure where to cut this initial PR, but I think maybe this is not a bad place.

I do need to add a sharness test.