### PR TITLE
kvs: provide mechanism to load KVS root from completed instance in subdir of another instance

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -82,12 +82,12 @@ is specified, until 'count' values have been displayed.
 *put* [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  If it already has a value,
 overwrite it.  If no options, value is stored directly.  If '-j', it is
-first encoded as JSON, then stored.  If '-r', the value may be read from
-standard input if specified as "-", and may include embedded NULL bytes.
-If '-t', value is stored as a RFC 11 object.  '-n' prevents the commit
-from being merged with with other contemporaneous commits.  '-A' appends the
-value to a key instead of overwriting the value.  Append is incompatible with
-the -j option.
+first encoded as JSON, then stored.  If '-r' or '-t', the value may optionally
+be read from standard input if specified as "-".  If '-r', the value may
+include embedded NULL bytes.  If '-t', value is stored as a RFC 11 object.
+'-n' prevents the commit from being merged with with other contemporaneous
+commits.  '-A' appends the value to a key instead of overwriting the value.
+Append is incompatible with the -j option.
 
 *ls* [-R] [-d] [-F] [-w COLS] [-1] ['key' ...]::
 Display directory referred to by _key_, or "." (root) if unspecified.

--- a/etc/rc3
+++ b/etc/rc3
@@ -3,7 +3,7 @@
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:
-shopt -s nullglob 
+shopt -s nullglob
 for rcdir in $all_dirs; do
     for rcfile in $rcdir/rc3.d/*; do
         echo running $rcfile

--- a/etc/rc3
+++ b/etc/rc3
@@ -22,9 +22,14 @@ flux module remove -r 0 cron
 flux module remove -r all job
 flux module remove -r all resource-hwloc
 flux module remove -r all aggregator
-flux module remove -r all kvs-watch
-flux module remove -r all kvs
 flux module remove -r all barrier
 
+flux module remove -r all kvs-watch
+flux module remove -r all -x 0 kvs
+if test -n "$PERSISTDIR"; then
+    flux kvs getroot >${PERSISTDIR}/kvsroot.final
+    flux content flush
+fi
+flux module remove -r 0 kvs
 flux module remove -r 0 content-sqlite
 

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -751,8 +751,17 @@ int cmd_put (optparse_t *p, int argc, char **argv)
         *val++ = '\0';
 
         if (optparse_hasopt (p, "treeobj")) {
+            int len;
+            uint8_t *buf = NULL;
+
+            if (!strcmp (val, "-")) { // special handling for "--treeobj key=-"
+                if ((len = read_all (STDIN_FILENO, (void **)&buf)) < 0)
+                    log_err_exit ("stdin");
+                val = (char *)buf;
+            }
             if (flux_kvs_txn_put_treeobj (txn, 0, key, val) < 0)
                 log_err_exit ("%s", key);
+            free (buf);
         }
         else if (optparse_hasopt (p, "json")) {
             json_t *obj;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -165,7 +165,7 @@ static sqlite_ctx_t *getctx (flux_t *h)
             cleanup = true;
         }
         ctx->dbdir = xasprintf ("%s/content", dir);
-        if (mkdir (ctx->dbdir, 0755) < 0) {
+        if (mkdir (ctx->dbdir, 0755) < 0 && errno != EEXIST) {
             saved_errno = errno;
             flux_log_error (h, "mkdir %s", ctx->dbdir);
             goto error;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -40,7 +40,7 @@
 const size_t lzo_buf_chunksize = 1024*1024;
 const size_t compression_threshold = 256; /* compress blobs >= this size */
 
-const char *sql_create_table = "CREATE TABLE objects("
+const char *sql_create_table = "CREATE TABLE if not exists objects("
                                "  hash CHAR(20) PRIMARY KEY,"
                                "  size INT,"
                                "  object BLOB"

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -116,16 +116,11 @@ static void freectx (void *arg)
             sqlite3_finalize (ctx->load_stmt);
         if (ctx->dump_stmt)
             sqlite3_finalize (ctx->dump_stmt);
-        if (ctx->dbdir)
-            free (ctx->dbdir);
-        if (ctx->dbfile) {
-            unlink (ctx->dbfile);
-            free (ctx->dbfile);
-        }
         if (ctx->db)
             sqlite3_close (ctx->db);
-        if (ctx->lzo_buf)
-            free (ctx->lzo_buf);
+        free (ctx->dbfile);
+        free (ctx->dbdir);
+        free (ctx->lzo_buf);
         free (ctx);
     }
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -94,6 +94,7 @@ TESTS = \
 	t2007-caliper.t \
 	t2008-althash.t \
 	t2009-hostlist.t \
+	t2010-kvs-snapshot-restore.t \
 	t2100-aggregate.t \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
@@ -207,6 +208,7 @@ check_SCRIPTS = \
 	t2007-caliper.t \
 	t2008-althash.t \
 	t2009-hostlist.t \
+	t2010-kvs-snapshot-restore.t \
 	t2100-aggregate.t \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+
+test_description='Test loading KVS snapshot from earlier instance
+
+Test recovery of KVS snapshot from persistdir.'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+
+test_expect_success 'created persist-directory' '
+	PERSISTDIR=$(mktemp -d --tmpdir=$(pwd))
+'
+
+test_expect_success 'run instance with persist-directory set' '
+	rm -f $PERSISTDIR/kvsroot.final &&
+	flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	    flux kvs put testkey=42
+'
+
+test_expect_success 'sqlite file exists in persist-directory' '
+	test -f $PERSISTDIR/content/sqlite &&
+	echo Size in bytes: $(stat --format "%s" $PERSISTDIR/content/sqlite)
+'
+
+test_expect_success 'kvsroot.final file exists in persist-directory' '
+	test -f $PERSISTDIR/kvsroot.final
+'
+
+test_expect_success 'recover KVS snapshot from persist-directory in new instance' '
+	run_timeout 10 \
+	    flux start -o,--setattr=persist-directory=$PERSISTDIR \
+	        "flux kvs put --treeobj snap=- <$PERSISTDIR/kvsroot.final && \
+		    flux kvs get snap.testkey >testkey.out" &&
+	echo 42 >testkey.exp &&
+	test_cmp testkey.exp testkey.out
+'
+
+test_done


### PR DESCRIPTION
This PR builds on @grondo's experiment in #777, which was further discussed recently in #1754:
* If the `persist-directory` is set, save the final kvs root reference to `kvsroot.final` in that directory
* Fix a bug in `content-sqlite` that was unconditionally unlinking the sqlite db file on exit, despite obvious intentions not to elsewhere in the code
* Misc cleanup in `content-sqlite` (errno, exit on error, etc)
* Add `flux kvs put --treeobj key=- <value` capability
* Modify @grondo's sharness test to create previous root as a snapshot in current root using `flux kvs put --treeobj`

One caveat is that the shutdown timer could interrupt rc3 before the content cache is fully flushed to disk, in which case it's possible the snapshot will have dangling references.  I  would prefer to treat that as a separate issue if/when it comes up though.