### PR TITLE
kvs: return errors to callers on asynchronous load/store failures

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -79,7 +79,7 @@ snapshot reference.  If '-w', after the initial value, display the
 new value each time the key changes until interrupted, or if '-c count'
 is specified, until 'count' values have been displayed.  If the
 initial value does not yet exist, `-W` can be specified to wait for it
-to be crated.
+to be created.
 
 *put* [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  If it already has a value,
@@ -169,7 +169,7 @@ display the namespace owner.  If '-s' is specified, display the root
 sequence number.  If '-w' is specified, display the current root,
 then a new value each time it is updated, up to 'count', if specified.
 If the namespace does not yet exist, `-W` can be specified to wait for
-it to be crated.
+it to be created.
 
 *eventlog get* [-w] [-c count] [-u] 'key'::
 Display the contents of an RFC 18 KVS eventlog referred to by 'key'.

--- a/src/common/libutil/iterators.h
+++ b/src/common/libutil/iterators.h
@@ -13,4 +13,11 @@
         (VALUE) = zhash_next(HASH),     \
         (KEY) = zhash_cursor(HASH))
 
+#define FOREACH_ZHASHX(HASH, KEY, VALUE) \
+    for((VALUE) = zhashx_first(HASH),    \
+        (KEY) = zhashx_cursor(HASH);     \
+        (VALUE) && (KEY);               \
+        (VALUE) = zhashx_next(HASH),     \
+        (KEY) = zhashx_cursor(HASH))
+
 #endif /* FLUX_ITERATORS_H */

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -66,7 +66,7 @@ struct cache_entry {
 };
 
 struct cache {
-    zhash_t *zh;
+    zhashx_t *zhx;
 };
 
 struct cache_entry *cache_entry_create (const char *ref)
@@ -303,7 +303,7 @@ int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait)
 struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
                                   int current_epoch)
 {
-    struct cache_entry *entry = zhash_lookup (cache->zh, ref);
+    struct cache_entry *entry = zhashx_lookup (cache->zhx, ref);
     if (entry && current_epoch > entry->lastuse_epoch)
         entry->lastuse_epoch = current_epoch;
     return entry;
@@ -314,17 +314,15 @@ int cache_insert (struct cache *cache, struct cache_entry *entry)
     int rc;
 
     if (cache && entry) {
-        rc = zhash_insert (cache->zh, entry->blobref, entry);
+        rc = zhashx_insert (cache->zhx, entry->blobref, entry);
         assert (rc == 0);
-
-        zhash_freefn (cache->zh, entry->blobref, cache_entry_destroy);
     }
     return 0;
 }
 
 int cache_remove_entry (struct cache *cache, const char *ref)
 {
-    struct cache_entry *entry = zhash_lookup (cache->zh, ref);
+    struct cache_entry *entry = zhashx_lookup (cache->zhx, ref);
 
     if (entry
         && !entry->dirty
@@ -332,7 +330,7 @@ int cache_remove_entry (struct cache *cache, const char *ref)
             || !wait_queue_length (entry->waitlist_notdirty))
         && (!entry->waitlist_valid
             || !wait_queue_length (entry->waitlist_valid))) {
-        zhash_delete (cache->zh, ref);
+        zhashx_delete (cache->zhx, ref);
         return 1;
     }
     return 0;
@@ -340,7 +338,7 @@ int cache_remove_entry (struct cache *cache, const char *ref)
 
 int cache_count_entries (struct cache *cache)
 {
-    return zhash_size (cache->zh);
+    return zhashx_size (cache->zhx);
 }
 
 static int cache_entry_age (struct cache_entry *entry, int current_epoch)
