### PR TITLE
kvs: support symlinks with namespaces within them

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -117,10 +117,12 @@ Remove 'key' from the KVS and commit the change.  If 'key' represents
 a directory, specify '-R' to remove all keys underneath it.  If '-f' is
 specified, ignore nonexistent files.
 
-*link* 'target' 'linkname'::
+*link* [-T ns] 'target' 'linkname'::
 Create a new name for 'target', similar to a symbolic link, and commit
 the change.  'target' does not have to exist.  If 'linkname' exists,
-it is overwritten.
+it is overwritten.  Optionally, specify a namespace the target is in.
+This namespace can be different that the one the linkname is being
+written to.
 
 *readlink* [-a treeobj] 'key' ['key...']::
 Retrieve the key a link refers to rather than its value, as would be

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -124,10 +124,13 @@ it is overwritten.  Optionally, specify a namespace the target is in.
 This namespace can be different that the one the linkname is being
 written to.
 
-*readlink* [-a treeobj] 'key' ['key...']::
+*readlink* [-a treeobj] [ -o | -k ] 'key' ['key...']::
 Retrieve the key a link refers to rather than its value, as would be
 returned by *get*.  '-a treeobj' causes the lookup to be relative to
-an RFC 11 snapshot reference.
+an RFC 11 snapshot reference.  If the link points to a namespace, the
+namespace and key will be output in the format '<namespace>::<key>'.
+The '-o' can be used to only output namespaces and the '-k' can be
+used to only output keys.
 
 *mkdir* 'key' ['key...']::
 Create an empty directory and commit the change.  If 'key' exists,

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -29,7 +29,8 @@ SYNOPSIS
 
  int flux_kvs_lookup_get_treeobj (flux_future_t *f, const char **treeobj);
 
- int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target);
+ int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **ns,
+                                  const char **target);
 
  const char *flux_kvs_lookup_get_key (flux_future_t *f);
 
@@ -87,7 +88,9 @@ function should work on all.
 
 `flux_kvs_lookup_get_symlink()` interprets the result as a symlink target,
 e.g. in response to a lookup with the FLUX_KVS_READLINK flag set.
-The result is parsed and symlink target is assigned to _target_.
+The result is parsed and symlink namespace is assigned to _ns_ and
+the symlink target is assigned to _target_.  If a namespace was not assigned
+to the symlink, _ns_ is set to NULL.
 
 `flux_kvs_lookup_get_key()` accesses the key argument from the original
 lookup.

--- a/doc/man3/flux_kvs_txn_create.adoc
+++ b/doc/man3/flux_kvs_txn_create.adoc
@@ -32,7 +32,8 @@ SYNOPSIS
                           const char *key);
 
  int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
-                           const char *key, const char *target);
+                           const char *key, const char *ns,
+                           const char *target);
 
  int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn, int flags,
                            const char *key, const void *data, int len);
@@ -71,8 +72,10 @@ from a JSON object built with `json_pack()` style arguments (see below).
 `flux_kvs_txn_unlink()` removes _key_.  If _key_ is a directory,
 all its contents are removed as well.
 
-`flux_kvs_txn_symlink()` sets _key_ to a symbolic link pointing to _target_,
-another key.  _target_ need not exist.
+`flux_kvs_txn_symlink()` sets _key_ to a symbolic link pointing to a
+namespace _ns_ and a _target_ key within that namespace.  Neither _ns_
+nor _target_ must exist.  The namespace _ns_ is optional, if set to
+NULL the _target_ is assumed to be in the key's current namespace.
 
 `flux_kvs_txn_put_raw()` sets _key_ to a value containing raw data
 referred to by _data_ of length _len_.

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -318,7 +318,7 @@ static int l_flux_kvs_type (lua_State *L)
         return lua_pusherror (L, "key expected in arg #2");
 
     if ((future = flux_kvs_lookup (f, FLUX_KVS_READLINK, key))
-            && flux_kvs_lookup_get_symlink (future, &target) == 0) {
+            && flux_kvs_lookup_get_symlink (future, NULL, &target) == 0) {
         lua_pushstring (L, "symlink");
         lua_pushstring (L, target);
         flux_future_destroy (future);

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -99,7 +99,7 @@ def put_unlink(flux_handle, key):
 def put_symlink(flux_handle, key, target):
     if flux_handle.aux_txn is None:
         flux_handle.aux_txn = RAW.flux_kvs_txn_create()
-    return RAW.flux_kvs_txn_symlink(flux_handle.aux_txn, 0, key, target)
+    return RAW.flux_kvs_txn_symlink(flux_handle.aux_txn, 0, key, None, target)
 
 
 def commit(flux_handle, flags=0):

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -925,7 +925,7 @@ int cmd_link (optparse_t *p, int argc, char **argv)
 
     if (!(txn = flux_kvs_txn_create ()))
         log_err_exit ("flux_kvs_txn_create");
-    if (flux_kvs_txn_symlink (txn, 0, argv[optindex + 1], argv[optindex]) < 0)
+    if (flux_kvs_txn_symlink (txn, 0, argv[optindex + 1], NULL, argv[optindex]) < 0)
         log_err_exit ("%s", argv[optindex + 1]);
     if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
         log_err_exit ("flux_kvs_commit");

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -957,7 +957,7 @@ int cmd_readlink (optparse_t *p, int argc, char **argv)
             if (!(f = flux_kvs_lookup (h, FLUX_KVS_READLINK, argv[i])))
                 log_err_exit ("%s", argv[i]);
         }
