### PR TITLE
mergify.yml: add config file for mergify.io

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=codecov/project
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~="^\[*(WIP|wip)"
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,10 @@ coverage:
  round: down
  range: "50...100"
  ignore:
- - "t/.*"
+ - "^t/.*"
  - ".*/test/.*"
  - ".*/tests/.*"
- - ".*/man3/*.c"
+ - ".*/man3/.*"
  - ".*/common/libtap/.*"
  - ".*/common/liblsd/.*"
  - ".*/common/libev/.*"
@@ -15,6 +15,12 @@ coverage:
  - ".*/common/libminilzo/.*"
  - "/usr/include/.*"
  - "/usr/lib/.*"
+
+ # Allow coverage to drop up to 0.1%
+ status:
+  project:
+   default:
+    threshold: .1
 
 comment:
  layout: "header, diff, changes, tree"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 coverage:
  round: down
- range: "50...100"
+ range: "65...100"
  ignore:
  - "^t/.*"
  - ".*/test/.*"
@@ -24,3 +24,4 @@ coverage:
 
 comment:
  layout: "header, diff, changes, tree"
+ behavior: new


### PR DESCRIPTION
Add an initial config file for mergify.io with strict merge enabled.
This config file enables the mergify bot to auto-rebase and merge
PRs once all of the following conditions are met:

 - The label "merge-when-passing" is applied
 - The label "work-in-progress" is not applied
 - The PR title doesn't start with "[wip|WIP]" or "wip" or "WIP"
 - Travis-CI checks pass
 - Codecov doesn't report a drop in project coverage
 - There is at least one approving review by a member of flux team
 - There are no outstanding changes requested.

I have the strict mode set to "auto" instead of "true" which supposedly will only rebase one PR at a time instead of all pending PRs on a change to master.

I haven't been able to test some of the features, i.e. I'm not sure if I got the title matching right, and I couldn't check to see if the syntax for the flux-framework "core" team is correct.

After this is merged I can enable mergify.io on the flux-core repo and we can carefully try this out.