### PR TITLE
API cleanup: simplify flux_attr_get(), flux_attr_set()

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -83,8 +83,6 @@ MAN3_FILES_SECONDARY = \
 	flux_reduce_opt_get.3 \
 	flux_get_size.3 \
 	flux_attr_set.3 \
-	flux_attr_first.3 \
-	flux_attr_next.3 \
 	flux_set_reactor.3 \
 	flux_reactor_destroy.3 \
 	flux_reactor_run.3 \
@@ -238,8 +236,6 @@ flux_reduce_opt_set.3: flux_reduce_create.3
 flux_reduce_opt_get.3: flux_reduce_create.3
 flux_get_size.3: flux_get_rank.3
 flux_attr_set.3: flux_attr_get.3
-flux_attr_first.3: flux_attr_get.3
-flux_attr_next.3: flux_attr_get.3
 flux_set_reactor.3: flux_get_reactor.3
 flux_reactor_destroy.3: flux_reactor_create.3
 flux_reactor_run.3: flux_reactor_create.3

--- a/doc/man3/flux_attr_get.adoc
+++ b/doc/man3/flux_attr_get.adoc
@@ -5,20 +5,17 @@ flux_attr_get(3)
 
 NAME
 ----
-flux_attr_get, flux_attr_set, flux_attr_first, flux_attr_next - query Flux broker attributes
+flux_attr_get, flux_attr_set - get/set Flux broker attributes
 
 
 SYNOPSIS
 --------
-#include <flux/core.h>
+ #include <flux/core.h>
 
-const char *flux_attr_get (flux_t *h, const char *name, int *flags);
+ const char *flux_attr_get (flux_t *h, const char *name);
 
-int flux_attr_set (flux_t *h, const char *name, const char *val);
+ int flux_attr_set (flux_t *h, const char *name, const char *val);
 
-const char *flux_attr_first (flux_t *h);
-
-const char *flux_attr_next (flux_t *h);
 
 DESCRIPTION
 -----------
@@ -28,33 +25,15 @@ store with scope limited to the local broker rank, and a method for the
 broker to export information needed by Flux comms modules and utilities.
 
 `flux_attr_get()` retrieves the value of the attribute _name_.
-If _flags_ is non-NULL, the flags associated with the attribute are
-stored there.  Flags are a mask of the following bit values:
 
-FLUX_ATTRFLAG_IMMUTABLE::
-The value of this attribute will never change.  It can be cached indefinitely.
-
-FLUX_ATTRFLAG_READONLY::
-The value of this attribute cannot be changed with `flux_attr_set()`,
-however it may change on the broker and should not be cached.
-
-FLUX_ATTRFLAG_ACTIVE::
-Getting or setting this attribute may have side effects in the broker.
-For example, retrieving the "snoop-uri" attribute triggers the creation
-of the snoop socket by the broker on the first call.
-
-Attributes that have the FLUX_ATTRFLAG_IMMUTABLE flag are cached automatically
+Attributes that have the broker tags as _immutable_ are cached automatically
 in the flux_t handle.  For example, the "rank" attribute is a frequently
 accessed attribute whose value never changes.  It will be cached on the first
 access and thereafter does not require an RPC to the broker to access.
 
 `flux_attr_set()` updates the value of attribute _name_ to _val_.
 If _name_ is not currently a valid attribute, it is created.
-Attributes created through this interface will have no flags set.
 If _val_ is NULL, the attribute is unset.
-
-`flux_attr_first()` and `flux_attr_next()` are used to iterate
-through the current set of valid attribute names.
 
 
 RETURN VALUE
@@ -65,9 +44,6 @@ is returned and errno is set appropriately.
 
 `flux_attr_set()` returns zero on success.  On error, -1 is returned
 and errno is set appropriately.
-
-`flux_attr_first()` and `flux_attr_next()` return an attribute name or
-NULL to indicate that iteration is complete.
 
 
 ERRORS
@@ -80,8 +56,8 @@ EINVAL::
 Some arguments were invalid.
 
 EPERM::
-Set was attempted on an attribute with the FLUX_ATTR_IMMUTABLE or
-FLUX_ATTR_READONLY flags.
+Set was attempted on an attribute that is not writable with the
+user's credentials.
 
 
 AUTHOR

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -458,7 +458,7 @@ static int l_flux_arity (lua_State *L)
     const char *s;
     int arity;
 
-    if (!(s = flux_attr_get (f, "tbon.arity", NULL)))
+    if (!(s = flux_attr_get (f, "tbon.arity")))
         return lua_pusherror (L, "flux_attr_get tbon.arity error");
     arity = strtoul (s, NULL, 10);
     return (l_pushresult (L, arity));
@@ -643,38 +643,15 @@ done:
     return (rc);
 }
 
-static void push_attr_flags (lua_State *L, int flags)
-{
-    int t;
-    lua_newtable (L);
-    if (flags == 0)
-        return;
-    t = lua_gettop (L);
-    if (flags & FLUX_ATTRFLAG_IMMUTABLE) {
-        lua_pushboolean (L, true);
-        lua_setfield (L, t, "FLUX_ATTRFLAG_IMMUTABLE");
-    }
-    if (flags & FLUX_ATTRFLAG_READONLY) {
-        lua_pushboolean (L, true);
-        lua_setfield (L, t, "FLUX_ATTRFLAG_READONLY");
-    }
-    if (flags & FLUX_ATTRFLAG_ACTIVE) {
-        lua_pushboolean (L, true);
-        lua_setfield (L, t, "FLUX_ATTRFLAG_ACTIVE");
-    }
-}
-
 static int l_flux_getattr (lua_State *L)
 {
     flux_t *f = lua_get_flux (L, 1);
-    int flags;
     const char *name = luaL_checkstring (L, 2);
-    const char *val = flux_attr_get (f, name, &flags);
+    const char *val = flux_attr_get (f, name);
     if (val == NULL)
         return lua_pusherror (L, (char *)flux_strerror (errno));
     lua_pushstring (L, val);
-    push_attr_flags (L, flags);
-    return (2);
+    return (1);
 }
 
 static int l_flux_subscribe (lua_State *L)

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -54,6 +54,7 @@ flux_broker_SOURCES = \
 	publisher.c
 
 flux_broker_LDADD = \
+	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libpmi/libpmi.la \
@@ -68,9 +69,10 @@ TESTS = test_shutdown.t \
 	test_service.t
 
 test_ldadd = \
+	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libtap/libtap.la 
+	$(top_builddir)/src/common/libtap/libtap.la
 
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -350,29 +350,38 @@ void setattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
     const char *name;
     const char *val;
 
-    if (flux_request_unpack (msg, NULL, "{s:s s:s}",       /* SET */
-                             "name", &name,
-                             "value", &val) == 0) {
-        if (attr_set (attrs, name, val, false) < 0) {
-            if (errno != ENOENT)
-                goto error;
-            if (attr_add (attrs, name, val, 0) < 0)
-                goto error;
-        }
-    }
-    else if (flux_request_unpack (msg, NULL, "{s:s s:n}",  /* DELETE */
-                                  "name", &name,
-                                  "value") == 0) {
-        if (attr_delete (attrs, name, false) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s s:s}", "name", &name,
+                                                     "value", &val) < 0)
+        goto error;
+    if (attr_set (attrs, name, val, false) < 0) {
+        if (errno != ENOENT)
+            goto error;
+        if (attr_add (attrs, name, val, 0) < 0)
             goto error;
     }
