### PR TITLE
various build system fixes

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -363,7 +363,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-        -I$(top_srcdir) -I$(top_srcdir)/src/include \
+        -I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
         $(ZMQ_CFLAGS)
 
 LDADD = \

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -2,8 +2,11 @@ AM_CFLAGS =	$(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
 		$(ZMQ_CFLAGS) \
 		-Wno-parentheses -Wno-error=parentheses
 AM_LDFLAGS =	$(CODE_COVERAGE_LIBS)
-AM_CPPFLAGS =	-I$(top_srcdir) -I$(top_srcdir)/src/include \
-		$(LUA_INCLUDE)
+AM_CPPFLAGS =	\
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(LUA_INCLUDE)
 
 fluxluadir =     $(luadir)/flux
 fluxometerdir =  $(luadir)/fluxometer

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -2,6 +2,7 @@ AM_CPPFLAGS = \
 	$(WARNING_CFLAGS) \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libflux \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(PYTHON_CPPFLAGS) \
 	$(CODE_COVERAGE_CFLAGS)
 
@@ -24,6 +25,7 @@ _build.py.c:
 
 _core_build.py: $(MAKE_BINDING)
 	$(PYTHON) $(MAKE_BINDING) --path $(top_srcdir)/src/common/libflux \
+		--search $(top_builddir)/src/common/libflux \
 		--package _flux \
 		--modname _core \
 		--add_sub '.*va_list.*|||' \

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = \
 
 AM_LDFLAGS = \
 	-avoid-version -module $(san_ld_zdef_flag) \
-	$(PYTHON_LDFLAGS) -Wl,-rpath,$(PYTHON_PREFIX)/lib \
+	-Wl,-rpath,$(PYTHON_PREFIX)/lib \
 	$(CODE_COVERAGE_LIBS)
 
 MAKE_BINDING=$(top_srcdir)/src/bindings/python/make_binding.py
@@ -15,7 +15,8 @@ SUFFIXES = _build.py
 
 common_libs = $(top_builddir)/src/common/libflux-core.la \
 	      $(top_builddir)/src/common/libflux-internal.la \
-	      $(ZMQ_LIBS)
+	      $(ZMQ_LIBS) \
+	      $(PYTHON_LDFLAGS)
 
 _build.py.c:
 	$(PYTHON) $*_build.py

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -5,7 +5,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(VALGRIND_CFLAGS)
 
 fluxcmd_PROGRAMS = flux-broker

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(LIBSODIUM_CFLAGS)
 
 AM_CXXFLAGS = \

--- a/src/common/libcompat/Makefile.am
+++ b/src/common/libcompat/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libcompat.la

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -78,7 +78,9 @@ fluxcoreinclude_HEADERS = \
 	future.h \
 	barrier.h \
 	buffer.h \
-	service.h \
+	service.h
+
+nodist_fluxcoreinclude_HEADERS = \
 	version.h
 
 noinst_LTLIBRARIES = \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -6,7 +6,10 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir) \
+	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) $(ZMQ_CFLAGS) $(LIBSODIUM_CFLAGS)
 
 installed_conf_cppflags = \

--- a/src/common/libidset/Makefile.am
+++ b/src/common/libidset/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libidset.la

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS) $(FLUX_SECURITY_CFLAGS) \
 	$(LIBSODIUM_CFLAGS)
 

--- a/src/common/libjsc/Makefile.am
+++ b/src/common/libjsc/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
 
 noinst_LTLIBRARIES = libjsc.la

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libkvs.la

--- a/src/common/libkz/Makefile.am
+++ b/src/common/libkz/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(LIBSODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = libkz.la

--- a/src/common/liboptparse/Makefile.am
+++ b/src/common/liboptparse/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = liboptparse.la

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libpmi.la

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
         $(CODE_COVERAGE_LDFLAGS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux
 
 
 noinst_LTLIBRARIES = \

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -9,7 +9,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libutil.la
 

--- a/src/common/libutil/cronodate.c
+++ b/src/common/libutil/cronodate.c
@@ -28,7 +28,6 @@
 #include <time.h>
 #include <sys/time.h>
 #include <ctype.h>
-#include <flux/core.h>
 #include <czmq.h>
 
 #include "src/common/libutil/nodeset.h"

--- a/src/common/libzio/Makefile.am
+++ b/src/common/libzio/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libzio.la

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -15,8 +15,9 @@ local_la_SOURCES = local.c
 
 local_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
-	--disable-static -avoid-version -shared -export-dynamic \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	--disable-static -avoid-version -shared -export-dynamic
 
-local_la_LIBADD = $(ZMQ_LIBS)
+local_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS)

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = local.la

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -15,8 +15,9 @@ loop_la_SOURCES = loop.c
 
 loop_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
-	--disable-static -avoid-version -shared -export-dynamic \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	--disable-static -avoid-version -shared -export-dynamic
 
-loop_la_LIBADD = $(ZMQ_LIBS)
+loop_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS)

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = loop.la

