### PR TITLE
kvs: misc fixes & cleanup

### DIFF
--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -176,7 +176,7 @@ ENOSYS::
 The KVS module is not loaded.
 
 ENOTSUP::
-An unknown namespace was requested.
+An unknown namespace was requested or namespace was deleted.
 
 ENODATA::
 A stream of responses requested with FLUX_KVS_WATCH was terminated

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -102,7 +102,7 @@ static struct optparse_option get_opts[] =  {
       .usage = "Print key= before value",
     },
     { .name = "watch", .key = 'w', .has_arg = 0,
-      .usage = "Monitor root changes",
+      .usage = "Monitor key changes",
     },
     { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "COUNT",
       .usage = "Display at most COUNT changes",

--- a/src/common/libkvs/kvs_getroot.c
+++ b/src/common/libkvs/kvs_getroot.c
@@ -85,10 +85,8 @@ flux_future_t *flux_kvs_getroot (flux_t *h, const char *namespace, int flags)
     if (!(ctx = alloc_ctx ()))
         return NULL;
     ctx->flags = flags;
-    if ((flags & FLUX_KVS_WATCH)) {
+    if ((flags & FLUX_KVS_WATCH))
         topic = "kvs-watch.getroot";
-        flags &= ~(FLUX_KVS_WATCH);
-    }
     if (!namespace && !(namespace = flux_kvs_get_namespace (h)))
         goto error;
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0, "{s:s}",

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -514,7 +514,7 @@ static void watcher_cancel_all (struct watch_ctx *ctx,
 }
 
 /* kvs.namespace-remove event
- * A namespace has been removed.  All watchers should receive ENOENT.
+ * A namespace has been removed.  All watchers should receive ENOTSUP.
  */
 static void remove_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
@@ -528,7 +528,7 @@ static void remove_cb (flux_t *h, flux_msg_handler_t *mh,
         return;
     }
     if ((ns = zhash_lookup (ctx->namespaces, namespace))) {
-        ns->errnum = ENOENT;
+        ns->errnum = ENOTSUP;
         watcher_respond_ns (ns);
     }
 }

--- a/t/kvs/kvs-helper.sh
+++ b/t/kvs/kvs-helper.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 #
 
-# KVS Watch helper functions
+# KVS helper functions
 
-# Various loops to wait for conditions before moving on.  There is
-# potential for racing between backgrounding processes and foreground
-# activities.
-#
 # Loop on KVS_WAIT_ITERS is just to make sure we don't spin forever on
 # error.
 
@@ -36,38 +32,4 @@ test_kvs_key_namespace() {
 	flux kvs --namespace="$1" get --json "$2" >output
 	echo "$3" >expected
 	test_cmp expected output
-}
-
-# arg1 - key to retrieve
-# arg2 - value to wait for
-wait_watch_put() {
-        i=0
-        while [ "$(flux kvs get --json $1 2> /dev/null)" != "$2" ] && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
-}
-
-# arg1 - namespace
-# arg2 - key to retrieve
-# arg3 - value to wait for
-wait_watch_put_namespace() {
-        export FLUX_KVS_NAMESPACE=$1
-        wait_watch_put $2 $3
-        exitvalue=$?
-        unset FLUX_KVS_NAMESPACE
-        return $exitvalue
-}
-
-# arg1 - key to retrieve
-wait_watch_empty() {
-        i=0
-        while flux kvs get --json $1 2> /dev/null && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
 }

--- a/t/kvs/kvs-helper.sh
+++ b/t/kvs/kvs-helper.sh
@@ -71,15 +71,3 @@ wait_watch_empty() {
         done
         return $(loophandlereturn $i)
 }
-
-# arg1 - file to watch
-# arg2 - value to wait for
-wait_watch_file() {
-        i=0
-        while [ "$(tail -n 1 $1 2> /dev/null)" != "$2" ] && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
-}

--- a/t/t1002-kvs-watch.t
+++ b/t/t1002-kvs-watch.t
@@ -18,6 +18,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 DIR=test.a.b
 
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
 # Note that we do not && after the final call to wait_watch_put or
 # wait_watch_empty.  We want that as a barrier before launching our
 # background watch process.
