### PR TITLE
travis-ci: fix travis build for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,20 @@ jobs:
       python: '3.6'
       install: pip install --upgrade black
       script: ./scripts/check-format
+      before_deploy: skip
+      deploy: skip
+      after_success: skip
+      after_failure: skip
     - stage: 'style checks'
       name: 'python lint'
       language: 'python'
       python: '3.6'
       install: pip install --upgrade pylint
       script: pylint --rcfile=src/bindings/python/.pylintrc src/bindings/python/flux
+      before_deploy: skip
+      deploy: skip
+      after_success: skip
+      after_failure: skip
     - name: "Ubuntu: no configure flags"
       stage: test
       compiler: gcc


### PR DESCRIPTION
Unfortunately, the `'style checks'` build stage broke Travis build of tags, because each stages tries to run all scripts, including `before_deploy` and `deploy`, which make no sense in this stage.

This PR is an attempt to set these targets to be ignored by in the style-checks stages. I considered making `deploy` a separate stage, but I don't think the results of one stage are available in subsequent stages, so this might have to do for now.

I'm not 100% sure this will work. I'll test on my personal repo I guess. I'll have to delete and repush the `v0.11.0` tag.