### PR TITLE
flux-exec:  support forced exit & misc fixes

### DIFF
--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -25,6 +25,10 @@ stdout and stderr.
 On receipt of SIGINT and SIGTERM signals, flux-exec(1) shall forward
 the received signal to all currently running remote processes.
 
+In the event subprocesses are hanging or ignoring SIGINT, two SIGINT
+signals (typically sent via Ctrl+C) in short succession can force
+flux-exec(1) to exit.
+
 flux-exec(1) is meant as an administrative and test utility, and cannot
 be used to launch Flux jobs.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -457,3 +457,4 @@ nokz
 LGPL
 SPDX
 MATCHDEBUG
+Ctrl

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -182,10 +182,10 @@ static void stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
 static void signal_cb (int signum)
 {
     flux_subprocess_t *p = zlist_first (subprocesses);
+    if (optparse_getopt (opts, "verbose", NULL) > 0)
+        fprintf (stderr, "sending signal %d to %d running processes\n",
+                 signum, started - exited);
     while (p) {
-        if (optparse_getopt (opts, "verbose", NULL) > 0)
-            fprintf (stderr, "sending signal %d to %d running processes\n",
-                     signum, started - exited);
         if (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
             flux_future_t *f = flux_subprocess_kill (p, signum);
             if (!f) {

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -183,7 +183,6 @@ static flux_subprocess_t * subprocess_create (flux_t *h,
     p->reactor = r;
     p->rank = rank;
     p->flags = flags;
-    p->kill_signum = 0;
 
     p->local = local;
 
@@ -875,12 +874,6 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signum)
         return NULL;
     }
 
-    if (p->kill_signum) {
-        /* XXX right errno? */
-        errno = EBUSY;
-        return NULL;
-    }
-
     if (p->state != FLUX_SUBPROCESS_RUNNING) {
         /* XXX right errno? */
         errno = EINVAL;
@@ -906,7 +899,6 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signum)
             flux_future_fulfill_error (f, save_errno, NULL);
         }
     }
-    p->kill_signum = signum;
     return f;
 }
 

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -988,9 +988,6 @@ void test_kill (flux_reactor_t *r)
     ok (f != NULL, "flux_subprocess_kill returns future_t");
     ok (flux_future_wait_for (f, 0.) == 0,
         "future fulfilled immediately for local process");
-    ok (flux_subprocess_kill (p, SIGINT) == NULL
-        && errno == EBUSY,
-        "flux_subprocess_kill returns EBUSY, trying to kill again");
 
     ok (flux_future_get (f, NULL) == 0, "flux_future_get (f) returns 0");
     ok (flux_reactor_run (r, 0) == 0, "reactor_run exits normally");


### PR DESCRIPTION
Support a pdsh-ish mechanism to support forced exits on flux-exec when processes hang or are ignoring signals.  Because flux-exec sends a signal on the first ctrl+c (which pdsh doesn't), I decided for it to behave a bit differently than pdsh.  Instead, on the second ctrl+c, you get the "please ctrl+c within a second to exit" message.  So it really takes 3 ctrl+c to force exit.  I know it's a tad different, but it made sense to me.

Also fixed up a corner case where I foolishly output verbosity for each subprocess instead of for all subprocesses.

Also fixed up ```flux_subprocess_kill()``` to allow users to send signals multiple times.  I have no idea why I didn't allow this at first, it makes no sense.