### PR TITLE
job-manager: centralize job state machine

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -103,4 +103,5 @@ test_restart_t_SOURCES = test/restart.c
 test_restart_t_CPPFLAGS = $(test_cppflags)
 test_restart_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/restart.o \
+        $(top_builddir)/src/modules/job-manager/alloc.o \
         $(test_ldadd)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -55,6 +55,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/queue.o \
         $(top_builddir)/src/modules/job-manager/job.o \
         $(top_builddir)/src/modules/job-manager/util.o \
+        $(top_builddir)/src/modules/job-manager/alloc.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -89,7 +90,6 @@ test_raise_t_SOURCES = test/raise.c
 test_raise_t_CPPFLAGS = $(test_cppflags)
 test_raise_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/raise.o \
-        $(top_builddir)/src/modules/job-manager/alloc.o \
         $(test_ldadd)
 
 test_util_t_SOURCES = test/util.c
@@ -103,5 +103,4 @@ test_restart_t_SOURCES = test/restart.c
 test_restart_t_CPPFLAGS = $(test_cppflags)
 test_restart_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/restart.o \
-        $(top_builddir)/src/modules/job-manager/alloc.o \
         $(test_ldadd)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -16,6 +16,8 @@ fluxmod_LTLIBRARIES = job-manager.la
 job_manager_la_SOURCES = job-manager.c \
 			 job.c \
 			 job.h \
+			 submit.c \
+			 submit.h \
 			 queue.c \
 			 queue.h \
 			 util.h \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -48,7 +48,8 @@ TESTS = \
 	test_list.t \
 	test_raise.t \
 	test_util.t \
-	test_restart.t
+	test_restart.t \
+	test_submit.t
 
 test_ldadd = \
         $(top_builddir)/src/modules/job-manager/event.o \
@@ -103,4 +104,10 @@ test_restart_t_SOURCES = test/restart.c
 test_restart_t_CPPFLAGS = $(test_cppflags)
 test_restart_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/restart.o \
+        $(test_ldadd)
+
+test_submit_t_SOURCES = test/submit.c
+test_submit_t_CPPFLAGS = $(test_cppflags)
+test_submit_t_LDADD = \
+        $(top_builddir)/src/modules/job-manager/submit.o \
         $(test_ldadd)

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -179,7 +179,7 @@ static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     job->free_pending = 0;
     job->has_resources = 0;
-    if (event_log (ctx->event_ctx, job->id, event_cb, ctx, "free", NULL) < 0)
+    if (event_log (ctx->event_ctx, job, event_cb, ctx, "free", NULL) < 0)
         goto teardown;
     return;
 teardown:
@@ -200,7 +200,7 @@ int free_request (struct alloc_ctx *ctx, struct job *job)
     if (flux_send (ctx->h, msg, 0) < 0)
         goto error;
     if ((job->flags & FLUX_JOB_DEBUG))
