### PR TITLE
modules/kvs: Fix error on lookup replay

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -427,7 +427,7 @@ static int getroot_request_send (kvs_ctx_t *ctx,
     }
 
     if (lh
-        && flux_msg_aux_set (msg, "lookup_handle", lh, NULL) < 0) {
+        && flux_msg_aux_set (msgcpy, "lookup_handle", lh, NULL) < 0) {
         flux_log_error (ctx->h, "%s: flux_msg_aux_set", __FUNCTION__);
         goto error;
     }


### PR DESCRIPTION
When a lookup requires a getroot on a namespace, the lookup handle
should be copied into the replay message so it will be recognized
as a lookup replay.  The lookup handle was not set appropriately on
the replay message, leading to a memleak.

Fixes #1940