### PR TITLE
kvs: remove 'magic' field in a few structures

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -54,8 +54,6 @@
 #include "kvstxn.h"
 #include "kvsroot.h"
 
-#define KVS_MAGIC 0xdeadbeef
-
 /* Expire cache_entry after 'max_lastuse_age' heartbeats.
  */
 const int max_lastuse_age = 5;
@@ -72,7 +70,6 @@ const int max_namespace_age = 1000;
 const bool event_includes_rootdir = true;
 
 typedef struct {
-    int magic;
     struct cache *cache;    /* blobref => cache_entry */
     kvsroot_mgr_t *krm;
     int faults;                 /* for kvs.stats.get, etc. */
@@ -130,7 +127,6 @@ static kvs_ctx_t *getctx (flux_t *h)
             saved_errno = ENOMEM;
             goto error;
         }
-        ctx->magic = KVS_MAGIC;
         if (!(r = flux_get_reactor (h))) {
             saved_errno = errno;
             goto error;

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -256,27 +256,6 @@ void basic_api_errors (void)
 
     lookup_destroy (lh);
 
-    /* Now lh destroyed */
-
-    ok (lookup (lh) == LOOKUP_PROCESS_ERROR,
-        "lookup does not segfault on bad pointer");
-    ok (lookup_get_errnum (lh) == EINVAL,
-        "lookup_get_errnum returns EINVAL on bad pointer");
-    ok (lookup_get_value (lh) == NULL,
-        "lookup_get_value fails on bad pointer");
-    ok (lookup_iter_missing_refs (lh, lookup_ref, NULL) < 0,
-        "lookup_iter_missing_refs fails on bad pointer");
-    ok (lookup_missing_namespace (lh) == NULL,
-        "lookup_missing_namespace fails on bad pointer");
-    ok (lookup_get_current_epoch (lh) < 0,
-        "lookup_get_current_epoch fails on bad pointer");
-    ok (lookup_get_namespace (lh) == NULL,
-        "lookup_get_namespace fails on bad pointer");
-    ok (lookup_set_current_epoch (lh, 42) < 0,
-        "lookup_set_current_epoch fails on bad pointer");
-    /* lookup_destroy ok on bad pointer */
-    lookup_destroy (lh);
-
     cache_destroy (cache);
     kvsroot_mgr_destroy (krm);
 }


### PR DESCRIPTION
With #1696 done, the 'magic' field is no longer needed in a few locations.  In addition, this fixes #1711.
