### PR TITLE
Jobspec emission script

### DIFF
--- a/t/jobspec/emit-jobspec.py
+++ b/t/jobspec/emit-jobspec.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import sys
+import argparse
+import json
+from collections import Sequence
+
+
+def create_resource(res_type, count, with_child=[]):
+    assert isinstance(with_child, Sequence)
+    assert not isinstance(with_child, str)
+    assert count > 0
+
+    res = {"type": res_type, "count": count}
+
+    if len(with_child) > 0:
+        res["with"] = with_child
+    return res
+
+
+def create_slot(label, count, with_child):
+    slot = create_resource("slot", count, with_child)
+    slot["label"] = label
+    return slot
+
+
+def main():
+    core = create_resource("core", args.cores_per_task)
+    slot = create_slot("task", 1, [core])
+    if args.num_nodes:
+        resource_section = create_resource("node", args.num_nodes, [slot])
+    else:
+        resource_section = slot
+
+    jobspec = {
+        "version": 1,
+        "resources": [resource_section],
+        "tasks": [
+            {
+                "command": args.command,
+                "slot": "task",
+                "count": {"total": args.num_tasks},
+            }
+        ],
+        "attributes": {"system": {"duration": "{} seconds".format(args.walltime)}},
+    }
+
+    if args.pretty:
+        out = json.dumps(jobspec, indent=4, sort_keys=True)
+    else:
+        out = json.dumps(jobspec)
+    print(out)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-N", "--num-nodes", type=int, default=0)
+    parser.add_argument("-n", "--num-tasks", type=int, default=1)
+    parser.add_argument("-c", "--cores-per-task", type=int, default=1)
+    parser.add_argument(
+        "-t", "--walltime", type=int, default=3600, help="walltime in seconds"
+    )
+    parser.add_argument(
+        "-p", "--pretty", action="store_true", help="pretty print the jobspec json"
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    if len(args.command) == 0:
+        parser.print_usage()
+        print("command is required")
+        sys.exit(1)
+
+    main()

--- a/t/jobspec/minimal-schema.json
+++ b/t/jobspec/minimal-schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_14/schema.json",
+  "title": "jobspec-minimal",
+
+  "description":         "Flux minimal jobspec version 1",
+
+  "definitions": {
+    "resource_vertex_base": {
+      "description": "base schema for slot/other resource vertex",
+      "type": "object",
+      "required": ["type", "count"],
+      "properties": {
+        "type": { "type": "string" },
+        "count": { "type": "integer", "minimum" : 1 },
+        "with": {
+            "type": "array",
+            "maxItems": 1,
+            "items": { "$ref": "#/definitions/resource_vertex_base" }
+        },
+        "id": { "type": "string" },
+        "unit": { "type": "string" },
+        "label": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "resource_vertex_node": {
+      "description": "node resource type",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "enum": ["node"] }
+          }
+        }
+      ]
+    },
+    "resource_vertex_core": {
+      "description": "core resource type",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "enum": ["core"] }
+          }
+        }
+      ]
+    },
+    "resource_vertex_slot": {
+      "description": "special slot resource type - label assigns to task slot",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+              "type": { "enum": ["slot"] },
+              "with": {
+                  "items": {"$ref": "#/definitions/resource_vertex_core" }
+              }
+          },
+          "required": ["label"]
+        }
+      ]
+    },
+    "first_resource_vertex": {
+      "oneOf":[
+        { "$ref": "#/definitions/resource_vertex_slot" },
+        { "$ref": "#/definitions/resource_vertex_node" }
+      ]
+    }
+  },
+
+  "type": "object",
+  "required": ["version", "resources", "attributes", "tasks"],
+  "properties": {
+    "version": {
+      "description": "the jobspec version",
+      "type": "integer",
+      "enum": [1]
+    },
+    "resources": {
+      "description": "requested resources",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/first_resource_vertex" }
+    },
+    "attributes": {
+      "description": "system and user attributes",
+      "type": ["object", "null"],
+      "properties": {
+        "system": {
+          "type": "object",
+          "properties": {
+            "duration": { "type": "string" }
+          },
+          "additonalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "tasks": {
+      "description": "task configuration",
+      "type": "array",
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["command", "slot", "count" ],
+        "properties": {
+          "command": {
+            "type": ["string", "array"],
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "slot": { "type": "string" },
+          "count": {
+            "type": "object",
+            "properties": {
+              "per_slot": { "type": "integer", "minimum" : 1 },
+              "total": { "type": "integer", "minimum" : 1 }
+            }
+          },
+          "distribution": { "type": "string" },
+          "attributes": {
+            "type": "object",
+	    "additionalProperties": { "type": "string" }
+          }
+        },
+	"additionalProperties": false
+      }
+    }
+  }
+}

--- a/t/jobspec/validate.py
+++ b/t/jobspec/validate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Usage: validate.py --schema=jobspec.json data.json [data.json ...]
+# Usage: cat data.json | validate.py --schema=jobspec.json
 
 import sys
 import argparse
@@ -9,43 +10,56 @@ import yaml
 import jsonschema
 
 
-def validate_input(filename, schema):
-    f = open(filename)
-    data = yaml.safe_load(f)
-    jsonschema.validate(data, schema)
+def validate_input(jobspec_stream, schema, label=""):
+    errors = 0
+    try:
+        data = yaml.safe_load(jobspec_stream)
+        jsonschema.validate(data, schema)
+    except (yaml.YAMLError) as e:
+        print("{}: {}".format(label, e.problem))
+        errors = errors + 1
+    except (Exception) as e:
+        print("{}: {}".format(label, e.message))
+        errors = errors + 1
+    except:
+        print("{}: unknown error".format(label))
+        errors = errors + 1
+    else:
+        print("{}: ok".format(label))
+    return errors
+
+
+def validate_inputfile(infile, schema):
+    errors = 0
+    try:
+        with open(infile) as fd:
+            errors += validate_input(fd, schema, label=infile)
+    except (OSError, IOError) as e:
+        print("{}: {}".format(infile, e.strerror))
+        errors = errors + 1
+    return errors
 
 
 # parse command line args
 parser = argparse.ArgumentParser()
 parser.add_argument("--schema", "-s", type=str, required=True)
-args, unknown = parser.parse_known_args()
+parser.add_argument("jobspecs", nargs="*")
+args = parser.parse_args()
 
 # Parse json-schema file (JSON format)
 try:
     schema = json.load(open(args.schema))
 except (OSError, IOError) as e:
-    sys.exit(args.schema + ": " + e.strerror)
+    sys.exit("{}: {}".format(args.schema, e.strerror))
 except:
-    sys.exit(args.schema + ": unknown error")
+    sys.exit("{}: unknown error".format(args.schema))
 
 # Validate each file on command line
 errors = 0
-for infile in unknown:
-    try:
-        validate_input(infile, schema)
-    except (OSError, IOError) as e:
-        print(infile + ": " + e.strerror)
-        errors = errors + 1
-    except (yaml.YAMLError) as e:
-        print(infile + ": " + e.problem)
-        errors = errors + 1
-    except (Exception) as e:
-        print(infile + ": " + e.message)
-        errors = errors + 1
-    except:
-        print(infile + ": unknown error")
-        errors = errors + 1
-    else:
-        print(infile + ": ok")
+if args.jobspecs:
+    for infile in args.jobspecs:
+        errors += validate_inputfile(infile, schema)
+else:
+    errors += validate_input(sys.stdin, schema, label="stdin")
 
 sys.exit(errors)

--- a/t/t0020-emit-jobspec.t
+++ b/t/t0020-emit-jobspec.t
@@ -7,10 +7,15 @@ test_description='Test the jobspec emission tool'
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 VALIDATE=${JOBSPEC}/validate.py
 SCHEMA=${JOBSPEC}/schema.json
+MINI_SCHEMA=${JOBSPEC}/minimal-schema.json
 EMIT=${JOBSPEC}/emit-jobspec.py
 
 validate_emission() {
     ${EMIT} $@ | ${VALIDATE} --schema ${SCHEMA}
+}
+
+validate_minimal_emission() {
+    ${EMIT} $@ | ${VALIDATE} --schema ${MINI_SCHEMA}
 }
 
 test_expect_success 'emit-jobspec.py with no args emits valid jobspec' '
@@ -33,4 +38,27 @@ test_expect_success 'emit-jobspec.py with all args emits valid jobspec' '
     validate_emission -N4 -n4 -c1 sleep 1
 '
 
+test_expect_success 'emit-jobspec.py with pretty printing emits valid jobspec' '
+    validate_emission --pretty sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with no args emits minimal jobspec' '
+    validate_minimal_emission sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with just num_tasks emits minimal jobspec' '
+    validate_minimal_emission -n4 sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with just cores_per_task emits minimal jobspec' '
+    validate_minimal_emission -c4 sleep 1
+'
+
+test_expect_success 'emit-jobspec.py without num_nodes emits minimal jobspec' '
+    validate_minimal_emission -n4 -c1 sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with all args emits minimal jobspec' '
+    validate_minimal_emission -N4 -n4 -c1 sleep 1
+'
 test_done

--- a/t/t0020-emit-jobspec.t
+++ b/t/t0020-emit-jobspec.t
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+test_description='Test the jobspec emission tool'
+
+. `dirname $0`/sharness.sh
+
+JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+VALIDATE=${JOBSPEC}/validate.py
+SCHEMA=${JOBSPEC}/schema.json
+EMIT=${JOBSPEC}/emit-jobspec.py
+
+validate_emission() {
+    ${EMIT} $@ | ${VALIDATE} --schema ${SCHEMA}
+}
+
+test_expect_success 'emit-jobspec.py with no args emits valid jobspec' '
+    validate_emission sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with just num_tasks emits valid jobspec' '
+    validate_emission -n4 sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with just cores_per_task emits valid jobspec' '
+    validate_emission -c4 sleep 1
+'
+
+test_expect_success 'emit-jobspec.py without num_nodes emits valid jobspec' '
+    validate_emission -n4 -c1 sleep 1
+'
+
+test_expect_success 'emit-jobspec.py with all args emits valid jobspec' '
+    validate_emission -N4 -n4 -c1 sleep 1
+'
+
+test_done


### PR DESCRIPTION
Adds a python script that emits jobspec json based on the common resource mananger CLI args: `-N` (number of nodes), `-n` (number of tasks), `-c` (cores per task), and a command.

Tests are added that validate the jobspec output against the full jobspec schema and the minimal schema that we whiteboarded.  As part of these tests, I tweaked the `validate.py` script to support reading from stdin (as well as a few other hiccups I ran into).

I have not added tests for the minimal json schema. As low hanging fruit, it would be good to feed some of the more complex jobspecs through and ensure they fail validation.  Potentially more useful would be to hand construct some simple jobspecs that still fail.

@garlick, @grondo: any other functionality that we want from `emit-jobspec.py` at this point?  Potentially having it connect into a running instance and having it submit to the job-ingest?