### PR TITLE
small valgrind test fixes

### DIFF
--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -32,19 +32,23 @@ BROKER=${FLUX_BUILD_DIR}/src/broker/flux-broker
 
 # broker run under valgrind may need extra retries in flux_open():
 export FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
+VALGRIND_NBROKERS=${VALGRIND_NBROKERS:-2}
+VALGRIND_SHUTDOWN_GRACE=${VALGRIND_SHUTDOWN_GRACE:-16}
 
-test_expect_success 'valgrind reports no new errors on single broker run' '
+test_expect_success \
+  "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
 	run_timeout 120 \
-	libtool e flux ${VALGRIND} \
-		--tool=memcheck \
-		--leak-check=full \
-		--gen-suppressions=all \
-		--trace-children=no \
-		--child-silent-after-fork=yes \
-		--num-callers=30 \
-		--leak-resolution=med \
-		--error-exitcode=1 \
-		--suppressions=$VALGRIND_SUPPRESSIONS \
-		${BROKER} --shutdown-grace=16 ${VALGRIND_WORKLOAD}
+	flux start -s ${VALGRIND_NBROKERS} --wrap=libtool,e,${VALGRIND} \
+		--wrap=--tool=memcheck \
+		--wrap=--leak-check=full \
+		--wrap=--gen-suppressions=all \
+		--wrap=--trace-children=no \
+		--wrap=--child-silent-after-fork=yes \
+		--wrap=--num-callers=30 \
+		--wrap=--leak-resolution=med \
+		--wrap=--error-exitcode=1 \
+		--wrap=--suppressions=$VALGRIND_SUPPRESSIONS \
+		-o,--shutdown-grace=${VALGRIND_SHUTDOWN_GRACE} \
+		 ${VALGRIND_WORKLOAD}
 '
 test_done

--- a/t/valgrind/valgrind-workload.sh
+++ b/t/valgrind/valgrind-workload.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
 echo FLUX_URI=$FLUX_URI
+exitcode=0
 
 for file in ${SHARNESS_TEST_SRCDIR:-..}/valgrind/workload.d/*; do
 	echo Running $(basename $file)
 	$file
+	rc=$?
+	if test $rc -gt 0; then
+		echo "$(basename $file): Failed with rc=$rc" >&2
+		exitcode=1
+	fi
 done
+exit $exitcode

--- a/t/valgrind/workload.d/wreck
+++ b/t/valgrind/workload.d/wreck
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 size=$(flux getattr size)
-NJOBS=10
+NJOBS=5
 
 for i in `seq 1 $NJOBS`; do
-     flux wreckrun --ntasks $size /bin/true
+     flux wreckrun -v --ntasks $size /bin/true
 done


### PR DESCRIPTION
This PR makes 2 small improvements to the valgrind sharness test:

 * Run valgrind on an instance of size=2 instead of just a single broker. Some code in Flux is only active on rank > 0, so this will help find leaks and errors in those code paths.
 * The valgrind-workload.sh ignored errors from the underlying workload scripts. Log an error on non-zero exit code from any one of these scripts and cause a test failure.

This PR will fail until #1940 is addressed.