-    else
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        FLUX_LOG_ERROR (h);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        FLUX_LOG_ERROR (h);
+}
+
+void rmattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
+                        const flux_msg_t *msg, void *arg)
+{
+    attr_t *attrs = arg;
+    const char *name;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
+        goto error;
+    if (attr_delete (attrs, name, false) < 0)
         goto error;
     if (flux_respond (h, msg, 0, NULL) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         FLUX_LOG_ERROR (h);
 }
 
@@ -420,6 +429,7 @@ static const struct flux_msg_handler_spec handlers[] = {
     { FLUX_MSGTYPE_REQUEST, "attr.get",    getattr_request_cb, FLUX_ROLE_ALL },
     { FLUX_MSGTYPE_REQUEST, "attr.list",   lsattr_request_cb, FLUX_ROLE_ALL },
     { FLUX_MSGTYPE_REQUEST, "attr.set",    setattr_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "attr.rm",     rmattr_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -4,6 +4,13 @@
 #include <stdint.h>
 #include <flux/core.h>
 
+enum {
+    FLUX_ATTRFLAG_IMMUTABLE = 1,    /* attribute is cacheable */
+    FLUX_ATTRFLAG_READONLY = 2,     /* attribute cannot be written */
+                                    /*   but may change on broker */
+    FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
+};
+
 /* Callbacks for active values.  Return 0 on succes, -1 on eror with
  * errno set.  Errors are propagated to the return of attr_set() and attr_get().
  */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -66,6 +66,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libpmi/pmi.h"
 #include "src/common/libpmi/pmi_strerror.h"
+#include "src/common/libflux/attr_private.h"
 
 #include "heartbeat.h"
 #include "module.h"
@@ -841,12 +842,12 @@ static int create_dummyattrs (flux_t *h, uint32_t rank, uint32_t size)
 {
     char *s;
     s = xasprintf ("%"PRIu32, rank);
-    if (flux_attr_fake (h, "rank", s, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_set_cacheonly (h, "rank", s) < 0)
         return -1;
     free (s);
 
     s = xasprintf ("%"PRIu32, size);
-    if (flux_attr_fake (h, "size", s, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_set_cacheonly (h, "size", s) < 0)
         return -1;
     free (s);
 

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -32,6 +32,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/wallclock.h"
 #include "src/common/libutil/stdlog.h"
+#include "src/common/libflux/attr_private.h"
 
 #include "log.h"
 
@@ -663,7 +664,7 @@ static int fake_rank (flux_t *h, uint32_t rank)
 {
     char buf[16];
     snprintf (buf, sizeof (buf), "%u", rank);
-    return flux_attr_fake (h, "rank", buf, FLUX_ATTRFLAG_IMMUTABLE);
+    return attr_set_cacheonly (h, "rank", buf);
 }
 
 int logbuf_initialize (flux_t *h, uint32_t rank, attr_t *attrs)

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -51,6 +51,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/oom.h"
 #include "src/common/libutil/iterators.h"
+#include "src/common/libflux/attr_private.h"
 
 #include "heartbeat.h"
 #include "module.h"
@@ -135,7 +136,7 @@ static void *module_thread (void *arg)
     if (!(p->h = flux_open (uri, 0)))
         log_err_exit ("flux_open %s", uri);
     rankstr = xasprintf ("%"PRIu32, p->rank);
-    if (flux_attr_fake (p->h, "rank", rankstr, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+    if (attr_set_cacheonly (p->h, "rank", rankstr) < 0) {
         log_err ("%s: error faking rank attribute", p->name);
         goto done;
     }

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -5,6 +5,7 @@
 #include "hello.h"
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libflux/attr_private.h"
 
 static flux_t *h;
 
@@ -39,8 +40,8 @@ int main (int argc, char **argv)
      * Since broker attrs are not set, hwm defaults to 1 (self).
      * It will immediately complete so no need to start reactor.
      */
-    flux_attr_fake (h, "size", "1", FLUX_ATTRFLAG_IMMUTABLE);
-    flux_attr_fake (h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE);
+    attr_set_cacheonly (h, "size", "1");
+    attr_set_cacheonly (h, "rank", "0");
     ok (flux_get_size (h, &size) == 0 && size == 1,
         "size == 1");
     ok (flux_get_rank (h, &rank) == 0 && rank == 0,
@@ -67,8 +68,8 @@ int main (int argc, char **argv)
     /* Simulate a 2 node session.
      * Same procedure as above except the session will not complete.
      */
-    flux_attr_fake (h, "size", "3", FLUX_ATTRFLAG_IMMUTABLE);
-    flux_attr_fake (h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE);
+    attr_set_cacheonly (h, "size", "3");
+    attr_set_cacheonly (h, "rank", "0");
     ok (flux_get_size (h, &size) == 0 && size == 3,
         "size == 1");
     ok (flux_get_rank (h, &rank) == 0 && rank == 0,

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -21,6 +21,8 @@
  *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
+#include <czmq.h>
+#include <jansson.h>
 #include "builtin.h"
 
 static struct optparse_option setattr_opts[] = {
@@ -32,26 +34,33 @@ static struct optparse_option setattr_opts[] = {
 
 static int cmd_setattr (optparse_t *p, int ac, char *av[])
 {
-    int n;
-    const char *name = NULL, *val = NULL;
-    flux_t *h;
+    int n = optparse_option_index (p);
+    flux_t *h = builtin_get_flux_handle (p);
+    const char *name;
+    const char *val;
 
     log_init ("flux-setattr");
 
-    n = optparse_option_index (p);
-    if (optparse_hasopt (p, "expunge") && n == ac - 1) {
+    if (optparse_hasopt (p, "expunge")) {
+        if (n != ac - 1) {
+            optparse_print_usage (p);
+            exit (1);
+        }
         name = av[n];
-    } else if (!optparse_hasopt (p, "expunge") && n == ac - 2) {
+        if (flux_attr_set (h, name, NULL) < 0)
+            log_err_exit ("flux_attr_set");
+    }
+    else {
+        if (n != ac - 2) {
+            optparse_print_usage (p);
+            exit (1);
+        }
         name = av[n];
         val = av[n + 1];
-    } else {
-        optparse_print_usage (p);
-        exit (1);
+        if (flux_attr_set (h, name, val) < 0)
+            log_err_exit ("flux_attr_set");
     }
 
-    h = builtin_get_flux_handle (p);
-    if (flux_attr_set (h, name, val) < 0)
-        log_err_exit ("%s", av[1]);
     flux_close (h);
     return (0);
 }
@@ -63,17 +72,68 @@ static struct optparse_option lsattr_opts[] = {
     OPTPARSE_TABLE_END
 };
 
+void attrfree (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+void *attrdup (const void *item)
+{
+    return strdup (item);
+}
+
+int attrcmp(const void *item1, const void *item2)
+{
+    return strcmp (item1, item2);
+}
+
+/* Get list of attributes from the broker, then insert
+ * into a sorted list and return it.
+ */
+zlistx_t *get_sorted_attrlist (flux_t *h)
+{
+    flux_future_t *f;
+    zlistx_t *list;
+    json_t *names; // array of attr names
+    size_t index;
+    json_t *value;
+
+    if (!(list = zlistx_new ()))
+        log_err_exit ("zlistx_new");
+    zlistx_set_comparator (list, attrcmp);
+    zlistx_set_duplicator (list, attrdup);
+    zlistx_set_destructor (list, attrfree);
+    if (!(f = flux_rpc (h, "attr.list", NULL, FLUX_NODEID_ANY, 0))
+                || flux_rpc_get_unpack  (f, "{s:o}", "names", &names) < 0)
+        log_err_exit ("attr.list");
+    json_array_foreach (names, index, value) {
+        const char *name = json_string_value (value);
+        if (!name)
+            log_msg_exit ("non-string attr name returned");
+        if (!zlistx_insert (list, (char *)name, false))
+            log_msg_exit ("zlistx_insert failed");
+    }
+    flux_future_destroy (f);
+    return list;
+}
+
 static int cmd_lsattr (optparse_t *p, int ac, char *av[])
 {
+    flux_t *h = builtin_get_flux_handle (p);
+    int n = optparse_option_index (p);
     const char *name, *val;
-    flux_t *h;
+    zlistx_t *list;
 
     log_init ("flux-lsatrr");
 
-    if (optparse_option_index (p) != ac)
+    if (n != ac)
         optparse_fatal_usage (p, 1, NULL);
-    h = builtin_get_flux_handle (p);
-    name = flux_attr_first (h);
+
+    list = get_sorted_attrlist (h);
+    name = zlistx_first (list);
     while (name) {
         if (optparse_hasopt (p, "values")) {
             val = flux_attr_get (h, name, NULL);
@@ -81,8 +141,9 @@ static int cmd_lsattr (optparse_t *p, int ac, char *av[])
         } else {
             printf ("%s\n", name);
         }
-        name = flux_attr_next (h);
+        name = zlistx_next (list);
     }
+    zlistx_destroy (&list);
     flux_close (h);
     return (0);
 }

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -136,7 +136,7 @@ static int cmd_lsattr (optparse_t *p, int ac, char *av[])
     name = zlistx_first (list);
     while (name) {
         if (optparse_hasopt (p, "values")) {
-            val = flux_attr_get (h, name, NULL);
+            val = flux_attr_get (h, name);
             printf ("%-40s%s\n", name, val ? val : "-");
         } else {
             printf ("%s\n", name);
@@ -150,19 +150,17 @@ static int cmd_lsattr (optparse_t *p, int ac, char *av[])
 
 static int cmd_getattr (optparse_t *p, int ac, char *av[])
 {
-    flux_t *h = NULL;
-    const char *val;
-    int n, flags;
+    flux_t *h = builtin_get_flux_handle (p);
+    int n = optparse_option_index (p);
+    const char *name, *val;
 
     log_init ("flux-getattr");
 
-    n = optparse_option_index (p);
     if (n != ac - 1)
         optparse_fatal_usage (p, 1, NULL);
-
-    h = builtin_get_flux_handle (p);
-    if (!(val = flux_attr_get (h, av[n], &flags)))
-        log_err_exit ("%s", av[n]);
+    name = av[n];
+    if (!(val = flux_attr_get (h, name)))
+        log_err_exit ("%s", name);
     printf ("%s\n", val);
     flux_close (h);
     return (0);

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -40,7 +40,7 @@ static void print_broker_version (optparse_t *p)
     flux_t *h = builtin_get_flux_handle (p);
     if (!h)
         log_err_exit ("flux_open %s failed", uri);
-    if (!(version = flux_attr_get (h, "version", NULL)))
+    if (!(version = flux_attr_get (h, "version")))
         log_err_exit ("flux_attr_get");
     printf ("broker:  \t\t%s\n", version);
     printf ("FLUX_URI:\t\t%s\n", uri);

--- a/src/cmd/flux-comms.c
+++ b/src/cmd/flux-comms.c
@@ -136,7 +136,7 @@ int main (int argc, char *argv[])
         const char *s;
         if (flux_get_rank (h, &rank) < 0 || flux_get_size (h, &size) < 0)
             log_err_exit ("flux_get_rank/size");
-        if (!(s = flux_attr_get (h, "tbon.arity", NULL)))
+        if (!(s = flux_attr_get (h, "tbon.arity")))
             log_err_exit ("flux_attr_get tbon.arity");
         arity = strtoul (s, NULL, 10);
         printf ("rank=%"PRIu32"\n", rank);

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -90,6 +90,7 @@ libflux_la_SOURCES = \
 	flog.c \
 	info.c \
 	attr.c \
+	attr_private.h \
 	handle.c \
 	reactor.c \
 	msg_handler.c \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -152,7 +152,8 @@ TESTS = test_message.t \
 	test_reactor_loop.t \
 	test_reduce.t \
 	test_rpc_security.t \
-	test_panic.t
+	test_panic.t \
+	test_attr.t
 
 test_ldadd = \
 	$(builddir)/test/libtestutil.la \
@@ -267,3 +268,7 @@ test_rpc_security_t_LDADD = $(test_ldadd) $(LIBDL)
 test_panic_t_SOURCES = test/panic.c
 test_panic_t_CPPFLAGS = $(test_cppflags)
 test_panic_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_attr_t_SOURCES = test/attr.c
+test_attr_t_CPPFLAGS = $(test_cppflags)
+test_attr_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -38,192 +38,143 @@ enum {
     FLUX_ATTRFLAG_IMMUTABLE = 1,
 };
 
-typedef struct {
-    zhash_t *hash;
-    flux_t *h;
-} attr_ctx_t;
+struct attr_cache {
+    zhashx_t *cache;        // immutable values
+    zhashx_t *temp;         // values that stay valid until next lookup
+};
 
-typedef struct {
-    char *val;
-    int flags;
-} attr_t;
-
-static void freectx (void *arg)
+static void attr_cache_destroy (struct attr_cache *c)
 {
-    attr_ctx_t *ctx = arg;
-    if (ctx) {
+    if (c) {
         int saved_errno = errno;
-        zhash_destroy (&ctx->hash);
-        free (ctx);
+        zhashx_destroy (&c->cache);
+        zhashx_destroy (&c->temp);
+        free (c);
         errno = saved_errno;
     }
 }
 
-static attr_ctx_t *attr_ctx_new (flux_t *h)
+static void valfree (void **item)
 {
-    attr_ctx_t *ctx = calloc (1, sizeof (*ctx));
-    if (!ctx || !(ctx->hash = zhash_new ())) {
-        /* Ensure errno set properly, in case zhash_new doesn't do it */
-        errno = ENOMEM;
-        goto error;
+    if (item) {
+        free (*item);
+        *item = NULL;
     }
-    ctx->h = h;
-    if (flux_aux_set (h, "flux::attr", ctx, freectx) < 0)
-        goto error;
-    return ctx;
-error:
-    freectx (ctx);
+}
+
+static struct attr_cache *attr_cache_create (flux_t *h)
+{
+    struct attr_cache *c = calloc (1, sizeof (*c));
+    if (!c)
+        return NULL;
+    if (!(c->cache = zhashx_new ()))
+        goto nomem;
+    zhashx_set_destructor (c->cache, valfree);
+    if (!(c->temp = zhashx_new ()))
+        goto nomem;
+    zhashx_set_destructor (c->temp, valfree);
+    return c;
+nomem:
+    errno = ENOMEM;
+    attr_cache_destroy (c);
     return NULL;
 }
 
-static attr_ctx_t *getctx (flux_t *h)
+static struct attr_cache *get_attr_cache (flux_t *h)
 {
-    attr_ctx_t *ctx = flux_aux_get (h, "flux::attr");
-    if (!ctx)
-        ctx = attr_ctx_new (h);
-    return ctx;
-}
-
-static void attr_destroy (void *arg)
-{
-    attr_t *attr = arg;
-    free (attr->val);
-    free (attr);
-}
-
-static attr_t *attr_create (const char *val, int flags)
-{
-    attr_t *attr = calloc (1, sizeof (*attr));
-    if (!attr || !(attr->val = strdup (val))) {
-        free (attr);
-        errno = ENOMEM;
-        return NULL;
+    const char *auxkey = "flux::attr_cache";
+    struct attr_cache *c = flux_aux_get (h, auxkey);
+    if (!c) {
+        if (!(c = attr_cache_create (h)))
+            return NULL;
+        if (flux_aux_set (h, auxkey, c, (flux_free_f)attr_cache_destroy) < 0) {
+            attr_cache_destroy (c);
+            return NULL;
+        }
     }
-    attr->flags = flags;
-    return attr;
-}
-
-static int attr_get_rpc (attr_ctx_t *ctx, const char *name, attr_t **attrp)
-{
-    flux_future_t *f;
-    const char *val;
-    int flags;
-    attr_t *attr;
-    int rc = -1;
-
-    if (!(f = flux_rpc_pack (ctx->h, "attr.get", FLUX_NODEID_ANY, 0,
-                             "{s:s}", "name", name)))
-        goto done;
-    if (flux_rpc_get_unpack (f, "{s:s, s:i}",
-                             "value", &val, "flags", &flags) < 0)
-        goto done;
-    if (!(attr = attr_create (val, flags)))
-        goto done;
-    zhash_update (ctx->hash, name, attr);
-    zhash_freefn (ctx->hash, name, attr_destroy);
-    *attrp = attr;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
-static int attr_set_rpc (attr_ctx_t *ctx, const char *name, const char *val)
-{
-    flux_future_t *f;
-    attr_t *attr;
-    int rc = -1;
-
-    f = flux_rpc_pack (ctx->h, "attr.set", FLUX_NODEID_ANY, 0,
-                       "{s:s, s:s}", "name", name, "value", val);
-    if (!f)
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    if (!(attr = attr_create (val, 0)))
-        goto done;
-    zhash_update (ctx->hash, name, attr);
-    zhash_freefn (ctx->hash, name, attr_destroy);
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
-static int attr_rm_rpc (attr_ctx_t *ctx, const char *name)
-{
-    flux_future_t *f;
-    int rc = -1;
-
-    f = flux_rpc_pack (ctx->h, "attr.rm", FLUX_NODEID_ANY, 0,
-                       "{s:s}", "name", name);
-    if (!f)
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    zhash_delete (ctx->hash, name);
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
+    return c;
 }
 
 const char *flux_attr_get (flux_t *h, const char *name)
 {
-    attr_ctx_t *ctx;
-    attr_t *attr;
+    struct attr_cache *c;
+    const char *val;
+    int flags;
+    flux_future_t *f;
+    char *cpy = NULL;
 
     if (!h || !name) {
         errno = EINVAL;
         return NULL;
     }
-    if (!(ctx = getctx (h)))
+    if (!(c = get_attr_cache (h)))
         return NULL;
-    if (!(attr = zhash_lookup (ctx->hash, name))
-                        || !(attr->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
-        if (attr_get_rpc (ctx, name, &attr) < 0)
-            return NULL;
-    }
-    return attr->val;
+    if ((val = zhashx_lookup (c->cache, name)))
+        return val;
+    if (!(f = flux_rpc_pack (h, "attr.get", FLUX_NODEID_ANY, 0, "{s:s}",
+                                                                "name", name)))
+        return NULL;
+    if (flux_rpc_get_unpack (f, "{s:s s:i}", "value", &val,
+                                             "flags", &flags) < 0)
+        goto done;
+    if (!(cpy = strdup (val)))
+        goto done;
+    if ((flags & FLUX_ATTRFLAG_IMMUTABLE))
+        zhashx_update (c->cache, name, cpy);
+    else
+        zhashx_update (c->temp, name, cpy);
+done:
+    flux_future_destroy (f);
+    return cpy;
 }
 
 int flux_attr_set (flux_t *h, const char *name, const char *val)
 {
-    int rc;
+    flux_future_t *f;
+
     if (!h || !name) {
         errno = EINVAL;
         return -1;
     }
-    attr_ctx_t *ctx = getctx (h);
-    if (!ctx)
-        return -1;
     if (val)
-        rc = attr_set_rpc (ctx, name, val);
+        f = flux_rpc_pack (h, "attr.set", FLUX_NODEID_ANY, 0, "{s:s s:s}",
+                                                              "name", name,
+                                                              "value", val);
     else
-        rc = attr_rm_rpc (ctx, name);
-    return rc;
+        f = flux_rpc_pack (h, "attr.rm", FLUX_NODEID_ANY, 0, "{s:s}",
+                                                             "name", name);
+    if (!f)
+        return -1;
+    if (flux_future_get (f, NULL) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    /* N.B. No cache update is necessary.
+     * If immutable, the RPC will fail.
+     * If not immutable, we have to look it up on next access anyway.
+     */
+    flux_future_destroy (f);
+    return 0;
 }
 
 int attr_set_cacheonly (flux_t *h, const char *name, const char *val)
 {
-    attr_ctx_t *ctx;
-    attr_t *attr;
+    struct attr_cache *c;
 
     if (!h || !name) {
         errno = EINVAL;
         return -1;
     }
-    if (!(ctx = getctx (h)))
+    if (!(c = get_attr_cache (h)))
         return -1;
     if (val) {
-        if (!(attr = attr_create (val, FLUX_ATTRFLAG_IMMUTABLE)))
+        char *cpy;
+        if (!(cpy = strdup (val)))
             return -1;
-        zhash_update (ctx->hash, name, attr);
-        zhash_freefn (ctx->hash, name, attr_destroy);
+        zhashx_update (c->cache, name, cpy);
     }
-    else {
-        zhash_delete (ctx->hash, name);
-    }
+    else
+        zhashx_delete (c->cache, name);
     return 0;
 }
 

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -163,21 +163,23 @@ done:
     return rc;
 }
 
-const char *flux_attr_get (flux_t *h, const char *name, int *flags)
+const char *flux_attr_get (flux_t *h, const char *name)
 {
-    attr_ctx_t *ctx = getctx (h);
+    attr_ctx_t *ctx;
     attr_t *attr;
 
-    if (!ctx)
+    if (!h || !name) {
+        errno = EINVAL;
         return NULL;
-
+    }
+    if (!(ctx = getctx (h)))
+        return NULL;
     if (!(attr = zhash_lookup (ctx->hash, name))
-                        || !(attr->flags & FLUX_ATTRFLAG_IMMUTABLE))
+                        || !(attr->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
         if (attr_get_rpc (ctx, name, &attr) < 0)
             return NULL;
-    if (flags && attr)
-        *flags = attr->flags;
-    return attr ? attr->val : NULL;
+    }
+    return attr->val;
 }
 
 int flux_attr_set (flux_t *h, const char *name, const char *val)

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -34,6 +34,10 @@
 #include "attr_private.h"
 #include "rpc.h"
 
+enum {
+    FLUX_ATTRFLAG_IMMUTABLE = 1,
+};
+
 typedef struct {
     zhash_t *hash;
     flux_t *h;

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -31,6 +31,7 @@
 #include <jansson.h>
 
 #include "attr.h"
+#include "attr_private.h"
 #include "rpc.h"
 
 typedef struct {
@@ -199,16 +200,26 @@ int flux_attr_set (flux_t *h, const char *name, const char *val)
     return rc;
 }
 
-int flux_attr_fake (flux_t *h, const char *name, const char *val, int flags)
+int attr_set_cacheonly (flux_t *h, const char *name, const char *val)
 {
-    attr_ctx_t *ctx = getctx (h);
-    attr_t *attr = attr_create (val, flags);
+    attr_ctx_t *ctx;
+    attr_t *attr;
 
-    if (!ctx || !attr)
+    if (!h || !name) {
+        errno = EINVAL;
         return -1;
-    
-    zhash_update (ctx->hash, name, attr);
-    zhash_freefn (ctx->hash, name, attr_destroy);
+    }
+    if (!(ctx = getctx (h)))
+        return -1;
+    if (val) {
+        if (!(attr = attr_create (val, FLUX_ATTRFLAG_IMMUTABLE)))
+            return -1;
+        zhash_update (ctx->hash, name, attr);
+        zhash_freefn (ctx->hash, name, attr_destroy);
+    }
+    else {
+        zhash_delete (ctx->hash, name);
+    }
     return 0;
 }
 

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -46,10 +46,6 @@ int flux_attr_set (flux_t *h, const char *name, const char *val);
 
 int flux_attr_fake (flux_t *h, const char *name, const char *val, int flags);
 
-const char *flux_attr_first (flux_t *h);
-
-const char *flux_attr_next (flux_t *h);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -25,14 +25,39 @@
 #ifndef _FLUX_CORE_ATTR_H
 #define _FLUX_CORE_ATTR_H
 
+/* broker attributes
+ *
+ * Brokers have configuration attributes.
+ * Values are local to a particular broker rank.
+ * Some may be overridden on the broker command line wtih -Sattr=val.
+ * The following commands are available for manipulating attributes
+ * on the running system:
+ *   flux lsattr [-v]
+ *   flux setattr name value
+ *   flux getattr name
+ * In additon, the following functions may be used to get/set broker
+ * attributes programmatically.
+ */
+
 #include "handle.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/* Get the value for attribute 'name' from the local broker.
+ * Returns value on success, NULL on failure with errno set.
+ * This function performs a synchronous RPC to the broker if the
+ * attribute is not found in cache, thus may block for the round-trip
+ * communication.
+ */
 const char *flux_attr_get (flux_t *h, const char *name);
 
+/* Set the value for attribute 'name' from the local broker.
+ * Returns value on success, NULL on failure with errno set.
+ * This function performs a synchronous RPC to the broker,
+ * thus blocks for the round-trip communication.
+ */
 int flux_attr_set (flux_t *h, const char *name, const char *val);
 
 #ifdef __cplusplus

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -31,15 +31,6 @@
 extern "C" {
 #endif
 
-/* Flags can only be set by the broker.
- */
-enum {
-    FLUX_ATTRFLAG_IMMUTABLE = 1,    /* attribute is cacheable */
-    FLUX_ATTRFLAG_READONLY = 2,     /* attribute cannot be written */
-                                    /*   but may change on broker */
-    FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
-};
-
 const char *flux_attr_get (flux_t *h, const char *name);
 
 int flux_attr_set (flux_t *h, const char *name, const char *val);

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -40,7 +40,7 @@ enum {
     FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
 };
 
-const char *flux_attr_get (flux_t *h, const char *name, int *flags);
+const char *flux_attr_get (flux_t *h, const char *name);
 
 int flux_attr_set (flux_t *h, const char *name, const char *val);
 

--- a/src/common/libflux/attr_private.h
+++ b/src/common/libflux/attr_private.h
@@ -22,33 +22,15 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#ifndef _FLUX_CORE_ATTR_H
-#define _FLUX_CORE_ATTR_H
+#ifndef _FLUX_ATTR_PRIVATE_H
+#define _FLUX_ATTR_PRIVATE_H
 
 #include "handle.h"
+#include "attr.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+int attr_set_cacheonly (flux_t *h, const char *name, const char *val);
 
-/* Flags can only be set by the broker.
- */
-enum {
-    FLUX_ATTRFLAG_IMMUTABLE = 1,    /* attribute is cacheable */
-    FLUX_ATTRFLAG_READONLY = 2,     /* attribute cannot be written */
-                                    /*   but may change on broker */
-    FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
-};
-
-const char *flux_attr_get (flux_t *h, const char *name);
-
-int flux_attr_set (flux_t *h, const char *name, const char *val);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* !_FLUX_CORE_ATTR_H */
+#endif /* !_FLUX_ATTR_PRIVATE_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/info.c
+++ b/src/common/libflux/info.c
@@ -39,7 +39,7 @@ int flux_get_size (flux_t *h, uint32_t *size)
 {
     const char *val;
 
-    if (!(val = flux_attr_get (h, "size", NULL)))
+    if (!(val = flux_attr_get (h, "size")))
         return -1;
     *size = strtoul (val, NULL, 10);
     return 0;
@@ -49,7 +49,7 @@ int flux_get_rank (flux_t *h, uint32_t *rank)
 {
     const char *val;
 
-    if (!(val = flux_attr_get (h, "rank", NULL)))
+    if (!(val = flux_attr_get (h, "rank")))
         return -1;
     *rank = strtoul (val, NULL, 10);
     return 0;

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -1,0 +1,286 @@
+#include <errno.h>
+#include <string.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libflux/attr_private.h"
+#include "util.h"
+
+struct entry {
+    char *key;
+    char *val;
+    int flags;
+};
+
+static struct entry hardwired[] = {
+    { .key = "cow",     .val = "moo",   .flags = 1 },
+    { .key = "duck",    .val = "quack", .flags = 1 },
+    { .key = "chick",   .val = "peep",  .flags = 1  },
+    { .key = "fox",     .val = "-",     .flags = 1  },
+    { .key = "bear",    .val = "roar",  .flags = 1  },
+    { .key = NULL,      .val = NULL,    .flags = 1  },
+};
+
+static bool lookup_hardwired (const char *key, const char **val, int *flags)
+{
+    int i;
+    for (i = 0; hardwired[i].key != NULL; i++) {
+        if (!strcmp (hardwired[i].key, key)) {
+            if (val)
+                *val = hardwired[i].val;
+            if (flags)
+                *flags = hardwired[i].flags;
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Two hardwired value:
+ *   cow=moo (flags = 1)
+ *   chicken=cluck (flags = 1)
+ * all other values come from the hash and are returned with (flags = 0)
+ */
+static volatile int get_count = 0;
+void get_cb (flux_t *h, flux_msg_handler_t *mh,
+             const flux_msg_t *msg, void *arg)
+{
+    zhashx_t *attrs = arg;
+    const char *name;
+    const char *value;
+    int flags = 0;
+    get_count++;
+    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
+        goto error;
+    if (!lookup_hardwired (name, &value, &flags)
+                            && !(value = zhashx_lookup (attrs, name))) {
+        errno = ENOENT;
+        goto error;
+    }
+    diag ("attr.get: %s=%s (flags=%d)", name, value, flags);
+    if (flux_respond_pack (h, msg, "{s:s s:i}", "value", value,
+                                                "flags", flags) < 0)
+        BAIL_OUT ("flux_respond failed");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        BAIL_OUT ("flux_respond_error failed");
+}
+
+void set_cb (flux_t *h, flux_msg_handler_t *mh,
+             const flux_msg_t *msg, void *arg)
+{
+    zhashx_t *attrs = arg;
+    const char *name;
+    const char *value;
+    if (flux_request_unpack (msg, NULL, "{s:s s:s}", "name", &name,
+                                                     "value", &value) < 0)
+        goto error;
+    if (lookup_hardwired (name, NULL, NULL)) {
+        errno = EPERM;
+        goto error;
+    }
+    diag ("attr.set: %s=%s", name, value);
+    zhashx_update (attrs, name, (char *)value);
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        BAIL_OUT ("flux_respond failed");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        BAIL_OUT ("flux_respond_error failed");
+}
+
+void rm_cb (flux_t *h, flux_msg_handler_t *mh,
+            const flux_msg_t *msg, void *arg)
+{
+    zhashx_t *attrs = arg;
+    const char *name;
+    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
+        goto error;
+    if (lookup_hardwired (name, NULL, NULL)) {
+        errno = EPERM;
+        goto error;
+    }
+    if (!zhashx_lookup (attrs, name)) {
+        errno = ENOENT;
+        goto error;
+    }
+    diag ("attr.rm: %s", name);
+    zhashx_delete (attrs, name);
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        BAIL_OUT ("flux_respond failed");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        BAIL_OUT ("flux_respond_error failed");
+}
+
+static const struct flux_msg_handler_spec tab[] = {
+    { FLUX_MSGTYPE_REQUEST, "attr.get",    get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "attr.set",    set_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "attr.rm",     rm_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void *valdup (const void *item)
+{
+    return strdup (item);
+}
+static void valfree (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+int test_server (flux_t *h, void *arg)
+{
+    flux_msg_handler_t **handlers;
+    zhashx_t *attrs;
+
+    if (!(attrs = zhashx_new ()))
+        BAIL_OUT ("zhashx_new");
+    zhashx_set_duplicator (attrs, valdup);
+    zhashx_set_destructor (attrs, valfree);
+
+    if (flux_msg_handler_addvec (h, tab, attrs, &handlers) < 0)
+        BAIL_OUT ("flux_msg_handler_addvec");
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        BAIL_OUT ("flux_reactor_run failed");
+
+    flux_msg_handler_delvec (handlers);
+    zhashx_destroy (&attrs);
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    const char *value;
+    const char *value2;
+
+    plan (NO_PLAN);
+
+    test_server_environment_init ("attr-test");
+
+    if (!(h = test_server_create (test_server, NULL)))
+        BAIL_OUT ("test_server_create failed");
+
+    /* get ENOENT */
+
+    errno = 0;
+    get_count = 0;
+    ok (flux_attr_get (h, "notakey") == NULL && errno == ENOENT
+        && get_count == 1,
+        "flux_attr_get name=notakey fails with ENOENT (with rpc)");
+
+    /* set, get */
+
+    ok (flux_attr_set (h, "foo", "bar") == 0,
+        "flux_attr_set foo=bar works");
+    ok (flux_attr_set (h, "baz", "meep") == 0,
+        "flux_attr_set baz=meep works");
+
+    get_count = 0;
+    value = flux_attr_get (h, "foo");
+    ok (value && !strcmp (value, "bar") && get_count == 1,
+        "flux_attr_get foo=bar (with rpc)");
+    value = flux_attr_get (h, "foo");
+    ok (value && !strcmp (value, "bar") && get_count == 2,
+        "flux_attr_get foo=bar (with 2nd rpc)");
+
+    get_count = 0;
+    value2 = flux_attr_get (h, "baz");
+    ok (value2 && !strcmp (value2, "meep") && get_count == 1,
+        "flux_attr_get baz=meep (with rpc)");
+    value2 = flux_attr_get (h, "baz");
+    ok (value2 && !strcmp (value2, "meep") && get_count == 2,
+        "flux_attr_get baz=meep (with 2nd rpc)");
+
+    ok (value && !strcmp (value, "bar"),
+        "const return value of flux_attr_get foo=bar still valid");
+
+    /* get (cached) */
+
+    get_count = 0;
+    value = flux_attr_get (h, "cow");
+    ok (value && !strcmp (value, "moo") && get_count == 1,
+        "flux_attr_get cow=moo (with rpc)");
+    get_count = 0;
+    value = flux_attr_get (h, "chick");
+    ok (value && !strcmp (value, "peep") && get_count == 1,
+        "flux_attr_get chick=peep (with rpc)");
+    get_count = 0;
+    value = flux_attr_get (h, "cow");
+    ok (value && !strcmp (value, "moo") && get_count == 0,
+        "flux_attr_get cow=moo (cached)");
+    get_count = 0;
+    value = flux_attr_get (h, "chick");
+    ok (value && !strcmp (value, "peep") && get_count == 0,
+        "flux_attr_get chick=peep (cached)");
+
+    /* rm (set val=NULL) */
+
+    errno = 0;
+    ok (flux_attr_set (h, "notakey", NULL) < 0 && errno == ENOENT,
+        "flux_attr_set notakey=NULL fails with ENOENT");
+
+    ok (flux_attr_set (h, "foo", NULL) == 0,
+        "flux_attr_set foo=NULL works");
+    errno = 0;
+    ok (flux_attr_get (h, "foo") == NULL && errno == ENOENT,
+        "flux_attr_get foo fails with ENOENT");
+
+    /* cacheonly */
+
+    ok (attr_set_cacheonly (h, "fake", "42") == 0,
+        "attr_set_cacheonly fake=42");
+    get_count = 0;
+    value = flux_attr_get (h, "fake");
+    ok (value && !strcmp (value, "42") && get_count == 0,
+        "flux_attr_get fake=42 (no rpc)");
+
+    ok (attr_set_cacheonly (h, "fake", NULL) == 0,
+        "attr_set_cacheonly fake=NULL");
+    get_count = 0;
+    errno = 0;
+    ok (flux_attr_get (h, "fake") == NULL && errno == ENOENT && get_count == 1,
+        "flux_attr_get fake failed with ENOENT (with rpc)");
+
+    /* set - invalid args */
+    errno = 0;
+    ok (flux_attr_set (NULL, "foo", "bar") < 0 && errno == EINVAL,
+        "flux_attr_set h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_attr_set (h, NULL, "bar") < 0 && errno == EINVAL,
+        "flux_attr_set name=NULL fails with EINVAL");
+
+    /* get - invalid args */
+    errno = 0;
+    ok (flux_attr_get (NULL, "foo") == NULL && errno == EINVAL,
+        "flux_attr_get h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_attr_get (h, NULL) == NULL && errno == EINVAL,
+        "flux_attr_get name=NULL fails with EINVAL");
+
+    /* cacheonly - invalid args */
+    errno = 0;
+    ok (attr_set_cacheonly (NULL, "foo", "bar") < 0 && errno == EINVAL,
+        "attr_set_cacheonly h=NULL fails with EINVAL");
+    errno = 0;
+    ok (attr_set_cacheonly (h, NULL, "bar") < 0 && errno == EINVAL,
+        "attr_set_cacheonly name=NULL fails with EINVAL");
+
+    test_server_stop (h);
+    flux_close (h);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/test/log.c
+++ b/src/common/libflux/test/log.c
@@ -3,6 +3,7 @@
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libflux/attr_private.h"
 #include "util.h"
 
 int main (int argc, char *argv[])
@@ -15,8 +16,8 @@ int main (int argc, char *argv[])
 
     if (!(h = test_server_create (NULL, NULL)))
         BAIL_OUT ("could not create test server");
-    if (flux_attr_fake (h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE) < 0)
-        BAIL_OUT ("flux_attr_fake failed");
+    if (attr_set_cacheonly (h, "rank", "0") < 0)
+        BAIL_OUT ("attr_set_cacheonly failed");
 
     errno = 1234;
     flux_log_error (h, "hello world");

--- a/src/common/libflux/test/mrpc.c
+++ b/src/common/libflux/test/mrpc.c
@@ -4,6 +4,7 @@
 
 #include "src/common/libutil/nodeset.h"
 #include "src/common/libtap/tap.h"
+#include "src/common/libflux/attr_private.h"
 
 #include "util.h"
 
@@ -185,7 +186,7 @@ static void rpctest_set_rank (flux_t *h, uint32_t newrank)
     char s[16];
     uint32_t rank = 42;
     snprintf (s, sizeof (s), "%"PRIu32, fake_rank);
-    flux_attr_fake (h, "rank", s, FLUX_ATTRFLAG_IMMUTABLE);
+    attr_set_cacheonly (h, "rank", s);
     flux_get_rank (h, &rank);
     cmp_ok (rank, "==", fake_rank,
         "successfully faked flux_get_rank() of %d", fake_rank);
@@ -197,7 +198,7 @@ static void rpctest_set_size (flux_t *h, uint32_t newsize)
     char s[16];
     uint32_t size = 0;
     snprintf (s, sizeof (s), "%"PRIu32, fake_size);
-    flux_attr_fake (h, "size", s, FLUX_ATTRFLAG_IMMUTABLE);
+    attr_set_cacheonly (h, "size", s);
     flux_get_size (h, &size);
     cmp_ok (size, "==", fake_size,
         "successfully faked flux_get_size() of %d", fake_size);

--- a/src/common/libflux/test/reduce.c
+++ b/src/common/libflux/test/reduce.c
@@ -5,6 +5,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/oom.h"
 #include "src/common/libtap/tap.h"
+#include "src/common/libflux/attr_private.h"
 
 #include "util.h"
 
@@ -351,9 +352,9 @@ int main (int argc, char *argv[])
     if (!(h = loopback_create (0)))
         BAIL_OUT ("can't continue without loop handle");
 
-    flux_attr_fake (h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE);
-    flux_attr_fake (h, "tbon.level", "0", FLUX_ATTRFLAG_IMMUTABLE);
-    flux_attr_fake (h, "tbon.maxlevel", "0", FLUX_ATTRFLAG_IMMUTABLE);
+    attr_set_cacheonly (h, "rank", "0");
+    attr_set_cacheonly (h, "tbon.level", "0");
+    attr_set_cacheonly (h, "tbon.maxlevel", "0");
 
     test_nopolicy (h); // 6
     test_hwm (h); // 37

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -20,6 +20,7 @@ loop_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 	--disable-static -avoid-version -shared -export-dynamic
 
 loop_la_LIBADD = \
+	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(ZMQ_LIBS)

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -35,6 +35,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/msglist.h"
+#include "src/common/libflux/attr_private.h"
 
 #define CTX_MAGIC   0xf434aaa0
 typedef struct {
@@ -146,11 +147,9 @@ flux_t *connector_init (const char *path, int flags)
         goto error;
     /* Fake out size, rank, tbon-arity attributes for testing.
      */
-    if (flux_attr_fake (c->h, "rank", "0", FLUX_ATTRFLAG_IMMUTABLE) < 0
-                || flux_attr_fake (c->h, "size", "1",
-                                   FLUX_ATTRFLAG_IMMUTABLE) < 0
-                || flux_attr_fake (c->h, "tbon-arity", "2",
-                                   FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_set_cacheonly(c->h, "rank", "0") < 0
+                || attr_set_cacheonly (c->h, "size", "1") < 0
+                || attr_set_cacheonly (c->h, "tbon-arity", "2") < 0)
         goto error;
     c->userid = geteuid ();
     c->rolemask = FLUX_ROLE_OWNER;

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -515,7 +515,7 @@ static int attr_get_int (flux_t *h, const char *attr)
 {
     unsigned long l;
     char *p;
-    const char *s = flux_attr_get (h, attr, 0);
+    const char *s = flux_attr_get (h, attr);
     if (!s)
         return (-1);
     errno = 0;

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -1278,7 +1278,7 @@ int mod_main (flux_t *h, int argc, char **argv)
 
     if (!ctx)
         goto done;
-    if (!(local_uri = flux_attr_get (h, "local-uri", NULL))) {
+    if (!(local_uri = flux_attr_get (h, "local-uri"))) {
         flux_log_error (h, "flux_attr_get local-uri");
         goto done;
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -135,7 +135,6 @@ static sqlite_ctx_t *getctx (flux_t *h)
     const char *dir;
     const char *tmp;
     bool cleanup = false;
-    int flags;
 
     if (!ctx) {
         if (!(ctx = calloc (1, sizeof (*ctx))))
@@ -144,18 +143,18 @@ static sqlite_ctx_t *getctx (flux_t *h)
             goto error;
         ctx->lzo_bufsize = lzo_buf_chunksize;
         ctx->h = h;
-        if (!(ctx->hashfun = flux_attr_get (h, "content.hash", &flags))) {
+        if (!(ctx->hashfun = flux_attr_get (h, "content.hash"))) {
             flux_log_error (h, "content.hash");
             goto error;
         }
-        if (!(tmp = flux_attr_get (h, "content.blob-size-limit", NULL))) {
+        if (!(tmp = flux_attr_get (h, "content.blob-size-limit"))) {
             flux_log_error (h, "content.blob-size-limit");
             goto error;
         }
         ctx->blob_size_limit = strtoul (tmp, NULL, 10);
 
-        if (!(dir = flux_attr_get (h, "persist-directory", NULL))) {
-            if (!(dir = flux_attr_get (h, "broker.rundir", NULL))) {
+        if (!(dir = flux_attr_get (h, "persist-directory"))) {
+            if (!(dir = flux_attr_get (h, "broker.rundir"))) {
                 flux_log_error (h, "broker.rundir");
                 goto error;
             }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -130,7 +130,7 @@ static kvs_ctx_t *getctx (flux_t *h)
             saved_errno = errno;
             goto error;
         }
-        if (!(ctx->hash_name = flux_attr_get (h, "content.hash", NULL))) {
+        if (!(ctx->hash_name = flux_attr_get (h, "content.hash"))) {
             saved_errno = errno;
             flux_log_error (h, "content.hash");
             goto error;

--- a/src/modules/wreck/job.c
+++ b/src/modules/wreck/job.c
@@ -524,7 +524,7 @@ static int flux_attr_get_int (flux_t *h, const char *attr, int *valp)
     const char *tmp;
     char *p;
 
-    if ((tmp = flux_attr_get (h, attr, 0)) == NULL)
+    if ((tmp = flux_attr_get (h, attr)) == NULL)
         return (-1);
     n = strtoul (tmp, &p, 10);
     if (n == LONG_MAX)
@@ -628,7 +628,7 @@ static flux_cmd_t *wrexecd_cmd_create (flux_t *h, struct wreck_job *job)
         flux_log_error (h, "wrexecd_cmd_create: flux_cmd_create");
         goto error;
     }
-    if (!(wrexecd_path = flux_attr_get (h, "wrexec.wrexecd_path", NULL))) {
+    if (!(wrexecd_path = flux_attr_get (h, "wrexec.wrexecd_path"))) {
         flux_log_error (h, "wrexecd_cmd_create: flux_attr_get");
         goto error;
     }
@@ -930,7 +930,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     }
 
-    if (!(local_uri = flux_attr_get (h, "local-uri", NULL))) {
+    if (!(local_uri = flux_attr_get (h, "local-uri"))) {
         flux_log_error (h, "flux_attr_get (\"local-uri\")");
         goto done;
     }

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1031,7 +1031,7 @@ static int flux_heartbeat_epoch (flux_t *h)
 {
     long int epoch;
     char *p;
-    const char *val = flux_attr_get (h, "heartbeat-epoch", NULL);
+    const char *val = flux_attr_get (h, "heartbeat-epoch");
     if (!val)
         return 0;
     epoch = strtol (val, &p, 10);
@@ -1066,7 +1066,7 @@ int prog_ctx_init_from_cmb (struct prog_ctx *ctx)
     if (flux_get_rank (ctx->flux, &ctx->noderank) < 0)
         wlog_fatal (ctx, 1, "flux_get_rank");
 
-    if ((lua_pattern = flux_attr_get (ctx->flux, "wrexec.lua_pattern", NULL)))
+    if ((lua_pattern = flux_attr_get (ctx->flux, "wrexec.lua_pattern")))
         ctx->lua_pattern = lua_pattern;
 
     wlog_debug (ctx, "initializing from CMB: rank=%d", ctx->noderank);

--- a/t/lua/t0004-getattr.t
+++ b/t/lua/t0004-getattr.t
@@ -5,7 +5,7 @@
 local t = require 'fluxometer'.init (...)
 t:start_session { size = 1 }
 
-plan (8)
+plan (6)
 
 local flux = require_ok ('flux')
 local f, err = flux.new()
@@ -15,10 +15,8 @@ is (err, nil, "error is nil")
 --
 --  Test getattr
 --
-local attrval, flags = f:getattr "size"
+local attrval = f:getattr "size"
 is (attrval, "1", "correctly got broker size attr")
-ok (not flags.FLUX_ATTRFLAG_ACTIVE, "FLUX_ATTRFLAG_ACTIVE is not set")
-ok (flags.FLUX_ATTRFLAG_IMMUTABLE, "FLUX_ATTRFLAG_IMMUTABLE is set")
 
 local v,err = f:getattr "nosuchthing"
 is (v, nil, "Non-existent attr has error")


### PR DESCRIPTION
This PR executes a cleanup plan for `flux_attr_*()` that I proposed in #1818,:

> Looking at this a bit more closely, I'm not sure it's a problem having `flux_attr_get()` and `flux_attr_set()` wrap synchronous RPCs, since when used in a module implementing a service, typically they run during initialization, before the service begins.  The cache allows commonly used values like `size` and `rank` to be reused later without an RPC.  Switching to a future-based interface would just require people to provide a bunch of extra code that isn't helping them.  Possibly documentation could be improved a bit so there are at least no surprises here.
>
> The _flags_ could be cleaned up though:
> [snip]
> There are no users "in the wild" of this (optional) flags parameter to `flux_attr_get()`.  The only flag that's even useful on the client side is IMMUTABLE, which determines whether a value can be cached indefinitely.  Since the cache is not directly exposed, even that could be hidden from the API.  I think we should drop the flags definitions and the flags parameter from `flux_attr_get()`.
> 
> The `flux_attr_first()` and `flux_attr_next()` iterators are only used in the `flux lsattr` command, and I can't think of a reason these would be generally useful, so perhaps `flux lsattr` should just construct the RPC directly and we should remove these from the API.
> 
> Finally `flux_attr_fake()` is mainly used in for brokerless testing.  Possibly this could be made private to flux-core, and the `loop://` connector could put a `flux_opt_set()` interface in front of it for external users?
>
> One thing that's prevented this API from getting cleaned up before is it's connected with the general concept of configuration, for which we have not developed a grand plan.  However, I think given that flux API use is likely to be growing, we should do the minor cleanups now and at least simplify it as much as possible to lessen the pain later if we need to change it.

I didn't get as far as wiring something into `flux_opt_set()` for the loop connector since it already internally sets up fake `size` and `rank`  attributes, and that probably covers 99% of the use cases.

Unrelated, but tacked on as something of a no brainer - the early `flux_reduce_t` stuff that only the broker uses was moved out of the public API.