-        if (flux_kvs_lookup_get_symlink (f, &target) < 0)
+        if (flux_kvs_lookup_get_symlink (f, NULL, &target) < 0)
             log_err_exit ("%s", argv[i]);
         printf ("%s\n", target);
         flux_future_destroy (f);
@@ -1243,7 +1243,7 @@ static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,
         if (flux_kvsdir_issymlink (dir, name)) {
             const char *link;
             if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READLINK, key, rootref))
-                    || flux_kvs_lookup_get_symlink (f, &link) < 0)
+                    || flux_kvs_lookup_get_symlink (f, NULL, &link) < 0)
                 log_err_exit ("%s", key);
             printf ("%s -> %s\n", key, link);
             flux_future_destroy (f);

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1274,13 +1274,16 @@ static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,
     while ((name = flux_kvsitr_next (itr))) {
         key = flux_kvsdir_key_at (dir, name);
         if (flux_kvsdir_issymlink (dir, name)) {
-            const char *link;
+            const char *ns = NULL;
+            const char *target = NULL;
             if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READLINK, key, rootref))
-                    || flux_kvs_lookup_get_symlink (f, NULL, &link) < 0)
+                    || flux_kvs_lookup_get_symlink (f, &ns, &target) < 0)
                 log_err_exit ("%s", key);
-            printf ("%s -> %s\n", key, link);
+            if (ns)
+                printf ("%s -> %s::%s\n", key, ns, target);
+            else
+                printf ("%s -> %s\n", key, target);
             flux_future_destroy (f);
-
         } else if (flux_kvsdir_isdir (dir, name)) {
             if (Ropt) {
                 const flux_kvsdir_t *ndir;

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -244,7 +244,7 @@ int flux_kvs_symlink (flux_t *h, const char *key, const char *target)
     flux_kvs_txn_t *txn = get_default_txn (h);
     if (!txn)
         return -1;
-    return flux_kvs_txn_symlink (txn, 0, key, target);
+    return flux_kvs_txn_symlink (txn, 0, key, NULL, target);
 }
 
 int flux_kvs_mkdir (flux_t *h, const char *key)

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -375,8 +375,7 @@ int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dirp)
 int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target)
 {
     struct lookup_ctx *ctx;
-    json_t *str;
-    const char *s;
+    const char *t = NULL;
 
     if (!(ctx = get_lookup_ctx (f)))
         return -1;
@@ -386,13 +385,10 @@ int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target)
         errno = EINVAL;
         return -1;
     }
-    if (!(str = treeobj_get_data (ctx->treeobj))
-                                || !(s = json_string_value (str))) {
-        errno = EINVAL;
+    if (treeobj_get_symlink (ctx->treeobj, NULL, &t) < 0)
         return -1;
-    }
     if (target)
-        *target = s;
+        *target = t;
     return 0;
 }
 

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -372,10 +372,12 @@ int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dirp)
     return 0;
 }
 
-int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target)
+int flux_kvs_lookup_get_symlink (flux_future_t *f,
+                                 const char **ns,
+                                 const char **target)
 {
     struct lookup_ctx *ctx;
-    const char *t = NULL;
+    const char *n = NULL, *t = NULL;
 
     if (!(ctx = get_lookup_ctx (f)))
         return -1;
@@ -385,8 +387,10 @@ int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target)
         errno = EINVAL;
         return -1;
     }
-    if (treeobj_get_symlink (ctx->treeobj, NULL, &t) < 0)
+    if (treeobj_get_symlink (ctx->treeobj, &n, &t) < 0)
         return -1;
+    if (ns)
+        *ns = n;
     if (target)
         *target = t;
     return 0;

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -24,7 +24,9 @@ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
 int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len);
 int flux_kvs_lookup_get_treeobj (flux_future_t *f, const char **treeobj);
 int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dir);
-int flux_kvs_lookup_get_symlink (flux_future_t *f, const char **target);
+int flux_kvs_lookup_get_symlink (flux_future_t *f,
+                                 const char **ns,
+                                 const char **target);
 
 const char *flux_kvs_lookup_get_key (flux_future_t *f);
 

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -285,7 +285,8 @@ error:
 }
 
 int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
-                          const char *key, const char *target)
+                          const char *key, const char *ns,
+                          const char *target)
 {
     json_t *dirent = NULL;
     int saved_errno;
@@ -296,7 +297,7 @@ int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
     }
     if (validate_flags (flags, 0) < 0)
         goto error;
-    if (!(dirent = treeobj_create_symlink (NULL, target)))
+    if (!(dirent = treeobj_create_symlink (ns, target)))
         goto error;
     if (append_op_to_txn (txn, flags, key, dirent) < 0)
         goto error;

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -296,7 +296,7 @@ int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
     }
     if (validate_flags (flags, 0) < 0)
         goto error;
-    if (!(dirent = treeobj_create_symlink (target)))
+    if (!(dirent = treeobj_create_symlink (NULL, target)))
         goto error;
     if (append_op_to_txn (txn, flags, key, dirent) < 0)
         goto error;

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -44,7 +44,8 @@ int flux_kvs_txn_unlink (flux_kvs_txn_t *txn, int flags,
                          const char *key);
 
 int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
-                          const char *key, const char *target);
+                          const char *key, const char *ns,
+                          const char *target);
 
 #ifdef __cplusplus
 }

