### PR TITLE
implement exec protocol in job-manager, add prototype job-exec service

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -420,6 +420,7 @@ AC_CONFIG_FILES( \
   src/modules/job-ingest/Makefile \
   src/modules/job-manager/Makefile \
   src/modules/job-info/Makefile \
+  src/modules/job-exec/Makefile \
   src/modules/sched-simple/Makefile \
   src/test/Makefile \
   etc/Makefile \

--- a/etc/rc1
+++ b/etc/rc1
@@ -18,6 +18,8 @@ flux module load -r 0 userdb ${FLUX_USERDB_OPTIONS}
 
 flux module load -r all job-ingest
 flux module load -r 0 job-manager
+flux module load -r 0 job-exec
+flux module load -r 0 sched-simple
 
 wait $pids
 

--- a/etc/rc3
+++ b/etc/rc3
@@ -12,6 +12,8 @@ for rcdir in $all_dirs; do
 done
 shopt -u nullglob
 
+flux module remove -r 0 sched-simple
+flux module remove -r 0 job-exec
 flux module remove -r 0 job-manager
 flux module remove -r all job-ingest
 

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -642,10 +642,7 @@ static int l_f_zi_resp_cb (lua_State *L,
     flux_t *f = arg;
     flux_msg_t **msgp = zmsg_info_zmsg (zi);
     int rc;
-    if ((rc = flux_respond (f, *msgp, 0, json_str)) == 0) {
-        flux_msg_destroy (*msgp);
-        *msgp = NULL;
-    }
+    rc = flux_respond (f, *msgp, 0, json_str);
     return l_pushresult (L, rc);
 }
 

--- a/src/cmd/flux-jobspec
+++ b/src/cmd/flux-jobspec
@@ -89,6 +89,49 @@ def validate_slurm_args(args):
     # IDEA: print a warning if the file already exists or if the parent dir doesn't exist
 
 
+#  Convert floating point "time" in seconds to duration string with suffix
+#   's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
+def sec_to_duration(time):
+    if time < 2 * 60.0:
+        return "%ss" % str(time)
+    elif time < 2 * 60 * 60:
+        return "%sm" % str(time / 60.0)
+    elif time < 60 * 60 * 24:
+        return "%sh" % str(time / (60 * 60))
+    else:
+        return "%sd" % str(time / (60 * 60 * 24))
+
+
+#  Convert slurm walltime string to Flux duration string
+def slurm_walltime_to_duration(time):
+    if not time:
+        return None
+    p1 = re.compile(
+        r"^((?P<days>\d+)-)?"
+        r"(?P<hours>\d+):"
+        r"(?P<minutes>\d+):"
+        r"(?P<seconds>\d+)$"
+    )
+    p2 = re.compile(r"^(?P<minutes>\d+)(:(?P<seconds>\d+))?$")
+
+    t = 0.0
+    m = p2.search(time) or p1.search(time)
+    if m is None:
+        return None
+    vals = {k: float(v) for k, v in m.groupdict().items() if v is not None}
+    if "days" in vals:
+        t = t + vals["days"] * 60 * 60 * 24
+    if "hours" in vals:
+        t = t + vals["hours"] * 60 * 60
+    if "minutes" in vals:
+        t = t + vals["minutes"] * 60
+    if "seconds" in vals:
+        t = t + vals["seconds"]
+    if t == 0.0:
+        return None
+    return sec_to_duration(t)
+
+
 def slurm_jobspec(args):
     if args.ntasks is None:
         args.ntasks = max(args.nodes, 1)
@@ -98,8 +141,9 @@ def slurm_jobspec(args):
     except ValueError as e:
         logger.error(e.message)
         sys.exit(1)
+    t = slurm_walltime_to_duration(args.time)
     return create_slurm_style_jobspec(
-        args.command, args.ntasks, args.cpus_per_task, args.nodes, args.time
+        args.command, args.ntasks, args.cpus_per_task, args.nodes, t
     )
 
 

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -11,4 +11,5 @@ SUBDIRS = \
  job-ingest \
  job-manager \
  job-info \
+ job-exec \
  sched-simple

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -1,0 +1,54 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+
+fluxmod_LTLIBRARIES = \
+	job-exec.la
+
+job_exec_la_SOURCES = \
+	job-exec.c \
+	rset.c \
+	rset.h
+
+job_exec_la_LDFLAGS = \
+	$(fluxmod_ldflags) \
+	-module
+
+job_exec_la_LIBADD = \
+	$(fluxmod_ldadd) \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS)
+
+test_ldadd = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)
+
+test_cppflags = \
+	$(AM_CPPFLAGS)
+
+TESTS = \
+	test_rset.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+test_rset_t_SOURCES = \
+	rset.c \
+	rset.h \
+	test/rset.c
+test_rset_t_CPPFLAGS = \
+	$(test_cppflags)
+test_rset_t_LDADD = \
+	$(test_ldadd)

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1,0 +1,1163 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Prototype flux job exec service
+ *
+ * DESCRIPTION
+ *
+ * This module implements the exec interface as described in
+ * job-manager/start.c, but does not currently support execution of
+ * real work. Execution is simulated by setting a timer for the duration
+ * specified in either the jobspec system.duration attribute or a test
+ * duration in system.exec.test.run_duration.  The module can optionally
+ * simulate an epilog/cleanup stage, and/or mock exceptions during run
+ * or initialization. See TEST CONFIGURATION below.
+ *
+ * OPERATION
+ *
+ * For deatils of startup protocol, see job-manager/start.c.
+ *
+ * JOB INIT:
+ *
+ * On reciept of a start request, the exec service enters initialization
+ * phase of the job, where the jobspec and R are fetched from the KVS,
+ * and the guest namespace is created and linked from the primary
+ * namespace. A guest.exec.eventlog is created with an initial "init"
+ * event posted.
+ *
+ * Jobspec and R are parsed as soon as asynchronous initialization tasks
+ * complete. If any of these steps fail, or a mock exception is configured
+ * for "init", an exec initialization exception * is thrown.
+ *
+ * JOB STARTING/RUNNING:
+ *
+ * The current exec service fakes a running job by initiating a timer for
+ * the configured duration of the job, or 10us by default. The "start"
+ * response to the job manager is sent just before the timer is started,
+ * to simulate the condition when all job shells have been launched.
+ *
+ * JOB FINISH/CLEANUP:
+ *
+ * When the timer callback fires, then a "finish" response is sent to
+ * the job-manager (with status set by TEST CONFIGURATION), and any
+ * configured "cleanup" tasks are initiated. By default, no cleanup work
+ * is configured unless the attributes.system.exec.test.cleanup_duration
+ * key is set in the jobspec.  This simulates a "job epilog" that takes
+ * some amount of time.
+ *
+ * JOB FINALIZATION:
+ *
+ * Once optional cleanup tasks have completed, the job is "finalized", which
+ * includes the following steps, in order:
+ *
+ *  - terminating "done" event is posted to the exec.eventlog
+ *  - the guest namespace, now quiesced, is copied to the primary namespace
+ *  - the guest namespace is removed
+ *  - the final "release final=1" response is sent to the job manager
+ *  - the local job object is destroyed
+ *
+ * TEST CONFIGURATION
+ *
+ * The job-exec module supports an object in the jobspec under
+ * attributes.system.exec.test, which supports the following keys
+ *
+ * {
+ *   "run_duration":s,      - alternate/override attributes.system.duration
+ *   "cleanup_duration":s   - enable a fake job epilog and set its duration
+ *   "wait_status":i        - report this value as status in the "finish" resp
+ *   "mock_exception":s     - mock an exception during this phase of job
+ *                             execution (currently "init" and "run")
+ * }
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libutil/fluid.h"
+#include "rset.h"
+
+struct job_exec_ctx {
+    flux_t *              h;
+    flux_msg_handler_t ** handlers;
+    zhashx_t *            jobs;
+};
+
+
+/*  Exec system testing configuration:
+ *  Set from jobspec attributes.system.exec.test object, if any.
+ */
+struct testconf {
+    double                run_duration;     /* duration of fake job in sec  */
+    double                cleanup_duration; /* if > 0., duration of epilog  */
+    int                   wait_status;      /* reported status for "finish" */
+    const char *          mock_exception;   /* fake excetion at this site   */
+                                            /* ("init", or "run")           */
+};
+
+struct jobinfo {
+    flux_jobid_t          id;
+    char                  ns [64];
+    flux_msg_t *          req;
+    uint32_t              userid;
+    int                   flags;
+
+    struct resource_set * R;
+    json_t *              jobspec;
+
+    uint8_t               needs_cleanup:1;
+    uint8_t               has_namespace:1;
+    uint8_t               exception_in_progress:1;
+    uint8_t               running:1;
+    uint8_t               finalizing:1;
+
+    int                   wait_status;
+
+    int                   refcount;
+
+    struct testconf       testconf;
+    flux_watcher_t *      timer;
+
+    zhashx_t *            cleanup;
+    struct job_exec_ctx * ctx;
+};
+
+typedef flux_future_t * (*cleanup_task_f) (struct jobinfo *job);
+
+static void jobinfo_incref (struct jobinfo *job)
+{
+    job->refcount++;
+}
+
+static void jobinfo_decref (struct jobinfo *job)
+{
+    if (job && (--job->refcount == 0)) {
+        int saved_errno = errno;
+        zhashx_delete (job->ctx->jobs, &job->id);
+        job->ctx = NULL;
+        flux_msg_destroy (job->req);
+        job->req = NULL;
+        resource_set_destroy (job->R);
+        json_decref (job->jobspec);
+        flux_watcher_destroy (job->timer);
+        zhashx_destroy (&job->cleanup);
+        free (job);
+        errno = saved_errno;
+    }
+}
+
+static struct jobinfo * jobinfo_new (void)
+{
+    struct jobinfo *job = calloc (1, sizeof (*job));
+    job->cleanup = zhashx_new ();
+    job->refcount = 1;
+    return job;
+}
+
+static int ev_context_vsprintf (char *context, size_t len,
+                                const char *fmt, va_list ap)
+{
+    int n;
+    if (fmt == NULL)
+        context[0] = '\0';
+    else if ((n = vsnprintf (context, len, fmt, ap)) < 0)
+        return -1;
+    else if (n >= len) {
+        context [len-2] = '+';
+        context [len-1] = '\0';
+    }
+    return 0;
+}
+
+/*  Emit an event to the exec system eventlog and return a future from
+ *   flux_kvs_commit().
+ */
+static flux_future_t * jobinfo_emit_eventv (struct jobinfo *job,
+                                            const char *name,
+                                            const char *fmt,
+                                            va_list ap)
+{
+    int saved_errno;
+    flux_t *h = job->ctx->h;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    char context [256];
+    char *event = NULL;
+    const char *key = "exec.eventlog";
+
+    if (ev_context_vsprintf (context, sizeof (context), fmt, ap) < 0) {
+        flux_log_error (h, "emit event: ev_context_vsprintf");
+        return NULL;
+    }
+    if (!(event = flux_kvs_event_encode (name, context))) {
+        flux_log_error (h, "emit event: flux_kvs_event_encode");
+        return NULL;
+    }
+    if (!(txn = flux_kvs_txn_create ())) {
+        flux_log_error (h, "emit event: flux_kvs_txn_create");
+        goto out;
+    }
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, key, event) < 0) {
+        flux_log_error (h, "emit event: flux_kvs_txn_put");
+        goto out;
+    }
+    if (!(f = flux_kvs_commit (h, job->ns, 0, txn)))
+        flux_log_error (h, "emit event: flux_kvs_commit");
+out:
+    saved_errno = errno;
+    free (event);
+    flux_kvs_txn_destroy (txn);
+    errno = saved_errno;
+    return f;
+}
+
+static flux_future_t * jobinfo_emit_event (struct jobinfo *job,
+                                           const char *name,
+                                           const char *fmt, ...)
+{
+    flux_future_t *f = NULL;
+    va_list ap;
+    va_start (ap, fmt);
+    f = jobinfo_emit_eventv (job, name, fmt, ap);
+    va_end (ap);
+    return f;
+}
+
+static void emit_event_continuation (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    if (flux_future_get (f, NULL) < 0)
+        flux_log_error (job->ctx->h, "%ju: emit_event", job->id);
+    flux_future_destroy (f);
+    jobinfo_decref (job);
+}
+
+/*
+ *  Send an event "open loop" -- takes a reference to the job and
+ *   releases it in the continuation, logging an error if one was
+ *   received.
+ */
+static int jobinfo_emit_event_nowait (struct jobinfo *job,
+                                      const char *name,
+                                      const char *fmt, ...)
+{
+    va_list ap;
+    va_start (ap, fmt);
+    flux_future_t *f = jobinfo_emit_eventv (job, name, fmt, ap);
+    va_end (ap);
+    if (f == NULL)
+        return -1;
+    jobinfo_incref (job);
+    if (flux_future_then (f, -1., emit_event_continuation, job) < 0) {
+        flux_log_error (job->ctx->h, "jobinfo_emit_event");
+        goto error;
+    }
+    return 0;
+error:
+    jobinfo_decref (job);
+    flux_future_destroy (f);
+    return -1;
+}
+
+
+static void jobinfo_add_cleanup (struct jobinfo *job, const char *name,
+                                 cleanup_task_f fn)
+{
+    (void) zhashx_insert (job->cleanup, name, (void *) fn);
+}
+
+
+static int jobid_respond_error (flux_t *h, flux_jobid_t id,
+                                const flux_msg_t *msg,
+                                int errnum, const char *text)
+{
+    char note [256];
+    if (errnum)
+        snprintf (note, sizeof (note), "%s%s%s",
+                                        text ? text : "",
+                                        text ? ": " : "",
+                                        strerror (errnum));
+    else
+        snprintf (note, sizeof (note), "%s", text ? text : "");
+    return flux_respond_pack (h, msg, "{s:I s:s s:{s:i s:s s:s}}",
+                                      "id", id,
+                                      "type", "exception",
+                                      "data",
+                                      "severity", 0,
+                                      "type", "exec",
+                                      "note", note);
+}
+
+static int jobinfo_respond_error (struct jobinfo *job, int errnum,
+                                  const char *msg)
+{
+    return jobid_respond_error (job->ctx->h, job->id, job->req, errnum, msg);
+}
+
+static int jobinfo_send_release (struct jobinfo *job,
+                                 const struct idset *idset)
+{
+    int rc;
+    flux_t *h = job->ctx->h;
+    // XXX: idset ignored for now. Always release all resources
+    rc = flux_respond_pack (h, job->req, "{s:I s:s s{s:s s:b}}",
+                                         "id", job->id,
+                                         "type", "release",
+                                         "data", "ranks", "all",
+                                                 "final", true);
+    return rc;
+}
+
+static int jobinfo_respond (flux_t *h, struct jobinfo *job,
+                            const char *event, int status)
+{
+    return flux_respond_pack (h, job->req, "{s:I s:s s:{}}",
+                                           "id", job->id,
+                                           "type", event,
+                                           "data");
+}
+
+static void jobinfo_complete (struct jobinfo *job)
+{
+    flux_t *h = job->ctx->h;
+    if (h && job->req) {
+        jobinfo_emit_event_nowait (job, "complete",
+                                        "status=%d",
+                                        job->wait_status);
+        if (flux_respond_pack (h, job->req, "{s:I s:s s:{s:i}}",
+                                            "id", job->id,
+                                            "type", "finish",
+                                            "data",
+                                            "status", job->wait_status) < 0)
+            flux_log_error (h, "jobinfo_complete: flux_respond");
+    }
+}
+
+static void jobinfo_started (struct jobinfo *job)
+{
+    flux_t *h = job->ctx->h;
+    if (h && job->req) {
+        if (jobinfo_respond (h, job, "start", 0) < 0)
+            flux_log_error (h, "jobinfo_started: flux_respond");
+    }
+}
+
+static void jobinfo_kill (struct jobinfo *job)
+{
+    flux_watcher_stop (job->timer);
+    job->running = 0;
+    job->wait_status = 0x9; /* Killed */
+
+    /* XXX: Manually send "finish" event here since our timer_cb won't
+     *  fire after we've canceled it. In a real workload a kill request
+     *  sent to all ranks would terminate processes that would exit and
+     *  report wait status through normal channels.
+     */
+    jobinfo_complete (job);
+}
+
+static int jobinfo_finalize (struct jobinfo *job);
+
+static void jobinfo_fatal_verror (struct jobinfo *job, int errnum,
+                                  const char *fmt, va_list ap)
+{
+    int n;
+    char msg [256];
+    int msglen = sizeof (msg);
+    flux_t *h = job->ctx->h;
+
+    if ((n = vsnprintf (msg, msglen, fmt, ap)) < 0)
+        strcpy (msg, "vsnprintf error");
+    else if (n >= msglen) {
+        msg [msglen-2] = '+';
+        msg [msglen-1] = '\0';
+    }
+    jobinfo_emit_event_nowait (job, "exception", msg);
+    /* If exception_in_progress set, then no need to respond with another
+     *  exception back to job manager. O/w, DO respond to job-manager
+     *  and set exception-in-progress.
+     */
+    if (!job->exception_in_progress) {
+        job->exception_in_progress = 1;
+        if (jobinfo_respond_error (job, errnum, msg) < 0)
+            flux_log_error (h, "jobinfo_fatal_verror: jobinfo_respond_error");
+    }
+    if (job->running)
+        jobinfo_kill (job);
+    if (jobinfo_finalize (job) < 0) {
+        flux_log_error (h, "jobinfo_fatal_verror: jobinfo_finalize");
+        jobinfo_decref (job);
+    }
+}
+
+static void jobinfo_fatal_error (struct jobinfo *job, int errnum,
+                                 const char *fmt, ...)
+{
+    flux_t *h = job->ctx->h;
+    int saved_errno = errno;
+    if (h && job->req) {
+        va_list ap;
+        va_start (ap, fmt);
+        jobinfo_fatal_verror (job, errnum, fmt, ap);
+        va_end (ap);
+    }
+    errno = saved_errno;
+}
+
+int parse_duration (const char *s, double *dp)
+{
+    double d;
+    char *p;
+    d = strtod (s, &p);
+    if ((d < 0.) || (*p && *(p+1)))
+        return -1;
+
+    if (*p != '\0') {
+        unsigned int multiplier = 0;
+        switch (*p) {
+            case 0:
+            case 's':
+                multiplier = 1;
+                break;
+            case 'm':
+                multiplier = 60;
+                break;
+            case 'h':
+                multiplier = 60 * 60;
+                break;
+            case 'd':
+                multiplier = 60 * 60 * 24;
+                break;
+        }
+        if (multiplier == 0)
+            return -1;
+        d *= multiplier;
+    }
+    *dp = d;
+    return (0);
+}
+
+static double jobspec_duration (flux_t *h, json_t *jobspec)
+{
+    const char *s;
+    double duration = 0.;
+    if (json_unpack (jobspec, "{s:{s:{s:s}}}",
+                              "attributes", "system",
+                              "duration", &s) < 0)
+        return -1.;
+    if (parse_duration (s, &duration) < 0) {
+        flux_log (h, LOG_ERR, "Unable to parse jobspec duration %s", s);
+        return -1.;
+    }
+    return duration;
+}
+
+static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
+{
+    const char *tclean = NULL;
+    const char *trun = NULL;
+    json_t *test = NULL;
+    json_error_t err;
+
+    /* get/set defaults */
+    conf->run_duration = jobspec_duration (h, jobspec);
+    conf->cleanup_duration = -1.;
+    conf->wait_status = 0;
+    conf->mock_exception = NULL;
+
+    if (json_unpack_ex (jobspec, &err, 0,
+                     "{s:{s:{s:{s:o}}}}",
+                     "attributes", "system", "exec",
+                     "test", &test) < 0)
+        return 0;
+    if (json_unpack_ex (test, &err, 0,
+                        "{s?s s?s s?i s?s}",
+                        "run_duration", &trun,
+                        "cleanup_duration", &tclean,
+                        "wait_status", &conf->wait_status,
+                        "mock_exception", &conf->mock_exception) < 0) {
+        flux_log (h, LOG_ERR, "init_testconf: %s", err.text);
+        return -1;
+    }
+    if (trun && parse_duration (trun, &conf->run_duration) < 0)
+        flux_log (h, LOG_ERR, "Unable to parse run duration: %s", trun);
+    if (tclean && parse_duration (tclean, &conf->cleanup_duration) < 0)
+        flux_log (h, LOG_ERR, "Unable to parse cleanup duration: %s", tclean);
+    return 0;
+}
+
+/*  Return true if a mock exception was configured for call site "where"
+ */
+static bool jobinfo_mock_exception (struct jobinfo *job, const char *where)
+{
+    const char *s = job->testconf.mock_exception;
+    return (s && strcmp (where, s) == 0);
+}
+
+static void namespace_delete (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_t *h = job->ctx->h;
+    flux_future_t *fnext = flux_kvs_namespace_remove (h, job->ns);
+    if (!fnext)
+        flux_future_continue_error (f, errno);
+    else
+        flux_future_continue (f, fnext);
+    flux_future_destroy (f);
+}
+
+static void namespace_copy (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_t *h = job->ctx->h;
+    flux_future_t *fnext = NULL;
+    char dst [265];
+
+    if (flux_job_kvs_key (dst, sizeof (dst), true, job->id, "guest") < 0) {
+        flux_log_error (h, "namespace_move: flux_job_kvs_key");
+        goto done;
+    }
+    if (!(fnext = flux_kvs_copy (h, job->ns, ".", NULL, dst, 0)))
+        flux_log_error (h, "namespace_move: flux_kvs_copy");
+done:
+    if (fnext)
+        flux_future_continue (f, fnext);
+    else
+        flux_future_continue_error (f, errno);
+    flux_future_destroy (f);
+}
+
+/*  Move the guest namespace for `job` into the primary namespace first
+ *   issuing the `done` terminating event into the exec.eventlog.
+ *
+ *  The process is split into a chained future of 3 parts:
+ *   1. Issue the final write into the exec.eventlog
+ *   2. Copy the namespace into the primary
+ *   3. Delete the guest namespace
+ */
+static void namespace_move (flux_future_t *fprev, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_t *h = job->ctx->h;
+    flux_future_t *f = NULL;
+    flux_future_t *fnext = NULL;
+
+    if (!(f = jobinfo_emit_event (job, "done", NULL))) {
+        flux_log_error (h, "namespace_move: jobinfo_emit_event");
+        goto error;
+    }
+    if (   !(fnext = flux_future_and_then (f, namespace_copy, job))
+        || !(fnext = flux_future_and_then (f=fnext, namespace_delete, job))) {
+        flux_log_error (h, "namespace_move: flux_future_and_then");
+        goto error;
+    }
+    flux_future_continue (fprev, fnext);
+    flux_future_destroy (fprev);
+    return;
+error:
+    flux_future_continue_error (fprev, errno);
+    flux_future_destroy (f);
+    flux_future_destroy (fnext);
+    flux_future_destroy (fprev);
+}
+
+/*  Start all cleanup tasks on the cleanup list and return
+ *   a composite future that will be ready when everything is done.
+ */
+static void jobinfo_cleanup (flux_future_t *fprev, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_t *h = job->ctx->h;
+    cleanup_task_f fn;
+    flux_future_t *f = NULL;
+    flux_future_t *cf = NULL;
+
+    if (!(cf = flux_future_wait_all_create ())) {
+        flux_log_error (job->ctx->h, "flux_future_wait_all_create");
+        goto error;
+    }
+    flux_future_set_flux (cf, h);
+
+    fn = zhashx_first (job->cleanup);
+    while (fn) {
+        const char *name = zhashx_cursor (job->cleanup);
+        if (!(f = (*fn) (job))) {
+            flux_log_error (h, "%s",
+                            (const char *) zhashx_cursor (job->cleanup));
+            goto error;
+        }
+        flux_future_push (cf, name, f);
+        fn = zhashx_next (job->cleanup);
+    }
+    flux_future_continue (fprev, cf);
+    flux_future_destroy (fprev);
+    return;
+error:
+    flux_future_continue_error (fprev, errno);
+    flux_future_destroy (fprev);
+}
+
+static void emit_cleanup_finish (flux_future_t *prev, void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_future_t *f = NULL;
+    int rc = flux_future_get (prev, NULL);
+
+    /*  XXX: It isn't clear what to do if a cleanup task fails.
+     *   For now, log the return code from the cleanup composite
+     *   future and errno if rc < 0 for informational purposes,
+     *   but do not generate an exception.
+     */
+    if (!(f = jobinfo_emit_event (job, "cleanup.finish",
+                                       "rc=%d%s%s", rc,
+                                        rc < 0 ? " " : "",
+                                        rc < 0 ? strerror (errno) : "")))
+        flux_future_continue_error (prev, errno);
+    else
+        flux_future_continue (prev, f);
+    flux_future_destroy (prev);
+}
+
+/*  Start all cleanup tasks:
+ *   1. emit cleanup.start event to exec.eventlog
+ *   2. start all cleanup work in parallel
+ *   3. emit cleanup.done event to exec.eventlog
+ *  Returns a chained future that will be fulfilled when these steps
+ *   are complete.
+ */
+static flux_future_t * jobinfo_start_cleanup (struct jobinfo *job)
+{
+    flux_future_t *f = NULL;
+    flux_future_t *fnext = NULL;
+
+    /* Skip cleanup if there are no items on the cleanup list.
+     * (e.g. an exception ocurred during job preparation)
+     */
+    if (zhashx_size (job->cleanup) == 0) {
+        /* Return an empty, fulfilled future */
+        if (!(f = flux_future_create (NULL, NULL)))
+            goto error;
+        flux_future_set_flux (f, job->ctx->h);
+        flux_future_fulfill (f, NULL, NULL);
+        return f;
+    }
+
+    /*  O/w, create cleanup composite future sandwiched by
+     *   cleanup.start and cleanup.finish events in the eventlog
+     */
+    if (!(f = jobinfo_emit_event (job, "cleanup.start", NULL)))
+        goto error;
+    if (!(fnext = flux_future_and_then (f, jobinfo_cleanup, job)))
+        goto error;
+    f = fnext;
+    if (!(fnext = flux_future_and_then (f, emit_cleanup_finish, job)))
+        goto error;
+    return fnext;
+error:
+    flux_future_destroy (f);
+    flux_future_destroy (fnext);
+    return NULL;
+}
+
+static void jobinfo_release (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    if (jobinfo_send_release (job, NULL) < 0)
+        flux_log_error (job->ctx->h, "jobinfo_send_release");
+    /* Should be final destruction */
+    jobinfo_decref (job);
+    flux_future_destroy (f);
+}
+
+/*
+ *  All job shells have exited or we've hit an exception:
+ *   start finalization steps:
+ *   1. Ensure all cleanup tasks have completed
+ *   2. Move namespace into primary namespace, emitting final event to log
+ */
+static int jobinfo_finalize (struct jobinfo *job)
+{
+    flux_future_t *f = NULL;
+    flux_future_t *fnext = NULL;
+
+    if (job->finalizing)
+        return 0;
+    job->finalizing = 1;
+
+    if (!(f = jobinfo_start_cleanup (job)))
+        goto error;
+    if (job->has_namespace &&
+        !(fnext = flux_future_and_then (f, namespace_move, job)))
+        goto error;
+    if (flux_future_then (fnext, -1., jobinfo_release, job) < 0)
+        goto error;
+    return 0;
+error:
+    jobinfo_respond_error (job, errno, "finalize error");
+    flux_future_destroy (f);
+    flux_future_destroy (fnext);
+    return -1;
+}
+
+/* Timer callback, post the "finish" event and start "cleanup" tasks.
+ */
+void timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct jobinfo *job = arg;
+    job->running = 0;
+    job->wait_status = job->testconf.wait_status;
+    jobinfo_complete (job);
+    if (jobinfo_finalize (job) < 0)
+        flux_log_error (job->ctx->h, "jobinfo_finalize");
+}
+
+/*  Start a timer to simulate job shell execution. A start event
+ *   is sent before the timer is started, and the "finish" event
+ *   is sent when the timer fires (simulating the exit of the final
+ *   job shell.)
+ */
+static int jobinfo_start_timer (struct jobinfo *job)
+{
+    flux_t *h = job->ctx->h;
+    flux_reactor_t *r = flux_get_reactor (h);
+    double t = job->testconf.run_duration;
+
+    /*  For now, if a job duration wasn't found, complete job almost
+     *   immediately.
+     */
+    if (t < 0.)
+        t = 1.e-5;
+    if (t > 0.) {
+        job->timer = flux_timer_watcher_create (r, t, 0., timer_cb, job);
+        if (!job->timer) {
+            flux_log_error (h, "jobinfo_start: timer_create");
+            return -1;
+        }
+        flux_watcher_start (job->timer);
+        jobinfo_emit_event_nowait (job, "running", "timer=%.6fs", t);
+        job->running = 1;
+    }
+    else
+        return -1;
+    return 0;
+}
+
+void epilog_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    flux_future_fulfill ((flux_future_t *) arg, NULL, NULL);
+    flux_watcher_destroy (w);
+}
+
+static flux_future_t * ersatz_epilog (struct jobinfo *job)
+{
+    flux_t *h = job->ctx->h;
+    flux_reactor_t *r = flux_get_reactor (h);
+    flux_future_t *f = NULL;
+    flux_watcher_t *timer = NULL;
+    double t = job->testconf.cleanup_duration;
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        return NULL;
+    flux_future_set_flux (f, h);
+
+    if (!(timer = flux_timer_watcher_create (r, t, 0.,
+                                             epilog_timer_cb, f))) {
+        flux_log_error (h, "flux_timer_watcher_create");
+        flux_future_fulfill_error (f, errno, "flux_timer_watcher_create");
+    }
+    flux_watcher_start (timer);
+    return f;
+}
+
+static int jobinfo_start_execution (struct jobinfo *job)
+{
+    jobinfo_emit_event_nowait (job, "starting", NULL);
+    if (jobinfo_start_timer (job) < 0) {
+        jobinfo_fatal_error (job, errno, "start timer failed");
+        return -1;
+    }
+    jobinfo_started (job);
+    if (job->needs_cleanup)
+        jobinfo_add_cleanup (job, "epilog simulator", ersatz_epilog);
+    return 0;
+}
+
+/*  Lookup key 'key' under jobid 'id' kvs dir:
+ */
+static flux_future_t *flux_jobid_kvs_lookup (flux_t *h, flux_jobid_t id,
+                                             int flags, const char *key)
+{
+    char path [256];
+    if (flux_job_kvs_key (path, sizeof (path), true, id, key) < 0)
+        return NULL;
+    return flux_kvs_lookup (h, NULL, flags, path);
+}
+
+/*
+ *  Call lookup_get on a child named 'name' of the composite future 'f'
+ */
+static const char * jobinfo_kvs_lookup_get (flux_future_t *f, const char *name)
+{
+    const char *result;
+    flux_future_t *child = flux_future_get_child (f, name);
+    if (child == NULL)
+        return NULL;
+    if (flux_kvs_lookup_get (child, &result) < 0)
+        return NULL;
+    return result;
+}
+
+/*  Completion for jobinfo_initialize(), finish init of jobinfo using
+ *   data fetched from KVS
+ */
+static void jobinfo_start_continue (flux_future_t *f, void *arg)
+{
+    json_error_t error;
+    const char *R = NULL;
+    const char *jobspec = NULL;
+    struct jobinfo *job = arg;
+
+    if (flux_future_get (flux_future_get_child (f, "ns"), NULL) < 0) {
+        jobinfo_fatal_error (job, errno, "failed to create guest ns");
+        goto done;
+    }
+    job->has_namespace = 1;
+
+    if (!(jobspec = jobinfo_kvs_lookup_get (f, "jobspec"))) {
+        jobinfo_fatal_error (job, errno, "unable to fetch jobspec");
+        goto done;
+    }
+    if (!(R = jobinfo_kvs_lookup_get (f, "R"))) {
+        jobinfo_fatal_error (job, errno, "job does not have allocation");
+        goto done;
+    }
+    if (!(job->R = resource_set_create (R, &error))) {
+        jobinfo_fatal_error (job, errno, "reading R: %s", error.text);
+        goto done;
+    }
+    if (!(job->jobspec = json_loads (jobspec, 0, &error))) {
+        jobinfo_fatal_error (job, errno, "reading jobspec: %s", error.text);
+        goto done;
+    }
+    if (init_testconf (job->ctx->h, &job->testconf, job->jobspec) < 0) {
+        jobinfo_fatal_error (job, errno, "failed to initialize testconf");
+        goto done;
+    }
+    if (job->testconf.cleanup_duration > 0.)
+        job->needs_cleanup = 1;
+    if (jobinfo_mock_exception (job, "init")) {
+        jobinfo_fatal_error (job, 0, "mock initialization exception generated");
+        goto done;
+    }
+    if (jobinfo_start_execution (job) < 0) {
+        jobinfo_fatal_error (job, errno, "failed to start execution");
+        goto done;
+    }
+    if (jobinfo_mock_exception (job, "run")) {
+        jobinfo_fatal_error (job, 0, "mock run exception generated");
+        goto done;
+    }
+done:
+    jobinfo_decref (job); /* clear init reference */
+    flux_future_destroy (f);
+}
+
+static flux_future_t * jobinfo_link_guestns (struct jobinfo *job)
+{
+    int saved_errno;
+    flux_t *h = job->ctx->h;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    char key [64];
+
+    if (flux_job_kvs_key (key, sizeof (key), true, job->id, "guest") < 0) {
+        flux_log_error (h, "link guestns: flux_job_kvs_key");
+        return NULL;
+    }
+    if (!(txn = flux_kvs_txn_create ())) {
+        flux_log_error (h, "link guestns: flux_kvs_txn_create");
+        return NULL;
+    }
+    if (flux_kvs_txn_symlink (txn, 0, key, job->ns, ".") < 0) {
+        flux_log_error (h, "link guestns: flux_kvs_txn_symlink");
+        goto out;
+    }
+    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
+        flux_log_error (h, "link_guestns: flux_kvs_commit");
+out:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    errno = saved_errno;
+    return f;
+}
+
+static void namespace_link (flux_future_t *fprev, void *arg)
+{
+    int saved_errno;
+    flux_t *h = flux_future_get_flux (fprev);
+    struct jobinfo *job = arg;
+    flux_future_t *cf = NULL;
+    flux_future_t *f = NULL;
+
+    if (!(cf = flux_future_wait_all_create ())) {
+        flux_log_error (h, "namespace_link: flux_future_wait_all_create");
+        goto error;
+    }
+    flux_future_set_flux (cf, h);
+    if (!(f = jobinfo_emit_event (job, "init", NULL))
+        || flux_future_push (cf, "emit event", f) < 0)
+        goto error;
+
+    if (!(f = jobinfo_link_guestns (job))
+        || flux_future_push (cf, "link guestns", f) < 0)
+        goto error;
+    flux_future_continue (fprev, cf);
+    flux_future_destroy (fprev);
+    return;
+error:
+    saved_errno = errno;
+    flux_future_destroy (cf);
+    flux_future_continue_error (fprev, saved_errno);
+    flux_future_destroy (fprev);
+}
+
+static flux_future_t *ns_create_and_link (flux_t *h,
+                                          struct jobinfo *job,
+                                          int flags)
+{
+    flux_future_t *f = NULL;
+    flux_future_t *f2 = NULL;
+
+    if (!(f = flux_kvs_namespace_create (h, job->ns, job->userid, flags))
+        || !(f2 = flux_future_and_then (f, namespace_link, job))) {
+        flux_log_error (h, "namespace_move: flux_future_and_then");
+        flux_future_destroy (f);
+        return NULL;
+    }
+    return f2;
+}
+
+/*  Asynchronously fetch job data from KVS and create namespace.
+ */
+static flux_future_t *jobinfo_start_init (struct jobinfo *job)
+{
+    flux_t *h = job->ctx->h;
+    flux_future_t *f_kvs = NULL;
+    flux_future_t *f = flux_future_wait_all_create ();
+    flux_future_set_flux (f, job->ctx->h);
+
+    if (!(f_kvs = flux_jobid_kvs_lookup (h, job->id, 0, "R"))
+        || flux_future_push (f, "R", f_kvs) < 0)
+        goto err;
+    if (!(f_kvs = flux_jobid_kvs_lookup (h, job->id, 0, "jobspec"))
+        || flux_future_push (f, "jobspec", f_kvs) < 0)
+        goto err;
+    if (!(f_kvs = ns_create_and_link (h, job, 0))
+        || flux_future_push (f, "ns", f_kvs))
+        goto err;
+
+    /* Increase refcount during init phase in case job is canceled:
+     */
+    jobinfo_incref (job);
+    return f;
+err:
+    flux_log_error (job->ctx->h, "jobinfo_kvs_lookup/namespace_create");
+    flux_future_destroy (f);
+    return NULL;
+}
+
+/*  Create namespace name for jobid 'id'
+ */
+static int job_get_ns_name (char *buf, int bufsz, flux_jobid_t id)
+{
+    return fluid_encode (buf, bufsz, id, FLUID_STRING_DOTHEX);
+}
+
+static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
+{
+    flux_future_t *f = NULL;
+    struct jobinfo *job;
+
+    if (!(job = jobinfo_new ()))
+        return -1;
+
+    if (!(job->req = flux_msg_copy (msg, true))) {
+        flux_log_error (ctx->h, "start: flux_msg_copy");
+        jobinfo_decref (job);
+        if (flux_respond_error (ctx->h, msg, errno, "flux_msg_copy failed") < 0)
+            flux_log_error (ctx->h, "flux_respond_error");
+        return -1;
+    }
+    job->ctx = ctx;
+
+    if (flux_request_unpack (job->req, NULL, "{s:I, s:i}",
+                                             "id", &job->id,
+                                             "userid", &job->userid) < 0) {
+        flux_log_error (ctx->h, "start: flux_request_unpack");
+        goto error;
+    }
+    if (job_get_ns_name (job->ns, sizeof (job->ns), job->id) < 0) {
+        jobinfo_fatal_error (job, errno, "failed to create ns name for job");
+        flux_log_error (ctx->h, "job_ns_create");
+        return -1;
+    }
+    if (zhashx_insert (ctx->jobs, &job->id, job) < 0) {
+        flux_log_error (ctx->h, "zhashx_insert");
+        jobinfo_fatal_error (job, errno, "failed to hash job");
+        return -1;
+    }
+    if (!(f = jobinfo_start_init (job))) {
+        flux_log_error (ctx->h, "start: jobinfo_kvs_lookup");
+        goto error;
+    }
+    if (flux_future_then (f, -1., jobinfo_start_continue, job) < 0) {
+        flux_log_error (ctx->h, "start: flux_future_then");
+        goto error;
+    }
+    return 0;
+error:
+    jobinfo_fatal_error (job, errno, "job start failure");
+    return -1;
+}
+
+static void start_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct job_exec_ctx *ctx = arg;
+
+    if (job_start (ctx, msg) < 0) {
+        flux_log_error (h, "job_start");
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
+            flux_log_error (h, "job-exec.start respond_error");
+    }
+}
+
+static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct job_exec_ctx *ctx = arg;
+    flux_jobid_t id;
+    int severity = 0;
+    const char *type = NULL;
+    struct jobinfo *job = NULL;
+
+    if (flux_event_unpack (msg, NULL, "{s:I s:s s:i}",
+                                      "id", &id,
+                                      "type", &type,
+                                      "severity", &severity) < 0) {
+        flux_log_error (h, "job-exception event");
+        return;
+    }
+    if (severity == 0
+        && (job = zhashx_lookup (ctx->jobs, &id))
+        && (!job->exception_in_progress)) {
+        job->exception_in_progress = 1;
+        flux_log (h, LOG_DEBUG, "exec aborted: id=%ld", id);
+        jobinfo_fatal_error (job, 0, "aborted due to exception type=%s", type);
+    }
+}
+
+static size_t job_hash_fn (const void *key)
+{
+    const flux_jobid_t *id = key;
+    return *id;
+}
+
+#define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
+
+static int job_hash_key_cmp (const void *x, const void *y)
+{
+    const flux_jobid_t *id1 = x;
+    const flux_jobid_t *id2 = y;
+
+    return NUMCMP (*id1, *id2);
+}
+
+static void job_exec_ctx_destroy (struct job_exec_ctx *ctx)
+{
+    if (ctx == NULL)
+        return;
+    zhashx_destroy (&ctx->jobs);
+    flux_msg_handler_delvec (ctx->handlers);
+    free (ctx);
+}
+
+static struct job_exec_ctx * job_exec_ctx_create (flux_t *h)
+{
+    struct job_exec_ctx *ctx = calloc (1, sizeof (*ctx));
+    if (ctx == NULL)
+        return NULL;
+    ctx->h = h;
+    ctx->jobs = zhashx_new ();
+    zhashx_set_key_hasher (ctx->jobs, job_hash_fn);
+    zhashx_set_key_comparator (ctx->jobs, job_hash_key_cmp);
+    zhashx_set_key_duplicator (ctx->jobs, NULL);
+    zhashx_set_key_destructor (ctx->jobs, NULL);
+    return (ctx);
+}
+
+static int exec_hello (flux_t *h, const char *service)
+{
+    int rc = -1;
+    flux_future_t *f;
+    if (!(f = flux_rpc_pack (h, "job-manager.exec-hello",
+                             FLUX_NODEID_ANY, 0,
+                             "{s:s}",
+                             "service", service))) {
+        flux_log_error (h, "flux_rpc (job-manager.exec-hello)");
+        return -1;
+    }
+    if ((rc = flux_future_get (f, NULL)) < 0)
+        flux_log_error (h, "job-manager.exec-hello");
+    flux_future_destroy (f);
+    return rc;
+}
+
+static const struct flux_msg_handler_spec htab[]  = {
+    { FLUX_MSGTYPE_REQUEST, "job-exec.start", start_cb,     0 },
+    { FLUX_MSGTYPE_EVENT,   "job-exception",  exception_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END
+};
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    int rc = -1;
+    struct job_exec_ctx *ctx = job_exec_ctx_create (h);
+
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0) {
+        flux_log_error (h, "flux_msg_handler_addvec");
+        goto out;
+    }
+    if (flux_event_subscribe (h, "job-exception") < 0) {
+        flux_log_error (h, "flux_event_subscribe");
+        goto out;
+    }
+    if (exec_hello (h, "job-exec") < 0)
+        goto out;
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+out:
+    if (flux_event_unsubscribe (h, "job-exception") < 0)
+        flux_log_error (h, "flux_event_unsubscribe ('job-exception')");
+    job_exec_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("job-exec");
+
+/*
+ * vi: tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -1,0 +1,150 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+#include "rset.h"
+
+struct resource_set {
+    json_t *R;
+    const json_t *R_lite;
+    struct idset *ranks;
+
+    double starttime;
+    double expiration;
+};
+
+void resource_set_destroy (struct resource_set *r)
+{
+    if (r) {
+        r->R_lite = NULL;
+        json_decref (r->R);
+        idset_destroy (r->ranks);
+        free (r);
+    }
+}
+
+static int idset_add_set (struct idset *set, struct idset *new)
+{
+    unsigned int i = idset_first (new);
+    while (i != IDSET_INVALID_ID) {
+        if (idset_test (set, i)) {
+            errno = EEXIST;
+            return -1;
+        }
+        if (idset_set (set, i) < 0)
+            return -1;
+        i = idset_next (new, i);
+    }
+    return 0;
+}
+
+static int idset_set_string (struct idset *idset, const char *ids)
+{
+    int rc;
+    struct idset *new = idset_decode (ids);
+    if (!new)
+        return -1;
+    rc = idset_add_set (idset, new);
+    idset_destroy (new);
+    return rc;
+}
+
+static struct idset *rset_ranks (struct resource_set *r)
+{
+    int i;
+    json_t *entry;
+    struct idset *idset = NULL;
+    const char *ranks = NULL;
+
+    if (!r || !r->R_lite) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(idset = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+    json_array_foreach (r->R_lite, i, entry) {
+        if ((json_unpack_ex (entry, NULL, 0, "{s:s}", "rank", &ranks) < 0)
+            || (idset_set_string (idset, ranks) < 0))
+            goto err;
+    }
+    return idset;
+err:
+    idset_destroy (idset);
+    return NULL;
+}
+
+static int rset_read_time_window (struct resource_set *r, json_error_t *errp)
+{
+    if (!r || !r->R_lite) {
+        errno = EINVAL;
+        return -1;
+    }
+    /*  Default values: < 0 indicates "unset"
+     */
+    r->expiration = -1.;
+    r-> starttime = -1.;
+    if (json_unpack_ex (r->R, errp, 0,
+                        "{s:{s?F s?F}}",
+                        "execution",
+                        "starttime",  &r->starttime,
+                        "expiration", &r->expiration) < 0)
+        return -1;
+    return 0;
+}
+
+struct resource_set * resource_set_create (const char *R, json_error_t *errp)
+{
+    int version = 0;
+    struct resource_set *r = calloc (1, sizeof (*r));
+    if (!(r->R = json_loads (R, 0, errp)))
+        goto err;
+    if (json_unpack_ex (r->R, errp, 0, "{s:i s:{s:o}}",
+                                       "version", &version,
+                                       "execution",
+                                       "R_lite", &r->R_lite) < 0)
+        goto err;
+    if (version != 1) {
+        if (errp)
+            snprintf (errp->text, sizeof (errp->text),
+                    "invalid version: %d", version);
+        goto err;
+    }
+    if (!(r->ranks = rset_ranks (r))) {
+        if (errp)
+            snprintf (errp->text, sizeof (errp->text),
+                    "R_lite: failed to read target rank list");
+        goto err;
+    }
+    if (rset_read_time_window (r, errp) < 0)
+        goto err;
+    return (r);
+err:
+    resource_set_destroy (r);
+    return NULL;
+}
+
+const struct idset * resource_set_ranks (struct resource_set *r)
+{
+    return r->ranks;
+}
+
+double resource_set_starttime (struct resource_set *r)
+{
+    return r->starttime;
+}
+
+double resource_set_expiration (struct resource_set *r)
+{
+    return r->expiration;
+}
+
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_JOB_EXEC_RSET_H
+#define HAVE_JOB_EXEC_RSET_H 1
+#include <flux/idset.h>
+#include <jansson.h>
+
+struct resource_set;
+
+struct resource_set *resource_set_create (const char *R, json_error_t *errp);
+
+void resource_set_destroy (struct resource_set *rset);
+
+const struct idset * resource_set_ranks (struct resource_set *rset);
+
+double resource_set_starttime (struct resource_set *rset);
+
+double resource_set_expiration (struct resource_set *rset);
+
+#endif /* !HAVE_JOB_EXEC_RSET_H */
+
+

