### PR TITLE
Add flux job submit plumbing command, load new job modules in rc1

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -18,6 +18,9 @@ flux module load -r 0 userdb ${FLUX_USERDB_OPTIONS}
 # make flux wreckrun/submit -onokz the default (override w/ -o kz):
 flux wreck setopt nokz
 
+flux module load -r all job-ingest
+flux module load -r 0 job-manager
+
 wait $pids
 
 core_dir=$(cd ${0%/*} && pwd -P)

--- a/etc/rc3
+++ b/etc/rc3
@@ -12,6 +12,9 @@ for rcdir in $all_dirs; do
 done
 shopt -u nullglob
 
+flux module remove -r 0 job-manager
+flux module remove -r all job-ingest
+
 if PERSISTDIR=$(flux getattr persist-directory 2>/dev/null); then
     flux wreck ls >${PERSISTDIR}/joblog 2>/dev/null || :
 fi

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* "plumbing" commands (see git(1)) for Flux job management */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -19,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <assert.h>
 #include <jansson.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
@@ -31,7 +34,7 @@
 #include "src/common/libutil/read_all.h"
 
 int cmd_list (optparse_t *p, int argc, char **argv);
-int cmd_submitbench (optparse_t *p, int argc, char **argv);
+int cmd_submit (optparse_t *p, int argc, char **argv);
 int cmd_id (optparse_t *p, int argc, char **argv);
 int cmd_purge (optparse_t *p, int argc, char **argv);
 int cmd_priority (optparse_t *p, int argc, char **argv);
@@ -50,20 +53,11 @@ static struct optparse_option list_opts[] =  {
     OPTPARSE_TABLE_END
 };
 
-static struct optparse_option submitbench_opts[] =  {
-    { .name = "repeat", .key = 'r', .has_arg = 1, .arginfo = "N",
-      .usage = "Run N instances of jobspec",
-    },
-    { .name = "fanout", .key = 'f', .has_arg = 1, .arginfo = "N",
-      .usage = "Run at most N RPCs in parallel",
-    },
+static struct optparse_option submit_opts[] =  {
     { .name = "priority", .key = 'p', .has_arg = 1, .arginfo = "N",
       .usage = "Set job priority (0-31, default=16)",
     },
 #if HAVE_FLUX_SECURITY
-    { .name = "reuse-signature", .key = 'R', .has_arg = 0,
-      .usage = "Sign jobspec once and reuse the result for multiple RPCs",
-    },
     { .name = "security-config", .key = 'c', .has_arg = 1, .arginfo = "pattern",
       .usage = "Use non-default security config glob",
     },
@@ -108,12 +102,12 @@ static struct optparse_subcommand subcommands[] = {
       0,
       NULL,
     },
-    { "submitbench",
-      "[OPTIONS] jobspec",
-      "Run job(s)",
-      cmd_submitbench,
+    { "submit",
+      "[OPTIONS] [jobspec]",
+      "Run job",
+      cmd_submit,
       0,
-      submitbench_opts
+      submit_opts
     },
     { "id",
       "[OPTIONS] [id ...]",
@@ -342,27 +336,6 @@ int cmd_list (optparse_t *p, int argc, char **argv)
    return (0);
 }
 
-struct submitbench_ctx {
-    flux_t *h;
-#if HAVE_FLUX_SECURITY
-    flux_security_t *sec;
-    const char *sign_type;
-#endif
-    int flags;
-    flux_watcher_t *prep;
-    flux_watcher_t *check;
-    flux_watcher_t *idle;
-    int txcount;
-    int rxcount;
-    int totcount;
-    int max_queue_depth;
-    optparse_t *p;
-    void *jobspec;
-    int jobspecsz;
-    const char *J;
-    int priority;
-};
-
 /* Read entire file 'name' ("-" for stdin).  Exit program on error.
  */
 size_t read_jobspec (const char *name, void **bufp)
@@ -385,16 +358,60 @@ size_t read_jobspec (const char *name, void **bufp)
     return size;
 }
 
-/* handle RPC response
- * Once all responses are received, stop prep/check watchers
- * so reactor will stop.
- */
-void submitbench_continuation (flux_future_t *f, void *arg)
+int cmd_submit (optparse_t *p, int argc, char **argv)
 {
-    struct submitbench_ctx *ctx = arg;
+    flux_t *h;
+#if HAVE_FLUX_SECURITY
+    flux_security_t *sec = NULL;
+    const char *sec_config;
+    const char *sign_type;
+#endif
+    int flags = 0;
+    void *jobspec;
+    int jobspecsz;
+    const char *J = NULL;
+    int priority;
+    int optindex = optparse_option_index (p);
+    flux_future_t *f;
     flux_jobid_t id;
     const char *errmsg;
+    const char *input = "-";
 
+    if (optindex != argc - 1 && optindex != argc) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (optindex < argc)
+        input = argv[optindex++];
+#if HAVE_FLUX_SECURITY
+    /* If any non-default security options are specified, create security
+     * context so jobspec can be pre-signed before submission.
+     */
+    if (optparse_hasopt (p, "security-config")
+                            || optparse_hasopt (p, "sign-type")) {
+        sec_config = optparse_get_str (p, "security-config", NULL);
+        if (!(sec = flux_security_create (0)))
+            log_err_exit ("security");
+        if (flux_security_configure (sec, sec_config) < 0)
+            log_err_exit ("security config %s", flux_security_last_error (sec));
+        sign_type = optparse_get_str (p, "sign-type", NULL);
+    }
+#endif
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    jobspecsz = read_jobspec (input, &jobspec);
+    assert (((char *)jobspec)[jobspecsz] == '\0');
+    priority = optparse_get_int (p, "priority", FLUX_JOB_PRIORITY_DEFAULT);
+
+#if HAVE_FLUX_SECURITY
+    if (sec) {
+        if (!(J = flux_sign_wrap (sec, jobspec, jobspecsz, sign_type, 0)))
+            log_err_exit ("flux_sign_wrap: %s", flux_security_last_error (sec));
+        flags |= FLUX_JOB_PRE_SIGNED;
+    }
+#endif
+    if (!(f = flux_job_submit (h, J ? J : jobspec, priority, flags)))
+        log_err_exit ("flux_job_submit");
     if (flux_job_submit_get_id (f, &id) < 0) {
         if ((errmsg = flux_future_error_string (f)))
             log_msg_exit ("submit: %s", errmsg);
@@ -405,116 +422,11 @@ void submitbench_continuation (flux_future_t *f, void *arg)
     }
     printf ("%llu\n", (unsigned long long)id);
     flux_future_destroy (f);
-
-    ctx->rxcount++;
-}
-
-/* prep - called before event loop would block
- * Prevent loop from blocking if 'check' could send RPCs.
- * Stop the prep/check watchers if RPCs have all been sent,
- * so that, once responses are received, the reactor will exit naturally.
- */
-void submitbench_prep (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
-{
-    struct submitbench_ctx *ctx = arg;
-
-    if (ctx->txcount == ctx->totcount) {
-        flux_watcher_stop (ctx->prep);
-        flux_watcher_stop (ctx->check);
-    }
-    else if ((ctx->txcount - ctx->rxcount) < ctx->max_queue_depth)
-        flux_watcher_start (ctx->idle); // keeps loop from blocking
-}
-
-/* check - called after event loop unblocks
- * If there are RPCs to send, send one.
- */
-void submitbench_check (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
-{
-    struct submitbench_ctx *ctx = arg;
-    int flags = ctx->flags;
-
-    flux_watcher_stop (ctx->idle);
-    if (ctx->txcount < ctx->totcount
-                    && (ctx->txcount - ctx->rxcount) < ctx->max_queue_depth) {
-        flux_future_t *f;
 #if HAVE_FLUX_SECURITY
-        if (ctx->sec) {
-            if (!ctx->J || !optparse_hasopt (ctx->p, "reuse-signature")) {
-                if (!(ctx->J = flux_sign_wrap (ctx->sec, ctx->jobspec,
-                                               ctx->jobspecsz,
-                                               ctx->sign_type, 0)))
-                    log_err_exit ("flux_sign_wrap: %s",
-                                  flux_security_last_error (ctx->sec));
-            }
-            flags |= FLUX_JOB_PRE_SIGNED;
-        }
+    flux_security_destroy (sec); // invalidates J
 #endif
-        if (!(f = flux_job_submit (ctx->h, ctx->J ? ctx->J : ctx->jobspec,
-                                   ctx->priority, flags)))
-            log_err_exit ("flux_job_submit");
-        if (flux_future_then (f, -1., submitbench_continuation, ctx) < 0)
-            log_err_exit ("flux_future_then");
-        ctx->txcount++;
-    }
-}
-
-int cmd_submitbench (optparse_t *p, int argc, char **argv)
-{
-    flux_reactor_t *r;
-    int optindex = optparse_option_index (p);
-    struct submitbench_ctx ctx;
-
-    memset (&ctx, 0, sizeof (ctx));
-
-    if (optindex != argc - 1) {
-        optparse_print_usage (p);
-        exit (1);
-    }
-#if HAVE_FLUX_SECURITY
-    /* If any non-default security options are specified, create security
-     * context so jobspec can be pre-signed before submission.
-     */
-    if (optparse_hasopt (p, "security-config")
-                            || optparse_hasopt (p, "reuse-signature")
-                            || optparse_hasopt (p, "sign-type")) {
-        const char *sec_config = optparse_get_str (p, "security-config", NULL);
-        if (!(ctx.sec = flux_security_create (0)))
-            log_err_exit ("security");
-        if (flux_security_configure (ctx.sec, sec_config) < 0)
-            log_err_exit ("security config %s", flux_security_last_error (ctx.sec));
-        ctx.sign_type = optparse_get_str (p, "sign-type", NULL);
-    }
-#endif
-    if (!(ctx.h = flux_open (NULL, 0)))
-        log_err_exit ("flux_open");
-    r = flux_get_reactor (ctx.h);
-    ctx.p = p;
-    ctx.max_queue_depth = optparse_get_int (p, "fanout", 256);
-    ctx.totcount = optparse_get_int (p, "repeat", 1);
-    ctx.jobspecsz = read_jobspec (argv[optindex++], &ctx.jobspec);
-    ctx.priority = optparse_get_int (p, "priority", FLUX_JOB_PRIORITY_DEFAULT);
-
-    /* Prep/check/idle watchers perform flow control, keeping
-     * at most ctx.max_queue_depth RPCs outstanding.
-     */
-    ctx.prep = flux_prepare_watcher_create (r, submitbench_prep, &ctx);
-    ctx.check = flux_check_watcher_create (r, submitbench_check, &ctx);
-    ctx.idle = flux_idle_watcher_create (r, NULL, NULL);
-    if (!ctx.prep || !ctx.check || !ctx.idle)
-        log_err_exit ("flux_watcher_create");
-    flux_watcher_start (ctx.prep);
-    flux_watcher_start (ctx.check);
-
-    if (flux_reactor_run (r, 0) < 0)
-        log_err_exit ("flux_reactor_run");
-#if HAVE_FLUX_SECURITY
-    flux_security_destroy (ctx.sec); // invalidates ctx.J
-#endif
-    flux_close (ctx.h);
-    free (ctx.jobspec);
+    flux_close (h);
+    free (jobspec);
     return 0;
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -275,7 +275,8 @@ check_PROGRAMS = \
 	reactor/reactorcat \
 	rexec/rexec \
 	rexec/rexec_signal \
-	rexec/rexec_ps
+	rexec/rexec_ps \
+	ingest/submitbench
 
 check_LTLIBRARIES = \
 	module/parent.la \
@@ -485,3 +486,8 @@ ingest_job_manager_dummy_la_CPPFLAGS = $(test_cppflags)
 ingest_job_manager_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
 ingest_job_manager_dummy_la_LIBADD = \
         $(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+ingest_submitbench_SOURCES = ingest/submitbench.c
+ingest_submitbench_CPPFLAGS = $(test_cppflags)
+ingest_submitbench_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)

--- a/t/ingest/submitbench.c
+++ b/t/ingest/submitbench.c
@@ -1,0 +1,262 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/optparse.h>
+#if HAVE_FLUX_SECURITY
+#include <flux/security/sign.h>
+#endif
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/fluid.h"
+#include "src/common/libjob/job.h"
+#include "src/common/libutil/read_all.h"
+
+int cmd_submitbench (optparse_t *p, int argc, char **argv);
+
+const char *usage_msg = "[OPTIONS] jobspec";
+static struct optparse_option opts[] =  {
+    { .name = "repeat", .key = 'r', .has_arg = 1, .arginfo = "N",
+      .usage = "Run N instances of jobspec",
+    },
+    { .name = "fanout", .key = 'f', .has_arg = 1, .arginfo = "N",
+      .usage = "Run at most N RPCs in parallel",
+    },
+    { .name = "priority", .key = 'p', .has_arg = 1, .arginfo = "N",
+      .usage = "Set job priority (0-31, default=16)",
+    },
+#if HAVE_FLUX_SECURITY
+    { .name = "reuse-signature", .key = 'R', .has_arg = 0,
+      .usage = "Sign jobspec once and reuse the result for multiple RPCs",
+    },
+    { .name = "security-config", .key = 'c', .has_arg = 1, .arginfo = "pattern",
+      .usage = "Use non-default security config glob",
+    },
+    { .name = "sign-type", .key = 's', .has_arg = 1, .arginfo = "TYPE",
+      .usage = "Use non-default mechanism type to sign J",
+    },
+#endif
+    OPTPARSE_TABLE_END
+};
+
+int main (int argc, char *argv[])
+{
+    optparse_t *p;
+    int exitval;
+
+    log_init ("submitbench");
+
+    p = optparse_create ("submitbench");
+
+    if (optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_option_table() failed");
+    if (optparse_set (p, OPTPARSE_USAGE, usage_msg) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_set (USAGE)");
+    if (optparse_parse_args (p, argc, argv) < 0)
+        log_msg_exit ("optprase_parse_args");
+
+    exitval = cmd_submitbench (p, argc, argv);
+
+    optparse_destroy (p);
+    log_fini ();
+    return (exitval);
+}
+
+struct submitbench_ctx {
+    flux_t *h;
+#if HAVE_FLUX_SECURITY
+    flux_security_t *sec;
+    const char *sign_type;
+#endif
+    int flags;
+    flux_watcher_t *prep;
+    flux_watcher_t *check;
+    flux_watcher_t *idle;
+    int txcount;
+    int rxcount;
+    int totcount;
+    int max_queue_depth;
+    optparse_t *p;
+    void *jobspec;
+    int jobspecsz;
+    const char *J;
+    int priority;
+};
+
+/* Read entire file 'name' ("-" for stdin).  Exit program on error.
+ */
+size_t read_jobspec (const char *name, void **bufp)
+{
+    int fd;
+    ssize_t size;
+    void *buf;
+
+    if (!strcmp (name, "-"))
+        fd = STDIN_FILENO;
+    else {
+        if ((fd = open (name, O_RDONLY)) < 0)
+            log_err_exit ("%s", name);
+    }
+    if ((size = read_all (fd, &buf)) < 0)
+        log_err_exit ("%s", name);
+    if (fd != STDIN_FILENO)
+        (void)close (fd);
+    *bufp = buf;
+    return size;
+}
+
+/* handle RPC response
+ * Once all responses are received, stop prep/check watchers
+ * so reactor will stop.
+ */
+void submitbench_continuation (flux_future_t *f, void *arg)
+{
+    struct submitbench_ctx *ctx = arg;
+    flux_jobid_t id;
+    const char *errmsg;
+
+    if (flux_job_submit_get_id (f, &id) < 0) {
+        if ((errmsg = flux_future_error_string (f)))
+            log_msg_exit ("submit: %s", errmsg);
+        else if (errno == ENOSYS)
+            log_msg_exit ("submit: job-ingest module is not loaded");
+        else
+            log_err_exit ("submit");
+    }
+    printf ("%llu\n", (unsigned long long)id);
+    flux_future_destroy (f);
+
+    ctx->rxcount++;
+}
+
+/* prep - called before event loop would block
+ * Prevent loop from blocking if 'check' could send RPCs.
+ * Stop the prep/check watchers if RPCs have all been sent,
+ * so that, once responses are received, the reactor will exit naturally.
+ */
+void submitbench_prep (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    struct submitbench_ctx *ctx = arg;
+
+    if (ctx->txcount == ctx->totcount) {
+        flux_watcher_stop (ctx->prep);
+        flux_watcher_stop (ctx->check);
+    }
+    else if ((ctx->txcount - ctx->rxcount) < ctx->max_queue_depth)
+        flux_watcher_start (ctx->idle); // keeps loop from blocking
+}
+
+/* check - called after event loop unblocks
+ * If there are RPCs to send, send one.
+ */
+void submitbench_check (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    struct submitbench_ctx *ctx = arg;
+    int flags = ctx->flags;
+
+    flux_watcher_stop (ctx->idle);
+    if (ctx->txcount < ctx->totcount
+                    && (ctx->txcount - ctx->rxcount) < ctx->max_queue_depth) {
+        flux_future_t *f;
+#if HAVE_FLUX_SECURITY
+        if (ctx->sec) {
+            if (!ctx->J || !optparse_hasopt (ctx->p, "reuse-signature")) {
+                if (!(ctx->J = flux_sign_wrap (ctx->sec, ctx->jobspec,
+                                               ctx->jobspecsz,
+                                               ctx->sign_type, 0)))
+                    log_err_exit ("flux_sign_wrap: %s",
+                                  flux_security_last_error (ctx->sec));
+            }
+            flags |= FLUX_JOB_PRE_SIGNED;
+        }
+#endif
+        if (!(f = flux_job_submit (ctx->h, ctx->J ? ctx->J : ctx->jobspec,
+                                   ctx->priority, flags)))
+            log_err_exit ("flux_job_submit");
+        if (flux_future_then (f, -1., submitbench_continuation, ctx) < 0)
+            log_err_exit ("flux_future_then");
+        ctx->txcount++;
+    }
+}
+
+int cmd_submitbench (optparse_t *p, int argc, char **argv)
+{
+    flux_reactor_t *r;
+    int optindex = optparse_option_index (p);
+    struct submitbench_ctx ctx;
+
+    memset (&ctx, 0, sizeof (ctx));
+
+    if (optindex != argc - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+#if HAVE_FLUX_SECURITY
+    /* If any non-default security options are specified, create security
+     * context so jobspec can be pre-signed before submission.
+     */
+    if (optparse_hasopt (p, "security-config")
+                            || optparse_hasopt (p, "reuse-signature")
+                            || optparse_hasopt (p, "sign-type")) {
+        const char *sec_config = optparse_get_str (p, "security-config", NULL);
+        if (!(ctx.sec = flux_security_create (0)))
+            log_err_exit ("security");
+        if (flux_security_configure (ctx.sec, sec_config) < 0)
+            log_err_exit ("security config %s", flux_security_last_error (ctx.sec));
+        ctx.sign_type = optparse_get_str (p, "sign-type", NULL);
+    }
+#endif
+    if (!(ctx.h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    r = flux_get_reactor (ctx.h);
+    ctx.p = p;
+    ctx.max_queue_depth = optparse_get_int (p, "fanout", 256);
+    ctx.totcount = optparse_get_int (p, "repeat", 1);
+    ctx.jobspecsz = read_jobspec (argv[optindex++], &ctx.jobspec);
+    ctx.priority = optparse_get_int (p, "priority", FLUX_JOB_PRIORITY_DEFAULT);
+
+    /* Prep/check/idle watchers perform flow control, keeping
+     * at most ctx.max_queue_depth RPCs outstanding.
+     */
+    ctx.prep = flux_prepare_watcher_create (r, submitbench_prep, &ctx);
+    ctx.check = flux_check_watcher_create (r, submitbench_check, &ctx);
+    ctx.idle = flux_idle_watcher_create (r, NULL, NULL);
+    if (!ctx.prep || !ctx.check || !ctx.idle)
+        log_err_exit ("flux_watcher_create");
+    flux_watcher_start (ctx.prep);
+    flux_watcher_start (ctx.check);
+
+    if (flux_reactor_run (r, 0) < 0)
+        log_err_exit ("flux_reactor_run");
+#if HAVE_FLUX_SECURITY
+    flux_security_destroy (ctx.sec); // invalidates ctx.J
+#endif
+    flux_close (ctx.h);
+    free (ctx.jobspec);
+    return 0;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -7,7 +7,7 @@ test_description='Test flux job ingest service'
 if test "$TEST_LONG" = "t"; then
     test_set_prereq LONGTEST
 fi
-if test -x ${FLUX_BUILD_DIR}/src/cmd/flux-jobspec-validate; then
+if test -x ${FLUX_BUILD_DIR}/src/common/libjobspec/test_validate; then
     test_set_prereq ENABLE_JOBSPEC
 fi
 if flux job submitbench --help 2>&1 | grep -q sign-type; then

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -10,10 +10,9 @@ fi
 if test -x ${FLUX_BUILD_DIR}/src/common/libjobspec/test_validate; then
     test_set_prereq ENABLE_JOBSPEC
 fi
-if flux job submitbench --help 2>&1 | grep -q sign-type; then
+if ${FLUX_BUILD_DIR}/t/ingest/submitbench --help 2>&1 | grep -q sign-type; then
     test_set_prereq HAVE_FLUX_SECURITY
     SUBMITBENCH_OPT_R="--reuse-signature"
-    SUBMITBENCH_OPT_NONE="--sign-type=none"
 fi
 
 test_under_flux 4 kvs
@@ -22,7 +21,7 @@ flux setattr log-stderr-level 1
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 Y2J=${JOBSPEC}/y2j.py
-SUBMITBENCH="flux job submitbench $SUBMITBENCH_OPT_NONE"
+SUBMITBENCH="${FLUX_BUILD_DIR}/t/ingest/submitbench"
 
 DUMMY_EVENTLOG=test.ingest.eventlog
 
@@ -53,7 +52,7 @@ test_expect_success 'job-ingest: convert use_case_2.6.yaml to json' '
 '
 
 test_expect_success 'job-ingest: submit fails without job-ingest' '
-	test_must_fail ${SUBMITBENCH} basic.json 2>nosys.out
+	test_must_fail flux job submit basic.json 2>nosys.out
 '
 
 test_expect_success 'job-ingest: load job-ingest' '
@@ -61,7 +60,7 @@ test_expect_success 'job-ingest: load job-ingest' '
 '
 
 test_expect_success 'job-ingest: submit fails without job-manager' '
-	test_must_fail ${SUBMITBENCH} basic.json 2>nosys.out
+	test_must_fail flux job submit basic.json 2>nosys.out
 '
 
 test_expect_success 'job-ingest: load job-manager-dummy module' '
@@ -69,16 +68,12 @@ test_expect_success 'job-ingest: load job-manager-dummy module' '
 		${FLUX_BUILD_DIR}/t/ingest/.libs/job-manager-dummy.so
 '
 
-test_expect_success 'job-ingest: can submit jobspec on stdin' '
-	cat basic.json | ${SUBMITBENCH} -
-'
-
 test_expect_success 'job-ingest: YAML jobspec is rejected' '
-	test_must_fail ${SUBMITBENCH} ${JOBSPEC}/valid/basic.yaml
+	test_must_fail flux job submit ${JOBSPEC}/valid/basic.yaml
 '
 
 test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
-	jobid=$(${SUBMITBENCH} basic.json) &&
+	jobid=$(flux job submit basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	flux kvs get --raw ${kvsdir}.jobspec >jobspec.out &&
 	test_cmp basic.json jobspec.out
@@ -86,14 +81,14 @@ test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 
 test_expect_success 'job-ingest: submitter userid stored in KVS' '
 	myuserid=$(id -u) &&
-	jobid=$(${SUBMITBENCH} basic.json) &&
+	jobid=$(flux job submit basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobuserid=$(flux kvs get --json ${kvsdir}.userid) &&
 	test $jobuserid -eq $myuserid
 '
 
 test_expect_success 'job-ingest: job announced to job manager' '
-	jobid=$(${SUBMITBENCH} --priority=10 basic.json) &&
+	jobid=$(flux job submit --priority=10 basic.json) &&
 	flux kvs eventlog get ${DUMMY_EVENTLOG} \
 		| grep "id=${jobid}" >jobman.out &&
 	grep -q priority=10 jobman.out &&
@@ -101,32 +96,32 @@ test_expect_success 'job-ingest: job announced to job manager' '
 '
 
 test_expect_success 'job-ingest: priority stored in KVS' '
-	jobid=$(${SUBMITBENCH} basic.json) &&
+	jobid=$(flux job submit basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
 	test $jobpri -eq 16
 '
 
 test_expect_success 'job-ingest: eventlog stored in KVS' '
-	jobid=$(${SUBMITBENCH} basic.json) &&
+	jobid=$(flux job submit basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	flux kvs eventlog get ${kvsdir}.eventlog | grep submit
 '
 
 test_expect_success 'job-ingest: instance owner can submit priority=31' '
-	jobid=$(${SUBMITBENCH} --priority=31 basic.json) &&
+	jobid=$(flux job submit --priority=31 basic.json) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	jobpri=$(flux kvs get --json ${kvsdir}.priority) &&
 	test $jobpri -eq 31
 '
 
 test_expect_success 'job-ingest: priority range is enforced' '
-	test_must_fail ${SUBMITBENCH} --priority=32 basic.json &&
-	test_must_fail ${SUBMITBENCH} --priority="-1" basic.json
+	test_must_fail flux job submit --priority=32 basic.json &&
+	test_must_fail flux job submit --priority="-1" basic.json
 '
 
 test_expect_success 'job-ingest: guest cannot submit priority=17' '
-	! FLUX_HANDLE_ROLEMASK=0x2 ${SUBMITBENCH} --priority=17 basic.json
+	! FLUX_HANDLE_ROLEMASK=0x2 flux job submit --priority=17 basic.json
 '
 
 test_expect_success 'job-ingest: valid jobspecs accepted' '
@@ -146,12 +141,13 @@ test_expect_success 'job-ingest: submit job 100 times, reuse signature' '
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'job-ingest: submit user != signed user fails' '
-	! FLUX_HANDLE_USERID=9999 ${SUBMITBENCH} basic.json 2>baduser.out &&
+	! FLUX_HANDLE_USERID=9999 flux job submit basic.json 2>baduser.out &&
 	grep -q "signer=$(id -u) != requestor=9999" baduser.out
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'job-ingest: non-owner mech=none fails' '
-	! FLUX_HANDLE_ROLEMASK=0x2 ${SUBMITBENCH} basic.json 2>badrole.out &&
+	! FLUX_HANDLE_ROLEMASK=0x2 flux job submit \
+		--sign-type=none basic.json 2>badrole.out &&
 	grep -q "only instance owner" badrole.out
 '
 


### PR DESCRIPTION
This PR moves `flux job submitbench` to a standalone, noinst test program, and replaces it with `flux job submit` a "plumbing" command that submits JSON jobspec.

Sharness tests are updated to use one of the two job submission interfaces.

In addition, sharness tests that formerly forced the "none" security mechanism when configured `--with-flux-security` no longer do that, now that munge is being started in our travis docker images.

To make it easier to work with the new `job-ingest` and `job-manager` modules, add them to rc1/rc3 so that they are automatically loaded/unloaded.

Finally, fix a bug introduced in #1913, which moved the C++ jobspec validator without updating its path in code that checks for its existence used as evidence that `job-ingest` should be expected to reject invalid jobspec.
