### PR TITLE
libidset: add idset_equal(3), improve efficiency of idset_count(3)

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -325,6 +325,7 @@ idset_clear.3: idset_create.3
 idset_first.3: idset_create.3
 idset_next.3: idset_create.3
 idset_count.3: idset_create.3
+# N.B. exceeds max 8 stubs  idset_equal.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -5,8 +5,7 @@ idset_create(3)
 
 NAME
 ----
-idset_create, idset_destroy, idset_encode, idset_decode, idset_set, idset_clear, idset_first, idset_next, idset_count - Manipulate numerically sorted sets of non-negative integers
-
+idset_create, idset_destroy, idset_encode, idset_decode, idset_set, idset_clear, idset_first, idset_next, idset_count, idset_equal - Manipulate numerically sorted sets of non-negative integers
 
 SYNOPSIS
 --------
@@ -41,6 +40,8 @@ SYNOPSIS
  unsigned int idset_last (const struct idset *idset)
 
  size_t idset_count (const struct idset *idset);
+
+ bool idset_equal (const struct idset *set1, const struct idset *set2);
 
 
 USAGE
@@ -98,6 +99,9 @@ empty.
 
 `idset_count()` returns the number of ids in the set.
 
+`idset_equal()` returns true if the two idset objects 'set1' and 'set2'
+are equal sets, i.e. the sets contain the same set of integers.
+
 
 FLAGS
 -----
@@ -130,6 +134,9 @@ with `free()`.  On error, NULL is returned with errno set.
 
 `idset_first()`, `idset_next()`, and `idset_last()` return an id,
 or IDSET_INVALID_ID if no id is available.
+
+`idset_equal()` returns true if 'set1' and 'set2' are equal sets,
+or false if they are not equal, or either argument is 'NULL'.
 
 Other functions return 0 on success, or -1 on error with errno set.
 

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -263,6 +263,31 @@ size_t idset_count (const struct idset *idset)
     return idset->count;
 }
 
+bool idset_equal (const struct idset *idset1,
+                  const struct idset *idset2)
+{
+    unsigned int id;
+
+    if (!idset1 || !idset2)
+        return false;
+    if (idset_count (idset1) != idset_count (idset2))
+        return false;
+
+    id = vebsucc (idset1->T, 0);
+    while (id < idset1->T.M) {
+        if (vebsucc (idset2->T, id) != id)
+            return false; // id in idset1 not set in idset2
+        id = vebsucc (idset1->T, id + 1);
+    }
+    id = vebsucc (idset2->T, 0);
+    while (id < idset2->T.M) {
+        if (vebsucc (idset1->T, id) != id)
+            return false; // id in idset2 not set in idset1
+        id = vebsucc (idset2->T, id + 1);
+    }
+    return true;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -48,6 +48,7 @@ struct idset *idset_create (size_t size, int flags)
         return NULL;
     }
     idset->flags = flags;
+    idset->count = 0;
     return idset;
 }
 
@@ -89,6 +90,7 @@ struct idset *idset_copy (const struct idset *idset)
         idset_destroy (cpy);
         return NULL;
     }
+    cpy->count = idset->count;
     return cpy;
 }
 
@@ -131,6 +133,24 @@ static int idset_grow (struct idset *idset, size_t size)
     return 0;
 }
 
+/* Wrapper for vebput() which increments idset count if needed
+ */
+static void idset_put (struct idset *idset, unsigned int id)
+{
+    if (!idset_test (idset, id))
+        idset->count++;
+    vebput (idset->T, id);
+}
+
+/* Wrapper for vebdel() which decrements idset count if needed
+ */
+static void idset_del (struct idset *idset, unsigned int id)
+{
+    if (idset_test (idset, id))
+        idset->count--;
+    vebdel (idset->T, id);
+}
+
 int idset_set (struct idset *idset, unsigned int id)
 {
     if (!idset || !valid_id (id)) {
@@ -139,7 +159,7 @@ int idset_set (struct idset *idset, unsigned int id)
     }
     if (idset_grow (idset, id + 1) < 0)
         return -1;
-    vebput (idset->T, id);
+    idset_put (idset, id);
     return 0;
 }
 