--- a/src/common/libkvs/test/kvs_dir.c
+++ b/src/common/libkvs/test/kvs_dir.c
@@ -135,7 +135,7 @@ void test_full (void)
 
     if (!(o = treeobj_create_dir ()))
         BAIL_OUT ("treeobj_create_dir failed");
-    if (!(dirent = treeobj_create_symlink ("a.b.c")))
+    if (!(dirent = treeobj_create_symlink (NULL, "a.b.c")))
         BAIL_OUT ("treeobj_create_symlink failed");
     if (treeobj_insert_entry (o, "foo", dirent) < 0)
         BAIL_OUT ("treeobj_insert_entry failed");

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -141,9 +141,9 @@ void basic (void)
     rc = flux_kvs_txn_mkdir (txn, 0, "b.b.b");
     ok (rc == 0,
         "4: flux_kvs_txn_mkdir works");
-    rc = flux_kvs_txn_symlink (txn, 0, "c.c.c", "b.b.b");
+    rc = flux_kvs_txn_symlink (txn, 0, "c.c.c", NULL, "b.b.b");
     ok (rc == 0,
-        "5: flux_kvs_txn_symlink works");
+        "5: flux_kvs_txn_symlink works (no namespace)");
     rc = flux_kvs_txn_put (txn, 0, "d.d.d", "43");
     ok (rc == 0,
         "6: flux_kvs_txn_put(i) works");
@@ -153,6 +153,9 @@ void basic (void)
     rc = flux_kvs_txn_put (txn, 0, "nerrrrb", NULL);
     ok (rc == 0,
         "8: flux_kvs_txn_put(NULL) works");
+    rc = flux_kvs_txn_symlink (txn, 0, "f.f.f", "g.g.g", "h.h.h");
+    ok (rc == 0,
+        "9: flux_kvs_txn_symlink works (namespace)");
     errno = 0;
     rc = flux_kvs_txn_pack (txn, 0xFFFF, "foo.bar.blorp",  "s", "foo");
     ok (rc < 0 && errno == EINVAL,
@@ -168,8 +171,8 @@ void basic (void)
 
     /* Verify transaction contents
      */
-    ok (txn_get_op_count (txn) == 8,
-        "txn contains 8 ops");
+    ok (txn_get_op_count (txn) == 9,
+        "txn contains 9 ops");
     ok (txn_get_op (txn, 0, &entry) == 0
         && entry != NULL,
         "1: retrieved");
@@ -218,10 +221,12 @@ void basic (void)
     ok (!strcmp (key, "c.c.c")
         && flags == 0
         && treeobj_is_symlink (dirent)
+        && !json_object_get (treeobj_get_data (dirent),
+                             "namespace")
         && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
                                                         "target")),
                     "b.b.b"),
-        "5: symlink c.c.c b.b.b");
+        "5: symlink c.c.c b.b.b (no namespace)");
 
     ok (txn_get_op (txn, 5, &entry) == 0 && entry != NULL,
         "6: retrieved");
@@ -253,9 +258,24 @@ void basic (void)
         && check_null_value (dirent) == 0,
         "8: put nerrrrb = NULL");
 
+    ok (txn_get_op (txn, 8, &entry) == 0 && entry != NULL,
+        "9: retrieved");
+    jdiag (entry);
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "9: txn_decode_op works");
+    ok (!strcmp (key, "f.f.f")
+        && flags == 0
+        && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
+                                                        "namespace")),
+                    "g.g.g")
+        && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
+                                                        "target")),
+                    "h.h.h"),
+        "9: symlink f.f.f g.g.g h.h.h (namespace)");
+
     errno = 0;
