### PR TITLE
libflux: use common code for aux_set/aux_get

### DIFF
--- a/doc/man3/flux_aux_set.adoc
+++ b/doc/man3/flux_aux_set.adoc
@@ -10,32 +10,40 @@ flux_aux_set, flux_aux_get - get/set auxiliary handle data
 
 SYNOPSIS
 --------
-#include <flux/core.h>
+ #include <flux/core.h>
 
-typedef void (*flux_free_f)(void *arg);
+ typedef void (*flux_free_f)(void *arg);
 
-void *flux_aux_get (flux_t *h, const char *name);
+ void *flux_aux_get (flux_t *h, const char *name);
 
-void flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);
+ int flux_aux_set (flux_t *h, const char *name,
+                   void *aux, flux_free_f destroy);
 
 
 DESCRIPTION
 -----------
 
-`flux_aux_set()` stores application-specific data _aux_ in handle
-_h_ under the key _name_ with destructor _destroy_.  If _destroy_
-is non-NULL, the destructor is called at `flux_close()` or when
-_name_ is overwritten by another `flux_aux_set()` call.
+`flux_aux_set()` attaches application-specific data
+to the parent object _h_.  It stores data _aux_ by key _name_,
+with optional destructor _destroy_.  The destructor, if non-NULL,
+is called when the parent object is destroyed, or when
+_key_ is overwritten by a new value.  If _aux_ is NULL,
+the destructor for a previous value, if any is called,
+ but no new value is stored.  If _name_ is NULL,
+_aux_ is stored anonymously.
 
-`flux_aux_get()` can be used to retrieve the data by _name_.
+`flux_aux_get()` retrieves application-specific data
+by _name_.  If the data was stored anonymously, it
+cannot be retrieved.
 
-Names beginning with "flux::" are reserved for internal use by libflux-core.
+Names beginning with "flux::" are reserved for internal use.
 
 RETURN VALUE
 ------------
 
-`flux_aux_get()` returns  data on success, or NULL on failure.
-It does not set errno.
+`flux_aux_get()` returns data on success, or NULL on failure, with errno set.
+
+`flux_aux_set()` returns 0 on success, or -1 on failure, with errno set.
 
 
 ERRORS
@@ -46,6 +54,9 @@ Some arguments were invalid.
 
 ENOMEM::
 Out of memory.
+
+ENOENT::
+`flux_aux_get()` could not find an entry for _key_.
 
 
 AUTHOR

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -97,13 +97,22 @@ value and an optional error string.  Unlike
 and takes precedence over all other fulfillments.  It is used for
 catastrophic error paths in future fulfillment.
 
-`flux_future_aux_set()` attaches an object _aux_, with optional destructor
-_destroy_, to the future under an optional _name_.  `flux_future_aux_get()`
-retrieves an object by _name_.  Destructors are called when the future is
-destroyed.  Objects may be stored anonymously under a NULL _name_ to be
-scheduled for destruction without the option of retrieval.
+`flux_future_aux_set()` attaches application-specific data
+to the parent object _f_.  It stores data _aux_ by key _name_,
+with optional destructor _destroy_.  The destructor, if non-NULL,
+is called when the parent object is destroyed, or when
+_key_ is overwritten by a new value.  If _aux_ is NULL,
+the destructor for a previous value, if any is called,
+ but no new value is stored.  If _name_ is NULL,
+_aux_ is stored anonymously.
 
-`flux_future_set_reactor()` may be used to associate a Flux reactor 
+`flux_future_aux_get()` retrieves application-specific data
+by _name_.  If the data was stored anonymously, it
+cannot be retrieved.
+
+Names beginning with "flux::" are reserved for internal use.
+
+`flux_future_set_reactor()` may be used to associate a Flux reactor
 with a future.  The reactor (or a temporary one, depending on the context)
 may be retrieved using `flux_future_get_reactor()`.
 

--- a/doc/man3/flux_mrpc.adoc
+++ b/doc/man3/flux_mrpc.adoc
@@ -109,8 +109,21 @@ When the RPC is complete, the continuation stops its message handler
 for responses.  The flux_mrpc_t should be destroyed.  It is safe to
 call `flux_mrpc_destroy(3)` from within the continuation callback.
 
+`flux_mrpc_aux_set()` attaches application-specific data
+to the parent object _mrpc_.  It stores data _aux_ by key _name_,
+with optional destructor _destroy_.  The destructor, if non-NULL,
+is called when the parent object is destroyed, or when
+_key_ is overwritten by a new value.  If _aux_ is NULL,
+the destructor for a previous value, if any is called,
+ but no new value is stored.  If _name_ is NULL,
+_aux_ is stored anonymously.
 
-include::JSON_PACK.adoc[]
+`flux_mrpc_aux_get()` retrieves application-specific data
+by _name_.  If the data was stored anonymously, it
+cannot be retrieved.
+
+Names beginning with "flux::" are reserved for internal use.
+
 
 
 RETURN VALUE
@@ -131,6 +144,10 @@ and errno is set appropriately.
 
 `flux_mrpc_check()` does not report errors.
 
+`flux_mrpc_aux_set()` returns 0 on success, -1 on failure with errno set.
+
+`flux_mrpc_aux_get()` returns _aux_ on success, NULL on failure with errno set.
+
 
 ERRORS
 ------
