### PR TITLE
jobspec: add schema for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ python-devel	| python-dev		| >= 2.7		|
 python-cffi	| python-cffi		| >= 1.1		|
 python-six	| python-six		| >= 1.9		|
 python-yaml	| python-yaml		| >= 3.10.0		|
+python-jsonschema | python-jsonschema	| >= 2.3.0		|
 asciidoc	| asciidoc         	| 			| *2*
 asciidoctor	| asciidoctor         	| >= 1.5.7		| *2*
 aspell		| aspell		|			| *3*

--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,11 @@ AM_CHECK_PYMOD(yaml,
                ,
                [AC_MSG_ERROR([could not find python module yaml, version 3.10+ required])]
                )
+AM_CHECK_PYMOD(jsonschema,
+               [StrictVersion(jsonschema.__version__) >= StrictVersion ('2.3.0')],
+               ,
+               [AC_MSG_ERROR([could not find python module jsonschema, version 2.3.0+ required])]
+               )
 
 # Remove -L<path> from PYTHON_LDFLAGS if it is in a standard path
 # (e.g. /usr/lib64).  Placing a standard path earlier in the linker

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -77,16 +77,6 @@ fluxcmd_PROGRAMS = \
 	flux-job \
 	flux-exec
 
-if ENABLE_JOBSPEC
-fluxcmd_PROGRAMS += \
-	flux-jobspec-validate
-
-flux_jobspec_validate_SOURCES = flux-jobspec-validate.cpp
-flux_jobspec_validate_LDADD = \
-        $(top_builddir)/src/common/libjobspec/libjobspec.la \
-        $(YAMLCPP_LIBS)
-endif
-
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \
 	$(top_builddir)/src/common/libpmi/libpmi.la \

--- a/src/common/libjobspec/Makefile.am
+++ b/src/common/libjobspec/Makefile.am
@@ -7,4 +7,12 @@ libjobspec_la_CXXFLAGS = \
 	$(YAMLCPP_CFLAGS)
 libjobspec_la_LIBADD = $(CODE_COVERAGE_LIBS) $(YAMLCPP_LIBS)
 libjobspec_la_SOURCES = jobspec.cpp jobspec.hpp
+
+check_PROGRAMS = test_validate
+
+test_validate_SOURCES = test/validate.cpp
+test_validate_LDADD = \
+	$(builddir)/libjobspec.la \
+	$(YAMLCPP_LIBS)
+
 endif

--- a/src/common/libjobspec/test/validate.cpp
+++ b/src/common/libjobspec/test/validate.cpp
@@ -12,7 +12,7 @@
 #include <fstream>
 #include <string>
 
-#include <flux/jobspec.hpp>
+#include "jobspec.hpp"
 #include <yaml-cpp/yaml.h>
 
 using namespace std;

--- a/src/test/docker/bionic-base/Dockerfile
+++ b/src/test/docker/bionic-base/Dockerfile
@@ -45,10 +45,12 @@ RUN apt-get -qq install -y --no-install-recommends \
         python-cffi \
         python-six \
 	python-yaml \
+	python-jsonschema \
         python3-dev \
         python3-cffi \
         python3-six \
-	python3-yaml
+	python3-yaml \
+	python3-jsonschema
 
 # Other deps
 RUN apt-get -qq install -y --no-install-recommends \

--- a/src/test/docker/centos7-base/Dockerfile
+++ b/src/test/docker/centos7-base/Dockerfile
@@ -44,10 +44,12 @@ RUN yum -y update \
       python-cffi \
       python-six \
       python-yaml \
+      python-jsonschema \
       python34-devel \
       python34-cffi \
       python34-six \
       python34-yaml \
+      python34-jsonschema \
       ruby \
       sqlite \
       yaml-cpp-devel \

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -48,8 +48,8 @@ RUN case $BASE_IMAGE in \
 
 # Add some packages for testing
 RUN case $BASE_IMAGE in \
-     bionic*) apt update && apt-get -qq install -y --no-install-recommends python-yaml python3-yaml ;; \
-     centos*) yum -y update && yum -y install python-yaml python34-yaml ;; \
+     bionic*) apt update && apt-get -qq install -y --no-install-recommends python-yaml python3-yaml python-jsonschema python3-jsonschema ;; \
+     centos*) yum -y update && yum -y install python-yaml python34-yaml python-jsonschema python34-jsonschema;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -59,6 +59,7 @@ TESTS = \
 	t0015-cron.t \
 	t0016-cron-faketime.t \
 	t0017-security.t \
