### PR TITLE
python: reformat and addition of format checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,13 +10,17 @@ AllowShortLoopsOnASingleLine : false
 BinPackParameters : false
 AllowAllParametersOfDeclarationOnNextLine : false
 AlignTrailingComments : true
-ColumnLimit : 80
-PenaltyBreakBeforeFirstCallParameter : 100
+ColumnLimit : 88
+
+# do not put all arguments on one line unless it's the same line as the call
+PenaltyBreakBeforeFirstCallParameter : 10000000
 PenaltyReturnTypeOnItsOwnLine : 65000
 PenaltyBreakString : 10
 
 # These improve formatting results but require clang 3.6/7 or higher
-# BreakBeforeBinaryOperators : NonAssignment
-# AlignAfterOpenBracket: true
-# BinPackArguments : false
-# AlignOperands : true
+BreakBeforeBinaryOperators : NonAssignment
+AlignAfterOpenBracket: true
+BinPackArguments : false
+AlignOperands : true
+BreakBeforeTernaryOperators : true
+AllowAllParametersOfDeclarationOnNextLine : false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,26 @@ services: docker
 dist: trusty
 language: c
 
-matrix:
+jobs:
   include:
+    - stage: 'style checks'
+      language: 'python'
+      python: '3.6'
+      install: pip install --upgrade black
+      script: ./scripts/check-format
     - name: "Ubuntu: no configure flags"
+      stage: test
       compiler: gcc
       env:
        - PYTHON_VERSION=2.7
     - name: "Ubuntu: py3.6 distcheck"
+      stage: test
       compiler: gcc
       env:
        - DISTCHECK=t
        - PYTHON_VERSION=3.6
     - name: "Ubuntu: gcc-8 --with-flux-security/caliper, distcheck"
+      stage: test
       compiler: gcc-8
       env:
        - CC=gcc-8
@@ -23,6 +31,7 @@ matrix:
        - DISTCHECK=t
        - PYTHON_VERSION=2.7
     - name: "Ubuntu: clang-6.0 chain-lint --with-flux-security --enable-pylint"
+      stage: test
       compiler: clang-6.0
       env:
        - CC=clang-6.0
@@ -31,12 +40,14 @@ matrix:
        - ARGS="--with-flux-security --enable-pylint"
        - PYTHON_VERSION=2.7
     - name: "Ubuntu: COVERAGE=t, --with-flux-security --enable-caliper"
+      stage: test
       compiler: gcc
       env:
        - COVERAGE=t
        - ARGS="--with-flux-security --enable-caliper"
        - PYTHON_VERSION=2.7
     - name: "Ubuntu: TEST_INSTALL docker-deploy"
+      stage: test
       compiler: gcc
       env:
        - ARGS="--with-flux-security --enable-caliper"
@@ -44,6 +55,7 @@ matrix:
        - DOCKER_TAG=t
        - PYTHON_VERSION=2.7
     - name: "Centos 7: --with-flux-security --enable-caliper docker-deploy"
+      stage: test
       compiler: gcc
       env:
        - ARGS="--with-flux-security --enable-caliper --prefix=/usr"
@@ -51,19 +63,12 @@ matrix:
        - DOCKER_TAG=t
        - PYTHON_VERSION=2.7
     - name: "Centos 7: py3.4 --with-flux-security"
+      stage: test
       compiler: gcc
       env:
        - ARGS="--with-flux-security --prefix=/usr"
        - IMG=centos7-base
        - PYTHON_VERSION=3.4
-
-jobs:
-  include:
-    - stage: 'style checks'
-      language: 'python'
-      python: '3.6'
-      install: pip install --upgrade black
-      script: ./scripts/check-format
 
 stages:
   - 'style checks'

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,18 @@ matrix:
        - IMG=centos7-base
        - PYTHON_VERSION=3.4
 
+jobs:
+  include:
+    - stage: 'style checks'
+      language: 'python'
+      python: '3.6'
+      install: pip install --upgrade black
+      script: ./scripts/check-format
+
+stages:
+  - 'style checks'
+  - test
+
 env:
   global:
    - TAP_DRIVER_QUIET=1
@@ -87,7 +99,7 @@ before_install:
      export TAGNAME="${DOCKERREPO}:${IMG}-${TRAVIS_TAG:-latest}"
      echo "Tagging new image $TAGNAME"
   fi
- 
+
 script:
  - |
   src/test/docker/docker-run-checks.sh -j2 \

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,17 @@ language: c
 jobs:
   include:
     - stage: 'style checks'
+      name: 'python format'
       language: 'python'
       python: '3.6'
       install: pip install --upgrade black
       script: ./scripts/check-format
+    - stage: 'style checks'
+      name: 'python lint'
+      language: 'python'
+      python: '3.6'
+      install: pip install --upgrade pylint
+      script: pylint --rcfile=src/bindings/python/.pylintrc src/bindings/python/flux
     - name: "Ubuntu: no configure flags"
       stage: test
       compiler: gcc
@@ -30,14 +37,14 @@ jobs:
        - ARGS="--with-flux-security --enable-caliper"
        - DISTCHECK=t
        - PYTHON_VERSION=2.7
-    - name: "Ubuntu: clang-6.0 chain-lint --with-flux-security --enable-pylint"
+    - name: "Ubuntu: clang-6.0 chain-lint --with-flux-security"
       stage: test
       compiler: clang-6.0
       env:
        - CC=clang-6.0
        - CXX=clang++-6.0
        - chain_lint=t
-       - ARGS="--with-flux-security --enable-pylint"
+       - ARGS="--with-flux-security"
        - PYTHON_VERSION=2.7
     - name: "Ubuntu: COVERAGE=t, --with-flux-security --enable-caliper"
       stage: test

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if command -v black 2>&1 > /dev/null ; then
+  find src t -name '*.py' -print0 | xargs -0 | black --check
+else
+  echo "black not found, failing"
+  exit 1
+fi

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -2,7 +2,7 @@
 set -e
 
 if command -v black 2>&1 > /dev/null ; then
-  find src t -name '*.py' -print0 | xargs -0 | black --check
+  find src t -name '*.py' -print0 | xargs -0 black --check
 else
   echo "black not found, failing"
   exit 1

--- a/scripts/format
+++ b/scripts/format
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if command -v black 2>&1 > /dev/null ; then
+  find src t -name '*.py' -print0 | xargs -0 black
+else
+  echo "black not found, python left unformatted"
+fi

--- a/src/bindings/python/.pylintrc
+++ b/src/bindings/python/.pylintrc
@@ -44,7 +44,7 @@ symbols=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme
+disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation
 
 
 [REPORTS]
@@ -175,7 +175,7 @@ docstring-min-length=-1
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=88
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -5,12 +5,8 @@ python bindings to flux-core, the main core of the flux resource manager
 # pylint: disable=invalid-name
 def Flux(*args, **kwargs):
     import flux.core.handle
+
     return flux.core.handle.Flux(*args, **kwargs)
 
-__all__ = ['core',
-           'kvs',
-           'jsc',
-           'rpc',
-           'mrpc',
-           'constants',
-           'Flux', ]
+
+__all__ = ["core", "kvs", "jsc", "rpc", "mrpc", "constants", "Flux"]

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -7,6 +7,7 @@ from flux.message import Message
 from flux.core.inner import raw
 from _flux._core import ffi, lib
 
+
 class Flux(Wrapper):
     """
   The general Flux handle class, create one of these to connect to the
@@ -17,12 +18,14 @@ class Flux(Wrapper):
 
     def __init__(self, url=ffi.NULL, flags=0, handle=None):
         super(Flux, self).__init__(
-            ffi, lib,
+            ffi,
+            lib,
             handle=handle,
             match=ffi.typeof(lib.flux_open).result,
             filter_match=False,
-            prefixes=['flux_', 'FLUX_',],
-            destructor=raw.flux_close,)
+            prefixes=["flux_", "FLUX_"],
+            destructor=raw.flux_close,
+        )
 
         if handle is None:
             self.handle = raw.flux_open(url, flags)
@@ -39,7 +42,7 @@ class Flux(Wrapper):
         """
         # Short-circuited because variadics can't be wrapped cleanly
         if isinstance(fstring, six.text_type):
-            fstring = fstring.encode('utf-8')
+            fstring = fstring.encode("utf-8")
         lib.flux_log(self.handle, level, fstring)
 
     def send(self, message, flags=0):
@@ -48,43 +51,39 @@ class Flux(Wrapper):
             message = message.handle
         return self.flux_send(message, flags)
 
-    def recv(self,
-             type_mask=raw.FLUX_MSGTYPE_ANY,
-             match_tag=raw.FLUX_MATCHTAG_NONE,
-             topic_glob=None,
-             flags=0):
+    def recv(
+        self,
+        type_mask=raw.FLUX_MSGTYPE_ANY,
+        match_tag=raw.FLUX_MATCHTAG_NONE,
+        topic_glob=None,
+        flags=0,
+    ):
         """
         Receive a message, returns a flux.Message containing the result or None
         """
-        match = ffi.new('struct flux_match *', {
-            'typemask': type_mask,
-            'matchtag': match_tag,
-            'topic_glob': topic_glob if topic_glob is not None else ffi.NULL,
-        })
+        match = ffi.new(
+            "struct flux_match *",
+            {
+                "typemask": type_mask,
+                "matchtag": match_tag,
+                "topic_glob": topic_glob if topic_glob is not None else ffi.NULL,
+            },
+        )
         handle = self.flux_recv(match[0], flags)
         if handle is not None:
             return Message(handle=handle)
         return None
 