@@ -144,6 +161,8 @@ Some arguments were invalid.
 EPROTO::
 A protocol error was encountered.
 
+ENOENT::
+An unknown key was passed to `flux_mrpc_aux_get()`.
 
 CAVEATS
 -------

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -1969,11 +1969,13 @@ static int l_flux_reactor_start (lua_State *L)
     }
     h = lua_get_flux (L, 1);
     rc = flux_reactor_run (flux_get_reactor (h), mode);
+    int saved_errno = errno;
     if (rc < 0 && (reason = flux_aux_get (h, "lua::reason"))) {
         lua_pushnil (L);
         lua_pushstring (L, reason);
         return (2);
     }
+    errno = saved_errno;
     return (l_pushresult (L, rc));
 }
 

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -227,7 +227,7 @@ static void runlevel_timeout (flux_reactor_t *reactor, flux_watcher_t *w,
  */
 static void completion_cb (flux_subprocess_t *p)
 {
-    runlevel_t *r = flux_subprocess_get_context (p, "runlevel");
+    runlevel_t *r = flux_subprocess_aux_get (p, "runlevel");
     const char *exit_string = NULL;
     int rc;
 
@@ -263,7 +263,7 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp;
 
-    r = flux_subprocess_get_context (p, "runlevel");
+    r = flux_subprocess_aux_get (p, "runlevel");
 
     assert (r);
     assert (r->level == 1 || r->level == 3);
@@ -315,7 +315,7 @@ static int runlevel_start_subprocess (runlevel_t *r, int level)
                              &ops)))
             goto error;
 
-        if (flux_subprocess_set_context (p, "runlevel", r) < 0)
+        if (flux_subprocess_aux_set (p, "runlevel", r, NULL) < 0)
             goto error;
 
         monotime (&r->rc[level].start);

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -814,7 +814,7 @@ done:
 
 static void completion_cb (flux_subprocess_t *p)
 {
-    proxy_ctx_t *ctx = flux_subprocess_get_context (p, "ctx");
+    proxy_ctx_t *ctx = flux_subprocess_aux_get (p, "ctx");
 
     assert (ctx);
 
@@ -883,7 +883,7 @@ static int child_create (proxy_ctx_t *ctx, int ac, char **av, const char *workpa
                                &ops)))
         goto error;
 
-    if (flux_subprocess_set_context (p, "ctx", ctx) < 0)
+    if (flux_subprocess_aux_set (p, "ctx", ctx, NULL) < 0)
         goto error;
 
     flux_cmd_destroy (cmd);

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -89,7 +89,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
     if (state == FLUX_SUBPROCESS_RUNNING) {
         started++;
         /* see FLUX_SUBPROCESS_FAILED case below */
-        (void)flux_subprocess_set_context (p, "started", p);
+        (void)flux_subprocess_aux_set (p, "started", p, NULL);
     }
     else if (state == FLUX_SUBPROCESS_EXITED)
         exited++;
@@ -103,7 +103,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
          * know if process started or not.  So we cheat with a
          * subprocess context setting.
          */
-        if (flux_subprocess_get_context (p, "started") == NULL)
+        if (flux_subprocess_aux_get (p, "started") == NULL)
             started++;
         exited++;
     }

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -289,7 +289,7 @@ void killer (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
 
 static void completion_cb (flux_subprocess_t *p)
 {
-    struct client *cli = flux_subprocess_get_context (p, "cli");
+    struct client *cli = flux_subprocess_aux_get (p, "cli");
     int rc;
 
     assert (cli);
@@ -313,7 +313,7 @@ static void completion_cb (flux_subprocess_t *p)
 
 static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 {
-    struct client *cli = flux_subprocess_get_context (p, "cli");
+    struct client *cli = flux_subprocess_aux_get (p, "cli");
 
     assert (cli);
 
@@ -345,7 +345,7 @@ static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
 void channel_cb (flux_subprocess_t *p, const char *stream)
 {
-    struct client *cli = flux_subprocess_get_context (p, "cli");
+    struct client *cli = flux_subprocess_aux_get (p, "cli");
     const char *ptr;
     int rc, lenp;
 
@@ -583,8 +583,8 @@ int client_run (struct client *cli)
                                     cli->cmd,
                                     &ops)))
         log_err_exit ("flux_exec");
-    if (flux_subprocess_set_context (cli->p, "cli", cli) < 0)
-        log_err_exit ("flux_subprocess_set_context");
+    if (flux_subprocess_aux_set (cli->p, "cli", cli, NULL) < 0)
+        log_err_exit ("flux_subprocess_aux_set");
     return 0;
 }
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -132,7 +132,8 @@ TESTS = test_module.t \
 	test_future.t \
 	test_composite_future.t \
 	test_reactor.t \
-	test_buffer.t
+	test_buffer.t \
+	test_mrpc.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
@@ -200,3 +201,7 @@ test_composite_future_t_LDADD = $(test_ldadd) $(LIBDL)
 test_buffer_t_SOURCES = test/buffer.c
 test_buffer_t_CPPFLAGS = $(test_cppflags)
 test_buffer_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_mrpc_t_SOURCES = test/mrpc.c
+test_mrpc_t_CPPFLAGS = $(test_cppflags)
+test_mrpc_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -133,7 +133,8 @@ TESTS = test_module.t \
 	test_composite_future.t \
 	test_reactor.t \
 	test_buffer.t \
