### PR TITLE
python: add job & mrpc bindings

### DIFF
--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -31,8 +31,8 @@ _core_build.py: $(MAKE_BINDING)
 		--add_long_sub 'FLUX_SEC_TYPE_ALL.*\n.*\),|||FLUX_SEC_TYPE_ALL = 7,'\
 		flux.h
 
-BUILT_SOURCES= _core.c _jsc.c _kvs.c _kz.c
-fluxso_LTLIBRARIES = _core.la _kvs.la _jsc.la _kz.la
+BUILT_SOURCES= _core.c _jsc.c _kvs.c _kz.c _job.c
+fluxso_LTLIBRARIES = _core.la _kvs.la _jsc.la _kz.la _job.la
 fluxso_PYTHON = __init__.py
 
 nodist__core_la_SOURCES = _core.c
@@ -78,6 +78,19 @@ nodist__kz_la_SOURCES = _kz.c $(top_srcdir)/src/common/libkz/kz.h
 _kz_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/common/libkz
 _kz_la_LIBADD = $(common_libs)
 _kz_la_DEPENDENCIES = _kz_build.py
+
+_job_build.py: $(top_srcdir)/src/common/libjob/job.h $(MAKE_BINDING) _core_build.py
+	$(PYTHON) $(MAKE_BINDING) --path $(top_srcdir)/src/common/libjob \
+		--package _flux \
+		--modname _job \
+		--add_sub '.*va_list.*|||' \
+		--include_ffi _core_build \
+		job.h
+
+nodist__job_la_SOURCES = _job.c $(top_srcdir)/src/common/libjob/job.h
+_job_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/common/libjob
+_job_la_LIBADD = $(common_libs)
+_job_la_DEPENDENCIES = _job_build.py
 
 if HAVE_FLUX_SECURITY
 BUILT_SOURCES += _security.c

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -8,7 +8,8 @@ fluxpy_PYTHON=\
 	      jsc.py\
 	      kz.py\
 	      sec.py \
-	      job.py
+	      job.py \
+	      mrpc.py
 
 if HAVE_FLUX_SECURITY
 fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -7,7 +7,8 @@ fluxpy_PYTHON=\
 	      constants.py\
 	      jsc.py\
 	      kz.py\
-	      sec.py
+	      sec.py \
+	      job.py
 
 if HAVE_FLUX_SECURITY
 fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -9,7 +9,8 @@ fluxpy_PYTHON=\
 	      kz.py\
 	      sec.py \
 	      job.py \
-	      mrpc.py
+	      mrpc.py \
+	      util.py
 
 if HAVE_FLUX_SECURITY
 fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -4,8 +4,8 @@ python bindings to flux-core, the main core of the flux resource manager
 # Manually lazy
 # pylint: disable=invalid-name
 def Flux(*args, **kwargs):
-    import flux.core
-    return flux.core.Flux(*args, **kwargs)
+    import flux.core.handle
+    return flux.core.handle.Flux(*args, **kwargs)
 
 __all__ = ['core',
            'kvs',

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -11,6 +11,7 @@ __all__ = ['core',
            'kvs',
            'jsc',
            'rpc',
+           'mrpc',
            'sec',
            'constants',
            'Flux', ]

--- a/src/bindings/python/flux/core/__init__.py
+++ b/src/bindings/python/flux/core/__init__.py
@@ -1,4 +1,0 @@
-from flux.core.handle import Flux
-from flux.core.trampoline import mod_main_trampoline
-
-__all__ = ["Flux", "mod_main_trampoline"]

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -2,6 +2,7 @@ import six
 
 from flux.wrapper import Wrapper
 from flux.rpc import RPC
+from flux.mrpc import MRPC
 from flux.message import Message
 from flux.core.inner import raw
 from _flux._core import ffi, lib
@@ -79,6 +80,20 @@ class Flux(Wrapper):
                    flags=0):
         """ Create a new RPC object """
         return RPC(self, topic, payload, nodeid, flags)