-    def rpc_send(self, topic,
-                 payload=None,
-                 nodeid=raw.FLUX_NODEID_ANY,
-                 flags=0):
+    def rpc_send(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
         """ Create and send an RPC in one step """
         with RPC(self, topic, payload, nodeid, flags) as rpc:
             return rpc.get()
 
-    def rpc_create(self, topic,
-                   payload=None,
-                   nodeid=raw.FLUX_NODEID_ANY,
-                   flags=0):
+    def rpc_create(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
         """ Create a new RPC object """
         return RPC(self, topic, payload, nodeid, flags)
 
-    def mrpc_create(self, topic,
-                    payload=None,
-                    rankset="any",
-                    flags=0):
+    def mrpc_create(self, topic, payload=None, rankset="any", flags=0):
         """
         Create a new MRPC object. Messages are sent on MRPC creation. Responses
         are accessible by iterating on the returned MRPC object. For example:
@@ -112,23 +111,27 @@ class Flux(Wrapper):
     def event_recv(self, topic=None):
         return self.recv(type_mask=raw.FLUX_MSGTYPE_EVENT, topic_glob=topic)
 
-    def msg_watcher_create(self, callback,
-                           type_mask=raw.FLUX_MSGTYPE_ANY,
-                           topic_glob='*',
-                           args=None,
-                           match_tag=raw.FLUX_MATCHTAG_NONE):
+    def msg_watcher_create(
+        self,
+        callback,
+        type_mask=raw.FLUX_MSGTYPE_ANY,
+        topic_glob="*",
+        args=None,
+        match_tag=raw.FLUX_MATCHTAG_NONE,
+    ):
         from flux.message import MessageWatcher
-        return MessageWatcher(self, type_mask, callback, topic_glob,
-                              match_tag, args)
+
+        return MessageWatcher(self, type_mask, callback, topic_glob, match_tag, args)
 
     def timer_watcher_create(self, after, callback, repeat=0.0, args=None):
         from flux.core.watchers import TimerWatcher
+
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)
 
     def barrier(self, name, nprocs):
         self.flux_barrier(name, nprocs)
 
     def get_rank(self):
-        rank = ffi.new('uint32_t [1]')
+        rank = ffi.new("uint32_t [1]")
         self.flux_get_rank(rank)
         return rank[0]

--- a/src/bindings/python/flux/core/inner.py
+++ b/src/bindings/python/flux/core/inner.py
@@ -9,12 +9,8 @@ class Core(Wrapper):
 
     def __init__(self):
         """Set up the wrapper interface for functions prefixed with flux_"""
-        super(Core, self).__init__(ffi,
-                                   lib,
-                                   prefixes=[
-                                       'flux_',
-                                       'FLUX_',
-                                   ])
+        super(Core, self).__init__(ffi, lib, prefixes=["flux_", "FLUX_"])
+
 
 # keeping this for compatibility
 # pylint: disable=invalid-name

--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -8,8 +8,7 @@ def mod_main_trampoline(name, int_handle, args):
     flux_instance = Flux(handle=lib.unpack_long(int_handle))
     user_mod = None
     try:
-        user_mod = importlib.import_module(
-            'flux.modules.' + name, 'flux.modules')
+        user_mod = importlib.import_module("flux.modules." + name, "flux.modules")
     except ImportError:  # check user paths for the module
         user_mod = importlib.import_module(name)
 

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -1,7 +1,7 @@
 import abc
 from flux.core.inner import raw, ffi
 
-__all__ = ['TimerWatcher', 'FDWatcher']
+__all__ = ["TimerWatcher", "FDWatcher"]
 
 
 class Watcher(object):
@@ -35,7 +35,8 @@ class Watcher(object):
             raw.flux_watcher_destroy(self.handle)
             self.handle = None
 
-@ffi.callback('flux_watcher_f')
+
+@ffi.callback("flux_watcher_f")
 def timeout_handler_wrapper(unused1, unused2, revents, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
@@ -43,8 +44,7 @@ def timeout_handler_wrapper(unused1, unused2, revents, opaque_handle):
 
 
 class TimerWatcher(Watcher):
-
-    def __init__(self, flux_handle, after, callback, repeat=0, args=None, ):
+    def __init__(self, flux_handle, after, callback, repeat=0, args=None):
         self.flux_handle = flux_handle
         self.after = after
         self.repeat = repeat
@@ -58,20 +58,20 @@ class TimerWatcher(Watcher):
                 float(after),
                 float(repeat),
                 timeout_handler_wrapper,
-                self.wargs))
+                self.wargs,
+            )
+        )
 
 
-@ffi.callback('flux_watcher_f')
+@ffi.callback("flux_watcher_f")
 def fd_handler_wrapper(unused1, unused2, revents, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
     fd_int = raw.fd_watcher_get_fd(watcher.handle)
-    watcher.callback(watcher.flux_handle, watcher,
-                     fd_int, revents, watcher.args)
+    watcher.callback(watcher.flux_handle, watcher, fd_int, revents, watcher.args)
 
 
 class FDWatcher(Watcher):
-
     def __init__(self, flux_handle, fd_int, events, callback, args=None):
         self.flux_handle = flux_handle
         self.fd_int = fd_int
@@ -86,4 +86,6 @@ class FDWatcher(Watcher):
                 self.fd_int,
                 self.events,
                 fd_handler_wrapper,
-                self.wargs))
+                self.wargs,
+            )
+        )

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -6,17 +6,18 @@ from flux.wrapper import Wrapper
 from flux.util import check_future_error
 from _flux._core import ffi, lib
 
+
 class JobWrapper(Wrapper):
     def __init__(self):
-        super(JobWrapper, self).__init__(ffi, lib, prefixes=['flux_job_',])
+        super(JobWrapper, self).__init__(ffi, lib, prefixes=["flux_job_"])
+
 
 RAW = JobWrapper()
 
-def submit_async(flux_handle, jobspec,
-                 priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
-                 flags=0):
+
+def submit_async(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
     if isinstance(jobspec, six.text_type):
-        jobspec = jobspec.encode('utf-8')
+        jobspec = jobspec.encode("utf-8")
     elif jobspec is None or jobspec == ffi.NULL:
         # catch this here rather than in C for a better error message
         raise EnvironmentError(errno.EINVAL, "jobspec must not be None/NULL")
@@ -26,14 +27,14 @@ def submit_async(flux_handle, jobspec,
     future = RAW.submit(flux_handle, jobspec, priority, flags)
     return future
 
+
 @check_future_error
 def submit_get_id(future):
-    jobid = ffi.new('flux_jobid_t[1]')
+    jobid = ffi.new("flux_jobid_t[1]")
     RAW.submit_get_id(future, jobid)
     return int(jobid[0])
 
-def submit(flux_handle, jobspec,
-           priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
-           flags=0):
+
+def submit(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
     future = submit_async(flux_handle, jobspec, priority, flags)
     return submit_get_id(future)

--- a/src/bindings/python/flux/jsc.py
+++ b/src/bindings/python/flux/jsc.py
@@ -15,6 +15,7 @@ for k in dir(lib):
         v = ffi.string(getattr(lib, k)).decode("ascii")
         setattr(MOD, k, v)
 
+
 class JSCWrapper(Wrapper):
     """
     Generic JSC wrapper
@@ -22,39 +23,37 @@ class JSCWrapper(Wrapper):
 
     def __init__(self):
         """Set up the wrapper interface for functions prefixed with jsc_"""
-        super(JSCWrapper, self).__init__(ffi,
-                                         lib,
-                                         prefixes=[
-                                             'jsc_',
-                                         ])
+        super(JSCWrapper, self).__init__(ffi, lib, prefixes=["jsc_"])
+
 
 RAW = JSCWrapper()
 
 
 def query_jcb(flux_handle, jobid, key):
-    jcb_str = ffi.new('char *[1]')
+    jcb_str = ffi.new("char *[1]")
     RAW.query_jcb(flux_handle, jobid, key, jcb_str)
     if jcb_str[0] == ffi.NULL:
         return None
-    return json.loads(ffi.string(jcb_str[0]).decode('utf-8'))
+    return json.loads(ffi.string(jcb_str[0]).decode("utf-8"))
 
 
 def update_jcb(flux_handle, jobid, key, jcb):
     # TODO: validate the key is one of the constants in jstatctl.h
     if isinstance(jcb, six.text_type):
-        jcb = jcb.encode('utf-8')
+        jcb = jcb.encode("utf-8")
     elif not isinstance(jcb, six.binary_type):
-        jcb = json.dumps(jcb).encode('utf-8')
+        jcb = json.dumps(jcb).encode("utf-8")
     return RAW.jsc_update_jcb(flux_handle, jobid, key, jcb)
 
 
-@ffi.callback('jsc_handler_f')
+@ffi.callback("jsc_handler_f")
 def jsc_notify_wrapper(jcb, arg, errnum):
     if jcb != ffi.NULL:
-        jcb = ffi.string(jcb).decode('utf-8')
+        jcb = ffi.string(jcb).decode("utf-8")
     callback, real_arg = ffi.from_handle(arg)
     ret = callback(jcb, real_arg, errnum)
     return ret if ret is not None else 0
+
 
 HANDLES = []
 
@@ -70,10 +69,11 @@ def job_num2state(job_state):
     ret = RAW.job_num2state(job_state)
     if ret == ffi.NULL:
         return None
-    return ret.decode('ascii')
+    return ret.decode("ascii")
+
 
 def job_state2num(job_state):
     if isinstance(job_state, six.text_type):
         # jsc doesn't use utf-8 internally, catch erroneous unicode here
-        job_state.encode('ascii')
+        job_state.encode("ascii")
     return RAW.job_state2num(job_state)

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -6,43 +6,47 @@ from flux.core.watchers import Watcher
 import flux.constants
 from flux.util import encode_payload, encode_topic
 
-__all__ = ['Message',
-           'MessageWatcher',
-           'msg_typestr']
+__all__ = ["Message", "MessageWatcher", "msg_typestr"]
 
 
 def msg_typestr(msg_type):
     # the returned string is guaranteed to be ascii
-    return ffi.string(raw.flux_msg_typestr(msg_type)).decode('ascii')
+    return ffi.string(raw.flux_msg_typestr(msg_type)).decode("ascii")
+
 
 class Message(WrapperPimpl):
     """ Flux message wrapper class. """
 
     class InnerWrapper(Wrapper):
-
-        def __init__(self,
-                     type_id=flux.constants.FLUX_MSGTYPE_REQUEST,
-                     handle=None,
-                     destruct=False,):
+        def __init__(
+            self,
+            type_id=flux.constants.FLUX_MSGTYPE_REQUEST,
+            handle=None,
+            destruct=False,
+        ):
             super(Message.InnerWrapper, self).__init__(
-                ffi, lib,
+                ffi,
+                lib,
                 handle=handle,
                 match=ffi.typeof(lib.flux_msg_create).result,
-                prefixes=['flux_msg_', 'FLUX_MSG'],
-                destructor=raw.flux_msg_destroy if destruct else None,)
+                prefixes=["flux_msg_", "FLUX_MSG"],
+                destructor=raw.flux_msg_destroy if destruct else None,
+            )
             self.destruct = destruct
             if handle is None:
                 self.handle = raw.flux_msg_create(type_id)
 
         def __del__(self):
-            if ((not self.external or self.destruct) and
-                    self.handle is not None and self.handle != ffi.NULL):
+            if (
+                (not self.external or self.destruct)
+                and self.handle is not None
+                and self.handle != ffi.NULL
+            ):
                 raw.flux_msg_destroy(self.handle)
 
-    def __init__(self,
-                 type_id=flux.constants.FLUX_MSGTYPE_REQUEST,
-                 handle=None,
-                 destruct=False,):
+    def __init__(
+        self, type_id=flux.constants.FLUX_MSGTYPE_REQUEST, handle=None, destruct=False
+    ):
         super(Message, self).__init__()
         self.pimpl = self.InnerWrapper(type_id, handle, destruct)
 
@@ -58,9 +62,9 @@ class Message(WrapperPimpl):
 
     @property
     def topic(self):
-        topic_string = ffi.new('char *[1]')
+        topic_string = ffi.new("char *[1]")
         self.pimpl.get_topic(topic_string)
-        return ffi.string(topic_string[0]).decode('utf-8')
+        return ffi.string(topic_string[0]).decode("utf-8")
 
     @topic.setter
     def topic(self, value):
@@ -69,10 +73,10 @@ class Message(WrapperPimpl):
 
     @property
     def payload_str(self):
-        string = ffi.new('char *[1]')
+        string = ffi.new("char *[1]")
         if self.pimpl.has_payload():
-            self.pimpl.get_string(ffi.cast('char**', string))
-            return ffi.string(string[0]).decode('utf-8')
+            self.pimpl.get_string(ffi.cast("char**", string))
+            return ffi.string(string[0]).decode("utf-8")
         return None
 
     @payload_str.setter
@@ -89,7 +93,7 @@ class Message(WrapperPimpl):
 
     @property
     def type(self):
-        message_type = ffi.new('int [1]')
+        message_type = ffi.new("int [1]")
         self.pimpl.get_type(message_type)
         return message_type[0]
 
@@ -101,40 +105,46 @@ class Message(WrapperPimpl):
     def type_str(self):
         return msg_typestr(self.type)
 
+
 # Residing here to avoid cyclic references
 
 
-@ffi.callback('flux_msg_handler_f')
+@ffi.callback("flux_msg_handler_f")
 def message_handler_wrapper(unused1, unused2, msg_handle, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
-    watcher.callback(watcher.flux_handle, watcher,
-                     Message(handle=msg_handle,
-                             destruct=False), watcher.args)
+    watcher.callback(
+        watcher.flux_handle,
+        watcher,
+        Message(handle=msg_handle, destruct=False),
+        watcher.args,
+    )
 
 
 class MessageWatcher(Watcher):
-
-    def __init__(self, flux_handle, type_mask, callback,
-                 topic_glob='*',
-                 match_tag=flux.constants.FLUX_MATCHTAG_NONE,
-                 args=None):
+    def __init__(
+        self,
+        flux_handle,
+        type_mask,
+        callback,
+        topic_glob="*",
+        match_tag=flux.constants.FLUX_MATCHTAG_NONE,
+        args=None,
+    ):
         self.flux_handle = flux_handle
         self.callback = callback
         self.args = args
         self.wargs = ffi.new_handle(self)
-        c_topic_glob = ffi.new('char[]', topic_glob)
-        match = ffi.new('struct flux_match *', {
-            'typemask': type_mask,
-            'matchtag': match_tag,
-            'topic_glob': c_topic_glob,
-        })
+        c_topic_glob = ffi.new("char[]", topic_glob)
+        match = ffi.new(
+            "struct flux_match *",
+            {"typemask": type_mask, "matchtag": match_tag, "topic_glob": c_topic_glob},
+        )
         super(MessageWatcher, self).__init__(
             raw.flux_msg_handler_create(
-                self.flux_handle.handle,
-                match[0],
-                message_handler_wrapper,
-                self.wargs))
+                self.flux_handle.handle, match[0], message_handler_wrapper, self.wargs
+            )
+        )
 
     def start(self):
         raw.flux_msg_handler_start(self.handle)

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -5,57 +5,59 @@ from flux.core.inner import ffi, lib, raw
 import flux.constants
 from flux.util import check_future_error, encode_payload, encode_topic
 
+
 class RPC(WrapperPimpl):
     """An RPC state object"""
-    class InnerWrapper(Wrapper):
 
-        def __init__(self,
-                     flux_handle,
-                     topic,
-                     payload=None,
-                     nodeid=flux.constants.FLUX_NODEID_ANY,
-                     flags=0):
+    class InnerWrapper(Wrapper):
+        def __init__(
+            self,
+            flux_handle,
+            topic,
+            payload=None,
+            nodeid=flux.constants.FLUX_NODEID_ANY,
+            flags=0,
+        ):
             # hold a reference for destructor ordering
             self._handle = flux_handle
             dest = raw.flux_future_destroy
             super(RPC.InnerWrapper, self).__init__(
-                ffi, lib,
+                ffi,
+                lib,
                 handle=None,
                 match=ffi.typeof(lib.flux_rpc).result,
-                prefixes=['flux_rpc_'],
-                destructor=dest)
+                prefixes=["flux_rpc_"],
+                destructor=dest,
+            )
             if isinstance(flux_handle, Wrapper):
                 flux_handle = flux_handle.handle
 
             topic = encode_topic(topic)
             payload = encode_payload(payload)
 
-            self.handle = raw.flux_rpc(
-                flux_handle, topic, payload, nodeid, flags)
+            self.handle = raw.flux_rpc(flux_handle, topic, payload, nodeid, flags)
 
-    def __init__(self,
-                 flux_handle,
-                 topic,
-                 payload=None,
-                 nodeid=flux.constants.FLUX_NODEID_ANY,
-                 flags=0):
+    def __init__(
+        self,
+        flux_handle,
+        topic,
+        payload=None,
+        nodeid=flux.constants.FLUX_NODEID_ANY,
+        flags=0,
+    ):
         super(RPC, self).__init__()
