### PR TITLE
flux_future_error_string: return optional error string or strerror of errnum

### DIFF
--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -78,9 +78,12 @@ another `flux_future_then()`, if desired.
 `flux_future_destroy()` destroys a future, including any result contained
 within.
 
-When flux futures are fulfilled with errors, they can optionally
-include an error string for callers.  `flux_future_error_string()`
-returns the error string if one is available.
+`flux_future_error_string()` returns the error string associated with
+a future.  If the future was fulfilled with an optional error string,
+`flux_future_error_string()` will return that string.  Otherwise, it
+will return the string associated with the error number set in a
+future.  If the future is not fulfilled or a NULL pointer is passed
+in, an appropriate error message is returned to indicate the issue.
 
 RETURN VALUE
 ------------

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -292,13 +292,9 @@ int cmd_priority (optparse_t *p, int argc, char **argv)
 
     if (!(f = flux_job_set_priority (h, id, priority)))
         log_err_exit ("flux_job_set_priority");
-    if (flux_rpc_get (f, NULL) < 0) {
-        const char *errmsg;
-        if ((errmsg = flux_future_error_string (f)))
-            log_msg_exit ("%llu: %s", (unsigned long long)id, errmsg);
-        else
-            log_err_exit ("%llu", (unsigned long long)id);
-    }
+    if (flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("%llu: %s", (unsigned long long)id,
+                      flux_future_error_string (f));
     flux_future_destroy (f);
     flux_close (h);
     return 0;
@@ -327,12 +323,9 @@ int cmd_raise (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
     if (!(f = flux_job_raise (h, id, type, severity, note)))
         log_err_exit ("flux_job_raise");
-    if (flux_rpc_get (f, NULL) < 0) {
-        const char *errmsg;
-        if ((errmsg = flux_future_error_string (f)))
-            log_msg_exit ("%llu: %s", (unsigned long long)id, errmsg);
-        log_err_exit ("%llu", (unsigned long long)id);
-    }
+    if (flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("%llu: %s", (unsigned long long)id,
+                      flux_future_error_string (f));
     flux_future_destroy (f);
     flux_close (h);
     free (note);
@@ -360,12 +353,9 @@ int cmd_cancel (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
     if (!(f = flux_job_cancel (h, id, note)))
         log_err_exit ("flux_job_cancel");
-    if (flux_rpc_get (f, NULL) < 0) {
-        const char *errmsg;
-        if ((errmsg = flux_future_error_string (f)))
-            log_msg_exit ("%llu: %s", (unsigned long long)id, errmsg);
-        log_err_exit ("%llu", (unsigned long long)id);
-    }
+    if (flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("%llu: %s", (unsigned long long)id,
+                      flux_future_error_string (f));
     flux_future_destroy (f);
     flux_close (h);
     free (note);
@@ -498,7 +488,6 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     flux_future_t *f;
     flux_jobid_t id;
-    const char *errmsg;
     const char *input = "-";
 
     if (optindex != argc - 1 && optindex != argc) {
@@ -546,12 +535,11 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
     if (!(f = flux_job_submit (h, J ? J : jobspec, priority, flags)))
         log_err_exit ("flux_job_submit");
     if (flux_job_submit_get_id (f, &id) < 0) {
-        if ((errmsg = flux_future_error_string (f)))
-            log_msg_exit ("submit: %s", errmsg);
-        else if (errno == ENOSYS)
+        if (errno == ENOSYS)
             log_msg_exit ("submit: job-ingest module is not loaded");
         else
-            log_err_exit ("submit");
+            log_msg_exit ("%llu: %s", (unsigned long long)id,
+                          flux_future_error_string (f));
     }
     printf ("%llu\n", (unsigned long long)id);
     flux_future_destroy (f);

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -824,14 +824,25 @@ void test_error_string (void)
     flux_future_t *f;
     const char *str;
 
+    ok ((str = flux_future_error_string (NULL)) != NULL
+        && !strcmp (str, "future NULL"),
+        "flux_future_error_string returns \"future NULL\" on NULL input");
+
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
+
+    ok ((str = flux_future_error_string (f)) != NULL
+        && !strcmp (str, "future not fulfilled"),
+        "flux_future_error_string returns \"future not fulfilled\" on "
+        "unfulfilled future");
 
     flux_future_fulfill (f, "Hello", NULL);
 
     ok (flux_future_get (f, NULL) == 0
-        && flux_future_error_string (f) == NULL,
-        "flux_future_error_string returns NULL when future fulfilled");
+        && (str = flux_future_error_string (f)) != NULL
+        && !strcmp (str, "Success"),
+        "flux_future_error_string returns \"Success\" when future fulfilled "
+        "with non-error result");
 
     flux_future_destroy (f);
 
@@ -842,8 +853,9 @@ void test_error_string (void)
 
     ok (flux_future_get (f, NULL) < 0
         && errno == ENOENT
-        && flux_future_error_string (f) == NULL,
-        "flux_future_error_string returns NULL when no error string set");
+        && (str = flux_future_error_string (f)) != NULL
+        && !strcmp (str, "No such file or directory"),
+        "flux_future_error_string returns ENOENT strerror string");
 
     flux_future_destroy (f);
 
@@ -867,8 +879,9 @@ void test_error_string (void)
 
     ok (flux_future_get (f, NULL) < 0
         && errno == ENOENT
-        && flux_future_error_string (f) == NULL,
-        "flux_future_error_string returns NULL when no fatal error string set");
+        && (str = flux_future_error_string (f)) != NULL
+        && !strcmp (str, "No such file or directory"),
+        "flux_future_error_string returns ENOENT strerror string");
 
     flux_future_destroy (f);
 
@@ -881,7 +894,8 @@ void test_error_string (void)
         && errno == ENOENT
         && (str = flux_future_error_string (f)) != NULL
         && !strcmp (str, "boobaz"),
-        "flux_future_error_string returns correct fatal error string when error string set");
+        "flux_future_error_string returns correct fatal error string "
+        "when error string set");
 
     flux_future_destroy (f);
 }

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -368,8 +368,8 @@ void test_error (flux_t *h)
     ok (flux_rpc_get (f, NULL) < 0 && errno == ENOTDIR,
         "flux_rpc_get failed with expected errno");
     errstr = flux_future_error_string (f);
