### PR TITLE
libflux/rpc: Add input parameter checks

### DIFF
--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -308,6 +308,12 @@ flux_future_t *flux_rpc (flux_t *h,
 {
     flux_msg_t *msg = NULL;
     flux_future_t *f = NULL;
+
+    if (!h || validate_flags (flags, FLUX_RPC_NORESPONSE
+                                   | FLUX_RPC_STREAMING)) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(msg = flux_request_encode (topic, s)))
         goto done;
     if (!(f = flux_rpc_message_nocopy (h, msg, nodeid, flags)))
@@ -327,6 +333,11 @@ flux_future_t *flux_rpc_raw (flux_t *h,
     flux_msg_t *msg;
     flux_future_t *f = NULL;
 
+    if (!h || validate_flags (flags, FLUX_RPC_NORESPONSE
+                                   | FLUX_RPC_STREAMING)) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(msg = flux_request_encode_raw (topic, data, len)))
         goto done;
     if (!(f = flux_rpc_message_nocopy (h, msg, nodeid, flags)))
@@ -345,6 +356,11 @@ static flux_future_t *flux_rpc_vpack (flux_t *h,
     flux_msg_t *msg;
     flux_future_t *f = NULL;
 
+    if (!h || validate_flags (flags, FLUX_RPC_NORESPONSE
+                                   | FLUX_RPC_STREAMING)) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(msg = flux_request_encode (topic, NULL)))
         goto done;
     if (flux_msg_vpack (msg, fmt, ap) < 0)

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -193,6 +193,74 @@ int test_server (flux_t *h, void *arg)
     return 0;
 }
 
+void test_corner_case (flux_t *h)
+{
+    flux_msg_t *msg;
+
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+
+    errno = 0;
+    ok (flux_rpc_message (NULL, msg, 0, 0) == NULL
+        && errno == EINVAL,
+        "flux_rpc_message fails with EINVAL on NULL handle");
+
+    errno = 0;
+    ok (flux_rpc (NULL, "topic", "data", 0, 0) == NULL
+        && errno == EINVAL,
+        "flux_rpc fails with EINVAL on NULL handle");
+
+    errno = 0;
+    ok (flux_rpc_raw (NULL, "topic", "data", 4, 0, 0) == NULL
+        && errno == EINVAL,
+        "flux_rpc_raw fails with EINVAL on NULL handle");
+
+    errno = 0;
+    ok (flux_rpc_pack (NULL, "topic", 0, 0, "{ s:s }", "foo", "bar") == NULL
+        && errno == EINVAL,
+        "flux_rpc_pack fails with EINVAL on NULL handle");
+
+    errno = 0;
+    ok (flux_rpc_message (h, NULL, 0, 0) == NULL
+        && errno == EINVAL,
+        "flux_rpc_message fails with EINVAL on NULL msg");
+
+    errno = 0;
+    ok (flux_rpc (h, NULL, "data", 0, 0) == NULL
+        && errno == EINVAL,
+        "flux_rpc fails with EINVAL on NULL topic");
+
+    errno = 0;
+    ok (flux_rpc_raw (h, NULL, "data", 4, 0, 0) == NULL
+        && errno == EINVAL,
+        "flux_rpc_raw fails with EINVAL on NULL topic");
+
+    errno = 0;
+    ok (flux_rpc_pack (h, NULL, 0, 0, "{ s:s }", "foo", "bar") == NULL
+        && errno == EINVAL,
+        "flux_rpc_pack fails with EINVAL on NULL topic");
+
+    errno = 0;
+    ok (flux_rpc_message (h, msg, 0, 0xFF) == NULL
+        && errno == EINVAL,
+        "flux_rpc_message fails with EINVAL on invalid flags");
+
+    errno = 0;
+    ok (flux_rpc (h, "topic", "data", 0, 0xFF) == NULL
+        && errno == EINVAL,
+        "flux_rpc fails with EINVAL on invalid flags");
+
+    errno = 0;
+    ok (flux_rpc_raw (h, "topic", "data", 4, 0, 0xFF) == NULL
+        && errno == EINVAL,
+        "flux_rpc_raw fails with EINVAL on invalid flags");
+
+    errno = 0;
+    ok (flux_rpc_pack (h, "topic", 0, 0xFF, "{ s:s }", "foo", "bar") == NULL
+        && errno == EINVAL,
+        "flux_rpc_pack fails with EINVAL on invalid flags");
+}
+
 void test_service (flux_t *h)
 {
     flux_future_t *r;
@@ -724,6 +792,7 @@ int main (int argc, char *argv[])
     flux_fatal_set (h, fatal_err, NULL);
     flux_flags_set (h, FLUX_O_MATCHDEBUG);
 
+    test_corner_case (h);
     test_service (h);
     test_basic (h);
     test_error (h);


### PR DESCRIPTION
Add input parameter checks to flux_rpc(), flux_rpc_raw(), and
flux_rpc_vpack().  NULL handle could lead to a segfault.  Add
appropriate unit tests.

Fixes #1979