### PR TITLE
wreck: add new -J, --name=JOBNAME option to flux-wreckrun and submit

### DIFF
--- a/doc/man1/wreck-options.adoc
+++ b/doc/man1/wreck-options.adoc
@@ -77,4 +77,9 @@
 	Apply extended job options to the current execution. Examples of
 	these options are described in the xref:extra-options[].
 
+--name='JOBNAME'::
+-J 'JOBNAME'::
+	Set an optional name to 'JOBNAME' for the submitted job. This name
+	will be saved in the KVS record for the job and displayed in place
+	of command name in `flux wreck ls` output.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -452,3 +452,4 @@ dstkey
 semver
 versioning
 kz
+JOBNAME

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -45,6 +45,7 @@ local lwj_options = {
 
 local default_opts = {
     ['help']    = { char = 'h'  },
+    ['name']    = { char = 'J', arg = "NAME" },
     ['verbose'] = { char = 'v'  },
     ['ntasks']  = { char = 'n', arg = "N" },
     ['gpus-per-task']  = { char = 'g', arg = "g" },
@@ -106,6 +107,7 @@ function wreck:usage()
     io.stderr:write ([[
   -h, --help                 Display this message
   -v, --verbose              Be verbose
+  -N, --name=NAME            Set an optional name for job to NAME
   -n, --ntasks=N             Request to run a total of N tasks
   -c, --cores-per-task=N     Request N cores per task
   -g, --gpus-per-task=N      Request N GPUs per task
@@ -462,6 +464,7 @@ function wreck:jobreq ()
         fixup_nnodes (self)
     end
     local jobreq = {
+        name   =  self.opts.J,
         nnodes =  self.nnodes or 0,
         ntasks =  self.ntasks,
         ncores =  self.ncores,

--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -404,6 +404,8 @@ LWJ.__index = function (self, key)
         return os.date ("%FT%T", self.lwj["create-time"])
     elseif key == "command" then
         return self.lwj.cmdline[1]
+    elseif key == "name" then
+        return self.lwj.name
     end
     return LWJ [key]
 end
@@ -465,7 +467,8 @@ prog:SubCommand {
     if not dirs then self:die (err) end
     if #dirs == 0 then return end
     local fmt = "%6s %6s %-9s %20s %12s %8s %-.13s\n";
-    printf (fmt, "ID", "NTASKS", "STATE", "START", "RUNTIME", "RANKS", "COMMAND")
+    printf (fmt, "ID", "NTASKS", "STATE", "START",
+                 "RUNTIME", "RANKS", "COMMAND/NAME")
     for _,dir in pairs (dirs) do
         local id = dir:match ("(%d+)$")
         if tonumber (id) then
@@ -474,7 +477,7 @@ prog:SubCommand {
                 printf (fmt, id, j.ntasks, j:state_string(), j.start,
                     seconds_to_string (j.runtime),
                     tostring (j:ranks()),
-                    j.command:match ("([^/]+)$"))
+                    j.name or j.command:match ("([^/]+)$"))
             end
         end
     end

--- a/t/t2000-wreck.t
+++ b/t/t2000-wreck.t
@@ -457,6 +457,11 @@ test_expect_success 'flux-wreck: ls works' '
 	flux wreck ls | sort -n >ls.out &&
 	tail -1 ls.out | grep "hostname$"
 '
+test_expect_success 'flux-wreck: --name option works' '
+	flux wreckrun -n2 -N2 --name=testname hostname &&
+	flux wreck ls | sort -n >ls-name.out &&
+	tail -q ls-name.out | grep "testname$"
+'
 test_expect_success 'flux-wreck: ls -n, --max works' '
         test $(flux wreck ls --max=1 | wc -l) = 2
 '


### PR DESCRIPTION
Add new `-J, --name=JOBNAME` option to `flux-wreckrun` and `flux-submit`. This option simply saves `JOBNAME` in the kvs for the job, and displays this name instead of `argv[0]` if it exists in the output of `flux wreck ls`.