### PR TITLE
cmd/flux-kvs: Create namespace subcommand

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -48,15 +48,15 @@ arguments are described below.
 
 COMMANDS
 --------
-*namespace-create* [-o owner] 'name' ['name...']::
+*namespace create* [-o owner] 'name' ['name...']::
 Create a new kvs namespace.  User may specify an alternate userid of a
 user that owns the namespace via '-o'.  Specifying an alternate owner
 would allow a non-instance owner to read/write to a namespace.
 
-*namespace-remove* 'name' ['name...']::
+*namespace remove* 'name' ['name...']::
 Remove a kvs namespace.
 
-*namespace-list*::
+*namespace list*::
 List all current namespaces and info on each namespace.
 
 *get* [-N ns] [-j|-r|-t] [-a treeobj] [-l] [-W] [-w] [-u] [-f] [-c count] 'key' ['key...']::

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -887,7 +887,7 @@ test_expect_success 'kvs: link: path resolution with intermediate link and nonex
 #
 
 test_expect_success 'kvs: namespace create setup' '
-	flux kvs namespace-create TESTSYMLINKNS
+	flux kvs namespace create TESTSYMLINKNS
 '
 test_expect_success 'kvs: symlink w/ Namespace works' '
 	TARGET=$DIR.target &&
@@ -967,7 +967,7 @@ test_expect_success 'kvs: symlinkNS: readlink on dangling link' '
 	test "$OUTPUT" = "TESTSYMLINKNS-FAKE::$DIR.dangle"
 '
 test_expect_success 'kvs: namespace remove cleanup' '
-	flux kvs namespace-remove TESTSYMLINKNS
+	flux kvs namespace remove TESTSYMLINKNS
 '
 
 #
@@ -1098,13 +1098,13 @@ test_expect_success 'flux kvs getroot --owner returns instance owner' '
 '
 
 test_expect_success 'flux kvs getroot works on alt namespace' '
-	flux kvs namespace-create testns1 &&
+	flux kvs namespace create testns1 &&
 	SEQ=$(flux kvs getroot --namespace=testns1 --sequence) &&
 	test $SEQ -eq 0 &&
 	flux kvs put --namespace=testns1 test.c=moop &&
 	SEQ2=$(flux kvs getroot --namespace=testns1 --sequence) &&
 	test $SEQ -lt $SEQ2 &&
-	flux kvs namespace-remove testns1
+	flux kvs namespace remove testns1
 '
 
 #

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -400,7 +400,7 @@ test_expect_success 'kvs: read-your-writes consistency on primary namespace' '
 '
 
 test_expect_success 'kvs: read-your-writes consistency on alt namespace' '
-        flux kvs namespace-create rywtestns &&
+        flux kvs namespace create rywtestns &&
         flux kvs put --namespace=rywtestns $DIR.test=1 &&
         VERS=$(flux kvs version --namespace=rywtestns) &&
         flux exec -n sh -c "flux kvs wait --namespace=rywtestns ${VERS}" &&
@@ -418,7 +418,7 @@ test_expect_success 'kvs: read-your-writes consistency on alt namespace' '
         flux exec -n -r 2 sh -c "flux kvs get --namespace=rywtestns $DIR.test" > rank2-b.out &&
         test_cmp rank1-b.out new.out &&
         test_cmp rank2-b.out new.out &&