-        self.pimpl = self.InnerWrapper(flux_handle,
-                                       topic,
-                                       payload,
-                                       nodeid,
-                                       flags)
+        self.pimpl = self.InnerWrapper(flux_handle, topic, payload, nodeid, flags)
         self.then_args = None
         self.then_cb = None
 
     # TODO: replace with first-class future support
     @check_future_error
     def get_str(self):
-        j_str = ffi.new('char *[1]')
+        j_str = ffi.new("char *[1]")
         self.pimpl.get(j_str)
         if j_str[0] == ffi.NULL:
             return None
-        return ffi.string(j_str[0]).decode('utf-8')
+        return ffi.string(j_str[0]).decode("utf-8")
 
     def get(self):
         resp_str = self.get_str()

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -6,9 +6,8 @@ import six
 
 from flux.core.inner import ffi, raw
 
-__all__ = ['check_future_error',
-           'encode_payload',
-           'encode_topic']
+__all__ = ["check_future_error", "encode_payload", "encode_topic"]
+
 
 def check_future_error(func):
     def func_wrapper(calling_obj, *args, **kwargs):
@@ -17,33 +16,37 @@ def check_future_error(func):
         except EnvironmentError as error:
             exception_tuple = sys.exc_info()
             try:
-                future = calling_obj.handle if hasattr(calling_obj, "handle") \
+                future = (
+                    calling_obj.handle
+                    if hasattr(calling_obj, "handle")
                     else calling_obj
+                )
                 errmsg = raw.flux_future_error_string(future)
             except EnvironmentError:
                 six.reraise(*exception_tuple)
             if errmsg is None:
                 six.reraise(*exception_tuple)
-            raise EnvironmentError(error.errno, errmsg.decode('utf-8'))
+            raise EnvironmentError(error.errno, errmsg.decode("utf-8"))
+
     return func_wrapper
+
 
 def encode_payload(payload):
     if payload is None or payload == ffi.NULL:
         payload = ffi.NULL
     elif isinstance(payload, six.text_type):
-        payload = payload.encode('UTF-8')
+        payload = payload.encode("UTF-8")
     elif not isinstance(payload, six.binary_type):
-        payload = json.dumps(payload,
-                             ensure_ascii=False).encode('UTF-8')
+        payload = json.dumps(payload, ensure_ascii=False).encode("UTF-8")
     return payload
+
 
 def encode_topic(topic):
     # Convert topic to utf-8 binary string
     if topic is None or topic == ffi.NULL:
-        raise EnvironmentError(errno.EINVAL,
-                               "Topic must not be None/NULL")
+        raise EnvironmentError(errno.EINVAL, "Topic must not be None/NULL")
     elif isinstance(topic, six.text_type):
-        topic = topic.encode('UTF-8')
+        topic = topic.encode("UTF-8")
     elif not isinstance(topic, six.binary_type):
         errmsg = "Topic must be a string, not {}".format(type(topic))
         raise TypeError(errno.EINVAL, errmsg)

--- a/src/bindings/python/make_binding.py
+++ b/src/bindings/python/make_binding.py
@@ -3,20 +3,50 @@ import os
 import re
 
 import argparse
+
 parser = argparse.ArgumentParser()
 
-parser.add_argument('header', help='C header file to parse', type=str)
-parser.add_argument('--include_header', help='Include base path', type=str, default='')
-parser.add_argument('--include_ffi', help='FFI module for inclusion', action='append', default=[])
-parser.add_argument('--package', help='Package prefix for module import', default=None)
-parser.add_argument('--path', help='Include base path', default='.')
-parser.add_argument('--search', help='append to header search path', action='append', default=[])
-parser.add_argument('--modname', help='Name for the module to be generated', default='_flux')
-parser.add_argument('--library', help='Library to include in the build', default='flux-core')
-parser.add_argument('--add_long_sub', help='Regex filter to apply whole-file of the form <match>|||<replacement>', action='append', default=[])
-parser.add_argument('--add_sub', '-a', help='Regex filter to apply in processing of the form <match>|||<replacement>', action='append', default=[])
-parser.add_argument('--extra_source', help='Source to add directly to the output, mainly for includes', type=str, default='')
-parser.add_argument('--ignore_header', help='Pattern to ignore when searching header files', default=[], action='append')
+parser.add_argument("header", help="C header file to parse", type=str)
+parser.add_argument("--include_header", help="Include base path", type=str, default="")
+parser.add_argument(
+    "--include_ffi", help="FFI module for inclusion", action="append", default=[]
+)
+parser.add_argument("--package", help="Package prefix for module import", default=None)
+parser.add_argument("--path", help="Include base path", default=".")
+parser.add_argument(
+    "--search", help="append to header search path", action="append", default=[]
+)
+parser.add_argument(
+    "--modname", help="Name for the module to be generated", default="_flux"
+)
+parser.add_argument(
+    "--library", help="Library to include in the build", default="flux-core"
+)
+parser.add_argument(
+    "--add_long_sub",
+    help="Regex filter to apply whole-file of the form <match>|||<replacement>",
+    action="append",
+    default=[],
+)
+parser.add_argument(
+    "--add_sub",
+    "-a",
+    help="Regex filter to apply in processing of the form <match>|||<replacement>",
+    action="append",
+    default=[],
+)
+parser.add_argument(
+    "--extra_source",
+    help="Source to add directly to the output, mainly for includes",
+    type=str,
+    default="",
+)
+parser.add_argument(
+    "--ignore_header",
+    help="Pattern to ignore when searching header files",
+    default=[],
+    action="append",
+)
 
 args = parser.parse_args()
 
@@ -26,116 +56,119 @@ absolute_head = os.path.abspath(os.path.join(args.path, args.header))
 args.search.insert(0, args.path)
 args.search = [os.path.abspath(f) for f in args.search]
 
+
 def find_first(path, name, extra=None):
-  for dirname in path:
-    filename = os.path.join(dirname, name)
-    if (os.path.isfile(filename)):
-      return filename
-  if extra is not None:
-    filename = os.path.join(extra, name)
-    if (os.path.isfile(filename)):
-      return filename
-  raise IOError(name)
+    for dirname in path:
+        filename = os.path.join(dirname, name)
+        if os.path.isfile(filename):
+            return filename
+    if extra is not None:
+        filename = os.path.join(extra, name)
+        if os.path.isfile(filename):
+            return filename
+    raise IOError(name)
 
-def process_header(f, including_path='.'):
-  global mega_header
-  if not os.path.isfile(f):
-      f = os.path.join(including_path, f)
-  f = os.path.abspath(f)
-  if f not in checked_heads:
-    for p in args.ignore_header:
-      if re.search(p, f):
-        checked_heads[f] = 1
-        return
-    with open(f, 'r') as header:
-      s = header.read()
-      # turn lin-continuations into single lines, any line ending in backslash
-      # newline has the backslash and newline removed
-      s = re.sub(r'\\\n', '', s)
-      # remove C-style comments, especially inside function declarations
-      s = re.sub(r'\/\*([\s\S]*?)\*\/', '', s)
-      # attempt to make argument lists single-line
-      s = re.sub(r',\s*\n', ', ', s, flags=re.MULTILINE)
-      # remove gcc-style attributes
-      s = re.sub(r'__attribute__\s*(([^;]*))', '', s)
 
-      for sub in args.add_long_sub:
-        [m, r] = sub.split('|||')
-        s = re.sub(m, r, s)
+def process_header(f, including_path="."):
+    global mega_header
+    if not os.path.isfile(f):
+        f = os.path.join(including_path, f)
+    f = os.path.abspath(f)
+    if f not in checked_heads:
+        for p in args.ignore_header:
+            if re.search(p, f):
+                checked_heads[f] = 1
+                return
+        with open(f, "r") as header:
+            s = header.read()
+            # turn lin-continuations into single lines, any line ending in backslash
+            # newline has the backslash and newline removed
+            s = re.sub(r"\\\n", "", s)
+            # remove C-style comments, especially inside function declarations
+            s = re.sub(r"\/\*([\s\S]*?)\*\/", "", s)
+            # attempt to make argument lists single-line
+            s = re.sub(r",\s*\n", ", ", s, flags=re.MULTILINE)
+            # remove gcc-style attributes
+            s = re.sub(r"__attribute__\s*(([^;]*))", "", s)
 
-      lines = s.split('\n')
+            for sub in args.add_long_sub:
+                [m, r] = sub.split("|||")
+                s = re.sub(m, r, s)
 
-      for sub in args.add_sub:
-        new_lines = []
-        [m, r] = sub.split('|||')
-        for l in lines:
-          l = re.sub(m, r, l)
-          new_lines.append(l)
-        lines = new_lines
+            lines = s.split("\n")
 
-      in_ifdef = False
-      in_ifndef = False
-      for l in lines:
-        # The compiler can't handle the 'extern "C" {' directive,
-        # so we need to manually honor the '#ifdef __cplusplus'
-        # preprocessor block to make the directive disappear.
-        # Assumes no nesting of preprocessor conditionals below
-        # __cplusplus conditionals.  Can handle either #ifdef or
-        # #ifndef, and the associated #else.
-        if in_ifndef:
-          if re.match("#\s*else", l):
-            in_ifndef = False
-            in_ifdef = True
-            continue
-          else:
-            pass # allow the line to be included
-        elif in_ifdef:
-          if re.match("#\s*(endif|else)", l):
+            for sub in args.add_sub:
+                new_lines = []
+                [m, r] = sub.split("|||")
+                for l in lines:
+                    l = re.sub(m, r, l)
+                    new_lines.append(l)
+                lines = new_lines
+
             in_ifdef = False
-          continue
-        elif re.match("#\s*ifdef\s+__cplusplus", l):
-          in_ifdef = True
-          continue
-        elif re.match("#\s*ifndef\s+__cplusplus", l):
-          in_ifndef = True
-          continue
+            in_ifndef = False
+            for l in lines:
+                # The compiler can't handle the 'extern "C" {' directive,
+                # so we need to manually honor the '#ifdef __cplusplus'
+                # preprocessor block to make the directive disappear.
+                # Assumes no nesting of preprocessor conditionals below
+                # __cplusplus conditionals.  Can handle either #ifdef or
+                # #ifndef, and the associated #else.
+                if in_ifndef:
+                    if re.match("#\s*else", l):
+                        in_ifndef = False
+                        in_ifdef = True
+                        continue
+                    else:
+                        pass  # allow the line to be included
+                elif in_ifdef:
+                    if re.match("#\s*(endif|else)", l):
+                        in_ifdef = False
+                    continue
+                elif re.match("#\s*ifdef\s+__cplusplus", l):
+                    in_ifdef = True
+                    continue
+                elif re.match("#\s*ifndef\s+__cplusplus", l):
+                    in_ifndef = True
+                    continue
 
-        m = re.search('#include\s*"([^"]*)"', l)
-        if m:
-          nf = find_first (args.search, m.group(1), including_path)
-          process_header(nf, os.path.dirname(os.path.abspath(nf)))
-        if not re.match("#\s*(ifdef|ifndef|endif|include|define)", l):
-          mega_header += l+'\n'
-    checked_heads[f] = 1
+                m = re.search('#include\s*"([^"]*)"', l)
+                if m:
+                    nf = find_first(args.search, m.group(1), including_path)
+                    process_header(nf, os.path.dirname(os.path.abspath(nf)))
+                if not re.match("#\s*(ifdef|ifndef|endif|include|define)", l):
+                    mega_header += l + "\n"
+        checked_heads[f] = 1
 
 
-with open('{}_build.py'.format(args.modname), 'w') as modfile:
-  os.chdir(args.path)
+with open("{}_build.py".format(args.modname), "w") as modfile:
+    os.chdir(args.path)
 
-  mega_header = ''
-  checked_heads = {}
+    mega_header = ""
+    checked_heads = {}
 
-  process_header(absolute_head)
+    process_header(absolute_head)
 
-  include_head = args.header
-  if args.include_header != '':
-    include_head = args.include_header
+    include_head = args.header
+    if args.include_header != "":
+        include_head = args.include_header
 
-  mega_header = """
-  """ + mega_header
+    mega_header = (
+        """
+  """
+        + mega_header
+    )
 