-    ok (txn_get_op (txn, 8, &entry) < 0 && errno == EINVAL,
-        "9: invalid (end of transaction)");
+    ok (txn_get_op (txn, 9, &entry) < 0 && errno == EINVAL,
+        "10: invalid (end of transaction)");
 
     flux_kvs_txn_destroy (txn);
 }

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -218,7 +218,9 @@ void basic (void)
     ok (!strcmp (key, "c.c.c")
         && flags == 0
         && treeobj_is_symlink (dirent)
-        && !strcmp (json_string_value (treeobj_get_data (dirent)), "b.b.b"),
+        && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
+                                                        "target")),
+                    "b.b.b"),
         "5: symlink c.c.c b.b.b");
 
     ok (txn_get_op (txn, 5, &entry) == 0 && entry != NULL,

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -20,9 +20,10 @@
  * valref, dirref: if blobref is NULL, treeobj_append_blobref()
  * must be called before object is valid.
  * val: copies argument (caller retains ownership)
+ * symlink: ns argument is optional
  * Return JSON object on success, NULL on failure with errno set.
  */
-json_t *treeobj_create_symlink (const char *target);
+json_t *treeobj_create_symlink (const char *ns, const char *target);
 json_t *treeobj_create_val (const void *data, int len);
 json_t *treeobj_create_valref (const char *blobref);
 json_t *treeobj_create_dir (void);
@@ -48,7 +49,7 @@ bool treeobj_is_dirref (const json_t *obj);
 /* get type-specific value.
  * For dirref/valref, this is an array of blobrefs.
  * For directory, this is dictionary of treeobjs
- * For symlink, this is a string.
+ * For symlink, this is an object with optinoal namespace and target.
  * For val this is string containing base64-encoded data.
  * Return JSON object on success, NULL on error with errno = EINVAL.
  * The returned object is owned by 'obj' and must not be destroyed.
@@ -57,7 +58,9 @@ json_t *treeobj_get_data (json_t *obj);
 
 /* get convenience functions, operate on type specific objects
  */
-const char *treeobj_get_symlink (const json_t *obj);
+int treeobj_get_symlink (const json_t *obj,
+                         const char **ns,
+                         const char **target);
 
 /* get decoded val data.
  * If len == 0, data will be NULL.

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -638,20 +638,16 @@ static int kvstxn_link_dirent (kvstxn_t *kt, int current_epoch,
             }
             json_decref (subdir);
         } else if (treeobj_is_symlink (dir_entry)) {
-            json_t *symlink = treeobj_get_data (dir_entry);
-            const char *symlinkstr;
+            const char *target = NULL;
             char *nkey = NULL;
 
-            if (!symlink) {
+            if (treeobj_get_symlink (dir_entry, NULL, &target) < 0) {
                 saved_errno = EINVAL;
                 goto done;
             }
+            assert (target);
 
-            assert (json_is_string (symlink));
-
-            symlinkstr = json_string_value (symlink);
-
-            if (asprintf (&nkey, "%s.%s", symlinkstr, next) < 0) {
+            if (asprintf (&nkey, "%s.%s", target, next) < 0) {
                 saved_errno = ENOMEM;
                 goto done;
             }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -638,14 +638,21 @@ static int kvstxn_link_dirent (kvstxn_t *kt, int current_epoch,
             }
             json_decref (subdir);
         } else if (treeobj_is_symlink (dir_entry)) {
+            const char *ns = NULL;
             const char *target = NULL;
             char *nkey = NULL;
 
-            if (treeobj_get_symlink (dir_entry, NULL, &target) < 0) {
+            if (treeobj_get_symlink (dir_entry, &ns, &target) < 0) {
                 saved_errno = EINVAL;
                 goto done;
             }
             assert (target);
+
+            /* can't cross into a new namespace */
+            if (ns && strcmp (ns, kt->ktm->ns_name)) {
+                saved_errno = EINVAL;
+                goto done;
+            }
 
             if (asprintf (&nkey, "%s.%s", target, next) < 0) {
                 saved_errno = ENOMEM;

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -226,12 +226,13 @@ static lookup_process_t walk_symlink (lookup_t *lh,
 {
     lookup_process_t ret = LOOKUP_PROCESS_ERROR;
     walk_level_t *wltmp;
-    const char *linkstr;
+    const char *target = NULL;
 
-    if (!(linkstr = treeobj_get_symlink (dirent_tmp))) {
+    if (treeobj_get_symlink (dirent_tmp, NULL, &target) < 0) {
         lh->errnum = errno;
         goto cleanup;
     }
+    assert (target);
 
     /* Follow link if in middle of path or if end of path,
      * flags say we can follow it
@@ -246,20 +247,20 @@ static lookup_process_t walk_symlink (lookup_t *lh,
         }
 
         /* Set wl->dirent, now that we've resolved any
-         * namespaces in the linkstr.
+         * namespaces in the target.
          */
         wl->dirent = dirent_tmp;
 
         /* if symlink is root, no need to recurse, just get
          * root_dirent and continue on.
          */
-        if (!strcmp (linkstr, "."))
+        if (!strcmp (target, "."))
             wl->dirent = wl->root_dirent;
         else {
             /* "recursively" determine link dirent */
             if (!(wltmp = walk_levels_push (lh,
                                             wl->root_ref,
-                                            linkstr,
+                                            target,
                                             wl->depth + 1))) {
                 lh->errnum = errno;
                 goto cleanup;

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -174,7 +174,7 @@ void _treeobj_insert_entry_val (json_t *obj, const char *name,
 void _treeobj_insert_entry_symlink (json_t *obj, const char *name,
                                     const char *target)
 {
-    json_t *symlink = treeobj_create_symlink (target);
+    json_t *symlink = treeobj_create_symlink (NULL, target);
     treeobj_insert_entry (obj, name, symlink);
     json_decref (symlink);
 }

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -171,9 +171,9 @@ void _treeobj_insert_entry_val (json_t *obj, const char *name,
  * created symlink can be properly dereferenced
  */
 void _treeobj_insert_entry_symlink (json_t *obj, const char *name,
-                                    const char *target)
+                                    const char *ns, const char *target)
 {
-    json_t *symlink = treeobj_create_symlink (NULL, target);
+    json_t *symlink = treeobj_create_symlink (ns, target);
     treeobj_insert_entry (obj, name, symlink);
     json_decref (symlink);
 }
@@ -694,6 +694,7 @@ void lookup_basic (void) {
      * "val" : val to "foo"
      * "dir" : dir w/ "val" : val to "bar"
      * "symlink" : symlink to "baz"
+     * "symlinkNS" : symlink to "boz" in namespace=primary
      *
      * root_ref
      * "dirref" : dirref to dirref_ref
@@ -719,7 +720,8 @@ void lookup_basic (void) {
     _treeobj_insert_entry_valref (dirref, "valref_with_dirref", dirref_test_ref);
     _treeobj_insert_entry_val (dirref, "val", "foo", 3);
     treeobj_insert_entry (dirref, "dir", dir);
-    _treeobj_insert_entry_symlink (dirref, "symlink", "baz");
+    _treeobj_insert_entry_symlink (dirref, "symlink", NULL, "baz");
+    _treeobj_insert_entry_symlink (dirref, "symlinkNS", KVS_PRIMARY_NAMESPACE, "boz");
 
     valref_multi = treeobj_create_valref (valref_ref);
     treeobj_append_blobref (valref_multi, valref2_ref);
@@ -878,6 +880,23 @@ void lookup_basic (void) {
     check_value (lh, test, "lookup dirref.symlink");
     json_decref (test);
 
+    /* lookup symlinkNS */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
+                             0,
+                             "dirref.symlinkNS",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             FLUX_KVS_READLINK,
+                             NULL)) != NULL,
+        "lookup_create on path dirref.symlinkNS");
+    test = treeobj_create_symlink (KVS_PRIMARY_NAMESPACE, "boz");
+    check_value (lh, test, "lookup dirref.symlinkNS");
+    json_decref (test);
+
     /* lookup dirref treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
@@ -961,6 +980,23 @@ void lookup_basic (void) {
     check_value (lh, test, "lookup dirref.symlink treeobj");
     json_decref (test);
 
+    /* lookup symlinkNS treeobj */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
+                             0,
+                             "dirref.symlinkNS",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             FLUX_KVS_TREEOBJ,
+                             NULL)) != NULL,
+        "lookup_create on path dirref.symlinkNS (treeobj)");
+    test = treeobj_create_symlink (KVS_PRIMARY_NAMESPACE, "boz");
+    check_value (lh, test, "lookup dirref.symlinkNS treeobj");
+    json_decref (test);
+
     cache_destroy (cache);
     kvsroot_mgr_destroy (krm);
     json_decref (dirref_test);
@@ -1001,6 +1037,11 @@ void lookup_errors (void) {
      * "symlink" : symlink to "symlinkstr"
      * "symlink1" : symlink to "symlink2"
      * "symlink2" : symlink to "symlink1"
+     * "symlinkNS" : symlink to "symlinkNSstr" in namespace=primary
+     * "symlinkNS1" : symlink to "symlinkNS2" in namespace=primary
+     * "symlinkNS2" : symlink to "symlinkNS1" in namespace=primary
+     * "ns2symlink" : symlink to "symlink2ns" in namespace=primary
+     * "symlink2ns" : symlink to "ns2symlink"
      * "val" : val to "foo"
      * "valref" : valref to valref_ref
      * "dirref" : dirref to dirref_ref
@@ -1021,9 +1062,14 @@ void lookup_errors (void) {
     _treeobj_insert_entry_val (dir, "val", "baz", 3);
 
     root = treeobj_create_dir ();
-    _treeobj_insert_entry_symlink (root, "symlink", "symlinkstr");
-    _treeobj_insert_entry_symlink (root, "symlink1", "symlink2");
-    _treeobj_insert_entry_symlink (root, "symlink2", "symlink1");
+    _treeobj_insert_entry_symlink (root, "symlink", NULL, "symlinkstr");
+    _treeobj_insert_entry_symlink (root, "symlink1", NULL, "symlink2");
+    _treeobj_insert_entry_symlink (root, "symlink2", NULL, "symlink1");
+    _treeobj_insert_entry_symlink (root, "symlinkNS", KVS_PRIMARY_NAMESPACE, "symlinkNSstr");
+    _treeobj_insert_entry_symlink (root, "symlinkNS1", KVS_PRIMARY_NAMESPACE, "symlinkNS2");
+    _treeobj_insert_entry_symlink (root, "symlinkNS2", KVS_PRIMARY_NAMESPACE, "symlinkNS1");
+    _treeobj_insert_entry_symlink (root, "symlinkNS2symlink", KVS_PRIMARY_NAMESPACE, "symlink2symlinkNS");
+    _treeobj_insert_entry_symlink (root, "symlink2symlinkNS", NULL, "symlinkNS2symlink");
     _treeobj_insert_entry_val (root, "val", "foo", 3);
     _treeobj_insert_entry_valref (root, "valref", valref_ref);
     _treeobj_insert_entry_dirref (root, "dirref", dirref_ref);
@@ -1117,6 +1163,36 @@ void lookup_errors (void) {
                              NULL)) != NULL,
         "lookup_create on link loop");
     check_error (lh, ELOOP, "lookup infinite links");
+
+    /* Lookup path w/ infinite symlinkNS loop, should get ELOOP */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
+                             0,
+                             "symlinkNS1",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create on symlinkNS loop");
+    check_error (lh, ELOOP, "lookup infinite symlinkNS loop");
+
+    /* Lookup path w/ infinite symlink w/ & w/o namespace loop, should get ELOOP */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
+                             0,
+                             "symlinkNS2symlink",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create on symlink (w/ & w/o namespace) loop");
+    check_error (lh, ELOOP, "lookup infinite symlink (w/ & w/o namespace) loop");
 
     /* Lookup a dirref, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
@@ -1252,6 +1328,21 @@ void lookup_errors (void) {
                              NULL)) != NULL,
         "lookup_create on symlink");
     check_error (lh, ENOTDIR, "lookup symlink, expecting dir");
+
+    /* Lookup a symlinkNS, but expecting a dir, should get ENOTDIR. */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
+                             0,
+                             "symlinkNS",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             FLUX_KVS_READLINK | FLUX_KVS_READDIR,
+                             NULL)) != NULL,
+        "lookup_create on symlinkNS");
+    check_error (lh, ENOTDIR, "lookup symlinkNS, expecting dir");
 
     /* Lookup a dirref that doesn't point to a dir, should get ENOTRECOVERABLE. */
     ok ((lh = lookup_create (cache,
@@ -1585,16 +1676,16 @@ void lookup_links (void) {
     _treeobj_insert_entry_valref (dirref2, "valref", valref_ref);
     treeobj_insert_entry (dirref2, "dir", dir);
     _treeobj_insert_entry_dirref (dirref2, "dirref", dirref3_ref);
-    _treeobj_insert_entry_symlink (dirref2, "symlink", "dirref2.val");
+    _treeobj_insert_entry_symlink (dirref2, "symlink", NULL, "dirref2.val");
     treeobj_hash ("sha1", dirref2, dirref2_ref, sizeof (dirref2_ref));
     (void)cache_insert (cache, create_cache_entry_treeobj (dirref2_ref, dirref2));
 
     dirref1 = treeobj_create_dir ();
-    _treeobj_insert_entry_symlink (dirref1, "link2dirref", "dirref2");
-    _treeobj_insert_entry_symlink (dirref1, "link2val", "dirref2.val");
-    _treeobj_insert_entry_symlink (dirref1, "link2valref", "dirref2.valref");
-    _treeobj_insert_entry_symlink (dirref1, "link2dir", "dirref2.dir");
-    _treeobj_insert_entry_symlink (dirref1, "link2symlink", "dirref2.symlink");
+    _treeobj_insert_entry_symlink (dirref1, "link2dirref", NULL, "dirref2");
+    _treeobj_insert_entry_symlink (dirref1, "link2val", NULL, "dirref2.val");
+    _treeobj_insert_entry_symlink (dirref1, "link2valref", NULL, "dirref2.valref");
+    _treeobj_insert_entry_symlink (dirref1, "link2dir", NULL, "dirref2.dir");
+    _treeobj_insert_entry_symlink (dirref1, "link2symlink", NULL, "dirref2.symlink");
     treeobj_hash ("sha1", dirref1, dirref1_ref, sizeof (dirref1_ref));
     (void)cache_insert (cache, create_cache_entry_treeobj (dirref1_ref, dirref1));
 
@@ -1919,13 +2010,13 @@ void lookup_root_symlink (void) {
     (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
 
     dirref = treeobj_create_dir ();
-    _treeobj_insert_entry_symlink (dirref, "symlinkroot", ".");
+    _treeobj_insert_entry_symlink (dirref, "symlinkroot", NULL, ".");
     treeobj_hash ("sha1", dirref, dirref_ref, sizeof (dirref_ref));
     (void)cache_insert (cache, create_cache_entry_treeobj (dirref_ref, dirref));
 
     root = treeobj_create_dir ();
     _treeobj_insert_entry_val (root, "val", "foo", 3);
-    _treeobj_insert_entry_symlink (root, "symlinkroot", ".");
+    _treeobj_insert_entry_symlink (root, "symlinkroot", NULL, ".");
     _treeobj_insert_entry_dirref (root, "dirref", dirref_ref);
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
     (void)cache_insert (cache, create_cache_entry_treeobj (root_ref, root));
@@ -2045,6 +2136,308 @@ void lookup_root_symlink (void) {
     kvsroot_mgr_destroy (krm);
     json_decref (dirref);
     json_decref (root);
+}
+
+/* lookup symlinkNS tests */
+void lookup_symlinkNS (void) {
+    json_t *rootA;
+    json_t *rootB;
+    json_t *test;
+    struct cache *cache;
+    kvsroot_mgr_t *krm;
+    lookup_t *lh;
+    char root_refA[BLOBREF_MAX_STRING_SIZE];
+    char root_refB[BLOBREF_MAX_STRING_SIZE];
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
+
+    /* This cache is
+     *
+     * root-refA
+     * "val" : val to "1"
+     * "symlinkNS2A-invalid" : symlinkNS to an invalid key in namespace=A
+     * "symlinkNS2B-invalid" : symlinkNS to an invalid key in namespace=B
+     * "symlinkNS2A" : symlinkNS to "." in namespace=A
+     * "symlinkNS2B" : symlinkNS to "." in namespace=B
+     * "symlinkNS2A-val" : symlinkNS to "val" in namespace=A
+     * "symlinkNS2B-val" : symlinkNS to "val" in namespace=B
+     *
+     * root-refB
+     * "val" : val to "2"
+     */
+
+    rootA = treeobj_create_dir ();
+    _treeobj_insert_entry_val (rootA, "val", "1", 1);
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2A-invalid", "A", "foobar");
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2B-invalid", "A", "foobar");
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2A", "A", ".");
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2B", "B", ".");
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2A-val", "A", "val");
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2B-val", "B", "val");
+    treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
+
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refA, rootA));
+
+    rootB = treeobj_create_dir ();
+    _treeobj_insert_entry_val (rootB, "val", "2", 1);
+    treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
+
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refB, rootB));
+
+    setup_kvsroot (krm, "A", cache, root_refA, 0);
+    setup_kvsroot (krm, "B", cache, root_refB, 0);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2A-invalid",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2A-invalid on namespace A");
+    check_value (lh, NULL, "symlinkNS2A-invalid on namespace A");
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2B-invalid",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2B-invalid on namespace A");
+    check_value (lh, NULL, "symlinkNS2B-invalid on namespace A");
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2A.val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2A.val on namespace A");
+    test = treeobj_create_val ("1", 1);
+    check_value (lh, test, "symlinkNS2A.val on namespace A");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2B.val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2B.val on namespace A");
+    test = treeobj_create_val ("2", 1);
+    check_value (lh, test, "symlinkNS2B.val on namespace A");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2A-val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2A-val on namespace A");
+    test = treeobj_create_val ("1", 1);
+    check_value (lh, test, "symlinkNS2A-val on namespace A");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2B-val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2B-val on namespace A");
+    test = treeobj_create_val ("2", 1);
+    check_value (lh, test, "symlinkNS2B-val on namespace A");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2A",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             FLUX_KVS_READDIR,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2A on namespace A, readdir");
+    check_value (lh, rootA, "symlinkNS2A on namespace A, readdir");
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2B",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             FLUX_KVS_READDIR,
+                             NULL)) != NULL,
+        "lookup_create symlinkNS2B on namespace A, readdir");
+    check_value (lh, rootB, "symlinkNS2B on namespace A, readdir");
+
+    cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
+    json_decref (rootA);
+    json_decref (rootB);
+}
+
+void lookup_symlinkNS_security (void) {
+    json_t *rootA;
+    json_t *rootB;
+    json_t *rootC;
+    json_t *test;
+    struct cache *cache;
+    kvsroot_mgr_t *krm;
+    lookup_t *lh;
+    char root_refA[BLOBREF_MAX_STRING_SIZE];
+    char root_refB[BLOBREF_MAX_STRING_SIZE];
+    char root_refC[BLOBREF_MAX_STRING_SIZE];
+
+    ok ((cache = cache_create ()) != NULL,
+        "cache_create works");
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
+
+    /* This cache is
+     *
+     * root-refA
+     * "val" : val to "1"
+     * "symlinkNS2B" : symlinkNS to "." in namespace=B
+     * "symlinkNS2C" : symlinkNS to "." in namespace=C
+     *
+     * root-refB
+     * "val" : val to "2"
+     *
+     * root-refC
+     * "val" : val to "3"
+     */
+
+    rootA = treeobj_create_dir ();
+    _treeobj_insert_entry_val (rootA, "val", "1", 1);
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2B", "B", ".");
+    _treeobj_insert_entry_symlink (rootA, "symlinkNS2C", "C", ".");
+    treeobj_hash ("sha1", rootA, root_refA, sizeof (root_refA));
+
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refA, rootA));
+
+    rootB = treeobj_create_dir ();
+    _treeobj_insert_entry_val (rootB, "val", "2", 1);
+    treeobj_hash ("sha1", rootB, root_refB, sizeof (root_refB));
+
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refB, rootB));
+
+    rootC = treeobj_create_dir ();
+    _treeobj_insert_entry_val (rootC, "val", "3", 1);
+    treeobj_hash ("sha1", rootC, root_refC, sizeof (root_refC));
+
+    (void)cache_insert (cache, create_cache_entry_treeobj (root_refC, rootC));
+
+    setup_kvsroot (krm, "A", cache, root_refA, 1000);
+    setup_kvsroot (krm, "B", cache, root_refB, 1000);
+    setup_kvsroot (krm, "C", cache, root_refC, 2000);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2B.val",
+                             FLUX_ROLE_OWNER,
+                             1000,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create on symlinkNS2B.val with rolemask owner");
+    test = treeobj_create_val ("2", 1);
+    check_value (lh, test, "lookup symlinkNS2B.val with rolemask owner");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2C.val",
+                             FLUX_ROLE_OWNER,
+                             1000,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create on symlinkNS2C.val with rolemask owner");
+    test = treeobj_create_val ("3", 1);
+    check_value (lh, test, "lookup symlinkNS2C.val with rolemask owner");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2B.val",
+                             FLUX_ROLE_USER,
+                             1000,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create on symlinkNS2B.val with rolemask user and valid owner");
+    test = treeobj_create_val ("2", 1);
+    check_value (lh, test, "lookup symlinkNS2B.val with rolemask user and valid owner");
+    json_decref (test);
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             "A",
+                             NULL,
+                             0,
+                             "symlinkNS2C.val",
+                             FLUX_ROLE_USER,
+                             1000,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create on symlinkNS2C.val with rolemask user and invalid owner");
+    check_error (lh, EPERM, "lookup_create on symlinkNS2C.val with rolemask user and invalid owner");
+
+    cache_destroy (cache);
+    kvsroot_mgr_destroy (krm);
+    json_decref (rootA);
+    json_decref (rootB);
+    json_decref (rootC);
 }
 
 /* lookup stall namespace tests */
