### PR TITLE
wreck: small fixes for nokz job output

### DIFF
--- a/src/cmd/flux-wreck
+++ b/src/cmd/flux-wreck
@@ -147,7 +147,7 @@ prog:SubCommand {
         }
     end
 
-    f:reactor ()
+    if not attach_job_complete (state, taskio) then f:reactor () end
 
     if options.nokz then dump_nokz_output (id) end
     log:dump()

--- a/src/cmd/flux-wreckrun
+++ b/src/cmd/flux-wreckrun
@@ -145,6 +145,18 @@ if not wreck:parse_cmdline (arg) then
     wreck:die ("Failed to process cmdline args\n")
 end
 
+-- if nokz is in effect and the --output option is not used, AND
+--  either --detach or --wait-until are active, then store output by
+--  default in the kvs; o/w it is just dropped:
+if (wreck.job_options.nokz and not wreck:getopt ('O')) and
+   (wreck:getopt ('d') or wreck:getopt ('w')) then
+    wreck.opts.O = "kvs://files.stdout"
+    if not wreck:getopt ('E') then wreck.opts.E = "kvs://files.stderr" end
+
+    -- Regenerate wreck.output output file configuration:
+    wreck.output = wreck:output_file_config ()
+end
+
 wreckrun_hooks_compile (wreck)
 
 -- Start in-program timer:


### PR DESCRIPTION
This PR includes a couple small fixes for wreck jobs with `nokz`.

 - #1899: fix flux-wreck attach with flux-wreckrun nokz jobs that are complete
 - Save output in kvs with flux-wreckrun for `nokz` jobs when `--detach` or `--wait-until` is used to avoid dropping all output.