### PR TITLE
Python Future Support

### DIFF
--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = \
-	$(WARNING_CFLAGS) \
+	$(WARNING_CFLAGS) -Wno-error=missing-field-initializers \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libflux \
@@ -29,6 +29,7 @@ _core_build.py: $(MAKE_BINDING)
 		--package _flux \
 		--modname _core \
 		--add_sub '.*va_list.*|||' \
+		--additional_headers src/bindings/python/_flux/callbacks.h \
 		--ignore_header 'macros' \
 		src/include/flux/core.h
 
@@ -36,6 +37,7 @@ BUILT_SOURCES= _core.c
 fluxso_LTLIBRARIES = _core.la
 fluxso_PYTHON = __init__.py
 
+dist__core_la_SOURCES = callbacks.h
 nodist__core_la_SOURCES = _core.c
 _core_la_LIBADD = $(common_libs)
 _core_la_DEPENDENCIES = _core_build.py

--- a/src/bindings/python/_flux/callbacks.h
+++ b/src/bindings/python/_flux/callbacks.h
@@ -1,0 +1,6 @@
+//flux_msg_handler_f
+extern "Python" void message_handler_wrapper(flux_t *, flux_msg_handler_t *, const flux_msg_t *, void *);
+
+//flux_watcher_f
+extern "Python" void timeout_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);
+extern "Python" void fd_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);

--- a/src/bindings/python/_flux/callbacks.h
+++ b/src/bindings/python/_flux/callbacks.h
@@ -4,3 +4,6 @@ extern "Python" void message_handler_wrapper(flux_t *, flux_msg_handler_t *, con
 //flux_watcher_f
 extern "Python" void timeout_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);
 extern "Python" void fd_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);
+
+//flux_continuation_f
+extern "Python" void continuation_callback(flux_future_t *, void *);

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -7,7 +7,8 @@ fluxpy_PYTHON=\
 	      constants.py\
 	      job.py \
 	      mrpc.py \
-	      util.py
+	      util.py \
+	      future.py
 
 if HAVE_FLUX_SECURITY
 fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -88,15 +88,6 @@ class Flux(Wrapper):
         """ Create a new RPC object """
         return RPC(self, topic, payload, nodeid, flags)
 
