### PR TITLE
submit jobspec as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ lua-posix 	| lua-posix             | 			| *1*
 python-devel	| python-dev		| >= 2.7		|
 python-cffi	| python-cffi		| >= 1.1		|
 python-six	| python-six		| >= 1.9		|
+python-yaml	| python-yaml		| >= 3.10.0		|
 asciidoc	| asciidoc         	| 			| *2*
 asciidoctor	| asciidoctor         	| >= 1.5.7		| *2*
 aspell		| aspell		|			| *3*

--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,11 @@ AM_CHECK_PYMOD(six,
                ,
                [AC_MSG_ERROR([could not find python module six, version 1.9.0+ required])]
                )
+AM_CHECK_PYMOD(yaml,
+               [StrictVersion(yaml.__version__) >= StrictVersion ('3.10.0')],
+               ,
+               [AC_MSG_ERROR([could not find python module yaml, version 3.10+ required])]
+               )
 
 # Remove -L<path> from PYTHON_LDFLAGS if it is in a standard path
 # (e.g. /usr/lib64).  Placing a standard path earlier in the linker

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -421,6 +421,31 @@ error:
     return -1;
 }
 
+/* Simply ensure that jobspec is valid JSON.
+ * For the time being, RFC 14 validation is performed by
+ * the C++ validator.
+ */
+static int jobspec_validate_json (const char *buf, int len,
+                                  char *errbuf, int errbufsz)
+{
+    json_t *o;
+    json_error_t error;
+
+    if (!(o = json_loadb (buf, len, 0, &error))) {
+        (void)snprintf (errbuf, errbufsz,
+                        "jobspec: invalid JSON: %s", error.text);
+        return -1;
+    }
+    if (!json_is_object (o)) {
+        (void)snprintf (errbuf, errbufsz,
+                        "jobspec: not a JSON object");
+        json_decref (o);
+        return 0;
+    }
+    json_decref (o);
+    return 0;
+}
+
 /* Handle "job-ingest.submit" request to add a new job.
  * Unwrap the signed jobspec and compare claimed userid to authenticated
  * userid from request (they must match).  Signature does not need to be
@@ -437,7 +462,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     const char *jobspec;
     char *jobspec_cpy = NULL;
     const char *errmsg = NULL;
-    char errbuf[80];
+    char errbuf[256];
     int jobspecsz;
     int rc;
     uint32_t userid;
@@ -515,6 +540,12 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
                   "only instance owner can use sign-type=none");
         errmsg = errbuf;
         errno = EPERM;
+        goto error;
+    }
+    if (jobspec_validate_json (jobspec, jobspecsz,
+                               errbuf, sizeof (errbuf)) < 0) {
+        errmsg = errbuf;
+        errno = EINVAL;
         goto error;
     }
 #if HAVE_JOBSPEC

--- a/src/test/docker/bionic-base/Dockerfile
+++ b/src/test/docker/bionic-base/Dockerfile
@@ -44,9 +44,11 @@ RUN apt-get -qq install -y --no-install-recommends \
         python-dev \
         python-cffi \
         python-six \
+	python-yaml \
         python3-dev \
         python3-cffi \
-        python3-six
+        python3-six \
+	python3-yaml
 
 # Other deps
 RUN apt-get -qq install -y --no-install-recommends \

--- a/src/test/docker/centos7-base/Dockerfile
+++ b/src/test/docker/centos7-base/Dockerfile
@@ -43,9 +43,11 @@ RUN yum -y update \
       python-devel \
       python-cffi \
       python-six \
+      python-yaml \
       python34-devel \
       python34-cffi \
       python34-six \
+      python34-yaml \
       ruby \
       sqlite \
       yaml-cpp-devel \

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -46,10 +46,10 @@ RUN case $BASE_IMAGE in \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
-# Make sure user in appropriate group for sudo on different platorms
+# Add some packages for testing
 RUN case $BASE_IMAGE in \
-     bionic*) apt-get -qq install -y --no-install-recommends python-six python3-six ;; \
-     centos*) yum -y install python-six python34-devel python34-cffi python34-six ;; \
+     bionic*) apt update && apt-get -qq install -y --no-install-recommends python-yaml python3-yaml ;; \
+     centos*) yum -y update && yum -y install python-yaml python34-yaml ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 

--- a/t/jobspec/y2j.py
+++ b/t/jobspec/y2j.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import sys, yaml, json
+
+try:
+    obj = yaml.safe_load(sys.stdin)
+except (OSError, IOError) as e:
+    sys.exit("y2j: " + e.strerror)
+except (yaml.YAMLError) as e:
+    sys.exit("y2j: " + e.problem)
+
+json.dump(obj, sys.stdout, separators=(",", ":"))

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -12,6 +12,9 @@
 
 import os
 import errno
+import sys
+import json
+import yaml
 
 import unittest
 
@@ -22,6 +25,11 @@ from flux.job import ffi
 
 def __flux_size():
     return 1
+
+
+def yaml_to_json(s):
+    obj = yaml.load(s)
+    return json.dumps(obj, separators=(",", ":"))
 
 
 class TestJob(unittest.TestCase):
@@ -43,7 +51,8 @@ class TestJob(unittest.TestCase):
         # get a valid jobspec
         basic_jobspec_fname = os.path.join(jobspec_dir, "valid", "basic.yaml")
         with open(basic_jobspec_fname, "rb") as infile:
-            self.jobspec = infile.read()
+            basic_yaml = infile.read()
+        self.jobspec = yaml_to_json(basic_yaml)
 
     def test_00_null_submit(self):
         with self.assertRaises(EnvironmentError) as error:

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -73,6 +73,10 @@ test_expect_success 'job-ingest: can submit jobspec on stdin' '
 	cat basic.json | ${SUBMITBENCH} -
 '
 
+test_expect_success 'job-ingest: YAML jobspec is rejected' '
+	test_must_fail ${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml
+'
+
 test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 	jobid=$(${SUBMITBENCH} basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -16,6 +16,7 @@ fi
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 SUBMITBENCH="flux job submitbench $SUBMITBENCH_OPT_NONE"
+Y2J=${JOBSPEC}/y2j.py
 
 # 2^64 - 1
 MAXJOBID_DEC=18446744073709551615
@@ -30,8 +31,12 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
+test_expect_success 'flux-job: convert basic.yaml to JSON' '
+	${Y2J} <${JOBSPEC}/valid/basic.yaml >basic.json
+'
+
 test_expect_success 'flux-job: submit one job to get one valid job in queue' '
-	validjob=$(${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml) &&
+	validjob=$(${SUBMITBENCH} basic.json) &&
 	echo Valid job is ${validjob}
 '
 
@@ -56,21 +61,20 @@ test_expect_success 'flux-job: submitbench with nonexistent jobpsec fails' '
 
 test_expect_success 'flux-job: submitbench with bad broker connection fails' '
 	! FLUX_URI=/wrong flux job submitbench \
-	    --sign-type=none \
-	    ${JOBSPEC}/valid/basic.yaml
+	    --sign-type=none basic.json
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'flux-job: submitbench with bad security config fails' '
 	test_must_fail flux job submitbench \
 	    --sign-type=none \
             --security-config=/nonexist \
-	    ${JOBSPEC}/valid/basic.yaml
+	    basic.json
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'flux-job: submitbench with bad sign type fails' '
 	test_must_fail flux job submitbench \
 	    --sign-type=notvalid \
-	    ${JOBSPEC}/valid/basic.yaml
+	    basic.json
 '
 
 test_expect_success 'flux-job: id without from/to args is dec to dec' '


### PR DESCRIPTION
This is a #1809, updated
* to use PyYAML instead of ruamel.yaml (I _think_ this is what we decided)
* pass black formatting
* fix travis Dockerfile to restore apt/yum cache prior to installing python-yaml

Whether this is the right direction may be an open question - #1909 was opened to track that decision.

(I still might need a bit of help understanding the proper procedure for submitting a PR with new package dependencies - though this seems to have worked for getting the initial PR through travis).

