### PR TITLE
cmd/flux-ping: exit(1) immediately on error

### DIFF
--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -100,7 +100,7 @@ void ping_continuation (flux_mrpc_t *mrpc, void *arg)
                               "route", &route,
                               "userid", &userid,
                               "rolemask", &rolemask) < 0) {
-        log_err ("%s!%s", ctx->rank, ctx->topic);
+        log_err_exit ("%s!%s", ctx->rank, ctx->topic);
         goto done;
     }
 

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -61,23 +61,22 @@ test_expect_success 'ping all works with 64K payload' '
 '
 
 test_expect_success 'ping fails on invalid rank (specified as target)' '
-	run_timeout 5 flux ping --count 1 $(invalid_rank) 2>stderr &&
+	! run_timeout 5 flux ping --count 1 $(invalid_rank) 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping fails on invalid rank (specified in option)' '
-	run_timeout 5 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr &&
+	! run_timeout 5 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
-test_expect_success 'ping works on valid and invalid rank' '
-	run_timeout 5 flux ping --count 1 --rank 0,$(invalid_rank) cmb 1>stdout 2>stderr &&
-	grep -q "No route to host" stderr &&
-	grep -q "0,$(invalid_rank)!cmb.ping" stdout
+test_expect_success 'ping fails on valid and invalid rank' '
+	! run_timeout 5 flux ping --count 1 --rank 0,$(invalid_rank) cmb 1>stdout 2>stderr &&
+	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping fails on invalid target' '
-	run_timeout 5 flux ping --count 1 --rank 0 nosuchtarget 2>stderr &&
+	! run_timeout 5 flux ping --count 1 --rank 0 nosuchtarget 2>stderr &&
 	grep -q "Function not implemented" stderr
 '
 
@@ -164,7 +163,7 @@ test_expect_success 'ping output format for all ranks is correct (format 3)' '
 # rank 1 should work
 
 test_expect_success 'ping with "upstream" fails on rank 0' '
-        run_timeout 5 flux exec -n --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
+        ! run_timeout 5 flux exec -n --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 


### PR DESCRIPTION
Problem: flux-ping exits indicating success even when
it receives an obviously fatal failure response,
such as ENOSYS.

Just have ping call err_exit() upon receiving any
kind of error response.

Update sharness ping test.

Fixes #2087