### PR TITLE
job-manager: add scheduler interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,7 @@ AC_CONFIG_FILES( \
   src/common/libidset/Makefile \
   src/common/libtomlc99/Makefile \
   src/common/libaggregate/Makefile \
+  src/common/libschedutil/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -10,7 +10,8 @@ SUBDIRS = libtap \
 	  libidset \
 	  libtomlc99 \
           libsubprocess \
-          libaggregate
+          libaggregate \
+          libschedutil
 
 AM_CFLAGS = $(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)

--- a/src/common/libschedutil/Makefile.am
+++ b/src/common/libschedutil/Makefile.am
@@ -1,0 +1,30 @@
+AM_CFLAGS = \
+        $(WARNING_CFLAGS) \
+        $(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+        $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+noinst_LTLIBRARIES = \
+	libschedutil.la
+
+libschedutil_la_SOURCES = \
+	schedutil.h \
+	hello.h \
+	hello.c \
+	ready.h \
+	ready.c \
+	ops.h \
+	ops.c \
+	alloc.h \
+	alloc.c \
+	free.h \
+	free.c \
+	jobkey.h \
+	jobkey.c

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -1,0 +1,154 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "alloc.h"
+#include "jobkey.h"
+
+int schedutil_alloc_request_decode (const flux_msg_t *msg,
+                                    flux_jobid_t *id,
+                                    int *priority,
+                                    uint32_t *userid,
+                                    double *t_submit)
+{
+    return flux_request_unpack (msg, NULL, "{s:I s:i s:i s:f}",
+                                           "id", id,
+                                           "priority", priority,
+                                           "userid", userid,
+                                           "t_submit", t_submit);
+}
+
+static int schedutil_alloc_respond (flux_t *h, const flux_msg_t *msg,
+                                    int type, const char *note)
+{
+    flux_jobid_t id;
+    int rc;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        return -1;
+    if (note)
+        rc = flux_respond_pack (h, msg, "{s:I s:i s:s}",
+                                        "id", id,
+                                        "type", type,
+                                        "note", note);
+    else
+        rc = flux_respond_pack (h, msg, "{s:I s:i}",
+                                        "id", id,
+                                        "type", type);
+    return rc;
+}
+
+int schedutil_alloc_respond_note (flux_t *h, const flux_msg_t *msg,
+                                  const char *note)
+{
+    return schedutil_alloc_respond (h, msg, 1, note);
+}
+
+int schedutil_alloc_respond_denied (flux_t *h, const flux_msg_t *msg,
+                                    const char *note)
+{
+    return schedutil_alloc_respond (h, msg, 2, note);
+}
+
+struct alloc {
+    char *note;
+    flux_msg_t *msg;
+    flux_kvs_txn_t *txn;
+};
+
+static void alloc_destroy (struct alloc *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_kvs_txn_destroy (ctx->txn);
+        flux_msg_destroy (ctx->msg);
+        free (ctx->note);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct alloc *alloc_create (const flux_msg_t *msg, const char *R,
+                                   const char *note)
+{
+    struct alloc *ctx;
+    flux_jobid_t id;
+    char key[64];
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        return NULL;
+    if (schedutil_jobkey (key, sizeof (key), true, id, "R") < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (!(ctx->msg = flux_msg_copy (msg, true)))
+        goto error;
+    if (note && !(ctx->note = strdup (note)))
+        goto error;
+    if (!(ctx->txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (ctx->txn, 0, key, R) < 0)
+        goto error;
+    return ctx;
+error:
+    alloc_destroy (ctx);
+    return NULL;
+}
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct alloc *ctx = arg;
+
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "commit R");
+        goto error;
+    }
+    if (schedutil_alloc_respond (h, ctx->msg, 0, ctx->note) < 0) {
+        flux_log_error (h, "alloc response");
+        goto error;
+    }
+    alloc_destroy (ctx);
+    flux_future_destroy (f);
+    return;
+error:
+    flux_reactor_stop_error (flux_get_reactor (h)); // XXX
+    alloc_destroy (ctx);
+    flux_future_destroy (f);
+}
+
+int schedutil_alloc_respond_R (flux_t *h, const flux_msg_t *msg,
+                               const char *R, const char *note)
+{
+    struct alloc *ctx;
+    flux_future_t *f;
+
+    if (!(ctx = alloc_create (msg, R, note)))
+        return -1;
+    if (!(f = flux_kvs_commit (h, NULL, 0, ctx->txn)))
+        goto error;
+    if (flux_future_then (f, -1, alloc_continuation, ctx) < 0)
+        goto error;
+    return 0;
+error:
+    alloc_destroy (ctx);
+    flux_future_destroy (f);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -1,0 +1,53 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_ALLOC_H
+#define _FLUX_SCHEDUTIL_ALLOC_H
+
+#include <stdint.h>
+#include <flux/core.h>
+
+/* Decode an alloc request message.
+ * Return 0 on success, -1 on error with errno set.
+ */
+int schedutil_alloc_request_decode (const flux_msg_t *msg,
+                                    flux_jobid_t *id,
+                                    int *priority,
+                                    uint32_t *userid,
+                                    double *t_submit);
+
+/* Respond to alloc request message - update annotation.
+ * A job's annotation may be updated any number of times before alloc request
+ * is finally terminated with alloc_respond_denied() or alloc_respond_R().
+ * Return 0 on success, -1 on error with errno set.
+ */
+int schedutil_alloc_respond_note (flux_t *h, const flux_msg_t *msg,
+                                  const char *note);
+
+/* Respond to alloc request message - the job cannot run.
+ * Include human readable error message in 'note'.
+ * Return 0 on success, -1 on error with errno set.
+ */
+int schedutil_alloc_respond_denied (flux_t *h, const flux_msg_t *msg,
+                                    const char *note);
+
+/* Respond to alloc request message - allocate R.
+ * R is committed to the KVS first, then the response is sent.
+ * If something goes wrong after this function returns, the reactor is stopped.
+ */
+int schedutil_alloc_respond_R (flux_t *h, const flux_msg_t *msg,
+                               const char *R, const char *note);
+
+
+#endif /* !_FLUX_SCHEDUTIL_ALLOC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/free.c
+++ b/src/common/libschedutil/free.c
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "free.h"
+
+
+int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id)
+{
+    return flux_request_unpack (msg, NULL, "{s:I}", "id", id);
+}
+
+int schedutil_free_respond (flux_t *h, const flux_msg_t *msg)
+{
+    flux_jobid_t id;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        return -1;
+    return flux_respond_pack (h, msg, "{s:I}", "id", id);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/free.h
+++ b/src/common/libschedutil/free.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_FREE_H
+#define _FLUX_SCHEDUTIL_FREE_H
+
+#include <flux/core.h>
+
+/* Decode a free request.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id);
+
+/* Respond to a free request.
+ */
+int schedutil_free_respond (flux_t *h, const flux_msg_t *msg);
+
+#endif /* !_FLUX_SCHEDUTIL_FREE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -1,0 +1,76 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "hello.h"
+#include "jobkey.h"
+
+static int schedutil_hello_job (flux_t *h, flux_jobid_t id,
+                                hello_f *cb, void *arg)
+{
+    char key[64];
+    flux_future_t *f;
+    const char *s;
+
+    if (schedutil_jobkey (key, sizeof (key), true, id, "R") < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        return -1;
+    if (flux_kvs_lookup_get (f, &s) < 0)
+        goto error;
+    if (cb (h, s, arg) < 0)
+        goto error;
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_log_error (h, "hello: error loading R for id=%llu",
+                    (unsigned long long)id);
+    flux_future_destroy (f);
+    return -1;
+}
+
+int schedutil_hello (flux_t *h, hello_f *cb, void *arg)
+{
+    flux_future_t *f;
+    json_t *ids;
+    json_t *id;
+    size_t index;
+
+    if (!h || !cb) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f = flux_rpc (h, "job-manager.sched-hello",
+                        NULL, FLUX_NODEID_ANY, 0)))
+        return -1;
+    if (flux_rpc_get_unpack (f, "{s:o}", "alloc", &ids) < 0)
+        goto error;
+    json_array_foreach (ids, index, id) {
+        flux_jobid_t jobid = json_integer_value (id);
+        if (schedutil_hello_job (h, jobid, cb, arg) < 0)
+            goto error;
+    }
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_future_destroy (f);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_HELLO_H
+#define _FLUX_SCHEDUTIL_HELLO_H
+
+#include <flux/core.h>
+
+/* Callback for ingesting allocated R's.
+ * Return 0 on success, -1 on failure with errno set.
+ * Failure of the callback aborts iteration and causes schedutil_hello()
+ * to return -1 with errno passed through.
+ */
+typedef int (hello_f)(flux_t *h, const char *R, void *arg);
+
+/* Send hello announcement to job-manager.
+ * The job-manager responds with a list of jobs that have resources assigned.
+ * This function looks up R for each job and passes it 'cb' with 'arg'.
+ */
+int schedutil_hello (flux_t *h, hello_f *cb, void *arg);
+
+#endif /* !_FLUX_SCHEDUTIL_HELLO_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/jobkey.c
+++ b/src/common/libschedutil/jobkey.c
@@ -1,0 +1,43 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/fluid.h"
+#include "jobkey.h"
+
+
+int schedutil_jobkey (char *buf, int bufsz, bool active,
+                      flux_jobid_t id, const char *key)
+{
+    char idstr[32];
+    int len;
+
+    if (fluid_encode (idstr, sizeof (idstr), id, FLUID_STRING_DOTHEX) < 0)
+        return -1;
+    len = snprintf (buf, bufsz, "job.%s.%s%s%s",
+                    active ? "active" : "inactive",
+                    idstr,
+                    key ? "." : "",
+                    key ? key : "");
+    if (len >= bufsz)
+        return -1;
+    return len;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/jobkey.h
+++ b/src/common/libschedutil/jobkey.h
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_JOBKEY_H
+#define _FLUX_SCHEDUTIL_JOBKEY_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+int schedutil_jobkey (char *buf, int bufsz, bool active,
+                      flux_jobid_t id, const char *key);
+
+#endif /* !_FLUX_SCHEDUTIL_JOBKEY_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -1,0 +1,248 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "ops.h"
+#include "jobkey.h"
+
+struct ops_context {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    op_alloc_f *alloc_cb;
+    op_free_f *free_cb;
+    op_exception_f *exception_cb;
+    void *arg;
+};
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_msg_t *msg = flux_future_aux_get (f, "flux::alloc_request");
+    const char *jobspec;
+
+    if (flux_kvs_lookup_get (f, &jobspec) < 0) {
+        flux_log_error (ctx->h, "sched.free lookup R");
+        goto error;
+    }
+    ctx->alloc_cb (ctx->h, msg, jobspec, ctx->arg);
+    flux_future_destroy (f);
+    return;
+error:
+    flux_log_error (ctx->h, "sched.alloc");
+    if (flux_respond_error (ctx->h, msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "sched.alloc respond_error");
+    flux_future_destroy (f);
+}
+
+static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_jobid_t id;
+    char key[64];
+    flux_future_t *f;
+    flux_msg_t *cpy;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        goto error;
+    if (schedutil_jobkey (key, sizeof (key), true, id, "jobspec") < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        goto error;
+    if (!(cpy = flux_msg_copy (msg, true)))
+        goto error_future;
+    if (flux_future_aux_set (f, "flux::alloc_request",
+                             cpy, (flux_free_f)flux_msg_destroy) < 0) {
+        flux_msg_destroy (cpy);
+        goto error_future;
+    }
+    if (flux_future_then (f, -1, alloc_continuation, ctx) < 0)
+        goto error_future;
+    return;
+error_future:
+    flux_future_destroy (f);
+error:
+    flux_log_error (h, "sched.alloc");
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "sched.alloc respond_error");
+}
+
+static void free_continuation (flux_future_t *f, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_msg_t *msg = flux_future_aux_get (f, "flux::free_request");
+    const char *R;
+
+    if (flux_kvs_lookup_get (f, &R) < 0) {
+        flux_log_error (ctx->h, "sched.free lookup R");
+        goto error;
+    }
+    ctx->free_cb (ctx->h, msg, R, ctx->arg);
+    flux_future_destroy (f);
+    return;
+error:
+    flux_log_error (ctx->h, "sched.alloc");
+    if (flux_respond_error (ctx->h, msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "sched.free respond_error");
+    flux_future_destroy (f);
+}
+
+static void free_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_jobid_t id;
+    flux_future_t *f;
+    char key[64];
+    flux_msg_t *cpy;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        goto error;
+    if (schedutil_jobkey (key, sizeof (key), true, id, "R") < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        goto error;
+    if (!(cpy = flux_msg_copy (msg, true)))
+        goto error_future;
+    if (flux_future_aux_set (f, "flux::free_request",
+                             cpy, (flux_free_f)flux_msg_destroy) < 0) {
+        flux_msg_destroy (cpy);
+        goto error_future;
+    }
+    if (flux_future_then (f, -1, free_continuation, ctx) < 0)
+        goto error_future;
+    return;
+error_future:
+    flux_future_destroy (f);
+error:
+    flux_log_error (h, "sched.free");
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "sched.free respond_error");
+}
+
+static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_jobid_t id;
+    const char *type;
+    int severity;
+
+    if (flux_event_unpack (msg, NULL, "{s:I s:s s:i}",
+                                      "id", &id,
+                                      "type", &type,
+                                      "severity", &severity) < 0) {
+        flux_log_error (h, "job-exception event");
+        return;
+    }
+    ctx->exception_cb (h, id, type, severity, ctx->arg);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "sched.alloc", alloc_cb, 0},
+    { FLUX_MSGTYPE_REQUEST,  "sched.free", free_cb, 0},
+    { FLUX_MSGTYPE_EVENT,  "job-exception", exception_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+/* Register dynamic service named 'sched'
+ */
+static int service_register (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_service_register (h, "sched")))
+        return -1;
+    if (flux_future_get (f, NULL) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_log (h, LOG_DEBUG, "service_register");
+    flux_future_destroy (f);
+    return 0;
+}
+
+/* Unregister dynamic service name 'sched'
+ */
+static void service_unregister (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_service_unregister (h, "sched"))) {
+        flux_log_error (h, "service_unregister");
+        return;
+    }
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "service_unregister");
+        flux_future_destroy (f);
+        return;
+    }
+    flux_log (h, LOG_DEBUG, "service_unregister");
+    flux_future_destroy (f);
+}
+
+struct ops_context *schedutil_ops_register (flux_t *h,
+                                            op_alloc_f *alloc_cb,
+                                            op_free_f *free_cb,
+                                            op_exception_f *exception_cb,
+                                            void *arg)
+{
+    struct ops_context *ctx;
+
+    if (!h || !alloc_cb || !free_cb || !exception_cb) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (service_register (h) < 0)
+        goto error;
+    ctx->h = h;
+    ctx->alloc_cb = alloc_cb;
+    ctx->free_cb = free_cb;
+    ctx->exception_cb = exception_cb;
+    ctx->arg = arg;
+
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (flux_event_subscribe (h, "job-exception") < 0)
+        goto error;
+    return ctx;
+error:
+    schedutil_ops_unregister (ctx);
+    return NULL;
+}
+
+
+void schedutil_ops_unregister (struct ops_context *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        (void)service_unregister (ctx->h);
+        (void)flux_event_unsubscribe (ctx->h, "job-exception");
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -1,0 +1,66 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_OPS_H
+#define _FLUX_SCHEDUTIL_OPS_H
+
+#include <flux/core.h>
+
+/* Callback for an alloc request.  jobspec is looked up as a convenience.
+ * Decode msg with schedutil_alloc_request_decode().
+ * 'msg' and 'jobspec' are only valid for hte duration of this call.
+ * You should either respond to the request immediately (see alloc.h),
+ * or cache this information for later response.
+ */
+typedef void (op_alloc_f)(flux_t *h,
+                          const flux_msg_t *msg,
+                          const char *jobspec,
+                          void *arg);
+
+/* Callback for a free request.  R is looked up as a convenience.
+ * Decode msg with schedutil_free_request_decode().
+ * 'msg' and 'R' are only valid for the duration of this call.
+ * You should either respond to the request immediately (see free.h),
+ * or cache this information for later response.
+ */
+typedef void (op_free_f)(flux_t *h,
+                         const flux_msg_t *msg,
+                         const char *R,
+                         void *arg);
+
+/* An exception occurred for job 'id'.
+ * If the severity is zero, and there is an allocation pending for 'id',
+ * you must fail it immediately using schedutil_alloc_respond_denied(),
+ * setting the note field to something like "alloc aborted due to
+ * exception type=%s"
+ */
+typedef void (op_exception_f)(flux_t *h,
+                              flux_jobid_t id,
+                              const char *type,
+                              int severity,
+                              void *arg);
+
+/* Register callbacks for alloc, free, exception.
+ */
+struct ops_context *schedutil_ops_register (flux_t *h,
+                                            op_alloc_f *alloc_cb,
+                                            op_free_f *free_cb,
+                                            op_exception_f *exception_cb,
+                                            void *arg);
+
+/* Unregister callbacks.
+ */
+void schedutil_ops_unregister (struct ops_context *ctx);
+
+#endif /* !_FLUX_SCHEDUTIL_OPS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ready.c
+++ b/src/common/libschedutil/ready.c
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "ready.h"
+
+int schedutil_ready (flux_t *h, const char *mode, int *queue_depth)
+{
+    flux_future_t *f;
+    int count;
+
+    if (!h || !mode) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f = flux_rpc_pack (h, "job-manager.sched-ready",
+                             FLUX_NODEID_ANY, 0,
+                             "{s:s}", "mode", mode)))
+        return -1;
+    if (flux_rpc_get_unpack (f, "{s:i}", "count", &count) < 0)
+        goto error;
+    if (queue_depth)
+        *queue_depth = count;
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_future_destroy (f);
+    return -1;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ready.h
+++ b/src/common/libschedutil/ready.h
@@ -1,0 +1,27 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_READY_H
+#define _FLUX_SCHEDUTIL_READY_H
+
+#include <flux/core.h>
+
+/* Send ready request to job-manager, selecting interface 'mode'
+ * ("single", "unlimited", ...).  'queue_depth', if non-NULL,
+ * is set to the number of jobs in SCHED state that have not yet requested
+ * resources.  Returns 0 on success, -1 on failure with errno set.
+ */
+int schedutil_ready (flux_t *h, const char *mode, int *queue_depth);
+
+#endif /* !_FLUX_SCHEDUTIL_READY_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/schedutil.h
+++ b/src/common/libschedutil/schedutil.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_H
+#define _FLUX_SCHEDUTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "hello.h"
+#include "ready.h"
+#include "alloc.h"
+#include "free.h"
+#include "ops.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_SCHEDUTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -415,14 +415,6 @@ static int batch_add_job (struct batch *batch, struct job *job)
     if (flux_kvs_txn_put_raw (batch->txn, 0, key,
                               job->jobspec, job->jobspecsz) < 0)
         goto error;