-  ffi_include_base = '''
+    ffi_include_base = """
 from {module} import ffi as {module}_ffi
 ffi.include({module}_ffi)
-  '''
-  ffi_include = ''
-  for inc in args.include_ffi:
-    ffi_include += ffi_include_base.format(module=inc)
+  """
+    ffi_include = ""
+    for inc in args.include_ffi:
+        ffi_include += ffi_include_base.format(module=inc)
 
-
-
-
-  print('''
+    print(
+        '''
 #pylint: skip-file
 # This is a generated file... linting is less than useful
 from cffi import FFI
@@ -171,11 +204,15 @@ void free(void *ptr);
 if __name__ == "__main__":
   ffi.emit_c_code('{modname}.c')
     '''.format(
-        cdefs=mega_header,
-        full_mod=args.modname if args.package is None else '.'.join([args.package,args.modname]),
-        modname=args.modname,
-        library=args.library,
-        header=include_head,
-        extra_source=args.extra_source,
-        includes=ffi_include
-        ),file=modfile)
+            cdefs=mega_header,
+            full_mod=args.modname
+            if args.package is None
+            else ".".join([args.package, args.modname]),
+            modname=args.modname,
+            library=args.library,
+            header=include_head,
+            extra_source=args.extra_source,
+            includes=ffi_include,
+        ),
+        file=modfile,
+    )

--- a/src/bindings/python/setup.py
+++ b/src/bindings/python/setup.py
@@ -2,16 +2,17 @@ from setuptools import setup
 import os
 
 here = os.path.abspath(os.path.dirname(__file__))
-cffi_dep='cffi>=1.1'
-setup(name="flux",
-      version="0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1a1",
-      description="Bindings to the flux resource manager API",
-      setup_requires=[cffi_dep],
-      cffi_modules=[
-          "_flux/_core_build.py:ffi",
-          "_flux/_jsc_build.py:ffi",
-          "_flux/_kvs_build.py:ffi",
-          "_flux/_kz_build.py:ffi",
-      ],
-      install_requires=[cffi_dep],
-      )
+cffi_dep = "cffi>=1.1"
+setup(
+    name="flux",
+    version="0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1a1",
+    description="Bindings to the flux resource manager API",
+    setup_requires=[cffi_dep],
+    cffi_modules=[
+        "_flux/_core_build.py:ffi",
+        "_flux/_jsc_build.py:ffi",
+        "_flux/_kvs_build.py:ffi",
+        "_flux/_kz_build.py:ffi",
+    ],
+    install_requires=[cffi_dep],
+)

--- a/src/modules/pymod/echo.py
+++ b/src/modules/pymod/echo.py
@@ -1,13 +1,15 @@
 import syslog
 import flux
 
+
 def echo_cb(h, typemask, message, arg):
     h.log(syslog.LOG_INFO, "in cb, args:{}".format((typemask, message, arg)))
-    h.respond (message, 0, message.payload_str)
+    h.respond(message, 0, message.payload_str)
     return 0
 
+
 def mod_main(h, *args):
-    with h.msg_watcher_create (echo_cb, topic_glob="echo.*") as mw:
-        if h.reactor_run (h.get_reactor(), 0) < 0:
-            h.fatal_error( "reactor start failed!")
+    with h.msg_watcher_create(echo_cb, topic_glob="echo.*") as mw:
+        if h.reactor_run(h.get_reactor(), 0) < 0:
+            h.fatal_error("reactor start failed!")
         h.log(syslog.LOG_INFO, "echo unloading")

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -8,26 +8,32 @@ import subprocess
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
 # ported from sharness.d/01-setup.sh
-srcdir = os.path.abspath(os.path.join(os.environ['srcdir'] if 'srcdir' in os.environ else "", ".."))
-builddir = os.path.abspath(os.path.join(os.environ['builddir'] if 'builddir' in os.environ else "", ".."))
+srcdir = os.path.abspath(
+    os.path.join(os.environ["srcdir"] if "srcdir" in os.environ else "", "..")
+)
+builddir = os.path.abspath(
+    os.path.join(os.environ["builddir"] if "builddir" in os.environ else "", "..")
+)
 flux_exe = os.path.join(builddir, "src", "cmd", "flux")
+
 
 def is_exe(fpath):
     return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
+
 def rerun_under_flux(size=1, personality="full"):
     try:
-        if os.environ['IN_SUBFLUX'] == "1":
+        if os.environ["IN_SUBFLUX"] == "1":
             return True
     except KeyError:
         pass
 
     child_env = dict(**os.environ)
-    child_env['IN_SUBFLUX'] = "1"
+    child_env["IN_SUBFLUX"] = "1"
 
     # ported from sharness.d/flux-sharness.sh
-    child_env['FLUX_BUILD_DIR'] = builddir
-    child_env['FLUX_SOURCE_DIR'] = srcdir
+    child_env["FLUX_BUILD_DIR"] = builddir
+    child_env["FLUX_SOURCE_DIR"] = srcdir
     for rc_num in [1, 3]:
         env_var = "FLUX_RC{}_PATH".format(rc_num)
         if personality == "full":
@@ -42,10 +48,17 @@ def rerun_under_flux(size=1, personality="full"):
                 print("cannot execute {}".format(path), file=sys.stderr)
                 sys.exit(1)
 
-    command = [flux_exe, 'start',
-               '--bootstrap=selfpmi',
-               '--size',str(size),
-               sys.executable, sys.argv[0]]
-    p = subprocess.Popen(command, env=child_env, bufsize=-1, stdout=sys.stdout, stderr=sys.stderr)
+    command = [
+        flux_exe,
+        "start",
+        "--bootstrap=selfpmi",
+        "--size",
+        str(size),
+        sys.executable,
+        sys.argv[0],
+    ]
+    p = subprocess.Popen(
+        command, env=child_env, bufsize=-1, stdout=sys.stdout, stderr=sys.stderr
+    )
     p.wait()
     return False

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -8,8 +8,10 @@ import six
 import flux
 from subflux import rerun_under_flux
 
+
 def __flux_size():
     return 2
+
 
 class TestHandle(unittest.TestCase):
     @classmethod
@@ -27,34 +29,38 @@ class TestHandle(unittest.TestCase):
 
     def test_log(self):
         """Successfully connected to flux"""
-        self.f.log(syslog.LOG_INFO, u'hello')
-        self.f.log(syslog.LOG_INFO, b'world')
+        self.f.log(syslog.LOG_INFO, u"hello")
+        self.f.log(syslog.LOG_INFO, b"world")
 
     def test_rpc_ping(self):
         """Sending a ping"""
         # python 3 json doesn't support bytes, but python 2 will treat them as str (i.e., bytes)
-        r = self.f.rpc_send(b'cmb.ping', {'seq': 1, 'pad': 'stuff'})
-        self.assertEqual(r['seq'], 1)
-        self.assertEqual(r['pad'], u'stuff')
-        self.assertTrue(isinstance(r['pad'], six.text_type))
+        r = self.f.rpc_send(b"cmb.ping", {"seq": 1, "pad": "stuff"})
+        self.assertEqual(r["seq"], 1)
+        self.assertEqual(r["pad"], u"stuff")
+        self.assertTrue(isinstance(r["pad"], six.text_type))
 
     def test_rpc_ping_unicode(self):
         """Sending a ping"""
-        r = self.f.rpc_send(u'cmb.ping', {u'\xa3' : u'value', u'key' : u'\u32db \u263a \u32e1'})
-        self.assertEqual(r[u'\xa3'], u'value')
-        self.assertEqual(r['key'], u'\u32db \u263a \u32e1')
-        self.assertTrue(isinstance(r['key'], six.text_type))
+        r = self.f.rpc_send(
+            u"cmb.ping", {u"\xa3": u"value", u"key": u"\u32db \u263a \u32e1"}
+        )
+        self.assertEqual(r[u"\xa3"], u"value")
+        self.assertEqual(r["key"], u"\u32db \u263a \u32e1")
+        self.assertTrue(isinstance(r["key"], six.text_type))
 
     def test_rpc_with(self):
         """Sending a ping"""
-        with self.f.rpc_create('cmb.ping', {'seq': 1, 'pad': 'stuff'}) as r:
+        with self.f.rpc_create("cmb.ping", {"seq": 1, "pad": "stuff"}) as r:
             j = r.get()
-            self.assertEqual(j['seq'], 1)
-            self.assertEqual(j['pad'], 'stuff')
+            self.assertEqual(j["seq"], 1)
+            self.assertEqual(j["pad"], "stuff")
 
     def test_rpc_null_payload(self):
         """Sending a request that receives a NULL response"""
-        resp = self.f.rpc_send("attr.set", {"name": "attr-that-doesnt-exist", "value": "foo"})
+        resp = self.f.rpc_send(
+            "attr.set", {"name": "attr-that-doesnt-exist", "value": "foo"}
+        )
         self.assertIsNone(resp)
 
     def test_get_rank(self):
@@ -62,7 +68,9 @@ class TestHandle(unittest.TestCase):
         rank = self.f.get_rank()
         self.assertEqual(rank, 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0002-wrapper.py
+++ b/t/python/t0002-wrapper.py
@@ -6,48 +6,55 @@ from flux.core.inner import ffi, raw
 import flux.wrapper
 from subflux import rerun_under_flux
 
+
 def __flux_size():
     return 1
 
+
 class TestWrapper(unittest.TestCase):
     def test_call_non_existant(self):
-        f = flux.Flux('loop://')
+        f = flux.Flux("loop://")
         with self.assertRaises(flux.wrapper.MissingFunctionError):
             f.non_existant_function_that_should_die("stuff")
 
     def test_call_insufficient_arguments(self):
-        f = flux.Flux('loop://')
+        f = flux.Flux("loop://")
         with self.assertRaises(flux.wrapper.WrongNumArguments):
             f.request_encode(self)
 
     def test_call_invalid_argument_type(self):
-        f = flux.Flux('loop://')
+        f = flux.Flux("loop://")
         with self.assertRaises(flux.wrapper.InvalidArguments):
-          f.request_encode(self, 15)
+            f.request_encode(self, 15)
 
     def test_automatic_unwrapping(self):
-      flux.core.inner.raw.flux_log(flux.Flux('loop://'), 0, 'stuff')
+        flux.core.inner.raw.flux_log(flux.Flux("loop://"), 0, "stuff")
 
     def test_masked_function(self):
-      with self.assertRaisesRegexp(AttributeError, r'.*masks function.*'):
-        flux.Flux('loop://').rpc_create('topic').pimpl.flux_request_encode('request', 15)
+        with self.assertRaisesRegexp(AttributeError, r".*masks function.*"):
+            flux.Flux("loop://").rpc_create("topic").pimpl.flux_request_encode(
+                "request", 15
+            )
 
     def test_set_pimpl_handle(self):
-      f = flux.Flux('loop://')
-      r = f.rpc_create('topic')
-      r.handle = raw.flux_rpc(f.handle, 'other topic', ffi.NULL, flux.constants.FLUX_NODEID_ANY, 0)
+        f = flux.Flux("loop://")
+        r = f.rpc_create("topic")
+        r.handle = raw.flux_rpc(
+            f.handle, "other topic", ffi.NULL, flux.constants.FLUX_NODEID_ANY, 0
+        )
 
     def test_set_pimpl_handle_invalid(self):
-      f = flux.Flux('loop://')
-      r = f.rpc_create('topic')
-      with self.assertRaisesRegexp(TypeError, r'.*expected a.*'):
-          r.handle = f.rpc_create("other topic")
+        f = flux.Flux("loop://")
+        r = f.rpc_create("topic")
+        with self.assertRaisesRegexp(TypeError, r".*expected a.*"):
+            r.handle = f.rpc_create("other topic")
 
     def test_read_basic_value(self):
-      self.assertGreater(flux.constants.FLUX_NODEID_ANY, 0)
+        self.assertGreater(flux.constants.FLUX_NODEID_ANY, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0003-barrier.py
+++ b/t/python/t0003-barrier.py
@@ -8,14 +8,17 @@ from six.moves import range as range
 import flux
 from subflux import rerun_under_flux
 
+
 def barr_count(x, name, count):
     print(x, name, count)
     f = flux.Flux()
-    f.barrier(name,count)
+    f.barrier(name, count)
     f.close()
+
 
 def __flux_size():
     return 8
+
 
 class TestBarrier(unittest.TestCase):
     @classmethod
@@ -27,11 +30,11 @@ class TestBarrier(unittest.TestCase):
         self.f.close()
 
     def test_single(self):
-        self.f.barrier('testbarrier1', 1)
-        self.f.barrier(u'testbarrier1', 1)
+        self.f.barrier("testbarrier1", 1)
+        self.f.barrier(u"testbarrier1", 1)
 
     def test_eight(self):
-        for topic in [b'testbarrier2', u'\xa3', u'\u32db \u263a \u32e1']:
+        for topic in [b"testbarrier2", u"\xa3", u"\u32db \u263a \u32e1"]:
             for i in range(1, 9):
                 p = mp.Pool(i)
                 reslist = []
@@ -39,7 +42,9 @@ class TestBarrier(unittest.TestCase):
                     res = p.apply_async(barr_count, (j, topic, i))
                     reslist.append(res)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0004-event.py
+++ b/t/python/t0004-event.py
@@ -6,6 +6,7 @@ import six
 import flux
 from subflux import rerun_under_flux
 
+
 def __flux_size():
     return 2
 
@@ -33,27 +34,27 @@ class TestEvent(unittest.TestCase):
 
     def test_full_event(self):
         """Subscribe send receive and unpack event"""
-        event_names = [b'testevent.3',
-                       u'\u32db \u263a \u32e1']
+        event_names = [b"testevent.3", u"\u32db \u263a \u32e1"]
         for event_name in event_names:
             self.assertGreaterEqual(self.f.event_subscribe(event_name), 0)
-            self.assertGreaterEqual(
-                self.f.event_send(event_name, {'test': 'yay!'}), 0)
+            self.assertGreaterEqual(self.f.event_send(event_name, {"test": "yay!"}), 0)
             evt = self.f.event_recv()
             self.assertIsNotNone(evt)
 
             if isinstance(event_name, six.binary_type):
-                self.assertEqual(evt.topic, event_name.decode('utf-8'))
+                self.assertEqual(evt.topic, event_name.decode("utf-8"))
             else:
                 self.assertEqual(evt.topic, event_name)
 
             pld = evt.payload
             self.assertIsNotNone(pld)
-            self.assertEqual(pld['test'], 'yay!')
+            self.assertEqual(pld["test"], "yay!")
             self.assertIsNotNone(evt.payload_str)
             self.assertGreaterEqual(self.f.event_unsubscribe(event_name), 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
-      from pycotap import TAPTestRunner
-      unittest.main(testRunner=TAPTestRunner())
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -8,8 +8,10 @@ import flux.kvs
 
 from subflux import rerun_under_flux
 
+
 def __flux_size():
     return 2
+
 
 class TestKVS(unittest.TestCase):
     @classmethod
@@ -28,7 +30,7 @@ class TestKVS(unittest.TestCase):
         with flux.kvs.get_dir(self.f) as d:
             self.assertIsNotNone(d)
 
-    def set_and_check_context(self, key, value, msg=''):
+    def set_and_check_context(self, key, value, msg=""):
         kd = flux.kvs.KVSDir(self.f)
         kd[key] = value
         kd.commit()
@@ -38,66 +40,62 @@ class TestKVS(unittest.TestCase):
         return kd
 
     def test_set_int(self):
-        self.set_and_check_context('int', 10)
+        self.set_and_check_context("int", 10)
 
     def test_set_float(self):
-        self.set_and_check_context('float', 10.5)
+        self.set_and_check_context("float", 10.5)
 
     def test_set_string(self):
-        self.set_and_check_context('string', "stuff")
+        self.set_and_check_context("string", "stuff")
 
     def test_set_unicode(self):
-        self.set_and_check_context(u'unicode', u'\u32db \u263a \u32e1')
+        self.set_and_check_context(u"unicode", u"\u32db \u263a \u32e1")
 
     def test_set_list(self):
-        self.set_and_check_context('list', [1, 2, 3, 4])
+        self.set_and_check_context("list", [1, 2, 3, 4])
 
     def test_set_dict(self):
         self.set_and_check_context(
-            'dict', {'thing': 'stuff',
-                     'other thing': 'more stuff'})
+            "dict", {"thing": "stuff", "other thing": "more stuff"}
+        )
 
     def test_exists_dir(self):
         with flux.kvs.get_dir(self.f) as kd:
-            kd.mkdir('pytestdir')
-        self.assertTrue(flux.kvs.exists(self.f, 'pytestdir'))
+            kd.mkdir("pytestdir")
+        self.assertTrue(flux.kvs.exists(self.f, "pytestdir"))
 
     def test_exists_true(self):
-        flux.kvs.put(self.f, 'thing', 15)
+        flux.kvs.put(self.f, "thing", 15)
         flux.kvs.commit(self.f)
-        self.assertTrue(flux.kvs.exists(self.f, 'thing'))
+        self.assertTrue(flux.kvs.exists(self.f, "thing"))
 
     def test_exists_false(self):
-        self.assertFalse(flux.kvs.exists(self.f, 'argbah'))
+        self.assertFalse(flux.kvs.exists(self.f, "argbah"))
 
     def test_commit_flags(self):
-        flux.kvs.put(self.f, 'flagcheck', 42)
+        flux.kvs.put(self.f, "flagcheck", 42)
         flux.kvs.commit(self.f, 1)
-        self.assertTrue(flux.kvs.exists(self.f, 'flagcheck'))
+        self.assertTrue(flux.kvs.exists(self.f, "flagcheck"))
 
     def test_remove(self):
-        kd = self.set_and_check_context('todel', "things to delete")
-        del kd['todel']
+        kd = self.set_and_check_context("todel", "things to delete")
+        del kd["todel"]
         kd.commit()
         with self.assertRaises(KeyError):
-            stuff = kd['todel']
-            print (stuff)
+            stuff = kd["todel"]
+            print(stuff)
 
     def test_fill(self):
         with flux.kvs.get_dir(self.f) as kd:
-            kd.fill({
-                'things': 1,
-                'stuff': 'strstuff',
-                'dir.other_thing': 'dirstuff'
-            })
+            kd.fill({"things": 1, "stuff": "strstuff", "dir.other_thing": "dirstuff"})
             kd.commit()
 
-            self.assertEqual(kd['things'], 1)
-            self.assertEqual(kd['stuff'], 'strstuff')
-            self.assertEqual(kd['dir']['other_thing'], 'dirstuff')
+            self.assertEqual(kd["things"], 1)
+            self.assertEqual(kd["stuff"], "strstuff")
+            self.assertEqual(kd["dir"]["other_thing"], "dirstuff")
 
     def test_set_deep(self):
-        self.set_and_check_context('a.b.c.e.f.j.k', 5)
+        self.set_and_check_context("a.b.c.e.f.j.k", 5)
 
     def test_bad_init(self):
         with self.assertRaises(ValueError):
@@ -105,56 +103,61 @@ class TestKVS(unittest.TestCase):
 
     def test_key_at(self):
         with flux.kvs.get_dir(self.f) as kd:
-            kd.mkdir('testkeyat')
-        with flux.kvs.get_dir(self.f, 'testkeyat') as kd:
-            self.assertEqual(kd.key_at('meh'), 'testkeyat.meh')
+            kd.mkdir("testkeyat")
+        with flux.kvs.get_dir(self.f, "testkeyat") as kd:
+            self.assertEqual(kd.key_at("meh"), "testkeyat.meh")
 
     def test_walk_with_no_handle(self):
         with self.assertRaises(ValueError):
-            flux.kvs.walk('dir').next()
+            flux.kvs.walk("dir").next()
 
     def test_read_non_existent(self):
         with self.assertRaises(KeyError):
-            print (flux.kvs.KVSDir(self.f)[
-                'crazykeythatclearlydoesntexistandneverwillinanyuniverse'
-            ])
+            print(
+                flux.kvs.KVSDir(self.f)[
+                    "crazykeythatclearlydoesntexistandneverwillinanyuniverse"
+                ]
+            )
 
     def test_read_non_existent_basedir(self):
         with self.assertRaisesRegexp(EnvironmentError, "No such file"):
-            print(flux.kvs.KVSDir(
-                self.f,
-                'crazykeythatclearlydoesntexistandneverwillinanyuniverse')
-                  )
+            print(
+                flux.kvs.KVSDir(
+                    self.f, "crazykeythatclearlydoesntexistandneverwillinanyuniverse"
+                )
+            )
 
     def test_iterator(self):
-        keys = ['testdir1a.' + str(x) for x in range(1, 15)]
+        keys = ["testdir1a." + str(x) for x in range(1, 15)]
         with flux.kvs.get_dir(self.f) as kd:
             for k in keys:
                 kd[k] = "bar"
 
-        with flux.kvs.get_dir(self.f, 'testdir1a') as kd:
+        with flux.kvs.get_dir(self.f, "testdir1a") as kd:
             print(kd.keys())
             for k, v in kd.items():
-                self.assertEqual(v, 'bar')
+                self.assertEqual(v, "bar")
                 print("passed {}".format(k))
 
     def test_walk(self):
-        keys = ['testwalk.' + str(x) for x in range(1, 15)]
+        keys = ["testwalk." + str(x) for x in range(1, 15)]
         with flux.kvs.get_dir(self.f) as kd:
             for k in keys:
                 kd[k] = "bar"
-                kd[k + 'd.' + k] = 'meh'
-        walk_gen = flux.kvs.walk('testwalk', flux_handle=self.f, topdown=True)
+                kd[k + "d." + k] = "meh"
+        walk_gen = flux.kvs.walk("testwalk", flux_handle=self.f, topdown=True)
         (r, ds, fs) = next(walk_gen)
         print(r, ds, fs)
-        self.assertEqual(r, '')
+        self.assertEqual(r, "")
         self.assertEqual(len(list(ds)), 14)
         self.assertEqual(len(list(fs)), 14)
 
         for r, ds, fs in walk_gen:
             pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0006-request.py
+++ b/t/python/t0006-request.py
@@ -5,28 +5,31 @@ import errno
 import flux
 from subflux import rerun_under_flux
 
+
 def __flux_size():
-  return 2
+    return 2
 
-json_str = '{"a":42}';
+
+json_str = '{"a":42}'
+
+
 class TestRequestMethods(unittest.TestCase):
+    def test_no_topic_invalid(self):
+        """flux_request_encode returns EINVAL with no topic string"""
+        f = flux.Flux("loop://")
+        with self.assertRaises(EnvironmentError) as err:
+            f.request_encode(None, json_str)
+        err = err.exception
+        self.assertEqual(err.errno, errno.EINVAL)
 
-  def test_no_topic_invalid(self):
-    """flux_request_encode returns EINVAL with no topic string"""
-    f = flux.Flux('loop://')
-    with self.assertRaises(EnvironmentError) as err:
-        f.request_encode(None, json_str)
-    err = err.exception
-    self.assertEqual(err.errno, errno.EINVAL)
+    def test_null_payload(self):
+        """flux_request_encode works with NULL payload"""
+        f = flux.Flux("loop://")
+        self.assertTrue(f.request_encode("foo.bar", None) is not None)
 
-  def test_null_payload(self):
-    """flux_request_encode works with NULL payload"""
-    f = flux.Flux('loop://')
-    self.assertTrue(
-        f.request_encode("foo.bar", None) is not None
-        )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
-      from pycotap import TAPTestRunner
-      unittest.main(testRunner=TAPTestRunner())
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -4,8 +4,10 @@ import unittest
 import flux
 from subflux import rerun_under_flux
 
+
 def __flux_size():
-  return 2
+    return 2
+
 
 class TestTimer(unittest.TestCase):
     @classmethod
@@ -19,20 +21,22 @@ class TestTimer(unittest.TestCase):
     def test_timer_add_negative(self):
         """Add a negative timer"""
         with self.assertRaises(EnvironmentError):
-            self.f.timer_watcher_create(-500, lambda x, y:
-                                        x.fatal_error('timer should not run'))
+            self.f.timer_watcher_create(
+                -500, lambda x, y: x.fatal_error("timer should not run")
+            )
 
     def test_s1_0_timer_add(self):
         """Add a timer"""
-        with self.f.timer_watcher_create(10000, lambda x, y, z, w:
-                                         x.fatal_error(
-                                             'timer should not run')) as tid:
+        with self.f.timer_watcher_create(
+            10000, lambda x, y, z, w: x.fatal_error("timer should not run")
+        ) as tid:
             self.assertIsNotNone(tid)
 
     def test_s1_1_timer_remove(self):
         """Remove a timer"""
-        to = self.f.timer_watcher_create(10000, lambda x, y:
-                                         x.fatal_error('timer should not run'))
+        to = self.f.timer_watcher_create(
+            10000, lambda x, y: x.fatal_error("timer should not run")
+        )
         to.stop()
         to.destroy()
 
@@ -43,13 +47,16 @@ class TestTimer(unittest.TestCase):
         def cb(x, y, z, w):
             timer_ran[0] = True
             x.reactor_stop(self.f.get_reactor())
+
         with self.f.timer_watcher_create(0.1, cb) as timer:
             self.assertIsNotNone(timer, msg="timeout create")
             ret = self.f.reactor_run(self.f.get_reactor(), 0)
             self.assertEqual(ret, 0, msg="Reactor exit")
             self.assertTrue(timer_ran[0], msg="Timer did not run successfully")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0008-jsc.py
+++ b/t/python/t0008-jsc.py
@@ -6,30 +6,30 @@ from multiprocessing import Queue
 import flux
 import flux.jsc as jsc
 
+
 def __flux_size():
     return 2
+
 
 def jsc_cb_wait_until_reserved(jcb_str, arg, errnum):
     flux_handle, job_wait_queue = arg
     job_to_wait_for = job_wait_queue.get()
 
     jcb = json.loads(jcb_str)
-    jobid = jcb['jobid']
+    jobid = jcb["jobid"]
     new_state = jsc.job_num2state(jcb[jsc.JSC_STATE_PAIR][jsc.JSC_STATE_PAIR_NSTATE])
 
-    if jobid == job_to_wait_for and new_state == 'reserved':
+    if jobid == job_to_wait_for and new_state == "reserved":
         flux_handle.reactor_stop(flux_handle.get_reactor())
+
 
 class TestJSC(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.f = flux.Flux()
-        self.job_spec = json.dumps({
-            'nnodes': 1,
-            'ntasks': 1,
-            'cmdline': ['sleep', '0'],
-            'walltime' : 15,
-        })
+        self.job_spec = json.dumps(
+            {"nnodes": 1, "ntasks": 1, "cmdline": ["sleep", "0"], "walltime": 15}
+        )
 
     @classmethod
     def tearDownClass(self):
@@ -37,7 +37,7 @@ class TestJSC(unittest.TestCase):
 
     def test_00_job_create(self):
         resp = self.f.rpc_send("job.create", self.job_spec)
-        jobid = resp['jobid']
+        jobid = resp["jobid"]
         self.assertGreaterEqual(jobid, 0)
 
     def get_current_statepair(self, jobid):
@@ -47,7 +47,7 @@ class TestJSC(unittest.TestCase):
 
     def test_01_query(self):
         resp = self.f.rpc_send("job.create", self.job_spec)
-        jobid = resp['jobid']
+        jobid = resp["jobid"]
 
         state_pair = self.get_current_statepair(jobid)
         new_state = state_pair[jsc.JSC_STATE_PAIR_NSTATE]
@@ -58,11 +58,10 @@ class TestJSC(unittest.TestCase):
 
     def test_02_update(self):
         resp = self.f.rpc_send("job.create", self.job_spec)
-        jobid = resp['jobid']
+        jobid = resp["jobid"]
 
         target_state = jsc.job_state2num("complete")
-        new_state_pair = {jsc.JSC_STATE_PAIR :
-                      { jsc.JSC_STATE_PAIR_NSTATE : target_state }}
+        new_state_pair = {jsc.JSC_STATE_PAIR: {jsc.JSC_STATE_PAIR_NSTATE: target_state}}
         jsc.update_jcb(self.f, jobid, jsc.JSC_STATE_PAIR, new_state_pair)
 
         curr_state_pair = self.get_current_statepair(jobid)
@@ -73,12 +72,15 @@ class TestJSC(unittest.TestCase):
         jsc.notify_status(self.f, jsc_cb_wait_until_reserved, (self.f, job_wait_queue))
 
         resp = self.f.rpc_send("job.create", self.job_spec)
-        job_wait_queue.put(resp['jobid'])
+        job_wait_queue.put(resp["jobid"])
 
         self.assertGreaterEqual(self.f.reactor_run(self.f.get_reactor(), 0), 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from subflux import rerun_under_flux
+
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -5,8 +5,10 @@ from tempfile import NamedTemporaryFile
 
 from flux.security import SecurityContext
 
+
 def __flux_size():
     return 1
+
 
 class TestSecurity(unittest.TestCase):
     @classmethod
@@ -26,7 +28,7 @@ allowed-types = [ "none" ]
         unsigned_str = u"hello world"
         signed_str = self.context.sign_wrap(unsigned_str, mech_type="none")
         unwrapped_payload, wrapping_user = self.context.sign_unwrap(signed_str)
-        unwrapped_str = unwrapped_payload[:].decode('utf-8')
+        unwrapped_str = unwrapped_payload[:].decode("utf-8")
 
         self.assertEqual(unsigned_str, unwrapped_str)
         self.assertEqual(wrapping_user, os.getuid())
@@ -35,8 +37,11 @@ allowed-types = [ "none" ]
         with self.assertRaisesRegexp(EnvironmentError, "sign-unwrap:.*"):
             unwrapped_payload, wrapping_user = self.context.sign_unwrap(b"foo")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from subflux import rerun_under_flux
+
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -8,28 +8,30 @@ import flux
 from flux import job
 from flux.job import ffi
 
+
 def __flux_size():
     return 1
+
 
 class TestJob(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fh = flux.Flux()
 
-        jobspec_dir = os.path.abspath(os.path.join(os.environ['FLUX_SOURCE_DIR'],
-                                                   't', 'jobspec'))
-        ingest_dir = os.path.abspath(os.path.join(os.environ['FLUX_BUILD_DIR'],
-                                                  't', 'ingest'))
+        jobspec_dir = os.path.abspath(
+            os.path.join(os.environ["FLUX_SOURCE_DIR"], "t", "jobspec")
+        )
+        ingest_dir = os.path.abspath(
+            os.path.join(os.environ["FLUX_BUILD_DIR"], "t", "ingest")
+        )
 
         # load the dummy job manager
-        job_manager_path = os.path.join(ingest_dir, '.libs',
-                                        'job-manager-dummy.so')
-        self.fh.mrpc_create("cmb.insmod", {"path" : job_manager_path,
-                                           "args" : []})
+        job_manager_path = os.path.join(ingest_dir, ".libs", "job-manager-dummy.so")
+        self.fh.mrpc_create("cmb.insmod", {"path": job_manager_path, "args": []})
 
         # get a valid jobspec
         basic_jobspec_fname = os.path.join(jobspec_dir, "valid", "basic.yaml")
-        with open(basic_jobspec_fname, 'rb') as infile:
+        with open(basic_jobspec_fname, "rb") as infile:
             self.jobspec = infile.read()
 
     def test_00_null_submit(self):
@@ -53,8 +55,11 @@ class TestJob(unittest.TestCase):
         jobid = job.submit(self.fh, self.jobspec)
         self.assertGreater(jobid, 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from subflux import rerun_under_flux
+
     if rerun_under_flux(size=__flux_size(), personality="job"):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0011-mrpc.py
+++ b/t/python/t0011-mrpc.py
@@ -9,10 +9,13 @@ import unittest
 
 import flux
 
+
 def _flux_size():
     return 4
 
+
 script_dir = os.path.dirname(os.path.realpath(__file__))
+
 
 class TestMRPC(unittest.TestCase):
     @classmethod
@@ -29,77 +32,86 @@ class TestMRPC(unittest.TestCase):
 
     def test_00_mrpc_invalid_rankset(self):
         with self.assertRaises(EnvironmentError) as error:
-            ret = self.fh.mrpc_create("topic", {'foo':'bar'}, [])
+            ret = self.fh.mrpc_create("topic", {"foo": "bar"}, [])
         self.assertEqual(error.exception.errno, errno.EINVAL)
 
         with self.assertRaises(EnvironmentError) as error:
-            ret = self.fh.mrpc_create("topic", {'foo':'bar'}, 'foo')
+            ret = self.fh.mrpc_create("topic", {"foo": "bar"}, "foo")
         self.assertEqual(error.exception.errno, errno.EINVAL)
 
         with self.assertRaises(TypeError) as error:
-            ret = self.fh.mrpc_create("topic", {'foo':'bar'}, ['foo'])
+            ret = self.fh.mrpc_create("topic", {"foo": "bar"}, ["foo"])
 
     def test_01_mrpc_single(self):
-        responses = list(self.fh.mrpc_create("cmb.ping", {'foo':'bar'}, [0]))
+        responses = list(self.fh.mrpc_create("cmb.ping", {"foo": "bar"}, [0]))
         self.assertEqual(len(responses), 1)
         nodeid, payload = responses[0]
         self.assertEqual(nodeid, 0)
 
     def test_02_mrpc_explicit_rankset(self):
         rankset = [0, 2]
-        responses = sorted(self.fh.mrpc_create("cmb.ping", {'foo':'bar'}, rankset),
-                           key=lambda x: x[0])
+        responses = sorted(
+            self.fh.mrpc_create("cmb.ping", {"foo": "bar"}, rankset), key=lambda x: x[0]
+        )
         self.assertEqual(len(responses), len(rankset))
         for rank, (nodeid, payload) in zip(rankset, responses):
             self.assertEqual(rank, nodeid)
-            self.assertEqual(payload['foo'], 'bar')
+            self.assertEqual(payload["foo"], "bar")
 
     def test_03_mrpc_all(self):
         self.assertGreaterEqual(_flux_size(), 2)
         # test both unicode and binary rankset shorthands
-        for rankset in [b'all', u'all']:
-            responses = sorted(self.fh.mrpc_create("cmb.ping", payload={'foo':'bar'},
-                                    rankset=rankset),
-                               key=lambda x: x[0])
+        for rankset in [b"all", u"all"]:
+            responses = sorted(
+                self.fh.mrpc_create(
+                    "cmb.ping", payload={"foo": "bar"}, rankset=rankset
+                ),
+                key=lambda x: x[0],
+            )
             self.assertEqual(len(responses), _flux_size())
             for rank, (nodeid, payload) in zip(range(_flux_size()), responses):
                 self.assertEqual(rank, nodeid)
-                self.assertEqual(payload['foo'], 'bar')
+                self.assertEqual(payload["foo"], "bar")
 
     def test_04_mrpc_access_previous_payload(self):
         # test that payloads from the C API are copying and not invalidated
         # while iterating through responses
         self.assertGreaterEqual(_flux_size(), 2)
         prev_payloads = []
-        for nodeid, payload in self.fh.mrpc_create("cmb.ping", {'foo':'bar'}, 'all'):
+        for nodeid, payload in self.fh.mrpc_create("cmb.ping", {"foo": "bar"}, "all"):
             for prev_payload in prev_payloads:
-                self.assertEqual(payload['foo'], prev_payload['foo'])
+                self.assertEqual(payload["foo"], prev_payload["foo"])
                 self.assertItemsEqual(payload.keys(), prev_payload.keys())
 
     def test_05_unicode_args(self):
-        binary_topic = b'cmb.ping'
-        unicode_topic = u'cmb.ping'
+        binary_topic = b"cmb.ping"
+        unicode_topic = u"cmb.ping"
 
-        json_payload = {'foo': u'bar'}
+        json_payload = {"foo": u"bar"}
         unicode_payload = json.dumps(json_payload, ensure_ascii=False)
-        binary_payload = json.dumps(json_payload, ensure_ascii=False).encode('utf-8')
+        binary_payload = json.dumps(json_payload, ensure_ascii=False).encode("utf-8")
 
         for topic in [unicode_topic, binary_topic]:
-            resp = self.fh.mrpc_create(topic=topic, payload=json_payload, rankset=[0]).get()
-            self.assertEqual(resp['foo'], u'bar')
+            resp = self.fh.mrpc_create(
+                topic=topic, payload=json_payload, rankset=[0]
+            ).get()
+            self.assertEqual(resp["foo"], u"bar")
 
         for payload in [json_payload, unicode_payload, binary_payload]:
             resp = self.fh.mrpc_create(binary_topic, payload=payload, rankset=[0]).get()
-            self.assertEqual(resp['foo'], u'bar')
+            self.assertEqual(resp["foo"], u"bar")
 
     def test_06_null_response_payload(self):
-        resp = self.fh.mrpc_create("attr.set",
-                                   {"name" : "attr-that-doesnt-exist", "value": "foo"},
-                                   rankset=[0]).get()
+        resp = self.fh.mrpc_create(
+            "attr.set", {"name": "attr-that-doesnt-exist", "value": "foo"}, rankset=[0]
+        ).get()
         self.assertEqual(resp, None)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from subflux import rerun_under_flux
+
     if rerun_under_flux(size=_flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -5,21 +5,24 @@ import errno
 import flux
 from flux.message import Message
 from flux.core.inner import ffi
-from flux.constants import(FLUX_MSGTYPE_REQUEST,
-                           FLUX_MSGTYPE_RESPONSE)
+from flux.constants import FLUX_MSGTYPE_REQUEST, FLUX_MSGTYPE_RESPONSE
 
 from subflux import rerun_under_flux
 
+
 def __flux_size():
     return 2
+
 
 def service_add(f, name):
     future = f.service_register(name)
     return f.future_get(future, ffi.NULL)
 
+
 def service_remove(f, name):
     future = f.service_unregister(name)
     return f.future_get(future, ffi.NULL)
+
 
 class TestServiceAddRemove(unittest.TestCase):
     @classmethod
@@ -44,14 +47,14 @@ class TestServiceAddRemove(unittest.TestCase):
             rc = f.respond(msg, 0, msg.payload_str)
             self.assertEqual(rc, 0)
 
-        self.f.watcher = self.f.msg_watcher_create(service_cb,
-                                                 FLUX_MSGTYPE_REQUEST,
-                                                 "foo.*")
+        self.f.watcher = self.f.msg_watcher_create(
+            service_cb, FLUX_MSGTYPE_REQUEST, "foo.*"
+        )
         self.assertIsNotNone(self.f.watcher)
         self.f.watcher.start()
 
     def test_004_service_rpc(self):
-        cb_called = [False] # So that cb_called[0] is mutable in inner function
+        cb_called = [False]  # So that cb_called[0] is mutable in inner function
         p = {"test": "foo"}
 
         def cb(f, t, msg, arg):
@@ -59,8 +62,7 @@ class TestServiceAddRemove(unittest.TestCase):
             self.assertEqual(msg.payload, p)
             f.reactor_stop(f.get_reactor())
 
-        w2 = self.f.msg_watcher_create(cb, FLUX_MSGTYPE_RESPONSE,
-                                       "foo.echo")
+        w2 = self.f.msg_watcher_create(cb, FLUX_MSGTYPE_RESPONSE, "foo.echo")
         w2.start()
         self.assertIsNotNone(w2, msg="msg_watcher_create response handler")
 
@@ -97,14 +99,17 @@ class TestServiceAddRemove(unittest.TestCase):
 
     def test_008_service_remove_on_disconnect(self):
         from multiprocessing import Process
+
         #  Add "baz" service in a different process and let the
         #   process exit to cause a disconnect.
         #   then, ensure "baz" service was removed.
         #
         def add_service_and_disconnect():
             import sys
+
             h = flux.Flux()
             sys.exit(service_add(h, "baz"))
+
         p = Process(target=add_service_and_disconnect)
         p.start()
         p.join()
@@ -126,7 +131,9 @@ class TestServiceAddRemove(unittest.TestCase):
             fut.get()
         self.assertEqual(e.exception.errno, errno.EPROTO)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
+
         unittest.main(testRunner=TAPTestRunner())

--- a/t/python/tap/example/test_example.py
+++ b/t/python/tap/example/test_example.py
@@ -2,26 +2,31 @@
 # pylint: disable=C0325
 
 import sys, os
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 import unittest
 from pycotap import TAPTestRunner, LogMode
 
+
 class MyTests(unittest.TestCase):
-  def test_that_it_passes(self):
-    print("First line of output")
-    print("Second line of output")
-    self.assertEqual(0, 0)
+    def test_that_it_passes(self):
+        print("First line of output")
+        print("Second line of output")
+        self.assertEqual(0, 0)
 
-  @unittest.skip("Not finished yet")
-  def test_that_it_skips(self):
-    raise Exception("Does not happen")
+    @unittest.skip("Not finished yet")
+    def test_that_it_skips(self):
+        raise Exception("Does not happen")
 
-  def test_that_it_fails(self):
-    print("First line of output")
-    print("Second line of output")
-    self.assertEqual(1, 0)
+    def test_that_it_fails(self):
+        print("First line of output")
+        print("Second line of output")
+        self.assertEqual(1, 0)
 
-if __name__ == '__main__':
-  suite = unittest.TestLoader().loadTestsFromTestCase(MyTests)
-  TAPTestRunner(message_log = LogMode.LogToYAML, test_output_log = LogMode.LogToDiagnostics).run(suite)
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(MyTests)
+    TAPTestRunner(
+        message_log=LogMode.LogToYAML, test_output_log=LogMode.LogToDiagnostics
+    ).run(suite)

--- a/t/python/tap/pycotap/__init__.py
+++ b/t/python/tap/pycotap/__init__.py
@@ -9,142 +9,153 @@
 import unittest
 import sys
 import base64
+
 if sys.hexversion >= 0x03000000:
-  from io import StringIO
+    from io import StringIO
 else:
-  from StringIO import StringIO
+    from StringIO import StringIO
 
 # Log modes
-class LogMode(object) :
-  LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)
+class LogMode(object):
+    LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)
 
 
 class TAPTestResult(unittest.TestResult):
-  def __init__(self, output_stream, error_stream, message_log, test_output_log):
-    super(TAPTestResult, self).__init__(self, output_stream)
-    self.output_stream = output_stream
-    self.error_stream = error_stream
-    self.orig_stdout = None
-    self.orig_stderr = None
-    self.message = error_stream
-    self.test_output = None
-    self.message_log = message_log
-    self.test_output_log = test_output_log
-    self.output_stream.write("TAP version 13\n")
+    def __init__(self, output_stream, error_stream, message_log, test_output_log):
+        super(TAPTestResult, self).__init__(self, output_stream)
+        self.output_stream = output_stream
+        self.error_stream = error_stream
+        self.orig_stdout = None
+        self.orig_stderr = None
+        self.message = error_stream
+        self.test_output = None
+        self.message_log = message_log
+        self.test_output_log = test_output_log
+        self.output_stream.write("TAP version 13\n")
 
-  def print_raw(self, text):
-    self.output_stream.write(text)
-    self.output_stream.flush()
+    def print_raw(self, text):
+        self.output_stream.write(text)
+        self.output_stream.flush()
 
-  def print_result(self, result, test, directive = None):
-    self.output_stream.write("%s %d %s" % (result, self.testsRun, test.id()))
-    if directive:
-      self.output_stream.write(" # " + directive)
-    self.output_stream.write("\n")
-    self.output_stream.flush()
+    def print_result(self, result, test, directive=None):
+        self.output_stream.write("%s %d %s" % (result, self.testsRun, test.id()))
+        if directive:
+            self.output_stream.write(" # " + directive)
+        self.output_stream.write("\n")
+        self.output_stream.flush()
 
-  def ok(self, test, directive = None):
-    self.print_result("ok", test, directive)
+    def ok(self, test, directive=None):
+        self.print_result("ok", test, directive)
 
-  def not_ok(self, test):
-    self.print_result("not ok", test)
+    def not_ok(self, test):
+        self.print_result("not ok", test)
 
-  def startTest(self, test):
-    self.orig_stdout = sys.stdout
-    self.orig_stderr = sys.stderr
-    if self.message_log == LogMode.LogToError:
-      self.message = self.error_stream
-    else:
-      self.message = StringIO()
-    if self.test_output_log == LogMode.LogToError:
-      self.test_output = self.error_stream
-    else:
-      self.test_output = StringIO()
+    def startTest(self, test):
+        self.orig_stdout = sys.stdout
+        self.orig_stderr = sys.stderr
+        if self.message_log == LogMode.LogToError:
+            self.message = self.error_stream
+        else:
+            self.message = StringIO()
+        if self.test_output_log == LogMode.LogToError:
+            self.test_output = self.error_stream
+        else:
+            self.test_output = StringIO()
 
-    if self.message_log == self.test_output_log:
-      self.test_output = self.message
+        if self.message_log == self.test_output_log:
+            self.test_output = self.message
 
-    sys.stdout = sys.stderr = self.test_output
-    super(TAPTestResult, self).startTest(test)
+        sys.stdout = sys.stderr = self.test_output
+        super(TAPTestResult, self).startTest(test)
 
-  def stopTest(self, test):
-    super(TAPTestResult, self).stopTest(test)
-    sys.stdout = self.orig_stdout
-    sys.stderr = self.orig_stderr
-    if self.message_log == self.test_output_log:
-      logs = [(self.message_log, self.message, "output")]
-    else:
-      logs = [
-          (self.test_output_log, self.test_output, "test_output"),
-          (self.message_log, self.message, "message")
-      ]
-    for log_mode, log, log_name in logs:
-      if log_mode != LogMode.LogToError:
-        output = log.getvalue()
-        if len(output):
-          if log_mode == LogMode.LogToYAML:
-            self.print_raw("  ---\n")
-            self.print_raw("    " + log_name + ": |\n")
-            self.print_raw("      " + output.rstrip().replace("\n", "\n      ") + "\n")
-            self.print_raw("  ...\n")
-          elif log_mode == LogMode.LogToAttachment:
-            self.print_raw("  ---\n")
-            self.print_raw("    " + log_name + ":\n")
-            self.print_raw("      File-Name: " + log_name + ".txt\n")
-            self.print_raw("      File-Type: text/plain\n")
-            self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
-            self.print_raw("  ...\n")
-          else:
-            self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
+    def stopTest(self, test):
+        super(TAPTestResult, self).stopTest(test)
+        sys.stdout = self.orig_stdout
+        sys.stderr = self.orig_stderr
+        if self.message_log == self.test_output_log:
+            logs = [(self.message_log, self.message, "output")]
+        else:
+            logs = [
+                (self.test_output_log, self.test_output, "test_output"),
+                (self.message_log, self.message, "message"),
+            ]
+        for log_mode, log, log_name in logs:
+            if log_mode != LogMode.LogToError:
+                output = log.getvalue()
+                if len(output):
+                    if log_mode == LogMode.LogToYAML:
+                        self.print_raw("  ---\n")
+                        self.print_raw("    " + log_name + ": |\n")
+                        self.print_raw(
+                            "      " + output.rstrip().replace("\n", "\n      ") + "\n"
+                        )
+                        self.print_raw("  ...\n")
+                    elif log_mode == LogMode.LogToAttachment:
+                        self.print_raw("  ---\n")
+                        self.print_raw("    " + log_name + ":\n")
+                        self.print_raw("      File-Name: " + log_name + ".txt\n")
+                        self.print_raw("      File-Type: text/plain\n")
+                        self.print_raw(
+                            "      File-Content: " + base64.b64encode(output) + "\n"
+                        )
+                        self.print_raw("  ...\n")
+                    else:
+                        self.print_raw(
+                            "# " + output.rstrip().replace("\n", "\n# ") + "\n"
+                        )
 
-  def addSuccess(self, test):
-    super(TAPTestResult, self).addSuccess(test)
-    self.ok(test)
+    def addSuccess(self, test):
+        super(TAPTestResult, self).addSuccess(test)
+        self.ok(test)
 
-  def addError(self, test, err):
-    super(TAPTestResult, self).addError(test, err)
-    self.message.write(self.errors[-1][1] + "\n")
-    self.not_ok(test)
+    def addError(self, test, err):
+        super(TAPTestResult, self).addError(test, err)
+        self.message.write(self.errors[-1][1] + "\n")
+        self.not_ok(test)
 
-  def addFailure(self, test, err):
-    super(TAPTestResult, self).addFailure(test, err)
-    self.message.write(self.failures[-1][1] + "\n")
-    self.not_ok(test)
+    def addFailure(self, test, err):
+        super(TAPTestResult, self).addFailure(test, err)
+        self.message.write(self.failures[-1][1] + "\n")
+        self.not_ok(test)
 
-  def addSkip(self, test, reason):
-    super(TAPTestResult, self).addSkip(test, reason)
-    self.ok(test, "SKIP " + reason)
+    def addSkip(self, test, reason):
+        super(TAPTestResult, self).addSkip(test, reason)
+        self.ok(test, "SKIP " + reason)
 
-  def addExpectedFailure(self, test, err):
-    super(TAPTestResult, self).addExpectedFailure(test, err)
-    self.message.write(self.expectedFailures[-1][1] + "\n")
-    self.ok(test)
+    def addExpectedFailure(self, test, err):
+        super(TAPTestResult, self).addExpectedFailure(test, err)
+        self.message.write(self.expectedFailures[-1][1] + "\n")
+        self.ok(test)
 
-  def addUnexpectedSuccess(self, test):
-    super(TAPTestResult, self).addUnexpectedSuccess(self, test)
-    self.not_ok(test)
+    def addUnexpectedSuccess(self, test):
+        super(TAPTestResult, self).addUnexpectedSuccess(self, test)
+        self.not_ok(test)
 
-  def printErrors(self):
-    self.print_raw("1..%d\n" % self.testsRun)
+    def printErrors(self):
+        self.print_raw("1..%d\n" % self.testsRun)
 
 
 class TAPTestRunner(object):
-  def __init__(self,
-      message_log = LogMode.LogToYAML,
-      test_output_log = LogMode.LogToDiagnostics,
-      output_stream = sys.stdout, error_stream = sys.stderr):
-    self.output_stream = output_stream
-    self.error_stream = error_stream
-    self.message_log = message_log
-    self.test_output_log = test_output_log
+    def __init__(
+        self,
+        message_log=LogMode.LogToYAML,
+        test_output_log=LogMode.LogToDiagnostics,
+        output_stream=sys.stdout,
+        error_stream=sys.stderr,
+    ):
+        self.output_stream = output_stream
+        self.error_stream = error_stream
+        self.message_log = message_log
+        self.test_output_log = test_output_log
 
-  def run(self, test):
-    result = TAPTestResult(
-        self.output_stream,
-        self.error_stream,
-        self.message_log,
-        self.test_output_log)
-    test(result)
-    result.printErrors()
+    def run(self, test):
+        result = TAPTestResult(
+            self.output_stream,
+            self.error_stream,
+            self.message_log,
+            self.test_output_log,
+        )
+        test(result)
+        result.printErrors()
 
-    return result
+        return result

--- a/t/python/tap/setup.py
+++ b/t/python/tap/setup.py
@@ -4,15 +4,14 @@
 from setuptools import setup, find_packages
 
 setup(
-  name = "pycotap",
-  version = "1.0.0",
-  packages = find_packages(),
-
-  # Metadata
-  author = "Remko Tronçon",
-  author_email = "dev@el-tramo.be",
-  description = """A tiny test runner that outputs TAP results to standard output.""",
-  long_description = """
+    name="pycotap",
+    version="1.0.0",
+    packages=find_packages(),
+    # Metadata
+    author="Remko Tronçon",
+    author_email="dev@el-tramo.be",
+    description="""A tiny test runner that outputs TAP results to standard output.""",
+    long_description="""
 `pycotap` is a simple Python test runner for ``unittest`` that outputs
 `Test Anything Protocol <http://testanything.org>`_ results directly to standard output.
 
@@ -37,15 +36,15 @@ Contrary to other TAP runners for Python, ``pycotap`` ...
 Documentation and examples can be found on `the pycotap page
 <https://el-tramo.be/pycotap>`_.
 """,
