### PR TITLE
kvs: add flux_kvs_copy(), flux_kvs_move()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,7 @@ AS_IF([test "x$with_flux_security" = "xyes"], [
                       [flux_sec_incdir=;])
     AS_IF([test "x$flux_sec_incdir" = x],
           [AC_MSG_ERROR([couldn't find flux-security or include directory])])
+    AC_CHECK_HEADERS([flux/security/version.h])
     AC_DEFINE([HAVE_FLUX_SECURITY], [1], [Define flux-security is available])
     AC_SUBST(FLUX_SECURITY_INCDIR, $flux_sec_incdir)
 ])

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -53,6 +53,7 @@ MAN3_FILES_PRIMARY = \
 	flux_kvs_set_namespace.3 \
 	flux_kvs_getroot.3 \
 	flux_kvs_eventlog_create.3 \
+	flux_kvs_copy.3 \
 	idset_create.3
 
 # These files are generated as roff .so includes of a primary page.
@@ -186,6 +187,7 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_eventlog_append.3 \
 	flux_kvs_eventlog_first.3 \
 	flux_kvs_eventlog_next.3 \
+	flux_kvs_move.3 \
 	idset_destroy.3 \
 	idset_encode.3 \
 	idset_decode.3
@@ -329,6 +331,7 @@ flux_kvs_eventlog_update.3: flux_kvs_eventlog_create.3
 flux_kvs_eventlog_append.3: flux_kvs_eventlog_create.3
 flux_kvs_eventlog_first.3: flux_kvs_eventlog_create.3
 flux_kvs_eventlog_next.3: flux_kvs_eventlog_create.3
+flux_kvs_move.3: flux_kvs_copy.3
 idset_destroy.3: idset_create.3
 idset_encode.3: idset_create.3
 idset_decode.3: idset_create.3

--- a/doc/man3/flux_kvs_copy.adoc
+++ b/doc/man3/flux_kvs_copy.adoc
@@ -1,0 +1,108 @@
+flux_kvs_copy(3)
+================
+:doctype: manpage
+
+
+NAME
+----
+flux_kvs_copy, flux_kvs_move - copy/move a KVS key
+
+
+SYNOPSIS
+--------
+ #include <flux/core.h>
+
+ flux_future_t *flux_kvs_copy (flux_t *h,
+                               const char *srckey,
+                               const char *dstkey,
+                               int commit_flags);
+
+ flux_future_t *flux_kvs_move (flux_t *h,
+                               const char *srckey,
+                               const char *dstkey,
+                               int commit_flags);
+
+
+DESCRIPTION
+-----------
+
+`flux_kvs_copy()` sends a request via handle _h_ to the KVS service
+to look up the directory entry of _srckey_.  Upon receipt of the response,
+it then sends another request to commit a duplicate at _dstkey_.
+_commit_flags_ are passed through to the commit operation.
+See the FLAGS section of flux_kvs_commit(3).
+
+The net effect is that all content below _srckey_ is copied to _dstkey_.
+Due to the hash tree organization of the KVS name space, only the
+directory entry needs to be duplicated to create a new, fully independent
+deep copy of the original data.
+
+`flux_kvs_move()` first performs a `flux_kvs_copy()`, then sends a
+commit request to unlink _srckey_.  _commit_flags_ are passed through to
+the commit within `flux_kvs_copy()`, and to the commit which performs
+the unlink.
+
+`flux_kvs_copy()` and `flux_kvs_move()` are capable of working across
+namespaces.  See `flux_kvs_commit(3)` for info on how to select a
+namespace other than the default.
+
+
+CAVEATS
+-------
+
+`flux_kvs_copy()` and `flux_kvs_commit()` are implemented as aggregates
+of multiple KVS operations.  As such they do not have the "all or nothing"
+guarantee of a being carried out within a single KVS transaction.
+
+In the unlikely event that the copy phase of a `flux_kvs_move()`
+succeeds but the unlink phase fails, `flux_kvs_move()` may return failure
+without cleaning up the new copy.  Since the copy phase already validated
+that the unlink target key exists by copying from it, the source of such a
+failure would be a transient error such as out of memory or communication
+failure.
+
+
+RETURN VALUE
+------------
+
+`flux_kvs_copy ()` and `flux_kvs_move ()` return a `flux_future_t` on
+success, or NULL on failure with errno set appropriately.
+
+
+ERRORS
+------
+
+EINVAL::
+One of the arguments was invalid.
+
+ENOMEM::
+Out of memory.
+
+EPROTO::
+A request was malformed.
+
+ENOSYS::
+The KVS module is not loaded.
+
+ENOTSUP::
+An unknown namespace was requested.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_future_get(3), flux_kvs_commit(3)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -447,3 +447,5 @@ getroot
 eventlog
 eventlogs
 nocopy
+srckey
+dstkey

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -25,6 +25,9 @@
 #include <config.h>
 
 #include "builtin.h"
+#if HAVE_FLUX_SECURITY_VERSION_H
+#include <flux/security/version.h>
+#endif
 
 
 static void print_broker_version (optparse_t *p)
@@ -39,14 +42,24 @@ static void print_broker_version (optparse_t *p)
         log_err_exit ("flux_open %s failed", uri);
     if (!(version = flux_attr_get (h, "version", NULL)))
         log_err_exit ("flux_attr_get");
-    printf ("broker:  \t%s\n", version);
-    printf ("FLUX_URI:\t%s\n", uri);
+    printf ("broker:  \t\t%s\n", version);
+    printf ("FLUX_URI:\t\t%s\n", uri);
 }
 
 static int cmd_version (optparse_t *p, int ac, char *av[])
 {
-    printf ("commands:    \t%s\n", FLUX_CORE_VERSION_STRING);
-    printf ("libflux-core:\t%s\n", flux_core_version_string ());
+    printf ("commands:    \t\t%s\n", FLUX_CORE_VERSION_STRING);
+    printf ("libflux-core:\t\t%s\n", flux_core_version_string ());
+#if HAVE_FLUX_SECURITY
+    /* N.B. flux_security_version_string () was added at the same
+     * time as the FLUX_SECURITY_VERSION_STRING macro.
+     * The inner #ifdef may be removed after configure is enforcing a
+     * pkg-config minimum version for flux-security.
+     */
+# ifdef FLUX_SECURITY_VERSION_STRING
+    printf ("libflux-security:\t%s\n", flux_security_version_string ());
+# endif
+#endif
     print_broker_version (p);
 
     return (0);

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -48,7 +48,8 @@ TESTS = \
 	test_kvs_watch.t \
 	test_kvs_getroot.t \
 	test_treeobj.t \
-	test_kvs_eventlog.t
+	test_kvs_eventlog.t \
+	test_kvs_copy.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -106,3 +107,7 @@ test_treeobj_t_LDADD = $(test_ldadd) $(LIBDL)
 test_kvs_eventlog_t_SOURCES = test/kvs_eventlog.c
 test_kvs_eventlog_t_CPPFLAGS = $(test_cppflags)
 test_kvs_eventlog_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_kvs_copy_t_SOURCES = test/kvs_copy.c
+test_kvs_copy_t_CPPFLAGS = $(test_cppflags)
+test_kvs_copy_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -24,7 +24,8 @@ libkvs_la_SOURCES = \
 	kvs_txn_private.h \
 	treeobj.h \
 	treeobj.c \
-	kvs_eventlog.c
+	kvs_eventlog.c \
+	kvs_copy.c
 
 fluxcoreinclude_HEADERS = \
 	kvs.h \
@@ -35,7 +36,8 @@ fluxcoreinclude_HEADERS = \
 	kvs_classic.h \
 	kvs_txn.h \
 	kvs_commit.h \
-	kvs_eventlog.h
+	kvs_eventlog.h \
+	kvs_copy.h
 
 TESTS = \
 	test_kvs.t \

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -35,6 +35,7 @@
 #include "kvs_txn.h"
 #include "kvs_commit.h"
 #include "kvs_eventlog.h"
+#include "kvs_copy.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/libkvs/kvs_copy.c
+++ b/src/common/libkvs/kvs_copy.c
@@ -1,0 +1,199 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* flux_kvs_copy() and flux_kvs_move() return composite futures.
+ *
+ * Copy is implemented as a sequential lookup + put.
+ *
+ * Move is implemented as a sequential copy + unlink.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "kvs_copy.h"
+
+struct copy_context {
+    int commit_flags;
+    char *srckey;
+    char *dstkey;
+};
+
+static void copy_context_destroy (struct copy_context *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        free (ctx->srckey);
+        free (ctx->dstkey);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct copy_context *copy_context_create (const char *srckey,
+                                                 const char *dstkey,
+                                                 int commit_flags)
+{
+    struct copy_context *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (!(ctx->srckey = strdup (srckey)) || !(ctx->dstkey = strdup (dstkey))) {
+        copy_context_destroy (ctx);
+        return NULL;
+    }
+    ctx->commit_flags = commit_flags;
+    return ctx;
+}
+
+/* Move: unlink 'srckey' once copy finishes.
+ * N.B. because copy (put) and unlink are not in the same transaction,
+ * it is possible for the copy to succeed and the unlink to fail,
+ * but since they are sequential, not the other way around.
+ * Unwinding the copy on the error path seems just as unlikely to
+ * fail, so we don't try that.  If the operations were placed in the
+ * same transaction, they could not cross namespaces.
+ */
+static void copy_continuation (flux_future_t *f, void *arg)
+{
+    struct copy_context *ctx = arg;
+    flux_t *h = flux_future_get_flux (f);
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f2;
+
+    if (flux_future_get (f, NULL) < 0)
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_unlink (txn, 0, ctx->srckey) < 0)
+        goto error;
+    if (!(f2 = flux_kvs_commit (h, ctx->commit_flags, txn)))
+        goto error;
+    if (flux_future_continue (f, f2) < 0) {
+        flux_future_destroy (f2);
+        goto error;
+    }
+    goto done;
+error:
+    flux_future_continue_error (f, errno);
+done:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+}
+
+/* Copy: put 'dstkey' once lookup finishes.
+ * The lookup returned an RFC 11 treeobj, which could be
+ * a self-contained value, or pointer(s) to content representing
+ * a directory or a value.  Creating a new key with the same
+ * treeobj is effectively creating a snapshot.
+ */
+static void lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct copy_context *ctx = arg;
+    flux_t *h = flux_future_get_flux (f);
+    const char *val;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f2;
+
+    if (flux_kvs_lookup_get_treeobj (f, &val) < 0)
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put_treeobj (txn, 0, ctx->dstkey, val) < 0)
+        goto error;
+    if (!(f2 = flux_kvs_commit (h, ctx->commit_flags, txn)))
+        goto error;
+    if (flux_future_continue (f, f2) < 0) {
+        flux_future_destroy (f2);
+        goto error;
+    }
+    goto done;
+error:
+    flux_future_continue_error (f, errno);
+done:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+}
+
+flux_future_t *flux_kvs_copy (flux_t *h, const char *srckey,
+                                         const char *dstkey,
+                                         int commit_flags)
+{
+    struct copy_context *ctx;
+    flux_future_t *f1;
+    flux_future_t *f2;
+
+    if (!h || !srckey || !dstkey) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f1 = flux_kvs_lookup (h, FLUX_KVS_TREEOBJ, srckey)))
+        return NULL;
+    if (!(ctx = copy_context_create (srckey, dstkey, commit_flags)))
+        goto error;
+    if (flux_aux_set (h, NULL, ctx, (flux_free_f)copy_context_destroy) < 0) {
+        copy_context_destroy (ctx);
+        goto error;
+    }
+    if (!(f2 = flux_future_and_then (f1, lookup_continuation, ctx)))
+        goto error;
+    return f2;
+error:
+    flux_future_destroy (f1);
+    return NULL;
+}
+
+flux_future_t *flux_kvs_move (flux_t *h, const char *srckey,
+                                         const char *dstkey,
+                                         int commit_flags)
+{
+    struct copy_context *ctx;
+    flux_future_t *f1;
+    flux_future_t *f2;
+
+    if (!h || !srckey || !dstkey) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f1 = flux_kvs_copy (h, srckey, dstkey, commit_flags)))
+        return NULL;
+    if (!(ctx = copy_context_create (srckey, dstkey, commit_flags)))
+        goto error;
+    if (flux_aux_set (h, NULL, ctx, (flux_free_f)copy_context_destroy) < 0) {
+        copy_context_destroy (ctx);
+        goto error;
+    }
+    if (!(f2 = flux_future_and_then (f1, copy_continuation, ctx)))
+        goto error;
+    return f2;
+error:
+    flux_future_destroy (f1);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/kvs_copy.h
+++ b/src/common/libkvs/kvs_copy.h
@@ -1,0 +1,61 @@
+/*****************************************************************************\
+ *  Copyright (c) 2018 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation; either version 2.1 of the license,
+ *  or (at your option) any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef _FLUX_CORE_KVS_COPY_H
+#define _FLUX_CORE_KVS_COPY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Create a copy of 'srckey' at 'dstkey'.
+ * Due to the hash-tree design of the KVS, dstkey is by definition a
+ * "deep copy" (or writable snapshot) of all content below srckey.
+ * The copy operation has a low overhead since it only copies a single
+ * directory entry.  'srckey' and 'dstkey' may be in different namespaces.
+ * Returns future on success, NULL on failure with errno set.
+ */
+flux_future_t *flux_kvs_copy (flux_t *h, const char *srckey,
+                                         const char *dstkey,
+                                         int commit_flags);
+
+/* Move 'srckey' to 'dstkey'.
+ * This is a copy followed by an unlink on 'srckey'.
+ * 'srckey' and 'dstkey' may be in different namespaces.
+ * The copy and unlink are not atomic.
+ * Returns future on success, NULL on failure with errno set.
+ */
+flux_future_t *flux_kvs_move (flux_t *h, const char *srckey,
+                                         const char *dstkey,
+                                         int commit_flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_KVS_COPY_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/test/kvs_copy.c
+++ b/src/common/libkvs/test/kvs_copy.c
@@ -1,0 +1,44 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h = (flux_t *)(uintptr_t)42;
+
+    plan (NO_PLAN);
+
+    errno = 0;
+    ok (flux_kvs_copy (NULL, "a", "b", 0) == NULL && errno == EINVAL,
+        "flux_kvs_copy h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_copy (h, NULL, "b", 0) == NULL && errno == EINVAL,
+        "flux_kvs_copy srckey=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_copy (h, "a", NULL, 0) == NULL && errno == EINVAL,
+        "flux_kvs_copy srckey=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_kvs_move (NULL, "a", "b", 0) == NULL && errno == EINVAL,
+        "flux_kvs_move h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_move (h, NULL, "b", 0) == NULL && errno == EINVAL,
+        "flux_kvs_move srckey=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_kvs_move (h, "a", NULL, 0) == NULL && errno == EINVAL,
+        "flux_kvs_move srckey=NULL fails with EINVAL");
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -75,6 +75,7 @@ TESTS = \
 	t1006-kvs-getroot.t \
 	t1007-kvs-lookup-watch.t \
 	t1008-kvs-eventlog.t \
+	t1009-kvs-copy.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -190,6 +191,7 @@ check_SCRIPTS = \
 	t1006-kvs-getroot.t \
 	t1007-kvs-lookup-watch.t \
 	t1008-kvs-eventlog.t \
+	t1009-kvs-copy.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -931,28 +931,6 @@ test_expect_success 'kvs: get --at: fails bad on dirent' '
 '
 
 #
-# copy/move tests
-#
-test_expect_success 'kvs: copy works' '
-        flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.src=\"foo\" &&
-        flux kvs copy $DIR.src $DIR.dest &&
-	OUTPUT1=$(flux kvs get --json $DIR.src) &&
-	OUTPUT2=$(flux kvs get --json $DIR.dest) &&
-	test "$OUTPUT1" = "foo" &&
-	test "$OUTPUT2" = "foo"
-'
-
-test_expect_success 'kvs: move works' '
-        flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.src=\"foo\" &&
-        flux kvs move $DIR.src $DIR.dest &&
-	test_must_fail flux kvs get --json $DIR.src &&
-	OUTPUT=$(flux kvs get --json $DIR.dest) &&
-	test "$OUTPUT" = "foo"
-'
-
-#
 # dropcache tests
 #
 

--- a/t/t1009-kvs-copy.t
+++ b/t/t1009-kvs-copy.t
@@ -1,0 +1,195 @@
+#!/bin/sh
+#
+
+test_description='Test flux-kvs copy
+Test flux-kvs copy and flux-kvs move.
+'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+SIZE=1
+test_under_flux ${SIZE} kvs
+
+# kvs-copy value
+
+test_expect_success 'kvs-copy value works' '
+        flux kvs unlink -Rf test &&
+	flux kvs put test.src=foo &&
+        flux kvs copy test.src test.dst
+'
+test_expect_success 'kvs-copy value does not unlink src' '
+	value=$(flux kvs get test.src) &&
+	test "$value" = "foo"
+'
+test_expect_success 'kvs-copy value dst contains expected value' '
+	value=$(flux kvs get test.dst) &&
+	test "$value" = "foo"
+'
+
+# kvs-move value
+
+test_expect_success 'kvs-move value works' '
+        flux kvs unlink -Rf test &&
+	flux kvs put test.src=bar &&
+        flux kvs move test.src test.dst
+'
+test_expect_success 'kvs-move value unlinks src' '
+	test_must_fail flux kvs get test.src
+'
+test_expect_success 'kvs-move value dst contains expected value' '
+	value=$(flux kvs get test.dst) &&
+	test "$value" = "bar"
+'
+
+# kvs-copy dir
+
+test_expect_success 'kvs-copy dir works' '
+        flux kvs unlink -Rf test &&
+	flux kvs put test.src.a.b.c=foo &&
+        flux kvs copy test.src test.dst
+'
+test_expect_success 'kvs-copy dir does not unlink src' '
+	value=$(flux kvs get test.src.a.b.c) &&
+	test "$value" = "foo"
+'
+test_expect_success 'kvs-copy dir dst contains expected value' '
+	value=$(flux kvs get test.dst.a.b.c) &&
+	test "$value" = "foo"
+'
+
+# kvs-move dir
+
+test_expect_success 'kvs-move dir works' '
+        flux kvs unlink -Rf test &&
+	flux kvs put test.src.a.b.c=bar &&
+        flux kvs move test.src test.dst
+'
+test_expect_success 'kvs-move dir unlinks src' '
+	test_must_fail flux kvs get --treeobj test.src
+'
+test_expect_success 'kvs-move dir dst contains expected value' '
+	value=$(flux kvs get test.dst.a.b.c) &&
+	test "$value" = "bar"
+'
+
+# from namespace
+#   copy a value, move a dir
+
+test_expect_success 'create test namespace' '
+	flux kvs namespace-create fromns
+'
+
+test_expect_success 'kvs-copy from namespace works' '
+        flux kvs unlink -Rf test &&
+        flux kvs unlink -Rf ns:fromns/test &&
+	flux kvs put ns:fromns/test.src=foo &&
+        flux kvs copy ns:fromns/test.src test.dst
+'
+test_expect_success 'kvs-copy from namespace does not unlink src' '
+	value=$(flux kvs get ns:fromns/test.src) &&
+	test "$value" = "foo"
+'
+test_expect_success 'kvs-copy from namespace dst contains expected value' '
+	value=$(flux kvs get test.dst) &&
+	test "$value" = "foo"
+'
+
+test_expect_success 'kvs-move from namespace works' '
+        flux kvs unlink -Rf test &&
+        flux kvs unlink -Rf ns:fromns/test &&
+	flux kvs put ns:fromns/test.src.a.b.c=foo &&
+        flux kvs move ns:fromns/test.src test.dst
+'
+test_expect_success 'kvs-move from namespace unlinks src' '
+	test_must_fail flux kvs get --treeobj ns:fromns/test.src
+'
+test_expect_success 'kvs-move from namespace dst contains expected value' '
+	value=$(flux kvs get test.dst.a.b.c) &&
+	test "$value" = "foo"
+'
+
+test_expect_success 'remove test namespace' '
+	flux kvs namespace-remove fromns
+'
+
+# to namespace
+#   copy a value, move a dir
+
+test_expect_success 'create test namespace' '
+	flux kvs namespace-create tons
+'
+
+test_expect_success 'kvs-copy to namespace works' '
+        flux kvs unlink -Rf ns:tons/test &&
+        flux kvs unlink -Rf test &&
+	flux kvs put test.src=foo &&
+        flux kvs copy test.src ns:tons/test.dst
+'
+test_expect_success 'kvs-copy to namespace does not unlink src' '
+	value=$(flux kvs get test.src) &&
+	test "$value" = "foo"
+'
+test_expect_success 'kvs-copy to namespace dst contains expected value' '
+	value=$(flux kvs get ns:tons/test.dst) &&
+	test "$value" = "foo"
+'
+
+test_expect_success 'kvs-move to namespace works' '
+        flux kvs unlink -Rf ns:tons/test &&
+        flux kvs unlink -Rf test &&
+	flux kvs put test.src.a.b.c=foo &&
+        flux kvs move test.src ns:tons/test.dst
+'
+test_expect_success 'kvs-move to namespace unlinks src' '
+	test_must_fail flux kvs get --treeobj test.src
+'
+test_expect_success 'kvs-move to namespace dst contains expected value' '
+	value=$(flux kvs get ns:tons/test.dst.a.b.c) &&
+	test "$value" = "foo"
+'
+
+test_expect_success 'remove test namespace' '
+	flux kvs namespace-remove tons
+'
+
+
+# expected failures
+
+test_expect_success 'kvs-copy missing argument fails' '
+	test_must_fail flux kvs copy foo
+'
+test_expect_success 'kvs-move missing argument fails' '
+	test_must_fail flux kvs move foo
+'
+test_expect_success 'kvs-copy nonexistent src fails' '
+	flux kvs unlink -Rf test.notakey &&
+	test_must_fail flux kvs copy test.notakey foo
+'
+test_expect_success 'kvs-move nonexistent src fails' '
+	flux kvs unlink -Rf test.notakey &&
+	test_must_fail flux kvs move test.notakey foo
+'
+test_expect_success 'kvs-copy nonexistent src namespace fails' '
+	flux kvs put test.foo=bar &&
+	test_must_fail flux kvs copy ns:nons/test.foo foo
+'
+test_expect_success 'kvs-move nonexistent src namespace fails' '
+	flux kvs put test.foo=bar &&
+	test_must_fail flux kvs move ns:nons/test.foo foo
+'
+test_expect_success 'kvs-copy nonexistent dst namespace fails' '
+	flux kvs put test.foo=69 &&
+	test_must_fail flux kvs copy test.foo ns:nons/test.foo
+'
+test_expect_success 'kvs-move nonexistent dst namespace fails' '
+	flux kvs put test.foo=69 &&
+	test_must_fail flux kvs move test.foo ns:nons/test.foo
+'
+
+test_done


### PR DESCRIPTION
This PR adds the `flux_kvs_copy()` and `flux_kvs_move()` composite operations that were discussed in #1747.