### PR TITLE
add job-manager and corresponding API and flux-job subcommands

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -381,6 +381,7 @@ AC_CONFIG_FILES( \
   src/modules/pymod/Makefile \
   src/modules/userdb/Makefile \
   src/modules/job-ingest/Makefile \
+  src/modules/job-manager/Makefile \
   src/test/Makefile \
   etc/Makefile \
   etc/flux-core.pc \

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -9,10 +9,7 @@
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the license, or (at your option)
- *  any later version.  Additionally, the libflux-core library may be
- *  redistributed under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2 of the license,
- *  or (at your option) any later version.
+ *  any later version.
  *
  *  Flux is distributed in the hope that it will be useful, but WITHOUT
  *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -181,6 +181,22 @@ flux_future_t *flux_job_purge (flux_t *h, flux_jobid_t id, int flags)
     return f;
 }
 
+flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority)
+{
+    flux_future_t *f;
+
+    if (!h) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, "job-manager.priority", FLUX_NODEID_ANY, 0,
+                             "{s:I s:i}",
+                             "id", id,
+                             "priority", priority)))
+        return NULL;
+    return f;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -165,6 +165,22 @@ flux_future_t *flux_job_list (flux_t *h, int max_entries, const char *json_str)
     return f;
 }
 
+flux_future_t *flux_job_purge (flux_t *h, flux_jobid_t id, int flags)
+{
+    flux_future_t *f;
+
+    if (!h) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, "job-manager.purge", FLUX_NODEID_ANY, 0,
+                             "{s:I s:i}",
+                             "id", id,
+                             "flags", flags)))
+        return NULL;
+    return f;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -7,11 +7,8 @@
  *  For details, see https://github.com/flux-framework.
  *
  *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the license, or (at your option)
- *  any later version.  Additionally, the libflux-core library may be
- *  redistributed under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2 of the license,
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
  *  or (at your option) any later version.
  *
  *  Flux is distributed in the hope that it will be useful, but WITHOUT
@@ -19,9 +16,9 @@
  *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -46,10 +46,19 @@ enum job_priority {
     FLUX_JOB_PRIORITY_MAX = 31,
 };
 
+enum job_status_flags {
+    FLUX_JOB_RESOURCE_REQUESTED     = 1,
+    FLUX_JOB_RESOURCE_ALLOCATED     = 2,
+    FLUX_JOB_EXEC_REQUESTED         = 4,
+    FLUX_JOB_EXEC_RUNNING           = 8,
+};
+
 typedef uint64_t flux_jobid_t;
 
 /* Submit a job to the system.
  * 'jobspec' should be RFC 14 jobspec.
+ * 'priority' should be a value from 0 to 31 (16 if not instance owner).
+ * 'flags' should be 0 for now.
  * The system assigns a jobid and returns it in the response.
  */
 flux_future_t *flux_job_submit (flux_t *h, const char *jobspec,
@@ -76,6 +85,10 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
  */
 flux_future_t *flux_job_list (flux_t *h, int max_entries,
                               const char *json_str);
+
+/* Remove a job from queue and KVS.
+ */
+flux_future_t *flux_job_purge (flux_t *h, flux_jobid_t id, int flags);
 
 #ifdef __cplusplus
 }

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -90,6 +90,10 @@ flux_future_t *flux_job_list (flux_t *h, int max_entries,
  */
 flux_future_t *flux_job_purge (flux_t *h, flux_jobid_t id, int flags);
 
+/* Change job priority.
+ */
+flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -1,3 +1,30 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.  Additionally, the libflux-core library may be
+ *  redistributed under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
 #ifndef _FLUX_CORE_JOB_H
 #define _FLUX_CORE_JOB_H
 
@@ -33,6 +60,22 @@ flux_future_t *flux_job_submit (flux_t *h, const char *jobspec,
  * error message may be available with flux_future_error_string().
  */
 int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
+
+/* Request a list of active jobs.
+ * If 'max_entries' > 0, fetch at most that many jobs.
+ * 'json_str' is an encoded JSON array of attribute strings, e.g.
+ * ["id","userid",...] that will be returned in response.
+
+ * Process the response payload with flux_rpc_get() or flux_rpc_get_unpack().
+ * It is a JSON object containing an array of job objects, e.g.
+ * { "jobs":[
+ *   {"id":m, "userid":n},
+ *   {"id":m, "userid":n},
+ *   ...
+ * ])
+ */
+flux_future_t *flux_job_list (flux_t *h, int max_entries,
+                              const char *json_str);
 
 #ifdef __cplusplus
 }

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -7,11 +7,8 @@
  *  For details, see https://github.com/flux-framework.
  *
  *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the license, or (at your option)
- *  any later version.  Additionally, the libflux-core library may be
- *  redistributed under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2 of the license,
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
  *  or (at your option) any later version.
  *
  *  Flux is distributed in the hope that it will be useful, but WITHOUT
@@ -19,9 +16,9 @@
  *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -10,6 +10,9 @@
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
+    flux_t *h = (flux_t *)(uintptr_t)42; // fake but non-NULL
+
+    /* flux_job_submit */
 
     errno = 0;
     ok (flux_job_submit (NULL, NULL, 0, 0) == NULL && errno == EINVAL,
@@ -18,6 +21,40 @@ int main (int argc, char *argv[])
     errno = 0;
     ok (flux_job_submit_get_id (NULL, NULL) < 0 && errno == EINVAL,
         "flux_job_submit_get_id with NULL args fails with EINVAL");
+
+    /* flux_job_list */
+
+    errno = 0;
+    ok (flux_job_list (NULL, 0, "{}") == NULL && errno == EINVAL,
+        "flux_job_list h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list (h, -1, "{}") == NULL && errno == EINVAL,
+        "flux_job_list max_entries=-1 fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list (h, 0, NULL) == NULL && errno == EINVAL,
+        "flux_job_list json_str=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list (h, 0, NULL) == NULL && errno == EINVAL,
+        "flux_job_list json_str=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list (h, 0, "wrong") == NULL && errno == EINVAL,
+        "flux_job_list json_str=(inval JSON) fails with EINVAL");
+
+    /* flux_job_purge */
+
+    errno = 0;
+    ok (flux_job_purge (NULL, 0, 0) == NULL && errno == EINVAL,
+        "flux_job_purge h=NULL fails with EINVAL");
+
+    /* flux_job_set_priority */
+
+    errno = 0;
+    ok (flux_job_set_priority (NULL, 0, 0) == NULL && errno == EINVAL,
+        "flux_job_set_priority h=NULL fails with EINVAL");
 
     done_testing ();
     return 0;

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -9,5 +9,6 @@ SUBDIRS = \
  cron \
  aggregator \
  userdb \
+ pymod \
  job-ingest \
- pymod
+ job-manager

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -7,7 +7,7 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-manager.la
 
@@ -33,11 +33,14 @@ job_manager_la_LIBADD = $(fluxmod_libadd) \
 		    $(ZMQ_LIBS)
 
 TESTS = \
-	test_queue.t
+	test_queue.t \
+	test_list.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD)
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)
@@ -51,6 +54,14 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 test_queue_t_SOURCES = test/queue.c
 test_queue_t_CPPFLAGS = $(test_cppflags)
 test_queue_t_LDADD = \
