### PR TITLE
flux-jobspec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ asciidoctor	| asciidoctor         	| >= 1.5.7		| *2*
 aspell		| aspell		|			| *3*
 valgrind	| valgrind		|			| *3*
 mpich		| mpich			|			| *3*
+jq		    | jq			|			| *3*
 
 *Note 1 - Due to a packaging issue, Ubuntu lua-posix may need the
 following symlink (true for version 33.4.0-2):*

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -2,7 +2,12 @@
 set -e
 
 if command -v black 2>&1 > /dev/null ; then
-  find src t -name '*.py' -print0 | xargs -0 black --check
+    # awk cmd copied from:
+    # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
+    find src t -type f \
+         \( -name "*.py" -print -o \
+         -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
+        | xargs black --check
 else
   echo "black not found, failing"
   exit 1

--- a/scripts/format
+++ b/scripts/format
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 if command -v black 2>&1 > /dev/null ; then
-  find src t -name '*.py' -print0 | xargs -0 black
+    # awk cmd copied from:
+    # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
+    find src t -type f \
+         \( -name "*.py" -print -o \
+         -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
+        | xargs black
 else
   echo "black not found, python left unformatted"
 fi

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -54,7 +54,8 @@ nodist_flux_SOURCES = \
 #
 
 dist_fluxcmd_SCRIPTS = \
-	flux-cron
+	flux-cron \
+	flux-jobspec
 
 fluxcmd_PROGRAMS = \
 	flux-aggregate \

--- a/src/cmd/flux-jobspec
+++ b/src/cmd/flux-jobspec
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import re
 import sys
+import math
 import logging
 import argparse
 import json
@@ -34,10 +35,21 @@ def create_slurm_style_jobspec(
     command, num_tasks, cores_per_task, num_nodes=0, walltime=None
 ):
     core = create_resource("core", cores_per_task)
-    slot = create_slot("task", 1, [core])
     if num_nodes > 0:
+        num_slots = int(math.ceil(num_tasks / float(num_nodes)))
+        if num_tasks % num_nodes != 0:
+            logging.warn(
+                "Number of tasks is not an integer multiple of the number of nodes. "
+                "More resources than required will be requested to satisfy your job."
+            )
+            task_count_dict = {"total": num_tasks}
+        else:
+            task_count_dict = {"per_slot": 1}
+        slot = create_slot("task", num_slots, [core])
         resource_section = create_resource("node", num_nodes, [slot])
     else:
+        task_count_dict = {"per_slot": 1}
+        slot = create_slot("task", num_tasks, [core])
         resource_section = slot
 
     jobspec = {
@@ -47,7 +59,7 @@ def create_slurm_style_jobspec(
             {
                 "command": command,
                 "slot": "task",
-                "count": {"total": num_tasks},
+                "count": task_count_dict,
                 "attributes": {},
             }
         ],
@@ -60,6 +72,9 @@ def create_slurm_style_jobspec(
 
 
 def validate_slurm_args(args):
+    if args.nodes > args.ntasks:
+        raise ValueError("Number of nodes greater than the number of tasks")
+
     if (
         args.time
         and re.match(r"^(\d+-)?\d+:\d+:\d+$") is None
@@ -75,6 +90,9 @@ def validate_slurm_args(args):
 
 
 def slurm_jobspec(args):
+    if args.ntasks is None:
+        args.ntasks = max(args.nodes, 1)
+
     try:
         validate_slurm_args(args)
     except ValueError as e:
@@ -93,7 +111,7 @@ def get_slurm_common_parser():
     """
     slurm_parser = argparse.ArgumentParser(add_help=False)
     slurm_parser.add_argument("-N", "--nodes", type=int, default=0)
-    slurm_parser.add_argument("-n", "--ntasks", type=int, default=1)
+    slurm_parser.add_argument("-n", "--ntasks", type=int)
     slurm_parser.add_argument("-c", "--cpus-per-task", type=int, default=1)
     slurm_parser.add_argument(
         "-t",

--- a/src/cmd/flux-jobspec
+++ b/src/cmd/flux-jobspec
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import sys
+import argparse
+import json
+from collections import Sequence
+
+
+def create_resource(res_type, count, with_child=[]):
+    assert isinstance(with_child, Sequence)
+    assert not isinstance(with_child, str)
+    assert count > 0
+
+    res = {"type": res_type, "count": count}
+
+    if len(with_child) > 0:
+        res["with"] = with_child
+    return res
+
+
+def create_slot(label, count, with_child):
+    slot = create_resource("slot", count, with_child)
+    slot["label"] = label
+    return slot
+
+
+def main():
+    core = create_resource("core", args.cores_per_task)
+    slot = create_slot("task", 1, [core])
+    if args.num_nodes:
+        resource_section = create_resource("node", args.num_nodes, [slot])
+    else:
+        resource_section = slot
+
+    jobspec = {
+        "version": 1,
+        "resources": [resource_section],
+        "tasks": [
+            {
+                "command": args.command,
+                "slot": "task",
+                "count": {"total": args.num_tasks},
+            }
+        ],
+        "attributes": {"system": {"duration": "{} seconds".format(args.walltime)}},
+    }
+
+    if args.pretty:
+        out = json.dumps(jobspec, indent=4, sort_keys=True)
+    else:
+        out = json.dumps(jobspec)
+    print(out)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-N", "--num-nodes", type=int, default=0)
+    parser.add_argument("-n", "--num-tasks", type=int, default=1)
+    parser.add_argument("-c", "--cores-per-task", type=int, default=1)
+    parser.add_argument(
+        "-t", "--walltime", type=int, default=3600, help="walltime in seconds"
+    )
+    parser.add_argument(
+        "-p", "--pretty", action="store_true", help="pretty print the jobspec json"
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    if len(args.command) == 0:
+        parser.print_usage()
+        print("command is required")
+        sys.exit(1)
+
+    main()

--- a/src/cmd/flux-jobspec
+++ b/src/cmd/flux-jobspec
@@ -77,8 +77,8 @@ def validate_slurm_args(args):
 
     if (
         args.time
-        and re.match(r"^(\d+-)?\d+:\d+:\d+$") is None
-        and re.match(r"^\d+(:\d+)?$") is None
+        and re.match(r"^(\d+-)?\d+:\d+:\d+$", args.time) is None
+        and re.match(r"^\d+(:\d+)?$", args.time) is None
     ):
         raise ValueError(
             "invalid time limit string format. "

--- a/src/cmd/flux-jobspec
+++ b/src/cmd/flux-jobspec
@@ -2,16 +2,20 @@
 
 from __future__ import print_function
 
+import re
 import sys
+import logging
 import argparse
 import json
 from collections import Sequence
 
+import yaml
+
 
 def create_resource(res_type, count, with_child=[]):
-    assert isinstance(with_child, Sequence)
-    assert not isinstance(with_child, str)
-    assert count > 0
+    assert isinstance(with_child, Sequence), "child resource must be a sequence"
+    assert not isinstance(with_child, str), "child resource must not be a string"
+    assert count > 0, "resource count must be > 0"
 
     res = {"type": res_type, "count": count}
 
@@ -26,11 +30,13 @@ def create_slot(label, count, with_child):
     return slot
 
 
-def main():
-    core = create_resource("core", args.cores_per_task)
+def create_slurm_style_jobspec(
+    command, num_tasks, cores_per_task, num_nodes=0, walltime=None
+):
+    core = create_resource("core", cores_per_task)
     slot = create_slot("task", 1, [core])
-    if args.num_nodes:
-        resource_section = create_resource("node", args.num_nodes, [slot])
+    if num_nodes > 0:
+        resource_section = create_resource("node", num_nodes, [slot])
     else:
         resource_section = slot
 
@@ -39,38 +45,106 @@ def main():
         "resources": [resource_section],
         "tasks": [
             {
-                "command": args.command,
+                "command": command,
                 "slot": "task",
-                "count": {"total": args.num_tasks},
+                "count": {"total": num_tasks},
+                "attributes": {},
             }
         ],
-        "attributes": {"system": {"duration": "{} seconds".format(args.walltime)}},
+        "attributes": {"system": {}},
     }
+    if walltime:
+        jobspec["attributes"]["system"]["duration"] = walltime
 
-    if args.pretty:
-        out = json.dumps(jobspec, indent=4, sort_keys=True)
+    return jobspec
+
+
+def validate_slurm_args(args):
+    if (
+        args.time
+        and re.match(r"^(\d+-)?\d+:\d+:\d+$") is None
+        and re.match(r"^\d+(:\d+)?$") is None
+    ):
+        raise ValueError(
+            "invalid time limit string format. "
+            "Acceptable formats include minutes[:seconds], [days-]hours:minutes:seconds"
+        )
+
+    # TODO: is there any validation of the stdout redirection path that we can do?
+    # IDEA: print a warning if the file already exists or if the parent dir doesn't exist
+
+
+def slurm_jobspec(args):
+    try:
+        validate_slurm_args(args)
+    except ValueError as e:
+        logger.error(e.message)
+        sys.exit(1)
+    return create_slurm_style_jobspec(
+        args.command, args.ntasks, args.cpus_per_task, args.nodes, args.time
+    )
+
+
+def get_slurm_common_parser():
+    """
+    Shared arguments amongst srun and sbatch.
+    Used src/srun/libsrun/opt.c and src/sbatch/opt.c of the
+    [SLURM repository](https://github.com/SchedMD/slurm.git) as reference
+    """
+    slurm_parser = argparse.ArgumentParser(add_help=False)
+    slurm_parser.add_argument("-N", "--nodes", type=int, default=0)
+    slurm_parser.add_argument("-n", "--ntasks", type=int, default=1)
+    slurm_parser.add_argument("-c", "--cpus-per-task", type=int, default=1)
+    slurm_parser.add_argument(
+        "-t",
+        "--time",
+        help="time limit. Acceptable formats include minutes[:seconds], "
+        "[days-]hours:minutes:seconds",
+    )
+    slurm_parser.add_argument("-o", "--output", help="location of stdout redirection")
+    slurm_parser.add_argument("command", nargs=argparse.REMAINDER)
+    return slurm_parser
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--format", choices=["json", "yaml"], default="json")
+
+    subparsers = parser.add_subparsers()
+    slurm_parser = get_slurm_common_parser()
+    srun_parser = subparsers.add_parser(
+        "srun", parents=[slurm_parser], help="subcommand for SLURM-style CLI arguments"
+    )
+    srun_parser.set_defaults(func=slurm_jobspec)
+
+    args = parser.parse_args()
+
+    if len(args.command) == 0:
+        parser.error("command is required")
+        sys.exit(1)
+
+    jobspec = args.func(args)
+
+    if args.format == "yaml":
+        out = yaml.dump(jobspec)
     else:
         out = json.dumps(jobspec)
     print(out)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-N", "--num-nodes", type=int, default=0)
-    parser.add_argument("-n", "--num-tasks", type=int, default=1)
-    parser.add_argument("-c", "--cores-per-task", type=int, default=1)
-    parser.add_argument(
-        "-t", "--walltime", type=int, default=3600, help="walltime in seconds"
+    logging.basicConfig(
+        level=logging.INFO, format="%(module)s: %(levelname)s: %(message)s"
     )
-    parser.add_argument(
-        "-p", "--pretty", action="store_true", help="pretty print the jobspec json"
-    )
-    parser.add_argument("command", nargs=argparse.REMAINDER)
-    args = parser.parse_args()
-
-    if len(args.command) == 0:
-        parser.print_usage()
-        print("command is required")
-        sys.exit(1)
-
-    main()
+    logger = logging.getLogger(__name__)
+    exit_code = 0
+    try:
+        main()
+    except SystemExit as e:  # don't intercept sys.exit calls
+        exit_code = e
+    except Exception as e:
+        logging.error(e.message)
+        exit_code = 1
+    finally:
+        logging.shutdown()
+        sys.exit(exit_code)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -61,6 +61,7 @@ TESTS = \
 	t0017-security.t \
 	t0019-jobspec-schema.t \
 	t0020-emit-jobspec.t \
+	t0021-flux-jobspec.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \
@@ -150,6 +151,7 @@ check_SCRIPTS = \
 	t0017-security.t \
 	t0019-jobspec-schema.t \
 	t0020-emit-jobspec.t \
+	t0021-flux-jobspec.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -60,6 +60,7 @@ TESTS = \
 	t0016-cron-faketime.t \
 	t0017-security.t \
 	t0019-jobspec-schema.t \
+	t0020-emit-jobspec.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \
@@ -148,6 +149,7 @@ check_SCRIPTS = \
 	t0016-cron-faketime.t \
 	t0017-security.t \
 	t0019-jobspec-schema.t \
+	t0020-emit-jobspec.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \

--- a/t/jobspec/summarize-minimal-jobspec.py
+++ b/t/jobspec/summarize-minimal-jobspec.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import sys
+import json
+import argparse
+
+import yaml
+
+
+def load_jobspec(stream, prefix=""):
+    try:
+        jobspec = yaml.safe_load(stream)
+        return jobspec
+    except (yaml.YAMLError) as e:
+        print("{}{}".format(prefix, e.problem))
+        sys.exit(1)
+
+
+def summarize_jobspec(jobspec):
+    first_resource = jobspec["resources"][0]
+    if first_resource["type"] == "node":
+        node_entry = first_resource
+        slot_entry = node_entry["with"][0]
+    else:
+        node_entry = None
+        slot_entry = first_resource
+    core_entry = slot_entry["with"][0]
+    task_entry = jobspec["tasks"][0]
+
+    num_nodes = node_entry["count"] if node_entry else 0
+    num_slots = slot_entry["count"] * max(num_nodes, 1)
+    num_cores = core_entry["count"] * num_slots
+
+    if "total" in task_entry["count"].keys():
+        num_tasks = task_entry["count"]["total"]
+    elif "per_slot" in task_entry["count"].keys():
+        num_tasks = task_entry["count"]["per_slot"] * num_slots
+    else:
+        raise ValueError("Unknown key in the task's `count` dict")
+
+    return {
+        "total_num_nodes": num_nodes,
+        "total_num_tasks": num_tasks,
+        "total_num_cores": num_cores,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-j", "--jobspec", help="path to file containing the jobspec to query"
+    )
+    args = parser.parse_args()
+
+    if args.jobspec:
+        try:
+            with open(args.jobspec, "r") as fd:
+                jobspec = yaml.safe_load(fd)
+        except (OSError, IOError) as e:
+            print("{}{}".format(args.jobspec, e.strerror))
+            sys.exit(1)
+    else:
+        jobspec = load_jobspec(sys.stdin, "stdin: ")
+
+    summary = summarize_jobspec(jobspec)
+    print(json.dumps(summary))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit as e:  # don't intercept sys.exit calls
+        sys.exit(e)
+    except Exception as e:
+        print("Unknown error: {}".format(e.message), file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)

--- a/t/t0020-emit-jobspec.t
+++ b/t/t0020-emit-jobspec.t
@@ -6,7 +6,7 @@ test_description='Test the jobspec emission tool'
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 VALIDATE=${JOBSPEC}/validate.py
-SCHEMA=${JOBSPEC}/schema.json
+SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
 MINI_SCHEMA=${JOBSPEC}/minimal-schema.json
 EMIT=${JOBSPEC}/emit-jobspec.py
 

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -71,6 +71,11 @@ test_expect_success HAVE_JQ 'ensure flux-jobspec does not gobble application arg
     test_cmp myApp.expected myApp.out
 '
 
+test_expect_success 'an improperly formatted time string should produce an error' '
+    test_must_fail flux jobspec srun -t foo myApp 2>&1 | 
+    grep -q "flux-jobspec: ERROR: invalid time limit string format"
+'
+
 test_expect_success 'requesting more nodes than tasks should produce an error' '
    test_must_fail flux jobspec srun -N8 -n2 hostname 2>&1 |
    grep -q "Number of nodes greater than the number of tasks"

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -116,6 +116,12 @@ test_expect_success HAVE_JQ 'specifying -N8 -n16 should produce (in total) 8 nod
     jq -e ".total_num_nodes == 8 and .total_num_tasks == 16 and .total_num_cores == 16" nodes-tasks.summary.json
 '
 
+test_expect_success HAVE_JQ 'specifying -N8 -n16 should produce tasks.count.per_slot == 1 and no warning' '
+    flux jobspec srun -N8 -n16 hostname > nodes-tasks-2.jobspec.json 2> nodes-tasks-2.err &&
+    jq -e ".tasks[0].count.per_slot == 1" nodes-tasks-2.jobspec.json &&
+    [ -f nodes-tasks-2.err ] && [ ! -s nodes-tasks-2.err ]
+'
+
 test_expect_success HAVE_JQ 'specifying -n16 -c4 should produce (in total) 0 nodes, 16 tasks, 64 cores' '
     flux jobspec srun -n16 -c4 hostname > tasks-cores.jobspec.json &&
     ${VALIDATE} -s ${MINI_SCHEMA} tasks-cores.jobspec.json &&

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -1,0 +1,171 @@
+#!/bin/sh
+
+test_description='Test the flux-jobspec command'
+
+. `dirname $0`/sharness.sh
+
+JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
+VALIDATE=${JOBSPEC}/validate.py
+SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
+MINI_SCHEMA=${JOBSPEC}/minimal-schema.json
+SUMMARIZE=${JOBSPEC}/summarize-minimal-jobspec.py
+
+#  Set path to jq
+#
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+
+validate_emission() {
+    flux jobspec $@ | ${VALIDATE} --schema ${SCHEMA}
+}
+
+validate_minimal_emission() {
+    flux jobspec $@ | ${VALIDATE} --schema ${MINI_SCHEMA}
+}
+
+test_expect_success 'flux-jobspec srun with no args emits valid canonical jobspec' '
+    validate_emission srun sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with no args emits minimal jobspec' '
+    validate_minimal_emission srun sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with just num_tasks emits valid canonical jobspec' '
+    validate_emission srun -n4 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with just num_tasks emits minimal jobspec' '
+    validate_minimal_emission srun -n4 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with just cores_per_task emits valid canonical jobspec' '
+    validate_emission srun -c4 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with just cores_per_task emits minimal jobspec' '
+    validate_minimal_emission srun -c4 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun without num_nodes emits valid canonical jobspec' '
+    validate_emission srun -n4 -c1 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun without num_nodes emits minimal jobspec' '
+    validate_minimal_emission srun -n4 -c1 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with all args emits valid canonical jobspec' '
+    validate_emission srun -N4 -n4 -c1 sleep 1
+'
+
+test_expect_success 'flux-jobspec srun with all args emits minimal jobspec' '
+    validate_minimal_emission srun -N4 -n4 -c1 sleep 1
+'
+
+test_expect_success HAVE_JQ 'ensure flux-jobspec does not gobble application arguments' '
+    flux jobspec srun myApp -c1 -n1 -N1 | $jq ".tasks[0].command" > myApp.out &&
+    cat <<-EOF | $jq . > myApp.expected &&
+    [ "myApp", "-c1", "-n1", "-N1" ]
+	EOF
+    test_cmp myApp.expected myApp.out
+'
+
+test_expect_success 'requesting more nodes than tasks should produce an error' '
+   test_must_fail flux jobspec srun -N8 -n2 hostname 2>&1 |
+   grep -q "Number of nodes greater than the number of tasks"
+'
+
+test_expect_success HAVE_JQ 'specifying only -N8 should produce (in total) 8 nodes, 8 tasks, 8 cores' '
+    flux jobspec srun -N8 hostname > only-nodes.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} only-nodes.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} only-nodes.jobspec.json &&
+    ${SUMMARIZE} -j only-nodes.jobspec.json > only-nodes.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 8 and .total_num_cores == 8" only-nodes.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying only -n8 should produce (in total) 0 nodes, 8 tasks, 8 cores' '
+    flux jobspec srun -n8 hostname > only-tasks.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} only-tasks.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} only-tasks.jobspec.json &&
+    ${SUMMARIZE} -j only-tasks.jobspec.json > only-tasks.summary.json &&
+    jq -e ".total_num_nodes == 0 and .total_num_tasks == 8 and .total_num_cores == 8" only-tasks.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying only -c8 should produce (in total) 0 nodes, 1 task, 8 cores' '
+    flux jobspec srun -c8 hostname > only-cores.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} only-cores.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} only-cores.jobspec.json &&
+    ${SUMMARIZE} -j only-cores.jobspec.json > only-cores.summary.json &&
+    jq -e ".total_num_nodes == 0 and .total_num_tasks == 1 and .total_num_cores == 8" only-cores.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying -N8 -c2 should produce (in total) 8 nodes, 8 tasks, 16 cores' '
+    flux jobspec srun -N8 -c2 hostname > nodes-cores.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} nodes-cores.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} nodes-cores.jobspec.json &&
+    ${SUMMARIZE} -j nodes-cores.jobspec.json > nodes-cores.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 8 and .total_num_cores == 16" nodes-cores.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying -N8 -n16 should produce (in total) 8 nodes, 16 tasks, 16 cores' '
+    flux jobspec srun -N8 -n16 hostname > nodes-tasks.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} nodes-tasks.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} nodes-tasks.jobspec.json &&
+    ${SUMMARIZE} -j nodes-tasks.jobspec.json > nodes-tasks.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 16 and .total_num_cores == 16" nodes-tasks.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying -n16 -c4 should produce (in total) 0 nodes, 16 tasks, 64 cores' '
+    flux jobspec srun -n16 -c4 hostname > tasks-cores.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} tasks-cores.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} tasks-cores.jobspec.json &&
+    ${SUMMARIZE} -j tasks-cores.jobspec.json > tasks-cores.summary.json &&
+    jq -e ".total_num_nodes == 0 and .total_num_tasks == 16 and .total_num_cores == 64" tasks-cores.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying -N8 -n16 -c4 should produce (in total) 8 nodes, 16 tasks, 64 cores' '
+    flux jobspec srun -N8 -n16 -c4 hostname > all-three-1.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} all-three-1.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} all-three-1.jobspec.json &&
+    ${SUMMARIZE} -j all-three-1.jobspec.json > all-three-1.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 16 and .total_num_cores == 64" all-three-1.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying -N9 -n9 -c2 should produce (in total) 9 nodes, 9 tasks, 18 cores' '
+    flux jobspec srun -N9 -n9 -c2 hostname > all-three-2.jobspec.json &&
+    ${VALIDATE} -s ${MINI_SCHEMA} all-three-2.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} all-three-2.jobspec.json &&
+    ${SUMMARIZE} -j all-three-2.jobspec.json > all-three-2.summary.json &&
+    jq -e ".total_num_nodes == 9 and .total_num_tasks == 9 and .total_num_cores == 18" all-three-2.summary.json
+'
+
+test_expect_success HAVE_JQ 'specifying -N8 -n9 -c1 should produce (in total) 8 nodes, 9 tasks, 16 cores and a warning' '
+    flux jobspec srun -N8 -n9 -c1 hostname > all-three-3.jobspec.json 2> all-three-3.warning.err &&
+    ${VALIDATE} -s ${MINI_SCHEMA} all-three-3.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} all-three-3.jobspec.json &&
+    ${SUMMARIZE} -j all-three-3.jobspec.json > all-three-3.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 9 and .total_num_cores == 16" all-three-3.summary.json &&
+    grep -q "Number of tasks is not an integer multiple of the number of nodes." all-three-3.warning.err
+'
+
+test_expect_success HAVE_JQ 'specifying -N8 -n9 -c2 should produce (in total) 8 nodes, 9 tasks, 32 cores and a warning' '
+    flux jobspec srun -N8 -n9 -c2 hostname > all-three-4.jobspec.json 2> all-three-4.warning.err &&
+    ${VALIDATE} -s ${MINI_SCHEMA} all-three-4.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} all-three-4.jobspec.json &&
+    ${SUMMARIZE} -j all-three-4.jobspec.json > all-three-4.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 9 and .total_num_cores == 32" all-three-4.summary.json &&
+    grep -q "Number of tasks is not an integer multiple of the number of nodes." all-three-4.warning.err
+'
+
+test_expect_success HAVE_JQ 'specifying -N8 -n25 -c2 should produce (in total) 8 nodes, 25 tasks, 64 cores and a warning' '
+    flux jobspec srun -N8 -n25 -c2 hostname > all-three-5.jobspec.json 2> all-three-5.warning.err &&
+    ${VALIDATE} -s ${MINI_SCHEMA} all-three-5.jobspec.json &&
+    ${VALIDATE} -s ${SCHEMA} all-three-5.jobspec.json &&
+    ${SUMMARIZE} -j all-three-5.jobspec.json > all-three-5.summary.json &&
+    jq -e ".total_num_nodes == 8 and .total_num_tasks == 25 and .total_num_cores == 64" all-three-5.summary.json &&
+    grep -q "Number of tasks is not an integer multiple of the number of nodes." all-three-5.warning.err
+'
+
+
+test_done


### PR DESCRIPTION
As promised today over coffee, here is what I have so far.  It currently supports several flags that are common amongst `sbatch` and `srun`.  Including `-N` (nodes), `-c` (cores), `-n` (tasks), `--time`, and `--output`.  I don't think there is anything else we need for Corona other than `-g` (gpus) and `--error`.

Oh, it also needs to actually do something when someone supplies `--output` (whoops, forgot that one).

Related #1929 (still needs oar support before closing it)
Closes #2003 