-  license = "MIT",
-  keywords = "tap unittest testing",
-  url = "https://el-tramo.be/pycotap",
-  classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Topic :: Utilities",
-    "License :: OSI Approved :: MIT License",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Software Development :: Testing"
-  ],
+    license="MIT",
+    keywords="tap unittest testing",
+    url="https://el-tramo.be/pycotap",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Topic :: Utilities",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Software Development :: Testing",
+    ],
 )

--- a/t/python/tap/test/test.py
+++ b/t/python/tap/test/test.py
@@ -3,170 +3,221 @@
 # pylint: disable=C0325
 
 import sys, os
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 import unittest
 import re
+
 if sys.hexversion >= 0x03000000:
-  from io import StringIO
+    from io import StringIO
 else:
-  from StringIO import StringIO
+    from StringIO import StringIO
 
 from pycotap import TAPTestRunner, LogMode
 
+
 class TAPTestRunnerTest(unittest.TestCase):
-  class OutputTest(unittest.TestCase):
-    def test_failing(self):
-      print("Foo")
-      self.assertEqual(1, 2)
-      print("Bar")
-    def test_passing(self):
-      print("Foo")
-      sys.stderr.write("Baz\n")
-      print("Bar")
+    class OutputTest(unittest.TestCase):
+        def test_failing(self):
+            print("Foo")
+            self.assertEqual(1, 2)
+            print("Bar")
 
