### PR TITLE
libkvs/eventlog: drop typedefs that violate RFC 7

### DIFF
--- a/doc/man3/flux_kvs_eventlog_create.adoc
+++ b/doc/man3/flux_kvs_eventlog_create.adoc
@@ -31,8 +31,8 @@ SYNOPSIS
 
  int flux_kvs_event_decode (const char *s,
                             double *timestamp,
-                            flux_kvs_event_name_t name,
-                            flux_kvs_event_context_t context);
+                            char *name, int name_size,
+                            char *context, int context_size);
 
  char *flux_kvs_event_encode (const char *name, const char *context);
 
@@ -81,10 +81,13 @@ Pointers returned by these functions remain valid until the object
 is destroyed.
 
 `flux_kvs_event_decode()` decodes a raw event, copying the timestamp,
-name, and context fields to the supplied storage.  A field may be
-ignored by setting the corresponding parameter to zero.  If the optional
-context is not present, the supplied storage will be filled with the
-empty string.
+name, and context fields to the corresponding output parameters.
+It is advised that the _name_ be large enough to contain
+`FLUX_KVS_MAX_EVENT_NAME + 1` bytes, and _context_ large enough to contain
+`FLUX_KVS_MAX_EVENT_CONTEXT + 1` bytes.  If an output parameter is NULL,
+the corresponding field is parsed internally, but not copied.
+If _context_ is not NULL, and the event does not contain the optional
+context field, the empty string is be copied to the supplied storage.
 
 `flux_kvs_event_encode()` creates a raw event from the supplied fields.
 The timestamp is assigned the current wallclock time. The caller must

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1860,11 +1860,12 @@ static int eventlog_timestr (double timestamp, char *buf, size_t size)
 static void eventlog_prettyprint (FILE *f, const char *s)
 {
     double timestamp;
-    flux_kvs_event_name_t name;
-    flux_kvs_event_context_t context;
+    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
+    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
     char buf[64];
 
-    if (flux_kvs_event_decode (s, &timestamp, name, context) < 0)
+    if (flux_kvs_event_decode (s, &timestamp, name, sizeof (name),
+                                              context, sizeof (context)) < 0)
         log_err_exit ("flux_kvs_event_decode");
     if (eventlog_timestr (timestamp, buf, sizeof (buf)) < 0)
         log_msg_exit ("error converting timestamp to ISO 8601");

--- a/src/common/libkvs/kvs_eventlog.c
+++ b/src/common/libkvs/kvs_eventlog.c
@@ -34,8 +34,6 @@
 
 #include "kvs_eventlog.h"
 
-#define MAX_KVS_EVENT_NAME  (sizeof (flux_kvs_event_name_t) - 1)
-#define MAX_KVS_EVENT_CONTEXT (sizeof (flux_kvs_event_context_t) - 1)
 
 /* eventlog is a list of RFC 18 events.
  * Once appended to the list, pointers to the events can be accessed by users
@@ -145,7 +143,7 @@ static bool event_validate (const char *tok, size_t toklen)
 
     if (!(s = strndup (tok, toklen)))
         return false;
-    rc = flux_kvs_event_decode (s, NULL, NULL, NULL);
+    rc = flux_kvs_event_decode (s, NULL, NULL, 0, NULL, 0);
     free (s);
     if (rc < 0)
         return false;
@@ -269,8 +267,8 @@ static const char *strnchr (const char *s, int c, size_t size)
 
 int flux_kvs_event_decode (const char *s,
                            double *timestamp,
-                           flux_kvs_event_name_t name,
-                           flux_kvs_event_context_t context)
+                           char *name, int name_size,
+                           char *context, int context_size)
 {
     const char *input;
     double t;
@@ -295,11 +293,13 @@ int flux_kvs_event_decode (const char *s,
     /* name */
     if (!(cp = strchr (input, ' ')) && !(cp = strchr (input, '\n')))
         goto error_inval;
-    if ((toklen = cp - input) > MAX_KVS_EVENT_NAME || toklen == 0)
+    if ((toklen = cp - input) > FLUX_KVS_MAX_EVENT_NAME || toklen == 0)
         goto error_inval;
     if (strnchr (input, '\n', toklen))
         goto error_inval;
     if (name) {
+        if (name_size < toklen + 1)
+            goto error_inval;
         memcpy (name, input, toklen);
         name[toklen] = '\0';
     }
@@ -313,9 +313,11 @@ int flux_kvs_event_decode (const char *s,
     else {
         if (!(cp = strchr (input, '\n')))
             goto error_inval;
-        if ((toklen = cp - input) > MAX_KVS_EVENT_CONTEXT)
+        if ((toklen = cp - input) > FLUX_KVS_MAX_EVENT_CONTEXT)
             goto error_inval;
         if (context) {
+            if (context_size < toklen + 1)
+                goto error_inval;
             memcpy (context, input, toklen);
             context[toklen] = '\0';
         }
@@ -337,12 +339,12 @@ char *flux_kvs_event_encode_timestamp (double timestamp, const char *name,
     int namelen;
 
     if (!name || timestamp <= 0.
-              || (namelen = strlen (name)) > MAX_KVS_EVENT_NAME
+              || (namelen = strlen (name)) > FLUX_KVS_MAX_EVENT_NAME
               || namelen == 0
               || strchr (name, ' ') != NULL
               || strchr (name, '\n') != NULL
               || (context && (strchr (context, '\n') != NULL
-                            || strlen (context) > MAX_KVS_EVENT_CONTEXT))) {
+                        || strlen (context) > FLUX_KVS_MAX_EVENT_CONTEXT))) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/common/libkvs/kvs_eventlog.h
+++ b/src/common/libkvs/kvs_eventlog.h
@@ -11,8 +11,9 @@ extern "C" {
  *   "timestamp name [context ...]\n"
  */
 
-typedef char flux_kvs_event_name_t[65];
-typedef char flux_kvs_event_context_t[257];
+#define FLUX_KVS_MAX_EVENT_NAME      (64)
+#define FLUX_KVS_MAX_EVENT_CONTEXT   (256)
+
 
 /* Create/destroy an eventlog
  */
@@ -41,13 +42,13 @@ const char *flux_kvs_eventlog_next (struct flux_kvs_eventlog *eventlog);
 
 /* Encode/decode an event.
  * flux_kvs_event_encode() sets timestamp to current wallclock.
- * flux_kvs_event_encode_timestmap() allows timestamp to be set to any value.
+ * flux_kvs_event_encode_timestamp() allows timestamp to be set to any value.
  * Caller must free return value of flux_kvs_event_encode().
  */
 int flux_kvs_event_decode (const char *s,
                            double *timestamp,
-                           flux_kvs_event_name_t name,
-                           flux_kvs_event_context_t context);
+                           char *name, int name_size,
+                           char *context, int context_size);
 char *flux_kvs_event_encode (const char *name, const char *context);
 char *flux_kvs_event_encode_timestamp (double timestamp,
                                        const char *name,

--- a/src/common/libkvs/test/kvs_eventlog.c
+++ b/src/common/libkvs/test/kvs_eventlog.c
@@ -65,8 +65,8 @@ void basic_check (struct flux_kvs_eventlog *log, bool first, bool xeof,
     const char *s;
     int rc;
     double timestamp;
-    flux_kvs_event_name_t name;
-    flux_kvs_event_context_t context;
+    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
+    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
 
     name[0] = '\0';
     context[0] = '\0';
@@ -82,7 +82,8 @@ void basic_check (struct flux_kvs_eventlog *log, bool first, bool xeof,
     else {
         ok (s != NULL,
             "flux_kvs_eventlog_%s != NULL", first ? "first" : "next");
-        rc = flux_kvs_event_decode (s, &timestamp, name, context);
+        rc = flux_kvs_event_decode (s, &timestamp, name, sizeof (name),
+                                                   context, sizeof (context));
         ok (rc == 0
             && timestamp == xtimestamp
             && (!xname || !strcmp (name, xname))
@@ -184,14 +185,15 @@ void bad_input (void)
         "flux_kvs_eventlog_next log=NULL returns NULL");
 
     errno = 0;
-    ok (flux_kvs_event_decode (NULL, NULL, NULL, NULL) < 0 && errno == EINVAL,
+    ok (flux_kvs_event_decode (NULL, NULL, NULL, 0, NULL, 0) < 0
+        && errno == EINVAL,
         "flux_kvs_event_decode log=NULL fails with EINVAL");
 
     /* decode bad events */
     for (i = 0; badevent[i] != NULL; i++) {
         char buf[80];
         errno = 0;
-        ok (flux_kvs_event_decode (badevent[i], NULL, NULL, NULL) < 0
+        ok (flux_kvs_event_decode (badevent[i], NULL, NULL, 0, NULL, 0) < 0
             && errno == EINVAL,
             "flux_kvs_event_decode event=\"%s\" fails with EINVAL",
             printable (buf, badevent[i]));


### PR DESCRIPTION
I've been sitting on this for a while, moving it around between pull requests I've been working on.  Maybe better to just submit standalone rather than keep withholding it.