### PR TITLE
jobspec: make attributes.system.duration a number of seconds

### DIFF
--- a/src/cmd/flux-jobspec
+++ b/src/cmd/flux-jobspec
@@ -89,20 +89,7 @@ def validate_slurm_args(args):
     # IDEA: print a warning if the file already exists or if the parent dir doesn't exist
 
 
-#  Convert floating point "time" in seconds to duration string with suffix
-#   's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days.
-def sec_to_duration(time):
-    if time < 2 * 60.0:
-        return "%ss" % str(time)
-    elif time < 2 * 60 * 60:
-        return "%sm" % str(time / 60.0)
-    elif time < 60 * 60 * 24:
-        return "%sh" % str(time / (60 * 60))
-    else:
-        return "%sd" % str(time / (60 * 60 * 24))
-
-
-#  Convert slurm walltime string to Flux duration string
+#  Convert slurm walltime string to floating point seconds
 def slurm_walltime_to_duration(time):
     if not time:
         return None
@@ -129,7 +116,7 @@ def slurm_walltime_to_duration(time):
         t = t + vals["seconds"]
     if t == 0.0:
         return None
-    return sec_to_duration(t)
+    return t
 
 
 def slurm_jobspec(args):

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -419,16 +419,11 @@ static void jobinfo_fatal_error (struct jobinfo *job, int errnum,
 
 static double jobspec_duration (flux_t *h, json_t *jobspec)
 {
-    const char *s;
     double duration = 0.;
-    if (json_unpack (jobspec, "{s:{s:{s:s}}}",
+    if (json_unpack (jobspec, "{s:{s:{s:F}}}",
                               "attributes", "system",
-                              "duration", &s) < 0)
+                              "duration", &duration) < 0)
         return -1.;
-    if (fsd_parse_duration (s, &duration) < 0) {
-        flux_log (h, LOG_ERR, "Unable to parse jobspec duration %s", s);
-        return -1.;
-    }
     return duration;
 }
 

--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -98,7 +98,7 @@
         "system": {
           "type": "object",
           "properties": {
-            "duration": { "type": "string" }
+            "duration": { "type": "number", "minimum": 0 }
           }
         },
         "user": {

--- a/t/jobspec/emit-jobspec.py
+++ b/t/jobspec/emit-jobspec.py
@@ -44,7 +44,7 @@ def main():
                 "count": {"total": args.num_tasks},
             }
         ],
-        "attributes": {"system": {"duration": "{} seconds".format(args.walltime)}},
+        "attributes": {"system": {"duration": args.walltime}},
     }
 
     if args.pretty:

--- a/t/jobspec/invalid/attributes_bad_entry.yaml
+++ b/t/jobspec/invalid/attributes_bad_entry.yaml
@@ -13,5 +13,5 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1
+    duration: 1h
   foo: 1

--- a/t/jobspec/minimal-schema.json
+++ b/t/jobspec/minimal-schema.json
@@ -90,7 +90,7 @@
         "system": {
           "type": "object",
           "properties": {
-            "duration": { "type": "string" }
+            "duration": { "type": "number", "minimum": 0 }
           }
         },
 	"user": {

--- a/t/jobspec/valid/example1.yaml
+++ b/t/jobspec/valid/example1.yaml
@@ -16,4 +16,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/jobspec/valid/example2.yaml
+++ b/t/jobspec/valid/example2.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/jobspec/valid/use_case_1.1.yaml
+++ b/t/jobspec/valid/use_case_1.1.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/jobspec/valid/use_case_1.2.yaml
+++ b/t/jobspec/valid/use_case_1.2.yaml
@@ -17,4 +17,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/jobspec/valid/use_case_1.3.yaml
+++ b/t/jobspec/valid/use_case_1.3.yaml
@@ -22,4 +22,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/jobspec/valid/use_case_1.4.yaml
+++ b/t/jobspec/valid/use_case_1.4.yaml
@@ -19,4 +19,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/jobspec/valid/use_case_1.5.yaml
+++ b/t/jobspec/valid/use_case_1.5.yaml
@@ -38,4 +38,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 4 hours
+    duration: 14400.

--- a/t/jobspec/valid/use_case_1.6.yaml
+++ b/t/jobspec/valid/use_case_1.6.yaml
@@ -19,4 +19,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/jobspec/valid/use_case_1.7.yaml
+++ b/t/jobspec/valid/use_case_1.7.yaml
@@ -16,4 +16,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1h
+    duration: 3600.

--- a/t/jobspec/valid/use_case_2.1.yaml
+++ b/t/jobspec/valid/use_case_2.1.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 5
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/jobspec/valid/use_case_2.2.yaml
+++ b/t/jobspec/valid/use_case_2.2.yaml
@@ -13,4 +13,4 @@ tasks:
       total: 5
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/jobspec/valid/use_case_2.3.yaml
+++ b/t/jobspec/valid/use_case_2.3.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/jobspec/valid/use_case_2.4.yaml
+++ b/t/jobspec/valid/use_case_2.4.yaml
@@ -32,4 +32,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/jobspec/valid/use_case_2.5.yaml
+++ b/t/jobspec/valid/use_case_2.5.yaml
@@ -17,4 +17,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/jobspec/valid/use_case_2.6.yaml
+++ b/t/jobspec/valid/use_case_2.6.yaml
@@ -18,4 +18,4 @@ tasks:
       total: 10
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -64,30 +64,6 @@ test_expect_success 'job-exec: canceling job during execution works' '
 	flux job wait-event -t 2.5 ${jobid} clean &&
 	exec_eventlog $jobid | grep "complete status=9"
 '
-test_expect_success HAVE_JQ 'job-exec: supports duration in minutes' '
-	flux jobspec srun hostname | \
-	  jq ".attributes.system.duration = \"0.5m\"" > 0.5m.json &&
-	jobid=$(flux job submit 0.5m.json) &&
-	flux job wait-event ${jobid} start &&
-	exec_eventlog ${jobid} | grep timer=30.000000s &&
-	flux job cancel ${jobid}
-'
-test_expect_success HAVE_JQ 'job-exec: supports duration in hours' '
-	flux jobspec srun hostname | \
-	  jq ".attributes.system.duration = \"0.5h\"" > 0.5h.json &&
-	jobid=$(flux job submit 0.5h.json) &&
-	flux job wait-event ${jobid} start &&
-	exec_eventlog ${jobid} | grep timer=1800.000000s &&
-	flux job cancel ${jobid}
-'
-test_expect_success HAVE_JQ 'job-exec: supports duration in days' '
-	flux jobspec srun hostname | \
-	  jq ".attributes.system.duration = \"0.5d\"" > 0.5d.json &&
-	jobid=$(flux job submit 0.5d.json) &&
-	flux job wait-event ${jobid} start &&
-	exec_eventlog ${jobid} | grep timer=43200.000000s &&
-	flux job cancel ${jobid}
-'
 test_expect_success HAVE_JQ 'job-exec: mock exception during initialization' '
 	flux jobspec srun hostname | \
 	  exec_testattr mock_exception init > ex1.json &&


### PR DESCRIPTION
As mentioned in #2095, make jobspec and minimal jobspec `attributes.system.duration` into a strict number of seconds, instead of an arbitrary string.

Updates all the tests, parsers, schemas and modules. Unfortunately, this had to be done in one big commit.

This should be merged after #2095.