### PR TITLE
add flux job drain

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -22,7 +22,7 @@
  *
  * OPERATION
  *
- * For deatils of startup protocol, see job-manager/start.c.
+ * For details of startup protocol, see job-manager/start.c.
  *
  * JOB INIT:
  *
@@ -34,7 +34,7 @@
  *
  * Jobspec and R are parsed as soon as asynchronous initialization tasks
  * complete. If any of these steps fail, or a mock exception is configured
- * for "init", an exec initialization exception * is thrown.
+ * for "init", an exec initialization exception is thrown.
  *
  * JOB STARTING/RUNNING:
  *
@@ -60,7 +60,7 @@
  *  - terminating "done" event is posted to the exec.eventlog
  *  - the guest namespace, now quiesced, is copied to the primary namespace
  *  - the guest namespace is removed
- *  - the final "release final=1" response is sent to the job manager
+ *  - the final "release final=true" response is sent to the job manager
  *  - the local job object is destroyed
  *
  * TEST CONFIGURATION

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -270,8 +270,9 @@ static void batch_announce_continuation (flux_future_t *f, void *arg)
     flux_t *h = batch->ctx->h;
 
     if (flux_future_get (f, NULL) < 0) {
-        flux_log_error (h, "%s: job-manager request failed", __FUNCTION__);
-        batch_respond_error (batch, errno, "job-manager request failed");
+        const char *errstr = flux_future_error_string (f);
+        batch_respond_error (batch, errno,
+                             errstr ? errstr : "job-manager request failed");
         if (batch_cleanup (batch) < 0)
             flux_log_error (h, "%s: KVS cleanup failure", __FUNCTION__);
     }

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -18,6 +18,8 @@ job_manager_la_SOURCES = job-manager.c \
 			 job.h \
 			 submit.c \
 			 submit.h \
+			 drain.c \
+			 drain.h \
 			 queue.c \
 			 queue.h \
 			 event.h \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -455,6 +455,16 @@ int alloc_enqueue_alloc_request (struct alloc_ctx *ctx, struct job *job)
     return 0;
 }
 
