### PR TITLE
build: add release notes for 0.11.0, and update README.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,69 @@
+flux-core version 0.11.0 - 2019-01-03
+-------------------------------------
+
+### Fixes
+ * flux-module: increase width of size field in list output (#1883)
+ * kvs: return errors to callers on asynchronous load/store failures (#1836)
+ * flux-start: dispatch orphan brokers, fully clean up temp directories (#1835)
+ * flux-exec: ensure stdin is restored to blocking mode on exit (#1814)
+ * broker: don't connect to enclosing instance (#1798)
+ * flux (command): handle inaccessible build directory, fix PATH issue (#1683)
+ * wreck: fix incorrect error handling in job module (#1617)
+ * libflux: improve efficiency of asynchronous futures (#1840)
+ * libflux: fix composite future implementation (#1791)
+ * libflux: improve lookup efficiency of RPC message handlers (#1807)
+ * libflux: give all aux set/get interfaces uniform semantics (#1797)
+ * update to libev 4.25, ensure valgrind runs clean on i686 (#1898)
+
+### New Features
+ * license: re-publish project under LGPLv3 (#1829, #1788, #1901)
+ * wreck: use direct stdio transport, unless -okz option (#1875, #1896, #1900)
+ * wreck: add new -J, --name=JOBNAME option to flux-wreckrun and submit (#1893)
+ * libflux: support queue of future fulfillments (#1610)
+ * libflux: support dynamic service registration (#1753, #1856)
+ * kvs: replace inefficient KVS watch implementation and outdated API (#1891,
+   #1890, #1882, #1878, #1879, #1873, #1870, #1868, #1863,
+   #1861, #1859, #1850, #1848, #1820, #1643, #1622)
+ * job: add job-ingest, job-manager modules, and API (experimental)
+   (#1867, #1774, #1734, #1626)
+ * libidset: expand API to replace internal nodeset class (#1862)
+ * libflux: add KVS copy and move composite functions (#1828)
+ * libflux: access broker, library, command versions (#1817)
+ * kvs: restart with existing content sqlite, root reference (#1800, #1812)
+ * python: add job & mrpc bindings (#1757, #1892)
+ * python: add flux python command to run configured python (#1766)
+ * python: add flux-security bindings (#1716)
+ * python: Python3 compatibility (#1673)
+ * kvs: add RFC 18 eventlog support (#1671)
+ * libsubprocess: cleanup and redesign
+   (#1713, #1664, #1659, #1658, #1654, #1645, #1636, #1629)
+ * libflux/buffer: Add trimmed peek/read line variants (#1639)
+ * build: add library versioning support (#1874)
+ * build: add support for asciidoctor as manpage generator (#1650, #1676)
+ * travis-ci: run tests under docker (#1688, #1684, #1670)
+
+### Cleanup
+ * libflux: drop broker zeromq security functions from public API (#1846)
+ * libflux: clean up interface for broker attributes (#1845)
+ * libflux: drop reduction code from public API (#1844)
+ * libutil: switch from munge to libsodium base64 implementation (#1786)
+ * python: python binding is no longer optional (#1772)
+ * python: add "black" format check, and reformat existing code (#1802)
+ * python/lua: avoid deprecated kvs functions (#1748)
+ * kvs: misc cleanup, refactoring, and fixes
+   (#1805, #1813, #1773, #1764, #1712, #1696, #1694)
+ * broker: drop epgm event distribution (and munge dependency) (#1746)
+ * content-sqlite: switch from lzo to lz4 (#1740)
+ * libpmi: drop PMIx client support (#1663)
+ * libpmi: avoid synchronous RPCs in simple-server kvs (#1615)
+ * modules/cron: misc cleanup (#1657)
+ * RFC 7: fix various style violations (#1705, #1717, #1706, #1611)
+ * gcc8: fix output truncation (#1642)
+ * sanitizer: fix memory leaks (#1737, #1736, #1739, #1737, #1735, #1733)
+ * build: misc. cleanup and fixes (#1886, #1795, #1824, #1827, #1701, #1678)
+ * test: misc. cleanup and fixes (#1644, #1704, #1691, 1640)
+
+
 flux-core version 0.10.0 - 2018-07-26
 -------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -32,33 +32,42 @@ Protocols and API's used in Flux will be documented as Flux RFC's.
 #### Build Requirements
 
 flux-core requires the following packages to build:
+
+**redhat**	| **ubuntu** 		| **version**		| **note**
+---------- 	| ---------- 		| -----------		| --------
+autoconf	| autoconf		|			|
+automake	| automake		|			|
+libtool		| libtool		|			|
+libsodium-devel	| libsodium-dev		| >= 1.0.14		|
+zeromq4-devel	| libzmq3-dev		| >= 4.0.4		|
+czmq-devel	| libczmq-dev		| >= 3.0.1		|
+jansson-devel	| libjansson-dev	| >= 2.6		|
+lz4-devel	| liblz4-dev		|			|
+hwloc-devel	| libhwloc-dev		| >= v1.11.1, < 2.0	|
+sqlite-devel	| libsqlite3-dev	| >= 3.0.0		|
+yaml-cpp-devel	| libyaml-cpp-dev	| >= 0.5.1		|
+lua		| lua5.1		| >= 5.1, < 5.3		|
+lua-devel	| liblua5.1-dev		| >= 5.1, < 5.3		|
+lua-posix 	| lua-posix             | 			| *1*
+python-devel	| python-dev		| >= 2.7		|
+python-cffi	| python-cffi		| >= 1.1		|
+python-six	| python-six		| >= 1.9		|
+asciidoc	| asciidoc         	| 			| *2*
+asciidoctor	| asciidoctor         	| >= 1.5.7		| *2*
+aspell		| aspell		|			| *3*
+valgrind	| valgrind		|			| *3*
+mpich		| mpich			|			| *3*
+
+*Note 1 - Due to a packaging issue, Ubuntu lua-posix may need the
+following symlink (true for version 33.4.0-2):*
 ```
-autoconf
-automake
-libtool
-libsodium-devel >= 1.0.14
-zeromq4-devel >= 4.0.4   # built --with-libsodium
-czmq-devel >= 3.0.1
-jansson-devel >= 2.6
-lua-devel >= 5.1, < 5.3
-luaposix
-libhwloc-devel >= v1.11.1, < 2.0
-lz4
-yaml-cpp-devel >= 0.5.1
-# for python bindings
-python-devel >= 2.7
-python-cffi >= 1.1
-python-six >= 1.9
-libsqlite3-devel
-# for man pages
-asciidoc
-# or
-asciidoctor >= 1.5.7
+$ sudo ln -s posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so
 ```
 
-If you want to build the MPI-based test programs, make sure that
-`mpicc` is in your PATH before you run configure.  These programs are
-not built if configure does not find MPI.
+*Note 2 - only needed if optional man pages are to be created.  Only one
+of asciidoc or asciidoctor is needed.  Asciidoc is used if both are installed.*
+
+*Note 3 - optional, for enabling additional tests*.
 
 ```
 ./autogen.sh   # skip if building from a release tarball


### PR DESCRIPTION
This PR is a placeholder for release notes for 0.11.0.   I ran the script `src/test/relnotes.sh` to get merge commit messages since 0.10.0, then hand edited the output to produce the proposed change to NEWS.md.

In addition, since the dependent package names are a bit different for redhat and ubuntu, and I happened to be installing a new Ubuntu system, I turned our dependency list in the README.md into a table with columns for both OS's.

I'll push changes to the release notes as we add our final changes.