### PR TITLE
modules/job-info: New module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,6 +419,7 @@ AC_CONFIG_FILES( \
   src/modules/userdb/Makefile \
   src/modules/job-ingest/Makefile \
   src/modules/job-manager/Makefile \
+  src/modules/job-info/Makefile \
   src/modules/sched-simple/Makefile \
   src/test/Makefile \
   etc/Makefile \

--- a/etc/rc1
+++ b/etc/rc1
@@ -7,6 +7,7 @@ flux module load -r 0  content-sqlite
 flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 flux module load -r all kvs-watch
+flux module load -r all job-info
 flux module load -r all aggregator
 
 flux hwloc reload & pids="$pids $!"

--- a/etc/rc3
+++ b/etc/rc3
@@ -25,6 +25,7 @@ flux module remove -r 0 cron
 flux module remove -r all aggregator
 flux module remove -r all barrier
 
+flux module remove -r all job-info
 flux module remove -r all kvs-watch
 flux module remove -r all -x 0 kvs
 if test -n "$PERSISTDIR"; then

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -457,7 +457,7 @@ int cmd_namespace_create (optparse_t *p, int argc, char **argv)
         char *endptr;
         owner = strtoul (str, &endptr, 10);
         if (*endptr != '\0')
-            log_err_exit ("--owner requires an unsigned integer argument");
+            log_msg_exit ("--owner requires an unsigned integer argument");
     }
 
     for (i = optindex; i < argc; i++) {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -30,6 +30,10 @@ enum job_priority {
     FLUX_JOB_PRIORITY_MAX = 31,
 };
 
+enum job_info_flags {
+    FLUX_JOB_INFO_WATCH = 1,
+};
+
 typedef enum {
     FLUX_JOB_NEW                    = 1,
     FLUX_JOB_DEPEND                 = 2,

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -100,6 +100,15 @@ flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority);
 int flux_job_kvs_key (char *buf, int bufsz, bool active,
                       flux_jobid_t id, const char *key);
 
+/* Job eventlog lookup functions
+ */
+flux_future_t *flux_job_eventlog_lookup (flux_t *h, flux_jobid_t id);
+int flux_job_eventlog_lookup_get (flux_future_t *f, const char **event);
+
+flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id);
+int flux_job_event_watch_get (flux_future_t *f, const char **event);
+int flux_job_event_watch_cancel (flux_future_t *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -138,6 +138,33 @@ void check_corner_case (void)
     ok (flux_job_kvs_key (NULL, 0, false, 0, NULL) < 0
         && errno == EINVAL,
         "flux_job_kvs_key fails with errno == EINVAL");
+
+    /* flux_job_eventlog_lookup */
+
+    errno = EINVAL;
+    ok (!flux_job_eventlog_lookup (NULL, 0)
+        && errno == EINVAL,
+        "flux_job_eventlog_lookup fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_job_eventlog_lookup_get (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_job_eventlog_lookup_get fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (!flux_job_event_watch (NULL, 0)
+        && errno == EINVAL,
+        "flux_job_event_watch fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_job_event_watch_get (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_job_event_watch_get fails with EINVAL on bad input");
+
+    errno = EINVAL;
+    ok (flux_job_event_watch_cancel (NULL) < 0
+        && errno == EINVAL,
+        "flux_job_event_watch_cancel fails with EINVAL on bad input");
 }
 
 int main (int argc, char *argv[])

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -10,4 +10,5 @@ SUBDIRS = \
  pymod \
  job-ingest \
  job-manager \