+        $(top_builddir)/src/modules/job-manager/queue.o \
+        $(top_builddir)/src/modules/job-manager/job.o \
+        $(test_ldadd)
+
+test_list_t_SOURCES = test/list.c
+test_list_t_CPPFLAGS = $(test_cppflags)
+test_list_t_LDADD = \
+        $(top_builddir)/src/modules/job-manager/list.o \
         $(top_builddir)/src/modules/job-manager/queue.o \
         $(top_builddir)/src/modules/job-manager/job.o \
         $(test_ldadd)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -31,3 +31,26 @@ job_manager_la_LIBADD = $(fluxmod_libadd) \
 		    $(top_builddir)/src/common/libflux-core.la \
 		    $(top_builddir)/src/common/libflux-optparse.la \
 		    $(ZMQ_LIBS)
+
+TESTS = \
+	test_queue.t
+
+test_ldadd = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD)
+
+test_cppflags = \
+	$(AM_CPPFLAGS)
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_queue_t_SOURCES = test/queue.c
+test_queue_t_CPPFLAGS = $(test_cppflags)
+test_queue_t_LDADD = \
+        $(top_builddir)/src/modules/job-manager/queue.o \
+        $(top_builddir)/src/modules/job-manager/job.o \
+        $(test_ldadd)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -1,0 +1,33 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	$(ZMQ_CFLAGS)
+
+fluxmod_LTLIBRARIES = job-manager.la
+
+job_manager_la_SOURCES = job-manager.c \
+			 job.c \
+			 job.h \
+			 queue.c \
+			 queue.h \
+			 active.h \
+			 active.c \
+			 purge.h \
+			 purge.c \
+			 list.h \
+			 list.c \
+			 priority.h \
+			 priority.c
+
+job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
+job_manager_la_LIBADD = $(fluxmod_libadd) \
+		    $(top_builddir)/src/common/libflux-internal.la \
+		    $(top_builddir)/src/common/libflux-core.la \
+		    $(top_builddir)/src/common/libflux-optparse.la \
+		    $(ZMQ_LIBS)

