### PR TITLE
wreck: set nokz by default in rc1, support '-o kz' to force use of kvs for output

### DIFF
--- a/doc/man1/flux-wreckrun.adoc
+++ b/doc/man1/flux-wreckrun.adoc
@@ -80,9 +80,10 @@ consists of the following steps:
   to 'starting'.
 . After starting tasks, all 'wrexecd' daemons synchronize on a
   barrier, and the job state is updated to 'running'.
-. As the tasks run, stdio is stored in the KVS and is (optionally)
-  available immediately for 'flux wreckrun' to display on the
-  user's console.
+. As the tasks run, stdio is either stored in the KVS or sent directly
+  to a per-job service as messages (when '-o nokz' job option is set),
+  and output is optionally displayed to user or redirected as requested
+  by command line options.
 . As tasks exit, their exit status is recorded in the kvs.
 . After all tasks have exited, 'wrexecd' daemons synchronize again
   and rank 0 updates the job state to 'completed'.

--- a/doc/man1/wreck-extra-options.adoc
+++ b/doc/man1/wreck-extra-options.adoc
@@ -29,6 +29,12 @@ via commas. Currently available options include:
         using messages directly sent to a per-job service registered by
         either wreckrun or the first wrexecd of the job.
 
+'kz'::
+	Force use of KVS based "kz" streams for stdout and stderr streams
+	for this job. This option may be used in place of '-o nokz=false'
+	when 'nokz' has been set as the default for all jobs via global
+	wreck options (i.e. if  'flux wreck getopt nokz' reports true)
+
 'stdio-commit-on-open'::
 	Commit to kvs on stdio open in each task. The default is to
 	delay commit. Without this option, stdio files for jobs will

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -453,3 +453,4 @@ semver
 versioning
 kz
 JOBNAME
+nokz

--- a/etc/rc1
+++ b/etc/rc1
@@ -15,6 +15,9 @@ flux module load -r 0 cron sync=hb
 
 flux module load -r 0 userdb ${FLUX_USERDB_OPTIONS}
 
+# make flux wreckrun/submit -onokz the default (override w/ -o kz):
+flux wreck setopt nokz
+
 wait $pids
 
 core_dir=$(cd ${0%/*} && pwd -P)

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -451,14 +451,13 @@ function wreck:setup_ioservices ()
         if self.output then
             -- Shunt stdio to nodeid 0 of the job if any output is being
             -- redirected to files via the output.lua plugin:
-            local FLUX_NODEID_ANY = require 'flux'.NODEID_ANY
             local outfile = self.output.files.stdout
             local errfile = self.output.files.stderr
             if outfile then
-                self.ioservices.stdout.rank = FLUX_NODEID_ANY
+                self.ioservices.stdout.rank = -1
             end
             if errfile or outfile then
-                self.ioservices.stderr.rank = FLUX_NODEID_ANY
+                self.ioservices.stderr.rank = -1
             end
         end
     end

--- a/src/bindings/lua/wreck.lua
+++ b/src/bindings/lua/wreck.lua
@@ -35,6 +35,7 @@ local lwj_options = {
     ['stdio-commit-on-open'] =  "Commit to kvs on stdio open in each task",
     ['stdio-commit-on-close'] = "Commit to kvs on stdio close in each task",
     ['nokz'] =                  "Do not store job output in kvs",
+    ['kz'] =                    "Force job output to kvs",
     ['stop-children-in-exec'] = "Start tasks in STOPPED state for debugger",
     ['no-pmi-server'] =         "Do not start simple-pmi server",
     ['trace-pmi-server'] =      "Log simple-pmi server protocol exchange",
@@ -360,6 +361,13 @@ function wreck:parse_cmdline (arg)
                 if tonumber(val) == 0 or val == "false" or val == "no" then
                     val = false
                 end
+            end
+            -- kz/nokz override global value of eachother
+            if opt == "kz" and self.job_options.nokz then
+                self.job_options.nokz = false
+            end
+            if opt == "nokz" and self.job_options.kz then
+                self.job_options.kz = false
             end
             self.job_options[opt] = val
         end

--- a/src/modules/wreck/lua.d/output.lua
+++ b/src/modules/wreck/lua.d/output.lua
@@ -57,11 +57,11 @@ local function fetch_ioservices (wreck)
     if not ioservice then return nil end
     local rank = wreck.flux.rank
 
-    -- Only streams with rank == FLUX_NODEID_ANY are handled by
+    -- Only streams with rank == -1 are handled by
     -- this plugin. Delete other entries and remap FLUX_NODEID_ANY
     -- to this rank:
     for s,v in pairs (ioservice) do
-        if v and v.rank == flux.NODEID_ANY then
+        if v and v.rank == -1 then
             ioservice[s].rank = rank
         else
             ioservice[s] = nil

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1090,9 +1090,9 @@ static void io_service_initialize (struct prog_ctx *ctx)
     /*  If ioservice rank is FLUX_NODEID_ANY, then replace with the rank
      *   of nodeid 0 in this job:
      */
-    if (ctx->outsvc.rank == FLUX_NODEID_ANY)
+    if (ctx->outsvc.rank == -1)
         ctx->outsvc.rank = ri.rank;
-    if (ctx->errsvc.rank == FLUX_NODEID_ANY)
+    if (ctx->errsvc.rank == -1)
         ctx->errsvc.rank = ri.rank;
 }
 

--- a/t/t2000-wreck-nokz.t
+++ b/t/t2000-wreck-nokz.t
@@ -28,7 +28,17 @@ test_expect_success 'wreckrun nokz: -o nokz=false disables nokz' '
 	hostname=$(hostname) &&
 	run_timeout 5 flux wreckrun -n${SIZE} -o nokz=false hostname  >output &&
 	for i in $(seq 1 ${SIZE}); do echo $hostname; done >expected &&
-	test_cmp expected output
+	test_cmp expected output &&
+	flux kvs dir $(flux wreck last-jobid -p).0.stdout &&
+	flux kvs dir $(flux wreck last-jobid -p).0.stderr
+'
+test_expect_success 'wreckrun nokz: -o kz disables nokz' '
+	hostname=$(hostname) &&
+	run_timeout 5 flux wreckrun -n${SIZE} -o kz hostname >output.kz &&
+	for i in $(seq 1 ${SIZE}); do echo $hostname; done   >expected.kz &&
+	test_cmp expected.kz output.kz &&
+	flux kvs dir $(flux wreck last-jobid -p).0.stdout &&
+	flux kvs dir $(flux wreck last-jobid -p).0.stderr
 '
 test_expect_success 'wreckrun nokz: kz streams in kvs' '
 	flux kvs dir $(flux wreck last-jobid -p).0.stdout &&


### PR DESCRIPTION
As discussed in #1865, add a `-o kz` option to more easily override global `nokz` setting.
Also add the option to `flux-wreckrun(1)` and `flux-submit(1)` and a simple test.