### PR TITLE
flux-exec: add two helper outputs

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -46,6 +46,7 @@ uint32_t rank_count;
 uint32_t started = 0;
 uint32_t exited = 0;
 int exit_code = 0;
+zhashx_t *exitsets;
 
 zlist_t *subprocesses;
 
@@ -60,17 +61,61 @@ flux_watcher_t *stdin_w;
 struct timespec last;
 int sigint_count = 0;
 
+void output_exitsets (const char *key, void *item)
+{
+    struct idset *idset = item;
+    int flags = IDSET_FLAG_BRACKETS | IDSET_FLAG_RANGE;
+    char *idset_str;
+
+    if (!(idset_str = idset_encode (idset, flags)))
+        log_err_exit ("idset_encode");
+
+    /* key is string form of exit code / signal */
+    fprintf (stderr, "%s: %s\n", idset_str, key);
+    free (idset_str);
+}
+
+void idset_destroy_wrapper (void *data)
+{
+    struct idset *idset = data;
+    idset_destroy (idset);
+}
+
 void completion_cb (flux_subprocess_t *p)
 {
-    int ec;
+    int rank = flux_subprocess_rank (p);
+    int ec, signum = 0;
 
     if ((ec = flux_subprocess_exit_code (p)) < 0) {
         /* bash standard, signals + 128 */
-        if ((ec = flux_subprocess_signaled (p)) > 0)
-            ec += 128;
+        if ((signum = flux_subprocess_signaled (p)) > 0)
+            ec = signum + 128;
     }
     if (ec > exit_code)
         exit_code = ec;
+
+    if (ec > 0) {
+        char buf[128];
+        struct idset *idset;
+
+        if (signum)
+            sprintf (buf, "%s", strsignal (signum));
+        else
+            sprintf (buf, "Exit %d", ec);
+
+        /* use exit code as key for hash */
+        if (!(idset = zhashx_lookup (exitsets, buf))) {
+            if (!(idset = idset_create (rank_count, 0)))
+                log_err_exit ("idset_create");
+            if (zhashx_insert (exitsets, buf, idset) < 0)
+                log_err_exit ("zhashx_insert");
+            if (!zhashx_freefn (exitsets, buf, idset_destroy_wrapper))
+                log_err_exit ("zhashx_freefn");
+        }
+
+        if (idset_set (idset, rank) < 0)
+            log_err_exit ("idset_set");
+    }
 }
 
 void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
@@ -326,6 +371,9 @@ int main (int argc, char *argv[])
     if (!(subprocesses = zlist_new ()))
         log_err_exit ("zlist_new");
 
+    if (!(exitsets = zhashx_new ()))
+        log_err_exit ("zhashx_new()");
+
     rank = idset_first (ns);
     while (rank != IDSET_INVALID_ID) {
         flux_subprocess_t *p;
@@ -379,6 +427,16 @@ int main (int argc, char *argv[])
         fprintf (stderr, "%03fms: %d tasks complete with code %d\n",
                  monotime_since (t0), exited, exit_code);
 
+    /* output message on any tasks that exited non-zero */
+    if (zhashx_size (exitsets) > 0) {
+        struct id_set *idset = zhashx_first (exitsets);
+        while (idset) {
+            const char *key = zhashx_cursor (exitsets);
+            output_exitsets (key, idset);
+            idset = zhashx_next (exitsets);
+        }
+    }
+
     /* Clean up.
      */
     idset_destroy (ns);
@@ -386,6 +444,8 @@ int main (int argc, char *argv[])
     flux_close (h);
     optparse_destroy (opts);
     log_fini ();
+
+    zhashx_destroy (&exitsets);
     zlist_destroy (&subprocesses);
 
     return exit_code;

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -219,7 +219,7 @@ static void signal_cb (int signum)
         if (sigint_count)
             fprintf (stderr,
                      "interrupt (Ctrl+C) one more time "
-                     "within %f sec to exit\n",
+                     "within %.2f sec to exit\n",
                      (INTERRUPT_MILLISECS / 1000.0));
 
         monotime (&last);

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -66,7 +66,7 @@ void completion_cb (flux_subprocess_t *p)
 
     if ((ec = flux_subprocess_exit_code (p)) < 0) {
         /* bash standard, signals + 128 */
-        if ((ec = flux_subprocess_signaled (p)) >= 0)
+        if ((ec = flux_subprocess_signaled (p)) > 0)
             ec += 128;
     }
     if (ec > exit_code)

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -62,7 +62,7 @@ int sigint_count = 0;
 
 void completion_cb (flux_subprocess_t *p)
 {
-    int ec = flux_subprocess_exit_code (p);
+    int ec;
 
     if ((ec = flux_subprocess_exit_code (p)) < 0) {
         /* bash standard, signals + 128 */

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -63,7 +63,6 @@ struct flux_subprocess {
     flux_reactor_t *reactor;
     uint32_t rank;
     int flags;
-    int kill_signum;
     bool local;                     /* This is a local process, not remote. */
 
     int refcount;

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -109,6 +109,15 @@ test_expect_success 'flux exec passes non-zero exit status' '
 	test_expect_code 139 flux exec -n sh -c "kill -11 \$\$"
 '
 
+test_expect_success 'flux exec outputs tasks with errors' '
+	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
+        grep "\[0-3\]: Exit 2" 2.out &&
+	! flux exec -n sh -c "exit 3" > 3.out 2>&1 &&
+        grep "\[0-3\]: Exit 3" 3.out &&
+	! flux exec -n sh -c "kill -11 \$\$" > 139.out 2>&1 &&
+        grep "\[0-3\]: Segmentation fault" 139.out
+'
+
 test_expect_success 'basic IO testing' '
 	flux exec -n -r0 echo Hello | grep ^Hello\$  &&
 	flux exec -n -r0 sh -c "echo Hello >&2" 2>stderr &&


### PR DESCRIPTION
On normal completion, output to stderr the tasks that exited with non-zero exit status.  Here's example output:

```
>flux exec -n sh -c ~/test.sh
[1,3]: Exit 1
2: Exit 2
```

and when I ctrl+c

```
>flux exec -n sh -c "sleep 10"
^C[0-3]: Exit 130
```

Also output a list of tasks that were still running when you do a force-exit (multiple ctrl+c in under a second).  Example output:

```
>flux exec -n sh -c ~/ignore_sigint.sh
^C^Cinterrupt (Ctrl+C) one more time within 1.000000 sec to exit
^C[0-3]: command still running at exit
```

and one dumb commit to remove a struct var that is no longer used.

and one dumb commit to limit the decimal places in a message output.