+
+    def mrpc_create(self, topic,
+                    payload=None,
+                    rankset="any",
+                    flags=0):
+        """
+        Create a new MRPC object. Messages are sent on MRPC creation. Responses
+        are accessible by iterating on the returned MRPC object. For example:
+        '''
+        for (response_nodeid, response_payload) in h.mrpc_create(...):
+            pass
+        '''
+        """
+        return MRPC(self, topic, payload, rankset, flags)
 
     def event_create(self, topic, payload=None):
         """ Create a new event message.

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -67,7 +67,7 @@ class Flux(Wrapper):
         return None
 
     def rpc_send(self, topic,
-                 payload=ffi.NULL,
+                 payload=None,
                  nodeid=raw.FLUX_NODEID_ANY,
                  flags=0):
         """ Create and send an RPC in one step """

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -1,0 +1,49 @@
+import os
+import six
+import sys
+import errno
+
+from flux.wrapper import Wrapper, FunctionWrapper
+from flux.core.inner import raw as core_raw
+from _flux._job import ffi, lib
+
+class JobWrapper(Wrapper):
+    def __init__(self):
+        super(JobWrapper, self).__init__(ffi, lib, prefixes=['flux_job_',])
+
+RAW = JobWrapper()
+
+def submit_async(flux_handle, jobspec,
+                 priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
+                 flags=0):
+    if isinstance(jobspec, six.text_type):
+        jobspec = jobspec.encode('utf-8')
+    elif jobspec is None or jobspec == ffi.NULL:
+        # catch this here rather than in C for a better error message
+        raise EnvironmentError(errno.EINVAL, "jobspec must not be None/NULL")
+    elif not isinstance(jobspec, six.binary_type):
+        raise TypeError("jobpsec must be a string (either binary or unicode)")
+
+    future = RAW.submit(flux_handle, jobspec, priority, flags)
+    return future
+
+def submit_get_id(future):
+    jobid = ffi.new('flux_jobid_t[1]')
+    try:
+        RAW.submit_get_id(future, jobid)
+    except EnvironmentError as error:
+        exception_tuple = sys.exc_info()
+        try:
+            errmsg = core_raw.flux_future_error_string(future)
+        except Exception:
+            six.reraise(*exception_tuple)
+        if errmsg is None:
+            six.reraise(*exception_tuple)
+        raise EnvironmentError(error.errno, errmsg.decode('utf-8'))
+    return int(jobid[0])
+
+def submit(flux_handle, jobspec,
+           priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
+           flags=0):
+    future = submit_async(flux_handle, jobspec, priority, flags)
+    return submit_get_id(future)

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -1,11 +1,10 @@
 import json
 
-import six
-
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 from flux.core.watchers import Watcher
 import flux.constants
+from flux.util import encode_payload, encode_topic
 
 __all__ = ['Message',
            'MessageWatcher',
@@ -15,7 +14,6 @@ __all__ = ['Message',
 def msg_typestr(msg_type):
     # the returned string is guaranteed to be ascii
     return ffi.string(raw.flux_msg_typestr(msg_type)).decode('ascii')
-
 
 class Message(WrapperPimpl):
     """ Flux message wrapper class. """
@@ -54,11 +52,7 @@ class Message(WrapperPimpl):
 
     @classmethod
     def from_event_encode(cls, topic, payload=None):
-        if payload is None:
-            payload = ffi.NULL
-        elif not isinstance(payload, six.string_types):
-            # Convert dict or list into json string
-            payload = json.dumps(payload)
+        payload = encode_payload(payload)
         handle = raw.flux_event_encode(topic, payload)
         return cls(handle=handle)
 
@@ -70,7 +64,8 @@ class Message(WrapperPimpl):
 
     @topic.setter
     def topic(self, value):
-        self.pimpl.set_topic(value)
+        topic = encode_topic(value)
+        self.pimpl.set_topic(topic)
 
     @property
     def payload_str(self):
@@ -90,7 +85,7 @@ class Message(WrapperPimpl):
 
     @payload.setter
     def payload(self, value):
-        self.payload_str = json.dumps(value)
+        self.payload_str = encode_payload(value)
 
     @property
     def type(self):

--- a/src/bindings/python/flux/mrpc.py
+++ b/src/bindings/python/flux/mrpc.py
@@ -105,10 +105,15 @@ class MRPC(WrapperPimpl):
     def get_str(self):
         j_str = ffi.new('char *[1]')
         self.pimpl.get(j_str)
+        if j_str[0] == ffi.NULL:
+            return None
         return ffi.string(j_str[0]).decode('utf-8')
 
     def get(self):
-        return json.loads(self.get_str())
+        resp_str = self.get_str()
+        if resp_str is None:
+            return None
+        return json.loads(resp_str)
 
     # not strictly necessary to define, added for better autocompletion
     def check(self):

--- a/src/bindings/python/flux/mrpc.py
+++ b/src/bindings/python/flux/mrpc.py
@@ -35,7 +35,7 @@ class MRPC(WrapperPimpl):
             elif isinstance(topic, six.text_type):
                 topic = topic.encode('UTF-8')
             elif not isinstance(topic, six.binary_type):
-                raise TypeError(errno.EINVAL, "Topic must be a string")
+                raise TypeError(errno.EINVAL, "Topic must be a string, not {}".format(type(topic)))
 
             # Convert payload to utf-8 binary string or NULL pointer
             if payload is None or payload == ffi.NULL:

--- a/src/bindings/python/flux/mrpc.py
+++ b/src/bindings/python/flux/mrpc.py
@@ -1,0 +1,115 @@
+import json
+import errno
+
+import six
+
+import flux.constants
+from flux.core.inner import ffi, lib, raw
+from flux.wrapper import Wrapper, WrapperPimpl
+
+class MRPC(WrapperPimpl):
+    """An MRPC state object"""
+    class InnerWrapper(Wrapper):
+
+        def __init__(self,
+                     flux_handle,
+                     topic,
+                     payload=None,
+                     rankset="all",
+                     flags=0):
+            # hold a reference for destructor ordering
+            self._handle = flux_handle
+            dest = raw.flux_mrpc_destroy
+            super(MRPC.InnerWrapper, self).__init__(
+                ffi, lib,
+                handle=None,
+                match=ffi.typeof(lib.flux_mrpc).result,
+                prefixes=['flux_mrpc_'],
+                destructor=dest)
+            if isinstance(flux_handle, Wrapper):
+                flux_handle = flux_handle.handle
+
+            # Convert topic to utf-8 binary string
+            if topic is None or topic == ffi.NULL:
+                raise EnvironmentError(errno.EINVAL, "Topic must not be None/NULL")
+            elif isinstance(topic, six.text_type):
+                topic = topic.encode('UTF-8')
+            elif not isinstance(topic, six.binary_type):
+                raise TypeError(errno.EINVAL, "Topic must be a string")
+
+            # Convert payload to utf-8 binary string or NULL pointer
+            if payload is None or payload == ffi.NULL:
+                payload = ffi.NULL
+            elif isinstance(payload, six.text_type):
+                payload = payload.encode('UTF-8')
+            elif not isinstance(payload, six.binary_type):
+                payload = json.dumps(payload, ensure_ascii=False).encode('UTF-8')
+
+            # Validate and convert rankset to ascii binary str in proper format
+            # (e.g., [0,2,3,4,9]).
+            # Accepts a list of integers or digit strings (i.e., "5")
+            # Also accepts the shorthands supported by the C API
+            # (i.e., 'all', 'any', 'upstream')
+            if isinstance(rankset, six.text_type):
+                rankset = rankset.encode('ascii')
+            shorthands = [b'all', b'any',  b'upstream']
+            if isinstance(rankset, six.binary_type):
+                if rankset not in shorthands:
+                    errmsg = "Invalid rankset shorthand, must be one of {}".format(
+                        shorthands)
+                    raise EnvironmentError(errno.EINVAL, errmsg)
+            else: # is not shorthand, should be a list of ranks
+                if len(rankset) < 1:
+                    raise EnvironmentError(errno.EINVAL, "Must supply at least one rank")
+                elif not all([isinstance(rank, int) or rank.isdigit() for rank in rankset]):
+                    raise TypeError("All ranks must be integers")
+                else:
+                    rankset = "[{}]".format(",".join([str(rank) for rank in rankset])).encode('ascii')
+
+            self.handle = raw.flux_mrpc(
+                flux_handle, topic, payload, rankset, flags)
+
+    def __init__(self,
+                 flux_handle,
+                 topic,
+                 payload=None,
+                 rankset="all",
+                 flags=0):
+        super(MRPC, self).__init__()
+        self.pimpl = self.InnerWrapper(flux_handle,
+                                       topic,
+                                       payload,
+                                       rankset,
+                                       flags)
+        self.then_args = None
+        self.then_cb = None
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        return self.__next__()
+
+    # returns a tuple with the nodeid and the response payload
+    def __next__(self):
+        ret = self.pimpl.next()
+        if ret < 0:
+            raise StopIteration()
+        return (self.get_nodeid(), self.get())
+
+    def get_nodeid(self):
+        nodeid = ffi.new('uint32_t [1]')
+        self.pimpl.get_nodeid(nodeid)
+        return int(nodeid[0])
+
+    def get_str(self):
+        j_str = ffi.new('char *[1]')
+        self.pimpl.get(j_str)
+        return ffi.string(j_str[0]).decode('utf-8')
+
+    def get(self):
+        return json.loads(self.get_str())
+
+    # not strictly necessary to define, added for better autocompletion
+    def check(self):
+        return self.pimpl.check()

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -62,7 +62,9 @@ class RPC(WrapperPimpl):
         j_str = ffi.new('char *[1]')
         try:
             self.pimpl.get(j_str)
-            return ffi.string(j_str[0])
+            if j_str[0] == ffi.NULL:
+                return None
+            return ffi.string(j_str[0]).decode('utf-8')
         except EnvironmentError as error:
             exception_tuple = sys.exc_info()
             try:
@@ -74,4 +76,7 @@ class RPC(WrapperPimpl):
             raise EnvironmentError(error.errno, errmsg.decode('utf-8'))
 
     def get(self):
-        return json.loads(self.get_str().decode('utf-8'))
+        resp_str = self.get_str()
+        if resp_str is None:
+            return None
+        return json.loads(resp_str)

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -68,6 +68,6 @@ class SecurityContext(WrapperPimpl):
         output_payload_len = output_payload_len[0]
         # deference void** to char* then convert to python binary string
         output_payload = ffi.cast("char *", output_payload[0])
-        output_payload = ffi.unpack(output_payload, output_payload_len)
+        output_payload = ffi.buffer(output_payload, output_payload_len)
 
         return (output_payload, output_userid)

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -1,0 +1,50 @@
+import sys
+import errno
+import json
+
+import six
+
+from flux.core.inner import ffi, raw
+
+__all__ = ['check_future_error',
+           'encode_payload',
+           'encode_topic']
+
+def check_future_error(func):
+    def func_wrapper(calling_obj, *args, **kwargs):
+        try:
+            return func(calling_obj, *args, **kwargs)
+        except EnvironmentError as error:
+            exception_tuple = sys.exc_info()
+            try:
+                future = calling_obj.handle if hasattr(calling_obj, "handle") \
+                    else calling_obj
+                errmsg = raw.flux_future_error_string(future)
+            except EnvironmentError:
+                six.reraise(*exception_tuple)
+            if errmsg is None:
+                six.reraise(*exception_tuple)
+            raise EnvironmentError(error.errno, errmsg.decode('utf-8'))
+    return func_wrapper
+
+def encode_payload(payload):
+    if payload is None or payload == ffi.NULL:
+        payload = ffi.NULL
+    elif isinstance(payload, six.text_type):
+        payload = payload.encode('UTF-8')
+    elif not isinstance(payload, six.binary_type):
+        payload = json.dumps(payload,
+                             ensure_ascii=False).encode('UTF-8')
+    return payload
+
+def encode_topic(topic):
+    # Convert topic to utf-8 binary string
+    if topic is None or topic == ffi.NULL:
+        raise EnvironmentError(errno.EINVAL,
+                               "Topic must not be None/NULL")
+    elif isinstance(topic, six.text_type):
+        topic = topic.encode('UTF-8')
+    elif not isinstance(topic, six.binary_type):
+        errmsg = "Topic must be a string, not {}".format(type(topic))
+        raise TypeError(errno.EINVAL, errmsg)
+    return topic

--- a/src/common/libflux/mrpc.h
+++ b/src/common/libflux/mrpc.h
@@ -98,7 +98,7 @@ int flux_mrpc_then (flux_mrpc_t *mrpc, flux_mrpc_continuation_f cb, void *arg);
  * This invalidates previous payload returned by flux_mrpc_get().
  * Returns 0 on success, -1 if all responses have been received, e.g.
  *   do {
- *     flux_mrpc_get (rpc, ...);
+ *     flux_mrpc_get (mrpc, ...);
  *   } while (flux_mrpc_next (mrpc) == 0);
  */
 int flux_mrpc_next (flux_mrpc_t *mrpc);

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -159,7 +159,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (!dlopen (PYTHON_LIBRARY, RTLD_LAZY|RTLD_GLOBAL))
         flux_log_error (h, "Unable to dlopen libpython");
 
-    PyObject *module = PyImport_ImportModule("flux.core");
+    PyObject *module = PyImport_ImportModule("flux.core.trampoline");
     if(!module){
         PyErr_Print();
         return EINVAL;

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -84,7 +84,7 @@ travis_fold "docker_build" \
   docker build \
     ${NO_CACHE} \
     ${QUIET} \
-    --build-arg OS=$IMAGE \
+    --build-arg BASE_IMAGE=$IMAGE \
     --build-arg IMAGESRC="fluxrm/testenv:$IMAGE" \
     --build-arg USER=$USER \
     --build-arg UID=$(id -u) \

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -53,6 +53,13 @@ RUN case $BASE_IMAGE in \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
+# Setup MUNGE directories & key
+RUN mkdir -p /var/run/munge \
+ && dd if=/dev/urandom bs=1 count=1024 > /etc/munge/munge.key \
+ && chown -R munge /etc/munge/munge.key /var/run/munge \
+ && chmod 600 /etc/munge/munge.key
+
+
 ENV BASE_IMAGE=$BASE_IMAGE
 USER $USER
 WORKDIR /home/$USER

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -9,7 +9,7 @@ ARG USER=flux
 ARG UID=1000
 ARG GID=1000
 ARG FLUX_SECURITY_VERSION
-ARG OS
+ARG BASE_IMAGE
 
 # Install flux-security by hand for now:
 #
@@ -40,16 +40,19 @@ RUN set -x && groupadd flux \
  && printf "flux ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
 
 # Make sure user in appropriate group for sudo on different platorms
-RUN case $OS in \
-     ubuntu*) adduser $USER sudo && adduser flux sudo ;; \
+RUN case $BASE_IMAGE in \
+     bionic*) adduser $USER sudo && adduser flux sudo ;; \
      centos*) usermod -G wheel $USER && usermod -G wheel flux ;; \
+     *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
 # Make sure user in appropriate group for sudo on different platorms
-RUN case $OS in \
-     ubuntu*) apt-get -qq install -y --no-install-recommends python-six python3-six ;; \
+RUN case $BASE_IMAGE in \
+     bionic*) apt-get -qq install -y --no-install-recommends python-six python3-six ;; \
      centos*) yum -y install python-six python34-devel python34-cffi python34-six ;; \
+     *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
+ENV BASE_IMAGE=$BASE_IMAGE
 USER $USER
 WORKDIR /home/$USER

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -103,6 +103,9 @@ if test "$CPPCHECK" = "t"; then
     sh -x src/test/cppcheck.sh
 fi
 
+echo "Starting MUNGE"
+sudo /sbin/runuser -u munge /usr/sbin/munged
+
 travis_fold "autogen.sh" "./autogen.sh..." ./autogen.sh
 travis_fold "configure"  "./configure ${ARGS}..." ./configure ${ARGS}
 travis_fold "make_clean" "make clean..." make clean

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -123,6 +123,7 @@ TESTS = \
 	python/t0007-watchers.py \
 	python/t0008-jsc.py \
 	python/t0010-job.py \
+	python/t0011-mrpc.py \
 	python/t1000-service-add-remove.py
 
 
@@ -245,6 +246,7 @@ check_SCRIPTS = \
 	python/t0008-jsc.py \
 	python/t0009-security.py \
 	python/t0010-job.py \
+	python/t0011-mrpc.py \
 	python/t1000-service-add-remove.py
 
 check_PROGRAMS = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -122,6 +122,7 @@ TESTS = \
 	python/t0006-request.py \
 	python/t0007-watchers.py \
 	python/t0008-jsc.py \
+	python/t0010-job.py \
 	python/t1000-service-add-remove.py
 
 
@@ -243,6 +244,7 @@ check_SCRIPTS = \
 	python/t0007-watchers.py \
 	python/t0008-jsc.py \
 	python/t0009-security.py \
+	python/t0010-job.py \
 	python/t1000-service-add-remove.py
 
 check_PROGRAMS = \

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import os
 import sys
 import subprocess
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
-# copied from sharness.d/01-setup.sh
+# ported from sharness.d/01-setup.sh
+srcdir = os.path.abspath(os.path.join(os.environ['srcdir'] if 'srcdir' in os.environ else "", ".."))
 builddir = os.path.abspath(os.path.join(os.environ['builddir'] if 'builddir' in os.environ else "", ".."))
 flux_exe = os.path.join(builddir, "src", "cmd", "flux")
 
-def rerun_under_flux(size=1):
+def is_exe(fpath):
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+def rerun_under_flux(size=1, personality="full"):
     try:
         if os.environ['IN_SUBFLUX'] == "1":
             return True

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -19,6 +19,23 @@ def rerun_under_flux(size=1):
     child_env = dict(**os.environ)
     child_env['IN_SUBFLUX'] = "1"
 
+    # ported from sharness.d/flux-sharness.sh
+    child_env['FLUX_BUILD_DIR'] = builddir
+    child_env['FLUX_SOURCE_DIR'] = srcdir
+    for rc_num in [1, 3]:
+        env_var = "FLUX_RC{}_PATH".format(rc_num)
+        if personality == "full":
+            if env_var in child_env:
+                del child_env[env_var]
+        elif personality == "minimal":
+            child_env[env_var] = ""
+        else:
+            path = "{}/t/rc/rc{}-{}".format(srcdir, rc_num, personality)
+            child_env[env_var] = path
+            if not is_exe(path):
+                print("cannot execute {}".format(path), file=sys.stderr)
+                sys.exit(1)
+
     command = [flux_exe, 'start',
                '--bootstrap=selfpmi',
                '--size',str(size),

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -52,6 +52,11 @@ class TestHandle(unittest.TestCase):
             self.assertEqual(j['seq'], 1)
             self.assertEqual(j['pad'], 'stuff')
 
+    def test_rpc_null_payload(self):
+        """Sending a request that receives a NULL response"""
+        resp = self.f.rpc_send("attr.set", {"name": "attr-that-doesnt-exist", "value": "foo"})
+        self.assertIsNone(resp)
+
     def test_get_rank(self):
         """Get flux rank"""
         rank = self.f.get_rank()

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -5,7 +5,7 @@ import unittest
 import syslog
 import six
 
-import flux.core as core
+import flux
 from subflux import rerun_under_flux
 
 def __flux_size():
@@ -15,7 +15,7 @@ class TestHandle(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         """Create a handle, connect to flux"""
-        self.f = core.Flux()
+        self.f = flux.Flux()
 
     @classmethod
     def tearDownClass(self):

--- a/t/python/t0002-wrapper.py
+++ b/t/python/t0002-wrapper.py
@@ -2,7 +2,6 @@
 import unittest
 
 import flux
-import flux.core as core
 from flux.core.inner import ffi, raw
 import flux.wrapper
 from subflux import rerun_under_flux
@@ -12,34 +11,34 @@ def __flux_size():
 
 class TestWrapper(unittest.TestCase):
     def test_call_non_existant(self):
-        f = core.Flux('loop://')
+        f = flux.Flux('loop://')
         with self.assertRaises(flux.wrapper.MissingFunctionError):
             f.non_existant_function_that_should_die("stuff")
 
     def test_call_insufficient_arguments(self):
-        f = core.Flux('loop://')
+        f = flux.Flux('loop://')
         with self.assertRaises(flux.wrapper.WrongNumArguments):
             f.request_encode(self)
 
     def test_call_invalid_argument_type(self):
-        f = core.Flux('loop://')
+        f = flux.Flux('loop://')
         with self.assertRaises(flux.wrapper.InvalidArguments):
           f.request_encode(self, 15)
 
     def test_automatic_unwrapping(self):
-      flux.core.inner.raw.flux_log(core.Flux('loop://'), 0, 'stuff')
+      flux.core.inner.raw.flux_log(flux.Flux('loop://'), 0, 'stuff')
 
     def test_masked_function(self):
       with self.assertRaisesRegexp(AttributeError, r'.*masks function.*'):
-        core.Flux('loop://').rpc_create('topic').pimpl.flux_request_encode('request', 15)
+        flux.Flux('loop://').rpc_create('topic').pimpl.flux_request_encode('request', 15)
 
     def test_set_pimpl_handle(self):
-      f = core.Flux('loop://')
+      f = flux.Flux('loop://')
       r = f.rpc_create('topic')
       r.handle = raw.flux_rpc(f.handle, 'other topic', ffi.NULL, flux.constants.FLUX_NODEID_ANY, 0)
 
     def test_set_pimpl_handle_invalid(self):
-      f = core.Flux('loop://')
+      f = flux.Flux('loop://')
       r = f.rpc_create('topic')
       with self.assertRaisesRegexp(TypeError, r'.*expected a.*'):
           r.handle = f.rpc_create("other topic")

--- a/t/python/t0003-barrier.py
+++ b/t/python/t0003-barrier.py
@@ -5,12 +5,12 @@ import multiprocessing as mp
 
 from six.moves import range as range
 
-import flux.core as core
+import flux
 from subflux import rerun_under_flux
 
 def barr_count(x, name, count):
     print(x, name, count)
-    f = core.Flux()
+    f = flux.Flux()
     f.barrier(name,count)
     f.close()
 
@@ -20,7 +20,7 @@ def __flux_size():
 class TestBarrier(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.f = core.Flux()
+        self.f = flux.Flux()
 
     @classmethod
     def tearDownClass(self):

--- a/t/python/t0004-event.py
+++ b/t/python/t0004-event.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import unittest
 import six
 
-import flux.core as core
+import flux
 from subflux import rerun_under_flux
 
 def __flux_size():
@@ -14,7 +14,7 @@ class TestEvent(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         """Create a handle, connect to flux"""
-        self.f = core.Flux()
+        self.f = flux.Flux()
 
     @classmethod
     def tearDownClass(self):

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -5,7 +5,6 @@ import six
 
 import flux
 import flux.kvs
-import flux.core as core
 
 from subflux import rerun_under_flux
 
@@ -15,7 +14,7 @@ def __flux_size():
 class TestKVS(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.f = core.Flux()
+        self.f = flux.Flux()
 
     @classmethod
     def tearDownClass(self):

--- a/t/python/t0006-request.py
+++ b/t/python/t0006-request.py
@@ -2,7 +2,7 @@
 import unittest
 
 import errno
-import flux.core as core
+import flux
 from subflux import rerun_under_flux
 
 def __flux_size():
@@ -13,7 +13,7 @@ class TestRequestMethods(unittest.TestCase):
 
   def test_no_topic_invalid(self):
     """flux_request_encode returns EINVAL with no topic string"""
-    f = core.Flux('loop://')
+    f = flux.Flux('loop://')
     with self.assertRaises(EnvironmentError) as err:
         f.request_encode(None, json_str)
     err = err.exception
@@ -21,7 +21,7 @@ class TestRequestMethods(unittest.TestCase):
 
   def test_null_payload(self):
     """flux_request_encode works with NULL payload"""
-    f = core.Flux('loop://')
+    f = flux.Flux('loop://')
     self.assertTrue(
         f.request_encode("foo.bar", None) is not None
         )

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
-import flux.core as core
+
+import flux
 from subflux import rerun_under_flux
 
 def __flux_size():
@@ -9,7 +10,7 @@ def __flux_size():
 class TestTimer(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.f = core.Flux()
+        self.f = flux.Flux()
 
     @classmethod
     def tearDownClass(self):

--- a/t/python/t0008-jsc.py
+++ b/t/python/t0008-jsc.py
@@ -3,7 +3,7 @@ import unittest
 import json
 from multiprocessing import Queue
 
-import flux.core as core
+import flux
 import flux.jsc as jsc
 
 def __flux_size():
@@ -23,7 +23,7 @@ def jsc_cb_wait_until_reserved(jcb_str, arg, errnum):
 class TestJSC(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.f = core.Flux()
+        self.f = flux.Flux()
         self.job_spec = json.dumps({
             'nnodes': 1,
             'ntasks': 1,

--- a/t/python/t0008-jsc.py
+++ b/t/python/t0008-jsc.py
@@ -20,7 +20,7 @@ def jsc_cb_wait_until_reserved(jcb_str, arg, errnum):
     if jobid == job_to_wait_for and new_state == 'reserved':
         flux_handle.reactor_stop(flux_handle.get_reactor())
 
-class TestKVS(unittest.TestCase):
+class TestJSC(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.f = core.Flux()

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -29,7 +29,7 @@ allowed-types = [ "none" ]
         unsigned_str = u"hello world"
         signed_str = self.context.sign_wrap(unsigned_str, mech_type="none")
         unwrapped_payload, wrapping_user = self.context.sign_unwrap(signed_str)
-        unwrapped_str = unwrapped_payload.decode('utf-8')
+        unwrapped_str = unwrapped_payload[:].decode('utf-8')
 
         self.assertEqual(unsigned_str, unwrapped_str)
         self.assertEqual(wrapping_user, os.getuid())

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import os
-import sys
 import unittest
 from tempfile import NamedTemporaryFile
 
@@ -11,7 +9,7 @@ from flux.security import SecurityContext
 def __flux_size():
     return 1
 
-class TestKVS(unittest.TestCase):
+class TestSecurity(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         conf = b"""[sign]

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -3,7 +3,6 @@ import os
 import unittest
 from tempfile import NamedTemporaryFile
 
