### PR TITLE
kvs: commit/fence return root ref / sequence after transaction

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -78,7 +78,7 @@ several unique situations, such as the replacement of an entire parent
 directory.  The '-f' option can be specified to monitor for many of
 these special situations.
 
-*put* [-N ns] [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
+*put* [-N ns] [-O|-s] [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  Specify an alternate
 namespace to commit value(s) via '-N'.  If it already has a value,
 overwrite it.  If no options, value is stored directly.  If '-j', it
@@ -88,7 +88,9 @@ the value may include embedded NULL bytes.  If '-t', value is stored
 as a RFC 11 object.  '-n' prevents the commit from being merged with
 with other contemporaneous commits.  '-A' appends the value to a key
 instead of overwriting the value.  Append is incompatible with the -j
-option.
+option.  After a successful put, '-O' or '-s' can be specified to
+output the RFC11 treeobj or root sequence number of the root
+containing the put(s).
 
 *ls* [-N ns] [-R] [-d] [-F] [-w COLS] [-1] ['key' ...]::
 Display directory referred to by _key_, or "." (root) if unspecified.
@@ -110,17 +112,21 @@ terminal width.  '-w COLS' sets the terminal width (0=unlimited).  '-a
 treeobj' causes the lookup to be relative to an RFC 11 snapshot
 reference.
 
-*unlink* [-N ns] [-R] [-f] 'key' ['key...']::
+*unlink* [-N ns] [-O|-s] [-R] [-f] 'key' ['key...']::
 Remove 'key' from the KVS and commit the change.  Specify an alternate
 namespace to commit to via '-N'.  If 'key' represents a directory,
 specify '-R' to remove all keys underneath it.  If '-f' is specified,
-ignore nonexistent files.
+ignore nonexistent files.  After a successful unlink, '-O' or '-s' can
+be specified to output the RFC11 treeobj or root sequence number of
+the root containing the unlink(s).
 
-*link* [-N ns] [-T ns] 'target' 'linkname'::
+*link* [-N ns] [-T ns] [-O|-s] 'target' 'linkname'::
 Create a new name for 'target', similar to a symbolic link, and commit
 the change.  'target' does not have to exist.  If 'linkname' exists,
 it is overwritten.  Specify an alternate namespace to commit linkname
-to via '-N'.  Specify the target's namespace via '-T'.
+to via '-N'.  Specify the target's namespace via '-T'.  After a
+successfully created link, '-O' or '-s' can be specified to output the
+RFC11 treeobj or root sequence number of the root containing the link.
 
 *readlink* [-N ns] [-a treeobj] [ -o | -k ] 'key' ['key...']::
 Retrieve the key a link refers to rather than its value, as would be
@@ -131,10 +137,12 @@ and key will be output in the format '<namespace>::<key>'.  The '-o'
 can be used to only output namespaces and the '-k' can be used to only
 output keys.
 
-*mkdir* [-N ns] 'key' ['key...']::
+*mkdir* [-N ns] [-O|-s] 'key' ['key...']::
 Create an empty directory and commit the change.  If 'key' exists,
 it is overwritten.  Specify an alternate namespace to commit to via
-'-N'.
+'-N'.  After a successful mkdir, '-O' or '-s' can be specified to
+output the RFC11 treeobj or root sequence number of the root
+containing the new directory.
 
 *copy* [-S src-ns] [-D dst-ns] 'source' 'destination'::
 Copy 'source' key to 'destination' key.  Optionally, specify a source

--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -172,12 +172,11 @@ of synchronization between peers is:  node A puts a value, commits it,
 reads version, sends version to node B.  Node B waits for version, gets
 value.
 
-*getroot* [-N ns] [-s | -o | -b]::
+*getroot* [-N ns] [-s | -o]::
 Retrieve the current KVS root, displaying it as an RFC 11 dirref object.
-Specify an alternate namespace to retrieve from via '-N'.  If '-b' is
-specified, display it as a blobref.  If '-o' is specified, display the
-namespace owner.  If '-s' is specified, display the root sequence
-number.
+Specify an alternate namespace to retrieve from via '-N'.  If '-o' is
+specified, display the namespace owner.  If '-s' is specified, display
+the root sequence number.
 
 *eventlog get* [-w] [-c count] [-u] 'key'::
 Display the contents of an RFC 18 KVS eventlog referred to by 'key'.

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -157,6 +157,8 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_getroot_get_owner.3 \
 	flux_kvs_getroot_cancel.3 \
 	flux_kvs_fence.3 \
+	flux_kvs_commit_get_treeobj.3 \
+	flux_kvs_commit_get_sequence.3 \
 	flux_kvs_txn_destroy.3 \
 	flux_kvs_txn_put.3 \
 	flux_kvs_txn_pack.3 \
@@ -289,6 +291,8 @@ flux_kvs_getroot_get_sequence.3: flux_kvs_getroot.3
 flux_kvs_getroot_get_owner.3: flux_kvs_getroot.3
 flux_kvs_getroot_cancel.3: flux_kvs_getroot.3
 flux_kvs_fence.3: flux_kvs_commit.3
+flux_kvs_commit_get_treeobj.3: flux_kvs_commit.3
+flux_kvs_commit_get_sequence.3: flux_kvs_commit.3
 flux_kvs_txn_destroy.3: flux_kvs_txn_create.3
 flux_kvs_txn_put.3: flux_kvs_txn_create.3
 flux_kvs_txn_pack.3: flux_kvs_txn_create.3

--- a/doc/man3/flux_kvs_commit.adoc
+++ b/doc/man3/flux_kvs_commit.adoc
@@ -5,7 +5,7 @@ flux_kvs_commit(3)
 
 NAME
 ----
-flux_kvs_commit, flux_kvs_fence - commit a KVS transaction
+flux_kvs_commit, flux_kvs_fence, flux_kvs_commit_get_treeobj, flux_kvs_commit_get_sequence - commit a KVS transaction
 
 
 SYNOPSIS
@@ -23,6 +23,12 @@ SYNOPSIS
                                 const char *name,
                                 int nprocs,
                                 flux_kvs_txn_t *txn);
+
+ int flux_kvs_commit_get_treeobj (flux_future_t *f,
+                                  const char **treeobj);
+
+ int flux_kvs_commit_get_sequence (flux_future_t *f,
+                                   int *seq);
 
 DESCRIPTION
 -----------
@@ -50,9 +56,24 @@ and should not be reused, even after the fence is complete.
 request has been received.  `flux_future_wait_for(3)` may be used to
 block until the response has been received.  Both accept an optional timeout.
 
-`flux_future_get()` decodes the response, and returns 0 if the commit/fence
-was successful, indicating the entire transaction was committed, or -1
-on failure, indicating none of the transaction was committed.
+`flux_future_get()`, `flux_kvs_commit_get_treeobj()`, or
+`flux_kvs_commit_get_sequence()` can decode the response.  A return of
+0 indicates success and the entire transaction was committed.  A
+return of -1 indicates failure, none of the transaction was committed.
+All can be used on the `flux_future_t` returned by `flux_kvs_commit()`
+or `flux_kvs_fence()`.
+
+In addition to checking for success or failure,
+`flux_kvs_commit_get_treeobj()` and `flux_kvs_commit_get_sequence()`
+can return information about the root snapshot that the commit or
+fence has completed its transaction on.
+
+`flux_kvs_commit_get_treeobj()` obtains the root hash in the form of
+an RFC 11 _dirref_ treeobj, suitable to be passed to
+`flux_kvs_lookupat(3)`.
+
+`flux_kvs_commit_get_sequence()` retrieves the monotonic sequence number
+for the root.
 
 FLAGS
 -----

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -199,9 +199,6 @@ static struct optparse_option getroot_opts[] =  {
     { .name = "namespace", .key = 'N', .has_arg = 1,
       .usage = "Specify KVS namespace to use.",
     },
-    { .name = "blobref", .key = 'b', .has_arg = 0,
-      .usage = "Show root as a blobref rather that an RFC 11 dirref",
-    },
     { .name = "sequence", .key = 's', .has_arg = 0,
       .usage = "Show sequence number",
     },
@@ -357,7 +354,7 @@ static struct optparse_subcommand subcommands[] = {
       namespace_opt
     },
     { "getroot",
-      "[-N ns] [-s|-o|-b]",
+      "[-N ns] [-s|-o]",
       "Get KVS root treeobj",
       cmd_getroot,
       0,
@@ -1702,13 +1699,6 @@ void getroot_continuation (flux_future_t *f, void *arg)
         if (flux_kvs_getroot_get_sequence (f, &sequence) < 0)
             log_err_exit ("flux_kvs_getroot_get_sequence");
         printf ("%d\n", sequence);
-    }
-    else if (optparse_hasopt (p, "blobref")) {
-        const char *blobref;
-
-        if (flux_kvs_getroot_get_blobref (f, &blobref) < 0)
-            log_err_exit ("flux_kvs_getroot_get_blobref");
-        printf ("%s\n", blobref);
     }
     else {
         const char *treeobj;

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -242,7 +242,7 @@ static struct optparse_subcommand subcommands[] = {
       get_opts
     },
     { "put",
-      "[-N ns] [-j|-r|-t] [-n] key=value [key=value...]",
+      "[-N ns] [-j|-r|-t] [-n] [-A] key=value [key=value...]",
       "Store value under key",
       cmd_put,
       0,

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -104,6 +104,12 @@ static struct optparse_option put_opts[] =  {
     { .name = "namespace", .key = 'N', .has_arg = 1,
       .usage = "Specify KVS namespace to use.",
     },
+    { .name = "treeobj-root", .key = 'O', .has_arg = 0,
+      .usage = "Output resulting RFC11 root containing puts",
+    },
+    { .name = "sequence", .key = 's', .has_arg = 0,
+      .usage = "Output root sequence of root containing puts",
+    },
     { .name = "json", .key = 'j', .has_arg = 0,
       .usage = "Store value(s) as encoded JSON",
     },
@@ -174,6 +180,12 @@ static struct optparse_option unlink_opts[] =  {
     { .name = "namespace", .key = 'N', .has_arg = 1,
       .usage = "Specify KVS namespace to use.",
     },
+    { .name = "treeobj-root", .key = 'O', .has_arg = 0,
+      .usage = "Output resulting RFC11 root containing unlinks",
+    },
+    { .name = "sequence", .key = 's', .has_arg = 0,
+      .usage = "Output root sequence of root containing unlinks",
+    },
     { .name = "recursive", .key = 'R', .has_arg = 0,
       .usage = "Remove directory contents recursively",
     },
@@ -216,6 +228,25 @@ static struct optparse_option link_opts[] =  {
     { .name = "target-namespace", .key = 'T', .has_arg = 1,
       .usage = "Specify target's namespace",
     },
+    { .name = "treeobj-root", .key = 'O', .has_arg = 0,
+      .usage = "Output resulting RFC11 root containing link",
+    },
+    { .name = "sequence", .key = 's', .has_arg = 0,
+      .usage = "Output root sequence of root containing link",
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option mkdir_opts[] =  {
+    { .name = "namespace", .key = 'N', .has_arg = 1,
+      .usage = "Specify KVS namespace to use.",
+    },
+    { .name = "treeobj-root", .key = 'O', .has_arg = 0,
+      .usage = "Output resulting RFC11 root containing new directory",
+    },
+    { .name = "sequence", .key = 's', .has_arg = 0,
+      .usage = "Output root sequence of root containing new directory",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -242,7 +273,7 @@ static struct optparse_subcommand subcommands[] = {
       get_opts
     },
     { "put",
-      "[-N ns] [-j|-r|-t] [-n] [-A] key=value [key=value...]",
+      "[-N ns] [-O|-s] [-j|-r|-t] [-n] [-A] key=value [key=value...]",
       "Store value under key",
       cmd_put,
       0,
@@ -263,14 +294,14 @@ static struct optparse_subcommand subcommands[] = {
       ls_opts
     },
     { "unlink",
-      "[-N ns] [-R] [-f] key [key...]",
+      "[-N ns] [-O|-s] [-R] [-f] key [key...]",
       "Remove key",
       cmd_unlink,
       0,
       unlink_opts
     },
     { "link",
-      "[-N ns] [-T ns] target linkname",
+      "[-N ns] [-T ns] [-O|-s] target linkname",
       "Create a new name for target",
       cmd_link,
       0,
@@ -284,11 +315,11 @@ static struct optparse_subcommand subcommands[] = {
       readlink_opts
     },
     { "mkdir",
-      "[-N ns] key [key...]",
+      "[-N ns] [-O|-s] key [key...]",
       "Create a directory",
       cmd_mkdir,
       0,
-      namespace_opt
+      mkdir_opts
     },
     { "copy",
       "[-S src-ns] [-D dst-ns] source destination",
@@ -787,6 +818,26 @@ int cmd_get (optparse_t *p, int argc, char **argv)
     return (0);
 }
 
+void commit_finish (flux_future_t *f, optparse_t *p)
+{
+    if (optparse_hasopt (p, "treeobj-root")) {
+        const char *treeobj = NULL;
+        if (flux_kvs_commit_get_treeobj (f, &treeobj) < 0)
+            log_err_exit ("flux_kvs_commit_get_treeobj");
+        printf ("%s\n", treeobj);
+    }
+    else if (optparse_hasopt (p, "sequence")) {
+        int sequence;
+        if (flux_kvs_commit_get_sequence (f, &sequence) < 0)
+            log_err_exit ("flux_kvs_commit_get_sequence");
+        printf ("%d\n", sequence);
+    }
+    else {
+        if (flux_future_get (f, NULL) < 0)
+            log_err_exit ("flux_kvs_commit");
+    }
+}
+
 int cmd_put (optparse_t *p, int argc, char **argv)
 {
     flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
@@ -866,9 +917,9 @@ int cmd_put (optparse_t *p, int argc, char **argv)
         }
         free (key);
     }
-    if (!(f = flux_kvs_commit (h, ns, commit_flags, txn))
-                                        || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, ns, commit_flags, txn)))
         log_err_exit ("flux_kvs_commit");
+    commit_finish (f, p);
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
     return (0);
@@ -939,9 +990,9 @@ int cmd_unlink (optparse_t *p, int argc, char **argv)
                 log_err_exit ("%s", argv[i]);
         }
     }
-    if (!(f = flux_kvs_commit (h, ns, 0, txn))
-        || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, ns, 0, txn)))
         log_err_exit ("flux_kvs_commit");
+    commit_finish (f, p);
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
     return (0);
@@ -974,9 +1025,9 @@ int cmd_link (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_kvs_txn_create");
     if (flux_kvs_txn_symlink (txn, 0, linkname, targetns, target) < 0)
         log_err_exit ("%s", linkname);
-    if (!(f = flux_kvs_commit (h, linkns, 0, txn))
-        || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, linkns, 0, txn)))
         log_err_exit ("flux_kvs_commit");
+    commit_finish (f, p);
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
     return (0);
@@ -1050,9 +1101,9 @@ int cmd_mkdir (optparse_t *p, int argc, char **argv)
         if (flux_kvs_txn_mkdir (txn, 0, argv[i]) < 0)
             log_err_exit ("%s", argv[i]);
     }
-    if (!(f = flux_kvs_commit (h, ns, 0, txn))
-        || flux_future_get (f, NULL) < 0)
+    if (!(f = flux_kvs_commit (h, ns, 0, txn)))
         log_err_exit ("kvs_commit");
+    commit_finish (f, p);
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
     return (0);

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -15,14 +15,41 @@
 #include <czmq.h>
 #include <flux/core.h>
 
+#include "treeobj.h"
 #include "kvs_txn_private.h"
 #include "kvs_util_private.h"
 #include "src/common/libutil/blobref.h"
+
+static const char *auxkey = "flux::commit_ctx";
+
+struct commit_ctx {
+    char *treeobj;      /* cached treeobj */
+};
+
+static void free_ctx (struct commit_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        free (ctx->treeobj);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct commit_ctx *alloc_ctx (void)
+{
+    struct commit_ctx *ctx;
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    return ctx;
+}
 
 flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
                                const char *name, int nprocs,
                                flux_kvs_txn_t *txn)
 {
+    flux_future_t *f;
+    struct commit_ctx *ctx = NULL;
     json_t *ops;
 
     if (!name || nprocs <= 0 || !txn) {
@@ -40,18 +67,35 @@ flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
         return NULL;
     }
 
-    return flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
-                          "{s:s s:i s:s s:i s:O}",
-                          "name", name,
-                          "nprocs", nprocs,
-                          "namespace", ns,
-                          "flags", flags,
-                          "ops", ops);
+    if (!(ctx = alloc_ctx ()))
+        return NULL;
+
+    if (!(f = flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
+                             "{s:s s:i s:s s:i s:O}",
+                             "name", name,
+                             "nprocs", nprocs,
+                             "namespace", ns,
+                             "flags", flags,
+                             "ops", ops)))
+        goto error;
+
+    if (flux_future_aux_set (f, auxkey, ctx, (flux_free_f)free_ctx) < 0)
+        goto error_future;
+
+    return f;
+
+error_future:
+    flux_future_destroy (f);
+error:
+    free_ctx (ctx);
+    return NULL;
 }
 
 flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,
                                 flux_kvs_txn_t *txn)
 {
+    flux_future_t *f;
+    struct commit_ctx *ctx = NULL;
     json_t *ops;
 
     if (!txn) {
@@ -69,11 +113,83 @@ flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,
         return NULL;
     }
 
-    return flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
-                          "{s:s s:i s:O}",
-                          "namespace", ns,
-                          "flags", flags,
-                          "ops", ops);
+    if (!(ctx = alloc_ctx ()))
+        return NULL;
+
+    if (!(f = flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
+                             "{s:s s:i s:O}",
+                             "namespace", ns,
+                             "flags", flags,
+                             "ops", ops)))
+        goto error;
+
+    if (flux_future_aux_set (f, auxkey, ctx, (flux_free_f)free_ctx) < 0)
+        goto error_future;
+
+    return f;
+
+error_future:
+    flux_future_destroy (f);
+error:
+    free_ctx (ctx);
+    return NULL;
+}
+
+static int decode_response (flux_future_t *f, const char **rootrefp,
+                            int *rootseqp)
+{
+    const char *rootref;
+    int rootseq;
+
+    if (flux_rpc_get_unpack (f, "{s:s s:i}",
+                             "rootref", &rootref,
+                             "rootseq", &rootseq) < 0)
+        return -1;
+    if (rootrefp)
+        *rootrefp = rootref;
+    if (rootseqp)
+        *rootseqp = rootseq;
+    return 0;
+}
+
+int flux_kvs_commit_get_sequence (flux_future_t *f, int *rootseq)
+{
+    if (!f || !rootseq) {
+        errno = EINVAL;
+        return -1;
+    }
+    return decode_response (f, NULL, rootseq);
+}
+
+/* Use cached value of ctx->treeobj */
+int flux_kvs_commit_get_treeobj (flux_future_t *f, const char **treeobj)
+{
+    struct commit_ctx *ctx;
+    const char *rootref;
+
+    if (!f || !treeobj) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((!(ctx = flux_future_aux_get (f, auxkey)))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (decode_response (f, &rootref, NULL) < 0)
+        return -1;
+    if (!ctx->treeobj) {
+        json_t *o;
+        if (!(o = treeobj_create_dirref (rootref)))
+            return -1;
+        if (!(ctx->treeobj = treeobj_encode (o))) {
+            json_decref (o);
+            errno = ENOMEM;
+            return -1;
+        }
+        json_decref (o);
+    }
+    *treeobj = ctx->treeobj;
+    return 0;
 }
 
 /*

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -26,6 +26,10 @@ flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
                                const char *name, int nprocs,
                                flux_kvs_txn_t *txn);
 
+/* accessors can be used for commit or fence futures */
+int flux_kvs_commit_get_treeobj (flux_future_t *f, const char **treeobj);
+int flux_kvs_commit_get_sequence (flux_future_t *f, int *rootseq);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libkvs/kvs_getroot.c
+++ b/src/common/libkvs/kvs_getroot.c
@@ -49,7 +49,7 @@ static struct getroot_ctx *alloc_ctx (void)
 flux_future_t *flux_kvs_getroot (flux_t *h, const char *ns, int flags)
 {
     flux_future_t *f;
-    struct getroot_ctx *ctx;
+    struct getroot_ctx *ctx = NULL;
 
     if (!h || flags) {
         errno = EINVAL;

--- a/src/common/libkvs/test/kvs_commit.c
+++ b/src/common/libkvs/test/kvs_commit.c
@@ -48,6 +48,16 @@ void errors (void)
         && errno == EINVAL,
         "flux_kvs_commit fails on bad handle");
 
+    errno = 0;
+    ok (flux_kvs_commit_get_treeobj (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_kvs_commit_get_treeobj fails on bad input");
+
+    errno = 0;
+    ok (flux_kvs_commit_get_sequence (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_kvs_commit_get_sequence fails on bad input");
+
     flux_kvs_txn_destroy (txn);
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -212,6 +212,7 @@ check_PROGRAMS = \
 	kvs/hashtest \
 	kvs/watch_disconnect \
 	kvs/commit \
+	kvs/fence_api \
 	kvs/transactionmerge \
 	kvs/fence_namespace_remove \
 	kvs/fence_invalid \
@@ -310,6 +311,11 @@ kvs_blobref_LDADD = \
 kvs_commit_SOURCES = kvs/commit.c
 kvs_commit_CPPFLAGS = $(test_cppflags)
 kvs_commit_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_fence_api_SOURCES = kvs/fence_api.c
+kvs_fence_api_CPPFLAGS = $(test_cppflags)
+kvs_fence_api_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 kvs_transactionmerge_SOURCES = kvs/transactionmerge.c

--- a/t/kvs/fence_api.c
+++ b/t/kvs/fence_api.c
@@ -1,0 +1,164 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* commit - performance test for KVS commits */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <libgen.h>
+#include <pthread.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/oom.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/monotime.h"
+#include "src/common/libutil/tstat.h"
+
+typedef struct {
+    pthread_t t;
+    pthread_attr_t attr;
+    int n;
+    flux_t *h;
+    char *treeobj;
+    int sequence;
+} thd_t;
+
+static int count = -1;
+static char *prefix = NULL;
+static char *fence_name;
+
+static void usage (void)
+{
+    fprintf (stderr, "Usage: fence_api count prefix\n");
+    exit (1);
+}
+
+void *thread (void *arg)
+{
+    thd_t *t = arg;
+    char *key;
+    uint32_t rank;
+    flux_future_t *f;
+    flux_kvs_txn_t *txn;
+    const char *treeobj;
+    int sequence;
+
+    if (!(t->h = flux_open (NULL, 0))) {
+        log_err ("%d: flux_open", t->n);
+        goto done;
+    }
+
+    if (flux_get_rank (t->h, &rank) < 0) {
+        log_err ("%d: flux_get_rank", t->n);
+        goto done;
+    }
+
+    /* create some key and write something to it */
+
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+
+    key = xasprintf ("%s.%"PRIu32".%d", prefix, rank, t->n);
+
+    if (flux_kvs_txn_pack (txn, 0, key, "i", 42) < 0)
+        log_err_exit ("%s", key);
+
+    if (!(f = flux_kvs_fence (t->h, NULL, 0, fence_name,
+                              count, txn))
+        || flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_kvs_fence");
+
+    /* save off fence root information */
+
+    if (flux_kvs_commit_get_treeobj (f, &treeobj) < 0)
+        log_err_exit ("flux_kvs_commit_get_treeobj");
+    if (flux_kvs_commit_get_sequence (f, &sequence) < 0)
+        log_err_exit ("flux_kvs_commit_get_sequence");
+
+    t->treeobj = xstrdup (treeobj);
+    t->sequence = sequence;
+
+    flux_future_destroy (f);
+
+    free (key);
+    flux_kvs_txn_destroy (txn);
+
+done:
+    if (t->h)
+        flux_close (t->h);
+    return NULL;
+}
+
+int main (int argc, char *argv[])
+{
+    thd_t *thd;
+    int i, num, rc;
+
+    log_init (basename (argv[0]));
+
+    if (argc != 3)
+        usage ();
+
+    count = strtoul (argv[1], NULL, 10);
+    if (count <= 1)
+        log_msg_exit ("commit count must be > 1");
+    prefix = argv[2];
+
+    /* create a fence name for this test that is random-ish */
+    srand (time (NULL));
+    num = rand ();
+    fence_name = xasprintf ("%s-%d", prefix, num);
+
+    thd = xzmalloc (sizeof (*thd) * count);
+
+    for (i = 0; i < count; i++) {
+        thd[i].n = i;
+        if ((rc = pthread_attr_init (&thd[i].attr)))
+            log_errn (rc, "pthread_attr_init");
+        if ((rc = pthread_create (&thd[i].t, &thd[i].attr, thread, &thd[i])))
+            log_errn (rc, "pthread_create");
+    }
+
+    for (i = 0; i < count; i++) {
+        if ((rc = pthread_join (thd[i].t, NULL)))
+            log_errn (rc, "pthread_join");
+    }
+
+    /* compare results from all of the fences, the root ref info
+     * should all be the same
+     */
+    for (i = 1; i < count; i++) {
+        if (strcmp (thd[0].treeobj, thd[i].treeobj))
+            log_msg_exit ("treeobj mismatch: %s != %s\n",
+                          thd[0].treeobj, thd[i].treeobj);
+        if (thd[0].sequence != thd[i].sequence)
+            log_msg_exit ("sequence mismatch: %d != %d\n",
+                          thd[0].sequence, thd[i].sequence);
+    }
+
+    for (i = 0; i < count; i++)
+        free (thd[i].treeobj);
+    free (thd);
+
+    log_fini ();
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1113,11 +1113,6 @@ test_expect_success 'flux kvs getroot returns valid dirref object' '
 # getroot tests
 #
 
-test_expect_success 'flux kvs getroot --blobref returns valid blobref' '
-	BLOBREF=$(flux kvs getroot --blobref) &&
-	flux content load $BLOBREF >/dev/null
-'
-
 test_expect_success 'flux kvs getroot --sequence returns increasing rootseq' '
 	SEQ=$(flux kvs getroot --sequence) &&
 	flux kvs put test.b=hello &&

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1044,6 +1044,39 @@ test_expect_success 'kvs: get --at: fails bad on dirent' '
 '
 
 #
+# -O, -s options in write commands
+#
+
+test_expect_success 'kvs: --treeobj-root on write ops works' '
+	flux kvs unlink -Rf $DIR &&
+        flux kvs put -O $DIR.a=1 > output &&
+        grep "dirref" output &&
+        flux kvs unlink -O $DIR.a > output &&
+        grep "dirref" output &&
+        flux kvs mkdir -O $DIR.a > output &&
+        grep "dirref" output &&
+        flux kvs link -O $DIR.a $DIR.b > output &&
+        grep "dirref" output
+'
+
+test_expect_success 'kvs: --sequence on write ops works' '
+	flux kvs unlink -Rf $DIR &&
+        VER=$(flux kvs version) &&
+        VER=$((VER + 1)) &&
+        SEQ=$(flux kvs put -s $DIR.a=1) &&
+        test $VER -eq $SEQ &&
+        VER=$((VER + 1)) &&
+        SEQ=$(flux kvs unlink -s $DIR.a) &&
+        test $VER -eq $SEQ &&
+        VER=$((VER + 1)) &&
+        SEQ=$(flux kvs mkdir -s $DIR.a) &&
+        test $VER -eq $SEQ &&
+        VER=$((VER + 1)) &&
+        SEQ=$(flux kvs link -s $DIR.a $DIR.b) &&
+        test $VER -eq $SEQ
+'
+
+#
 # dropcache tests
 #
 

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -431,6 +431,14 @@ test_expect_success 'kvs: clear stats globally' '
 '
 
 #
+# test fence api
+#
+
+test_expect_success 'kvs: test fence returns identical root info on all responses' '
+        ${FLUX_BUILD_DIR}/t/kvs/fence_api 8 apitest
+'
+
+#
 # test invalid fence arguments
 #
 


### PR DESCRIPTION
After a kvs commit/fence, have the rpc return the root reference / seq of the resulting root that has all of the changes in a transaction.  This root ref / seq can then be used for causal consistency.  Add associated library "get" functions in ```libkvs/kvs_commit```.

The more questionable part of this PR is probably all of the new options I added in ```flux-kvs```.  Now every write operation (put, mkdir, link, unlink) can output the resulting treeobj, root ref, or sequence number after the write operation has completed.  Is it too much?  If it's too much, I'd have to add tests another way.