### PR TITLE
update to libev 4.25, ensure valgrind runs clean on i686

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1689,7 +1689,7 @@ static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
     int signum = flux_signal_watcher_get_signum (w);
 
     shutdown_arm (ctx->shutdown, ctx->shutdown_grace, 0,
-                  "signal %d (%s) %d", signum, strsignal (signum));
+                  "signal %d (%s)", signum, strsignal (signum));
 }
 
 /* TRICKY:  Fix up ROUTER socket used in reverse direction.

--- a/src/common/libev/ev.c
+++ b/src/common/libev/ev.c
@@ -1,7 +1,7 @@
 /*
  * libev event processing core, watcher management
  *
- * Copyright (c) 2007,2008,2009,2010,2011,2012,2013 Marc Alexander Lehmann <libev@schmorp.de>
+ * Copyright (c) 2007-2018 Marc Alexander Lehmann <libev@schmorp.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modifica-
@@ -164,6 +164,16 @@
  
 #endif
 
+/* OS X, in its infinite idiocy, actually HARDCODES
+ * a limit of 1024 into their select. Where people have brains,
+ * OS X engineers apparently have a vacuum. Or maybe they were
+ * ordered to have a vacuum, or they do anything for money.
+ * This might help. Or not.
+ * Note that this must be defined early, as other include files
+ * will rely on this define as well.
+ */
+#define _DARWIN_UNLIMITED_SELECT 1
+
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
@@ -210,14 +220,6 @@
 # endif
 # undef EV_AVOID_STDIO
 #endif
-
-/* OS X, in its infinite idiocy, actually HARDCODES
- * a limit of 1024 into their select. Where people have brains,
- * OS X engineers apparently have a vacuum. Or maybe they were
- * ordered to have a vacuum, or they do anything for money.
- * This might help. Or not.
- */
-#define _DARWIN_UNLIMITED_SELECT 1
 
 /* this block tries to deduce configuration from header-defined symbols and defaults */
 
@@ -365,7 +367,7 @@
 # define EV_HEAP_CACHE_AT EV_FEATURE_DATA
 #endif
 
-#ifdef ANDROID
+#ifdef __ANDROID__
 /* supposedly, android doesn't typedef fd_mask */
 # undef EV_USE_SELECT
 # define EV_USE_SELECT 0
@@ -609,6 +611,8 @@ struct signalfd_siginfo
 
 #define ECB_CPP   (__cplusplus+0)
 #define ECB_CPP11 (__cplusplus >= 201103L)
+#define ECB_CPP14 (__cplusplus >= 201402L)
+#define ECB_CPP17 (__cplusplus >= 201703L)
 
 #if ECB_CPP
   #define ECB_C            0
@@ -620,6 +624,7 @@ struct signalfd_siginfo
 
 #define ECB_C99   (ECB_STDC_VERSION >= 199901L)
 #define ECB_C11   (ECB_STDC_VERSION >= 201112L)
+#define ECB_C17   (ECB_STDC_VERSION >= 201710L)
 
 #if ECB_CPP
   #define ECB_EXTERN_C extern "C"
@@ -658,11 +663,11 @@ struct signalfd_siginfo
     #if __i386 || __i386__
       #define ECB_MEMORY_FENCE         __asm__ __volatile__ ("lock; orb $0, -1(%%esp)" : : : "memory")
       #define ECB_MEMORY_FENCE_ACQUIRE __asm__ __volatile__ (""                        : : : "memory")
-      #define ECB_MEMORY_FENCE_RELEASE __asm__ __volatile__ ("")
+      #define ECB_MEMORY_FENCE_RELEASE __asm__ __volatile__ (""                        : : : "memory")
     #elif ECB_GCC_AMD64
       #define ECB_MEMORY_FENCE         __asm__ __volatile__ ("mfence"   : : : "memory")
       #define ECB_MEMORY_FENCE_ACQUIRE __asm__ __volatile__ (""         : : : "memory")
-      #define ECB_MEMORY_FENCE_RELEASE __asm__ __volatile__ ("")
+      #define ECB_MEMORY_FENCE_RELEASE __asm__ __volatile__ (""         : : : "memory")
     #elif __powerpc__ || __ppc__ || __powerpc64__ || __ppc64__
       #define ECB_MEMORY_FENCE         __asm__ __volatile__ ("sync"     : : : "memory")
     #elif defined __ARM_ARCH_2__ \
@@ -1677,11 +1682,11 @@ ev_printerr (const char *msg)
 }
 #endif
 
-static void (*syserr_cb)(const char *msg) EV_THROW;
+static void (*syserr_cb)(const char *msg) EV_NOEXCEPT;
 
 ecb_cold
 void
-ev_set_syserr_cb (void (*cb)(const char *msg) EV_THROW) EV_THROW
+ev_set_syserr_cb (void (*cb)(const char *msg) EV_NOEXCEPT) EV_NOEXCEPT
 {
   syserr_cb = cb;
 }
@@ -1710,7 +1715,7 @@ ev_syserr (const char *msg)
 }
 
 static void *