-  def setUp(self):
-    self.output_stream = StringIO()
-    self.error_stream = StringIO()
+        def test_passing(self):
+            print("Foo")
+            sys.stderr.write("Baz\n")
+            print("Bar")
 
-  def run_test(self, test_class, **kwargs):
-    suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
-    return TAPTestRunner(output_stream = self.output_stream, error_stream = self.error_stream, **kwargs).run(suite)
+    def setUp(self):
+        self.output_stream = StringIO()
+        self.error_stream = StringIO()
 
-  def process_output(self, output):
-    return re.sub(
-        r"File \".*\"",
-        "File \"test.py\"",
-        re.sub(r"line \d+", "line X", output))
+    def run_test(self, test_class, **kwargs):
+        suite = unittest.TestLoader().loadTestsFromTestCase(test_class)
+        return TAPTestRunner(
+            output_stream=self.output_stream, error_stream=self.error_stream, **kwargs
+        ).run(suite)
 
-  def test_all_test_outcomes(self):
-    class Test(unittest.TestCase):
-      def test_passing(self):
-        self.assertEqual(1, 1)
-      def test_failing(self):
-        self.assertEqual(1, 2)
-      @unittest.skip("Not finished yet")
-      def test_skipped(self):
-        self.assertEqual(1, 2)
+    def process_output(self, output):
+        return re.sub(
+            r"File \".*\"", 'File "test.py"', re.sub(r"line \d+", "line X", output)
+        )
 