-    ok (errstr == NULL,
-        "flux_future_error_string returned NULL, no error string set");
+    ok (errstr != NULL && !strcmp (errstr, "Not a directory"),
+        "flux_future_error_string returned ENOTDIR strerror string");
     flux_future_destroy (f);
 }
 

--- a/t/ingest/submitbench.c
+++ b/t/ingest/submitbench.c
@@ -135,15 +135,12 @@ void submitbench_continuation (flux_future_t *f, void *arg)
 {
     struct submitbench_ctx *ctx = arg;
     flux_jobid_t id;
-    const char *errmsg;
 
     if (flux_job_submit_get_id (f, &id) < 0) {
-        if ((errmsg = flux_future_error_string (f)))
-            log_msg_exit ("submit: %s", errmsg);
-        else if (errno == ENOSYS)
+        if (errno == ENOSYS)
             log_msg_exit ("submit: job-ingest module is not loaded");
         else
-            log_err_exit ("submit");
+            log_msg_exit ("submit: %s", flux_future_error_string (f));
     }
     printf ("%llu\n", (unsigned long long)id);
     flux_future_destroy (f);


### PR DESCRIPTION
Per discussion in #2075 and updated usage where I felt it could be updated.  Note that I did re-order logic of some error output, but I don't believe it's an issue.

@SteVwonder given your comment in #2075 I thought the python `check_future_error` should be tweaked, but it ended up breaking a test when I changed it.  The function `flux_future_wait_for()` will simply return -1 and ETIMEDOUT if you pass in a timeout of 0.  So in that particular case, the future is never fulfilled with an error.  So keeping `if errmsg is None` is still necessary.