-    def rpc_create(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
-        """ Create a new RPC object """
-        return RPC(self, topic, payload, nodeid, flags)
-
-    def rpc_send(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
-        """ Create and send an RPC in one step """
-        with RPC(self, topic, payload, nodeid, flags) as rpc:
-            return rpc.get()
-
     def mrpc_create(self, topic, payload=None, rankset="any", flags=0):
         """
         Create a new MRPC object. Messages are sent on MRPC creation. Responses

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -84,14 +84,18 @@ class Flux(Wrapper):
             return Message(handle=handle)
         return None
 
-    def rpc_send(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
-        """ Create and send an RPC in one step """
-        with RPC(self, topic, payload, nodeid, flags) as rpc:
-            return rpc.get()
+    def rpc(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
+        """ Create a new RPC object """
+        return RPC(self, topic, payload, nodeid, flags)
 
     def rpc_create(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
         """ Create a new RPC object """
         return RPC(self, topic, payload, nodeid, flags)
+
+    def rpc_send(self, topic, payload=None, nodeid=raw.FLUX_NODEID_ANY, flags=0):
+        """ Create and send an RPC in one step """
+        with RPC(self, topic, payload, nodeid, flags) as rpc:
+            return rpc.get()
 
     def mrpc_create(self, topic, payload=None, rankset="any", flags=0):
         """

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -9,7 +9,7 @@
 ###############################################################
 
 import abc
-from flux.core.inner import raw, ffi
+from flux.core.inner import raw, lib, ffi
 
 __all__ = ["TimerWatcher", "FDWatcher"]
 
@@ -46,7 +46,7 @@ class Watcher(object):
             self.handle = None
 
 
-@ffi.callback("flux_watcher_f")
+@ffi.def_extern()
 def timeout_handler_wrapper(unused1, unused2, revents, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
@@ -67,13 +67,13 @@ class TimerWatcher(Watcher):
                 raw.flux_get_reactor(flux_handle),
                 float(after),
                 float(repeat),
-                timeout_handler_wrapper,
+                lib.timeout_handler_wrapper,
                 self.wargs,
             )
         )
 
 
-@ffi.callback("flux_watcher_f")
+@ffi.def_extern()
 def fd_handler_wrapper(unused1, unused2, revents, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
@@ -95,7 +95,7 @@ class FDWatcher(Watcher):
                 raw.flux_get_reactor(flux_handle),
                 self.fd_int,
                 self.events,
-                fd_handler_wrapper,
+                lib.fd_handler_wrapper,
                 self.wargs,
             )
         )

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -1,0 +1,114 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import errno
+
+import flux
+from flux.util import check_future_error
+from flux.wrapper import Wrapper, WrapperPimpl
+from flux.core.inner import ffi, lib, raw
+
+
+_THEN_HANDLES = set()
+
+
+@ffi.def_extern()
+def continuation_callback(c_future, opaque_handle):
+    try:
+        py_future = ffi.from_handle(opaque_handle)
+        assert c_future == py_future.pimpl.handle
+        py_future.then_cb(py_future, py_future.then_arg)
+    finally:
+        # allow future object to be garbage collected now that all
+        # registered callbacks have completed
+        py_future.cleanup_then()
+
+
+class Future(WrapperPimpl):
+    """
+    A wrapper for interfaces that create and consume flux futures
+    """
+
+    class InnerWrapper(Wrapper):
+        def __init__(
+            self,
+            handle=None,
+            match=ffi.typeof("flux_future_t *"),
+            filter_match=True,
+            prefixes=None,
+            destructor=raw.flux_future_destroy,
+        ):
+            # avoid using a static list as a default argument
+            # pylint error 'dangerous-default-value'
+            if prefixes is None:
+                prefixes = ["flux_future_"]
+
+            super(Future.InnerWrapper, self).__init__(
+                ffi, lib, handle, match, filter_match, prefixes, destructor
+            )
+
+        def check_wrap(self, fun, name):
+            func = super(Future.InnerWrapper, self).check_wrap(fun, name)
+            return check_future_error(func)
+
+    def __init__(self, future_handle, prefixes=None):
+        super(Future, self).__init__()
+        self.pimpl = self.InnerWrapper(handle=future_handle, prefixes=prefixes)
+        self.then_cb = None
+        self.then_arg = None
+        self.cb_handle = None
+
+    def cleanup_then(self):
+        self.then_cb = None
+        self.then_arg = None
+        self.cb_handle = None
+        if self in _THEN_HANDLES:
+            _THEN_HANDLES.remove(self)
+
+    def __del__(self):
+        self.cleanup_then()
+
+    def error_string(self):
+        try:
+            errmsg = self.pimpl.error_string()
+        except EnvironmentError:
+            return None
+        return errmsg.decode("utf-8") if errmsg else None
+
+    def get_flux(self):
+        flux_handle = self.pimpl.get_flux()
+        if flux_handle == ffi.NULL:
+            return None
+        return flux.Flux(handle=flux_handle)
+
+    def get_reactor(self):
+        return self.pimpl.get_reactor()
+
+    def then(self, callback, arg=None, timeout=-1.0):
+        if self in _THEN_HANDLES:
+            raise EnvironmentError(
+                errno.EEXIST, "then callback already exists for this future"
+            )
+
+        self.then_cb = callback
+        self.then_arg = arg
+        self.cb_handle = ffi.new_handle(self)
+        self.pimpl.then(timeout, lib.continuation_callback, self.cb_handle)
+
+        # ensure that this future object is not garbage collected with a
+        # callback outstanding. Particularly important for anonymous calls.
+        # For example, `f.rpc.('topic').then(cb)`
+        _THEN_HANDLES.add(self)
+
+    def is_ready(self):
+        return self.pimpl.is_ready()
+
+    def wait_for(self, timeout=-1.0):
+        self.pimpl.wait_for(timeout)

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -10,7 +10,6 @@
 
 import errno
 
