### PR TITLE
job-ingest: require signed jobspec to be in JSON form

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ yaml-cpp-devel >= 0.5.1
 python-devel >= 2.7
 python-cffi >= 1.1
 python-six >= 1.9
+python-ruamel-yaml
 libsqlite3-devel
 # for man pages
 asciidoc

--- a/configure.ac
+++ b/configure.ac
@@ -343,7 +343,6 @@ AC_CONFIG_FILES( \
   src/common/liboptparse/Makefile \
   src/common/libidset/Makefile \
   src/common/libjobspec/Makefile \
-  src/common/libjobspec/flux-jobspec.pc \
   src/common/libtomlc99/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -41,7 +41,7 @@ libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
 lib_LTLIBRARIES = libflux-core.la libflux-optparse.la libflux-idset.la
 if ENABLE_JOBSPEC
-lib_LTLIBRARIES += libflux-jobspec.la
+noinst_LTLIBRARIES += libflux-jobspec.la
 endif
 fluxlib_LTLIBRARIES = libpmi.la libpmi2.la
 

--- a/src/common/libjobspec/Makefile.am
+++ b/src/common/libjobspec/Makefile.am
@@ -8,9 +8,4 @@ libjobspec_la_CXXFLAGS = \
 libjobspec_la_LIBADD = $(CODE_COVERAGE_LIBS) $(YAMLCPP_LIBS)
 libjobspec_la_SOURCES = jobspec.cpp jobspec.hpp
 
-fluxinclude_HEADERS = jobspec.hpp
-
-if WITH_PKG_CONFIG
-pkgconfig_DATA = flux-jobspec.pc
-endif
 endif

--- a/src/test/docker/bionic-base/Dockerfile
+++ b/src/test/docker/bionic-base/Dockerfile
@@ -44,9 +44,11 @@ RUN apt-get -qq install -y --no-install-recommends \
         python-dev \
         python-cffi \
         python-six \
+        python-ruamel.yaml \
         python3-dev \
         python3-cffi \
-        python3-six
+        python3-six \
+        python3-ruamel.yaml
 
 # Other deps
 RUN apt-get -qq install -y --no-install-recommends \

--- a/src/test/docker/centos7-base/Dockerfile
+++ b/src/test/docker/centos7-base/Dockerfile
@@ -43,9 +43,11 @@ RUN yum -y update \
       python-devel \
       python-cffi \
       python-six \
+      python-ruamel-yaml \
       python34-devel \
       python34-cffi \
       python34-six \
+      python34-ruamel-yaml \
       ruby \
       sqlite \
       yaml-cpp-devel \

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -48,8 +48,8 @@ RUN case $BASE_IMAGE in \
 
 # Make sure user in appropriate group for sudo on different platorms
 RUN case $BASE_IMAGE in \
-     bionic*) apt-get -qq install -y --no-install-recommends python-six python3-six ;; \
-     centos*) yum -y install python-six python34-devel python34-cffi python34-six ;; \
+     bionic*) apt-get -qq install -y --no-install-recommends python-six python3-six python-ruamel.yaml python3-ruamel.yaml ;; \
+     centos*) yum -y install python-six python34-devel python34-cffi python34-six python-ruamel-yaml python34-ruamel-yaml ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 

--- a/t/jobspec/y2j
+++ b/t/jobspec/y2j
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import sys, json
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')   # default, if not specfied, is 'rt' (round-trip)
+
+obj = yaml.load(sys.stdin)
+
+json.dump(obj, sys.stdout, separators=(',',':'))

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 import os
 import errno
+import sys
+import json
+from ruamel.yaml import YAML
 
 import unittest
 
@@ -10,6 +13,11 @@ from flux.job import ffi
 
 def __flux_size():
     return 1
+
+def yaml_to_json(s):
+    yaml = YAML(typ='safe')
+    obj = yaml.load(s)
+    return json.dumps(obj, separators=(',',':'))
 
 class TestJob(unittest.TestCase):
     @classmethod
@@ -30,7 +38,8 @@ class TestJob(unittest.TestCase):
         # get a valid jobspec
         basic_jobspec_fname = os.path.join(jobspec_dir, "valid", "basic.yaml")
         with open(basic_jobspec_fname, 'rb') as infile:
-            self.jobspec = infile.read()
+            basic_yaml = infile.read()
+        self.jobspec = yaml_to_json(basic_yaml)
 
     def test_00_null_submit(self):
         with self.assertRaises(EnvironmentError) as error:

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -64,6 +64,10 @@ test_expect_success 'job-ingest: can submit jobspec on stdin' '
 	cat basic.json | ${SUBMITBENCH} -
 '
 
