### PR TITLE
travis-ci: unshallow git repo before running docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,9 @@ before_install:
   fi
 
 script:
+ # Unshallow repository so git describe works.
+ # (The one inside docker-run-checks may fail if git version is too old)
+ - git fetch --unshallow --tags
  - |
   src/test/docker/docker-run-checks.sh -j2 \
     --image=${IMG} \


### PR DESCRIPTION
On travis-ci the version of git(1) inside of our docker image may
be too old for the `git fetch --unshallow --tags` to succeed, as
evidenced by errors like:

 git fetch --unshallow --tags
 fatal: unknown value for config 'protocol.version': 2

in our travis builds. To ensure we don't hit this error, run
the command to fetch tags *before* running docker, using the version
of git installed in travis.

Fixes #2024