### PR TITLE
add simple fcfs node and core scheduler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       name: 'python lint'
       language: 'python'
       python: '3.6'
-      install: pip install --upgrade pylint
+      install: pip install 'pylint==2.2.2' --force-reinstall
       script: pylint --rcfile=src/bindings/python/.pylintrc src/bindings/python/flux
       before_deploy: skip
       deploy: skip

--- a/configure.ac
+++ b/configure.ac
@@ -419,6 +419,7 @@ AC_CONFIG_FILES( \
   src/modules/userdb/Makefile \
   src/modules/job-ingest/Makefile \
   src/modules/job-manager/Makefile \
+  src/modules/sched-simple/Makefile \
   src/test/Makefile \
   etc/Makefile \
   etc/flux-core.pc \

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -9,4 +9,5 @@ SUBDIRS = \
  userdb \
  pymod \
  job-ingest \
- job-manager
+ job-manager \
+ sched-simple

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -306,7 +306,12 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     job->has_resources = 1;
 
     eventlog_append (ctx, job, "alloc", note);
-    job->state = FLUX_JOB_RUN;
+    if (job->state == FLUX_JOB_SCHED)
+        job->state = FLUX_JOB_RUN;
+    else { /* state == FLUX_JOB_CLEANUP */
+        if (free_request (ctx, job) < 0)
+            goto teardown;
+    }
     return;
 teardown:
     interface_teardown (ctx, "alloc response error", errno);

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -17,6 +17,9 @@ fluxmod_LTLIBRARIES = \
 noinst_LTLIBRARIES = \
 	libjj.la
 
+noinst_PROGRAMS = \
+	rlist-query
+
 libjj_la_SOURCES = \
 	libjj.h \
 	libjj.c
@@ -55,7 +58,8 @@ TESTS = \
 	test_rlist.t
 
 check_PROGRAMS = \
-	$(TESTS)
+	$(TESTS) \
+	rlist-query
 
 test_rnode_t_SOURCES = \
 	rnode.c \
@@ -77,3 +81,15 @@ test_rlist_t_CPPFLAGS = \
 test_rlist_t_LDADD = \
 	$(test_ldadd)
 
+rlist_query_SOURCES = \
+	rnode.c \
+	rnode.h \
+	rlist.c \
+	rlist.h \
+	test/rlist-query.c
+rlist_query_CPPFLAGS = \
+	$(test_cppflags)
+rlist_query_LDADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -1,0 +1,19 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+
+noinst_LTLIBRARIES = \
+	libjj.la
+
+libjj_la_SOURCES = \
+	libjj.h \
+	libjj.c

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -17,3 +17,41 @@ noinst_LTLIBRARIES = \
 libjj_la_SOURCES = \
 	libjj.h \
 	libjj.c
+
+
+test_ldadd = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)
+
+test_cppflags = \
+	$(AM_CPPFLAGS)
+
+TESTS = \
+	test_rnode.t \
+	test_rlist.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+test_rnode_t_SOURCES = \
+	rnode.c \
+	rnode.h \
+	test/rnode.c
+test_rnode_t_CPPFLAGS = \
+	$(test_cppflags)
+test_rnode_t_LDADD = \
+	$(test_ldadd)
+
+test_rlist_t_SOURCES = \
+	rnode.c \
+	rnode.h \
+	rlist.c \
+	rlist.h \
+	test/rlist.c
+test_rlist_t_CPPFLAGS = \
+	$(test_cppflags)
+test_rlist_t_LDADD = \
+	$(test_ldadd)
+

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -11,6 +11,9 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
 
+fluxmod_LTLIBRARIES = \
+	sched-simple.la
+
 noinst_LTLIBRARIES = \
 	libjj.la
 
@@ -18,6 +21,25 @@ libjj_la_SOURCES = \
 	libjj.h \
 	libjj.c
 
+sched_simple_la_SOURCES = \
+	sched.c \
+	rnode.c \
+	rnode.h \
+	rlist.c \
+	rlist.h
+
+sched_simple_la_LDFLAGS = \
+	$(fluxmod_ldflags) \
+	-module
+
+sched_simple_la_LIBADD = \
+	$(fluxmod_ldadd) \
+	libjj.la \
+	$(top_builddir)/src/common/libschedutil/libschedutil.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS)
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \

--- a/src/modules/sched-simple/libjj.c
+++ b/src/modules/sched-simple/libjj.c
@@ -1,0 +1,123 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "libjj.h"
+
+static int jj_read_level (json_t *o, int level, struct jj_counts *jj)
+{
+    int count;
+    const char *type = NULL;
+    json_t *with = NULL;
+    json_error_t error;
+
+    /* Only one item per level allowed */
+    if (json_unpack_ex (o, &error, 0, "[{s:s,s:i,s?o}]",
+                       "type", &type,
+                       "count", &count,
+                       "with", &with) < 0) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                  "level %d: %s", level, error.text);
+        errno = EINVAL;
+        return -1;
+    }
+    if (count <= 0) {
+        sprintf (jj->error, "Invalid count %d for type '%s'",
+                            count, type);
+        errno = EINVAL;
+        return -1;
+    }
+    if (strcmp (type, "node") == 0)
+        jj->nnodes = count;
+    else if (strcmp (type, "slot") == 0)
+        jj->nslots = count;
+    else if (strcmp (type, "core") == 0)
+        jj->slot_size = count;
+    else {
+        sprintf (jj->error, "Invalid type '%s'", type);
+        errno = EINVAL;
+        return -1;
+    }
+    if (with)
+        return jj_read_level (with, level+1, jj);
+    return 0;
+}
+
+int libjj_get_counts (const char *spec, struct jj_counts *jj)
+{
+    int saved_errno;
+    int rc = -1;
+    int version;
+    json_t *resources = NULL;
+    json_t *o = NULL;
+    json_error_t error;
+
+    if (!jj) {
+        errno = EINVAL;
+        return -1;
+    }
+    memset (jj, 0, sizeof (*jj));
+
+    if ((o = json_loads (spec, 0, &error)) == NULL) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                  "JSON load: %s", error.text);
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (json_unpack_ex (o, &error, 0, "{s:i,s:o}",
+                        "version", &version,
+                        "resources", &resources) < 0) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                  "at top level: %s", error.text);
+        errno = EINVAL;
+        goto err;
+    }
+    if (version != 1) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                 "Invalid version: expected 1, got %d", version);
+        errno = EINVAL;
+        goto err;
+    }
+    if (jj_read_level (resources, 0, jj) < 0)
+        goto err;
+
+    if (jj->nslots <= 0) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                 "Unable to determine slot count");
+        errno = EINVAL;
+        goto err;
+    }
+    if (jj->slot_size <= 0) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                 "Unable to determine slot size");
+        errno = EINVAL;
+        goto err;
+    }
+    if (jj->nnodes)
+        jj->nslots *= jj->nnodes;
+    rc = 0;
+err:
+    saved_errno = errno;
+    json_decref (o);
+    errno = saved_errno;
+    return rc;
+}
+                       
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/sched-simple/libjj.h
+++ b/src/modules/sched-simple/libjj.h
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_SCHED_LIBJJ_H
+#define HAVE_SCHED_LIBJJ_H 1
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#define JJ_ERROR_TEXT_LENGTH 256
+
+struct jj_counts {
+    int nnodes;    /* total number of nodes requested */
+    int nslots;    /* total number of slots requested */
+    int slot_size; /* number of cores per slot        */
+
+    char error[JJ_ERROR_TEXT_LENGTH]; /* On error, contains error description */
+};
+
+/*  Parse jobspec from json string `spec`, return resource request summary
+ *   in `counts` on success.
+ *  Returns 0 on success and -1 on failure with errno set and jj->error[]
+ *   with an error message string.
+ */
+int libjj_get_counts (const char *spec, struct jj_counts *counts);
+
+#endif /* !HAVE_SCHED_LIBJJ_H */

