### PR TITLE
libkvs/watch: add deprecated attr to old API

### DIFF
--- a/src/common/libkvs/kvs_watch.h
+++ b/src/common/libkvs/kvs_watch.h
@@ -35,8 +35,8 @@ extern "C" {
  * is triggered when the key changes, and one that accepts an initial value
  * and returns a new value when it changes.
  *
- * N.B. These interfaces and the internal watch mechanisms are long overdue
- * for an overhaul.
+ * Use flux_kvs_lookup() with watch flags instead.  These interfaces are
+ * deprecated.
  */
 
 enum kvs_watch_flags {
@@ -65,7 +65,8 @@ typedef int (*kvs_set_dir_f)(const char *key, flux_kvsdir_t *dir, void *arg,
  * Once the reactor is (re-)entered, it will then be called each time the
  * key changes.
  */
-int flux_kvs_watch (flux_t *h, const char *key, kvs_set_f set, void *arg);
+int flux_kvs_watch (flux_t *h, const char *key, kvs_set_f set, void *arg)
+                    __attribute__ ((deprecated));
 
 /* Register 'set' callback on directory 'key'.
  * Callback is triggered once during registration to get the initial value,
@@ -76,12 +77,13 @@ int flux_kvs_watch (flux_t *h, const char *key, kvs_set_f set, void *arg);
  */
 int flux_kvs_watch_dir (flux_t *h, kvs_set_dir_f set, void *arg,
                         const char *fmt, ...)
-                        __attribute__ ((format (printf, 4, 5)));
+                        __attribute__ ((format (printf, 4, 5),deprecated));
 
 /* Cancel a flux_kvs_watch(), freeing server-side state, and unregistering
  * any callback.  Returns 0 on success, or -1 with errno set on error.
  */
-int flux_kvs_unwatch (flux_t *h, const char *key);
+int flux_kvs_unwatch (flux_t *h, const char *key)
+                      __attribute__ ((deprecated));
 
 /* Block until 'key' changes from value represented by '*json_str'.
  * 'json_str' is an IN/OUT parameter;  that is, it used to construct
@@ -95,13 +97,13 @@ int flux_kvs_unwatch (flux_t *h, const char *key);
  * If 'key' initially exists, then is removed, the function fails with
  * ENOENT and the initial value is not freed.
  */
-int flux_kvs_watch_once (flux_t *h, const char *key, char **json_str);
-
+int flux_kvs_watch_once (flux_t *h, const char *key, char **json_str)
+                         __attribute__ ((deprecated));
 /* Same as above except value is a directory pointed to by 'dirp'.
  */
 int flux_kvs_watch_once_dir (flux_t *h, flux_kvsdir_t **dirp,
                              const char *fmt, ...)
-                             __attribute__ ((format (printf, 3, 4)));
+                             __attribute__ ((format (printf, 3, 4),deprecated));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Problem: we don't want new users of the old KVS
watch API.

Add the deprecated attribute to the old functions,
and add a pointer to the new ones in the header.

Fixes #1851