### PR TITLE
libidset: include stdbool.h in header

### DIFF
--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -17,6 +17,7 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
+#include <stdbool.h>
 
 enum idset_flags {
     IDSET_FLAG_AUTOGROW = 1, // allow idset size to automatically grow


### PR DESCRIPTION
Problem: idset.h uses bool type without including its
definition, thus cannot be used standalone.

Include stdbool.h.

Fixes #1973