### PR TITLE
flux-exec: ensure stdin is restored to blocking mode on exit

### DIFF
--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -25,8 +25,8 @@ stdout and stderr.
 On receipt of SIGINT and SIGTERM signals, flux-exec(1) shall forward
 the received signal to all currently running remote processes.
 
-flux-exec(1) is meant as an administrative and test utility, and should not
-be used for executing lightweight jobs (LWJs) or user commands.
+flux-exec(1) is meant as an administrative and test utility, and cannot
+be used to launch Flux jobs.
 
 EXIT STATUS
 -----------

--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -46,7 +46,7 @@ OPTIONS
 Label lines of output with the source RANK.
 
 *-n, --noinput*::
-Redirect `stdin` from `/dev/null`.
+Do not attempt to forward stdin.  Send EOF to remote process stdin.
 
 *-d, --dir*'=DIR'::
 Set the working directory of remote 'COMMANDS' to 'DIR'. The default is to

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -69,7 +69,6 @@ zlist_t *subprocesses;
 optparse_t *opts = NULL;
 
 flux_watcher_t *stdin_w;
-int stdin_fd = STDIN_FILENO;
 
 void completion_cb (flux_subprocess_t *p)
 {
@@ -108,10 +107,12 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
         exited++;
     }
 
-    if (started == rank_count)
-        flux_watcher_start (stdin_w);
-    if (exited == rank_count)
-        flux_watcher_stop (stdin_w);
+    if (stdin_w) {
+        if (started == rank_count)
+            flux_watcher_start (stdin_w);
+        if (exited == rank_count)
+            flux_watcher_stop (stdin_w);
+    }
 
     if (state == FLUX_SUBPROCESS_EXEC_FAILED
         || state == FLUX_SUBPROCESS_FAILED) {
@@ -315,16 +316,23 @@ int main (int argc, char *argv[])
     if (optparse_getopt (opts, "verbose", NULL) > 0)
         fprintf (stderr, "%03fms: Sent all requests\n", monotime_since (t0));
 
+    /* -n,--noinput: close subprocess STDIN
+     */
     if (optparse_getopt (opts, "noinput", NULL) > 0) {
-        if ((stdin_fd = open ("/dev/null", O_RDONLY)) < 0)
-            log_err_exit ("open");
+        flux_subprocess_t *p;
+        p = zlist_first (subprocesses);
+        while (p) {
+            if (flux_subprocess_close (p, "STDIN") < 0)
+                log_err_exit ("flux_subprocess_close");
+            p = zlist_next (subprocesses);
+        }
     }
-
-    if (!(stdin_w = flux_buffer_read_watcher_create (r, stdin_fd,
-                                                     1 << 20, stdin_cb,
-                                                     0, NULL)))
-        log_err_exit ("flux_buffer_read_watcher_create");
-
+    else {
+        if (!(stdin_w = flux_buffer_read_watcher_create (r, STDIN_FILENO,
+                                                         1 << 20, stdin_cb,
+                                                         0, NULL)))
+            log_err_exit ("flux_buffer_read_watcher_create");
+    }
     if (signal (SIGINT, signal_cb) == SIG_ERR)
         log_err_exit ("signal");
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -379,30 +379,6 @@ int flux_fd_watcher_get_fd (flux_watcher_t *w)
 /* buffer
  */
 
-static int fd_set_nonblocking (int fd, int *flags_orig)
-{
-    int fval;
-
-    if ((fval = fcntl (fd, F_GETFL, 0)) < 0)
-        return (-1);
-
-    if (fcntl (fd, F_SETFL, fval | O_NONBLOCK) < 0)
-        return (-1);
-
-    if (flags_orig)
-        (*flags_orig) = fval;
-
-    return (0);
-}
-
-static int fd_set_flags (int fd, int flags)
-{
-    if (fcntl (fd, F_SETFL, flags) < 0)
-        return (-1);
-
-    return (0);
-}
-
 static void buffer_read_start (flux_watcher_t *w)
 {
     struct ev_buffer_read *ebr = (struct ev_buffer_read *)w->data;
@@ -442,15 +418,18 @@ flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
 {
     struct ev_buffer_read *ebr;
     flux_watcher_t *w = NULL;
-    int flags_orig;
+    int fd_flags;
 
     if (fd < 0) {
         errno = EINVAL;
         return NULL;
     }
-
-    if (fd_set_nonblocking (fd, &flags_orig) < 0)
+    if ((fd_flags = fcntl (fd, F_GETFL)) < 0)
         return NULL;
+    if (!(fd_flags & O_NONBLOCK)) {
+        errno = EINVAL;
+        return NULL;
+    }
 
     if (!(w = flux_watcher_create (r,
                                    sizeof (*ebr),
@@ -477,7 +456,6 @@ flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
 
 cleanup:
     flux_watcher_destroy (w);
-    fd_set_flags (fd, flags_orig);
     return NULL;
 }
 
@@ -527,15 +505,19 @@ flux_watcher_t *flux_buffer_write_watcher_create (flux_reactor_t *r, int fd,
 {
     struct ev_buffer_write *ebw;
     flux_watcher_t *w = NULL;
-    int flags_orig;
+    int fd_flags;
 
     if (fd < 0) {
         errno = EINVAL;
         return NULL;
     }
 
-    if (fd_set_nonblocking (fd, &flags_orig) < 0)
+    if ((fd_flags = fcntl (fd, F_GETFL)) < 0)
         return NULL;
+    if (!(fd_flags & O_NONBLOCK)) {
+        errno = EINVAL;
+        return NULL;
+    }
 
     if (!(w = flux_watcher_create (r,
                                    sizeof (*ebw),
@@ -559,7 +541,6 @@ flux_watcher_t *flux_buffer_write_watcher_create (flux_reactor_t *r, int fd,
 
 cleanup:
     flux_watcher_destroy (w);
-    fd_set_flags (fd, flags_orig);
     return NULL;
 }
 

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -42,6 +42,7 @@
 #include "src/common/libev/ev.h"
 #include "src/common/libutil/ev_zmq.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/fdutils.h"
 
 struct flux_reactor {
     struct ev_loop *loop;
@@ -424,7 +425,7 @@ flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
         errno = EINVAL;
         return NULL;
     }
-    if ((fd_flags = fcntl (fd, F_GETFL)) < 0)
+    if ((fd_flags = fd_get_flags (fd)) < 0)
         return NULL;
     if (!(fd_flags & O_NONBLOCK)) {
         errno = EINVAL;
@@ -512,7 +513,7 @@ flux_watcher_t *flux_buffer_write_watcher_create (flux_reactor_t *r, int fd,
         return NULL;
     }
 
-    if ((fd_flags = fcntl (fd, F_GETFL)) < 0)
+    if ((fd_flags = fd_get_flags (fd)) < 0)
         return NULL;
     if (!(fd_flags & O_NONBLOCK)) {
         errno = EINVAL;

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -6,6 +6,7 @@
 
 #include "src/common/libflux/reactor.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/fdutils.h"
 #include "src/common/libtap/tap.h"
 
 static const size_t zmqwriter_msgcount = 1024;
@@ -589,6 +590,19 @@ static void test_buffer (flux_reactor_t *reactor)
     count = 0;
     ok (pipe (pfds) == 0,
         "buffer: hey I can has a pipe!");
+
+    w = flux_buffer_write_watcher_create (reactor,
+                                          pfds[1],
+                                          1024,
+                                          buffer_write,
+                                          0,
+                                          &count);
+    ok (w == NULL && errno == EINVAL,
+        "buffer: write_watcher_create fails with EINVAL if fd !nonblocking");
+
+    ok (fd_set_nonblocking (pfds[1]) >= 0,
+        "buffer: fd_set_nonblocking");
+
     w = flux_buffer_write_watcher_create (reactor,
                                           pfds[1],
                                           1024,

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -171,23 +171,12 @@ error:
     flux_reactor_stop_error (r);
 }
 
-static int set_nonblock (int fd)
-{
-    int flags = fcntl (fd, F_GETFL, NULL);
-    if (flags < 0 || fcntl (fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-        fprintf (stderr, "fcntl: %s\n", strerror (errno));
-        return -1;
-    }
-    return 0;
-}
-
 static void test_fd (flux_reactor_t *reactor)
 {
     int fd[2];
     flux_watcher_t *r, *w;
 
-    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0
-        && set_nonblock (fd[0]) == 0 && set_nonblock (fd[1]) == 0,
+    ok (socketpair (PF_LOCAL, SOCK_STREAM|SOCK_NONBLOCK, 0, fd) == 0,
         "fd: successfully created non-blocking socketpair");
     r = flux_fd_watcher_create (reactor, fd[0], FLUX_POLLIN, fdreader, NULL);
     w = flux_fd_watcher_create (reactor, fd[1], FLUX_POLLOUT, fdwriter, NULL);
@@ -375,10 +364,8 @@ static void test_buffer (flux_reactor_t *reactor)
     int count;
     char buf[1024];
 
-    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
+    ok (socketpair (PF_LOCAL, SOCK_STREAM|SOCK_NONBLOCK, 0, fd) == 0,
         "buffer: successfully created socketpair");
-    if (set_nonblock (fd[0]) < 0)
-        BAIL_OUT ("set_nonblock");
 
     /* read buffer test */
 
@@ -827,10 +814,8 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
 
     /* read buffer corner case test - other end closes stream */
 
-    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
+    ok (socketpair (PF_LOCAL, SOCK_STREAM|SOCK_NONBLOCK, 0, fd) == 0,
         "buffer corner case: successfully created socketpair");
-    if (set_nonblock (fd[0]) < 0)
-        BAIL_OUT ("set_nonblock");
 
     bfc.count = 0;
     bfc.fd = fd[1];
@@ -866,10 +851,8 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
 
     /* read line buffer corner case test - other end closes stream */
 
-    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
+    ok (socketpair (PF_LOCAL, SOCK_STREAM|SOCK_NONBLOCK, 0, fd) == 0,
         "buffer corner case: successfully created socketpair");
-    if (set_nonblock (fd[0]) < 0)
-        BAIL_OUT ("set_nonblock");
 
     bfc.count = 0;
     bfc.fd = fd[1];
@@ -905,10 +888,8 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
 
     /* read line buffer corner case test - left over data not a line */
 
-    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
+    ok (socketpair (PF_LOCAL, SOCK_STREAM|SOCK_NONBLOCK, 0, fd) == 0,
         "buffer corner case: successfully created socketpair");
-    if (set_nonblock (fd[0]) < 0)
-        BAIL_OUT ("set_nonblock");
 
     bfc.count = 0;
     bfc.fd = fd[1];

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -376,6 +376,8 @@ static void test_buffer (flux_reactor_t *reactor)
 
     ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
         "buffer: successfully created socketpair");
+    if (set_nonblock (fd[0]) < 0)
+        BAIL_OUT ("set_nonblock");
 
     /* read buffer test */
 
@@ -813,6 +815,8 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
 
     ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
         "buffer corner case: successfully created socketpair");
+    if (set_nonblock (fd[0]) < 0)
+        BAIL_OUT ("set_nonblock");
 
     bfc.count = 0;
     bfc.fd = fd[1];
@@ -850,6 +854,8 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
 
     ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
         "buffer corner case: successfully created socketpair");
+    if (set_nonblock (fd[0]) < 0)
+        BAIL_OUT ("set_nonblock");
 
     bfc.count = 0;
     bfc.fd = fd[1];
@@ -887,6 +893,8 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
 
     ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
         "buffer corner case: successfully created socketpair");
+    if (set_nonblock (fd[0]) < 0)
+        BAIL_OUT ("set_nonblock");
 
     bfc.count = 0;
     bfc.fd = fd[1];

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -82,7 +82,9 @@ libutil_la_SOURCES = \
 	fluid.c \
 	fluid.h \
 	aux.c \
-	aux.h
+	aux.h \
+	fdutils.c \
+	fdutils.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -109,7 +109,9 @@ TESTS = test_nodeset.t \
 	test_cf.t \
 	test_ipaddr.t \
 	test_fluid.t \
-	test_aux.t
+	test_aux.t \
+	test_fdutils.t
+
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -216,3 +218,7 @@ test_fluid_t_LDADD = $(test_ldadd)
 test_aux_t_SOURCES = test/aux.c
 test_aux_t_CPPFLAGS = $(test_cppflags)
 test_aux_t_LDADD = $(test_ldadd)
+
+test_fdutils_t_SOURCES = test/fdutils.c
+test_fdutils_t_CPPFLAGS = $(test_cppflags)
+test_fdutils_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/fdutils.c
+++ b/src/common/libutil/fdutils.c
@@ -1,0 +1,85 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <fcntl.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#include "fdutils.h"
+
+int fd_get_flags (int fd)
+{
+    return fcntl (fd, F_GETFL);
+}
+
+int fd_set_flags (int fd, int flags)
+{
+    return fcntl (fd, F_SETFL, flags);
+}
+
+static int fd_setfl (int fd, int flag, bool set)
+{
+    int flags = fd_get_flags (fd);
+    if ((flags < 0)
+       || (fd_set_flags (fd, set ? flags|flag : flags & ~flag) < 0))
+        return -1;
+    return (flags);
+}
+
+static int fd_setfd (int fd, int flag, bool set)
+{
+    int flags = fcntl (fd, F_GETFD);
+    if ((flags < 0)
+       || (fcntl (fd, F_SETFD, (set ? flags|flag : flags&~flag)) < 0))
+        return -1;
+    return (flags);
+}
+
+int fd_set_blocking (int fd)
+{
+    return (fd_setfl (fd, O_NONBLOCK, false));
+}
+
+int fd_set_nonblocking (int fd)
+{
+    return (fd_setfl (fd, O_NONBLOCK, true));
+}
+
+int fd_set_cloexec (int fd)
+{
+    return (fd_setfd (fd, FD_CLOEXEC, true));
+}
+
+int fd_unset_cloexec (int fd)
+{
+    return (fd_setfd (fd, FD_CLOEXEC, false));
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/fdutils.h
+++ b/src/common/libutil/fdutils.h
@@ -1,0 +1,39 @@
+#ifndef _UTIL_FDUTILS_H
+#define _UTIL_FDUTILS_H 1
+
+/*
+ *  fdutils: convenient functions for file descriptors
+ */
+
+/*  Clear O_NONBLOCK flag from file descriptor fd.
+ *  Returns 0 on Success, -1 on Failure with errno set.
+ */
+int fd_set_blocking (int fd);
+
+/*  Set O_NONBLOCK flag for the file descriptor fd.
+ *  Returns original flags on Success, -1 on Failure with errno set.
+ */
+int fd_set_nonblocking (int fd);
+
+/*  Set O_CLOEXEC file descriptor flag on file descriptor fd.
+ *  Returns original flags on Success, -1 on Failure with errno set.
+ */
+int fd_set_cloexec (int fd);
+
+/* Unset O_CLOEXEC file descriptor flag on file descriptor fd.
+ *  Returns original flags on Success, -1 on Failure with errno set.
+ */
+int fd_unset_cloexec (int fd);
+
+/*  Return current file status flags on file descriptor fd */
+int fd_get_flags (int fd);
+
+/*  Set file status flags on file descriptor fd */
+int fd_set_flags (int fd, int flags);
+
+#endif /* !_UTIL_FDUTILS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -40,6 +40,7 @@
 
 #include "popen2.h"
 #include "fdwalk.h"
+#include "fdutils.h"
 
 #define PXOPEN_CHILD_MAGIC 0xc00ceeee
 
@@ -101,7 +102,7 @@ error:
 struct popen2_child *popen2 (const char *path, char *const argv[])
 {
     struct popen2_child *p = NULL;
-    int n, saved_errno, flags;
+    int n, saved_errno;
 
     if (!(p = malloc (sizeof (*p)))) {
         saved_errno = ENOMEM;
@@ -117,8 +118,7 @@ struct popen2_child *popen2 (const char *path, char *const argv[])
         saved_errno = errno;
         goto error;
     }
-    if ((flags = fcntl (p->fd[SP_PARENT], F_GETFL)) < 0
-              || fcntl (p->fd[SP_PARENT], F_SETFL, flags | O_CLOEXEC) < 0) {
+    if (fd_set_cloexec (p->fd[SP_PARENT]) < 0) {
         saved_errno = errno;
         goto error;
     }

--- a/src/common/libutil/test/fdutils.c
+++ b/src/common/libutil/test/fdutils.c
@@ -1,0 +1,104 @@
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/fdutils.h"
+
+int myfree_count;
+void myfree (void *arg)
+{
+    myfree_count++;
+}
+
+int main (int argc, char *argv[])
+{
+    int pfds[2];
+    int fd, fd2;
+    int flags, flags2;
+    int rc;
+    plan (NO_PLAN);
+
+    if (pipe (pfds) < 0)
+        BAIL_OUT ("pipe");
+
+    fd = pfds[0];
+    fd2 = pfds[1];
+
+    ok (fd_get_flags (-1) < 0 && errno == EBADF,
+            "fd_get_flags fails on invalid fd");
+    ok (fd_set_flags (-1, 0) < 0 && errno == EBADF,
+            "fd_set_flags fails on invalid fd");
+    ok (fd_set_blocking (-1) < 0 && errno == EBADF,
+            "fd_set_blocking fails on invalid fd");
+    ok (fd_set_nonblocking (-1) < 0 && errno == EBADF,
+            "fd_set_nonblocking fails on invalid fd");
+    ok (fd_set_cloexec (-1) < 0 && errno == EBADF,
+            "fd_set_cloexec fails on invalid fd");
+    ok (fd_unset_cloexec (-1) < 0 && errno == EBADF,
+            "fd_unset_cloexec fails on invalid fd");
+
+    flags = fd_get_flags (fd);
+    cmp_ok (flags, ">=", 0,
+            "fd_get_flags() works");
+
+    rc = fd_set_nonblocking (fd);
+    cmp_ok (rc, ">=", 0,
+            "fd_set_nonblocking() returns Success");
+    cmp_ok (rc, "==", flags,
+            "fd_set_nonblocking returned original flags");
+
+    flags2 = fd_get_flags (fd);
+    cmp_ok (flags2, ">=", 0,
+            "fd_get_flags() works");
+    cmp_ok (flags2, "==", flags|O_NONBLOCK,
+            "fd_set_nonblocking added O_NONBLOCK to flags");
+
+    rc = fd_set_blocking (fd);
+    cmp_ok (rc, ">=", 0,
+            "fd_set_blocking() returns Success");
+    cmp_ok (rc, "==", flags2,
+            "fd_set_blocking() returned previous flags");
+
+    flags2 = fd_get_flags (fd);
+    cmp_ok (flags2, ">=", 0,
+            "fd_get_flags() works");
+    cmp_ok (flags2, "==", flags,
+            "fd_set_blocking removed O_NONBLOCK flag");
+
+    flags = fd_get_flags (fd2);
+    cmp_ok (flags, ">=", 0,
+            "fd_get_flags() works");
+    cmp_ok (fd_set_nonblocking (fd2), ">=", 0,
+            "fd_set_nonblocking() rc=0");
+    flags2 = fd_get_flags (fd2);
+    cmp_ok (flags2, ">=", 0,
+            "fd_get_flags() works");
+    cmp_ok (flags2, "==", flags|O_NONBLOCK,
+            "fd_set_nonblocking added O_NONBLOCK to flags");
+    cmp_ok (fd_set_flags (fd2, flags), "==", 0,
+            "fd_set_flags() rc=0");
+    flags2 = fd_get_flags (fd2);
+    cmp_ok (flags2, "==", flags,
+            "fd_set_flags restored flags");
+
+    rc = fd_set_cloexec (fd);
+    cmp_ok (rc, ">=", 0,
+        "fd_set_cloexec() works rc=%d", rc);
+    cmp_ok (rc&FD_CLOEXEC, "==", 0,
+        "fd_set_cloexec() returns old flags");
+    rc = fd_unset_cloexec (fd);
+    cmp_ok (rc, ">=", 0,
+        "fd_unset_cloexec() works rc=%d", rc);
+    cmp_ok (rc&FD_CLOEXEC, "==", 1,
+        "fd_unset_cloexec() returns old flags");
+
+    done_testing ();
+    close (fd);
+    close (fd2);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libzio/zio.c
+++ b/src/common/libzio/zio.c
@@ -26,7 +26,6 @@
 #include "config.h"
 #endif
 #include <stdio.h>
-#include <fcntl.h>
 #include <string.h>
 #include <jansson.h>
 #include <czmq.h>
@@ -36,6 +35,7 @@
 #include "src/common/liblsd/cbuf.h"
 #include "src/common/libutil/macros.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/fdutils.h"
 
 #include "zio.h"
 
@@ -184,19 +184,6 @@ static inline void zio_handler_end (zio_t *zio)
     zio->flags &= ~ZIO_IN_HANDLER;
     if (zio_is_destroyed (zio))
         zio_destroy (zio);
-}
-
-static int fd_set_nonblocking (int fd)
-{
-    int fval;
-
-    assert (fd >= 0);
-
-    if ((fval = fcntl (fd, F_GETFL, 0)) < 0)
-        return (-1);
-    if (fcntl (fd, F_SETFL, fval | O_NONBLOCK) < 0)
-        return (-1);
-    return (0);
 }
 
 void zio_destroy (zio_t *z)

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -35,11 +35,11 @@
 #include <signal.h>
 #include <poll.h>
 #include <unistd.h>
-#include <fcntl.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/macros.h"
+#include "src/common/libutil/fdutils.h"
 
 #define CTX_MAGIC   0xf434aaab
 typedef struct {
@@ -57,15 +57,11 @@ static const struct flux_handle_ops handle_ops;
 
 static int set_nonblock (local_ctx_t *c, int nonblock)
 {
-    int flags;
-    if (c->fd_nonblock != nonblock) {
-        if ((flags = fcntl (c->fd, F_GETFL)) < 0)
-            return -1;
-        if (fcntl (c->fd, F_SETFL, nonblock ? flags | O_NONBLOCK
-                                            : flags & ~O_NONBLOCK) < 0)
-            return -1;
-        c->fd_nonblock = nonblock;
-    }
+    if (c->fd_nonblock == nonblock)
+        return 0;
+    if ((nonblock ? fd_set_nonblocking (c->fd) : fd_set_blocking (c->fd)) < 0)
+        return -1;
+    c->fd_nonblock = nonblock;
     return 0;
 }
 

--- a/src/modules/wreck/luastack.c
+++ b/src/modules/wreck/luastack.c
@@ -33,7 +33,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <libgen.h>
-#include <fcntl.h>
 #include <glob.h>
 
 #include "list.h"

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -170,7 +170,7 @@ test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
        ! flux start flux getattr tbon.parent-endpoint
 '
 test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
-       NUM=`flux start --size 4 flux exec flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
+       NUM=`flux start --size 4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
        test $NUM -eq 3
 '
 test_expect_success 'broker.rundir override works' '

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -10,7 +10,7 @@ test_under_flux ${SIZE} minimal
 
 test_expect_success 'heartbeat is received on all ranks' '
 	run_timeout 5 \
-          flux exec flux event sub --count=1 hb >output_event_sub &&
+          flux exec -n flux event sub --count=1 hb >output_event_sub &&
 	hb_count=`grep "^hb" output_event_sub | wc -l` &&
         test $hb_count -eq $SIZE
 '

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -164,24 +164,24 @@ test_expect_success 'ping output format for all ranks is correct (format 3)' '
 # rank 1 should work
 
 test_expect_success 'ping with "upstream" fails on rank 0' '
-        run_timeout 5 flux exec --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
+        run_timeout 5 flux exec -n --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping with "upstream" works (format 1)' '
-        run_timeout 5 flux exec --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout &&
+        run_timeout 5 flux exec -n --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 2)' '
-        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream!cmb 1>stdout &&
+        run_timeout 5 flux exec -n --rank 1 flux ping --count 1 upstream!cmb 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 3)' '
-        run_timeout 5 flux exec --rank 1 flux ping --count 1 upstream 1>stdout &&
+        run_timeout 5 flux exec -n --rank 1 flux ping --count 1 upstream 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -47,32 +47,32 @@ test_expect_success LONGTEST "cannot store blob that exceeds max size of $MAXBLO
 
 test_expect_success 'load and verify 0b blob on all ranks' '
 	HASHSTR=`cat 0.0.hash` &&
-	flux exec echo ${HASHSTR} >0.0.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >0.0.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>0.0.all.output &&
 	test_cmp 0.0.all.expect 0.0.all.output
 '
 
 test_expect_success 'load and verify 64b blob on all ranks' '
 	HASHSTR=`cat 64.0.hash` &&
-	flux exec echo ${HASHSTR} >64.0.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >64.0.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>64.0.all.output &&
 	test_cmp 64.0.all.expect 64.0.all.output
 '
 
 test_expect_success 'load and verify 4k blob on all ranks' '
 	HASHSTR=`cat 4k.0.hash` &&
-	flux exec echo ${HASHSTR} >4k.0.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >4k.0.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>4k.0.all.output &&
 	test_cmp 4k.0.all.expect 4k.0.all.output
 '
 
 test_expect_success 'load and verify 1m blob on all ranks' '
 	HASHSTR=`cat 1m.0.hash` &&
-	flux exec echo ${HASHSTR} >1m.0.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >1m.0.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>1m.0.all.output &&
 	test_cmp 1m.0.all.expect 1m.0.all.output
 '
@@ -82,33 +82,33 @@ test_expect_success 'load and verify 1m blob on all ranks' '
 
 test_expect_success 'store blobs on rank 3' '
 	dd if=/dev/urandom count=1 bs=64 >64.3.store 2>/dev/null &&
-	flux exec --rank 3 sh -c "flux content store <64.3.store >64.3.hash" &&
+	flux exec -n --rank 3 sh -c "flux content store <64.3.store >64.3.hash" &&
 	dd if=/dev/urandom count=1 bs=4096 >4k.3.store 2>/dev/null &&
-	flux exec --rank 3 sh -c "flux content store <4k.3.store >4k.3.hash" &&
+	flux exec -n --rank 3 sh -c "flux content store <4k.3.store >4k.3.hash" &&
 	dd if=/dev/urandom count=256 bs=4096 >1m.3.store 2>/dev/null &&
-	flux exec --rank 3 sh -c "flux content store <1m.3.store >1m.3.hash"
+	flux exec -n --rank 3 sh -c "flux content store <1m.3.store >1m.3.hash"
 '
 
 test_expect_success 'load and verify 64b blob on all ranks' '
 	HASHSTR=`cat 64.3.hash` &&
-	flux exec echo ${HASHSTR} >64.3.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >64.3.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>64.3.all.output &&
 	test_cmp 64.3.all.expect 64.3.all.output
 '
 
 test_expect_success 'load and verify 4k blob on all ranks' '
 	HASHSTR=`cat 4k.3.hash` &&
-	flux exec echo ${HASHSTR} >4k.3.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >4k.3.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>4k.3.all.output &&
 	test_cmp 4k.3.all.expect 4k.3.all.output
 '
 
 test_expect_success 'load and verify 1m blob on all ranks' '
 	HASHSTR=`cat 1m.3.hash` &&
-	flux exec echo ${HASHSTR} >1m.3.all.expect &&
-	flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+	flux exec -n echo ${HASHSTR} >1m.3.all.expect &&
+	flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
 						>1m.3.all.output &&
 	test_cmp 1m.3.all.expect 1m.3.all.output
 '
@@ -120,9 +120,9 @@ test_expect_success 'load and verify 1m blob on all ranks' '
 test_expect_success 'negative entries are not cached' '
 	VALUESTR=sdflskdjflsdkjfsdjf &&
 	HASHSTR=`echo $VALUESTR | $BLOBREF $HASHFUN` &&
-	test_must_fail flux exec flux content load ${HASHSTR} 2>/dev/null &&
+	test_must_fail flux exec -n flux content load ${HASHSTR} 2>/dev/null &&
 	echo $VALUESTR | flux content store >/dev/null &&
-	flux exec flux content load ${HASHSTR} >/dev/null
+	flux exec -n flux content load ${HASHSTR} >/dev/null
 '
 
 # Store the same content on all ranks
@@ -130,7 +130,7 @@ test_expect_success 'negative entries are not cached' '
 # (Really we want to test whther stores were squashed, fill in later)
 
 test_expect_success 'store on all ranks can be retrieved from rank 0' '
-	flux exec sh -c "echo foof | flux content store" >/dev/null &&
+	flux exec -n sh -c "echo foof | flux content store" >/dev/null &&
 	flux content load `echo foof | $BLOBREF $HASHFUN` >/dev/null
 '
 
@@ -155,7 +155,7 @@ test_expect_success 'store 8K blobs from rank 0 using async RPC' '
 
 # Write 1024 blobs per rank
 test_expect_success 'store 1K blobs from all ranks using async RPC' '
-	flux exec flux content spam 1024 256
+	flux exec -n flux content spam 1024 256
 '
 
 test_done

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -86,24 +86,24 @@ test_expect_success 'load 1m blob bypassing cache' '
 
 test_expect_success 'load and verify 64b blob on all ranks' '
         HASHSTR=`cat 64.0.hash` &&
-        flux exec echo ${HASHSTR} >64.0.all.expect &&
-        flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+        flux exec -n echo ${HASHSTR} >64.0.all.expect &&
+        flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
                                                 >64.0.all.output &&
         test_cmp 64.0.all.expect 64.0.all.output
 '
 
 test_expect_success 'load and verify 4k blob on all ranks' '
         HASHSTR=`cat 4k.0.hash` &&
-        flux exec echo ${HASHSTR} >4k.0.all.expect &&
-        flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+        flux exec -n echo ${HASHSTR} >4k.0.all.expect &&
+        flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
                                                 >4k.0.all.output &&
         test_cmp 4k.0.all.expect 4k.0.all.output
 '
 
 test_expect_success 'load and verify 1m blob on all ranks' '
         HASHSTR=`cat 1m.0.hash` &&
-        flux exec echo ${HASHSTR} >1m.0.all.expect &&
-        flux exec sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
+        flux exec -n echo ${HASHSTR} >1m.0.all.expect &&
+        flux exec -n sh -c "flux content load ${HASHSTR} | $BLOBREF $HASHFUN" \
                                                 >1m.0.all.output &&
         test_cmp 1m.0.all.expect 1m.0.all.output
 '

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -258,13 +258,13 @@ test_expect_success 'kvs: multi blob-ref valref with a blobref pointing to a tre
 test_expect_success 'kvs: put on rank 0, exists on all ranks' '
 	flux kvs put --json $DIR.xxx=99 &&
 	VERS=$(flux kvs version) &&
-	flux exec sh -c "flux kvs wait ${VERS} && flux kvs get --json $DIR.xxx"
+	flux exec -n sh -c "flux kvs wait ${VERS} && flux kvs get --json $DIR.xxx"
 '
 
 test_expect_success 'kvs: unlink on rank 0, does not exist all ranks' '
 	flux kvs unlink -Rf $DIR.xxx &&
 	VERS=$(flux kvs version) &&
-	flux exec sh -c "flux kvs wait ${VERS} && ! flux kvs get --json $DIR.xxx"
+	flux exec -n sh -c "flux kvs wait ${VERS} && ! flux kvs get --json $DIR.xxx"
 '
 
 #
@@ -288,13 +288,13 @@ test_expect_success 'kvs: clear stats locally' '
 test_expect_success 'kvs: clear stats globally' '
         flux kvs unlink -Rf $DIR &&
         flux module stats -C kvs &&
-        flux exec sh -c "flux module stats kvs | grep no-op | grep -q 0" &&
+        flux exec -n sh -c "flux module stats kvs | grep no-op | grep -q 0" &&
         for i in `seq 0 $((${SIZE} - 1))`; do
-            flux exec -r $i sh -c "flux kvs put --json $DIR.$i.largeval1=$largeval $DIR.$i.largeval2=$largeval"
+            flux exec -n -r $i sh -c "flux kvs put --json $DIR.$i.largeval1=$largeval $DIR.$i.largeval2=$largeval"
         done &&
-        ! flux exec sh -c "flux module stats kvs | grep no-op | grep -q 0" &&
+        ! flux exec -n sh -c "flux module stats kvs | grep no-op | grep -q 0" &&
         flux module stats -C kvs &&
-        flux exec sh -c "flux module stats kvs | grep no-op | grep -q 0"
+        flux exec -n sh -c "flux module stats kvs | grep no-op | grep -q 0"
 '
 
 #
@@ -307,7 +307,7 @@ test_expect_success 'kvs: test invalid fence arguments on rank 0' '
 '
 
 test_expect_success 'kvs: test invalid fence arguments on rank 1' '
-        flux exec -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_invalid invalidtest2" > invalid_output &&
+        flux exec -n -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_invalid invalidtest2" > invalid_output &&
         grep "flux_future_get: Invalid argument" invalid_output
 '
 

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -60,19 +60,19 @@ test_expect_success 'kvs: store 3x4 directory tree using kvsdir classic function
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit ${THREADS} 100 \
+	flux exec -n ${FLUX_BUILD_DIR}/t/kvs/commit ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop, no merging' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge 1 ${THREADS} 100 \
+	flux exec -n ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge 1 ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop, mixed no merging' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge 2 ${THREADS} 100 \
+	flux exec -n ${FLUX_BUILD_DIR}/t/kvs/commit --nomerge 2 ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
@@ -80,21 +80,21 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,commits in a loop, m
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
+	flux exec -n ${FLUX_BUILD_DIR}/t/kvs/commit \
 		--fence $((${SIZE}*${THREADS})) ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, no merging' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
+	flux exec -n ${FLUX_BUILD_DIR}/t/kvs/commit \
 		--fence $((${SIZE}*${THREADS})) --nomerge 1 ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '
 
 test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, mixed no merging' '
 	THREADS=8 &&
-	flux exec ${FLUX_BUILD_DIR}/t/kvs/commit \
+	flux exec -n ${FLUX_BUILD_DIR}/t/kvs/commit \
 		--fence $((${SIZE}*${THREADS})) --nomerge 2 ${THREADS} 100 \
 		$(basename ${SHARNESS_TEST_FILE})
 '

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -45,7 +45,7 @@ namespace_create_loop() {
 
 get_kvs_namespace_all_ranks_loop() {
         i=0
-        while ! flux exec sh -c "flux kvs --namespace=$1 get $2" \
+        while ! flux exec -n sh -c "flux kvs --namespace=$1 get $2" \
               && [ $i -lt ${KVS_WAIT_ITERS} ]
         do
                 sleep 0.1
@@ -56,7 +56,7 @@ get_kvs_namespace_all_ranks_loop() {
 
 get_kvs_namespace_fails_all_ranks_loop() {
         i=0
-        while ! flux exec sh -c "! flux kvs --namespace=$1 get $2" \
+        while ! flux exec -n sh -c "! flux kvs --namespace=$1 get $2" \
               && [ $i -lt ${KVS_WAIT_ITERS} ]
         do
                 sleep 0.1
@@ -67,7 +67,7 @@ get_kvs_namespace_fails_all_ranks_loop() {
 
 wait_fencecount_nonzero() {
         i=0
-        while [ "$(flux exec -r $1 sh -c "flux module stats --parse namespace.$2.#transactions kvs" 2> /dev/null)" = "0" ] \
+        while [ "$(flux exec -n -r $1 sh -c "flux module stats --parse namespace.$2.#transactions kvs" 2> /dev/null)" = "0" ] \
               && [ $i -lt ${KVS_WAIT_ITERS} ]
         do
                 sleep 0.1
@@ -168,7 +168,7 @@ test_expect_success 'kvs: new namespace exists/is listed' '
 '
 
 test_expect_success 'kvs: namespace create on rank 1 works' '
-	flux exec -r 1 sh -c "flux kvs namespace-create $NAMESPACERANK1"
+	flux exec -n -r 1 sh -c "flux kvs namespace-create $NAMESPACERANK1"
 '
 
 test_expect_success 'kvs: new namespace exists/is listed' '
@@ -264,14 +264,14 @@ test_expect_success 'kvs: put value in new namespace, available on other ranks' 
         flux kvs --namespace=$NAMESPACETEST unlink -Rf $DIR &&
         flux kvs --namespace=$NAMESPACETEST put --json $DIR.all=1 &&
         VERS=`flux kvs --namespace=$NAMESPACETEST version` &&
-        flux exec sh -c "flux kvs --namespace=$NAMESPACETEST wait ${VERS} && \
+        flux exec -n sh -c "flux kvs --namespace=$NAMESPACETEST wait ${VERS} && \
                          flux kvs --namespace=$NAMESPACETEST get $DIR.all"
 '
 
 test_expect_success 'kvs: unlink value in new namespace, does not exist all ranks' '
         flux kvs --namespace=$NAMESPACETEST unlink $DIR.all &&
         VERS=`flux kvs --namespace=$NAMESPACETEST version` &&
-        flux exec sh -c "flux kvs --namespace=$NAMESPACETEST wait ${VERS} && \
+        flux exec -n sh -c "flux kvs --namespace=$NAMESPACETEST wait ${VERS} && \
                          ! flux kvs --namespace=$NAMESPACETEST get $DIR.all"
 '
 
@@ -281,7 +281,7 @@ test_expect_success 'kvs: namespace remove works, recognized on other ranks' '
 	flux kvs namespace-create $NAMESPACETMP-ALL &&
         flux kvs --namespace=$NAMESPACETMP-ALL put --json $DIR.all=1 &&
         VERS=`flux kvs --namespace=$NAMESPACETMP-ALL version` &&
-        flux exec sh -c "flux kvs --namespace=$NAMESPACETMP-ALL wait ${VERS} && \
+        flux exec -n sh -c "flux kvs --namespace=$NAMESPACETMP-ALL wait ${VERS} && \
                          flux kvs --namespace=$NAMESPACETMP-ALL get $DIR.all" &&
 	flux kvs namespace-remove $NAMESPACETMP-ALL &&
         get_kvs_namespace_fails_all_ranks_loop $NAMESPACETMP-ALL $DIR.all
@@ -538,7 +538,7 @@ test_expect_success 'kvs: namespace create on existing namespace fails' '
 '
 
 test_expect_success 'kvs: namespace create on existing namespace fails on rank 1' '
-	! flux exec -r 1 sh -c "flux kvs namespace-create $NAMESPACETEST"
+	! flux exec -n -r 1 sh -c "flux kvs namespace-create $NAMESPACETEST"
 '
 
 test_expect_success 'kvs: get fails on invalid namespace' '
@@ -546,7 +546,7 @@ test_expect_success 'kvs: get fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: get fails on invalid namespace on rank 1' '
-	! flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD get $DIR.test"
+	! flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD get $DIR.test"
 '
 
 test_expect_success 'kvs: put fails on invalid namespace' '
@@ -554,7 +554,7 @@ test_expect_success 'kvs: put fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: put fails on invalid namespace on rank 1' '
-        ! flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD put $DIR.test=1"
+        ! flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD put $DIR.test=1"
 '
 
 test_expect_success 'kvs: version fails on invalid namespace' '
@@ -562,7 +562,7 @@ test_expect_success 'kvs: version fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: version fails on invalid namespace on rank 1' '
-	! flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD version"
+	! flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD version"
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs: wait fails on invalid namespace' '
@@ -570,7 +570,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: wait fails on invalid namespace on rank 1' '
-        ! flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD wait 1"
+        ! flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD wait 1"
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs: watch fails on invalid namespace' '
@@ -578,7 +578,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: watch fails on invalid namespace on rank 1' '
-        ! flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD watch -c 1 $DIR.test"
+        ! flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACEBAD watch -c 1 $DIR.test"
 '
 
 # watch errors are output to stdout, so grep for "Operation not supported"
@@ -601,7 +601,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namesp
         flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 put --json $DIR.watch=0 &&
         VERS=`flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 version` &&
         rm -f watch_out
-        stdbuf -oL flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 wait ${VERS}; \
+        stdbuf -oL flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 wait ${VERS}; \
                                          flux kvs --namespace=$NAMESPACETMP-REMOVE-WATCH1 watch -o -c 1 $DIR.watch" > watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out &&
@@ -633,7 +633,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence gets ENOTSUP when names
 test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence on rank 1 gets ENOTSUP when namespace is removed' '
         flux kvs namespace-create $NAMESPACETMP-REMOVE-FENCE1 &&
         rm -f fence_out
-        flux exec -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE1 fence1" > fence_out &
+        flux exec -n -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE1 fence1" > fence_out &
         watchpid=$! &&
         wait_fencecount_nonzero 1 $NAMESPACETMP-REMOVE-FENCE1 &&
         flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE1 &&

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -70,13 +70,13 @@ test_expect_success 'kvs: get fails (user)' '
 '
 
 test_expect_success 'kvs: get fails on other ranks (user)' '
-        ! flux exec -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
+        ! flux exec -n -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
                                 FLUX_HANDLE_ROLEMASK=0x2 \
                                 flux kvs --namespace=$NAMESPACETMP-OWNER get $DIR.test"
 '
 
 test_expect_success 'kvs: get works on other ranks (owner)' '
-        flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-OWNER get $DIR.test"
+        flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-OWNER get $DIR.test"
 '
 
 
@@ -109,7 +109,7 @@ test_expect_success 'kvs: version fails (user)' '
 '
 
 test_expect_success 'kvs: version fails on other ranks (user)' '
-        ! flux exec -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
+        ! flux exec -n -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
                                 FLUX_HANDLE_ROLEMASK=0x2 \
                                 flux kvs --namespace=$NAMESPACETMP-OWNER version"
 '
@@ -164,13 +164,13 @@ test_expect_success 'kvs: put fails (wrong user)' '
 '
 
 test_expect_success 'kvs: get works on other ranks (user)' '
-        flux exec -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
+        flux exec -n -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
                               FLUX_HANDLE_ROLEMASK=0x2 \
                               flux kvs --namespace=$NAMESPACETMP-USER get $DIR.test"
 '
 
 test_expect_success 'kvs: get works on other ranks (owner)' '
-        flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-USER get $DIR.test"
+        flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-USER get $DIR.test"
 '
 
 test_expect_success 'kvs: get fails (wrong user)' '
@@ -180,7 +180,7 @@ test_expect_success 'kvs: get fails (wrong user)' '
 '
 
 test_expect_success 'kvs: get fails on other ranks (wrong user)' '
-        ! flux exec -r 1 sh -c "FLUX_HANDLE_USERID=9000 \
+        ! flux exec -n -r 1 sh -c "FLUX_HANDLE_USERID=9000 \
                                 FLUX_HANDLE_ROLEMASK=0x2 \
                                 flux kvs --namespace=$NAMESPACETMP-USER get $DIR.test"
 '
@@ -246,13 +246,13 @@ test_expect_success NO_CHAIN_LINT 'kvs: version & wait works (user)' '
 '
 
 test_expect_success 'kvs: version works on other ranks (user)' '
-        flux exec -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
+        flux exec -n -r 1 sh -c "FLUX_HANDLE_USERID=9999 \
                               FLUX_HANDLE_ROLEMASK=0x2 \
                               flux kvs --namespace=$NAMESPACETMP-USER version"
 '
 
 test_expect_success 'kvs: version works on other ranks (owner)' '
-        flux exec -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-USER version"
+        flux exec -n -r 1 sh -c "flux kvs --namespace=$NAMESPACETMP-USER version"
 '
 
 test_expect_success 'kvs: version fails (wrong user)' '
@@ -262,7 +262,7 @@ test_expect_success 'kvs: version fails (wrong user)' '
 '
 
 test_expect_success 'kvs: version fails on other ranks (wrong user)' '
-        ! flux exec -r 1 sh -c "FLUX_HANDLE_USERID=9000 \
+        ! flux exec -n -r 1 sh -c "FLUX_HANDLE_USERID=9000 \
                                 FLUX_HANDLE_ROLEMASK=0x2 \
                                 flux kvs --namespace=$NAMESPACETMP-USER version"
 '

--- a/t/t1101-barrier-basic.t
+++ b/t/t1101-barrier-basic.t
@@ -23,7 +23,7 @@ test_expect_success 'barrier: returns when complete' '
 '
 
 test_expect_success 'barrier: returns when complete (all ranks)' '
-	flux exec ${tbarrier} --nprocs ${SIZE} abc
+	flux exec -n ${tbarrier} --nprocs ${SIZE} abc
 '
 
 test_expect_success 'barrier: blocks while incomplete' '
@@ -40,13 +40,13 @@ test_expect_success 'barrier: fails with name=NULL outside of LWJ' '
 test_expect_success 'barrier: succeeds with name=NULL inside LWJ' '
 	unset SLURM_STEPID &&
         FLUX_JOB_ID=1 && export FLUX_JOB_ID &&
-	flux exec ${tbarrier} --nprocs ${SIZE}
+	flux exec -n ${tbarrier} --nprocs ${SIZE}
 '
 
 test_expect_success 'barrier: succeeds with name=NULL inside SLURM step' '
 	unset FLUX_LWJ_ID &&
         SLURM_STEPID=1 && export SLURM_STEPID &&
-	flux exec ${tbarrier} --nprocs ${SIZE}
+	flux exec -n ${tbarrier} --nprocs ${SIZE}
 '
 
 test_expect_success 'barrier: remove barrier module' '

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -565,12 +565,12 @@ test_expect_success 'wreck job is linked in lwj-complete after failure' '
 '
 
 test_expect_success 'wreck: no KVS watchers leaked after 10 jobs' '
-	flux exec -r 1-$(($SIZE-1)) -l \
+	flux exec -n -r 1-$(($SIZE-1)) -l \
 		flux module stats --parse "namespace.primary.#watchers" kvs | sort -n >w.before &&
 	for i in `seq 1 10`; do
 		flux wreckrun --ntasks $SIZE /bin/true
 	done &&
-	flux exec -r 1-$(($SIZE-1)) -l \
+	flux exec -n -r 1-$(($SIZE-1)) -l \
 		flux module stats --parse "namespace.primary.#watchers" kvs | sort -n >w.after &&
 	test_cmp w.before w.after
 '

--- a/t/t2100-aggregate.t
+++ b/t/t2100-aggregate.t
@@ -13,24 +13,24 @@ test_expect_success 'have aggregator module' '
 '
 
 test_expect_success 'flux-aggreagate: works' '
-    run_timeout 2 flux exec -r 0-7 flux aggregate test 1 &&
+    run_timeout 2 flux exec -n -r 0-7 flux aggregate test 1 &&
     $kvscheck test "x.count == 8"
 '
 
 test_expect_success 'flux-aggreagate: works for floating-point numbers' '
-    run_timeout 2 flux exec -r 0-7 flux aggregate test 1.825 &&
+    run_timeout 2 flux exec -n -r 0-7 flux aggregate test 1.825 &&
     $kvscheck test "x.count == 8" &&
     $kvscheck test "x.min == 1.825" &&
     $kvscheck test "x.max == 1.825"
 '
 test_expect_success 'flux-aggreagate: works for strings' '
-    run_timeout 2 flux exec -r 0-7 flux aggregate test foo &&
+    run_timeout 2 flux exec -n -r 0-7 flux aggregate test foo &&
     flux kvs get test &&
     $kvscheck test "x.count == 8" &&
     $kvscheck test "x.entries[\"[0-7]\"] == \"foo\""
 '
 test_expect_success 'flux-aggreagate: works for arrays' '
-    run_timeout 2 flux exec -r 0-7 flux aggregate -e "{7,8,9}" test &&
+    run_timeout 2 flux exec -n -r 0-7 flux aggregate -e "{7,8,9}" test &&
     flux kvs get test &&
     $kvscheck test "x.count == 8" &&
     $kvscheck test "#x.entries[\"[0-7]\"] == 3" &&
@@ -39,7 +39,7 @@ test_expect_success 'flux-aggreagate: works for arrays' '
     $kvscheck test "x.entries[\"[0-7]\"][3] == 9"
 '
 test_expect_success 'flux-aggreagate: works for objects' '
-    run_timeout 2 flux exec -r 0-7 flux aggregate \
+    run_timeout 2 flux exec -n -r 0-7 flux aggregate \
                                    -e "{foo = 42, bar = {baz = 2}}" test &&
     flux kvs get test &&
     $kvscheck test "x.count == 8" &&
@@ -47,25 +47,25 @@ test_expect_success 'flux-aggreagate: works for objects' '
     $kvscheck test "x.entries[\"[0-7]\"].bar.baz == 2"
 '
 test_expect_success 'flux-aggregate: abort works' '
-    test_expect_code 1 run_timeout 5 flux exec -r 0-7 flux aggregate . 1
+    test_expect_code 1 run_timeout 5 flux exec -n -r 0-7 flux aggregate . 1
 '
 
 test_expect_success 'flux-aggregate: different value per rank' '
-    run_timeout 2 flux exec -r 0-7 bash -c "flux aggregate test \$(flux getattr rank)" &&
+    run_timeout 2 flux exec -n -r 0-7 bash -c "flux aggregate test \$(flux getattr rank)" &&
     $kvstest test "x.count == 8" &&
     $kvstest test "x.min == 0" &&
     $kvstest test "x.max == 7"
 '
 
 test_expect_success 'flux-aggregate: different fp value per rank' '
-    run_timeout 2 flux exec -r 0-7 bash -c "flux aggregate test 1.\$(flux getattr rank)" &&
+    run_timeout 2 flux exec -n -r 0-7 bash -c "flux aggregate test 1.\$(flux getattr rank)" &&
     $kvstest test "x.count == 8" &&
     $kvstest test "x.min == 1" &&
     $kvstest test "x.max == 1.7"
 '
 
 test_expect_success 'flux-aggregate: --timeout=0. - immediate forward' '
-    run_timeout 2 flux exec -r 0-7 flux aggregate -t 0. test 1 &&
+    run_timeout 2 flux exec -n -r 0-7 flux aggregate -t 0. test 1 &&
     $kvstest test "x.count == 8" &&
     $kvstest test "x.total == 8" &&
     $kvstest test "x.min == 1" &&
@@ -73,7 +73,7 @@ test_expect_success 'flux-aggregate: --timeout=0. - immediate forward' '
 '
 
 test_expect_success 'flux-aggregate: --fwd-count works' '
-    run_timeout 2 flux exec -r 0-7 bash -c \
+    run_timeout 2 flux exec -n -r 0-7 bash -c \
      "flux aggregate -t10 -c \$((1+\$(flux getattr tbon.descendants))) test 1" &&
     $kvstest test "x.count == 8" &&
     $kvstest test "x.total == 8" &&


### PR DESCRIPTION
This hopefully fixes #1803, a problem mainly seen with bash on Ubuntu based systems, where after running `make check`, sometimes the next commands run by the shell fail with EAGAIN.  The culprit was narrowed down to `flux-exec` and its handling of the O_NONBLOCK flag on the sometimes inherited stdin file descriptor.

First, several sharness tests that use `flux exec` are modified so that if stdin is not required, the `-n` option is used.

Then `buffer_read_watcher_create()` no longer sets O_NONBLOCK on its file descriptor.  Instead, the user must pass it in that way (or fail with EINVAL).  Various, users such as in `libsubprocess`, `flux exec`, and unit tests, are then modified to set this flag before calling the function.  Special care is taken in `flux exec` save and restore the original flags on stdin.

I'll open a bug to do the same for `buffer_write_watcher_create()` (no time for that now).