### PR TITLE
kvs: flux_kvs_lookupat() should not assume namespaces and always take rootref

### DIFF
--- a/doc/man3/flux_kvs_commit.adoc
+++ b/doc/man3/flux_kvs_commit.adoc
@@ -53,8 +53,7 @@ the default KVS namespace.  A different namespace can be chosen
 several ways.  A namespace can be set via the
 `flux_kvs_set_namespace()` function, or set via the environment
 variable FLUX_KVS_NAMESPACE.  Note that all transactions must operate
-on the same namespace.  It is an error if multiple different
-namespaces are specified via a namespace prefix.
+on the same namespace.
 
 FLAGS
 -----

--- a/doc/man3/flux_kvs_lookup.adoc
+++ b/doc/man3/flux_kvs_lookup.adoc
@@ -48,15 +48,14 @@ It returns a `flux_future_t` object which acts as handle for synchronization
 and container for the result.  _flags_ modifies the request as described
 below.
 
+By default,`flux_kvs_lookup()` operates on the default KVS namespace.
+An alternate namespace can be set via the `flux_kvs_set_namespace()`
+function, or set via the environment variable FLUX_KVS_NAMESPACE.
+
 `flux_kvs_lookupat()` is identical to `flux_kvs_lookup()` except
 _treeobj_ is a serialized RFC 11 object that references a particular
 static set of content within the KVS, effectively a snapshot.
 See `flux_kvs_lookup_get_treeobj()` below.
-
-By default, both `flux_kvs_lookup()` and `flux_kvs_lookupat()` operate
-on the default KVS namespace.  An alternate namespace can be set via
-the `flux_kvs_set_namespace()` function, or set via the environment
-variable FLUX_KVS_NAMESPACE.
 
 All the functions below are variations on a common theme.  First they
 complete the lookup RPC by blocking on the response, if not already received.

--- a/doc/man3/flux_kvs_set_namespace.adoc
+++ b/doc/man3/flux_kvs_set_namespace.adoc
@@ -22,8 +22,7 @@ DESCRIPTION
 `flux_kvs_set_namespace()` sets the KVS namespace to use for all
 KVS operations within a flux handle.  By setting a KVS namespace
 in the flux handle, this namespace will override any KVS namespace
-specified in the environment variable FLUX_KVS_NAMESPACE.  However,
-a namespace specified via a key prefix will override this setting.
+specified in the environment variable FLUX_KVS_NAMESPACE.
 
 `flux_kvs_get_namespace()` will determine the current namespace to
 use, whether set via `flux_kvs_set_namespace()` or the environment

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1055,7 +1055,7 @@ int cmd_wait (optparse_t *p, int argc, char **argv)
         log_msg_exit ("wait: specify a version");
     vers = strtoul (argv[optindex], NULL, 10);
     if (flux_kvs_wait_version (h, vers) < 0)
-        log_err_exit ("flux_kvs_get_version");
+        log_err_exit ("flux_kvs_wait_version");
     return (0);
 }
 

--- a/src/common/libkvs/kvs_classic.c
+++ b/src/common/libkvs/kvs_classic.c
@@ -89,8 +89,14 @@ int flux_kvsdir_get (const flux_kvsdir_t *dir, const char *name, char **valp)
 
     if (!(key = flux_kvsdir_key_at (dir, name)))
         goto done;
