### PR TITLE
broker: don't connect to enclosing instance

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -132,7 +132,6 @@ typedef struct {
     /* Bootstrap
      */
     hello_t *hello;
-    flux_t *enclosing_h;
     runlevel_t *runlevel;
 
     char *init_shell_cmd;
@@ -341,13 +340,6 @@ int main (int argc, char *argv[])
     ctx.userid = geteuid ();
     ctx.rolemask = FLUX_ROLE_OWNER;
 
-    /* Connect to enclosing instance, if any.
-     */
-    if (getenv ("FLUX_URI")) {
-        if (!(ctx.enclosing_h = flux_open (NULL, 0)))
-            log_err_exit ("flux_open enclosing instance");
-    }
-
     if (content_cache_register_attrs (ctx.cache, ctx.attrs) < 0)
         log_err_exit ("content cache attributes");
 
@@ -485,8 +477,6 @@ int main (int argc, char *argv[])
      */
     if (content_cache_set_flux (ctx.cache, ctx.h) < 0)
         log_err_exit ("content_cache_set_flux");
-
-    content_cache_set_enclosing_flux (ctx.cache, ctx.enclosing_h);
 
     /* Configure attributes.
      */
@@ -671,8 +661,6 @@ int main (int argc, char *argv[])
 
     if (ctx.verbose)
         log_msg ("cleaning up");
-    if (ctx.enclosing_h)
-        flux_close (ctx.enclosing_h);
     if (ctx.sec)
         flux_sec_destroy (ctx.sec);
     overlay_destroy (ctx.overlay);

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -70,7 +70,6 @@ struct cache_entry {
 
 struct content_cache {
     flux_t *h;
-    flux_t *enclosing_h;
     flux_msg_handler_t **handlers;
     uint32_t rank;
     zhash_t *entries;
@@ -898,11 +897,6 @@ int content_cache_set_flux (content_cache_t *cache, flux_t *h)
     if (flux_event_subscribe (h, "hb") < 0)
         return -1;
     return 0;
-}
-
-void content_cache_set_enclosing_flux (content_cache_t *cache, flux_t *h)
-{
-    cache->enclosing_h = h;
 }
 
 static int content_cache_setattr (const char *name, const char *val, void *arg)

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -1,7 +1,6 @@
 typedef struct content_cache content_cache_t;
 
 int content_cache_set_flux (content_cache_t *cache, flux_t *h);
-void content_cache_set_enclosing_flux (content_cache_t *cache, flux_t *h);
 
 content_cache_t *content_cache_create (void);
 void content_cache_destroy (content_cache_t *cache);


### PR DESCRIPTION
This PR removes some code in the broker that attempted to set up for the content-cache to use its enclosing instance as a tertiary level of content storage.  That feature was not fully implemented, is not motivated by a use case, and creates a complication for test environments, as pointed out in #1784.

There is a corresponding PR to make this feature optional instead of mandatory in RFC 10 in flux-framework/rfc#141.