-    self.run_test(Test, message_log = LogMode.LogToDiagnostics, test_output_log = LogMode.LogToDiagnostics)
-    self.assertEqual(self.process_output(self.output_stream.getvalue()), (
-      "TAP version 13\n"
-      "not ok 1 __main__.Test.test_failing\n"
-      "# Traceback (most recent call last):\n"
-      "#   File \"test.py\", line X, in test_failing\n"
-      "#     self.assertEqual(1, 2)\n"
-      "# AssertionError: 1 != 2\n"
-      "ok 2 __main__.Test.test_passing\n"
-      "ok 3 __main__.Test.test_skipped # SKIP Not finished yet\n"
-      "1..3\n"
-    ))
-    self.assertEqual("", self.error_stream.getvalue())
+    def test_all_test_outcomes(self):
+        class Test(unittest.TestCase):
+            def test_passing(self):
+                self.assertEqual(1, 1)
 
-  def test_log_output_to_diagnostics(self):
-    self.run_test(TAPTestRunnerTest.OutputTest, message_log = LogMode.LogToDiagnostics, test_output_log = LogMode.LogToDiagnostics)
-    self.assertEqual(self.process_output(self.output_stream.getvalue()), (
-      "TAP version 13\n"
-      "not ok 1 __main__.OutputTest.test_failing\n"
-      "# Foo\n"
-      "# Traceback (most recent call last):\n"
-      "#   File \"test.py\", line X, in test_failing\n"
-      "#     self.assertEqual(1, 2)\n"
-      "# AssertionError: 1 != 2\n"
-      "ok 2 __main__.OutputTest.test_passing\n"
-      "# Foo\n"
-      "# Baz\n"
-      "# Bar\n"
-      "1..2\n"
-    ))
-    self.assertEqual("", self.error_stream.getvalue())
+            def test_failing(self):
+                self.assertEqual(1, 2)
 