@@ -164,7 +184,7 @@ int idset_range_set (struct idset *idset, unsigned int lo, unsigned int hi)
     if (idset_grow (idset, hi + 1) < 0)
         return -1;
     for (id = lo; id <= hi; id++)
-        vebput (idset->T, id);
+        idset_put (idset, id);
     return 0;
 }
 
@@ -174,7 +194,7 @@ int idset_clear (struct idset *idset, unsigned int id)
         errno = EINVAL;
         return -1;
     }
-    vebdel (idset->T, id);
+    idset_del (idset, id);
     return 0;
 }
 
@@ -188,7 +208,7 @@ int idset_range_clear (struct idset *idset, unsigned int lo, unsigned int hi)
     }
     normalize_range (&lo, &hi);
     for (id = lo; id <= hi && id < idset->T.M; id++)
-        vebdel (idset->T, id);
+        idset_del (idset, id);
     return 0;
 }
 
@@ -238,17 +258,9 @@ unsigned int idset_last (const struct idset *idset)
 
 size_t idset_count (const struct idset *idset)
 {
-    unsigned int id;
-    size_t count = 0;
-
     if (!idset)
         return 0;
-    id = vebsucc (idset->T, 0);
-    while (id < idset->T.M) {
-        count++;
-        id = vebsucc (idset->T, id + 1);
-    }
-    return count;
+    return idset->count;
 }
 
 /*

--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -90,6 +90,11 @@ unsigned int idset_last (const struct idset *idset);
  */
 size_t idset_count (const struct idset *idset);
 
