### PR TITLE
doc: clean up idset_create(3) man page

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -179,7 +179,12 @@ MAN3_FILES_SECONDARY = \
 	flux_core_version_string.3 \
 	idset_destroy.3 \
 	idset_encode.3 \
-	idset_decode.3
+	idset_decode.3 \
+	idset_set.3 \
+	idset_clear.3 \
+	idset_first.3 \
+	idset_next.3 \
+	idset_count.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -315,6 +320,11 @@ flux_core_version_string.3: flux_core_version.3
 idset_destroy.3: idset_create.3
 idset_encode.3: idset_create.3
 idset_decode.3: idset_create.3
+idset_set.3: idset_create.3
+idset_clear.3: idset_create.3
+idset_first.3: idset_create.3
+idset_next.3: idset_create.3
+idset_count.3: idset_create.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -5,20 +5,43 @@ idset_create(3)
 
 NAME
 ----
-idset_create, idset_destroy, idset_encode, idset_decode - Manipulate numerically sorted sets of non-negative integers
+idset_create, idset_destroy, idset_encode, idset_decode, idset_set, idset_clear, idset_first, idset_next, idset_count - Manipulate numerically sorted sets of non-negative integers
 
 
 SYNOPSIS
 --------
-#include <flux/idset.h>
+ #include <flux/idset.h>
 
-struct idset *idset_create (size_t slots, int flags);
+ struct idset *idset_create (size_t slots, int flags);
 
-void idset_destroy (struct idset *idset);
+ void idset_destroy (struct idset *idset);
 
-char *idset_encode (const struct idset *idset, int flags);
+ struct idset *idset_copy (const struct idset *idset);
 
-struct idset *idset_decode (const char *s);
+ struct idset *idset_decode (const char *s);
+
+ char *idset_encode (const struct idset *idset, int flags);
+
+ int idset_set (struct idset *idset, unsigned int id);
+
+ int idset_range_set (struct idset *idset,
+                      unsigned int lo, unsigned int hi);
+
+ int idset_clear (struct idset *idset, unsigned int id);
+
+ int idset_range_clear (struct idset *idset,
+                        unsigned int lo, unsigned int hi)
+
+ bool idset_test (const struct idset *idset, unsigned int id);
+
+ unsigned int idset_first (const struct idset *idset);
+
+ unsigned int idset_next (const struct idset *idset, unsigned int prev);
+
+ unsigned int idset_last (const struct idset *idset)
+
+ size_t idset_count (const struct idset *idset);
+
 
 USAGE
 -----
@@ -41,6 +64,8 @@ numbered 'id' it can hold, plus one.  The size is fixed unless
 
 `idset_destroy()` destroys an idset.
 
+`idset_copy()` copies an idset.
+
 `idset_decode ()` creates an idset from a string 's'.  The string may
 have been produced by `idset_encode()`.  It must consist of comma-separated
 non-negative integer ids, and may also contain hyphenated ranges.
@@ -58,6 +83,21 @@ of valid input strings are:
 `idset_encode()` creates a string from 'idset'.  The string contains
 a comma-separated list of ids, potentially modified by 'flags'
 (see FLAGS below).
+
+`idset_set()` and `idset_clear()` set or clear 'id'.
+
+`idset_range_set()` and `idset_range_clear()` set or clear an inclusive
+range of ids, from 'lo' to 'hi'.
+
+`idset_test()` returns true if 'id' is set, false if not.
+
+`idset_first()` and `idset_next()` can be used to iterate over ids
+in the set, returning IDSET_INVALID_ID at the end.  `idset_last()`
+returns the last (highest) id, or IDSET_INVALID_ID if the set is
+empty.
+
+`idset_count()` returns the number of ids in the set.
+
 
 FLAGS
 -----
@@ -81,12 +121,17 @@ compressed into hyphenated ranges in the encoded string.
 RETURN VALUE
 ------------
 
-`idset_create()` and `idset_encode()` return an idset on success
-which must be freed with `idset_destroy()`.  On error, NULL is
-returned with errno set.
+`idset_create()`, `idset_encode()`, and `idset_copy()` return an
+idset on success which must be freed with `idset_destroy()`.
+On error, NULL is returned with errno set.
 
 `idset_decode()` returns a string on success which must be freed
 with `free()`.  On error, NULL is returned with errno set.
+
+`idset_first()`, `idset_next()`, and `idset_last()` return an id,
+or IDSET_INVALID_ID if no id is available.
+
+Other functions return 0 on success, or -1 on error with errno set.
 
 ERRORS
 ------

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -115,5 +115,5 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
-flux-dmesg(1), flux-logger(1),
-https://tools.ietf.org/html/rfc5424[RFC 5424 The Syslog Protocol]
+
+https://github.com/flux-framework/rfc/blob/master/spec_22.adoc[RFC 22: Idset String Representation]

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -43,7 +43,7 @@ numbered 'id' it can hold, plus one.  The size is fixed unless
 
 `idset_decode ()` creates an idset from a string 's'.  The string may
 have been produced by `idset_encode()`.  It must consist of comma-separated
-non-negative integer id's, and may also contain hyphenated ranges.
+non-negative integer ids, and may also contain hyphenated ranges.
 If enclosed in square brackets, the brackets are ignored.  Some examples
 of valid input strings are:
 
@@ -56,7 +56,7 @@ of valid input strings are:
   [99-101]
 
 `idset_encode()` creates a string from 'idset'.  The string contains
-a comma-separated list of id's, potentially modified by 'flags'
+a comma-separated list of ids, potentially modified by 'flags'
 (see FLAGS below).
 
 FLAGS
@@ -66,7 +66,7 @@ IDSET_FLAG_AUTOGROW::
 Valid for `idset_create()` only.  If set, the idset will grow to
 accommodate any id inserted into it. The internal vEB tree is doubled
 in size until until the new id can be inserted.  Resizing is a costly
-operation that requires all id's in the old tree to be inserted into
+operation that requires all ids in the old tree to be inserted into
 the new one.
 
 IDSET_FLAG_BRACKETS::
@@ -75,7 +75,7 @@ enclosed in brackets, unless the idset is a singleton (contains only
 one id).
 
 IDSET_FLAG_RANGE::
-Valid for `idset_encode()` only.  If set, any consecutive id's are
+Valid for `idset_encode()` only.  If set, any consecutive ids are
 compressed into hyphenated ranges in the encoded string.
 
 RETURN VALUE


### PR DESCRIPTION
Add a reference to the freshly minted RFC 22, fill in missing functions, and fix punctuation error.