-import flux.core as core
 from flux.security import SecurityContext
 
 def __flux_size():

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import os
+import errno
+
+import unittest
+
+import flux
+from flux import job
+from flux.job import ffi
+
+def __flux_size():
+    return 1
+
+class TestJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.fh = flux.Flux()
+
+        jobspec_dir = os.path.abspath(os.path.join(os.environ['FLUX_SOURCE_DIR'],
+                                                   't', 'jobspec'))
+        ingest_dir = os.path.abspath(os.path.join(os.environ['FLUX_BUILD_DIR'],
+                                                  't', 'ingest'))
+
+        # load the dummy job manager
+        job_manager_path = os.path.join(ingest_dir, '.libs',
+                                        'job-manager-dummy.so')
+        self.fh.mrpc_create("cmb.insmod", {"path" : job_manager_path,
+                                           "args" : []})
+
+        # get a valid jobspec
+        basic_jobspec_fname = os.path.join(jobspec_dir, "valid", "basic.yaml")
+        with open(basic_jobspec_fname, 'rb') as infile:
+            self.jobspec = infile.read()
+
+    def test_00_null_submit(self):
+        with self.assertRaises(EnvironmentError) as error:
+            job.submit(ffi.NULL, self.jobspec)
+        self.assertEqual(error.exception.errno, errno.EINVAL)
+
+        with self.assertRaises(EnvironmentError) as error:
+            job.submit_get_id(ffi.NULL)
+        self.assertEqual(error.exception.errno, errno.EINVAL)
+
+        with self.assertRaises(EnvironmentError) as error:
+            job.submit(self.fh, ffi.NULL)
+        self.assertEqual(error.exception.errno, errno.EINVAL)
+
+    def test_01_nonstring_submit(self):
+        with self.assertRaises(TypeError):
+            job.submit(self.fh, 0)
+
+    def test_02_sync_submit(self):
+        jobid = job.submit(self.fh, self.jobspec)
+        self.assertGreater(jobid, 0)
+
+if __name__ == '__main__':
+    from subflux import rerun_under_flux
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0011-mrpc.py
+++ b/t/python/t0011-mrpc.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import sys
+import os
+import errno
+import json
+
+import unittest
+
+import flux
+
+def _flux_size():
+    return 4
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+
+class TestMRPC(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.fh = flux.Flux()
+
+    def test_00_mrpc_invalid_topic(self):
+        with self.assertRaises(EnvironmentError) as error:
+            ret = self.fh.mrpc_create(None)
+        self.assertEqual(error.exception.errno, errno.EINVAL)
+
+        with self.assertRaises(TypeError):
+            ret = self.fh.mrpc_create(5)
+
+    def test_00_mrpc_invalid_rankset(self):
+        with self.assertRaises(EnvironmentError) as error:
+            ret = self.fh.mrpc_create("topic", {'foo':'bar'}, [])
+        self.assertEqual(error.exception.errno, errno.EINVAL)
+
+        with self.assertRaises(EnvironmentError) as error:
+            ret = self.fh.mrpc_create("topic", {'foo':'bar'}, 'foo')
+        self.assertEqual(error.exception.errno, errno.EINVAL)
+
+        with self.assertRaises(TypeError) as error:
+            ret = self.fh.mrpc_create("topic", {'foo':'bar'}, ['foo'])
+
+    def test_01_mrpc_single(self):
+        responses = list(self.fh.mrpc_create("cmb.ping", {'foo':'bar'}, [0]))
+        self.assertEqual(len(responses), 1)
+        nodeid, payload = responses[0]
+        self.assertEqual(nodeid, 0)
+
+    def test_02_mrpc_explicit_rankset(self):
+        rankset = [0, 2]
+        responses = sorted(self.fh.mrpc_create("cmb.ping", {'foo':'bar'}, rankset),
+                           key=lambda x: x[0])
+        self.assertEqual(len(responses), len(rankset))
+        for rank, (nodeid, payload) in zip(rankset, responses):
+            self.assertEqual(rank, nodeid)
+            self.assertEqual(payload['foo'], 'bar')
+
+    def test_03_mrpc_all(self):
+        self.assertGreaterEqual(_flux_size(), 2)
+        # test both unicode and binary rankset shorthands
+        for rankset in [b'all', u'all']:
+            responses = sorted(self.fh.mrpc_create("cmb.ping", payload={'foo':'bar'},
+                                    rankset=rankset),
+                               key=lambda x: x[0])
+            self.assertEqual(len(responses), _flux_size())
+            for rank, (nodeid, payload) in zip(range(_flux_size()), responses):
+                self.assertEqual(rank, nodeid)
+                self.assertEqual(payload['foo'], 'bar')
+
+    def test_04_mrpc_access_previous_payload(self):
+        # test that payloads from the C API are copying and not invalidated
+        # while iterating through responses
+        self.assertGreaterEqual(_flux_size(), 2)
+        prev_payloads = []
+        for nodeid, payload in self.fh.mrpc_create("cmb.ping", {'foo':'bar'}, 'all'):
+            for prev_payload in prev_payloads:
+                self.assertEqual(payload['foo'], prev_payload['foo'])
+                self.assertItemsEqual(payload.keys(), prev_payload.keys())
+
+    def test_05_unicode_args(self):
+        binary_topic = b'cmb.ping'
+        unicode_topic = u'cmb.ping'
+
+        json_payload = {'foo': u'bar'}
+        unicode_payload = json.dumps(json_payload, ensure_ascii=False)
+        binary_payload = json.dumps(json_payload, ensure_ascii=False).encode('utf-8')
+
+        for topic in [unicode_topic, binary_topic]:
+            resp = self.fh.mrpc_create(topic=topic, payload=json_payload, rankset=[0]).get()
+            self.assertEqual(resp['foo'], u'bar')
+
+        for payload in [json_payload, unicode_payload, binary_payload]:
+            resp = self.fh.mrpc_create(binary_topic, payload=payload, rankset=[0]).get()
+            self.assertEqual(resp['foo'], u'bar')
+
+if __name__ == '__main__':
+    from subflux import rerun_under_flux
+    if rerun_under_flux(size=_flux_size()):
+        from pycotap import TAPTestRunner
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0011-mrpc.py
+++ b/t/python/t0011-mrpc.py
@@ -92,6 +92,12 @@ class TestMRPC(unittest.TestCase):
             resp = self.fh.mrpc_create(binary_topic, payload=payload, rankset=[0]).get()
             self.assertEqual(resp['foo'], u'bar')
 
+    def test_06_null_response_payload(self):
+        resp = self.fh.mrpc_create("attr.set",
+                                   {"name" : "attr-that-doesnt-exist", "value": "foo"},
+                                   rankset=[0]).get()
+        self.assertEqual(resp, None)
+
 if __name__ == '__main__':
     from subflux import rerun_under_flux
     if rerun_under_flux(size=_flux_size()):

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import unittest
 import errno
-import flux.core as core
+
+import flux
 from flux.message import Message
 from flux.core.inner import ffi
 from flux.constants import(FLUX_MSGTYPE_REQUEST,
@@ -23,7 +24,7 @@ def service_remove(f, name):
 class TestServiceAddRemove(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.f = core.Flux()
+        self.f = flux.Flux()
 
     @classmethod
     def tearDownClass(self):
@@ -102,7 +103,7 @@ class TestServiceAddRemove(unittest.TestCase):
         #
         def add_service_and_disconnect():
             import sys
-            h = core.Flux()
+            h = flux.Flux()
             sys.exit(service_add(h, "baz"))
         p = Process(target=add_service_and_disconnect)
         p.start()

--- a/t/python/tap/pycotap/__init__.py
+++ b/t/python/tap/pycotap/__init__.py
@@ -26,7 +26,7 @@ class TAPTestResult(unittest.TestResult):
     self.error_stream = error_stream
     self.orig_stdout = None
     self.orig_stderr = None
-    self.message = None
+    self.message = error_stream
     self.test_output = None
     self.message_log = message_log
     self.test_output_log = test_output_log


### PR DESCRIPTION
The bulk of this PR is the addition of bindings and tests for `job.h` and `mrpc.h`.

A few minor changes also included:

- adds support for flux testing personalities (e.g. job or full)
  - required for testing the job bindings
- improves RPC errors by automatically calling `flux_future_error_string` on failure
- fixes #1738 by using `ffi.buffer` rather than `ffi.unpack`
- fixes some typos and copy-paste errors in `mrpc.h` and `t/python`
- pycotap now will not throw its own exception when an exception occurs within a test's `setUpClass`
- closes #1741 by launching the munge daemon within the test container
- closes #1781 by replacing calls to `flux.core.Flux` with `flux.Flux`, so that flux.core no longer needs to import `flux.core.handle.Flux`
- related to #1649 (mrpc bindings)