### PR TITLE
kvs: re-work kvs.sync

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -26,7 +26,9 @@ kvs_la_SOURCES = \
 	kvstxn.h \
 	kvstxn.c \
 	kvsroot.h \
-	kvsroot.c
+	kvsroot.c \
+	kvssync.h \
+	kvssync.c
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \
@@ -40,7 +42,8 @@ TESTS = \
 	test_lookup.t \
 	test_treq.t \
 	test_kvstxn.t \
-	test_kvsroot.t
+	test_kvsroot.t \
+	test_kvssync.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
@@ -105,6 +108,17 @@ test_kvsroot_t_CPPFLAGS = $(test_cppflags)
 test_kvsroot_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/kvsroot.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/kvstxn.o \
+	$(top_builddir)/src/modules/kvs/cache.o \
+	$(top_builddir)/src/modules/kvs/treq.o \
+	$(test_ldadd)
+
+test_kvssync_t_SOURCES = test/kvssync.c
+test_kvssync_t_CPPFLAGS = $(test_cppflags)
+test_kvssync_t_LDADD = \
+	$(top_builddir)/src/modules/kvs/kvssync.o \
+	$(top_builddir)/src/modules/kvs/waitqueue.o \
+	$(top_builddir)/src/modules/kvs/kvsroot.o \
 	$(top_builddir)/src/modules/kvs/kvstxn.o \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/treq.o \

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -38,6 +38,7 @@
 #include "treq.h"
 #include "kvstxn.h"
 #include "kvsroot.h"
+#include "kvssync.h"
 
 /* Expire cache_entry after 'max_lastuse_age' heartbeats.
  */
