### PR TITLE
configure: enable maintainer-mode by default

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,6 +8,4 @@ echo "Running libtoolize --automake --copy ... "
 libtoolize --automake --copy || exit
 echo "Running autoreconf --verbose --install"
 autoreconf --verbose --install || exit
-echo "Moving aclocal.m4 to config/ ..."
-mv aclocal.m4 config/ || exit
 echo "Now run ./configure."

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ X_AC_EXPAND_INSTALL_DIRS
 AM_INIT_AUTOMAKE([subdir-objects tar-pax])
 AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER([config/config.h])
-AM_MAINTAINER_MODE
+AM_MAINTAINER_MODE([enable])
 
 AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])


### PR DESCRIPTION
Use of `AM_MAINTAINER_MODE` (which disables so-called maintainer-mode by default) has been discouraged for awhile, See 

https://www.gnu.org/software/automake/manual/html_node/maintainer_002dmode.html
https://autotools.io/automake/maintainer.html
https://blogs.gnome.org/desrt/2011/09/08/am_maintainer_mode-is-not-cool/

This also explains why flux-core wasn't suffering from the same issue as flux-sched, where configure was forced be rerun after `./autogen.sh && ./configure && make` -- it is because the maintainer-mode rules were disabled by default.

Add the `enable` option to `AM_MAINTAINER_MODE` as suggested by internet fiat, and fix the issue with `aclocal.m4` by removing the lines that move it into `config/` from `autogen.sh`