-        flux kvs namespace-remove rywtestns
+        flux kvs namespace remove rywtestns
 '
 
 #

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -34,7 +34,7 @@ NAMESPACEORDER=namespaceorder
 
 namespace_create_loop() {
         i=0
-        while ! flux kvs namespace-create $1 && [ $i -lt ${KVS_WAIT_ITERS} ]
+        while ! flux kvs namespace create $1 && [ $i -lt ${KVS_WAIT_ITERS} ]
         do
                 sleep 0.1
                 i=$((i + 1))
@@ -80,15 +80,15 @@ wait_fencecount_nonzero() {
 #
 
 test_expect_success 'kvs: primary namespace exists/is listed' '
-        flux kvs namespace-list | grep primary
+        flux kvs namespace list | grep primary
 '
 
 test_expect_success 'kvs: create primary namespace fails' '
-	! flux kvs namespace-create $PRIMARYNAMESPACE
+	! flux kvs namespace create $PRIMARYNAMESPACE
 '
 
 test_expect_success 'kvs: remove primary namespace fails' '
-	! flux kvs namespace-remove $PRIMARYNAMESPACE
+	! flux kvs namespace remove $PRIMARYNAMESPACE
 '
 
 test_expect_success 'kvs: get with primary namespace works' '
@@ -159,19 +159,19 @@ EOF
 #
 
 test_expect_success 'kvs: namespace create on rank 0 works' '
-	flux kvs namespace-create $NAMESPACETEST
+	flux kvs namespace create $NAMESPACETEST
 '
 
 test_expect_success 'kvs: new namespace exists/is listed' '
-        flux kvs namespace-list | grep $NAMESPACETEST
+        flux kvs namespace list | grep $NAMESPACETEST
 '
 
 test_expect_success 'kvs: namespace create on rank 1 works' '
-	flux exec -n -r 1 sh -c "flux kvs namespace-create $NAMESPACERANK1"
+	flux exec -n -r 1 sh -c "flux kvs namespace create $NAMESPACERANK1"
 '
 
 test_expect_success 'kvs: new namespace exists/is listed' '
-        flux kvs namespace-list | grep $NAMESPACERANK1
+        flux kvs namespace list | grep $NAMESPACERANK1
 '
 
 test_expect_success 'kvs: put/get value in new namespace works' '
@@ -228,31 +228,31 @@ EOF
 '
 
 test_expect_success 'kvs: namespace remove non existing namespace silently passes' '
-	flux kvs namespace-remove $NAMESPACETMP
+	flux kvs namespace remove $NAMESPACETMP
 '
 
 test_expect_success 'kvs: namespace remove works' '
-	flux kvs namespace-create $NAMESPACETMP-BASIC &&
+	flux kvs namespace create $NAMESPACETMP-BASIC &&
         flux kvs put --namespace=$NAMESPACETMP-BASIC --json $DIR.tmp=1 &&
         test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.tmp 1 &&
-	flux kvs namespace-remove $NAMESPACETMP-BASIC &&
+	flux kvs namespace remove $NAMESPACETMP-BASIC &&
         ! flux kvs get --namespace=$NAMESPACETMP-BASIC --json $DIR.tmp
 '
 
-# A namespace-create races against the namespace-remove above, as we
-# can't confirm if the namespace-remove has garbage collected itself
+# A namespace create races against the namespace remove above, as we
+# can't confirm if the namespace remove has garbage collected itself
 # yet.  So we use namespace_create_loop() to iterate and try
-# namespace-create many times until it succeeds.
+# namespace create many times until it succeeds.
 test_expect_success 'kvs: namespace can be re-created after remove' '
         namespace_create_loop $NAMESPACETMP-BASIC &&
         flux kvs put --namespace=$NAMESPACETMP-BASIC --json $DIR.recreate=1 &&
         test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.recreate 1 &&
-	flux kvs namespace-remove $NAMESPACETMP-BASIC &&
+	flux kvs namespace remove $NAMESPACETMP-BASIC &&
         ! flux kvs get --namespace=$NAMESPACETMP-BASIC --json $DIR.recreate
 '
 
 test_expect_success 'kvs: removed namespace not listed' '
-        ! flux kvs namespace-list | grep $NAMESPACETMP-BASIC
+        ! flux kvs namespace list | grep $NAMESPACETMP-BASIC
 '
 
 #
@@ -274,22 +274,22 @@ test_expect_success 'kvs: unlink value in new namespace, does not exist all rank
                          ! flux kvs get --namespace=$NAMESPACETEST $DIR.all"
 '
 
-# namespace-remove on other ranks can take time, so we loop via
+# namespace remove on other ranks can take time, so we loop via
 # get_kvs_namespace_fails_all_ranks_loop()
 test_expect_success 'kvs: namespace remove works, recognized on other ranks' '
-	flux kvs namespace-create $NAMESPACETMP-ALL &&
+	flux kvs namespace create $NAMESPACETMP-ALL &&
         flux kvs put --namespace=$NAMESPACETMP-ALL --json $DIR.all=1 &&
         VERS=`flux kvs version --namespace=$NAMESPACETMP-ALL` &&
         flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETMP-ALL ${VERS} && \
                          flux kvs get --namespace=$NAMESPACETMP-ALL $DIR.all" &&
-	flux kvs namespace-remove $NAMESPACETMP-ALL &&
+	flux kvs namespace remove $NAMESPACETMP-ALL &&
         get_kvs_namespace_fails_all_ranks_loop $NAMESPACETMP-ALL $DIR.all
 '
 
-# A namespace-create races against the namespace-remove above, as we
-# can't confirm if the namespace-remove has garbage collected itself
+# A namespace create races against the namespace remove above, as we
+# can't confirm if the namespace remove has garbage collected itself
 # yet.  So we use namespace_create_loop() to iterate and try
-# namespace-create many times until it succeeds.
+# namespace create many times until it succeeds.
 #
 # After putting the new value, we still don't know if ranks > 0 have
 # recognized the original remove.  So we will loop until the new
@@ -299,7 +299,7 @@ test_expect_success 'kvs: namespace can be re-created after remove, recognized o
         namespace_create_loop $NAMESPACETMP-ALL &&
         flux kvs put --namespace=$NAMESPACETMP-ALL --json $DIR.recreate=1 &&
         get_kvs_namespace_all_ranks_loop $NAMESPACETMP-ALL $DIR.recreate &&
-	flux kvs namespace-remove $NAMESPACETMP-ALL
+	flux kvs namespace remove $NAMESPACETMP-ALL
 '
 
 #
@@ -307,8 +307,8 @@ test_expect_success 'kvs: namespace can be re-created after remove, recognized o
 #
 
 test_expect_success 'kvs: namespace order setup' '
-	flux kvs namespace-create $NAMESPACEORDER-1 &&
-	flux kvs namespace-create $NAMESPACEORDER-2 &&
+	flux kvs namespace create $NAMESPACEORDER-1 &&
+	flux kvs namespace create $NAMESPACEORDER-2 &&
         flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.ordertest=1 &&
         flux kvs put --namespace=$NAMESPACEORDER-1 $DIR.ordertest=2 &&
         flux kvs put --namespace=$NAMESPACEORDER-2 $DIR.ordertest=3 &&
@@ -369,11 +369,11 @@ test_expect_success 'kvs: put - namespace specified in command line overrides en
 NAMESPACEBAD=namespacebad
 
 test_expect_success 'kvs: namespace create on existing namespace fails' '
-	! flux kvs namespace-create $NAMESPACETEST
+	! flux kvs namespace create $NAMESPACETEST
 '
 
 test_expect_success 'kvs: namespace create on existing namespace fails on rank 1' '
-	! flux exec -n -r 1 sh -c "flux kvs namespace-create $NAMESPACETEST"
+	! flux exec -n -r 1 sh -c "flux kvs namespace create $NAMESPACETEST"
 '
 
 test_expect_success 'kvs: get fails on invalid namespace' '
@@ -418,13 +418,13 @@ test_expect_success 'kvs: watch fails on invalid namespace on rank 1' '
 
 # watch errors are output to stdout, so grep for "Operation not supported"
 test_expect_success NO_CHAIN_LINT 'kvs: watch gets ENOTSUP when namespace is removed' '
-        flux kvs namespace-create $NAMESPACETMP-REMOVE-WATCH0 &&
+        flux kvs namespace create $NAMESPACETMP-REMOVE-WATCH0 &&
         flux kvs put --namespace=$NAMESPACETMP-REMOVE-WATCH0 --json $DIR.watch=0 &&
         rm -f watch_out
         flux kvs watch --namespace=$NAMESPACETMP-REMOVE-WATCH0 -o -c 1 $DIR.watch >watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out
-        flux kvs namespace-remove $NAMESPACETMP-REMOVE-WATCH0 &&
+        flux kvs namespace remove $NAMESPACETMP-REMOVE-WATCH0 &&
         wait $watchpid &&
         grep "Operation not supported" watch_out
 '
@@ -432,7 +432,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch gets ENOTSUP when namespace is rem
 # watch errors are output to stdout, so grep for "Operation not supported"
 # stdbuf -oL necessary to ensure waitfile can succeed
 test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namespace is removed' '
-        flux kvs namespace-create $NAMESPACETMP-REMOVE-WATCH1 &&
+        flux kvs namespace create $NAMESPACETMP-REMOVE-WATCH1 &&
         flux kvs put --namespace=$NAMESPACETMP-REMOVE-WATCH1 --json $DIR.watch=0 &&
         VERS=`flux kvs version --namespace=$NAMESPACETMP-REMOVE-WATCH1` &&
         rm -f watch_out
@@ -440,7 +440,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namesp
                                          flux kvs watch --namespace=$NAMESPACETMP-REMOVE-WATCH1 -o -c 1 $DIR.watch" > watch_out &
         watchpid=$! &&
         $waitfile -q -t 5 -p "0" watch_out &&
-        flux kvs namespace-remove $NAMESPACETMP-REMOVE-WATCH1 &&
+        flux kvs namespace remove $NAMESPACETMP-REMOVE-WATCH1 &&
         wait $watchpid &&
         grep "Operation not supported" watch_out
 '
@@ -450,12 +450,12 @@ test_expect_success NO_CHAIN_LINT 'kvs: watch on rank 1 gets ENOTSUP when namesp
 # avoid racing in this test, we iterate on the fence stat until it is
 # non-zero to know it's ready for this test.
 test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence gets ENOTSUP when namespace is removed' '
-        flux kvs namespace-create $NAMESPACETMP-REMOVE-FENCE0 &&
+        flux kvs namespace create $NAMESPACETMP-REMOVE-FENCE0 &&
         rm -f fence_out
         ${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE0 fence0 > fence_out &
         watchpid=$! &&
         wait_fencecount_nonzero 0 $NAMESPACETMP-REMOVE-FENCE0 &&
-        flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE0 &&
+        flux kvs namespace remove $NAMESPACETMP-REMOVE-FENCE0 &&
         wait $watchpid &&
         grep "flux_future_get: Operation not supported" fence_out
 '
@@ -466,12 +466,12 @@ test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence gets ENOTSUP when names
 # avoid racing in this test, we iterate on the fence stat until it is
 # non-zero to know it's ready for this test.
 test_expect_success NO_CHAIN_LINT 'kvs: incomplete fence on rank 1 gets ENOTSUP when namespace is removed' '
-        flux kvs namespace-create $NAMESPACETMP-REMOVE-FENCE1 &&
+        flux kvs namespace create $NAMESPACETMP-REMOVE-FENCE1 &&
         rm -f fence_out
         flux exec -n -r 1 sh -c "${FLUX_BUILD_DIR}/t/kvs/fence_namespace_remove $NAMESPACETMP-REMOVE-FENCE1 fence1" > fence_out &
         watchpid=$! &&
         wait_fencecount_nonzero 1 $NAMESPACETMP-REMOVE-FENCE1 &&
-        flux kvs namespace-remove $NAMESPACETMP-REMOVE-FENCE1 &&
+        flux kvs namespace remove $NAMESPACETMP-REMOVE-FENCE1 &&
         wait $watchpid &&
         grep "flux_future_get: Operation not supported" fence_out
 '

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -44,12 +44,12 @@ unset_userid() {
 
 test_expect_success 'kvs: namespace create fails (user)' '
         set_userid 9999 &&
-	! flux kvs namespace-create $NAMESPACETMP-OWNER &&
+	! flux kvs namespace create $NAMESPACETMP-OWNER &&
         unset_userid
 '
 
 test_expect_success 'kvs: namespace create works (owner)' '
-	flux kvs namespace-create $NAMESPACETMP-OWNER
+	flux kvs namespace create $NAMESPACETMP-OWNER
 '
 
 test_expect_success 'kvs: put fails (user)' '
@@ -134,14 +134,14 @@ test_expect_success 'kvs: setroot pause / unpause fails (user)' '
 
 test_expect_success 'kvs: namespace remove fails (user)' '
         set_userid 9999 &&
-	! flux kvs namespace-remove $NAMESPACETMP-OWNER &&
+	! flux kvs namespace remove $NAMESPACETMP-OWNER &&
         unset_userid
 '
 
 test_expect_success 'kvs: namespace remove works (owner)' '
         flux kvs put --namespace=$NAMESPACETMP-OWNER --json $DIR.tmp=1 &&
         test_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.tmp 1 &&
-        flux kvs namespace-remove $NAMESPACETMP-OWNER &&
+        flux kvs namespace remove $NAMESPACETMP-OWNER &&
         ! flux kvs get --namespace=$NAMESPACETMP-OWNER --json $DIR.tmp
 '
 
@@ -150,11 +150,11 @@ test_expect_success 'kvs: namespace remove works (owner)' '
 #
 
 test_expect_success 'kvs: namespace create works (owner, for user)' '
-	flux kvs namespace-create -o 9999 $NAMESPACETMP-USER
+	flux kvs namespace create -o 9999 $NAMESPACETMP-USER
 '
 
 test_expect_success 'kvs: namespace listed with correct owner' '
-        flux kvs namespace-list | grep $NAMESPACETMP-USER | grep 9999
+        flux kvs namespace list | grep $NAMESPACETMP-USER | grep 9999
 '
 
 test_expect_success 'kvs: namespace put/get works (user)' '
@@ -306,14 +306,14 @@ test_expect_success 'kvs: setroot pause / unpause fails (wrong user)' '
 
 test_expect_success 'kvs: namespace remove still fails (user)' '
         set_userid 9999 &&
-        ! flux kvs namespace-remove $NAMESPACETMP-USER &&
+        ! flux kvs namespace remove $NAMESPACETMP-USER &&
         unset_userid
 '
 
 test_expect_success 'kvs: namespace remove still works (owner)' '
         flux kvs put --namespace=$NAMESPACETMP-USER --json $DIR.tmp=1 &&
         test_kvs_key_namespace $NAMESPACETMP-USER $DIR.tmp 1 &&
-        flux kvs namespace-remove $NAMESPACETMP-USER &&
+        flux kvs namespace remove $NAMESPACETMP-USER &&
         ! flux kvs get --namespace=$NAMESPACETMP-USER --json $DIR.tmp
 '
 
@@ -322,9 +322,9 @@ test_expect_success 'kvs: namespace remove still works (owner)' '
 #
 
 test_expect_success 'kvs: namespace create works (owner, for user)' '
-	flux kvs namespace-create -o 9000 $NAMESPACETMP-SYMLINKNS1 &&
-	flux kvs namespace-create -o 9001 $NAMESPACETMP-SYMLINKNS2 &&
-	flux kvs namespace-create -o 9001 $NAMESPACETMP-SYMLINKNS3
+	flux kvs namespace create -o 9000 $NAMESPACETMP-SYMLINKNS1 &&
+	flux kvs namespace create -o 9001 $NAMESPACETMP-SYMLINKNS2 &&
+	flux kvs namespace create -o 9001 $NAMESPACETMP-SYMLINKNS3
 '
 
 test_expect_success 'kvs: symlink w/ Namespace works (owner)' '

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -18,12 +18,12 @@ test_expect_success 'flux kvs get --watch --count=1 works' '
 '
 
 test_expect_success 'flux kvs get --watch works on alt namespace' '
-	flux kvs namespace-create testns1 &&
+	flux kvs namespace create testns1 &&
 	flux kvs put --namespace=testns1 test.b=foo &&
 	run_timeout 2 flux kvs get --namespace=testns1 --watch --count=1 test.b >getns.out &&
 	echo foo >getns.exp &&
 	test_cmp getns.exp getns.out &&
-	flux kvs namespace-remove testns1
+	flux kvs namespace remove testns1
 '
 
 test_expect_success 'kvs-watch stats reports no namespaces when there are no watchers' '
@@ -94,13 +94,13 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by key remova
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by namespace removal' '
-	flux kvs namespace-create testns2 &&
+	flux kvs namespace create testns2 &&
 	flux kvs put --namespace=testns2 meep=1 &&
 	flux kvs get --namespace=testns2 --watch meep >seq4.out &
 	pid=$! &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="[0-9]+" seq4.out >/dev/null &&
-	flux kvs namespace-remove testns2 &&
+	flux kvs namespace remove testns2 &&
 	! wait $pid
 '
 
@@ -171,7 +171,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existe
                      test.waitcreate3 > waitcreate3.out &
         pid=$! &&
         wait_watcherscount_nonzero ns_waitcreate &&
-        flux kvs namespace-create ns_waitcreate &&
+        flux kvs namespace create ns_waitcreate &&
         flux kvs put --namespace=ns_waitcreate test.waitcreate3=3 &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="3" waitcreate3.out >/dev/null &&
@@ -217,23 +217,23 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, create 
                      test.ns_create_and_remove > waitcreate4.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero ns_create_and_remove &&
-        flux kvs namespace-create ns_create_and_remove &&
+        flux kvs namespace create ns_create_and_remove &&
         flux kvs put --namespace=ns_create_and_remove test.ns_create_and_remove=0 &&
         $waitfile --count=1 --timeout=10 \
                   --pattern="0" waitcreate4.out >/dev/null &&
-        flux kvs namespace-remove ns_create_and_remove &&
+        flux kvs namespace remove ns_create_and_remove &&
         ! wait $pid &&
         grep "Operation not supported" waitcreate4.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt work on removed namespace' '
-        flux kvs namespace-create ns_remove &&
+        flux kvs namespace create ns_remove &&
         ! flux kvs get --namespace=ns_remove --watch test.ns_remove &&
         flux kvs get --namespace=ns_remove --watch --waitcreate --count=1 \
                      test.ns_remove > waitcreate5.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero ns_remove &&
-        flux kvs namespace-remove ns_remove &&
+        flux kvs namespace remove ns_remove &&
         ! wait $pid &&
         grep "Operation not supported" waitcreate5.out
 '
@@ -393,7 +393,7 @@ xyz
 # make sure keys are normalized
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch, normalized key matching works ' '
-	flux kvs namespace-create testnorm1 &&
+	flux kvs namespace create testnorm1 &&
         flux kvs put --namespace=testnorm1 testnormkey1.a=1 &&
         flux kvs get --namespace=testnorm1 --watch --count=2 \
                      testnormkey1...a > norm1.out &
@@ -420,27 +420,27 @@ test_expect_success 'flux kvs get --watch allows owner userid' '
 '
 
 test_expect_success 'flux kvs get --watch allows guest access to its ns' '
-	flux kvs namespace-create --owner=9999 testns3 &&
+	flux kvs namespace create --owner=9999 testns3 &&
 	flux kvs put --namespace=testns3 test.i=69 &&
 	FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9999 \
 		flux kvs get --namespace=testns3 --watch --count=1 test.i &&
-	flux kvs namespace-remove testns3
+	flux kvs namespace remove testns3
 '
 
 test_expect_success 'flux kvs get --watch denies guest access to anothers ns' '
-	flux kvs namespace-create --owner=9999 testns4 &&
+	flux kvs namespace create --owner=9999 testns4 &&
 	flux kvs put --namespace=testns4 test.j=102 &&
 	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=9998 \
 		flux kvs get --namespace=testns4 --watch --count=1 test.j &&
-	flux kvs namespace-remove testns4
+	flux kvs namespace remove testns4
 '
 
 test_expect_success 'flux kvs get --watch allows owner access to guest ns' '
-	flux kvs namespace-create --owner=9999 testns5 &&
+	flux kvs namespace create --owner=9999 testns5 &&
 	flux kvs put --namespace=testns5 test.k=100 &&
 	! FLUX_HANDLE_ROLEMASK=0x1 FLUX_HANDLE_USERID=9998 \
 		flux kvs get --namespace=testns4 --watch --count=1 test.k &&
-	flux kvs namespace-remove testns4
+	flux kvs namespace remove testns4
 '
 
 test_done

--- a/t/t1009-kvs-copy.t
+++ b/t/t1009-kvs-copy.t
@@ -82,7 +82,7 @@ test_expect_success 'kvs-move dir dst contains expected value' '
 #   copy a value, move a dir
 
 test_expect_success 'create test namespace' '
-	flux kvs namespace-create fromns
+	flux kvs namespace create fromns
 '
 
 test_expect_success 'kvs-copy from namespace works' '
@@ -115,14 +115,14 @@ test_expect_success 'kvs-move from namespace dst contains expected value' '
 '
 
 test_expect_success 'remove test namespace' '
-	flux kvs namespace-remove fromns
+	flux kvs namespace remove fromns
 '
 
 # to namespace
 #   copy a value, move a dir
 
 test_expect_success 'create test namespace' '
-	flux kvs namespace-create tons
+	flux kvs namespace create tons
 '
 
 test_expect_success 'kvs-copy to namespace works' '
@@ -155,7 +155,7 @@ test_expect_success 'kvs-move to namespace dst contains expected value' '
 '
 
 test_expect_success 'remove test namespace' '
-	flux kvs namespace-remove tons
+	flux kvs namespace remove tons
 '
 
 # expected failures


### PR DESCRIPTION
Convert namespace-create, namespace-remove, and namespace-list
into a general namespace subcommand with "create", "remove", and
"list" sub-sub-commands.

Fixes #1445