### PR TITLE
libidset: add missing bounds check

### DIFF
--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -194,7 +194,7 @@ int idset_range_clear (struct idset *idset, unsigned int lo, unsigned int hi)
 
 bool idset_test (const struct idset *idset, unsigned int id)
 {
-    if (!idset || !valid_id (id))
+    if (!idset || !valid_id (id) || id >= idset->T.M)
         return false;
     return (vebsucc (idset->T, id) == id);
 }

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -484,6 +484,18 @@ void test_autogrow (void)
     idset_destroy (idset);
 }
 
+void issue_1974(void)
+{
+    struct idset *idset;
+
+    idset = idset_create (1024, 0);
+    ok (idset != NULL,
+        "1974: idset_create size=1024 worked");
+    ok (idset_test (idset, 1024) == false,
+        "1974: idset_test id=1024 returned false");
+    idset_destroy (idset);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -499,6 +511,7 @@ int main (int argc, char *argv[])
     test_range_clear ();
     test_copy ();
     test_autogrow ();
+    issue_1974 ();
 
     done_testing ();
 }


### PR DESCRIPTION
Add missing bounds check to `idset_test()` found by @grondo, and a regression test.