-  def test_log_output_to_yaml(self):
-    self.run_test(TAPTestRunnerTest.OutputTest, message_log = LogMode.LogToYAML, test_output_log = LogMode.LogToYAML)
-    self.assertEqual(self.process_output(self.output_stream.getvalue()), (
-      "TAP version 13\n"
-      "not ok 1 __main__.OutputTest.test_failing\n"
-      "  ---\n"
-      "    output: |\n"
-      "      Foo\n"
-      "      Traceback (most recent call last):\n"
-      "        File \"test.py\", line X, in test_failing\n"
-      "          self.assertEqual(1, 2)\n"
-      "      AssertionError: 1 != 2\n"
-      "  ...\n"
-      "ok 2 __main__.OutputTest.test_passing\n"
-      "  ---\n"
-      "    output: |\n"
-      "      Foo\n"
-      "      Baz\n"
-      "      Bar\n"
-      "  ...\n"
-      "1..2\n"
-    ))
-    self.assertEqual("", self.error_stream.getvalue())
+            @unittest.skip("Not finished yet")
+            def test_skipped(self):
+                self.assertEqual(1, 2)
 
-  def test_log_output_to_error(self):
-    self.run_test(TAPTestRunnerTest.OutputTest, message_log = LogMode.LogToError, test_output_log = LogMode.LogToError)
-    self.assertEqual(self.output_stream.getvalue(), (
-      "TAP version 13\n"
-      "not ok 1 __main__.OutputTest.test_failing\n"
-      "ok 2 __main__.OutputTest.test_passing\n"
-      "1..2\n"
-    ))
-    self.assertEqual(self.process_output(self.error_stream.getvalue()), (
-      "Foo\n"
-      "Traceback (most recent call last):\n"
-      "  File \"test.py\", line X, in test_failing\n"
-      "    self.assertEqual(1, 2)\n"
-      "AssertionError: 1 != 2\n"
-      "\n"
-      "Foo\n"
-      "Baz\n"
-      "Bar\n"
-    ))
+        self.run_test(
+            Test,
+            message_log=LogMode.LogToDiagnostics,
+            test_output_log=LogMode.LogToDiagnostics,
+        )
+        self.assertEqual(
+            self.process_output(self.output_stream.getvalue()),
+            (
+                "TAP version 13\n"
+                "not ok 1 __main__.Test.test_failing\n"
+                "# Traceback (most recent call last):\n"
+                '#   File "test.py", line X, in test_failing\n'
+                "#     self.assertEqual(1, 2)\n"
+                "# AssertionError: 1 != 2\n"
+                "ok 2 __main__.Test.test_passing\n"
+                "ok 3 __main__.Test.test_skipped # SKIP Not finished yet\n"
+                "1..3\n"
+            ),
+        )
+        self.assertEqual("", self.error_stream.getvalue())
 
-  def test_log_to_error_order(self):
-    self.output_stream = self.error_stream
-    self.run_test(TAPTestRunnerTest.OutputTest, message_log = LogMode.LogToError, test_output_log = LogMode.LogToError)
-    self.assertEqual(self.process_output(self.output_stream.getvalue()), (
-      "TAP version 13\n"
-      "Foo\n"
-      "Traceback (most recent call last):\n"
-      "  File \"test.py\", line X, in test_failing\n"
-      "    self.assertEqual(1, 2)\n"
-      "AssertionError: 1 != 2\n"
-      "\n"
-      "not ok 1 __main__.OutputTest.test_failing\n"
-      "Foo\n"
-      "Baz\n"
-      "Bar\n"
-      "ok 2 __main__.OutputTest.test_passing\n"
-      "1..2\n"
-    ))
+    def test_log_output_to_diagnostics(self):
+        self.run_test(
+            TAPTestRunnerTest.OutputTest,
+            message_log=LogMode.LogToDiagnostics,
+            test_output_log=LogMode.LogToDiagnostics,
+        )
+        self.assertEqual(
+            self.process_output(self.output_stream.getvalue()),
+            (
+                "TAP version 13\n"
+                "not ok 1 __main__.OutputTest.test_failing\n"
+                "# Foo\n"
+                "# Traceback (most recent call last):\n"
+                '#   File "test.py", line X, in test_failing\n'
+                "#     self.assertEqual(1, 2)\n"
+                "# AssertionError: 1 != 2\n"
+                "ok 2 __main__.OutputTest.test_passing\n"
+                "# Foo\n"
+                "# Baz\n"
+                "# Bar\n"
+                "1..2\n"
+            ),
+        )
+        self.assertEqual("", self.error_stream.getvalue())
 
-  def test_different_error_and_test_output_log(self):
-    self.run_test(TAPTestRunnerTest.OutputTest,
-        message_log = LogMode.LogToYAML, test_output_log = LogMode.LogToDiagnostics)
-    self.assertEqual(self.process_output(self.output_stream.getvalue()), (
-      "TAP version 13\n"
-      "not ok 1 __main__.OutputTest.test_failing\n"
-      "# Foo\n"
-      "  ---\n"
-      "    message: |\n"
-      "      Traceback (most recent call last):\n"
-      "        File \"test.py\", line X, in test_failing\n"
-      "          self.assertEqual(1, 2)\n"
-      "      AssertionError: 1 != 2\n"
-      "  ...\n"
-      "ok 2 __main__.OutputTest.test_passing\n"
-      "# Foo\n"
-      "# Baz\n"
-      "# Bar\n"
-      "1..2\n"
-    ))
-    self.assertEqual("", self.error_stream.getvalue())
+    def test_log_output_to_yaml(self):
+        self.run_test(
+            TAPTestRunnerTest.OutputTest,
+            message_log=LogMode.LogToYAML,
+            test_output_log=LogMode.LogToYAML,
+        )
+        self.assertEqual(
+            self.process_output(self.output_stream.getvalue()),
+            (
+                "TAP version 13\n"
+                "not ok 1 __main__.OutputTest.test_failing\n"
+                "  ---\n"
+                "    output: |\n"
+                "      Foo\n"
+                "      Traceback (most recent call last):\n"
+                '        File "test.py", line X, in test_failing\n'
+                "          self.assertEqual(1, 2)\n"
+                "      AssertionError: 1 != 2\n"
+                "  ...\n"
+                "ok 2 __main__.OutputTest.test_passing\n"
+                "  ---\n"
+                "    output: |\n"
+                "      Foo\n"
+                "      Baz\n"
+                "      Bar\n"
+                "  ...\n"
+                "1..2\n"
+            ),
+        )
+        self.assertEqual("", self.error_stream.getvalue())
+
+    def test_log_output_to_error(self):
+        self.run_test(
+            TAPTestRunnerTest.OutputTest,
+            message_log=LogMode.LogToError,
+            test_output_log=LogMode.LogToError,
+        )
+        self.assertEqual(
+            self.output_stream.getvalue(),
+            (
+                "TAP version 13\n"
+                "not ok 1 __main__.OutputTest.test_failing\n"
+                "ok 2 __main__.OutputTest.test_passing\n"
+                "1..2\n"
+            ),
+        )
+        self.assertEqual(
+            self.process_output(self.error_stream.getvalue()),
+            (
+                "Foo\n"
+                "Traceback (most recent call last):\n"
+                '  File "test.py", line X, in test_failing\n'
+                "    self.assertEqual(1, 2)\n"
+                "AssertionError: 1 != 2\n"
+                "\n"
+                "Foo\n"
+                "Baz\n"
+                "Bar\n"
+            ),
+        )
+
+    def test_log_to_error_order(self):
+        self.output_stream = self.error_stream
+        self.run_test(
+            TAPTestRunnerTest.OutputTest,
+            message_log=LogMode.LogToError,
+            test_output_log=LogMode.LogToError,
+        )
+        self.assertEqual(
+            self.process_output(self.output_stream.getvalue()),
+            (
+                "TAP version 13\n"
+                "Foo\n"
+                "Traceback (most recent call last):\n"
+                '  File "test.py", line X, in test_failing\n'
+                "    self.assertEqual(1, 2)\n"
+                "AssertionError: 1 != 2\n"
+                "\n"
+                "not ok 1 __main__.OutputTest.test_failing\n"
+                "Foo\n"
+                "Baz\n"
+                "Bar\n"
+                "ok 2 __main__.OutputTest.test_passing\n"
+                "1..2\n"
+            ),
+        )
+
+    def test_different_error_and_test_output_log(self):
+        self.run_test(
+            TAPTestRunnerTest.OutputTest,
+            message_log=LogMode.LogToYAML,
+            test_output_log=LogMode.LogToDiagnostics,
+        )
+        self.assertEqual(
+            self.process_output(self.output_stream.getvalue()),
+            (
+                "TAP version 13\n"
+                "not ok 1 __main__.OutputTest.test_failing\n"
+                "# Foo\n"
+                "  ---\n"
+                "    message: |\n"
+                "      Traceback (most recent call last):\n"
+                '        File "test.py", line X, in test_failing\n'
+                "          self.assertEqual(1, 2)\n"
+                "      AssertionError: 1 != 2\n"
+                "  ...\n"
+                "ok 2 __main__.OutputTest.test_passing\n"
+                "# Foo\n"
+                "# Baz\n"
+                "# Bar\n"
+                "1..2\n"
+            ),
+        )
+        self.assertEqual("", self.error_stream.getvalue())
 
 
-if __name__ == '__main__':
-  # unittest.main()
-  TAPTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(TAPTestRunnerTest))
+if __name__ == "__main__":
+    # unittest.main()
+    TAPTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(TAPTestRunnerTest))


### PR DESCRIPTION
Currently this applies the "black" formatter to our python code globally and adds two scripts, one that runs it to format all python code int the tree and another that checks whether formatting would change the code.  I'm planning to have the check script run in at least one of the travis targets, probably along with pylint.

The question now, is should I also add the clang-format formatting for our C code to this.  It's not materially harder, but before I do it, we need to pick a standard version to use (I suggest 6.0 or 7.0) and agree that the format file as defined in this PR (same as we had but disregarding support for 3.6, which is now ancient) is what we want code to look like or modify it such that it is.  Thoughts?