@@ -354,29 +352,30 @@ static int cache_entry_age (struct cache_entry *entry, int current_epoch)
 
 int cache_expire_entries (struct cache *cache, int current_epoch, int thresh)
 {
-    zlist_t *keys;
+    zlistx_t *keys;
     char *ref;
     struct cache_entry *entry;
     int count = 0;
 
-    /* Do not use zhash_first()/zhash_next() or FOREACH_ZHASH, as
-     * zhash_delete() call below modifies hash */
-    if (!(keys = zhash_keys (cache->zh))) {
+    /* Do not use zhashx_first()/zhashx_next() or FOREACH_ZHASHX, as
+     * zhashx_delete() call below modifies hash */
+    if (!(keys = zhashx_keys (cache->zhx))) {
         errno = ENOMEM;
         return -1;
     }
-    while ((ref = zlist_pop (keys))) {
-        if ((entry = zhash_lookup (cache->zh, ref))
+    ref = zlistx_first (keys);
+    while (ref) {
+        if ((entry = zhashx_lookup (cache->zhx, ref))
             && !cache_entry_get_dirty (entry)
             && cache_entry_get_valid (entry)
             && (thresh == 0
                 || cache_entry_age (entry, current_epoch) > thresh)) {
-                zhash_delete (cache->zh, ref);
+                zhashx_delete (cache->zhx, ref);
                 count++;
         }
-        free (ref);
+        ref = zlistx_next (keys);
     }
-    zlist_destroy (&keys);
+    zlistx_destroy (&keys);
     return count;
 }
 
@@ -389,7 +388,7 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *sizep,
     int incomplete = 0;
     int dirty = 0;
 
-    FOREACH_ZHASH (cache->zh, key, entry) {
+    FOREACH_ZHASHX (cache->zhx, key, entry) {
         if (cache_entry_get_valid (entry)) {
             int obj_size = 0;
 
@@ -419,7 +418,7 @@ int cache_wait_destroy_msg (struct cache *cache, wait_test_msg_f cb, void *arg)
     int n, count = 0;
     int rc = -1;
 
-    FOREACH_ZHASH (cache->zh, key, entry) {
+    FOREACH_ZHASHX (cache->zhx, key, entry) {
         if (entry->waitlist_valid) {
             if ((n = wait_destroy_msg (entry->waitlist_valid, cb, arg)) < 0)
                 goto done;
@@ -441,6 +440,13 @@ const char *cache_entry_get_blobref (struct cache_entry *entry)
     return entry ? entry->blobref : NULL;
 }
 
+static void cache_entry_destroy_wrapper (void **arg)
+{
+    struct cache_entry **entry = (struct cache_entry **)arg;
+    if (entry)
+        cache_entry_destroy (*entry);
+}
+
 struct cache *cache_create (void)
 {
     struct cache *cache = calloc (1, sizeof (*cache));
@@ -448,18 +454,22 @@ struct cache *cache_create (void)
         errno = ENOMEM;
         return NULL;
     }
-    if (!(cache->zh = zhash_new ())) {
+    if (!(cache->zhx = zhashx_new ())) {
         free (cache);
         errno = ENOMEM;
         return NULL;
     }
+    /* do not duplicate hash keys, use blobrefs stored in cache entry */
+    zhashx_set_key_destructor (cache->zhx, NULL);
+    zhashx_set_key_duplicator (cache->zhx, NULL);
+    zhashx_set_destructor (cache->zhx, cache_entry_destroy_wrapper);
     return cache;
 }
 
 void cache_destroy (struct cache *cache)
 {
     if (cache) {
-        zhash_destroy (&cache->zh);
+        zhashx_destroy (&cache->zhx);
         free (cache);
     }
 }

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -75,6 +75,12 @@ int cache_entry_set_raw (struct cache_entry *entry, const void *data, int len);
 
 const json_t *cache_entry_get_treeobj (struct cache_entry *entry);
 
+/* in the event of a load or store RPC error, inform the cache to set
+ * an error on all waiters of a type on a cache entry.
+ */
+int cache_entry_set_errnum_on_valid (struct cache_entry *entry, int errnum);
+int cache_entry_set_errnum_on_notdirty (struct cache_entry *entry, int errnum);
+
 /* Arrange for message handler represented by 'wait' to be restarted
  * once cache entry becomes valid or not dirty at completion of a
  * load or store RPC.

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -89,6 +89,11 @@ int cache_entry_set_errnum_on_notdirty (struct cache_entry *entry, int errnum);
 int cache_entry_wait_notdirty (struct cache_entry *entry, wait_t *wait);
 int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait);
 
+/* Get the blobref this entry is stored in the cache with.  Returns
+ * blobref on success, NULL if not yet stored in the cache.
+ */
+const char *cache_entry_get_blobref (struct cache_entry *entry);
+
 /* Create/destroy the cache container and its contents.
  */
 struct cache *cache_create (void);
@@ -104,8 +109,8 @@ struct cache_entry *cache_lookup (struct cache *cache,
 /* Insert an entry in the cache by blobref 'ref'.
  * Ownership of the cache entry is transferred to the cache.
  */
-void cache_insert (struct cache *cache, const char *ref,
-                   struct cache_entry *entry);
+int cache_insert (struct cache *cache, const char *ref,
+                  struct cache_entry *entry);
 
 /* Remove a cache_entry from the cache.  Will not be removed if dirty
  * or there are any waiters of any sort.

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -15,7 +15,7 @@ struct cache;
  * cache_entry_create() creates an empty cache entry.  Data can be set
  * in an entry via cache_entry_set_raw().
  */
-struct cache_entry *cache_entry_create (void);
+struct cache_entry *cache_entry_create (const char *ref);
 void cache_entry_destroy (void *arg);
 
 /* Return true if cache entry contains valid data.  False would
@@ -89,9 +89,7 @@ int cache_entry_set_errnum_on_notdirty (struct cache_entry *entry, int errnum);
 int cache_entry_wait_notdirty (struct cache_entry *entry, wait_t *wait);
 int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait);
 
-/* Get the blobref this entry is stored in the cache with.  Returns
- * blobref on success, NULL if not yet stored in the cache.
- */
+/* Get the blobref of this entry */
 const char *cache_entry_get_blobref (struct cache_entry *entry);
 
 /* Create/destroy the cache container and its contents.
@@ -106,11 +104,11 @@ void cache_destroy (struct cache *cache);
 struct cache_entry *cache_lookup (struct cache *cache,
                                   const char *ref, int current_epoch);
 
-/* Insert an entry in the cache by blobref 'ref'.
- * Ownership of the cache entry is transferred to the cache.
+/* Insert entry in the cache.  Reference for entry created during
+ * cache_entry_create() time.  Ownership of the cache entry is
+ * transferred to the cache.
  */
-int cache_insert (struct cache *cache, const char *ref,
-                  struct cache_entry *entry);
+int cache_insert (struct cache *cache, struct cache_entry *entry);
 
 /* Remove a cache_entry from the cache.  Will not be removed if dirty
  * or there are any waiters of any sort.

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -654,12 +654,12 @@ static int load (kvs_ctx_t *ctx, const char *ref, wait_t *wait, bool *stall)
     /* Create an incomplete hash entry if none found.
      */
     if (!entry) {
-        if (!(entry = cache_entry_create ())) {
+        if (!(entry = cache_entry_create (ref))) {
             flux_log_error (ctx->h, "%s: cache_entry_create",
                             __FUNCTION__);
             return -1;
         }
-        if (cache_insert (ctx->cache, ref, entry) < 0) {
+        if (cache_insert (ctx->cache, entry) < 0) {
             flux_log_error (ctx->h, "%s: cache_insert",
                             __FUNCTION__);
             cache_entry_destroy (entry);
@@ -2380,7 +2380,7 @@ static void prime_cache_with_rootdir (kvs_ctx_t *ctx, json_t *rootdir)
     }
     if ((entry = cache_lookup (ctx->cache, ref, ctx->epoch)))
         goto done; // already in cache, possibly dirty/invalid - we don't care
-    if (!(entry = cache_entry_create ())) {
+    if (!(entry = cache_entry_create (ref))) {
         flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
         goto done;
     }
@@ -2389,7 +2389,7 @@ static void prime_cache_with_rootdir (kvs_ctx_t *ctx, json_t *rootdir)
         cache_entry_destroy (entry);
         goto done;
     }
-    if (cache_insert (ctx->cache, ref, entry) < 0) {
+    if (cache_insert (ctx->cache, entry) < 0) {
         flux_log_error (ctx->h, "%s: cache_insert", __FUNCTION__);
         cache_entry_destroy (entry);
         goto done;
@@ -3049,11 +3049,11 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, char *ref, int ref_len)
         goto error;
     }
     if (!(entry = cache_lookup (ctx->cache, ref, ctx->epoch))) {
-        if (!(entry = cache_entry_create ())) {
+        if (!(entry = cache_entry_create (ref))) {
             flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
         }
-        if (cache_insert (ctx->cache, ref, entry) < 0) {
+        if (cache_insert (ctx->cache, entry) < 0) {
             flux_log_error (ctx->h, "%s: cache_insert", __FUNCTION__);
             cache_entry_destroy (entry);
             goto error;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -659,7 +659,12 @@ static int load (kvs_ctx_t *ctx, const char *ref, wait_t *wait, bool *stall)
                             __FUNCTION__);
             return -1;
         }
-        cache_insert (ctx->cache, ref, entry);
+        if (cache_insert (ctx->cache, ref, entry) < 0) {
+            flux_log_error (ctx->h, "%s: cache_insert",
+                            __FUNCTION__);
+            cache_entry_destroy (entry);
+            return -1;
+        }
         if (content_load_request_send (ctx, ref) < 0) {
             saved_errno = errno;
             flux_log_error (ctx->h, "%s: content_load_request_send",
@@ -2327,7 +2332,11 @@ static void prime_cache_with_rootdir (kvs_ctx_t *ctx, json_t *rootdir)
         cache_entry_destroy (entry);
         goto done;
     }
-    cache_insert (ctx->cache, ref, entry);
+    if (cache_insert (ctx->cache, ref, entry) < 0) {
+        flux_log_error (ctx->h, "%s: cache_insert", __FUNCTION__);
+        cache_entry_destroy (entry);
+        goto done;
+    }
 done:
     free (data);
 }
@@ -2987,7 +2996,11 @@ static int store_initial_rootdir (kvs_ctx_t *ctx, char *ref, int ref_len)
             flux_log_error (ctx->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
         }
-        cache_insert (ctx->cache, ref, entry);
+        if (cache_insert (ctx->cache, ref, entry) < 0) {
+            flux_log_error (ctx->h, "%s: cache_insert", __FUNCTION__);
+            cache_entry_destroy (entry);
+            goto error;
+        }
     }
     if (!cache_entry_get_valid (entry)) {
         if (cache_entry_set_raw (entry, data, len) < 0) { // makes entry valid

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -333,7 +333,11 @@ static int store_cache (kvstxn_t *kt, int current_epoch, json_t *o,
             flux_log_error (kt->ktm->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
         }
-        cache_insert (kt->ktm->cache, ref, entry);
+        if (cache_insert (kt->ktm->cache, ref, entry) < 0) {
+            cache_entry_destroy (entry);
+            flux_log_error (kt->ktm->h, "%s: cache_insert", __FUNCTION__);
+            goto error;
+        }
     }
     if (cache_entry_get_valid (entry)) {
         kt->ktm->noop_stores++;

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -329,11 +329,11 @@ static int store_cache (kvstxn_t *kt, int current_epoch, json_t *o,
         goto error;
     }
     if (!(entry = cache_lookup (kt->ktm->cache, ref, current_epoch))) {
-        if (!(entry = cache_entry_create ())) {
+        if (!(entry = cache_entry_create (ref))) {
             flux_log_error (kt->ktm->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
         }
-        if (cache_insert (kt->ktm->cache, ref, entry) < 0) {
+        if (cache_insert (kt->ktm->cache, entry) < 0) {
             cache_entry_destroy (entry);
             flux_log_error (kt->ktm->h, "%s: cache_insert", __FUNCTION__);
             goto error;

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -438,6 +438,28 @@ void waiter_tests (void)
     free (data);
 }
 
+void cache_blobref_tests (void)
+{
+    struct cache *cache;
+    struct cache_entry *e;
+    const char *ref;
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+    ok ((e = cache_entry_create ()) != NULL,
+        "cache_entry_create works");
+    ok (cache_entry_get_blobref (e) == NULL,
+        "cache_entry_get_blobref fails on non inserted entry");
+    ok (cache_insert (cache, "abcd", e) == 0,
+        "cache_insert works");
+    ok ((ref = cache_entry_get_blobref (e)) != NULL,
+        "cache_entry_get_blobref success");
+    ok (!strcmp (ref, "abcd"),
+        "cache_entry_get_blobref returned correct ref");
+
+    cache_destroy (cache);
+}
+
 void cache_remove_entry_tests (void)
 {
     struct cache *cache;
@@ -451,7 +473,8 @@ void cache_remove_entry_tests (void)
 
     ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    cache_insert (cache, "remove-ref", e);
+    ok (cache_insert (cache, "remove-ref", e) == 0,
+        "cache_insert works");
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
     ok (cache_remove_entry (cache, "blalalala") == 0,
@@ -466,7 +489,8 @@ void cache_remove_entry_tests (void)
         "wait_create works");
     ok ((e = cache_entry_create ()) != NULL,
         "cache_entry_create created empty object");
-    cache_insert (cache, "remove-ref", e);
+    ok (cache_insert (cache, "remove-ref", e) == 0,
+        "cache_insert works");
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
     ok (cache_entry_get_valid (e) == false,
@@ -497,7 +521,8 @@ void cache_remove_entry_tests (void)
     ok (cache_entry_set_treeobj (e, o) == 0,
         "cache_entry_set_treeobj success");
     json_decref (o);
-    cache_insert (cache, "remove-ref", e);
+    ok (cache_insert (cache, "remove-ref", e) == 0,
+        "cache_insert works");
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
     ok (cache_entry_set_dirty (e, true) == 0,
@@ -540,7 +565,8 @@ void cache_expiration_tests (void)
     /* first test w/ entry w/o treeobj object */
     ok ((e1 = cache_entry_create ()) != NULL,
         "cache_entry_create works");
-    cache_insert (cache, "xxx1", e1);
+    ok (cache_insert (cache, "xxx1", e1) == 0,
+        "cache_insert works");
     ok (cache_count_entries (cache) == 1,
         "cache contains 1 entry after insert");
     ok (cache_lookup (cache, "yyy1", 0) == NULL,
@@ -574,7 +600,8 @@ void cache_expiration_tests (void)
     ok (cache_entry_set_treeobj (e3, o1) == 0,
         "cache_entry_set_treeobj success");
     json_decref (o1);
-    cache_insert (cache, "xxx2", e3);
+    ok (cache_insert (cache, "xxx2", e3) == 0,
+        "cache_insert works");
     ok (cache_count_entries (cache) == 2,
         "cache contains 2 entries after insert");
     ok (cache_lookup (cache, "yyy2", 0) == NULL,
@@ -635,6 +662,7 @@ int main (int argc, char *argv[])
     cache_entry_raw_and_treeobj_tests ();
     waiter_tests ();
     cache_expiration_tests ();
+    cache_blobref_tests ();
     cache_remove_entry_tests ();
 
     done_testing ();

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -89,6 +89,10 @@ void cache_entry_basic_tests (void)
 
     /* corner case tests */
 
+    ok (cache_entry_create (NULL) == NULL
+        && errno == EINVAL,
+        "cache_entry_create fails with EINVAL on bad input");
+
     cache_entry_destroy (NULL);
     diag ("cache_entry_destroy accept NULL arg");
 
@@ -96,7 +100,7 @@ void cache_entry_basic_tests (void)
         && errno == EINVAL,
         "cache_entry_set_treeobj fails with EINVAL with bad input");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create success");
 
     o = json_string ("yabadabadoo");
@@ -152,7 +156,7 @@ void cache_entry_raw_tests (void)
     data = strdup ("abcd");
     data2 = strdup ("abcd");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_get_valid (e) == false,
         "cache entry initially non-valid");
@@ -210,7 +214,7 @@ void cache_entry_raw_tests (void)
 
     data = strdup ("abcd");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_set_raw (e, NULL, 0) == 0,
         "cache_entry_set_raw success");
@@ -254,7 +258,7 @@ void cache_entry_raw_and_treeobj_tests (void)
 
     data = strdup ("foo");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_set_raw (e, data, strlen (data) + 1) == 0,
         "cache_entry_set_raw success");
@@ -265,7 +269,7 @@ void cache_entry_raw_and_treeobj_tests (void)
 
     /* test cache entry filled with zero length raw data */
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_set_raw (e, NULL, 0) == 0,
         "cache_entry_set_raw success");
@@ -280,7 +284,7 @@ void cache_entry_raw_and_treeobj_tests (void)
     o1 = treeobj_create_val ("foo", 3);
     data = treeobj_encode (o1);
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_set_raw (e, data, strlen (data)) == 0,
         "cache_entry_set_raw success");
@@ -300,7 +304,7 @@ void cache_entry_raw_and_treeobj_tests (void)
     o1 = treeobj_create_val ("abcd", 3);
     data = treeobj_encode (o1);
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_set_treeobj (e, o1) == 0,
         "cache_entry_set_treeobj success");
@@ -331,7 +335,7 @@ void waiter_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e) == false,
         "cache entry invalid, adding waiter");
@@ -421,7 +425,7 @@ void waiter_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("a-reference")) != NULL,
         "cache_entry_create created empty object");
     ok (cache_entry_get_valid (e) == false,
         "cache entry invalid, adding waiter");
@@ -446,11 +450,9 @@ void cache_blobref_tests (void)
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("abcd")) != NULL,
         "cache_entry_create works");
-    ok (cache_entry_get_blobref (e) == NULL,
-        "cache_entry_get_blobref fails on non inserted entry");
-    ok (cache_insert (cache, "abcd", e) == 0,
+    ok (cache_insert (cache, e) == 0,
         "cache_insert works");
     ok ((ref = cache_entry_get_blobref (e)) != NULL,
         "cache_entry_get_blobref success");
@@ -471,9 +473,9 @@ void cache_remove_entry_tests (void)
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
 
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("remove-ref")) != NULL,
         "cache_entry_create works");
-    ok (cache_insert (cache, "remove-ref", e) == 0,
+    ok (cache_insert (cache, e) == 0,
         "cache_insert works");
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
@@ -487,9 +489,9 @@ void cache_remove_entry_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("remove-ref")) != NULL,
         "cache_entry_create created empty object");
-    ok (cache_insert (cache, "remove-ref", e) == 0,
+    ok (cache_insert (cache, e) == 0,
         "cache_insert works");
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
@@ -515,13 +517,13 @@ void cache_remove_entry_tests (void)
     count = 0;
     ok ((w = wait_create (wait_cb, &count)) != NULL,
         "wait_create works");
-    ok ((e = cache_entry_create ()) != NULL,
+    ok ((e = cache_entry_create ("remove-ref")) != NULL,
         "cache_entry_create works");
     o = treeobj_create_val ("foobar", 6);
     ok (cache_entry_set_treeobj (e, o) == 0,
         "cache_entry_set_treeobj success");
     json_decref (o);
-    ok (cache_insert (cache, "remove-ref", e) == 0,
+    ok (cache_insert (cache, e) == 0,
         "cache_insert works");
     ok (cache_lookup (cache, "remove-ref", 0) != NULL,
         "cache_lookup verify entry exists");
@@ -563,9 +565,9 @@ void cache_expiration_tests (void)
         "cache contains 0 entries");
 
     /* first test w/ entry w/o treeobj object */
-    ok ((e1 = cache_entry_create ()) != NULL,
+    ok ((e1 = cache_entry_create ("xxx1")) != NULL,
         "cache_entry_create works");
-    ok (cache_insert (cache, "xxx1", e1) == 0,
+    ok (cache_insert (cache, e1) == 0,
         "cache_insert works");
     ok (cache_count_entries (cache) == 1,
         "cache contains 1 entry after insert");
@@ -595,12 +597,12 @@ void cache_expiration_tests (void)
 
     /* second test w/ entry with treeobj object */
     o1 = treeobj_create_val ("foo", 3);
-    ok ((e3 = cache_entry_create ()) != NULL,
+    ok ((e3 = cache_entry_create ("xxx2")) != NULL,
         "cache_entry_create works");
     ok (cache_entry_set_treeobj (e3, o1) == 0,
         "cache_entry_set_treeobj success");
     json_decref (o1);
-    ok (cache_insert (cache, "xxx2", e3) == 0,
+    ok (cache_insert (cache, e3) == 0,
         "cache_insert works");
     ok (cache_count_entries (cache) == 2,
         "cache contains 2 entries after insert");

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -138,7 +138,8 @@ struct cache *create_cache_with_empty_rootdir (char *ref, int ref_len)
         "treeobj_hash worked");
     ok ((entry = create_cache_entry_treeobj (rootdir)) != NULL,
         "create_cache_entry_treeobj works");
-    cache_insert (cache, ref, entry);
+    ok (cache_insert (cache, ref, entry) == 0,
+        "cache_insert works");
     json_decref (rootdir);
     return cache;
 }
@@ -945,7 +946,7 @@ void kvstxn_basic_root_not_dir (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -995,7 +996,7 @@ int rootref_cb (kvstxn_t *kt, const char *ref, void *data)
     ok ((entry = create_cache_entry_treeobj (rootdir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (rd->cache, ref, entry);
+    (void)cache_insert (rd->cache, ref, entry);
 
     json_decref (rootdir);
 
@@ -1126,7 +1127,7 @@ void kvstxn_process_missing_ref (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1160,7 +1161,7 @@ void kvstxn_process_missing_ref (void)
     ok ((entry = create_cache_entry_treeobj (dir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (cache, dir_ref, entry);
+    (void)cache_insert (cache, dir_ref, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1256,7 +1257,7 @@ void kvstxn_process_multiple_missing_ref (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1300,17 +1301,17 @@ void kvstxn_process_multiple_missing_ref (void)
     ok ((entry = create_cache_entry_treeobj (dir1)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (cache, dir_ref1, entry);
+    (void)cache_insert (cache, dir_ref1, entry);
 
     ok ((entry = create_cache_entry_treeobj (dir2)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (cache, dir_ref2, entry);
+    (void)cache_insert (cache, dir_ref2, entry);
 
     ok ((entry = create_cache_entry_treeobj (dir3)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (cache, dir_ref3, entry);
+    (void)cache_insert (cache, dir_ref3, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1381,7 +1382,7 @@ void kvstxn_process_multiple_identical_missing_ref (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1425,7 +1426,7 @@ void kvstxn_process_multiple_identical_missing_ref (void)
     ok ((entry = create_cache_entry_treeobj (dir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (cache, dir_ref, entry);
+    (void)cache_insert (cache, dir_ref, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1494,7 +1495,7 @@ void kvstxn_process_missing_ref_removed (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1536,7 +1537,7 @@ void kvstxn_process_missing_ref_removed (void)
     ok ((entry = create_cache_entry_treeobj (dir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    cache_insert (cache, dir_ref, entry);
+    (void)cache_insert (cache, dir_ref, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1617,7 +1618,7 @@ void kvstxn_process_error_callbacks (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1641,7 +1642,7 @@ void kvstxn_process_error_callbacks (void)
 
     /* insert cache entry now, want don't want missing refs on next
      * kvstxn_process call */
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1708,7 +1709,7 @@ void kvstxn_process_error_callbacks_partway (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -1716,7 +1717,7 @@ void kvstxn_process_error_callbacks_partway (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1775,7 +1776,7 @@ void kvstxn_process_invalid_operation (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1873,7 +1874,7 @@ void kvstxn_process_invalid_hash (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1937,7 +1938,7 @@ void kvstxn_process_follow_link (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -1946,7 +1947,7 @@ void kvstxn_process_follow_link (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2015,7 +2016,7 @@ void kvstxn_process_dirval_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2085,7 +2086,7 @@ void kvstxn_process_delete_test (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -2093,7 +2094,7 @@ void kvstxn_process_delete_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2152,7 +2153,7 @@ void kvstxn_process_delete_nosubdir_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2217,7 +2218,7 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -2225,7 +2226,7 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2291,7 +2292,7 @@ void kvstxn_process_bad_dirrefs (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     dirref = treeobj_create_dirref (dir_ref);
     treeobj_append_blobref (dirref, dir_ref);
@@ -2302,7 +2303,7 @@ void kvstxn_process_bad_dirrefs (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -2384,7 +2385,7 @@ void kvstxn_process_big_fileval (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2541,7 +2542,7 @@ void kvstxn_process_giant_dir (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (dir, "dir", dir_ref);
@@ -2549,7 +2550,7 @@ void kvstxn_process_giant_dir (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2629,7 +2630,7 @@ void kvstxn_process_append (void)
      */
 
     blobref_hash ("sha1", "ABCD", 4, valref_ref, sizeof (valref_ref));
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("ABCD", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("ABCD", 4));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_val (root, "val", "abcd", 4);
@@ -2638,7 +2639,7 @@ void kvstxn_process_append (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2777,7 +2778,7 @@ void kvstxn_process_append_errors (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -3149,7 +3150,7 @@ void kvstxn_namespace_prefix_symlink (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, "A", cache, root_ref);
 

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -73,7 +73,9 @@ static int cache_entry_set_treeobj (struct cache_entry *entry, const json_t *o)
 }
 
 /* convenience function */
-static struct cache_entry *create_cache_entry_raw (void *data, int len)
+static struct cache_entry *create_cache_entry_raw (const char *ref,
+                                                   void *data,
+                                                   int len)
 {
     struct cache_entry *entry;
     int ret;
@@ -81,7 +83,7 @@ static struct cache_entry *create_cache_entry_raw (void *data, int len)
     assert (data);
     assert (len);
 
-    entry = cache_entry_create ();
+    entry = cache_entry_create (ref);
     assert (entry);
     ret = cache_entry_set_raw (entry, data, len);
     assert (ret == 0);
@@ -89,14 +91,15 @@ static struct cache_entry *create_cache_entry_raw (void *data, int len)
 }
 
 /* convenience function */
-static struct cache_entry *create_cache_entry_treeobj (json_t *o)
+static struct cache_entry *create_cache_entry_treeobj (const char *ref,
+                                                       json_t *o)
 {
     struct cache_entry *entry;
     int ret;
 
     assert (o);
 
-    entry = cache_entry_create ();
+    entry = cache_entry_create (ref);
     assert (entry);
     ret = cache_entry_set_treeobj (entry, o);
     assert (ret == 0);
@@ -136,9 +139,9 @@ struct cache *create_cache_with_empty_rootdir (char *ref, int ref_len)
         "cache_create works");
     ok (treeobj_hash ("sha1", rootdir, ref, ref_len) == 0,
         "treeobj_hash worked");
-    ok ((entry = create_cache_entry_treeobj (rootdir)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (ref, rootdir)) != NULL,
         "create_cache_entry_treeobj works");
-    ok (cache_insert (cache, ref, entry) == 0,
+    ok (cache_insert (cache, entry) == 0,
         "cache_insert works");
     json_decref (rootdir);
     return cache;
@@ -946,7 +949,7 @@ void kvstxn_basic_root_not_dir (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -993,10 +996,10 @@ int rootref_cb (kvstxn_t *kt, const char *ref, void *data)
     ok ((rootdir = treeobj_create_dir ()) != NULL,
         "treeobj_create_dir works");
 
-    ok ((entry = create_cache_entry_treeobj (rootdir)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (ref, rootdir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (rd->cache, ref, entry);
+    (void)cache_insert (rd->cache, entry);
 
     json_decref (rootdir);
 
@@ -1127,7 +1130,7 @@ void kvstxn_process_missing_ref (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1158,10 +1161,10 @@ void kvstxn_process_missing_ref (void)
 
     /* add missing ref into cache */
 
-    ok ((entry = create_cache_entry_treeobj (dir)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (dir_ref, dir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (cache, dir_ref, entry);
+    (void)cache_insert (cache, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1257,7 +1260,7 @@ void kvstxn_process_multiple_missing_ref (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1298,20 +1301,20 @@ void kvstxn_process_multiple_missing_ref (void)
 
     /* add missing refs into cache */
 
-    ok ((entry = create_cache_entry_treeobj (dir1)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (dir_ref1, dir1)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (cache, dir_ref1, entry);
+    (void)cache_insert (cache, entry);
 
-    ok ((entry = create_cache_entry_treeobj (dir2)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (dir_ref2, dir2)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (cache, dir_ref2, entry);
+    (void)cache_insert (cache, entry);
 
-    ok ((entry = create_cache_entry_treeobj (dir3)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (dir_ref3, dir3)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (cache, dir_ref3, entry);
+    (void)cache_insert (cache, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1382,7 +1385,7 @@ void kvstxn_process_multiple_identical_missing_ref (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1423,10 +1426,10 @@ void kvstxn_process_multiple_identical_missing_ref (void)
 
     /* add missing ref into cache */
 
-    ok ((entry = create_cache_entry_treeobj (dir)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (dir_ref, dir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (cache, dir_ref, entry);
+    (void)cache_insert (cache, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1495,7 +1498,7 @@ void kvstxn_process_missing_ref_removed (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -1534,10 +1537,10 @@ void kvstxn_process_missing_ref_removed (void)
 
     /* add missing ref into cache, even though it should be removed */
 
-    ok ((entry = create_cache_entry_treeobj (dir)) != NULL,
+    ok ((entry = create_cache_entry_treeobj (dir_ref, dir)) != NULL,
         "create_cache_entry_treeobj works");
 
-    (void)cache_insert (cache, dir_ref, entry);
+    (void)cache_insert (cache, entry);
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1618,7 +1621,7 @@ void kvstxn_process_error_callbacks (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1642,7 +1645,7 @@ void kvstxn_process_error_callbacks (void)
 
     /* insert cache entry now, want don't want missing refs on next
      * kvstxn_process call */
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
@@ -1709,7 +1712,7 @@ void kvstxn_process_error_callbacks_partway (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -1717,7 +1720,7 @@ void kvstxn_process_error_callbacks_partway (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1776,7 +1779,7 @@ void kvstxn_process_invalid_operation (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1874,7 +1877,7 @@ void kvstxn_process_invalid_hash (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -1938,7 +1941,7 @@ void kvstxn_process_follow_link (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -1947,7 +1950,7 @@ void kvstxn_process_follow_link (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2016,7 +2019,7 @@ void kvstxn_process_dirval_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2086,7 +2089,7 @@ void kvstxn_process_delete_test (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -2094,7 +2097,7 @@ void kvstxn_process_delete_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2153,7 +2156,7 @@ void kvstxn_process_delete_nosubdir_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2218,7 +2221,7 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dir", dir_ref);
@@ -2226,7 +2229,7 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2292,7 +2295,7 @@ void kvstxn_process_bad_dirrefs (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     dirref = treeobj_create_dirref (dir_ref);
     treeobj_append_blobref (dirref, dir_ref);
@@ -2303,7 +2306,7 @@ void kvstxn_process_bad_dirrefs (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -2385,7 +2388,7 @@ void kvstxn_process_big_fileval (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2542,7 +2545,7 @@ void kvstxn_process_giant_dir (void)
     ok (treeobj_hash ("sha1", dir, dir_ref, sizeof (dir_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, dir_ref, create_cache_entry_treeobj (dir));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (dir, "dir", dir_ref);
@@ -2550,7 +2553,7 @@ void kvstxn_process_giant_dir (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2630,7 +2633,7 @@ void kvstxn_process_append (void)
      */
 
     blobref_hash ("sha1", "ABCD", 4, valref_ref, sizeof (valref_ref));
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("ABCD", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "ABCD", 4));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_val (root, "val", "abcd", 4);
@@ -2639,7 +2642,7 @@ void kvstxn_process_append (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref);
 
@@ -2778,7 +2781,7 @@ void kvstxn_process_append_errors (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok ((ktm = kvstxn_mgr_create (cache,
                                   KVS_PRIMARY_NAMESPACE,
@@ -3150,7 +3153,7 @@ void kvstxn_namespace_prefix_symlink (void)
     ok (treeobj_hash ("sha1", root, root_ref, sizeof (root_ref)) == 0,
         "treeobj_hash worked");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, "A", cache, root_ref);
 

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -475,11 +475,11 @@ void lookup_root (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     root = treeobj_create_dir ();
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -594,16 +594,16 @@ void lookup_basic (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (valref2_ref));
-    cache_insert (cache, valref2_ref, create_cache_entry_raw ("efgh", 4));
+    (void)cache_insert (cache, valref2_ref, create_cache_entry_raw ("efgh", 4));
 
     dirref_test = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref_test, "dummy", "dummy", 5);
 
     treeobj_hash ("sha1", dirref_test, dirref_test_ref, sizeof (dirref_test_ref));
-    cache_insert (cache, dirref_test_ref, create_cache_entry_treeobj (dirref_test));
+    (void)cache_insert (cache, dirref_test_ref, create_cache_entry_treeobj (dirref_test));
 
     dir = treeobj_create_dir ();
     _treeobj_insert_entry_val (dir, "val", "bar", 3);
@@ -626,13 +626,13 @@ void lookup_basic (void) {
     treeobj_insert_entry (dirref, "valref_multi_with_dirref", valref_multi_with_dirref);
 
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref", dirref_ref);
 
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -891,12 +891,12 @@ void lookup_errors (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     dirref = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref, "val", "bar", 3);
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     dir = treeobj_create_dir ();
     _treeobj_insert_entry_val (dir, "val", "baz", 3);
@@ -917,7 +917,7 @@ void lookup_errors (void) {
     treeobj_insert_entry (root, "dirref_multi", dirref_multi);
 
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1246,7 +1246,7 @@ void lookup_security (void) {
 
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 5);
     setup_kvsroot (krm, "altnamespace", cache, root_ref, 6);
@@ -1423,12 +1423,12 @@ void lookup_links (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     dirref3 = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref3, "val", "baz", 3);
     treeobj_hash ("sha1", dirref3, dirref3_ref, sizeof (dirref3_ref));
-    cache_insert (cache, dirref3_ref, create_cache_entry_treeobj (dirref3));
+    (void)cache_insert (cache, dirref3_ref, create_cache_entry_treeobj (dirref3));
 
     dir = treeobj_create_dir ();
     _treeobj_insert_entry_val (dir, "val", "bar", 3);
@@ -1440,7 +1440,7 @@ void lookup_links (void) {
     _treeobj_insert_entry_dirref (dirref2, "dirref", dirref3_ref);
     _treeobj_insert_entry_symlink (dirref2, "symlink", "dirref2.val");
     treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (dirref2_ref));
-    cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
+    (void)cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     dirref1 = treeobj_create_dir ();
     _treeobj_insert_entry_symlink (dirref1, "link2dirref", "dirref2");
@@ -1449,13 +1449,13 @@ void lookup_links (void) {
     _treeobj_insert_entry_symlink (dirref1, "link2dir", "dirref2.dir");
     _treeobj_insert_entry_symlink (dirref1, "link2symlink", "dirref2.symlink");
     treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (dirref1_ref));
-    cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
+    (void)cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref1", dirref1_ref);
     _treeobj_insert_entry_dirref (root, "dirref2", dirref2_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1670,18 +1670,18 @@ void lookup_alt_root (void) {
     dirref1 = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref1, "val", "foo", 3);
     treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (dirref1_ref));
-    cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
+    (void)cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     dirref2 = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref2, "val", "bar", 3);
     treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (dirref2_ref));
-    cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
+    (void)cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref1", dirref1_ref);
     _treeobj_insert_entry_dirref (root, "dirref2", dirref2_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1756,19 +1756,19 @@ void lookup_root_symlink (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     dirref = treeobj_create_dir ();
     _treeobj_insert_entry_symlink (dirref, "symlinkroot", ".");
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_val (root, "val", "foo", 3);
     _treeobj_insert_entry_symlink (root, "symlinkroot", ".");
     _treeobj_insert_entry_dirref (root, "dirref", dirref_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1909,13 +1909,13 @@ void lookup_namespace_prefix (void) {
     _treeobj_insert_entry_val (root1, "val", "foo", 3);
     treeobj_hash ("sha1", root1, root_ref1, sizeof (root_ref1));
 
-    cache_insert (cache, root_ref1, create_cache_entry_treeobj (root1));
+    (void)cache_insert (cache, root_ref1, create_cache_entry_treeobj (root1));
 
     root2 = treeobj_create_dir ();
     _treeobj_insert_entry_val (root2, "val", "bar", 3);
     treeobj_hash ("sha1", root2, root_ref2, sizeof (root_ref2));
 
-    cache_insert (cache, root_ref2, create_cache_entry_treeobj (root2));
+    (void)cache_insert (cache, root_ref2, create_cache_entry_treeobj (root2));
 
     setup_kvsroot (krm, "foo", cache, root_ref1, 0);
     setup_kvsroot (krm, "bar", cache, root_ref2, 0);
@@ -2080,13 +2080,13 @@ void lookup_namespace_prefix_symlink (void) {
     _treeobj_insert_entry_symlink (rootA, "symlink2B-val", "ns:B/val");
     treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
 
-    cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
+    (void)cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
 
     rootB = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootB, "val", "2", 1);
     treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
 
-    cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
+    (void)cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
 
     setup_kvsroot (krm, "A", cache, root_refA, 0);
     setup_kvsroot (krm, "B", cache, root_refB, 0);
@@ -2246,19 +2246,19 @@ void lookup_namespace_prefix_symlink_security (void) {
     _treeobj_insert_entry_symlink (rootA, "symlink2C", "ns:C/.");
     treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
 
-    cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
+    (void)cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
 
     rootB = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootB, "val", "2", 1);
     treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
 
-    cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
+    (void)cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
 
     rootC = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootC, "val", "3", 1);
     treeobj_hash ("sha1", rootC, root_refC, sizeof (root_refC));
 
-    cache_insert (cache, root_refC, create_cache_entry_treeobj (rootC));
+    (void)cache_insert (cache, root_refC, create_cache_entry_treeobj (rootC));
 
     setup_kvsroot (krm, "A", cache, root_refA, 1000);
     setup_kvsroot (krm, "B", cache, root_refB, 1000);
@@ -2363,8 +2363,8 @@ void lookup_stall_namespace (void) {
     _treeobj_insert_entry_val (root2, "val", "bar", 3);
     treeobj_hash ("sha1", root2, root_ref2, sizeof (root_ref2));
 
-    cache_insert (cache, root_ref1, create_cache_entry_treeobj (root1));
-    cache_insert (cache, root_ref2, create_cache_entry_treeobj (root2));
+    (void)cache_insert (cache, root_ref1, create_cache_entry_treeobj (root1));
+    (void)cache_insert (cache, root_ref2, create_cache_entry_treeobj (root2));
 
     /* do not insert root into kvsroot_mgr until later for these stall tests */
 
@@ -2528,7 +2528,7 @@ void lookup_stall_ref_root (void) {
         "lookup_create stalltest \".\"");
     check_stall (lh, EAGAIN, 1, root_ref, "root \".\" stall");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* lookup root ".", should succeed */
     check_value (lh, root, "root \".\" #1");
@@ -2666,12 +2666,12 @@ void lookup_stall_ref (void) {
         "lookup_create stalltest dirref1.val");
     check_stall (lh, EAGAIN, 1, root_ref, "dirref1.val stall #1");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     /* next call to lookup, should stall */
     check_stall (lh, EAGAIN, 1, dirref1_ref, "dirref1.val stall #2");
 
-    cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
+    (void)cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
 
     /* final call to lookup, should succeed */
     test = treeobj_create_val ("foo", 3);
@@ -2708,7 +2708,7 @@ void lookup_stall_ref (void) {
         "lookup_create stalltest symlink.val");
     check_stall (lh, EAGAIN, 1, dirref2_ref, "symlink.val stall");
 
-    cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
+    (void)cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
 
     /* lookup symlink.val, should succeed */
     test = treeobj_create_val ("bar", 3);
@@ -2745,7 +2745,7 @@ void lookup_stall_ref (void) {
         "lookup_create stalltest dirref1.valref");
     check_stall (lh, EAGAIN, 1, valref1_ref, "dirref1.valref stall");
 
-    cache_insert (cache, valref1_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref1_ref, create_cache_entry_raw ("abcd", 4));
 
     /* lookup dirref1.valref, should succeed */
     test = treeobj_create_val ("abcd", 4);
@@ -2784,7 +2784,7 @@ void lookup_stall_ref (void) {
      * the 'valref' above */
     check_stall (lh, EAGAIN, 1, valref2_ref, "dirref1.valref_multi stall");
 
-    cache_insert (cache, valref2_ref, create_cache_entry_raw ("efgh", 4));
+    (void)cache_insert (cache, valref2_ref, create_cache_entry_raw ("efgh", 4));
 
     /* lookup dirref1.valref_multi, should succeed */
     test = treeobj_create_val ("abcdefgh", 8);
@@ -2822,8 +2822,8 @@ void lookup_stall_ref (void) {
     /* should two missing refs, as we have not loaded either here */
     check_stall (lh, EAGAIN, 2, NULL, "dirref1.valref_multi2 stall");
 
-    cache_insert (cache, valref3_ref, create_cache_entry_raw ("ijkl", 4));
-    cache_insert (cache, valref4_ref, create_cache_entry_raw ("mnop", 4));
+    (void)cache_insert (cache, valref3_ref, create_cache_entry_raw ("ijkl", 4));
+    (void)cache_insert (cache, valref4_ref, create_cache_entry_raw ("mnop", 4));
 
     /* lookup dirref1.valref_multi2, should succeed */
     test = treeobj_create_val ("ijklmnop", 8);
@@ -2967,7 +2967,7 @@ void lookup_stall_namespace_removed (void) {
 
     /* insert cache entry, but remove namespace */
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -2993,7 +2993,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2");
 
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3019,7 +3019,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3");
 
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3055,7 +3055,7 @@ void lookup_stall_namespace_removed (void) {
 
     /* insert cache entry, but remove namespace */
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3084,7 +3084,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2");
 
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3114,7 +3114,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3");
 
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3159,15 +3159,15 @@ void lookup_stall_namespace_removed (void) {
 
     check_stall (lh, EAGAIN, 1, root_ref, "dirref.valref stall #1 w/ root_ref");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2 w/ root_ref");
 
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3 w/ root_ref");
 
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     test = treeobj_create_val ("abcd", 4);
     check_value (lh, test, "lookup_create dirref.valref w/ root_ref");
@@ -3202,15 +3202,15 @@ void lookup_stall_namespace_removed (void) {
 
     check_stall (lh, EAGAIN, 1, root_ref, "dirref.valref stall #1 w/ root_ref & role user");
 
-    cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
 
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2 w/ root_ref & role user");
 
-    cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
 
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3 w/ root_ref & role user");
 
-    cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
 
     test = treeobj_create_val ("abcd", 4);
     check_value (lh, test, "lookup_create dirref.valref w/ root_ref & role user");
@@ -3262,13 +3262,13 @@ void lookup_stall_namespace_prefix_in_symlink (void) {
     _treeobj_insert_entry_symlink (rootA, "symlink", "ns:B/.");
     treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
 
-    cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
+    (void)cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
 
     rootB = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootB, "val", "2", 1);
     treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
 
-    cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
+    (void)cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
 
     /* do not insert root into kvsroot_mgr until later for these stall tests */
 

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -73,7 +73,9 @@ done:
 }
 
 /* convenience function */
-static struct cache_entry *create_cache_entry_raw (void *data, int len)
+static struct cache_entry *create_cache_entry_raw (const char *ref,
+                                                   void *data,
+                                                   int len)
 {
     struct cache_entry *entry;
     int ret;
@@ -81,7 +83,7 @@ static struct cache_entry *create_cache_entry_raw (void *data, int len)
     assert (data);
     assert (len);
 
-    entry = cache_entry_create ();
+    entry = cache_entry_create (ref);
     assert (entry);
     ret = cache_entry_set_raw (entry, data, len);
     assert (ret == 0);
@@ -89,14 +91,15 @@ static struct cache_entry *create_cache_entry_raw (void *data, int len)
 }
 
 /* convenience function */
-static struct cache_entry *create_cache_entry_treeobj (json_t *o)
+static struct cache_entry *create_cache_entry_treeobj (const char *ref,
+                                                       json_t *o)
 {
     struct cache_entry *entry;
     int ret;
 
     assert (o);
 
-    entry = cache_entry_create ();
+    entry = cache_entry_create (ref);
     assert (entry);
     ret = cache_entry_set_treeobj (entry, o);
     assert (ret == 0);
@@ -475,11 +478,11 @@ void lookup_root (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     root = treeobj_create_dir ();
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -594,16 +597,16 @@ void lookup_basic (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     blobref_hash ("sha1", "efgh", 4, valref2_ref, sizeof (valref2_ref));
-    (void)cache_insert (cache, valref2_ref, create_cache_entry_raw ("efgh", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref2_ref, "efgh", 4));
 
     dirref_test = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref_test, "dummy", "dummy", 5);
 
     treeobj_hash ("sha1", dirref_test, dirref_test_ref, sizeof (dirref_test_ref));
-    (void)cache_insert (cache, dirref_test_ref, create_cache_entry_treeobj (dirref_test));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_test_ref, dirref_test));
 
     dir = treeobj_create_dir ();
     _treeobj_insert_entry_val (dir, "val", "bar", 3);
@@ -626,13 +629,13 @@ void lookup_basic (void) {
     treeobj_insert_entry (dirref, "valref_multi_with_dirref", valref_multi_with_dirref);
 
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref", dirref_ref);
 
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -891,12 +894,12 @@ void lookup_errors (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     dirref = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref, "val", "bar", 3);
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     dir = treeobj_create_dir ();
     _treeobj_insert_entry_val (dir, "val", "baz", 3);
@@ -917,7 +920,7 @@ void lookup_errors (void) {
     treeobj_insert_entry (root, "dirref_multi", dirref_multi);
 
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1246,7 +1249,7 @@ void lookup_security (void) {
 
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 5);
     setup_kvsroot (krm, "altnamespace", cache, root_ref, 6);
@@ -1423,12 +1426,12 @@ void lookup_links (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     dirref3 = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref3, "val", "baz", 3);
     treeobj_hash ("sha1", dirref3, dirref3_ref, sizeof (dirref3_ref));
-    (void)cache_insert (cache, dirref3_ref, create_cache_entry_treeobj (dirref3));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref3_ref, dirref3));
 
     dir = treeobj_create_dir ();
     _treeobj_insert_entry_val (dir, "val", "bar", 3);
@@ -1440,7 +1443,7 @@ void lookup_links (void) {
     _treeobj_insert_entry_dirref (dirref2, "dirref", dirref3_ref);
     _treeobj_insert_entry_symlink (dirref2, "symlink", "dirref2.val");
     treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (dirref2_ref));
-    (void)cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref2_ref, dirref2));
 
     dirref1 = treeobj_create_dir ();
     _treeobj_insert_entry_symlink (dirref1, "link2dirref", "dirref2");
@@ -1449,13 +1452,13 @@ void lookup_links (void) {
     _treeobj_insert_entry_symlink (dirref1, "link2dir", "dirref2.dir");
     _treeobj_insert_entry_symlink (dirref1, "link2symlink", "dirref2.symlink");
     treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (dirref1_ref));
-    (void)cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref1_ref, dirref1));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref1", dirref1_ref);
     _treeobj_insert_entry_dirref (root, "dirref2", dirref2_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1670,18 +1673,18 @@ void lookup_alt_root (void) {
     dirref1 = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref1, "val", "foo", 3);
     treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (dirref1_ref));
-    (void)cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref1_ref, dirref1));
 
     dirref2 = treeobj_create_dir ();
     _treeobj_insert_entry_val (dirref2, "val", "bar", 3);
     treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (dirref2_ref));
-    (void)cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref2_ref, dirref2));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref1", dirref1_ref);
     _treeobj_insert_entry_dirref (root, "dirref2", dirref2_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1756,19 +1759,19 @@ void lookup_root_symlink (void) {
      */
 
     blobref_hash ("sha1", "abcd", 4, valref_ref, sizeof (valref_ref));
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     dirref = treeobj_create_dir ();
     _treeobj_insert_entry_symlink (dirref, "symlinkroot", ".");
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_val (root, "val", "foo", 3);
     _treeobj_insert_entry_symlink (root, "symlinkroot", ".");
     _treeobj_insert_entry_dirref (root, "dirref", dirref_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
 
@@ -1909,13 +1912,13 @@ void lookup_namespace_prefix (void) {
     _treeobj_insert_entry_val (root1, "val", "foo", 3);
     treeobj_hash ("sha1", root1, root_ref1, sizeof (root_ref1));
 
-    (void)cache_insert (cache, root_ref1, create_cache_entry_treeobj (root1));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref1, root1));
 
     root2 = treeobj_create_dir ();
     _treeobj_insert_entry_val (root2, "val", "bar", 3);
     treeobj_hash ("sha1", root2, root_ref2, sizeof (root_ref2));
 
-    (void)cache_insert (cache, root_ref2, create_cache_entry_treeobj (root2));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref2, root2));
 
     setup_kvsroot (krm, "foo", cache, root_ref1, 0);
     setup_kvsroot (krm, "bar", cache, root_ref2, 0);
@@ -2080,13 +2083,13 @@ void lookup_namespace_prefix_symlink (void) {
     _treeobj_insert_entry_symlink (rootA, "symlink2B-val", "ns:B/val");
     treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
 
-    (void)cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refA, rootA));
 
     rootB = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootB, "val", "2", 1);
     treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
 
-    (void)cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refB, rootB));
 
     setup_kvsroot (krm, "A", cache, root_refA, 0);
     setup_kvsroot (krm, "B", cache, root_refB, 0);
@@ -2246,19 +2249,19 @@ void lookup_namespace_prefix_symlink_security (void) {
     _treeobj_insert_entry_symlink (rootA, "symlink2C", "ns:C/.");
     treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
 
-    (void)cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refA, rootA));
 
     rootB = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootB, "val", "2", 1);
     treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
 
-    (void)cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refB, rootB));
 
     rootC = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootC, "val", "3", 1);
     treeobj_hash ("sha1", rootC, root_refC, sizeof (root_refC));
 
-    (void)cache_insert (cache, root_refC, create_cache_entry_treeobj (rootC));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refC, rootC));
 
     setup_kvsroot (krm, "A", cache, root_refA, 1000);
     setup_kvsroot (krm, "B", cache, root_refB, 1000);
@@ -2363,8 +2366,8 @@ void lookup_stall_namespace (void) {
     _treeobj_insert_entry_val (root2, "val", "bar", 3);
     treeobj_hash ("sha1", root2, root_ref2, sizeof (root_ref2));
 
-    (void)cache_insert (cache, root_ref1, create_cache_entry_treeobj (root1));
-    (void)cache_insert (cache, root_ref2, create_cache_entry_treeobj (root2));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref1, root1));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref2, root2));
 
     /* do not insert root into kvsroot_mgr until later for these stall tests */
 
@@ -2528,7 +2531,7 @@ void lookup_stall_ref_root (void) {
         "lookup_create stalltest \".\"");
     check_stall (lh, EAGAIN, 1, root_ref, "root \".\" stall");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     /* lookup root ".", should succeed */
     check_value (lh, root, "root \".\" #1");
@@ -2666,12 +2669,12 @@ void lookup_stall_ref (void) {
         "lookup_create stalltest dirref1.val");
     check_stall (lh, EAGAIN, 1, root_ref, "dirref1.val stall #1");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     /* next call to lookup, should stall */
     check_stall (lh, EAGAIN, 1, dirref1_ref, "dirref1.val stall #2");
 
-    (void)cache_insert (cache, dirref1_ref, create_cache_entry_treeobj (dirref1));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref1_ref, dirref1));
 
     /* final call to lookup, should succeed */
     test = treeobj_create_val ("foo", 3);
@@ -2708,7 +2711,7 @@ void lookup_stall_ref (void) {
         "lookup_create stalltest symlink.val");
     check_stall (lh, EAGAIN, 1, dirref2_ref, "symlink.val stall");
 
-    (void)cache_insert (cache, dirref2_ref, create_cache_entry_treeobj (dirref2));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref2_ref, dirref2));
 
     /* lookup symlink.val, should succeed */
     test = treeobj_create_val ("bar", 3);
@@ -2745,7 +2748,7 @@ void lookup_stall_ref (void) {
         "lookup_create stalltest dirref1.valref");
     check_stall (lh, EAGAIN, 1, valref1_ref, "dirref1.valref stall");
 
-    (void)cache_insert (cache, valref1_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref1_ref, "abcd", 4));
 
     /* lookup dirref1.valref, should succeed */
     test = treeobj_create_val ("abcd", 4);
@@ -2784,7 +2787,7 @@ void lookup_stall_ref (void) {
      * the 'valref' above */
     check_stall (lh, EAGAIN, 1, valref2_ref, "dirref1.valref_multi stall");
 
-    (void)cache_insert (cache, valref2_ref, create_cache_entry_raw ("efgh", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref2_ref, "efgh", 4));
 
     /* lookup dirref1.valref_multi, should succeed */
     test = treeobj_create_val ("abcdefgh", 8);
@@ -2822,8 +2825,8 @@ void lookup_stall_ref (void) {
     /* should two missing refs, as we have not loaded either here */
     check_stall (lh, EAGAIN, 2, NULL, "dirref1.valref_multi2 stall");
 
-    (void)cache_insert (cache, valref3_ref, create_cache_entry_raw ("ijkl", 4));
-    (void)cache_insert (cache, valref4_ref, create_cache_entry_raw ("mnop", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref3_ref, "ijkl", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref4_ref, "mnop", 4));
 
     /* lookup dirref1.valref_multi2, should succeed */
     test = treeobj_create_val ("ijklmnop", 8);
@@ -2967,7 +2970,7 @@ void lookup_stall_namespace_removed (void) {
 
     /* insert cache entry, but remove namespace */
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -2993,7 +2996,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2");
 
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3019,7 +3022,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3");
 
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3055,7 +3058,7 @@ void lookup_stall_namespace_removed (void) {
 
     /* insert cache entry, but remove namespace */
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3084,7 +3087,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2");
 
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3114,7 +3117,7 @@ void lookup_stall_namespace_removed (void) {
         "lookup_create stalltest dirref.valref");
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3");
 
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     ok (!kvsroot_mgr_remove_root (krm, KVS_PRIMARY_NAMESPACE),
         "kvsroot_mgr_remove_root removed root successfully");
@@ -3159,15 +3162,15 @@ void lookup_stall_namespace_removed (void) {
 
     check_stall (lh, EAGAIN, 1, root_ref, "dirref.valref stall #1 w/ root_ref");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2 w/ root_ref");
 
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3 w/ root_ref");
 
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     test = treeobj_create_val ("abcd", 4);
     check_value (lh, test, "lookup_create dirref.valref w/ root_ref");
@@ -3202,15 +3205,15 @@ void lookup_stall_namespace_removed (void) {
 
     check_stall (lh, EAGAIN, 1, root_ref, "dirref.valref stall #1 w/ root_ref & role user");
 
-    (void)cache_insert (cache, root_ref, create_cache_entry_treeobj (root));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
 
     check_stall (lh, EAGAIN, 1, dirref_ref, "dirref.valref stall #2 w/ root_ref & role user");
 
-    (void)cache_insert (cache, dirref_ref, create_cache_entry_treeobj (dirref));
+    (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     check_stall (lh, EAGAIN, 1, valref_ref, "dirref.valref stall #3 w/ root_ref & role user");
 
-    (void)cache_insert (cache, valref_ref, create_cache_entry_raw ("abcd", 4));
+    (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     test = treeobj_create_val ("abcd", 4);
     check_value (lh, test, "lookup_create dirref.valref w/ root_ref & role user");
@@ -3262,13 +3265,13 @@ void lookup_stall_namespace_prefix_in_symlink (void) {
     _treeobj_insert_entry_symlink (rootA, "symlink", "ns:B/.");
     treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
 
-    (void)cache_insert (cache, root_refA, create_cache_entry_treeobj (rootA));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refA, rootA));
 
     rootB = treeobj_create_dir ();
     _treeobj_insert_entry_val (rootB, "val", "2", 1);
     treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
 
-    (void)cache_insert (cache, root_refB, create_cache_entry_treeobj (rootB));
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refB, rootB));
 
     /* do not insert root into kvsroot_mgr until later for these stall tests */
 

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -156,6 +156,20 @@ int wait_queue_length (waitqueue_t *q)
     return zlist_size (q->q);
 }
 
+int wait_queue_iter (waitqueue_t *q, wait_iter_cb_f cb, void *arg)
+{
+    wait_t *w;
+
+    assert (q->magic == WAITQUEUE_MAGIC);
+    w = zlist_first (q->q);
+    while (w) {
+        if (cb)
+            cb (w, arg);
+        w = zlist_next (q->q);
+    }
+    return 0;
+}
+
 int wait_addqueue (waitqueue_t *q, wait_t *w)
 {
     assert (q->magic == WAITQUEUE_MAGIC);

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -45,6 +45,9 @@ struct wait_struct {
     wait_cb_f cb;
     void *cb_arg;
     struct handler hand; /* optional special case */
+    int errnum;
+    wait_error_f error_cb;
+    void *error_arg;
 };
 
 #define WAITQUEUE_MAGIC 0xafad7778
@@ -201,6 +204,32 @@ int wait_runqueue (waitqueue_t *q)
         while ((w = zlist_pop (cpy)))
             wait_runone (w);
         zlist_destroy (&cpy);
+    }
+    return 0;
+}
+
+int wait_aux_set_errnum (wait_t *w, int errnum)
+{
+    if (w) {
+        w->errnum = errnum;
+        if (w->error_cb)
+            w->error_cb (w, w->errnum, w->error_arg);
+    }
+    return 0;
+}
+
+int wait_aux_get_errnum (wait_t *w)
+{
+    if (w)
+        return w->errnum;
+    return -1;
+}
+
+int wait_set_error_cb (wait_t *w, wait_error_f cb, void *arg)
+{
+    if (w) {
+        w->error_cb = cb;
+        w->error_arg = arg;
     }
     return 0;
 }

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -42,6 +42,9 @@ int wait_queue_length (waitqueue_t *q);
  */
 int wait_addqueue (waitqueue_t *q, wait_t *wait);
 
+typedef void (*wait_iter_cb_f)(wait_t *w, void *arg);
+int wait_queue_iter (waitqueue_t *q, wait_iter_cb_f cb, void *arg);
+
 /* Remove all wait_t's from the specified queue.
  * Note: wait_runqueue() empties the waitqueue_t before invoking wait_t
  * callbacks for waiters that have a usecount of zero, hence it is safe

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -64,6 +64,17 @@ int wait_msg_aux_set (wait_t *w, const char *name, void *aux,
                       flux_free_f destroy);
 void *wait_msg_aux_get (wait_t *w, const char *name);
 
+/* Get/set an aux errnum on a wait that can be retrieved later.
+ * In addition, a callback can be set which can be triggered
+ * via wait_set_errnum().  This can be useful for setting
+ * information that an error occurred during asynchronous
+ * communication.
+ */
+int wait_aux_set_errnum (wait_t *w, int errnum);
+int wait_aux_get_errnum (wait_t *w);
+typedef void (*wait_error_f)(wait_t *w, int errnum, void *arg);
+int wait_set_error_cb (wait_t *w, wait_error_f cb, void *arg);
+
 /* Destroy all wait_t's fitting message match critieria, tested with
  * wait_test_msg_f callback.
  * On error, the waitqueue is unaltered.

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -252,6 +252,75 @@ test_expect_success 'kvs: multi blob-ref valref with a blobref pointing to a tre
 '
 
 #
+# invalid blobrefs don't hang
+#
+
+# create valref with illegal content store blob
+# call flux kvs get $DIR.bad_X twice, to ensure first time cleaned up properly
+
+badhash="sha1-0123456789012345678901234567890123456789"
+
+test_expect_success 'kvs: invalid valref lookup wont hang' '
+        flux kvs put --treeobj $DIR.bad_valref="{\"data\":[\"${badhash}\"],\"type\":\"valref\",\"ver\":1}" &&
+        ! flux kvs get $DIR.bad_valref &&
+        ! flux kvs get $DIR.bad_valref
+'
+
+test_expect_success 'kvs: invalid valref get --watch wont hang' '
+        ! flux kvs get --watch $DIR.bad_valref &&
+        ! flux kvs get --watch $DIR.bad_valref
+'
+
+test_expect_success 'kvs: invalid valref watch returns nil' '
+        flux kvs watch -c 1 $DIR.bad_valref > output &&
+        echo "nil" > expected &&
+	test_cmp output expected
+'
+
+test_expect_success 'kvs: invalid multi-blobref valref lookup wont hang' '
+        flux kvs put --treeobj $DIR.bad_multi_valref="{\"data\":[\"${badhash}\", \"${badhash}\"],\"type\":\"valref\",\"ver\":1}" &&
+        ! flux kvs get $DIR.bad_multi_valref &&
+        ! flux kvs get $DIR.bad_multi_valref
+'
+
+test_expect_success 'kvs: invalid multi-blobref valref get --watch wont hang' '
+        ! flux kvs get --watch $DIR.bad_multi_valref &&
+        ! flux kvs get --watch $DIR.bad_multi_valref
+'
+
+test_expect_success 'kvs: invalid multi-blobref valref watch returns nil' '
+        flux kvs watch -c 1 $DIR.bad_multi_valref > output &&
+        echo "nil" > expected &&
+	test_cmp output expected
+'
+
+test_expect_success 'kvs: invalid dirref lookup wont hang' '
+        flux kvs put --treeobj $DIR.bad_dirref="{\"data\":[\"${badhash}\"],\"type\":\"dirref\",\"ver\":1}" &&
+        ! flux kvs get $DIR.bad_dirref.a &&
+        ! flux kvs get $DIR.bad_dirref.a
+'
+
+test_expect_success 'kvs: invalid dirref get --watch wont hang' '
+        ! flux kvs get --watch $DIR.bad_dirref.a &&
+        ! flux kvs get --watch $DIR.bad_dirref.a
+'
+
+test_expect_success 'kvs: invalid dirref watch returns nil' '
+        flux kvs watch -c 1 $DIR.bad_dirref > output &&
+	cat >expected <<-EOF &&
+nil
+======================
+	EOF
+	test_cmp output expected
+'
+
+test_expect_success 'kvs: invalid dirref write wont hang' '
+        flux kvs put --treeobj $DIR.bad_dirref="{\"data\":[\"${badhash}\"],\"type\":\"dirref\",\"ver\":1}" &&
+        ! flux kvs put $DIR.bad_dirref.a=1 &&
+        ! flux kvs put $DIR.bad_dirref.b=1
+'
+
+#
 # test synchronization based on commit sequence no.
 #
 

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -320,6 +320,21 @@ test_expect_success 'kvs: invalid dirref write wont hang' '
         ! flux kvs put $DIR.bad_dirref.b=1
 '
 
+test_expect_success "kvs: failure to store blob that exceeds max size does not hang" '
+        dd if=/dev/zero count=$((1048576/4096+1)) bs=4096 \
+                        skip=$((1048576/4096)) >toobig 2>/dev/null &&
+        test_must_fail flux start --size=4 -o,--setattr=content.blob-size-limit=1048576 \
+                       flux kvs put -r $DIR.bad_toobig=- <toobig
+'
+
+MAXBLOB=`flux getattr content.blob-size-limit`
+
+test_expect_success LONGTEST "kvs: failure to store blob that exceeds max size default does not hang" '
+	dd if=/dev/zero count=$(($MAXBLOB/4096+1)) bs=4096 \
+			skip=$(($MAXBLOB/4096)) >toobig_long 2>/dev/null &&
+	test_must_fail flux kvs put -r $DIR.bad_toobig_long=- < toobig_long
+'
+
 #
 # test synchronization based on commit sequence no.
 #


### PR DESCRIPTION
Previously, all asynchronous loads/stores in the kvs that failed would not return an error to the original kvs rpc request.  The rpc request would just hang.  Example errors are when a blobref is invalid or if the store size is larger than the maximum allowed.

The fix for this was semi involved.

- support the ability for an error callback to be registered on waiters.  On an error condition, that callback can be called on a waiter.  Ultimately, these are used so that ```set_aux_errnum()``` functions can be called, leading to replays that can be informed that an error occurred during a load/store.

- functions in the cache were added so that the error callbacks above can be called on specific cache entries and their waitqueues.

- stores were a little bit more complex to handle than loads, b/c ```flux_content_store_get()``` returns the cache ```blobref``` on success, but no blobref on an error.  In the event of the error, we need to the blobref to get the cache entry that is associated with the error.  So changes were made in the cache so that a cache entry knows the blobref it was stored under, and subsequently that blobref can be retrieved under error scenarios.

- things sort of fell into place at that point and tests were added.

- included are a few cleanup patches too.