### PR TITLE
python: prevent early garbage collection of flux handles

### DIFF
--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -29,6 +29,8 @@ class RPC(Future):
         flags=0,
     ):
         if isinstance(flux_handle, Wrapper):
+            # keep the flux_handle alive for the lifetime of the RPC
+            self.flux_handle = flux_handle
             flux_handle = flux_handle.handle
 
         topic = encode_topic(topic)

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -51,6 +51,13 @@ class TestHandle(unittest.TestCase):
         self.assertEqual(r["pad"], u"stuff")
         self.assertTrue(isinstance(r["pad"], six.text_type))
 
+    def test_anonymous_handle_rpc_ping(self):
+        """Send a ping using an anonymous/unnamed flux handle"""
+        r = flux.Flux().rpc(b"cmb.ping", {"seq": 1, "pad": "stuff"}).get()
+        self.assertIsNotNone(r)
+        self.assertEqual(r["seq"], 1)
+        self.assertEqual(r["pad"], u"stuff")
+
     def test_rpc_ping_unicode(self):
         """Sending a ping"""
         r = self.f.rpc(


### PR DESCRIPTION
Prevents early GC of `Flux` handles by tying the lifetime of a `Flux` object used to create an `RPC` to the `RPC` lifetime.

Closes #2045