### PR TITLE
resource-hwloc: add synchronization to startup and reload

### DIFF
--- a/doc/man1/flux-hwloc.adoc
+++ b/doc/man1/flux-hwloc.adoc
@@ -58,12 +58,6 @@ Options:
  Only reload XML on provided 'NODESET'.  See NODESET FORMAT below for
  more information.
 
- --walk-topology=['yes|no']:::
- -t ['yes|no']:::
- If 'yes', force resource-hwloc module to walk full topology on each reloaded
- rank and insert broken down topology into KVS under. If 'no', force disable
- the topology walk if enabled by default in module.
-
 *topology*::
 Dump current aggregate topology XML for the current session to stdout.
 

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -255,35 +255,11 @@ static void config_hwloc_paths (flux_t *h, const char *dirpath)
     flux_kvs_txn_destroy (txn);
 }
 
-static bool hwloc_reload_bool_value (const char *walk_topology)
-{
-    bool v = true;
-
-    if (strcmp (walk_topology, "no") == 0
-        || strcmp (walk_topology, "0") == 0
-        || strcmp (walk_topology, "false") == 0)
-        v = false;
-    return (v);
-}
-
-static void request_hwloc_reload (flux_t *h, const char *nodeset,
-                                  const char *walk_topology)
+static void request_hwloc_reload (flux_t *h, const char *nodeset)
 {
     flux_mrpc_t *mrpc;
-
-    if (!walk_topology) {
-        if (!(mrpc = flux_mrpc_pack (h, "resource-hwloc.reload",
-                                     nodeset, 0, "{}")))
-            log_err_exit ("flux_mrpc_pack");
-    }
-    else {
-        bool v = hwloc_reload_bool_value (walk_topology);
-
-        if (!(mrpc = flux_mrpc_pack (h, "resource-hwloc.reload", nodeset, 0,
-                                     "{ s:b }", "walk_topology", v)))
-            log_err_exit ("flux_mrpc_pack");
-    }
-
+    if (!(mrpc = flux_mrpc_pack (h, "resource-hwloc.reload", nodeset, 0, "{}")))
+        log_err_exit ("flux_mrpc_pack");
     do {
         uint32_t nodeid = FLUX_NODEID_ANY;
         if (flux_mrpc_get (mrpc, NULL) < 0
@@ -302,7 +278,6 @@ static int internal_hwloc_reload (optparse_t *p, int ac, char *av[])
     int n = optparse_option_index (p);
     const char *default_nodeset = "all";
     const char *nodeset = optparse_get_str (p, "rank", default_nodeset);
-    const char *walk_topology = optparse_get_str (p, "walk-topology", NULL);
     char *dirpath = NULL;
     flux_t *h;
 
@@ -312,7 +287,7 @@ static int internal_hwloc_reload (optparse_t *p, int ac, char *av[])
         log_err_exit ("%s", av[n]);
 
     config_hwloc_paths (h, dirpath);
-    request_hwloc_reload (h, nodeset, walk_topology);
+    request_hwloc_reload (h, nodeset);
 
     free (dirpath);
     flux_close (h);
@@ -330,9 +305,6 @@ int cmd_hwloc (optparse_t *p, int ac, char *av[])
 static struct optparse_option reload_opts[] = {
     { .name = "rank",  .key = 'r',  .has_arg = 1,
       .usage = "Target specified nodeset, or \"all\" (default)", },
-    { .name = "walk-topology",  .key = 't',  .has_arg = 1,
-      .arginfo = "yes/no",
-      .usage = "Force enable/disable topology walk for reload", },
     OPTPARSE_TABLE_END,
 };
 

--- a/src/modules/resource-hwloc/Makefile.am
+++ b/src/modules/resource-hwloc/Makefile.am
@@ -16,7 +16,10 @@ AM_CPPFLAGS = \
 #
 fluxmod_LTLIBRARIES = resource-hwloc.la
 
-resource_hwloc_la_SOURCES = resource.c
+resource_hwloc_la_SOURCES = \
+	resource.c \
+	aggregate.c \
+	aggregate.h
 resource_hwloc_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_CFLAGS)
 resource_hwloc_la_LDFLAGS = $(fluxmod_ldflags) -module
 resource_hwloc_la_LIBADD = $(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/resource-hwloc/aggregate.c
+++ b/src/modules/resource-hwloc/aggregate.c
@@ -155,7 +155,8 @@ int aggregate_unpack_to_kvs (flux_future_t *f, const char *path)
     return (rc);
 }
 
-flux_future_t *aggregator_push_json (flux_t *h, const char *key, json_t *o)
+flux_future_t *aggregator_push_json (flux_t *h, int fwd_count,
+                                     const char *key, json_t *o)
 {
     uint32_t size;
     uint32_t rank;
@@ -169,9 +170,10 @@ flux_future_t *aggregator_push_json (flux_t *h, const char *key, json_t *o)
         return NULL;
 
     return flux_rpc_pack (h, "aggregator.push", FLUX_NODEID_ANY, 0,
-                             "{s:s,s:i,s:{s:o}}",
+                             "{s:s,s:i,s:i,s:{s:o}}",
                              "key", key,
                              "total", size,
+                             "fwd_count", fwd_count,
                              "entries", rankstr, o);
 }
 

--- a/src/modules/resource-hwloc/aggregate.c
+++ b/src/modules/resource-hwloc/aggregate.c
@@ -12,27 +12,78 @@
 #include "config.h"
 #endif
 
+#include <stdarg.h>
+
 #include <flux/core.h>
 #include <jansson.h>
+
+static void aggregate_wait_set_errnum (flux_future_t *f, int errnum)
+{
+    if (flux_future_aux_set (f, "aggregate::errnum",
+                             (void *) (intptr_t) errnum, NULL) < 0) {
+        /* Not much we can do here but immediately fulfill future and
+         *  hope for the best.
+         */
+        flux_future_fulfill_error (f, errnum, NULL);
+    }
+}
+
+static intptr_t aggregate_wait_get_errnum (flux_future_t *f)
+{
+    void *v = flux_future_aux_get (f, "aggregate::errnum");
+    if (v == NULL)
+        return (0);
+    return ((intptr_t) v);
+}
+
+static void aggregate_fulfill_finalize (flux_future_t *f)
+{
+    intptr_t errnum = aggregate_wait_get_errnum (f);
+    if (errnum)
+        flux_future_fulfill_error (f, (int) errnum, NULL);
+    else
+        flux_future_fulfill (f, NULL, NULL);
+}
 
 static void aggregate_check (flux_future_t *f, void *arg)
 {
     int count, total;
-    const void *result;
+    const char *result;
+    json_t *o = NULL;
     flux_future_t *f_orig = arg;
 
-    if (flux_future_get (f, &result) < 0 ||
-        flux_kvs_lookup_get_unpack (f, "{s:i, s:i}",
-                                       "count", &count,
-                                       "total", &total) < 0) {
-        flux_future_fulfill_error (f_orig, errno, NULL);
+    if (flux_kvs_lookup_get (f, &result) < 0) {
+        if (errno == ENODATA) {
+            /* flux_kvs_lookup is now canceled, so it is now safe to destroy
+             *  the lookup future and finalize fulfillment of the
+             *  aggregate_wait future.
+             */
+            flux_future_destroy (f);
+            aggregate_fulfill_finalize (f_orig);
+            return;
+        }
         flux_kvs_lookup_cancel (f);
-        return;
+        aggregate_wait_set_errnum (f_orig, errno);
     }
-    if (count == total) {
-        flux_future_fulfill (f_orig, NULL, NULL);
+    else if (!(o = json_loads (result, 0, NULL))
+            || (json_unpack (o, "{s:i,s:i}",
+                                "count", &count,
+                                "total", &total) < 0)) {
         flux_kvs_lookup_cancel (f);
+        aggregate_wait_set_errnum (f_orig, errno);
     }
+    else if (count == total) {
+        flux_future_aux_set (f_orig, "aggregate::json_t",
+                             json_incref (o), (flux_free_f) json_decref);
+        flux_kvs_lookup_cancel (f);
+        /*  f_orig will be fulfilled by aggregate_fulfill_finalize() once
+         *   flux_kvs_lookup_get() returns ENODATA. This ensures there
+         *   are no stray RPC responses and allows safe deletion of the
+         *   kvs lookup future
+         */
+    }
+    flux_future_reset (f);
+    json_decref (o);
 }
 
 static void initialize_cb (flux_future_t *f, void *arg)
@@ -43,9 +94,7 @@ static void initialize_cb (flux_future_t *f, void *arg)
 
     f2 = flux_kvs_lookup (h, FLUX_KVS_WATCH|FLUX_KVS_WAITCREATE, key);
     if ((f2 == NULL)
-        || (flux_future_then (f2, -1., aggregate_check, f) < 0)
-        || (flux_future_aux_set (f, "flux::lookup_f", f2,
-                                 (flux_free_f) flux_future_destroy) < 0)) {
+        || (flux_future_then (f2, -1., aggregate_check, f) < 0)) {
         flux_future_destroy (f2);
         flux_future_fulfill_error (f, errno, NULL);
     }
@@ -53,32 +102,48 @@ static void initialize_cb (flux_future_t *f, void *arg)
 
 flux_future_t *aggregate_wait (flux_t *h, const char *key)
 {
+    char *s;
     flux_future_t *f = flux_future_create (initialize_cb, (void *) key);
-    if (f == NULL)
+    if ((f == NULL) || !(s = strdup (key))) {
+        flux_future_destroy (f);
         return NULL;
+    }
     flux_future_set_flux (f, h);
+    flux_future_aux_set (f, "aggregate::key", s, free);
     return (f);
 }
 
-flux_future_t *aggregate_get (flux_future_t *f)
+int aggregate_wait_get_unpack (flux_future_t *f, const char *fmt, ...)
 {
-    return (flux_future_aux_get (f, "flux::lookup_f"));
+    int rc;
+    va_list ap;
+    json_t *o = NULL;
+    if (!(o = flux_future_aux_get (f, "aggregate::json_t")))
+        return -1;
+    va_start (ap, fmt);
+    rc = json_vunpack_ex (o, NULL, 0, fmt, ap);
+    va_end (ap);
+    return rc;
 }
 
-int aggregate_unpack (flux_future_t *f_orig, const char *path)
+const char *aggregate_wait_get_key (flux_future_t *f)
+{
+    return flux_future_aux_get (f, "aggregate::key");
+}
+
+int aggregate_unpack_to_kvs (flux_future_t *f, const char *path)
 {
     int errnum = 0;
     int rc = 0;
     json_t *entries = NULL;
     flux_kvs_txn_t *txn = NULL;
     flux_future_t *fkvs = NULL;
-    flux_future_t *f = aggregate_get (f_orig);
     flux_t *h = flux_future_get_flux (f);
 
-    if ((flux_kvs_lookup_get_unpack (f, "{s:o}", "entries", &entries) < 0)
+    if ((aggregate_wait_get_unpack (f, "{s:o}", "entries", &entries) < 0)
         || !(txn = flux_kvs_txn_create ())
         || (flux_kvs_txn_pack (txn, 0, path, "O", entries) < 0)
-        || (flux_kvs_txn_unlink (txn, 0, flux_kvs_lookup_get_key (f)) < 0)
+        || (flux_kvs_txn_unlink (txn, 0, aggregate_wait_get_key (f)) < 0)
         || !(fkvs = flux_kvs_commit (h, 0, txn))
         || (flux_future_get (fkvs, NULL) < 0)) {
         errnum = errno;

--- a/src/modules/resource-hwloc/aggregate.c
+++ b/src/modules/resource-hwloc/aggregate.c
@@ -1,0 +1,114 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <jansson.h>
+
+static void aggregate_check (flux_future_t *f, void *arg)
+{
+    int count, total;
+    const void *result;
+    flux_future_t *f_orig = arg;
+
+    if (flux_future_get (f, &result) < 0 ||
+        flux_kvs_lookup_get_unpack (f, "{s:i, s:i}",
+                                       "count", &count,
+                                       "total", &total) < 0) {
+        flux_future_fulfill_error (f_orig, errno, NULL);
+        flux_kvs_lookup_cancel (f);
+        return;
+    }
+    if (count == total) {
+        flux_future_fulfill (f_orig, NULL, NULL);
+        flux_kvs_lookup_cancel (f);
+    }
+}
+
+static void initialize_cb (flux_future_t *f, void *arg)
+{
+    const char *key = arg;
+    flux_future_t *f2 = NULL;
+    flux_t *h = flux_future_get_flux (f);
+
+    f2 = flux_kvs_lookup (h, FLUX_KVS_WATCH|FLUX_KVS_WAITCREATE, key);
+    if ((f2 == NULL)
+        || (flux_future_then (f2, -1., aggregate_check, f) < 0)
+        || (flux_future_aux_set (f, "flux::lookup_f", f2,
+                                 (flux_free_f) flux_future_destroy) < 0)) {
+        flux_future_destroy (f2);
+        flux_future_fulfill_error (f, errno, NULL);
+    }
+}
+
+flux_future_t *aggregate_wait (flux_t *h, const char *key)
+{
+    flux_future_t *f = flux_future_create (initialize_cb, (void *) key);
+    if (f == NULL)
+        return NULL;
+    flux_future_set_flux (f, h);
+    return (f);
+}
+
+flux_future_t *aggregate_get (flux_future_t *f)
+{
+    return (flux_future_aux_get (f, "flux::lookup_f"));
+}
+
+int aggregate_unpack (flux_future_t *f_orig, const char *path)
+{
+    int errnum = 0;
+    int rc = 0;
+    json_t *entries = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *fkvs = NULL;
+    flux_future_t *f = aggregate_get (f_orig);
+    flux_t *h = flux_future_get_flux (f);
+
+    if ((flux_kvs_lookup_get_unpack (f, "{s:o}", "entries", &entries) < 0)
+        || !(txn = flux_kvs_txn_create ())
+        || (flux_kvs_txn_pack (txn, 0, path, "O", entries) < 0)
+        || (flux_kvs_txn_unlink (txn, 0, flux_kvs_lookup_get_key (f)) < 0)
+        || !(fkvs = flux_kvs_commit (h, 0, txn))
+        || (flux_future_get (fkvs, NULL) < 0)) {
+        errnum = errno;
+        rc = -1;
+    }
+    flux_future_destroy (fkvs);
+    flux_kvs_txn_destroy (txn);
+    errno = errnum;
+    return (rc);
+}
+
+flux_future_t *aggregator_push_json (flux_t *h, const char *key, json_t *o)
+{
+    uint32_t size;
+    uint32_t rank;
+    int n;
+    char rankstr [16]; /* aggregator expects ranks as string */
+
+    if ((flux_get_size (h, &size) < 0)
+        || (flux_get_rank (h, &rank) < 0)
+        || ((n = snprintf (rankstr, sizeof (rankstr), "%d", rank)) < 0)
+        || (n >= sizeof (rankstr)))
+        return NULL;
+
+    return flux_rpc_pack (h, "aggregator.push", FLUX_NODEID_ANY, 0,
+                             "{s:s,s:i,s:{s:o}}",
+                             "key", key,
+                             "total", size,
+                             "entries", rankstr, o);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/resource-hwloc/aggregate.h
+++ b/src/modules/resource-hwloc/aggregate.h
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*
+ *  Push single json object `o` to local aggregator module via RPC.
+ *   Steals the reference to `o`.
+ */
+flux_future_t *aggregator_push_json (flux_t *h, const char *key, json_t *o);
+
+/*  Fulfill future when aggregate at `key` is "complete", i.e.
+ *   count == total. The future `f` is fulfilled with the result of
+ *   flux_kvs_lookup() and thus the aggregate json object can be
+ *   unpacked with flux_kvs_lookup_unpack().
+ */
+flux_future_t *aggregate_wait (flux_t *h, const char *key);
+
+/*  Get the underlying future returned from flux_kvs_lookup(3)
+ *   from the future returned by aggregate_wait().
+ */
+flux_future_t *aggregate_get (flux_future_t *f);
+
+/*  Unpack the aggregate fulfilled in `f` into the kvs at path.
+ *   Just the aggregate `entries` object is pushed to the new location,
+ *   dropping the aggregate context count, total, min, max, etc.
+ *
+ *  The original aggregate key is removed.
+ */
+int aggregate_unpack (flux_future_t *f, const char *path);

--- a/src/modules/resource-hwloc/aggregate.h
+++ b/src/modules/resource-hwloc/aggregate.h
@@ -15,16 +15,14 @@
 flux_future_t *aggregator_push_json (flux_t *h, const char *key, json_t *o);
 
 /*  Fulfill future when aggregate at `key` is "complete", i.e.
- *   count == total. The future `f` is fulfilled with the result of
- *   flux_kvs_lookup() and thus the aggregate json object can be
- *   unpacked with flux_kvs_lookup_unpack().
+ *   count == total. Use aggreate_wait_get_unpack () to unpack final
+ *   aggregate kvs value after successful fulfillment.
  */
 flux_future_t *aggregate_wait (flux_t *h, const char *key);
 
-/*  Get the underlying future returned from flux_kvs_lookup(3)
- *   from the future returned by aggregate_wait().
+/*  Get final aggregate JSON object using Jansson json_unpack() format:
  */
-flux_future_t *aggregate_get (flux_future_t *f);
+int aggregate_wait_get_unpack (flux_future_t *f, const char *fmt, ...);
 
 /*  Unpack the aggregate fulfilled in `f` into the kvs at path.
  *   Just the aggregate `entries` object is pushed to the new location,
@@ -32,4 +30,4 @@ flux_future_t *aggregate_get (flux_future_t *f);
  *
  *  The original aggregate key is removed.
  */
-int aggregate_unpack (flux_future_t *f, const char *path);
+int aggregate_unpack_to_kvs (flux_future_t *f, const char *path);

--- a/src/modules/resource-hwloc/aggregate.h
+++ b/src/modules/resource-hwloc/aggregate.h
@@ -12,7 +12,8 @@
  *  Push single json object `o` to local aggregator module via RPC.
  *   Steals the reference to `o`.
  */
-flux_future_t *aggregator_push_json (flux_t *h, const char *key, json_t *o);
+flux_future_t *aggregator_push_json (flux_t *h, int fwd_count,
+		                     const char *key, json_t *o);
 
 /*  Fulfill future when aggregate at `key` is "complete", i.e.
  *   count == total. Use aggreate_wait_get_unpack () to unpack final

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -246,7 +246,7 @@ static int reload_event_wait (flux_t *h, resource_ctx_t *ctx)
         flux_log_error (h, "reload_event_wait: flux_future_wait_for");
         goto done;
     }
-    rc = aggregate_unpack (f, "resource.hwloc.by_rank");
+    rc = aggregate_unpack_to_kvs (f, "resource.hwloc.by_rank");
     flux_log (h, LOG_DEBUG, "seq=%d: reload complete", ctx->reload_count);
 done:
     flux_future_destroy (f);

--- a/src/modules/resource-hwloc/resource.c
+++ b/src/modules/resource-hwloc/resource.c
@@ -451,9 +451,7 @@ static void reload_event_cb (flux_t *h,
     const char *nodeset;
     int seq;
 
-    /*  Ignored on rank 0 */
-    if (ctx->rank == 0)
-        return;
+    assert (ctx->rank != 0);
 
     if (flux_event_unpack (msg, NULL, "{s:s,s:i}",
                            "ranks", &nodeset, "sequence", &seq) < 0) {
@@ -612,7 +610,9 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     }
 
-    if (flux_event_subscribe (h, "resource-hwloc.reload") < 0) {
+    // Only ranks other than 0 need to listen for the reload event
+    if (ctx->rank != 0
+        && flux_event_subscribe (h, "resource-hwloc.reload") < 0) {
         flux_log_error (h, "flux_event_subscribe");
         goto done;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -289,6 +289,8 @@ dist_check_DATA = \
 	hwloc-data/1N/shared/02-brokers/1.xml \
 	hwloc-data/1N/nonoverlapping/02-brokers/0.xml \
 	hwloc-data/1N/nonoverlapping/02-brokers/1.xml \
+	hwloc-data/02N-sierra/0.xml \
+	hwloc-data/02N-sierra/1.xml \
 	valgrind/valgrind.supp \
 	conf.d/private.conf \
 	conf.d/shared.conf \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -312,6 +312,7 @@ dist_check_SCRIPTS = \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/wreck \
 	valgrind/workload.d/job \
+	valgrind/workload.d/hwloc \
 	kvs/kvs-helper.sh
 
 test_ldadd = \

--- a/t/hwloc-data/02N-sierra/0.xml
+++ b/t/hwloc-data/02N-sierra/0.xml
@@ -1,0 +1,721 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3682"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132310528">
+        <page_type size="65536" count="2092473"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="8" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="12" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="16" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="20" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="24" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="28" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="32" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="36" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="40" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="44" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="48" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="52" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="56" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="60" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="64" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="68" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="72" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="76" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+            <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+            <object type="OSDev" name="nvme0n1" osdev_type="0">
+              <info name="LinuxDeviceID" value="259:0"/>
+              <info name="SerialNumber" value="S3RVNA0J802449"/>
+              <info name="Type" value="Disk"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            <object type="OSDev" name="card4" osdev_type="1"/>
+            <object type="OSDev" name="controlD68" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi0" osdev_type="2">
+              <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:12"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_0" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2dbf"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a212"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi1" osdev_type="2">
+              <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:13"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_1" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a213"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2dc0"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a213"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+            <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+          </object>
+          <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="renderD128" osdev_type="1"/>
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="cuda0" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card1" osdev_type="1"/>
+            <object type="OSDev" name="renderD129" osdev_type="1"/>
+            <object type="OSDev" name="cuda1" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:6c:1c"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:6c:1d"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2068" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2072" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2076" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2080" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2084" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2088" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2092" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2096" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2112" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2116" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi2" osdev_type="2">
+              <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:14"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_2" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a214"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e21"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a214"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi3" osdev_type="2">
+              <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:15"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_3" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a215"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e1f"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a215"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card2" osdev_type="1"/>
+            <object type="OSDev" name="renderD130" osdev_type="1"/>
+            <object type="OSDev" name="cuda2" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card3" osdev_type="1"/>
+            <object type="OSDev" name="renderD131" osdev_type="1"/>
+            <object type="OSDev" name="cuda3" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/hwloc-data/02N-sierra/1.xml
+++ b/t/hwloc-data/02N-sierra/1.xml
@@ -1,0 +1,721 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3179"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132310528">
+        <page_type size="65536" count="2092473"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="8" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="12" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="16" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="20" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="24" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="28" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="32" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="36" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="40" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="44" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="48" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="52" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="56" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="60" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="64" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="68" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="72" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="76" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+            <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+            <object type="OSDev" name="nvme0n1" osdev_type="0">
+              <info name="LinuxDeviceID" value="259:0"/>
+              <info name="SerialNumber" value="S3RVNA0JA01484"/>
+              <info name="Type" value="Disk"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            <object type="OSDev" name="card4" osdev_type="1"/>
+            <object type="OSDev" name="controlD68" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi0" osdev_type="2">
+              <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:18"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_0" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x32ed"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a418"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi1" osdev_type="2">
+              <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:19"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_1" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a419"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x32ee"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a419"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+            <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+          </object>
+          <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="renderD128" osdev_type="1"/>
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="cuda0" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card1" osdev_type="1"/>
+            <object type="OSDev" name="renderD129" osdev_type="1"/>
+            <object type="OSDev" name="cuda1" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:9d:1f"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:9d:20"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2064" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2068" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2072" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2076" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2080" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2084" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2088" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2092" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2108" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2112" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi2" osdev_type="2">
+              <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:1a"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_2" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a41a"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x335d"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a41a"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi3" osdev_type="2">
+              <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:1b"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_3" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a41b"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x3333"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a41b"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card2" osdev_type="1"/>
+            <object type="OSDev" name="renderD130" osdev_type="1"/>
+            <object type="OSDev" name="cuda2" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card3" osdev_type="1"/>
+            <object type="OSDev" name="renderD131" osdev_type="1"/>
+            <object type="OSDev" name="cuda3" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -13,6 +13,7 @@ test_under_flux ${SIZE} kvs
 
 shared2=`readlink -e ${SHARNESS_TEST_SRCDIR}/hwloc-data/1N/shared/02-brokers`
 exclu2=`readlink -e ${SHARNESS_TEST_SRCDIR}/hwloc-data/1N/nonoverlapping/02-brokers`
+sierra2="${SHARNESS_TEST_SRCDIR}/hwloc-data/02N-sierra/"
 
 test_debug '
     echo ${dn} &&
@@ -107,6 +108,11 @@ test_expect_success HAVE_LSTOPO 'hwloc: test failure of lstopo command' '
 test_expect_success 'hwloc: reload fails on invalid rank' '
     test_expect_code 1 flux hwloc reload -r $(invalid_rank) 2> stderr &&
     grep "No route to host" stderr
+'
+
+test_expect_success 'hwloc: reload xml with GPU objects' '
+    flux hwloc reload ${sierra2} &&
+    flux kvs get resource.hwloc.by_rank | grep "\"GPU\":  *4"
 '
 
 test_expect_success 'hwloc: remove hwloc module' '

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -123,12 +123,6 @@ test_expect_success 'hwloc: reload fails on invalid rank' '
     grep "No route to host" stderr
 '
 
-test_expect_success 'hwloc: HostName is populated in by_rank' '
-    HW_HOST=$(flux kvs get --json resource.hwloc.by_rank.0.HostName) &&
-    REAL_HOST=$(hostname) &&
-    test x"$HW_HOST" = x"$REAL_HOST"
-'
-
 test_expect_success 'hwloc: remove hwloc module' '
     flux module remove -r all resource-hwloc
 '

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -118,15 +118,6 @@ test_expect_success 'hwloc: no broken down resource info by default' '
     test_must_fail flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
 '
 
-test_expect_success 'hwloc: reload --walk-topology=yes works' '
-    flux hwloc reload --walk-topology=yes &&
-    flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
-'
-test_expect_success 'hwloc: reload --walk-topology=no removes broken down topo' '
-    flux hwloc reload --walk-topology=no &&
-    test_must_fail flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
-'
-
 test_expect_success 'hwloc: reload fails on invalid rank' '
     flux hwloc reload -r $(invalid_rank) 2> stderr &&
     grep "No route to host" stderr

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -104,10 +104,6 @@ test_expect_success HAVE_LSTOPO 'hwloc: test failure of lstopo command' '
     test_must_fail flux hwloc lstopo --input f:g:y
 '
 
-test_expect_success 'hwloc: no broken down resource info by default' '
-    test_must_fail flux kvs get --json resource.hwloc.by_rank.0.Machine_0.OSName
-'
-
 test_expect_success 'hwloc: reload fails on invalid rank' '
     test_expect_code 1 flux hwloc reload -r $(invalid_rank) 2> stderr &&
     grep "No route to host" stderr

--- a/t/valgrind/workload.d/hwloc
+++ b/t/valgrind/workload.d/hwloc
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Ensure reloads do not leak memory
+flux hwloc reload
+flux hwloc reload
+flux hwloc reload
+flux hwloc reload -r 1


### PR DESCRIPTION
This PR started as a simple change, but ended up with a rework of the `resource-hwloc` startup and topology reload functions to add a synchronization point and aggregation.

The basic change here is that the `resource.hwloc.by_rank.` directory, which had one subdir per rank, is replaced with a single aggregate JSON object generated by the aggregator module, where the keys are `idset` strings and values are JSON objects containing the same fields from the original `by_rank`. 

Also, as part of cleanup the unused `walk_topology` support was removed, along `by_rank.HostName`, which is superseded by `resource.hosts` (and makes it more difficult to aggregate like resources for different hosts)

E.g. of the new format:
```
$ src/cmd/flux start -b selfpmi -s 4 flux kvs get resource.hwloc.by_rank | jq
{
  "[0-3]": {
    "NUMANode": 2,
    "Package": 2,
    "Core": 16,
    "PU": 32
  }
}

```
or on a real system with different resources per-rank:
```
$ srun -p pall -N4 src/cmd/flux start flux kvs get resource.hwloc.by_rank | jq
{
  "[1-3]": {
    "NUMANode": 2,
    "Package": 2,
    "Core": 36,
    "PU": 72
  },
  "0": {
    "NUMANode": 2,
    "Package": 2,
    "Core": 16,
    "PU": 32
  }
}
```

As a consequence of having all ranks push an aggregate instead of individually to the KVS, the topology load is now synchronized by having the rank 0 module wait for the aggregate to be "complete" before entering the reactor on startup. Thus, after these changes, once `flux module load -r all resource-hwloc` completes, it is guaranteed that all ranks have finished populating the kvs.

In order to support the aggregate however, `flux hwloc reload` support was changed to always be a global event. All `resource-hwloc.reload` RPCs are now sent to rank 0, which then issues a reload event. Only the targeted ranks in the reload event payload *actually* reload the topology, however *all* ranks participate in another aggregation so that rank 0 can synchronously wait for the reload to complete. This is probably unnecessary at this point, but the reloads are sequenced to ensure multiple reload requests do not stomp on each other. (This could allow `resource-hwloc` to asynchronously wait for the aggregates to complete for reloads, but that is saved for future work)

I apologize for the large diff in 8b7116e, there wasn't a good way to really stage this rewrite into a series of functional, understandable chunks. Since the previous cleanup commits don't really help readability of the final large change, I'd be willing to squash most of this together if that would be better.