-import flux
 from flux.util import check_future_error
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
@@ -83,10 +82,13 @@ class Future(WrapperPimpl):
         return errmsg.decode("utf-8") if errmsg else None
 
     def get_flux(self):
+        # pylint: disable=cyclic-import
+        import flux.core.handle
+
         flux_handle = self.pimpl.get_flux()
         if flux_handle == ffi.NULL:
             return None
-        return flux.Flux(handle=flux_handle)
+        return flux.core.handle.Flux(handle=flux_handle)
 
     def get_reactor(self):
         return self.pimpl.get_reactor()

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -164,7 +164,10 @@ class MessageWatcher(Watcher):
         )
         super(MessageWatcher, self).__init__(
             raw.flux_msg_handler_create(
-                self.flux_handle.handle, match[0], lib.message_handler_wrapper, self.wargs
+                self.flux_handle.handle,
+                match[0],
+                lib.message_handler_wrapper,
+                self.wargs,
             )
         )
 

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -122,7 +122,7 @@ class Message(WrapperPimpl):
 # Residing here to avoid cyclic references
 
 
-@ffi.callback("flux_msg_handler_f")
+@ffi.def_extern()
 def message_handler_wrapper(unused1, unused2, msg_handle, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
@@ -164,7 +164,7 @@ class MessageWatcher(Watcher):
         )
         super(MessageWatcher, self).__init__(
             raw.flux_msg_handler_create(
-                self.flux_handle.handle, match[0], message_handler_wrapper, self.wargs
+                self.flux_handle.handle, match[0], lib.message_handler_wrapper, self.wargs
             )
         )
 

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -10,42 +10,15 @@
 
 import json
 
-from flux.wrapper import Wrapper, WrapperPimpl
-from flux.core.inner import ffi, lib, raw
+from flux.wrapper import Wrapper
+from flux.future import Future
+from flux.core.inner import ffi, raw
 import flux.constants
-from flux.util import check_future_error, encode_payload, encode_topic
+from flux.util import encode_payload, encode_topic
 
 
-class RPC(WrapperPimpl):
+class RPC(Future):
     """An RPC state object"""
-
-    class InnerWrapper(Wrapper):
-        def __init__(
-            self,
-            flux_handle,
-            topic,
-            payload=None,
-            nodeid=flux.constants.FLUX_NODEID_ANY,
-            flags=0,
-        ):
-            # hold a reference for destructor ordering
-            self._handle = flux_handle
-            dest = raw.flux_future_destroy
-            super(RPC.InnerWrapper, self).__init__(
-                ffi,
-                lib,
-                handle=None,
-                match=ffi.typeof(lib.flux_rpc).result,
-                prefixes=["flux_rpc_"],
-                destructor=dest,
-            )
-            if isinstance(flux_handle, Wrapper):
-                flux_handle = flux_handle.handle
-
-            topic = encode_topic(topic)
-            payload = encode_payload(payload)
-
-            self.handle = raw.flux_rpc(flux_handle, topic, payload, nodeid, flags)
 
     def __init__(
         self,
@@ -55,19 +28,21 @@ class RPC(WrapperPimpl):
         nodeid=flux.constants.FLUX_NODEID_ANY,
         flags=0,
     ):
-        super(RPC, self).__init__()
-        self.pimpl = self.InnerWrapper(flux_handle, topic, payload, nodeid, flags)
-        self.then_args = None
-        self.then_cb = None
+        if isinstance(flux_handle, Wrapper):
+            flux_handle = flux_handle.handle
 
-    # TODO: replace with first-class future support
-    @check_future_error
+        topic = encode_topic(topic)
+        payload = encode_payload(payload)
+
+        future_handle = raw.flux_rpc(flux_handle, topic, payload, nodeid, flags)
+        super(RPC, self).__init__(future_handle, prefixes=["flux_rpc_", "flux_future_"])
+
     def get_str(self):
