### PR TITLE
flux-version: show broker, library, and command version, and add API version access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ libtool
 .libs/
 libltdl/
 
+# generated library version header
+/src/common/libflux/version.h
+
 # libtool pull-ins
 /config/libtool.m4
 /config/ltoptions.m4

--- a/config/ax_split_version.m4
+++ b/config/ax_split_version.m4
@@ -1,0 +1,38 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_split_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_SPLIT_VERSION
+#
+# DESCRIPTION
+#
+#   Splits a version number in the format MAJOR.MINOR.POINT into its
+#   separate components.
+#
+#   Sets the variables.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tom Howard <tomhoward@users.sf.net>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 10
+
+AC_DEFUN([AX_SPLIT_VERSION],[
+    AC_REQUIRE([AC_PROG_SED])
+    AX_MAJOR_VERSION=`echo "$VERSION" | $SED 's/\([[^.]][[^.]]*\).*/\1/'`
+    AX_MINOR_VERSION=`echo "$VERSION" | $SED 's/[[^.]][[^.]]*.\([[^.]][[^.]]*\).*/\1/'`
+    AX_POINT_VERSION=`echo "$VERSION" | $SED 's/[[^.]][[^.]]*.[[^.]][[^.]]*.\(.*\)/\1/'`
+    AC_MSG_CHECKING([Major version])
+    AC_MSG_RESULT([$AX_MAJOR_VERSION])
+    AC_MSG_CHECKING([Minor version])
+    AC_MSG_RESULT([$AX_MINOR_VERSION])
+    AC_MSG_CHECKING([Point version])
+    AC_MSG_RESULT([$AX_POINT_VERSION])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,7 @@ AC_CONFIG_FILES( \
   src/common/libev/Makefile \
   src/common/libpmi/Makefile \
   src/common/libflux/Makefile \
+  src/common/libflux/version.h \
   src/common/libkvs/Makefile \
   src/common/libkz/Makefile \
   src/common/libjsc/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,15 @@ AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])
 
 ##
+# Generate project versions from PACKAGE_VERSION (set from git describe above)
+##
+AX_SPLIT_VERSION
+AX_POINT_VERSION=$(echo $AX_POINT_VERSION | $SED 's/-.*$//')
+AC_SUBST([AX_MAJOR_VERSION])
+AC_SUBST([AX_MINOR_VERSION])
+AC_SUBST([AX_POINT_VERSION])
+
+##
 # Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
 ##
 PKG_PROG_PKG_CONFIG

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -746,6 +746,9 @@ static void init_attrs (attr_t *attrs, pid_t pid)
     /* Initialize other miscellaneous attrs
      */
     init_attrs_broker_pid (attrs, pid);
+    if (attr_add (attrs, "version", FLUX_CORE_VERSION_STRING,
+                                            FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        log_err_exit ("attr_add version");
 }
 
 static void hello_update_cb (hello_t *hello, void *arg)

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -26,9 +26,29 @@
 
 #include "builtin.h"
 
+
+static void print_broker_version (optparse_t *p)
+{
+    const char *uri = getenv ("FLUX_URI");
+    const char *version;
+
+    if (!uri)
+        return;
+    flux_t *h = builtin_get_flux_handle (p);
+    if (!h)
+        log_err_exit ("flux_open %s failed", uri);
+    if (!(version = flux_attr_get (h, "version", NULL)))
+        log_err_exit ("flux_attr_get");
+    printf ("broker:  \t%s\n", version);
+    printf ("FLUX_URI:\t%s\n", uri);
+}
+
 static int cmd_version (optparse_t *p, int ac, char *av[])
 {
-    printf ("%s-%s\n", PACKAGE_NAME, PACKAGE_VERSION);
+    printf ("commands:    \t%s\n", FLUX_CORE_VERSION_STRING);
+    printf ("libflux-core:\t%s\n", flux_core_version_string ());
+    print_broker_version (p);
+
     return (0);
 }
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -331,12 +331,8 @@ static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
         if ((status = flux_subprocess_status (p)) >= 0) {
             if (WIFSIGNALED (status))
-                log_msg ("%d (pid %d) %s", cli->rank, pid, strsignal (WSTOPSIG (status)));
-            else if (WIFCONTINUED (status))
-                log_msg ("%d (pid %d) %s", cli->rank, pid, strsignal (SIGCONT));
-            else if (WIFSIGNALED (status))
                 log_msg ("%d (pid %d) %s", cli->rank, pid, strsignal (WTERMSIG (status)));
-            else if (WIFEXITED (status))
+            else if (WIFEXITED (status) && WEXITSTATUS (status) != 0)
                 log_msg ("%d (pid %d) exited with rc=%d", cli->rank, pid, WEXITSTATUS (status));
         } else
             log_msg ("%d (pid %d) exited, unknown status", cli->rank, pid);

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -75,7 +75,8 @@ fluxcoreinclude_HEADERS = \
 	future.h \
 	barrier.h \
 	buffer.h \
-	service.h
+	service.h \
+	version.h
 
 noinst_LTLIBRARIES = \
 	libflux.la
@@ -114,7 +115,8 @@ libflux_la_SOURCES = \
 	barrier.c \
 	buffer_private.h \
 	buffer.c \
-	service.c
+	service.c \
+	version.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -137,7 +137,8 @@ TESTS = test_module.t \
 	test_buffer.t \
 	test_mrpc.t \
 	test_handle.t \
-	test_msg_handler.t
+	test_msg_handler.t \
+	test_version.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
@@ -217,3 +218,7 @@ test_handle_t_LDADD = $(test_ldadd) $(LIBDL)
 test_msg_handler_t_SOURCES = test/msg_handler.c
 test_msg_handler_t_CPPFLAGS = $(test_cppflags)
 test_msg_handler_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_version_t_SOURCES = test/version.c
+test_version_t_CPPFLAGS = $(test_cppflags)
+test_version_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/test/version.c
+++ b/src/common/libflux/test/version.c
@@ -1,0 +1,36 @@
+#include "src/common/libflux/version.h"
+#include "src/common/libtap/tap.h"
+
+#include <string.h>
+
+int main (int argc, char *argv[])
+{
+    const char *s;
+    int a,b,c,d;
+    char vs[32];
+
+    plan (NO_PLAN);
+
+    d = flux_core_version (&a, &b, &c);
+    ok (d == (a<<16 | b<<8 | c),
+        "flux_core_version returned sane value");
+
+    lives_ok ({flux_core_version (NULL, NULL, NULL);},
+        "flux_core_version NULL, NULL, NULL doesn't crash");
+
+    snprintf (vs, sizeof (vs), "%d.%d.%d", a,b,c);
+    s = flux_core_version_string ();
+    ok (s != NULL && !strncmp (s, vs, strlen (vs)),
+        "flux_core_version_string returned expected string");
+    diag (s);
+
+
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/version.c
+++ b/src/common/libflux/version.c
@@ -1,5 +1,5 @@
 /*****************************************************************************\
- *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
  *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
  *  LLNL-CODE-658032 All rights reserved.
  *
@@ -22,38 +22,28 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#ifndef _FLUX_CORE_FLUX_H
-#define _FLUX_CORE_FLUX_H
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 
-#include "types.h"
-#include "handle.h"
-#include "reactor.h"
-#include "msg_handler.h"
-#include "connector.h"
-#include "security.h"
-#include "reduce.h"
-#include "message.h"
-#include "request.h"
-#include "response.h"
-#include "keepalive.h"
-#include "rpc.h"
-#include "mrpc.h"
-#include "panic.h"
-#include "event.h"
-#include "module.h"
-#include "info.h"
-#include "attr.h"
-#include "flog.h"
-#include "conf.h"
-#include "heartbeat.h"
-#include "content.h"
-#include "future.h"
-#include "barrier.h"
-#include "buffer.h"
-#include "service.h"
 #include "version.h"
 
-#endif /* !_FLUX_CORE_FLUX_H */
+const char *flux_core_version_string (void)
+{
+    return FLUX_CORE_VERSION_STRING;
+}
+
+int flux_core_version (int *major, int *minor, int *patch)
+{
+    if (major)
+        *major = FLUX_CORE_VERSION_MAJOR;
+    if (minor)
+        *minor = FLUX_CORE_VERSION_MINOR;
+    if (patch)
+        *patch = FLUX_CORE_VERSION_PATCH;
+    return FLUX_CORE_VERSION_HEX;
+}
+
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/version.h.in
+++ b/src/common/libflux/version.h.in
@@ -1,0 +1,75 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef _FLUX_CORE_VERSION_H
+#define _FLUX_CORE_VERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Flux uses semantic versioning: <major>.<minor>.<patch>
+ */
+
+/* The VERSION_STRING may include a "-N-hash" suffix from git describe
+ * if this snapshot is not tagged.  This is not reflected in VERSION_PATCH.
+ */
+#define FLUX_CORE_VERSION_STRING    "@PACKAGE_VERSION@"
+#define FLUX_CORE_VERSION_MAJOR     @AX_MAJOR_VERSION@
+#define FLUX_CORE_VERSION_MINOR     @AX_MINOR_VERSION@
+#define FLUX_CORE_VERSION_PATCH     @AX_POINT_VERSION@
+
+/* The version in 3 bytes, for numeric comparison.
+ */
+#define FLUX_CORE_VERSION_HEX       ((FLUX_CORE_VERSION_MAJOR << 16) | \
+                                     (FLUX_CORE_VERSION_MINOR << 8) | \
+                                     (FLUX_CORE_VERSION_PATCH << 0))
+
+
+/* These functions return the compiled-in versions.
+ * Useful for determining the version of dynamically linked libflux-core.
+ */
+
+/* Returns FLUX_CORE_VERSION_STRING.
+ */
+const char *flux_core_version_string (void);
+
+/* If major is non-NULL set it to FLUX_CORE_VERSION_MAJOR.
+ * If minor is non-NULL set it to FLUX_CORE_VERSION_MINOR.
+ * If patch is non-NULL set it to FLUX_CORE_VERSION_PATCH.
+ * Returns FLUX_CORE_VERSION_HEX.
+ */
+int flux_core_version (int *major, int *minor, int *patch);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_VERSION_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -26,8 +26,19 @@ test_expect_success 'event: can subscribe' '
 	grep "^hb" output_event_sub
 '
 
-test_expect_success 'version: reports an expected string' '
-	flux version | grep -Eq "flux-core-[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+(-[a-z0-9]+))?"
+test_expect_success 'version: reports expected values under an instance' '
+	flux version >version.out &&
+	grep -q libflux-core version.out &&
+	grep -q commands     version.out &&
+	grep -q broker       version.out &&
+	grep -q FLUX_URI     version.out
+'
+test_expect_success 'version: reports expected values not under an instance' '
+	(unset FLUX_URI; flux version >version2.out) &&
+	grep -q libflux-core version2.out &&
+	grep -q commands     version2.out &&
+	! grep -q broker     version2.out &&
+	! grep -q FLUX_URI   version2.out
 '
 
 heaptrace_error_check()


### PR DESCRIPTION
This adds a new broker attribute `version` which reports the broker's compiled in version, e.g.
```
$ flux getattr version
0.10.0-469-g0605e1a0
```

Then it adds a  `--remote` option to `flux version` so that, in addition to reporting _its_ compiled in version, it can fetch the broker's version if desired:
```
$ flux version --remote
flux-core-0.10.0-469-g0605e1a0
```

We mused in #1810 that this might come in handy as our flux deployments get more complicated, and it was super simple to add, so here it is.