### PR TITLE
kvs-watch: Fix race condition on getroot continuation

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -262,6 +262,7 @@ check_PROGRAMS = \
 	kvs/fence_invalid \
 	kvs/commit_order \
 	kvs/issue1760 \
+	kvs/issue1876 \
 	kvs/waitcreate_cancel \
 	request/treq \
 	barrier/tbarrier \
@@ -397,6 +398,11 @@ kvs_hashtest_LDADD = \
 kvs_issue1760_SOURCES = kvs/issue1760.c
 kvs_issue1760_CPPFLAGS = $(test_cppflags)
 kvs_issue1760_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_issue1876_SOURCES = kvs/issue1876.c
+kvs_issue1876_CPPFLAGS = $(test_cppflags)
+kvs_issue1876_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 kvs_waitcreate_cancel_SOURCES = kvs/waitcreate_cancel.c

--- a/t/issues/t1876-kvs-watch-cancel-race.sh
+++ b/t/issues/t1876-kvs-watch-cancel-race.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+# initial call to getroot() can race with an early call to
+# flux_kvs_lookup_cancel(), leading to a namespace data
+# structure being destroyed then used afterwards.
+
+TEST=issue1876
+${FLUX_BUILD_DIR}/t/kvs/issue1876 test.a

--- a/t/kvs/issue1876.c
+++ b/t/kvs/issue1876.c
@@ -1,0 +1,40 @@
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    const char *key;
+    int i;
+
+    if (argc != 2) {
+        fprintf (stderr, "Usage: watch_cancel_loop key\n");
+        return (1);
+    }
+    key = argv[1];
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    for (i = 0; i < 1000; i++) {
+        flux_future_t *f;
+
+        log_msg ("loop=%d", i);
+
+        if (!(f = flux_kvs_lookup (h, FLUX_KVS_WATCH
+                                   | FLUX_KVS_WAITCREATE, key)))
+            log_err_exit ("flux_kvs_lookup");
+        if (flux_kvs_lookup_cancel (f) < 0)
+            log_err_exit ("flux_kvs_lookup_cancel");
+        /* Consume responses until ENODATA from cancel appears
+         */
+        while (flux_kvs_lookup_get (f, NULL) == 0)
+            ;
+        if (errno != ENODATA)
+            log_err_exit ("flux_kvs_lookup_get");
+        flux_future_destroy (f);
+    }
+
+    flux_close (h);
+    return (0);
+}
+


### PR DESCRIPTION
In #1876, a race was found in which a namespace monitor was destroyed before a continuation was called, leading to a use after free error.

@garlick, I was never able to reproduce the segfault you show in the ticket.  So I'm just assuming this use-after-free is what causes your segfault but just somehow doesn't show up for me.  If you can, double check it solves the segfault.