### PR TITLE
kvs-watch: Allow cancellation of lookups with only WAITCREATE

### DIFF
--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -416,8 +416,10 @@ int flux_kvs_lookup_cancel (flux_future_t *f)
     struct lookup_ctx *ctx;
     flux_future_t *f2;
 
-    if (!f || !(ctx = flux_future_aux_get (f, auxkey))
-           || !(ctx->flags & FLUX_KVS_WATCH)) {
+    if (!f
+        || !(ctx = flux_future_aux_get (f, auxkey))
+        || (!(ctx->flags & FLUX_KVS_WATCH)
+            && !(ctx->flags & FLUX_KVS_WAITCREATE))) {
         errno = EINVAL;
         return -1;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -262,6 +262,7 @@ check_PROGRAMS = \
 	kvs/fence_invalid \
 	kvs/commit_order \
 	kvs/issue1760 \
+	kvs/waitcreate_cancel \
 	request/treq \
 	barrier/tbarrier \
 	wreck/rcalc \
@@ -396,6 +397,11 @@ kvs_hashtest_LDADD = \
 kvs_issue1760_SOURCES = kvs/issue1760.c
 kvs_issue1760_CPPFLAGS = $(test_cppflags)
 kvs_issue1760_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_waitcreate_cancel_SOURCES = kvs/waitcreate_cancel.c
+kvs_waitcreate_cancel_CPPFLAGS = $(test_cppflags)
+kvs_waitcreate_cancel_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 request_treq_SOURCES = request/treq.c

--- a/t/kvs/waitcreate_cancel.c
+++ b/t/kvs/waitcreate_cancel.c
@@ -1,0 +1,34 @@
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    const char *key;
+    flux_future_t *f;
+
+    if (argc != 2) {
+        fprintf (stderr, "Usage: waitcreate_cancel key\n");
+        return (1);
+    }
+    key = argv[1];
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_kvs_lookup (h, FLUX_KVS_WAITCREATE, key)))
+        log_err_exit ("flux_kvs_lookup");
+
+    if (flux_kvs_lookup_cancel (f) < 0)
+        log_err_exit ("flux_kvs_lookup_cancel");
+
+    if (flux_kvs_lookup_get (f, NULL) < 0) {
+        if (errno != ENODATA)
+            log_err_exit ("flux_kvs_lookup_get");
+        flux_future_destroy (f);
+    }
+    else
+        log_msg_exit ("flux_kvs_lookup_get returned success");
+
+    flux_close (h);
+    return (0);
+}

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -178,6 +178,10 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existe
         wait $pid
 '
 
+test_expect_success 'flux_kvs_lookup with waitcreate can be canceled' '
+        $FLUX_BUILD_DIR/t/kvs/waitcreate_cancel test.not_a_key
+'
+
 # in --watch & --waitcreate tests, call wait_watcherscount_nonzero to
 # ensure background watcher has started, otherwise test can be racy
 


### PR DESCRIPTION
nothing too extraordinary here.  Fixes #1877 