-        j_str = ffi.new("char *[1]")
-        self.pimpl.get(j_str)
-        if j_str[0] == ffi.NULL:
+        payload_str = ffi.new("char *[1]")
+        self.pimpl.flux_rpc_get(payload_str)
+        if payload_str[0] == ffi.NULL:
             return None
-        return ffi.string(j_str[0]).decode("utf-8")
+        return ffi.string(payload_str[0]).decode("utf-8")
 
     def get(self):
         resp_str = self.get_str()

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -162,6 +162,12 @@ class FunctionWrapper(object):
     def __call__(self, calling_object, *args_in):
         calling_object.ffi.errno = 0
         caller = calling_object.handle
+        if self.add_handle and caller is None:
+            raise ValueError(
+                "Attempting to call a cached, bound method that requires a "
+                "handle with a NULL handle"
+            )
+
         args = [caller] + list(args_in) if self.add_handle else list(args_in)
 
         if len(self.function_type.args) != len(args):

--- a/src/bindings/python/make_binding.py
+++ b/src/bindings/python/make_binding.py
@@ -19,6 +19,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument("header", help="C header file to parse", type=str)
 parser.add_argument("--include_header", help="Include base path", type=str, default="")
 parser.add_argument(
+    "--additional_headers", help="Additional headers to parse", nargs="*", default=[]
+)
+parser.add_argument(
     "--include_ffi", help="FFI module for inclusion", action="append", default=[]
 )
 parser.add_argument("--package", help="Package prefix for module import", default=None)
@@ -159,6 +162,9 @@ with open("{}_build.py".format(args.modname), "w") as modfile:
 
     process_header(absolute_head)
 
+    for header in args.additional_headers:
+        process_header(header)
+
     include_head = args.header
     if args.include_header != "":
         include_head = args.include_header
@@ -207,9 +213,7 @@ void * unpack_long(ptrdiff_t num);
 void free(void *ptr);
 typedef int... pid_t;
 
-
         {cdefs}
