### PR TITLE
testsuite: improve test reliability and prepare for asan testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,11 @@ cache:
     - $HOME/.ccache
 
 before_install:
+ # work around persistent write error bug from make in travis
+ # see https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959
+ - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+ # die if non-blocking is still enabled
+ - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); exit(flags&os.O_NONBLOCK);'
  # coveralls-lcov required only for coveralls upload:
  - if test "$COVERAGE" = "t" ; then gem install coveralls-lcov; fi
  - if test -z "${IMG}"; then IMG="bionic-base"; fi

--- a/configure.ac
+++ b/configure.ac
@@ -59,11 +59,17 @@ AS_CASE($ax_cv_cxx_compiler_vendor,
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 X_AC_ENABLE_SANITIZER
-if test "x$san_enabled" != "xno" ; then
-  AC_DEFINE([DEEPBIND], [0],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[
+  #include <dlfcn.h>
+  #if !(defined(RTLD_DEEPBIND))
+  #error nope
+  #endif
+])], [has_deepbind=yes], [has_deepbind=no])
+if test "x$san_enabled" != "xno" || test "x$has_deepbind" = "xno" ; then
+  AC_DEFINE([FLUX_DEEPBIND], [0],
             [deepbind is unsupported with asan, musl and so-forth])
 else
-  AC_DEFINE([DEEPBIND], [RTLD_DEEPBIND],
+  AC_DEFINE([FLUX_DEEPBIND], [RTLD_DEEPBIND],
             [deepbind is unsupported with asan, musl and so-forth])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,15 @@ AS_CASE($ax_cv_cxx_compiler_vendor,
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 X_AC_ENABLE_SANITIZER
+if test "x$san_enabled" != "xno" ; then
+  AC_DEFINE([DEEPBIND], [0],
+            [deepbind is unsupported with asan, musl and so-forth])
+else
+  AC_DEFINE([DEEPBIND], [RTLD_DEEPBIND],
+            [deepbind is unsupported with asan, musl and so-forth])
+fi
+
+
 LT_INIT
 AC_PROG_AWK
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -531,7 +531,7 @@ module_t *module_add (modhash_t *mh, const char *path)
     int rc;
 
     dlerror ();
-    if (!(dso = dlopen (path, RTLD_NOW | RTLD_LOCAL | DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_NOW | RTLD_LOCAL | FLUX_DEEPBIND))) {
         log_msg ("%s", dlerror ());
         errno = ENOENT;
         return NULL;

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -531,7 +531,7 @@ module_t *module_add (modhash_t *mh, const char *path)
     int rc;
 
     dlerror ();
-    if (!(dso = dlopen (path, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_NOW | RTLD_LOCAL | DEEPBIND))) {
         log_msg ("%s", dlerror ());
         errno = ENOENT;
         return NULL;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -230,7 +230,7 @@ static connector_init_f *find_connector (const char *scheme, void **dsop)
     }
     if (!(path = find_file (name, searchpath)))
         goto done;
-    if (!(dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | DEEPBIND))) {
         errno = EINVAL;
         goto done;
     }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -230,7 +230,7 @@ static connector_init_f *find_connector (const char *scheme, void **dsop)
     }
     if (!(path = find_file (name, searchpath)))
         goto done;
-    if (!(dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | FLUX_DEEPBIND))) {
         errno = EINVAL;
         goto done;
     }

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -263,7 +263,7 @@ char *flux_modname(const char *path)
     char *name = NULL;
 
     dlerror ();
