### PR TITLE
t/kvs/watch_disconnect: Fix racy behavior

### DIFF
--- a/t/t1103-apidisconnect.t
+++ b/t/t1103-apidisconnect.t
@@ -29,7 +29,7 @@ test_expect_success 'kvs watcher gets disconnected on client exit' '
 '
 
 test_expect_success 'multi-node kvs watcher gets disconnected on client exit' '
-	${FLUX_BUILD_DIR}/t/kvs/watch_disconnect
+	${FLUX_BUILD_DIR}/t/kvs/watch_disconnect $SIZE
 '
 
 


### PR DESCRIPTION
Add several loops / waits to wait for rpcs / disconnects to be
processed, to hopefully avoid several racy scenarios.

Fixes #2015