### PR TITLE
cmd/flux-kvs: Hide watch subcommand

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -144,16 +144,6 @@ Tell the local KVS to drop any cache it is holding.  If '--all' is
 specified, send an event across the comms session instructing all KVS
 instances to drop their caches.
 
-*watch* [-R] [-d] [-o] [-c count] 'key'::
-Watch 'key' and output changes.  If 'key' is a single value, each
-change will be displayed on a line of output.  If 'key' is a
-directory, changes within the directory and changes within it will be
-displayed.  If '-R' is specified, recursively display keys under
-subdirectories.  If '-d' is specified, do not output key values.  If
-'count' is specified, display at most 'count' changes.  Otherwise,
-this command runs forever.  If '-o' is specified, output the current
-value before outputting changes.
-
 *version*::
 Display the current KVS version, an integer value.  The version starts
 at zero and is incremented on each KVS commit.  Note that some commits

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -322,7 +322,7 @@ static struct optparse_subcommand subcommands[] = {
       "[-R] [-d] [-o] [-c count] key",
       "Watch key and output changes",
       cmd_watch,
-      0,
+      OPTPARSE_OPT_HIDDEN,
       watch_opts
     },
     { "version",
@@ -364,7 +364,8 @@ int usage (optparse_t *p, struct optparse_option *o, const char *optarg)
     fprintf (stderr, "Common commands from flux-kvs:\n");
     s = subcommands;
     while (s->name) {
-        fprintf (stderr, "   %-15s %s\n", s->name, s->doc);
+        if (!(s->flags & OPTPARSE_OPT_HIDDEN))
+            fprintf (stderr, "   %-15s %s\n", s->name, s->doc);
         s++;
     }
     exit (1);


### PR DESCRIPTION
The old watch interface is being deprecated, so similarly hide
the option from flux-kvs help output and remove documentation
of it from the manpage.

Fixes #1888