### PR TITLE
common/libkvs: Remove flux_kvs_eventlog_update()

### DIFF
--- a/doc/man3/flux_kvs_eventlog_create.adoc
+++ b/doc/man3/flux_kvs_eventlog_create.adoc
@@ -5,7 +5,7 @@ flux_kvs_eventlog_create(3)
 
 NAME
 ----
-flux_kvs_eventlog_create, flux_kvs_eventlog_destroy, flux_kvs_eventlog_encode, flux_kvs_eventlog_decode, flux_kvs_eventlog_update, flux_kvs_eventlog_append, flux_kvs_eventlog_first, flux_kvs_eventlog_next - manipulate RFC 18 KVS eventlogs
+flux_kvs_eventlog_create, flux_kvs_eventlog_destroy, flux_kvs_eventlog_encode, flux_kvs_eventlog_decode, flux_kvs_eventlog_append, flux_kvs_eventlog_first, flux_kvs_eventlog_next - manipulate RFC 18 KVS eventlogs
 
 
 SYNOPSIS
@@ -18,9 +18,6 @@ SYNOPSIS
  char *flux_kvs_eventlog_encode (const struct flux_kvs_eventlog *eventlog);
 
  struct flux_kvs_eventlog *flux_kvs_eventlog_decode (const char *s);
-
- int flux_kvs_eventlog_update (struct flux_kvs_eventlog *eventlog,
-                               const char *s);
 
  int flux_kvs_eventlog_append (struct flux_kvs_eventlog *eventlog,
                                const char *s);
@@ -56,8 +53,10 @@ character.
 
 Raw event strings can be atomically appended to an eventlog stored in the KVS
 using `flux_kvs_txn_put()` with the the 'FLUX_KVS_APPEND' flag.
-The eventlog can be accessed with `flux_kvs_lookup()`, optionally with
-the 'FLUX_KVS_WATCH' flag.
+The eventlog can be accessed with `flux_kvs_lookup()`.  When watching
+an eventlog with the 'FLUX_KVS_WATCH' flag, it is recommended to also
+specify the 'FLUX_KVS_WATCH_APPEND' flag so only new events are seen
+in responses.
 
 `flux_kvs_eventlog_create()` creates an empty eventlog object in memory,
 and `flux_kvs_eventlog_destroy()` disposes of it.
@@ -68,11 +67,13 @@ eventlog data in string form, such as would be returned by
 `flux_kvs_eventlog_encode()` performs the opposite function; again, the
 caller must free the returned string.
 
-`flux_kvs_eventlog_update()` updates an eventlog object with a new snapshot
-of the raw log, such as might be returned from `flux_kvs_lookup_get()`.
-This function does not change the iterator cursor.
-
-`flux_kvs_eventlog_append()` appends a single raw event to the eventlog.
+`flux_kvs_eventlog_append()` appends raw event(s) to an eventlog
+object.  Multiple events can be appended using this call, such as
+initializing the eventlog object with the raw snapshot returned from a
+`flux_kvs_lookup()`.  It is also convenient to call
+`flux_kvs_eventlog_append()` with results from watching an eventlog
+with the 'FLUX_KVS_WATCH' and 'FLUX_KVS_WATCH_APPEND' flags.  This
+function does not change the iterator cursor.
 
 The events in an eventlog object may be accessed in raw form  with the
 iterators `flux_kvs_eventlog_first()` and `flux_kvs_eventlog_next()`.
@@ -104,9 +105,8 @@ an eventlog object on success, or NULL on failure with errno set.
 `flux_kvs_event_encode_timestamp()` return encoded strings on success,
 or NULL on failure with errno set.
 
-`flux_kvs_eventlog_update()`, `flux_kvs_eventlog_append()`, and
-`flux_kvs_event_decode()` return 0 on success, or -1 on failure
-with errno set.
+`flux_kvs_eventlog_append()`, and `flux_kvs_event_decode()` return 0
+on success, or -1 on failure with errno set.
 
 `flux_kvs_eventlog_first()` and `flux_kvs_eventlog_next()` return
 a const pointer to a raw event, or NULL if the internal cursor has

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1876,15 +1876,10 @@ void eventlog_get_continuation (flux_future_t *f, void *arg)
         return;
     }
 
-    /* Each KVS get response returns a new snapshot of the eventlog.
-     * Pass it to eventlog_update() which ensures the shapshot is consistent
-     * with any existing events in the log, and makes new events available to
-     * the iterator.
-     */
     if (flux_kvs_lookup_get (f, &s) < 0)
         log_err_exit ("flux_kvs_lookup_get");
-    if (flux_kvs_eventlog_update (ctx->log, s) < 0)
-        log_err_exit ("flux_kvs_eventlog_update");
+    if (flux_kvs_eventlog_append (ctx->log, s) < 0)
+        log_err_exit ("flux_kvs_eventlog_append");
 
     /* Display any new events.
      */
@@ -1927,8 +1922,10 @@ int cmd_eventlog_get (optparse_t *p, int argc, char **argv)
         exit (1);
     }
     key = argv[optindex++];
-    if (optparse_hasopt (p, "watch"))
+    if (optparse_hasopt (p, "watch")) {
         flags |= FLUX_KVS_WATCH;
+        flags |= FLUX_KVS_WATCH_APPEND;
+    }
 
     if (!(ctx.log = flux_kvs_eventlog_create()))
         log_err_exit ("flux_kvs_eventlog_create");

--- a/src/common/libkvs/kvs_eventlog.h
+++ b/src/common/libkvs/kvs_eventlog.h
@@ -35,12 +35,7 @@ void flux_kvs_eventlog_destroy (struct flux_kvs_eventlog *eventlog);
 char *flux_kvs_eventlog_encode (const struct flux_kvs_eventlog *eventlog);
 struct flux_kvs_eventlog *flux_kvs_eventlog_decode (const char *s);
 
-/* Update an eventlog with new encoded snapshot 's'.
- */
-int flux_kvs_eventlog_update (struct flux_kvs_eventlog *eventlog,
-                              const char *s);
-
-/* Append an encoded event to eventlog.
+/* Append encoded event(s) to eventlog.
  */
 int flux_kvs_eventlog_append (struct flux_kvs_eventlog *eventlog,
                               const char *s);


### PR DESCRIPTION
With addition of FLUX_KVS_WATCH_APPEND, the flux_kvs_eventlog_update()
function is no longer needed.

Internally adjust flux_kvs_eventlog_append() to be able to handle more than
a single event append.

Update documentation and unit tests appropriately.

Update callers in flux-kvs.