### PR TITLE
[WIP] eventlog proxy (#2041)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -409,6 +409,7 @@ AC_CONFIG_FILES( \
   src/connectors/ssh/Makefile \
   src/modules/Makefile \
   src/modules/connector-local/Makefile \
+  src/modules/eventlog-proxy/Makefile \
   src/modules/kvs/Makefile \
   src/modules/kvs-watch/Makefile \
   src/modules/content-sqlite/Makefile \

--- a/etc/rc1
+++ b/etc/rc1
@@ -7,6 +7,7 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 flux module load -r all kvs-watch
+flux module load -r all eventlog-proxy
 flux module load -r all aggregator
 
 flux hwloc reload & pids="$pids $!"

--- a/etc/rc3
+++ b/etc/rc3
@@ -25,6 +25,7 @@ flux module remove -r 0 cron
 flux module remove -r all aggregator
 flux module remove -r all barrier
 
+flux module remove -r all eventlog-proxy
 flux module remove -r all kvs-watch
 flux module remove -r all -x 0 kvs
 if test -n "$PERSISTDIR"; then

--- a/src/common/libkvs/kvs_eventlog.c
+++ b/src/common/libkvs/kvs_eventlog.c
@@ -330,6 +330,61 @@ char *flux_kvs_event_encode (const char *name, const char *context)
     return flux_kvs_event_encode_timestamp (timestamp, name, context);
 }
 
+static int validate_lookup_flags (int flags)
+{
+    if (flags & ~FLUX_KVS_EVENTLOG_WATCH)
+        return -1;
+    return 0;
+}
+
+flux_future_t *flux_kvs_eventlog_lookup (flux_t *h, int flags, const char *key)
+{
+    flux_future_t *f;
+    const char *topic = "eventlog-proxy.lookup";
+    int rpc_flags = FLUX_RPC_STREAMING;
+
+    if (!h || validate_lookup_flags (flags) < 0 || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
+                             "{s:s s:i}",
+                             "key", key,
+                             "flags", flags)))
+        return NULL;
+    return f;
+}
+
+int flux_kvs_eventlog_lookup_get (flux_future_t *f, const char **event)
+{
+    const char *s;
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "event", &s) < 0)
+        return -1;
+    if (event)
+        *event = s;
+    return 0;
+}
+
+int flux_kvs_eventlog_lookup_cancel (flux_future_t *f)
+{
+    flux_future_t *f2;
+
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f2 = flux_rpc_pack (flux_future_get_flux (f),
+                              "eventlog-proxy.cancel",
+                              FLUX_NODEID_ANY,
+                              FLUX_RPC_NORESPONSE,
+                              "{s:i}",
+                              "matchtag", (int)flux_rpc_get_matchtag (f))))
+        return -1;
+    flux_future_destroy (f2);
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libkvs/kvs_eventlog.h
+++ b/src/common/libkvs/kvs_eventlog.h
@@ -24,6 +24,9 @@ extern "C" {
 #define FLUX_KVS_MAX_EVENT_NAME      (64)
 #define FLUX_KVS_MAX_EVENT_CONTEXT   (256)
 
+enum kvs_eventlog_op {
+    FLUX_KVS_EVENTLOG_WATCH = 1
+};
 
 /* Create/destroy an eventlog
  */
@@ -59,6 +62,13 @@ char *flux_kvs_event_encode_timestamp (double timestamp,
                                        const char *name,
                                        const char *context);
 
+/* Eventlog streaming functions, return a single event per response.
+ * The flux_kvs_eventlog_lookup_cancel() function can be called
+ * to end the stream early.
+ */
+flux_future_t *flux_kvs_eventlog_lookup (flux_t *h, int flags, const char *key);
+int flux_kvs_eventlog_lookup_get (flux_future_t *f, const char **event);
+int flux_kvs_eventlog_lookup_cancel (flux_future_t *f);
 
 #ifdef __cplusplus
 }

--- a/src/common/libkvs/test/kvs_eventlog.c
+++ b/src/common/libkvs/test/kvs_eventlog.c
@@ -189,6 +189,22 @@ void bad_input (void)
     ok (flux_kvs_eventlog_next (NULL) == NULL,
         "flux_kvs_eventlog_next log=NULL returns NULL");
 
