### PR TITLE
Fix pymod on 32 bit architectures

### DIFF
--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -4,11 +4,8 @@ from flux.core.handle import Flux
 
 
 def mod_main_trampoline(name, int_handle, args):
-    # print "trampoline entered"
     # generate a flux wrapper class instance from the handle
     flux_instance = Flux(handle=lib.unpack_long(int_handle))
-    # print "flux instance retrieved, loading:", name
-    # impo__import__('flux.modules.' + name)rt the user's module dynamically
     user_mod = None
     try:
         user_mod = importlib.import_module(
@@ -16,7 +13,6 @@ def mod_main_trampoline(name, int_handle, args):
     except ImportError:  # check user paths for the module
         user_mod = importlib.import_module(name)
 
-    # print "user module loaded:", name
     # call into mod_main with a flux class instance and the argument dict
     # it might be more pythonic to unpack the args as keyword/positional
     # arguments to this function, but I think this is cleaner for now

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <wchar.h>
 #include <errno.h>

--- a/src/modules/pymod/py_mod.c
+++ b/src/modules/pymod/py_mod.c
@@ -122,6 +122,18 @@ done:
     return rc;
 }
 
+// Based on code from https://bugs.python.org/issue17870
+PyObject* PyLong_FromUintptr_t(uintptr_t value)
+{
+    if (sizeof(uintptr_t) == sizeof(long)) {
+        return PyLong_FromLong(value);
+    } else if (sizeof(uintptr_t) <= sizeof(PY_LONG_LONG)) {
+        return PyLong_FromLongLong((PY_LONG_LONG)value);
+    } else {
+        return NULL;
+    }
+}
+
 int mod_main (flux_t *h, int argc, char **argv)
 {
     optparse_t *p = optparse_create ("pymod");
@@ -173,7 +185,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         PyObject *py_args = PyTuple_New(3);
         PyObject *pystr_mod_name = py_unicode_or_string(module_name);
         PyTuple_SetItem(py_args, 0, pystr_mod_name);
-        PyTuple_SetItem(py_args, 1, PyLong_FromVoidPtr(h));
+        PyObject *py_flux_handle = PyLong_FromUintptr_t((uintptr_t)h);
+        if (py_flux_handle == NULL)
+          return -1;
+        PyTuple_SetItem(py_args, 1, py_flux_handle);
 
         //Convert zhash to native python dict, should preserve mods
         //through switch to argc-style arguments


### PR DESCRIPTION
PyLong_FromVoidPtr overflows on 32-bit architectures.
Switch to using PyLong_FromLong.
Include support for architectures where a pointer is larger than `long` (i.e., PyLong_FromLongLong).

Also includes two minor cleanups.

Fixes #1801