### PR TITLE
[WIP] job-eventlog module proxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,6 +419,7 @@ AC_CONFIG_FILES( \
   src/modules/userdb/Makefile \
   src/modules/job-ingest/Makefile \
   src/modules/job-manager/Makefile \
+  src/modules/job-eventlog/Makefile \
   src/modules/sched-simple/Makefile \
   src/test/Makefile \
   etc/Makefile \

--- a/etc/rc1
+++ b/etc/rc1
@@ -7,6 +7,7 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 flux module load -r all kvs-watch
+flux module load -r all job-eventlog
 flux module load -r all aggregator
 
 flux hwloc reload & pids="$pids $!"

--- a/etc/rc3
+++ b/etc/rc3
@@ -25,6 +25,7 @@ flux module remove -r 0 cron
 flux module remove -r all aggregator
 flux module remove -r all barrier
 
+flux module remove -r all job-eventlog
 flux module remove -r all kvs-watch
 flux module remove -r all -x 0 kvs
 if test -n "$PERSISTDIR"; then

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -13,7 +13,7 @@ AM_CPPFLAGS = \
 	$(LIBSODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = libjob.la
-fluxcoreinclude_HEADERS = job.h
+fluxcoreinclude_HEADERS = job.h job_types.h
 
 libjob_la_SOURCES = \
 	job.c \

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -17,11 +17,14 @@ fluxcoreinclude_HEADERS = job.h job_types.h
 
 libjob_la_SOURCES = \
 	job.c \
+	job_util.c \
+	job_util_private.h \
 	sign_none.c \
 	sign_none.h
 
 TESTS = \
 	test_job.t \
+	test_job_util.t \
 	test_sign_none.t
 
 check_PROGRAMS = \
@@ -46,6 +49,10 @@ test_cppflags = \
 test_job_t_SOURCES = test/job.c
 test_job_t_CPPFLAGS = $(test_cppflags)
 test_job_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_job_util_t_SOURCES = test/job_util.c
+test_job_util_t_CPPFLAGS = $(test_cppflags)
+test_job_util_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_sign_none_t_SOURCES = test/sign_none.c
 test_sign_none_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -13,10 +13,11 @@ AM_CPPFLAGS = \
 	$(LIBSODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = libjob.la
-fluxcoreinclude_HEADERS = job.h job_types.h
+fluxcoreinclude_HEADERS = job.h job_eventlog.h job_types.h
 
 libjob_la_SOURCES = \
 	job.c \
+	job_eventlog.c \
 	job_util.c \
 	job_util_private.h \
 	sign_none.c \
@@ -25,6 +26,7 @@ libjob_la_SOURCES = \
 TESTS = \
 	test_job.t \
 	test_job_util.t \
+	test_job_eventlog.t \
 	test_sign_none.t
 
 check_PROGRAMS = \
@@ -49,6 +51,10 @@ test_cppflags = \
 test_job_t_SOURCES = test/job.c
 test_job_t_CPPFLAGS = $(test_cppflags)
 test_job_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_job_eventlog_t_SOURCES = test/job_eventlog.c
+test_job_eventlog_t_CPPFLAGS = $(test_cppflags)
+test_job_eventlog_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_job_util_t_SOURCES = test/job_util.c
 test_job_util_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -20,6 +20,7 @@
 #include <jansson.h>
 
 #include "job.h"
+#include "job_eventlog.h"
 #include "sign_none.h"
 
 #if HAVE_FLUX_SECURITY

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -32,6 +32,10 @@ enum job_priority {
     FLUX_JOB_PRIORITY_MAX = 31,
 };
 
+enum job_eventlog_flags {
+    FLUX_JOB_EVENTLOG_WATCH = 1,
+};
+
 typedef enum {
     FLUX_JOB_NEW                    = 1,
     FLUX_JOB_DEPEND                 = 2,

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -16,6 +16,7 @@
 #include <flux/core.h>
 
 #include "job_types.h"
+#include "job_eventlog.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -15,6 +15,8 @@
 #include <stdint.h>
 #include <flux/core.h>
 
+#include "job_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -38,8 +40,6 @@ typedef enum {
     FLUX_JOB_CLEANUP                = 16,
     FLUX_JOB_INACTIVE               = 32,   // captive end state
 } flux_job_state_t;
-
-typedef uint64_t flux_jobid_t;
 
 /* Submit a job to the system.
  * 'jobspec' should be RFC 14 jobspec.

--- a/src/common/libjob/job_eventlog.c
+++ b/src/common/libjob/job_eventlog.c
@@ -1,0 +1,77 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <sys/types.h>
+#include <flux/core.h>
+
+#include "job.h"
+
+static int validate_lookup_flags (int flags)
+{
+    if (flags & ~FLUX_JOB_EVENTLOG_WATCH)
+        return -1;
+    return 0;
+}
+
+flux_future_t *flux_job_eventlog_lookup (flux_t *h, int flags, flux_jobid_t id)
+{
+    flux_future_t *f;
+    const char *topic = "job-eventlog.lookup";
+    int rpc_flags = FLUX_RPC_STREAMING;
+
+    if (!h || validate_lookup_flags (flags) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
+                             "{s:I s:i}",
+                             "id", id,
+                             "flags", flags)))
+        return NULL;
+    return f;
+}
+
+int flux_job_eventlog_lookup_get (flux_future_t *f, const char **event)
+{
+    const char *s;
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "event", &s) < 0)
+        return -1;
+    if (event)
+        *event = s;
+    return 0;
+}
+
+int flux_job_eventlog_lookup_cancel (flux_future_t *f)
+{
+    flux_future_t *f2;
+
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f2 = flux_rpc_pack (flux_future_get_flux (f),
+                              "job-eventlog.cancel",
+                              FLUX_NODEID_ANY,
+                              FLUX_RPC_NORESPONSE,
+                              "{s:i}",
+                              "matchtag", (int)flux_rpc_get_matchtag (f))))
+        return -1;
+    flux_future_destroy (f2);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/job_eventlog.h
+++ b/src/common/libjob/job_eventlog.h
@@ -1,0 +1,40 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_JOB_EVENTLOG_H
+#define _FLUX_CORE_JOB_EVENTLOG_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <flux/core.h>
+
+#include "job_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Eventlog streaming functions, return a single event per response.
+ * The flux_job_eventlog_lookup_cancel() function can be called
+ * to end the stream early.
+ */
+flux_future_t *flux_job_eventlog_lookup (flux_t *h, int flags, flux_jobid_t id);
+int flux_job_eventlog_lookup_get (flux_future_t *f, const char **event);
+int flux_job_eventlog_lookup_cancel (flux_future_t *f);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_JOB_EVENTLOG_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/job_types.h
+++ b/src/common/libjob/job_types.h
@@ -1,0 +1,28 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_TYPES_H
+#define _FLUX_JOB_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint64_t flux_jobid_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_JOB_TYPES_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/job_util.c
+++ b/src/common/libjob/job_util.c
@@ -1,0 +1,47 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* util - misc. job manager support
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <ctype.h>
+#include <argz.h>
+#include <envz.h>
+
+#include <flux/core.h>
+
+#include "job_types.h"
+#include "src/common/libutil/fluid.h"
+
+int job_util_jobkey (char *buf, int bufsz, bool active,
+                     flux_jobid_t id, const char *key)
+{
+    char idstr[32];
+    int len;
+
+    if (fluid_encode (idstr, sizeof (idstr), id, FLUID_STRING_DOTHEX) < 0)
+        return -1;
+    len = snprintf (buf, bufsz, "job.%s.%s%s%s",
+                    active ? "active" : "inactive",
+                    idstr,
+                    key ? "." : "",
+                    key ? key : "");
+    if (len >= bufsz)
+        return -1;
+    return len;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/job_util_private.h
+++ b/src/common/libjob/job_util_private.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_UTIL_H
+#define _FLUX_JOB_UTIL_H
+
+#include <flux/core.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+#include "job_types.h"
+
+/* Write KVS path to 'key' relative to active job directory for job 'id'.
+ * If key=NULL, write the job directory.
+ * Returns string length on success, or -1 on failure.
+ */
+int job_util_jobkey (char *buf, int bufsz, bool active,
+                     flux_jobid_t id, const char *key);
+
+#endif /* _FLUX_JOB_UTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libjob/test/job_eventlog.c
+++ b/src/common/libjob/test/job_eventlog.c
@@ -1,0 +1,45 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libjob/job.h"
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    errno = EINVAL;
+    ok (!flux_job_eventlog_lookup (NULL, 0, 0)
+        && errno == EINVAL,
+        "flux_job_eventlog_lookup fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_job_eventlog_lookup_get (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_job_eventlog_lookup_get fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_job_eventlog_lookup_cancel (NULL) < 0
+        && errno == EINVAL,
+        "flux_job_eventlog_lookup_cancel fails with EINVAL on bad input");
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/test/job_util.c
+++ b/src/common/libjob/test/job_util.c
@@ -1,0 +1,100 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libkvs/treeobj.h"
+
+#include "src/common/libjob/job.h"
+#include "src/common/libjob/job_util_private.h"
+
+struct jobkey_input {
+    flux_jobid_t id;
+    bool active;
+    const char *key;
+    const char *expected;
+};
+
+struct jobkey_input jobkeytab[] = {
+    { 1, true, NULL,            "job.active.0000.0000.0000.0001" },
+    { 1, false, NULL,           "job.inactive.0000.0000.0000.0001" },
+    { 2, true, "foo",           "job.active.0000.0000.0000.0002.foo" },
+    { 2, false, "foo",          "job.inactive.0000.0000.0000.0002.foo" },
+    { 3, true, "a.b.c",         "job.active.0000.0000.0000.0003.a.b.c" },
+    { 0xdeadbeef, true, NULL,   "job.active.0000.0000.dead.beef" },
+
+    /* expected failure: overflow */
+    { 4, true, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", NULL },
+
+    { 0, false, NULL, NULL },
+};
+bool is_jobkeytab_end (struct jobkey_input *try)
+{
+    if (try->id == 0 && try->active == false && !try->key && !try->expected)
+        return true;
+    return false;
+}
+
+void check_one_jobkey (struct jobkey_input *try)
+{
+    char path[64];
+    int len;
+    bool valid = false;
+
+    memset (path, 0, sizeof (path));
+    len = job_util_jobkey (path, sizeof (path), try->active, try->id, try->key);
+
+    if (try->expected) {
+        if (len >= 0 && len == strlen (try->expected)
+                     && !strcmp (path, try->expected))
+            valid = true;
+    }
+    else { // expected failure
+        if (len < 0)
+            valid = true;
+    }
+    ok (valid == true,
+        "util_jobkey id=%llu active=%s key=%s %s",
+        (unsigned long long)try->id,
+        try->active ? "true" : "false",
+        try->key ? try->key : "NULL",
+        try->expected ? "works" : "fails");
+
+    if (!valid)
+        diag ("jobkey: %s", path);
+}
+
+void check_jobkey (void)
+{
+    int i;
+    for (i = 0; !is_jobkeytab_end (&jobkeytab[i]); i++)
+        check_one_jobkey (&jobkeytab[i]);
+}
+
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+
+    check_jobkey ();
+
+    done_testing ();
+
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -10,4 +10,5 @@ SUBDIRS = \
  pymod \
  job-ingest \
  job-manager \
+ job-eventlog \
  sched-simple

--- a/src/modules/job-eventlog/Makefile.am
+++ b/src/modules/job-eventlog/Makefile.am
@@ -1,0 +1,27 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+
+fluxmod_LTLIBRARIES = job-eventlog.la
+
+job_eventlog_la_SOURCES = \
+	job-eventlog.c
+
+
+job_eventlog_la_LDFLAGS = $(fluxmod_ldflags) -module
+job_eventlog_la_LIBADD = $(fluxmod_libadd) \
+	$(top_builddir)/src/common/libkvs/libkvs.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS)

--- a/src/modules/job-eventlog/job-eventlog.c
+++ b/src/modules/job-eventlog/job-eventlog.c
@@ -1,0 +1,396 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job-eventlog - track eventlog changes */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libjob/job_util_private.h"
+
+/* Module state.
+ */
+struct eventlog_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    zlist_t *lookups;
+};
+
+/* Lookup context
+ */
+struct lookup_ctx {
+    struct eventlog_ctx *ctx;
+    flux_msg_t *msg;
+    flux_jobid_t id;
+    int flags;
+    int lookup_flags;
+    bool active;
+    flux_future_t *f;
+    char key[64];
+    int offset;
+};
+
+void lookup_ctx_destroy (void *data)
+{
+    if (data) {
+        struct lookup_ctx *ctx = data;
+        flux_msg_destroy (ctx->msg);
+        flux_future_destroy (ctx->f);
+        free (ctx);
+    }
+}
+
+static void lookup_continuation (flux_future_t *f, void *arg);
+
+struct lookup_ctx *lookup_ctx_create (struct eventlog_ctx *ctx,
+                                      const flux_msg_t *msg,
+                                      flux_jobid_t id,
+                                      int flags)
+{
+    struct lookup_ctx *l = calloc (1, sizeof (*l));
+    int saved_errno;
+
+    if (!l)
+        return NULL;
+
+    l->ctx = ctx;
+    l->id = id;
+    l->flags = flags;
+    l->active = true;
+
+    if (flags & FLUX_JOB_EVENTLOG_WATCH) {
+        l->lookup_flags |= FLUX_KVS_WATCH;
+        l->lookup_flags |= FLUX_KVS_WATCH_APPEND;
+    }
+
+    if (!(l->msg = flux_msg_copy (msg, true))) {
+        flux_log_error (ctx->h, "%s: flux_msg_copy", __FUNCTION__);
+        goto error;
+    }
+
+    return l;
+
+error:
+    saved_errno = errno;
+    lookup_ctx_destroy (l);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* 'pp' is an in/out parameter pointing to input buffer.
+ * Set 'tok' to next \n-terminated token, and 'toklen' to its length.
+ * Advance 'pp' past token.  Returns false when input is exhausted.
+ */
+static bool eventlog_parse_next (const char **pp, const char **tok,
+                                 size_t *toklen)
+{
+    char *term;
+
+    if (!(term = strchr (*pp, '\n')))
+        return false;
+    *tok = *pp;
+    *toklen = term - *pp + 1;
+    *pp = term + 1;
+    return true;
+}
+
+static int lookup_key (struct lookup_ctx *l)
+{
+    if (l->f) {
+        flux_future_destroy (l->f);
+        l->f = NULL;
+    }
+
+    if (job_util_jobkey (l->key, sizeof (l->key),
+                         l->active, l->id, "eventlog") < 0) {
+        flux_log_error (l->ctx->h, "%s: job_util_jobkey", __FUNCTION__);
+        return -1;
+    }
+
+    if (!(l->f = flux_kvs_lookup (l->ctx->h, NULL, l->lookup_flags, l->key))) {
+        flux_log_error (l->ctx->h, "%s: flux_kvs_lookup", __FUNCTION__);
+        return -1;
+    }
+
+    if (flux_future_then (l->f, -1, lookup_continuation, l) < 0) {
+        flux_log_error (l->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct lookup_ctx *l = arg;
+    struct eventlog_ctx *ctx = l->ctx;
+    const char *s;
+    const char *input;
+    const char *tok;
+    size_t toklen;
+
+    if (flux_kvs_lookup_get (f, &s) < 0) {
+        if (errno == ENOENT && l->active) {
+            /* transition / try the inactive key */
+            l->active = false;
+            if (lookup_key (l) < 0)
+                goto error;
+            return;
+        }
+        else if (errno != ENODATA) {
+            flux_log_error (ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+            goto error;
+        }
+        else
+            goto done;
+    }
+
+    input = s;
+    while (eventlog_parse_next (&input, &tok, &toklen)) {
+        if (l->active)
+            l->offset += toklen;
+
+        if (l->active || !l->offset) {
+            if (flux_respond_pack (ctx->h, l->msg,
+                                   "{s:s#}",
+                                   "event", tok, toklen) < 0) {
+                flux_log_error (ctx->h, "%s: flux_respond_pack", __FUNCTION__);
+                goto error;
+            }
+        }
+
+        if (!l->active && l->offset)
+            l->offset -= toklen;
+    }
+
+    /* if not watching, this is the only lookup_continuation we're
+     * going to get, return ENODATA to indicate end */
+    if (!(l->flags & FLUX_JOB_EVENTLOG_WATCH)) {
+        errno = ENODATA;
+        goto error;
+    }
+    else
+        flux_future_reset (f);
+
+    return;
+
+error:
+    /* flux future destroyed in lookup_ctx_destroy, which is called
+     * via zlist_remove() */
+    if (flux_respond_error (ctx->h, l->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+done:
+    zlist_remove (ctx->lookups, l);
+}
+
+static void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct eventlog_ctx *ctx = arg;
+    struct lookup_ctx *l = NULL;
+    flux_jobid_t id;
+    int flags;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:i}",
+                             "id", &id,
+                             "flags", &flags) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        goto error;
+    }
+
+    if (!(l = lookup_ctx_create (ctx, msg, id, flags)))
+        goto error;
+
+    if (lookup_key (l) < 0)
+        goto error;
+
+    if (zlist_append (ctx->lookups, l) < 0) {
+        flux_log_error (h, "%s: zlist_append", __FUNCTION__);
+        goto error;
+    }
+    zlist_freefn (ctx->lookups, l, lookup_ctx_destroy, true);
+    l = NULL;
+
+    return;
+
+error:
+    lookup_ctx_destroy (l);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* Cancel lookup 'l' if it matches (sender, matchtag).
+ * matchtag=FLUX_MATCHTAG_NONE matches any matchtag.
+ */
+static void lookup_cancel (struct eventlog_ctx *ctx,
+                           struct lookup_ctx *l,
+                           const char *sender, uint32_t matchtag)
+{
+    uint32_t t;
+    char *s;
+
+    if (matchtag != FLUX_MATCHTAG_NONE
+        && (flux_msg_get_matchtag (l->msg, &t) < 0 || matchtag != t))
+        return;
+    if (flux_msg_get_route_first (l->msg, &s) < 0)
+        return;
+    if (!strcmp (sender, s)) {
+        if (flux_respond_error (ctx->h, l->msg, ENODATA, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        zlist_remove (ctx->lookups, l);
+    }
+    free (s);
+}
+
+/* Cancel all lookups that match (sender, matchtag). */
+static void lookups_cancel (struct eventlog_ctx *ctx,
+                            const char *sender, uint32_t matchtag)
+{
+    struct lookup_ctx *l;
+
+    l = zlist_first (ctx->lookups);
+    while (l) {
+        lookup_cancel (ctx, l, sender, matchtag);
+        l = zlist_next (ctx->lookups);
+    }
+}
+
+static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct eventlog_ctx *ctx = arg;
+    uint32_t matchtag;
+    char *sender;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    lookups_cancel (ctx, sender, matchtag);
+    free (sender);
+}
+
+static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
+                           const flux_msg_t *msg, void *arg)
+{
+    struct eventlog_ctx *ctx = arg;
+    char *sender;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        flux_log_error (h, "%s: flux_request_decode", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    lookups_cancel (ctx, sender, FLUX_MATCHTAG_NONE);
+    free (sender);
+}
+
+static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct eventlog_ctx *ctx = arg;
+
+    if (flux_respond_pack (h, msg, "{s:i}",
+                           "lookups", zlist_size (ctx->lookups)) < 0) {
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
+
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-eventlog.lookup",
+      .cb           = lookup_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-eventlog.cancel",
+      .cb           = cancel_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-eventlog.disconnect",
+      .cb           = disconnect_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-eventlog.stats.get",
+      .cb           = stats_cb,
+      .rolemask     = 0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void eventlog_ctx_destroy (struct eventlog_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->lookups)
+            zlist_destroy (&ctx->lookups);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct eventlog_ctx *eventlog_ctx_create (flux_t *h)
+{
+    struct eventlog_ctx *ctx = calloc (1, sizeof (*ctx));
+    if (!ctx)
+        return NULL;
+    ctx->h = h;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (!(ctx->lookups = zlist_new ()))
+        goto error;
+    return ctx;
+error:
+    eventlog_ctx_destroy (ctx);
+    return NULL;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct eventlog_ctx *ctx;
+    int rc = -1;
+
+    if (!(ctx = eventlog_ctx_create (h))) {
+        flux_log_error (h, "initialization error");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    eventlog_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("job-eventlog");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -35,6 +35,7 @@ job_manager_la_SOURCES = job-manager.c \
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = $(fluxmod_libadd) \
+		    $(top_builddir)/src/common/libjob/libjob.la \
 		    $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la \
 		    $(top_builddir)/src/common/libflux-optparse.la \
@@ -53,6 +54,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/queue.o \
         $(top_builddir)/src/modules/job-manager/job.o \
         $(top_builddir)/src/modules/job-manager/util.o \
+	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -94,7 +96,7 @@ test_util_t_SOURCES = test/util.c
 test_util_t_CPPFLAGS = $(test_cppflags)
 # Test uses unexported KVS functions
 test_util_t_LDADD = \
-        $(top_builddir)/src/common/libkvs/libkvs.la \
+	$(top_builddir)/src/common/libkvs/libkvs.la \
         $(test_ldadd)
 
 test_restart_t_SOURCES = test/restart.c

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -18,6 +18,7 @@
 
 #include "util.h"
 #include "event.h"
+#include "src/common/libjob/job_util_private.h"
 
 const double batch_timeout = 0.01;
 
@@ -178,7 +179,7 @@ int event_log (struct event_ctx *ctx, flux_jobid_t id,
     char *event = NULL;
     int saved_errno;
 
-    if (util_jobkey (key, sizeof (key), true, id, "eventlog") < 0)
+    if (job_util_jobkey (key, sizeof (key), true, id, "eventlog") < 0)
         return -1;
     if (!(event = flux_kvs_event_encode (name, context)))
         return -1;

--- a/src/modules/job-manager/test/util.c
+++ b/src/modules/job-manager/test/util.c
@@ -21,69 +21,6 @@
 #include "src/modules/job-manager/job.h"
 #include "src/modules/job-manager/util.h"
 
-struct jobkey_input {
-    flux_jobid_t id;
-    bool active;
-    const char *key;
-    const char *expected;
-};
-
-struct jobkey_input jobkeytab[] = {
-    { 1, true, NULL,            "job.active.0000.0000.0000.0001" },
-    { 1, false, NULL,           "job.inactive.0000.0000.0000.0001" },
-    { 2, true, "foo",           "job.active.0000.0000.0000.0002.foo" },
-    { 2, false, "foo",          "job.inactive.0000.0000.0000.0002.foo" },
-    { 3, true, "a.b.c",         "job.active.0000.0000.0000.0003.a.b.c" },
-    { 0xdeadbeef, true, NULL,   "job.active.0000.0000.dead.beef" },
-
-    /* expected failure: overflow */
-    { 4, true, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", NULL },
-
-    { 0, false, NULL, NULL },
-};
-bool is_jobkeytab_end (struct jobkey_input *try)
-{
-    if (try->id == 0 && try->active == false && !try->key && !try->expected)
-        return true;
-    return false;
-}
-
-void check_one_jobkey (struct jobkey_input *try)
-{
-    char path[64];
-    int len;
-    bool valid = false;
-
-    memset (path, 0, sizeof (path));
-    len = util_jobkey (path, sizeof (path), try->active, try->id, try->key);
-
-    if (try->expected) {
-        if (len >= 0 && len == strlen (try->expected)
-                     && !strcmp (path, try->expected))
-            valid = true;
-    }
-    else { // expected failure
-        if (len < 0)
-            valid = true;
-    }
-    ok (valid == true,
-        "util_jobkey id=%llu active=%s key=%s %s",
-        (unsigned long long)try->id,
-        try->active ? "true" : "false",
-        try->key ? try->key : "NULL",
-        try->expected ? "works" : "fails");
-
-    if (!valid)
-        diag ("jobkey: %s", path);
-}
-
-void check_jobkey (void)
-{
-    int i;
-    for (i = 0; !is_jobkeytab_end (&jobkeytab[i]); i++)
-        check_one_jobkey (&jobkeytab[i]);
-}
-
 struct context_input {
     const char *context;
     const char *key;
@@ -163,7 +100,6 @@ int main (int argc, char **argv)
 {
     plan (NO_PLAN);
 
-    check_jobkey ();
     check_context ();
 
     done_testing ();

--- a/src/modules/job-manager/util.c
+++ b/src/modules/job-manager/util.c
@@ -21,6 +21,7 @@
 
 #include <flux/core.h>
 #include "src/common/libutil/fluid.h"
+#include "src/common/libjob/job_util_private.h"
 
 #include "job.h"
 #include "util.h"
@@ -117,30 +118,12 @@ const char *util_note_from_context (const char *context)
     return context;
 }
 
-int util_jobkey (char *buf, int bufsz, bool active,
-                 flux_jobid_t id, const char *key)
-{
-    char idstr[32];
-    int len;
-
-    if (fluid_encode (idstr, sizeof (idstr), id, FLUID_STRING_DOTHEX) < 0)
-        return -1;
-    len = snprintf (buf, bufsz, "job.%s.%s%s%s",
-                    active ? "active" : "inactive",
-                    idstr,
-                    key ? "." : "",
-                    key ? key : "");
-    if (len >= bufsz)
-        return -1;
-    return len;
-}
-
 flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,
                                  int flags, const char *key)
 {
     char path[64];
 
-    if (util_jobkey (path, sizeof (path), active, id, key) < 0) {
+    if (job_util_jobkey (path, sizeof (path), active, id, key) < 0) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/modules/job-manager/util.h
+++ b/src/modules/job-manager/util.h
@@ -29,13 +29,6 @@ int util_str_from_context (const char *context, const char *key,
  */
 const char *util_note_from_context (const char *context);
 
-/* Write KVS path to 'key' relative to active job directory for job 'id'.
- * If key=NULL, write the job directory.
- * Returns string length on success, or -1 on failure.
- */
-int util_jobkey (char *buf, int bufsz, bool active,
-                 flux_jobid_t id, const char *key);
-
 /* Look up 'key' relative to active/inactive job directory for job 'id'.
  */
 flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -85,6 +85,7 @@ TESTS = \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched.t \
+	t2204-job-eventlog.t \
 	t2300-sched-simple.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
@@ -179,6 +180,7 @@ check_SCRIPTS = \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched.t \
+	t2204-job-eventlog.t \
 	t2300-sched-simple.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \

--- a/t/t2204-job-eventlog.t
+++ b/t/t2204-job-eventlog.t
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+test_description='Test flux job eventlog service'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+wait_lookups_nonzero() {
+        i=0
+        while (! flux module stats --parse lookups job-eventlog > /dev/null 2>&1 \
+               || [ "$(flux module stats --parse lookups job-eventlog 2> /dev/null)" = "0" ]) \
+              && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success 'sched-simple: load kvs-watch & job-eventlog module' '
+	flux module load -r all kvs-watch &&
+	flux module load -r all job-eventlog
+'
+
+test_expect_success 'flux job eventlog works (active)' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+	flux job eventlog $jobid > eventlog_a.out &&
+        grep submit eventlog_a.out
+'
+
+test_expect_success 'flux job eventlog works on multiple entries (active)' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foo &&
+	flux job eventlog $jobid >eventlog_b.out &&
+	grep -q submit eventlog_b.out &&
+	grep -q foo eventlog_b.out
+'
+
+# we cheat and manually move active to inactive in these tests
+
+test_expect_success 'flux job eventlog works (inactive)' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux job eventlog $jobid > eventlog_c.out &&
+        grep submit eventlog_c.out
+'
+
+test_expect_success 'flux job eventlog works on multiple entries (inactive)' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${activekvsdir}.eventlog foo &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux job eventlog $jobid >eventlog_d.out &&
+	grep -q submit eventlog_d.out &&
+	grep -q foo eventlog_d.out
+'
+
+test_expect_success 'flux job eventlog works on multiple entries (active -> inactive)' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux kvs eventlog append ${inactivekvsdir}.eventlog foo &&
+	flux job eventlog $jobid >eventlog_e.out &&
+	grep -q submit eventlog_e.out &&
+	grep -q foo eventlog_e.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job eventlog --watch --count=N works (active)' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+        flux job eventlog --watch --count=4 $jobid > eventlog_watch_a.out &
+        waitpid=$! &&
+        wait_lookups_nonzero &&
+        wait_watcherscount_nonzero primary &&
+        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foo &&
+	flux kvs eventlog append ${kvsdir}.eventlog bar &&
+	flux kvs eventlog append ${kvsdir}.eventlog baz &&
+        wait $waitpid &&
+        grep submit eventlog_watch_a.out &&
+        grep foo eventlog_watch_a.out &&
+        grep bar eventlog_watch_a.out &&
+        grep baz eventlog_watch_a.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job eventlog --watch --count=N works (active -> inactive) ' '
+        jobid=$(flux jobspec --format json srun -N1 hostname | flux job submit)
+        flux job eventlog --watch --count=4 $jobid > eventlog_watch_b.out &
+        waitpid=$! &&
+        wait_lookups_nonzero &&
+        wait_watcherscount_nonzero primary &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${activekvsdir}.eventlog foo &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux kvs eventlog append ${inactivekvsdir}.eventlog bar &&
+	flux kvs eventlog append ${inactivekvsdir}.eventlog baz &&
+        wait $waitpid &&
+        test $(grep submit eventlog_watch_b.out | wc -l) -eq 1 &&
+        test $(grep foo eventlog_watch_b.out | wc -l) -eq 1 &&
+        test $(grep bar eventlog_watch_b.out | wc -l) -eq 1 &&
+        test $(grep baz eventlog_watch_b.out | wc -l) -eq 1
+'
+
+test_expect_success 'job-eventlog stats works' '
+        flux module stats job-eventlog | grep "lookups"
+'
+test_expect_success 'sched-simple: remove kvs-watch, sched-simple' '
+        flux module remove -r all kvs-watch &&
+        flux module remove -r all job-eventlog
+'
+test_done


### PR DESCRIPTION
Follow up from PR #2065, this is re-worked as a job specific module called `job-eventlog` with a new `flux job eventlog` command and some new API functions in `libjob`.

The main different in this PR is `flux job eventlog` takes a jobid as input and will gather the eventlog regardless if it is in `job.active` or `job.inactive` or if it gets moved in between.

Was going to add the guest-access-proxy mechanisms after this, but thought this was a good stopping off point.