+    /* lookup, lookup_get, lookup_cancel */
+    errno = EINVAL;
+    ok (!flux_kvs_eventlog_lookup (NULL, 0, NULL)
+        && errno == EINVAL,
+        "flux_kvs_eventlog_lookup fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_kvs_eventlog_lookup_get (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_kvs_eventlog_lookup_get fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_kvs_eventlog_lookup_cancel (NULL) < 0
+        && errno == EINVAL,
+        "flux_kvs_eventlog_lookup_cancel fails with EINVAL on bad input");
+
     errno = 0;
     ok (flux_kvs_event_decode (NULL, NULL, NULL, 0, NULL, 0) < 0
         && errno == EINVAL,

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = \
  barrier \
  connector-local \
+ eventlog-proxy \
  kvs \
  kvs-watch \
  content-sqlite \

--- a/src/modules/eventlog-proxy/Makefile.am
+++ b/src/modules/eventlog-proxy/Makefile.am
@@ -1,0 +1,26 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+
+fluxmod_LTLIBRARIES = eventlog-proxy.la
+
+eventlog_proxy_la_SOURCES = \
+	eventlog-proxy.c
+
+
+eventlog_proxy_la_LDFLAGS = $(fluxmod_ldflags) -module
+eventlog_proxy_la_LIBADD = $(fluxmod_libadd) \
+	$(top_builddir)/src/common/libkvs/libkvs.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS)

