### PR TITLE
job-ingest: update rfc14 examples and jobspec schema to allow optional "max" property for resource counts

### DIFF
--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -9,15 +9,19 @@
     "complex_range": {
       "description": "a complex range of numbers",
       "type": "object",
-      "required":["min", "max", "operator", "operand"],
       "properties":{
         "min": { "type": "integer", "minimum" : 1 },
         "max": { "type": "integer", "minimum" : 1 },
         "operator": { "type": "string", "enum": ["+", "*", "^"] },
         "operand": { "type": "integer", "minimum" : 1 }
       },
+      "required": ["min"],
+      "dependencies": {
+         "max":      { "required": ["operator", "operand"] },
+         "operator": { "required": ["max", "operand"] },
+         "operand":  { "required": ["max", "operator"] }
+      },
       "additionalProperties": false
-
     },
     "resource_vertex_base": {
       "description": "base schema for slot/other resource vertex",

--- a/t/jobspec/valid/use_case_1.3.yaml
+++ b/t/jobspec/valid/use_case_1.3.yaml
@@ -5,13 +5,16 @@ resources:
     label: nodelevel
     with:
     - type: node
+      exclusive: false
       count: 1
       with:
         - type: socket
-          count: 2
+          count:
+            min: 2
           with:
             - type: core
-              count: 4
+              count:
+                min: 4
 tasks:
   - command: [ "flux", "start" ]
     slot: nodelevel

--- a/t/jobspec/valid/use_case_2.5.yaml
+++ b/t/jobspec/valid/use_case_2.5.yaml
@@ -5,7 +5,8 @@ resources:
     count: 10
     with:
     - type: memory
-      count: 2
+      count:
+        min: 2
       unit: GB
     - type: core
       count: 1

--- a/t/jobspec/valid/use_case_2.6.yaml
+++ b/t/jobspec/valid/use_case_2.6.yaml
@@ -8,7 +8,8 @@ resources:
       count: 1
       with:
         - type: memory
-          count: 4
+          count:
+            min: 4
           unit: GB
 tasks:
   - command: app


### PR DESCRIPTION
Update jobspec schema to make `min` the only required property for resource `count` specification. If any of `max`, `operator`, or `operand` are present, then all are required. (I think I got this right)

Update test input to latest examples from rfc14, which should now pass the validation tests in the testsuite.

Closes #1995