### PR TITLE
job-manager: add job submit debug flag

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -69,6 +69,10 @@ static struct optparse_option submit_opts[] =  {
     { .name = "priority", .key = 'p', .has_arg = 1, .arginfo = "N",
       .usage = "Set job priority (0-31, default=16)",
     },
+    { .name = "flags", .key = 'f', .has_arg = 3,
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Set submit comma-separated flags (e.g. debug)",
+    },
 #if HAVE_FLUX_SECURITY
     { .name = "security-config", .key = 'c', .has_arg = 1, .arginfo = "pattern",
       .usage = "Use non-default security config glob",
@@ -464,6 +468,15 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
     }
     if (optindex < argc)
         input = argv[optindex++];
+    if (optparse_hasopt (p, "flags")) {
+        const char *name;
+        while ((name = optparse_getopt_next (p, "flags"))) {
+            if (!strcmp (name, "debug"))
+                flags |= FLUX_JOB_DEBUG;
+            else
+                log_msg_exit ("unknown flag: %s", name);
+        }
+    }
 #if HAVE_FLUX_SECURITY
     /* If any non-default security options are specified, create security
      * context so jobspec can be pre-signed before submission.

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -21,6 +21,7 @@ extern "C" {
 
 enum job_submit_flags {
     FLUX_JOB_PRE_SIGNED = 1,    // 'jobspec' is already signed
+    FLUX_JOB_DEBUG = 2,
 };
 
 enum job_priority {

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -220,6 +220,8 @@ int free_request (struct alloc_ctx *ctx, struct job *job)
         goto error;
     if (flux_send (ctx->h, msg, 0) < 0)
         goto error;
+    if ((job->flags & FLUX_JOB_DEBUG))
+        eventlog_append (ctx, job, "debug.free-request", NULL);
 
     job->free_pending = 1;
 
@@ -334,6 +336,8 @@ int alloc_request (struct alloc_ctx *ctx, struct job *job)
         goto error;
     if (flux_send (ctx->h, msg, 0) < 0)
         goto error;
+    if ((job->flags & FLUX_JOB_DEBUG))
+        eventlog_append (ctx, job, "debug.alloc-request", NULL);
 
     job->alloc_pending = 1;
     queue_delete (ctx->inqueue, job, job->aux_queue_handle);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -51,14 +51,16 @@ zlist_t *enqueue_jobs (struct queue *queue, json_t *jobs)
         uint32_t userid;
         int priority;
         double t_submit;
+        int flags;
 
-        if (json_unpack (el, "{s:I s:i s:i s:f}", "id", &id,
-                                                  "priority", &priority,
-                                                  "userid", &userid,
-                                                  "t_submit", &t_submit) < 0) {
+        if (json_unpack (el, "{s:I s:i s:i s:f s:i}", "id", &id,
+                                                      "priority", &priority,
+                                                      "userid", &userid,
+                                                      "t_submit", &t_submit,
+                                                      "flags", &flags) < 0) {
             goto error;
         }
-        if (!(job = job_create (id, priority, userid, t_submit)))
+        if (!(job = job_create (id, priority, userid, t_submit, flags)))
             goto error;
         if (queue_insert (queue, job, &job->queue_handle) < 0) {
             job_decref (job);

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -48,7 +48,7 @@ static struct job *job_create_uninit (flux_jobid_t id)
 }
 
 struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
-                        double t_submit)
+                        double t_submit, int flags)
 {
     struct job *job;
 
@@ -57,6 +57,7 @@ struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
     job->userid = userid;
     job->priority = priority;
     job->t_submit = t_submit;
+    job->flags = flags;
     job->state = FLUX_JOB_NEW;
     return job;
 }
@@ -83,14 +84,17 @@ struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
                                    context, sizeof (context)) < 0)
             goto error;
         if (!strcmp (name, "submit")) {
-            int priority, userid;
+            int priority, userid, flags;
             if (util_int_from_context (context, "priority", &priority) < 0)
                 goto error;
             if (util_int_from_context (context, "userid", &userid) < 0)
                 goto error;
+            if (util_int_from_context (context, "flags", &flags) < 0)
+                goto error;
             job->t_submit = timestamp;
             job->userid = userid;
             job->priority = priority;
+            job->flags = flags;
             submit_valid = true;
         }
         else if (!strcmp (name, "priority")) {

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -19,6 +19,7 @@ struct job {
     uint32_t userid;
     int priority;
     double t_submit;
+    int flags;
     flux_job_state_t state;
 
     uint8_t exception_pending:1;
@@ -37,7 +38,8 @@ struct job *job_incref (struct job *job);
 struct job *job_create (flux_jobid_t id,
                         int priority,
                         uint32_t userid,
-                        double t_submit);
+                        double t_submit,
+                        int flags);
 
 /* (re-)create job by replaying its KVS eventlog.
  */

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -21,7 +21,7 @@ void test_create (void)
 {
     struct job *job;
 
-    job = job_create (42, 1, FLUX_USERID_UNKNOWN, 2);
+    job = job_create (42, 1, FLUX_USERID_UNKNOWN, 2, 3);
     if (job == NULL)
         BAIL_OUT ("job_create failed");
     ok (job->refcount == 1,
@@ -29,6 +29,8 @@ void test_create (void)
     ok (job->id == 42 && job->priority == 1 && job->state == FLUX_JOB_NEW
         && job->userid == FLUX_USERID_UNKNOWN && job->t_submit == 2,
         "job_create set id, priority, userid, and t_submit to expected values");
+    ok (job->flags == 3,
+        "job_create set submit flags to expected value");
     ok (!job->alloc_pending
         && !job->free_pending
         && !job->has_resources
@@ -54,29 +56,29 @@ void test_create (void)
 
 const char *test_input[] = {
     /* 0 */
-    "42.2 submit userid=66 priority=16\n",
+    "42.2 submit userid=66 priority=16 flags=42\n",
 
     /* 1 */
-    "42.2 submit userid=66 priority=16\n"
+    "42.2 submit userid=66 priority=16 flags=42\n"
     "42.3 priority userid=42 priority=1\n",
 
     /* 2 */
-    "42.2 submit userid=66 priority=16\n"
+    "42.2 submit userid=66 priority=16 flags=42\n"
     "42.3 exception type=cancel severity=0 userid=42 free form notes...\n",
 
     /* 3 */
-    "42.2 submit userid=66 priority=16\n"
+    "42.2 submit userid=66 priority=16 flags=42\n"
     "42.3 exception type=meep severity=1 userid=42 this one is non-fatal\n",
 
     /* 4 */
-    "42.2 submit userid=66 priority=16\n"
+    "42.2 submit userid=66 priority=16 flags=42\n"
     "42.3 alloc\n",
 
     /* 5 */
     "42.3 alloc\n",
 
     /* 6 */
-    "42.2 submit userid=66 priority=16\n"
+    "42.2 submit userid=66 priority=16 flags=42\n"
     "42.3 alloc\n"
     "42.4 free\n",
 };
@@ -100,6 +102,8 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit)  set no internal flags");
     ok (job->userid == 66,
         "job_create_from_eventlog log=(submit) set userid from submit");
+    ok (job->flags == 42,
+        "job_create_from_eventlog log=(submit) set flags from submit");
     ok (job->priority == 16,
         "job_create_from_eventlog log=(submit) set priority from submit");
     ok (job->t_submit == 42.2,

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -30,7 +30,7 @@ struct queue *make_test_queue (int size)
 
     for (id = 0; id < size; id++) {
         struct job *j;
-        if (!(j = job_create (id, 0, 0, 0)))
+        if (!(j = job_create (id, 0, 0, 0, 0)))
             BAIL_OUT ("job_create failed");
         if (queue_insert (q, j, &j->queue_handle) < 0)
             BAIL_OUT ("queue_insert failed");

--- a/src/modules/job-manager/test/queue.c
+++ b/src/modules/job-manager/test/queue.c
@@ -18,7 +18,7 @@
 struct job *job_create_test (flux_jobid_t id, int priority)
 {
     struct job *j;
-    if (!(j = job_create (id, priority, 1, 0)))
+    if (!(j = job_create (id, priority, 1, 0, 2)))
         BAIL_OUT ("job_create failed");
     return j;
 }

--- a/t/ingest/submitbench.c
+++ b/t/ingest/submitbench.c
@@ -43,6 +43,10 @@ static struct optparse_option opts[] =  {
     { .name = "priority", .key = 'p', .has_arg = 1, .arginfo = "N",
       .usage = "Set job priority (0-31, default=16)",
     },
+    { .name = "flags", .key = 'F', .has_arg = 3,
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Set comma-separated flags (e.g. debug)",
+    },
 #if HAVE_FLUX_SECURITY
     { .name = "reuse-signature", .key = 'R', .has_arg = 0,
       .usage = "Sign jobspec once and reuse the result for multiple RPCs",
@@ -210,6 +214,15 @@ int cmd_submitbench (optparse_t *p, int argc, char **argv)
     if (optindex != argc - 1) {
         optparse_print_usage (p);
         exit (1);
+    }
+    if (optparse_hasopt (p, "flags")) {
+        const char *name;
+        while ((name = optparse_getopt_next (p, "flags"))) {
+            if (!strcmp (name, "debug"))
+                ctx.flags |= FLUX_JOB_DEBUG;
+            else
+                log_msg_exit ("unknown flag: %s", name);
+        }
     }
 #if HAVE_FLUX_SECURITY
     /* If any non-default security options are specified, create security

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/bin/sh 
 test_description='Test flux job command'
 
 . $(dirname $0)/sharness.sh
@@ -28,6 +27,11 @@ test_expect_success 'flux-job: generate jobspec for simple test job' '
 test_expect_success 'flux-job: submit one job to get one valid job in queue' '
 	validjob=$(flux job submit basic.json) &&
 	echo Valid job is ${validjob}
+'
+
+test_expect_success 'flux-job: submit --flags=badflag fails with unknown flag' '
+	! flux job submit --flags=badflag basic.json 2>badflag.out &&
+	grep -q "unknown flag" badflag.out
 '
 
 test_expect_success 'flux-job: unknown sub-command fails with usage message' '


### PR DESCRIPTION
This PR adds a debug flag to the submission API, and a `--debug` option to `flux job submit` as proposed in #2033.

This causes the job manager to emit some "extra" events that are not justified for every job but which might be useful to provide context when debugging. For now, it just adds `alloc-request` and `free-request` debug events indicating that the `sched.alloc` or `sched.free`  request has been _sent_.  Normally events are only logged when the response is received.

The sharness test with the dummy scheduler is modified to verify that these events are added as expected for sched mode=single.

This scheme may be too simple, but perhaps its a reasonable first step?