--- a/src/modules/sched-simple/rlist.c
+++ b/src/modules/sched-simple/rlist.c
@@ -1,0 +1,867 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <czmq.h>
+#include <jansson.h>
+
+#include "src/common/libidset/idset.h"
+#include "rnode.h"
+#include "rlist.h"
+#include "libjj.h"
+
+void rlist_destroy (struct rlist *rl)
+{
+    if (rl) {
+        zlistx_destroy (&rl->nodes);
+        free (rl);
+    }
+}
+
+static void rn_free_fn (void **x)
+{
+    rnode_destroy (*(struct rnode **)x);
+    *x = NULL;
+}
+
+struct rlist *rlist_create (void)
+{
+    struct rlist *rl = calloc (1, sizeof (*rl));
+    if (!(rl->nodes = zlistx_new ()))
+        goto err;
+    zlistx_set_destructor (rl->nodes, rn_free_fn);
+    return (rl);
+err:
+    rlist_destroy (rl);
+    return (NULL);
+}
+
+struct rlist *rlist_copy_empty (const struct rlist *orig)
+{
+    struct rnode *n;
+    struct rlist *rl = rlist_create ();
+    if (!rl)
+        return NULL;
+    n = zlistx_first (orig->nodes);
+    while (n) {
+        n = rnode_create_idset (n->rank, n->ids);
+        if (!n || !zlistx_add_end (rl->nodes, n))
+            goto fail;
+        rl->total += rnode_count (n);
+        n = zlistx_next (orig->nodes);
+    }
+    rl->avail = rl->total;
+    return rl;
+fail:
+    rlist_destroy (rl);
+    return NULL;
+}
+
+
+static struct rnode *rlist_find_rank (struct rlist *rl, uint32_t rank)
+{
+    struct rnode *n = zlistx_first (rl->nodes);
+    while (n) {
+        if (n->rank == rank)
+            return (n);
+        n = zlistx_next (rl->nodes);
+    }
+    return NULL;
+}
+
+static int idset_cmp (struct idset *set1, struct idset *set2)
+{
+    int rc;
+    if ((rc = idset_count (set1) - idset_count (set2)) == 0) {
+        char *x = idset_encode (set1, IDSET_FLAG_RANGE);
+        char *y = idset_encode (set2, IDSET_FLAG_RANGE);
+        rc = strcmp (x, y);
+        free (x);
+        free (y);
+    }
+    return rc;
+}
+
+static int idset_add_set (struct idset *set, struct idset *new)
+{
+    unsigned int i = idset_first (new);
+    while (i != IDSET_INVALID_ID) {
+        if (idset_test (set, i)) {
+            errno = EEXIST;
+            return -1;
+        }
+        if (idset_set (set, i) < 0)
+            return -1;
+        i = idset_next (new, i);
+    }
+    return 0;
+}
+
+static int idset_remove_set (struct idset *set, struct idset *remove)
+{
+    unsigned int i = idset_first (remove);
+    while (i != IDSET_INVALID_ID) {
+        if (!idset_test (set, i)) {
+            errno = ENOENT;
+            return -1;
+        }
+        if (idset_clear (set, i) < 0)
+            return -1;
+        i = idset_next (remove, i);
+    }
+    return 0;
+}
+
+static int rlist_add_rnode (struct rlist *rl, struct rnode *n)
+{
+    struct rnode *found = rlist_find_rank (rl, n->rank);
+    if (found) {
+        if (idset_add_set (found->ids, n->ids) < 0)
+            return (-1);
+        if (idset_add_set (found->avail, n->avail) < 0) {
+            idset_remove_set (found->ids, n->ids);
+            return (-1);
+        }
+    }
+    else if (!zlistx_add_end (rl->nodes, n))
+        return -1;
+    rl->total += rnode_count (n);
+    rl->avail += rnode_avail (n);
+    if (found)
+        rnode_destroy (n);
+    return 0;
+}
+
+static int rlist_append (struct rlist *rl, const char *ranks, json_t *e)
+{
+    int rc = -1;
+    unsigned int n;
+    unsigned int i;
+    const char *corelist = NULL;
+    struct rnode *node;
+    struct idset *ids = idset_decode (ranks);
+    json_error_t err;
+
+    if (!ids || json_unpack_ex (e, &err, 0, "{s:i,s?s}",
+                                "Core", &n,
+                                "cpuset", &corelist) < 0)
+        goto out;
+    i = idset_first (ids);
+    while (i != IDSET_INVALID_ID) {
+        if (corelist)
+            node = rnode_create (i, corelist);
+        else
+            node = rnode_create_count (i, n);
+        if (!node || rlist_add_rnode (rl, node) < 0) {
+            rnode_destroy (node);
+            goto out;
+        }
+        i = idset_next (ids, i);
+    }
+    rc = 0;
+out:
+    idset_destroy (ids);
+    return rc;
+}
+
+struct rlist *rlist_from_hwloc_by_rank (const char *by_rank)
+{
+    struct rlist *rl = NULL;
+    const char *key = NULL;
+    json_t *entry = NULL;
+
+    json_t *o = json_loads (by_rank, 0, NULL);
+    if (o == NULL)
+        return NULL;
+    if (!(rl = rlist_create ()))
+        goto err;
+
+    json_object_foreach (o, key, entry) {
+        if (rlist_append (rl, key, entry) < 0)
+            goto err;
+    }
+    json_decref (o);
+
+    return (rl);
+err:
+    json_decref (o);
+    rlist_destroy (rl);
+    return NULL;
+}
+
+int rlist_append_rank (struct rlist *rl, unsigned int rank, const char *ids)
+{
+    struct rnode *n = rnode_create (rank, ids);
+    if (!n || rlist_add_rnode (rl, n) < 0) {
+        rnode_destroy (n);
+        return -1;
+    }
+    return 0;
+}
+
+int rlist_append_ranks (struct rlist *rl, const char *rank, const char *ids)
+{
+    int rc = -1;
+    unsigned int i;
+    struct idset * ranks = idset_decode (rank);
+    if (!ranks)
+        return -1;
+    i = idset_first (ranks);
+    while (i != IDSET_INVALID_ID) {
+        if (rlist_append_rank (rl, i, ids) < 0)
+            goto err;
+        i = idset_next (ranks, i);
+    }
+    rc = 0;
+err:
+    idset_destroy (ranks);
+    return rc;
+}
+
+int rlist_append_idset (struct rlist *rl, int rank, struct idset *idset)
+{
+    struct rnode *n = rnode_create_idset (rank, idset);
+    if (!n || rlist_add_rnode (rl, n) < 0) {
+        rnode_destroy (n);
+        return -1;
+    }
+    return 0;
+}
+
+static int rlist_append_rank_entry (struct rlist *rl, json_t *entry,
+                                    json_error_t *ep)
+{
+    const char *ranks;
+    const char *cores;
+    if (json_unpack_ex (entry, ep, 0,
+                        "{s:s,s:{s:s}}",
+                        "rank", &ranks,
+                        "children", "core", &cores) < 0) {
+        return -1;
+    }
+    return rlist_append_ranks (rl, ranks, cores);
+}
+
+struct rlist *rlist_from_R (const char *s)
+{
+    int i, version;
+    struct rlist *rl = NULL;
+    json_t *entry = NULL;
+    json_t *R_lite = NULL;
+    json_error_t error;
+
+    json_t *o = json_loads (s, 0, NULL);
+    if (o == NULL)
+        return NULL;
+    if (!o || json_unpack_ex (o, &error, 0,
+                              "{s:i,s:{s:o}}",
+                              "version", &version,
+                              "execution", "R_lite", &R_lite) < 0) {
+        goto err;
+    }
+    if (version != 1)
+        goto err;
+    if (!(rl = rlist_create ()))
+        goto err;
+    json_array_foreach (R_lite, i, entry) {
+        if (rlist_append_rank_entry (rl, entry, &error) < 0)
+            goto err;
+    }
+    json_decref (o);
+    return (rl);
+err:
+    rlist_destroy (rl);
+    json_decref (o);
+    return (NULL);
+}
+
+/* Helper for rlist_compressed */
+struct multi_rnode {
+    struct idset *ids;
+    const struct rnode *rnode;
+};
+
+static int multi_rnode_cmp (struct multi_rnode *x, struct idset *ids)
+{
+    return (idset_cmp (x->rnode->avail, ids));
+}
+
+static void multi_rnode_destroy (struct multi_rnode **mrn)
+{
+    if (mrn && *mrn) {
+        (*mrn)->rnode = NULL;
+        idset_destroy ((*mrn)->ids);
+        free (*mrn);
+        *mrn = NULL;
+    }
+}
+
+struct multi_rnode * multi_rnode_create (struct rnode *rnode)
+{
+    struct multi_rnode *mrn = calloc (1, sizeof (*mrn));
+    if (mrn == NULL)
+        return NULL;
+    if (!(mrn->ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || (idset_set (mrn->ids, rnode->rank) < 0))
+        goto fail;
+    mrn->rnode = rnode;
+    return (mrn);
+fail:
+    multi_rnode_destroy (&mrn);
+    return NULL;
+}
+
+json_t *multi_rnode_tojson (struct multi_rnode *mrn)
+{
+    json_t *o = NULL;
+    char *ids = idset_encode (mrn->rnode->avail, IDSET_FLAG_RANGE);
+    char *ranks = idset_encode (mrn->ids, IDSET_FLAG_RANGE);
+
+    if (!ids || !ranks)
+        goto done;
+    o = json_pack ("{s:s,s:{s:s}}", "rank", ranks, "children", "core", ids);
+done:
+    free (ids);
+    free (ranks);
+    return (o);
+}
+
+static zlistx_t * rlist_mrlist (struct rlist *rl)
+{
+    struct rnode *n = NULL;
+    struct multi_rnode *mrn = NULL;
+    zlistx_t *l = zlistx_new ();
+
+    zlistx_set_comparator (l, (czmq_comparator *) multi_rnode_cmp);
+    zlistx_set_destructor (l, (czmq_destructor *) multi_rnode_destroy);
+
+    n = zlistx_first (rl->nodes);
+    while (n) {
+        if (zlistx_find (l, n->avail)) {
+            if (!(mrn = zlistx_handle_item (zlistx_cursor (l)))
+              || idset_set (mrn->ids, n->rank) < 0) {
+                goto fail;
+            }
+        }
+        else if (rnode_avail (n) > 0) {
+            if (!(mrn = multi_rnode_create (n))
+                || !zlistx_add_end (l, mrn)) {
+                goto fail;
+            }
+        }
+        n = zlistx_next (rl->nodes);
+    }
+    return (l);
+fail:
+    zlistx_destroy (&l);
+    return NULL;
+}
+
+static json_t * rlist_compressed (struct rlist *rl)
+{
+    struct multi_rnode *mrn = NULL;
+    json_t *o = json_array ();
+    zlistx_t *l = rlist_mrlist (rl);
+
+    if (!l)
+        return NULL;
+    mrn = zlistx_first (l);
+    while (mrn) {
+        json_t *entry = multi_rnode_tojson (mrn);
+        if (!entry || json_array_append_new (o, entry) != 0) {
+            json_decref (entry);
+            goto fail;
+        }
+        mrn = zlistx_next (l);
+    }
+    zlistx_destroy (&l);
+    return (o);
+fail:
+    zlistx_destroy (&l);
+    json_decref (o);
+    return NULL;
+}
+
+static int
+sprintfcat (char **s, size_t *sz, size_t *lenp, const char *fmt, ...)
+{
+    int done = false;
+    va_list ap;
+    int n = 0;
+    while (!done) {
+        int nleft = *sz-*lenp;
+        va_start (ap, fmt);
+        n = vsnprintf ((*s)+*lenp, nleft, fmt, ap);
+        if (n < 0 || n >= nleft) {
+            char *p;
+            *sz += 128;
+            if (!(p = realloc (*s, *sz)))
+                return -1;
+            *s = p;
+        }
+        else
+            done = true;
+        va_end (ap);
+    }
+    *lenp += n;
+    return (n);
+}
+
+char * rlist_dumps (struct rlist *rl)
+{
+    int flags = IDSET_FLAG_RANGE | IDSET_FLAG_BRACKETS;
+    char * result = NULL;
+    size_t len = 0;
+    size_t size = 64;
+    struct multi_rnode *mrn = NULL;
+    zlistx_t *l = NULL;
+
+    if (rl == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(l = rlist_mrlist (rl))
+        || !(result = calloc (size, sizeof (char))))
+        goto fail;
+
+    mrn = zlistx_first (l);
+    while (mrn) {
+        char *ranks = idset_encode (mrn->ids, flags);
+        char *cores = idset_encode (mrn->rnode->avail, flags);
+        if (sprintfcat (&result, &size, &len , "%srank%s/core%s",
+                         result[0] != '\0' ? " ": "",
+                         ranks, cores) < 0)
+            goto fail;
+        free (ranks);
+        free (cores);
+        mrn = zlistx_next (l);
+    }
+    zlistx_destroy (&l);
+    return (result);
+fail:
+    free (result);
+    zlistx_destroy (&l);
+    return NULL;
+}
+
+json_t *rlist_to_R (struct rlist *rl)
+{
+    json_t *R = NULL;
+    json_t *R_lite = rlist_compressed (rl);
+    if (!R_lite)
+        return NULL;
+    if (!(R = json_pack ("{s:i, s:{s:o}}",
+                         "version", 1,
+                         "execution",
+                         "R_lite", R_lite)))
+        json_decref (R_lite);
+    return (R);
+}
+
+static int by_rank (const void *item1, const void *item2)
+{
+    const struct rnode *x = item1;
+    const struct rnode *y = item2;
+    return (x->rank - y->rank);
+}
+
+static int by_avail (const void *item1, const void *item2)
+{
+    int n;
+    const struct rnode *x = item1;
+    const struct rnode *y = item2;
+    if ((n = rnode_avail (x) - rnode_avail (y)) == 0)
+        n = by_rank (x, y);
+    return n;
+}
+
+static int by_used (const void *item1, const void *item2)
+{
+    int n;
+    const struct rnode *x = item1;
+    const struct rnode *y = item2;
+    if ((n = rnode_avail (y) - rnode_avail (x)) == 0)
+        n = by_rank (x, y);
+    return n;
+}
+
+static int rlist_rnode_alloc (struct rlist *rl, struct rnode *n,
+                              int count, struct idset **idsetp)
+{
+    if (!n || rnode_alloc (n, count, idsetp) < 0)
+        return -1;
+    rl->avail -= idset_count (*idsetp);
+    return 0;
+}
+
+#if 0
+static uint32_t rlist_rnode_rank (struct rlist *rl)
+{
+    struct rnode *n = zlistx_item (rl->nodes);
+    if (n)
+        return n->rank;
+    else
+        return (uint32_t)-1;
+}
+#endif
+
+static struct rnode *rlist_first (struct rlist *rl)
+{
+    return zlistx_first (rl->nodes);
+}
+
+static struct rnode *rlist_next (struct rlist *rl)
+{
+    return zlistx_next (rl->nodes);
+}
+
+/*
+ *  Allocate the first available N slots of size cores_per_slot from
+ *   resource list rl after sorting the nodes with the current sort strategy.
+ */
+static struct rlist * rlist_alloc_first_fit (struct rlist *rl,
+                                             int cores_per_slot,
+                                             int slots)
+{
+    int rc;
+    struct idset *ids = NULL;
+    struct rnode *n = NULL;
+    struct rlist *result = NULL;
+
+    zlistx_sort (rl->nodes);
+
+    if (!(n = rlist_first (rl)))
+        return NULL;
+
+    if (!(result = rlist_create ()))
+        return NULL;
+
+    /* 2. assign slots to first nodes where they fit
+     */
+    while (n && slots) {
+        /*  Try to allocate a slot on this node. If we fail with ENOSPC,
+         *   then advance to the next node and try again.
+         */
+        if ((rc = rlist_rnode_alloc (rl, n, cores_per_slot, &ids)) < 0) {
+            if (errno != ENOSPC)
+                goto unwind;
+            n = rlist_next (rl);
+            continue;
+        }
+        /*  Append the allocated cores to the result set and continue
+         *   if needed
+         */
+        rc = rlist_append_idset (result, n->rank, ids);
+        idset_destroy (ids);
+        if (rc < 0)
+            goto unwind;
+        slots--;
+    }
+    if (slots != 0) {
+unwind:
+        rlist_free (rl, result);
+        rlist_destroy (result);
+        errno = ENOSPC;
+        return NULL;
+    }
+    return result;
+}
+
+/*
+ *  Allocate `slots` of size cores_per_slot from rlist `rl` and return
+ *   the result. Sorts the node list by smallest available first, so that
+ *   we get something like "best fit". (minimize nodes used)
+ */
+static struct rlist * rlist_alloc_best_fit (struct rlist *rl,
+                                            int cores_per_slot,
+                                            int slots)
+{
+    zlistx_set_comparator (rl->nodes, by_avail);
+    return rlist_alloc_first_fit (rl, cores_per_slot, slots);
+}
+
+/*
+ *  Allocate `slots` of size cores_per_slot from rlist `rl` and return
+ *   the result. Sorts the node list by least utilized first, so that
+ *   we get something like "worst fit". (Spread jobs across nodes)
+ */
+static struct rlist * rlist_alloc_worst_fit (struct rlist *rl,
+                                             int cores_per_slot,
+                                             int slots)
+{
+    zlistx_set_comparator (rl->nodes, by_used);
+    return rlist_alloc_first_fit (rl, cores_per_slot, slots);
+}
+
+
+static zlistx_t *rlist_get_nnodes (struct rlist *rl, int nnodes)
+{
+    struct rnode *n;
+    zlistx_t *l = zlistx_new ();
+    if (!l)
+        return NULL;
+    n = zlistx_first (rl->nodes);
+    while (nnodes > 0) {
+        if (zlistx_add_end (l, n) < 0)
+            goto err;
+        n = zlistx_next (rl->nodes);
+        nnodes--;
+    }
+    return (l);
+err:
+    zlistx_destroy (&l);
+    return NULL;
+}
+
+/*  Allocate 'slots' of size 'cores_per_slot' across exactly `nnodes`.
+ *  Works by getting the first N least utilized nodes and spreading
+ *  the nslots evenly across the result.
+ */
+static struct rlist *rlist_alloc_nnodes (struct rlist *rl, int nnodes,
+                                         int cores_per_slot, int slots)
+{
+    struct rlist *result = NULL;
+    struct rnode *n = NULL;
+    zlistx_t *cl = NULL;
+
+    if (rlist_nnodes (rl) < nnodes) {
+        errno = ENOSPC;
+        return NULL;
+    }
+    if (slots < nnodes) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(result = rlist_create ()))
+        return NULL;
+
+    /* 1. sort rank list by used cores ascending:
+     */
+    zlistx_set_comparator (rl->nodes, by_used);
+    zlistx_sort (rl->nodes);
+
+    /* 2. get a list of the first n nodes
+     */
+    if (!(cl = rlist_get_nnodes (rl, nnodes)))
+        return NULL;
+
+    /* We will sort candidate list by used cores on each iteration to
+     *  ensure even spread of slots across nodes
+     */
+    zlistx_set_comparator (cl, by_used);
+
+    /*
+     * 3. divide slots across all nodes, placing each slot
+     *    on most empty node first
+     */
+    while (slots > 0) {
+        int rc;
+        struct idset *ids = NULL;
+        n = zlistx_first (cl);
+        /*
+         * if we can't allocate on this node, give up. Since it is the
+         *  least loaded node from the least loaded nodelist, we know
+         *  we don't have enough resources to satisfy request.
+         */
+        if (rlist_rnode_alloc (rl, n, cores_per_slot, &ids) < 0)
+            goto unwind;
+        rc = rlist_append_idset (result, n->rank, ids);
+        idset_destroy (ids);
+        if (rc < 0)
+            goto unwind;
+
+        /*  Reorder the current item in list so we get least loaded node
+         *   at front again for the next call to zlistx_first()
+         */
+        zlistx_reorder (cl, zlistx_cursor (cl), false);
+        slots--;
+    }
+    zlistx_destroy (&cl);
+    return result;
+unwind:
+    zlistx_destroy (&cl);
+    rlist_free (rl, result);
+    rlist_destroy (result);
+    errno = ENOSPC;
+    return NULL;
+}
+
+static struct rlist *rlist_try_alloc (struct rlist *rl, const char *mode,
+                                      int nnodes, int slots, int cores_per_slot)
+{
+    struct rlist *result = NULL;
+
+    if (!rl) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /*  Reset default sort to order nodes by "rank" */
+    zlistx_set_comparator (rl->nodes, by_rank);
+
+    if (nnodes > 0)
+        result = rlist_alloc_nnodes (rl, nnodes, cores_per_slot, slots);
+    else if (mode == NULL || strcmp (mode, "worst-fit") == 0)
+        result = rlist_alloc_worst_fit (rl, cores_per_slot, slots);
+    else if (mode && strcmp (mode, "best-fit") == 0)
+        result = rlist_alloc_best_fit (rl, cores_per_slot, slots);
+    else if (mode && strcmp (mode, "first-fit") == 0)
+        result = rlist_alloc_first_fit (rl, cores_per_slot, slots);
+    else
+        errno = EINVAL;
+    return result;
+}
+
+/*  Determine if allocation request is feasible for rlist `rl`.
+ */
+static bool rlist_alloc_feasible (const struct rlist *rl, const char *mode,
+                                  int nnodes, int slots, int slotsz)
+{
+    bool rc = false;
+    struct rlist *result = NULL;
+    struct rlist *all = rlist_copy_empty (rl);
+    if (all && (result = rlist_try_alloc (all, mode, nnodes, slots, slotsz)))
+        rc = true;
+    rlist_destroy (all);
+    rlist_destroy (result);
+    return rc;
+}
+
+struct rlist *rlist_alloc (struct rlist *rl, const char *mode,
+                          int nnodes, int slots, int slotsz)
+{
+    int total = slots * slotsz;
+    struct rlist *result = NULL;
+
+    if (slots <= 0 || slotsz <= 0 || nnodes < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (total > rl->total) {
+        errno = EOVERFLOW;
+        return NULL;
+    }
+    if (total > rl->avail) {
+        if (rlist_alloc_feasible (rl, mode, nnodes, slots, slotsz))
+            errno = ENOSPC;
+        else
+            errno = EOVERFLOW;
+        return NULL;
+    }
+
+    /*
+     *   Try allocation. If it fails with not enough resources (ENOSPC),
+     *    then try again on an empty copy of rlist to see the request could
+     *    *ever* be satisfied. Adjust errno to EOVERFLOW if not.
+     */
+    result = rlist_try_alloc (rl, mode, nnodes, slots, slotsz);
+    if (!result && (errno == ENOSPC)) {
+        if (rlist_alloc_feasible (rl, mode, nnodes, slots, slotsz))
+            errno = ENOSPC;
+        else
+            errno = EOVERFLOW;
+    }
+    return (result);
+}
+
+static int rlist_free_rnode (struct rlist *rl, struct rnode *n)
+{
+    struct rnode *rnode = rlist_find_rank (rl, n->rank);
+    if (!rnode) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (rnode_free_idset (rnode, n->ids) < 0)
+        return -1;
+    rl->avail += idset_count (n->ids);
+    return 0;
+}
+
+static int rlist_remove_rnode (struct rlist *rl, struct rnode *n)
+{
+    struct rnode *rnode = rlist_find_rank (rl, n->rank);
+    if (!rnode) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (rnode_alloc_idset (rnode, n->avail) < 0)
+        return -1;
+    rl->avail -= idset_count (n->avail);
+    return 0;
+}
+
+int rlist_free (struct rlist *rl, struct rlist *alloc)
+{
+    zlistx_t *freed = NULL;
+    struct rnode *n = NULL;
+
+    if (!(freed = zlistx_new ()))
+        return -1;
+
+    n = zlistx_first (alloc->nodes);
+    while (n) {
+        if (rlist_free_rnode (rl, n) < 0)
+            goto cleanup;
+        zlistx_add_end (freed, n);
+        n = zlistx_next (alloc->nodes);
+    }
+    zlistx_destroy (&freed);
+    return (0);
+cleanup:
+    /* re-allocate all freed items */
+    n = zlistx_first (freed);
+    while (n) {
+        rlist_remove_rnode (rl, n);
+        n = zlistx_next (freed);
+    }
+    zlistx_destroy (&freed);
+    return (-1);
+}
+
+int rlist_remove (struct rlist *rl, struct rlist *alloc)
+{
+    zlistx_t *allocd = NULL;
+    struct rnode *n = NULL;
+    if (!alloc || !(allocd = zlistx_new ()))
+        return -1;
+    n = zlistx_first (alloc->nodes);
+    while (n) {
+        if (rlist_remove_rnode (rl, n) < 0)
+            goto cleanup;
+        zlistx_add_end (allocd, n);
+        n = zlistx_next (alloc->nodes);
+    }
+    zlistx_destroy (&allocd);
+    return 0;
+cleanup:
+    n = zlistx_first (allocd);
+    while (n) {
+        rlist_free_rnode (rl, n);
+        n = zlistx_next (allocd);
+    }
+    zlistx_destroy (&allocd);
+    return -1;
+}
+
+size_t rlist_nnodes (struct rlist *rl)
+{
+    return zlistx_size (rl->nodes);
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/sched-simple/rlist.h
+++ b/src/modules/sched-simple/rlist.h
@@ -1,0 +1,98 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_SCHED_RLIST_H
+#define HAVE_SCHED_RLIST_H 1
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/idset.h>
+
+/* A list of resource nodes */
+struct rlist {
+    int total;
+    int avail;
+    zlistx_t *nodes;
+};
+
+/*  Create an empty rlist object */
+struct rlist *rlist_create (void);
+
+/*  Create a copy of rlist rl with all cores available */
+struct rlist *rlist_copy_empty (const struct rlist *rl);
+
+/*  Create an rlist object from resource.hwloc.by_rank JSON input
+ */
+struct rlist *rlist_from_hwloc_by_rank (const char *by_rank);
+
+/*  Destroy an rlist object */
+void rlist_destroy (struct rlist *rl);
+
+/*  Append a new resource node with rank==rank and idset string `ids`
+ */
+int rlist_append_rank (struct rlist *rl, unsigned int rank, const char *ids);
+
+/*  Same as rlist_append_rank(), but `ids` is a struct idset
+ */
+int rlist_append_idset (struct rlist *rl, int rank, struct idset *ids);
+
+/*  Return number of resource nodes in resource list `rl`
+ */
+size_t rlist_nnodes (struct rlist *rl);
+
+/*
+ *  Serialize a resource list into v1 "R" format. This encodes only the
+ *   "available" ids in each resource node into execution.R_lite
+ */
+json_t * rlist_to_R (struct rlist *rl);
+
+/*
+ *  Dump short form description of rlist `rl` as a single line string.
+ *    Caller must free returned string.
+ */
+char *rlist_dumps (struct rlist *rl);
+
+/*
+ *  De-serialize a v1 "R" format string into a new resource list object.
+ *  Returns a new resource list object on success, NULL on failure.
+ */
+struct rlist *rlist_from_R (const char *R);
+
+/*  Attempt to allocate nslots of slot_size across optional nnodes
+ *   from the resource list `rl` using algorithm `mode`.
+ *
+ *  Valid modes (nnodes == 0 only):
+ *   NULL or "worst-fit" - allocate from least-used nodes first
+ *   "best-fit"          - allocate from most-used nodes first
+ *   "first-fit"         - allocate first free slots found in rank order
+ *
+ *  Returns a new rlist representing the allocation on success,
+ *   NULL on failure with errno set:
+ *
+ *   ENOSPC - unable to fulfill allocation.
+ *   EINVAL - An argument was invalid.
+ */
+struct rlist * rlist_alloc (struct rlist *rl, const char *mode,
+                            int nnodes, int slot_size, int nslots);
+
+
+/*  Remove rlist "alloc" from rlist "rl".
+ */
+int rlist_remove (struct rlist *rl, struct rlist *alloc);
+
+/*  Free resource list `to_free` from resource list `rl`
+ */
+int rlist_free (struct rlist *rl, struct rlist *to_free);
+
+#endif /* !HAVE_SCHED_RLIST_H */

--- a/src/modules/sched-simple/rnode.c
+++ b/src/modules/sched-simple/rnode.c
@@ -1,0 +1,198 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <assert.h>
+#include <errno.h>
+#include <jansson.h>
+#include <flux/idset.h>
+
+#include "rnode.h"
+
+void rnode_destroy (struct rnode *n)
+{
+    if (n) {
+        idset_destroy (n->avail);
+        idset_destroy (n->ids);
+        free (n);
+    }
+}
+
+struct rnode *rnode_create (uint32_t rank, const char *ids)
+{
+    struct rnode *n = calloc (1, sizeof (*n));
+    if (n == NULL)
+        return NULL;
+    n->rank = rank;
+    if (!(n->ids = idset_decode (ids))
+        || !(n->avail = idset_copy (n->ids)))
+        goto fail;
+    return (n);
+fail:
+    rnode_destroy (n);
+    return NULL;
+}
+
+struct rnode *rnode_create_idset (uint32_t rank, struct idset *ids)
+{
+    struct rnode *n = calloc (1, sizeof (*n));
+    if (n == NULL)
+        return NULL;
+    n->rank = rank;
+    if (!(n->ids = idset_copy (ids))
+        || !(n->avail = idset_copy (ids)))
+        goto fail;
+    return (n);
+fail:
+    rnode_destroy (n);
+    return NULL;
+}
+
+struct rnode *rnode_create_count (uint32_t rank, int count)
+{
+    struct rnode *n = calloc (1, sizeof (*n));
+    if (n == NULL)
+        return NULL;
+    n->rank = rank;
+    if (!(n->ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || (idset_range_set (n->ids, 0, count-1) < 0)
+        || !(n->avail = idset_copy (n->ids)))
+        goto fail;
+    return (n);
+fail:
+    rnode_destroy (n);
+    return NULL;
+}
+
+int rnode_alloc (struct rnode *n, int count, struct idset **setp)
+{
+    struct idset *ids = NULL;
+    unsigned int i;
+    if (idset_count (n->avail) < count) {
+        errno = ENOSPC;
+        return -1;
+    }
+    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return -1;
+    i = idset_first (n->avail);
+    while (count--) {
+        idset_set (ids, i);
+        idset_clear (n->avail, i);
+        i = idset_next (n->avail, i);
+    }
+    if (setp != NULL)
+        *setp = ids;
+    return (0);
+}
+
+/*
+ *  Test if idset `ids` is a valid set of ids to allocate from the rnode `n`
+ *  Return true if the idset is valid, false otherwise.
+ */
+static bool alloc_ids_valid (struct rnode *n, struct idset *ids)
+{
+    unsigned int i = idset_first (ids);
+    while (i != IDSET_INVALID_ID) {
+        if (!idset_test (n->ids, i)) {
+            errno = ENOENT;
+            return false;
+        }
+        if (!idset_test (n->avail, i)) {
+            errno = EEXIST;
+            return false;
+        }
+        i = idset_next (ids, i);
+    }
+    return (true);
+}
+
+int rnode_alloc_idset (struct rnode *n, struct idset *ids)
+{
+    unsigned int i;
+    if (!ids) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!alloc_ids_valid (n, ids))
+        return -1;
+    i = idset_first (ids);
+    while (i != IDSET_INVALID_ID) {
+        idset_clear (n->avail, i);
+        i = idset_next (ids, i);
+    }
+    return 0;
+}
+
+/*
+ *  Test if idset `ids` is a valid set of ids to free from the rnode `n`
+ *  Return true if the idset is valid, false otherwise.
+ */
+static bool free_ids_valid (struct rnode *n, struct idset *ids)
+{
+    unsigned int i = idset_first (ids);
+    while (i != IDSET_INVALID_ID) {
+        if (!idset_test (n->ids, i)) {
+            errno = ENOENT;
+            return false;
+        }
+        if (idset_test (n->avail, i)) {
+            errno = EEXIST;
+            return false;
+        }
+        i = idset_next (ids, i);
+    }
+    return (true);
+}
+
+int rnode_free_idset (struct rnode *n, struct idset *ids)
+{
+    unsigned int i;
+    if (!ids) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!free_ids_valid (n, ids))
+        return -1;
+    i = idset_first (ids);
+    while (i != IDSET_INVALID_ID) {
+        idset_set (n->avail, i);
+        i = idset_next (ids, i);
+    }
+    return 0;
+}
+
+int rnode_free (struct rnode *n, const char *s)
+{
+    int saved_errno;
+    struct idset *ids = idset_decode (s);
+    int rc = rnode_free_idset (n, ids);
+    saved_errno = errno;
+    idset_destroy (ids);
+    errno = saved_errno;
+    return (rc);
+}
+
+size_t rnode_avail (const struct rnode *n)
+{
+    return (idset_count (n->avail));
+}
+
+size_t rnode_count (const struct rnode *n)
+{
+    return (idset_count (n->ids));
+}
+
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/sched-simple/rnode.h
+++ b/src/modules/sched-simple/rnode.h
@@ -1,0 +1,75 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_SCHED_RNODE_H
+#define HAVE_SCHED_RNODE_H 1
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <inttypes.h>
+#include <jansson.h>
+#include <flux/idset.h>
+
+/* Simple resource node object */
+struct rnode {
+    uint32_t rank;
+    struct idset * ids;
+    struct idset * avail;
+};
+
+/*  Create a resource node object from an existing idset `set`
+ */
+struct rnode *rnode_create_idset (uint32_t rank, struct idset *ids);
+
+/*  Create a resource node from a string representation of an idset.
+ */
+struct rnode *rnode_create (uint32_t rank, const char *ids);
+
+/*  Create a resource node with `count` ids, starting at 0, i.e.
+ *   same as rnode_create (rank, "0-"..count-1).
+ */
+struct rnode *rnode_create_count (uint32_t rank, int count);
+
+/*  Destroy rnode object
+ */
+void rnode_destroy (struct rnode *n);
+
+/*  Allocate `count` ids from rnode object `n`.
+ *   On success, return 0 and allocated ids in `setp`.
+ *   On failure, return -1 with errno set:
+ *   ENOSPC - there are not `count` ids available in `n`
+ *   EINVAL - Invalid arguments
+ */
+int rnode_alloc (struct rnode *n, int count, struct idset **setp);
+
+/*  Free the idset `ids` from resource node `n`.
+ *  Returns 0 on success, -1 if one or more ids is not allocated.
+ */
+int rnode_free (struct rnode *n, const char *ids);
+
+/*  As above, but free a struct idset instead of string.
+ */
+int rnode_free_idset (struct rnode *n, struct idset *ids);
+
+/*  Allocate specific idset `ids` from a resource node
+ */
+int rnode_alloc_idset (struct rnode *n, struct idset *ids);
+
+/*  Return the number of ids available in resource node `n`.
+ */
+size_t rnode_avail (const struct rnode *n);
+
+/*  Return the total number of ids in resource node `n`.
+ */
+size_t rnode_count (const struct rnode *n);
+
+#endif /* !HAVE_SCHED_RNODE_H */

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -1,0 +1,376 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libschedutil/schedutil.h"
+#include "libjj.h"
+#include "rlist.h"
+
+struct jobreq {
+    flux_msg_t *msg;
+    flux_jobid_t id;
+    struct jj_counts jj;
+    int errnum;
+};
+
+struct simple_sched {
+    char *mode;             /* allocation mode */
+    struct rlist *rlist;    /* list of resources */
+    struct jobreq *job;     /* currently processed job */
+    struct ops_context *ops;
+};
+
+static void jobreq_destroy (struct jobreq *job)
+{
+    if (job) {
+        flux_msg_destroy (job->msg);
+        free (job);
+    }
+}
+
+static struct jobreq *
+jobreq_create (const flux_msg_t *msg, const char *jobspec)
+{
+    struct jobreq *job = calloc (1, sizeof (*job));
+    int pri;
+    uint32_t uid;
+    double t_submit;
+
+    if (job == NULL)
+        return NULL;
+    if (schedutil_alloc_request_decode (msg, &job->id,
+                            &pri, &uid, &t_submit) < 0)
+        goto err;
+    if (!(job->msg = flux_msg_copy (msg, true)))
+        goto err;
+    if (libjj_get_counts (jobspec, &job->jj) < 0)
+        job->errnum = errno;
+    return job;
+err:
+    jobreq_destroy (job);
+    return NULL;
+}
+
+static void simple_sched_destroy (flux_t *h, struct simple_sched *ss)
+{
+    schedutil_ops_unregister (ss->ops);
+    if (ss->job) {
+        flux_respond_error (h, ss->job->msg, ENOSYS, "simple sched exiting");
+        jobreq_destroy (ss->job);
+    }
+    rlist_destroy (ss->rlist);
+    free (ss->mode);
+    free (ss);
+}
+
+static struct simple_sched * simple_sched_create (void)
+{
+    struct simple_sched *ss = calloc (1, sizeof (*ss));
+    if (ss == NULL)
+        return NULL;
+    return ss;
+}
+
+static char *Rstring_create (struct rlist *l)
+{
+    char *s = NULL;
+    json_t *R = rlist_to_R (l);
+    if (R) {
+        s = json_dumps (R, JSON_COMPACT);
+        json_decref (R);
+    }
+    return (s);
+}
+
+static void try_alloc (flux_t *h, struct simple_sched *ss)
+{
+    char *s = NULL;
+    struct rlist *alloc = NULL;
+    struct jj_counts *jj = NULL;
+    char *R = NULL;
+    if (!ss->job)
+        return;
+    jj = &ss->job->jj;
+    alloc = rlist_alloc (ss->rlist, ss->mode,
+                         jj->nnodes, jj->nslots, jj->slot_size);
+    if (!alloc) {
+        const char *note = "unable to allocate provided jobspec";
+        if (errno == ENOSPC)
+            return;
+        if (errno == EOVERFLOW)
+            note = "unsatisfiable request";
+        if (schedutil_alloc_respond_denied (h, ss->job->msg, note) < 0)
+            flux_log_error (h, "schedutil_alloc_respond_denied");
+        goto out;
+    }
+    s = rlist_dumps (alloc);
+    if (!(R = Rstring_create (alloc)))
+        flux_log_error (h, "Rstring_create");
+
+    if (R && schedutil_alloc_respond_R (h, ss->job->msg, R, s) < 0)
+        flux_log_error (h, "schedutil_alloc_respond_R");
+
+    flux_log (h, LOG_DEBUG, "alloc: %ju: %s", (uintmax_t) ss->job->id, s);
+
+out:
+    jobreq_destroy (ss->job);
+    ss->job = NULL;
+    rlist_destroy (alloc);
+    free (R);
+    free (s);
+}
+
+void exception_cb (flux_t *h, flux_jobid_t id,
+                   const char *type, int severity, void *arg)
+{
+    char note [80];
+    struct simple_sched *ss = arg;
+    if (ss->job == NULL || ss->job->id != id || severity > 0)
+        return;
+    flux_log (h, LOG_DEBUG, "alloc aborted: id=%ju", (uintmax_t) id);
+    snprintf (note, sizeof (note) - 1, "alloc aborted due to exception");
+    if (schedutil_alloc_respond_denied (h, ss->job->msg, note) < 0)
+        flux_log_error (h, "alloc_respond_denied");
+    jobreq_destroy (ss->job);
+    ss->job = NULL;
+}
+
+static int try_free (flux_t *h, struct simple_sched *ss, const char *R)
+{
+    int rc = -1;
+    char *r = NULL;
+    struct rlist *alloc = rlist_from_R (R);
+    if (!alloc) {
+        flux_log_error (h, "hello: unable to parse R=%s", R);
+        return -1;
+    }
+    r = rlist_dumps (alloc);
+    if ((rc = rlist_free (ss->rlist, alloc)) < 0)
+        flux_log_error (h, "free: %s", r);
+    else
+        flux_log (h, LOG_DEBUG, "free: %s", r);
+    free (r);
+    rlist_destroy (alloc);
+    return rc;
+}
+
+void free_cb (flux_t *h, const flux_msg_t *msg, const char *R, void *arg)
+{
+    struct simple_sched *ss = arg;
+
+    if (try_free (h, ss, R) < 0) {
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "free_cb: flux_respond_error");
+        return;
+    }
+    if (schedutil_free_respond (h, msg) < 0)
+        flux_log_error (h, "free_cb: schedutil_free_respond");
+
+    /* See if we can fulfill alloc for a pending job */
+    try_alloc (h, ss);
+}
+
+static void alloc_cb (flux_t *h, const flux_msg_t *msg,
+                      const char *jobspec, void *arg)
+{
+    struct simple_sched *ss = arg;
+
+    if (ss->job) {
+        flux_log (h, LOG_ERR, "alloc received before previous one handled");
+        goto err;
+    }
+    if (!(ss->job = jobreq_create (msg, jobspec))) {
+        flux_log_error (h, "alloc: jobreq_create");
+        goto err;
+    }
+    if (ss->job->errnum != 0) {
+        if (schedutil_alloc_respond_denied (h, msg, ss->job->jj.error) < 0)
+            flux_log_error (h, "alloc_respond_denied");
+        jobreq_destroy (ss->job);
+        ss->job = NULL;
+        return;
+    }
+    flux_log (h, LOG_DEBUG, "req: %ju: spec={%d,%d,%d}",
+                            (uintmax_t) ss->job->id, ss->job->jj.nnodes,
+                            ss->job->jj.nslots, ss->job->jj.slot_size);
+    try_alloc (h, ss);
+    return;
+err:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "alloc: flux_respond");
+}
+
+static int hello_cb (flux_t *h, const char *R, void *arg)
+{
+    char *s;
+    int rc = -1;
+    struct simple_sched *ss = arg;
+
+    struct rlist *alloc = rlist_from_R (R);
+    if (!alloc) {
+        flux_log_error (h, "hello: R=%s", R);
+        return -1;
+    }
+    s = rlist_dumps (alloc);
+    if ((rc = rlist_remove (ss->rlist, alloc)) < 0)
+        flux_log_error (h, "hello: rlist_remove (%s)", s);
+    else
+        flux_log (h, LOG_DEBUG, "hello: alloc %s", s);
+    free (s);
+    rlist_destroy (alloc);
+    return 0;
+}
+
+static void status_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct simple_sched *ss = arg;
+    json_t *o = NULL;
+
+    if (ss->rlist == NULL) {
+        flux_respond_error (h, msg, EAGAIN, "sched-simple not initialized");
+        return;
+    }
+    if (!(o = rlist_to_R (ss->rlist))) {
+        flux_log_error (h, "rlist_to_R_compressed");
+        goto err;
+    }
+    if (flux_respond_pack (h, msg, "o", o) < 0) {
+        flux_log_error (h, "flux_respond_pack");
+        goto err;
+    }
+    return;
+err:
+    json_decref (o);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "flux_respond_error");
+}
+
+static int simple_sched_init (flux_t *h, struct simple_sched *ss)
+{
+    int rc = -1;
+    char *s = NULL;
+    flux_future_t *f = NULL;
+    const char *by_rank = NULL;
+
+    /* synchronously lookup by_rank for initialization */
+    if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_WAITCREATE,
+                                  "resource.hwloc.by_rank"))) {
+        flux_log_error (h, "lookup resource.hwloc.by_rank");
+        goto out;
+    }
+    if (flux_kvs_lookup_get (f, &by_rank) < 0) {
+        flux_log_error (h, "kvs_lookup_get (resource.hwloc.by_rank)");
+        goto out;
+    }
+    if (!(ss->rlist = rlist_from_hwloc_by_rank (by_rank))) {
+        flux_log_error (h, "rank_list_create");
+        goto out;
+    }
+    /*  Complete synchronous hello protocol:
+     */
+    if (schedutil_hello (h, hello_cb, ss) < 0) {
+        flux_log_error (h, "schedutil_hello");
+        goto out;
+    }
+    if (schedutil_ready (h, "single", NULL) < 0) {
+        flux_log_error (h, "schedutil_ready");
+        goto out;
+    }
+    s = rlist_dumps (ss->rlist);
+    flux_log (h, LOG_DEBUG, "ready: %d of %d cores: %s",
+                            ss->rlist->avail, ss->rlist->total, s);
+    free (s);
+    rc = 0;
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+static char * get_alloc_mode (flux_t *h, const char *mode)
+{
+    if (strcmp (mode, "worst-fit") == 0
+       || strcmp (mode, "first-fit") == 0
+       || strcmp (mode, "best-fit") == 0)
+        return strdup (mode);
+    flux_log_error (h, "unknown allocation mode: %s\n", mode);
+    return NULL;
+}
+
+static int process_args (flux_t *h, struct simple_sched *ss,
+                         int argc, char *argv[])
+{
+    int i;
+    for (i = 0; i < argc; i++) {
+        if (strncmp ("mode=", argv[i], 5) == 0) {
+            free (ss->mode);
+            ss->mode = get_alloc_mode (h, argv[i]+5);
+        }
+        else {
+            flux_log_error (h, "Unknown module option: '%s'", argv[i]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "sched-simple.status", status_cb, FLUX_ROLE_USER },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    int rc = -1;
+    struct simple_sched *ss = NULL;
+    flux_msg_handler_t **handlers = NULL;
+    flux_reactor_t *r = flux_get_reactor (h);
+
+    if (!(ss = simple_sched_create ())) {
+        flux_log_error (h, "simple_sched_create");
+        return -1;
+    }
+
+    if (process_args (h, ss, argc, argv) < 0)
+        return -1;
+
+    ss->ops = schedutil_ops_register (h, alloc_cb, free_cb, exception_cb, ss);
+    if (!(ss->ops)) {
+        flux_log_error (h, "schedutil_ops_register");
+        goto done;
+    }
+    if (simple_sched_init (h, ss) < 0)
+        goto done;
+    if (flux_msg_handler_addvec (h, htab, ss, &handlers) < 0) {
+        flux_log_error (h, "flux_msg_handler_add");
+        goto done;
+    }
+    if (flux_reactor_run (r, 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done;
+    }
+    rc = 0;
+done:
+    simple_sched_destroy (h, ss);
+    flux_msg_handler_delvec (handlers);
+    return rc;
+}
+
+MOD_NAME ("sched-simple");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/sched-simple/test/rlist-query.c
+++ b/src/modules/sched-simple/test/rlist-query.c
@@ -1,0 +1,51 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#include <flux/core.h>
+#include "src/modules/sched-simple/rlist.h"
+
+int main (int ac, char *av[])
+{
+    const char *s = NULL;
+    char *result = NULL;
+    struct rlist *rl = NULL;
+    flux_future_t *f = NULL;
+    flux_t *h = flux_open (NULL, 0);
+
+    if (h == NULL) {
+        fprintf (stderr, "flux_open: %s\n", strerror (errno));
+        exit (1);
+    }
+    if (!(f = flux_rpc (h, "sched-simple.status", "{}", 0, 0))) {
+        fprintf (stderr, "flux_rpc: %s\n", strerror (errno));
+        exit (1);
+    }
+    if (flux_rpc_get (f, &s) < 0) {
+        fprintf (stderr, "sched-simple.status: %s", strerror (errno));
+        exit (1);
+    }
+    if (!(rl = rlist_from_R (s))) {
+        fprintf (stderr, "unable to read R: %s", strerror (errno));
+        exit (1);
+    }
+    flux_future_destroy (f);
+    result = rlist_dumps (rl);
+    printf ("%s\n", result);
+    free (result);
+    flux_close (h);
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/sched-simple/test/rlist.c
+++ b/src/modules/sched-simple/test/rlist.c
@@ -1,0 +1,257 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <unistd.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+#include "rlist.h"
+
+struct testalloc {
+    int nnodes;
+    int nslots;
+    int slot_size;
+};
+
+struct rlist_test_entry {
+    const char *description;
+    const char *mode;
+    struct testalloc alloc;
+    const char *result;
+    int expected_errno;
+    bool free;
+};
+
+#define RLIST_TEST_END { NULL, NULL, { 0, 0, 0 }, NULL, 0, false }
+
+struct rlist_test_entry test_2n_4c[] = {
+    { "too large of slot returns EOVERFLOW", NULL,
+      { 0, 1, 5 }, NULL, EOVERFLOW, false },
+    { "too many slots returns error", NULL,
+      { 0, 9, 1 }, NULL, EOVERFLOW, false },
+    { "invalid number of nodes returns error", NULL,
+      { -1, 1, 1 }, NULL, EINVAL, false },
+    { "invalid number of slots return error", NULL,
+      { 0, 0, 1 }, NULL, EINVAL, false },
+    { "invalid slot size returns error", NULL,
+      { 0, 1, -1}, NULL, EINVAL, false },
+    { "allocating a single core gets expected result", NULL,
+      { 0, 1, 1 }, "rank0/core0", 0, false },
+    { "allocating another core gets expected result", NULL,
+      { 0, 1, 1 }, "rank1/core0", 0, false },
+    { "allocating another core gets expected result", NULL,
+      { 0, 1, 1 }, "rank0/core1", 0, false },
+    { "allocate 1 slot of size 3 lands on correct node", NULL,
+      { 0, 1, 3 }, "rank1/core[1-3]", 0, false },
+    { "allocate 4 slots of 1 core now returns ENOSPC", NULL,
+      { 0, 4, 1 }, NULL, ENOSPC, false },
+    { "allocate remaining 2 cores", NULL,
+      { 0, 1, 2 }, "rank0/core[2-3]", 0, false },
+    RLIST_TEST_END,
+};
+
+struct rlist_test_entry test_6n_4c[] = {
+    { "best-fit: alloc 1 core", "best-fit",
+      { 0, 1, 1 }, "rank0/core0", 0, false },
+    { "best-fit: alloc 1 slot/size 3 fits on rank0", "best-fit",
+      { 0, 1, 3 }, "rank0/core[1-3]", 0, false },
+    { "best-fit: alloc 2 slots/size 2 fits on rank1","best-fit",
+      { 0, 2, 2 }, "rank1/core[0-3]", 0, false },
+    { "best-fit: alloc 3 slot of size 1",            "best-fit",
+      { 0, 3, 1 }, "rank2/core[0-2]", 0, false },
+    { "best-fit alloc 3 slots of 1 core",            "best-fit",
+      { 0, 3, 1 }, "rank2/core3 rank3/core[0-1]", 0, false },
+    RLIST_TEST_END,
+};
+
+struct rlist_test_entry test_1024n_4c[] = {
+    { "large: 512 nodes with 2 cores", NULL,
+      { 512, 512, 2 }, "rank[0-511]/core[0-1]", 0, false },
+    { "large: 512 slots of 4 cores", NULL,
+      { 0, 512, 4 }, "rank[512-1023]/core[0-3]", 0, true },
+    { "large: 1 core on 10 nodes", NULL,
+      { 10, 10, 1 },  "rank[512-521]/core0", 0, false },
+    { "large: alloc 2 cores on 128 nodes with free", NULL,
+      { 128, 256, 1 }, "rank[522-649]/core[0-1]", 0, true },
+    RLIST_TEST_END,
+};
+
+char *R_create (int ranks, int cores)
+{
+    char *retval;
+    char corelist[64];
+    char ranklist[64];
+    json_t *o = NULL;
+    json_t *R_lite = NULL;
+
+    if ((snprintf (corelist, sizeof (corelist)-1, "0-%d", cores-1) < 0)
+        || (snprintf (ranklist, sizeof (ranklist)-1, "0-%d", ranks -1) < 0))
+        goto err;
+
+    if (!(R_lite = json_pack ("{s:s,s:{s:s}}",
+                    "rank", ranklist,
+                    "children", "core", corelist)))
+        goto err;
+    if (!(o = json_pack ("{s:i, s:{s:[O]}}",
+                   "version", 1,
+                   "execution", "R_lite", R_lite)))
+        goto err;
+    retval = json_dumps (o, JSON_COMPACT);
+    json_decref (o);
+    json_decref (R_lite);
+    return (retval);
+err:
+    json_decref (o);
+    json_decref (R_lite);
+    return NULL;
+}
+
+static struct rlist * rlist_testalloc (struct rlist *rl,
+                                       struct rlist_test_entry *e)
+{
+    return rlist_alloc (rl, e->mode,
+                        e->alloc.nnodes,
+                        e->alloc.nslots,
+                        e->alloc.slot_size);
+}
+
+void run_test_entries (struct rlist_test_entry tests[], int ranks, int cores)
+{
+    struct rlist *rl = NULL;
+    struct rlist *alloc = NULL;
+    struct rlist_test_entry *e = NULL;
+    char *R = R_create (ranks, cores);
+    if (R == NULL)
+        BAIL_OUT ("R_create (ranks=%d, cores=%d) failed", ranks, cores);
+    if (!(rl = rlist_from_R (R)))
+        BAIL_OUT ("rlist_from_R (%s)", R);
+    free (R);
+
+    e = &tests[0];
+    while (e && e->description) {
+        int avail_start = rl->avail;
+
+        alloc = rlist_testalloc (rl, e);
+        if (e->result == NULL) {  // Test for expected failure
+            ok (alloc == NULL && errno == e->expected_errno,
+                "%s: errno=%d", e->description, errno);
+        }
+        else {
+            if (alloc) {
+                char *result = rlist_dumps (alloc);
+                is (result, e->result, "%s: %s", e->description, result);
+                if (e->free) {
+                    ok (rlist_free (rl, alloc) == 0, "rlist_free (%s)", result);
+                    ok (avail_start == rl->avail, "freed all cores");
+                }
+                free (result);
+                rlist_destroy (alloc);
+            }
+            else {
+                fail ("%s: %s", e->description, strerror (errno));
+            }
+        }
+        char *s = rlist_dumps (rl);
+        // diag ("avail=%s", s);
+        free (s);
+        e++;
+    }
+    rlist_destroy (rl);
+}
+
+static void test_simple (void)
+{
+    struct rlist *rl = NULL;
+    struct rlist *alloc = NULL;
+    struct rlist *copy = NULL;
+
+    if (!(rl = rlist_create ()))
+        BAIL_OUT ("Failed to create rlist");
+
+    ok (rl->total == 0 && rl->avail == 0,
+        "rlist_create creates empty list");
+    ok (rlist_append_rank (rl, 0, "0-3") == 0,
+        "rlist_append_rank 0, 0-3");
+    ok (rl->total == 4 && rl->avail == 4,
+        "rlist: avail and total == 4");
+    ok (rlist_append_rank (rl, 1, "0-3") == 0,
+        "rlist_append_rank 1, 0-3");
+    ok (rl->total == 8 && rl->avail == 8,
+        "rlist: avail and total == 4");
+    ok ((alloc = rlist_alloc (rl, NULL, 0, 8, 1)) != NULL,
+        "rlist: alloc all cores works");
+    ok (alloc->total == 8 && alloc->avail == 8,
+        "rlist: alloc: avail = 8, total == 8");
+    ok (rl->total == 8 && rl->avail == 0,
+        "rlist: avail == 0, total == 8");
+    ok ((copy = rlist_copy_empty (rl)) != NULL,
+        "rlist: rlist_copy_empty");
+    ok (copy->total == 8 && copy->avail == 8,
+        "rlist: copy: total = %d, avail = %d", copy->total, copy->avail);
+
+    rlist_destroy (rl);
+    rlist_destroy (alloc);
+    rlist_destroy (copy);
+}
+
+static void test_dumps (void)
+{
+    char *result = NULL;
+    struct rlist *rl = NULL;
+
+    if (!(rl = rlist_create ()))
+        BAIL_OUT ("rlist_dumps: failed to create rlist");
+
+    ok (rlist_dumps (NULL) == NULL,
+        "rlist_dumps (NULL) == NULL");
+
+    result = rlist_dumps (rl);
+    is (result, "",
+        "rlist_dumps: empty list returns empty string");
+    free (result);
+
+    rlist_append_rank (rl, 0, "0-3");
+    result = rlist_dumps (rl);
+    is (result, "rank0/core[0-3]",
+        "rlist_dumps with one rank 4 cores gets expected result");
+    free (result);
+
+    rlist_append_rank (rl, 1, "0-7");
+    result = rlist_dumps (rl);
+    is (result, "rank0/core[0-3] rank1/core[0-7]",
+        "rlist_dumps with two ranks gets expected result");
+    free (result);
+
+    rlist_append_rank (rl, 1234567, "0-12345");
+    rlist_append_rank (rl, 1234568, "0-12346");
+    result = rlist_dumps (rl);
+    is (result, "rank0/core[0-3] rank1/core[0-7] "
+                "rank1234567/core[0-12345] rank1234568/core[0-12346]",
+        "rlist_dumps with long reuslt");
+    free (result);
+    rlist_destroy (rl);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_simple ();
+    test_dumps ();
+    run_test_entries (test_2n_4c,       2, 4);
+    run_test_entries (test_6n_4c,       6, 4);
+    run_test_entries (test_1024n_4c, 1024, 4);
+
+    done_testing ();
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/sched-simple/test/rnode.c
+++ b/src/modules/sched-simple/test/rnode.c
@@ -1,0 +1,149 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "rnode.h"
+
+static void rnode_alloc_and_check (struct rnode *n, int count, char *expected)
+{
+    struct idset *ids = NULL;
+    char *result = NULL;
+    int avail = rnode_avail (n);
+    ok (rnode_alloc (n, count, &ids) == 0,
+        "rnode_alloc: count=%d", count);
+    ok (ids != NULL,
+        "rnode_alloc: returns non-null idset");
+    ok (idset_count (ids) == count,
+        "rnode_alloc: returned idset with expected count (%d)",
+        idset_count (ids));
+    if (!(result = idset_encode (ids, IDSET_FLAG_RANGE)))
+        BAIL_OUT ("failed to encode idset result");
+    is (result, expected,
+        "rnode_alloc: count=%d: returned expected result %s", count, result);
+    ok (rnode_avail (n) == avail - count,
+        "rnode_alloc: rnode_avail now %d, expected %d",
+        rnode_avail (n), avail - count);
+    idset_destroy (ids);
+    free (result);
+}
+
+static void rnode_avail_check (struct rnode *n, const char *expected)
+{
+    char *avail = idset_encode (n->avail, IDSET_FLAG_RANGE);
+    if (avail == NULL)
+        BAIL_OUT ("failed to encode n->avail");
+    is (avail, expected,
+        "rnode->avail is expected: %s", avail);
+    free (avail);
+}
+
+int main (int ac, char *av[])
+{
+    struct idset *ids = NULL;
+    struct rnode *n = NULL;
+
+    plan (NO_PLAN);
+
+    if (!(n = rnode_create (0, "0-3")))
+        BAIL_OUT ("could not create an rnode object");
+    ok (rnode_avail (n) == 4,
+        "rnode_avail == 4");
+
+    ok (rnode_alloc (n, 5, &ids) < 0 && errno == ENOSPC,
+        "rnode_alloc too many cores returns errno ENOSPC");
+
+    rnode_alloc_and_check (n, 1, "0");
+    ok (rnode_avail (n) == 3,
+        "rnode_avail == 3");
+    rnode_avail_check (n, "1-3");
+
+    rnode_alloc_and_check (n, 1, "1");
+    ok (rnode_avail (n) == 2,
+        "rnode_avail == 2");
+    rnode_avail_check (n, "2-3");
+
+    rnode_alloc_and_check (n, 2, "2-3");
+    ok (rnode_avail (n) == 0,
+        "rnode_avail == 0");
+    rnode_avail_check (n, "");
+
+    ok (rnode_alloc (n, 1, &ids) < 0 && errno == ENOSPC && ids == NULL,
+        "rnode_alloc on empty rnode fails with ENOSPC");
+
+    ok (rnode_free (n, "3-4") < 0 && errno == ENOENT,
+        "rnode_free with invalid ids fails");
+    ok (rnode_avail (n) == 0,
+        "rnode_avail still is 0");
+    rnode_avail_check (n, "");
+
+    ok (rnode_free (n, "0-1") == 0,
+        "rnode_free (0-1) works");
+    ok (rnode_avail (n) == 2,
+        "rnode_avail now is 2");
+    rnode_avail_check (n, "0-1");
+    ok (rnode_free (n, "0") < 0 && errno == EEXIST,
+        "rnode_free of already available id fails");
+    ok (rnode_avail (n) == 2,
+        "rnode_avail is still 2");
+    ok (rnode_free (n, "3") == 0,
+        "rnode_free '3' works");
+    rnode_avail_check (n, "0-1,3");
+
+    rnode_alloc_and_check (n, 3, "0-1,3");
+
+    rnode_destroy (n);
+
+    n = rnode_create_count (1, 8);
+    if (n == NULL)
+        BAIL_OUT ("rnode_create_count failed");
+    ok (n->rank == 1, "rnode rank set correctly");
+    ok (n != NULL, "rnode_create_count");
+    rnode_avail_check (n, "0-7");
+    rnode_destroy (n);
+
+    struct idset *idset = idset_decode ("0-3");
+    n = rnode_create_idset (3, idset);
+    idset_destroy (idset);
+    if (n == NULL)
+        BAIL_OUT ("rnode_create_idset failed");
+    ok (n != NULL, "rnode_create_idset");
+    ok (n->rank == 3, "rnode rank set correctly");
+    rnode_avail_check (n, "0-3");
+
+    struct idset *alloc = idset_decode ("1,3");
+    ok (rnode_alloc_idset (n, alloc) == 0,
+        "rnode_alloc_idset (1,3)");
+    rnode_avail_check (n, "0,2");
+    ok (rnode_alloc_idset (n, alloc) < 0 && errno == EEXIST,
+        "rnode_alloc_idset with idset already allocated returns EEXIST");
+
+    ok (rnode_free_idset (n, alloc) == 0,
+        "rnode_free_idset (1,3)");
+    rnode_avail_check (n, "0-3");
+
+    ok (rnode_free_idset (n, alloc) < 0 && errno == EEXIST,
+        "rnode_free_idset with idset already available returns EEXIST");
+
+    idset_destroy (alloc);
+    alloc = idset_decode ("4-7");
+    ok (rnode_alloc_idset (n, alloc) < 0 && errno == ENOENT,
+        "rnode_alloc_idset with invalid ids return ENOENT");
+    ok (rnode_free_idset (n, alloc) < 0 && errno == ENOENT,
+        "rnode_free_idset with invalid ids return ENOENT");
+
+    idset_destroy (alloc);
+    rnode_destroy (n);
+    done_testing ();
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
 	t0019-jobspec-schema.t \
 	t0020-emit-jobspec.t \
 	t0021-flux-jobspec.t \
+	t0022-jj-reader.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \
@@ -154,6 +155,7 @@ check_SCRIPTS = \
 	t0019-jobspec-schema.t \
 	t0020-emit-jobspec.t \
 	t0021-flux-jobspec.t \
+	t0022-jj-reader.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \
@@ -232,7 +234,8 @@ check_PROGRAMS = \
 	rexec/rexec \
 	rexec/rexec_signal \
 	rexec/rexec_ps \
-	ingest/submitbench
+	ingest/submitbench \
+	sched-simple/jj-reader
 
 check_LTLIBRARIES = \
 	module/parent.la \
@@ -443,3 +446,9 @@ job_manager_sched_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
 job_manager_sched_dummy_la_LIBADD = \
         $(top_builddir)/src/common/libschedutil/libschedutil.la \
         $(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+sched_simple_jj_reader_SOURCES = sched-simple/jj-reader.c
+sched_simple_jj_reader_CPPFLAGS = $(test_cppflags)
+sched_simple_jj_reader_LDADD = \
+	$(top_builddir)/src/modules/sched-simple/libjj.la \
+	$(test_ldadd)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -85,6 +85,7 @@ TESTS = \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched.t \
+	t2300-sched-simple.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \
@@ -178,6 +179,7 @@ check_SCRIPTS = \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched.t \
+	t2300-sched-simple.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \

--- a/t/sched-simple/jj-reader.c
+++ b/t/sched-simple/jj-reader.c
@@ -1,0 +1,38 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <flux/optparse.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/read_all.h"
+#include "src/modules/sched-simple/libjj.h"
+
+int main (int ac, char *av[])
+{
+    char *s;
+    struct jj_counts jj;
+    log_init ("jj-reader");
+    if (read_all (STDIN_FILENO, (void **) &s) < 0)
+        log_err_exit ("Failed to read stdin");
+    if (libjj_get_counts (s, &jj) < 0)
+        log_msg_exit ("%s", jj.error);
+    printf ("nnodes=%d nslots=%d slot_size=%d\n",
+            jj.nnodes, jj.nslots, jj.slot_size);
+    log_fini ();
+    free (s);
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -1,0 +1,124 @@
+#!/bin/sh
+
+test_description='Test json-jobspec *cough* parser *cough*'
+
+. `dirname $0`/sharness.sh
+
+#  Set path to jq
+#
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+jj=${FLUX_BUILD_DIR}/t/sched-simple/jj-reader
+y2j=${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py
+
+test_expect_success HAVE_JQ 'jj-reader: unexpected version throws error' '
+	flux jobspec srun hostname | jq ".version = 2" >input.$test_count &&
+	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	cat >expected.$test_count <<-EOF &&
+	jj-reader: Invalid version: expected 1, got 2
+	EOF
+	test_cmp expected.$test_count out.$test_count
+'
+test_expect_success HAVE_JQ 'jj-reader: no version throws error' '
+	flux jobspec srun hostname | jq "del(.version)" >input.$test_count &&
+	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	cat >expected.$test_count <<-EOF &&
+	jj-reader: at top level: Object item not found: version
+	EOF
+	test_cmp expected.$test_count out.$test_count
+'
+test_expect_success HAVE_JQ 'jj-reader: bad count throws error' '
+	flux jobspec srun hostname | \
+	  jq ".resources[0].with[0].count = -1" >input.$test_count &&
+	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	cat >expected.$test_count <<-EOF &&
+	jj-reader: Invalid count -1 for type '\''core'\''
+	EOF
+	test_cmp expected.$test_count out.$test_count
+'
+test_expect_success HAVE_JQ 'jj-reader: bad type throws error' '
+	flux jobspec srun hostname | \
+	  jq --arg f beans ".resources[0].type = \$f" >input.$test_count &&
+	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	cat >expected.$test_count <<-EOF &&
+	jj-reader: Invalid type '\''beans'\''
+	EOF
+	test_cmp expected.$test_count out.$test_count
+'
+test_expect_success HAVE_JQ 'jj-reader: missing count throws error' '
+	flux jobspec srun hostname | \
+	  jq "del(.resources[0].with[0].count)" >input.$test_count &&
+	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	cat >expected.$test_count <<-EOF &&
+	jj-reader: level 1: Object item not found: count
+	EOF
+	test_cmp expected.$test_count out.$test_count
+'
+test_expect_success HAVE_JQ 'jj-reader: wrong count type throws error' '
+	flux jobspec srun hostname | \
+	  jq ".resources[0].with[0].count = 1.5" >input.$test_count &&
+	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	cat >expected.$test_count <<-EOF &&
+	jj-reader: level 1: Expected integer, got real
+	EOF
+	test_cmp expected.$test_count out.$test_count
+'
+
+# Invalid inputs:
+# jobspec.yaml ==<expected error>
+#
+cat <<EOF>invalid.txt
+jobspec/valid/basic.yaml        ==jj-reader: Unable to determine slot size
+jobspec/valid/example2.yaml     ==jj-reader: Unable to determine slot size
+jobspec/valid/use_case_1.2.yaml ==jj-reader: level 0: Expected integer, got object
+jobspec/valid/use_case_1.3.yaml ==jj-reader: level 2: Expected integer, got object
+jobspec/valid/use_case_1.4.yaml ==jj-reader: Invalid type 'socket'
+jobspec/valid/use_case_1.5.yaml ==jj-reader: Invalid type 'cluster'
+jobspec/valid/use_case_1.6.yaml ==jj-reader: Invalid type 'cluster'
+jobspec/valid/use_case_1.7.yaml ==jj-reader: Invalid type 'switch'
+jobspec/valid/use_case_2.1.yaml ==jj-reader: Unable to determine slot size
+jobspec/valid/use_case_2.2.yaml ==jj-reader: Unable to determine slot size
+jobspec/valid/use_case_2.5.yaml ==jj-reader: level 1: Expected integer, got object
+jobspec/valid/use_case_2.6.yaml ==jj-reader: level 2: Expected integer, got object
+EOF
+
+while read line; do
+  yaml=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
+  expected=$(echo $line | awk -F== '{print $2}')
+
+  test_expect_success "jj-reader: $(basename $yaml) gets expected error" '
+	echo $expected >expected.$test_count &&
+	$y2j<$SHARNESS_TEST_SRCDIR/$yaml >$test_count.json &&
+	test_expect_code 1 $jj<$test_count.json > out.$test_count 2>&1 &&
+	test_cmp expected.$test_count out.$test_count
+  '
+done <invalid.txt
+
+
+# Valid inputs:
+# <jobspec command args> == <expected result>
+#
+cat <<EOF >inputs.txt
+srun              ==nnodes=0 nslots=1 slot_size=1
+srun -N1          ==nnodes=1 nslots=1 slot_size=1
+srun -N1 -n4      ==nnodes=1 nslots=4 slot_size=1
+srun -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4
+srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4
+srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4
+srun -n4 -c1      ==nnodes=0 nslots=4 slot_size=1
+srun -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4
+EOF
+
+while read line; do
+
+  args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
+  expected=$(echo $line | awk -F== '{print $2}')
+
+  test_expect_success "jj-reader: $args returns $expected" '
+	echo $expected >expected.$test_count &&
+	flux jobspec $args hostname | $jj > output.$test_count &&
+	test_cmp expected.$test_count output.$test_count
+  '
+done < inputs.txt
+
+test_done

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -62,7 +62,10 @@ test_expect_success 'hwloc: internal aggregate-load cmd works' '
     cat <<-EOF | $jq -S . >aggregate.expected &&
 	{ "count": 2, "total": 2,
 	  "entries": {
-	    "[0-1]": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1 }
+	    "0": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1,
+                   "cpuset": "0-7" },
+	    "1": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1,
+	           "cpuset": "8-15"}
 	  }
 	}
 	EOF
@@ -73,7 +76,12 @@ test_expect_success 'hwloc: internal aggregate-load cmd works' '
 test_expect_success HAVE_JQ 'hwloc: by_rank aggregate key exists after reload' '
     flux kvs get resource.hwloc.by_rank | $jq -S . >  by_rank.out &&
     cat <<-EOF | $jq -S . >by_rank.expected &&
-	{"[0-1]": {"NUMANode": 1, "Package": 1, "Core": 8, "PU": 8}}
+	{
+	  "0": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1,
+                 "cpuset": "0-7" },
+	  "1": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1,
+	         "cpuset": "8-15"}
+	}
 	EOF
     test_cmp by_rank.expected by_rank.out
 '
@@ -111,8 +119,10 @@ test_expect_success HAVE_JQ 'hwloc: only one rank reloads an xml file' '
     flux kvs get resource.hwloc.by_rank | $jq -S . > mixed.out &&
     cat <<-EOF | $jq -S . >mixed.expected &&
 	{
-	 "0": {"NUMANode": 1, "Package": 1, "Core": 8, "PU": 8},
-	 "1": {"NUMANode": 2, "Package": 2, "Core": 16, "PU": 16}
+	 "0": {"NUMANode": 1, "Package": 1, "Core": 8, "PU": 8,
+               "cpuset": "0-7" },
+	 "1": {"NUMANode": 2, "Package": 2, "Core": 16, "PU": 16,
+	       "cpuset": "0-15" }
 	}
 	EOF
     test_cmp mixed.expected mixed.out
@@ -123,7 +133,8 @@ test_expect_success HAVE_JQ 'hwloc: reload xml with GPU resources' '
     flux kvs get resource.hwloc.by_rank | $jq -S . > sierra.out &&
     cat <<-EOF | $jq -S . > sierra.expected &&
 	{"[0-1]":
-          {"NUMANode": 6, "Package": 2, "Core": 44, "PU": 176, "GPU": 4}
+          {"NUMANode": 6, "Package": 2, "Core": 44, "PU": 176, "GPU": 4,
+           "cpuset": "0-175" }
         }
 	EOF
     test_cmp sierra.expected sierra.out

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -1,0 +1,188 @@
+#!/bin/sh
+
+test_description='simple sched-simple tests'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+query=${FLUX_BUILD_DIR}/src/modules/sched-simple/rlist-query
+
+hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
+hwloc_by_rank_first_fit='{"0": {"Core": 2}, "1": {"Core": 1}}'
+
+kvs_active() {
+	flux job id --to=kvs-active $1
+}
+job_wait_event() {
+	rc=1
+	mkfifo eventlog.$1
+	run_timeout 5 flux kvs eventlog get -w $(kvs_active $1).eventlog \
+                               2>>eventlog.errors > eventlog.$1 &
+	pid=$!
+	maxtime=$(($(date +%S) + 2))
+	while test $(date +%S) -lt $maxtime; do # retry fifo up for up to 2s
+	  while read line; do
+		event=$(echo $line | awk '{print $2}')
+		if test "$event" = "$2"; then
+			echo "# id=$1 $line" >&2
+			rc=0
+			break 2
+		fi
+	  done < eventlog.$1
+	done
+	kill -11 $pid
+	rm -f eventlog.$1
+	return $rc
+}
+list_R() {
+	for id in "$@"; do
+		flux kvs eventlog get $(kvs_active $id).eventlog \
+			| sed -n 's/.*alloc //gp'
+	done
+}
+
+test_expect_success 'sched-simple: load kvs-watch module' '
+	flux module load -r all kvs-watch
+'
+test_expect_success 'sched-simple: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+test_expect_success 'sched-simple: load default by_rank' '
+	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank)" &&
+	flux kvs get resource.hwloc.by_rank
+'
+test_expect_success 'sched-simple: load sched-simple' '
+	flux module load -r 0 sched-simple &&
+	flux dmesg 2>&1 | grep "ready:.*rank\[0-1\]/core\[0-1\]" &&
+	test "$($query)" = "rank[0-1]/core[0-1]"
+'
+test_expect_success 'sched-simple: unsatisfiable request is canceled' '
+	flux jobspec srun -c 3 hostname | flux job submit >job0.id &&
+	job0id=$(cat job0.id) &&
+	job_wait_event $job0id exception &&
+	flux kvs eventlog get $(kvs_active $job0id).eventlog \
+		| grep "unsatisfiable request"
+'
+
+Y2J=${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py
+SPEC=${SHARNESS_TEST_SRCDIR}/jobspec/valid/basic.yaml
+test_expect_success 'sched-simple: invalid minimal jobspec is canceled' '
+	${Y2J}<${SPEC} | flux job submit >job00.id &&
+	jobid=$(cat job00.id) &&
+	job_wait_event $jobid exception &&
+	flux kvs eventlog get $(kvs_active $jobid).eventlog \
+		| grep "Unable to determine slot size"
+'
+test_expect_success 'sched-simple: submit 5 jobs' '
+	flux job submit basic.json >job1.id &&
+	flux job submit basic.json >job2.id &&
+	flux job submit basic.json >job3.id &&
+	flux job submit basic.json >job4.id &&
+	flux job submit basic.json >job5.id &&
+	job_wait_event $(cat job4.id) alloc &&
+	job_wait_event $(cat job5.id) submit
+'
+test_expect_success 'sched-simple: check allocations for running jobs' '
+	list_R $(cat job1.id job2.id job3.id job4.id) > allocs.out &&
+	cat <<-EOF >allocs.expected &&
+	rank0/core0
+	rank1/core0
+	rank0/core1
+	rank1/core1
+	EOF
+	test_cmp allocs.expected allocs.out
+'
+test_expect_success 'sched-simple: no remaining resources' '
+	test "$($query)" = ""
+'
+test_expect_success 'sched-simple: cancel one job' '
+	flux job cancel $(cat job3.id) &&
+	job_wait_event $(cat job3.id) exception &&
+	job_wait_event $(cat job3.id) free
+'
+test_expect_success 'sched-simple: waiting job now has alloc event' '
+	job_wait_event $(cat job5.id) alloc &&
+	test "$(list_R $(cat job5.id))" = "rank0/core1"
+'
+test_expect_success 'sched-simple: cancel all jobs' '
+	flux job cancel $(cat job5.id) &&
+	flux job cancel $(cat job4.id) &&
+	flux job cancel $(cat job2.id) &&
+	flux job cancel $(cat job1.id) &&
+	job_wait_event $(cat job1.id) exception &&
+	job_wait_event $(cat job1.id) free &&
+	test "$($query)" = "rank[0-1]/core[0-1]"
+'
+test_expect_success 'sched-simple: reload in best-fit mode' '
+	flux module remove -r 0 sched-simple &&
+	flux module load -r 0 sched-simple mode=best-fit
+'
+test_expect_success 'sched-simple: submit 5 more jobs' '
+	flux job submit basic.json >job6.id &&
+	flux job submit basic.json >job7.id &&
+	flux job submit basic.json >job8.id &&
+	flux job submit basic.json >job9.id &&
+	flux job submit basic.json >job10.id &&
+	job_wait_event $(cat job9.id) alloc &&
+	job_wait_event $(cat job10.id) submit
+'
+test_expect_success 'sched-simple: check allocations for running jobs' '
+	list_R $(cat job6.id job7.id job8.id job9.id) > best-fit-allocs.out &&
+	cat <<-EOF >best-fit-allocs.expected &&
+	rank0/core0
+	rank0/core1
+	rank1/core0
+	rank1/core1
+	EOF
+	test_cmp best-fit-allocs.expected best-fit-allocs.out
+'
+test_expect_success 'sched-simple: cancel pending job' '
+	id=$(cat job10.id) &&
+	flux job cancel $id &&
+	job_wait_event $id exception &&
+	flux job cancel $(cat job6.id) &&
+	test_expect_code 1 flux kvs get $(kvs_active $id).R
+'
+test_expect_success 'sched-simple: cancel remaining jobs' '
+	flux job cancel $(cat job7.id) &&
+	flux job cancel $(cat job8.id) &&
+	flux job cancel $(cat job9.id) &&
+	job_wait_event $(cat job9.id) free
+'
+test_expect_success 'sched-simple: reload in first-fit mode' '
+        flux module remove -r 0 sched-simple &&
+	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank_first_fit)" &&
+        flux module load -r 0 sched-simple mode=first-fit &&
+	flux dmesg | grep "ready:.*rank0/core\[0-1\] rank1/core0"
+'
+test_expect_success 'sched-simple: submit 3 more jobs' '
+	flux job submit basic.json >job11.id &&
+	flux job submit basic.json >job12.id &&
+	flux job submit basic.json >job13.id &&
+	job_wait_event $(cat job13.id) alloc
+'
+test_expect_success 'sched-simple: check allocations for running jobs' '
+	list_R $(cat job11.id job12.id job13.id ) \
+		 > first-fit-allocs.out &&
+	cat <<-EOF >first-fit-allocs.expected &&
+	rank0/core0
+	rank0/core1
+	rank1/core0
+	EOF
+	test_cmp first-fit-allocs.expected first-fit-allocs.out
+'
+test_expect_success 'sched-simple: reload with outstanding allocations' '
+	flux module remove -r 0 sched-simple &&
+	flux module load sched-simple &&
+	flux dmesg | grep "hello: alloc rank0/core0" &&
+	test "$($query)" = ""
+'
+test_expect_success 'sched-simple: remove kvs-watch, sched-simple' '
+	flux module remove -r all kvs-watch &&
+	flux module remove -r 0 sched-simple
+'
+
+test_done


### PR DESCRIPTION
Putting this draft PR up mainly to synchronize with #2031 and proffer a simple (embarrassingly so) scheduler for flux-core, to be used for experimentation and testing of the job-manager/scheduler interface, as well an in-tree testing target and possible vehicle for simulated execution and other upcoming sprints.

This scheduler (really a node/core allocator) just maintains a list of nodes an free cores, generated from the `resource.hwloc.by_rank` object, and attempts to allocate to the current job based on a simple strategies (allocate from "most available" node by default).

I can put more detail up a bit later, but wanted to get the initial PR up in case @garlick (or anyone else) wanted to give early feedback.

In case I have to defend myself, we did say we wanted a simple allocator initially for our first cut at a fcfs scheduler in flux-core.. 