--- a/src/modules/job-exec/test/rset.c
+++ b/src/modules/job-exec/test/rset.c
@@ -1,0 +1,141 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+#include <string.h>
+
+#include "src/common/libtap/tap.h"
+#include "rset.h"
+
+struct resource_set_test {
+    const char *descr;
+    const char *input;
+    const char *expected_ranks;
+    double      starttime;
+    double      expiration;
+    const char *error_string;
+};
+
+#define RESOURCE_SET_TEST_END { NULL, NULL, NULL, 0., 0., NULL }
+
+#define BASIC_R \
+    "{ \"version\": 1," \
+    "  \"execution\": { " \
+    "    \"starttime\":  12345, " \
+    "    \"expiration\": 12445, " \
+    "    \"R_lite\": " \
+    "       [ {\"rank\": \"0-2\", " \
+    "          \"children\": { \"core\": \"0-3\" } " \
+    "         } " \
+    "       ] " \
+    "    } " \
+    "}"
+
+#define BAD_VERSION \
+    "{ \"version\": 2," \
+    "  \"execution\": { " \
+    "    \"starttime\":  12345, " \
+    "    \"expiration\": 12445, " \
+    "    \"R_lite\": " \
+    "       [ {\"rank\": \"0-2\", " \
+    "          \"children\": { \"core\": \"0-3\" } " \
+    "         } " \
+    "       ] " \
+    "    } " \
+    "}"
+
+#define BAD_IDSET \
+    "{ \"version\": 1," \
+    "  \"execution\": { " \
+    "    \"starttime\":  12345, " \
+    "    \"expiration\": 12445, " \
+    "    \"R_lite\": " \
+    "       [ {\"rank\": \"-2\", " \
+    "          \"children\": { \"core\": \"0-3\" } " \
+    "         } " \
+    "       ] " \
+    "    } " \
+    "}"
+
+struct resource_set_test tests[] = {
+
+    { "no R_lite",
+     "{\"version\":1,\"execution\":{\"starttime\":0,\"expiration\":0}}",
+      NULL, 0., 0.,
+      "Object item not found: R_lite",
+    },
+    { "invalid version",
+      BAD_VERSION,
+      NULL, 0., 0.,
+      "invalid version: 2",
+    },
+    { "invalid R_lite idset",
+      BAD_IDSET,
+      NULL, 0., 0.,
+      "R_lite: failed to read target rank list",
+    },
+    { "basic R check",
+      BASIC_R,
+      "0-2", 12345., 12445.,
+      NULL
+    },
+    RESOURCE_SET_TEST_END
+};
+
+int main (int ac, char *av[])
+{
+    struct resource_set_test *e = NULL;
+
+    plan (NO_PLAN);
+
+    e = &tests[0];
+    while (e && e->descr) {
+        json_error_t err;
+        struct resource_set *r = resource_set_create (e->input, &err);
+        if (e->expected_ranks == NULL) { // Expected failure
+            ok (r == NULL,
+                "%s: resource_set_create expected failure", e->descr);
+            is (err.text, e->error_string,
+                "%s: got expected error text", e->descr);
+        }
+        else {
+            if (r) {
+                const struct idset *ids = resource_set_ranks (r);
+                double starttime = resource_set_starttime (r);
+                double expiration = resource_set_expiration (r);
+                if (ids == NULL)
+                    fail ("%s: resource_set_ranks() failed", e->descr);
+                else {
+                    char * ranks = idset_encode (ids, IDSET_FLAG_RANGE);
+                    is (ranks, e->expected_ranks,
+                        "%s: expect target ranks (%s)", e->descr, ranks);
+                    free (ranks);
+                }
+                ok (starttime == e->starttime,
+                    "%s: expect starttime %.2f (got %.2f)", e->descr,
+                    e->starttime, starttime);
+                ok (expiration == e->expiration,
+                    "%s: expect expiration %.2f (got %.2f)", e->descr,
+                    e->expiration, expiration);
+            }
+            else {
+                fail ("%s: %d:[%s]",
+                      e->descr, err.position, err.text);
+            }
+        }
+        resource_set_destroy (r);
+        e++;
+    }
+
+    done_testing ();
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -28,6 +28,8 @@ job_manager_la_SOURCES = job-manager.c \
 			 raise.c \
 			 alloc.h \
 			 alloc.c \
+			 start.h \
+			 start.c \
 			 list.h \
 			 list.c \
 			 priority.h \
@@ -53,6 +55,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/queue.o \
         $(top_builddir)/src/modules/job-manager/job.o \
         $(top_builddir)/src/modules/job-manager/alloc.o \
+        $(top_builddir)/src/modules/job-manager/start.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -265,8 +265,6 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
 
-    job->has_resources = 1;
-
     if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "alloc",
                              "{ s:s }",
                              "note", note ? note : "") < 0)

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -359,11 +359,11 @@ int event_job_post (struct event_ctx *ctx, struct job *job,
         return -1;
     if (event_job_update (job, event) < 0)
         goto error;
-    if (event_job_action (ctx, job) < 0)
-        goto error;
     if (event_batch_start (ctx) < 0)
         goto error;
     if (event_batch_append (ctx->batch, key, event, cb, arg) < 0)
+        goto error;
+    if (event_job_action (ctx, job) < 0)
         goto error;
     free (event);
     return 0;

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -16,6 +16,7 @@
 
 #include "job.h"
 #include "alloc.h"
+#include "start.h"
 
 struct event_ctx;
 struct alloc_ctx;
@@ -51,6 +52,8 @@ int event_job_post_pack (struct event_ctx *ctx, struct job *job,
 
 void event_ctx_set_alloc_ctx (struct event_ctx *ctx,
                               struct alloc_ctx *alloc_ctx);
+void event_ctx_set_start_ctx (struct event_ctx *ctx,
+                              struct start_ctx *start_ctx);
 
 void event_ctx_destroy (struct event_ctx *ctx);
 struct event_ctx *event_ctx_create (flux_t *h);

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -56,7 +56,7 @@ void event_ctx_set_start_ctx (struct event_ctx *ctx,
                               struct start_ctx *start_ctx);
 
 void event_ctx_destroy (struct event_ctx *ctx);
-struct event_ctx *event_ctx_create (flux_t *h);
+struct event_ctx *event_ctx_create (flux_t *h, struct queue *queue);
 
 #endif /* _FLUX_JOB_MANAGER_EVENT_H */
 

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -21,6 +21,7 @@
 #include "list.h"
 #include "priority.h"
 #include "alloc.h"
+#include "start.h"
 #include "event.h"
 
 
@@ -28,6 +29,7 @@ struct job_manager_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     struct queue *queue;
+    struct start_ctx *start_ctx;
     struct alloc_ctx *alloc_ctx;
     struct event_ctx *event_ctx;
 };
@@ -89,6 +91,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating scheduler interface");
         goto done;
     }
