### PR TITLE
libjob and job-ingest: improve submit API and submit/queue synchronization

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -270,12 +270,8 @@ void submitbench_check (flux_reactor_t *r, flux_watcher_t *w,
         if (!(f = flux_job_submit (ctx->h, ctx->J, ctx->priority, ctx->flags)))
             log_err_exit ("flux_job_submit");
 #else
-        char *cpy = strndup (ctx->jobspec, ctx->jobspecsz);
-        if (!cpy)
-            log_err_exit ("strndup");
-        if (!(f = flux_job_submit (ctx->h, cpy, ctx->priority, ctx->flags)))
+        if (!(f = flux_job_submit (ctx->h, ctx->jobspec, ctx->priority, ctx->flags)))
             log_err_exit ("flux_job_submit");
-        free (cpy);
 #endif
         if (flux_future_then (f, -1., submitbench_continuation, ctx) < 0)
             log_err_exit ("flux_future_then");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -255,24 +255,27 @@ void submitbench_check (flux_reactor_t *r, flux_watcher_t *w,
                      int revents, void *arg)
 {
     struct submitbench_ctx *ctx = arg;
+    int flags = ctx->flags;
 
     flux_watcher_stop (ctx->idle);
     if (ctx->txcount < ctx->totcount
                     && (ctx->txcount - ctx->rxcount) < ctx->max_queue_depth) {
         flux_future_t *f;
 #if HAVE_FLUX_SECURITY
-        if (!ctx->J || !optparse_hasopt (ctx->p, "reuse-signature")) {
-            if (!(ctx->J = flux_sign_wrap (ctx->sec, ctx->jobspec,
-                                           ctx->jobspecsz, ctx->sign_type, 0)))
-                log_err_exit ("flux_sign_wrap: %s",
-                              flux_security_last_error (ctx->sec));
+        if (ctx->sec) {
+            if (!ctx->J || !optparse_hasopt (ctx->p, "reuse-signature")) {
+                if (!(ctx->J = flux_sign_wrap (ctx->sec, ctx->jobspec,
+                                               ctx->jobspecsz,
+                                               ctx->sign_type, 0)))
+                    log_err_exit ("flux_sign_wrap: %s",
+                                  flux_security_last_error (ctx->sec));
+            }
+            flags |= FLUX_JOB_PRE_SIGNED;
         }
-        if (!(f = flux_job_submit (ctx->h, ctx->J, ctx->priority, ctx->flags)))
-            log_err_exit ("flux_job_submit");
-#else
-        if (!(f = flux_job_submit (ctx->h, ctx->jobspec, ctx->priority, ctx->flags)))
-            log_err_exit ("flux_job_submit");
 #endif
+        if (!(f = flux_job_submit (ctx->h, ctx->J ? ctx->J : ctx->jobspec,
+                                   ctx->priority, flags)))
+            log_err_exit ("flux_job_submit");
         if (flux_future_then (f, -1., submitbench_continuation, ctx) < 0)
             log_err_exit ("flux_future_then");
         ctx->txcount++;
@@ -292,12 +295,19 @@ int cmd_submitbench (optparse_t *p, int argc, char **argv)
         exit (1);
     }
 #if HAVE_FLUX_SECURITY
-    const char *sec_config = optparse_get_str (p, "security-config", NULL);
-    if (!(ctx.sec = flux_security_create (0)))
-        log_err_exit ("security");
-    if (flux_security_configure (ctx.sec, sec_config) < 0)
-        log_err_exit ("security config %s", flux_security_last_error (ctx.sec));
-    ctx.sign_type = optparse_get_str (p, "sign-type", NULL);
+    /* If any non-default security options are specified, create security
+     * context so jobspec can be pre-signed before submission.
+     */
+    if (optparse_hasopt (p, "security-config")
+                            || optparse_hasopt (p, "reuse-signature")
+                            || optparse_hasopt (p, "sign-type")) {
+        const char *sec_config = optparse_get_str (p, "security-config", NULL);
+        if (!(ctx.sec = flux_security_create (0)))
+            log_err_exit ("security");
+        if (flux_security_configure (ctx.sec, sec_config) < 0)
+            log_err_exit ("security config %s", flux_security_last_error (ctx.sec));
+        ctx.sign_type = optparse_get_str (p, "sign-type", NULL);
+    }
 #endif
     if (!(ctx.h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -217,10 +217,10 @@ void submitbench_continuation (flux_future_t *f, void *arg)
     const char *errmsg;
 
     if (flux_job_submit_get_id (f, &id) < 0) {
-        if (errno == ENOSYS)
-            log_msg_exit ("submit: job-ingest module is not loaded");
-        else if ((errmsg = flux_future_error_string (f)))
+        if ((errmsg = flux_future_error_string (f)))
             log_msg_exit ("submit: %s", errmsg);
+        else if (errno == ENOSYS)
+            log_msg_exit ("submit: job-ingest module is not loaded");
         else
             log_err_exit ("submit");
     }

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -36,7 +36,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libcompat/libcompat.la \
 	$(builddir)/libtomlc99/libtomlc99.la \
 	$(LIBMUNGE) $(JANSSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
-	$(LIBDL) $(LIBRT)
+	$(LIBDL) $(LIBRT) $(FLUX_SECURITY_LIBS)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
 lib_LTLIBRARIES = libflux-core.la libflux-optparse.la libflux-idset.la

--- a/src/common/core.h
+++ b/src/common/core.h
@@ -32,6 +32,7 @@
 #include "core/flux.h"
 #include "core/kvs.h"
 #include "core/jstatctl.h"
+#include "core/job.h"
 
 #endif /* !_FLUX_CORE_H */
 

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -18,7 +18,8 @@ libjob_la_SOURCES = \
 	sign_none.h
 
 TESTS = \
-        test_job.t
+	test_job.t \
+	test_sign_none.t
 
 check_PROGRAMS = \
         $(TESTS)
@@ -41,3 +42,7 @@ test_cppflags = \
 test_job_t_SOURCES = test/job.c
 test_job_t_CPPFLAGS = $(test_cppflags)
 test_job_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_sign_none_t_SOURCES = test/sign_none.c
+test_sign_none_t_CPPFLAGS = $(test_cppflags)
+test_sign_none_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -13,7 +13,9 @@ noinst_LTLIBRARIES = libjob.la
 fluxcoreinclude_HEADERS = job.h
 
 libjob_la_SOURCES = \
-	job.c
+	job.c \
+	sign_none.c \
+	sign_none.h
 
 TESTS = \
         test_job.t

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -7,7 +7,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
-	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS) $(FLUX_SECURITY_CFLAGS)
 
 noinst_LTLIBRARIES = libjob.la
 fluxcoreinclude_HEADERS = job.h
@@ -33,7 +33,8 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux/libflux.la \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) $(LIBDL) $(LIBMUNGE)
+        $(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) \
+        $(FLUX_SECURITY_LIBS) $(LIBDL) $(LIBMUNGE)
 
 test_cppflags = \
         $(AM_CPPFLAGS) \

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -31,7 +31,8 @@
 #include "job.h"
 
 
-flux_future_t *flux_job_submit (flux_t *h, const char *J, int flags)
+flux_future_t *flux_job_submit (flux_t *h, const char *J, int priority,
+                                int flags)
 {
     flux_future_t *f;
 
@@ -40,8 +41,9 @@ flux_future_t *flux_job_submit (flux_t *h, const char *J, int flags)
         return NULL;
     }
     if (!(f = flux_rpc_pack (h, "job-ingest.submit", FLUX_NODEID_ANY, 0,
-                             "{s:s s:i}",
+                             "{s:s s:i s:i}",
                              "J", J,
+                             "priority", priority,
                              "flags", flags)))
         return NULL;
     return f;

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -25,28 +25,99 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-
+#include <unistd.h>
+#include <sys/types.h>
 #include <flux/core.h>
-
+#if HAVE_FLUX_SECURITY
+#include <flux/security/sign.h>
+#endif
 #include "job.h"
+#include "sign_none.h"
 
+#if HAVE_FLUX_SECURITY
+/* If a textual error message is available in flux-security,
+ * enclose it in a future and return.  Otherwise return NULL
+ * with errno set to the original error.
+ */
+static flux_future_t *get_security_error (flux_security_t *sec)
+{
+    int errnum = flux_security_last_errnum (sec);
+    const char *errmsg = flux_security_last_error (sec);
+    flux_future_t *f = NULL;
 
-flux_future_t *flux_job_submit (flux_t *h, const char *J, int priority,
+    if (errmsg && (f = flux_future_create (NULL, NULL)))
+        flux_future_fulfill_error (f, errnum, errmsg);
+    errno = errnum;
+    return f;
+}
+
+/* Cache flux-security context in the handle on first use.
+ * On failure, return NULL and set the value of 'f_error' to NULL,
+ * or if a textual error message is available such as from config
+ * file parsing, set the value of 'f_error' to a future containing
+ * the textual error.
+ */
+static flux_security_t *get_security_ctx (flux_t *h, flux_future_t **f_error)
+{
+    const char *auxkey = "flux::job_security_ctx";
+    flux_security_t *sec = flux_aux_get (h, auxkey);
+
+    if (!sec) {
+        if (!(sec = flux_security_create (0)))
+            goto error;
+        if (flux_security_configure (sec, NULL) < 0)
+            goto error;
+        flux_aux_set (h, auxkey, sec, (flux_free_f)flux_security_destroy);
+    }
+    return sec;
+error:
+    *f_error = sec ? get_security_error (sec) : NULL;
+    flux_security_destroy (sec);
+    return NULL;
+}
+#endif
+
+flux_future_t *flux_job_submit (flux_t *h, const char *jobspec, int priority,
                                 int flags)
 {
-    flux_future_t *f;
+    flux_future_t *f = NULL;
+    const char *J;
+    char *s = NULL;
+    int saved_errno;
 
-    if (!h || !J) {
+    if (!h || !jobspec) {
         errno = EINVAL;
         return NULL;
+    }
+    if (!(flags & FLUX_JOB_PRE_SIGNED)) {
+#if HAVE_FLUX_SECURITY
+        flux_security_t *sec;
+        if (!(sec = get_security_ctx (h, &f)))
+            return f;
+        if (!(J = flux_sign_wrap (sec, jobspec, strlen (jobspec), NULL, 0)))
+            return get_security_error (sec);
+#else
+        if (!(s = sign_none_wrap (jobspec, strlen (jobspec), geteuid ())))
+            goto error;
+        J = s;
+#endif
+    }
+    else {
+        J = jobspec;
+        flags &= ~FLUX_JOB_PRE_SIGNED; // client only flag
     }
     if (!(f = flux_rpc_pack (h, "job-ingest.submit", FLUX_NODEID_ANY, 0,
                              "{s:s s:i s:i}",
                              "J", J,
                              "priority", priority,
                              "flags", flags)))
-        return NULL;
+        goto error;
     return f;
+error:
+    saved_errno = errno;
+    free (s);
+    errno = saved_errno;
+    return NULL;
 }
 
 int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *jobid)

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -9,6 +9,12 @@
 extern "C" {
 #endif
 
+enum job_priority {
+    FLUX_JOB_PRIORITY_MIN = 0,
+    FLUX_JOB_PRIORITY_DEFAULT = 16,
+    FLUX_JOB_PRIORITY_MAX = 31,
+};
+
 typedef uint64_t flux_jobid_t;
 
 /* Submit a job to the system.
@@ -17,7 +23,8 @@ typedef uint64_t flux_jobid_t;
  * Currently the 'flags' parameter must be set to 0.
  * The system assigns a jobid and returns it in the response.
  */
-flux_future_t *flux_job_submit (flux_t *h, const char *J, int flags);
+flux_future_t *flux_job_submit (flux_t *h, const char *J,
+                                int priority, int flags);
 
 /* Parse jobid from response to flux_job_submit() request.
  * Returns 0 on success, -1 on failure with errno set - and an extended

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -9,6 +9,10 @@
 extern "C" {
 #endif
 
+enum job_submit_flags {
+    FLUX_JOB_PRE_SIGNED = 1,    // 'jobspec' is already signed
+};
+
 enum job_priority {
     FLUX_JOB_PRIORITY_MIN = 0,
     FLUX_JOB_PRIORITY_DEFAULT = 16,
@@ -18,12 +22,10 @@ enum job_priority {
 typedef uint64_t flux_jobid_t;
 
 /* Submit a job to the system.
- * J should be RFC 14 jobspec signed by flux_sign_wrap(), provided
- * flux was built --with-flux-security.  If not, then J should be bare jobspec.
- * Currently the 'flags' parameter must be set to 0.
+ * 'jobspec' should be RFC 14 jobspec.
  * The system assigns a jobid and returns it in the response.
  */
-flux_future_t *flux_job_submit (flux_t *h, const char *J,
+flux_future_t *flux_job_submit (flux_t *h, const char *jobspec,
                                 int priority, int flags);
 
 /* Parse jobid from response to flux_job_submit() request.

--- a/src/common/libjob/sign_none.c
+++ b/src/common/libjob/sign_none.c
@@ -1,0 +1,200 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <argz.h>
+
+#include "src/common/libutil/base64.h"
+
+#include "sign_none.h"
+
+int header_decode (const char *src, int srclen, uint32_t *useridp)
+{
+    int dstlen;
+    char *dst = NULL;
+    char *entry = NULL;
+    char *key;
+    char *val;
+    char *val_userid = NULL;
+    char *val_version = NULL;
+    char *val_mech = NULL;
+    uint32_t userid;
+    char *endptr;
+
+    dstlen = base64_decode_length (srclen);
+    if (!(dst = calloc (1, dstlen)))
+        return -1;
+    if (base64_decode_block (dst, &dstlen, src, srclen) < 0)
+        goto error_inval;
+    if (dst[dstlen - 1] != '\0')
+        goto error_inval;
+    while ((key = entry = argz_next (dst, dstlen, entry))) {
+        if (!(val = entry = argz_next (dst, dstlen, entry)))
+            goto error_inval;
+        if (!strcmp (key, "version"))
+            val_version = val;
+        else if (!strcmp (key, "userid"))
+            val_userid = val;
+        else if (!strcmp (key, "mech"))
+            val_mech = val;
+        else
+            goto error_inval;
+    }
+    if (!val_version || !val_mech || strcmp (val_version, "i1") != 0
+                                  || strcmp (val_mech, "snone") != 0)
+        goto error_inval;
+    if (!val_userid || *val_userid != 'i')
+        goto error_inval;
+    if (val_userid[1] < '0' || val_userid[1] > '9') // no sign or wspace allowed
+        goto error_inval;
+    errno = 0;
+    userid = strtoul (val_userid + 1, &endptr, 10);
+    if (errno != 0 || *endptr != '\0' || endptr == val_userid)
+        goto error_inval;
+    free (dst);
+    *useridp = userid;
+    return 0;
+error_inval:
+    free (dst);
+    errno = EINVAL;
+    return -1;
+}
+
+static char *header_encode (uint32_t userid)
+{
+    char src[128];
+    int srclen;
+    char *dst;
+    int dstlen;
+    int i;
+
+    srclen = snprintf (src, sizeof (src), "version:i1:userid:i%lu:mech:snone:",
+                       (unsigned long)userid);
+    assert (srclen < sizeof (src));
+    for (i = 0; i < srclen; i++) {
+        if (src[i] == ':')
+            src[i] = '\0';
+    }
+    dstlen = base64_encode_length (srclen);
+    if (!(dst = calloc (1, dstlen)))
+        return NULL;
+    (void)base64_encode_block (dst, &dstlen, src, srclen);
+    return dst;
+}
+
+static char *payload_encode (const void *src, int srclen)
+{
+    char *dst;
+    int dstlen;
+
+    dstlen = base64_encode_length (srclen);
+    if (!(dst = calloc (1, dstlen)))
+        return NULL;
+    (void)base64_encode_block (dst, &dstlen, src, srclen);
+    return dst;
+}
+
+static int payload_decode (const void *src, int srclen,
+                           void **payload, int *payloadsz)
+{
+    int dstlen;
+    void *dst;
+
+    dstlen = base64_decode_length (srclen);
+    if (!(dst = calloc (1, dstlen)))
+        return -1;
+    if (base64_decode_block (dst, &dstlen, src, srclen) < 0)
+        goto error_inval;
+    *payload = dst;
+    *payloadsz = dstlen;
+    return 0;
+error_inval:
+    free (dst);
+    errno = EINVAL;
+    return -1;
+}
+
+char *sign_none_wrap (const void *payload, int payloadsz,
+                      uint32_t userid)
+{
+    char *h = NULL;
+    char *p = NULL;
+    char *result;
+
+    if (payloadsz < 0 || (payloadsz > 0 && payload == NULL)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(h = header_encode (userid)))
+        goto error_nomem;
+    if (!(p = payload_encode (payload, payloadsz)))
+        goto error_nomem;
+    if (asprintf (&result, "%s.%s.none", h, p) < 0)
+        goto error_nomem;
+    free (h);
+    free (p);
+    return result;
+error_nomem:
+    free (h);
+    free (p);
+    errno = ENOMEM;
+    return NULL;
+}
+
+int sign_none_unwrap (const char *input,
+                      void **payload, int *payloadsz,
+                      uint32_t *userid)
+{
+    char *p;
+
+    if (!input || !userid || !payload || !payloadsz)
+        goto error_inval;
+    if (!(p = strchr (input, '.')))
+        goto error_inval;
+    if (header_decode (input, p - input, userid) < 0)
+        goto error;
+    input = p + 1;
+    if (!(p = strchr (input, '.')))
+        goto error_inval;
+    if (strcmp (p, ".none") != 0)
+        goto error_inval;
+    if (payload_decode (input, p - input, payload, payloadsz) < 0)
+        goto error;
+    return 0;
+error_inval:
+    errno = EINVAL;
+error:
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/sign_none.h
+++ b/src/common/libjob/sign_none.h
@@ -1,0 +1,22 @@
+#ifndef _SIGN_NONE_H
+#define _SIGN_NONE_H
+
+/* sign wrap/unwrap to be used for job submission/ingest
+ * when flux-security is unavailable.  This simplified version
+ * assumes mech=none and is for flux-core internal use only.
+ */
+
+#include <stdint.h>
+
+char *sign_none_wrap (const void *payload, int payloadsz,
+                      uint32_t userid);
+
+int sign_none_unwrap (const char *input,
+                      void **payload, int *payloadsz,
+                      uint32_t *userid);
+
+#endif /* !_SIGN_NONE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -12,7 +12,7 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     errno = 0;
-    ok (flux_job_submit (NULL, NULL, 0) == NULL && errno == EINVAL,
+    ok (flux_job_submit (NULL, NULL, 0, 0) == NULL && errno == EINVAL,
         "flux_job_submit with NULL args fails with EINVAL");
 
     errno = 0;

--- a/src/common/libjob/test/sign_none.c
+++ b/src/common/libjob/test/sign_none.c
@@ -1,0 +1,339 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libjob/sign_none.h"
+#include "src/common/libutil/base64.h"
+
+void simple (void)
+{
+    uint32_t userid;
+    void *payload;
+    int payloadsz;
+    char *s;
+    int rc;
+
+    s = sign_none_wrap ("foo", 4, 1000);
+    if (!s)
+        BAIL_OUT ("sign_none_wrap returned NULL");
+    ok (s != NULL,
+        "sign_none_wrap works");
+    diag (s);
+
+    userid = 0;
+    payload = NULL;
+    payloadsz = 0;
+    rc = sign_none_unwrap (s, &payload, &payloadsz, &userid);
+    ok (rc == 0 && userid == 1000
+        && payloadsz == 4 && memcmp (payload, "foo", 4) == 0,
+        "sign_none_unwrap works");
+
+    free (s);
+}
+
+char *encode_base64 (const void *src, int srclen)
+{
+    int dstlen = base64_encode_length (srclen);
+    char *dst = calloc (1, dstlen);
+    if (!dst)
+        BAIL_OUT ("calloc failed");
+    (void)base64_encode_block (dst, &dstlen, src, srclen);
+    return dst;
+}
+
+char *wrap (const char *header, int headerlen, void *payload, int payloadlen)
+{
+    char *h = encode_base64 (header, headerlen);
+    char *p = encode_base64 (payload, payloadlen);
+    char *result;
+    if (asprintf (&result, "%s.%s.none", h, p) < 0)
+        BAIL_OUT ("asprintf failed");
+    free (h);
+    free (p);
+    return result;
+}
+
+/* Try header kv's in different orders, and possible corner cases
+ * on payload and userid.
+ */
+void decode_good (void)
+{
+    const char good1_header[] = "version\0i1\0userid\0i1000\0mech\0snone";
+    char *good1 = wrap (good1_header, sizeof (good1_header), "foo", 4);
+    const char good2_header[] = "userid\0i1000\0mech\0snone\0version\0i1";
+    char *good2 = wrap (good2_header, sizeof (good2_header), NULL, 0);
+    const char good3_header[] = "mech\0snone\0version\0i1\0userid\0i0";
+    char *good3 = wrap (good3_header, sizeof (good3_header), "", 1);
+
+    uint32_t userid;
+    void *payload;
+    int payloadsz;
+    int rc;
+
+    userid = 0;
+    payload = NULL;
+    payloadsz = 0;
+    diag ("test 1: %s", good1);
+    rc = sign_none_unwrap (good1, &payload, &payloadsz, &userid);
+    ok (rc == 0 && userid == 1000
+        && payloadsz == 4 && memcmp (payload, "foo", 4) == 0,
+        "dummy encode 1 decodes as expected");
+
+    userid = 0;
+    payload = NULL;
+    payloadsz = 0;
+    diag ("test 2: %s", good2);
+    rc = sign_none_unwrap (good2, &payload, &payloadsz, &userid);
+    ok (rc == 0 && userid == 1000 && payloadsz == 0,
+        "dummy encode 2 decodes as expected");
+
+    userid = 1;
+    payload = NULL;
+    payloadsz = 0;
+    diag ("test 3: %s", good3);
+    rc = sign_none_unwrap (good3, &payload, &payloadsz, &userid);
+    ok (rc == 0 && userid == 0 && payloadsz == 1 && *(char *)payload == '\0',
+        "dummy encode 3 decodes as expected");
+
+    free (good1);
+    free (good2);
+    free (good3);
+}
+
+void decode_bad_header (void)
+{
+    /* version 2 */
+    const char bad1_header[] = "version\0i2\0userid\0i1000\0mech\0snone";
+    char *bad1 = wrap (bad1_header, sizeof (bad1_header), NULL, 0);
+    /* string version */
+    const char bad2_header[] = "version\0s1\0userid\0i1000\0mech\0snone";
+    char *bad2 = wrap (bad2_header, sizeof (bad2_header), NULL, 0);
+    /* missing version */
+    const char bad3_header[] = "userid\0i1000\0mech\0snone";
+    char *bad3 = wrap (bad3_header, sizeof (bad3_header), NULL, 0);
+    /* extra foo field */
+    const char bad4_header[] = "foo\0i0\0version\0i1\0userid\0i1000\0mech\0snone";
+    char *bad4 = wrap (bad4_header, sizeof (bad4_header), NULL, 0);
+    /* negative userid */
+    const char bad5_header[] = "version\0i1\0userid\0i-1\0mech\0snone";
+    char *bad5 = wrap (bad5_header, sizeof (bad5_header), NULL, 0);
+    /* wrong type userid */
+    const char bad6_header[] = "version\0i1\0userid\0s42\0mech\0snone";
+    char *bad6 = wrap (bad6_header, sizeof (bad6_header), NULL, 0);
+    /* missing userid */
+    const char bad7_header[] = "version\0i1\0mech\0snone";
+    char *bad7 = wrap (bad7_header, sizeof (bad7_header), NULL, 0);
+    /* wrong mech */
+    const char bad8_header[] = "version\0i1\0userid\0i1000\0mech\0smunge";
+    char *bad8 = wrap (bad8_header, sizeof (bad8_header), NULL, 0);
+    /* wrong type mech */
+    const char bad9_header[] = "version\0i1\0userid\0i1000\0mech\0inone";
+    char *bad9 = wrap (bad9_header, sizeof (bad9_header), NULL, 0);
+    /* missing mech */
+    const char bad10_header[] = "version\0i1\0userid\0i1000";
+    char *bad10 = wrap (bad10_header, sizeof (bad10_header), NULL, 0);
+    /* extra separator */
+    const char bad11_header[] = "\0version\0i1\0userid\0i1000\0mech\0snone";
+    char *bad11 = wrap (bad11_header, sizeof (bad11_header), NULL, 0);
+
+    uint32_t userid;
+    void *payload;
+    int payloadsz;
+    int rc;
+
+    errno = 0;
+    rc = sign_none_unwrap (bad1, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap bad header version fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad2, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap bad header version type fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad3, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap missing header version fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad4, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap extra header field fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad5, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap bad header userid value fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad6, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap bad header userid type fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad7, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap missing header userid fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad8, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap bad mech value fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad9, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap bad mech type fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad10, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap missing mech fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad11, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap extra seprator fails with EINVAL");
+
+    free (bad1);
+    free (bad2);
+    free (bad3);
+    free (bad4);
+    free (bad5);
+    free (bad6);
+    free (bad7);
+    free (bad8);
+    free (bad9);
+    free (bad10);
+    free (bad11);
+}
+
+void decode_bad_other (void)
+{
+    const char *good = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.Zm9vAA==.none";
+    /* wrong suffix */
+    const char *bad1  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.Zm9vAA==.wrong";
+    /* missing field */
+    const char *bad2  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.none";
+    /* two missing fields */
+    const char *bad3  = "none";
+    /* invalid base64 payload (% character) */
+    const char *bad4  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.%m9vAA==.none";
+    /* invalid base64 header (% character) */
+    const char *bad5  = "%mVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.Zm9vAA==.none";
+
+    uint32_t userid;
+    void *payload;
+    int payloadsz;
+    int rc;
+
+    /* Double check good input, the basis for bad input.
+     */
+    rc = sign_none_unwrap (good, &payload, &payloadsz, &userid);
+    ok (rc == 0,
+        "sign_none_unwrap baseline for bad input tests works");
+    if (rc == 0)
+        free (payload);
+
+    errno = 0;
+    rc = sign_none_unwrap (bad1, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap wrong suffix fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad2, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap missing field fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad3, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap two missing fields fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad4, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap invalid base64 payload fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (bad5, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap invalid base64 header fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap ("", &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap emtpy input fails with EINVAL");
+}
+
+
+void badarg (void)
+{
+    uint32_t userid;
+    void *payload;
+    int payloadsz;
+    int rc;
+    char *s;
+
+    /* unwrap */
+
+    const char good1_header[] = "version\0i1\0userid\0i1000\0mech\0snone";
+    char *good1 = wrap (good1_header, sizeof (good1_header), "foo", 4);
+
+    errno = 0;
+    rc = sign_none_unwrap (NULL, &payload, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap input=NULL fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (good1, NULL, &payloadsz, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap payload=NULL fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (good1, &payload, NULL, &userid);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap payloadsz=NULL fails with EINVAL");
+
+    errno = 0;
+    rc = sign_none_unwrap (good1, &payload, &payloadsz, NULL);
+    ok (rc < 0 && errno == EINVAL,
+        "sign_none_unwrap userid=NULL fails with EINVAL");
+
+    free (good1);
+
+    /* wrap */
+
+    errno = 0;
+    s = sign_none_wrap (NULL, 4, 1000);
+    ok (s == NULL && errno == EINVAL,
+        "sign_none_wrap payload=NULL, payloadsz=4 fails with EINVAL");
+
+    errno = 0;
+    s = sign_none_wrap ("foo", -1, 1000);
+    ok (s == NULL && errno == EINVAL,
+        "sign_none_wrap payloadsz=-1 fails with EINVAL");
+
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    simple ();
+    decode_good ();
+    decode_bad_header ();
+    decode_bad_other ();
+    badarg ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/include/flux/core.h
+++ b/src/include/flux/core.h
@@ -7,5 +7,6 @@
 #include "src/common/libflux/flux.h"
 #include "src/common/libkvs/kvs.h"
 #include "src/common/libjsc/jstatctl.h"
+#include "src/common/libjob/job.h"
 
 #endif /* FLUX_CORE_H */

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -157,6 +157,7 @@ static void batch_destroy (struct batch *batch)
                 job_destroy (job);
             zlist_destroy (&batch->jobs);
             json_decref (batch->idlist);
+            flux_kvs_txn_destroy (batch->txn);
         }
         free (batch);
         errno = saved_errno;

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -317,7 +317,7 @@ static int make_key (char *buf, int bufsz, struct job *job, const char *name)
  * On error, ensure that no remnants of job made into KVS transaction.
  */
 static int batch_add_job (struct batch *batch, struct job *job,
-                          const char *J, uint32_t userid,
+                          const char *J, uint32_t userid, int priority,
                           const char *jobspec, int jobspecsz)
 {
     char key[64];
@@ -342,9 +342,14 @@ static int batch_add_job (struct batch *batch, struct job *job,
         goto error;
     if (flux_kvs_txn_pack (batch->txn, 0, key, "i", userid) < 0)
         goto error;
+    if (make_key (key, sizeof (key), job, "priority") < 0)
+        goto error;
+    if (flux_kvs_txn_pack (batch->txn, 0, key, "i", priority) < 0)
+        goto error;
 
-    if (!(jobentry = json_pack ("{s:I s:i}", "id", job->id,
-                                             "userid", userid)))
+    if (!(jobentry = json_pack ("{s:I s:i s:i}", "id", job->id,
+                                                 "userid", userid,
+                                                 "priority", priority)))
         goto nomem;
     if (json_array_append_new (batch->joblist, jobentry) < 0) {
         json_decref (jobentry);
@@ -382,9 +387,11 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     int rc;
     uint32_t userid;
     uint32_t rolemask;
+    int priority;
 
-    if (flux_request_unpack (msg, NULL, "{s:s s:i}",
+    if (flux_request_unpack (msg, NULL, "{s:s s:i s:i}",
                              "J", &J,
+                             "priority", &priority,
                              "flags", &flags) < 0)
         goto error;
     if (flags != 0) {
@@ -395,6 +402,21 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if (flux_msg_get_rolemask (msg, &rolemask) < 0)
         goto error;
+    if (priority < FLUX_JOB_PRIORITY_MIN || priority > FLUX_JOB_PRIORITY_MAX) {
+        snprintf (errbuf, sizeof (errbuf), "priority range is [%d:%d]",
+                  FLUX_JOB_PRIORITY_MIN, FLUX_JOB_PRIORITY_MAX);
+        errmsg = errbuf;
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(rolemask & FLUX_ROLE_OWNER) && priority > FLUX_JOB_PRIORITY_DEFAULT) {
+        snprintf (errbuf, sizeof (errbuf),
+                  "only the instance owner can submit with priority >%d",
+                  FLUX_JOB_PRIORITY_DEFAULT);
+        errmsg = errbuf;
+        errno = EINVAL;
+        goto error;
+    }
 #if HAVE_FLUX_SECURITY
     int64_t userid_signer;
     const char *mech_type;
@@ -458,7 +480,8 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     if (!(job = job_create (&ctx->gen, msg)))
         goto error;
-    if (batch_add_job (ctx->batch, job, J, userid, jobspec, jobspecsz) < 0) {
+    if (batch_add_job (ctx->batch, job, J, userid, priority,
+                       jobspec, jobspecsz) < 0) {
         job_destroy (job);
         goto error;
     }

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -51,13 +51,10 @@
  *
  * For performance, the above actions are batched, so that if job requests
  * arrive within the 'batch_timeout' window, they are combined into one
- * KVS transaction and one event message.  The event message payload
- * contains an array of integer jobids, e.g.
- *   {"ids":[I,I,...]}
+ * KVS transaction and one event message.
  *
  * The jobid is returned to the user in response to the "submit" RPC.
- * Responses are sent after the KVS commit for the batch is completed,
- * and concurrent with event publication.
+ * Responses are sent after the job has been successfully ingested.
  *
  * Currently all KVS data is committed under job.active.<fluid-dothex>,
  * where <fluid-dothex> is the jobid converted to 16-bit, 0-padded hex
@@ -108,7 +105,7 @@ struct batch {
     struct job_ingest_ctx *ctx;
     flux_kvs_txn_t *txn;
     zlist_t *jobs;
-    json_t *idlist;
+    json_t *joblist;
 };
 
 static void job_destroy (struct job *job)
@@ -156,7 +153,7 @@ static void batch_destroy (struct batch *batch)
             while ((job = zlist_pop (batch->jobs)))
                 job_destroy (job);
             zlist_destroy (&batch->jobs);
-            json_decref (batch->idlist);
+            json_decref (batch->joblist);
             flux_kvs_txn_destroy (batch->txn);
         }
         free (batch);
@@ -178,7 +175,7 @@ static struct batch *batch_create (struct job_ingest_ctx *ctx)
         goto nomem;
     if (!(batch->txn = flux_kvs_txn_create ()))
         goto error;
-    if (!(batch->idlist = json_array ()))
+    if (!(batch->joblist = json_array ()))
         goto nomem;
     batch->ctx = ctx;
     return batch;
@@ -241,7 +238,7 @@ static void batch_event_pub (struct batch *batch)
     flux_future_t *f;
 
     if (!(f = flux_event_publish_pack (h, "job-ingest.submit", 0, "{s:O}",
-                                       "ids", batch->idlist))) {
+                                       "jobs", batch->joblist))) {
         flux_log_error (h, "%s: flux_event_publish_pack", __FUNCTION__);
         goto error;
     }
@@ -325,7 +322,7 @@ static int batch_add_job (struct batch *batch, struct job *job,
 {
     char key[64];
     int saved_errno;
-    json_t *id;
+    json_t *jobentry;
 
     if (zlist_append (batch->jobs, job) < 0) {
         errno = ENOMEM;
@@ -345,10 +342,12 @@ static int batch_add_job (struct batch *batch, struct job *job,
         goto error;
     if (flux_kvs_txn_pack (batch->txn, 0, key, "i", userid) < 0)
         goto error;
-    if (!(id = json_integer (job->id)))
+
+    if (!(jobentry = json_pack ("{s:I s:i}", "id", job->id,
+                                             "userid", userid)))
         goto nomem;
-    if (json_array_append_new (batch->idlist, id) < 0) {
-        json_decref (id);
+    if (json_array_append_new (batch->joblist, jobentry) < 0) {
+        json_decref (jobentry);
         goto nomem;
     }
     return 0;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -279,7 +279,8 @@ check_LTLIBRARIES = \
 	module/parent.la \
 	module/child.la \
 	request/req.la \
-	wreck/sched-dummy.la
+	wreck/sched-dummy.la \
+	ingest/job-manager-dummy.la
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -493,3 +494,9 @@ rexec_rexec_ps_SOURCES = rexec/rexec_ps.c
 rexec_rexec_ps_CPPFLAGS = $(test_cppflags)
 rexec_rexec_ps_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+ingest_job_manager_dummy_la_SOURCES = ingest/job-manager-dummy.c
+ingest_job_manager_dummy_la_CPPFLAGS = $(test_cppflags)
+ingest_job_manager_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
+ingest_job_manager_dummy_la_LIBADD = \
+        $(test_ldadd) $(LIBDL) $(LIBUTIL)

--- a/t/ingest/job-manager-dummy.c
+++ b/t/ingest/job-manager-dummy.c
@@ -1,0 +1,149 @@
+/* dummy job manager for test */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+const char *eventlog_path = "test.ingest.eventlog";
+
+/* KVS commit completed.
+ * Respond to original request which was copied and passed as 'arg'.
+ */
+static void commit_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    flux_msg_t *msg = arg;
+
+    if (flux_future_get (f, NULL) < 0) {
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    }
+    else {
+        if (flux_respond (h, msg, 0, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    }
+    flux_msg_destroy (msg);
+    flux_future_destroy (f);
+}
+
+/* Given a JSON job object, encode a KVS eventlog entry
+ * to represent its submission, timestamped now.  Caller must free.
+ */
+static char *create_eventlog_entry (json_t *job)
+{
+    char context[128];
+    int priority;
+    flux_jobid_t id;
+    uint32_t userid;
+    double t_submit;
+    int n;
+    char *event;
+
+    if (json_unpack (job, "{s:I s:i s:i s:f}", "id", &id,
+                                               "userid", &userid,
+                                               "priority", &priority,
+                                               "t_submit", &t_submit) < 0)
+        goto error_inval;
+    n = snprintf (context, sizeof (context),
+                  "id=%llu priority=%d userid=%lu t_submit=%lf",
+                  (unsigned long long)id,
+                  priority,
+                  (unsigned long)userid,
+                  t_submit);
+    if (n >= sizeof (context))
+        goto error_inval;
+    if (!(event = flux_kvs_event_encode ("submit", context)))
+        goto error;
+    return event;
+error_inval:
+    errno = EINVAL;
+error:
+    return NULL;
+}
+
+/* Given a JSON array of job records, add an eventlog
+ * update for each job to a KVS transaction and return it.
+ */
+static flux_kvs_txn_t *create_eventlog_txn (json_t *jobs)
+{
+    flux_kvs_txn_t *txn;
+    size_t index;
+    json_t *job;
+
+    if (!(txn = flux_kvs_txn_create ()))
+        return NULL;
+    json_array_foreach (jobs, index, job) {
+        char *event = create_eventlog_entry (job);
+        if (!event)
+            goto error;
+        if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, eventlog_path, event) < 0) {
+            int saved_errno = errno;
+            free (event);
+            errno = saved_errno;
+            goto error;
+        }
+        free (event);
+    }
+    return txn;
+error:
+    flux_kvs_txn_destroy (txn);
+    return NULL;
+}
+
+static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    json_t *jobs;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    flux_msg_t *cpy = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0)
+        goto error;
+    if (!(cpy = flux_msg_copy (msg, false)))
+        goto error;
+    if (!(txn = create_eventlog_txn (jobs)))
+        goto error;
+    if (!(f = flux_kvs_commit (h, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1., commit_continuation, cpy) < 0)
+        goto error;
+    flux_kvs_txn_destroy (txn);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_future_destroy (f);
+    flux_msg_destroy (cpy);
+    flux_kvs_txn_destroy (txn);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "job-manager.submit", submit_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int mod_main (flux_t *h, int argc, char *argv[])
+{
+    flux_msg_handler_t **handlers = NULL;
+    int rc = -1;
+
+    if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0) {
+        flux_log_error (h, "flux_msghandler_add");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_msg_handler_delvec (handlers);
+    return rc;
+}
+
+MOD_NAME ("job-manager");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -78,6 +78,32 @@ test_expect_success 'job-ingest: job announced to job manager' '
 	grep -q userid=$(id -u) jobman.out
 '
 
+test_expect_success 'job-ingest: priority stored in KVS' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
+	test $jobpri -eq 16
+'
+
+test_expect_success 'job-ingest: instance owner can submit priority=31' '
+	jobid=$(${SUBMITBENCH} --priority=31 ${JOBSPEC}/valid/basic.yaml) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
+	test $jobpri -eq 31
+'
+
+test_expect_success 'job-ingest: priority range is enforced' '
+	test_must_fail ${SUBMITBENCH} --priority=32 \
+		${JOBSPEC}/valid/basic.yaml &&
+	test_must_fail ${SUBMITBENCH} --priority="-1" \
+		${JOBSPEC}/valid/basic.yaml
+'
+
+test_expect_success 'job-ingest: guest cannot submit priority=17' '
+	! FLUX_HANDLE_ROLEMASK=0x2 \
+	    ${SUBMITBENCH} --priority=17 ${JOBSPEC}/valid/basic.yaml
+'
+
 test_expect_success 'job-ingest: valid jobspecs accepted' '
 	test_valid ${JOBSPEC}/valid/*
 '

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -85,6 +85,12 @@ test_expect_success 'job-ingest: priority stored in KVS' '
 	test $jobpri -eq 16
 '
 
+test_expect_success 'job-ingest: eventlog stored in KVS' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog get ${kvsdir}.eventlog | grep submit
+'
+
 test_expect_success 'job-ingest: instance owner can submit priority=31' '
 	jobid=$(${SUBMITBENCH} --priority=31 ${JOBSPEC}/valid/basic.yaml) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -23,6 +23,8 @@ flux setattr log-stderr-level 1
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 SUBMITBENCH="flux job submitbench $SUBMITBENCH_OPT_NONE"
 
+DUMMY_EVENTLOG=test.ingest.eventlog
+
 test_valid ()
 {
     local rc=0
@@ -41,6 +43,14 @@ test_invalid ()
     return ${rc}
 }
 
+test_expect_success 'job-ingest: submit fails without job-manager' '
+	test_must_fail ${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml 2>nosys.out
+'
+
+test_expect_success 'job-ingest: load job-manager-dummy module' '
+	flux module load ${FLUX_BUILD_DIR}/t/ingest/.libs/job-manager-dummy.so
+'
+
 test_expect_success 'job-ingest: can submit jobspec on stdin' '
 	cat ${JOBSPEC}/valid/basic.yaml | ${SUBMITBENCH} -
 '
@@ -58,6 +68,14 @@ test_expect_success 'job-ingest: submitter userid stored in KVS' '
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobuserid=$(flux kvs get --json ${kvsdir}.userid) &&
 	test $jobuserid -eq $myuserid
+'
+
+test_expect_success 'job-ingest: job announced to job manager' '
+	jobid=$(${SUBMITBENCH} --priority=10 ${JOBSPEC}/valid/basic.yaml) &&
+	flux kvs eventlog get ${DUMMY_EVENTLOG} \
+		| grep "id=${jobid}" >jobman.out &&
+	grep -q priority=10 jobman.out &&
+	grep -q userid=$(id -u) jobman.out
 '
 
 test_expect_success 'job-ingest: valid jobspecs accepted' '
@@ -88,6 +106,10 @@ test_expect_success HAVE_FLUX_SECURITY 'job-ingest: non-owner mech=none fails' '
 	! FLUX_HANDLE_ROLEMASK=0x2 ${SUBMITBENCH} \
 	     ${JOBSPEC}/valid/basic.yaml 2>badrole.out &&
 	grep -q "only instance owner" badrole.out
+'
+
+test_expect_success 'job-ingest: unload job-manager-dummy module' '
+	flux module remove job-manager
 '
 
 test_done


### PR DESCRIPTION
This PR solves a few problems with the `flux_job_submit()` API call and the `job-ingest` module identified in discussions and while building the `job-manager` module.

First, `flux_job_submit()` requires the user to sign jobspec before submitting it, which means the user must interact with the flux-security API.  This is extra work for little gain, since most of the time the default config file and signing method is appropriate.  In addition, flux-core can be built without flux-security, and then `flux_job_submit()` expects jobspec to be sent in the clear.  This means the user has to know how flux-core was built.

To clean this up, add a `FLUX_JOB_PRE_SIGNED` flag to indicate that jobspec is already signed when passed to `flux_job_submit()` for the uncommon case.  In the common case, this flag is not used, and the flux-security API is used internally to sign using the default configuration  When flux-core is not built with flux-security, a dumbed down wrap/unwrap interface is used internally to wrap the jobspec with the "none" method using the same encoding as flux-security.

Next, the `job-ingest` module announces new jobs with an event message, and the event payload contains only an array of jobid's.  The `job-manager` module must immediately put these into a queue ordered by priority and regulate access to them based on the userid, so it must fetch the userid and priority from the KVS.  To fix this, add userid and priority to the payload so instead of an array of integers, we send an array of objects containing id, userid, and priority.

Finally, the event created an "eventually consistent" relationship between the submit command/API and the queue which at minimum makes testing the job manager difficult, and at worst, might confuse users.  Change the announcing event to an RPC to the job manager, and add a dummy job manager module for testing.