-    if ((dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | DEEPBIND))) {
+    if ((dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | FLUX_DEEPBIND))) {
         int errnum = EINVAL;
         if ((np = dlsym (dso, "mod_name")) && *np)
             if (!(name = strdup (*np)))

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -263,7 +263,7 @@ char *flux_modname(const char *path)
     char *name = NULL;
 
     dlerror ();
-    if ((dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND))) {
+    if ((dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | DEEPBIND))) {
         int errnum = EINVAL;
         if ((np = dlsym (dso, "mod_name")) && *np)
             if (!(name = strdup (*np)))

--- a/src/test/docker/centos7-base/Dockerfile
+++ b/src/test/docker/centos7-base/Dockerfile
@@ -3,8 +3,11 @@ FROM centos:7
 LABEL maintainer="Tom Scogland <scogland1@llnl.gov>"
 
 # add EPEL so we don't have to build everything by hand
+# add scl and devtoolset-7 so we can use next-rhel tools, just make 4 for now
+# so we can avoid make sync issues on travis
 RUN yum -y update \
  && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+ && yum -y install centos-release-scl-rh \
  && yum -y update \
  && yum -y install \
       which \
@@ -50,6 +53,7 @@ RUN yum -y update \
       man-db \
       aspell \
       aspell-en \
+      devtoolset-7-make \
  && yum clean all
 
 # The cmake from yum is incredibly ancient, download a less ancient one

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -25,7 +25,7 @@
 
 ARGS="$@"
 JOBS=${JOBS:-2}
-MAKECMDS="make -j ${JOBS} ${DISTCHECK:+dist}check"
+MAKECMDS="make --output-sync=line -j ${JOBS} ${DISTCHECK:+dist}check"
 
 # Add non-standard path for libfaketime to LD_LIBRARY_PATH:
 export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/faketime"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -141,6 +141,9 @@ EXTRA_DIST= \
 	sharness.sh \
 	sharness.d \
 	$(T) \
+	test-under-flux/expected.modcheck \
+	test-under-flux/t_modcheck.t \
+	test-under-flux/test.t \
 	rc/rc1-kvs \
 	rc/rc1-wreck \
 	rc/rc1-testenv \

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -121,53 +121,24 @@ test_expect_success 'flux-start --wrap option works with --size' '
 
 test_expect_success 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&
-	mkdir -p test-under-flux && (
-		cd test-under-flux &&
-		cat >.test.t <<-EOF &&
-		#!/bin/sh
-		pwd
-		test_description="test_under_flux (in sub sharness)"
-		. "\$SHARNESS_TEST_SRCDIR"/sharness.sh
-		test_under_flux 2
-		test_expect_success "flux comms info" "
-			flux comms info
-		"
-		test_done
-		EOF
-	chmod +x .test.t &&
+        mkdir -p test-under-flux && (
+        cd test-under-flux &&
 	SHARNESS_TEST_DIRECTORY=`pwd` &&
 	export SHARNESS_TEST_SRCDIR SHARNESS_TEST_DIRECTORY FLUX_BUILD_DIR debug &&
-	run_timeout 5 ./.test.t --verbose --debug >out 2>err
+	run_timeout 5 "$SHARNESS_TEST_SRCDIR"/test-under-flux/test.t --verbose --debug >out 2>err
 	) &&
 	grep "size=2" test-under-flux/out
 '
 
 test_expect_success 'test_under_flux fails if loaded modules are not unloaded' '
-    mkdir -p test-under-flux && (
-		cd test-under-flux &&
-		cat >.test.modcheck.t <<-EOF &&
-		#!/bin/sh
-		test_description="test_under_flux with module loaded, but not unloaded"
-		. "\$SHARNESS_TEST_SRCDIR"/sharness.sh
-		test_under_flux 2 minimal
-		test_expect_success "flux module load kvs" "
-			flux module load -r 0 kvs
-		"
-		test_done
-		EOF
-		chmod +x .test.modcheck.t &&
-		SHARNESS_TEST_DIRECTORY=`pwd` &&
-		export SHARNESS_TEST_SRCDIR SHARNESS_TEST_DIRECTORY FLUX_BUILD_DIR debug &&
-		test_expect_code 1 ./.test.modcheck.t 2>err.modcheck \
+        mkdir -p test-under-flux && (
+        cd test-under-flux &&
+	SHARNESS_TEST_DIRECTORY=`pwd` &&
+	export SHARNESS_TEST_SRCDIR SHARNESS_TEST_DIRECTORY FLUX_BUILD_DIR debug &&
+	test_expect_code 1 "$SHARNESS_TEST_SRCDIR"/test-under-flux/t_modcheck.t 2>err.modcheck \
 			| grep -v sharness: >out.modcheck
 	) &&
-	cat >expected.modcheck <<-EOF &&
-	ok 1 - flux module load kvs
-	# passed all 1 test(s)
-	1..1
-	error: manually loaded module(s) not unloaded: kvs
-	EOF
-	test_cmp expected.modcheck test-under-flux/out.modcheck
+	test_cmp "$SHARNESS_TEST_SRCDIR"/test-under-flux/expected.modcheck test-under-flux/out.modcheck
 '
 
 test_expect_success 'flux-start -o,--setattr ATTR=VAL can set broker attributes' '

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -27,7 +27,7 @@ test_expect_success 'event: can subscribe' '
 '
 
 test_expect_success 'version: reports an expected string' '
-	flux version | grep -q "flux-core-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"
+	flux version | grep -Eq "flux-core-[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+(-[a-z0-9]+))?"
 '
 
 heaptrace_error_check()

--- a/t/test-under-flux/expected.modcheck
+++ b/t/test-under-flux/expected.modcheck
@@ -1,0 +1,4 @@
+ok 1 - flux module load kvs
+# passed all 1 test(s)
+1..1
+error: manually loaded module(s) not unloaded: kvs

--- a/t/test-under-flux/t_modcheck.t
+++ b/t/test-under-flux/t_modcheck.t
@@ -1,0 +1,8 @@
+#!/bin/sh
+test_description="test_under_flux with module loaded, but not unloaded"
+. "$SHARNESS_TEST_SRCDIR"/sharness.sh
+test_under_flux 2 minimal
+test_expect_success "flux module load kvs" "
+flux module load -r 0 kvs
+"
+test_done

--- a/t/test-under-flux/test.t
+++ b/t/test-under-flux/test.t
@@ -1,0 +1,9 @@
+#!/bin/sh
+pwd
+test_description="test_under_flux (in sub sharness)"
+. "$SHARNESS_TEST_SRCDIR"/sharness.sh
+test_under_flux 2 minimal
+test_expect_success "flux comms info" "
+flux comms info
+"
+test_done


### PR DESCRIPTION
This is a collection of changes to reduce the non-determinism in the tests and to prepare for using the address sanitizer in an automated way.  Mainly meant to address #1687 and the various issues related to it.  As predicted, turning on asan produces a non-trivial number of errors, I've filed issues for all of the ones that crop up before the sharness tests start, hopefully squashing some of those will help with the sharness ones.