-ev_realloc_emul (void *ptr, long size) EV_THROW
+ev_realloc_emul (void *ptr, long size) EV_NOEXCEPT
 {
   /* some systems, notably openbsd and darwin, fail to properly
    * implement realloc (x, 0) (as required by both ansi c-89 and
@@ -1726,11 +1731,11 @@ ev_realloc_emul (void *ptr, long size) EV_THROW
   return 0;
 }
 
-static void *(*alloc)(void *ptr, long size) EV_THROW = ev_realloc_emul;
+static void *(*alloc)(void *ptr, long size) EV_NOEXCEPT = ev_realloc_emul;
 
 ecb_cold
 void
-ev_set_allocator (void *(*cb)(void *ptr, long size) EV_THROW) EV_THROW
+ev_set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT) EV_NOEXCEPT
 {
   alloc = cb;
 }
@@ -1857,7 +1862,7 @@ typedef struct
 
 #ifndef EV_HAVE_EV_TIME
 ev_tstamp
-ev_time (void) EV_THROW
+ev_time (void) EV_NOEXCEPT
 {
 #if EV_USE_REALTIME
   if (expect_true (have_realtime))
@@ -1891,14 +1896,14 @@ get_clock (void)
 
 #if EV_MULTIPLICITY
 ev_tstamp
-ev_now (EV_P) EV_THROW
+ev_now (EV_P) EV_NOEXCEPT
 {
   return ev_rt_now;
 }
 #endif
 
 void
-ev_sleep (ev_tstamp delay) EV_THROW
+ev_sleep (ev_tstamp delay) EV_NOEXCEPT
 {
   if (delay > 0.)
     {
@@ -1908,6 +1913,8 @@ ev_sleep (ev_tstamp delay) EV_THROW
       EV_TS_SET (ts, delay);
       nanosleep (&ts, 0);
 #elif defined _WIN32
+      /* maybe this should round up, as ms is very low resolution */
+      /* compared to select (µs) or nanosleep (ns) */
       Sleep ((unsigned long)(delay * 1e3));
 #else
       struct timeval tv;
@@ -1992,7 +1999,7 @@ pendingcb (EV_P_ ev_prepare *w, int revents)
 
 noinline
 void
-ev_feed_event (EV_P_ void *w, int revents) EV_THROW
+ev_feed_event (EV_P_ void *w, int revents) EV_NOEXCEPT
 {
   W w_ = (W)w;
   int pri = ABSPRI (w_);
@@ -2063,7 +2070,7 @@ fd_event (EV_P_ int fd, int revents)
 }
 
 void
-ev_feed_fd_event (EV_P_ int fd, int revents) EV_THROW
+ev_feed_fd_event (EV_P_ int fd, int revents) EV_NOEXCEPT
 {
   if (fd >= 0 && fd < anfdmax)
     fd_event_nocheck (EV_A_ fd, revents);
@@ -2473,7 +2480,7 @@ evpipe_write (EV_P_ EV_ATOMIC_T *flag)
 #ifdef _WIN32
           WSABUF buf;
           DWORD sent;
-          buf.buf = &buf;
+          buf.buf = (char *)&buf;
           buf.len = 1;
           WSASend (EV_FD_TO_WIN32_HANDLE (evpipe [1]), &buf, 1, &sent, 0, 0, 0);
 #else
@@ -2555,7 +2562,7 @@ pipecb (EV_P_ ev_io *iow, int revents)
 /*****************************************************************************/
 
 void
-ev_feed_signal (int signum) EV_THROW
+ev_feed_signal (int signum) EV_NOEXCEPT
 {
 #if EV_MULTIPLICITY
   EV_P;
@@ -2582,7 +2589,7 @@ ev_sighandler (int signum)
 
 noinline
 void
-ev_feed_signal_event (EV_P_ int signum) EV_THROW
+ev_feed_signal_event (EV_P_ int signum) EV_NOEXCEPT
 {
   WL w;
 
@@ -2709,13 +2716,13 @@ childcb (EV_P_ ev_signal *sw, int revents)
 #endif
 
 ecb_cold int
-ev_version_major (void) EV_THROW
+ev_version_major (void) EV_NOEXCEPT
 {
   return EV_VERSION_MAJOR;
 }
 
 ecb_cold int
-ev_version_minor (void) EV_THROW
+ev_version_minor (void) EV_NOEXCEPT
 {
   return EV_VERSION_MINOR;
 }
@@ -2734,7 +2741,7 @@ enable_secure (void)
 
 ecb_cold
 unsigned int
-ev_supported_backends (void) EV_THROW
+ev_supported_backends (void) EV_NOEXCEPT
 {
   unsigned int flags = 0;
 
@@ -2749,7 +2756,7 @@ ev_supported_backends (void) EV_THROW
 
 ecb_cold
 unsigned int
-ev_recommended_backends (void) EV_THROW
+ev_recommended_backends (void) EV_NOEXCEPT
 {
   unsigned int flags = ev_supported_backends ();
 
@@ -2772,7 +2779,7 @@ ev_recommended_backends (void) EV_THROW
 
 ecb_cold
 unsigned int
-ev_embeddable_backends (void) EV_THROW
+ev_embeddable_backends (void) EV_NOEXCEPT
 {
   int flags = EVBACKEND_EPOLL | EVBACKEND_KQUEUE | EVBACKEND_PORT;
 
@@ -2784,56 +2791,56 @@ ev_embeddable_backends (void) EV_THROW
 }
 
 unsigned int
-ev_backend (EV_P) EV_THROW
+ev_backend (EV_P) EV_NOEXCEPT
 {
   return backend;
 }
 
 #if EV_FEATURE_API
 unsigned int
-ev_iteration (EV_P) EV_THROW
+ev_iteration (EV_P) EV_NOEXCEPT
 {
   return loop_count;
 }
 
 unsigned int
-ev_depth (EV_P) EV_THROW
+ev_depth (EV_P) EV_NOEXCEPT
 {
   return loop_depth;
 }
 
 void
-ev_set_io_collect_interval (EV_P_ ev_tstamp interval) EV_THROW
+ev_set_io_collect_interval (EV_P_ ev_tstamp interval) EV_NOEXCEPT
 {
   io_blocktime = interval;
 }
 
 void
-ev_set_timeout_collect_interval (EV_P_ ev_tstamp interval) EV_THROW
+ev_set_timeout_collect_interval (EV_P_ ev_tstamp interval) EV_NOEXCEPT
 {
   timeout_blocktime = interval;
 }
 
 void
-ev_set_userdata (EV_P_ void *data) EV_THROW
+ev_set_userdata (EV_P_ void *data) EV_NOEXCEPT
 {
   userdata = data;
 }
 
 void *
-ev_userdata (EV_P) EV_THROW
+ev_userdata (EV_P) EV_NOEXCEPT
 {
   return userdata;
 }
 
 void
-ev_set_invoke_pending_cb (EV_P_ ev_loop_callback invoke_pending_cb) EV_THROW
+ev_set_invoke_pending_cb (EV_P_ ev_loop_callback invoke_pending_cb) EV_NOEXCEPT
 {
   invoke_cb = invoke_pending_cb;
 }
 
 void
-ev_set_loop_release_cb (EV_P_ void (*release)(EV_P) EV_THROW, void (*acquire)(EV_P) EV_THROW) EV_THROW
+ev_set_loop_release_cb (EV_P_ void (*release)(EV_P) EV_NOEXCEPT, void (*acquire)(EV_P) EV_NOEXCEPT) EV_NOEXCEPT
 {
   release_cb = release;
   acquire_cb = acquire;
@@ -2843,7 +2850,7 @@ ev_set_loop_release_cb (EV_P_ void (*release)(EV_P) EV_THROW, void (*acquire)(EV
 /* initialise a loop structure, must be zero-initialised */
 noinline ecb_cold
 static void
-loop_init (EV_P_ unsigned int flags) EV_THROW
+loop_init (EV_P_ unsigned int flags) EV_NOEXCEPT
 {
   if (!backend)
     {
@@ -3094,7 +3101,7 @@ loop_fork (EV_P)
 
 ecb_cold
 struct ev_loop *
-ev_loop_new (unsigned int flags) EV_THROW
+ev_loop_new (unsigned int flags) EV_NOEXCEPT
 {
   EV_P = (struct ev_loop *)ev_malloc (sizeof (struct ev_loop));
 
@@ -3151,7 +3158,7 @@ array_verify (EV_P_ W *ws, int cnt)
 
 #if EV_FEATURE_API
 void ecb_cold
-ev_verify (EV_P) EV_THROW
+ev_verify (EV_P) EV_NOEXCEPT
 {
 #if EV_VERIFY
   int i;
@@ -3242,7 +3249,7 @@ struct ev_loop *
 #else
 int
 #endif
-ev_default_loop (unsigned int flags) EV_THROW
+ev_default_loop (unsigned int flags) EV_NOEXCEPT
 {
   if (!ev_default_loop_ptr)
     {
@@ -3271,7 +3278,7 @@ ev_default_loop (unsigned int flags) EV_THROW
 }
 
 void
-ev_loop_fork (EV_P) EV_THROW
+ev_loop_fork (EV_P) EV_NOEXCEPT
 {
   postfork = 1;
 }
@@ -3285,7 +3292,7 @@ ev_invoke (EV_P_ void *w, int revents)
 }
 
 unsigned int
-ev_pending_count (EV_P) EV_THROW
+ev_pending_count (EV_P) EV_NOEXCEPT
 {
   int pri;
   unsigned int count = 0;
@@ -3302,10 +3309,11 @@ ev_invoke_pending (EV_P)
 {
   pendingpri = NUMPRI;
 
-  while (pendingpri) /* pendingpri possibly gets modified in the inner loop */
+  do
     {
       --pendingpri;
 
+      /* pendingpri possibly gets modified in the inner loop */
       while (pendingcnt [pendingpri])
         {
           ANPENDING *p = pendings [pendingpri] + --pendingcnt [pendingpri];
@@ -3315,6 +3323,7 @@ ev_invoke_pending (EV_P)
           EV_FREQUENT_CHECK;
         }
     }
+  while (pendingpri);
 }
 
 #if EV_IDLE_ENABLE
@@ -3733,37 +3742,37 @@ ev_run (EV_P_ int flags)
 }
 
 void
-ev_break (EV_P_ int how) EV_THROW
+ev_break (EV_P_ int how) EV_NOEXCEPT
 {
   loop_done = how;
 }
 
 void
-ev_ref (EV_P) EV_THROW
+ev_ref (EV_P) EV_NOEXCEPT
 {
   ++activecnt;
 }
 
 void
-ev_unref (EV_P) EV_THROW
+ev_unref (EV_P) EV_NOEXCEPT
 {
   --activecnt;
 }
 
 void
-ev_now_update (EV_P) EV_THROW
+ev_now_update (EV_P) EV_NOEXCEPT
 {
   time_update (EV_A_ 1e100);
 }
 
 void
-ev_suspend (EV_P) EV_THROW
+ev_suspend (EV_P) EV_NOEXCEPT
 {
   ev_now_update (EV_A);
 }
 
 void
-ev_resume (EV_P) EV_THROW
+ev_resume (EV_P) EV_NOEXCEPT
 {
   ev_tstamp mn_prev = mn_now;
 
@@ -3812,7 +3821,7 @@ clear_pending (EV_P_ W w)
 }
 
 int
-ev_clear_pending (EV_P_ void *w) EV_THROW
+ev_clear_pending (EV_P_ void *w) EV_NOEXCEPT
 {
   W w_ = (W)w;
   int pending = w_->pending;
@@ -3856,7 +3865,7 @@ ev_stop (EV_P_ W w)
 
 noinline
 void
-ev_io_start (EV_P_ ev_io *w) EV_THROW
+ev_io_start (EV_P_ ev_io *w) EV_NOEXCEPT
 {
   int fd = w->fd;
 
@@ -3883,7 +3892,7 @@ ev_io_start (EV_P_ ev_io *w) EV_THROW
 
 noinline
 void
-ev_io_stop (EV_P_ ev_io *w) EV_THROW
+ev_io_stop (EV_P_ ev_io *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -3903,7 +3912,7 @@ ev_io_stop (EV_P_ ev_io *w) EV_THROW
 
 noinline
 void
-ev_timer_start (EV_P_ ev_timer *w) EV_THROW
+ev_timer_start (EV_P_ ev_timer *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -3928,7 +3937,7 @@ ev_timer_start (EV_P_ ev_timer *w) EV_THROW
 
 noinline
 void
-ev_timer_stop (EV_P_ ev_timer *w) EV_THROW
+ev_timer_stop (EV_P_ ev_timer *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -3959,7 +3968,7 @@ ev_timer_stop (EV_P_ ev_timer *w) EV_THROW
 
 noinline
 void
-ev_timer_again (EV_P_ ev_timer *w) EV_THROW
+ev_timer_again (EV_P_ ev_timer *w) EV_NOEXCEPT
 {
   EV_FREQUENT_CHECK;
 
@@ -3986,7 +3995,7 @@ ev_timer_again (EV_P_ ev_timer *w) EV_THROW
 }
 
 ev_tstamp
-ev_timer_remaining (EV_P_ ev_timer *w) EV_THROW
+ev_timer_remaining (EV_P_ ev_timer *w) EV_NOEXCEPT
 {
   return ev_at (w) - (ev_is_active (w) ? mn_now : 0.);
 }
@@ -3994,7 +4003,7 @@ ev_timer_remaining (EV_P_ ev_timer *w) EV_THROW
 #if EV_PERIODIC_ENABLE
 noinline
 void
-ev_periodic_start (EV_P_ ev_periodic *w) EV_THROW
+ev_periodic_start (EV_P_ ev_periodic *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4025,7 +4034,7 @@ ev_periodic_start (EV_P_ ev_periodic *w) EV_THROW
 
 noinline
 void
-ev_periodic_stop (EV_P_ ev_periodic *w) EV_THROW
+ev_periodic_stop (EV_P_ ev_periodic *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4054,7 +4063,7 @@ ev_periodic_stop (EV_P_ ev_periodic *w) EV_THROW
 
 noinline
 void
-ev_periodic_again (EV_P_ ev_periodic *w) EV_THROW
+ev_periodic_again (EV_P_ ev_periodic *w) EV_NOEXCEPT
 {
   /* TODO: use adjustheap and recalculation */
   ev_periodic_stop (EV_A_ w);
@@ -4070,7 +4079,7 @@ ev_periodic_again (EV_P_ ev_periodic *w) EV_THROW
 
 noinline
 void
-ev_signal_start (EV_P_ ev_signal *w) EV_THROW
+ev_signal_start (EV_P_ ev_signal *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4153,7 +4162,7 @@ ev_signal_start (EV_P_ ev_signal *w) EV_THROW
 
 noinline
 void
-ev_signal_stop (EV_P_ ev_signal *w) EV_THROW
+ev_signal_stop (EV_P_ ev_signal *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4194,7 +4203,7 @@ ev_signal_stop (EV_P_ ev_signal *w) EV_THROW
 #if EV_CHILD_ENABLE
 
 void
-ev_child_start (EV_P_ ev_child *w) EV_THROW
+ev_child_start (EV_P_ ev_child *w) EV_NOEXCEPT
 {
 #if EV_MULTIPLICITY
   assert (("libev: child watchers are only supported in the default loop", loop == ev_default_loop_ptr));
@@ -4211,7 +4220,7 @@ ev_child_start (EV_P_ ev_child *w) EV_THROW
 }
 
 void
-ev_child_stop (EV_P_ ev_child *w) EV_THROW
+ev_child_stop (EV_P_ ev_child *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4486,7 +4495,7 @@ infy_fork (EV_P)
 #endif
 
 void
-ev_stat_stat (EV_P_ ev_stat *w) EV_THROW
+ev_stat_stat (EV_P_ ev_stat *w) EV_NOEXCEPT
 {
   if (lstat (w->path, &w->attr) < 0)
     w->attr.st_nlink = 0;
@@ -4536,7 +4545,7 @@ stat_timer_cb (EV_P_ ev_timer *w_, int revents)
 }
 
 void
-ev_stat_start (EV_P_ ev_stat *w) EV_THROW
+ev_stat_start (EV_P_ ev_stat *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4567,7 +4576,7 @@ ev_stat_start (EV_P_ ev_stat *w) EV_THROW
 }
 
 void
-ev_stat_stop (EV_P_ ev_stat *w) EV_THROW
+ev_stat_stop (EV_P_ ev_stat *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4593,7 +4602,7 @@ ev_stat_stop (EV_P_ ev_stat *w) EV_THROW
 
 #if EV_IDLE_ENABLE
 void
-ev_idle_start (EV_P_ ev_idle *w) EV_THROW
+ev_idle_start (EV_P_ ev_idle *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4616,7 +4625,7 @@ ev_idle_start (EV_P_ ev_idle *w) EV_THROW
 }
 
 void
-ev_idle_stop (EV_P_ ev_idle *w) EV_THROW
+ev_idle_stop (EV_P_ ev_idle *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4640,7 +4649,7 @@ ev_idle_stop (EV_P_ ev_idle *w) EV_THROW
 
 #if EV_PREPARE_ENABLE
 void
-ev_prepare_start (EV_P_ ev_prepare *w) EV_THROW
+ev_prepare_start (EV_P_ ev_prepare *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4655,7 +4664,7 @@ ev_prepare_start (EV_P_ ev_prepare *w) EV_THROW
 }
 
 void
-ev_prepare_stop (EV_P_ ev_prepare *w) EV_THROW
+ev_prepare_stop (EV_P_ ev_prepare *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4678,7 +4687,7 @@ ev_prepare_stop (EV_P_ ev_prepare *w) EV_THROW
 
 #if EV_CHECK_ENABLE
 void
-ev_check_start (EV_P_ ev_check *w) EV_THROW
+ev_check_start (EV_P_ ev_check *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4693,7 +4702,7 @@ ev_check_start (EV_P_ ev_check *w) EV_THROW
 }
 
 void
-ev_check_stop (EV_P_ ev_check *w) EV_THROW
+ev_check_stop (EV_P_ ev_check *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4717,7 +4726,7 @@ ev_check_stop (EV_P_ ev_check *w) EV_THROW
 #if EV_EMBED_ENABLE
 noinline
 void
-ev_embed_sweep (EV_P_ ev_embed *w) EV_THROW
+ev_embed_sweep (EV_P_ ev_embed *w) EV_NOEXCEPT
 {
   ev_run (w->other, EVRUN_NOWAIT);
 }
@@ -4775,7 +4784,7 @@ embed_idle_cb (EV_P_ ev_idle *idle, int revents)
 #endif
 
 void
-ev_embed_start (EV_P_ ev_embed *w) EV_THROW
+ev_embed_start (EV_P_ ev_embed *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4806,7 +4815,7 @@ ev_embed_start (EV_P_ ev_embed *w) EV_THROW
 }
 
 void
-ev_embed_stop (EV_P_ ev_embed *w) EV_THROW
+ev_embed_stop (EV_P_ ev_embed *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4826,7 +4835,7 @@ ev_embed_stop (EV_P_ ev_embed *w) EV_THROW
 
 #if EV_FORK_ENABLE
 void
-ev_fork_start (EV_P_ ev_fork *w) EV_THROW
+ev_fork_start (EV_P_ ev_fork *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4841,7 +4850,7 @@ ev_fork_start (EV_P_ ev_fork *w) EV_THROW
 }
 
 void
-ev_fork_stop (EV_P_ ev_fork *w) EV_THROW
+ev_fork_stop (EV_P_ ev_fork *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4864,7 +4873,7 @@ ev_fork_stop (EV_P_ ev_fork *w) EV_THROW
 
 #if EV_CLEANUP_ENABLE
 void
-ev_cleanup_start (EV_P_ ev_cleanup *w) EV_THROW
+ev_cleanup_start (EV_P_ ev_cleanup *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4881,7 +4890,7 @@ ev_cleanup_start (EV_P_ ev_cleanup *w) EV_THROW
 }
 
 void
-ev_cleanup_stop (EV_P_ ev_cleanup *w) EV_THROW
+ev_cleanup_stop (EV_P_ ev_cleanup *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4905,7 +4914,7 @@ ev_cleanup_stop (EV_P_ ev_cleanup *w) EV_THROW
 
 #if EV_ASYNC_ENABLE
 void
-ev_async_start (EV_P_ ev_async *w) EV_THROW
+ev_async_start (EV_P_ ev_async *w) EV_NOEXCEPT
 {
   if (expect_false (ev_is_active (w)))
     return;
@@ -4924,7 +4933,7 @@ ev_async_start (EV_P_ ev_async *w) EV_THROW
 }
 
 void
-ev_async_stop (EV_P_ ev_async *w) EV_THROW
+ev_async_stop (EV_P_ ev_async *w) EV_NOEXCEPT
 {
   clear_pending (EV_A_ (W)w);
   if (expect_false (!ev_is_active (w)))
@@ -4945,7 +4954,7 @@ ev_async_stop (EV_P_ ev_async *w) EV_THROW
 }
 
 void
-ev_async_send (EV_P_ ev_async *w) EV_THROW
+ev_async_send (EV_P_ ev_async *w) EV_NOEXCEPT
 {
   w->sent = 1;
   evpipe_write (EV_A_ &async_pending);
@@ -4992,7 +5001,7 @@ once_cb_to (EV_P_ ev_timer *w, int revents)
 }
 
 void
-ev_once (EV_P_ int fd, int events, ev_tstamp timeout, void (*cb)(int revents, void *arg), void *arg) EV_THROW
+ev_once (EV_P_ int fd, int events, ev_tstamp timeout, void (*cb)(int revents, void *arg), void *arg) EV_NOEXCEPT
 {
   struct ev_once *once = (struct ev_once *)ev_malloc (sizeof (struct ev_once));
 
@@ -5025,7 +5034,7 @@ ev_once (EV_P_ int fd, int events, ev_tstamp timeout, void (*cb)(int revents, vo
 #if EV_WALK_ENABLE
 ecb_cold
 void
-ev_walk (EV_P_ int types, void (*cb)(EV_P_ int type, void *w)) EV_THROW
+ev_walk (EV_P_ int types, void (*cb)(EV_P_ int type, void *w)) EV_NOEXCEPT
 {
   int i, j;
   ev_watcher_list *wl, *wn;

--- a/src/common/libev/ev.h
+++ b/src/common/libev/ev.h
@@ -1,7 +1,7 @@
 /*
  * libev native API header
  *
- * Copyright (c) 2007,2008,2009,2010,2011,2012,2015 Marc Alexander Lehmann <libev@schmorp.de>
+ * Copyright (c) 2007-2018 Marc Alexander Lehmann <libev@schmorp.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modifica-
@@ -43,14 +43,15 @@
 #ifdef __cplusplus
 # define EV_CPP(x) x
 # if __cplusplus >= 201103L
-#  define EV_THROW noexcept
+#  define EV_NOEXCEPT noexcept
 # else
-#  define EV_THROW throw ()
+#  define EV_NOEXCEPT
 # endif
 #else
 # define EV_CPP(x)
-# define EV_THROW
+# define EV_NOEXCEPT
 #endif
+#define EV_THROW EV_NOEXCEPT /* pre-4.25, do not use in new code */
 
 EV_CPP(extern "C" {)
 
@@ -211,7 +212,7 @@ struct ev_loop;
 /*****************************************************************************/
 
 #define EV_VERSION_MAJOR 4
-#define EV_VERSION_MINOR 24
+#define EV_VERSION_MINOR 25
 
 /* eventmask, revents, events... */
 enum {
@@ -339,7 +340,7 @@ typedef struct ev_periodic
 
   ev_tstamp offset; /* rw */
   ev_tstamp interval; /* rw */
-  ev_tstamp (*reschedule_cb)(struct ev_periodic *w, ev_tstamp now) EV_THROW; /* rw */
+  ev_tstamp (*reschedule_cb)(struct ev_periodic *w, ev_tstamp now) EV_NOEXCEPT; /* rw */
 } ev_periodic;
 
 /* invoked when the given signal has been received */
@@ -526,15 +527,15 @@ enum {
 };
 
 #if EV_PROTOTYPES
-EV_API_DECL int ev_version_major (void) EV_THROW;
-EV_API_DECL int ev_version_minor (void) EV_THROW;
+EV_API_DECL int ev_version_major (void) EV_NOEXCEPT;
+EV_API_DECL int ev_version_minor (void) EV_NOEXCEPT;
 
-EV_API_DECL unsigned int ev_supported_backends (void) EV_THROW;
-EV_API_DECL unsigned int ev_recommended_backends (void) EV_THROW;
-EV_API_DECL unsigned int ev_embeddable_backends (void) EV_THROW;
+EV_API_DECL unsigned int ev_supported_backends (void) EV_NOEXCEPT;
+EV_API_DECL unsigned int ev_recommended_backends (void) EV_NOEXCEPT;
+EV_API_DECL unsigned int ev_embeddable_backends (void) EV_NOEXCEPT;
 
-EV_API_DECL ev_tstamp ev_time (void) EV_THROW;
-EV_API_DECL void ev_sleep (ev_tstamp delay) EV_THROW; /* sleep for a while */
+EV_API_DECL ev_tstamp ev_time (void) EV_NOEXCEPT;
+EV_API_DECL void ev_sleep (ev_tstamp delay) EV_NOEXCEPT; /* sleep for a while */
 
 /* Sets the allocation function to use, works like realloc.
  * It is used to allocate and free memory.
@@ -542,26 +543,26 @@ EV_API_DECL void ev_sleep (ev_tstamp delay) EV_THROW; /* sleep for a while */
  * or take some potentially destructive action.
  * The default is your system realloc function.
  */
-EV_API_DECL void ev_set_allocator (void *(*cb)(void *ptr, long size) EV_THROW) EV_THROW;
+EV_API_DECL void ev_set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT) EV_NOEXCEPT;
 
 /* set the callback function to call on a
  * retryable syscall error
  * (such as failed select, poll, epoll_wait)
  */
-EV_API_DECL void ev_set_syserr_cb (void (*cb)(const char *msg) EV_THROW) EV_THROW;
+EV_API_DECL void ev_set_syserr_cb (void (*cb)(const char *msg) EV_NOEXCEPT) EV_NOEXCEPT;
 
 #if EV_MULTIPLICITY
 
 /* the default loop is the only one that handles signals and child watchers */
 /* you can call this as often as you like */
-EV_API_DECL struct ev_loop *ev_default_loop (unsigned int flags EV_CPP (= 0)) EV_THROW;
+EV_API_DECL struct ev_loop *ev_default_loop (unsigned int flags EV_CPP (= 0)) EV_NOEXCEPT;
 
 #ifdef EV_API_STATIC
 EV_API_DECL struct ev_loop *ev_default_loop_ptr;
 #endif
 
 EV_INLINE struct ev_loop *
-ev_default_loop_uc_ (void) EV_THROW
+ev_default_loop_uc_ (void) EV_NOEXCEPT
 {
   extern struct ev_loop *ev_default_loop_ptr;
 
@@ -569,31 +570,31 @@ ev_default_loop_uc_ (void) EV_THROW
 }
 
 EV_INLINE int
-ev_is_default_loop (EV_P) EV_THROW
+ev_is_default_loop (EV_P) EV_NOEXCEPT
 {
   return EV_A == EV_DEFAULT_UC;
 }
 
 /* create and destroy alternative loops that don't handle signals */
-EV_API_DECL struct ev_loop *ev_loop_new (unsigned int flags EV_CPP (= 0)) EV_THROW;
+EV_API_DECL struct ev_loop *ev_loop_new (unsigned int flags EV_CPP (= 0)) EV_NOEXCEPT;
 
-EV_API_DECL ev_tstamp ev_now (EV_P) EV_THROW; /* time w.r.t. timers and the eventloop, updated after each poll */
+EV_API_DECL ev_tstamp ev_now (EV_P) EV_NOEXCEPT; /* time w.r.t. timers and the eventloop, updated after each poll */
 
 #else
 
-EV_API_DECL int ev_default_loop (unsigned int flags EV_CPP (= 0)) EV_THROW; /* returns true when successful */
+EV_API_DECL int ev_default_loop (unsigned int flags EV_CPP (= 0)) EV_NOEXCEPT; /* returns true when successful */
 
 EV_API_DECL ev_tstamp ev_rt_now;
 
 EV_INLINE ev_tstamp
-ev_now (void) EV_THROW
+ev_now (void) EV_NOEXCEPT
 {
   return ev_rt_now;
 }
 
 /* looks weird, but ev_is_default_loop (EV_A) still works if this exists */
 EV_INLINE int
-ev_is_default_loop (void) EV_THROW
+ev_is_default_loop (void) EV_NOEXCEPT
 {
   return 1;
 }
@@ -607,17 +608,17 @@ EV_API_DECL void ev_loop_destroy (EV_P);
 /* when you want to re-use it in the child */
 /* you can call it in either the parent or the child */
 /* you can actually call it at any time, anywhere :) */
-EV_API_DECL void ev_loop_fork (EV_P) EV_THROW;
+EV_API_DECL void ev_loop_fork (EV_P) EV_NOEXCEPT;
 
-EV_API_DECL unsigned int ev_backend (EV_P) EV_THROW; /* backend in use by loop */
+EV_API_DECL unsigned int ev_backend (EV_P) EV_NOEXCEPT; /* backend in use by loop */
 
-EV_API_DECL void ev_now_update (EV_P) EV_THROW; /* update event loop time */
+EV_API_DECL void ev_now_update (EV_P) EV_NOEXCEPT; /* update event loop time */
 
 #if EV_WALK_ENABLE
 /* walk (almost) all watchers in the loop of a given type, invoking the */
 /* callback on every such watcher. The callback might stop the watcher, */
 /* but do nothing else with the loop */
-EV_API_DECL void ev_walk (EV_P_ int types, void (*cb)(EV_P_ int type, void *w)) EV_THROW;
+EV_API_DECL void ev_walk (EV_P_ int types, void (*cb)(EV_P_ int type, void *w)) EV_NOEXCEPT;
 #endif
 
 #endif /* prototypes */
@@ -637,46 +638,46 @@ enum {
 
 #if EV_PROTOTYPES
 EV_API_DECL int  ev_run (EV_P_ int flags EV_CPP (= 0));
-EV_API_DECL void ev_break (EV_P_ int how EV_CPP (= EVBREAK_ONE)) EV_THROW; /* break out of the loop */
+EV_API_DECL void ev_break (EV_P_ int how EV_CPP (= EVBREAK_ONE)) EV_NOEXCEPT; /* break out of the loop */
 
 /*
  * ref/unref can be used to add or remove a refcount on the mainloop. every watcher
  * keeps one reference. if you have a long-running watcher you never unregister that
  * should not keep ev_loop from running, unref() after starting, and ref() before stopping.
  */
-EV_API_DECL void ev_ref   (EV_P) EV_THROW;
-EV_API_DECL void ev_unref (EV_P) EV_THROW;
+EV_API_DECL void ev_ref   (EV_P) EV_NOEXCEPT;
+EV_API_DECL void ev_unref (EV_P) EV_NOEXCEPT;
 
 /*
  * convenience function, wait for a single event, without registering an event watcher
  * if timeout is < 0, do wait indefinitely
  */
-EV_API_DECL void ev_once (EV_P_ int fd, int events, ev_tstamp timeout, void (*cb)(int revents, void *arg), void *arg) EV_THROW;
+EV_API_DECL void ev_once (EV_P_ int fd, int events, ev_tstamp timeout, void (*cb)(int revents, void *arg), void *arg) EV_NOEXCEPT;
 
 # if EV_FEATURE_API
-EV_API_DECL unsigned int ev_iteration (EV_P) EV_THROW; /* number of loop iterations */
-EV_API_DECL unsigned int ev_depth     (EV_P) EV_THROW; /* #ev_loop enters - #ev_loop leaves */
-EV_API_DECL void         ev_verify    (EV_P) EV_THROW; /* abort if loop data corrupted */
+EV_API_DECL unsigned int ev_iteration (EV_P) EV_NOEXCEPT; /* number of loop iterations */
+EV_API_DECL unsigned int ev_depth     (EV_P) EV_NOEXCEPT; /* #ev_loop enters - #ev_loop leaves */
+EV_API_DECL void         ev_verify    (EV_P) EV_NOEXCEPT; /* abort if loop data corrupted */
 
-EV_API_DECL void ev_set_io_collect_interval (EV_P_ ev_tstamp interval) EV_THROW; /* sleep at least this time, default 0 */
-EV_API_DECL void ev_set_timeout_collect_interval (EV_P_ ev_tstamp interval) EV_THROW; /* sleep at least this time, default 0 */
+EV_API_DECL void ev_set_io_collect_interval (EV_P_ ev_tstamp interval) EV_NOEXCEPT; /* sleep at least this time, default 0 */
+EV_API_DECL void ev_set_timeout_collect_interval (EV_P_ ev_tstamp interval) EV_NOEXCEPT; /* sleep at least this time, default 0 */
 
 /* advanced stuff for threading etc. support, see docs */
-EV_API_DECL void ev_set_userdata (EV_P_ void *data) EV_THROW;
-EV_API_DECL void *ev_userdata (EV_P) EV_THROW;
+EV_API_DECL void ev_set_userdata (EV_P_ void *data) EV_NOEXCEPT;
+EV_API_DECL void *ev_userdata (EV_P) EV_NOEXCEPT;
 typedef void (*ev_loop_callback)(EV_P);
-EV_API_DECL void ev_set_invoke_pending_cb (EV_P_ ev_loop_callback invoke_pending_cb) EV_THROW;
+EV_API_DECL void ev_set_invoke_pending_cb (EV_P_ ev_loop_callback invoke_pending_cb) EV_NOEXCEPT;
 /* C++ doesn't allow the use of the ev_loop_callback typedef here, so we need to spell it out */
-EV_API_DECL void ev_set_loop_release_cb (EV_P_ void (*release)(EV_P) EV_THROW, void (*acquire)(EV_P) EV_THROW) EV_THROW;
+EV_API_DECL void ev_set_loop_release_cb (EV_P_ void (*release)(EV_P) EV_NOEXCEPT, void (*acquire)(EV_P) EV_NOEXCEPT) EV_NOEXCEPT;
 
-EV_API_DECL unsigned int ev_pending_count (EV_P) EV_THROW; /* number of pending events, if any */
+EV_API_DECL unsigned int ev_pending_count (EV_P) EV_NOEXCEPT; /* number of pending events, if any */
 EV_API_DECL void ev_invoke_pending (EV_P); /* invoke all pending watchers */
 
 /*
  * stop/start the timer handling.
  */
-EV_API_DECL void ev_suspend (EV_P) EV_THROW;
-EV_API_DECL void ev_resume  (EV_P) EV_THROW;
+EV_API_DECL void ev_suspend (EV_P) EV_NOEXCEPT;
+EV_API_DECL void ev_resume  (EV_P) EV_NOEXCEPT;
 #endif
 
 #endif
@@ -744,85 +745,85 @@ EV_API_DECL void ev_resume  (EV_P) EV_THROW;
 
 /* feeds an event into a watcher as if the event actually occurred */
 /* accepts any ev_watcher type */
-EV_API_DECL void ev_feed_event     (EV_P_ void *w, int revents) EV_THROW;
-EV_API_DECL void ev_feed_fd_event  (EV_P_ int fd, int revents) EV_THROW;
+EV_API_DECL void ev_feed_event     (EV_P_ void *w, int revents) EV_NOEXCEPT;
+EV_API_DECL void ev_feed_fd_event  (EV_P_ int fd, int revents) EV_NOEXCEPT;
 #if EV_SIGNAL_ENABLE
-EV_API_DECL void ev_feed_signal    (int signum) EV_THROW;
-EV_API_DECL void ev_feed_signal_event (EV_P_ int signum) EV_THROW;
+EV_API_DECL void ev_feed_signal    (int signum) EV_NOEXCEPT;
+EV_API_DECL void ev_feed_signal_event (EV_P_ int signum) EV_NOEXCEPT;
 #endif
 EV_API_DECL void ev_invoke         (EV_P_ void *w, int revents);
-EV_API_DECL int  ev_clear_pending  (EV_P_ void *w) EV_THROW;
+EV_API_DECL int  ev_clear_pending  (EV_P_ void *w) EV_NOEXCEPT;
 
-EV_API_DECL void ev_io_start       (EV_P_ ev_io *w) EV_THROW;
-EV_API_DECL void ev_io_stop        (EV_P_ ev_io *w) EV_THROW;
+EV_API_DECL void ev_io_start       (EV_P_ ev_io *w) EV_NOEXCEPT;
+EV_API_DECL void ev_io_stop        (EV_P_ ev_io *w) EV_NOEXCEPT;
 
-EV_API_DECL void ev_timer_start    (EV_P_ ev_timer *w) EV_THROW;
-EV_API_DECL void ev_timer_stop     (EV_P_ ev_timer *w) EV_THROW;
+EV_API_DECL void ev_timer_start    (EV_P_ ev_timer *w) EV_NOEXCEPT;
+EV_API_DECL void ev_timer_stop     (EV_P_ ev_timer *w) EV_NOEXCEPT;
 /* stops if active and no repeat, restarts if active and repeating, starts if inactive and repeating */
-EV_API_DECL void ev_timer_again    (EV_P_ ev_timer *w) EV_THROW;
+EV_API_DECL void ev_timer_again    (EV_P_ ev_timer *w) EV_NOEXCEPT;
 /* return remaining time */
-EV_API_DECL ev_tstamp ev_timer_remaining (EV_P_ ev_timer *w) EV_THROW;
+EV_API_DECL ev_tstamp ev_timer_remaining (EV_P_ ev_timer *w) EV_NOEXCEPT;
 
 #if EV_PERIODIC_ENABLE
-EV_API_DECL void ev_periodic_start (EV_P_ ev_periodic *w) EV_THROW;
-EV_API_DECL void ev_periodic_stop  (EV_P_ ev_periodic *w) EV_THROW;
-EV_API_DECL void ev_periodic_again (EV_P_ ev_periodic *w) EV_THROW;
+EV_API_DECL void ev_periodic_start (EV_P_ ev_periodic *w) EV_NOEXCEPT;
+EV_API_DECL void ev_periodic_stop  (EV_P_ ev_periodic *w) EV_NOEXCEPT;
+EV_API_DECL void ev_periodic_again (EV_P_ ev_periodic *w) EV_NOEXCEPT;
 #endif
 
 /* only supported in the default loop */
 #if EV_SIGNAL_ENABLE
-EV_API_DECL void ev_signal_start   (EV_P_ ev_signal *w) EV_THROW;
-EV_API_DECL void ev_signal_stop    (EV_P_ ev_signal *w) EV_THROW;
+EV_API_DECL void ev_signal_start   (EV_P_ ev_signal *w) EV_NOEXCEPT;
+EV_API_DECL void ev_signal_stop    (EV_P_ ev_signal *w) EV_NOEXCEPT;
 #endif
 
 /* only supported in the default loop */
 # if EV_CHILD_ENABLE
-EV_API_DECL void ev_child_start    (EV_P_ ev_child *w) EV_THROW;
-EV_API_DECL void ev_child_stop     (EV_P_ ev_child *w) EV_THROW;
+EV_API_DECL void ev_child_start    (EV_P_ ev_child *w) EV_NOEXCEPT;
+EV_API_DECL void ev_child_stop     (EV_P_ ev_child *w) EV_NOEXCEPT;
 # endif
 
 # if EV_STAT_ENABLE
-EV_API_DECL void ev_stat_start     (EV_P_ ev_stat *w) EV_THROW;
-EV_API_DECL void ev_stat_stop      (EV_P_ ev_stat *w) EV_THROW;
-EV_API_DECL void ev_stat_stat      (EV_P_ ev_stat *w) EV_THROW;
+EV_API_DECL void ev_stat_start     (EV_P_ ev_stat *w) EV_NOEXCEPT;
+EV_API_DECL void ev_stat_stop      (EV_P_ ev_stat *w) EV_NOEXCEPT;
+EV_API_DECL void ev_stat_stat      (EV_P_ ev_stat *w) EV_NOEXCEPT;
 # endif
 
 # if EV_IDLE_ENABLE
-EV_API_DECL void ev_idle_start     (EV_P_ ev_idle *w) EV_THROW;
-EV_API_DECL void ev_idle_stop      (EV_P_ ev_idle *w) EV_THROW;
+EV_API_DECL void ev_idle_start     (EV_P_ ev_idle *w) EV_NOEXCEPT;
+EV_API_DECL void ev_idle_stop      (EV_P_ ev_idle *w) EV_NOEXCEPT;
 # endif
 
 #if EV_PREPARE_ENABLE
-EV_API_DECL void ev_prepare_start  (EV_P_ ev_prepare *w) EV_THROW;
-EV_API_DECL void ev_prepare_stop   (EV_P_ ev_prepare *w) EV_THROW;
+EV_API_DECL void ev_prepare_start  (EV_P_ ev_prepare *w) EV_NOEXCEPT;
+EV_API_DECL void ev_prepare_stop   (EV_P_ ev_prepare *w) EV_NOEXCEPT;
 #endif
 
 #if EV_CHECK_ENABLE
-EV_API_DECL void ev_check_start    (EV_P_ ev_check *w) EV_THROW;
-EV_API_DECL void ev_check_stop     (EV_P_ ev_check *w) EV_THROW;
+EV_API_DECL void ev_check_start    (EV_P_ ev_check *w) EV_NOEXCEPT;
+EV_API_DECL void ev_check_stop     (EV_P_ ev_check *w) EV_NOEXCEPT;
 #endif
 
 # if EV_FORK_ENABLE
-EV_API_DECL void ev_fork_start     (EV_P_ ev_fork *w) EV_THROW;
-EV_API_DECL void ev_fork_stop      (EV_P_ ev_fork *w) EV_THROW;
+EV_API_DECL void ev_fork_start     (EV_P_ ev_fork *w) EV_NOEXCEPT;
+EV_API_DECL void ev_fork_stop      (EV_P_ ev_fork *w) EV_NOEXCEPT;
 # endif
 
 # if EV_CLEANUP_ENABLE
-EV_API_DECL void ev_cleanup_start  (EV_P_ ev_cleanup *w) EV_THROW;
-EV_API_DECL void ev_cleanup_stop   (EV_P_ ev_cleanup *w) EV_THROW;
+EV_API_DECL void ev_cleanup_start  (EV_P_ ev_cleanup *w) EV_NOEXCEPT;
+EV_API_DECL void ev_cleanup_stop   (EV_P_ ev_cleanup *w) EV_NOEXCEPT;
 # endif
 
 # if EV_EMBED_ENABLE
 /* only supported when loop to be embedded is in fact embeddable */
-EV_API_DECL void ev_embed_start    (EV_P_ ev_embed *w) EV_THROW;
-EV_API_DECL void ev_embed_stop     (EV_P_ ev_embed *w) EV_THROW;
-EV_API_DECL void ev_embed_sweep    (EV_P_ ev_embed *w) EV_THROW;
+EV_API_DECL void ev_embed_start    (EV_P_ ev_embed *w) EV_NOEXCEPT;
+EV_API_DECL void ev_embed_stop     (EV_P_ ev_embed *w) EV_NOEXCEPT;
+EV_API_DECL void ev_embed_sweep    (EV_P_ ev_embed *w) EV_NOEXCEPT;
 # endif
 
 # if EV_ASYNC_ENABLE
-EV_API_DECL void ev_async_start    (EV_P_ ev_async *w) EV_THROW;
-EV_API_DECL void ev_async_stop     (EV_P_ ev_async *w) EV_THROW;
-EV_API_DECL void ev_async_send     (EV_P_ ev_async *w) EV_THROW;
+EV_API_DECL void ev_async_start    (EV_P_ ev_async *w) EV_NOEXCEPT;
+EV_API_DECL void ev_async_stop     (EV_P_ ev_async *w) EV_NOEXCEPT;
+EV_API_DECL void ev_async_send     (EV_P_ ev_async *w) EV_NOEXCEPT;
 # endif
 
 #if EV_COMPAT3

--- a/src/common/libev/ev_epoll.c
+++ b/src/common/libev/ev_epoll.c
@@ -239,7 +239,7 @@ inline_size
 int
 epoll_init (EV_P_ int flags)
 {
-#ifdef EPOLL_CLOEXEC
+#if defined EPOLL_CLOEXEC && !defined __ANDROID__
   backend_fd = epoll_create1 (EPOLL_CLOEXEC);
 
   if (backend_fd < 0 && (errno == EINVAL || errno == ENOSYS))

--- a/src/common/libev/ev_vars.h
+++ b/src/common/libev/ev_vars.h
@@ -195,8 +195,8 @@ VARx(unsigned int, loop_depth) /* #ev_run enters - #ev_run leaves */
 
 VARx(void *, userdata)
 /* C++ doesn't support the ev_loop_callback typedef here. stinks. */
-VAR (release_cb, void (*release_cb)(EV_P) EV_THROW)
-VAR (acquire_cb, void (*acquire_cb)(EV_P) EV_THROW)
+VAR (release_cb, void (*release_cb)(EV_P) EV_NOEXCEPT)
+VAR (acquire_cb, void (*acquire_cb)(EV_P) EV_NOEXCEPT)
 VAR (invoke_cb , ev_loop_callback invoke_cb)
 #endif
 

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -45,6 +45,6 @@ test_expect_success 'valgrind reports no new errors on single broker run' '
 		--leak-resolution=med \
 		--error-exitcode=1 \
 		--suppressions=$VALGRIND_SUPPRESSIONS \
-		${BROKER} --shutdown-grace=4 ${VALGRIND_WORKLOAD} 10
+		${BROKER} --shutdown-grace=16 ${VALGRIND_WORKLOAD} 10
 '
 test_done

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -31,7 +31,7 @@ VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh
 BROKER=${FLUX_BUILD_DIR}/src/broker/flux-broker
 
 # broker run under valgrind may need extra retries in flux_open():
-FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
+export FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
 
 test_expect_success 'valgrind reports no new errors on single broker run' '
 	run_timeout 120 \

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -73,3 +73,10 @@
    fun:boot_pmi
    fun:main
 }
+{
+   <issue_1897>
+   Memcheck:Addr1
+   fun:ev_run
+   fun:flux_reactor_run
+   ...
+}


### PR DESCRIPTION
This PR includes a gratuitous update of libev from 4.24 to 4.25.  I pulled it in to see if it would fix #1897 because it happened to touch the ECB_MEMORY_FENCE macros, but then left it in since the changes were fairly minor and it's probably useful to track upstream releases.  (maybe the darwin fix is useful when @trws gets back to flux mac port?)
```
   4.25 Fri Dec 21 07:49:20 CET 2018
      - INCOMPATIBLE CHANGE: EV_THROW was renamed to EV_NOEXCEPT
        (EV_THROW sitll provided) and now uses noexcept on C++11 or newer.
      - move the darwin select workaround higher in ev.c, as newer versions of
        darwin managed to break their broken select even more.
      - ANDROID => __ANDROID__ (reported by enh@google.com).
      - disable epoll_create1 on android because it has broken header files
        and google is unwilling to fix them (reported by enh@google.com).
      - avoid a minor compilation warning on win32.
      - c++: remove deprecated dynamic throw() specifications.
      - c++: improve the (unsupported) bad_loop exception class.
      - backport perl ev_periodic example to C, untested.
      - update libecb, biggest change is to include a memory fence
        in ECB_MEMORY_FENCE_RELEASE on x86/amd64.
      - minor autoconf/automake modernisation.
```

The other fixes are to get the valgrind test to run successfully on an i686 test box.  I expect the shutdown grace increase and FLUX_LOCAL_CONNECTOR_RETRY_COUNT fix may improve reliability in travis also.  The shutdown grace increase does slow down the test some.