--- a/src/modules/eventlog-proxy/eventlog-proxy.c
+++ b/src/modules/eventlog-proxy/eventlog-proxy.c
@@ -1,0 +1,347 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* evenlog-watcher - track eventlog changes */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/fluid.h"
+
+/* Module state.
+ */
+struct proxy_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    zlist_t *lookups;
+};
+
+/* Lookup context
+ */
+struct lookup_ctx {
+    struct proxy_ctx *ctx;
+    flux_msg_t *msg;
+    int flags;
+    flux_future_t *f;
+};
+
+void lookup_ctx_destroy (void *data)
+{
+    if (data) {
+        struct lookup_ctx *ctx = data;
+        flux_msg_destroy (ctx->msg);
+        flux_future_destroy (ctx->f);
+        free (ctx);
+    }
+}
+
+struct lookup_ctx *lookup_ctx_create (struct proxy_ctx *ctx,
+                                      const flux_msg_t *msg,
+                                      int flags)
+{
+    struct lookup_ctx *l = calloc (1, sizeof (*l));
+    int saved_errno;
+
+    if (!l)
+        return NULL;
+
+    l->ctx = ctx;
+    l->flags = flags;
+
+    if (!(l->msg = flux_msg_copy (msg, true))) {
+        flux_log_error (ctx->h, "%s: flux_msg_copy", __FUNCTION__);
+        goto error;
+    }
+
+    return l;
+
+error:
+    saved_errno = errno;
+    lookup_ctx_destroy (l);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* 'pp' is an in/out parameter pointing to input buffer.
+ * Set 'tok' to next \n-terminated token, and 'toklen' to its length.
+ * Advance 'pp' past token.  Returns false when input is exhausted.
+ */
+static bool eventlog_parse_next (const char **pp, const char **tok,
+                                 size_t *toklen)
+{
+    char *term;
+
+    if (!(term = strchr (*pp, '\n')))
+        return false;
+    *tok = *pp;
+    *toklen = term - *pp + 1;
+    *pp = term + 1;
+    return true;
+}
+
+static void lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct lookup_ctx *l = arg;
+    struct proxy_ctx *ctx = l->ctx;
+    const char *s;
+    const char *input;
+    const char *tok;
+    size_t toklen;
+
+    if (flux_kvs_lookup_get (f, &s) < 0) {
+        if (errno != ENODATA)
+            flux_log_error (ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+        goto error;
+    }
+
+    input = s;
+    while (eventlog_parse_next (&input, &tok, &toklen)) {
+        if (flux_respond_pack (ctx->h, l->msg, "{s:s#}", "event", tok, toklen) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond_pack", __FUNCTION__);
+            goto error;
+        }
+    }
+
+    /* if not watching, this is the only lookup_continuation we're
+     * going to get, return ENODATA to indicate end */
+    if (!(l->flags & FLUX_KVS_EVENTLOG_WATCH)) {
+        errno = ENODATA;
+        goto error;
+    }
+    else
+        flux_future_reset (l->f);
+
+    return;
+
+error:
+    /* flux future destroyed in lookup_ctx_destroy, which is called
+     * via zlist_remove() */
+    if (flux_respond_error (ctx->h, l->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+    zlist_remove (ctx->lookups, l);
+}
+
+static void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct proxy_ctx *ctx = arg;
+    struct lookup_ctx *l = NULL;
+    const char *key;
+    int flags;
+    int lookup_flags = 0;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:i}",
+                             "key", &key,
+                             "flags", &flags) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        goto error;
+    }
+
+    if (!(l = lookup_ctx_create (ctx, msg, flags)))
+        goto error;
+
+    if (flags & FLUX_KVS_EVENTLOG_WATCH) {
+        lookup_flags |= FLUX_KVS_WATCH;
+        lookup_flags |= FLUX_KVS_WATCH_APPEND;
+    }
+
+    if (!(l->f = flux_kvs_lookup (h, NULL, lookup_flags, key))) {
+        flux_log_error (h, "%s: flux_kvs_lookup", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (l->f, -1, lookup_continuation, l) < 0) {
+        flux_log_error (h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    if (zlist_append (ctx->lookups, l) < 0) {
+        flux_log_error (h, "%s: zlist_append", __FUNCTION__);
+        goto error;
+    }
+    zlist_freefn (ctx->lookups, l, lookup_ctx_destroy, true);
+    l = NULL;
+
+    return;
+
+error:
+    lookup_ctx_destroy (l);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* Cancel lookup 'l' if it matches (sender, matchtag).
+ * matchtag=FLUX_MATCHTAG_NONE matches any matchtag.
+ */
+static void lookup_cancel (struct proxy_ctx *ctx,
+                           struct lookup_ctx *l,
+                           const char *sender, uint32_t matchtag)
+{
+    uint32_t t;
+    char *s;
+
+    if (matchtag != FLUX_MATCHTAG_NONE
+        && (flux_msg_get_matchtag (l->msg, &t) < 0 || matchtag != t))
+        return;
+    if (flux_msg_get_route_first (l->msg, &s) < 0)
+        return;
+    if (!strcmp (sender, s)) {
+        if (flux_respond_error (ctx->h, l->msg, ENODATA, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        zlist_remove (ctx->lookups, l);
+    }
+    free (s);
+}
+
+/* Cancel all lookups that match (sender, matchtag). */
+static void lookups_cancel (struct proxy_ctx *ctx,
+                            const char *sender, uint32_t matchtag)
+{
+    struct lookup_ctx *l;
+
+    l = zlist_first (ctx->lookups);
+    while (l) {
+        lookup_cancel (ctx, l, sender, matchtag);
+        l = zlist_next (ctx->lookups);
+    }
+}
+
+static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct proxy_ctx *ctx = arg;
+    uint32_t matchtag;
+    char *sender;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    lookups_cancel (ctx, sender, matchtag);
+    free (sender);
+}
+
+static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
+                           const flux_msg_t *msg, void *arg)
+{
+    struct proxy_ctx *ctx = arg;
+    char *sender;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        flux_log_error (h, "%s: flux_request_decode", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    lookups_cancel (ctx, sender, FLUX_MATCHTAG_NONE);
+    free (sender);
+}
+
+static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct proxy_ctx *ctx = arg;
+
+    if (flux_respond_pack (h, msg, "{s:i}",
+                           "lookups", zlist_size (ctx->lookups)) < 0) {
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
+
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "eventlog-proxy.lookup",
+      .cb           = lookup_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "eventlog-proxy.cancel",
+      .cb           = cancel_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "eventlog-proxy.disconnect",
+      .cb           = disconnect_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "eventlog-proxy.stats.get",
+      .cb           = stats_cb,
+      .rolemask     = 0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void proxy_ctx_destroy (struct proxy_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->lookups)
+            zlist_destroy (&ctx->lookups);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct proxy_ctx *proxy_ctx_create (flux_t *h)
+{
+    struct proxy_ctx *ctx = calloc (1, sizeof (*ctx));
+    if (!ctx)
+        return NULL;
+    ctx->h = h;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (!(ctx->lookups = zlist_new ()))
+        goto error;
+    return ctx;
+error:
+    proxy_ctx_destroy (ctx);
+    return NULL;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct proxy_ctx *ctx;
+    int rc = -1;
+
+    if (!(ctx = proxy_ctx_create (h))) {
+        flux_log_error (h, "initialization error");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    proxy_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("eventlog-proxy");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -3,6 +3,7 @@
 flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
+flux module load -r all eventlog-proxy
 
 flux module load -r all job-ingest
 flux module load -r 0 job-manager

--- a/t/rc/rc1-kvs
+++ b/t/rc/rc1-kvs
@@ -4,3 +4,4 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 flux module load -r all kvs-watch
+flux module load -r all eventlog-proxy

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -3,6 +3,7 @@
 flux module remove -r 0 job-manager
 flux module remove -r all job-ingest
 
+flux module remove -r all eventlog-proxy
 flux module remove -r all -x 0 kvs
 flux module remove -r 0 kvs
 flux module remove -r 0  content-sqlite

--- a/t/rc/rc3-kvs
+++ b/t/rc/rc3-kvs
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+flux module remove -r all eventlog-proxy
 flux module remove -r all kvs-watch
 flux module remove -r all -x 0 kvs
 flux module remove -r 0 kvs

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -21,6 +21,18 @@ test_expect_success 'flux kvs eventlog append works' '
 	grep -q foo get_b.out
 '
 
+test_expect_success 'flux kvs eventlog append multiple appends works' '
+	flux kvs eventlog append test.b foo &&
+	flux kvs eventlog append test.b bar &&
+	flux kvs eventlog get test.b >get_b.out &&
+	grep -q foo get_b.out &&
+	grep -q bar get_b.out
+'
+
+test_expect_success 'flux kvs eventlog get on invalid key fails' '
+	! flux kvs eventlog get test.bad
+'
+
 test_expect_success 'flux kvs eventlog get --watch --count=N works' '
 	flux kvs eventlog append --timestamp=42 test.c foo &&
 	flux kvs eventlog append --timestamp=43 test.c bar &&

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -55,4 +55,9 @@ test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --watch returns append 
 	wait $pid &&
 	test_cmp get_d.exp get_d.out
 '
+
+test_expect_success 'eventlog proxy stats works' '
+        flux module stats eventlog-proxy | grep "lookups"
+'
+
 test_done


### PR DESCRIPTION
This is an initial step 1 to the eventlog proxy, just starting development to see where it takes me and get some initial thoughts.

So far, it's a very simple module.  It implements a simple lookup & cancel rpc target, not so unlike what's in `kvs-watch`.  Every lookup is a streaming RPC, returning a single event per response.  This is
regardless of whether the caller sets WATCH or not.

My initial goal was to implement just this simple lookup/watch proxy so that `flux kvs eventlog get` command could be simplified.  I think that was accomplished, as you can see the code in `flux kvs eventlog get` seems a lot simpler.

I didn't update the job-manager yet, but hopefully that code could be simplified and ultimately a lot of the kvs-eventlog API can be removed. (Edit: trying this a bit tonight, not sure if it's going to work out.  I think the current use of the API might be right with the job-manager.  There will probably be use cases of "get entire eventlog - the parse entries 1 by 1" and that part of the kvs-eventlog API should maybe stay).

I stopped at this point, b/c the next step of taking an id instead of a key as input would break a lot of stuff and a new API / command would probably be needed to replace both "kvs eventlog append" and
"kvs eventlog get" (perhaps `flux job eventlog get/append`?)