--- a/src/connectors/shmem/Makefile.am
+++ b/src/connectors/shmem/Makefile.am
@@ -15,8 +15,9 @@ shmem_la_SOURCES = shmem.c
 
 shmem_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
-	--disable-static -avoid-version -shared -export-dynamic \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	--disable-static -avoid-version -shared -export-dynamic
 
-shmem_la_LIBADD = $(ZMQ_LIBS)
+shmem_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS)

--- a/src/connectors/shmem/Makefile.am
+++ b/src/connectors/shmem/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = shmem.la

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -15,8 +15,9 @@ ssh_la_SOURCES = ssh.c
 
 ssh_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
-	--disable-static -avoid-version -shared -export-dynamic \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	--disable-static -avoid-version -shared -export-dynamic
 
-ssh_la_LIBADD = $(ZMQ_LIBS)
+ssh_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS)

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = ssh.la

--- a/src/modules/aggregator/Makefile.am
+++ b/src/modules/aggregator/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 #

--- a/src/modules/barrier/Makefile.am
+++ b/src/modules/barrier/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 #

--- a/src/modules/connector-local/Makefile.am
+++ b/src/modules/connector-local/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 #

--- a/src/modules/content-sqlite/Makefile.am
+++ b/src/modules/content-sqlite/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(SQLITE_CFLAGS) \
 	$(LZ4_CFLAGS)
 

--- a/src/modules/cron/Makefile.am
+++ b/src/modules/cron/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 #

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-ingest.la

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-manager.la

--- a/src/modules/kvs-watch/Makefile.am
+++ b/src/modules/kvs-watch/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs-watch.la

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs.la

--- a/src/modules/pymod/Makefile.am
+++ b/src/modules/pymod/Makefile.am
@@ -18,7 +18,7 @@ AM_CPPFLAGS = \
 fluxmod_LTLIBRARIES = pymod.la
 
 pymod_la_SOURCES = py_mod.c
-pymod_la_LDFLAGS = $(fluxmod_ldflags) -module $(PYTHON_LDFLAGS)
+pymod_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 # allow pymod to find the configured libpython at runtime
 pymod_la_LDFLAGS += -Wl,-rpath -Wl,$(PYTHON_PREFIX)/lib
@@ -26,7 +26,8 @@ pymod_la_LDFLAGS += -Wl,-rpath -Wl,$(PYTHON_PREFIX)/lib
 pymod_la_LIBADD = $(top_builddir)/src/common/libflux-core.la \
 		  $(top_builddir)/src/common/libflux-internal.la \
 		  $(top_builddir)/src/common/libflux-optparse.la \
-		  $(ZMQ_LIBS)
+		  $(ZMQ_LIBS) \
+		  $(PYTHON_LDFLAGS)
 
 fluxpymod_PYTHON = echo.py __init__.py
 

--- a/src/modules/pymod/Makefile.am
+++ b/src/modules/pymod/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	-DPYTHON_LIBRARY=\"$(PYTHON_LIBRARY)\" \
 	$(ZMQ_CFLAGS) \
 	$(PYTHON_CPPFLAGS) \

--- a/src/modules/resource-hwloc/Makefile.am
+++ b/src/modules/resource-hwloc/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 #

--- a/src/modules/userdb/Makefile.am
+++ b/src/modules/userdb/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 fluxmod_LTLIBRARIES = userdb.la

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -8,11 +8,8 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_srcdir)/src/common/libflux \
+	-I$(top_builddir)/src/common/libflux \
 	-I$(top_srcdir)/src/common/liblsd \