@@ -32,7 +34,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs put --json $DIR.foo=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -48,7 +50,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist' 
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "nil" &&
+        $waitfile -q -t 5 -p "nil" watch_out &&
         flux kvs put --json $DIR.foo=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -65,7 +67,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$!
-        wait_watch_file watch_out "0" &&
+        $waitfile -q -t 5 -p "0" watch_out &&
         flux kvs unlink $DIR.foo &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -82,7 +84,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0" &&
+        $waitfile -q -t 5 -p "0" watch_out &&
         flux kvs put --json $DIR.foo.bar.baz=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -102,7 +104,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "======================" &&
+        $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -120,7 +122,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist' 
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "nil" &&
+        $waitfile -q -t 5 -p "nil" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -140,7 +142,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "======================" &&
+        $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs unlink -R $DIR.a &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -160,7 +162,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "======================" &&
+        $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -183,7 +185,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, prefix path converted into 
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "======================" &&
+        $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR=1 &&
         wait $watchpid
 	cat >expected <<-EOF &&
@@ -223,7 +225,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -R -o -c 1 $DIR >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "======================" &&
+        $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
         sort_watch_output
@@ -246,7 +248,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R and -d'  '
         rm -f watch_out
 	stdbuf -oL flux kvs watch -R -d -o -c 1 $DIR >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "======================" &&
+        $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
         wait $watchpid
         sort_watch_output

--- a/t/t1002-kvs-watch.t
+++ b/t/t1002-kvs-watch.t
@@ -27,7 +27,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.foo=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+	flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs put --json $DIR.foo=1 &&
@@ -42,7 +42,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist'  '
 	flux kvs unlink -Rf $DIR &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+	flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "nil" watch_out &&
         flux kvs put --json $DIR.foo=1 &&
@@ -58,7 +58,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.foo=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+	flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$!
         $waitfile -q -t 5 -p "0" watch_out &&
         flux kvs unlink $DIR.foo &&
@@ -74,7 +74,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.foo=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
+	flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out &&
         flux kvs put --json $DIR.foo.bar.baz=1 &&
@@ -92,7 +92,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
+	flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
@@ -109,7 +109,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist'  '
 	flux kvs unlink -Rf $DIR &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
+	flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "nil" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
@@ -127,7 +127,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
+	flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs unlink -R $DIR.a &&
@@ -145,7 +145,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
+	flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a=1 &&
@@ -166,7 +166,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, prefix path converted into 
         flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
+	flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR=1 &&
@@ -204,7 +204,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
         flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -R -o -c 1 $DIR >watch_out &
+	flux kvs watch -R -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&
@@ -225,7 +225,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R and -d'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
         rm -f watch_out
-	stdbuf -oL flux kvs watch -R -d -o -c 1 $DIR >watch_out &
+	flux kvs watch -R -d -o -c 1 $DIR >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "======================" watch_out &&
         flux kvs put --json $DIR.a.a=1 &&

--- a/t/t1002-kvs-watch.t
+++ b/t/t1002-kvs-watch.t
@@ -20,17 +20,12 @@ DIR=test.a.b
 
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 
-# Note that we do not && after the final call to wait_watch_put or
-# wait_watch_empty.  We want that as a barrier before launching our
-# background watch process.
-#
 # We rm -f watch_out to remove any potential race with backgrounding
 # of kvs watch process and a previous test's watch_out file.
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.foo=0 &&
-        wait_watch_put "$DIR.foo" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
@@ -46,7 +41,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key'  '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist'  '
 	flux kvs unlink -Rf $DIR &&
-        wait_watch_empty "$DIR.foo"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
@@ -63,7 +57,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that at first doesnt exist' 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.foo=0 &&
-        wait_watch_put "$DIR.foo" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$!
@@ -80,7 +73,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that gets removed'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.foo=0 &&
-        wait_watch_put "$DIR.foo" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.foo >watch_out &
         watchpid=$! &&