@@ -319,12 +320,7 @@ static void setroot (kvs_ctx_t *ctx, struct kvsroot *root,
 {
     if (rootseq == 0 || rootseq > root->seq) {
         kvsroot_setroot (ctx->krm, root, rootref, rootseq);
-
-        /* log error on wait_runqueue(), don't error out.  watchers
-         * may miss value change, but will never get older one.
-         * Maintains consistency model */
-        if (wait_runqueue (root->watchlist) < 0)
-            flux_log_error (ctx->h, "%s: wait_runqueue", __FUNCTION__);
+        kvssync_process (root, false);
         root->last_update_epoch = ctx->epoch;
     }
 }
@@ -1227,7 +1223,7 @@ static int heartbeat_root_cb (struct kvsroot *root, void *arg)
     kvs_ctx_t *ctx = arg;
 
     if (root->remove) {
-        if (!wait_queue_length (root->watchlist)
+        if (!zlist_size (root->synclist)
             && !treq_mgr_transactions_count (root->trm)
             && !kvstxn_mgr_ready_transaction_count (root->ktm)) {
 
@@ -1244,7 +1240,7 @@ static int heartbeat_root_cb (struct kvsroot *root, void *arg)
              && !root->remove
              && strcasecmp (root->ns_name, KVS_PRIMARY_NAMESPACE)
              && (ctx->epoch - root->last_update_epoch) > max_namespace_age
-             && !wait_queue_length (root->watchlist)
+             && !zlist_size (root->synclist)
              && !treq_mgr_transactions_count (root->trm)
              && !kvstxn_mgr_ready_transaction_count (root->ktm)) {
         /* remove a root if it not the primary one, has timed out
@@ -1253,20 +1249,8 @@ static int heartbeat_root_cb (struct kvsroot *root, void *arg)
          */
         start_root_remove (ctx, root->ns_name);
     }
-    else {
-        /* "touch" objects involved in watched keys */
-        if (wait_queue_length (root->watchlist) > 0
-            && (ctx->epoch - root->last_update_epoch) > max_lastuse_age) {
-            /* log error on wait_runqueue(), don't error out.  watchers
-             * may miss value change, but will never get older one.
-             * Maintains consistency model */
-            if (wait_runqueue (root->watchlist) < 0)
-                flux_log_error (ctx->h, "%s: wait_runqueue", __FUNCTION__);
-            root->last_update_epoch = ctx->epoch;
-        }
-        /* "touch" root */
+    else /* "touch" root */
         (void)cache_lookup (ctx->cache, root->ref, ctx->epoch);
-    }
 
     return 0;
 }
@@ -1966,8 +1950,7 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
     kvs_ctx_t *ctx = arg;
     const char *ns;
     struct kvsroot *root;
-    int saved_errno, rootseq;
-    wait_t *wait = NULL;
+    int rootseq;
     bool stall = false;
 
     if (flux_request_unpack (msg, NULL, "{ s:i s:s }",
@@ -1985,17 +1968,13 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
     }
 
     if (root->seq < rootseq) {
-        if (!(wait = wait_create_msg_handler (h, mh, msg, arg,
-                                              sync_request_cb)))
-            goto error;
-        if (wait_addqueue (root->watchlist, wait) < 0) {
-            saved_errno = errno;
-            wait_destroy (wait);
-            errno = saved_errno;
+        if (kvssync_add (root, sync_request_cb, h, mh, msg, ctx, rootseq) < 0) {
+            flux_log_error (h, "%s: kvssync_add", __FUNCTION__);
             goto error;
         }
         return; /* stall */
     }
+
     if (flux_respond_pack (h, msg, "{ s:i s:s }",
                            "rootseq", root->seq,
                            "rootref", root->ref) < 0) {
@@ -2247,8 +2226,8 @@ static int disconnect_request_root_cb (struct kvsroot *root, void *arg)
 
     /* Log error, but don't return -1, can continue to iterate
      * remaining roots */
-    if (wait_destroy_msg (root->watchlist, disconnect_cmp, cbd->sender) < 0)
-        flux_log_error (cbd->ctx->h, "%s: wait_destroy_msg", __FUNCTION__);
+    if (kvssync_remove_msg (root, disconnect_cmp, cbd->sender) < 0)
+        flux_log_error (cbd->ctx->h, "%s: kvssync_remove_msg", __FUNCTION__);
 
     return 0;
 }
@@ -2264,13 +2243,6 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
         return;
     if (flux_msg_get_route_first (msg, &sender) < 0)
         return;
-   /* N.B. impossible for a watch to be on watchlist and cache waiter
-     * at the same time (i.e. on watchlist means we're watching, if on
-     * cache waiter we're not done processing towards being on the
-     * watchlist).  So if wait_destroy_msg() on the waitlist succeeds
-     * but cache_wait_destroy_msg() fails, it's not that big of a
-     * deal.  The current state is still maintained.
-     */
     cbd.ctx = ctx;
     cbd.sender = sender;
     if (kvsroot_mgr_iter_roots (ctx->krm, disconnect_request_root_cb, &cbd) < 0)
@@ -2287,8 +2259,8 @@ static int stats_get_root_cb (struct kvsroot *root, void *arg)
     json_t *s;
 
     if (!(s = json_pack ("{ s:i s:i s:i s:i s:i }",
-                         "#watchers",
-                         wait_queue_length (root->watchlist),
+                         "#syncers",
+                         zlist_size (root->synclist),
                          "#no-op stores",
                          kvstxn_mgr_get_noop_stores (root->ktm),
                          "#transactions",
@@ -2577,13 +2549,11 @@ static void start_root_remove (kvs_ctx_t *ctx, const char *ns)
 
         root->remove = true;
 
-        /* Now that root has been marked for removal from roothash, run
-         * the watchlist.  watch requests will notice root removed, return
-         * ENOTSUP to watchers.
+        /* Now that root has been marked for removal from roothash, run through
+         * the whole synclist.  requests will notice root removed, return
+         * ENOTSUP to all those trying to sync.
          */
-
-        if (wait_runqueue (root->watchlist) < 0)
-            flux_log_error (ctx->h, "%s: wait_runqueue", __FUNCTION__);
+        kvssync_process (root, true);
 
         /* Ready transactions will be processed and errors returned to
          * callers via the code path in kvstxn_apply().  But not ready

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -86,8 +86,8 @@ static void kvsroot_destroy (void *data)
             kvstxn_mgr_destroy (root->ktm);
         if (root->trm)
             treq_mgr_destroy (root->trm);
-        if (root->watchlist)
-            wait_queue_destroy (root->watchlist);
+        if (root->synclist)
+            zlist_destroy (&root->synclist);
         if (root->setroot_queue)
             zlist_destroy (&root->setroot_queue);
         free (data);
@@ -134,8 +134,8 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *krm,
         goto error;
     }
 
-    if (!(root->watchlist = wait_queue_create ())) {
-        flux_log_error (krm->h, "wait_queue_create");
+    if (!(root->synclist = zlist_new ())) {
+        flux_log_error (krm->h, "zlist_new");
         goto error;
     }
 

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -30,7 +30,7 @@ struct kvsroot {
     kvstxn_mgr_t *ktm;
     treq_mgr_t *trm;
     waitqueue_t *watchlist;
-    int watchlist_lastrun_epoch;
+    int last_update_epoch;
     int flags;
     bool remove;
     bool setroot_pause;

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -29,7 +29,7 @@ struct kvsroot {
     char ref[BLOBREF_MAX_STRING_SIZE];
     kvstxn_mgr_t *ktm;
     treq_mgr_t *trm;
-    waitqueue_t *watchlist;
+    zlist_t *synclist;
     int last_update_epoch;
     int flags;
     bool remove;

--- a/src/modules/kvs/kvssync.c
+++ b/src/modules/kvs/kvssync.c
@@ -1,0 +1,164 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "kvssync.h"
+
+struct kvssync {
+    flux_msg_handler_f cb;
+    flux_t *h;
+    flux_msg_handler_t *mh;
+    flux_msg_t *msg;
+    void *arg;
+    int seq;
+};
+
+static int kvssync_cmp (void *item1, void *item2)
+{
+    struct kvssync *ks1 = item1;
+    struct kvssync *ks2 = item2;
+
+    if (ks1->seq < ks2->seq)
+        return -1;
+    if (ks1->seq > ks2->seq)
+        return 1;
+    return 0;
+}
+
+static void kvssync_destroy (void *data)
+{
+    struct kvssync *ks = data;
+    if (ks) {
+        if (ks->msg)
+            flux_msg_destroy (ks->msg);
+        free (ks);
+    }
+}
+
+int kvssync_add (struct kvsroot *root, flux_msg_handler_f cb, flux_t *h,
+                 flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg,
+                 int seq)
+{
+    struct kvssync *ks = NULL;
+
+    if (!root || !msg || root->seq >= seq) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (!(ks = calloc (1, sizeof (*ks)))) {
+        errno = ENOMEM;
+        goto error;
+    }
+
+    if (!(ks->msg = flux_msg_copy (msg, true))) {
+        errno = ENOMEM;
+        goto error;
+    }
+
+    ks->cb = cb;
+    ks->h = h;
+    ks->mh = mh;
+    ks->arg = arg;
+    ks->seq = seq;
+
+    if (zlist_push (root->synclist, ks) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlist_freefn (root->synclist, ks, kvssync_destroy, false);
+
+    zlist_sort (root->synclist, kvssync_cmp);
+
+    return 0;
+
+error:
+    kvssync_destroy (ks);
+    return -1;
+}
+
+void kvssync_process (struct kvsroot *root, bool all)
+{
+    struct kvssync *ks;
+
+    if (!root)
+        return;
+
+    /* notify sync waiters that version has been reached */
+
+    ks = zlist_first (root->synclist);
+    while (ks && (all || root->seq >= ks->seq)) {
+        ks = zlist_pop (root->synclist);
+        ks->cb (ks->h, ks->mh, ks->msg, ks->arg);
+        kvssync_destroy (ks);
+        ks = zlist_first (root->synclist);
+    }
+}
+
+int kvssync_remove_msg (struct kvsroot *root,
+                        kvssync_test_msg_f cmp,
+                        void *arg)
+{
+    zlist_t *tmp = NULL;
+    struct kvssync *ks;
+    int rc = -1;
+    int saved_errno;
+
+    if (!root || !cmp) {
+        saved_errno = EINVAL;
+        goto error;
+    }
+
+    ks = zlist_first (root->synclist);
+    while (ks) {
+        if (cmp (ks->msg, arg)) {
+            if (!tmp && !(tmp = zlist_new ())) {
+                saved_errno = ENOMEM;
+                goto error;
+            }
+            if (zlist_append (tmp, ks) < 0) {
+                saved_errno = ENOMEM;
+                goto error;
+            }
+        }
+        ks = zlist_next (root->synclist);
+    }
+    if (tmp) {
+        while ((ks = zlist_pop (tmp)))
+            zlist_remove (root->synclist, ks);
+    }
+    rc = 0;
+error:
+    /* if an error occurs above in zlist_new() or zlist_append(),
+     * simply destroy the tmp list.  Nothing has been removed off of
+     * the original queue yet.  Allow user to handle error as they see
+     * fit.
+     */
+    zlist_destroy (&tmp);
+    if (rc < 0)
+        errno = saved_errno;
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvssync.h
+++ b/src/modules/kvs/kvssync.h
@@ -1,0 +1,41 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_KVS_KVSSYNC_H
+#define _FLUX_KVS_KVSSYNC_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "kvsroot.h"
+
+typedef bool (*kvssync_test_msg_f)(const flux_msg_t *msg, void *arg);
+
+/* add a kvssync structure to the kvsroot synclist */
+int kvssync_add (struct kvsroot *root, flux_msg_handler_f cb, flux_t *h,
+                 flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg,
+                 int seq);
+
+/* if a root sequence number has gone past a sync sequence number,
+ * call the callback.  If 'all' is true, run callback on all synclist
+ * regardless.
+ */
+void kvssync_process (struct kvsroot *root, bool all);
+
+/* remove message on synclist that meet 'cmp' conditions */
+int kvssync_remove_msg (struct kvsroot *root,
+                        kvssync_test_msg_f cmp,
+                        void *arg);
+
+#endif /* !_FLUX_KVS_KVSROOT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/test/kvssync.c
+++ b/src/modules/kvs/test/kvssync.c
@@ -1,0 +1,267 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+#include <unistd.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libkvs/kvs.h"
+#include "src/modules/kvs/kvsroot.h"
+#include "src/modules/kvs/kvssync.h"
+#include "src/modules/kvs/cache.h"
+
+const char *root_ref = "1234";  /* random string, doesn't matter for tests */
+int count = 0;
+
+void basic_corner_case_tests (void)
+{
+    ok (kvssync_add (NULL, NULL, NULL, NULL, NULL, NULL, 0) < 0
+        && errno == EINVAL,
+        "kvssync_add fails with EINVAL on bad input");
+
+    ok (kvssync_remove_msg (NULL, NULL, NULL) < 0
+        && errno == EINVAL,
+        "kvssync_remove_msg fails with EINVAL on bad input");
+
+    /* doesn't segfault on NULL */
+    kvssync_process (NULL, false);
+}
+
+void cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+{
+    count++;
+}
+
+void basic_api_tests (void)
+{
+    kvsroot_mgr_t *krm;
+    struct cache *cache;
+    struct kvsroot *root;
+    flux_msg_t *msg;
+
+    cache = cache_create ();
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
+
+    ok (kvsroot_mgr_root_count (krm) == 0,
+        "kvsroot_mgr_root_count returns correct count of roots");
+
+    ok ((root = kvsroot_mgr_create_root (krm,
+                                         cache,
+                                         "sha1",
+                                         KVS_PRIMARY_NAMESPACE,
+                                         1234,
+                                         0)) != NULL,
+         "kvsroot_mgr_create_root works");
+
+    msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
+
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 2),
+        "kvssync_add w/ seq = 2 works");
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 3),
+        "kvssync_add w/ seq = 3 works");
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 4),
+        "kvssync_add w/ seq = 4 works");
+
+    ok (zlist_size (root->synclist) == 3,
+        "synclist is length 3");
+
+    kvsroot_setroot (krm, root, root_ref, 1);
+
+    count = 0;
+
+    kvssync_process (root, false);
+
+    ok (count == 0,
+        "kvssync_process did not call cb on seq = 1");
+
+    ok (zlist_size (root->synclist) == 3,
+        "synclist is length 3");
+
+    kvsroot_setroot (krm, root, root_ref, 2);
+
+    count = 0;
+
+    kvssync_process (root, false);
+
+    ok (count == 1,
+        "kvssync_process called callback once on seq = 2");
+
+    ok (zlist_size (root->synclist) == 2,
+        "synclist is length 2");
+
+    kvsroot_setroot (krm, root, root_ref, 4);
+
+    count = 0;
+
+    kvssync_process (root, false);
+
+    ok (count == 2,
+        "kvssync_process called callback twice on seq = 4");
+
+    ok (zlist_size (root->synclist) == 0,
+        "synclist is length 0");
+
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 5),
+        "kvssync_add w/ seq = 5 works");
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 6),
+        "kvssync_add w/ seq = 6 works");
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 7),
+        "kvssync_add w/ seq = 7 works");
+
+    ok (zlist_size (root->synclist) == 3,
+        "synclist is length 3");
+
+    count = 0;
+
+    kvssync_process (root, true);
+
+    ok (count == 3,
+        "kvssync_process called callback thrice on all flag = true");
+
+    ok (zlist_size (root->synclist) == 0,
+        "synclist is length 0");
+
+    /* cover some alternate insertion pattern, descending and
+     * duplicate numbers */
+
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 9),
+        "kvssync_add w/ seq = 9 works");
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 8),
+        "kvssync_add w/ seq = 8 works");
+    ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, 8),
+        "kvssync_add w/ seq = 8 works");
+
+    ok (zlist_size (root->synclist) == 3,
+        "synclist is length 3");
+
+    count = 0;
+
+    kvssync_process (root, true);
+
+    ok (count == 3,
+        "kvssync_process called callback thrice on all flag = true");
+
+    flux_msg_destroy (msg);
+
+    kvsroot_mgr_destroy (krm);
+
+    cache_destroy (cache);
+}
+
+bool msgcmp (const flux_msg_t *msg, void *arg)
+{
+    char *id = NULL;
+    bool match = false;
+    if (flux_msg_get_route_first (msg, &id) == 0
+        && (!strcmp (id, "1")
+            || !strcmp (id, "2")
+            || !strcmp (id, "3")
+            || !strcmp (id, "4")
+            || !strcmp (id, "5")))
+        match = true;
+    if (id)
+        free (id);
+    return match;
+}
+
+bool msgcmp_true (const flux_msg_t *msg, void *arg)
+{
+    return true;
+}
+
+void basic_remove_tests (void)
+{
+    kvsroot_mgr_t *krm;
+    struct cache *cache;
+    struct kvsroot *root;
+    int i;
+
+    cache = cache_create ();
+
+    ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
+        "kvsroot_mgr_create works");
+
+    ok (kvsroot_mgr_root_count (krm) == 0,
+        "kvsroot_mgr_root_count returns correct count of roots");
+
+    ok ((root = kvsroot_mgr_create_root (krm,
+                                         cache,
+                                         "sha1",
+                                         KVS_PRIMARY_NAMESPACE,
+                                         1234,
+                                         0)) != NULL,
+         "kvsroot_mgr_create_root works");
+
+
+    /* Add 10 syncs to queue, selectively destroy */
+    for (i = 1; i <= 10; i++) {
+        flux_msg_t *msg;
+        char s[16];
+        snprintf (s, sizeof (s), "%d", i);
+        if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+            break;
+        if (flux_msg_enable_route (msg) < 0 || flux_msg_push_route (msg, s) < 0)
+            break;
+        ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, i),
+            "kvssync_add w/ seq = %d works", i);
+        flux_msg_destroy (msg);
+    }
+
+    ok (zlist_size (root->synclist) == 10,
+        "synclist is length 10");
+
+    count = 0;
+
+    ok (!kvssync_remove_msg (root, msgcmp, NULL),
+        "kvssync_remove_msg works");
+
+    ok (zlist_size (root->synclist) == 5,
+        "synclist is length 5");
+
+    ok (!kvssync_remove_msg (root, msgcmp, NULL),
+        "kvssync_remove_msg works");
+
+    ok (zlist_size (root->synclist) == 5,
+        "synclist is still length 5");
+
+    ok (!kvssync_remove_msg (root, msgcmp_true, NULL),
+        "kvssync_remove_msg works");
+
+    ok (zlist_size (root->synclist) == 0,
+        "synclist is length 0");
+
+    kvsroot_mgr_destroy (krm);
+
+    cache_destroy (cache);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic_corner_case_tests ();
+    basic_api_tests ();
+    basic_remove_tests ();
+
+    done_testing ();
+    return (0);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
The last vestige of watch in ```modules/kvs``` was the use of the "watchlist" by ```kvs.sync```.  I considered leaving the code there b/c it was still useful by ```kvs.sync```, but the implementation was inefficient.  It would continually run through the whole watchlist (err "synclist") on every setroot event.

Instead, I created a new internal lib called "kvssync", that is a very simplified version of the former "watchlist" just for ```kvs.sync```.  The "synclist" is sorted by the sequence number people are waiting on.  So everytime a setroot even occurs, you only traverse the list as far as you need to to alert syncers.