### PR TITLE
job: misc fixes

### DIFF
--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -88,7 +88,7 @@ error:
  * Set 'tok' to next \n-terminated token, and 'toklen' to its length.
  * Advance 'pp' past token.  Returns false when input is exhausted.
  */
-static bool info_parse_next (const char **pp, const char **tok,
+static bool eventlog_parse_next (const char **pp, const char **tok,
                                  size_t *toklen)
 {
     char *term;
@@ -164,7 +164,7 @@ static void lookup_continuation (flux_future_t *f, void *arg)
         const char *input = s;
         const char *tok;
         size_t toklen;
-        while (info_parse_next (&input, &tok, &toklen)) {
+        while (eventlog_parse_next (&input, &tok, &toklen)) {
             if (l->active)
                 l->offset += toklen;
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -240,12 +240,15 @@ int event_job_update (struct job *job, const char *event)
         if (job->state != FLUX_JOB_NEW)
             goto inval;
         job->t_submit = timestamp;
-        if (util_int_from_context (context, "priority", &priority) == 0)
-            job->priority = priority;
-        if (util_int_from_context (context, "userid", &userid) == 0)
-            job->userid = userid;
-        if (util_int_from_context (context, "flags", &flags) == 0)
-            job->flags = flags;
+        if (util_int_from_context (context, "priority", &priority) < 0)
+            goto error;
+        job->priority = priority;
+        if (util_int_from_context (context, "userid", &userid) < 0)
+            goto error;
+        job->userid = userid;
+        if (util_int_from_context (context, "flags", &flags) < 0)
+            goto error;
+        job->flags = flags;
         job->state = FLUX_JOB_SCHED;
     }
     else if (!strcmp (name, "priority")) {

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -53,6 +53,7 @@ static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
     flux_future_t *f;
     const char *eventlog;
     struct job *job = NULL;
+    char path[64];
     int rc = -1;
 
     if (strlen (key) <= dirskip) {
@@ -61,7 +62,11 @@ static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
     }
     if (fluid_decode (key + dirskip + 1, &id, FLUID_STRING_DOTHEX) < 0)
         return -1;
-    if (!(f = util_attr_lookup (h, id, true, 0, "eventlog")))
+    if (flux_job_kvs_key (path, sizeof (path), true, id, "eventlog") < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, path)))
         goto done;
     if (flux_kvs_lookup_get (f, &eventlog) < 0)
         goto done;

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -102,13 +102,18 @@ error:
 /* Submit event requires special handling.  It cannot go through
  * event_job_post() because job-ingest already logged it.
  * However, we want to let the state machine choose the next state and action,
- * So we create a "dummy" event here and run it directly through
+ * We instead re-create the event and run it directly through
  * event_job_update() and event_job_action().
  */
 int submit_post_event (struct event_ctx *event_ctx, struct job *job)
 {
         char event[64];
-        (void)snprintf (event, sizeof (event), "%.6f submit\n", job->t_submit);
+        (void)snprintf (event, sizeof (event),
+                        "%.6f submit userid=%lu priority=%d flags=%d\n",
+                        job->t_submit,
+                        (unsigned long)job->userid,
+                        job->priority,
+                        job->flags);
         if (event_job_update (job, event) < 0)
             return -1;
         if (event_job_action (event_ctx, job) < 0)

--- a/src/modules/job-manager/util.c
+++ b/src/modules/job-manager/util.c
@@ -117,18 +117,6 @@ const char *util_note_from_context (const char *context)
     return context;
 }
 
-flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,
-                                 int flags, const char *key)
-{
-    char path[64];
-
-    if (flux_job_kvs_key (path, sizeof (path), active, id, key) < 0) {
-        errno = EINVAL;
-        return NULL;
-    }
-    return flux_kvs_lookup (h, NULL, flags, path);
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/util.h
+++ b/src/modules/job-manager/util.h
@@ -29,11 +29,6 @@ int util_str_from_context (const char *context, const char *key,
  */
 const char *util_note_from_context (const char *context);
 
-/* Look up 'key' relative to active/inactive job directory for job 'id'.
- */
-flux_future_t *util_attr_lookup (flux_t *h, flux_jobid_t id, bool active,
-                                 int flags, const char *key);
-
 #endif /* _FLUX_JOB_MANAGER_UTIL_H */
 
 /*

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test flux job eventlog service'
+test_description='Test flux job info service'
 
 . `dirname $0`/kvs/kvs-helper.sh
 


### PR DESCRIPTION
A few misc fixes I fixed along the way while working on #2076.  The most notable one is requiring that all submit events in the eventlog must contain userid, priority, and flags.  Faking a dummy submit even is no longer allowed.