-    if (make_key (key, sizeof (key), job, "userid") < 0)
-        goto error;
-    if (flux_kvs_txn_pack (batch->txn, 0, key, "i", job->userid) < 0)
-        goto error;
-    if (make_key (key, sizeof (key), job, "priority") < 0)
-        goto error;
-    if (flux_kvs_txn_pack (batch->txn, 0, key, "i", job->priority) < 0)
-        goto error;
     if (get_timestamp_now (&t) < 0)
         goto error;
     n = snprintf (context, sizeof (context), "userid=%d priority=%d",

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -406,7 +406,7 @@ static int batch_add_job (struct batch *batch, struct job *job)
         errno = ENOMEM;
         return -1;
     }
-    if (make_key (key, sizeof (key), job, "J-signed") < 0)
+    if (make_key (key, sizeof (key), job, "J") < 0)
         goto error;
     if (flux_kvs_txn_put (batch->txn, 0, key, job->J) < 0)
         goto error;

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -39,6 +39,7 @@ job_manager_la_LIBADD = $(fluxmod_libadd) \
 		    $(ZMQ_LIBS)
 
 TESTS = \
+	test_job.t \
 	test_queue.t \
 	test_list.t \
 	test_raise.t \
@@ -62,6 +63,11 @@ check_PROGRAMS = $(TESTS)
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
        $(top_srcdir)/config/tap-driver.sh
