### PR TITLE
kvs: Support FLUX_KVS_WATCH_FULL

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -68,7 +68,7 @@ Remove a kvs namespace.
 *namespace-list*::
 List all current namespaces and info on each namespace.
 
-*get* [-j|-r|-t] [-a treeobj] [-l] [-w] [-W] [-c count] 'key' ['key...']::
+*get* [-j|-r|-t] [-a treeobj] [-l] [-w] [-W] [-f] [-c count] 'key' ['key...']::
 Retrieve the value stored under 'key'.  If nothing has been stored under
 'key', display an error message.  If no options, value is displayed with
 a newline appended (if value length is nonzero).  If '-l', a 'key=' prefix is
@@ -79,7 +79,10 @@ snapshot reference.  If '-w', after the initial value, display the
 new value each time the key is written to until interrupted, or if '-c count'
 is specified, until 'count' values have been displayed.  If the
 initial value does not yet exist, `-W` can be specified to wait for it
-to be created.
+to be created.  By default, only a direct write to a key is monitored,
+which may miss several unique situations, such as the replacement of
+an entire parent directory.  The '-f' option can be specified to
+monitor for many of these unique situations.
 
 *put* [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  If it already has a value,

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -76,7 +76,7 @@ added. If '-j', value is interpreted as encoded JSON and formatted accordingly.
 If '-r', value is displayed without a newline.  If '-t', the RFC 11 object
 is displayed.  '-a treeobj' causes the lookup to be relative to an RFC 11
 snapshot reference.  If '-w', after the initial value, display the
-new value each time the key changes until interrupted, or if '-c count'
+new value each time the key is written to until interrupted, or if '-c count'
 is specified, until 'count' values have been displayed.  If the
 initial value does not yet exist, `-W` can be specified to wait for it
 to be created.

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -107,6 +107,9 @@ static struct optparse_option get_opts[] =  {
     { .name = "waitcreate", .key = 'W', .has_arg = 0,
       .usage = "Wait for creation to occur on watch",
     },
+    { .name = "full", .key = 'f', .has_arg = 0,
+      .usage = "Monitor key changes with more complete accuracy",
+    },
     { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "COUNT",
       .usage = "Display at most COUNT changes",
     },
@@ -245,7 +248,7 @@ static struct optparse_subcommand subcommands[] = {
       NULL
     },
     { "get",
-      "[-j|-r|-t] [-a treeobj] [-l] [-w] [-W] [-c COUNT] key [key...]",
+      "[-j|-r|-t] [-a treeobj] [-l] [-w] [-W] [-f] [-c COUNT] key [key...]",
       "Get value stored under key",
       cmd_get,
       0,
@@ -687,6 +690,8 @@ void cmd_get_one (flux_t *h, const char *key, struct lookup_ctx *ctx)
         flags |= FLUX_KVS_WATCH;
         if (optparse_hasopt (ctx->p, "waitcreate"))
             flags |= FLUX_KVS_WATCH_WAITCREATE;
+        if (optparse_hasopt (ctx->p, "full"))
+            flags |= FLUX_KVS_WATCH_FULL;
     }
     if (optparse_hasopt (ctx->p, "at")) {
         const char *reference = optparse_get_str (ctx->p, "at", "");

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -50,6 +50,7 @@ enum kvs_op {
     FLUX_KVS_WATCH_WAITCREATE = 8,
     FLUX_KVS_TREEOBJ = 16,
     FLUX_KVS_APPEND = 32,
+    FLUX_KVS_WATCH_FULL = 64
 };
 
 typedef struct flux_kvs_namespace_itr flux_kvs_namespace_itr_t;

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -91,9 +91,13 @@ static int validate_lookup_flags (int flags, bool watch_ok)
     if (flags & FLUX_KVS_WATCH_WAITCREATE
         && !(flags & FLUX_KVS_WATCH))
         return -1;
+    if (flags & FLUX_KVS_WATCH_FULL
+        && !(flags & FLUX_KVS_WATCH))
+        return -1;
 
     flags &= ~FLUX_KVS_WATCH;
     flags &= ~FLUX_KVS_WATCH_WAITCREATE;
+    flags &= ~FLUX_KVS_WATCH_FULL;
     switch (flags) {
         case 0:
         case FLUX_KVS_TREEOBJ:


### PR DESCRIPTION
This implements FLUX_KVS_WATCH_PEDANTIC as discussed in #1653.

Note that I still dislike the option being called "pedantic" and am wondering what a better name is.  I originally wrote this using the word "classic", but that felt wrong, as "classic" implies the API would stay the same, which is not the case.