### PR TITLE
job-manager:  improve internal eventlog support

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -44,6 +44,9 @@ TESTS = \
 	test_restart.t
 
 test_ldadd = \
+        $(top_builddir)/src/modules/job-manager/queue.o \
+        $(top_builddir)/src/modules/job-manager/job.o \
+        $(top_builddir)/src/modules/job-manager/util.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -61,32 +64,24 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 test_queue_t_SOURCES = test/queue.c
 test_queue_t_CPPFLAGS = $(test_cppflags)
 test_queue_t_LDADD = \
-        $(top_builddir)/src/modules/job-manager/queue.o \
-        $(top_builddir)/src/modules/job-manager/job.o \
         $(test_ldadd)
 
 test_list_t_SOURCES = test/list.c
 test_list_t_CPPFLAGS = $(test_cppflags)
 test_list_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/list.o \
-        $(top_builddir)/src/modules/job-manager/queue.o \
-        $(top_builddir)/src/modules/job-manager/job.o \
         $(test_ldadd)
 
 test_raise_t_SOURCES = test/raise.c
 test_raise_t_CPPFLAGS = $(test_cppflags)
 test_raise_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/raise.o \
-        $(top_builddir)/src/modules/job-manager/queue.o \
-        $(top_builddir)/src/modules/job-manager/job.o \
-        $(top_builddir)/src/modules/job-manager/util.o \
         $(test_ldadd)
 
 test_util_t_SOURCES = test/util.c
 test_util_t_CPPFLAGS = $(test_cppflags)
+# Test uses unexported KVS functions
 test_util_t_LDADD = \
-        $(top_builddir)/src/modules/job-manager/util.o \
-        $(top_builddir)/src/modules/job-manager/job.o \
         $(top_builddir)/src/common/libkvs/libkvs.la \
         $(test_ldadd)
 
@@ -94,5 +89,4 @@ test_restart_t_SOURCES = test/restart.c
 test_restart_t_CPPFLAGS = $(test_cppflags)
 test_restart_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/restart.o \
-        $(top_builddir)/src/modules/job-manager/job.o \
         $(test_ldadd)

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include "src/common/libjob/job.h"
 #include "job.h"
+#include "util.h"
 
 void job_decref (struct job *job)
 {
@@ -32,8 +33,7 @@ struct job *job_incref (struct job *job)
     return job;
 }
 
-struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
-                        double t_submit, int flags)
+static struct job *job_create_uninit (flux_jobid_t id)
 {
     struct job *job;
 
@@ -41,12 +41,83 @@ struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
         return NULL;
     job->refcount = 1;
     job->id = id;
+    job->userid = FLUX_USERID_UNKNOWN;
+    job->priority = FLUX_JOB_PRIORITY_DEFAULT;
+    job->state = FLUX_JOB_NEW;
+    return job;
+}
+
+struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
+                        double t_submit, int flags)
+{
+    struct job *job;
+
+    if (!(job = job_create_uninit (id)))
+        return NULL;
     job->userid = userid;
     job->priority = priority;
     job->t_submit = t_submit;
     job->flags = flags;
     job->state = FLUX_JOB_NEW;
     return job;
+}
+
+struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
+{
+    struct flux_kvs_eventlog *eventlog;
+    const char *event;
+    double timestamp;
+    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
+    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
+    bool submit_valid = false;
+    struct job *job;
+
+    if (!(job = job_create_uninit (id)))
+        return NULL;
+    if (!(eventlog = flux_kvs_eventlog_decode (s)))
+        goto error;
+    event = flux_kvs_eventlog_first (eventlog);
+    while (event) {
+        if (flux_kvs_event_decode (event, &timestamp,
+                                   name, sizeof (name),
+                                   context, sizeof (context)) < 0)
+            goto error;
+        if (!strcmp (name, "submit")) {
+            int priority, userid;
+            if (util_int_from_context (context, "priority", &priority) < 0)
+                goto error;
+            if (util_int_from_context (context, "userid", &userid) < 0)
+                goto error;
+            job->t_submit = timestamp;
+            job->userid = userid;
+            job->priority = priority;
+            submit_valid = true;
+        }
+        else if (!strcmp (name, "priority")) {
+            int priority;
+            if (util_int_from_context (context, "priority", &priority) < 0)
+                goto error;
+            job->priority = priority;
+        }
+        else if (!strcmp (name, "exception")) {
+            int severity;
+            if (util_int_from_context (context, "severity", &severity) < 0)
+                goto error;
+            if (severity == 0)
+                job->state = FLUX_JOB_CLEANUP;
+        }
+        event = flux_kvs_eventlog_next (eventlog);
+    }
+    if (!submit_valid) {
+        errno = EINVAL;
+        goto error;
+    }
+    flux_kvs_eventlog_destroy (eventlog);
+    return job;
+error:
+    job_decref (job);
+    flux_kvs_eventlog_destroy (eventlog);
+    return NULL;
 }
 
 /*

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -38,6 +38,10 @@ struct job *job_create (flux_jobid_t id,
                         double t_submit,
                         int flags);
 
+/* (re-)create job by replaying its KVS eventlog.
+ */
+struct job *job_create_from_eventlog (flux_jobid_t id, const char *eventlog);
+
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 
 /*

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -159,11 +159,11 @@ void priority_handle_request (flux_t *h, struct queue *queue,
      */
     if (!(p = priority_create (queue, job, msg, priority)))
         goto error;