@@ -99,8 +91,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key that becomes a dir'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
-        wait_watch_put "$DIR.a.a" "0" &&
-        wait_watch_put "$DIR.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
@@ -118,7 +108,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir'  '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist'  '
 	flux kvs unlink -Rf $DIR &&
-        wait_watch_empty "$DIR"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR >watch_out &
         watchpid=$! &&
@@ -137,8 +126,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that at first doesnt exist' 
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
-        wait_watch_put "$DIR.a.a.a" "0" &&
-        wait_watch_put "$DIR.a.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
@@ -157,8 +144,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir that gets removed'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
-        wait_watch_put "$DIR.a.a.a" "0" &&
-        wait_watch_put "$DIR.a.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
@@ -180,8 +165,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, converted into a key'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir, prefix path converted into a key'  '
         flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a.a=0 $DIR.a.a.b=0 &&
-        wait_watch_put "$DIR.a.a.a" "0" &&
-        wait_watch_put "$DIR.a.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -o -c 1 $DIR.a >watch_out &
         watchpid=$! &&
@@ -220,8 +203,6 @@ sort_watch_output() {
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
         flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
-        wait_watch_put "$DIR.a.a" "0" &&
-        wait_watch_put "$DIR.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -R -o -c 1 $DIR >watch_out &
         watchpid=$! &&
@@ -243,8 +224,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R'  '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a dir with -R and -d'  '
 	flux kvs unlink -Rf $DIR &&
         flux kvs put --json $DIR.a.a=0 $DIR.a.b=0 &&
-        wait_watch_put "$DIR.a.a" "0" &&
-        wait_watch_put "$DIR.a.b" "0"
         rm -f watch_out
 	stdbuf -oL flux kvs watch -R -d -o -c 1 $DIR >watch_out &
         watchpid=$! &&

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -143,7 +143,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in primary namespace works' 
         flux kvs --namespace=$PRIMARYNAMESPACE unlink -Rf $DIR &&
         flux kvs --namespace=$PRIMARYNAMESPACE put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs --namespace=$PRIMARYNAMESPACE watch -o -c 1 $DIR.watch >watch_out &
+        flux kvs --namespace=$PRIMARYNAMESPACE watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$PRIMARYNAMESPACE put --json $DIR.watch=1 &&
@@ -216,7 +216,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in new namespace works'  '
         flux kvs --namespace=$NAMESPACETEST unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >watch_out &
+        flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.watch=1 &&
@@ -515,7 +515,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key with namespace prefix'  '
         flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix unlink -Rf $DIR &&
         flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs watch -o -c 1 ns:${NAMESPACEPREFIX}-watchprefix/$DIR.watch >watch_out &
+        flux kvs watch -o -c 1 ns:${NAMESPACEPREFIX}-watchprefix/$DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix put --json $DIR.watch=1 &&
@@ -586,7 +586,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch gets ENOTSUP when namespace is rem
         flux kvs namespace-create $NAMESPACETMP-REMOVE-WATCH0 &&
         flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH0 put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH0 watch -o -c 1 $DIR.watch >watch_out &
+        flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH0 watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-WATCH0 &&
@@ -595,6 +595,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch gets ENOTSUP when namespace is rem
 '
 
 # watch errors are output to stdout, so grep for "Operation not supported"
+# stdbuf -oL necessary to ensure waitfile can succeed
 test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namespace is removed' '
         flux kvs namespace-create $NAMESPACETMP-REMOVE-WATCH1 &&
         flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 put --json $DIR.watch=0 &&
@@ -616,7 +617,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namesp
 test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence gets ENOTSUP when namespace is removed' '
         flux kvs namespace-create $NAMESPACETMP-REMOVE-FENCE0 &&
         rm -f fence_out
-        stdbuf -oL ${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE0 fence0 > fence_out &
+        ${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE0 fence0 > fence_out &
         watchpid=$! &&
         wait_fencecount_nonzero 0 $NAMESPACETMP-REMOVE-FENCE0 &&
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE0 &&
@@ -632,7 +633,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence gets ENOTSUP when names
 test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence on rank 1 gets ENOTSUP when namespace is removed' '
         flux kvs namespace-create $NAMESPACETMP-REMOVE-FENCE1 &&
         rm -f fence_out
-        stdbuf -oL flux exec -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE1 fence1" > fence_out &
+        flux exec -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE1 fence1" > fence_out &
         watchpid=$! &&
         wait_fencecount_nonzero 1 $NAMESPACETMP-REMOVE-FENCE1 &&
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE1 &&
@@ -732,11 +733,11 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in different namespaces work
         rm -f primary_watch_out
         rm -f test_watch_out
 
-        stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >primary_watch_out &
+        flux kvs watch -o -c 1 $DIR.watch >primary_watch_out &
         primarywatchpid=$! &&
         $waitfile -q -t 5 -p "0" primary_watch_out
 
-        stdbuf -oL flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >test_watch_out &
+        flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >test_watch_out &
         testwatchpid=$! &&
         $waitfile -q -t 5 -p "1" test_watch_out
 

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -142,7 +142,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait on primary namespace works' '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key in primary namespace works'  '
         flux kvs --namespace=$PRIMARYNAMESPACE unlink -Rf $DIR &&
         flux kvs --namespace=$PRIMARYNAMESPACE put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $PRIMARYNAMESPACE "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$PRIMARYNAMESPACE watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
@@ -216,7 +215,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait in new namespace works' '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key in new namespace works'  '
         flux kvs --namespace=$NAMESPACETEST unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $NAMESPACETEST "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
@@ -516,7 +514,6 @@ test_expect_success 'kvs: namespace prefix works across symlinks' '
 test_expect_success NO_CHAIN_LINT 'kvs: watch a key with namespace prefix'  '
         flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix unlink -Rf $DIR &&
         flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix put --json $DIR.watch=0 &&
-        wait_watch_put_namespace ${NAMESPACEPREFIX}-watchprefix "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs watch -o -c 1 ns:${NAMESPACEPREFIX}-watchprefix/$DIR.watch >watch_out &
         watchpid=$! &&
@@ -588,7 +585,6 @@ test_expect_success 'kvs: watch fails on invalid namespace on rank 1' '
 test_expect_success NO_CHAIN_LINT 'kvs: watch gets ENOTSUP when namespace is removed' '
         flux kvs namespace-create $NAMESPACETMP-REMOVE-WATCH0 &&
         flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH0 put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $NAMESPACETMP-REMOVE-WATCH0 "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH0 watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
@@ -732,9 +728,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in different namespaces work
         flux kvs --namespace=$PRIMARYNAMESPACE unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETEST unlink -Rf $DIR &&
         flux kvs --namespace=$PRIMARYNAMESPACE put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $PRIMARYNAMESPACE "$DIR.watch" "0"
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.watch=1 &&
-        wait_watch_put_namespace $NAMESPACETEST "$DIR.watch" "1"
         rm -f primary_watch_out
         rm -f test_watch_out
 

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -21,6 +21,8 @@ echo "# $0: flux session size will be ${SIZE}"
 DIR=test.a.b
 KEY=test.a.b.c
 
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
 # Just in case its set in the environment
 unset FLUX_KVS_NAMESPACE
 
@@ -144,7 +146,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in primary namespace works' 
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$PRIMARYNAMESPACE watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$PRIMARYNAMESPACE put --json $DIR.watch=1 &&
         wait $watchpid
 cat >expected <<-EOF &&
@@ -218,7 +220,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in new namespace works'  '
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.watch=1 &&
         wait $watchpid
 cat >expected <<-EOF &&
@@ -518,7 +520,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key with namespace prefix'  '
         rm -f watch_out
         stdbuf -oL flux kvs watch -o -c 1 ns:${NAMESPACEPREFIX}-watchprefix/$DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=${NAMESPACEPREFIX}-watchprefix put --json $DIR.watch=1 &&
         wait $watchpid
 cat >expected <<-EOF &&
@@ -590,7 +592,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch gets ENOTSUP when namespace is rem
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH0 watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-WATCH0 &&
         wait $watchpid &&
         grep "Operation not supported" watch_out
@@ -605,7 +607,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namesp
         stdbuf -oL flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 wait ${VERS}; \
                                          flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 watch -o -c 1 $DIR.watch" > watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0" &&
+        $waitfile -q -t 5 -p "0" watch_out &&
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-WATCH1 &&
         wait $watchpid &&
         grep "Operation not supported" watch_out
@@ -738,11 +740,11 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch a key in different namespaces work
 
         stdbuf -oL flux kvs watch -o -c 1 $DIR.watch >primary_watch_out &
         primarywatchpid=$! &&
-        wait_watch_file primary_watch_out "0"
+        $waitfile -q -t 5 -p "0" primary_watch_out
 
         stdbuf -oL flux kvs --namespace=$NAMESPACETEST watch -o -c 1 $DIR.watch >test_watch_out &
         testwatchpid=$! &&
-        wait_watch_file test_watch_out "1"
+        $waitfile -q -t 5 -p "1" test_watch_out
 
         flux kvs --namespace=$PRIMARYNAMESPACE put --json $DIR.watch=1 &&
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.watch=2 &&

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -20,6 +20,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 DIR=test.a.b
 
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
 # Just in case its set in the environment
 unset FLUX_KVS_NAMESPACE
 
@@ -85,7 +87,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-OWNER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETMP-OWNER put --json $DIR.watch=1 &&
         wait $watchpid
 cat >expected <<-EOF &&
@@ -201,7 +203,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (user)'  '
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=1 &&
         wait $watchpid
         unset_userid
@@ -219,7 +221,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
-        wait_watch_file watch_out "0"
+        $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=1 &&
         wait $watchpid
 cat >expected <<-EOF &&

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -83,7 +83,6 @@ test_expect_success 'kvs: get works on other ranks (owner)' '
 test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
         flux kvs --namespace=$NAMESPACETMP-OWNER unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETMP-OWNER put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $NAMESPACETMP-OWNER "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-OWNER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
@@ -199,7 +198,6 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (user)'  '
         set_userid 9999 &&
         flux kvs --namespace=$NAMESPACETMP-USER unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $NAMESPACETMP-USER "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
@@ -217,7 +215,6 @@ EOF
 test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
         flux kvs --namespace=$NAMESPACETMP-USER unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=0 &&
-        wait_watch_put_namespace $NAMESPACETMP-USER "$DIR.watch" "0"
         rm -f watch_out
         stdbuf -oL flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -84,7 +84,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
         flux kvs --namespace=$NAMESPACETMP-OWNER unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETMP-OWNER put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs --namespace=$NAMESPACETMP-OWNER watch -o -c 1 $DIR.watch >watch_out &
+        flux kvs --namespace=$NAMESPACETMP-OWNER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETMP-OWNER put --json $DIR.watch=1 &&
@@ -199,7 +199,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (user)'  '
         flux kvs --namespace=$NAMESPACETMP-USER unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
+        flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=1 &&
@@ -216,7 +216,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch works (owner)'  '
         flux kvs --namespace=$NAMESPACETMP-USER unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=0 &&
         rm -f watch_out
-        stdbuf -oL flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
+        flux kvs --namespace=$NAMESPACETMP-USER watch -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
         flux kvs --namespace=$NAMESPACETMP-USER put --json $DIR.watch=1 &&


### PR DESCRIPTION
misc fixes / cleanup while working on #1651.

- return ENOTSUP instead of ENOENT when a namespace is removed, is more consistent with other error returns.
- use ```waitfile``` script in tests, b/c I didn't know it existed when I wrote a lot of the watch tests eons ago.
- remove now unnecessary waits and buffering in tests
- remove an unnecessary flag clear
- fix some cut & paste typos