+/* Return true if the two idsets set1, set2 are equal, i.e. they both
+ * have the same integers set.
+ */
+bool idset_equal (const struct idset *set1, const struct idset *set2);
+
 #endif /* !FLUX_IDSET_H */
 
 /*

--- a/src/common/libidset/idset_private.h
+++ b/src/common/libidset/idset_private.h
@@ -17,6 +17,7 @@
 #include "idset.h"
 
 struct idset {
+    size_t count;
     Veb T;
     int flags;
 };

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -263,8 +263,16 @@ void test_set (void)
     if (!(idset = idset_create (100, 0)))
         BAIL_OUT ("idset_create failed");
 
+    ok (idset_count (idset) == 0,
+        "idset_count (idset) == 0");
     ok (idset_set (idset, 0) == 0,
         "idset_set 0 worked");
+    ok (idset_count (idset) == 1,
+        "idset_count (idset) == 1");
+    ok (idset_set (idset, 0) == 0,
+        "idset_set 0 again  succeeds");
+    ok (idset_count (idset) == 1,
+        "idset_count (idset) == 1");
     ok (idset_set (idset, 3) == 0,
         "idset_set 3 worked");
     ok (idset_set (idset, 99) == 0,
@@ -300,8 +308,16 @@ void test_range_set (void)
 
     ok (idset_range_set (idset, 0, 2) == 0,
         "idset_range_set 0-2 worked");
+    ok (idset_count (idset) == 3,
+        "idset_count == 3");
+    ok (idset_range_set (idset, 0, 2) == 0,
+        "idset_range_set 0-2 again worked");
+    ok (idset_count (idset) == 3,
+        "idset_count == 3");
     ok (idset_range_set (idset, 80, 79) == 0, // reversed
         "idset_set 80-79 worked");
+    ok (idset_count (idset) == 5,
+        "idset_count == 5");
 
     errno = 0;
     ok (idset_range_set (idset, 100, 101) < 0 && errno == EINVAL,
@@ -352,6 +368,8 @@ void test_clear (void)
 
     ok (idset_clear (idset, 100) == 0,
         "idset_clear idset=[8-10], id=100 works");
+    ok (idset_count (idset) == 3,
+        "idset_count still returns 3");
     errno = 0;
     ok (idset_clear (idset, UINT_MAX) < 0 && errno == EINVAL,
         "idset_clear idset=[8-10], id=UINT_MAX failed with EINVAL");
@@ -380,6 +398,12 @@ void test_range_clear (void)
 
     ok (idset_range_clear (idset, 2, 5) == 0,
         "idset_range_clear 2-5 works");
+    ok (idset_count (idset) == 6,
+        "idset_count == 6");
+    ok (idset_range_clear (idset, 2, 5) == 0,
+        "idset_range_clear 2-5 again succeeds");
+    ok (idset_count (idset) == 6,
+        "idset_count is still 6");
     ok (idset_range_clear (idset, 9, 6) == 0, // reversed
         "idset_range_clear 9-6 works");
     errno = 0;

--- a/src/modules/sched-simple/rlist.c
+++ b/src/modules/sched-simple/rlist.c
@@ -85,15 +85,9 @@ static struct rnode *rlist_find_rank (struct rlist *rl, uint32_t rank)
 
 static int idset_cmp (struct idset *set1, struct idset *set2)
 {
-    int rc;
-    if ((rc = idset_count (set1) - idset_count (set2)) == 0) {
-        char *x = idset_encode (set1, IDSET_FLAG_RANGE);
-        char *y = idset_encode (set2, IDSET_FLAG_RANGE);
-        rc = strcmp (x, y);
-        free (x);
-        free (y);
-    }
-    return rc;
+    if (idset_equal (set1, set2))
+        return 0;
+    return idset_count (set1) - idset_count (set2);
 }
 
 static int idset_add_set (struct idset *set, struct idset *new)


### PR DESCRIPTION
As a sanity check I was running a test workload to exercise the ingest->job-manager<->scheduler logic, and while doing some profiling I noticed the workload was spending 10% of the total CPU cycles in `vebsucc()`. As it turns out `sched-simple` is a heavy user of `idset_count(3)` (to sort nodes by least or most available), and currently that function needs to traverse the entire vEB tree for every call.

This PR adds a `count` member to `struct idset` and keeps the counted updated with `idset_set` and `idset_clear` calls.

This small change had a large improvement, so at the risk of premature optimization, I went ahead and proposed it here.

On current master, a set of 4K 1 core jobs submitted to a instance with 4K cores across 128 nodes shows
```
sched-bench: starting test with 4096 jobs. broker.pid=14085
sched-bench: ingested 4096 jobs in 16.13s (253.94 job/s)
sched-bench: allocated 4096 jobs in 33.526s (122.17 job/s)
sched-bench: elapsed time: 34.024s (120.38 job/s)
```

With the change to `idset_count(3)`:
```
sched-bench: starting test with 4096 jobs. broker.pid=23102
sched-bench: ingested 4096 jobs in 16.34s (250.67 job/s)
sched-bench: allocated 4096 jobs in 20.115s (203.63 job/s)
sched-bench: elapsed time: 20.545s (199.37 job/s)
```

Where the `ingested` time is the time for `t/ingest/submitbench -r 4096 -f 16` to complete, the `allocated` time is the difference in time between the `submit` event for the first job and the `alloc` event for the last job, and the `elapsed` time is the total time from the start of `submitbench` and all jobs getting allocated resources. (ingest and "scheduling" are happening together here)

While adding new tests, I noticed that there was already an idset comparator function within the  unit test, and since this was needed for sched-simple, I moved  that code into `idset_equal(3)` now exported by libidset.

Man page entry for `idset_equal` is also added, but I can't add it to the manpage stubs for `idset_create.adoc` because of the old problem where `a2x` won't generate more than 9 stubs for a manpage (any workaround for that?)