-        (void)event_log (ctx->event_ctx, job->id, NULL, NULL,
+        (void)event_log (ctx->event_ctx, job, NULL, NULL,
                          "debug.free-request", NULL);
     job->free_pending = 1;
 
@@ -261,7 +261,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
      * Raise alloc exception and transition to CLEANUP state.
      */
     if (type == 2) { // error: alloc was rejected
-        if (event_log_fmt (ctx->event_ctx, job->id, event_cb, ctx,
+        if (event_log_fmt (ctx->event_ctx, job, event_cb, ctx,
                            "exception", "type=%s severity=%d userid=%u%s%s",
                            "alloc", 0, FLUX_USERID_UNKNOWN,
                            note ? " " : "",
@@ -284,7 +284,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
 
     job->has_resources = 1;
 
-    if (event_log (ctx->event_ctx, job->id, event_cb, ctx, "alloc", note) < 0)
+    if (event_log (ctx->event_ctx, job, event_cb, ctx, "alloc", note) < 0)
         goto teardown;
     if (job->state == FLUX_JOB_SCHED)
         job->state = FLUX_JOB_RUN;
@@ -315,7 +315,7 @@ int alloc_request (struct alloc_ctx *ctx, struct job *job)
     if (flux_send (ctx->h, msg, 0) < 0)
         goto error;
     if ((job->flags & FLUX_JOB_DEBUG))
-        (void)event_log (ctx->event_ctx, job->id, NULL, NULL,
+        (void)event_log (ctx->event_ctx, job, NULL, NULL,
                          "debug.alloc-request", NULL);
     job->alloc_pending = 1;
     queue_delete (ctx->inqueue, job, job->aux_queue_handle);

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -534,6 +534,7 @@ struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue,
     }
     flux_watcher_start (ctx->prep);
     flux_watcher_start (ctx->check);
+    event_ctx_set_alloc_ctx (event_ctx, ctx);
     return ctx;
 error:
     alloc_ctx_destroy (ctx);

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -24,14 +24,15 @@ void alloc_ctx_destroy (struct alloc_ctx *ctx);
 struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue,
                                     struct event_ctx *event_ctx);
 
-int alloc_enqueue_alloc_request (struct alloc_ctx *ctx, struct job *job);
-int alloc_send_free_request (struct alloc_ctx *ctx, struct job *job);
-
-/* Call this from other parts of the job manager when the alloc
- * machinery might need to take action on 'job'.  The action taken
- * depends on job state and internal flags.
+/* Call from SCHED state to put job in queue to request resources.
+ * This function is a no-op if job->alloc_queued or job->alloc_pending is set.
  */
-int alloc_do_request (struct alloc_ctx *scd, struct job *job);
+int alloc_enqueue_alloc_request (struct alloc_ctx *ctx, struct job *job);
+
+/* Call from CLEANUP state to release resources.
+ * This function is a no-op if job->free_pending is set.
+ */
+int alloc_send_free_request (struct alloc_ctx *ctx, struct job *job);
 
 #endif /* ! _FLUX_JOB_MANAGER_ALLOC_H */
 

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -18,10 +18,14 @@
 #include "event.h"
 
 struct alloc_ctx;
+struct event_ctx;
 
 void alloc_ctx_destroy (struct alloc_ctx *ctx);
 struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue,
                                     struct event_ctx *event_ctx);
+
+int alloc_enqueue_alloc_request (struct alloc_ctx *ctx, struct job *job);
+int alloc_send_free_request (struct alloc_ctx *ctx, struct job *job);
 
 /* Call this from other parts of the job manager when the alloc
  * machinery might need to take action on 'job'.  The action taken

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -229,7 +229,7 @@ error:
     return -1;
 }
 
-int event_log (struct event_ctx *ctx, flux_jobid_t id,
+int event_log (struct event_ctx *ctx, struct job *job,
                event_completion_f cb, void *arg,
                const char *name, const char *context)
 {
@@ -237,7 +237,7 @@ int event_log (struct event_ctx *ctx, flux_jobid_t id,
     char *event = NULL;
     int saved_errno;
 
-    if (flux_job_kvs_key (key, sizeof (key), true, id, "eventlog") < 0)
+    if (flux_job_kvs_key (key, sizeof (key), true, job->id, "eventlog") < 0)
         return -1;
     if (!(event = flux_kvs_event_encode (name, context)))
         return -1;
@@ -254,7 +254,7 @@ error:
     return -1;
 }
 
-int event_log_fmt (struct event_ctx *ctx, flux_jobid_t id,
+int event_log_fmt (struct event_ctx *ctx, struct job *job,
                    event_completion_f cb, void *arg, const char *name,
                    const char *fmt, ...)
 {
@@ -269,7 +269,7 @@ int event_log_fmt (struct event_ctx *ctx, flux_jobid_t id,
         errno = EINVAL;
         return -1;
     }
-    return event_log (ctx, id, cb, arg, name, context);
+    return event_log (ctx, job, cb, arg, name, context);
 }
 
 /* N.B. any in-flight batches are destroyed here.

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -24,18 +24,18 @@ typedef void (*event_completion_f)(flux_future_t *f, void *arg);
  */
 int event_job_update (struct job *job, const char *event);
 
-/* Log event (name, context) to jobs.active.<id>.eventlog.
+/* Log event (name, context) to jobs.active.<jobid>.eventlog.
  * Once event is committed, cb(f, arg) is invoked if cb != NULL.
  * The callback may call flux_future_get() to determine if the commit
  * succeeded.
  */
-int event_log (struct event_ctx *ctx, flux_jobid_t id,
+int event_log (struct event_ctx *ctx, struct job *job,
                event_completion_f cb, void *arg,
                const char *name, const char *context);
 
 /* Same as above except event context is constructed from (fmt, ...).
  */
-int event_log_fmt (struct event_ctx *ctx, flux_jobid_t id,
+int event_log_fmt (struct event_ctx *ctx, struct job *job,
                    event_completion_f cb, void *arg,
                    const char *name, const char *fmt, ...);
 

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -31,9 +31,9 @@ int event_job_action (struct event_ctx *ctx, struct job *job);
 int event_job_update (struct job *job, const char *event);
 
 /* Log event (name, context) to jobs.active.<jobid>.eventlog.
- * Once event is committed, cb(f, arg) is invoked if cb != NULL.
- * The callback may call flux_future_get() to determine if the commit
- * succeeded.
+ * Commit is delayed briefly and possibly batched with others.
+ * Upon completion, 'cb' is called with 'arg', if cb != NULL.
+ * On failure, the error is logged and reactor is stopped.
  */
 int event_log (struct event_ctx *ctx, struct job *job,
                event_completion_f cb, void *arg,

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -15,10 +15,16 @@
 #include <flux/core.h>
 
 #include "job.h"
+#include "alloc.h"
 
 struct event_ctx;
+struct alloc_ctx;
 
 typedef void (*event_completion_f)(flux_future_t *f, void *arg);
+
+/* Take any action for 'job' currently needed based on its internal state.
+ */
+int event_job_action (struct event_ctx *ctx, struct job *job);
 
 /* Call to update 'job' internal state based on 'event'.
  */
@@ -38,6 +44,9 @@ int event_log (struct event_ctx *ctx, struct job *job,
 int event_log_fmt (struct event_ctx *ctx, struct job *job,
                    event_completion_f cb, void *arg,
                    const char *name, const char *fmt, ...);
+
+void event_ctx_set_alloc_ctx (struct event_ctx *ctx,
+                              struct alloc_ctx *alloc_ctx);
 
 void event_ctx_destroy (struct event_ctx *ctx);
 struct event_ctx *event_ctx_create (flux_t *h);

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -14,9 +14,15 @@
 #include <stdarg.h>
 #include <flux/core.h>
 
+#include "job.h"
+
 struct event_ctx;
 
 typedef void (*event_completion_f)(flux_future_t *f, void *arg);
+
+/* Call to update 'job' internal state based on 'event'.
+ */
+int event_job_update (struct job *job, const char *event);
 
 /* Log event (name, context) to jobs.active.<id>.eventlog.
  * Once event is committed, cb(f, arg) is invoked if cb != NULL.

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -60,40 +60,6 @@ static void priority_cb (flux_t *h, flux_msg_handler_t *mh,
     priority_handle_request (h, ctx->queue, ctx->event_ctx, msg);
 }
 
-/* reload_map_f callback
- * This is called for each job encountered in the KVS during startup.
- * The 'job' struct is valid only during the callback.
- * queue_insert() increments the 'job' usecount upon successful insert.
- */
-static int restart_map_cb (struct job *job, void *arg)
-{
-    struct job_manager_ctx *ctx = arg;
-
-    if (queue_insert (ctx->queue, job, &job->queue_handle) < 0)
-        return -1;
-    if (job->state == FLUX_JOB_NEW)
-        job->state = FLUX_JOB_SCHED;
-    if (job->state == FLUX_JOB_SCHED) {
-        if (alloc_do_request (ctx->alloc_ctx, job) < 0) {
-            flux_log_error (ctx->h, "%s: error notifying scheduler of job %llu",
-                __FUNCTION__, (unsigned long long)job->id);
-        }
-    }
-    return 0;
-}
-
-/* Load any active jobs present in the KVS at startup.
- */
-static int restart_from_kvs (flux_t *h, struct job_manager_ctx *ctx)
-{
-    int count;
-
-    if ((count = restart_map (h, restart_map_cb, ctx)) < 0)
-        return -1;
-    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__, count);
-    return 0;
-}
-
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "job-manager.submit", submit_cb, 0},
     { FLUX_MSGTYPE_REQUEST, "job-manager.list", list_cb, FLUX_ROLE_USER},
@@ -127,7 +93,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "flux_msghandler_add");
         goto done;
     }
-    if (restart_from_kvs (h, &ctx) < 0) {
+    if (restart_from_kvs (h, ctx.queue, ctx.alloc_ctx) < 0) {
         flux_log_error (h, "restart_from_kvs");
         goto done;
     }

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -11,13 +11,11 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <czmq.h>
-#include <jansson.h>
 #include <flux/core.h>
 
 #include "job.h"
 #include "queue.h"
-#include "util.h"
+#include "submit.h"
 #include "restart.h"
 #include "raise.h"
 #include "list.h"
@@ -34,115 +32,20 @@ struct job_manager_ctx {
     struct event_ctx *event_ctx;
 };
 
-/* Enqueue jobs from 'jobs' array in queue.
- * On success, return a list of struct job's.
- * On failure, return NULL with errno set (no jobs enqueued).
- */
-zlist_t *enqueue_jobs (struct queue *queue, json_t *jobs)
-{
-    size_t index;
-    json_t *el;
-    zlist_t *newjobs;
-    struct job *job;
-    int saved_errno;
-
-    if (!(newjobs = zlist_new ()))
-        goto error;
-    json_array_foreach (jobs, index, el) {
-        flux_jobid_t id;
-        uint32_t userid;
-        int priority;
-        double t_submit;
-        int flags;
-
-        if (json_unpack (el, "{s:I s:i s:i s:f s:i}", "id", &id,
-                                                      "priority", &priority,
-                                                      "userid", &userid,
-                                                      "t_submit", &t_submit,
-                                                      "flags", &flags) < 0) {
-            goto error;
-        }
-        if (!(job = job_create (id, priority, userid, t_submit, flags)))
-            goto error;
-        if (queue_insert (queue, job, &job->queue_handle) < 0) {
-            job_decref (job);
-            if (errno == EEXIST)
-                continue; // don't report error - might be a race with restart
-            goto error;
-        }
-        if (zlist_push (newjobs, job) < 0) {
-            queue_delete (queue, job, job->queue_handle);
-            job_decref (job);
-            errno = ENOMEM;
-            goto error;
-        }
-    }
-    return newjobs;
-error:
-    saved_errno = errno;
-    while ((job = zlist_pop (newjobs))) {
-        queue_delete (queue, job, job->queue_handle);
-        job_decref (job);
-    }
-    zlist_destroy (&newjobs);
-    errno = saved_errno;
-    return NULL;
-}
-
-/* handle submit request (from job-ingest module)
- * This is a batched request for one or more jobs already validated
- * by the ingest module, and already instantiated in the KVS.
- * The user isn't handed the jobid though until we accept the job here.
- */
 static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-    json_t *jobs;
-    zlist_t *newjobs;
-    struct job *job;
-
-    if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0) {
-        flux_log_error (h, "%s", __FUNCTION__);
-        goto error;
-    }
-    if (!(newjobs = enqueue_jobs (ctx->queue, jobs))) {
-        flux_log_error (h, "%s: error enqueuing batch", __FUNCTION__);
-        goto error;
-    }
-    if (flux_respond (h, msg, 0, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__,
-                            (int)zlist_size (newjobs));
-    /* Submitting user is being responded to with jobid's.
-     * Now walk the list of new jobs and advance their state.
-     */
-    while ((job = zlist_pop (newjobs))) {
-        job->state = FLUX_JOB_SCHED;
-        if (alloc_do_request (ctx->alloc_ctx, job) < 0)
-            flux_log_error (h, "%s: error notifying scheduler of new job %llu",
-                            __FUNCTION__, (unsigned long long)job->id);
-        job_decref (job);
-    }
-    zlist_destroy (&newjobs);
-    return;
-error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    submit_handle_request (h, ctx->queue, ctx->alloc_ctx, msg);
 }
 
-/* list request handled in list.c
- */
 static void list_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-
     list_handle_request (h, ctx->queue, msg);
 }
 
-/* exception request handled in raise.c
- */
 static void raise_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
@@ -150,8 +53,6 @@ static void raise_cb (flux_t *h, flux_msg_handler_t *mh,
     raise_handle_request (h, ctx->queue, ctx->event_ctx, ctx->alloc_ctx, msg);
 }
 
-/* priority request handled in priority.c
- */
 static void priority_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -36,7 +36,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-    submit_handle_request (h, ctx->queue, ctx->alloc_ctx, msg);
+    submit_handle_request (h, ctx->queue, ctx->event_ctx, msg);
 }
 
 static void list_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -50,7 +50,7 @@ static void raise_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     struct job_manager_ctx *ctx = arg;
-    raise_handle_request (h, ctx->queue, ctx->event_ctx, ctx->alloc_ctx, msg);
+    raise_handle_request (h, ctx->queue, ctx->event_ctx, msg);
 }
 
 static void priority_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -93,7 +93,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "flux_msghandler_add");
         goto done;
     }
