### PR TITLE
libutil: add fsd_parse_duration(), support standard duration string in some utilities

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -54,6 +54,7 @@
 #include "src/common/libutil/zsecurity.h"
 #include "src/common/libpmi/pmi.h"
 #include "src/common/libpmi/pmi_strerror.h"
+#include "src/common/libutil/fsd.h"
 
 #include "heartbeat.h"
 #include "module.h"
@@ -237,12 +238,10 @@ void parse_command_line_arguments(int argc, char *argv[],
                 log_err_exit ("heartrate `%s'", optarg);
             break;
         case 'g':   /* --shutdown-grace SECS */
-            errno = 0;
-            ctx->shutdown_grace = strtod (optarg, &endptr);
-            if (errno || *endptr != '\0')
+            if (fsd_parse_duration (optarg, &ctx->shutdown_grace) < 0) {
                 log_err_exit ("shutdown-grace '%s'", optarg);
-            if (ctx->shutdown_grace < 0)
                 usage ();
+            }
             break;
         case 'S': { /* --setattr ATTR=VAL */
             char *val, *attr = xstrdup (optarg);

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -17,6 +17,7 @@
 
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/fsd.h"
 
 #include "heartbeat.h"
 
@@ -76,15 +77,8 @@ error:
 
 int heartbeat_set_ratestr (heartbeat_t *hb, const char *s)
 {
-    char *endptr;
-    double rate = strtod (s, &endptr);
-    if (rate == HUGE_VAL || endptr == optarg)
-        goto error;
-    if (!strcasecmp (endptr, "s") || *endptr == '\0')
-        ;
-    else if (!strcasecmp (endptr, "ms"))
-        rate /= 1000.0;
-    else
+    double rate;
+    if (fsd_parse_duration (s, &rate) < 0)
         goto error;
     return heartbeat_set_rate (hb, rate);
 error:

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -22,6 +22,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/monotime.h"
+#include "src/common/libutil/fsd.h"
 
 #include "runlevel.h"
 
@@ -125,7 +126,7 @@ static int runlevel_attr_set (const char *name, const char *val, void *arg)
         if (runlevel_set_mode (r, val) < 0)
             goto error;
     } else if (!strcmp (name, "init.rc2_timeout")) {
-        if ((r->rc[2].timeout = strtod (val, NULL)) < 0.) {
+        if (fsd_parse_duration (val, &r->rc[2].timeout) < 0) {
             errno = EINVAL;
             goto error;
         }
@@ -158,8 +159,7 @@ int runlevel_register_attrs (runlevel_t *r, attr_t *attrs)
         return -1;
 
     if (attr_get (attrs, "init.rc2_timeout", &val, NULL) == 0) {
-
-        if ((r->rc[2].timeout = strtod (val, NULL)) < 0.
+        if ((fsd_parse_duration (val, &r->rc[2].timeout) < 0)
                 || attr_delete (attrs, "init.rc2_timeout", true) < 0)
             return -1;
     }

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -79,8 +79,8 @@ int main (int argc, char **argv)
     errno = 0;
     ok (heartbeat_set_rate (hb, 1000000) < 1 && errno == EINVAL,
         "heartbeat_set_rate 1000000 fails with EINVAL");
-    ok (heartbeat_set_ratestr (hb, "250ms") == 0,
-        "heartbeat_set_ratestr 250ms works");
+    ok (heartbeat_set_ratestr (hb, ".250s") == 0,
+        "heartbeat_set_ratestr .250s works");
     ok (heartbeat_get_rate (hb) == 0.250,
         "heartbeat_get_rate returns what was set");
     ok (heartbeat_set_rate (hb, 0.1) == 0,

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -786,7 +786,7 @@ static void aggregate_load_wait (optparse_t *p, flux_t *h, const char *key)
     double timeout;
     flux_future_t *f = NULL;
 
-    timeout = optparse_get_double (p, "timeout", 15.);
+    timeout = optparse_get_duration (p, "timeout", 15.);
 
     if (!(f = aggregate_wait (h, key))
        || flux_future_wait_for (f, timeout) < 0)
@@ -950,7 +950,7 @@ static struct optparse_option aggregate_load_opts[] = {
       .usage = "Increase verbosity (only affects rank 0)",
     },
     { .name = "timeout", .key = 't', .has_arg = 1,
-      .usage = "Time to wait for aggregate completion (default 15.0s)",
+      .usage = "Duration to wait for aggregate completion (default 15.0s)",
     },
     { .name = "rank", .key = 'r', .has_arg = 1,
       .usage = "ranks on which to perform a local topology reload",

--- a/src/cmd/flux-aggregate.c
+++ b/src/cmd/flux-aggregate.c
@@ -226,7 +226,7 @@ int main (int argc, char *argv[])
 
     args.verbose = optparse_hasopt (p, "verbose");
     args.fwd_count = optparse_get_int (p, "fwd-count", 0);
-    args.timeout = optparse_get_double (p, "timeout", -1.);
+    args.timeout = optparse_get_duration (p, "timeout", -1.);
 
     if (!(args.h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -109,8 +109,8 @@ static struct optparse_option wait_event_opts[] =  {
     { .name = "context-format", .key = 'c', .has_arg = 1, .arginfo = "FORMAT",
       .usage = "Specify context format: text, json",
     },
-    { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "SECONDS",
-      .usage = "Timeout in seconds to give up waiting",
+    { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "DURATION",
+      .usage = "timeout after DURATION",
     },
     { .name = "quiet", .key = 'q', .has_arg = 0,
       .usage = "Do not output matched event",
@@ -827,7 +827,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
     ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
     ctx.p = p;
     ctx.wait_event = argv[optindex++];
-    ctx.timeout = optparse_get_double (p, "timeout", -1.0);
+    ctx.timeout = optparse_get_duration (p, "timeout", -1.0);
     ctx.format = optparse_get_str (p, "context-format", "text");
     if (strcasecmp (ctx.format, "text")
         && strcasecmp (ctx.format, "json"))

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -217,7 +217,7 @@ int main (int argc, char *argv[])
 
     ctx.rank = optparse_get_str (opts, "rank", NULL);
 
-    ctx.interval = optparse_get_double (opts, "interval", 1.0);
+    ctx.interval = optparse_get_duration (opts, "interval", 1.0);
     if (ctx.interval < 0.)
         log_msg_exit ("interval must be >= 0");
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -88,8 +88,8 @@ static struct optparse_option opts[] = {
     { .name = "broker-opts",.key = 'o', .has_arg = 1, .arginfo = "OPTS",
       .flags = OPTPARSE_OPT_AUTOSPLIT,
       .usage = "Add comma-separated broker options, e.g. \"-o,-v\"", },
-    { .name = "killer-timeout",.key = 'k', .has_arg = 1, .arginfo = "SECONDS",
-      .usage = "After a broker exits, kill other brokers after SECONDS", },
+    { .name = "killer-timeout",.key = 'k', .has_arg = 1, .arginfo = "DURATION",
+      .usage = "After a broker exits, kill other brokers after DURATION", },
     { .name = "trace-pmi-server", .has_arg = 0, .arginfo = NULL,
       .usage = "Trace pmi simple server protocol exchange", },
     { .name = "scratchdir", .key = 'D', .has_arg = 1, .arginfo = "DIR",
@@ -162,8 +162,8 @@ int main (int argc, char *argv[])
         log_msg_exit ("optparse_set usage");
     if ((optindex = optparse_parse_args (ctx.opts, argc, argv)) < 0)
         exit (1);
-    ctx.killer_timeout = optparse_get_double (ctx.opts, "killer-timeout",
-                                              DEFAULT_KILLER_TIMEOUT);
+    ctx.killer_timeout = optparse_get_duration (ctx.opts, "killer-timeout",
+                                                DEFAULT_KILLER_TIMEOUT);
     if (ctx.killer_timeout < 0.)
         log_msg_exit ("--killer-timeout argument must be >= 0");
     if (optindex < argc) {

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -51,6 +51,7 @@ libflux_optparse_la_SOURCES =
 libflux_optparse_la_LIBADD = \
 	$(builddir)/liboptparse/liboptparse.la \
 	$(builddir)/liblsd/liblsd.la \
+	$(builddir)/libutil/fsd.lo \
 	$(ZMQ_LIBS) $(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libflux-optparse.map \

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -23,6 +23,7 @@
 #include <czmq.h>
 
 #include "src/common/liblsd/list.h"
+#include "src/common/libutil/fsd.h"
 #include "optparse.h"
 #include "getopt.h"
 #include "getopt_int.h"
@@ -872,6 +873,29 @@ badarg:
                        "%s: Option '%s' requires a floating point argument\n",
                        p->program_name, name);
     return -1;
+}
+
+double optparse_get_duration (optparse_t *p, const char *name,
+                              double default_value)
+{
+    int n;
+    double d;
+    const char *s = NULL;
+
+    if ((n = optparse_getopt (p, name, &s)) < 0) {
+        optparse_fatalmsg (p, 1,
+                           "%s: optparse error: no such argument '%s'\n",
+                           p->program_name, name);
+    }
+    if (n == 0)
+        return default_value;
+    if (fsd_parse_duration (s, &d) < 0) {
+        optparse_fatalmsg (p, 1,
+                           "%s: Invalid argument for option '%s': '%s'",
+                           p->program_name, name, s);
+        return -1;
+    }
+    return d;
 }
 
 const char *optparse_get_str (optparse_t *p, const char *name,

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -363,6 +363,16 @@ bool optparse_hasopt (optparse_t *p, const char *name);
 int optparse_get_int (optparse_t *p, const char *name, int default_value);
 
 /*
+ *   Return the option argument parsed as a duration in floating-point
+ *   'seconds[suffix]', where optional suffix is one of s,m,h,d for seconds
+ *   hours, minutes, or days. If 'name' was not used, returns the provided
+ *   default_value. If there was an error parsing the duration string,
+ *   call the fatal error function.
+ */
+double optparse_get_duration (optparse_t *p, const char *name,
+                              double default_value);
+
+/*
  *   Return the option argument as a double if 'name' was used,
  *    'default_value' if not.  If the option is unknown, or the argument
  *    could not be converted to a double, call the fatal error function.

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -339,11 +339,12 @@ void test_convenience_accessors (void)
 { .name = "neg", .key = 6, .has_arg = 1, .arginfo = "", .usage = "" },
 { .name = "dub", .key = 7, .has_arg = 1, .arginfo = "", .usage = "" },
 { .name = "ndb", .key = 8, .has_arg = 1, .arginfo = "", .usage = "" },
+{ .name = "dur", .key = 9, .has_arg = 1, .arginfo = "", .usage = "" },
         OPTPARSE_TABLE_END,
     };
 
     char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", "--neg=-4",
-                   "--dub=5.7", "--ndb=-3.2", NULL };
+                   "--dub=5.7", "--ndb=-3.2", "--dur=1.5m", NULL };
     int ac = sizeof (av) / sizeof (av[0]) - 1;
     int rc, optindex;
 
@@ -408,6 +409,25 @@ void test_convenience_accessors (void)
             "get_double returns arg when present");
     ok (optparse_get_double (p, "ndb", 42) == -3.2,
             "get_double returns negative arg when present");
+
+    /* get duration
+     */
+    dies_ok ({optparse_get_duration (p, "no-exist", 0); },
+            "get_duration exits on unknown arg");
+    dies_ok ({optparse_get_duration (p, "foo", 0); },
+            "get_duration exits on option with no argument");
+    dies_ok ({optparse_get_duration (p, "baz", 0); },
+            "get_duration exits on option with wrong type argument (string)");
+    dies_ok ({optparse_get_duration (p, "neg", 42); },
+            "get_duration exits on negative arg");
+    lives_ok ({optparse_get_duration (p, "bar", 0); },
+            "get_duration lives on known arg");
+    ok (optparse_get_duration (p, "bar", 42.0) == 42.0,
+            "get_duration returns default argument when arg not present");
+    ok (optparse_get_duration (p, "mnf", 42) == 7.0,
+            "get_duration returns arg when present");
+    ok (optparse_get_duration (p, "dur", 42) == 90.,
+            "get_duration returns duration arg when present");
 
     /* get_str
      */
@@ -1114,7 +1134,7 @@ void test_non_option_arguments (void)
 int main (int argc, char *argv[])
 {
 
-    plan (251);
+    plan (259);
 
     test_convenience_accessors (); /* 35 tests */
     test_usage_output (); /* 42 tests */

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -114,6 +114,7 @@ TESTS = test_ev.t \
 	test_fluid.t \
 	test_aux.t \
 	test_fdutils.t \
+	test_fsd.t \
 	test_zsecurity.t
 
 
@@ -227,6 +228,10 @@ test_aux_t_LDADD = $(test_ldadd)
 test_fdutils_t_SOURCES = test/fdutils.c
 test_fdutils_t_CPPFLAGS = $(test_cppflags)
 test_fdutils_t_LDADD = $(test_ldadd)
+
+test_fsd_t_SOURCES = test/fsd.c
+test_fsd_t_CPPFLAGS = $(test_cppflags)
+test_fsd_t_LDADD = $(test_ldadd)
 
 test_zsecurity_t_SOURCES = test/zsecurity.c
 test_zsecurity_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -85,6 +85,8 @@ libutil_la_SOURCES = \
 	aux.h \
 	fdutils.c \
 	fdutils.h \
+	fsd.c \
+	fsd.h \
 	zsecurity.c \
 	zsecurity.h
 

--- a/src/common/libutil/fsd.c
+++ b/src/common/libutil/fsd.c
@@ -1,0 +1,80 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "fsd.h"
+
+int fsd_parse_duration (const char *s, double *dp)
+{
+    double d;
+    char *p;
+    if (s == NULL || dp == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    d = strtod (s, &p);
+    if ((d < 0.) || (*p && *(p+1))) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (*p != '\0') {
+        unsigned int multiplier = 0;
+        switch (*p) {
+            case 0:
+            case 's':
+                multiplier = 1;
+                break;
+            case 'm':
+                multiplier = 60;
+                break;
+            case 'h':
+                multiplier = 60 * 60;
+                break;
+            case 'd':
+                multiplier = 60 * 60 * 24;
+                break;
+        }
+        if (multiplier == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        d *= multiplier;
+    }
+    *dp = d;
+    return 0;
+}
+
+int fsd_format_duration (char *buf, size_t len, double duration)
+{
+    if (buf == NULL || len <= 0 || duration < 0.) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (duration < 60.)
+        return snprintf (buf, len, "%gs", duration);
+    else if (duration < 60. * 60.)
+        return snprintf (buf, len, "%gm", duration / 60.);
+    else if (duration < 60. * 60. * 24.)
+        return snprintf (buf, len, "%gh", duration / (60. * 60.));
+    else
+        return snprintf (buf, len, "%gd", duration / (60. * 60. * 24.));
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/fsd.h
+++ b/src/common/libutil/fsd.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_FSD_H
+#define _UTIL_FSD_H
+
+#include <stddef.h>
+
+/*  Attempt to parse a string duration 's' as Flux Standard Duration
+ *   string (floating point seconds with optional suffix).
+ */
+int fsd_parse_duration (const char *s, double *dp);
+
+/*  Format 'duration' in floating point seconds into a human readable
+ *   string in Flux Standard Duration form.
+ */
+int fsd_format_duration (char *buf, size_t len, double duration);
+
+#endif /* !_UTIL_FSD_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/fsd.c
+++ b/src/common/libutil/test/fsd.c
@@ -1,0 +1,122 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/fsd.h"
+
+int main(int argc, char** argv)
+{
+    double d;
+    char buf [64];
+    plan (NO_PLAN);
+
+    ok (fsd_parse_duration (NULL, NULL) < 0 && errno == EINVAL,
+        "fsd_parse_duration (NULL, NULL) is an error");
+    ok (fsd_parse_duration (NULL, &d) < 0 && errno == EINVAL,
+        "fsd_parse_duration (NULL, &d) is an error");
+    ok (fsd_parse_duration ("0", NULL) < 0 && errno == EINVAL,
+        "fsd_parse_duration (s, NULL) is an error");
+    ok (fsd_parse_duration ("-1.", &d) < 0 && errno == EINVAL,
+        "fsd_parse_duration (-1) is an error");
+    ok (fsd_parse_duration ("1.0f", &d) < 0 && errno == EINVAL,
+        "fsd_parse_duration (1.0f) is an error");
+    ok (fsd_parse_duration ("1.0sec", &d) < 0 && errno == EINVAL,
+        "fsd_parse_duration (1.0sec) is an error");
+
+    ok (fsd_parse_duration ("0", &d) == 0,
+        "fsd_parse_duration (0) returns success");
+    ok (d == 0., "got d == %g", d);
+
+    ok (fsd_parse_duration ("0s", &d) == 0,
+        "fsd_parse_duration (0s) returns success");
+    ok (d == 0., "got d == %g", d);
+
+    ok (fsd_parse_duration ("0m", &d) == 0,
+        "fsd_parse_duration (0m) returns success");
+    ok (d == 0., "got d == %g", d);
+
+    ok (fsd_parse_duration ("0h", &d) == 0,
+        "fsd_parse_duration (0h) returns success");
+    ok (d == 0., "got d == %g", d);
+
+    ok (fsd_parse_duration ("0d", &d) == 0,
+        "fsd_parse_duration (0d) returns success");
+    ok (d == 0., "got d == %g", d);
+
+    ok (fsd_parse_duration ("0.5", &d) == 0,
+        "fsd_parse_duration (0.5) returns success");
+    ok (d == 0.5, "got d == %g", d);
+
+    ok (fsd_parse_duration ("0.5s", &d) == 0,
+        "fsd_parse_duration (0.5s) returns success");
+    ok (d == 0.5, "got d == %g", d);
+
+    ok (fsd_parse_duration ("0.5m", &d) == 0,
+        "fsd_parse_duration (0.5m) returns success");
+    ok (d == 30., "got d == %g", d);
+    
+    ok (fsd_parse_duration ("0.5h", &d) == 0,
+        "fsd_parse_duration (0.5h) returns success");
+    ok (d == .5 * 60. * 60., "got d == %g", d);
+
+    ok (fsd_parse_duration ("1.0d", &d) == 0,
+        "fsd_parse_duration (1.0d) returns success");
+    ok (d == 24. * 60. * 60., "got d == %g", d);
+
+    ok (fsd_format_duration (buf, sizeof (buf), -1.) < 0 && errno == EINVAL,
+        "fsd_format_duration with duration < 0. returns EINVAL");
+
+    ok (fsd_format_duration (buf, 0, 1.) < 0 && errno == EINVAL,
+        "fsd_format_duration with buflen <= 0. returns EINVAL");
+
+    ok (fsd_format_duration (NULL, 1024, 1000.) < 0 && errno == EINVAL,
+        "fsd_format_duration with buf == NULL returns EINVAL");
+    
+    ok (fsd_format_duration (buf, sizeof (buf), .001),
+        "fsd_format_duration (.001) works");
+    is (buf, "0.001s", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 5.),
+        "fsd_format_duration (5.0) works");
+    is (buf, "5s", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 5.1),
+        "fsd_format_duration (5.1) works");
+    is (buf, "5.1s", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 62.0),
+        "fsd_format_duration (62.) works");
+    is (buf, "1.03333m", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 3600.),
+        "fsd_format_duration (3600.) works");
+    is (buf, "1h", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 4500.),
+        "fsd_format_duration (4500.) works");
+    is (buf, "1.25h", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 86400.),
+        "fsd_format_duration (86400.) works");
+    is (buf, "1d", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 103680.0),
+        "fsd_format_duration (86400.) works");
+    is (buf, "1.2d", "returns expected string = %s", buf);
+
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -33,6 +33,7 @@
 #include <jansson.h>
 
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/fsd.h"
 
 #include "task.h"
 #include "entry.h"
@@ -883,12 +884,8 @@ static void process_args (cron_ctx_t *ctx, int ac, char **av)
             cron_ctx_sync_event_init (ctx, (av[i])+5);
         else if (strncmp (av[i], "sync_epsilon=", 13) == 0) {
             char *s = (av[i])+13;
-            char *endptr;
-            double d = strtod (s, &endptr);
-            if (d == 0 && endptr == s)
+            if (fsd_parse_duration (s, &ctx->sync_epsilon) < 0)
                 flux_log_error (ctx->h, "option %s ignored", av[i]);
-            else
-                ctx->sync_epsilon = d;
         }
         else
             flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);


### PR DESCRIPTION
This PR adds a libutil function to parse the proposed RFC 23 Flux Standard Duration, and uses that function to add an`optparse_get_duration()` call. Several commands using `optparse_get_double()` were update to `optparse_get_duration()` to allow them to take duration strings with `s,m,h,d` suffixes.

At the same time, all uses of jobspec duration were updated to take duration as a strict float number of seconds as proposed in flux-framework/rfc#177. Unfortunately, this had to go in as one big commit since everything depends on everything else.

In retrospect perhaps the jobspec duration should be a separate PR, but first people could comment on the change. It is best to get this done now, since making the change in the future will likely be more work.