### PR TITLE
Convert code to use new KVS functions and not KVS classic

### DIFF
--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -44,7 +44,7 @@
 static int l_kvsdir_commit (lua_State *L);
 
 /* aukey shared between wreck, lua, and kz */
-const char *lua_default_txn_auxkey = "flux::kvs_default_txn";
+const char *lua_default_txn_auxkey = "flux::wreck_lua_kz_txn";
 flux_kvs_txn_t *lua_kvs_get_default_txn (flux_t *h)
 {
     flux_kvs_txn_t *txn = NULL;

--- a/src/bindings/lua/kvs-lua.c
+++ b/src/bindings/lua/kvs-lua.c
@@ -243,7 +243,7 @@ static int l_kvsdir_watch (lua_State *L)
             goto err;
     }
     else {
-        /*  Otherwise, the alue at top of stack is initial json_object */
+        /*  Otherwise, the value at top of stack is initial json_object */
         lua_value_to_json_string (L, -1, &json_str);
     }
 

--- a/src/bindings/lua/kvs-lua.h
+++ b/src/bindings/lua/kvs-lua.h
@@ -4,6 +4,10 @@
 #include <lua.h>
 #include <lauxlib.h>
 
+/* wrappers to store a default txn for all kvs write operations */
+flux_kvs_txn_t *lua_kvs_get_default_txn (flux_t *h);
+void lua_kvs_clear_default_txn (flux_t *h);
+
 int luaopen_kvs (lua_State *L);
 
 /*

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -26,6 +26,8 @@ class Flux(Wrapper):
         if handle is None:
             self.handle = raw.flux_open(url, flags)
 
+        self._aux_txn=None
+
     def log(self, level, fstring):
         """
         Log to the flux logging facility

--- a/src/common/libkz/kz.c
+++ b/src/common/libkz/kz.c
@@ -156,7 +156,7 @@ static int errnum_check (kz_t *kz)
 }
 
 /* aukey shared between wreck, lua, and kz */
-static const char *kz_default_txn_auxkey = "flux::kvs_default_txn";
+static const char *kz_default_txn_auxkey = "flux::wreck_lua_kz_txn";
 static flux_kvs_txn_t *kz_kvs_get_default_txn (flux_t *h)
 {
     flux_kvs_txn_t *txn = NULL;

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1175,10 +1175,12 @@ int update_job_state (struct prog_ctx *ctx, const char *state)
         wlog_err (ctx, "update_job_state: asprintf: %s", strerror (errno));
         return (-1);
     }
-    if (flux_kvsdir_pack (ctx->kvs, key, "s", timestr) < 0)
+    if (flux_kvsdir_pack (ctx->kvs, key, "s", timestr) < 0) {
+        free (key);
         return (-1);
-    free (key);
+    }
 
+    free (key);
     return (0);
 }
 

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -199,7 +199,7 @@ static flux_t *prog_ctx_flux_handle (struct prog_ctx *ctx)
 }
 
 /* aukey shared between wreck, lua, and kz */
-static const char *wreck_default_txn_auxkey = "flux::kvs_default_txn";
+static const char *wreck_default_txn_auxkey = "flux::wreck_lua_kz_txn";
 static flux_kvs_txn_t *wreck_kvs_get_default_txn (struct prog_ctx *ctx)
 {
     flux_kvs_txn_t *txn = NULL;


### PR DESCRIPTION
As discussed at the meeting, I'm not entirely convinced that this effort has more pros than cons.  Maybe it should mostly be dropped.

What were the issues in this effort.

- ```kvs_classic``` was used in more places than I think we originally assumed.  I think I originally assumed it was almost only in lua & python bindings, but there were good chunks in ```libkz```, ```wrexecd```, and ```flux-kvs```.

- There are code chunks in the lua bindings & libkz & wreck that assume they can work on the same KVS transaction as each other, but don't pass the ```kvs txn``` between each other.  Without changing any  APIs, and not sharing any code (i.e. creating new helper functions), code duplication is a result.

- The kvs classic APIs often returned allocated buffers that the user was required to free'd.  The newer kvs functions often return a value that is not required to be free'd, b/c the memory is still within a flux future.  Without rearchitecting code / APIs, it leads to more code being written than desired.  This is compounded by the fact that KVS watch API uses an in & out variables for its interface.

- There is a fair amount of cut & paste.  At some point, it's basically the code that was in ```kvs_classic.[ch]```, but now in multiple files.  I elected to do this intentionally, b/c I did not want to create any new "common" functions.

So why did I even bother to submit this given all the crap above?  Partially, it's b/c I already invested the time to bother with this ... but here are the minor pros:

- I don't want continued pollution of use of the ```kvs_classic``` interface.  Minimally @SteVWonder is going to be working on new KVS  python bindings, it's just time to move on.

- This removes a mountain of the deprecated warnings to show up in the compile logs and on travis output.

- We are moving forward in things, and getting rid of the old interfaces is a good step forward.

- I really wanted to get rid of ```kvs_classic```

Note that these are not great "pros" to accepting this PR, it's just what I could come up with :-)

Maybe it just means we keep a few of the changes and not all of them.  I think an alternate to merging this monstrosity is to merge just the python changes + some of the stupid fixes I found along the way.

Also, one other note, I did not remove ```kvs_classic``` in this PR, b/c I suddenly found out it was used in a couple of tests (did not show up when I compiled and checked for "deprecated").  I'll fix that up later, but wanted to post this for initial reaction.  

One note on the Python change.

A few functions in the past may have been flexible enough to take a python ```Flux()``` or the internal ```flux_t``` representation, but now it must take a ```Flux()``` object type b/c of the ```__aux_txn```
I added to ```Flux()```.  AFAICT, all usage out there properly passes in ```Flux()``` except for 1 internal location I changed.