+    if (!(ctx.start_ctx = start_ctx_create (h, ctx.queue, ctx.event_ctx))) {
+        flux_log_error (h, "error creating exec interface");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -104,6 +110,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    start_ctx_destroy (ctx.start_ctx);
     alloc_ctx_destroy (ctx.alloc_ctx);
     event_ctx_destroy (ctx.event_ctx);
     queue_destroy (ctx.queue);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -83,7 +83,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating queue");
         goto done;
     }
-    if (!(ctx.event_ctx = event_ctx_create (h))) {
+    if (!(ctx.event_ctx = event_ctx_create (h, ctx.queue))) {
         flux_log_error (h, "error creating event batcher");
         goto done;
     }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -26,6 +26,7 @@ struct job {
     uint8_t alloc_pending:1;
     uint8_t free_pending:1;
     uint8_t has_resources:1;
+    uint8_t start_pending:1;
 
     void *aux_queue_handle;
     void *queue_handle; // primary queue handle (for listing all active jobs)

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -1,0 +1,332 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* start.c - exec interface
+ *
+ * Interface is built so that exec service loads after job-manager
+ * and dynamically registers its service name.  It is possible for
+ * another instance of the service to be registered after that one,
+ * to override it.
+ *
+ * Use case: simulator initial program overrides "normal" exec service.
+ *
+ * STARTUP:
+ *
+ * Exec service sends job-manager.exec-hello request with its service name,
+ * {"service":s}.  Job-manager responds with success/failure.
+ *
+ * Active jobs are scanned and hello fails if any jobs have outstanding
+ * start request (e.g. to existing exec service).
+ *
+ * OPERATION:
+ *
+ * Job manager makes a <exec_service>.start request once resources are
+ * allocated.  The request is made without matchtag, so the job id must
+ * be present in all response payloads.
+ *
+ * A response looks like this:
+ * {"id":I "type":s "data":o}
+ *
+ * where "type" determines the content of data:
+ *
+ * "start" - indicates job shells have started
+ *           data: {}
+ *
+ * "release" - release R fragment to job-manager
+ *             data: {"ranks":s "final":b}
+ *
+ * "exception" - raise an exception (0 is fatal)
+ *               data: {"severity":i "type":s "note"?:s}
+ *
+ * "finish" - data: {"status":i}
+ *
+ * Responses stream back until a 'release' response is received with
+ * final=true.  This means all resources allocated to the job are no
+ * longer in use by the exec system.
+ *
+ * TEARDOWN:
+ *
+ * If an ENOSYS (or other "normal RPC error" response is returned to an
+ * alloc request, it is assumed that the current service is unloading
+ * or a fatal error has occurred.  Start requests are paused waiting
+ * for another hello.
+ *
+ * No attempt is made to restart the interface with a previously overridden
+ * exec service.
+ *
+ * NOTES:
+ * - The "finish" response may be preceded by "release" final=false responses.
+ * - The "finish" response must precede the "release" final=true response.
+ * - For now, release responses with final=false are ignored, and resources
+ *   are released to the scheduler only upon receipt of release final=true.
+ * - A normal RPC error response, while logged at LOG_ERR level, has no
+ *   effect on a particular job, nor does it tear down the interface as
+ *   with alloc.
+ * - Even if an exception is raised, the "release" final=true response
+ *   is required.  "start" and "finish" may or may not be sent depending
+ *   on when the exception occurs.
+ * - Response message topic strings are checked against registered service,
+ *   so as long as services use unique service names, no confusion is possible
+ *   between service instances, e.g. due to multiple in-flight ENOSYS or
+ *   whatever.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <assert.h>
+
+#include "queue.h"
+#include "job.h"
+#include "queue.h"
+#include "event.h"
+
+#include "start.h"
+
+struct start_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    struct queue *queue;    // main active job queue
+    struct event_ctx *event_ctx;
+    char *start_topic;
+};
+
+static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct start_ctx *ctx = arg;
+    struct job *job;
+    const char *service_name;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "service", &service_name) < 0)
+        goto error;
+    /* If existing exec service is loaded, ensure it is idle before
+     * allowing new exec service to override.
+     */
+    if (ctx->start_topic) {
+        job = queue_first (ctx->queue);
+        while (job) {
+            if (job->start_pending) {
+                errno = EINVAL;
+                goto error;
+            }
+            job = queue_next (ctx->queue);
+        }
+        free (ctx->start_topic);
+        ctx->start_topic = NULL;
+    }
+    if (asprintf (&ctx->start_topic, "%s.start", service_name) < 0)
+        goto error;
+    if (flux_respond (h, msg, 0, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    /* Response has been sent, now take action on jobs in run state.
+     */
+    job = queue_first (ctx->queue);
+    while (job) {
+        if (job->state == FLUX_JOB_RUN) {
+            if (event_job_action (ctx->event_ctx, job) < 0)
+                flux_log_error (h, "%s: event_job_action id=%llu", __FUNCTION__,
+                                (unsigned long long)job->id);
+        }
+        job = queue_next (ctx->queue);
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static void interface_teardown (struct start_ctx *ctx, char *s, int errnum)
+{
+    if (ctx->start_topic) {
+        struct job *job;
+
+        flux_log (ctx->h, LOG_DEBUG, "start: stop due to %s: %s",
+                  s, flux_strerror (errnum));
+
+        free (ctx->start_topic);
+        ctx->start_topic = NULL;
+
+        job = queue_first (ctx->queue);
+        while (job) {
+            if (job->start_pending) {
+                if ((job->flags & FLUX_JOB_DEBUG))
+                    (void)event_job_post_pack (ctx->event_ctx, job, NULL, NULL,
+                                               "debug.start-lost",
+                                               "{ s:s }", "note", s);
+                job->start_pending = 0;
+            }
+            job = queue_next (ctx->queue);
+        }
+    }
+}
+
+static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
+                               const flux_msg_t *msg, void *arg)
+{
+    struct start_ctx *ctx = arg;
+    const char *topic;
+    flux_jobid_t id;
+    const char *type;
+    json_t *data;
+    struct job *job;
+
+    if (flux_response_decode (msg, &topic, NULL) < 0)
+        goto teardown; // e.g. ENOSYS
+    if (!ctx->start_topic || strcmp (ctx->start_topic, topic) != 0) {
+        flux_log_error (h, "start: topic=%s not registered", topic);
+        goto error;
+    }
+    if (flux_msg_unpack (msg, "{s:I s:s s:o}", "id", &id,
+                                               "type", &type,
+                                               "data", &data) < 0) {
+        flux_log_error (h, "start response payload");
+        goto error;
+    }
+    if (!(job = queue_lookup_by_id (ctx->queue, id))) {
+        flux_log_error (h, "start response: id=%llu not active",
+                        (unsigned long long)id);
+        goto error;
+    }
+    if (!strcmp (type, "start")) {
+        if (event_job_post (ctx->event_ctx, job, NULL, NULL,
+                            "start", NULL) < 0)
+            goto error_post;
+    }
+    else if (!strcmp (type, "release")) {
+        const char *idset;
+        int final;
+        if (json_unpack (data, "{s:s s:b}", "ranks", &idset,
+                                            "final", &final) < 0) {
+            errno = EPROTO;
+            flux_log_error (h, "start: release response: malformed data");
+            goto error;
+        }
+        if (final) // final release is end-of-stream
+            job->start_pending = 0;
+        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "release",
+                                 "{ s:s s:b }",
+                                 "ranks", idset,
+                                 "final", final) < 0)
+            goto error_post;
+    }
+    else if (!strcmp (type, "exception")) {
+        int xseverity;
+        const char *xtype;
+        const char *xnote = NULL;
+        if (json_unpack (data, "{s:i s:s s?:s}", "severity", &xseverity,
+                                                 "type", &xtype,
+                                                 "note", &xnote) < 0) {
+            errno = EPROTO;
+            flux_log_error (h, "start: exception response: malformed data");
+            goto error;
+        }
+        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "exception",
+                                 "{ s:s s:i s:i s:s }",
+                                 "type", xtype,
+                                 "severity", xseverity,
+                                 "userid", FLUX_USERID_UNKNOWN,
+                                 "note", xnote ? xnote : "")  < 0)
+            goto error_post;
+    }
+    else if (!strcmp (type, "finish")) {
+        int status;
+        if (json_unpack (data, "{s:i}", "status", &status) < 0) {
+            errno = EPROTO;
+            flux_log_error (h, "start: finish response: malformed data");
+            goto error;
+        }
+        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "finish",
+                                 "{ s:i }", "status", status) < 0)
+            goto error_post;
+    }
+    else {
+        flux_log (h, LOG_ERR, "start: unknown response type=%s", type);
+        goto error;
+    }
+    return;
+error_post:
+    flux_log_error (h, "start: failed to post event type=%s", type);
+error:
+    return;
+teardown:
+    interface_teardown (ctx, "start response error", errno);
+}
+
+/* Send <exec_service>.start request for job.
+ * Idempotent.
+ */
+int start_send_request (struct start_ctx *ctx, struct job *job)
+{
+    flux_msg_t *msg;
+
+    assert (job->state == FLUX_JOB_RUN);
+    if (!job->start_pending && ctx->start_topic != NULL) {
+        if (!(msg = flux_request_encode (ctx->start_topic, NULL)))
+            return -1;
+        if (flux_msg_pack (msg, "{s:I s:i}",
+                                "id", job->id,
+                                "userid", job->userid) < 0)
+            goto error;
+        if (flux_send (ctx->h, msg, 0) < 0)
+            goto error;
+        flux_msg_destroy (msg);
+        job->start_pending = 1;
+        if ((job->flags & FLUX_JOB_DEBUG))
+            (void)event_job_post (ctx->event_ctx, job, NULL, NULL,
+                                  "debug.start-request", NULL);
+    }
+    return 0;
+error:
+    flux_msg_destroy (msg);
+    return -1;
+}
+
+void start_ctx_destroy (struct start_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;;
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx->start_topic);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-manager.exec-hello", hello_cb, 0},
+    { FLUX_MSGTYPE_RESPONSE, "*.start", start_response_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct start_ctx *start_ctx_create (flux_t *h, struct queue *queue,
+                                    struct event_ctx *event_ctx)
+{
+    struct start_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+    ctx->queue = queue;
+    ctx->event_ctx = event_ctx;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    event_ctx_set_start_ctx (event_ctx, ctx);
+    return ctx;
+error:
+    start_ctx_destroy (ctx);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/start.h
+++ b/src/modules/job-manager/start.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_START_H
+#define _FLUX_JOB_MANAGER_START_H
+
+#include <flux/core.h>
+
+#include "queue.h"
+#include "job.h"
+#include "event.h"
+
+struct event_ctx;
+struct start_ctx;
+
+void start_ctx_destroy (struct start_ctx *ctx);
+struct start_ctx *start_ctx_create (flux_t *h, struct queue *queue,
+                                    struct event_ctx *event_ctx);
+
+int start_send_request (struct start_ctx *ctx, struct job *job);
+
+#endif /* ! _FLUX_JOB_MANAGER_START_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -81,7 +81,8 @@ const char *test_input[] = {
     /* 6 */
     "42.2 submit {\"userid\":66,\"priority\":16,\"flags\":42}\n"
     "42.3 alloc\n"
-    "42.4 free\n",
+    "42.4 exception {\"type\":\"gasp\",\"severity\":0,\"userid\":42}\n"
+    "42.5 free\n",
 };
 
 void test_create_from_eventlog (void)
@@ -180,16 +181,16 @@ void test_create_from_eventlog (void)
     ok (job == NULL && errno == EINVAL,
         "job_create_from_eventlog log=(alloc) fails with EINVAL");
 
-    /* 6 - submit + alloc + free */
+    /* 6 - submit + alloc + ex0 + free */
     job = job_create_from_eventlog (3, test_input[6]);
     if (job == NULL)
-        BAIL_OUT ("job_create_from_eventlog log=(submit+alloc+free) failed");
+        BAIL_OUT ("job_create_from_eventlog log=(submit+alloc+ex0+free) failed");
     ok (!job->alloc_pending
         && !job->free_pending
         && !job->has_resources,
-        "job_create_from_eventlog log=(submit+alloc+free) set no internal flags");
+        "job_create_from_eventlog log=(submit+alloc+ex0+free) set no internal flags");
     ok (job->state == FLUX_JOB_CLEANUP,
-        "job_create_from_eventlog log=(submit+alloc+free) set state=CLEANUP");
+        "job_create_from_eventlog log=(submit+alloc+ex0+free) set state=CLEANUP");
     job_decref (job);
 
 }

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -12,7 +12,8 @@ AM_CPPFLAGS = \
 	$(ZMQ_CFLAGS)
 
 noinst_SCRIPTS = \