-	-I$(top_srcdir)/src/modules/broker \
-	-I$(top_srcdir)/src/modules/kvs \
-	-I$(top_srcdir)/src/broker \
 	$(LUA_INCLUDE) \
 	$(ZMQ_CFLAGS)
 

--- a/src/modules/wreck/Makefile.am
+++ b/src/modules/wreck/Makefile.am
@@ -30,9 +30,15 @@ fluxlibexec_PROGRAMS = \
 fluxmod_libadd = $(top_builddir)/src/common/libflux-core.la \
 		 $(top_builddir)/src/common/libflux-internal.la
 
-job_la_SOURCES = job.c rcalc.c rcalc.h wreck_job.c wreck_job.h
+noinst_LTLIBRARIES = \
+	librcalc.la
+librcalc_la_SOURCES = \
+	rcalc.c \
+	rcalc.h
+
+job_la_SOURCES = job.c wreck_job.c wreck_job.h
 job_la_LDFLAGS = $(AM_LDFLAGS) $(fluxmod_ldflags) -module
-job_la_LIBADD = $(fluxmod_libadd)
+job_la_LIBADD = $(fluxmod_libadd) librcalc.la
 
 wrexecd_SOURCES = \
 	wrexecd.c \
@@ -50,7 +56,7 @@ wrexecd_LDFLAGS = \
 	$(AM_LDFLAGS) -export-dynamic
 
 wrexecd_LDADD = \
-	rcalc.o \
+	librcalc.la \
 	$(wrexecd_libs) \
 	$(ZMQ_LIBS) $(LUA_LIB) $(LIBPTHREAD) $(HWLOC_LIBS)
 

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/src/include \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
 noinst_SCRIPTS = \

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -23,7 +23,7 @@
 # if make is old, and scl is here, and devtoolset is available and not turned
 # on, re-exec ourself with it active to get a newer make
 if make --version | grep 'GNU Make 4' 2>&1 > /dev/null ; then
-  MAKE="make --output-sync=target"
+  MAKE="make --output-sync=target --no-print-directory"
 else
   MAKE="make" #use this if all else fails
   if test "X$X_SCLS" = "X" ; then

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -441,8 +441,8 @@ request_req_la_LIBADD = \
 wreck_rcalc_SOURCES = wreck/rcalc.c
 wreck_rcalc_CPPFLAGS = $(test_cppflags)
 wreck_rcalc_LDADD = \
-        $(test_ldadd) $(LIBDL) $(LIBUTIL) \
-	$(top_builddir)/src/modules/wreck/rcalc.o
+	$(top_builddir)/src/modules/wreck/librcalc.la \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 wreck_sched_dummy_la_SOURCES = wreck/sched-dummy.c
 wreck_sched_dummy_la_CPPFLAGS = $(test_cppflags)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -6,7 +6,9 @@ AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS = \
-        -I$(top_srcdir) -I$(top_srcdir)/src/include \
+        -I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
         $(ZMQ_CFLAGS)
 
 #  If LUA_PATH is already set, ensure ./?.lua appears in LUA_PATH so that


### PR DESCRIPTION
Just parking this PR here for the moment in case someone else hits this issue.

If an existing libflux-core.so is installed in the system path (e.g. `/usr/lib64`), and flux-core is configured to side install to a different prefix (e.g. `--prefix=/tmp/flux`), `make install` will fail because, during relink, the linker will find the system libflux-core.so before the libflux-core.so that was *just* installed :-1:.

e.g.:
```
.libs/py_mod.o: In function `register_pymod_service_name':
/tmp/flux-core/src/modules/pymod/py_mod.c:109: undefined reference to `flux_service_register'
collect2: error: ld returned 1 exit status
libtool: install: error: relink `pymod.la' with the above command before installing it
make[4]: *** [install-fluxmodLTLIBRARIES] Error 1
```

The problem is that there is a couple places where `-l` and `-L` flags are passed to `target_LDFLAGS` or `AM_LDFLAGS`, and I guess this is confusing libtool, which then promotes `-L` to the front of the arguments and if that happens to be `-L/usr/lib64`, the system path is searched before the prefix/lb path.

This patch just cleans up the few places I found where flags should have been put on `_LDADD` or `_LIBADD`.