-	test_mrpc.t
+	test_mrpc.t \
+	test_handle.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
@@ -205,3 +206,7 @@ test_buffer_t_LDADD = $(test_ldadd) $(LIBDL)
 test_mrpc_t_SOURCES = test/mrpc.c
 test_mrpc_t_CPPFLAGS = $(test_cppflags)
 test_mrpc_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_handle_t_SOURCES = test/handle.c
+test_handle_t_CPPFLAGS = $(test_cppflags)
+test_handle_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/barrier.c
+++ b/src/common/libflux/barrier.c
@@ -41,8 +41,10 @@ static void freectx (void *arg)
 {
     libbarrier_ctx_t *ctx = arg;
     if (ctx) {
+        int saved_errno = errno;
         free (ctx->name);
         free (ctx);
+        errno = saved_errno;
     }
 }
 
@@ -65,7 +67,8 @@ static libbarrier_ctx_t *getctx (flux_t *h)
             goto error;
         }
         ctx->id = id;
-        flux_aux_set (h, "flux::barrier_client", ctx, freectx);
+        if (flux_aux_set (h, "flux::barrier_client", ctx, freectx) < 0)
+            goto error;
     }
     return ctx;
 error:

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -135,7 +135,7 @@ bool flux_fatality (flux_t *h);
  * Key names used internally by flux-core are prefixed with "flux::".
  */
 void *flux_aux_get (flux_t *h, const char *name);