-	relnotes.sh
+	relnotes.sh \
+	sched-bench.sh
 
 LDADD = $(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/test/sched-bench.sh
+++ b/src/test/sched-bench.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Run a set of jobs (with or without exec subsystem loaded) and
+#  print some timing stats gathered from job eventlogs.
+#
+declare prog=$(basename $0)
+
+declare NNODES=8
+declare CPN=32
+
+declare -r long_opts="help,nnodes:,cores-per-node:,jobs:,noexec"
+declare -r short_opts="hn:c:j:"
+declare -r usage="\
+\n\
+Usage: $prog [OPTIONS]\n\
+Simple Flux sched/exec test benchmark.\n\
+\n\
+Options:\n\
+ -h, --help              display this messages\n\
+ -n, --nnodes=NNODES     set simulated number of nodes (default=${NNODES})\n\
+ -c, --cores-per-node=N  set simulated cores per node (default=${CPN})\n\
+ -j, --jobs=NJOBS        set number of jobs to run (default nnodes*cpn)\n\
+     --noexec            do not simulate execution, just scheduling\n"
+
+log() { local fmt=$1; shift; printf >&2 "$prog: $fmt" "$@"; }
+die() { log "$@" && exit 1; }
+
+log_timing_msg() {
+    local name=$1
+    local start=$2
+    local end=$3
+    local elapsed=$(echo "$end - $start" | bc -l)
+    local jps=$(echo "$NJOBS/$elapsed" | bc -l)
+    log "$name $NJOBS jobs in %.3fs (%.2f job/s)\n" $elapsed $jps
+}
+
+GETOPTS=$(/usr/bin/getopt -u -o $short_opts -l $long_opts -n $prog -- $@)
+if test $? != 0; then
+    echo  "$usage"
+    exit 1
+fi
+
+eval set -- "$GETOPTS"
+while true; do
+    case "$1" in
+      -n|--nnodes)          NNODES=$2;  shift 2 ;;
+      -c|--cores-per-node)  CPN=$2;     shift 2 ;;
+      -j|--jobs)            NJOBS=$2;   shift 2 ;;
+      --noexec)             NOEXEC=t;   shift   ;;
+      --)                   shift ; break ;     ;;
+      -h|--help)            echo -e "$usage" ; exit 0           ;;
+      *)                    die "Invalid option '$1'\n$usage"   ;;
+    esac
+done
+
+# If not set, set number of jobs to nnodes * cores-per-node:
+NJOBS=${NJOBS:-$((${NNODES}*${CPN}))}
+
+log "On branch $(git rev-parse --abbrev-ref HEAD): $(git describe)\n"
+log "starting with $NJOBS jobs across ${NNODES} nodes with ${CPN} cores/node.\n"
+log "broker.pid=$(flux getattr broker.pid)\n"
+
+#  Reload scheduler so we can insert a fake resource set:
+flux module remove sched-simple
+flux kvs put --json \
+    resource.hwloc.by_rank="{\"[1-$NNODES]\":{\"Core\":$CPN}}"
+flux jobspec srun hostname | jq '.attributes.system.duration = ".0001s"' > job.json
+flux module load sched-simple
+
+#  If not testing exec system, remove the job-exec module
+test "$NOEXEC" = "t" && flux module remove job-exec
+
+t_start=$(date +%s.%N)
+t/ingest/submitbench -f 24 -r $NJOBS job.json > job.list
+t_ingest=$(date +%s.%N)
+log_timing_msg ingested $t_start $t_ingest
+
+first=$(flux job list -s -c 1 | awk '{print $1}')
+last=$(flux job list -s | tail -1 | awk '{print $1}')
+
+starttime=$(flux job eventlog $first | awk '$2 == "submit" {print $1}')
+alloctime=$(flux job wait-event $last alloc | awk '$2 == "alloc" {print $1}')
+log_timing_msg allocated $starttime $alloctime
+
+if test -z "$NOEXEC"; then
+    runtime=$(flux job wait-event $last clean | awk '{print $1}')
+    log_timing_msg ran $starttime $runtime
+fi
+
+t_done=$(date +%s.%N)
+log_timing_msg "total walltime for" $t_start $t_done
+
+#  If not testing exec system, reinstall job-exec to avoid error from rc3
+# test "$NOEXEC" = "t" && flux module load job-exec
+# XXX: Not a good idea, starts running jobs just before script exit
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -88,6 +88,7 @@ TESTS = \
 	t2204-job-info.t \
 	t2300-sched-simple.t \
 	t2400-job-exec-test.t \