-    if (restart_from_kvs (h, ctx.queue, ctx.alloc_ctx) < 0) {
+    if (restart_from_kvs (h, ctx.queue, ctx.event_ctx) < 0) {
         flux_log_error (h, "restart_from_kvs");
         goto done;
     }

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -12,9 +12,10 @@
 #include "config.h"
 #endif
 #include <stdlib.h>
-#include "src/common/libjob/job.h"
+#include <flux/core.h>
+
 #include "job.h"
-#include "util.h"
+#include "event.h"
 
 void job_decref (struct job *job)
 {
@@ -50,67 +51,25 @@ struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
 {
     struct flux_kvs_eventlog *eventlog;
     const char *event;
-    double timestamp;
-    char name[FLUX_KVS_MAX_EVENT_NAME + 1];
-    char context[FLUX_KVS_MAX_EVENT_CONTEXT + 1];
-    bool submit_valid = false;
     struct job *job;
 
     if (!(job = job_create ()))
         return NULL;
     job->id = id;
-    job->state = FLUX_JOB_SCHED;
     if (!(eventlog = flux_kvs_eventlog_decode (s)))
         goto error;
     event = flux_kvs_eventlog_first (eventlog);
     while (event) {
-        if (flux_kvs_event_decode (event, &timestamp,
-                                   name, sizeof (name),
-                                   context, sizeof (context)) < 0)
+        if (event_job_update (job, event) < 0)
             goto error;
-        if (!strcmp (name, "submit")) {
-            int priority, userid, flags;
-            if (util_int_from_context (context, "priority", &priority) < 0)
-                goto error;
-            if (util_int_from_context (context, "userid", &userid) < 0)
-                goto error;
-            if (util_int_from_context (context, "flags", &flags) < 0)
-                goto error;
-            job->t_submit = timestamp;
-            job->userid = userid;
-            job->priority = priority;
-            job->flags = flags;
-            submit_valid = true;
-        }
-        else if (!strcmp (name, "priority")) {
-            int priority;
-            if (util_int_from_context (context, "priority", &priority) < 0)
-                goto error;
-            job->priority = priority;
-        }
-        else if (!strcmp (name, "exception")) {
-            int severity;
-            if (util_int_from_context (context, "severity", &severity) < 0)
-                goto error;
-            if (severity == 0)
-                job->state = FLUX_JOB_CLEANUP;
-        }
-        else if (!strcmp (name, "alloc")) {
-            job->has_resources = 1;
-            job->state = FLUX_JOB_RUN;
-        }
-        else if (!strcmp (name, "free")) {
-            job->has_resources = 0;
-            job->state = FLUX_JOB_CLEANUP;
-        }
         event = flux_kvs_eventlog_next (eventlog);
     }
-    if (!submit_valid) {
-        errno = EINVAL;
-        goto error;
-    }
+    if (job->state == FLUX_JOB_NEW)
+        goto inval;
     flux_kvs_eventlog_destroy (eventlog);
     return job;
+inval:
+    errno = EINVAL;
 error:
     job_decref (job);
     flux_kvs_eventlog_destroy (eventlog);

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -33,31 +33,15 @@ struct job *job_incref (struct job *job)
     return job;
 }
 
-static struct job *job_create_uninit (flux_jobid_t id)
+struct job *job_create (void)
 {
     struct job *job;
 
     if (!(job = calloc (1, sizeof (*job))))
         return NULL;
     job->refcount = 1;
-    job->id = id;
     job->userid = FLUX_USERID_UNKNOWN;
     job->priority = FLUX_JOB_PRIORITY_DEFAULT;
-    job->state = FLUX_JOB_NEW;
-    return job;
-}
-
-struct job *job_create (flux_jobid_t id, int priority, uint32_t userid,
-                        double t_submit, int flags)
-{
-    struct job *job;
-
-    if (!(job = job_create_uninit (id)))
-        return NULL;
-    job->userid = userid;
-    job->priority = priority;
-    job->t_submit = t_submit;
-    job->flags = flags;
     job->state = FLUX_JOB_NEW;
     return job;
 }
@@ -72,8 +56,9 @@ struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
     bool submit_valid = false;
     struct job *job;
 
-    if (!(job = job_create_uninit (id)))
+    if (!(job = job_create ()))
         return NULL;
+    job->id = id;
     job->state = FLUX_JOB_SCHED;
     if (!(eventlog = flux_kvs_eventlog_decode (s)))
         goto error;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -34,11 +34,7 @@ struct job {
 void job_decref (struct job *job);
 struct job *job_incref (struct job *job);
 
-struct job *job_create (flux_jobid_t id,
-                        int priority,
-                        uint32_t userid,
-                        double t_submit,
-                        int flags);
+struct job *job_create (void);
 
 /* (re-)create job by replaying its KVS eventlog.
  */

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -36,8 +36,6 @@ struct job *job_incref (struct job *job);
 
 struct job *job_create (void);
 
-/* (re-)create job by replaying its KVS eventlog.
- */
 struct job *job_create_from_eventlog (flux_jobid_t id, const char *eventlog);
 
 #endif /* _FLUX_JOB_MANAGER_JOB_H */

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -22,6 +22,7 @@ struct job {
     int flags;
     flux_job_state_t state;
 
+    uint8_t alloc_queued:1;
     uint8_t alloc_pending:1;
     uint8_t free_pending:1;
     uint8_t has_resources:1;

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -151,7 +151,7 @@ void priority_handle_request (flux_t *h, struct queue *queue,
      */
     if (!(p = priority_create (queue, event_ctx, job, msg, priority)))
         goto error;
-    if (event_log_fmt (p->event_ctx, job->id, priority_continuation, p,
+    if (event_log_fmt (p->event_ctx, job, priority_continuation, p,
                        "priority", "userid=%lu priority=%d",
                        (unsigned long)userid, priority) < 0)
         goto error;

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -80,13 +80,12 @@ void priority_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
-    /* Log event, change job's queue position, and respond.
+    /* Post event, change job's queue position, and respond.
      */
-    if (event_log_fmt (event_ctx, job, NULL, NULL,
-                       "priority", "userid=%lu priority=%d",
-                       (unsigned long)userid, priority) < 0)
+    if (event_job_post_fmt (event_ctx, job, NULL, NULL,
+                            "priority", "userid=%lu priority=%d",
+                            (unsigned long)userid, priority) < 0)
         goto error;
-    job->priority = priority;
     queue_reorder (queue, job, job->queue_handle);
     if (flux_respond (h, msg, 0, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -11,7 +11,7 @@
 /* priority - adjust job priority
  *
  * Purpose:
- *   Support flux job set-priority command for adjusting job priority
+ *   Support flux job priority command for adjusting job priority
  *   after submission.  Guests can reduce their jobs' priority, or increase
  *   up to the default priority.
  *
@@ -33,72 +33,10 @@
 
 #include "job.h"
 #include "queue.h"
-#include "util.h"
 #include "event.h"
 #include "priority.h"
 
 #define MAXOF(a,b)   ((a)>(b)?(a):(b))
-
-struct priority {
-    flux_msg_t *request;
-    struct job *job;
-    int priority;
-
-    struct queue *queue;
-    struct event_ctx *event_ctx;
-};
-
-static void priority_destroy (struct priority *p)
-{
-    if (p) {
-        int saved_errno = errno;
-        flux_msg_destroy (p->request);
-        free (p);
-        errno = saved_errno;
-    }
-}
-
-static struct priority *priority_create (struct queue *queue,
-                                         struct event_ctx *event_ctx,
-                                         struct job *job,
-                                         const flux_msg_t *request,
-                                         int priority)
-{
-    struct priority *p;
-
-    if (!(p = calloc (1, sizeof (*p))))
-        return NULL;
-    p->queue = queue;
-    p->event_ctx = event_ctx;
-    p->job = job;
-    p->priority = priority;
-    if (!(p->request = flux_msg_copy (request, false)))
-        goto error;
-    return p;
-error:
-    priority_destroy (p);
-    return NULL;
-}
-
-/* KVS update completed.  Remove job from queue and reinsert.
- */
-static void priority_continuation (flux_future_t *f, void *arg)
-{
-    flux_t *h = flux_future_get_flux (f);
-    struct priority *p = arg;
-
-    if (flux_rpc_get (f, NULL) < 0) {
-        if (flux_respond_error (h, p->request, errno, NULL) < 0)
-            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-        goto done;
-    }
-    p->job->priority = p->priority;
-    queue_reorder (p->queue, p->job, p->job->queue_handle);
-    if (flux_respond (h, p->request, 0, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-done:
-    priority_destroy (p);
-}
 
 void priority_handle_request (flux_t *h, struct queue *queue,
                               struct event_ctx *event_ctx,
@@ -108,7 +46,6 @@ void priority_handle_request (flux_t *h, struct queue *queue,
     uint32_t rolemask;
     flux_jobid_t id;
     struct job *job;
-    struct priority *p = NULL;
     int priority;
     int rc;
     const char *errstr = NULL;
@@ -143,18 +80,16 @@ void priority_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
-    /* TODO: If job has requested resources/exec, don't allow adjustment.
+    /* Log event, change job's queue position, and respond.
      */
-    /* Log KVS event and set KVS priority key asynchronously.
-     * Upon successful completion, insert job in new queue position and
-     * send response.
-     */
-    if (!(p = priority_create (queue, event_ctx, job, msg, priority)))
-        goto error;
-    if (event_log_fmt (p->event_ctx, job, priority_continuation, p,
+    if (event_log_fmt (event_ctx, job, NULL, NULL,
                        "priority", "userid=%lu priority=%d",
                        (unsigned long)userid, priority) < 0)
         goto error;
+    job->priority = priority;
+    queue_reorder (queue, job, job->queue_handle);
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
     if (errstr)
@@ -163,7 +98,6 @@ error:
         rc = flux_respond_error (h, msg, errno, NULL);
     if (rc < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    priority_destroy (p);
 }
 
 /*

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -212,7 +212,7 @@ void raise_eventlog_cb (flux_future_t *f, void *arg)
 
 void raise_eventlog (struct raise_ctx *c)
 {
-    if (event_log_fmt (c->event_ctx, c->job->id, raise_eventlog_cb, c,
+    if (event_log_fmt (c->event_ctx, c->job, raise_eventlog_cb, c,
                        "exception", "type=%s severity=%d userid=%lu%s%s",
                        c->type,
                        c->severity,

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -109,20 +109,13 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPROTO;
         goto error;
     }
-    if (event_log_fmt (event_ctx, job, NULL, NULL,
-                       "exception", "type=%s severity=%d userid=%lu%s%s",
-                       type,
-                       severity,
-                       (unsigned long)userid,
-                       note ? " " : "",
-                       note ? note : "") < 0)
-        goto error;
-    char event[64];
-    (void)snprintf (event, sizeof (event),
-                    "%.6f exception severity=%d\n", 1., severity);
-    if (event_job_update (job, event) < 0)
-        goto error;
-    if (event_job_action (event_ctx, job) < 0)
+    if (event_job_post_fmt (event_ctx, job, NULL, NULL,
+                            "exception", "type=%s severity=%d userid=%lu%s%s",
+                            type,
+                            severity,
+                            (unsigned long)userid,
+                            note ? " " : "",
+                            note ? note : "") < 0)
         goto error;
     if (!(f = flux_event_publish_pack (h, "job-exception",
                                        FLUX_MSGFLAG_PRIVATE,

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -19,12 +19,10 @@
  * Action:
  * - publish exception event (for e.g. scheduler to abort queued requests)
  * - update kvs event log
- * - response indicating success or failure
  * - transition state to CLEANUP for severity=0
  *
  * Caveats:
- * - Although the first error encountered during parallel work is propagated
- *   to the user, no attempt is made to unwind prior successful actions.
+ * - Exception event publishing is "open loop" (unlikely error not caught).
  */
 
 #if HAVE_CONFIG_H
@@ -33,197 +31,10 @@
 #include <ctype.h>
 #include <flux/core.h>
 
-#include "src/common/libjob/job.h"
-
 #include "job.h"
 #include "queue.h"
 #include "event.h"
-#include "util.h"
 #include "raise.h"
-
-struct raise_ctx {
-    flux_t *h;
-    flux_msg_t *request;
-    struct job *job;
-    uint32_t userid;
-    int severity;
-    char *type;
-    char *note;
-    int errnum;
-    char *errstr;
-
-    struct queue *queue;
-    struct event_ctx *event_ctx;
-    int refcount;
-};
-
-void raise_respond (struct raise_ctx *c)
-{
-    int rc;
-
-    if (c->errnum != 0 && c->errstr != NULL)
-        rc = flux_respond_error (c->h, c->request, c->errnum, "%s", c->errstr);
-    else if (c->errnum != 0 && c->errstr == NULL)
-        rc = flux_respond_error (c->h, c->request, c->errnum, NULL);
-    else
-        rc = flux_respond (c->h, c->request, 0, NULL);
-    if (rc < 0)
-        flux_log_error (c->h, "%s: flux_respond", __FUNCTION__);
-}
-
-/* If c->message is non-NULL, assume refcount reaches zero when all (parallel)
- * work to raise the exception is complete.  If any errors occurred,
- * c->errno will be non-zero.  Respond to the request and, advance the job
- * state to CLEANUP (if severity=0)
- */
-void raise_ctx_decref (struct raise_ctx *c)
-{
-    if (c && --c->refcount == 0) {
-        int saved_errno = errno;
-        if (c->request) {
-            raise_respond (c);
-            flux_msg_destroy (c->request);
-        }
-        free (c->note);
-        free (c->type);
-        free (c->errstr);
-        free (c);
-        errno = saved_errno;
-    }
-}
-
-struct raise_ctx *raise_ctx_incref (struct raise_ctx *c)
-{
-    if (c)
-        c->refcount++;
-    return c;
-}
-
-struct raise_ctx *raise_ctx_create (flux_t *h,
-                                    struct queue *queue,
-                                    struct event_ctx *event_ctx,
-                                    struct job *job,
-                                    const flux_msg_t *request,
-                                    uint32_t userid,
-                                    int severity,
-                                    const char *type,
-                                    const char *note)
-{
-    struct raise_ctx *c;
-
-    if (!(c = calloc (1, sizeof (*c))))
-        return NULL;
-    c->queue = queue;
-    c->event_ctx = event_ctx;
-    c->job = job;
-    c->userid = userid;
-    c->h = h;
-    c->refcount = 1;
-    c->severity = severity;
-    if (!(c->type = strdup (type)))
-        goto error;
-    if (note && !(c->note = strdup (note)))
-        goto error;
-    if (!(c->request = flux_msg_copy (request, false)))
-        goto error;
-    return c;
-error:
-    raise_ctx_decref (c);
-    return NULL;
-}
-
-void raise_set_error (struct raise_ctx *c, int errnum, const char *errstr)
-{
-    if (c && c->errnum == 0) {
-        int saved_errno = errno;
-        c->errnum = errno;
-        free (c->errstr);
-        c->errstr = NULL;
-        if (errstr) {
-            if (!(c->errstr = strdup (errstr)))
-                flux_log_error (c->h, "%s: strdup", __FUNCTION__);
-        }
-        errno = saved_errno;
-    }
-}
-
-void raise_publish_continuation (flux_future_t *f, void *arg)
-{
-    flux_t *h = flux_future_get_flux (f);
-    struct raise_ctx *c = arg;
-
-    if (flux_future_get (f, NULL) < 0) {
-        raise_set_error (c, errno, "error publishing job-exception event");
-        flux_log_error (h, "publish job-exception id=%llu",
-                        (unsigned long long)c->job->id);
-    }
-    flux_future_destroy (f);
-    raise_ctx_decref (c);
-}
-
-/* Publish a 'job-exception' event message.
- */
-void raise_publish (struct raise_ctx *c)
-{
-    flux_future_t *f;
-
-    if (!(f = flux_event_publish_pack (c->h, "job-exception",
-                                       FLUX_MSGFLAG_PRIVATE,
-                                       "{s:I s:s s:i}",
-                                       "id", c->job->id,
-                                       "type", c->type,
-                                       "severity", c->severity)))
-        goto error;
-    if (flux_future_then (f, -1., raise_publish_continuation, c) < 0) {
-        flux_future_destroy (f);
-        goto error;
-    }
-    raise_ctx_incref (c);
-    return;
-error:
-    raise_set_error (c, errno, "error publishing job-exception event");
-    flux_log_error (c->h, "publish job-exception id=%llu",
-                    (unsigned long long)c->job->id);
-}
-
-void raise_eventlog_cb (flux_future_t *f, void *arg)
-{
-    struct raise_ctx *c = arg;
-    flux_t *h = flux_future_get_flux (f);
-
-    if (flux_future_get (f, NULL) < 0) {
-        raise_set_error (c, errno, "error updating KVS event log");
-        flux_log_error (h, "eventlog_update id=%llu",
-                        (unsigned long long)c->job->id);
-    }
-    raise_ctx_decref (c);
-}
-
-void raise_eventlog (struct raise_ctx *c)
-{
-    if (event_log_fmt (c->event_ctx, c->job, raise_eventlog_cb, c,
-                       "exception", "type=%s severity=%d userid=%lu%s%s",
-                       c->type,
-                       c->severity,
-                       (unsigned long)c->userid,
-                       c->note ? " " : "",
-                       c->note ? c->note : "") < 0)
-        goto error;
-
-    char event[64];
-    (void)snprintf (event, sizeof (event),
-                    "%.6f exception severity=%d\n", 1., c->severity);
-    if (event_job_update (c->job, event) < 0)
-        goto error;
-    if (event_job_action (c->event_ctx, c->job) < 0)
-        goto error;
-    raise_ctx_incref (c);
-    return;
-error:
-    raise_set_error (c, errno, "error updating KVS event log");
-    flux_log_error (c->h, "eventlog_update id=%llu",
-                    (unsigned long long)c->job->id);
-}
 
 int raise_check_type (const char *s)
 {
@@ -262,7 +73,7 @@ void raise_handle_request (flux_t *h, struct queue *queue,
     int severity;
     const char *type;
     const char *note = NULL;
-    struct raise_ctx *c;
+    flux_future_t *f;
     const char *errstr = NULL;
     int rc;
 
@@ -298,17 +109,31 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPROTO;
         goto error;
     }
-    /* Perform some tasks asynchronously.
-     * When the last one completes, 'c' is destroyed and
-     * the user receives a response to the job-manager.raise request.
-     */
-    if (!(c = raise_ctx_create (h, queue, event_ctx,
-                                job, msg, userid, severity, type, note)))
+    if (event_log_fmt (event_ctx, job, NULL, NULL,
+                       "exception", "type=%s severity=%d userid=%lu%s%s",
+                       type,
+                       severity,
+                       (unsigned long)userid,
+                       note ? " " : "",
+                       note ? note : "") < 0)
         goto error;
-
-    raise_eventlog (c);
-    raise_publish (c);
-    raise_ctx_decref (c);
+    char event[64];
+    (void)snprintf (event, sizeof (event),
+                    "%.6f exception severity=%d\n", 1., severity);
+    if (event_job_update (job, event) < 0)
+        goto error;
+    if (event_job_action (event_ctx, job) < 0)
+        goto error;
+    if (!(f = flux_event_publish_pack (h, "job-exception",
+                                       FLUX_MSGFLAG_PRIVATE,
+                                       "{s:I s:s s:i}",
+                                       "id", job->id,
+                                       "type", type,
+                                       "severity", severity)))
+        goto error;
+    flux_future_destroy (f);
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     return;
 error:
     if (errstr)

--- a/src/modules/job-manager/raise.h
+++ b/src/modules/job-manager/raise.h
@@ -19,7 +19,6 @@
  */
 void raise_handle_request (flux_t *h, struct queue *queue,
                            struct event_ctx *event_ctx,
-                           struct alloc_ctx *alloc_ctx,
                            const flux_msg_t *msg);
 
 /* exposed for unit testing only */

--- a/src/modules/job-manager/restart.h
+++ b/src/modules/job-manager/restart.h
@@ -13,7 +13,7 @@
 
 #include <flux/core.h>
 
-#include "alloc.h"
+#include "event.h"
 #include "job.h"
 #include "queue.h"
 
@@ -22,7 +22,7 @@ int restart_count_char (const char *s, char c);
 
 int restart_from_kvs (flux_t *h,
                       struct queue *queue,
-                      struct alloc_ctx *alloc_ctx);
+                      struct event_ctx *event_ctx);
 
 #endif /* _FLUX_JOB_MANAGER_RESTART_H */
 

--- a/src/modules/job-manager/restart.h
+++ b/src/modules/job-manager/restart.h
@@ -12,20 +12,17 @@
 #define _FLUX_JOB_MANAGER_RESTART_H
 
 #include <flux/core.h>
+
+#include "alloc.h"
 #include "job.h"
-
-/* restart_map callback should return -1 on error to stop map with error,
- * or 0 on success.  'job' is only valid for the duration of the callback.
- */
-typedef int (*restart_map_f)(struct job *job, void *arg);
-
-/* call 'cb' once for each job found in active job directory.
- * Returns number of jobs mapped, or -1 on error.
- */
-int restart_map (flux_t *h, restart_map_f cb, void *arg);
+#include "queue.h"
 
 /* exposed for unit testing only */
 int restart_count_char (const char *s, char c);
+
+int restart_from_kvs (flux_t *h,
+                      struct queue *queue,
+                      struct alloc_ctx *alloc_ctx);
 
 #endif /* _FLUX_JOB_MANAGER_RESTART_H */
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -1,0 +1,127 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* submit.c - handle job-manager.submit request from job-ingest */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "job.h"
+#include "queue.h"
+#include "alloc.h"
+#include "event.h"
+
+#include "submit.h"
+
+/* Enqueue jobs from 'jobs' array in queue.
+ * On success, return a list of struct job's.
+ * On failure, return NULL with errno set (no jobs enqueued).
+ */
+static zlist_t *enqueue_jobs (struct queue *queue, json_t *jobs)
+{
+    size_t index;
+    json_t *el;
+    zlist_t *newjobs;
+    struct job *job;
+    int saved_errno;
+
+    if (!(newjobs = zlist_new ()))
+        goto error;
+    json_array_foreach (jobs, index, el) {
+        flux_jobid_t id;
+        uint32_t userid;
+        int priority;
+        double t_submit;
+        int flags;
+
+        if (json_unpack (el, "{s:I s:i s:i s:f s:i}", "id", &id,
+                                                      "priority", &priority,
+                                                      "userid", &userid,
+                                                      "t_submit", &t_submit,
+                                                      "flags", &flags) < 0) {
+            goto error;
+        }
+        if (!(job = job_create (id, priority, userid, t_submit, flags)))
+            goto error;
+        if (queue_insert (queue, job, &job->queue_handle) < 0) {
+            job_decref (job);
+            if (errno == EEXIST)
+                continue; // don't report error - might be a race with restart
+            goto error;
+        }
+        if (zlist_push (newjobs, job) < 0) {
+            queue_delete (queue, job, job->queue_handle);
+            job_decref (job);
+            errno = ENOMEM;
+            goto error;
+        }
+    }
+    return newjobs;
+error:
+    saved_errno = errno;
+    while ((job = zlist_pop (newjobs))) {
+        queue_delete (queue, job, job->queue_handle);
+        job_decref (job);
+    }
+    zlist_destroy (&newjobs);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* handle submit request (from job-ingest module)
+ * This is a batched request for one or more jobs already validated
+ * by the ingest module, and already instantiated in the KVS.
+ * The user isn't handed the jobid though until we accept the job here.
+ */
+void submit_handle_request (flux_t *h,
+                            struct queue *queue,
+                            struct alloc_ctx *alloc_ctx,
+                            const flux_msg_t *msg)
+{
+    json_t *jobs;
+    zlist_t *newjobs;
+    struct job *job;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0) {
+        flux_log_error (h, "%s", __FUNCTION__);
+        goto error;
+    }
+    if (!(newjobs = enqueue_jobs (queue, jobs))) {
+        flux_log_error (h, "%s: error enqueuing batch", __FUNCTION__);
+        goto error;
+    }
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__,
+                            (int)zlist_size (newjobs));
+    /* Submitting user is being responded to with jobid's.
+     * Now walk the list of new jobs and advance their state.
+     */
+    while ((job = zlist_pop (newjobs))) {
+        job->state = FLUX_JOB_SCHED;
+        if (alloc_do_request (alloc_ctx, job) < 0)
+            flux_log_error (h, "%s: error notifying scheduler of new job %llu",
+                            __FUNCTION__, (unsigned long long)job->id);
+        job_decref (job);
+    }
+    zlist_destroy (&newjobs);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -24,56 +24,97 @@
 
 #include "submit.h"
 
+/* Decode 'o' into a struct job, then add it to the queue.
+ * Also record the job in 'newjobs'.
+ */
+int submit_enqueue_one_job (struct queue *queue, zlist_t *newjobs, json_t *o)
+{
+    struct job *job;
+
+    if (!(job = job_create ()))
+        return -1;
+    if (json_unpack (o, "{s:I s:i s:i s:f s:i}",
+                        "id", &job->id,
+                        "priority", &job->priority,
+                        "userid", &job->userid,
+                        "t_submit", &job->t_submit,
+                        "flags", &job->flags) < 0) {
+        errno = EPROTO;
+        job_decref (job);
+        return -1;
+    }
+    if (queue_insert (queue, job, &job->queue_handle) < 0) {
+        job_decref (job);
+        // EEXIST is not an error - there is a window for restart_from_kvs()
+        // to pick up a job that also has a submit request in flight.
+        return (errno == EEXIST ? 0 : -1);
+    }
+    if (zlist_push (newjobs, job) < 0) {
+        queue_delete (queue, job, job->queue_handle);
+        job_decref (job);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+/* The submit request has failed.  Dequeue jobs recorded in 'newjobs',
+ * then destroy the newjobs list.
+ */
+void submit_enqueue_jobs_cleanup (struct queue *queue, zlist_t *newjobs)
+{
+    if (newjobs) {
+        int saved_errno = errno;
+        struct job *job;
+        while ((job = zlist_pop (newjobs))) {
+            queue_delete (queue, job, job->queue_handle);
+            job_decref (job);
+        }
+        zlist_destroy (&newjobs);
+        errno = saved_errno;
+    }
+}
+
 /* Enqueue jobs from 'jobs' array in queue.
  * On success, return a list of struct job's.
  * On failure, return NULL with errno set (no jobs enqueued).
  */
-static zlist_t *enqueue_jobs (struct queue *queue, json_t *jobs)
+zlist_t *submit_enqueue_jobs (struct queue *queue, json_t *jobs)
 {
     size_t index;
     json_t *el;
     zlist_t *newjobs;
-    struct job *job;
-    int saved_errno;
 
-    if (!(newjobs = zlist_new ()))
-        goto error;
+    if (!(newjobs = zlist_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
     json_array_foreach (jobs, index, el) {
-        if (!(job = job_create ()))
+        if (submit_enqueue_one_job (queue, newjobs, el) < 0)
             goto error;
-        if (json_unpack (el, "{s:I s:i s:i s:f s:i}",
-                             "id", &job->id,
-                             "priority", &job->priority,
-                             "userid", &job->userid,
-                             "t_submit", &job->t_submit,
-                             "flags", &job->flags) < 0) {
-            job_decref (job);
-            goto error;
-        }
-        if (queue_insert (queue, job, &job->queue_handle) < 0) {
-            job_decref (job);
-            if (errno == EEXIST)
-                continue; // don't report error - might be a race with restart
-            goto error;
-        }
-        if (zlist_push (newjobs, job) < 0) {
-            queue_delete (queue, job, job->queue_handle);
-            job_decref (job);
-            errno = ENOMEM;
-            goto error;
-        }
     }
     return newjobs;
 error:
-    saved_errno = errno;
-    while ((job = zlist_pop (newjobs))) {
-        queue_delete (queue, job, job->queue_handle);
-        job_decref (job);
-    }
-    zlist_destroy (&newjobs);
-    errno = saved_errno;
+    submit_enqueue_jobs_cleanup (queue, newjobs);
     return NULL;
 }
+
+/* Submit event requires special handling.  It cannot go through
+ * event_job_post() because job-ingest already logged it.
+ * However, we want to let the state machine choose the next state and action,
+ * So we create a "dummy" event here and run it directly through
+ * event_job_update() and event_job_action().
+ */
+int submit_post_event (struct event_ctx *event_ctx, struct job *job)
+{
+        char event[64];
+        (void)snprintf (event, sizeof (event), "%.6f submit\n", job->t_submit);
+        if (event_job_update (job, event) < 0)
+            return -1;
+        if (event_job_action (event_ctx, job) < 0)
+            return -1;
+        return 0;
+};
 
 /* handle submit request (from job-ingest module)
  * This is a batched request for one or more jobs already validated
@@ -93,7 +134,7 @@ void submit_handle_request (flux_t *h,
         flux_log_error (h, "%s", __FUNCTION__);
         goto error;
     }
-    if (!(newjobs = enqueue_jobs (queue, jobs))) {
+    if (!(newjobs = submit_enqueue_jobs (queue, jobs))) {
         flux_log_error (h, "%s: error enqueuing batch", __FUNCTION__);
         goto error;
     }
@@ -101,17 +142,13 @@ void submit_handle_request (flux_t *h,
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__,
                             (int)zlist_size (newjobs));
+
     /* Submitting user is being responded to with jobid's.
      * Now walk the list of new jobs and advance their state.
      */
     while ((job = zlist_pop (newjobs))) {
-        char event[64];
-        (void)snprintf (event, sizeof (event), "%.6f submit\n", job->t_submit);
-        if (event_job_update (job, event) < 0)
-            flux_log_error (h, "%s: event_job_update id=%llu",
-                            __FUNCTION__, (unsigned long long)job->id);
-        if (event_job_action (event_ctx, job) < 0)
-            flux_log_error (h, "%s: event_job_action id=%llu",
+        if (submit_post_event (event_ctx, job) < 0)
+            flux_log_error (h, "%s: submit_post_event id=%llu",
                             __FUNCTION__, (unsigned long long)job->id);
         job_decref (job);
     }

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -39,21 +39,17 @@ static zlist_t *enqueue_jobs (struct queue *queue, json_t *jobs)
     if (!(newjobs = zlist_new ()))
         goto error;
     json_array_foreach (jobs, index, el) {
-        flux_jobid_t id;
-        uint32_t userid;
-        int priority;
-        double t_submit;
-        int flags;
-
-        if (json_unpack (el, "{s:I s:i s:i s:f s:i}", "id", &id,
-                                                      "priority", &priority,
-                                                      "userid", &userid,
-                                                      "t_submit", &t_submit,
-                                                      "flags", &flags) < 0) {
+        if (!(job = job_create ()))
+            goto error;
+        if (json_unpack (el, "{s:I s:i s:i s:f s:i}",
+                             "id", &job->id,
+                             "priority", &job->priority,
+                             "userid", &job->userid,
+                             "t_submit", &job->t_submit,
+                             "flags", &job->flags) < 0) {
+            job_decref (job);
             goto error;
         }
-        if (!(job = job_create (id, priority, userid, t_submit, flags)))
-            goto error;
         if (queue_insert (queue, job, &job->queue_handle) < 0) {
             job_decref (job);
             if (errno == EEXIST)

--- a/src/modules/job-manager/submit.h
+++ b/src/modules/job-manager/submit.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_SUBMIT_H
+#define _FLUX_JOB_MANAGER_SUBMIT_H
+
+#include <flux/core.h>
+
+#include "queue.h"
+#include "alloc.h"
+
+void submit_handle_request (flux_t *h,
+                            struct queue *queue,
+                            struct alloc_ctx *alloc_ctx,
+                            const flux_msg_t *msg);
+
+
+#endif /* ! _FLUX_JOB_MANAGER_SUBMIT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/submit.h
+++ b/src/modules/job-manager/submit.h
@@ -11,6 +11,8 @@
 #ifndef _FLUX_JOB_MANAGER_SUBMIT_H
 #define _FLUX_JOB_MANAGER_SUBMIT_H
 
+#include <czmq.h>
+#include <jansson.h>
 #include <flux/core.h>
 
 #include "queue.h"
@@ -21,6 +23,11 @@ void submit_handle_request (flux_t *h,
                             struct event_ctx *event_ctx,
                             const flux_msg_t *msg);
 
+/* exposed for unit testing only */
+int submit_enqueue_one_job (struct queue *queue, zlist_t *newjobs, json_t *o);
+void submit_enqueue_jobs_cleanup (struct queue *queue, zlist_t *newjobs);
+zlist_t *submit_enqueue_jobs (struct queue *queue, json_t *jobs);
+int submit_post_event (struct event_ctx *event_ctx, struct job *job);
 
 #endif /* ! _FLUX_JOB_MANAGER_SUBMIT_H */
 

--- a/src/modules/job-manager/submit.h
+++ b/src/modules/job-manager/submit.h
@@ -18,7 +18,7 @@
 
 void submit_handle_request (flux_t *h,
                             struct queue *queue,
-                            struct alloc_ctx *alloc_ctx,
+                            struct event_ctx *event_ctx,
                             const flux_msg_t *msg);
 
 

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -21,22 +21,24 @@ void test_create (void)
 {
     struct job *job;
 
-    job = job_create (42, 1, FLUX_USERID_UNKNOWN, 2, 3);
+    job = job_create ();
     if (job == NULL)
         BAIL_OUT ("job_create failed");
     ok (job->refcount == 1,
         "job_create set refcount to 1");
-    ok (job->id == 42 && job->priority == 1 && job->state == FLUX_JOB_NEW
-        && job->userid == FLUX_USERID_UNKNOWN && job->t_submit == 2,
+    ok (job->id == 0
+        && job->priority == FLUX_JOB_PRIORITY_DEFAULT
+        && job->state == FLUX_JOB_NEW
+        && job->userid == FLUX_USERID_UNKNOWN
+        && job->t_submit == 0
+        && job->flags == 0,
         "job_create set id, priority, userid, and t_submit to expected values");
-    ok (job->flags == 3,
-        "job_create set submit flags to expected value");
     ok (!job->alloc_pending
         && !job->free_pending
         && !job->has_resources,
         "job_create set no internal flags");
     ok (job->aux_queue_handle == NULL && job->queue_handle == NULL,
-        "job_Create set queue handles to NULL");
+        "job_create set queue handles to NULL");
     ok (job_incref (job) == job && job->refcount == 2,
         "job_incref incremented refcount and returned original job pointer");
     job_decref (job);

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -30,8 +30,9 @@ struct queue *make_test_queue (int size)
 
     for (id = 0; id < size; id++) {
         struct job *j;
-        if (!(j = job_create (id, 0, 0, 0, 0)))
+        if (!(j = job_create ()))
             BAIL_OUT ("job_create failed");
+        j->id = id;
         if (queue_insert (q, j, &j->queue_handle) < 0)
             BAIL_OUT ("queue_insert failed");
     }

--- a/src/modules/job-manager/test/queue.c
+++ b/src/modules/job-manager/test/queue.c
@@ -18,8 +18,10 @@
 struct job *job_create_test (flux_jobid_t id, int priority)
 {
     struct job *j;
-    if (!(j = job_create (id, priority, 1, 0, 2)))
+    if (!(j = job_create ()))
         BAIL_OUT ("job_create failed");
+    j->id = id;
+    j->priority = priority;
     return j;
 }
 

--- a/src/modules/job-manager/test/submit.c
+++ b/src/modules/job-manager/test/submit.c
@@ -1,0 +1,126 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+#include "src/modules/job-manager/submit.h"
+#include "src/common/libtap/tap.h"
+
+void single_job_check (struct queue *queue)
+{
+    zlist_t *newjobs;
+    json_t *job1;
+    json_t *job2;
+    struct job *job;
+
+    ok (queue_size (queue) == 0,
+        "queue is initially empty");
+
+    if (!(newjobs = zlist_new ()))
+        BAIL_OUT ("zlist_new() failed");
+
+    /* good job */
+    if (!(job1 = json_pack ("{s:I s:i s:i s:f s:i}",
+                            "id", 1,
+                            "priority", 10,
+                            "userid", 42,
+                            "t_submit", 1.0,
+                            "flags", 0)))
+        BAIL_OUT ("json_pack() failed");
+    ok (submit_enqueue_one_job (queue, newjobs, job1) == 0,
+        "submit_enqueue_one_job works");
+    ok (queue_size (queue) == 1,
+        "queue contains one job");
+    ok ((job = zlist_head (newjobs)) != NULL,
+        "newjobs contains one job");
+    ok (job->id == 1 && job->priority == 10 && job->userid == 42
+        && job->t_submit == 1.0 && job->flags == 0,
+        "struct job was properly decoded");
+
+    /* malformed job */
+    if (!(job2 = json_pack ("{s:I}", "id", 2)))
+        BAIL_OUT ("json_pack() failed");
+    errno = 0;
+    ok (submit_enqueue_one_job (queue, newjobs, job2) < 0 && errno == EPROTO,
+        "submit_enqueue_one job o=(malformed) fails with EPROTO");
+
+    /* resubmit orig job */
+    ok (submit_enqueue_one_job (queue, newjobs, job1) == 0,
+        "submit_enqueue_one_job o=(dup id) works");
+    ok (queue_size (queue) == 1,
+        "but queue contains one job");
+    ok (zlist_size (newjobs) == 1,
+        "and newjobs still contains one job");
+
+    /* clean up (batch submit error path) */
+    submit_enqueue_jobs_cleanup (queue, newjobs); // destroys newjobs
+    ok (queue_size (queue) == 0,
+        "submit_enqueue_jobs_cleanup removed orig queue entry");
+
+    json_decref (job2);
+    json_decref (job1);
+}
+
+void multi_job_check (struct queue *queue)
+{
+
+    zlist_t *newjobs;
+    json_t *jobs;
+
+    ok (queue_size (queue) == 0,
+        "queue is initially empty");
+    if (!(jobs = json_pack ("[{s:I s:i s:i s:f s:i},"
+                             "{s:I s:i s:i s:f s:i}]",
+                            "id", 1,
+                            "priority", 10,
+                            "userid", 42,
+                            "t_submit", 1.0,
+                            "flags", 0,
+                            "id", 2,
+                            "priority", 11,
+                            "userid", 43,
+                            "t_submit", 1.1,
+                            "flags", 1)))
+        BAIL_OUT ("json_pack() failed");
+
+    newjobs = submit_enqueue_jobs (queue, jobs);
+    ok (newjobs != NULL,
+        "submit_enqueue_jobs works");
+    ok (queue_size (queue) == 2,
+        "queue contains 2 jobs");
+    ok (zlist_size (newjobs) == 2,
+        "newjobs contains 2 jobs");
+    submit_enqueue_jobs_cleanup (queue, newjobs);
+    ok (queue_size (queue) == 0,
+        "submit_enqueue_jobs_cleanup removed queue entries");
+
+    json_decref (jobs);
+}
+
+int main (int argc, char *argv[])
+{
+    struct queue *queue;
+
+    plan (NO_PLAN);
+
+    if (!(queue = queue_create (true)))
+        BAIL_OUT ("queue_create() failed");
+
+    single_job_check (queue);
+    multi_job_check (queue);
+
+    queue_destroy (queue);
+    done_testing ();
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR is a refactoring of the job manager to put all of the job state machine logic in `event.c` rather than sprinkling it all around.  Hopefully this will make it easier to understand and modify.  Parts of the system like the request handlers, and handlers for alloc/free responses now simply log events, and the event now is not only committed to the KVS, but also drives a state machine update, which in turn initiates new actions.

One other change that wasn't strictly required:  The priority and "raise" RPC's now respond to the user before the event has been committed to the KVS.  This was to simplify some code that seemed gratuitously complex to me as I was refactoring.  However it caused a race in the `t2202-job-manager.t` test, which then had to be addressed by borrowing a clever shell function from @grondo's scheduler test.  Hopefully these tests can be simplified after we get a user facing tool for waiting on events.

I struggled with structuring this PR so that commits were reviewable and didn't entirely get there.  I'm happy to try again if the result is hard to look at.