### PR TITLE
t/kvs/dtree: Add non-kvs classic functions mkdir test

### DIFF
--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -44,9 +44,15 @@ test_expect_success 'kvs: add other types to 2x4 directory and walk' '
 	test $(flux kvs dir -R $DIR.dtree | wc -l) = 19
 '
 
-test_expect_success 'kvs: store 3x4 directory tree using kvsdir_put functions' '
+test_expect_success 'kvs: store 3x4 directory tree using kvsdir functions' '
 	flux kvs unlink -Rf $DIR.dtree &&
 	${FLUX_BUILD_DIR}/t/kvs/dtree --mkdir -h4 -w3 --prefix $DIR.dtree &&
+	test $(flux kvs dir -R $DIR.dtree | wc -l) = 81
+'
+
+test_expect_success 'kvs: store 3x4 directory tree using kvsdir classic functions' '
+	flux kvs unlink -Rf $DIR.dtree &&
+	${FLUX_BUILD_DIR}/t/kvs/dtree --mkdir-classic -h4 -w3 --prefix $DIR.dtree &&
 	test $(flux kvs dir -R $DIR.dtree | wc -l) = 81
 '
 


### PR DESCRIPTION
Rename --mkdir to --mkdir-classic and remake --mkdir into a test that uses non-deprecated kvs classic functions.  This is simply to prepare for when ```kvs_classic``` is removed and we won't have to update this test later.