### PR TITLE
job-manager: combine coincident eventlog updates into single KVS commit

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -20,6 +20,8 @@ job_manager_la_SOURCES = job-manager.c \
 			 queue.h \
 			 util.h \
 			 util.c \
+			 event.h \
+			 event.c \
 			 restart.h \
 			 restart.c \
 			 raise.h \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -49,6 +49,7 @@ TESTS = \
 	test_restart.t
 
 test_ldadd = \
+        $(top_builddir)/src/modules/job-manager/event.o \
         $(top_builddir)/src/modules/job-manager/queue.o \
         $(top_builddir)/src/modules/job-manager/job.o \
         $(top_builddir)/src/modules/job-manager/util.o \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -89,6 +89,7 @@
 #include "alloc.h"
 #include "queue.h"
 #include "util.h"
+#include "event.h"
 
 typedef enum {
     SCHED_SINGLE,       // only allow one outstanding sched.alloc request
@@ -99,6 +100,7 @@ struct alloc_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     struct queue *queue;    // main active job queue
+    struct event_ctx *event_ctx;
     struct queue *inqueue;  // secondary queue of jobs to be scheduled
     sched_interface_t mode;
     bool ready;
@@ -108,39 +110,6 @@ struct alloc_ctx {
     unsigned int active_alloc_count; // for mode=single, max of 1
 };
 
-static void eventlog_continuation (flux_future_t *f, void *arg)
-{
-    flux_t *h = flux_future_get_flux (f);
-    if (flux_rpc_get (f, NULL) < 0)
-        flux_log_error (h, "eventlog commit");
-    flux_future_destroy (f);
-}
-
-static void eventlog_append (struct alloc_ctx *ctx, struct job *job,
-                            const char *name, const char *note)
-{
-    flux_kvs_txn_t *txn;
-    flux_future_t *f;
-
-    if (!note)
-        note = "";
-    if (!(txn = flux_kvs_txn_create ()))
-        goto error;
-    if (util_eventlog_append (txn, job->id, name, "%s", note) < 0)
-        goto error;
-    if (!(f = flux_kvs_commit (ctx->h, NULL, 0, txn)))
-        goto error;
-    if (flux_future_then (f, -1, eventlog_continuation, NULL) < 0) {
-        flux_future_destroy (f);
-        goto error;
-    }
-    flux_kvs_txn_destroy (txn);
-    return;
-error:
-    flux_log_error (ctx->h, "eventlog commit");
-    flux_kvs_txn_destroy (txn);
-}
-
 /* Initiate teardown.  Clear any alloc/free requests, and clear
  * the alloc->ready flag to stop prep/check from allocating.
  */
@@ -149,8 +118,8 @@ static void interface_teardown (struct alloc_ctx *ctx, char *s, int errnum)
     if (ctx->ready) {
         struct job *job;
 
-        flux_log (ctx->h, LOG_DEBUG, "alloc: stop due to %s",
-                  flux_strerror (errnum));
+        flux_log (ctx->h, LOG_DEBUG, "alloc: stop due to %s: %s",
+                  s, flux_strerror (errnum));
 
         job = queue_first (ctx->queue);
         while (job) {
@@ -174,6 +143,15 @@ static void interface_teardown (struct alloc_ctx *ctx, char *s, int errnum)
         ctx->active_alloc_count = 0;
     }
 }
+
+static void event_cb (flux_future_t *f, void *arg)
+{
+    struct alloc_ctx *ctx = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        flux_log_error (ctx->h, "alloc eventlog commit");
+}
+
 
 /* Handle a sched.free response.
  */
@@ -201,7 +179,8 @@ static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     job->free_pending = 0;
     job->has_resources = 0;
-    eventlog_append (ctx, job, "free", NULL);
+    if (event_log (ctx->event_ctx, job->id, event_cb, ctx, "free", NULL) < 0)
+        goto teardown;
     return;
 teardown:
     interface_teardown (ctx, "free response error", errno);
@@ -221,8 +200,8 @@ int free_request (struct alloc_ctx *ctx, struct job *job)
     if (flux_send (ctx->h, msg, 0) < 0)
         goto error;
     if ((job->flags & FLUX_JOB_DEBUG))
-        eventlog_append (ctx, job, "debug.free-request", NULL);
-
+        (void)event_log (ctx->event_ctx, job->id, NULL, NULL,
+                         "debug.free-request", NULL);
     job->free_pending = 1;
 
     flux_msg_destroy (msg);
@@ -282,13 +261,12 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
      * Raise alloc exception and transition to CLEANUP state.
      */
     if (type == 2) { // error: alloc was rejected
-        char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
-        (void)snprintf (context, sizeof (context),
-                        "type=%s severity=%d userid=%u%s%s",
-                        "alloc", 0, FLUX_USERID_UNKNOWN,
-                        note ? " " : "",
-                        note ? note : "");
-        eventlog_append (ctx, job, "exception", context);
+        if (event_log_fmt (ctx->event_ctx, job->id, event_cb, ctx,
+                           "exception", "type=%s severity=%d userid=%u%s%s",
+                           "alloc", 0, FLUX_USERID_UNKNOWN,
+                           note ? " " : "",
+                           note ? note : "") < 0)
+            goto teardown;
         job->state = FLUX_JOB_CLEANUP;
         // FIXME: integrate with exception framework
         return;
@@ -306,7 +284,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
 
     job->has_resources = 1;
 
-    eventlog_append (ctx, job, "alloc", note);
+    if (event_log (ctx->event_ctx, job->id, event_cb, ctx, "alloc", note) < 0)
+        goto teardown;
     if (job->state == FLUX_JOB_SCHED)
         job->state = FLUX_JOB_RUN;
     else { /* state == FLUX_JOB_CLEANUP */
@@ -336,8 +315,8 @@ int alloc_request (struct alloc_ctx *ctx, struct job *job)
     if (flux_send (ctx->h, msg, 0) < 0)
         goto error;
     if ((job->flags & FLUX_JOB_DEBUG))
-        eventlog_append (ctx, job, "debug.alloc-request", NULL);
-
+        (void)event_log (ctx->event_ctx, job->id, NULL, NULL,
+                         "debug.alloc-request", NULL);
     job->alloc_pending = 1;
     queue_delete (ctx->inqueue, job, job->aux_queue_handle);
     job->aux_queue_handle = NULL;
@@ -514,7 +493,8 @@ static const struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue)
+struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue,
+                                    struct event_ctx *event_ctx)
 {
     struct alloc_ctx *ctx;
     flux_reactor_t *r = flux_get_reactor (h);
@@ -523,6 +503,7 @@ struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue)
         return NULL;
     ctx->h = h;
     ctx->queue = queue;
+    ctx->event_ctx = event_ctx;
     if (!(ctx->inqueue = queue_create (false)))
         goto error;
     if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -290,7 +290,6 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                         note ? note : "");
         eventlog_append (ctx, job, "exception", context);
         job->state = FLUX_JOB_CLEANUP;