+test_expect_success 'job-ingest: YAML jobspec is rejected' '
+	test_must_fail ${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml
+'
+
 test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 	jobid=$(${SUBMITBENCH} basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -21,6 +21,7 @@ test_under_flux 4 job
 flux setattr log-stderr-level 1
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+Y2J=${JOBSPEC}/y2j
 SUBMITBENCH="flux job submitbench $SUBMITBENCH_OPT_NONE"
 
 DUMMY_EVENTLOG=test.ingest.eventlog
@@ -29,7 +30,7 @@ test_valid ()
 {
     local rc=0
     for job in $*; do
-        ${SUBMITBENCH} ${job} || rc=1
+        cat ${job} | ${Y2J} | ${SUBMITBENCH} -
     done
     return ${rc}
 }
@@ -38,13 +39,21 @@ test_invalid ()
 {
     local rc=0
     for job in $*; do
-        ${SUBMITBENCH} ${job} && rc=1
+        cat ${job} | ${Y2J} | ${SUBMITBENCH} - && rc=1
     done
     return ${rc}
 }
 
+test_expect_success 'job-ingest: convert basic.yaml to json' '
+	${Y2J} <${JOBSPEC}/valid/basic.yaml >basic.json
+'
+
+test_expect_success 'job-ingest: convert use_case_2.6.yaml to json' '
+	${Y2J} <${JOBSPEC}/valid/use_case_2.6.yaml >use_case_2.6.json
+'
+
 test_expect_success 'job-ingest: submit fails without job-manager' '
-	test_must_fail ${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml 2>nosys.out
+	test_must_fail ${SUBMITBENCH} basic.json 2>nosys.out
 '
 
 test_expect_success 'job-ingest: load job-manager-dummy module' '
@@ -52,26 +61,26 @@ test_expect_success 'job-ingest: load job-manager-dummy module' '
 '
 
 test_expect_success 'job-ingest: can submit jobspec on stdin' '
-	cat ${JOBSPEC}/valid/basic.yaml | ${SUBMITBENCH} -
+	cat basic.json | ${SUBMITBENCH} -
 '
 
 test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
-	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	jobid=$(${SUBMITBENCH} basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	flux kvs get --raw ${kvsdir}.jobspec >jobspec.out &&
-	test_cmp ${JOBSPEC}/valid/basic.yaml jobspec.out
+	test_cmp basic.json jobspec.out
 '
 
 test_expect_success 'job-ingest: submitter userid stored in KVS' '
 	myuserid=$(id -u) &&
-	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	jobid=$(${SUBMITBENCH} basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobuserid=$(flux kvs get --json ${kvsdir}.userid) &&
 	test $jobuserid -eq $myuserid
 '
 
 test_expect_success 'job-ingest: job announced to job manager' '
-	jobid=$(${SUBMITBENCH} --priority=10 ${JOBSPEC}/valid/basic.yaml) &&
+	jobid=$(${SUBMITBENCH} --priority=10 basic.json) &&
 	flux kvs eventlog get ${DUMMY_EVENTLOG} \
 		| grep "id=${jobid}" >jobman.out &&
 	grep -q priority=10 jobman.out &&
@@ -79,35 +88,32 @@ test_expect_success 'job-ingest: job announced to job manager' '
 '
 
 test_expect_success 'job-ingest: priority stored in KVS' '
-	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	jobid=$(${SUBMITBENCH} basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
 	test $jobpri -eq 16
 '
 
 test_expect_success 'job-ingest: eventlog stored in KVS' '
-	jobid=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	jobid=$(${SUBMITBENCH} basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	flux kvs eventlog get ${kvsdir}.eventlog | grep submit
 '
 
 test_expect_success 'job-ingest: instance owner can submit priority=31' '
-	jobid=$(${SUBMITBENCH} --priority=31 ${JOBSPEC}/valid/basic.yaml) &&
+	jobid=$(${SUBMITBENCH} --priority=31 basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
 	test $jobpri -eq 31
 '
 
 test_expect_success 'job-ingest: priority range is enforced' '
-	test_must_fail ${SUBMITBENCH} --priority=32 \
-		${JOBSPEC}/valid/basic.yaml &&
-	test_must_fail ${SUBMITBENCH} --priority="-1" \
-		${JOBSPEC}/valid/basic.yaml
+	test_must_fail ${SUBMITBENCH} --priority=32 basic.json &&
+	test_must_fail ${SUBMITBENCH} --priority="-1" basic.json
 '
 
 test_expect_success 'job-ingest: guest cannot submit priority=17' '
-	! FLUX_HANDLE_ROLEMASK=0x2 \
-	    ${SUBMITBENCH} --priority=17 ${JOBSPEC}/valid/basic.yaml
+	! FLUX_HANDLE_ROLEMASK=0x2 ${SUBMITBENCH} --priority=17 basic.json
 '
 
 test_expect_success 'job-ingest: valid jobspecs accepted' '
@@ -119,24 +125,20 @@ test_expect_success ENABLE_JOBSPEC 'job-ingest: invalid jobs rejected' '
 '
 
 test_expect_success 'job-ingest: submit job 100 times' '
-	${SUBMITBENCH} -r 100 ${JOBSPEC}/valid/use_case_2.6.yaml
+	${SUBMITBENCH} -r 100 use_case_2.6.json
 '
 
 test_expect_success 'job-ingest: submit job 100 times, reuse signature' '
-	echo $SUBMITBENCH_OPT_R &&
-	${SUBMITBENCH} ${SUBMITBENCH_OPT_R} \
-		-r 100 ${JOBSPEC}/valid/use_case_2.6.yaml
+	${SUBMITBENCH} ${SUBMITBENCH_OPT_R} -r 100 use_case_2.6.json
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'job-ingest: submit user != signed user fails' '
-	! FLUX_HANDLE_USERID=9999 ${SUBMITBENCH} \
-	     ${JOBSPEC}/valid/basic.yaml 2>baduser.out &&
+	! FLUX_HANDLE_USERID=9999 ${SUBMITBENCH} basic.json 2>baduser.out &&
 	grep -q "signer=$(id -u) != requestor=9999" baduser.out
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'job-ingest: non-owner mech=none fails' '
-	! FLUX_HANDLE_ROLEMASK=0x2 ${SUBMITBENCH} \
-	     ${JOBSPEC}/valid/basic.yaml 2>badrole.out &&
+	! FLUX_HANDLE_ROLEMASK=0x2 ${SUBMITBENCH} basic.json 2>badrole.out &&
 	grep -q "only instance owner" badrole.out
 '
 

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -13,6 +13,7 @@ if flux job submitbench --help 2>&1 | grep -q sign-type; then
 fi
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+Y2J=${JOBSPEC}/y2j
 
 # 2^64 - 1
 MAXJOBID_DEC=18446744073709551615
@@ -26,6 +27,11 @@ MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
 test_under_flux 1 job
 
 flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: convert basic.yaml to JSON' '
+	${Y2J} <${JOBSPEC}/valid/basic.yaml >basic.json
+'
+
 
 test_expect_success 'flux-job: unknown sub-command fails with usage message' '
 	test_must_fail flux job wrongsubcmd 2>usage.out &&
@@ -49,21 +55,20 @@ test_expect_success 'flux-job: submitbench with nonexistent jobpsec fails' '
 test_expect_success 'flux-job: submitbench with bad broker connection fails' '
 	FLUX_URI=/wrong \
 	test_must_fail flux job submitbench \
-	    --sign-type=none \
-	    ${JOBSPEC}/valid/basic.yaml
+	    --sign-type=none basic.json
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'flux-job: submitbench with bad security config fails' '
 	test_must_fail flux job submitbench \
 	    --sign-type=none \
             --security-config=/nonexist \
-	    ${JOBSPEC}/valid/basic.yaml
+	    basic.json
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'flux-job: submitbench with bad sign type fails' '
 	test_must_fail flux job submitbench \
 	    --sign-type=notvalid \
-	    ${JOBSPEC}/valid/basic.yaml
+	    basic.json
 '
 
 test_expect_success 'flux-job: id without from/to args is dec to dec' '


### PR DESCRIPTION
This PR follows up a plan discussed in #1714 in which internal components of the system deal with jobspec exclusively in JSON form.  The intent is for YAML input from users to be converted to JSON by front end commands (not yet written) before signing and submission.

The main change here is `job-ingest` now checks that jobspec is valid JSON, returning EINVAL to the submitter if it isn't.  It then goes on, as before, to run the JSON jobspec through the C++ validator.

The rest of the changes update tests to convert YAML test input to JSON before submitting via the API directly, or using `flux job submitbench` (which passes jobspec through to the API without parsing it).

libjobspec is made internal only (not installed).

(Still having some problems getting travis to pull in the python-ruamel.yaml package but wanted to get this submitted in case anyone can spot what's going wrong)