+
+test_job_t_SOURCES = test/job.c
+test_job_t_CPPFLAGS = $(test_cppflags)
+test_job_t_LDADD = \
+        $(test_ldadd)
 
 test_queue_t_SOURCES = test/queue.c
 test_queue_t_CPPFLAGS = $(test_cppflags)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -84,6 +84,7 @@ test_raise_t_SOURCES = test/raise.c
 test_raise_t_CPPFLAGS = $(test_cppflags)
 test_raise_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/raise.o \
+        $(top_builddir)/src/modules/job-manager/alloc.o \
         $(test_ldadd)
 
 test_util_t_SOURCES = test/util.c

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -24,6 +24,8 @@ job_manager_la_SOURCES = job-manager.c \
 			 restart.c \
 			 raise.h \
 			 raise.c \
+			 alloc.h \
+			 alloc.c \
 			 list.h \
 			 list.c \
 			 priority.h \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -1,0 +1,539 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* alloc.c - scheduler interface
+ *
+ * STARTUP:
+ *
+ * 1) Scheduler sends job-manager.sched-hello request:
+ *   <empty payload>
+ * Job manager responds with array of jobids that have allocated resources:
+ *   {"alloc":[I,I,I,...]}
+ * Scheduler should read those jobs' R from KVS and mark resources allocated.
+ *
+ * 2) Scheduler sends job-manager.sched-ready request:
+ *   {"mode":s}
+ * mode is scheduler's preference for throttling alloc requests:
+ *   "single"    - limit of one pending alloc request (e.g. for FCFS)
+ *   "unlimited" - no limit on number of pending alloc requests
+ * Job manager responds with alloc queue depth (sched may ignore this)
+ *   {"count":i}
+ *
+ * ALLOCATION (see notes 3-4 below):
+ *
+ * Job manager sends sched.alloc request:
+ *   {"id":I, "priority":i, "userid":i, "t_submit":f}
+ * Scheduler responds with:
+*    {"id":I, "type":i, "note"?:s}
+ * Where type is one of:
+ * 0 - resources allocated (sched commits R to KVS before responding)
+ * 1 - annotation (just updates note, see below)
+ * 2 - job cannot run (note is set to error string)
+ * Type 0 or 2 are taken as final responses, type 1 is not.
+ *
+ * DE-ALLOCATION (see notes 3-4 below):
+ *
+ * Job manager sends sched.free request:
+ *   {"id":I}
+ * Scheduler reads R from KVS and marks resources free and responds with
+ *   {"id":I}
+ *
+ * EXCEPTION:
+ *
+ * Job manager sends a job-exception event:
+ *   {"id":I, "type":s, "severity":i}
+ * If severity=0 exception is received for a job with a pending alloc request,
+ * scheduler responds with with type=2 (error).
+ *
+ * TEARDOWN:
+ *
+ * Scheduler sends each internally queued alloc request a regular ENOSYS
+ * RPC error response.
+ *
+ * The receipt of a regular RPC error of any type from the scheduler
+ * causes the job manager to assume the scheduler is unloading and to
+ * stop sending requests.
+ *
+ * Notes:
+ * 1) scheduler can be loaded after jobs have begun to be submitted
+ * 2) scheduler can be unloaded without affecting workload
+ * 3) alloc/free requests and responses are matched using jobid, not
+ *    the normal matchtag, for scalability.
+ * 4) a normal RPC error response to alloc/free triggers teardown
+ * 5) 'note' in alloc response is intended to be human readable note displayed
+ *    with job info (could be estimated start time, or error detail)
+ *
+ * TODO:
+ * - handle type=1 annotation for queue listing (currently ignored)
+ * - handle type=2 alloc failure, which should raise exception for job
+ * - implement flow control (credit based?) interface mode
+ * - handle post alloc request job priority change
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <assert.h>
+
+#include "queue.h"
+#include "job.h"
+#include "alloc.h"
+#include "queue.h"
+#include "util.h"
+
+typedef enum {
+    SCHED_SINGLE,       // only allow one outstanding sched.alloc request
+    SCHED_UNLIMITED,    // send all sched.alloc requests immediately
+} sched_interface_t;
+
+struct alloc_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    struct queue *queue;    // main active job queue
+    struct queue *inqueue;  // secondary queue of jobs to be scheduled
+    sched_interface_t mode;
+    bool ready;
+    flux_watcher_t *prep;
+    flux_watcher_t *check;
+    flux_watcher_t *idle;
+    unsigned int active_alloc_count; // for mode=single, max of 1
+};
+
+static void eventlog_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    if (flux_rpc_get (f, NULL) < 0)
+        flux_log_error (h, "eventlog commit");
+    flux_future_destroy (f);
+}
+
+static void eventlog_append (struct alloc_ctx *ctx, struct job *job,
+                            const char *name, const char *note)
+{
+    flux_kvs_txn_t *txn;
+    flux_future_t *f;
+
+    if (!note)
+        note = "";
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (util_eventlog_append (txn, job->id, name, "%s", note) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (ctx->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, eventlog_continuation, NULL) < 0) {
+        flux_future_destroy (f);
+        goto error;
+    }
+    flux_kvs_txn_destroy (txn);
+    return;
+error:
+    flux_log_error (ctx->h, "eventlog commit");
+    flux_kvs_txn_destroy (txn);
+}
+
+/* Initiate teardown.  Clear any alloc/free requests, and clear
+ * the alloc->ready flag to stop prep/check from allocating.
+ */
+static void interface_teardown (struct alloc_ctx *ctx, char *s, int errnum)
+{
+    if (ctx->ready) {
+        struct job *job;
+
+        flux_log (ctx->h, LOG_DEBUG, "alloc: stop due to %s",
+                  flux_strerror (errnum));
+
+        job = queue_first (ctx->queue);
+        while (job) {
+            /* jobs with alloc pending need to go back in the queue
+             * so they will automatically send alloc again.
+             */
+            if (job->alloc_pending) {
+                assert (job->aux_queue_handle == NULL);
+                if (queue_insert (ctx->inqueue, job,
+                                                &job->aux_queue_handle) < 0)
+                    flux_log_error (ctx->h, "%s: queue_insert", __FUNCTION__);
+                job->alloc_pending = 0;
+            }
+            /* jobs with free pending (much smaller window for this to be true)
+             * need to be picked up again after 'hello'.
+             */
+            job->free_pending = 0;
+            job = queue_next (ctx->queue);
+        }
+        ctx->ready = false;
+        ctx->active_alloc_count = 0;
+    }
+}
+
+/* Handle a sched.free response.
+ */
+static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
+                              const flux_msg_t *msg, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+    flux_jobid_t id = 0;
+    struct job *job;
+
+    if (flux_response_decode (msg, NULL, NULL) < 0)
+        goto teardown;
+    if (flux_msg_unpack (msg, "{s:I}", "id", &id) < 0)
+        goto teardown;
+    if (!(job = queue_lookup_by_id (ctx->queue, id))) {
+        flux_log_error (h, "sched.free-response: id=%llu not active",
+                        (unsigned long long)id);
+        goto teardown;
+    }
+    if (!job->has_resources) {
+        flux_log (h, LOG_ERR, "sched.free-response: id=%lld not allocated",
+                  (unsigned long long)id);
+        errno = EINVAL;
+        goto teardown;
+    }
+    job->free_pending = 0;
+    job->has_resources = 0;
+    eventlog_append (ctx, job, "free", NULL);
+    return;
+teardown:
+    interface_teardown (ctx, "free response error", errno);
+}
+
+/* Send sched.free request for job.
+ * Update flags.
+ */
+int free_request (struct alloc_ctx *ctx, struct job *job)
+{
+    flux_msg_t *msg;
+
+    if (!(msg = flux_request_encode ("sched.free", NULL)))
+        return -1;
+    if (flux_msg_pack (msg, "{s:I}", "id", job->id) < 0)
+        goto error;
+    if (flux_send (ctx->h, msg, 0) < 0)
+        goto error;
+
+    job->free_pending = 1;
+
+    flux_msg_destroy (msg);
+    return 0;
+error:
+    flux_msg_destroy (msg);
+    return -1;
+}
+
+/* Handle a sched.alloc response.
+ * Update flags.
+ */
+static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
+                               const flux_msg_t *msg, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+    flux_jobid_t id = 0;
+    int type = -1;
+    const char *note = NULL;
+    struct job *job;
+
+    if (flux_response_decode (msg, NULL, NULL) < 0)
+        goto teardown; // ENOSYS here if scheduler not loaded/shutting down
+    if (flux_msg_unpack (msg, "{s:I s:i s?:s}",
+                              "id", &id,
+                              "type", &type,
+                              "note", &note) < 0)
+        goto teardown;
+    if (type != 0 && type != 1 && type != 2) {
+        errno = EPROTO;
+        goto teardown;
+    }
+    if (!(job = queue_lookup_by_id (ctx->queue, id))) {
+        flux_log_error (h, "sched.alloc-response: id=%llu not active",
+                        (unsigned long long)id);
+        goto teardown;
+    }
+    if (!job->alloc_pending) {
+        flux_log (h, LOG_ERR, "sched.alloc-response: id=%lld not requested",
+                  (unsigned long long)id);
+        errno = EINVAL;
+        goto teardown;
+    }
+
+    /* Handle job annotation update.
+     * This does not terminate the response stream/
+     */
+    if (type == 1) {
+        // FIXME
+        return;
+    }
+
+    ctx->active_alloc_count--;
+    job->alloc_pending = 0;
+
+    /* Handle alloc error.
+     * Raise alloc exception and transition to CLEANUP state.
+     */
+    if (type == 2) { // error: alloc was rejected
+        char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
+        (void)snprintf (context, sizeof (context),
+                        "type=%s severity=%d userid=%u%s%s",
+                        "alloc", 0, FLUX_USERID_UNKNOWN,
+                        note ? " " : "",
+                        note ? note : "");
+        eventlog_append (ctx, job, "exception", context);
+        job->state = FLUX_JOB_CLEANUP;
+        //job->exception_pending = 1;
+        // FIXME: integrate with exception framework
+        return;
+    }
+
+    /* Handle alloc success (type == 0)
+     * Log alloc event and transtion to RUN state.
+     */
+    if (job->has_resources) {
+        flux_log (h, LOG_ERR, "sched.alloc-response: id=%lld already allocated",
+                  (unsigned long long)id);
+        errno = EEXIST;
+        goto teardown;
+    }
+
+    job->has_resources = 1;
+
+    eventlog_append (ctx, job, "alloc", note);
+    job->state = FLUX_JOB_RUN;
+    return;
+teardown:
+    interface_teardown (ctx, "alloc response error", errno);
+}
+
+/* Send sched.alloc request for job.
+ * Update flags.
+ */
+int alloc_request (struct alloc_ctx *ctx, struct job *job)
+{
+    flux_msg_t *msg;
+
+    if (!(msg = flux_request_encode ("sched.alloc", NULL)))
+        return -1;
+    if (flux_msg_pack (msg, "{s:I s:i s:i s:f}",
+                            "id", job->id,
+                            "priority", job->priority,
+                            "userid", job->userid,
+                            "t_submit", job->t_submit) < 0)
+        goto error;
+    if (flux_send (ctx->h, msg, 0) < 0)
+        goto error;
+
+    job->alloc_pending = 1;
+    queue_delete (ctx->inqueue, job, job->aux_queue_handle);
+    job->aux_queue_handle = NULL;
+    ctx->active_alloc_count++;
+
+    flux_msg_destroy (msg);
+    return 0;
+error:
+    flux_msg_destroy (msg);
+    return -1;
+}
+
+/* sched-hello:
+ * Scheduler obtains a list of jobs that have resources allocated.
+ */
+static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+    struct job *job;
+    json_t *o = NULL;
+    json_t *jobid;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    flux_log (h, LOG_DEBUG, "scheduler: hello");
+    if (!(o = json_array ()))
+        goto nomem;
+    job = queue_first (ctx->queue);
+    while (job) {
+        if (job->has_resources) {
+            if (!(jobid = json_integer (job->id)))
+                goto nomem;
+            if (json_array_append_new (o, jobid) < 0) {
+                json_decref (jobid);
+                goto nomem;
+            }
+        }
+        job = queue_next (ctx->queue);
+    }
+    if (flux_respond_pack (h, msg, "{s:O}", "alloc", o) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    /* Restart any free requests that might have been interrupted
+     * when scheduler was lsat unloaded.
+     */
+    job = queue_first (ctx->queue);
+    while (job) {
+        if (job->state == FLUX_JOB_CLEANUP && job->has_resources) {
+            /* FIXME: check if exec is all done with resources first */
+            if (free_request (ctx, job) < 0)
+                flux_log_error (h, "%s: scheduler_free", __FUNCTION__);
+        }
+        job = queue_next (ctx->queue);
+    }
+    json_decref (o);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    json_decref (o);
+}
+
+/* sched-ready:
+ * Scheduler indicates what style of alloc concurrency is requires,
+ * and tells job-manager to start allocations.  job-manager tells
+ * scheduler how many jobs are in the queue.
+ */
+static void ready_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+    const char *mode;
+    int count;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "mode", &mode) < 0)
+        goto error;
+    if (!strcmp (mode, "single"))
+        ctx->mode = SCHED_SINGLE;
+    else if (!strcmp (mode, "unlimited"))
+        ctx->mode = SCHED_UNLIMITED;
+    else {
+        errno = EPROTO;
+        goto error;
+    }
+    ctx->ready = true;
+    flux_log (h, LOG_DEBUG, "scheduler: ready %s", mode);
+    count = queue_size (ctx->inqueue);
+    if (flux_respond_pack (h, msg, "{s:i}", "count", count) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* prep:
+ * Runs right before reactor calls poll(2).
+ * If a job can be scheduled, start idle watcher.
+ */
+static void prep_cb (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+    if (!ctx->ready)
+        return;
+    if (ctx->mode == SCHED_SINGLE && ctx->active_alloc_count > 0)
+        return;
+    if (queue_first (ctx->inqueue))
+        flux_watcher_start (ctx->idle);
+}
+
+/* check:
+ * Runs right after reactor calls poll(2).
+ * Stop idle watcher, and send next alloc request, if available.
+ */
+static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+    struct job *job;
+
+    flux_watcher_stop (ctx->idle);
+    if (!ctx->ready)
+        return;
+    if (ctx->mode == SCHED_SINGLE && ctx->active_alloc_count > 0)
+        return;
+    if ((job = queue_first (ctx->inqueue))) {
+        if (alloc_request (ctx, job) < 0) {
+            flux_log_error (ctx->h, "alloc_request fatal error");
+            flux_reactor_stop_error (flux_get_reactor (ctx->h));
+            return;
+        }
+    }
+}
+
+int alloc_do_request (struct alloc_ctx *ctx, struct job *job)
+{
+    if (job->state == FLUX_JOB_CLEANUP && job->has_resources
+                                       && !job->free_pending) {
+        /* FIXME: check if exec is all done with resources first */
+        if (free_request (ctx, job) < 0)
+            return -1;
+    }
+    else if (job->state == FLUX_JOB_SCHED && !job->has_resources
+                                          && !job->alloc_pending) {
+        assert (job->aux_queue_handle == NULL);
+        if (queue_insert (ctx->inqueue, job, &job->aux_queue_handle) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+void alloc_ctx_destroy (struct alloc_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;;
+        flux_msg_handler_delvec (ctx->handlers);
+        flux_watcher_destroy (ctx->prep);
+        flux_watcher_destroy (ctx->check);
+        flux_watcher_destroy (ctx->idle);
+        queue_destroy (ctx->inqueue);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "job-manager.sched-hello", hello_cb, 0},
+    { FLUX_MSGTYPE_REQUEST,  "job-manager.sched-ready", ready_cb, 0},
+    { FLUX_MSGTYPE_RESPONSE, "sched.alloc", alloc_response_cb, 0},
+    { FLUX_MSGTYPE_RESPONSE, "sched.free", free_response_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue)
+{
+    struct alloc_ctx *ctx;
+    flux_reactor_t *r = flux_get_reactor (h);
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+    ctx->queue = queue;
+    if (!(ctx->inqueue = queue_create (false)))
+        goto error;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    ctx->prep = flux_prepare_watcher_create (r, prep_cb, ctx);
+    ctx->check = flux_check_watcher_create (r, check_cb, ctx);
+    ctx->idle = flux_idle_watcher_create (r, NULL, NULL);
+    if (!ctx->prep || !ctx->check || !ctx->idle) {
+        errno = ENOMEM;
+        goto error;
+    }
+    flux_watcher_start (ctx->prep);
+    flux_watcher_start (ctx->check);
+    return ctx;
+error:
+    alloc_ctx_destroy (ctx);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_ALLOC_H
+#define _FLUX_JOB_MANAGER_ALLOC_H
+
+#include <flux/core.h>
+
+#include "queue.h"
+#include "job.h"
+
+struct alloc_ctx;
+
+void alloc_ctx_destroy (struct alloc_ctx *ctx);
+struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue);
+
+/* Call this from other parts of the job manager when the alloc
+ * machinery might need to take action on 'job'.  The action taken
+ * depends on job state and internal flags.
+ */
+int alloc_do_request (struct alloc_ctx *scd, struct job *job);
+
+#endif /* ! _FLUX_JOB_MANAGER_ALLOC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -11,6 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <czmq.h>
 #include <jansson.h>
 #include <flux/core.h>
 
@@ -29,6 +30,59 @@ struct job_manager_ctx {
     struct queue *queue;
 };
 
+/* Enqueue jobs from 'jobs' array in queue.
+ * On success, return a list of struct job's.
+ * On failure, return NULL with errno set (no jobs enqueued).
+ */
+zlist_t *enqueue_jobs (struct queue *queue, json_t *jobs)
+{
+    size_t index;
+    json_t *el;
+    zlist_t *newjobs;
+    struct job *job;
+    int saved_errno;
+
+    if (!(newjobs = zlist_new ()))
+        goto error;
+    json_array_foreach (jobs, index, el) {
+        flux_jobid_t id;
+        uint32_t userid;
+        int priority;
+        double t_submit;
+
+        if (json_unpack (el, "{s:I s:i s:i s:f}", "id", &id,
+                                                  "priority", &priority,
+                                                  "userid", &userid,
+                                                  "t_submit", &t_submit) < 0) {
+            goto error;
+        }
+        if (!(job = job_create (id, priority, userid, t_submit)))
+            goto error;
+        if (queue_insert (queue, job, &job->queue_handle) < 0) {
+            job_decref (job);
+            if (errno == EEXIST)
+                continue; // don't report error - might be a race with restart
+            goto error;
+        }
+        if (zlist_push (newjobs, job) < 0) {
+            queue_delete (queue, job, job->queue_handle);
+            job_decref (job);
+            errno = ENOMEM;
+            goto error;
+        }
+    }
+    return newjobs;
+error:
+    saved_errno = errno;
+    while ((job = zlist_pop (newjobs))) {
+        queue_delete (queue, job, job->queue_handle);
+        job_decref (job);
+    }
+    zlist_destroy (&newjobs);
+    errno = saved_errno;
+    return NULL;
+}
+
 /* handle submit request (from job-ingest module)
  * This is a batched request for one or more jobs already validated
  * by the ingest module, and already instantiated in the KVS.
@@ -39,46 +93,29 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct job_manager_ctx *ctx = arg;
     json_t *jobs;
-    size_t index;
-    json_t *el;
+    zlist_t *newjobs;
+    struct job *job;
 
     if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0) {
         flux_log_error (h, "%s", __FUNCTION__);
         goto error;
     }
-    json_array_foreach (jobs, index, el) {
-        flux_jobid_t id;
-        uint32_t userid;
-        int priority;
-        double t_submit;
-        struct job *job = NULL;
-
-        if (json_unpack (el, "{s:I s:i s:i s:f}", "id", &id,
-                                                  "priority", &priority,
-                                                  "userid", &userid,
-                                                  "t_submit", &t_submit) < 0) {
-            flux_log (h, LOG_ERR, "%s: error decoding job index %u",
-                      __FUNCTION__, (unsigned int)index);
-            goto error;
-        }
-        if (!(job = job_create (id, priority, userid, t_submit)))
-            goto error;
-        /* N.B. ignore EEXIST, in case restart_from_kvs() loaded a job
-         * while its submit request was in still flight.
-         */
-        if (queue_insert (ctx->queue, job, &job->queue_handle) < 0
-                                                        && errno != EEXIST) {
-            flux_log_error (h, "%s: queue_insert %llu",
-                            __FUNCTION__, (unsigned long long)id);
-            job_decref (job);
-            goto error;
-        }
-        job_decref (job);
+    if (!(newjobs = enqueue_jobs (ctx->queue, jobs))) {
+        flux_log_error (h, "%s: error enqueuing batch", __FUNCTION__);
+        goto error;
     }
     if (flux_respond (h, msg, 0, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-    flux_log (h, LOG_DEBUG, "%s: added %u jobs", __FUNCTION__,
-                            (unsigned int)index);
+    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__,
+                            (int)zlist_size (newjobs));
+    /* Submitting user is being responded to with jobid's.
+     * Now walk the list of new jobs and advance their state.
+     */
+    while ((job = zlist_pop (newjobs))) {
+        /* FILL IN */
+        job_decref (job);
+    }
+    zlist_destroy (&newjobs);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -66,7 +66,8 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         /* N.B. ignore EEXIST, in case restart_from_kvs() loaded a job
          * while its submit request was in still flight.
          */
-        if (queue_insert (ctx->queue, job) < 0 && errno != EEXIST) {
+        if (queue_insert (ctx->queue, job, &job->queue_handle) < 0
+                                                        && errno != EEXIST) {
             flux_log_error (h, "%s: queue_insert %llu",
                             __FUNCTION__, (unsigned long long)id);
             job_decref (job);
@@ -121,7 +122,7 @@ static int restart_map_cb (struct job *job, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
 
-    if (queue_insert (ctx->queue, job) < 0)
+    if (queue_insert (ctx->queue, job, &job->queue_handle) < 0)
         return -1;
     return 0;
 }
@@ -155,7 +156,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     memset (&ctx, 0, sizeof (ctx));
     ctx.h = h;
 
-    if (!(ctx.queue = queue_create ())) {
+    if (!(ctx.queue = queue_create (true))) {
         flux_log_error (h, "error creating queue");
         goto done;
     }

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -143,7 +143,7 @@ static void raise_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-    raise_handle_request (h, ctx->queue, msg);
+    raise_handle_request (h, ctx->queue, ctx->alloc_ctx, msg);
 }
 
 /* priority request handled in priority.c

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -61,7 +61,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
                       __FUNCTION__, (unsigned int)index);
             goto error;
         }
-        if (!(job = job_create (id, priority, userid, t_submit, 0)))
+        if (!(job = job_create (id, priority, userid, t_submit)))
             goto error;
         /* N.B. ignore EEXIST, in case restart_from_kvs() loaded a job
          * while its submit request was in still flight.

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -48,7 +48,7 @@ static struct job *job_create_uninit (flux_jobid_t id)
 }
 
 struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
-                        double t_submit, int flags)
+                        double t_submit)
 {
     struct job *job;
 
@@ -57,7 +57,6 @@ struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
     job->userid = userid;
     job->priority = priority;
     job->t_submit = t_submit;
-    job->flags = flags;
     job->state = FLUX_JOB_NEW;
     return job;
 }

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -73,6 +73,7 @@ struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
 
     if (!(job = job_create_uninit (id)))
         return NULL;
+    job->state = FLUX_JOB_SCHED;
     if (!(eventlog = flux_kvs_eventlog_decode (s)))
         goto error;
     event = flux_kvs_eventlog_first (eventlog);
@@ -104,6 +105,14 @@ struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
                 goto error;
             if (severity == 0)
                 job->state = FLUX_JOB_CLEANUP;
+        }
+        else if (!strcmp (name, "alloc")) {
+            job->has_resources = 1;
+            job->state = FLUX_JOB_RUN;
+        }
+        else if (!strcmp (name, "free")) {
+            job->has_resources = 0;
+            job->state = FLUX_JOB_CLEANUP;
         }
         event = flux_kvs_eventlog_next (eventlog);
     }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -22,6 +22,9 @@ struct job {
     flux_job_state_t state;
 
     uint8_t exception_pending:1;
+    uint8_t alloc_pending:1;
+    uint8_t free_pending:1;
+    uint8_t has_resources:1;
 
     void *aux_queue_handle;
     void *queue_handle; // primary queue handle (for listing all active jobs)

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -11,19 +11,17 @@
 #ifndef _FLUX_JOB_MANAGER_JOB_H
 #define _FLUX_JOB_MANAGER_JOB_H
 
+#include <stdint.h>
 #include "src/common/libjob/job.h"
-
-enum job_status_flags {
-    JOB_EXCEPTION_PENDING = 1,  // exception not yet commited to eventlog
-};
 
 struct job {
     flux_jobid_t id;
     uint32_t userid;
     int priority;
     double t_submit;
-    int flags;
     flux_job_state_t state;
+
+    uint8_t exception_pending:1;
 
     void *aux_queue_handle;
     void *queue_handle; // primary queue handle (for listing all active jobs)
@@ -36,8 +34,7 @@ struct job *job_incref (struct job *job);
 struct job *job_create (flux_jobid_t id,
                         int priority,
                         uint32_t userid,
-                        double t_submit,
-                        int flags);
+                        double t_submit);
 
 /* (re-)create job by replaying its KVS eventlog.
  */

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -25,7 +25,8 @@ struct job {
     int flags;
     flux_job_state_t state;
 
-    void *list_handle;  // private to queue.c
+    void *aux_queue_handle;
+    void *queue_handle; // primary queue handle (for listing all active jobs)
     int refcount;       // private to job.c
 };
 

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -95,7 +95,7 @@ static void priority_continuation (flux_future_t *f, void *arg)
         goto done;
     }
     p->job->priority = p->priority;
-    queue_reorder (p->queue, p->job);
+    queue_reorder (p->queue, p->job, p->job->queue_handle);
     if (flux_respond (h, p->request, 0, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 done:

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -146,13 +146,8 @@ void priority_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
-    /* If job has requested resources/exec, don't allow adjustment.
+    /* TODO: If job has requested resources/exec, don't allow adjustment.
      */
-    if (job->flags != 0) {
-        errstr = "it is too late to reprioritize this job";
-        errno = EPERM;
-        goto error;
-    }
     /* Log KVS event and set KVS priority key asynchronously.
      * Upon successful completion, insert job in new queue position and
      * send response.

--- a/src/modules/job-manager/queue.h
+++ b/src/modules/job-manager/queue.h
@@ -11,31 +11,35 @@
 #ifndef _FLUX_JOB_MANAGER_QUEUE_H
 #define _FLUX_JOB_MANAGER_QUEUE_H
 
+#include <stdbool.h>
 #include "src/common/libjob/job.h"
 #include "job.h"
 
-struct queue *queue_create (void);
+/* Create a job queue, sorted by priority, then t_submit.
+ * If lookup_hash=true, create a hash to speed up queue_lookup_by_id().
+ */
+struct queue *queue_create (bool lookup_hash);
 void queue_destroy (struct queue *queue);
 
 /* Insert job into queue.  The queue takes a reference on job,
  * so the caller retains its reference.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int queue_insert (struct queue *queue, struct job *job);
+int queue_insert (struct queue *queue, struct job *job, void **handle);
 
 /* Find new position in queue for job (e.g. after priority change).
  * Returns 0 on success, -1 on failure with errno set.
  */
-void queue_reorder (struct queue *queue, struct job *job);
+void queue_reorder (struct queue *queue, struct job *job, void *handle);
 
 /* Find a job by jobid.
- * Returns job on success, NULL on failure wtih errno set.
+ * Returns job on success, NULL on failure with errno set.
  */
 struct job *queue_lookup_by_id (struct queue *queue, flux_jobid_t id);
 
-/* Delete queue entry associated with 'job' (dropping its refence on job).
+/* Delete queue entry associated with 'job' (dropping its reference on job).
  */
-void queue_delete (struct queue *queue, struct job *job);
+void queue_delete (struct queue *queue, struct job *job, void *handle);
 
 /* deletion-safe iterator
  * Returns first/next job, or NULL on empty list or at end of list.

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -79,7 +79,7 @@ void raise_ctx_decref (struct raise_ctx *c)
 {
     if (c && --c->refcount == 0) {
         int saved_errno = errno;
-        c->job->flags &= ~JOB_EXCEPTION_PENDING;
+        c->job->exception_pending = 0;
         if (c->severity == 0)
             c->job->state = FLUX_JOB_CLEANUP;
         if (c->request) {
@@ -308,7 +308,7 @@ void raise_handle_request (flux_t *h, struct queue *queue,
     if (!(c = raise_ctx_create (h, queue, job, msg, userid,
                                 severity, type, note)))
         goto error;
-    job->flags |= JOB_EXCEPTION_PENDING;
+    job->exception_pending = 1;
     raise_eventlog (c);
     raise_publish (c);
     raise_ctx_decref (c);

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -53,6 +53,7 @@ struct raise_ctx {
     char *errstr;
 
     struct queue *queue;
+    struct alloc_ctx *alloc_ctx;
     int refcount;
 };
 
@@ -80,11 +81,17 @@ void raise_ctx_decref (struct raise_ctx *c)
     if (c && --c->refcount == 0) {
         int saved_errno = errno;
         c->job->exception_pending = 0;
-        if (c->severity == 0)
-            c->job->state = FLUX_JOB_CLEANUP;
         if (c->request) {
             raise_respond (c);
             flux_msg_destroy (c->request);
+        }
+        if (c->severity == 0) {
+            c->job->state = FLUX_JOB_CLEANUP;
+            if (alloc_do_request (c->alloc_ctx, c->job) < 0) {
+                flux_log_error (c->h,
+                    "%s: error notifying scheduler of job %llu cleanup",
+                    __FUNCTION__, (unsigned long long)c->job->id);
+            }
         }
         flux_kvs_txn_destroy (c->txn);
         free (c->note);
@@ -104,6 +111,7 @@ struct raise_ctx *raise_ctx_incref (struct raise_ctx *c)
 
 struct raise_ctx *raise_ctx_create (flux_t *h,
                                     struct queue *queue,
+                                    struct alloc_ctx *alloc_ctx,
                                     struct job *job,
                                     const flux_msg_t *request,
                                     uint32_t userid,
@@ -116,6 +124,7 @@ struct raise_ctx *raise_ctx_create (flux_t *h,
     if (!(c = calloc (1, sizeof (*c))))
         return NULL;
     c->queue = queue;
+    c->alloc_ctx = alloc_ctx;
     c->job = job;
     c->userid = userid;
     c->h = h;
@@ -256,6 +265,7 @@ int raise_allow (uint32_t rolemask, uint32_t userid, uint32_t job_userid)
 }
 
 void raise_handle_request (flux_t *h, struct queue *queue,
+                           struct alloc_ctx *alloc_ctx,
                            const flux_msg_t *msg)
 {
     uint32_t userid;
@@ -305,7 +315,7 @@ void raise_handle_request (flux_t *h, struct queue *queue,
      * When the last one completes, 'c' is destroyed and
      * the user receives a response to the job-manager.raise request.
      */
-    if (!(c = raise_ctx_create (h, queue, job, msg, userid,
+    if (!(c = raise_ctx_create (h, queue, alloc_ctx, job, msg, userid,
                                 severity, type, note)))
         goto error;
     job->exception_pending = 1;

--- a/src/modules/job-manager/raise.h
+++ b/src/modules/job-manager/raise.h
@@ -11,12 +11,14 @@
 #ifndef _FLUX_JOB_MANAGER_RAISE_H
 #define _FLUX_JOB_MANAGER_RAISE_H
 
-#include "queue.h"
 #include <stdint.h>
+#include "queue.h"
+#include "alloc.h"
 
 /* Hande a request to raise an exception on job.
  */
 void raise_handle_request (flux_t *h, struct queue *queue,
+                           struct alloc_ctx *ctx,
                            const flux_msg_t *msg);
 
 /* exposed for unit testing only */

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -1,0 +1,210 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/modules/job-manager/job.h"
+
+void test_create (void)
+{
+    struct job *job;
+
+    job = job_create (42, 1, FLUX_USERID_UNKNOWN, 2);
+    if (job == NULL)
+        BAIL_OUT ("job_create failed");
+    ok (job->refcount == 1,
+        "job_create set refcount to 1");
+    ok (job->id == 42 && job->priority == 1 && job->state == FLUX_JOB_NEW
+        && job->userid == FLUX_USERID_UNKNOWN && job->t_submit == 2,
+        "job_create set id, priority, userid, and t_submit to expected values");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && !job->has_resources
+        && !job->exception_pending,
+        "job_create set no internal flags");
+    ok (job->aux_queue_handle == NULL && job->queue_handle == NULL,
+        "job_Create set queue handles to NULL");
+    ok (job_incref (job) == job && job->refcount == 2,
+        "job_incref incremented refcount and returned original job pointer");
+    job_decref (job);
+    ok (job->refcount == 1,
+        "job_decref decremented refcount");
+    errno = 42;
+    job_decref (job);
+    ok (errno == 42,
+        "job_decref doesn't clobber errno");
+
+    lives_ok({job_incref (NULL);},
+        "job_incref on NULL pointer doesn't crash");
+    lives_ok({job_decref (NULL);},
+        "job_decref on NULL pointer doesn't crash");
+}
+
+const char *test_input[] = {
+    /* 0 */
+    "42.2 submit userid=66 priority=16\n",
+
+    /* 1 */
+    "42.2 submit userid=66 priority=16\n"
+    "42.3 priority userid=42 priority=1\n",
+
+    /* 2 */
+    "42.2 submit userid=66 priority=16\n"
+    "42.3 exception type=cancel severity=0 userid=42 free form notes...\n",
+
+    /* 3 */
+    "42.2 submit userid=66 priority=16\n"
+    "42.3 exception type=meep severity=1 userid=42 this one is non-fatal\n",
+
+    /* 4 */
+    "42.2 submit userid=66 priority=16\n"
+    "42.3 alloc\n",
+
+    /* 5 */
+    "42.3 alloc\n",
+
+    /* 6 */
+    "42.2 submit userid=66 priority=16\n"
+    "42.3 alloc\n"
+    "42.4 free\n",
+};
+
+void test_create_from_eventlog (void)
+{
+    struct job *job;
+
+    /* 0 - submit only */
+    job = job_create_from_eventlog (2, test_input[0]);
+    if (job == NULL)
+        BAIL_OUT ("job_create_from_eventlog log=(submit) failed");
+    ok (job->refcount == 1,
+        "job_create_from_eventlog log=(submit) set refcount to 1");
+    ok (job->id == 2,
+        "job_create_from_eventlog log=(submit) set id from param");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && !job->has_resources
+        && !job->exception_pending,
+        "job_create_from_eventlog log=(submit)  set no internal flags");
+    ok (job->userid == 66,
+        "job_create_from_eventlog log=(submit) set userid from submit");
+    ok (job->priority == 16,
+        "job_create_from_eventlog log=(submit) set priority from submit");
+    ok (job->t_submit == 42.2,
+        "job_create_from_eventlog log=(submit) set t_submit from submit");
+    ok (job->state == FLUX_JOB_SCHED,
+        "job_create_from_eventlog log=(submit) set state=SCHED");
+    job_decref (job);
+
+    /* 1 - submit + priority */
+    job = job_create_from_eventlog (3, test_input[1]);
+    if (job == NULL)
+        BAIL_OUT ("job_create_from_eventlog log=(submit+pri) failed");
+    ok (job->id == 3,
+        "job_create_from_eventlog log=(submit+pri) set id from param");
+    ok (job->userid == 66,
+        "job_create_from_eventlog log=(submit+pri) set userid from submit");
+    ok (job->priority == 1,
+        "job_create_from_eventlog log=(submit+pri) set priority from priority");
+    ok (job->t_submit == 42.2,
+        "job_create_from_eventlog log=(submit+pri) set t_submit from submit");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && !job->has_resources
+        && !job->exception_pending,
+        "job_create_from_eventlog log=(submit+pri) set no internal flags");
+    ok (job->state == FLUX_JOB_SCHED,
+        "job_create_from_eventlog log=(submit+pri) set state=SCHED");
+    job_decref (job);
+
+    /* 2 - submit + exception severity 0 */
+    job = job_create_from_eventlog (3, test_input[2]);
+    if (job == NULL)
+        BAIL_OUT ("job_create_from_eventlog log=(submit+ex0) failed");
+    ok (job->userid == 66,
+        "job_create_from_eventlog log=(submit+ex0) set userid from submit");
+    ok (job->priority == 16,
+        "job_create_from_eventlog log=(submit+ex0) set priority from submit");
+    ok (job->t_submit == 42.2,
+        "job_create_from_eventlog log=(submit+ex0) set t_submit from submit");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && !job->has_resources
+        && !job->exception_pending,
+        "job_create_from_eventlog log=(submit+ex0) set no internal flags");
+    ok (job->state == FLUX_JOB_CLEANUP,
+        "job_create_from_eventlog log=(submit+ex0) set state=CLEANUP");
+    job_decref (job);
+
+    /* 3 - submit + exception severity 1 */
+    job = job_create_from_eventlog (3, test_input[3]);
+    if (job == NULL)
+        BAIL_OUT ("job_create_from_eventlog log=(submit+ex1) failed");
+    ok (job->state == FLUX_JOB_SCHED,
+        "job_create_from_eventlog log=(submit+ex1) set state=SCHED");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && !job->has_resources
+        && !job->exception_pending,
+        "job_create_from_eventlog log=(submit+ex1) set no internal flags");
+    job_decref (job);
+
+    /* 4 - submit + alloc */
+    job = job_create_from_eventlog (3, test_input[4]);
+    if (job == NULL)
+        BAIL_OUT ("job_create_from_eventlog log=(submit+alloc) failed");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && job->has_resources
+        && !job->exception_pending,
+        "job_create_from_eventlog log=(submit+alloc) set has_resources flag");
+    ok (job->state == FLUX_JOB_RUN,
+        "job_create_from_eventlog log=(submit+alloc) set state=RUN");
+    job_decref (job);
+
+    /* 5 - missing submit */
+    errno = 0;
+    job = job_create_from_eventlog (3, test_input[5]);
+    ok (job == NULL && errno == EINVAL,
+        "job_create_from_eventlog log=(alloc) fails with EINVAL");
+
+    /* 6 - submit + alloc + free */
+    job = job_create_from_eventlog (3, test_input[6]);
+    if (job == NULL)
+        BAIL_OUT ("job_create_from_eventlog log=(submit+alloc+free) failed");
+    ok (!job->alloc_pending
+        && !job->free_pending
+        && !job->has_resources
+        && !job->exception_pending,
+        "job_create_from_eventlog log=(submit+alloc+free) set no internal flags");
+    ok (job->state == FLUX_JOB_CLEANUP,
+        "job_create_from_eventlog log=(submit+alloc+free) set state=CLEANUP");
+    job_decref (job);
+
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_create ();
+    test_create_from_eventlog ();
+
+    done_testing ();
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -24,7 +24,7 @@ struct queue *make_test_queue (int size)
     struct queue *q;
     flux_jobid_t id;
 
-    q = queue_create ();
+    q = queue_create (true);
     if (!q)
         BAIL_OUT ("could not create queue");
 
@@ -32,7 +32,7 @@ struct queue *make_test_queue (int size)
         struct job *j;
         if (!(j = job_create (id, 0, 0, 0, 0)))
             BAIL_OUT ("job_create failed");
-        if (queue_insert (q, j) < 0)
+        if (queue_insert (q, j, &j->queue_handle) < 0)
             BAIL_OUT ("queue_insert failed");
     }
     return q;

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -30,7 +30,7 @@ struct queue *make_test_queue (int size)
 
     for (id = 0; id < size; id++) {
         struct job *j;
-        if (!(j = job_create (id, 0, 0, 0, 0)))
+        if (!(j = job_create (id, 0, 0, 0)))
             BAIL_OUT ("job_create failed");
         if (queue_insert (q, j, &j->queue_handle) < 0)
             BAIL_OUT ("queue_insert failed");

--- a/src/modules/job-manager/test/queue.c
+++ b/src/modules/job-manager/test/queue.c
@@ -18,7 +18,7 @@
 struct job *job_create_test (flux_jobid_t id, int priority)
 {
     struct job *j;
-    if (!(j = job_create (id, priority, 1, 0, 0)))
+    if (!(j = job_create (id, priority, 1, 0)))
         BAIL_OUT ("job_create failed");
     return j;
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -236,7 +236,8 @@ check_LTLIBRARIES = \
 	module/parent.la \
 	module/child.la \
 	request/req.la \
-	ingest/job-manager-dummy.la
+	ingest/job-manager-dummy.la \
+	job-manager/sched-dummy.la
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -433,3 +434,10 @@ ingest_submitbench_SOURCES = ingest/submitbench.c
 ingest_submitbench_CPPFLAGS = $(test_cppflags)
 ingest_submitbench_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+job_manager_sched_dummy_la_SOURCES = job-manager/sched-dummy.c
+job_manager_sched_dummy_la_CPPFLAGS = $(test_cppflags)
+job_manager_sched_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
+job_manager_sched_dummy_la_LIBADD = \
+        $(top_builddir)/src/common/libschedutil/libschedutil.la \
+        $(test_ldadd) $(LIBDL) $(LIBUTIL)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -83,6 +83,7 @@ TESTS = \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
+	t2203-job-manager-dummysched.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \
@@ -174,6 +175,7 @@ check_SCRIPTS = \
 	t2200-job-ingest.t \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
+	t2203-job-manager-dummysched.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -1,0 +1,296 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Simple scheduler for testing:
+ * - presume that each job is requesting one core
+ * - track core counts, not specific core id's
+ * - mode=single
+ *
+ * Command line usage:
+ *   flux module load sched-dummy [--cores=N]
+ * Options
+ *   --cores=N      specifies the total number of cores available (default 16)
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+#include <czmq.h>
+#include "src/common/liboptparse/optparse.h"
+#include "src/common/libschedutil/schedutil.h"
+
+// flux module debug --setbit 0x1 sched-dummy
+// flux module debug --clearbit 0x1 sched-dummy
+enum module_debug_flags {
+    DEBUG_FAIL_ALLOC = 1, // while set, alloc requests fail
+};
+
+struct job {
+    flux_msg_t *msg;
+    flux_jobid_t id;
+    int priority;
+    uint32_t userid;
+    double t_submit;
+    char *jobspec;
+};
+
+struct sched_ctx {
+    flux_t *h;
+    struct ops_context *sched_ops;
+    optparse_t *opt;
+    struct job *job; // backlog of 1 alloc request
+    int cores_total;
+    int cores_free;
+    flux_watcher_t *prep;
+};
+
+static void job_destroy (struct job *job)
+{
+    if (job) {
+        int saved_errno = errno;
+        free (job->jobspec);
+        flux_msg_destroy (job->msg);
+        free (job);
+        errno = saved_errno;
+    }
+}
+
+/* Create job struct from sched.alloc request.
+ */
+static struct job *job_create (const flux_msg_t *msg, const char *jobspec)
+{
+    struct job *job;
+
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    if (schedutil_alloc_request_decode (msg, &job->id, &job->priority,
+                                        &job->userid, &job->t_submit) < 0)
+        goto error;
+    if (!(job->jobspec = strdup (jobspec)))
+        goto error;
+    if (!(job->msg = flux_msg_copy (msg, true)))
+        goto error;
+    return job;
+error:
+    job_destroy (job);
+    return NULL;
+}
+
+static bool test_debug_flag (flux_t *h, int mask)
+{
+    int *debug_flags = flux_aux_get (h, "flux::debug_flags");
+
+    if (debug_flags && (*debug_flags & mask))
+        return true;
+    return false;
+}
+
+void try_alloc (struct sched_ctx *sc)
+{
+    if (sc->job) {
+        if (test_debug_flag (sc->h, DEBUG_FAIL_ALLOC)) {
+            if (schedutil_alloc_respond_denied (sc->h, sc->job->msg,
+                                                "DEBUG_FAIL_ALLOC") < 0)
+                flux_log_error (sc->h, "schedutil_alloc_respond_denied");
+            goto done;
+        }
+        if (sc->cores_free > 0) {
+            if (schedutil_alloc_respond_R (sc->h, sc->job->msg,
+                                           "1core", NULL) < 0)
+                flux_log_error (sc->h, "schedutil_alloc_respond_R");
+            sc->cores_free--;
+            goto done;
+        }
+        if (schedutil_alloc_respond_note (sc->h, sc->job->msg,
+                                          "no cores available") < 0)
+            flux_log_error (sc->h, "schedutil_alloc_respond_note");
+    }
+    return;
+done:
+    job_destroy (sc->job);
+    sc->job = NULL;
+}
+
+void exception_cb (flux_t *h, flux_jobid_t id,
+                   const char *type, int severity, void *arg)
+{
+    struct sched_ctx *sc = arg;
+    char note[80];
+
+    if (severity > 0 || sc->job == NULL || sc->job->id != id)
+        return;
+    (void)snprintf (note, sizeof(note),
+                    "alloc aborted due to exception type=%s", type);
+    if (schedutil_alloc_respond_denied (h, sc->job->msg, note) < 0)
+        flux_log_error (h, "%s: alloc_respond_denied", __FUNCTION__);
+    job_destroy (sc->job);
+    sc->job = NULL;
+}
+
+void free_cb (flux_t *h, const flux_msg_t *msg, const char *R, void *arg)
+{
+    struct sched_ctx *sc = arg;
+    flux_jobid_t id;
+
+    if (schedutil_free_request_decode (msg, &id) < 0)
+        goto error;
+    flux_log (h, LOG_DEBUG, "free: id=%llu R=%s",
+              (unsigned long long)id, R);
+    sc->cores_free++;
+    if (schedutil_free_respond (h, msg) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    try_alloc (sc);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+void alloc_cb (flux_t *h, const flux_msg_t *msg,
+               const char *jobspec, void *arg)
+{
+    struct sched_ctx *sc = arg;
+    struct job *job;
+
+    if (!(job = job_create (msg, jobspec))) {
+        flux_log_error (h, "%s: job_create", __FUNCTION__);
+        goto error;
+    }
+    if (sc->job) {
+        flux_log_error (h, "alloc received before previous one handled");
+        goto error;
+    }
+    sc->job = job;
+    flux_log (h, LOG_DEBUG, "alloc: id=%llu jobspec=%s",
+              (unsigned long long)job->id, job->jobspec);
+    try_alloc (sc);
+    return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+int hello_cb (flux_t *h, const char *R, void *arg)
+{
+    struct sched_ctx *sc = arg;
+
+    flux_log (h, LOG_DEBUG, "%s: R=%s", __FUNCTION__, R);
+    sc->cores_free--;
+    return 0;
+}
+
+static struct optparse_option dummy_opts[] = {
+    {   .name = "cores",
+        .has_arg = 1,
+        .flags = 0,
+        .arginfo = "COUNT",
+        .usage = "Core count (default 16)",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+/* N.B. module argv[0] is first argument, not module name.
+ */
+optparse_t *options_parse (int argc, char **argv)
+{
+    optparse_t *opt;
+    if (!(opt = optparse_create ("sched-dummy"))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (optparse_add_option_table (opt, dummy_opts) != OPTPARSE_SUCCESS)
+        goto error;
+    if (optparse_parse_args (opt,  argc + 1, argv - 1) < 0)
+        goto error;
+    return opt;
+error:
+    optparse_destroy (opt);
+    errno = EINVAL;
+    return NULL;
+}
+
+void sched_destroy (struct sched_ctx *sc)
+{
+    if (sc) {
+        int saved_errno = errno;
+        schedutil_ops_unregister (sc->sched_ops);
+        optparse_destroy (sc->opt);
+        if (sc->job) {
+            /* Causes job-manager to pause scheduler interface.
+             */
+            if (flux_respond_error (sc->h, sc->job->msg, ENOSYS,
+                                    "scheduler unloading") < 0)
+                flux_log_error (sc->h, "flux_respond_error");
+            job_destroy (sc->job);
+        }
+        free (sc);
+        errno = saved_errno;
+    }
+}
+
+struct sched_ctx *sched_create (flux_t *h, int argc, char **argv)
+{
+    struct sched_ctx *sc;
+
+    if (!(sc = calloc (1, sizeof (*sc))))
+        return NULL;
+    sc->h = h;
+    if (!(sc->sched_ops = schedutil_ops_register (h,
+                                                  alloc_cb,
+                                                  free_cb,
+                                                  exception_cb,
+                                                  sc))) {
+        flux_log_error (h, "schedutil_ops_register");
+        goto error;
+    }
+    if (!(sc->opt = options_parse (argc, argv))) {
+        errno = EINVAL;
+        goto error;
+    }
+    sc->cores_total = optparse_get_int (sc->opt, "cores", 16);
+    sc->cores_free = sc->cores_total;
+    return sc;
+error:
+    sched_destroy (sc);
+    return NULL;
+}
+
+int mod_main (flux_t *h, int argc, char *argv[])
+{
+    int rc = -1;
+    struct sched_ctx *sc;
+    int count;
+
+    if (!(sc = sched_create (h, argc, argv)))
+        return -1;
+    flux_log (h, LOG_DEBUG, "res pool is %d cores", sc->cores_total);
+    if (schedutil_hello (h, hello_cb, sc) < 0) {
+        flux_log_error (h, "schedutil_hello");
+        goto done;
+    }
+    if (schedutil_ready (h, "single", &count) < 0) {
+        flux_log_error (h, "schedutil_ready");
+        goto done;
+    }
+    flux_log (sc->h, LOG_DEBUG, "ready: count=%d", count);
+
+    if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
+        flux_log_error (h, "flux_reactor_run");
+done:
+    sched_destroy (sc);
+    return rc;
+}
+MOD_NAME ("sched-dummy");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -4,16 +4,9 @@ test_description='Test flux job command'
 
 . $(dirname $0)/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 if flux job submit --help 2>&1 | grep -q sign-type; then
     test_set_prereq HAVE_FLUX_SECURITY
 fi
-
-JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
-Y2J=${JOBSPEC}/y2j.py
 
 # 2^64 - 1
 MAXJOBID_DEC=18446744073709551615
@@ -28,8 +21,8 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
-test_expect_success 'flux-job: convert basic.yaml to JSON' '
-	${Y2J} <${JOBSPEC}/valid/basic.yaml >basic.json
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
 '
 
 test_expect_success 'flux-job: submit one job to get one valid job in queue' '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -4,19 +4,9 @@ test_description='Test flux job manager service'
 
 . $(dirname $0)/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-if flux job submit --help 2>&1 | grep -q sign-type; then
-    test_set_prereq HAVE_FLUX_SECURITY
-fi
-
 test_under_flux 4 kvs
 
 flux setattr log-stderr-level 1
-
-JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
-Y2J=${JOBSPEC}/y2j.py
 
 # List jobs without header
 # N.B. cancellation only advances job to CLEANUP state at the moment
@@ -25,8 +15,8 @@ list_jobs() {
 	flux job list -s | awk '$2 != "C"'
 }
 
-test_expect_success 'flux-job: convert basic.yaml to JSON' '
-        ${Y2J} <${JOBSPEC}/valid/basic.yaml >basic.json
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
 '
 
 test_expect_success 'job-manager: load job-ingest, job-manager' '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -49,7 +49,7 @@ test_expect_success 'job-manager: queue lists job with correct jobid' '
 '
 
 test_expect_success 'job-manager: queue lists job with state=N' '
-	echo "N" >list1_state.exp &&
+	echo "S" >list1_state.exp &&
 	cut -f2 <list1.out >list1_state.out &&
 	test_cmp list1_state.exp list1_state.out
 '

--- a/t/t2203-job-manager-dummysched.t
+++ b/t/t2203-job-manager-dummysched.t
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+test_description='Test flux job manager service with dummy scheduler'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+get_state() {
+	local id=$1
+	flux job list -s | awk '$1 == "'${id}'" { print $2; }'
+}
+check_state() {
+	local id=$1
+	local wantstate=$2
+	for try in $(seq 1 10); do
+		test $(get_state $id) = $wantstate && return 0
+	done
+	return 1
+}
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+	flux module load -r all job-ingest &&
+	flux module load -r 0 job-manager
+'
+
+test_expect_success 'job-manager: submit 5 jobs' '
+	flux job submit basic.json >job1.id &&
+	flux job submit basic.json >job2.id &&
+	flux job submit basic.json >job3.id &&
+	flux job submit basic.json >job4.id &&
+	flux job submit basic.json >job5.id
+'
+
+test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
+	check_state $(cat job1.id) S &&
+	check_state $(cat job2.id) S &&
+	check_state $(cat job3.id) S &&
+	check_state $(cat job4.id) S &&
+	check_state $(cat job5.id) S
+
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=2' '
+	flux module load -r 0 ${SCHED_DUMMY} --cores=2
+'
+
+test_expect_success 'job-manager: job state RRSSS' '
+	check_state $(cat job1.id) R &&
+	check_state $(cat job2.id) R &&
+	check_state $(cat job3.id) S &&
+	check_state $(cat job4.id) S &&
+	check_state $(cat job5.id) S
+'
+
+test_expect_success 'job-manager: running job has alloc event' '
+	kvsdir=$(flux job id --to=kvs-active $(cat job1.id)) &&
+	flux kvs eventlog get ${kvsdir}.eventlog | grep alloc
+'
+
+test_expect_success 'job-manager: cancel 2' '
+	flux job cancel $(cat job2.id)
+'
+
+test_expect_success 'job-manager: job state RCRSS' '
+	check_state $(cat job1.id) R &&
+	check_state $(cat job2.id) C &&
+	check_state $(cat job3.id) R &&
+	check_state $(cat job4.id) S &&
+	check_state $(cat job5.id) S
+'
+
+test_expect_success 'job-manager: canceled job has exception, free events' '
+	kvsdir=$(flux job id --to=kvs-active $(cat job2.id)) &&
+	flux kvs eventlog get ${kvsdir}.eventlog >eventlog.out &&
+	grep -q exception eventlog.out &&
+	grep -q free eventlog.out
+'
+
+test_expect_success 'job-manager: reload sched-dummy --cores=4' '
+	flux module remove -r 0 sched-dummy &&
+	flux module load -r 0 ${SCHED_DUMMY} --cores=4
+'
+
+test_expect_success 'job-manager: job state RCRRR' '
+	check_state $(cat job1.id) R &&
+	check_state $(cat job2.id) C &&
+	check_state $(cat job3.id) R &&
+	check_state $(cat job4.id) R &&
+	check_state $(cat job5.id) R
+'
+
+test_expect_success 'job-manager: cancel 1' '
+	flux job cancel $(cat job1.id)
+'
+
+test_expect_success 'job-manager: job state CCRRR' '
+	check_state $(cat job1.id) C &&
+	check_state $(cat job2.id) C &&
+	check_state $(cat job3.id) R &&
+	check_state $(cat job4.id) R &&
+	check_state $(cat job5.id) R
+'
+
+test_expect_success 'job-manager: cancel all jobs' '
+	flux job cancel $(cat job3.id) &&
+	flux job cancel $(cat job4.id) &&
+	flux job cancel $(cat job5.id)
+'
+
+test_expect_success 'job-manager: job state CCCCC' '
+	check_state $(cat job1.id) C &&
+	check_state $(cat job2.id) C &&
+	check_state $(cat job3.id) C &&
+	check_state $(cat job4.id) C &&
+	check_state $(cat job5.id) C
+'
+
+test_expect_success 'job-manager: simulate alloc failure' '
+	flux module debug --setbit 0x1 sched-dummy &&
+	flux job submit basic.json >job6.id &&
+	check_state $(cat job6.id) C &&
+	kvsdir=$(flux job id --to=kvs-active $(cat job6.id)) &&
+	flux kvs eventlog get ${kvsdir}.eventlog | grep exception >ex.out &&
+	grep -q type=alloc ex.out &&
+	grep -q severity=0 ex.out &&
+	grep -q DEBUG_FAIL_ALLOC ex.out
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+	flux module remove -r 0 sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-manager, job-ingest' '
+	flux module remove -r 0 job-manager &&
+	flux module remove -r all job-ingest
+'
+
+test_done


### PR DESCRIPTION
This is pretty rough, but it adds a scheduler interface to the job manager, a `sched-dummy` test scheduler, and a basic sharness test.

Jobs transition immediately to SCHED state upon being submitted.  If a scheduler is loaded, the job manager sends `alloc` requests to the scheduler for each job.  (The maximum number of concurrent outstanding `alloc` requests is regulated by the negotiated scheduler interface mode - current choices are _single_ and _unlimited_)

Once an `alloc` request is fulfilled, an `alloc` event is logged to the job eventlog and the job transitions to RUN state.  The only way out of this currently is cancellation, which triggers a `free` request to be sent to the scheduler.

When the scheduler is loaded, it executes a two-phase startup.  It first sends an (empty) `hello` request to the job manager.  The job manager responds with an array of job id's that are currently holding resources.  The scheduler must mark these as allocated in its internal bookkeeping system.   The scheduler then sends a `ready` request, requesting an interface mode.  The job manager responds with the number of jobs that are queued up to send alloc requests.

After this handshake, the scheduler can expect to receive `alloc` and `free` requests for resources from the job manager.  These RPCs have one oddity - to improve throughput, they do not carry unique matchtags, but instead include the jobid in the response so that the job manager can match them to requests.  This means a normal error response cannot be mapped to a specific job, so an alloc failure is encoded within a "success" response.  If a regular RPC error is returned for any reason, this will cause the job manager to assume something is really wrong and abort its  "session" with the scheduler.  It works out that if the scheduler is not loaded (e.g. if it was unloaded on a live system), then the ENOSYS response returned automatically to sched requests has the effect of aborting the scheduler session.

The job manager does not pass a _jobpec_ to the scheduler in an `alloc` request.  Instead it passes a job id, and the scheduler fetches the jobspec from the expected KVS location per RFC 18.  Also, the scheduler does not pass _R_ to the job manager in an `alloc` response.  Instead it commits _R_ to the KVS, and returns the jobid to the job manager.   Thus far the job manager does not directly consume either of those.