-        //job->exception_pending = 1;
         // FIXME: integrate with exception framework
         return;
     }

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -15,11 +15,13 @@
 
 #include "queue.h"
 #include "job.h"
+#include "event.h"
 
 struct alloc_ctx;
 
 void alloc_ctx_destroy (struct alloc_ctx *ctx);
-struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue);
+struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue,
+                                    struct event_ctx *event_ctx);
 
 /* Call this from other parts of the job manager when the alloc
  * machinery might need to take action on 'job'.  The action taken

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -1,0 +1,260 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* event.c - batch up eventlog updates into a timed commit */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "util.h"
+#include "event.h"
+
+const double batch_timeout = 0.01;
+
+struct event_ctx {
+    flux_t *h;
+    struct event_batch *batch;
+    flux_watcher_t *timer;
+    zlist_t *pending;
+};
+
+struct event_batch {
+    struct event_ctx *ctx;
+    flux_kvs_txn_t *txn;
+    zlist_t *callbacks;
+    flux_future_t *f;
+};
+
+struct event_callback {
+    event_completion_f cb;
+    void *arg;
+};
+
+struct event_batch *event_batch_create (struct event_ctx *ctx);
+void event_batch_destroy (struct event_batch *batch);
+
+/* Batch commit has completed.
+ * Destroy 'batch', which notifies any registered callbacks.
+ */
+void commit_continuation (flux_future_t *f, void *arg)
+{
+    struct event_batch *batch = arg;
+    struct event_ctx *ctx = batch->ctx;
+
+    zlist_remove (ctx->pending, batch);
+    event_batch_destroy (batch);
+}
+
+/* Close the current batch, if any, and commit it.
+ */
+void event_batch_commit (struct event_ctx *ctx)
+{
+    struct event_batch *batch = ctx->batch;
+    if (batch) {
+        ctx->batch = NULL;
+        if (!(batch->f = flux_kvs_commit (ctx->h, NULL, 0, batch->txn)))
+            goto error;
+        if (flux_future_then (batch->f, -1., commit_continuation, batch) < 0)
+            goto error;
+        if (zlist_append (ctx->pending, batch) < 0)
+            goto nomem;
+    }
+    return;
+nomem:
+    errno = ENOMEM;
+error: // unlikely (e.g. ENOMEM)
+    flux_log_error (ctx->h, "%s: aborting reactor", __FUNCTION__);
+    flux_reactor_stop_error (flux_get_reactor (ctx->h));
+    event_batch_destroy (batch);
+}
+
+void timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct event_ctx *ctx = arg;
+    event_batch_commit (ctx);
+}
+
+void event_batch_destroy (struct event_batch *batch)
+{
+    if (batch) {
+        int saved_errno = errno;
+        struct event_callback *ec;
+
+        flux_kvs_txn_destroy (batch->txn);
+        if (batch->f)
+            (void)flux_future_wait_for (batch->f, -1);
+        if (batch->callbacks) {
+            while ((ec = zlist_pop (batch->callbacks))) {
+                ec->cb (batch->f, ec->arg);
+                free (ec);
+            }
+            zlist_destroy (&batch->callbacks);
+        }
+        flux_future_destroy (batch->f);
+        free (batch);
+        errno = saved_errno;
+    }
+}
+
+struct event_batch *event_batch_create (struct event_ctx *ctx)
+{
+    struct event_batch *batch;
+
+    if (!(batch = calloc (1, sizeof (*batch))))
+        return NULL;
+    if (!(batch->txn = flux_kvs_txn_create ()))
+        goto error;
+    if (!(batch->callbacks = zlist_new ()))
+        goto nomem;
+    batch->ctx = ctx;
+    return batch;
+nomem:
+    errno = ENOMEM;
+error:
+    event_batch_destroy (batch);
+    return NULL;
+}
+
+/* Append event to batch, registering callback 'cb' if non-NULL.
+ */
+int event_batch_append (struct event_batch *batch,
+                        const char *key, const char *event,
+                        event_completion_f cb, void *arg)
+{
+    if (cb) {
+        struct event_callback *ec;
+        if (!(ec = calloc (1, sizeof (*ec))))
+            return -1;
+        ec->cb = cb;
+        ec->arg = arg;
+        if (zlist_push (batch->callbacks, ec) < 0) {
+            free (ec);
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+    if (flux_kvs_txn_put (batch->txn, FLUX_KVS_APPEND, key, event) < 0) {
+        if (cb) {
+            struct event_callback *ec;
+            int saved_errno = errno;
+            ec = zlist_pop (batch->callbacks);
+            free (ec);
+            errno = saved_errno;
+        }
+        return -1;
+    }
+    return 0;
+}
+
+/* Create a new "batch" if there is none.
+ * No-op if batch already started.
+ */
+int event_batch_start (struct event_ctx *ctx)
+{
+    if (!ctx->batch) {
+        if (!(ctx->batch = event_batch_create (ctx)))
+            return -1;
+        flux_timer_watcher_reset (ctx->timer, batch_timeout, 0.);
+        flux_watcher_start (ctx->timer);
+    }
+    return 0;
+}
+
+int event_log (struct event_ctx *ctx, flux_jobid_t id,
+               event_completion_f cb, void *arg,
+               const char *name, const char *context)
+{
+    char key[64];
+    char *event = NULL;
+    int saved_errno;
+
+    if (util_jobkey (key, sizeof (key), true, id, "eventlog") < 0)
+        return -1;
+    if (!(event = flux_kvs_event_encode (name, context)))
+        return -1;
+    if (event_batch_start (ctx) < 0)
+        goto error;
+    if (event_batch_append (ctx->batch, key, event, cb, arg) < 0)
+        goto error;
+    free (event);
+    return 0;
+error:
+    saved_errno = errno;
+    free (event);
+    errno = saved_errno;
+    return -1;
+}
+
+int event_log_fmt (struct event_ctx *ctx, flux_jobid_t id,
+                   event_completion_f cb, void *arg, const char *name,
+                   const char *fmt, ...)
+{
+    va_list ap;
+    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
+    int n;
+
+    va_start (ap, fmt);
+    n = vsnprintf (context, sizeof (context), fmt, ap);
+    va_end (ap);
+    if (n < 0 || n >= sizeof (context)) {
+        errno = EINVAL;
+        return -1;
+    }
+    return event_log (ctx, id, cb, arg, name, context);
+}
+
+/* N.B. any in-flight batches are destroyed here.
+ * If they are not yet fulfilled, user callbacks may synchronously block on
+ * flux_future_get().
+ */
+void event_ctx_destroy (struct event_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_watcher_destroy (ctx->timer);
+        event_batch_commit (ctx);
+        if (ctx->pending) {
+            struct event_batch *batch;
+            while ((batch = zlist_pop (ctx->pending)))
+                event_batch_destroy (batch);
+        }
+        zlist_destroy (&ctx->pending);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+struct event_ctx *event_ctx_create (flux_t *h)
+{
+    struct event_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+    if (!(ctx->timer = flux_timer_watcher_create (flux_get_reactor (h),
+                                                  0., 0., timer_cb, ctx)))
+        goto error;
+    if (!(ctx->pending = zlist_new ()))
+        goto nomem;
+    return ctx;
+nomem:
+    errno = ENOMEM;
+error:
+    event_ctx_destroy (ctx);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_EVENT_H
+#define _FLUX_JOB_MANAGER_EVENT_H
+
+#include <stdarg.h>
+#include <flux/core.h>
+
+struct event_ctx;
+
+typedef void (*event_completion_f)(flux_future_t *f, void *arg);
+
+/* Log event (name, context) to jobs.active.<id>.eventlog.
+ * Once event is committed, cb(f, arg) is invoked if cb != NULL.
+ * The callback may call flux_future_get() to determine if the commit
+ * succeeded.
+ */
+int event_log (struct event_ctx *ctx, flux_jobid_t id,
+               event_completion_f cb, void *arg,
+               const char *name, const char *context);
+
+/* Same as above except event context is constructed from (fmt, ...).
+ */
+int event_log_fmt (struct event_ctx *ctx, flux_jobid_t id,
+                   event_completion_f cb, void *arg,
+                   const char *name, const char *fmt, ...);
+
+void event_ctx_destroy (struct event_ctx *ctx);
+struct event_ctx *event_ctx_create (flux_t *h);
+
+#endif /* _FLUX_JOB_MANAGER_EVENT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -23,6 +23,7 @@
 #include "list.h"
 #include "priority.h"
 #include "alloc.h"
+#include "event.h"
 
 
 struct job_manager_ctx {
@@ -30,6 +31,7 @@ struct job_manager_ctx {
     flux_msg_handler_t **handlers;
     struct queue *queue;
     struct alloc_ctx *alloc_ctx;
+    struct event_ctx *event_ctx;
 };
 
 /* Enqueue jobs from 'jobs' array in queue.
@@ -216,6 +218,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating scheduler interface");
         goto done;
     }
+    if (!(ctx.event_ctx = event_ctx_create (h))) {
+        flux_log_error (h, "error creating event batcher");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -232,6 +238,7 @@ int mod_main (flux_t *h, int argc, char **argv)
 done:
     flux_msg_handler_delvec (ctx.handlers);
     alloc_ctx_destroy (ctx.alloc_ctx);
+    event_ctx_destroy (ctx.event_ctx);
     queue_destroy (ctx.queue);
     return rc;
 }

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -147,7 +147,7 @@ static void raise_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-    raise_handle_request (h, ctx->queue, ctx->alloc_ctx, msg);
+    raise_handle_request (h, ctx->queue, ctx->event_ctx, ctx->alloc_ctx, msg);
 }
 
 /* priority request handled in priority.c

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -214,12 +214,12 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating queue");
         goto done;
     }
-    if (!(ctx.alloc_ctx = alloc_ctx_create (h, ctx.queue))) {
-        flux_log_error (h, "error creating scheduler interface");
-        goto done;
-    }
     if (!(ctx.event_ctx = event_ctx_create (h))) {
         flux_log_error (h, "error creating event batcher");
+        goto done;
+    }
+    if (!(ctx.alloc_ctx = alloc_ctx_create (h, ctx.queue, ctx.event_ctx))) {
+        flux_log_error (h, "error creating scheduler interface");
         goto done;
     }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -156,7 +156,7 @@ static void priority_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-    priority_handle_request (h, ctx->queue, msg);
+    priority_handle_request (h, ctx->queue, ctx->event_ctx, msg);
 }
 
 /* reload_map_f callback

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -22,7 +22,6 @@ struct job {
     int flags;
     flux_job_state_t state;
 
-    uint8_t exception_pending:1;
     uint8_t alloc_pending:1;
     uint8_t free_pending:1;
     uint8_t has_resources:1;

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -31,11 +31,10 @@
 #endif
 #include <flux/core.h>
 
-#include "src/common/libjob/job.h"
-
 #include "job.h"
 #include "queue.h"
 #include "util.h"
+#include "event.h"
 #include "priority.h"
 
 #define MAXOF(a,b)   ((a)>(b)?(a):(b))
@@ -43,10 +42,10 @@
 struct priority {
     flux_msg_t *request;
     struct job *job;
-    flux_kvs_txn_t *txn;
     int priority;
 
     struct queue *queue;
+    struct event_ctx *event_ctx;
 };
 
 static void priority_destroy (struct priority *p)
@@ -54,27 +53,26 @@ static void priority_destroy (struct priority *p)
     if (p) {
         int saved_errno = errno;
         flux_msg_destroy (p->request);
-        flux_kvs_txn_destroy (p->txn);
         free (p);
         errno = saved_errno;
     }
 }
 
 static struct priority *priority_create (struct queue *queue,
-                                   struct job *job,
-                                   const flux_msg_t *request,
-                                   int priority)
+                                         struct event_ctx *event_ctx,
+                                         struct job *job,
+                                         const flux_msg_t *request,
+                                         int priority)
 {
     struct priority *p;
 
     if (!(p = calloc (1, sizeof (*p))))
         return NULL;
     p->queue = queue;
+    p->event_ctx = event_ctx;
     p->job = job;
     p->priority = priority;
     if (!(p->request = flux_msg_copy (request, false)))
-        goto error;
-    if (!(p->txn = flux_kvs_txn_create ()))
         goto error;
     return p;
 error:
@@ -100,10 +98,10 @@ static void priority_continuation (flux_future_t *f, void *arg)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 done:
     priority_destroy (p);
-    flux_future_destroy (f);
 }
 
 void priority_handle_request (flux_t *h, struct queue *queue,
+                              struct event_ctx *event_ctx,
                               const flux_msg_t *msg)
 {
     uint32_t userid;
@@ -111,7 +109,6 @@ void priority_handle_request (flux_t *h, struct queue *queue,
     flux_jobid_t id;
     struct job *job;
     struct priority *p = NULL;
-    flux_future_t *f;
     int priority;
     int rc;
     const char *errstr = NULL;
@@ -152,18 +149,12 @@ void priority_handle_request (flux_t *h, struct queue *queue,
      * Upon successful completion, insert job in new queue position and
      * send response.
      */
-    if (!(p = priority_create (queue, job, msg, priority)))
+    if (!(p = priority_create (queue, event_ctx, job, msg, priority)))
         goto error;
-    if (util_eventlog_append (p->txn, job->id, "priority",
-                              "userid=%lu priority=%d",
-                              (unsigned long)userid, priority) < 0)
+    if (event_log_fmt (p->event_ctx, job->id, priority_continuation, p,
+                       "priority", "userid=%lu priority=%d",
+                       (unsigned long)userid, priority) < 0)
         goto error;
-    if (!(f = flux_kvs_commit (h, NULL, 0, p->txn)))
-        goto error;
-    if (flux_future_then (f, -1., priority_continuation, p) < 0) {
-        flux_future_destroy (f);
-        goto error;
-    }
     return;
 error:
     if (errstr)

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -158,8 +158,6 @@ void priority_handle_request (flux_t *h, struct queue *queue,
                               "userid=%lu priority=%d",
                               (unsigned long)userid, priority) < 0)
         goto error;
-    if (util_attr_pack (p->txn, job->id, "priority", "i", priority) < 0)
-        goto error;
     if (!(f = flux_kvs_commit (h, NULL, 0, p->txn)))
         goto error;
     if (flux_future_then (f, -1., priority_continuation, p) < 0) {

--- a/src/modules/job-manager/priority.h
+++ b/src/modules/job-manager/priority.h
@@ -12,11 +12,13 @@
 #define _FLUX_JOB_MANAGER_PRIORITY_H
 
 #include "queue.h"
+#include "event.h"
 
 /* Handle a 'priority' request - job priority adjustment
  */
 void priority_handle_request (flux_t *h, struct queue *queue,
-                           const flux_msg_t *msg);
+                              struct event_ctx *event_ctx,
+                              const flux_msg_t *msg);
 
 
 #endif /* ! _FLUX_JOB_MANAGER_PRIORITY_H */

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -37,6 +37,7 @@
 
 #include "job.h"
 #include "queue.h"
+#include "event.h"
 #include "util.h"
 #include "raise.h"
 
@@ -44,7 +45,6 @@ struct raise_ctx {
     flux_t *h;
     flux_msg_t *request;
     struct job *job;
-    flux_kvs_txn_t *txn;
     uint32_t userid;
     int severity;
     char *type;
@@ -53,6 +53,7 @@ struct raise_ctx {
     char *errstr;
 
     struct queue *queue;
+    struct event_ctx *event_ctx;
     struct alloc_ctx *alloc_ctx;
     int refcount;
 };
@@ -92,7 +93,6 @@ void raise_ctx_decref (struct raise_ctx *c)
                     __FUNCTION__, (unsigned long long)c->job->id);
             }
         }
-        flux_kvs_txn_destroy (c->txn);
         free (c->note);
         free (c->type);
         free (c->errstr);
@@ -110,6 +110,7 @@ struct raise_ctx *raise_ctx_incref (struct raise_ctx *c)
 
 struct raise_ctx *raise_ctx_create (flux_t *h,
                                     struct queue *queue,
+                                    struct event_ctx *event_ctx,
                                     struct alloc_ctx *alloc_ctx,
                                     struct job *job,
                                     const flux_msg_t *request,
@@ -124,6 +125,7 @@ struct raise_ctx *raise_ctx_create (flux_t *h,
         return NULL;
     c->queue = queue;
     c->alloc_ctx = alloc_ctx;
+    c->event_ctx = event_ctx;
     c->job = job;
     c->userid = userid;
     c->h = h;
@@ -132,8 +134,6 @@ struct raise_ctx *raise_ctx_create (flux_t *h,
     if (!(c->type = strdup (type)))
         goto error;
     if (note && !(c->note = strdup (note)))
-        goto error;
-    if (!(c->txn = flux_kvs_txn_create ()))
         goto error;
     if (!(c->request = flux_msg_copy (request, false)))
         goto error;
@@ -197,7 +197,7 @@ error:
                     (unsigned long long)c->job->id);
 }
 
-void raise_eventlog_continuation (flux_future_t *f, void *arg)
+void raise_eventlog_cb (flux_future_t *f, void *arg)
 {
     struct raise_ctx *c = arg;
     flux_t *h = flux_future_get_flux (f);
@@ -207,28 +207,19 @@ void raise_eventlog_continuation (flux_future_t *f, void *arg)
         flux_log_error (h, "eventlog_update id=%llu",
                         (unsigned long long)c->job->id);
     }
-    flux_future_destroy (f);
     raise_ctx_decref (c);
 }
 
 void raise_eventlog (struct raise_ctx *c)
 {
-    flux_future_t *f;
-
-    if (util_eventlog_append (c->txn, c->job->id, "exception",
-                              "type=%s severity=%d userid=%lu%s%s",
-                              c->type,
-                              c->severity,
-                              (unsigned long)c->userid,
-                              c->note ? " " : "",
-                              c->note ? c->note : "") < 0)
+    if (event_log_fmt (c->event_ctx, c->job->id, raise_eventlog_cb, c,
+                       "exception", "type=%s severity=%d userid=%lu%s%s",
+                       c->type,
+                       c->severity,
+                       (unsigned long)c->userid,
+                       c->note ? " " : "",
+                       c->note ? c->note : "") < 0)
         goto error;
-    if (!(f = flux_kvs_commit (c->h, NULL, 0, c->txn)))
-        goto error;
-    if (flux_future_then (f, -1, raise_eventlog_continuation, c) < 0) {
-        flux_future_destroy (f);
-        goto error;
-    }
     raise_ctx_incref (c);
     return;
 error:
@@ -264,6 +255,7 @@ int raise_allow (uint32_t rolemask, uint32_t userid, uint32_t job_userid)
 }
 
 void raise_handle_request (flux_t *h, struct queue *queue,
+                           struct event_ctx *event_ctx,
                            struct alloc_ctx *alloc_ctx,
                            const flux_msg_t *msg)
 {
@@ -314,8 +306,8 @@ void raise_handle_request (flux_t *h, struct queue *queue,
      * When the last one completes, 'c' is destroyed and
      * the user receives a response to the job-manager.raise request.
      */
-    if (!(c = raise_ctx_create (h, queue, alloc_ctx, job, msg, userid,
-                                severity, type, note)))
+    if (!(c = raise_ctx_create (h, queue, event_ctx, alloc_ctx,
+                                job, msg, userid, severity, type, note)))
         goto error;
     raise_eventlog (c);
     raise_publish (c);

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -80,7 +80,6 @@ void raise_ctx_decref (struct raise_ctx *c)
 {
     if (c && --c->refcount == 0) {
         int saved_errno = errno;
-        c->job->exception_pending = 0;
         if (c->request) {
             raise_respond (c);
             flux_msg_destroy (c->request);
@@ -318,7 +317,6 @@ void raise_handle_request (flux_t *h, struct queue *queue,
     if (!(c = raise_ctx_create (h, queue, alloc_ctx, job, msg, userid,
                                 severity, type, note)))
         goto error;
-    job->exception_pending = 1;
     raise_eventlog (c);
     raise_publish (c);
     raise_ctx_decref (c);

--- a/src/modules/job-manager/raise.h
+++ b/src/modules/job-manager/raise.h
@@ -18,7 +18,8 @@
 /* Hande a request to raise an exception on job.
  */
 void raise_handle_request (flux_t *h, struct queue *queue,
-                           struct alloc_ctx *ctx,
+                           struct event_ctx *event_ctx,
+                           struct alloc_ctx *alloc_ctx,
                            const flux_msg_t *msg);
 
 /* exposed for unit testing only */

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -33,8 +33,7 @@ void test_create (void)
         "job_create set submit flags to expected value");
     ok (!job->alloc_pending
         && !job->free_pending
-        && !job->has_resources
-        && !job->exception_pending,
+        && !job->has_resources,
         "job_create set no internal flags");
     ok (job->aux_queue_handle == NULL && job->queue_handle == NULL,
         "job_Create set queue handles to NULL");
@@ -97,8 +96,7 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit) set id from param");
     ok (!job->alloc_pending
         && !job->free_pending
-        && !job->has_resources
-        && !job->exception_pending,
+        && !job->has_resources,
         "job_create_from_eventlog log=(submit)  set no internal flags");
     ok (job->userid == 66,
         "job_create_from_eventlog log=(submit) set userid from submit");
@@ -126,8 +124,7 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit+pri) set t_submit from submit");
     ok (!job->alloc_pending
         && !job->free_pending
-        && !job->has_resources
-        && !job->exception_pending,
+        && !job->has_resources,
         "job_create_from_eventlog log=(submit+pri) set no internal flags");
     ok (job->state == FLUX_JOB_SCHED,
         "job_create_from_eventlog log=(submit+pri) set state=SCHED");
@@ -145,8 +142,7 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit+ex0) set t_submit from submit");
     ok (!job->alloc_pending
         && !job->free_pending
-        && !job->has_resources
-        && !job->exception_pending,
+        && !job->has_resources,
         "job_create_from_eventlog log=(submit+ex0) set no internal flags");
     ok (job->state == FLUX_JOB_CLEANUP,
         "job_create_from_eventlog log=(submit+ex0) set state=CLEANUP");
@@ -160,8 +156,7 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit+ex1) set state=SCHED");
     ok (!job->alloc_pending
         && !job->free_pending
-        && !job->has_resources
-        && !job->exception_pending,
+        && !job->has_resources,
         "job_create_from_eventlog log=(submit+ex1) set no internal flags");
     job_decref (job);
 
@@ -171,8 +166,7 @@ void test_create_from_eventlog (void)
         BAIL_OUT ("job_create_from_eventlog log=(submit+alloc) failed");
     ok (!job->alloc_pending
         && !job->free_pending
-        && job->has_resources
-        && !job->exception_pending,
+        && job->has_resources,
         "job_create_from_eventlog log=(submit+alloc) set has_resources flag");
     ok (job->state == FLUX_JOB_RUN,
         "job_create_from_eventlog log=(submit+alloc) set state=RUN");
@@ -190,8 +184,7 @@ void test_create_from_eventlog (void)
         BAIL_OUT ("job_create_from_eventlog log=(submit+alloc+free) failed");
     ok (!job->alloc_pending
         && !job->free_pending
-        && !job->has_resources
-        && !job->exception_pending,
+        && !job->has_resources,
         "job_create_from_eventlog log=(submit+alloc+free) set no internal flags");
     ok (job->state == FLUX_JOB_CLEANUP,
         "job_create_from_eventlog log=(submit+alloc+free) set state=CLEANUP");

--- a/src/modules/job-manager/test/util.c
+++ b/src/modules/job-manager/test/util.c
@@ -17,7 +17,6 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libkvs/treeobj.h"
-#include "src/common/libkvs/kvs_txn_private.h"
 
 #include "src/modules/job-manager/job.h"
 #include "src/modules/job-manager/util.h"
@@ -83,86 +82,6 @@ void check_jobkey (void)
     int i;
     for (i = 0; !is_jobkeytab_end (&jobkeytab[i]); i++)
         check_one_jobkey (&jobkeytab[i]);
-}
-
-char *decode_value (flux_kvs_txn_t *txn, int index, const char **key)
-{
-    json_t *txn_entry;
-    const char *txn_key;
-    int txn_flags;
-    json_t *txn_dirent;
-    char *data = "";
-    int len = -1;
-
-    if (txn_get_op (txn, index, &txn_entry) < 0)
-        return NULL;
-    if (txn_decode_op (txn_entry, &txn_key, &txn_flags, &txn_dirent) < 0)
-        return NULL;
-    if (treeobj_decode_val (txn_dirent, (void **)&data, &len) < 0)
-        return NULL;
-    if (len == 0)
-        return NULL;
-    *key = txn_key;
-    return data; // includes terminating \0 not included in len
-}
-
-void check_eventlog_append (void)
-{
-    flux_kvs_txn_t *txn;
-    char *event;
-    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
-    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
-    const char *key;
-
-    if (!(txn = flux_kvs_txn_create ()))
-        BAIL_OUT ("flux_kvs_txn_create failed");
-
-    /* verify with context */
-    ok (util_eventlog_append (txn, 3, "foo", "%s", "testing") == 0,
-        "util_eventlog_append id=3 name=foo ctx=testing works");
-    event = decode_value (txn, 0, &key);
-    ok (event && !strcmp (key, "job.active.0000.0000.0000.0003.eventlog"),
-        "event appended to txn has expected key");
-    ok (event && flux_kvs_event_decode (event, NULL, name, sizeof (name),
-                                        context, sizeof (context)) == 0
-        && !strcmp (name, "foo") && !strcmp (context, "testing"),
-        "event appended to txn matches input");
-    free (event);
-
-    /* verify event without context */
-    ok (util_eventlog_append (txn, 3, "foo", "") == 0,
-        "util_eventlog_append id=3 name=foo ctx=\"\" works");
-    event = decode_value (txn, 1, &key);
-    ok (event && !strcmp (key, "job.active.0000.0000.0000.0003.eventlog"),
-        "event appended to txn has expected key");
-    ok (event && flux_kvs_event_decode (event, NULL, name, sizeof (name),
-                                        context, sizeof (context)) == 0
-        && !strcmp (name, "foo") && !strcmp (context, ""),
-        "event appended to txn matches input");
-    free (event);
-
-    flux_kvs_txn_destroy (txn);
-}
-
-void check_attr_set (void)
-{
-    flux_kvs_txn_t *txn;
-    char *value;
-    const char *key;
-
-    if (!(txn = flux_kvs_txn_create ()))
-        BAIL_OUT ("flux_kvs_txn_create failed");
-
-    ok (util_attr_pack (txn, 3, "a", "i", 42) == 0,
-        "util_attr_pack id=3 i=42 works");
-    value = decode_value (txn, 0, &key);
-    ok (value && !strcmp (key, "job.active.0000.0000.0000.0003.a"),
-        "job attr in txn has expected key");
-    ok (value && !strcmp (value, "42"),
-        "job attr in txn has expected value");
-    free (value);
-
-    flux_kvs_txn_destroy (txn);
 }
 
 struct context_input {
@@ -245,8 +164,6 @@ int main (int argc, char **argv)
     plan (NO_PLAN);
 
     check_jobkey ();
-    check_eventlog_append ();
-    check_attr_set ();
     check_context ();
 
     done_testing ();

--- a/src/modules/job-manager/util.h
+++ b/src/modules/job-manager/util.h
@@ -36,22 +36,6 @@ const char *util_note_from_context (const char *context);
 int util_jobkey (char *buf, int bufsz, bool active,
                  flux_jobid_t id, const char *key);
 
-/* Set 'key' within active job directory for job 'id'.
- */
-int util_attr_pack (flux_kvs_txn_t *txn,
-                    flux_jobid_t id,
-                    const char *key,
-                    const char *fmt, ...);
-
-/* Log an event to eventlog in active job directory for job 'id'.
- * The event consists of current wallclock, 'name', and optional context
- * formatted from (fmt, ...).  Set fmt="" to skip logging a context.
- */
-int util_eventlog_append (flux_kvs_txn_t *txn,
-                          flux_jobid_t id,
-                          const char *name,
-                          const char *fmt, ...);
-
 /* Look up 'key' relative to active/inactive job directory for job 'id'.
  */
 flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -148,9 +148,9 @@ test_expect_success 'job-manager: flux job priority sets last job priority=31' '
 test_expect_success 'job-manager: priority was updated in KVS' '
 	jobid=$(tail -1 <list10_ids.out) &&
 	kvsdir=$(flux job id --to=kvs-active $jobid) &&
-	flux kvs get ${kvsdir}.priority >pri.out &&
-	echo 31 >pri.exp &&
-	test_cmp pri.exp pri.out
+	flux kvs eventlog get ${kvsdir}.eventlog \
+		| cut -d" " -f2- | grep ^priority >pri.out &&
+	grep -q priority=31 pri.out
 '
 
 test_expect_success 'job-manager: that job is now the first job' '


### PR DESCRIPTION
This removes some duplicated code in the job manager for appending to a job's eventlog, replacing it with a more sophisticated mechanism to batch KVS eventlog updates that occur close together in time.

Logic is added to ensure that any in-flight commits are finalized (and callbacks invoked, if any) if the job manager module is unloaded while busy, thus ensuring no data is lost from KVS job records.