-    if (util_eventlog_append (p->txn, job, "priority",
+    if (util_eventlog_append (p->txn, job->id, "priority",
                               "userid=%lu priority=%d",
                               (unsigned long)userid, priority) < 0)
         goto error;
-    if (util_attr_pack (p->txn, job, "priority", "i", priority) < 0)
+    if (util_attr_pack (p->txn, job->id, "priority", "i", priority) < 0)
         goto error;
     if (!(f = flux_kvs_commit (h, NULL, 0, p->txn)))
         goto error;

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -207,7 +207,7 @@ void raise_eventlog (struct raise_ctx *c)
 {
     flux_future_t *f;
 
-    if (util_eventlog_append (c->txn, c->job, "exception",
+    if (util_eventlog_append (c->txn, c->job->id, "exception",
                               "type=%s severity=%d userid=%lu%s%s",
                               c->type,
                               c->severity,

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -296,6 +296,11 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
+    if (note && strchr (note, '=')) {
+        errstr = "exception note may not contain key=value attributes";
+        errno = EPROTO;
+        goto error;
+    }
     /* Perform some tasks asynchronously.
      * When the last one completes, 'c' is destroyed and
      * the user receives a response to the job-manager.raise request.

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -22,36 +22,7 @@
 
 #include "job.h"
 #include "restart.h"
-
-/* Parse severity (0-7) from exception event context.
- * Returns severity on success, -1 on failure.
- */
-int restart_decode_exception_severity (const char *s)
-{
-    char *argz = NULL;
-    size_t argz_len = 0;
-    char *sevstr;
-    int severity;
-    char *endptr;
-
-    if (argz_create_sep (s, ' ', &argz, &argz_len) != 0)
-        return -1;
-    if (!(sevstr = envz_get (argz, argz_len, "severity")))
-        goto error;
-    errno = 0;
-    severity = strtol (sevstr, &endptr, 10);
-    if (errno != 0)
-        goto error;
-    if (*endptr != '\0')
-        goto error;
-    if (severity < 0 || severity > 7)
-        goto error;
-    free (argz);
-    return severity;
-error:
-    free (argz);
-    return -1;
-}
+#include "util.h"
 
 int restart_count_char (const char *s, char c)
 {
@@ -61,45 +32,6 @@ int restart_count_char (const char *s, char c)
             count++;
     }
     return count;
-}
-
-int restart_replay_eventlog (const char *s, double *t_submit,
-                             int *flagsp, int *statep)
-{
-    struct flux_kvs_eventlog *eventlog;
-    const char *event;
-    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
-    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
-    double t;
-    int flags = 0;
-    int state = FLUX_JOB_NEW;
-
-    if (!(eventlog = flux_kvs_eventlog_decode (s)))
-        return -1;
-    if (!(event = flux_kvs_eventlog_first (eventlog)))
-        goto error_inval;
-    if (flux_kvs_event_decode (event, &t, name, sizeof (name), NULL, 0) < 0)
-        goto error;
-    if (strcmp (name, "submit") != 0)
-        goto error_inval;
-    while ((event = flux_kvs_eventlog_next (eventlog))) {
-        if (flux_kvs_event_decode (event, NULL, name, sizeof (name),
-                                   context, sizeof (context)) < 0)
-            goto error;
-        if (!strcmp (name, "exception")
-                    && restart_decode_exception_severity (context) == 0)
-            state = FLUX_JOB_CLEANUP;
-    }
-    *t_submit = t;
-    *flagsp = flags;
-    *statep = state;
-    flux_kvs_eventlog_destroy (eventlog);
-    return 0;
-error_inval:
-    errno = EINVAL;
-error:
-    flux_kvs_eventlog_destroy (eventlog);
-    return -1;
 }
 
 static flux_future_t *lookup_job_attr (flux_t *h, const char *jobdir,
@@ -118,14 +50,10 @@ static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
                                restart_map_f cb, void *arg)
 {
     flux_jobid_t id;
-    flux_future_t *f = NULL;
-    uint32_t userid;
-    int priority;
+    flux_future_t *f;
     const char *eventlog;
-    struct job *job;
-    double t_submit;
-    int flags;
-    int state;
+    struct job *job = NULL;
+    int rc = -1;
 
     if (strlen (key) <= dirskip) {
         errno = EINVAL;
@@ -133,43 +61,19 @@ static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
     }
     if (fluid_decode (key + dirskip + 1, &id, FLUID_STRING_DOTHEX) < 0)
         return -1;
-    /* userid */
-    if (!(f = lookup_job_attr (h, key, "userid")))
-        goto error;
-    if (flux_kvs_lookup_get_unpack (f, "i", &userid) < 0)
-        goto error_future;
-    flux_future_destroy (f);
-
-    /* priority */
-    if (!(f = lookup_job_attr (h, key, "priority")))
-        goto error;
-    if (flux_kvs_lookup_get_unpack (f, "i", &priority) < 0)
-        goto error_future;
-    flux_future_destroy (f);
-
-    /* get t_submit, flags, state from eventlog) */
     if (!(f = lookup_job_attr (h, key, "eventlog")))
-        goto error;
+        goto done;
     if (flux_kvs_lookup_get (f, &eventlog) < 0)
-        goto error_future;
-    if (restart_replay_eventlog (eventlog, &t_submit, &flags, &state) < 0)
-        goto error_future;
+        goto done;
+    if (!(job = job_create_from_eventlog (id, eventlog)))
+        goto done;
+    if (cb (job, arg) < 0)
+        goto done;
+    rc = 1;
+done:
     flux_future_destroy (f);
-
-    /* make callback */
-    if (!(job = job_create (id, priority, userid, t_submit, flags)))
-        goto error;
-    job->state = state;
-    if (cb (job, arg) < 0) {
-        job_decref (job);
-        goto error;
-    }
     job_decref (job);
-    return 1;
-error_future:
-    flux_future_destroy (f);
-error:
-    return -1;
+    return rc;
 }
 
 static int depthfirst_map (flux_t *h, const char *key,

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -34,18 +34,6 @@ int restart_count_char (const char *s, char c)
     return count;
 }
 
-static flux_future_t *lookup_job_attr (flux_t *h, const char *jobdir,
-                                       const char *name)
-{
-    char key[80];
-
-    if (snprintf (key, sizeof (key), "%s.%s", jobdir, name) >= sizeof (key)) {
-        errno = EINVAL;
-        return NULL;
-    }
-    return flux_kvs_lookup (h, NULL, 0, key);
-}
-
 static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
                                restart_map_f cb, void *arg)
 {
@@ -61,7 +49,7 @@ static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
     }
     if (fluid_decode (key + dirskip + 1, &id, FLUID_STRING_DOTHEX) < 0)
         return -1;
-    if (!(f = lookup_job_attr (h, key, "eventlog")))
+    if (!(f = util_attr_lookup (h, id, true, 0, "eventlog")))
         goto done;
     if (flux_kvs_lookup_get (f, &eventlog) < 0)
         goto done;

--- a/src/modules/job-manager/restart.h
+++ b/src/modules/job-manager/restart.h
@@ -25,10 +25,7 @@ typedef int (*restart_map_f)(struct job *job, void *arg);
 int restart_map (flux_t *h, restart_map_f cb, void *arg);
 
 /* exposed for unit testing only */
-int restart_decode_exception_severity (const char *s);
 int restart_count_char (const char *s, char c);
-int restart_replay_eventlog (const char *s, double *t_submit,
-                             int *flagsp, int *statep);
 
 #endif /* _FLUX_JOB_MANAGER_RESTART_H */
 

--- a/src/modules/job-manager/test/restart.c
+++ b/src/modules/job-manager/test/restart.c
@@ -17,10 +17,6 @@
 
 int main (int argc, char *argv[])
 {
-    double t_submit;
-    int flags;
-    int state;
-
     plan (NO_PLAN);
 
     /* restart_count_char */
@@ -33,60 +29,6 @@ int main (int argc, char *argv[])
         "restart_count_char s=.a.b.c c=. returns 3");
     ok (restart_count_char (".a.b.c.", '/') == 0,
         "restart_count_char s=.a.b.c. c=. returns 4");
-
-    /* restart_decode_exception_severity */
-
-    ok (restart_decode_exception_severity ("type=cancel severity=0 foo") == 0,
-        "restart_decode_exception_severity severity=0 works");
-    ok (restart_decode_exception_severity ("severity=7") == 7,
-        "restart_decode_exception_severity severity=7 works");
-
-    ok (restart_decode_exception_severity ("severity=x") < 0,
-        "restart_decode_exception_severity severity=x fails");
-    ok (restart_decode_exception_severity ("severity=1x") < 0,
-        "restart_decode_exception_severity severity=1x fails");
-    ok (restart_decode_exception_severity ("severity=x1") < 0,
-        "restart_decode_exception_severity severity=x1 fails");
-    ok (restart_decode_exception_severity ("severity=-1") < 0,
-        "restart_decode_exception_severity severity=-1 fails");
-    ok (restart_decode_exception_severity ("severity=8") < 0,
-        "restart_decode_exception_severity severity=8 fails");
-    ok (restart_decode_exception_severity ("foo=8") < 0,
-        "restart_decode_exception_severity severity=missing fails");
-
-    /* restart_replay_eventlog */
-    errno = 0;
-    ok (restart_replay_eventlog (NULL, &t_submit, &flags, &state) < 0
-        && errno == EINVAL,
-        "restart_replay_eventlog log=NULL fails with EINVAL");
-
-    errno = 0;
-    ok (restart_replay_eventlog ("", &t_submit, &flags, &state) < 0
-        && errno == EINVAL,
-        "restart_replay_eventlog log=empty fails with EINVAL");
-
-    errno = 0;
-    ok (restart_replay_eventlog ("0 foo\n", &t_submit, &flags, &state) < 0
-        && errno == EINVAL,
-        "restart_replay_eventlog log=(missing submit) fails with EINVAL");
-
-    ok (restart_replay_eventlog ("42 submit\n", &t_submit, &flags, &state) == 0
-        && t_submit == 42
-        && flags == 0
-        && state == FLUX_JOB_NEW,
-        "restart_replay_eventlog log=(submit only) works");
-
-    ok (restart_replay_eventlog ("43 submit\n44 exception type=cancel severity=0\n", &t_submit, &flags, &state) == 0
-        && t_submit == 43
-        && flags == 0
-        && state == FLUX_JOB_CLEANUP,
-        "restart_replay_eventlog log=(with cancel exception) works");
-
-    ok (restart_replay_eventlog ("44 submit\n45 exception type=foo severity=1\n", &t_submit, &flags, &state) == 0
-        && t_submit == 44
-        && flags == 0
-        && state == FLUX_JOB_NEW,
-        "restart_replay_eventlog log=(with non-fatal cancel exception) works");
 
     done_testing ();
 }

--- a/src/modules/job-manager/test/util.c
+++ b/src/modules/job-manager/test/util.c
@@ -22,14 +22,14 @@
 #include "src/modules/job-manager/job.h"
 #include "src/modules/job-manager/util.h"
 
-struct test_input {
+struct jobkey_input {
     flux_jobid_t id;
     bool active;
     const char *key;
     const char *expected;
 };
 
-struct test_input intab[] = {
+struct jobkey_input jobkeytab[] = {
     { 1, true, NULL,            "job.active.0000.0000.0000.0001" },
     { 1, false, NULL,           "job.inactive.0000.0000.0000.0001" },
     { 2, true, "foo",           "job.active.0000.0000.0000.0002.foo" },
@@ -42,14 +42,14 @@ struct test_input intab[] = {
 
     { 0, false, NULL, NULL },
 };
-bool is_intab_end (struct test_input *try)
+bool is_jobkeytab_end (struct jobkey_input *try)
 {
     if (try->id == 0 && try->active == false && !try->key && !try->expected)
         return true;
     return false;
 }
 
-void check_one_jobkey (struct test_input *try)
+void check_one_jobkey (struct jobkey_input *try)
 {
     char path[64];
     struct job *job;
@@ -87,8 +87,8 @@ void check_one_jobkey (struct test_input *try)
 void check_jobkey (void)
 {
     int i;
-    for (i = 0; !is_intab_end (&intab[i]); i++)
-        check_one_jobkey (&intab[i]);
+    for (i = 0; !is_jobkeytab_end (&jobkeytab[i]); i++)
+        check_one_jobkey (&jobkeytab[i]);
 }
 
 char *decode_value (flux_kvs_txn_t *txn, int index, const char **key)
@@ -181,6 +181,81 @@ void check_attr_set (void)
     flux_kvs_txn_destroy (txn);
 }
 
+struct context_input {
+    const char *context;
+    const char *key;
+    int intval;
+    const char *strval;
+    const char *note;
+    int rc;
+    int errnum;
+};
+
+struct context_input contexttab[] = {
+    /* Integer */
+    { "foo=42",                         "foo", 42, NULL, NULL, 0, 0 },
+    { "a=10 b=2 c=3 Testing one two",   "a", 10, NULL, "Testing one two", 0, 0},
+    { "a=10 b=2 c=3 Meep = Moop",       "b", 2, NULL, "Meep = Moop", 0, 0},
+    { "a=10 b=2 c=-3",                  "c", -3, NULL, NULL, 0, 0},
+    { "a=b=c=3",                        "a", 0, NULL, NULL, -1, EINVAL},
+    { "foo=x42",                        "foo", 0, NULL, NULL, -1, EINVAL },
+    { "foo=42x",                        "foo", 0, NULL, NULL, -1, EINVAL },
+    { "foo=bar",                        "foo", 0, NULL, NULL, -1, EINVAL },
+    { "foo= 1",                         "foo", 0, NULL, "1", -1, EINVAL },
+    { "foo=",                           "foo", 0, NULL, NULL, -1, EINVAL },
+    { "type=cancel severity=7 userid=42", "severity", 7, NULL, NULL, 0, 0 },
+    { "type=cancel severity=7 userid=42 Hah!", "userid", 42, NULL, "Hah!", 0, 0 },
+    { "",                               "foo", 42, NULL, NULL, -1, ENOENT },
+
+    /* String */
+    { "type=cancel severity=7 userid=42", "type", 0, "cancel", NULL, 0, 0 },
+    { "foo=42",                         "foo", 0, "42", NULL, 0, 0 },
+    { "a=foo b= c=bar One!",            "a", 0, "foo", "One!", 0, 0},
+    { "a=foo b= c=bar Two!",            "b", 0, "", "Two!", 0, 0},
+    { "a=foo b= c=bar Three!",          "c", 0, "bar", "Three!", 0, 0},
+    { "",                               "foo", 0, "bar", NULL, -1, ENOENT },
+
+    /* End */
+    { NULL, NULL, 0, NULL, NULL, 0, 0 },
+};
+
+void check_one_context (struct context_input *c)
+{
+    int rc;
+    const char *s;
+
+    if (c->strval) {
+        char val[64] = "";
+        errno = 0;
+        rc = util_str_from_context (c->context, c->key, val, sizeof (val));
+        ok (rc == c->rc && (rc != 0 || !strcmp (val, c->strval))
+                        && (rc == 0 || errno == c->errnum),
+            "util_str_from_context ctx=%s %s", c->context,
+            c->rc == 0 ? "works" : "fails");
+    }
+    else {
+        int val = 0;
+        errno = 0;
+        rc = util_int_from_context (c->context, c->key, &val);
+        ok (rc == c->rc && (rc != 0 || val == c->intval)
+                        && (rc == 0 || errno == c->errnum),
+            "util_int_from_context ctx=%s %s", c->context,
+            c->rc == 0 ? "works" : "fails");
+    }
+    s = util_note_from_context (c->context);
+    ok ((c->note == NULL && s == NULL)
+        || (c->note && s && !strcmp (s, c->note)),
+        "util_note_from_context ctx=%s returned %s", c->context,
+        c->note ? c->note : "NULL");
+}
+
+void check_context (void)
+{
+    int i;
+    for (i = 0; contexttab[i].context != NULL; i++)
+        check_one_context (&contexttab[i]);
+}
+
 int main (int argc, char **argv)
 {
     plan (NO_PLAN);
@@ -188,6 +263,7 @@ int main (int argc, char **argv)
     check_jobkey ();
     check_eventlog_append ();
     check_attr_set ();
+    check_context ();
 
     done_testing ();
 

--- a/src/modules/job-manager/util.c
+++ b/src/modules/job-manager/util.c
@@ -192,6 +192,18 @@ error:
     return -1;
 }
 
+flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,
+                                 int flags, const char *key)
+{
+    char path[64];
+
+    if (util_jobkey (path, sizeof (path), active, id, key) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_kvs_lookup (h, NULL, flags, path);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/util.c
+++ b/src/modules/job-manager/util.c
@@ -15,12 +15,107 @@
 #include "config.h"
 #endif
 #include <stdlib.h>
+#include <ctype.h>
+#include <argz.h>
+#include <envz.h>
 
-#include "src/common/libjob/job.h"
+#include <flux/core.h>
 #include "src/common/libutil/fluid.h"
 
 #include "job.h"
 #include "util.h"
+
+int util_int_from_context (const char *context, const char *key, int *val)
+{
+    char *argz = NULL;
+    size_t argz_len = 0;
+    char *endptr;
+    unsigned long i;
+    char *s;
+
+    if (argz_create_sep (context, ' ', &argz, &argz_len) != 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (!(s = envz_get (argz, argz_len, key))) {
+        free (argz);
+        errno = ENOENT;
+        return -1;
+    }
+    errno = 0;
+    i = strtoll (s, &endptr, 10);
+    if (errno != 0 || *endptr != '\0' || endptr == s) {
+        free (argz);
+        errno = EINVAL;
+        return -1;
+    }
+    if (val)
+        *val = i;
+    free (argz);
+    return 0;
+}
+
+int util_str_from_context (const char *context, const char *key,
+                           char *val, int valsize)
+{
+    char *argz = NULL;
+    size_t argz_len = 0;
+    char *s;
+
+    if (argz_create_sep (context, ' ', &argz, &argz_len) != 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (!(s = envz_get (argz, argz_len, key))) {
+        free (argz);
+        errno = ENOENT;
+        return -1;
+    }
+    if (val) {
+        if (valsize < strlen (s) + 1) {
+            free (argz);
+            errno = EINVAL;
+            return -1;
+        }
+        strcpy (val, s);
+    }
+    free (argz);
+    return 0;
+}
+
+/* Skip over key=val and any trailing whitespace
+ */
+static const char *skip_keyval (const char *s)
+{
+    const char *equal = strchr (s, '=');
+    const char *cp = s;
+
+    if (equal) {
+        while (cp < equal && !isspace (*cp))
+            cp++;
+        if (cp++ != equal)
+            return NULL;
+        while (*cp && !isspace (*cp))
+            cp++;
+        while (*cp && isspace (*cp))
+            cp++;
+        return cp;
+    }
+    return NULL;
+}
+
+const char *util_note_from_context (const char *context)
+{
+    const char *p;
+
+    if (context) {
+        while ((p = skip_keyval (context)))
+            context = p;
+        if (strlen (context) == 0)
+            context = NULL;
+    }
+    return context;
+}
 
 int util_jobkey (char *buf, int bufsz, bool active,
                  struct job *job, const char *key)

--- a/src/modules/job-manager/util.c
+++ b/src/modules/job-manager/util.c
@@ -118,12 +118,12 @@ const char *util_note_from_context (const char *context)
 }
 
 int util_jobkey (char *buf, int bufsz, bool active,
-                 struct job *job, const char *key)
+                 flux_jobid_t id, const char *key)
 {
     char idstr[32];
     int len;
 
-    if (fluid_encode (idstr, sizeof (idstr), job->id, FLUID_STRING_DOTHEX) < 0)
+    if (fluid_encode (idstr, sizeof (idstr), id, FLUID_STRING_DOTHEX) < 0)
         return -1;
     len = snprintf (buf, bufsz, "job.%s.%s%s%s",
                     active ? "active" : "inactive",
@@ -136,7 +136,7 @@ int util_jobkey (char *buf, int bufsz, bool active,
 }
 
 int util_eventlog_append (flux_kvs_txn_t *txn,
-                          struct job *job,
+                          flux_jobid_t id,
                           const char *name,
                           const char *fmt, ...)
 {
@@ -152,7 +152,7 @@ int util_eventlog_append (flux_kvs_txn_t *txn,
     va_end (ap);
     if (n >= sizeof (context))
         goto error_inval;
-    if (util_jobkey (path, sizeof (path), true, job, "eventlog") < 0)
+    if (util_jobkey (path, sizeof (path), true, id, "eventlog") < 0)
         goto error_inval;
     if (!(event = flux_kvs_event_encode (name, context)))
         goto error;
@@ -170,7 +170,7 @@ error:
 }
 
 int util_attr_pack (flux_kvs_txn_t *txn,
-                    struct job *job,
+                    flux_jobid_t id,
                     const char *key,
                     const char *fmt, ...)
 {
@@ -178,7 +178,7 @@ int util_attr_pack (flux_kvs_txn_t *txn,
     int n;
     char path[64];
 
-    if (util_jobkey (path, sizeof (path), true, job, key) < 0)
+    if (util_jobkey (path, sizeof (path), true, id, key) < 0)
         goto error_inval;
     va_start (ap, fmt);
     n = flux_kvs_txn_vpack (txn, 0, path, fmt, ap);

--- a/src/modules/job-manager/util.h
+++ b/src/modules/job-manager/util.h
@@ -52,6 +52,11 @@ int util_eventlog_append (flux_kvs_txn_t *txn,
                           const char *name,
                           const char *fmt, ...);
 
+/* Look up 'key' relative to active/inactive job directory for job 'id'.
+ */
+flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,
+                                 int flags, const char *key);
+
 #endif /* _FLUX_JOB_MANAGER_UTIL_H */
 
 /*

--- a/src/modules/job-manager/util.h
+++ b/src/modules/job-manager/util.h
@@ -14,7 +14,6 @@
 #include <flux/core.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#include "job.h"
 
 /* Parse key=val integer from event context.  val may be NULL.
  * Return 0 on success, -1 on failure with errno set.
@@ -30,26 +29,26 @@ int util_str_from_context (const char *context, const char *key,
  */
 const char *util_note_from_context (const char *context);
 
-/* Write KVS path to 'key' relative to active job directory for 'job'.
+/* Write KVS path to 'key' relative to active job directory for job 'id'.
  * If key=NULL, write the job directory.
  * Returns string length on success, or -1 on failure.
  */
 int util_jobkey (char *buf, int bufsz, bool active,
-                 struct job *job, const char *key);
+                 flux_jobid_t id, const char *key);
 
-/* Set 'key' within active job directory for 'job'.
+/* Set 'key' within active job directory for job 'id'.
  */
 int util_attr_pack (flux_kvs_txn_t *txn,
-                    struct job *job,
+                    flux_jobid_t id,
                     const char *key,
                     const char *fmt, ...);
 
-/* Log an event to eventlog in active job directory for 'job'.
+/* Log an event to eventlog in active job directory for job 'id'.
  * The event consists of current wallclock, 'name', and optional context
  * formatted from (fmt, ...).  Set fmt="" to skip logging a context.
  */
 int util_eventlog_append (flux_kvs_txn_t *txn,
-                          struct job *job,
+                          flux_jobid_t id,
                           const char *name,
                           const char *fmt, ...);
 

--- a/src/modules/job-manager/util.h
+++ b/src/modules/job-manager/util.h
@@ -13,7 +13,22 @@
 
 #include <flux/core.h>
 #include <stdbool.h>
+#include <stdarg.h>
 #include "job.h"
+
+/* Parse key=val integer from event context.  val may be NULL.
+ * Return 0 on success, -1 on failure with errno set.
+ */
+int util_int_from_context (const char *context, const char *key, int *val);
+/* Parse key=val string from event context.  val may be NULL.
+ * Return 0 on success, -1 on failure with errno set.
+ */
+int util_str_from_context (const char *context, const char *key,
+                           char *val, int valsize);
+/* Parse trailing non key=val context.  Context must not contain \n.
+ * NULL if there is none.
+ */
+const char *util_note_from_context (const char *context);
 
 /* Write KVS path to 'key' relative to active job directory for 'job'.
  * If key=NULL, write the job directory.

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -77,6 +77,11 @@ test_expect_success 'job-manager: raise non-fatal exception on job' '
 	grep -q "Mumble grumble" list1_exception.out
 '
 
+test_expect_success 'job-manager: exception note with embedded = is rejected' '
+	jobid=$(cat list1_jobid.out) &&
+	! flux job raise --severity=1 --type=testing ${jobid} foo=bar
+'
+
 test_expect_success 'job-manager: queue contains 1 jobs' '
 	test $(list_jobs | wc -l) -eq 1
 '


### PR DESCRIPTION
This PR is definitely a WIP, but I wanted to get it out there for some early review if that's OK.

The job eventlog is a sort of fine grained synchronization facility for single jobs, and also a record of what has happened so far to a job sitting in the queue.  In addition, the job manager implements a "restart" capability where active jobs are pulled in from the KVS and their job manager state recreated by replaying the job's eventlog.

The first thing this PR does is ensure that full in-memory job state can be recreated from the eventlog, as the number of events increases.  The "restart" code is refactored so that replay occurs in a new constructor for a `struct job`.  Some util functions for parsing key=value attributes out of the event context were added to make this job easier.  The `submit` event, which is added by the ingest module, was modified to include the userid and initial job priority, so that the job manager only needs to access the eventlog, not individual keys, when it restarts (RFC 16 should be updated to reflect this).

The second part of this PR adds a proxy service in the job manager to allow guests to access their jobs' eventlogs by job id.   There's a matching job.h api function and a `flux job eventlog` subcommand.  In this first cut, the service only supports fetching a snapshot of the eventlog.  The subcommand dumps events in raw form.
```
$ flux job eventlog 53418655744
1550463786.443906 submit userid=5588 priority=16
1550463800.251430 exception type=cancel severity=0 userid=5588
1550477469.741397 exception type=cancel severity=0 userid=5588
```
The API function:
```c
/* Lookup eventlog for job, using job-manager as proxy to the KVS.
 * Response contains raw RFC 18 KVS eventlog string, which may be decoded
 * with flux_kvs_eventlog_decode().
 */
flux_future_t *flux_job_lookup_eventlog (flux_t *h, flux_jobid_t id, int flags);
```

Obviously a watch flag is the big missing piece here.  I paused here partly because I felt we might want to do better with the way events are returned by that API call.  It currently retrieves an eventlog snapshot in RFC 18 format, what you get from a `kvs_lookup` response, which you can parse and iterate over with functions in `kvs_eventlog.h`.  When we add WATCH, if the `kvs_lookup` semantics are preserved, each change causes a progressively larger block of events to be returned, rather than only the new ones.  `kvs_eventlog.h` handles this well, but it seems like exposing this weirdness at the job API level might be a bad idea, for example if a python script wants to synchronize on events.  Maybe having each response return a single event in JSON form would be better?

TODO:
* Handle a WATCH flag to stream events as they arrive
* Transparently handle the eventlog moving from active to inactive
* Consider translating odd KVS lookup semantics to a stream of JSON objects
* Better event formatting + options for the command