+	t2401-job-exec-hello.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \
@@ -184,6 +185,7 @@ check_SCRIPTS = \
 	t2204-job-info.t \
 	t2300-sched-simple.t \
 	t2400-job-exec-test.t \
+	t2401-job-exec-hello.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \
@@ -281,7 +283,8 @@ dist_check_SCRIPTS = \
 	scripts/tssh \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
-	kvs/kvs-helper.sh
+	kvs/kvs-helper.sh \
+	job-manager/exec-service.lua
 
 test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -87,6 +87,7 @@ TESTS = \
 	t2203-job-manager-dummysched.t \
 	t2204-job-info.t \
 	t2300-sched-simple.t \
+	t2400-job-exec-test.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \
@@ -182,6 +183,7 @@ check_SCRIPTS = \
 	t2203-job-manager-dummysched.t \
 	t2204-job-info.t \
 	t2300-sched-simple.t \
+	t2400-job-exec-test.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \

--- a/t/job-manager/exec-service.lua
+++ b/t/job-manager/exec-service.lua
@@ -1,0 +1,98 @@
+#!/usr/bin/lua
+-------------------------------------------------------------
+-- Copyright 2019 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+--
+--  Simple test exec service in-a-script
+--  Run as "exec.lua servicename <job duration seconds>"
+--
+local flux = require 'flux'
+local posix = require 'posix'
+local f = assert (flux.new())
+
+local service = assert(arg[1], "Required service name argument")
+local timeout = arg[2] or 0.
+timeout = timeout * 1000.
+
+io.stdout:setvbuf("line")
+
+local function printf (...)
+    io.stdout:write (string.format (...))
+end
+
+local function die (...)
+    io.stderr:write (string.format (...))
+    os.exit (1)
+end
+
+local jobs = {}
+
+local function job_complete (msg, id, rc)
+    assert (msg:respond {
+                id = id,
+                type = "finish",
+                data = {status = rc}
+            })
+    assert (msg:respond {
+                id = id,
+                type = "release",
+                data = {ranks = "all", final = true}
+            })
+    jobs[id].timer:remove()
+    jobs[id] = nil
+    printf ("%s: finish: %d\n", service, id)
+end
+
+assert (f:msghandler {
+    pattern =   service .. ".start",
+    msgtypes =  { flux.MSGTYPE_REQUEST },
+    handler = function (f, msg, mh)
+        local id = msg.data.id
+        jobs[id] = { msg = msg }
+        printf ("%s: start: %d\n", service, id)
+        assert (msg:respond {id = id, type = "start", data = {}})
+
+        -- Launch job timer:
+        jobs[id].timer = assert (f:timer {
+            timeout = timeout,
+            oneshot = true,
+            handler = function () job_complete (msg, id, 0) end
+        })
+
+    end
+})
+
+assert (f:msghandler {
+    pattern = "job-exception",
+    msgtypes = { flux.MSGTYPE_EVENT },
+    handler = function (f, msg, mh)
+        local id = msg.data.id
+        printf ("%s: exeception for %d\n", service, id)
+        if jobs[id] then
+            job_complete (jobs[id].msg, id, 9)
+        end
+    end
+})
+
+printf ("Adding service %s\n", service)
+local rc,err = f:rpc ("service.add", { service = service })
+if not rc then die ("service.add: %s\n", err) end
+
+assert (f:subscribe ("job-exception"))
+
+local rc,err = f:rpc ("job-manager.exec-hello", { service = service })
+if not rc then die ("job-manager.exec-hello: %s\n", err) end
+
+-- Synchronize with test driver by creating a ready key for this service
+-- in the kvs:
+os.execute ("flux kvs put test.exec-hello."..service.."=1")
+
+f:reactor ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -1,0 +1,144 @@
+#!/bin/sh
+
+test_description='Test flux job execution service in simulated mode'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+#  Set path to jq(1)
+#
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+
+
+hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
+
+job_kvsdir()    { flux job id --to=kvs-active $1; }
+exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; } 
+exec_testattr() {
+	${jq} --arg key "$1" --arg value $2 \
+	      '.attributes.system.exec.test[$key] = $value'
+}
+
+test_expect_success 'job-exec: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+test_expect_success 'job-exec: load job-exec,sched-simple modules' '
+	#  Add fake by_rank configuration to kvs:
+	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+	flux module load -r 0 sched-simple &&
+	flux module load -r 0 job-exec
+'
+test_expect_success 'job-exec: basic job runs in simulated mode' '
+	jobid=$(flux job submit basic.json) &&
+	flux job wait-event -t 1 ${jobid} start &&
+	flux job wait-event -t 1 ${jobid} finish &&
+	flux job wait-event -t 1 ${jobid} release &&
+	flux job wait-event -t 1 ${jobid} clean
+'
+test_expect_success 'job-exec: guestns linked into primary' '
+	#  guest key is not a link
+	test_must_fail \
+	  flux kvs readlink $(job_kvsdir ${jobid}).guest 2>readlink.err &&
+	grep "Invalid argument" readlink.err &&
+	#  gues key is a directory
+	test_must_fail \
+	  flux kvs get $(job_kvsdir ${jobid}).guest 2>kvsdir.err &&
+	grep "Is a directory" kvsdir.err
+'
+test_expect_success 'job-exec: exec.eventlog exists with expected states' '
+	exec_eventlog ${jobid} > eventlog.1.out &&
+	head -1 eventlog.1.out | grep "init" &&
+	tail -1 eventlog.1.out | grep "done"
+'
+test_expect_success 'job-exec: canceling job during execution works' '
+	jobid=$(flux jobspec srun -t 1 hostname | flux job submit) &&
+	flux job wait-event -t 2.5 ${jobid} start &&
+	flux job cancel ${jobid} &&
+	flux job wait-event -t 2.5 ${jobid} exception &&
+	flux job wait-event -t 2.5 ${jobid} finish | grep status=9 &&
+	flux job wait-event -t 2.5 ${jobid} release &&
+	flux job wait-event -t 2.5 ${jobid} clean &&
+	exec_eventlog $jobid | grep "complete status=9"
+'
+test_expect_success HAVE_JQ 'job-exec: supports duration in minutes' '
+	flux jobspec srun hostname | \
+	  jq ".attributes.system.duration = \"0.5m\"" > 0.5m.json &&
+	jobid=$(flux job submit 0.5m.json) &&
+	flux job wait-event ${jobid} start &&
+	exec_eventlog ${jobid} | grep timer=30.000000s &&
+	flux job cancel ${jobid}
+'
+test_expect_success HAVE_JQ 'job-exec: supports duration in hours' '
+	flux jobspec srun hostname | \
+	  jq ".attributes.system.duration = \"0.5h\"" > 0.5h.json &&
+	jobid=$(flux job submit 0.5h.json) &&
+	flux job wait-event ${jobid} start &&
+	exec_eventlog ${jobid} | grep timer=1800.000000s &&
+	flux job cancel ${jobid}
+'
+test_expect_success HAVE_JQ 'job-exec: supports duration in days' '
+	flux jobspec srun hostname | \
+	  jq ".attributes.system.duration = \"0.5d\"" > 0.5d.json &&
+	jobid=$(flux job submit 0.5d.json) &&
+	flux job wait-event ${jobid} start &&
+	exec_eventlog ${jobid} | grep timer=43200.000000s &&
+	flux job cancel ${jobid}
+'
+test_expect_success HAVE_JQ 'job-exec: mock exception during initialization' '
+	flux jobspec srun hostname | \
+	  exec_testattr mock_exception init > ex1.json &&
+	jobid=$(flux job submit ex1.json) &&
+	flux job wait-event -t 2.5 ${jobid} exception > exception.1.out &&
+	test_debug "flux job eventlog ${jobid}" &&
+	grep "type=\"exec\"" exception.1.out &&
+	grep "mock initialization exception generated" exception.1.out &&
+	flux job wait-event -qt 2.5 ${jobid} clean &&
+	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
+	test_must_fail grep "finish" eventlog.${jobid}.out
+'
+test_expect_success HAVE_JQ 'job-exec: mock exception during run' '
+	flux jobspec srun hostname | \
+	  exec_testattr mock_exception run > ex2.json &&
+	jobid=$(flux job submit ex2.json) &&
+	flux job wait-event -t 2.5 ${jobid} exception > exception.2.out &&
+	grep "type=\"exec\"" exception.2.out &&
+	grep "mock run exception generated" exception.2.out &&
+	flux job wait-event -qt 2.5 ${jobid} clean &&
+	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
+	grep "finish status=9" eventlog.${jobid}.out
+'
+test_expect_success HAVE_JQ 'job-exec: simulate epilog/cleanup tasks' '
+	flux jobspec srun hostname | \
+	  exec_testattr cleanup_duration 0.01s > cleanup.json &&
+	jobid=$(flux job submit cleanup.json) &&
+	flux job wait-event -vt 2.5 ${jobid} clean &&
+	exec_eventlog $jobid > exec.eventlog.$jobid &&
+	grep "cleanup\.start" exec.eventlog.$jobid &&
+	grep "cleanup\.finish" exec.eventlog.$jobid
+'
+#
+# XXX: Trying to generate an exception during cleanup is racy, however,
+#  there is not currently another way to do this until we have a *real*
+#  epilog script which could be triggered by events. If this test becoms
+#  a problem, we can disable it until that time.
+#
+test_expect_success HAVE_JQ 'job-exec: exception during cleanup' '
+	flux jobspec srun hostname | \
+	  exec_testattr cleanup_duration 1s > cleanup-long.json &&
+	jobid=$(flux job submit cleanup-long.json) &&
+	flux job wait-event -vt 2.5 ${jobid} finish &&
+	flux job cancel ${jobid} &&
+	flux job wait-event -t 2.5 ${jobid} clean &&
+	exec_eventlog $jobid > exec.eventlog.$jobid &&
+	grep "cleanup\.finish " exec.eventlog.$jobid
+'
+test_expect_success 'job-exec: remove sched-simple,job-exec modules' '
+	flux module remove -r 0 sched-simple &&
+	flux module remove -r 0 job-exec
+'
+
+test_done

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+test_description='Test flux job exec hello protocol with multiple providers'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
+execservice=${SHARNESS_TEST_SRCDIR}/job-manager/exec-service.lua
+
+lastevent() { flux job eventlog $1 | awk 'END{print $2}'; }
+
+test_expect_success 'exec hello: load sched-simple module' '
+	#  Add fake by_rank configuration to kvs:
+	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+	flux module load -r 0 sched-simple
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: start exec server-in-a-script' '
+	${execservice} test-exec > server1.log &
+	SERVER1=$! &&
+	id=$(flux jobspec srun hostname | flux job submit --flags=debug) &&
+	flux job wait-event ${id} clean &&
+	test_debug "cat server1.log" &&
+	grep "start: ${id}" server1.log
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: takeover: start new service' '
+	${execservice} test-exec2 > server2.log &
+	SERVER2=$! &&
+	flux kvs get -c 1 --watch --waitcreate test.exec-hello.test-exec2 &&
+	id=$(flux jobspec srun hostname | flux job submit --flags=debug) &&
+	flux job wait-event ${id} clean &&
+	grep "start: ${id}" server2.log
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: teardown existing servers' "
+	kill -9 ${SERVER1} && kill -9 ${SERVER2} &&
+	wait ${SERVER1} || : &&
+	wait ${SERVER2} || : &&
+	flux module list > module.list &&
+	test_must_fail grep test-exec module.list
+"
+test_expect_success NO_CHAIN_LINT 'exec hello: job start events are paused' '
+	id=$(flux jobspec srun hostname | flux job submit --flags=debug) &&
+	flux job wait-event -vt 5 ${id} alloc &&
+	test_debug "flux job eventlog ${id}" &&
+	test $(lastevent ${id}) = "debug.start-lost"
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: start server with job timer' '
+	${execservice} test-exec3 30 > server3.log &
+	SERVER3=$! &&
+	flux kvs get -c 1 --watch --waitcreate test.exec-hello.test-exec3
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: paused job now has start event' '
+	flux job wait-event -t 2 ${id} start &&
+	test_debug "cat server3.log" &&
+	grep "test-exec3: start: ${id}" server3.log
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: hello now returns error due to running job' '
+	run_timeout 5 test_must_fail ${execservice} testexecfoo
+'
+test_expect_success NO_CHAIN_LINT 'exec hello: terminate all jobs and servers' '
+	flux job cancel ${id} &&
+	test_debug "cat server3.log" &&
+	flux job wait-event -t 2.5 ${id} clean &&
+	kill ${SERVER3}
+'
+test_expect_success 'job-exec: remove sched-simple module' '
+	flux module remove -r 0 sched-simple
+'
+
+test_done

