### PR TITLE
Improve efficiency of asynchronous futures

### DIFF
--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -150,6 +150,7 @@ void test_simple (void)
         && !strcmp (result_destroy_arg, "Hello"),
         "flux_future_destroy called result destructor correctly");
 
+    flux_reactor_destroy (r);
     diag ("%s: simple tests completed", __FUNCTION__);
 }
 


### PR DESCRIPTION
As described in #1839, this PR improves efficiency of asynchronous use of `flux_future_t` by eliminating the `prepare` watcher and only starting the `check` and `idle` watchers at the time of fulfillment instead of immediately when `flux_future_then(3)` is called. This reduces the number of active watchers significantly when there are many unfulfilled futures associated with the reactor loop.

This PR should be carefully examined and tested to ensure I haven't missed some  subtle use case that is not covered in our testsuite. During development, I did find one case that was missed by the unit tests and luckily caught by another test in `make check`. I'll see if I can figure out what that particular use case was, and codify it in the future_t unit tests.