+void alloc_dequeue_alloc_request (struct alloc_ctx *ctx, struct job *job)
+{
+    if (job->alloc_queued) {
+        queue_delete (ctx->inqueue, job, job->aux_queue_handle);
+        job->aux_queue_handle = NULL;
+        job->alloc_queued = 0;
+        ctx->active_alloc_count--;
+    }
+}
+
 void alloc_ctx_destroy (struct alloc_ctx *ctx)
 {
     if (ctx) {

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -29,6 +29,11 @@ struct alloc_ctx *alloc_ctx_create (flux_t *h, struct queue *queue,
  */
 int alloc_enqueue_alloc_request (struct alloc_ctx *ctx, struct job *job);
 
+/* Dequeue job from sched inqueue, e.g. on exception.
+ * This function is a no-op if job->alloc_queued is not set.
+ */
+void alloc_dequeue_alloc_request (struct alloc_ctx *ctx, struct job *job);
+
 /* Call from CLEANUP state to release resources.
  * This function is a no-op if job->free_pending is set.
  */

--- a/src/modules/job-manager/drain.c
+++ b/src/modules/job-manager/drain.c
@@ -1,0 +1,149 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* drain.c - support queue drain/undrain
+ *
+ * The "flux job drain" command can be used to disable job submission,
+ * then wait until the queue is empty.
+ *
+ * Use case:  initial program submits work, then calls "flux job drain"
+ * before exiting.
+ *
+ * Job submission can be re-enabled using "flux job undrain".
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "drain.h"
+#include "submit.h"
+
+struct drain_ctx {
+    flux_t *h;
+    struct submit_ctx *submit_ctx;
+    struct queue *queue;
+    flux_msg_handler_t **handlers;
+    zlist_t *requests;
+};
+
+static void drain_complete_cb (struct queue *queue, void *arg)
+{
+    struct drain_ctx *ctx = arg;
+    flux_msg_t *msg;
+
+    while ((msg = zlist_pop (ctx->requests))) {
+        if (flux_respond (ctx->h, msg, 0, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+        flux_msg_destroy (msg);
+    }
+}
+
+static void drain_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct drain_ctx *ctx = arg;
+    flux_msg_t *cpy;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (!(cpy = flux_msg_copy (msg, false)))
+        goto error;
+    if (zlist_append (ctx->requests, cpy) < 0) {
+        flux_msg_destroy (cpy);
+        errno = ENOMEM;
+        goto error;
+    }
+    submit_disable (ctx->submit_ctx);
+    /* N.B. If queue is empty, calls drain_complete_cb() immediately */
+    queue_set_notify_empty (ctx->queue, drain_complete_cb, ctx);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static void undrain_cb (flux_t *h, flux_msg_handler_t *mh,
+                        const flux_msg_t *msg, void *arg)
+{
+    struct drain_ctx *ctx = arg;
+    flux_msg_t *req;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        return;
+    }
+    submit_enable (ctx->submit_ctx);
+    while ((req = zlist_pop (ctx->requests))) {
+        if (flux_respond_error (ctx->h, req, EINVAL,
+                                "queue was re-enabled") < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        flux_msg_destroy (req);
+    }
+    if (flux_respond (ctx->h, msg, 0, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+}
+
+void drain_ctx_destroy (struct drain_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->requests) {
+            flux_msg_t *msg;
+            while ((msg = zlist_pop (ctx->requests))) {
+                if (flux_respond_error (ctx->h, msg, ENOSYS,
+                                        "job-manager is unloading") < 0)
+                    flux_log_error (ctx->h, "%s: flux_respond_error",
+                                    __FUNCTION__);
+                flux_msg_destroy (msg);
+            }
+            zlist_destroy (&ctx->requests);
+        }
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-manager.drain", drain_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "job-manager.undrain", undrain_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct drain_ctx *drain_ctx_create (flux_t *h, struct queue *queue,
+                                    struct submit_ctx *submit_ctx)
+{
+    struct drain_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+    ctx->queue = queue;
+    ctx->submit_ctx = submit_ctx;
+    if (!(ctx->requests = zlist_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    return ctx;
+error:
+    drain_ctx_destroy (ctx);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/drain.h
+++ b/src/modules/job-manager/drain.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_DRAIN_H
+#define _FLUX_JOB_MANAGER_DRAIN_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "queue.h"
+#include "submit.h"
+
+struct drain_ctx;
+
+void drain_ctx_destroy (struct drain_ctx *ctx);
+struct drain_ctx *drain_ctx_create (flux_t *h, struct queue *queue,
+                                    struct submit_ctx *submit_ctx);
+
+#endif /* ! _FLUX_JOB_MANAGER_DRAIN_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -219,6 +219,9 @@ int event_job_action (struct event_ctx *ctx, struct job *job)
                 return -1;
             break;
         case FLUX_JOB_CLEANUP:
+            if (job->alloc_queued)
+                alloc_dequeue_alloc_request (ctx->alloc_ctx, job);
+
             /* N.B. start_pending indicates that the start request is still
              * expecting responses.  The final response is the 'release'
              * response with final=true.  Thus once the flag is clear,

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -16,7 +16,7 @@
  * event transitions a job from SCHED to RUN state.
  *
  * event_job_action() is called after event_job_update().  It takes actions
- * appropriate for job state and flags.  flags.  For example, in RUN state,
+ * appropriate for job state and flags.  For example, in RUN state,
  * job shells are started.
  *
  * Events are logged in the job eventlog in the KVS.  For performance,

--- a/src/modules/job-manager/queue.h
+++ b/src/modules/job-manager/queue.h
@@ -15,6 +15,10 @@
 #include "src/common/libjob/job.h"
 #include "job.h"
 
+struct queue;
+
+typedef void (*queue_notify_f) (struct queue *queue, void *arg);
+
 /* Create a job queue, sorted by priority, then t_submit.
  * If lookup_hash=true, create a hash to speed up queue_lookup_by_id().
  */
@@ -50,6 +54,11 @@ struct job *queue_next (struct queue *queue);
 /* Return the number of jobs in the queue
  */
 int queue_size (struct queue *queue);
+
+/* Arrange to be notified when queue size decreases to zero.
+ */
+void queue_set_notify_empty (struct queue *queue,
+                             queue_notify_f cb, void *arg);
 
 #endif /* _FLUX_JOB_MANAGER_QUEUE_H */
 

--- a/src/modules/job-manager/submit.h
+++ b/src/modules/job-manager/submit.h
@@ -11,6 +11,7 @@
 #ifndef _FLUX_JOB_MANAGER_SUBMIT_H
 #define _FLUX_JOB_MANAGER_SUBMIT_H
 
+#include <stdbool.h>
 #include <czmq.h>
 #include <jansson.h>
 #include <flux/core.h>
@@ -18,10 +19,15 @@
 #include "queue.h"
 #include "alloc.h"
 
-void submit_handle_request (flux_t *h,
-                            struct queue *queue,
-                            struct event_ctx *event_ctx,
-                            const flux_msg_t *msg);
+struct submit_ctx;
+
+void submit_ctx_destroy (struct submit_ctx *ctx);
+struct submit_ctx *submit_ctx_create (flux_t *h,
+                                      struct queue *queue,
+                                      struct event_ctx *event_ctx);
+
+void submit_enable (struct submit_ctx *ctx);
+void submit_disable (struct submit_ctx *ctx);
 
 /* exposed for unit testing only */
 int submit_enqueue_one_job (struct queue *queue, zlist_t *newjobs, json_t *o);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -158,7 +158,9 @@ dist_check_SCRIPTS = \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \
-	job-manager/exec-service.lua
+	job-manager/exec-service.lua \
+	job-manager/drain-cancel.py \
+	job-manager/drain-undrain.py
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/job-manager/drain-cancel.py
+++ b/t/job-manager/drain-cancel.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: drain-cancel.py jobid
+#
+# Send a blocking drain request, then cancel jobid.
+# The drain response should be received, assuming the queue
+# was set up with only one job in it.
+#
+
+import flux
+from flux import job
+from flux.job import ffi
+import sys
+
+if len(sys.argv) != 2:
+    print("{}: {}".format("Usage", "drain.py jobid"))
+    sys.exit(1)
+
+h = flux.Flux()
+
+# Drain the queue.
+# Response will not be sent until queue size reaches zero.
+f = h.rpc("job-manager.drain")
+
+# Cancel the job so queue size reaches zero
+payload = {"id": int(sys.argv[1]), "type": "cancel", "severity": 0}
+f2 = h.rpc("job-manager.raise", payload)
+
+# Get the drain response.
+try:
+    f.get()
+except EnvironmentError as e:
+    print("{}: {}".format("drain", e.strerror))
+    sys.exit(1)
+else:
+    print("{}: {}".format("drain", "OK"))
+
+# Get the cancel response.
+try:
+    f2.get()
+except EnvironmentError as e:
+    print("{}: {}".format("cancel", e.strerror))
+    sys.exit(1)
+
+h.close()

--- a/t/job-manager/drain-undrain.py
+++ b/t/job-manager/drain-undrain.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: drain-undrain.py
+#
+# Send a drain request immediately followed by an undrain request.
+#
+# Assumes that the first drain request will be canceled by the undrain request.
+# Make sure there is a job in the queue to ensure the drain request does
+# not immediately succeed.
+#
+# Exits with rc=1 if the drain request unexpectedly succeeds.
+
+import flux
+import sys
+
+h = flux.Flux()
+
+# Drain the queue.
+# Response will not be sent until queue size reaches zero.
+f = h.rpc("job-manager.drain")
+
+# Undrain the queue.
+# Response is sent after any pending drain requests are canceled.
+f2 = h.rpc("job-manager.undrain")
+
+# Receive drain response (expect fail due to cancellation)
+try:
+    f.get()
+except EnvironmentError as e:
+    print("{}: {}".format("drain", e.strerror))
+else:
+    print("{}: {}".format("drain", "succeeded unexpectedly"))
+    sys.exit(1)
+
+# Receive undrain response (expect success)
+try:
+    f2.get()
+except EnvironmentError as e:
+    print("{}: {}".format("undrain", e.strerror))
+    sys.exit(1)
+
+h.close()

--- a/t/valgrind/workload.d/job
+++ b/t/valgrind/workload.d/job
@@ -2,24 +2,11 @@
 
 NJOBS=${NJOBS:-10}
 
-#  Reconfigure sched-simple with only 1 core so that only a single job is
-#   run at a time (and we can wait for the
-#   last job to determine we're done without a race.)
-#
-#  XXX: Remove and replace final synchronization with flux job drain
-#   when ready.
-#
-flux module remove sched-simple
-flux kvs put resource.hwloc.by_rank="{\"0\":{\"Core\":1}}"
-flux module load sched-simple
-
 flux jobspec srun -n 1 /bin/true > job.json
 for i in `seq 1 $NJOBS`; do
      id=$(flux job submit < job.json)
      echo id=$id
 done
-
-flux job wait-event -v ${id} clean
 
 #  Test job cancelation
 set -x
@@ -27,3 +14,5 @@ id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
 flux job wait-event ${id} start
 flux job cancel ${id}
 flux job wait-event ${id} clean
+
+flux job drain


### PR DESCRIPTION
Add a "drain" method to the job manager which 1) shuts off new job submissions, then 2) waits for the queue size to reach zero.  This supports the use case of an initial program that submits some jobs and exits as soon as they are all transitioned to INACTIVE.

Add a corresponding command `flux job drain [--timeout SECONDS]` which uses the drain RPC.  No API wrapper as yet - not sure if there will be a need?  (Easy to add if needed).

This was described in #2044.  I did make two changes from that description:
* `flux job drain --timeout N` was implemented with `flux_future_wait_for()`, not built in to the protocol.
* Multiple waiters are allowed.