@@ -2370,7 +2763,7 @@ void lookup_stall_ref (void) {
     root = treeobj_create_dir ();
     _treeobj_insert_entry_dirref (root, "dirref1", dirref1_ref);
     _treeobj_insert_entry_dirref (root, "dirref2", dirref2_ref);
-    _treeobj_insert_entry_symlink (root, "symlink", "dirref2");
+    _treeobj_insert_entry_symlink (root, "symlink", NULL, "dirref2");
     treeobj_hash ("sha1", root, root_ref, sizeof (root_ref));
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref, 0);
@@ -2990,6 +3383,8 @@ int main (int argc, char *argv[])
     lookup_links ();
     lookup_alt_root ();
     lookup_root_symlink ();
+    lookup_symlinkNS ();
+    lookup_symlinkNS_security ();
     lookup_stall_namespace ();
     lookup_stall_ref_root ();
     lookup_stall_ref ();

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -173,7 +173,7 @@ void _treeobj_insert_entry_val (json_t *obj, const char *name,
 void _treeobj_insert_entry_symlink (json_t *obj, const char *name,
                                     const char *target)
 {
-    json_t *symlink = treeobj_create_symlink (target);
+    json_t *symlink = treeobj_create_symlink (NULL, target);
     treeobj_insert_entry (obj, name, symlink);
     json_decref (symlink);
 }
@@ -874,7 +874,7 @@ void lookup_basic (void) {
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on path dirref.symlink");
-    test = treeobj_create_symlink ("baz");
+    test = treeobj_create_symlink (NULL, "baz");
     check_value (lh, test, "lookup dirref.symlink");
     json_decref (test);
 
@@ -957,7 +957,7 @@ void lookup_basic (void) {
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref.symlink (treeobj)");
-    test = treeobj_create_symlink ("baz");
+    test = treeobj_create_symlink (NULL, "baz");
     check_value (lh, test, "lookup dirref.symlink treeobj");
     json_decref (test);
 
@@ -1700,7 +1700,7 @@ void lookup_links (void) {
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create link to symlink");
-    test = treeobj_create_symlink ("dirref2.val");
+    test = treeobj_create_symlink (NULL, "dirref2.val");
     check_value (lh, test, "dirref1.link2dirref.symlink");
     json_decref (test);
 
@@ -1781,7 +1781,7 @@ void lookup_links (void) {
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create link to symlink (last part path)");
-    test = treeobj_create_symlink ("dirref2.symlink");
+    test = treeobj_create_symlink (NULL, "dirref2.symlink");
     check_value (lh, test, "dirref1.link2symlink");
     json_decref (test);
 
@@ -1991,7 +1991,7 @@ void lookup_root_symlink (void) {
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on symlinkroot w/ flag = FLUX_KVS_TREEOBJ, works");
-    test = treeobj_create_symlink (".");
+    test = treeobj_create_symlink (NULL, ".");
     check_value (lh, test, "symlinkroot w/ FLUX_KVS_TREEOBJ");
     json_decref (test);
 

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -318,6 +318,37 @@ test_expect_success 'kvs: namespace remove still works (owner)' '
 '
 
 #
+# namespace link cross
+#
+
+test_expect_success 'kvs: namespace create works (owner, for user)' '
+	flux kvs namespace-create -o 9000 $NAMESPACETMP-SYMLINKNS1 &&
+	flux kvs namespace-create -o 9001 $NAMESPACETMP-SYMLINKNS2 &&
+	flux kvs namespace-create -o 9001 $NAMESPACETMP-SYMLINKNS3
+'
+
+test_expect_success 'kvs: symlink w/ Namespace works (owner)' '
+        flux kvs --namespace=${NAMESPACETMP}-SYMLINKNS1 put $DIR.linktest=1 &&
+        flux kvs --namespace=${NAMESPACETMP}-SYMLINKNS2 put $DIR.linktest=2 &&
+        flux kvs --namespace=${NAMESPACETMP}-SYMLINKNS1 link --target-namespace=${NAMESPACETMP}-SYMLINKNS2 $DIR.linktest $DIR.link &&
+        test_kvs_key_namespace ${NAMESPACETMP}-SYMLINKNS1 $DIR.link 2
+'
+
+test_expect_success 'kvs: symlinkw/ Namespace fails (wrong user)' '
+        set_userid 9000 &&
+        ! flux kvs --namespace=${NAMESPACETMP}-SYMLINKNS1 get $DIR.link &&
+        unset_userid
+'
+
+test_expect_success 'kvs: symlink w/ Namespace works (user)' '
+        set_userid 9001 &&
+        flux kvs --namespace=${NAMESPACETMP}-SYMLINKNS3 put $DIR.linktest=3 &&
+        flux kvs --namespace=${NAMESPACETMP}-SYMLINKNS2 link --target-namespace=${NAMESPACETMP}-SYMLINKNS3 $DIR.linktest $DIR.link &&
+        test_kvs_key_namespace ${NAMESPACETMP}-SYMLINKNS2 $DIR.link 3 &&
+        unset_userid
+'
+
+#
 # Basic tests, user can't perform non-namespace operations
 #
 


### PR DESCRIPTION
This is the third part to issue #1860, implementing namespace symlink support as described by RFC change https://github.com/flux-framework/rfc/pull/147.

Basically, we're changing the treeobj of a symlink to:

```
{ "ver":1,
  "type":"symlink",
  "data":{"namespace":"a","target":"b.b"},
}
```

where the "namespace" field is optional.  Adjustments to all functions that relate to symlinks are done (```treeobj_create_symlink()```, ```flux_kvs_lookup_get_symlink()```, and ```flux_kvs_txn_symlink()```
are the obvious ones).  Subsequently new options to ```flux kvs link``` and ```flux kvs readlink```.

The one part of this PR I really like is how so little changed in ```modules/kvs``` and there were no changes in ```modules/kvs-watch```.  So I think this was a much better choice than the ns prefix we did earlier.

The one part of this PR that folks may find weird is in the function ```treeobj_get_symlink_namespace()```.  If the symlink does not contain a namespace, I elect to return NULL and set errno to ENODATA, instead of EINVAL.  So that callers have a way to differentiate between no namespace and an invalid treeobj.  I'm not 100% if this is the right errno or the right pattern to use.  Thoughts?

Also up for discussion may be the "ns::key" output format I use in ```flux-kvs```.