-void flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);
+int flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);
 
 /* Set/clear FLUX_O_* on a flux_t handle.
  */

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -149,29 +149,25 @@ const char *flux_get_nodeset (flux_t *h, const char *nodeset,
     nodeset_t *ns = NULL, *mns = NULL, *xns = NULL;
     int saved_errno;
 
-    if (!(ns = ns_special (h, nodeset))) {
-        saved_errno = errno;
+    if (!(ns = ns_special (h, nodeset)))
         goto error;
-    }
-    if (exclude && !(xns = ns_special (h, exclude))) {
-        saved_errno = errno;
+    if (exclude && !(xns = ns_special (h, exclude)))
         goto error;
-    }
     if (mask && !(mns = ns_special (h, mask))) {
-        saved_errno = EINVAL;
+        errno = EINVAL;
         goto error;
     }
-    if (ns_subtract(ns, xns) < 0 || ns_intersection (ns, mns) < 0) {
-        saved_errno = errno;
+    if (ns_subtract(ns, xns) < 0 || ns_intersection (ns, mns) < 0)
         goto error;
-    }
     if (xns)
         nodeset_destroy (xns);
     if (mns)
         nodeset_destroy (mns);
-    flux_aux_set (h, "flux::nodeset", ns, (flux_free_f) nodeset_destroy);
+    if (flux_aux_set (h, "flux::nodeset", ns, (flux_free_f) nodeset_destroy) < 0)
+        goto error;
     return nodeset_string (ns);
 error:
+    saved_errno = errno;
     if (ns)
         nodeset_destroy (ns);
     if (xns)

--- a/src/common/libflux/security.c
+++ b/src/common/libflux/security.c
@@ -32,7 +32,6 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <libgen.h>
-#include <munge.h>
 #include <czmq.h>
 
 #include "security.h"

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -10,7 +10,7 @@
 
 int aux_destroy_called;
 void *aux_destroy_arg;
-void aux_destroy (void *arg)
+void aux_destroy_fun (void *arg)
 {
     aux_destroy_called++;
     aux_destroy_arg = arg;
@@ -71,12 +71,12 @@ void test_simple (void)
          && errno == EINVAL,
         "flux_future_aux_set anon w/o destructor is EINVAL");
     errno = 0;
-    ok (flux_future_aux_set (NULL, "foo", "bar", aux_destroy) < 0
+    ok (flux_future_aux_set (NULL, "foo", "bar", aux_destroy_fun) < 0
          && errno == EINVAL,
         "flux_future_aux_set w/ NULL future is EINVAL");
     aux_destroy_called = 0;
     aux_destroy_arg = NULL;
-    ok (flux_future_aux_set (f, "foo", "bar", aux_destroy) == 0,
+    ok (flux_future_aux_set (f, "foo", "bar", aux_destroy_fun) == 0,
         "flux_future_aux_set works");
     errno = 0;
     p = flux_future_aux_get (NULL, "baz");
@@ -92,7 +92,7 @@ void test_simple (void)
     ok (p != NULL && !strcmp (p, "bar"),
         "flux_future_aux_get of known returns it");
     // same value as "foo" key to not muck up destructor arg test
-    ok (flux_future_aux_set (f, NULL, "bar", aux_destroy) == 0,
+    ok (flux_future_aux_set (f, NULL, "bar", aux_destroy_fun) == 0,
         "flux_future_aux_set with NULL key works");
 
     /* is_ready/wait_for/get - no future_init; artificially call fulfill */

--- a/src/common/libflux/test/handle.c
+++ b/src/common/libflux/test/handle.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    errno = 0;
+    ok (flux_aux_set (NULL, "foo", "bar", NULL) < 0 && errno == EINVAL,
+        "flux_aux_set h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_aux_get (NULL, "foo") == NULL && errno == EINVAL,
+        "flux_aux_get h=NULL fails with EINVAL");
+
+    done_testing();
+
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -605,6 +605,12 @@ void check_aux (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "created test message");
+    errno = 0;
+    ok (flux_msg_aux_set (NULL, "foo", "bar", NULL) < 0 && errno == EINVAL,
+        "flux_msg_aux_set msg=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_msg_aux_get (NULL, "foo") == NULL && errno == EINVAL,
+        "flux_msg_aux_get msg=NULL fails with EINVAL");
     ok (flux_msg_aux_set (msg, "test", test_data, myfree) == 0,
         "hang aux data member on message with destructor");
     ok (flux_msg_aux_get (msg, "incorrect") == NULL,

--- a/src/common/libflux/test/mrpc.c
+++ b/src/common/libflux/test/mrpc.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    errno = 0;
+    ok (flux_mrpc_aux_set (NULL, "foo", "bar", NULL) < 0 && errno == EINVAL,
+        "flux_mrpc_aux_set mrpc=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_mrpc_aux_get (NULL, "foo") == NULL && errno == EINVAL,
+        "flux_mrpc_aux_get mrpc=NULL fails with EINVAL");
+
+    done_testing();
+
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -67,7 +67,9 @@ static flux_security_t *get_security_ctx (flux_t *h, flux_future_t **f_error)
             goto error;
         if (flux_security_configure (sec, NULL) < 0)
             goto error;
-        flux_aux_set (h, auxkey, sec, (flux_free_f)flux_security_destroy);
+        if (flux_aux_set (h, auxkey, sec,
+                          (flux_free_f)flux_security_destroy) < 0)
+            goto error;
     }
     return sec;
 error:

--- a/src/common/libjsc/jstatctl.c
+++ b/src/common/libjsc/jstatctl.c
@@ -139,7 +139,8 @@ static jscctx_t *getctx (flux_t *h)
         if (!(ctx->callbacks = zlist_new ()))
             oom ();
         ctx->h = h;
-        flux_aux_set (h, "jstatctrl", ctx, freectx);
+        if (flux_aux_set (h, "jstatctrl", ctx, freectx) < 0)
+            oom ();
     }
     return ctx;
 }

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -164,7 +164,12 @@ int flux_kvs_set_namespace (flux_t *h, const char *namespace)
         return -1;
     }
 
-    flux_aux_set (h, FLUX_HANDLE_KVS_NAMESPACE, str, free);
+    if (flux_aux_set (h, FLUX_HANDLE_KVS_NAMESPACE, str, free) < 0) {
+        int saved_errno = errno;
+        free (str);
+        errno = saved_errno;
+        return -1;
+    }
     return 0;
 }
 

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -108,8 +108,8 @@ cleanup:
 
 static void subprocess_cleanup (flux_subprocess_t *p)
 {
-    flux_subprocess_server_t *s = flux_subprocess_get_context (p, "server_ctx");
-    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_get_context (p, "msg");
+    flux_subprocess_server_t *s = flux_subprocess_aux_get (p, "server_ctx");
+    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_aux_get (p, "msg");
 
     assert (s && msg);
 
@@ -120,8 +120,8 @@ static void subprocess_cleanup (flux_subprocess_t *p)
 
 static void rexec_completion_cb (flux_subprocess_t *p)
 {
-    flux_subprocess_server_t *s = flux_subprocess_get_context (p, "server_ctx");
-    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_get_context (p, "msg");
+    flux_subprocess_server_t *s = flux_subprocess_aux_get (p, "server_ctx");
+    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_aux_get (p, "msg");
 
     assert (s && msg);
 
@@ -158,8 +158,8 @@ static void internal_fatal (flux_subprocess_server_t *s, flux_subprocess_t *p)
 
 static void rexec_state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 {
-    flux_subprocess_server_t *s = flux_subprocess_get_context (p, "server_ctx");
-    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_get_context (p, "msg");
+    flux_subprocess_server_t *s = flux_subprocess_aux_get (p, "server_ctx");
+    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_aux_get (p, "msg");
 
     assert (s && msg);
 
@@ -268,8 +268,8 @@ static int rexec_output_eof (flux_subprocess_t *p, const char *stream,
 
 static void rexec_output_cb (flux_subprocess_t *p, const char *stream)
 {
-    flux_subprocess_server_t *s = flux_subprocess_get_context (p, "server_ctx");
-    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_get_context (p, "msg");
+    flux_subprocess_server_t *s = flux_subprocess_aux_get (p, "server_ctx");
+    flux_msg_t *msg = (flux_msg_t *) flux_subprocess_aux_get (p, "msg");
     const char *ptr;
     int lenp;
 
@@ -376,9 +376,9 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (!(copy = flux_msg_copy (msg, true)))
         goto error;
-    if (flux_subprocess_set_context (p, "msg", (void *) copy) < 0)
+    if (flux_subprocess_aux_set (p, "msg", copy, NULL) < 0)
         goto error;
-    if (flux_subprocess_set_context (p, "server_ctx", s) < 0)
+    if (flux_subprocess_aux_set (p, "server_ctx", s, NULL) < 0)
         goto error;
 
     flux_cmd_destroy (cmd);
@@ -548,7 +548,7 @@ char *subprocess_sender (flux_subprocess_t *p)
     flux_msg_t *msg;
     char *sender;
 
-    msg = flux_subprocess_get_context (p, "msg");
+    msg = flux_subprocess_aux_get (p, "msg");
     if (!msg || flux_msg_get_route_first (msg, &sender) < 0)
         return NULL;
 
@@ -679,7 +679,7 @@ void terminate_uuid (flux_subprocess_t *p, const char *id)
         flux_future_t *f;
         if (!(f = flux_subprocess_kill (p, SIGKILL))) {
             flux_subprocess_server_t *s;
-            s = flux_subprocess_get_context (p, "server_ctx");
+            s = flux_subprocess_aux_get (p, "server_ctx");
             flux_log_error (s->h, "%s: flux_subprocess_kill", __FUNCTION__);
             return;
         }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -387,13 +387,13 @@ flux_reactor_t * flux_subprocess_get_reactor (flux_subprocess_t *p);
  *
  *  Returns 0 on success
  */
-int flux_subprocess_set_context (flux_subprocess_t *p,
-                                 const char *name, void *ctx);
+int flux_subprocess_aux_set (flux_subprocess_t *p,
+                             const char *name, void *ctx, flux_free_f free);
 
 /*
  *  Return pointer to any context associated with `p` under `name`. If
  *   no such context exists, then NULL is returned.
  */
-void *flux_subprocess_get_context (flux_subprocess_t *p, const char *name);
+void *flux_subprocess_aux_get (flux_subprocess_t *p, const char *name);
 
 #endif /* !_FLUX_CORE_SUBPROCESS_H */

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -63,7 +63,7 @@ struct flux_subprocess {
 
     flux_cmd_t *cmd;                /* readonly/o copy of the command     */
 
-    zhash_t *aux;                   /* hash for auxillary data            */
+    struct aux_item *aux;           /* auxillary data                     */
 
     zhash_t *channels;              /* hash index by name to channel info */
     int channels_eof_expected;      /* number of eofs to expect */

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -213,12 +213,12 @@ void test_basic_errors (flux_reactor_t *r)
     ok (flux_subprocess_get_reactor (NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_get_reactor fails with NULL pointer inputs");
-    ok (flux_subprocess_set_context (NULL, "foo", "bar") < 0
+    ok (flux_subprocess_aux_set (NULL, "foo", "bar", NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_set_context fails with NULL pointer inputs");
-    ok (flux_subprocess_get_context (NULL, "foo") == NULL
+        "flux_subprocess_aux_set fails with NULL pointer inputs");
+    ok (flux_subprocess_aux_get (NULL, "foo") == NULL
         && errno == EINVAL,
-        "flux_subprocess_get_context fails with NULL pointer inputs");
+        "flux_subprocess_aux_get fails with NULL pointer inputs");
 }
 
 void test_errors (flux_reactor_t *r)
@@ -1245,12 +1245,12 @@ void test_context (flux_reactor_t *r)
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
-    ok (flux_subprocess_set_context (p, "extra", extra) == 0,
-        "flux_subprocess_set_context success");
-    ok ((tmp = flux_subprocess_get_context (p, "extra")) != NULL,
-        "flux_subprocess_get_context success");
+    ok (flux_subprocess_aux_set (p, "extra", extra, NULL) == 0,
+        "flux_subprocess_aux_set success");
+    ok ((tmp = flux_subprocess_aux_get (p, "extra")) != NULL,
+        "flux_subprocess_aux_get success");
     ok (tmp == extra,
-        "flux_subprocess_get_context returned correct pointer");
+        "flux_subprocess_aux_get returned correct pointer");
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
@@ -1278,8 +1278,8 @@ void test_refcount (flux_reactor_t *r)
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
-    ok (flux_subprocess_set_context (p, "extra", extra) == 0,
-        "flux_subprocess_set_context success");
+    ok (flux_subprocess_aux_set (p, "extra", extra, NULL) == 0,
+        "flux_subprocess_aux_set success");
     flux_subprocess_ref (p);
 
     int rc = flux_reactor_run (r, 0);
@@ -1289,10 +1289,10 @@ void test_refcount (flux_reactor_t *r)
 
     /* normally this should fail, but we've increased the refcount so
      * subprocess should not be destroyed */
-    ok ((tmp = flux_subprocess_get_context (p, "extra")) != NULL,
-        "flux_subprocess_get_context success");
+    ok ((tmp = flux_subprocess_aux_get (p, "extra")) != NULL,
+        "flux_subprocess_aux_get success");
     ok (tmp == extra,
-        "flux_subprocess_get_context returned correct pointer");
+        "flux_subprocess_aux_get returned correct pointer");
 
     flux_subprocess_unref (p);
     flux_cmd_destroy (cmd);

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -106,7 +106,8 @@ TESTS = test_nodeset.t \
 	test_tomltk.t \
 	test_cf.t \
 	test_ipaddr.t \
-	test_fluid.t
+	test_fluid.t \
+	test_aux.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -209,3 +210,7 @@ test_ipaddr_t_LDADD = $(test_ldadd)
 test_fluid_t_SOURCES = test/fluid.c
 test_fluid_t_CPPFLAGS = $(test_cppflags)
 test_fluid_t_LDADD = $(test_ldadd)
+
+test_aux_t_SOURCES = test/aux.c
+test_aux_t_CPPFLAGS = $(test_cppflags)
+test_aux_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -80,7 +80,9 @@ libutil_la_SOURCES = \
 	mnemonic.h \
 	mn_wordlist.c \
 	fluid.c \
-	fluid.h
+	fluid.h \
+	aux.c \
+	aux.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/aux.c
+++ b/src/common/libutil/aux.c
@@ -1,0 +1,178 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "aux.h"
+
+struct aux_item {
+    char *key;
+    void *val;
+    aux_free_f free_fn;
+    struct aux_item *next;
+};
+
+/* Destroy an aux item.
+ * It is assumed to already be unlinked from list.
+ */
+static void aux_item_destroy (struct aux_item *aux)
+{
+    if (aux) {
+        int saved_errno = errno;
+        if (aux->free_fn && aux->val)
+            aux->free_fn (aux->val);
+        free (aux->key);
+        free (aux);
+        errno = saved_errno;
+    }
+}
+
+/* Create an aux item.
+ * Return item on success, NULL on failure with errno set (ENOMEM).
+ */
+static struct aux_item *aux_item_create (const char *key,
+                                         void *val, aux_free_f free_fn)
+{
+    struct aux_item *aux;
+
+    if (!(aux = calloc (1, sizeof (*aux))))
+        return NULL;
+    if (key && !(aux->key = strdup (key)))
+        goto error;
+    aux->val = val;
+    aux->free_fn = free_fn;
+    return aux;
+error:
+    aux_item_destroy (aux);
+    return NULL;
+}
+
+/* Delete from 'head' an aux item that was stored under 'key', if any.
+ * 'head' is an in/out parameter.
+ */
+static void aux_item_delete (struct aux_item **head, const char *key)
+{
+    if (key && head) {
+        struct aux_item *item;
+
+        while ((item = *head)) {
+            if (item->key && !strcmp (item->key, key)) {
+                *head = item->next;
+                aux_item_destroy (item);
+                break;
+            }
+            head = &item->next;
+        }
+    }
+}
+
+/* Find in 'head' an aux item stored under 'key'.
+ * Returns item on success, NULL on failure.
+ */
+static struct aux_item *aux_item_find (struct aux_item *head, const char *key)
+{
+    if (key) {
+        while (head) {
+            if (head->key && !strcmp (key, head->key))
+                return head;
+            head = head->next;
+        }
+    }
+    return NULL;
+}
+
+/* Insert at the beginning of 'head' an aux 'item'.
+ * 'head' is an in/out parameter.
+ */
+static void aux_item_insert (struct aux_item **head, struct aux_item *item)
+{
+    if (head && item) {
+        if (*head)
+            item->next = *head;
+        *head = item;
+    }
+}
+
+/* Look up 'key' in 'head'.
+ * Returns value on success, NULL on failure with errno set (EINVAL, ENOENT).
+ */
+void *aux_get (struct aux_item *head, const char *key)
+{
+    struct aux_item *item;
+
+    if (!key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(item = aux_item_find (head, key))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return item->val;
+}
+
+/* Insert ('key', 'value', 'free_fn') tuple in 'head'.
+ * If 'key' is present in list, remove it first.
+ * 'head' is an in/out parameter.
+ * Returns 0 on success, -1 on failure with errno set (EINVAL, ENOMEM).
+ */
+int aux_set (struct aux_item **head,
+             const char *key, void *val, aux_free_f free_fn)
+{
+    struct aux_item *item;
+
+    if (!head || (!key && !val) || (!val && free_fn) || (!key && !free_fn)) {
+        errno = EINVAL;
+        return -1;
+    }
+    aux_item_delete (head, key);
+    if (val) {
+        if (!(item = aux_item_create (key, val, free_fn)))
+            return -1;
+        aux_item_insert (head, item);
+    }
+    return 0;
+}
+
+/* Destroy aux list 'head', calling destructors on items that have them.
+ */
+void aux_destroy (struct aux_item **head)
+{
+    if (head) {
+        while (*head) {
+            struct aux_item *next = (*head)->next;
+            aux_item_destroy (*head);
+            *head = next;
+        }
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/aux.h
+++ b/src/common/libutil/aux.h
@@ -1,0 +1,38 @@
+#ifndef _UTIL_AUX_H
+#define _UTIL_AUX_H
+
+/* aux container - associate auxiliary data with a host object
+ *
+ * The object declares a 'struct aux_item *aux', initialized to NULL.
+ * The object's destructor calls aux_destroy (&aux).
+ * The object's aux_get/aux_set functions call aux_get ()/aux_set () below.
+ *
+ * An empty aux list is represented by a NULL pointer.
+ *
+ * It is legal to aux_set (key=NULL, value!=NULL).  aux_get (key=NULL) fails,
+ * but aux_destroy () calls the anonymous value's destructor, if any.
+ *
+ * It is legal to aux_set () a duplicate key.  The new value replaces the old,
+ * after calling its destructor, if any.
+ *
+ * It is legal to aux_set (key!=NULL, value=NULL).  Any value previously
+ * stored under key is deleted, calling its destructor, if any.
+ */
+
+typedef void (*aux_free_f)(void *arg);
+
+struct aux_item;
+
+int aux_set (struct aux_item **aux, const char *key,
+             void *val, aux_free_f free_fn);
+
+void *aux_get (struct aux_item *aux, const char *key);
+
+void aux_destroy (struct aux_item **aux);
+
+#endif /* !_UTIL_AUX_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libutil/test/aux.c
+++ b/src/common/libutil/test/aux.c
@@ -1,0 +1,109 @@
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/aux.h"
+
+int myfree_count;
+void myfree (void *arg)
+{
+    myfree_count++;
+}
+
+int main (int argc, char *argv[])
+{
+    struct aux_item *aux = NULL;
+
+    plan (NO_PLAN);
+
+    errno = 0;
+    ok (aux_get (aux, "frog") == NULL && errno == ENOENT,
+        "aux_get fails with ENOENT on unknown item");
+
+    /* set 1st item no destructor */
+    ok (aux_set (&aux, "frog", "ribbit", NULL) == 0,
+        "aux_set frog=ribbit free_fn=NULL works");
+    is (aux_get (aux, "frog"), "ribbit",
+        "aux_get frog returns ribbit");
+
+    /* set 2nd item with destructor */
+    ok (aux_set (&aux, "dog", "woof", myfree) == 0,
+        "aux_set dog=woof free_fn=myfree");
+    is (aux_get (aux, "dog"), "woof",
+        "aux_get dog returns woof");
+    is (aux_get (aux, "frog"), "ribbit",
+        "aux_get frog still returns ribbit");
+
+    /* set 3rd item with destructor */
+    ok (aux_set (&aux, "cow", "moo", myfree) == 0,
+        "aux_set cow=moo free_fn=myfree");
+    is (aux_get (aux, "cow"), "moo",
+        "aux_get cow returns moo");
+    is (aux_get (aux, "dog"), "woof",
+        "aux_get dog still returns woof");
+    is (aux_get (aux, "frog"), "ribbit",
+        "aux_get frog still returns ribbit");
+
+    /* aux_set duplicate */
+    myfree_count = 0;
+    ok (aux_set (&aux, "cow", "oink", myfree) == 0,
+        "aux_set cow=oink free_fn=myfree");
+    cmp_ok (myfree_count, "==", 1,
+        "dup key=cow triggered destructor");
+    is (aux_get (aux, "cow"), "oink",
+        "aux_get cow now returns oink");
+
+    /* aux_set val=NULL */
+    myfree_count = 0;
+    ok (aux_set (&aux, "cow", NULL, NULL) == 0,
+        "aux_set cow=NULL does not fail");
+    cmp_ok (myfree_count, "==", 1,
+        "and called destructor once");
+    errno = 0;
+    ok (aux_get (aux, "cow") == NULL && errno == ENOENT,
+        "aux_get cow fails with ENOENT");
+    ok (aux_set (&aux, "unknown-key", NULL, NULL) == 0,
+        "aux_set unknown-key=NULL does not fail");
+
+    /* invalid args */
+    errno = 0;
+    ok (aux_get (aux, NULL) == NULL && errno == EINVAL,
+        "aux_get key=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "aux_set key=NULL val=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (NULL, "frog", NULL, NULL) < 0 && errno == EINVAL,
+        "aux_set aux=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "aux_set key=NULL val=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, "frog", NULL, myfree) < 0 && errno == EINVAL,
+        "aux_set val=NULL free_fn!=NULL fails with EINVAL");
+    errno = 0;
+    ok (aux_set (&aux, NULL, "baz", NULL) < 0 && errno == EINVAL,
+        "aux_set key=NULL free_fn=NULL fails with EINVAL");
+
+    /* add anonymous item */
+    ok (aux_set (&aux, NULL, "foo", myfree) == 0,
+        "aux-set key=NULL works for anonymous items");
+
+    /* destroy */
+    myfree_count = 0;
+    aux_destroy (&aux);
+    cmp_ok (myfree_count, "==", 2,
+        "aux_destroy called myfree twice");
+    ok (aux == NULL,
+        "aux_destroy set aux to NULL");
+
+    lives_ok ({aux_destroy (NULL);},
+        "aux_destroy aux=NULL doesn't crash");
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -94,7 +94,8 @@ static barrier_ctx_t *getctx (flux_t *h)
             goto error;
         }
         ctx->h = h;
-        flux_aux_set (h, "flux::barrier", ctx, freectx);
+        if (flux_aux_set (h, "flux::barrier", ctx, freectx) < 0)
+            goto error;
     }
     return ctx;
 error:

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -146,7 +146,8 @@ static mod_local_ctx_t *getctx (flux_t *h)
             goto error;
         }
         ctx->instance_owner = geteuid ();
-        flux_aux_set (h, "flux::local_connector", ctx, freectx);
+        if (flux_aux_set (h, "flux::local_connector", ctx, freectx) < 0)
+            goto error;
     }
     return ctx;
 error:

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -205,7 +205,8 @@ static sqlite_ctx_t *getctx (flux_t *h)
             log_sqlite_error (ctx, "preparing dump stmt");
             goto error_sqlite;
         }
-        flux_aux_set (h, "flux::content-sqlite", ctx, freectx);
+        if (flux_aux_set (h, "flux::content-sqlite", ctx, freectx) < 0)
+            goto error;
     }
     return ctx;
 error_sqlite:

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -195,7 +195,7 @@ static void cron_task_handle_finished (flux_subprocess_t *p, cron_task_t *t)
 
 static void completion_cb (flux_subprocess_t *p)
 {
-    cron_task_t *t = flux_subprocess_get_context (p, "task");
+    cron_task_t *t = flux_subprocess_aux_get (p, "task");
 
     assert (t);
 
@@ -205,7 +205,7 @@ static void completion_cb (flux_subprocess_t *p)
 
 static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 {
-    cron_task_t *t = flux_subprocess_get_context (p, "task");
+    cron_task_t *t = flux_subprocess_aux_get (p, "task");
 
     assert (t);
 
@@ -248,7 +248,7 @@ static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state
 
 static void io_cb (flux_subprocess_t *p, const char *stream)
 {
-    cron_task_t *t = flux_subprocess_get_context (p, "task");
+    cron_task_t *t = flux_subprocess_aux_get (p, "task");
     const char *ptr = NULL;
     int lenp;
     bool is_stderr = false;
@@ -369,8 +369,8 @@ int cron_task_run (cron_task_t *t,
         goto done;
     }
 
-    if (flux_subprocess_set_context (p, "task", t) < 0) {
-        flux_log_error (h, "flux_subprocess_set_context");
+    if (flux_subprocess_aux_set (p, "task", t, NULL) < 0) {
+        flux_log_error (h, "flux_subprocess_aux_set");
         goto done;
     }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -169,7 +169,10 @@ static kvs_ctx_t *getctx (flux_t *h)
             flux_watcher_start (ctx->check_w);
         }
         ctx->transaction_merge = 1;
-        flux_aux_set (h, "kvssrv", ctx, freectx);
+        if (flux_aux_set (h, "kvssrv", ctx, freectx) < 0) {
+            saved_errno = errno;
+            goto error;
+        }
     }
     return ctx;
 error:

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -138,7 +138,8 @@ static userdb_ctx_t *getctx (flux_t *h, int argc, char **argv)
             errno = ENOMEM;
             goto error;
         }
-        flux_aux_set (h, "flux::userdb", ctx, freectx);
+        if (flux_aux_set (h, "flux::userdb", ctx, freectx) < 0)
+            goto error;
     }
     return ctx;
 error:

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -543,8 +543,8 @@ static void completion_cb (flux_subprocess_t *p)
     struct wreck_job *job = NULL;
     int tmp;
 
-    h = flux_subprocess_get_context (p, "handle");
-    job = flux_subprocess_get_context (p, "job");
+    h = flux_subprocess_aux_get (p, "handle");
+    job = flux_subprocess_aux_get (p, "job");
 
     assert (h && job);
 
@@ -575,8 +575,8 @@ static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state
     flux_t *h;
     struct wreck_job *job;
 
-    h = flux_subprocess_get_context (p, "handle");
-    job = flux_subprocess_get_context (p, "job");
+    h = flux_subprocess_aux_get (p, "handle");
+    job = flux_subprocess_aux_get (p, "job");
 
     assert (h && job);
 
@@ -602,8 +602,8 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
         struct wreck_job *job;
         int level = LOG_INFO;
 
-        h = flux_subprocess_get_context (p, "handle");
-        job = flux_subprocess_get_context (p, "job");
+        h = flux_subprocess_aux_get (p, "handle");
+        job = flux_subprocess_aux_get (p, "job");
 
         assert (h && job);
 
@@ -696,13 +696,13 @@ static int spawn_exec_handler (flux_t *h, struct wreck_job *job)
         goto error;
     }
 
-    if (flux_subprocess_set_context (p, "handle", h) < 0) {
-        flux_log_error (h, "flux_subprocess_set_context");
+    if (flux_subprocess_aux_set (p, "handle", h, NULL) < 0) {
+        flux_log_error (h, "flux_subprocess_aux_set");
         goto error;
     }
 
-    if (flux_subprocess_set_context (p, "job", job) < 0) {
-        flux_log_error (h, "flux_subprocess_set_context");
+    if (flux_subprocess_aux_set (p, "job", job, NULL) < 0) {
+        flux_log_error (h, "flux_subprocess_aux_set");
         goto error;
     }
 


### PR DESCRIPTION
This is a cleanup of the aux get/set functions in  the`flux_t`, `flux_mrpc_t`, `flux_future_t`, and `flux_message_t` objects to normalize their semantics, as called out in #1796.

I think this is a good idea as we stabilize our API, though  I'm less sure that the switch from a zhash to a one-off singly linked list is justified, though it should save some memory in those objects.

The header from the shared implementation summarizes the semantics:
```c
/* aux list - associate auxiliary data with a host object
 *
 * The object declares a 'struct aux_item *aux', initialized to NULL.
 * The object's destructor calls aux_destroy (&aux).
 * The object's aux_get/aux_set functions call aux_get ()/aux_set () below.
 *
 * An empty aux list is represented by a NULL pointer.
 *
 * It is legal to aux_set (key=NULL, value!=NULL).  aux_get (key=NULL) fails,
 * but aux_destroy () calls the anonymous value's destructor, if any.
 *
 * It is legal to aux_set () a duplicate key.  The new value replaces the old,
 * after calling its destructor, if any.
 *
 * It is legal to aux_set (key!=NULL, value=NULL).  Any value previously
 * stored under key is deleted, calling its destructor, if any.
 */
```