+	t0019-jobspec-schema.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1002-kvs-watch.t \
@@ -175,6 +176,7 @@ check_SCRIPTS = \
 	t0015-cron.t \
 	t0016-cron-faketime.t \
 	t0017-security.t \
+	t0019-jobspec-schema.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1002-kvs-watch.t \

--- a/t/jobspec/schema.json
+++ b/t/jobspec/schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_14/schema.json",
+  "title": "jobspec-01",
+
+  "description":         "Flux jobspec version 1",
+
+  "definitions": {
+    "complex_range": {
+      "description": "a complex range of numbers",
+      "type": "object",
+      "required":["min", "max", "operator", "operand"],
+      "properties":{
+        "min": { "type": "integer", "minimum" : 1 },
+        "max": { "type": "integer", "minimum" : 1 },
+        "operator": { "type": "string", "enum": ["+", "*", "^"] },
+        "operand": { "type": "integer", "minimum" : 1 }
+      },
+      "additionalProperties": false
+
+    },
+    "resource_vertex_base": {
+      "description": "base schema for slot/other resource vertex",
+      "type": "object",
+      "required": ["type", "count"],
+      "properties": {
+        "type": { "type": "string" },
+        "count": {
+          "oneOf": [
+            { "type": "integer", "minimum" : 1 },
+            { "$ref": "#/definitions/complex_range" }
+          ]
+        },
+        "exclusive": { "type": "boolean" },
+        "with": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/resource_vertex" }
+        },
+        "id": { "type": "string" },
+        "unit": { "type": "string" },
+        "label": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "resource_vertex_slot": {
+      "description": "special slot resource type - label assigns to task slot",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "enum": ["slot"] }
+          },
+          "required": ["label"]
+        }
+      ]
+    },
+    "resource_vertex_other": {
+      "description": "other (non-slot) resource type",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "not": { "enum": ["slot"] } }
+          }
+        }
+      ]
+    },
+    "resource_vertex": {
+      "oneOf":[
+        { "$ref": "#/definitions/resource_vertex_slot" },
+        { "$ref": "#/definitions/resource_vertex_other" }
+      ]
+    }
+  },
+
+  "type": "object",
+  "required": ["version", "resources", "attributes", "tasks"],
+  "properties": {
+    "version": {
+      "description": "the jobspec version",
+      "type": "integer",
+      "enum": [1]
+    },
+    "resources": {
+      "description": "requested resources",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/resource_vertex" }
+    },
+    "attributes": {
+      "description": "system and user attributes",
+      "type": ["object", "null"],
+      "properties": {
+        "system": {
+          "type": "object",
+          "properties": {
+            "duration": { "type": "string" }
+          },
+          "additonalProperties": { "type": "string" }
+        },
+        "user": {
+          "type": "object",
+          "additonalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "tasks": {
+      "description": "task configuration",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["command", "slot", "count" ],
+        "properties": {
+          "command": {
+            "type": ["string", "array"],
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "slot": { "type": "string" },
+          "count": {
+            "type": "object",
+            "properties": {
+              "per_slot": { "type": "integer", "minimum" : 1 },
+              "total": { "type": "integer", "minimum" : 1 }
+            }
+          },
+          "distribution": { "type": "string" },
+          "attributes": {
+            "type": "object",
+	    "additionalProperties": { "type": "string" }
+          }
+        },
+	"additionalProperties": false
+      }
+    }
+  }
+}

--- a/t/jobspec/validate.py
+++ b/t/jobspec/validate.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# Usage: validate.py --schema=jobspec.json data.json [data.json ...]
+
+import sys
+import argparse
+import json
+import yaml
+import jsonschema
+
+
+def validate_input(filename, schema):
+    f = open(filename)
+    data = yaml.safe_load(f)
+    jsonschema.validate(data, schema)
+
+
+# parse command line args
+parser = argparse.ArgumentParser()
+parser.add_argument("--schema", "-s", type=str, required=True)
+args, unknown = parser.parse_known_args()
+
+# Parse json-schema file (JSON format)
+try:
+    schema = json.load(open(args.schema))
+except (OSError, IOError) as e:
+    sys.exit(args.schema + ": " + e.strerror)
+except:
+    sys.exit(args.schema + ": unknown error")
+
+# Validate each file on command line
+errors = 0
+for infile in unknown:
+    try:
+        validate_input(infile, schema)
+    except (OSError, IOError) as e:
+        print(infile + ": " + e.strerror)
+        errors = errors + 1
+    except (yaml.YAMLError) as e:
+        print(infile + ": " + e.problem)
+        errors = errors + 1
+    except (Exception) as e:
+        print(infile + ": " + e.message)
+        errors = errors + 1
+    except:
+        print(infile + ": unknown error")
+        errors = errors + 1
+    else:
+        print(infile + ": ok")
+
+sys.exit(errors)

--- a/t/t0018-jobspec.t
+++ b/t/t0018-jobspec.t
@@ -4,18 +4,19 @@ test_description='Test the jobspec parsing library'
 
 . `dirname $0`/sharness.sh
 
+JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 validate="${FLUX_BUILD_DIR}/src/common/libjobspec/test_validate"
 
 # Check that the valid jobspecs all pass
-for jobspec in ${FLUX_SOURCE_DIR}/t/jobspec/valid/*.yaml; do
+for jobspec in ${JOBSPEC}/valid/*.yaml; do
     testname=`basename $jobspec`
-    test_expect_success $testname "$validate $jobspec"
+    test_expect_success 'valid: '$testname "$validate $jobspec"
 done
 
 # Check that the invalid jobspec all fail
-for jobspec in ${FLUX_SOURCE_DIR}/t/jobspec/invalid/*.yaml; do
+for jobspec in ${JOBSPEC}/invalid/*.yaml; do
     testname=`basename $jobspec`
-    test_expect_success $testname "test_must_fail $validate $jobspec"
+    test_expect_success 'error: '$testname "test_must_fail $validate $jobspec"
 done
 
 test_done

--- a/t/t0018-jobspec.t
+++ b/t/t0018-jobspec.t
@@ -4,7 +4,7 @@ test_description='Test the jobspec parsing library'
 
 . `dirname $0`/sharness.sh
 
-validate="${FLUX_BUILD_DIR}/src/cmd/flux-jobspec-validate"
+validate="${FLUX_BUILD_DIR}/src/common/libjobspec/test_validate"
 
 # Check that the valid jobspecs all pass
 for jobspec in ${FLUX_SOURCE_DIR}/t/jobspec/valid/*.yaml; do

--- a/t/t0019-jobspec-schema.t
+++ b/t/t0019-jobspec-schema.t
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+test_description='Test the jobspec schema validation'
+
+. `dirname $0`/sharness.sh
+
+JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+VALIDATE=${JOBSPEC}/validate.py
+SCHEMA=${JOBSPEC}/schema.json
+
+validate() {
+   ${VALIDATE} --schema ${SCHEMA} $1
+}
+
+# Check that the valid jobspecs all pass
+for jobspec in ${JOBSPEC}/valid/*.yaml; do
+    testname=`basename $jobspec`
+    test_expect_success 'valid: '$testname "validate $jobspec"
+done
+
+# Check that the invalid jobspec all fail
+for jobspec in ${JOBSPEC}/invalid/*.yaml; do
+    testname=`basename $jobspec`
+    test_expect_success 'error: '$testname "test_must_fail validate $jobspec"
+done
+
+test_done


### PR DESCRIPTION
This PR adds a [json-schema](https://json-schema.org/) schema for jobspec and a python script for validation based [python-jsonschema](https://github.com/Julian/jsonschema).  It might form the basis for a future ingest validation plugin, as described in #1908.  The schema and test script are exercised by a new sharness test, using the test jobspec in `t/jobspec`.

Walking through the explicit checks in libjobspec, validation by this schema is is on a par with the explicit checks there, as they exist now.  I did find one check that seemed inexpressible in the schema - the test for `max < min` in the non-scalar count.  This limitation of json-schema was discussed at length in json-schema-org/json-schema-spec#51.

Other things that seemingly ought to be caught in validation, but aren't currently checked by libjobspec, would be inexpressible in json-schema.  For example, as far as I understand, the schema cannot ensure that a task `slot` references a valid resource label.

This PR includes a little bit of cleanup of the existing jobspec sharness test, including turning `flux-jobspec-validate` into an uninstalled `check_PROGRAM`.

The new dependency on `python-jsonschema` creates a build problem on our TOSS systems.  I will open a jira ticket to ask Trent to pull it in from EPEL in the next release.