+ job-info \
  sched-simple

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -1,0 +1,25 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+
+fluxmod_LTLIBRARIES = job-info.la
+
+job_info_la_SOURCES = \
+	job-info.c
+
+
+job_info_la_LDFLAGS = $(fluxmod_ldflags) -module
+job_info_la_LIBADD = $(fluxmod_libadd) \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS)

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -1,0 +1,430 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+/* Module state.
+ */
+struct info_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    zlist_t *lookups;
+};
+
+/* Lookup context
+ */
+struct lookup_ctx {
+    struct info_ctx *ctx;
+    flux_msg_t *msg;
+    flux_jobid_t id;
+    int flags;
+    int lookup_flags;
+    bool active;
+    flux_future_t *f;
+    int offset;
+    bool cancel;
+};
+
+void lookup_ctx_destroy (void *data)
+{
+    if (data) {
+        struct lookup_ctx *ctx = data;
+        flux_msg_destroy (ctx->msg);
+        flux_future_destroy (ctx->f);
+        free (ctx);
+    }
+}
+
+static void lookup_continuation (flux_future_t *f, void *arg);
+
+struct lookup_ctx *lookup_ctx_create (struct info_ctx *ctx,
+                                      const flux_msg_t *msg,
+                                      flux_jobid_t id,
+                                      int flags)
+{
+    struct lookup_ctx *l = calloc (1, sizeof (*l));
+    int saved_errno;
+
+    if (!l)
+        return NULL;
+
+    l->ctx = ctx;
+    l->id = id;
+    l->flags = flags;
+    l->active = true;
+
+    if (l->flags & FLUX_JOB_INFO_WATCH) {
+        l->lookup_flags |= FLUX_KVS_WATCH;
+        l->lookup_flags |= FLUX_KVS_WATCH_APPEND;
+    }
+
+    if (!(l->msg = flux_msg_copy (msg, true))) {
+        flux_log_error (ctx->h, "%s: flux_msg_copy", __FUNCTION__);
+        goto error;
+    }
+
+    return l;
+
+error:
+    saved_errno = errno;
+    lookup_ctx_destroy (l);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* 'pp' is an in/out parameter pointing to input buffer.
+ * Set 'tok' to next \n-terminated token, and 'toklen' to its length.
+ * Advance 'pp' past token.  Returns false when input is exhausted.
+ */
+static bool info_parse_next (const char **pp, const char **tok,
+                                 size_t *toklen)
+{
+    char *term;
+
+    if (!(term = strchr (*pp, '\n')))
+        return false;
+    *tok = *pp;
+    *toklen = term - *pp + 1;
+    *pp = term + 1;
+    return true;
+}
+
+static int lookup_key (struct lookup_ctx *l)
+{
+    char key[64];
+
+    if (l->f) {
+        flux_future_destroy (l->f);
+        l->f = NULL;
+    }
+
+    if (flux_job_kvs_key (key, sizeof (key), l->active, l->id, "eventlog") < 0) {
+        flux_log_error (l->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
+        return -1;
+    }
+
+    if (!(l->f = flux_kvs_lookup (l->ctx->h, NULL, l->lookup_flags, key))) {
+        flux_log_error (l->ctx->h, "%s: flux_kvs_lookup", __FUNCTION__);
+        return -1;
+    }
+
+    if (flux_future_then (l->f, -1, lookup_continuation, l) < 0) {
+        flux_log_error (l->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct lookup_ctx *l = arg;
+    struct info_ctx *ctx = l->ctx;
+    const char *s;
+
+    if (flux_kvs_lookup_get (f, &s) < 0) {
+        if (errno == ENOENT && l->active) {
+            /* transition / try the inactive key */
+            l->active = false;
+            if (lookup_key (l) < 0)
+                goto error;
+            return;
+        }
+        else if (errno == ENODATA && (l->flags & FLUX_JOB_INFO_WATCH)) {
+            if (flux_respond_error (ctx->h, l->msg, ENODATA, NULL) < 0)
+                flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+            goto done;
+        }
+        else if (errno != ENOENT)
+            flux_log_error (ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+        goto error;
+    }
+
+    if (l->cancel) {
+        if ((l->flags & FLUX_JOB_INFO_WATCH)) {
+            if (flux_respond_error (ctx->h, l->msg, ENODATA, NULL) < 0)
+                flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        }
+        goto done;
+    }
+
+    if ((l->flags & FLUX_JOB_INFO_WATCH)) {
+        const char *input = s;
+        const char *tok;
+        size_t toklen;
+        while (info_parse_next (&input, &tok, &toklen)) {
+            if (l->active)
+                l->offset += toklen;
+
+            if (l->active || !l->offset) {
+                if (flux_respond_pack (ctx->h, l->msg,
+                                       "{s:s#}",
+                                       "event", tok, toklen) < 0) {
+                    flux_log_error (ctx->h, "%s: flux_respond_pack",
+                                    __FUNCTION__);
+                    goto error;
+                }
+            }
+
+            if (!l->active && l->offset)
+                l->offset -= toklen;
+        }
+
+        if (l->active)
+            flux_future_reset (f);
+        else {
+            /* we're in inactive state, there are no more events coming */
+            if (flux_respond_error (ctx->h, l->msg, ENODATA, NULL) < 0)
+                flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+            goto done;
+        }
+    }
+    else {
+        if (flux_respond_pack (ctx->h, l->msg, "{s:s}", "event", s) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond_pack", __FUNCTION__);
+            goto error;
+        }
+        goto done;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (ctx->h, l->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+done:
+    /* flux future destroyed in lookup_ctx_destroy, which is called
+     * via zlist_remove() */
+    zlist_remove (ctx->lookups, l);
+}
+
+static void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    struct lookup_ctx *l = NULL;
+    flux_jobid_t id;
+    int flags;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:i}",
+                             "id", &id,
+                             "flags", &flags) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        goto error;
+    }
+
+    if (!(l = lookup_ctx_create (ctx, msg, id, flags)))
+        goto error;
+
+    if (lookup_key (l) < 0)
+        goto error;
+
+    if (zlist_append (ctx->lookups, l) < 0) {
+        flux_log_error (h, "%s: zlist_append", __FUNCTION__);
+        goto error;
+    }
+    zlist_freefn (ctx->lookups, l, lookup_ctx_destroy, true);
+    l = NULL;
+
+    return;
+
+error:
+    lookup_ctx_destroy (l);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* Cancel lookup 'l' if it matches (sender, matchtag).
+ * matchtag=FLUX_MATCHTAG_NONE matches any matchtag.
+ */
+static void lookup_cancel (struct info_ctx *ctx,
+                           struct lookup_ctx *l,
+                           const char *sender, uint32_t matchtag)
+{
+    uint32_t t;
+    char *s;
+
+    if (matchtag != FLUX_MATCHTAG_NONE
+        && (flux_msg_get_matchtag (l->msg, &t) < 0 || matchtag != t))
+        return;
+    if (flux_msg_get_route_first (l->msg, &s) < 0)
+        return;
+    if (!strcmp (sender, s)) {
+        if ((l->flags & FLUX_JOB_INFO_WATCH)) {
+            if (flux_kvs_lookup_cancel (l->f) < 0)
+                flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+                                __FUNCTION__);
+        }
+        l->cancel = true;
+    }
+    free (s);
+}
+
+/* Cancel all lookups that match (sender, matchtag). */
+static void lookups_cancel (struct info_ctx *ctx,
+                            const char *sender, uint32_t matchtag)
+{
+    struct lookup_ctx *l;
+
+    l = zlist_first (ctx->lookups);
+    while (l) {
+        lookup_cancel (ctx, l, sender, matchtag);
+        l = zlist_next (ctx->lookups);
+    }
+}
+
+static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    uint32_t matchtag;
+    char *sender;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    lookups_cancel (ctx, sender, matchtag);
+    free (sender);
+}
+
+static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
+                           const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    char *sender;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        flux_log_error (h, "%s: flux_request_decode", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    lookups_cancel (ctx, sender, FLUX_MATCHTAG_NONE);
+    free (sender);
+}
+
+static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+
+    if (flux_respond_pack (h, msg, "{s:i}",
+                           "lookups", zlist_size (ctx->lookups)) < 0) {
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
+
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.eventlog-lookup",
+      .cb           = lookup_cb,
+      .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.eventlog-cancel",
+      .cb           = cancel_cb,
+      .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.disconnect",
+      .cb           = disconnect_cb,
+      .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.stats.get",
+      .cb           = stats_cb,
+      .rolemask     = 0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static void info_ctx_destroy (struct info_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->lookups) {
+            struct lookup_ctx *l;
+
+            while ((l = zlist_pop (ctx->lookups))) {
+                if ((l->flags & FLUX_JOB_INFO_WATCH)) {
+                    if (flux_kvs_lookup_cancel (l->f) < 0)
+                        flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+                                        __FUNCTION__);
+
+                    if (flux_respond_error (ctx->h, l->msg, ENOSYS, NULL) < 0)
+                        flux_log_error (ctx->h, "%s: flux_respond_error",
+                                        __FUNCTION__);
+                }
+                lookup_ctx_destroy (l);
+            }
+            zlist_destroy (&ctx->lookups);
+        }
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct info_ctx *info_ctx_create (flux_t *h)
+{
+    struct info_ctx *ctx = calloc (1, sizeof (*ctx));
+    if (!ctx)
+        return NULL;
+    ctx->h = h;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (!(ctx->lookups = zlist_new ()))
+        goto error;
+    return ctx;
+error:
+    info_ctx_destroy (ctx);
+    return NULL;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct info_ctx *ctx;
+    int rc = -1;
+
+    if (!(ctx = info_ctx_create (h))) {
+        flux_log_error (h, "initialization error");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    info_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("job-info");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -85,6 +85,7 @@ TESTS = \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched.t \
+	t2204-job-info.t \
 	t2300-sched-simple.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
@@ -179,6 +180,7 @@ check_SCRIPTS = \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched.t \
+	t2204-job-info.t \
 	t2300-sched-simple.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -5,4 +5,6 @@ flux module load -r 0 kvs
 flux module load -r all -x 0 kvs
 
 flux module load -r all job-ingest
+flux module load -r all kvs-watch
+flux module load -r all job-info
 flux module load -r 0 job-manager

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
 flux module remove -r 0 job-manager
+flux module remove -r all job-info
+flux module remove -r all kvs-watch
 flux module remove -r all job-ingest
 
 flux module remove -r all -x 0 kvs

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -52,8 +52,9 @@ test_expect_success 'job-ingest: submit fails without job-ingest' '
 	test_must_fail flux job submit basic.json 2>nosys.out
 '
 
-test_expect_success 'job-ingest: load job-ingest' '
-	flux module load -r all job-ingest
+test_expect_success 'job-ingest: load job-ingest && job-info' '
+	flux module load -r all job-ingest &&
+	flux module load -r all job-info
 '
 
 test_expect_success 'job-ingest: submit fails without job-manager' '
@@ -86,8 +87,7 @@ test_expect_success 'job-ingest: job announced to job manager' '
 
 test_expect_success 'job-ingest: submit event logged with userid, priority' '
 	jobid=$(flux job submit --priority=11 basic.json) &&
-	kvsdir=$(flux job id --to=kvs-active $jobid) &&
-	flux kvs eventlog get ${kvsdir}.eventlog |grep submit >eventlog.out &&
+	flux job eventlog $jobid |grep submit >eventlog.out &&
 	grep -q priority=11 eventlog.out &&
 	grep -q userid=$(id -u) eventlog.out
 '
@@ -134,6 +134,7 @@ test_expect_success HAVE_FLUX_SECURITY 'job-ingest: non-owner mech=none fails' '
 
 test_expect_success 'job-ingest: remove modules' '
 	flux module remove -r 0 job-manager &&
+	flux module remove -r all job-info &&
 	flux module remove -r all job-ingest
 '
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -153,6 +153,7 @@ test_expect_success 'job-manager: flux job priority sets last job priority=31' '
 
 test_expect_success 'job-manager: priority was updated in KVS' '
 	jobid=$(tail -1 <list10_ids.out) &&
+        flux job wait-event --timeout=5.0 ${jobid} priority &&
 	flux job eventlog $jobid \
 		| cut -d" " -f2- | grep ^priority >pri.out &&
 	grep -q priority=31 pri.out

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -89,13 +89,13 @@ test_expect_success 'flux job eventlog fails on bad id' '
 #
 
 test_expect_success 'flux job wait-event works (active)' '
-        jobid=$(flux job submit test.json)
+        jobid=$(flux job submit test.json) &&
         flux job wait-event $jobid submit > wait_event1.out &&
         grep submit wait_event1.out
 '
 
 test_expect_success 'flux job wait-event works (inactive)' '
-        jobid=$(flux job submit test.json)
+        jobid=$(flux job submit test.json) &&
         activekvsdir=$(flux job id --to=kvs-active $jobid) &&
         inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
         flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
@@ -138,7 +138,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event works, event is later (ac
 '
 
 test_expect_success 'flux job wait-event exits if never receives event (inactive) ' '
-        jobid=$(flux job submit test.json)
+        jobid=$(flux job submit test.json) &&
         activekvsdir=$(flux job id --to=kvs-active $jobid) &&
         inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
         flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
@@ -166,13 +166,13 @@ test_expect_success 'flux job wait-event fails on bad id' '
 '
 
 test_expect_success 'flux job wait-event --quiet works' '
-        jobid=$(flux job submit test.json)
+        jobid=$(flux job submit test.json) &&
         flux job wait-event --quiet $jobid submit > wait_event7.out &&
         ! test -s wait_event7.out
 '
 
 test_expect_success 'flux job wait-event --verbose works' '
-        jobid=$(flux job submit test.json)
+        jobid=$(flux job submit test.json) &&
         kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobaz &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
@@ -184,21 +184,21 @@ test_expect_success 'flux job wait-event --verbose works' '
 
 test_expect_success 'flux job wait-event --verbose doesnt show events after wait event' '
         jobid=$(flux job submit test.json) &&
-        kvsdir=$(flux job id --to=kvs-active $jobid)
+        kvsdir=$(flux job id --to=kvs-active $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
         flux job wait-event --verbose $jobid submit > wait_event9.out &&
         grep submit wait_event9.out &&
         ! grep foobar wait_event9.out
 '
 
-test_expect_success NO_CHAIN_LINT 'flux job wait-event --timeout works' '
-        jobid=$(flux job submit test.json)
+test_expect_success 'flux job wait-event --timeout works' '
+        jobid=$(flux job submit test.json) &&
         ! flux job wait-event --timeout=0.2 $jobid foobar 2> wait_event8.err &&
         grep "wait-event timeout" wait_event8.err
 '
 
-test_expect_success NO_CHAIN_LINT 'flux job wait-event hangs on no event' '
-        jobid=$(flux job submit test.json)
+test_expect_success 'flux job wait-event hangs on no event' '
+        jobid=$(flux job submit test.json) &&
         ! run_timeout 0.2 flux job wait-event $jobid foobar
 '
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -1,0 +1,209 @@
+#!/bin/sh
+
+test_description='Test flux job eventlog service'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+wait_lookups_nonzero() {
+        i=0
+        while (! flux module stats --parse lookups job-info > /dev/null 2>&1 \
+               || [ "$(flux module stats --parse lookups job-info 2> /dev/null)" = "0" ]) \
+              && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success 'job-info: generate jobspec for simple test job' '
+        flux jobspec --format json srun -N1 hostname > test.json
+'
+
+#
+# job eventlog tests
+#
+
+test_expect_success 'flux job eventlog works (active)' '
+        jobid=$(flux job submit test.json) &&
+	flux job eventlog $jobid > eventlog_a.out &&
+        grep submit eventlog_a.out
+'
+
+test_expect_success 'flux job eventlog works on multiple entries (active)' '
+        jobid=$(flux job submit test.json) &&
+        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foo &&
+	flux job eventlog $jobid >eventlog_b.out &&
+	grep -q submit eventlog_b.out &&
+	grep -q foo eventlog_b.out
+'
+
+# we cheat and manually move active to inactive in these tests
+
+test_expect_success 'flux job eventlog works (inactive)' '
+        jobid=$(flux job submit test.json) &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux job eventlog $jobid > eventlog_c.out &&
+        grep submit eventlog_c.out
+'
+
+test_expect_success 'flux job eventlog works on multiple entries (inactive)' '
+        jobid=$(flux job submit test.json) &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${activekvsdir}.eventlog foo &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux job eventlog $jobid >eventlog_d.out &&
+	grep -q submit eventlog_d.out &&
+	grep -q foo eventlog_d.out
+'
+
+test_expect_success 'flux job eventlog works on multiple entries (active -> inactive)' '
+        jobid=$(flux job submit test.json) &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+	flux kvs eventlog append ${inactivekvsdir}.eventlog foo &&
+	flux job eventlog $jobid >eventlog_e.out &&
+	grep -q submit eventlog_e.out &&
+	grep -q foo eventlog_e.out
+'
+
+test_expect_success 'flux job eventlog fails on bad id' '
+	! flux job eventlog 12345
+'
+
+#
+# job wait-event tests
+#
+
+test_expect_success 'flux job wait-event works (active)' '
+        jobid=$(flux job submit test.json)
+        flux job wait-event $jobid submit > wait_event1.out &&
+        grep submit wait_event1.out
+'
+
+test_expect_success 'flux job wait-event works (inactive)' '
+        jobid=$(flux job submit test.json)
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+        flux kvs eventlog append ${inactivekvsdir}.eventlog foobar &&
+        flux job wait-event $jobid submit > wait_event2.out &&
+        grep submit wait_event2.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event works, event is later (active)' '
+        jobid=$(flux job submit test.json)
+        flux job wait-event $jobid foobar > wait_event3.out &
+        waitpid=$! &&
+        wait_lookups_nonzero &&
+        wait_watcherscount_nonzero primary &&
+        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
+        wait $waitpid &&
+        grep foobar wait_event3.out
+'
+
+# must carefully fake active -> inactive transition to avoid race
+# where job-info module sees inactive transition but does not see any
+# new events.  We do this by copying the eventlog, modifying the
+# inactive eventlog, then removing the active one.
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event works, event is later (active -> inactive) ' '
+        jobid=$(flux job submit test.json)
+        flux job wait-event $jobid foobar > wait_event4.out &
+        waitpid=$! &&
+        wait_lookups_nonzero &&
+        wait_watcherscount_nonzero primary &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        flux kvs eventlog append ${activekvsdir}.eventlog foobaz &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs copy ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+        flux kvs eventlog append ${inactivekvsdir}.eventlog foobar &&
+        flux kvs unlink ${activekvsdir}.eventlog &&
+        wait $waitpid &&
+        grep foobar wait_event4.out
+'
+
+test_expect_success 'flux job wait-event exits if never receives event (inactive) ' '
+        jobid=$(flux job submit test.json)
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+        ! flux job wait-event $jobid foobar > wait_event5.out 2> wait_event5.err &&
+        ! test -s wait_event5.out &&
+        grep "never received" wait_event5.err
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event exits if never receives event (active -> inactive) ' '
+        jobid=$(flux job submit test.json)
+        flux job wait-event $jobid foobar > wait_event6.out 2> wait_event6.err &
+        waitpid=$! &&
+        wait_lookups_nonzero &&
+        wait_watcherscount_nonzero primary &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/') &&
+        flux kvs move ${activekvsdir}.eventlog ${inactivekvsdir}.eventlog &&
+        ! wait $waitpid &&
+        ! test -s wait_event6.out &&
+        grep "never received" wait_event6.err
+'
+
+test_expect_success 'flux job wait-event fails on bad id' '
+	! flux job wait-event 12345 foobar
+'
+
+test_expect_success 'flux job wait-event --quiet works' '
+        jobid=$(flux job submit test.json)
+        flux job wait-event --quiet $jobid submit > wait_event7.out &&
+        ! test -s wait_event7.out
+'
+
+test_expect_success 'flux job wait-event --verbose works' '
+        jobid=$(flux job submit test.json)
+        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobaz &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
+        flux job wait-event --verbose $jobid foobar > wait_event8.out &&
+        grep submit wait_event8.out &&
+        grep foobaz wait_event8.out &&
+        grep foobar wait_event8.out
+'
+
+test_expect_success 'flux job wait-event --verbose doesnt show events after wait event' '
+        jobid=$(flux job submit test.json) &&
+        kvsdir=$(flux job id --to=kvs-active $jobid)
+	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
+        flux job wait-event --verbose $jobid submit > wait_event9.out &&
+        grep submit wait_event9.out &&
+        ! grep foobar wait_event9.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event --timeout works' '
+        jobid=$(flux job submit test.json)
+        ! flux job wait-event --timeout=0.2 $jobid foobar 2> wait_event8.err &&
+        grep "wait-event timeout" wait_event8.err
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event hangs on no event' '
+        jobid=$(flux job submit test.json)
+        ! run_timeout 0.2 flux job wait-event $jobid foobar
+'
+
+test_expect_success 'job-info stats works' '
+        flux module stats job-info | grep "lookups"
+'
+
+test_done


### PR DESCRIPTION
After several WIPs (#2066, #2065), I think this PR is a candidate for merger.

At this moment, the module only supports getting/watching eventlog entries by jobid.  Included are two new job subcommands, `flux job eventlog` and `flux job wait-event`.  They do about what you think they would do.

Adjusted tests that previously used `flux kvs eventlog get` to use new subcommands, removing the need to do `flux job id` commands to get paths.  `flux job wait-event` conveniently removes a big function in `t2300-sched-simple.t` that emulated the same exact thing (Edit: after rebase, also in t2202-job-manager.t`).

I had begun to add a proxy to ensure guest access to the eventlog was possible, but when I tried to add tests, it wasn't clear to me how one submits a job as a guest user, or if I have to fake it in some way right now.  In addition, a number of the functions in `job-manager/util.[ch]` should probably be exported for convenience first.  So I decided perhaps that could be in a follow up PR.