--- a/t/valgrind/workload.d/job
+++ b/t/valgrind/workload.d/job
@@ -1,15 +1,29 @@
 #!/bin/bash
 
-runjob() {
-    local size=$1
-    flux job submit <<EOT
-{"attributes":null,"tasks":[{"slot":"foo","count":{"per_slot":1},"command":"/bin/true"}],"version":1,"resources":[{"count":1,"type":"slot","with":[{"count":${size},"type":"node"}],"label":"foo"}]}
-EOT
-}
+NJOBS=${NJOBS:-10}
 
-NJOBS=10
-NTASKS_PER_JOB=1
+#  Reconfigure sched-simple with only 1 core so that only a single job is
+#   run at a time (and we can wait for the
+#   last job to determine we're done without a race.)
+#
+#  XXX: Remove and replace final synchronization with flux job drain
+#   when ready.
+#
+flux module remove sched-simple
+flux kvs put resource.hwloc.by_rank="{\"0\":{\"Core\":1}}"
+flux module load sched-simple
 
+flux jobspec srun -n 1 /bin/true > job.json
 for i in `seq 1 $NJOBS`; do
-     runjob ${NTASKS_PER_JOB}
+     id=$(flux job submit < job.json)
+     echo id=$id
 done
+
+flux job wait-event -v ${id} clean
+
+#  Test job cancelation
+set -x
+id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
+flux job wait-event ${id} start
+flux job cancel ${id}
+flux job wait-event ${id} clean


### PR DESCRIPTION
This is an early draft PR that implements the exec rpc protocol in the job-manager (by @garlick) along with a prototype job-exec module which implements that protocol and simulates execution of jobs by sleeping for the duration specified in the jobspec (or a default duration)

I will let @garlick follow up with a detailed description of the implemented exec protocol.

Other things of note included in this PR:
 - `flux jobspec srun` now converts any Slurm timeout given into a duration string (floating point seconds with optional `s,m,h,d` suffix.
 - `t5000-valgrind.t` now runs with `sched-simple` and `job-exec` loaded, and includes synchronization at the end using `flux job wait-event`
 - I've cleaned up and added the simple `sched-bench.sh` test into `src/test/scripts` which can be used to benchmark running a large set of jobs (with or without execution) through flux.