-
 
     """)
 if __name__ == "__main__":

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -25,8 +25,8 @@ void flux_kvs_txn_destroy (flux_kvs_txn_t *txn);
 int flux_kvs_txn_put (flux_kvs_txn_t *txn, int flags,
                       const char *key, const char *value);
 
-/* N.B. splitting at 80 columns confuses python cffi parser */
-int flux_kvs_txn_vpack (flux_kvs_txn_t *txn, int flags, const char *key, const char *fmt, va_list ap);
+int flux_kvs_txn_vpack (flux_kvs_txn_t *txn, int flags, const char *key,
+                        const char *fmt, va_list ap);
 
 int flux_kvs_txn_pack (flux_kvs_txn_t *txn, int flags, const char *key,
                        const char *fmt, ...);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -103,6 +103,7 @@ TESTS = \
 	python/t0007-watchers.py \
 	python/t0010-job.py \
 	python/t0011-mrpc.py \
+	python/t0012-futures.py \
 	python/t1000-service-add-remove.py
 
 
@@ -201,6 +202,7 @@ check_SCRIPTS = \
 	python/t0009-security.py \
 	python/t0010-job.py \
 	python/t0011-mrpc.py \
+	python/t0012-futures.py \
 	python/t1000-service-add-remove.py
 
 check_PROGRAMS = \

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -46,32 +46,32 @@ class TestHandle(unittest.TestCase):
     def test_rpc_ping(self):
         """Sending a ping"""
         # python 3 json doesn't support bytes, but python 2 will treat them as str (i.e., bytes)
-        r = self.f.rpc_send(b"cmb.ping", {"seq": 1, "pad": "stuff"})
+        r = self.f.rpc(b"cmb.ping", {"seq": 1, "pad": "stuff"}).get()
         self.assertEqual(r["seq"], 1)
         self.assertEqual(r["pad"], u"stuff")
         self.assertTrue(isinstance(r["pad"], six.text_type))
 
     def test_rpc_ping_unicode(self):
         """Sending a ping"""
-        r = self.f.rpc_send(
+        r = self.f.rpc(
             u"cmb.ping", {u"\xa3": u"value", u"key": u"\u32db \u263a \u32e1"}
-        )
+        ).get()
         self.assertEqual(r[u"\xa3"], u"value")
         self.assertEqual(r["key"], u"\u32db \u263a \u32e1")
         self.assertTrue(isinstance(r["key"], six.text_type))
 
     def test_rpc_with(self):
         """Sending a ping"""
-        with self.f.rpc_create("cmb.ping", {"seq": 1, "pad": "stuff"}) as r:
+        with self.f.rpc("cmb.ping", {"seq": 1, "pad": "stuff"}) as r:
             j = r.get()
             self.assertEqual(j["seq"], 1)
             self.assertEqual(j["pad"], "stuff")
 
     def test_rpc_null_payload(self):
         """Sending a request that receives a NULL response"""
-        resp = self.f.rpc_send(
+        resp = self.f.rpc(
             "attr.set", {"name": "attr-that-doesnt-exist", "value": "foo"}
-        )
+        ).get()
         self.assertIsNone(resp)
 
     def test_get_rank(self):

--- a/t/python/t0002-wrapper.py
+++ b/t/python/t0002-wrapper.py
@@ -38,6 +38,19 @@ class TestWrapper(unittest.TestCase):
         with self.assertRaises(flux.wrapper.InvalidArguments):
             f.request_encode(self, 15)
 
+    def test_null_handle_exception(self):
+        f = flux.Flux()
+        payload = {"seq": 1, "pad": "stuff"}
+        future = f.rpc("cmb.ping", payload)
+        resp = future.get()
+        future.pimpl.handle = None
+        with self.assertRaises(ValueError) as cm:
+            resp = future.get()
+        self.assertRegexpMatches(
+            cm.exception.message,
+            "Attempting to call a cached, " "bound method.*NULL handle",
+        )
+
     def test_automatic_unwrapping(self):
         flux.core.inner.raw.flux_log(flux.Flux("loop://"), 0, "stuff")
 

--- a/t/python/t0002-wrapper.py
+++ b/t/python/t0002-wrapper.py
@@ -56,22 +56,20 @@ class TestWrapper(unittest.TestCase):
 
     def test_masked_function(self):
         with self.assertRaisesRegexp(AttributeError, r".*masks function.*"):
-            flux.Flux("loop://").rpc_create("topic").pimpl.flux_request_encode(
-                "request", 15
-            )
+            flux.Flux("loop://").rpc("topic").pimpl.flux_request_encode("request", 15)
 
     def test_set_pimpl_handle(self):
         f = flux.Flux("loop://")
-        r = f.rpc_create("topic")
+        r = f.rpc("topic")
         r.handle = raw.flux_rpc(
             f.handle, "other topic", ffi.NULL, flux.constants.FLUX_NODEID_ANY, 0
         )
 
     def test_set_pimpl_handle_invalid(self):
         f = flux.Flux("loop://")
-        r = f.rpc_create("topic")
+        r = f.rpc("topic")
         with self.assertRaisesRegexp(TypeError, r".*expected a.*"):
-            r.handle = f.rpc_create("other topic")
+            r.handle = f.rpc("other topic")
 
     def test_read_basic_value(self):
         self.assertGreater(flux.constants.FLUX_NODEID_ANY, 0)

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from __future__ import print_function
+
+import gc
+import errno
+import unittest
+
+import flux
+import flux.constants
+from flux.core.inner import ffi
+from flux.future import Future
+from subflux import rerun_under_flux
+
+
+def __flux_size():
+    return 2
+
+
+class TestHandle(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        """Create a handle, connect to flux"""
+        self.f = flux.Flux()
+
+    @classmethod
+    def tearDownClass(self):
+        self.f.close()
+
+    def test_01_rpc_get(self):
+        payload = {"seq": 1, "pad": "stuff"}
+        future = self.f.rpc("cmb.ping", payload)
+        resp_payload = future.get()
+        self.assertDictContainsSubset(payload, resp_payload)
+
+    def test_02_future_wait_for(self):
+        payload = {"seq": 1, "pad": "stuff"}
+        future = self.f.rpc("cmb.ping", payload)
+        try:
+            future.wait_for(5)
+            resp_payload = future.get()
+        except EnvironmentError as e:
+            if e.errno == errno.ETIMEDOUT:
+                self.fail(msg="future fulfillment timed out")
+            else:
+                raise
+        self.assertDictContainsSubset(payload, resp_payload)
+
+    def test_03_future_then(self):
+        """Register a 'then' cb and run the reactor to ensure it runs"""
+        cb_ran = [False]
+
+        def then_cb(future, arg):
+            flux_handle = future.get_flux()
+            reactor = future.get_reactor()
+            try:
+                resp_payload = future.get()
+                cb_ran[0] = True
+                self.assertDictContainsSubset(arg, resp_payload)
+            finally:
+                # ensure that reactor is always stopped, avoiding a hung test
+                flux_handle.reactor_stop(reactor)
+
+        payload = {"seq": 1, "pad": "stuff"}
+        self.f.rpc(b"cmb.ping", payload).then(then_cb, arg=payload)
+        # force a full garbage collection pass to test that our anonymous RPC doesn't disappear
+        gc.collect(2)
+        ret = self.f.reactor_run(self.f.get_reactor(), 0)
+        self.assertGreaterEqual(ret, 0, msg="Reactor exited with {}".format(ret))
+        self.assertTrue(cb_ran[0], msg="Callback did not run successfully")
+
+    def test_04_double_future_then(self):
+        """Register two 'then' cbs and ensure it throws an exception"""
+        with self.assertRaises(EnvironmentError) as cm:
+            rpc = self.f.rpc(b"cmb.ping")
+            rpc.then(lambda x, y: None)
+            rpc.then(lambda x, y: None)
+        self.assertEqual(cm.exception.errno, errno.EEXIST)
+
+    def test_05_future_error_string(self):
+        with self.assertRaises(EnvironmentError) as cm:
+            payload = {"J": "", "priority": -1000, "flags": 0}
+            future = self.f.rpc("job-ingest.submit", payload=payload)
+            future.get()
+        self.assertEqual(cm.exception.errno, errno.EINVAL)
+        # Ensure that the result of flux_future_error_string propagated up
+        self.assertEqual(cm.exception.strerror, future.error_string())
+        self.assertRegexpMatches(cm.exception.strerror, "priority range is .*")
+
+    def test_06_blocking_methods(self):
+        future = Future(self.f.future_create(ffi.NULL, ffi.NULL))
+
+        self.assertFalse(future.is_ready())
+        with self.assertRaises(EnvironmentError) as cm:
+            future.wait_for(timeout=0)
+        self.assertEqual(cm.exception.errno, errno.ETIMEDOUT)
+
+        future.pimpl.fulfill(ffi.NULL, ffi.NULL)
+        self.assertTrue(future.is_ready())
+        try:
+            future.wait_for(0)
+        except EnvironmentError as e:
+            self.fail("future.wait_for raised an unexpected exception: {}".format(e))
+
+
+if __name__ == "__main__":
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -103,7 +103,7 @@ class TestServiceAddRemove(unittest.TestCase):
         self.assertEqual(e.exception.errno, errno.ENOENT)
 
     def test_007_service_rpc_enosys(self):
-        fut = self.f.rpc_create("foo.echo")
+        fut = self.f.rpc("foo.echo")
         with self.assertRaises(EnvironmentError) as e:
             fut.get()
         self.assertEqual(e.exception.errno, errno.ENOSYS)
@@ -127,17 +127,17 @@ class TestServiceAddRemove(unittest.TestCase):
         self.assertEqual(p.exitcode, 0)
 
         #  Ensure no "baz" service remains
-        fut = self.f.rpc_create("baz.echo")
+        fut = self.f.rpc("baz.echo")
         with self.assertRaises(EnvironmentError) as e:
             fut.get()
         self.assertEqual(e.exception.errno, errno.ENOSYS)
 
     def test_009_service_add_remove_eproto(self):
-        fut = self.f.rpc_create("service.add")
+        fut = self.f.rpc("service.add")
         with self.assertRaises(EnvironmentError) as e:
             fut.get()
         self.assertEqual(e.exception.errno, errno.EPROTO)
-        fut = self.f.rpc_create("service.remove")
+        fut = self.f.rpc("service.remove")
         with self.assertRaises(EnvironmentError) as e:
             fut.get()
         self.assertEqual(e.exception.errno, errno.EPROTO)

--- a/t/t9001-pymod.t
+++ b/t/t9001-pymod.t
@@ -26,7 +26,7 @@ test_expect_success 'pymod echo.py function works' '
 	import flux,sys
 	p = { "data": "foo" }
 	f = flux.Flux()
-	r = f.rpc_send ("echo.foo", p)
+	r = f.rpc ("echo.foo", p).get()
 	sys.exit (not all(item in r.items() for item in p.items()))
 EOF
 '


### PR DESCRIPTION
Adds a `Future` class that inherits from `WrapperPimpl`, and makes `RPC` a subclass of `Future`.  `f.rpc_create()` and `f.rpc_send()` are now dropped in favor of  `f.rpc()` and `f.rpc().get()`, respectively.  The `Future` class wasn't designed to be directly instantiated, it is more of an abstract class currently.

This PR also switches the bindings over to the [new-style cffi callbacks](https://cffi.readthedocs.io/en/latest/using.html#extern-python-and-void-arguments).  They should be faster and avoid any issues with SELinux [[1]](https://cffi.readthedocs.io/en/latest/using.html#callbacks-old-style).  The unfortunate side-effect being that the default compiler on TOSS3 doesn't appreciate the auto-generated C code:
```
_core.c:2272:3: warning: missing initializer for field ‘reserved1’ of ‘struct _cffi_externpy_s’ [-Wmissing-field-initializers]
   { "continuation_callback", 0 };
   ^
_core.c:174:11: note: ‘reserved1’ declared here
     void *reserved1, *reserved2;
```
So I had to throw a `-Wno-error=missing-field-initializers` into the python bindings `CFLAGS` to get things working.

Design questions for the broader group (@trws especially):

- Does the class inhertiance structure look reasonable?  It feels kind of weird to me to have `RPC.InnerWrapper` inherit from `Future.InnerWrapper`, but it works :man_shrugging: It also kind of bothers me that the Future class should not be directly instantiated (in the current design) **and** that there is nothing in the code preventing it (e.g., some `ABCmeta` magic).  Feels like one or the other of those two limitations should go away.
- What to do when `.then` times out?  What happens in `C`?  I assume `ETIMEDOUT` is set before the reactor calls the callback, but I don't see any examples in flux-core of anything checking for `ETIMEDOUT` inside a callback.
- If `.wait_for` times out, do we want to raise an exception, if so, which one?  Just a plain ol' `EnvironmentError` with errno set to ETIMEDOUT?  Or do we want to go the way that [`socket`](https://docs.python.org/2/library/socket.html#socket.timeout) and [`requests`](http://docs.python-requests.org/en/master/api/#requests.Timeout) did, and have a Flux-specific `timeout` exception?    I think what we do here is influenced by the answer to the previous question.
- Is returning an [`ffi.buffer`](https://cffi.readthedocs.io/en/latest/ref.html#ffi-buffer-ffi-from-buffer) of the raw future payload the "right thing" to do as the default implemetion for `Future.get()`?  I don't expect many, if any python users to use this interface, but for those that do, I was hoping to do something sane.  AFAIU with an ffi buffer, users can easily get a `bytes` object or initialize a struct; which seems pretty useful.

Another step towards #1649
Closes #1778 