### PR TITLE
kvs: cleanups & refactoring

### DIFF
--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -80,7 +80,7 @@ struct watch_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     zhash_t *namespaces;        // hash of monitored namespaces
-    int subscriptions;          // count of kvs.setroot-<name> subscriptions
+    int subscriptions;          // count of kvs.namespace-remove subscriptions
 };
 
 

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -555,7 +555,7 @@ static void setroot_cb (flux_t *h, flux_msg_handler_t *mh,
                            "rootref", &rootref,
                            "owner", &owner,
                            "keys", &keys) < 0) {
-        flux_log_error (h, "%s: flux_event_decode", __FUNCTION__);
+        flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
         return;
     }
     if (!(ns = zhash_lookup (ctx->namespaces, namespace))

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -67,7 +67,7 @@ get_kvs_namespace_fails_all_ranks_loop() {
 
 wait_fencecount_nonzero() {
         i=0
-        while [ "$(flux exec -r $1 sh -c "flux module stats --parse namespace.$2.#transactions kvs" 2> /dev/null)" == "0" ] \
+        while [ "$(flux exec -r $1 sh -c "flux module stats --parse namespace.$2.#transactions kvs" 2> /dev/null)" = "0" ] \
               && [ $i -lt ${KVS_WAIT_ITERS} ]
         do
                 sleep 0.1


### PR DESCRIPTION
This PR follows #1812.

A bunch of fixes and refactoring.  The most major one is the refactoring of ```kvs.namespace-remove``` event into the ```kvs.namespace-remove-<namespace>``` event, so that subscribers need only subscribe to remove events for the namespaces they are concerned about.