### PR TITLE
jobspec: allow non-string attributes

### DIFF
--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -99,12 +99,10 @@
           "type": "object",
           "properties": {
             "duration": { "type": "string" }
-          },
-          "additonalProperties": { "type": "string" }
+          }
         },
         "user": {
-          "type": "object",
-          "additonalProperties": { "type": "string" }
+          "type": "object"
         }
       },
       "additionalProperties": false

--- a/t/jobspec/minimal-schema.json
+++ b/t/jobspec/minimal-schema.json
@@ -91,9 +91,11 @@
           "type": "object",
           "properties": {
             "duration": { "type": "string" }
-          },
-          "additonalProperties": { "type": "string" }
-        }
+          }
+        },
+	"user": {
+          "type": "object"
+	}
       },
       "additionalProperties": false
     },

--- a/t/jobspec/valid/attributes_system.yaml
+++ b/t/jobspec/valid/attributes_system.yaml
@@ -1,0 +1,20 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:
+  system:
+    a: "string"
+    b: 42
+    c: [ 1, 2, 3 ]
+    d:
+    foo: "string"

--- a/t/jobspec/valid/attributes_user.yaml
+++ b/t/jobspec/valid/attributes_user.yaml
@@ -1,0 +1,20 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:
+  user:
+    a: "string"
+    b: 42
+    c: [ 1, 2, 3 ]
+    d:
+    foo: "string"

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -26,7 +26,7 @@ test_valid ()
 {
     local rc=0
     for job in $*; do
-        cat ${job} | ${Y2J} | ${SUBMITBENCH} -
+        cat ${job} | ${Y2J} | ${SUBMITBENCH} - || rc=1
     done
     return ${rc}
 }


### PR DESCRIPTION
This relaxes the requirement that jobspec user and system attributes must be of type string.  They can be anything with this change.

Adds a couple of valid yaml inputs that demonstrate this.

Also fixes a bug in the ingest sharness test that would mask ingest failures of valid jobspec.

Finally, makes the same change to `minimal-schema.json` in anticipation of adding the ability to set arbitrary attributes to `flux jobspec`.

A corresponding change (or is it a clarification?) to RFC 14 is proposed in flux-framework/rfc#172