### PR TITLE
travis-ci: try harder to fix deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ jobs:
       compiler: gcc
       env:
        - PYTHON_VERSION=2.7
-       - GITHUB_RELEASES_DEPLOY=t
     - name: "Ubuntu: py3.6 distcheck"
       stage: test
       compiler: gcc
       env:
        - DISTCHECK=t
        - PYTHON_VERSION=3.6
+       - GITHUB_RELEASES_DEPLOY=t
     - name: "Ubuntu: gcc-8 --with-flux-security/caliper, distcheck"
       stage: test
       compiler: gcc-8


### PR DESCRIPTION
I apologize, but I put the GitHub deploy into the wrong travis builder (it doesn't run make distcheck, so there was no tarball to deploy).

I've tested this now as best I could on my own branch, and I believe it should be fixed this time.

Really sorry about the extra noise!