### PR TITLE
python: flux-security bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,10 @@ matrix:
        - IMG=centos7-base
        - DOCKER_TAG=t
        - PYTHON_VERSION=2.7
-    - name: "Centos 7: py3.4"
+    - name: "Centos 7: py3.4 --with-flux-security"
       compiler: gcc
       env:
+       - ARGS="--with-flux-security --prefix=/usr"
        - IMG=centos7-base
        - PYTHON_VERSION=3.4
 

--- a/configure.ac
+++ b/configure.ac
@@ -227,8 +227,13 @@ AX_CODE_COVERAGE
 AC_ARG_WITH([flux-security], AS_HELP_STRING([--with-flux-security],
              [Build with flux-security]))
 AS_IF([test "x$with_flux_security" = "xyes"], [
-    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security], [], [])
+    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security],
+                      [flux_sec_incdir=`$PKG_CONFIG --variable=includedir flux-security`],
+                      [flux_sec_incdir=;])
+    AS_IF([test "x$flux_sec_incdir" = x],
+          [AC_MSG_ERROR([couldn't find flux-security or include directory])])
     AC_DEFINE([HAVE_FLUX_SECURITY], [1], [Define flux-security is available])
+    AC_SUBST(FLUX_SECURITY_INCDIR, $flux_sec_incdir)
 ])
 AM_CONDITIONAL([HAVE_FLUX_SECURITY], [test "x$with_flux_security" = "xyes"])
 

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -79,6 +79,23 @@ _kz_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/common/libkz
 _kz_la_LIBADD = $(common_libs)
 _kz_la_DEPENDENCIES = _kz_build.py
 
+if HAVE_FLUX_SECURITY
+BUILT_SOURCES += _security.c
+fluxso_LTLIBRARIES += _security.la
+_security_build.py: $(MAKE_BINDING)
+	$(PYTHON) $(MAKE_BINDING) --path $(FLUX_SECURITY_INCDIR)/flux/security \
+		--package _flux \
+		--modname _security \
+		--include_header flux/security/sign.h \
+		--add_sub '.*va_list.*|||' \
+		sign.h
+
+nodist__security_la_SOURCES = _security.c
+_security_la_CPPFLAGS = $(AM_CPPFLAGS) $(FLUX_SECURITY_CFLAGS)
+_security_la_LIBADD = $(common_libs) $(FLUX_SECURITY_LIBS)
+_security_la_DEPENDENCIES = _security_build.py
+endif
+
 .PHONY: lib-copy
 
 lib-copy-vpath: ${fluxso_PYTHON} ${fluxso_LTLIBRARIES}

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -9,6 +9,10 @@ fluxpy_PYTHON=\
 	      kz.py\
 	      sec.py
 
+if HAVE_FLUX_SECURITY
+fluxpy_PYTHON += security.py
+endif
+
 if ENABLE_PYLINT
 #TODO: there must be a better way to do this
 # scan flux bindings with pylint, currently fails on any exit but 0

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -1,0 +1,73 @@
+import six
+
+from _flux._security import ffi, lib
+from flux.wrapper import Wrapper, WrapperPimpl, FunctionWrapper
+
+class SecurityFunctionWrapper(FunctionWrapper):
+    def __init__(self, *args, **kwargs):
+        super(SecurityFunctionWrapper, self).__init__(*args, **kwargs)
+
+    def __call__(self, calling_object, *args_in):
+        try:
+            return super(SecurityFunctionWrapper,
+                         self).__call__(calling_object, *args_in)
+        except EnvironmentError:
+            errstr = calling_object.last_error()
+            errnum = calling_object.last_errnum()
+            raise EnvironmentError(errnum, errstr)
+
+class SecurityContext(WrapperPimpl):
+    '''A Flux Security Context object'''
+
+    class InnerWrapper(Wrapper):
+        # pylint: disable=no-value-for-parameter
+        def __init__(self, flags=0):
+            super(SecurityContext.InnerWrapper, self).__init__(
+                ffi, lib,
+                match=ffi.typeof('flux_security_t *'),
+                prefixes=['flux_security_', 'flux_sign_'],
+                destructor=lib.flux_security_destroy,
+                handle=None)
+
+            self.handle = lib.flux_security_create(flags)
+
+        def check_wrap(self, fun, name):
+            fun_type = self.ffi.typeof(fun)
+            add_handle = self.check_handle(name, fun_type)
+            return SecurityFunctionWrapper(fun, name, fun_type, self.ffi,
+                                           add_handle=add_handle)
+
+    def __init__(self, config_pattern, flags=0):
+        super(SecurityContext, self).__init__()
+        self.pimpl = self.InnerWrapper(flags)
+        self.pimpl.configure(config_pattern)
+
+    def sign_wrap(self, payload, mech_type=ffi.NULL, flags=0):
+        if isinstance(payload, six.text_type):
+            payload = payload.encode('utf-8')
+        elif not isinstance(payload, six.binary_type):
+            errstr = "payload must be a text or binary type, not {}"
+            raise TypeError(errstr.format(type(payload)))
+        return self.pimpl.wrap(payload, len(payload), mech_type, flags)
+
+    def sign_unwrap(self, signed_payload, flags=0):
+        if not isinstance(signed_payload, six.binary_type):
+            errstr = "signed_payload must be a binary type, not {}"
+            raise TypeError(errstr.format(type(signed_payload)))
+
+        output_payload = ffi.new('void *[1]') # char**
+        output_payload_len = ffi.new('int [1]') # int*
+        output_userid = ffi.new('int64_t [1]') # int64_t*
+        self.pimpl.unwrap(signed_payload, output_payload, output_payload_len,
+                          output_userid, flags)
+
+        # deference int* to int then copy into python int
+        output_userid = int(output_userid[0])
+        # deference int* to int
+        # no need to copy since it doesn't leave this scope
+        output_payload_len = output_payload_len[0]
+        # deference void** to char* then convert to python binary string
+        output_payload = ffi.cast("char *", output_payload[0])
+        output_payload = ffi.unpack(output_payload, output_payload_len)
+
+        return (output_payload, output_userid)

--- a/src/bindings/python/make_binding.py
+++ b/src/bindings/python/make_binding.py
@@ -10,7 +10,6 @@ parser.add_argument('--include_header', help='Include base path', type=str, defa
 parser.add_argument('--include_ffi', help='FFI module for inclusion', action='append', default=[]) 
 parser.add_argument('--package', help='Package prefix for module import', default=None)
 parser.add_argument('--path', help='Include base path', default='.')
-parser.add_argument('--lib_path', help='Library base path', default='.')
 parser.add_argument('--modname', help='Name for the module to be generated', default='_flux')
 parser.add_argument('--library', help='Library to include in the build', default='flux-core')
 parser.add_argument('--add_long_sub', help='Regex filter to apply whole-file of the form <match>|||<replacement>', action='append', default=[])

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -125,6 +125,7 @@ docker run --rm \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
     --tty \
+    ${INTERACTIVE:+--interactive} \
     travis-builder:${IMAGE} \
     ${INTERACTIVE:-./src/test/travis_run.sh ${CONFIGURE_ARGS}} \
     || die "docker run failed"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -128,6 +128,11 @@ TESTS += \
 	python/t0006-request.py \
 	python/t0007-watchers.py \
 	python/t0008-jsc.py
+
+if HAVE_FLUX_SECURITY
+TESTS += python/t0009-security.py
+endif
+
 endif
 
 EXTRA_DIST= \
@@ -232,7 +237,8 @@ check_SCRIPTS = \
 	python/t0005-kvs.py \
 	python/t0006-request.py \
 	python/t0007-watchers.py \
-	python/t0008-jsc.py
+	python/t0008-jsc.py \
+	python/t0009-security.py
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import os
+import sys
+import unittest
+from tempfile import NamedTemporaryFile
+
+import flux.core as core
+from flux.security import SecurityContext
+
+def __flux_size():
+    return 1
+
+class TestKVS(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        conf = b"""[sign]
+max-ttl = 30
+default-type = "none"
+allowed-types = [ "none" ]
+"""
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.file.write(conf)
+            tmpfile.file.flush()
+            os.fsync(tmpfile.file)
+            self.context = SecurityContext(tmpfile.name)
+
+    def test_00_sign_none(self):
+        unsigned_str = u"hello world"
+        signed_str = self.context.sign_wrap(unsigned_str, mech_type="none")
+        unwrapped_payload, wrapping_user = self.context.sign_unwrap(signed_str)
+        unwrapped_str = unwrapped_payload.decode('utf-8')
+
+        self.assertEqual(unsigned_str, unwrapped_str)
+        self.assertEqual(wrapping_user, os.getuid())
+
+    def test_01_security_error(self):
+        with self.assertRaisesRegexp(EnvironmentError, "sign-unwrap:.*"):
+            unwrapped_payload, wrapping_user = self.context.sign_unwrap(b"foo")
+
+if __name__ == '__main__':
+    from subflux import rerun_under_flux
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+        unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Enables submitting signed jobspec via python 

This will be less necessary once #1715 is handled, but in the meantime, I believe it is the only way to submit jobs to flux instances configured with flux-security.