### PR TITLE
libflux/flog: minor fixes and cleanup

### DIFF
--- a/doc/man3/flux_log.adoc
+++ b/doc/man3/flux_log.adoc
@@ -39,11 +39,6 @@ levels, which are, in order of decreasing importance:
 'LOG_INFO'::       informational message
 'LOG_DEBUG'::      debug-level message
 
-In addition, the flag 'FLUX_LOG_CHECK' may be logically ORed with
-the 'level' to direct `flux_log()` to wait for a response from the broker
-indicating whether the log request was accepted or not.  Otherwise, log
-requests are "fire and forget".
-
 When 'h' is specified, log messages are are added to the broker's
 circular buffer which can be accessed with flux-dmesg(3).  From there,
 a message's disposition is up to the broker's log configuration.
@@ -98,9 +93,8 @@ characters.  At this time non-ASCII UTF-8 is not supported by `flux_log()`.
 RETURN VALUE
 ------------
 
-`flux_log()` normally returns 0 with no possibility of error.
-However, if the 'FLUX_LOG_CHECK' check flag is specified, it may
-return -1 with errno set on error.
+`flux_log()` normally returns 0 on success, or -1 if there was
+a problem building or sending the log message, with errno set.
 
 
 ERRORS

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -79,7 +79,7 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_open");
 
     flux_log_set_appname (h, appname);
-    if (flux_log (h, severity | FLUX_LOG_CHECK, "%s", message) < 0)
+    if (flux_log (h, severity, "%s", message) < 0)
         log_err_exit ("flux_log");
 
     flux_close (h);

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -25,6 +25,7 @@
 #include "flog.h"
 #include "attr.h"
 #include "message.h"
+#include "request.h"
 #include "rpc.h"
 
 #include "src/common/libutil/wallclock.h"
@@ -111,14 +112,13 @@ const char *flux_strerror (int errnum)
 
 static int log_rpc (flux_t *h, const char *buf, int len)
 {
-    flux_future_t *f;
+    flux_msg_t *msg;
     int rc;
 
-    if (!(f = flux_rpc_raw (h, "log.append", buf, len,
-                            FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE)))
+    if (!(msg = flux_request_encode_raw ("log.append", buf, len)))
         return -1;
-    rc = flux_future_get (f, NULL);
-    flux_future_destroy (f);
+    rc = flux_send (h, msg, 0);
+    flux_msg_destroy (msg);
     return rc;
 }
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -138,7 +138,9 @@ int flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)
         const char *lstr = stdlog_severity_to_string (LOG_PRI (level));
 
         (void)vsnprintf (buf, sizeof (buf), fmt, ap);
-        return fprintf (stderr, "%s: %s\n", lstr, buf);
+        if (fprintf (stderr, "%s: %s\n", lstr, buf) < 0)
+            return -1;
+        return 0;
     }
 
     if (!(ctx = getctx (h))) {

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -25,11 +25,6 @@ extern "C" {
 
 #define FLUX_MAX_LOGBUF     2048
 
-/* May be ored with 'level' to cause log request
- * to wait for a success/fail response.
- */
-#define FLUX_LOG_CHECK      0x1000
-
 typedef void (*flux_log_f)(const char *buf, int len, void *arg);
 
 /* Set log appname for handle instance.

--- a/src/common/libflux/test/log.c
+++ b/src/common/libflux/test/log.c
@@ -38,6 +38,9 @@ int main (int argc, char *argv[])
     ok (errno == 1236,
        "flux_log didn't clobber errno");
 
+    ok (flux_log (NULL, LOG_INFO, "# flux_t=NULL") == 0,
+       "flux_log h=NULL works");
+
     test_server_stop (h);
     flux_close (h);
     done_testing();

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test broker security' 
+test_description='Test broker security'
 
 . `dirname $0`/sharness.sh
 
@@ -139,13 +139,13 @@ test_expect_success 'flux setattr NOT allowed for non-owner' '
 '
 
 test_expect_success 'flux logger not allowed for non-owner' '
-	MSG="hello world $$" &&
-	! FLUX_HANDLE_ROLEMASK=0x2 flux logger $MSG 2>logger.err &&
-	grep -q "Operation not permitted" logger.err
+	MSG="hello-unauthorized-world $$" &&
+	FLUX_HANDLE_ROLEMASK=0x2 flux logger $MSG &&
+	! flux dmesg | grep -q $MSG
+
 '
 
 test_expect_success 'flux dmesg not allowed for non-owner' '
-	MSG="hello world $$" &&
 	! FLUX_HANDLE_ROLEMASK=0x2 flux dmesg 2>dmesg.err &&
 	grep -q "Operation not permitted" dmesg.err
 '


### PR DESCRIPTION
This PR drops a logging option FLUX_LOG_CHECK, which makes `flux_log()` into a synchronous RPC.  It seems to only be used in `flux-logger(1)`, and there (as far as I can tell) only so that a sharness security test can verify that `flux_log()` receives an EPERM response for non instance owner.  Rework that test and then drop the option.

In addition, `flux_log()` calls `flux_rpc(FLUX_RPC_NORESPONSE)` which creates a future and then immediately destroys it.  Replace this with a direct `flux_send()` of the request message to make logging a bit less malloc heavy, now that the FLUX_LOG_CHECK option isn't supported.

Finally, ensure that `flux_log()` always returns 0 on success, as documented in its manual page, and add a test for logging with the `flux_t` handle set to NULL.