-    if (!(f = flux_kvs_lookupat (h, 0, key, rootref)))
-        goto done;
+    if (rootref) {
+        if (!(f = flux_kvs_lookupat (h, 0, key, rootref)))
+            goto done;
+    }
+    else {
+        if (!(f = flux_kvs_lookup (h, 0, key)))
+            goto done;
+    }
     if (flux_kvs_lookup_get (f, &json_str) < 0)
         goto done;
     if (valp) {
@@ -127,8 +133,14 @@ int flux_kvsdir_get_dir (const flux_kvsdir_t *dir, flux_kvsdir_t **dirp,
         goto done;
     if (!(key = flux_kvsdir_key_at (dir, name)))
         goto done;
-    if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READDIR, key, rootref)))
-        goto done;
+    if (rootref) {
+        if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READDIR, key, rootref)))
+            goto done;
+    }
+    else {
+        if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, key)))
+            goto done;
+    }
     if (flux_kvs_lookup_get_dir (f, &subdir) < 0)
         goto done;
     if (!(cpy = flux_kvsdir_copy (subdir)))

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -174,10 +174,6 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
         }
     }
     else {
-        const char *ns;
-
-        if (!(ns = flux_kvs_get_namespace (h)))
-            return NULL;
         if (!(ctx->atref = strdup (treeobj)))
             return NULL;
         if (!(obj = json_loads (treeobj, 0, NULL))) {
@@ -185,9 +181,8 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
             return NULL;
         }
         if (!(f = flux_rpc_pack (h, "kvs.lookup", FLUX_NODEID_ANY, 0,
-                                 "{s:s s:s s:i s:O}",
+                                 "{s:s s:i s:O}",
                                  "key", key,
-                                 "namespace", ns,
                                  "flags", flags,
                                  "rootdir", obj))) {
             free_ctx (ctx);

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -482,9 +482,8 @@ static flux_future_t *lookupat (flux_t *h,
     else {
         if (!(o = treeobj_create_dirref (blobref)))
             goto error;
-        if (flux_msg_pack (msg, "{s:s s:s s:i s:i s:O}",
+        if (flux_msg_pack (msg, "{s:s s:i s:i s:O}",
                            "key", w->key,
-                           "namespace", ns,
                            "flags", w->flags,
                            "rootseq", root_seq,
                            "rootdir", o) < 0)

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -512,7 +512,13 @@ lookup_t *lookup_create (struct cache *cache,
     lookup_t *lh = NULL;
     int saved_errno;
 
-    if (!cache || !krm || !ns || !path) {
+    if (!cache || !krm || !path) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* have to specify atleast one */
+    if (!ns && !root_ref) {
         errno = EINVAL;
         return NULL;
     }
@@ -526,10 +532,12 @@ lookup_t *lookup_create (struct cache *cache,
     lh->krm = krm;
     lh->current_epoch = current_epoch;
 
-    /* must duplicate strings, user may not keep pointer alive */
-    if (!(lh->ns_name = strdup (ns))) {
-        saved_errno = ENOMEM;
-        goto cleanup;
+    if (ns) {
+        /* must duplicate strings, user may not keep pointer alive */
+        if (!(lh->ns_name = strdup (ns))) {
+            saved_errno = ENOMEM;
+            goto cleanup;
+        }
     }
 
     if (!(lh->path = kvs_util_normalize_key (path, NULL))) {

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -91,9 +91,7 @@ const char *lookup_missing_namespace (lookup_t *lh);
 int lookup_get_current_epoch (lookup_t *lh);
 
 /* Convenience function to get namespace from earlier instantiation.
- * Convenient if replaying RPC and don't have it presently.  May not
- * necessarily return namespace passed in via 'namespace' in
- * lookup_create().  Could have been namespace via a namespace prefix.
+ * Convenient if replaying RPC and don't have it presently.
  */
 const char *lookup_get_namespace (lookup_t *lh);
 

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -33,8 +33,7 @@ typedef int (*lookup_ref_f)(lookup_t *c,
 
 /* Initialize a lookup handle
  *
- * - root_ref is optional.  If not specified, will use root ref
- *   specified in namespace.
+ * - atleast one of namespace & root_ref is required.
  * - root_seq is not used and is solely used for convenience being
  *   passed alongside root_ref.  Can be retrieved later with
  *   lookup_get_root_seq().  Will not be stored if root_ref is NULL.

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -277,6 +277,20 @@ void basic_api_errors (void)
         "cache_create works");
     ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
         "kvsroot_mgr_create works");
+
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             42,
+                             NULL,
+                             NULL,
+                             0,
+                             "path.bar",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) == NULL,
+        "lookup_create fails on no namespace or root ref");
+
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, "root.ref.foo", 0);
 
     ok ((lh = lookup_create (cache,
@@ -385,7 +399,7 @@ void basic_lookup (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              root_ref,
                              18,
                              "val",
@@ -636,7 +650,7 @@ void lookup_root (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              valref_ref,
                              0,
                              ".",
@@ -1429,7 +1443,7 @@ void lookup_errors (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              valref_ref,
                              0,
                              "val",
@@ -1531,7 +1545,7 @@ void lookup_security (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              root_ref,
                              0,
                              "val",
@@ -1938,7 +1952,7 @@ void lookup_alt_root (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              dirref1_ref,
                              0,
                              "val",
@@ -1955,7 +1969,7 @@ void lookup_alt_root (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              dirref2_ref,
                              0,
                              "val",
@@ -1964,6 +1978,40 @@ void lookup_alt_root (void) {
                              0,
                              NULL)) != NULL,
         "lookup_create val w/ dirref2 root_ref");
+    test = treeobj_create_val ("bar", 3);
+    check_value (lh, test, "alt root val");
+    json_decref (test);
+
+    /* lookup val, alt root-ref dirref1_ref */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             dirref1_ref,
+                             0,
+                             "val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create val w/ dirref1 root_ref & input namespace");
+    test = treeobj_create_val ("foo", 3);
+    check_value (lh, test, "alt root val");
+    json_decref (test);
+
+    /* lookup val, alt root-ref dirref2_ref */
+    ok ((lh = lookup_create (cache,
+                             krm,
+                             1,
+                             KVS_PRIMARY_NAMESPACE,
+                             dirref2_ref,
+                             0,
+                             "val",
+                             FLUX_ROLE_OWNER,
+                             0,
+                             0,
+                             NULL)) != NULL,
+        "lookup_create val w/ dirref2 root_ref & input namespace");
     test = treeobj_create_val ("bar", 3);
     check_value (lh, test, "alt root val");
     json_decref (test);
@@ -2106,7 +2154,7 @@ void lookup_root_symlink (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              dirref_ref,
                              0,
                              "symlinkroot",
@@ -2121,7 +2169,7 @@ void lookup_root_symlink (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              valref_ref,
                              0,
                              "symlinkroot",
@@ -2818,7 +2866,7 @@ void lookup_stall_ref (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              root_ref,
                              0,
                              "symlink.val",
@@ -3277,7 +3325,7 @@ void lookup_stall_namespace_removed (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              root_ref,
                              0,
                              "dirref.valref",
@@ -3319,7 +3367,7 @@ void lookup_stall_namespace_removed (void) {
     ok ((lh = lookup_create (cache,
                              krm,
                              1,
-                             KVS_PRIMARY_NAMESPACE,
+                             NULL,
                              root_ref,
                              0,
                              "dirref.valref",

--- a/src/modules/wreck/wrexecd.c
+++ b/src/modules/wreck/wrexecd.c
@@ -1396,7 +1396,7 @@ static int wait_for_task_exit_aggregate (struct prog_ctx *ctx)
     prog_ctx_add_completion_ref (ctx, "exit_status");
 
     if ((rc = flux_kvs_watch (h, key, exitstatus_watcher, ctx)) < 0)
-        flux_log_error (h, "flux_kvs_watch_dir");
+        flux_log_error (h, "flux_kvs_watch");
     free (key);
     return (rc);
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -258,6 +258,7 @@ check_PROGRAMS = \
 	kvs/transactionmerge \
 	kvs/fence_namespace_remove \
 	kvs/fence_invalid \
+	kvs/lookup_invalid \
 	kvs/commit_order \
 	kvs/issue1760 \
 	kvs/issue1876 \
@@ -380,6 +381,11 @@ kvs_fence_namespace_remove_LDADD = \
 kvs_fence_invalid_SOURCES = kvs/fence_invalid.c
 kvs_fence_invalid_CPPFLAGS = $(test_cppflags)
 kvs_fence_invalid_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_lookup_invalid_SOURCES = kvs/lookup_invalid.c
+kvs_lookup_invalid_CPPFLAGS = $(test_cppflags)
+kvs_lookup_invalid_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 kvs_commit_order_SOURCES = kvs/commit_order.c

--- a/t/kvs/dtree.c
+++ b/t/kvs/dtree.c
@@ -203,8 +203,15 @@ void dtree_mkdir (flux_t *h, const flux_kvsdir_t *dir,
             setup_dir (h, keyat);
 
             rootref = flux_kvsdir_rootref (dir);
-            if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READDIR, keyat, rootref)))
-                log_err_exit ("flux_kvs_lookupat");
+            if (rootref) {
+                if (!(f = flux_kvs_lookupat (h, FLUX_KVS_READDIR, keyat,
+                                             rootref)))
+                    log_err_exit ("flux_kvs_lookupat");
+            }
+            else {
+                if (!(f = flux_kvs_lookup (h, FLUX_KVS_READDIR, keyat)))
+                    log_err_exit ("flux_kvs_lookup");
+            }
             if (flux_kvs_lookup_get_dir (f, &ndir) < 0)
                 log_err_exit ("flux_kvs_lookup_get_dir");
 

--- a/t/kvs/lookup_invalid.c
+++ b/t/kvs/lookup_invalid.c
@@ -1,0 +1,72 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/oom.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+static void usage (void)
+{
+    fprintf (stderr, "Usage: lookup_invalid key\n");
+    exit (1);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h = NULL;
+    char *key = NULL;
+    flux_future_t *f = NULL;
+
+    log_init (basename (argv[0]));
+
+    if (argc != 2)
+        usage ();
+    key = argv[1];
+
+    if (!(h = flux_open (NULL, 0))) {
+        log_err_exit ("flux_open");
+        goto done;
+    }
+
+    /* invalid lookup - do not specify namespace or root ref */
+    if (!(f = flux_rpc_pack (h, "kvs.lookup", FLUX_NODEID_ANY, 0,
+                             "{s:s s:i}",
+                             "key", key,
+                             "flags", 0)))
+        log_err_exit ("flux_rpc_pack");
+
+    if (flux_future_get (f, NULL) < 0) {
+        printf ("flux_future_get: %s\n", flux_strerror (errno));
+        goto done;
+    }
+
+done:
+    flux_future_destroy (f);
+    flux_close (h);
+    log_fini ();
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1016,6 +1016,7 @@ test_expect_success 'kvs: directory with multiple subdirs using dir --at' '
         flux kvs put --json $DIR.c.a.b=3.14 &&
         flux kvs put --json $DIR.d=\"snerg\" &&
         flux kvs put --json $DIR.e=true &&
+        flux kvs link $DIR.a $DIR.f &&
         DIRREF=$(flux kvs get --treeobj $DIR) &&
 	flux kvs dir -R --at $DIRREF . | sort >output &&
 	cat >expected <<EOF &&
@@ -1024,6 +1025,7 @@ b.c.d.e.f.g = 70
 c.a.b = 3.140000
 d = snerg
 e = true
+f -> $DIR.a
 EOF
 	test_cmp expected output
 '

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -465,4 +465,13 @@ test_expect_success 'kvs: test invalid fence arguments on rank 1' '
         grep "flux_future_get: Invalid argument" invalid_output
 '
 
+#
+# test invalid lookup rpc
+#
+
+test_expect_success 'kvs: test invalid lookup rpc' '
+        ${FLUX_BUILD_DIR}/t/kvs/lookup_invalid a-key > lookup_invalid_output &&
+        grep "flux_future_get: Protocol error" lookup_invalid_output
+'
+
 test_done


### PR DESCRIPTION
```flux_kvs_lookupat()``` would lookup a namespace, which does not make sense given it takes a rootref.   Also, the rootref was optional and would call ```flux_kvs_lookup()``` if it was not set.  This doesn't really make sense.  So require a root reference to be passed in, don't call ```flux_kvs_lookup()```, and don't lookup a namespace.

As a side effect, don't send a namespace in the lookup RPC if an at reference is mentioned.  So in the kvs module, make it so a lookup rpc is required to specify a namespace OR a root reference, but does not require both.

Also fix up some stupid documentation and typos found along the way.