--- a/src/modules/job-manager/active.c
+++ b/src/modules/job-manager/active.c
@@ -1,0 +1,309 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* active - manipulate active jobs in the KVS
+ *
+ * Active jobs are stored in the KVS under "jobs.active" per RFC 16.
+ *
+ * To avoid the job.active directory becoming large and impacting KVS
+ * performance over time, jobs are spread across subdirectries using
+ * FLUID_STRING_DOTHEX encoding (see fluid.h).
+ *
+ * In general, an operation that alters the job state follows this pattern:
+ * - prepare KVS transaction
+ * - commit KVS transaction, with continuation
+ * - on success: continuation updates in-memory job state and completes request
+ * - on error: in-memory job state is unchanged and error is returned to caller
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+
+#include "src/common/libjob/job.h"
+#include "src/common/libutil/fluid.h"
+
+#include "job.h"
+#include "active.h"
+
+int active_key (char *buf, int bufsz, struct job *job, const char *key)
+{
+    char idstr[32];
+    int len;
+
+    if (fluid_encode (idstr, sizeof (idstr), job->id, FLUID_STRING_DOTHEX) < 0)
+        return -1;
+    len = snprintf (buf, bufsz, "job.active.%s%s%s",
+                    idstr,
+                    key ? "." : "",
+                    key ? key : "");
+    if (len >= bufsz)
+        return -1;
+    return len;
+}
+
+int active_eventlog_append (flux_kvs_txn_t *txn,
+                            struct job *job,
+                            const char *key,
+                            const char *name,
+                            const char *fmt, ...)
+{
+    va_list ap;
+    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
+    int n;
+    char path[64];
+    char *event = NULL;
+    int saved_errno;
+
+    va_start (ap, fmt);
+    n = vsnprintf (context, sizeof (context), fmt, ap);
+    va_end (ap);
+    if (n >= sizeof (context))
+        goto error_inval;
+    if (active_key (path, sizeof (path), job, key) < 0)
+        goto error_inval;
+    if (!(event = flux_kvs_event_encode (name, context)))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, path, event) < 0)
+        goto error;
+    free (event);
+    return 0;
+error_inval:
+    errno = EINVAL;
+error:
+    saved_errno = errno;
+    free (event);
+    errno = saved_errno;
+    return -1;
+}
+
+int active_pack (flux_kvs_txn_t *txn,
+                 struct job *job,
+                 const char *key,
+                 const char *fmt, ...)
+{
+    va_list ap;
+    int n;
+    char path[64];
+
+    if (active_key (path, sizeof (path), job, key) < 0)
+        goto error_inval;
+    va_start (ap, fmt);
+    n = flux_kvs_txn_vpack (txn, 0, path, fmt, ap);
+    va_end (ap);
+    if (n < 0)
+        goto error;
+    return 0;
+error_inval:
+    errno = EINVAL;
+error:
+    return -1;
+}
+
+int active_unlink (flux_kvs_txn_t *txn, struct job *job)
+{
+    char path[64];
+
+    if (active_key (path, sizeof (path), job, NULL) < 0)
+        goto error_inval;
+    if (flux_kvs_txn_unlink (txn, 0, path) < 0)
+        goto error;
+    return 0;
+error_inval:
+    errno = EINVAL;
+error:
+    return -1;
+}
+
+static int count_char (const char *s, char c)
+{
+    int count = 0;
+    while (*s) {
+        if (*s++ == c)
+            count++;
+    }
+    return count;
+}
+
+static int decode_eventlog (const char *s, double *t_submit, int *flagsp)
+{
+    struct flux_kvs_eventlog *eventlog;
+    const char *event;
+    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
+    double t;
+    int flags = 0;
+
+    if (!(eventlog = flux_kvs_eventlog_decode (s)))
+        return -1;
+    if (!(event = flux_kvs_eventlog_first (eventlog)))
+        goto error;
+    if (flux_kvs_event_decode (event, &t, name, sizeof (name), NULL, 0) < 0)
+        goto error;
+    if (strcmp (name, "submit") != 0)
+        goto error_inval;
+    while ((event = flux_kvs_eventlog_next (eventlog))) {
+        if (flux_kvs_event_decode (event, NULL, name, sizeof (name),
+                                                                NULL, 0) < 0)
+            goto error;
+        /* Set flags based on events here */
+    }
+    *t_submit = t;
+    *flagsp = flags;
+    flux_kvs_eventlog_destroy (eventlog);
+    return 0;
+error_inval:
+    errno = EINVAL;
+error:
+    flux_kvs_eventlog_destroy (eventlog);
+    return -1;
+}
+
+static flux_future_t *lookup_job_attr (flux_t *h, const char *jobdir,
+                                       const char *name)
+{
+    char key[80];
+
+    if (snprintf (key, sizeof (key), "%s.%s", jobdir, name) >= sizeof (key)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_kvs_lookup (h, 0, key);
+}
+
+static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
+                               active_map_f cb, void *arg)
+{
+    flux_jobid_t id;
+    flux_future_t *f = NULL;
+    uint32_t userid;
+    int priority;
+    const char *eventlog;
+    struct job *job;
+    double t_submit;
+    int flags;
+
+    if (strlen (key) <= dirskip) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (fluid_decode (key + dirskip + 1, &id, FLUID_STRING_DOTHEX) < 0)
+        return -1;
+    /* userid */
+    if (!(f = lookup_job_attr (h, key, "userid")))
+        goto error;
+    if (flux_kvs_lookup_get_unpack (f, "i", &userid) < 0)
+        goto error_future;
+    flux_future_destroy (f);
+
+    /* priority */
+    if (!(f = lookup_job_attr (h, key, "priority")))
+        goto error;
+    if (flux_kvs_lookup_get_unpack (f, "i", &priority) < 0)
+        goto error_future;
+    flux_future_destroy (f);
+
+    /* t_submit, inactive (via eventlog) */
+    if (!(f = lookup_job_attr (h, key, "eventlog")))
+        goto error;
+    if (flux_kvs_lookup_get (f, &eventlog) < 0)
+        goto error_future;
+    if (decode_eventlog (eventlog, &t_submit, &flags) < 0)
+        goto error_future;
+    flux_future_destroy (f);
+
+    /* make callback */
+    if (!(job = job_create (id, priority, userid, t_submit, flags)))
+        goto error;
+    if (cb (job, arg) < 0) {
+        job_decref (job);
+        goto error;
+    }
+    job_decref (job);
+    return 1;
+error_future:
+    flux_future_destroy (f);
+error:
+    return -1;
+}
+
+static int depthfirst_map (flux_t *h, const char *key,
+                           int dirskip, active_map_f cb, void *arg)
+{
+    flux_future_t *f;
+    const flux_kvsdir_t *dir;
+    flux_kvsitr_t *itr;
+    const char *name;
+    int path_level;
+    int count = 0;
+    int rc = -1;
+
+    path_level = count_char (key + dirskip, '.');
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key)))
+        return -1;
+    if (flux_kvs_lookup_get_dir (f, &dir) < 0) {
+        if (errno == ENOENT && path_level == 0)
+            rc = 0;
+        goto done;
+    }
+    if (!(itr = flux_kvsitr_create (dir)))
+        goto done;
+    while ((name = flux_kvsitr_next (itr))) {
+        char *nkey;
+        int n;
+        if (!flux_kvsdir_isdir (dir, name))
+            continue;
+        if (!(nkey = flux_kvsdir_key_at (dir, name)))
+            goto done_destroyitr;
+        if (path_level == 3) // orig 'key' = .A.B.C, thus 'nkey' is complete
+            n = depthfirst_map_one (h, nkey, dirskip, cb, arg);
+        else
+            n = depthfirst_map (h, nkey, dirskip, cb, arg);
+        if (n < 0) {
+            int saved_errno = errno;
+            free (nkey);
+            errno = saved_errno;
+            goto done_destroyitr;
+        }
+        count += n;
+        free (nkey);
+    }
+    rc = count;
+done_destroyitr:
+    flux_kvsitr_destroy (itr);
+done:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int active_map (flux_t *h, active_map_f cb, void *arg)
+{
+    const char *dirname = "job.active";
+
+    return depthfirst_map (h, dirname, strlen (dirname), cb, arg);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/active.h
+++ b/src/modules/job-manager/active.h
@@ -1,0 +1,54 @@
+#ifndef _FLUX_JOB_MANAGER_ACTIVE_H
+#define _FLUX_JOB_MANAGER_ACTIVE_H
+
+/* Operations on active jobs in KVS
+ */
+
+#include <flux/core.h>
+#include "job.h"
+
+/* Write KVS path to 'key' relative to active job directory for 'job'.
+ * If key=NULL, write the job directory.
+ * Returns string length on success, or -1 on failure.
+ */
+int active_key (char *buf, int bufsz, struct job *job, const char *key);
+
+/* Set 'key' within active job directory for 'job'.
+ */
+int active_pack (flux_kvs_txn_t *txn,
+                 struct job *job,
+                 const char *key,
+                 const char *fmt, ...);
+
+/* Log an event to eventlog 'key', relative to active job directory for 'job'.
+ * The event consists of current wallclock, 'name', and optional context
+ * formatted from (fmt, ...).  Set fmt="" to skip logging a context.
+ */
+int active_eventlog_append (flux_kvs_txn_t *txn,
+                            struct job *job,
+                            const char *key,
+                            const char *name,
+                            const char *fmt, ...);
+
+/* Unlink the active job directory for 'job'.
+ */
+int active_unlink (flux_kvs_txn_t *txn, struct job *job);
+
+
+/* active_map callback should return -1 on error to stop map with error,
+ * or 0 on success.  'job' is only valid for the duration of the callback.
+ */
+typedef int (*active_map_f)(struct job *job, void *arg);
+
+/* call 'cb' once for each job found in active job directory.
+ * Returns number of jobs mapped, or -1 on error.
+ */
+int active_map (flux_t *h, active_map_f cb, void *arg);
+
+
+#endif /* _FLUX_JOB_MANAGER_ACTIVE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -1,0 +1,198 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "job.h"
+#include "queue.h"
+#include "active.h"
+#include "purge.h"
+#include "list.h"
+#include "priority.h"
+
+
+struct job_manager_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    struct queue *queue;
+};
+
+/* handle submit request (from job-ingest module)
+ * This is a batched request for one or more jobs already validated
+ * by the ingest module, and already instantiated in the KVS.
+ * The user isn't handed the jobid though until we accept the job here.
+ */
+static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+    json_t *jobs;
+    size_t index;
+    json_t *el;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0) {
+        flux_log_error (h, "%s", __FUNCTION__);
+        goto error;
+    }
+    json_array_foreach (jobs, index, el) {
+        flux_jobid_t id;
+        uint32_t userid;
+        int priority;
+        double t_submit;
+        struct job *job = NULL;
+
+        if (json_unpack (el, "{s:I s:i s:i s:f}", "id", &id,
+                                                  "priority", &priority,
+                                                  "userid", &userid,
+                                                  "t_submit", &t_submit) < 0) {
+            flux_log (h, LOG_ERR, "%s: error decoding job index %u",
+                      __FUNCTION__, (unsigned int)index);
+            goto error;
+        }
+        if (!(job = job_create (id, priority, userid, t_submit, 0)))
+            goto error;
+        /* N.B. ignore EEXIST, in case restart_from_kvs() loaded a job
+         * while its submit request was in still flight.
+         */
+        if (queue_insert (ctx->queue, job) < 0 && errno != EEXIST) {
+            flux_log_error (h, "%s: queue_insert %llu",
+                            __FUNCTION__, (unsigned long long)id);
+            job_decref (job);
+            goto error;
+        }
+        job_decref (job);
+    }
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_log (h, LOG_DEBUG, "%s: added %u jobs", __FUNCTION__,
+                            (unsigned int)index);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* list request handled in list.c
+ */
+static void list_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+
+    list_handle_request (h, ctx->queue, msg);
+}
+
+/* purge request handled in purge.c
+ */
+static void purge_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+    purge_handle_request (h, ctx->queue, msg);
+}
+
+/* priority request handled in priority.c
+ */
+static void priority_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+    priority_handle_request (h, ctx->queue, msg);
+}
+
+/* active_map_f callback
+ * This is called for each job encountered in the KVS during startup.
+ * The 'job' struct is valid only during the callback.
+ * queue_insert() increments the 'job' usecount upon successful insert.
+ */
+static int restart_map_cb (struct job *job, void *arg)
+{
+    struct job_manager_ctx *ctx = arg;
+
+    if (queue_insert (ctx->queue, job) < 0)
+        return -1;
+    return 0;
+}
+
+/* Load any active jobs present in the KVS at startup.
+ */
+static int restart_from_kvs (flux_t *h, struct job_manager_ctx *ctx)
+{
+    int count;
+
+    if ((count = active_map (h, restart_map_cb, ctx)) < 0)
+        return -1;
+    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__, count);
+    return 0;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-manager.submit", submit_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "job-manager.list", list_cb, FLUX_ROLE_USER},
+    { FLUX_MSGTYPE_REQUEST, "job-manager.purge", purge_cb, FLUX_ROLE_USER},
+    { FLUX_MSGTYPE_REQUEST, "job-manager.priority", priority_cb, FLUX_ROLE_USER},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    flux_reactor_t *r = flux_get_reactor (h);
+    int rc = -1;
+    struct job_manager_ctx ctx;
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+
+    if (!(ctx.queue = queue_create ())) {
+        flux_log_error (h, "error creating queue");
+        goto done;
+    }
+    if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
+        flux_log_error (h, "flux_msghandler_add");
+        goto done;
+    }
+    if (restart_from_kvs (h, &ctx) < 0) {
+        flux_log_error (h, "restart_from_kvs");
+        goto done;
+    }
+    if (flux_reactor_run (r, 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done;
+    }
+    rc = 0;
+done:
+    flux_msg_handler_delvec (ctx.handlers);
+    queue_destroy (ctx.queue);
+    return rc;
+}
+
+MOD_NAME ("job-manager");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -1,0 +1,68 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include "src/common/libjob/job.h"
+#include "job.h"
+
+void job_decref (struct job *job)
+{
+    if (job && --job->refcount == 0) {
+        int saved_errno = errno;
+        free (job);
+        errno = saved_errno;
+    }
+}
+
+struct job *job_incref (struct job *job)
+{
+    if (!job)
+        return NULL;
+    job->refcount++;
+    return job;
+}
+
+struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
+                        double t_submit, int flags)
+{
+    struct job *job;
+
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    job->refcount = 1;
+    job->id = id;
+    job->userid = userid;
+    job->priority = priority;
+    job->t_submit = t_submit;
+    job->flags = flags;
+    return job;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -1,0 +1,31 @@
+#ifndef _FLUX_JOB_MANAGER_JOB_H
+#define _FLUX_JOB_MANAGER_JOB_H
+
+#include "src/common/libjob/job.h"
+
+struct job {
+    flux_jobid_t id;
+    uint32_t userid;
+    int priority;
+    double t_submit;
+    int flags;
+
+    void *list_handle;  // private to queue.c
+    int refcount;       // private to job.c
+};
+
+void job_decref (struct job *job);
+struct job *job_incref (struct job *job);
+
+struct job *job_create (flux_jobid_t id,
+                        int priority,
+                        uint32_t userid,
+                        double t_submit,
+                        int flags);
+
+#endif /* _FLUX_JOB_MANAGER_JOB_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -1,0 +1,188 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* list - list jobs
+ *
+ * Purpose:
+ *   Support queue lister tool like "flux queue" or queue watcher tool like
+ *   "flux top" to obtain the jobs at head of queue with low overhead.
+ *   Allow the set of job attributes returned to be customized, for
+ *   customizable tool output.
+ *
+ *   The entire queue can be dumped if desired.  This is useful for testing
+ *   job-manager queue management.
+ *
+ * Input:
+ * - set of attributes to list per job
+ * - max number of jobs to return from head of queue
+ *
+ * Output:
+ * - array of job objects (job objects contain the requested attributes
+ *   and their values)
+ *
+ * Caveats:
+ * - Always returns one response message regardless of number of jobs.
+ * - Only a hardwired list of attributes is supported.
+ * - No limits on guest access.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+
+#include "job.h"
+#include "queue.h"
+
+/* For a given job, create a JSON object containing the requested
+ * attributes and their values.  Returns JSON object which the caller
+ * must free.  On error, return NULL with errno set:
+ *
+ * EPROTO - malformed attrs array
+ * ENOMEM - out of memory
+ */
+json_t *list_one_job (struct job *job, json_t *attrs)
+{
+    size_t index;
+    json_t *value;
+    json_t *o;
+    int saved_errno;
+
+    if (!(o = json_object ()))
+        goto error_nomem;
+    json_array_foreach (attrs, index, value) {
+        const char *attr = json_string_value (value);
+        json_t *val = NULL;
+        if (!attr) {
+            errno = EPROTO;
+            goto error;
+        }
+        if (!strcmp (attr, "id")) {
+            val = json_integer (job->id);
+        }
+        else if (!strcmp (attr, "userid")) {
+            val = json_integer (job->userid);
+        }
+        else if (!strcmp (attr, "priority")) {
+            val = json_integer (job->priority);
+        }
+        else if (!strcmp (attr, "t_submit")) {
+            val = json_real (job->t_submit);
+        }
+        else if (!strcmp (attr, "flags")) {
+            val = json_integer (job->flags);
+        }
+        else {
+            errno = EINVAL;
+            goto error;
+        }
+        if (val == NULL)
+            goto error_nomem;
+        if (json_object_set_new (o, attr, val) < 0) {
+            json_decref (val);
+            goto error_nomem;
+        }
+    }
+    return o;
+error_nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (o);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* Create a JSON array of 'job' objects, representing the head of the queue.
+ * 'max_entries' determines the max number of jobs to return, 0=unlimited.
+ * Returns JSON object which the caller must free.  On error, return NULL
+ * with errno set:
+ *
+ * EPROTO - malformed or empty attrs array, max_entries out of range
+ * ENOMEM - out of memory
+ */
+json_t *list_job_array (struct queue *queue, int max_entries, json_t *attrs)
+{
+    json_t *jobs = NULL;
+    struct job *job;
+    int saved_errno;
+
+    if (max_entries < 0 || !json_is_array (attrs)
+                        || json_array_size (attrs) == 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(jobs = json_array ()))
+        goto error_nomem;
+    job = queue_first (queue);
+    while (job) {
+        json_t *o;
+        if (!(o = list_one_job (job, attrs)))
+            goto error;
+        if (json_array_append_new (jobs, o) < 0) {
+            json_decref (o);
+            goto error_nomem;
+        }
+        if (json_array_size (jobs) == max_entries)
+            break;
+        job = queue_next (queue);
+    }
+    return jobs;
+error_nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (jobs);
+    errno = saved_errno;
+    return NULL;
+}
+
+void list_handle_request (flux_t *h, struct queue *queue,
+                          const flux_msg_t *msg)
+{
+    int max_entries;
+    json_t *jobs;
+    json_t *attrs;
+
+    if (flux_request_unpack (msg, NULL, "{s:i s:o}",
+                                        "max_entries", &max_entries,
+                                        "attrs", &attrs) < 0)
+        goto error;
+    if (!(jobs = list_job_array (queue, max_entries, attrs)))
+        goto error;
+    if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    json_decref (jobs);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/list.h
+++ b/src/modules/job-manager/list.h
@@ -1,0 +1,19 @@
+#ifndef _FLUX_JOB_MANAGER_LIST_H
+#define _FLUX_JOB_MANAGER_LIST_H
+
+#include <jansson.h>
+#include "queue.h"
+
+/* Handle a 'list' request - to list the queue.
+ */
+void list_handle_request (flux_t *h, struct queue *queue,
+                          const flux_msg_t *msg);
+
+/* exposed for unit testing only */
+json_t *list_one_job (struct job *job, json_t *attrs);
+json_t *list_job_array (struct queue *queue, int max_entries, json_t *attrs);
+
+#endif /* ! _FLUX_JOB_MANAGER_LIST_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -1,0 +1,189 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* priority - adjust job priority
+ *
+ * Purpose:
+ *   Support flux job set-priority command for adjusting job priority
+ *   after submission.  Guests can reduce their jobs' priority, or increase
+ *   up to the default priority.
+ *
+ * Input:
+ * - job id
+ * - new priority
+ *
+ * Output:
+ * - n/a
+ *
+ * Caveats:
+ * - Need to handle case where job has already made request for resources.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+
+#include "job.h"
+#include "queue.h"
+#include "active.h"
+#include "priority.h"
+
+#define MAXOF(a,b)   ((a)>(b)?(a):(b))
+
+struct priority {
+    flux_msg_t *request;
+    struct job *job;
+    flux_kvs_txn_t *txn;
+    int priority;
+
+    struct queue *queue;
+};
+
+static void priority_destroy (struct priority *p)
+{
+    if (p) {
+        int saved_errno = errno;
+        flux_msg_destroy (p->request);
+        flux_kvs_txn_destroy (p->txn);
+        free (p);
+        errno = saved_errno;
+    }
+}
+
+static struct priority *priority_create (struct queue *queue,
+                                   struct job *job,
+                                   const flux_msg_t *request,
+                                   int priority)
+{
+    struct priority *p;
+
+    if (!(p = calloc (1, sizeof (*p))))
+        return NULL;
+    p->queue = queue;
+    p->job = job;
+    p->priority = priority;
+    if (!(p->request = flux_msg_copy (request, false)))
+        goto error;
+    if (!(p->txn = flux_kvs_txn_create ()))
+        goto error;
+    return p;
+error:
+    priority_destroy (p);
+    return NULL;
+}
+
+/* KVS update completed.  Remove job from queue and reinsert.
+ */
+static void priority_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct priority *p = arg;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        if (flux_respond_error (h, p->request, errno, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+        goto done;
+    }
+    p->job->priority = p->priority;
+    queue_reorder (p->queue, p->job);
+    if (flux_respond (h, p->request, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+done:
+    priority_destroy (p);
+    flux_future_destroy (f);
+}
+
+void priority_handle_request (flux_t *h, struct queue *queue,
+                              const flux_msg_t *msg)
+{
+    uint32_t userid;
+    uint32_t rolemask;
+    flux_jobid_t id;
+    struct job *job;
+    struct priority *p = NULL;
+    flux_future_t *f;
+    int priority;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:i}",
+                                        "id", &id,
+                                        "priority", &priority) < 0
+                    || flux_msg_get_userid (msg, &userid) < 0
+                    || flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+    if (priority < FLUX_JOB_PRIORITY_MIN || priority > FLUX_JOB_PRIORITY_MAX) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(job = queue_lookup_by_id (queue, id)))
+        goto error;
+    /* Security: guests can only adjust jobs that they submitted.
+     */
+    if (!(rolemask & FLUX_ROLE_OWNER) && userid != job->userid) {
+        errno = EPERM;
+        goto error;
+    }
+    /* Security: guests can only reduce priority, or increase up to default.
+     */
+    if (!(rolemask & FLUX_ROLE_OWNER)
+            && priority > MAXOF (FLUX_JOB_PRIORITY_DEFAULT, job->priority)) {
+        errno = EPERM;
+        goto error;
+    }
+    /* If job has requested resources/exec, don't allow adjustment.
+     */
+    if (job->flags != 0) {
+        errno = EPERM;
+        goto error;
+    }
+    /* Log KVS event and set KVS priority key asynchronously.
+     * Upon successful completion, insert job in new queue position and
+     * send response.
+     */
+    if (!(p = priority_create (queue, job, msg, priority)))
+        goto error;
+    if (active_eventlog_append (p->txn, job, "eventlog", "priority",
+                                "userid=%lu priority=%d",
+                                (unsigned long)userid, priority) < 0)
+        goto error;
+    if (active_pack (p->txn, job, "priority", "i", priority) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (h, 0, p->txn)))
+        goto error;
+    if (flux_future_then (f, -1., priority_continuation, p) < 0) {
+        flux_future_destroy (f);
+        goto error;
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    priority_destroy (p);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/priority.h
+++ b/src/modules/job-manager/priority.h
@@ -1,0 +1,15 @@
+#ifndef _FLUX_JOB_MANAGER_PRIORITY_H
+#define _FLUX_JOB_MANAGER_PRIORITY_H
+
+#include "queue.h"
+
+/* Handle a 'priority' request - job priority adjustment
+ */
+void priority_handle_request (flux_t *h, struct queue *queue,
+                           const flux_msg_t *msg);
+
+
+#endif /* ! _FLUX_JOB_MANAGER_PRIORITY_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/purge.c
+++ b/src/modules/job-manager/purge.c
@@ -1,0 +1,176 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* purge - remove job
+ *
+ * Purpose:
+ *   Support "flux job purge" command to remove a job from the queue and KVS.
+ *   This allows backing out of a job that was submitted in error, or is no
+ *   longer needed, without contributing noise to the job historical data.
+ *
+ *   Purge is also helpful in writing tests of job-manager queue management.
+ *
+ * Input:
+ * - job id
+ * - flags (set to 0)
+ *
+ * Output:
+ * - n/a
+ *
+ * Caveats:
+ * - No flag to force removal if resources already requested/allocated.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+
+#include "job.h"
+#include "queue.h"
+#include "active.h"
+#include "purge.h"
+
+struct purge {
+    flux_msg_t *request;
+    struct job *job;
+    flux_kvs_txn_t *txn;
+    int flags;
+
+    struct queue *queue;
+};
+
+static void purge_destroy (struct purge *r)
+{
+    if (r) {
+        int saved_errno = errno;
+        flux_msg_destroy (r->request);
+        flux_kvs_txn_destroy (r->txn);
+        free (r);
+        errno = saved_errno;
+    }
+}
+
+static struct purge *purge_create (struct queue *queue,
+                                   struct job *job,
+                                   const flux_msg_t *request,
+                                   int flags)
+{
+    struct purge *r;
+
+    if (!(r = calloc (1, sizeof (*r))))
+        return NULL;
+    r->queue = queue;
+    r->job = job;
+    r->flags = flags;
+    if (!(r->request = flux_msg_copy (request, false)))
+        goto error;
+    if (!(r->txn = flux_kvs_txn_create ()))
+        goto error;
+    return r;
+error:
+    purge_destroy (r);
+    return NULL;
+}
+
+/* KVS unlink completed.  Remove job from queue and respond.
+ */
+static void purge_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct purge *r = arg;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        if (flux_respond_error (h, r->request, errno, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+        goto done;
+    }
+    queue_delete (r->queue, r->job);
+    if (flux_respond (h, r->request, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+done:
+    purge_destroy (r);
+    flux_future_destroy (f);
+}
+
+void purge_handle_request (flux_t *h, struct queue *queue,
+                           const flux_msg_t *msg)
+{
+    uint32_t userid;
+    uint32_t rolemask;
+    flux_jobid_t id;
+    struct job *job;
+    struct purge *r = NULL;
+    flux_future_t *f;
+    int flags;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:i}",
+                                        "id", &id,
+                                        "flags", &flags) < 0
+                    || flux_msg_get_userid (msg, &userid) < 0
+                    || flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+    if (flags != 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(job = queue_lookup_by_id (queue, id)))
+        goto error;
+    /* Security: guests can only remove jobs that they submitted.
+     */
+    if (!(rolemask & FLUX_ROLE_OWNER) && userid != job->userid) {
+        errno = EPERM;
+        goto error;
+    }
+    /* If job has requested resources/exec, don't allow purge.
+     */
+    if (job->flags != 0) {
+        errno = EPERM;
+        goto error;
+    }
+    /* Perfrom KVS unlink asynchronously.
+     * Upon successful completion, remove job from queue and send response.
+     */
+    if (!(r = purge_create (queue, job, msg, flags)))
+        goto error;
+    if (active_unlink (r->txn, job) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (h, 0, r->txn)))
+        goto error;
+    if (flux_future_then (f, -1., purge_continuation, r) < 0) {
+        flux_future_destroy (f);
+        goto error;
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    purge_destroy (r);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/purge.h
+++ b/src/modules/job-manager/purge.h
@@ -1,0 +1,15 @@
+#ifndef _FLUX_JOB_MANAGER_PURGE_H
+#define _FLUX_JOB_MANAGER_PURGE_H
+
+#include "queue.h"
+
+/* Handle a 'purge' request - to remove a job from queue and KVS
+ */
+void purge_handle_request (flux_t *h, struct queue *queue,
+                           const flux_msg_t *msg);
+
+
+#endif /* ! _FLUX_JOB_MANAGER_PURGE_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -1,0 +1,206 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* queue - maintain job queue
+ *
+ * The queue is kept sorted first by priority, then by submission time.
+ * Submission time is appriximated by integer FLUID jobid.
+ *
+ * The list entries point to jobs stored in a hash, keyed by jobid.
+ * Upon insertion into the hash, the job reference count is incremented;
+ * upon deletion from the hash, the job reference count is decremented.
+ * Invariant: job are either in both the hash and the list, or neither.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <stdlib.h>
+
+#include "src/common/libjob/job.h"
+#include "job.h"
+#include "queue.h"
+
+struct queue {
+    zhashx_t *active_jobs;
+    zlistx_t *active_jobs_list;
+};
+
+#define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
+
+
+/* Hash numerical jobid in 'key' for 'active_jobs'.
+ * N.B. zhashx_hash_fn signature
+ */
+static size_t job_hasher (const void *key)
+{
+    const flux_jobid_t *id = key;
+    return *id;
+}
+
+/* Compare keys for sorting 'active_jobs'.
+ * N.B. zhashx_comparator_fn signature
+ */
+static int job_hash_key_cmp (const void *key1, const void *key2)
+{
+    const flux_jobid_t *id1 = key1;
+    const flux_jobid_t *id2 = key2;
+
+    return NUMCMP (*id1, *id2);
+}
+
+/* Destroy job entry in 'active_jobs'.
+ * N.B. zhashx_destructor_fn signature.
+ */
+static void job_destructor (void **item)
+{
+    job_decref (*(struct job **)item);
+    *item = NULL;
+}
+
+/* Compare items for sorting 'active_jobs_list'.
+ * N.B. zlistx_comparator_fn signature
+ */
+static int job_list_cmp (const void *a1, const void *a2)
+{
+    const struct job *j1 = a1;
+    const struct job *j2 = a2;
+    int rc;
+
+    if ((rc = (-1)*NUMCMP (j1->priority, j2->priority)) == 0)
+        rc = NUMCMP (j1->id, j2->id);
+    return rc;
+}
+
+/* zlistx_insert() and zlistx_reorder() take a 'low_value' parameter
+ * which indicates which end of the list to search from.
+ * false=search begins at tail (lowest priority, youngest)
+ * true=search begins at head (highest priority, oldest)
+ * Attempt to minimize search distance based on job priority.
+ */
+static bool search_direction (struct job *job)
+{
+    if (job->priority > FLUX_JOB_PRIORITY_DEFAULT)
+        return true;
+    else
+        return false;
+}
+
+/* Insert 'job' into active_jobs hash and active_jobs_list (pri, id order).
+ */
+int queue_insert (struct queue *queue, struct job *job)
+{
+    if (zhashx_insert (queue->active_jobs, &job->id, job) < 0) {
+        errno = EEXIST;
+        return -1;
+    }
+    job_incref (job);
+    if (!(job->list_handle = zlistx_insert (queue->active_jobs_list,
+                                            job, search_direction (job)))) {
+        zhashx_delete (queue->active_jobs, &job->id); // implicit job_decref
+        errno = ENOMEM; // presumed
+        return -1;
+    }
+    return 0;
+}
+
+void queue_reorder (struct queue *queue, struct job *job)
+{
+    zlistx_reorder (queue->active_jobs_list, job->list_handle,
+                    search_direction (job));
+}
+
+struct job *queue_lookup_by_id  (struct queue *queue, flux_jobid_t id)
+{
+    struct job *job;
+
+    if (!(job = zhashx_lookup (queue->active_jobs, &id))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return job;
+}
+
+void queue_delete (struct queue *queue, struct job *job)
+{
+    if (job->list_handle)
+        (void)zlistx_delete (queue->active_jobs_list, job->list_handle);
+    zhashx_delete (queue->active_jobs, &job->id); // implicit job_decref
+}
+
+int queue_size (struct queue *queue)
+{
+    return zlistx_size (queue->active_jobs_list);
+}
+
+struct job *queue_first (struct queue *queue)
+{
+    return zlistx_first (queue->active_jobs_list); // deletion-safe
+}
+
+struct job *queue_next (struct queue *queue)
+{
+    return zlistx_next (queue->active_jobs_list); // deletion-safe
+}
+
+void queue_destroy (struct queue *queue)
+{
+    if (queue) {
+        int saved_errno = errno;
+        if (queue->active_jobs_list)
+            zlistx_destroy (&queue->active_jobs_list);
+        if (queue->active_jobs)
+            zhashx_destroy (&queue->active_jobs);
+        free (queue);
+        errno = saved_errno;
+    }
+}
+
+struct queue *queue_create (void)
+{
+    struct queue *queue;
+
+    if (!(queue = calloc (1, sizeof (*queue))))
+        return NULL;
+    if (!(queue->active_jobs = zhashx_new ()))
+        goto error;
+    if (!(queue->active_jobs_list = zlistx_new ()))
+        goto error;
+    zhashx_set_key_hasher (queue->active_jobs, job_hasher);
+    zhashx_set_key_comparator (queue->active_jobs, job_hash_key_cmp);
+    zhashx_set_key_duplicator (queue->active_jobs, NULL);
+    zhashx_set_key_destructor (queue->active_jobs, NULL);
+    zhashx_set_destructor (queue->active_jobs, job_destructor);
+    zlistx_set_comparator (queue->active_jobs_list, job_list_cmp);
+    return queue;
+error:
+    queue_destroy (queue);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/queue.h
+++ b/src/modules/job-manager/queue.h
@@ -1,0 +1,45 @@
+#ifndef _FLUX_JOB_MANAGER_QUEUE_H
+#define _FLUX_JOB_MANAGER_QUEUE_H
+
+#include "src/common/libjob/job.h"
+#include "job.h"
+
+struct queue *queue_create (void);
+void queue_destroy (struct queue *queue);
+
+/* Insert job into queue.  The queue takes a reference on job,
+ * so the caller retains its reference.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int queue_insert (struct queue *queue, struct job *job);
+
+/* Find new position in queue for job (e.g. after priority change).
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+void queue_reorder (struct queue *queue, struct job *job);
+
+/* Find a job by jobid.
+ * Returns job on success, NULL on failure wtih errno set.
+ */
+struct job *queue_lookup_by_id (struct queue *queue, flux_jobid_t id);
+
+/* Delete queue entry associated with 'job' (dropping its refence on job).
+ */
+void queue_delete (struct queue *queue, struct job *job);
+
+/* deletion-safe iterator
+ * Returns first/next job, or NULL on empty list or at end of list.
+ */
+struct job *queue_first (struct queue *queue);
+struct job *queue_next (struct queue *queue);
+
+/* Return the number of jobs in the queue
+ */
+int queue_size (struct queue *queue);
+
+#endif /* _FLUX_JOB_MANAGER_QUEUE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -1,0 +1,112 @@
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "src/modules/job-manager/queue.h"
+#include "src/modules/job-manager/job.h"
+#include "src/modules/job-manager/list.h"
+
+/* Create queue of size jobs
+ *   id: [0:size-1]
+ */
+struct queue *make_test_queue (int size)
+{
+    struct queue *q;
+    flux_jobid_t id;
+
+    q = queue_create ();
+    if (!q)
+        BAIL_OUT ("could not create queue");
+
+    for (id = 0; id < size; id++) {
+        struct job *j;
+        if (!(j = job_create (id, 0, 0, 0, 0)))
+            BAIL_OUT ("job_create failed");
+        if (queue_insert (q, j) < 0)
+            BAIL_OUT ("queue_insert failed");
+    }
+    return q;
+}
+
+int main (int argc, char *argv[])
+{
+    const int q_size = 16;
+    struct queue *q;
+    struct job *j;
+    json_t *attrs;
+    json_t *badattrs;
+    json_t *o;
+    json_t *el;
+    json_t *id_o;
+    flux_jobid_t id;
+
+    plan (NO_PLAN);
+
+    q = make_test_queue (q_size);
+    if (!(attrs = json_pack ("[s]", "id")))
+        BAIL_OUT ("json_pack failed");
+
+    /* list_job_array */
+
+    o = list_job_array (q, 0, attrs);
+    ok (o != NULL && json_is_array (o),
+        "list_job_array returns array");
+    ok (json_array_size (o) == q_size,
+        "array has expected size");
+    json_decref (o);
+
+    o = list_job_array (q, 4, attrs);
+    ok (o != NULL && json_is_array (o),
+        "list_job_array max_entries=4 returns array");
+    ok (json_array_size (o) == 4,
+        "array has expected size");
+    el = json_array_get (o, 1);
+    ok (el != NULL && json_is_object (el),
+        "array[1] is an object");
+    ok ((id_o = json_object_get (el, "id")) != NULL,
+        "array[1] id is set");
+    id = json_integer_value (id_o);
+    ok (id == 1,
+        "array[1] id=1");
+    if (id != 1)
+        diag ("id=%d", (int)id);
+    ok (json_object_size (el) == 1,
+        "array[1] size=1");
+    json_decref (o);
+
+    errno = 0;
+    ok (list_job_array (q, -1, attrs) == NULL && errno == EPROTO,
+        "list_job_array max_entries < 0 fails with EPROTO");
+
+    errno = 0;
+    ok (list_job_array (q, -1, NULL) == NULL && errno == EPROTO,
+        "list_job_array attrs=NULL fails with EPROTO");
+
+    /* list_one_job */
+
+    if (!(j = queue_lookup_by_id (q, 0)))
+        BAIL_OUT ("queue_lookup_by_id 0 failed");
+    if (!(badattrs = json_pack ("[s]", "foo")))
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (list_one_job (j, badattrs) == NULL && errno == EINVAL,
+        "list_one_job attrs=[\"foo\"] fails with EINVAL");
+    json_decref (badattrs);
+
+    if (!(badattrs = json_pack ("[i]", 42)))
+        BAIL_OUT ("json_pack failed");
+    errno = 0;
+    ok (list_one_job (j, badattrs) == NULL && errno == EPROTO,
+        "list_one_job attrs=[42] fails with EPROTO");
+    json_decref (badattrs);
+
+
+    json_decref (attrs);
+    queue_destroy (q);
+
+    done_testing ();
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-manager/test/queue.c
+++ b/src/modules/job-manager/test/queue.c
@@ -1,0 +1,123 @@
+#include "src/common/libtap/tap.h"
+
+#include "src/modules/job-manager/job.h"
+#include "src/modules/job-manager/queue.h"
+
+/* Create job with only params that affect queue order.
+ */
+struct job *job_create_test (flux_jobid_t id, int priority)
+{
+    struct job *j;
+    if (!(j = job_create (id, priority, 1, 0, 0)))
+        BAIL_OUT ("job_create failed");
+    return j;
+}
+
+int main (int argc, char *argv[])
+{
+    struct queue *q;
+    struct job *job[3];
+    struct job *njob[2];
+    struct job *j, *j_prev;
+
+    plan (NO_PLAN);
+
+    q = queue_create ();
+    if (!q)
+        BAIL_OUT ("could not create queue");
+    ok (queue_size (q) == 0,
+        "queue_size returns 0");
+
+    /* insert 1,2,3 */
+
+    job[0] = job_create_test (1, FLUX_JOB_PRIORITY_DEFAULT);
+    job[1] = job_create_test (2, FLUX_JOB_PRIORITY_DEFAULT);
+    job[2] = job_create_test (3, FLUX_JOB_PRIORITY_DEFAULT);
+    ok (queue_insert (q, job[0]) == 0,
+        "queue_insert 1 pri=def");
+    ok (queue_insert (q, job[1]) == 0,
+        "queue_insert 2 pri=def");
+    ok (queue_insert (q, job[2]) == 0,
+        "queue_insert 3 pri=def");
+
+    errno = 0;
+    ok (queue_insert (q, job[2]) < 0 && errno == EEXIST,
+        "queue_insert 3 again fails with EEXIST");
+
+    /* queue size, refcounts */
+
+    ok (queue_size (q) == 3,
+        "queue_size returns 3");
+    ok (job[0]->refcount == 2 && job[1]->refcount == 2 && job[2]->refcount == 2,
+        "queue took reference on inserted jobs");
+
+    /* iterators */
+
+    ok (queue_first (q) == job[0] && queue_next (q) == job[1]
+                                  && queue_next (q) == job[2]
+                                  && queue_next (q) == NULL,
+        "queue iterators return job 1,2,3,NULL");
+
+    /* lookup_by_id */
+
+    ok (queue_lookup_by_id (q, 1) == job[0]
+        && queue_lookup_by_id (q, 2) == job[1]
+        && queue_lookup_by_id (q, 3) == job[2],
+        "queue_lookup_by_id works for all three jobs");
+    errno = 0;
+    ok (queue_lookup_by_id (q, 42) == NULL && errno == ENOENT,
+        "queue_lookupby_id 42 fails with ENOENT");
+
+    /* insert high priority */
+
+    njob[0] = job_create_test (100, FLUX_JOB_PRIORITY_MAX);
+    ok (queue_insert (q, njob[0]) == 0,
+        "queue_insert 100 pri=max");
+    ok (queue_first (q) == njob[0],
+        "queue_first returns high priority job");
+
+    /* insert low priority */
+
+    njob[1] = job_create_test (101, FLUX_JOB_PRIORITY_MIN);
+    ok (queue_insert (q, njob[1]) == 0,
+        "queue_insert 101 pri=min");
+
+    j_prev = NULL;
+    j = queue_first (q);
+    while (j) {
+        j_prev = j;
+        j = queue_next (q);
+    }
+    ok (j_prev == njob[1],
+        "iterators find low priority job last");
+
+    /* set high priority and reorder
+     *   review: queue contains 100,1,2,3,101
+     */
+    job[2]->priority = FLUX_JOB_PRIORITY_MAX; // job 3
+    queue_reorder (q, job[2]);
+    ok (queue_first (q) == job[2],
+        "reorder job 3 pri=max moves that job first");
+
+    /* destroy */
+
+    queue_destroy (q);
+    ok (job[0]->refcount == 1 && job[1]->refcount == 1
+                              && job[2]->refcount == 1
+                              && njob[0]->refcount == 1
+                              && njob[0]->refcount == 1,
+        "queue dropped reference on jobs at destruction");
+
+    job_decref (job[0]);
+    job_decref (job[1]);
+    job_decref (job[2]);
+
+    job_decref (njob[0]);
+    job_decref (njob[1]);
+
+    done_testing ();
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -98,6 +98,7 @@ TESTS = \
 	t2100-aggregate.t \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
+	t2202-job-manager.t \
 	t3000-mpi-basic.t \
         t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \
@@ -212,6 +213,7 @@ check_SCRIPTS = \
 	t2100-aggregate.t \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
+	t2202-job-manager.t \
 	t3000-mpi-basic.t \
         t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -5,3 +5,4 @@ flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 
 flux module load -r all job-ingest
+flux module load -r 0 job-manager

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+flux module remove -r 0 job-manager
 flux module remove -r all job-ingest
 
 flux module remove -r all -x 0 kvs

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -1,0 +1,202 @@
+#!/bin/sh
+
+test_description='Test flux job manager service'
+
+. $(dirname $0)/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+if flux job submitbench --help 2>&1 | grep -q sign-type; then
+    test_set_prereq HAVE_FLUX_SECURITY
+    SUBMITBENCH_OPT_R="--reuse-signature"
+    SUBMITBENCH_OPT_NONE="--sign-type=none"
+fi
+
+test_under_flux 4 kvs
+
+flux setattr log-stderr-level 1
+
+JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+SUBMITBENCH="flux job submitbench $SUBMITBENCH_OPT_NONE"
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+	flux module load -r all job-ingest &&
+	flux module load -r 0 job-manager
+'
+
+test_expect_success 'job-manager: submit one job' '
+	${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml >submit1.out
+'
+
+test_expect_success 'job-manager: queue contains 1 job' '
+	flux job list -s >list1.out &&
+	test $(wc -l <list1.out) -eq 1
+'
+
+test_expect_success 'job-manager: queue lists job with correct jobid' '
+	cut -f1 <list1.out >list1_jobid.out &&
+	test_cmp submit1.out list1_jobid.out
+'
+
+test_expect_success 'job-manager: queue lists job with correct userid' '
+	id -u >list1_userid.exp &&
+	cut -f2 <list1.out >list1_userid.out &&
+	test_cmp list1_userid.exp list1_userid.out
+'
+
+test_expect_success 'job-manager: queue list job with correct priority' '
+	echo 16 >list1_priority.exp &&
+	cut -f3 <list1.out >list1_priority.out &&
+	test_cmp list1_priority.exp list1_priority.out
+'
+
+test_expect_success 'job-manager: purge job' '
+	flux job purge $(cat list1_jobid.out)
+'
+
+test_expect_success 'job-manager: queue contains 0 jobs' '
+	test $(flux job list -s | wc -l) -eq 0
+'
+
+test_expect_success 'job-manager: submit jobs with priority=min,default,max' '
+	${SUBMITBENCH} -p0  ${JOBSPEC}/valid/basic.yaml >submit_min.out &&
+	${SUBMITBENCH}      ${JOBSPEC}/valid/basic.yaml >submit_def.out &&
+	${SUBMITBENCH} -p31 ${JOBSPEC}/valid/basic.yaml >submit_max.out
+'
+
+test_expect_success 'job-manager: queue contains 3 jobs' '
+	flux job list -s >list3.out &&
+	test $(wc -l <list3.out) -eq 3
+'
+
+test_expect_success 'job-manager: queue is sorted in priority order' '
+	cat >list3_pri.exp <<-EOT
+	31
+	16
+	0
+	EOT &&
+	cut -f3 <list3.out >list3_pri.out &&
+	test_cmp list3_pri.exp list3_pri.out
+'
+
+test_expect_success 'job-manager: flux job list --count shows highest priority jobs' '
+	cat >list3_lim2.exp <<-EOT
+	31
+	16
+	EOT &&
+	flux job list -s -c 2 >list3_lim2.out &&
+	test_cmp list3_lim2.exp list3_lim2.out
+'
+
+test_expect_success 'job-manager: purge jobs' '
+	for jobid in $(cut -f1 <list3.out); do \
+		flux job purge ${jobid}; \
+	done
+'
+
+test_expect_success 'job-manager: queue contains 0 jobs' '
+       test $(flux job list -s | wc -l) -eq 0
+'
+
+test_expect_success 'job-manager: submit 10 jobs of equal priority' '
+	${SUBMITBENCH} -r10 ${JOBSPEC}/valid/basic.yaml >submit10.out
+'
+
+test_expect_success 'job-manager: jobs are listed in submit order' '
+	flux job list -s >list10.out &&
+	cut -f1 <list10.out >list10_ids.out &&
+	test_cmp submit10.out list10_ids.out
+'
+
+test_expect_success 'job-manager: flux job priority sets last job priority=31' '
+	lastid=$(tail -1 <list10_ids.out) &&
+	flux job priority ${lastid} 31
+'
+
+test_expect_success 'job-manager: priority was updated in KVS' '
+	jobid=$(tail -1 <list10_ids.out) &&
+	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs get ${kvsdir}.priority >pri.out &&
+	echo 31 >pri.exp &&
+	test_cmp pri.exp pri.out
+'
+
+test_expect_success 'job-manager: that job is now the first job' '
+	flux job list -s >list10_reordered.out &&
+	firstid=$(cut -f1 <list10_reordered.out | head -1) &&
+	lastid=$(tail -1 <list10_ids.out) &&
+	test "${lastid}" -eq "${firstid}"
+'
+
+test_expect_success 'job-manager: reload the job manager' '
+	flux module remove job-manager &&
+	flux module load job-manager
+'
+
+test_expect_success 'job-manager: queue was successfully reconstructed' '
+	flux job list -s >list_reload.out &&
+	test_cmp list10_reordered.out list_reload.out
+'
+
+test_expect_success 'job-manager: purge jobs' '
+	for jobid in $(cut -f1 <list_reload.out); do \
+		flux job purge ${jobid}; \
+	done &&
+	test $(flux job list -s | wc -l) -eq 0
+'
+
+test_expect_success 'job-manager: flux job priority fails on invalid priority' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	flux job priority ${jobid} 31 &&
+	test_must_fail flux job priority ${jobid} -1 &&
+	test_must_fail flux job priority ${jobid} 32 &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: guest can reduce priority from default' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	FLUX_HANDLE_ROLEMASK=0x2 flux job priority ${jobid} 5 &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: guest can increase to default' '
+	jobid=$(${SUBMITBENCH} -p 0 ${JOBSPEC}/valid/basic.yaml) &&
+	FLUX_HANDLE_ROLEMASK=0x2 flux job priority ${jobid} 16 &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: guest cannot increase past default' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	! FLUX_HANDLE_ROLEMASK=0x2 flux job priority ${jobid} 17 &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: guest can decrease from from >default' '
+	jobid=$(${SUBMITBENCH} -p 31 ${JOBSPEC}/valid/basic.yaml) &&
+	FLUX_HANDLE_ROLEMASK=0x2 flux job priority ${jobid} 17 &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: guest cannot set priority of others jobs' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	newid=$(($(id -u)+1)) &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${newid} \
+		flux job priority ${jobid} 0 &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: guest cannot purge others jobs' '
+	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	newid=$(($(id -u)+1)) &&
+	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${newid} \
+		flux job purge ${jobid} &&
+	flux job purge ${jobid}
+'
+
+test_expect_success 'job-manager: remove job-manager, job-ingest' '
+	flux module remove -r 0 job-manager && \
+	flux module remove -r all job-ingest
+'
+
+test_done


### PR DESCRIPTION
This PR adds a `job-manager` module that handles `submit` requests from ingest module(s) and builds a queue.   It orders the queue by 1) job priority, 2) jobid.

It supports the following operations
* list - list queue (entire thing or some number from head of queue), with configurable attributes
* purge - remove a job (including all KVS vestiges) if it hasn't yet been seen by the scheduler
* priority - set priority of a job that has already been submitting (changing its queue position)

The module can be unloaded and reloaded, and it rebuilds its state.

Each operation is going to need more work once we have scheduler allocations and exec requests involved.  I tried to keep the module functionality divided up in multiple source files to make it easier to follow as we add to it.

This is intended for early comments.  It needs more detail in the commit messages.  It needs more extensive testing.

There are some comments about the operations in list.c, purge.c, and priority.c, including caveats for the initial implementation.