### PR TITLE
libsubprocess: fix mem-leak on subprocess server teardown

### DIFF
--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -8,8 +8,8 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux
-
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	libsubprocess.la

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -128,7 +128,7 @@ static void internal_fatal (flux_subprocess_server_t *s, flux_subprocess_t *p)
         return;
 
     /* report of state change handled through typical state change
-     * callback.  Normaly cleanup occurs through completion of local
+     * callback.  Normally cleanup occurs through completion of local
      * subprocess.
      */
     p->state = FLUX_SUBPROCESS_FAILED;

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -17,6 +17,8 @@ int server_start (flux_subprocess_server_t *s, const char *prefix);
 
 void server_stop (flux_subprocess_server_t *s);
 
+int server_terminate_subprocesses (flux_subprocess_server_t *s);
+
 int server_terminate_by_uuid (flux_subprocess_server_t *s,
                               const char *id);
 

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -201,7 +201,7 @@ static void subprocess_server_destroy (void *arg)
 {
     flux_subprocess_server_t *s = arg;
     if (s && s->magic == SUBPROCESS_SERVER_MAGIC) {
-        /* s->handlers handle in server_stop, this is for destroying
+        /* s->handlers handled in server_stop, this is for destroying
          * things only
          */
         zhash_destroy (&s->subprocesses);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -286,6 +286,7 @@ void flux_subprocess_server_stop (flux_subprocess_server_t *s)
 {
     if (s && s->magic == SUBPROCESS_SERVER_MAGIC) {
         server_stop (s);
+        server_terminate_subprocesses (s);
         subprocess_server_destroy (s);
     }
 }


### PR DESCRIPTION
Fix mem-leak when subprocess server is being torn down but a local subprocess has not yet completed.