### PR TITLE
Fix memleaks caught by leak sanitizer

### DIFF
--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -40,6 +40,8 @@ void check_codec (void)
         && grace == 3.14 && exitcode == 69 && rank ==41 
         && !strcmp (r, "foo"),
         "shutdown_decode works");
+
+    flux_msg_destroy (msg);
 }
 
 int main (int argc, char **argv)

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1415,7 +1415,7 @@ static void optparse_reset_one (optparse_t *p)
 
 void optparse_reset (optparse_t *p)
 {
-    zlist_t *cmds = subcmd_list_sorted (p);
+    zlist_t *cmds = NULL;
 
     if ((cmds = subcmd_list_sorted (p))) {
         const char *cmd = zlist_first (cmds);

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -645,6 +645,7 @@ void test_optional_argument (void)
     ok (rc == 2, "saw --optional-arg again", rc);
     is (optarg, "foo", "got argument to --optional-arg");
 
+    optparse_destroy (p);
 }
 
 int subcmd (optparse_t *p, int ac, char **av)

--- a/src/common/libpmi/clique.c
+++ b/src/common/libpmi/clique.c
@@ -94,6 +94,7 @@ int pmi_process_mapping_parse (const char *s,
     }
     *nblocksp = nblocks;
     *blocksp = blocks;
+    free (argz);
     return PMI_SUCCESS;
 error:
     if (blocks)

--- a/src/common/libtomlc99/test/toml.c
+++ b/src/common/libtomlc99/test/toml.c
@@ -291,6 +291,7 @@ void parse_good_input (void)
         ok (parse_good_file (results.gl_pathv[i], errbuf, 255) == true,
             "%s: %s", basename (results.gl_pathv[i]), errbuf);
     }
+    globfree (&results);
 }
 
 /* Recreate the TOML input from the tomlc99/test/extra directory.

--- a/src/common/libutil/test/tomltk.c
+++ b/src/common/libutil/test/tomltk.c
@@ -83,6 +83,7 @@ void test_json_ts(void)
 
     ok (tomltk_json_to_epoch (obj, &t2) == 0 && t == t2,
         "tomltk_json_to_epoch works, correct value");
+    json_decref (obj);
 }
 
 void test_tojson_t1 (void)

--- a/src/common/libzio/test/zio.c
+++ b/src/common/libzio/test/zio.c
@@ -154,6 +154,7 @@ void test_encode (void)
     ok (rlen == 0 && r != NULL && strcmp (r, q) == 0,
         "zio_json_decode returned empty string");
     free (r);
+    free (json);
 }
 
 int main (int argc, char **argv)

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -124,6 +124,7 @@ docker run --rm \
     -e USER \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
+    --cap-add SYS_PTRACE \
     --tty \
     ${INTERACTIVE:+--interactive} \
     travis-builder:${IMAGE} \


### PR DESCRIPTION
Fixes various memory leaks caught by leak sanitizer.  Most of the leaks were just in test code, but at least one was in an actual library.

This PR is on top of #1733, so that should go in first before merging this.