### PR TITLE
libflux: Add error string to continue error

### DIFF
--- a/doc/man3/flux_future_and_then.adoc
+++ b/doc/man3/flux_future_and_then.adoc
@@ -18,7 +18,8 @@ SYNOPSIS
                                      flux_continuation_f cb, void *arg);
 
  int flux_future_continue (flux_future_t *prev, flux_future_t *f);
- void flux_future_continue_error (flux_future_t *prev, int errnum);
+ void flux_future_continue_error (flux_future_t *prev, int errnum,
+                                  const char *errstr);
 
 
 
@@ -70,9 +71,9 @@ a sequential chain of futures created earlier. After the call to
 destroyed.
 
 `flux_future_continue_error(3)` is like `flux_future_continue()`
-but immediately fulfills the next future in the chain with an error.
-Once `flux_future_continue_error(3)` completes, the future `prev`
-may safely be destroyed.
+but immediately fulfills the next future in the chain with an error and
+an optional error string.  Once `flux_future_continue_error(3)`
+completes, the future `prev` may safely be destroyed.
 
 RETURN VALUE
 ------------

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -388,11 +388,12 @@ int flux_future_continue (flux_future_t *prev, flux_future_t *f)
 
 /* "Continue" the chained "next" future embedded in `prev` with an error
  */
-void flux_future_continue_error (flux_future_t *prev, int errnum)
+void flux_future_continue_error (flux_future_t *prev, int errnum,
+                                 const char *errstr)
 {
     struct chained_future *cf = chained_future_get (prev);
     if (cf && cf->next)
-        flux_future_fulfill_error (cf->next, errnum, NULL);
+        flux_future_fulfill_error (cf->next, errnum, errstr);
 }
 
 flux_future_t *flux_future_and_then (flux_future_t *prev,

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -110,9 +110,10 @@ flux_future_t *flux_future_or_then (flux_future_t *f,
 int flux_future_continue (flux_future_t *prev, flux_future_t *f);
 
 /*  Set the next future for the chained future `prev` to be fulfilled
- *   with an error `errnum`.
+ *   with an error `errnum` and an optional error string.
  */
-void flux_future_continue_error (flux_future_t *prev, int errnum);
+void flux_future_continue_error (flux_future_t *prev, int errnum,
+                                 const char *errstr);
 
 #ifdef __cplusplus
 }

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -190,7 +190,7 @@ static void step2_err (flux_future_t *f, void *arg)
     ok (flux_future_get (f, (const void **)&result) == 0,
         "chained: step2: flux_future_get returns success");
     strcat (str, "-step2_err");
-    flux_future_continue_error (f, 123);
+    flux_future_continue_error (f, 123, NULL);
     flux_future_destroy (f);
 }
 

--- a/src/common/libkvs/kvs_copy.c
+++ b/src/common/libkvs/kvs_copy.c
@@ -99,7 +99,7 @@ static void copy_continuation (flux_future_t *f, void *arg)
     }
     goto done;
 error:
-    flux_future_continue_error (f, errno);
+    flux_future_continue_error (f, errno, NULL);
 done:
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);
@@ -139,7 +139,7 @@ static void lookup_continuation (flux_future_t *f, void *arg)
     }
     goto done;
 error:
-    flux_future_continue_error (f, errno);
+    flux_future_continue_error (f, errno, NULL);
 done:
     flux_future_destroy (f);
     flux_kvs_txn_destroy (txn);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -512,7 +512,7 @@ static void namespace_delete (flux_future_t *f, void *arg)
     flux_t *h = job->ctx->h;
     flux_future_t *fnext = flux_kvs_namespace_remove (h, job->ns);
     if (!fnext)
-        flux_future_continue_error (f, errno);
+        flux_future_continue_error (f, errno, NULL);
     else
         flux_future_continue (f, fnext);
     flux_future_destroy (f);
@@ -535,7 +535,7 @@ done:
     if (fnext)
         flux_future_continue (f, fnext);
     else
-        flux_future_continue_error (f, errno);
+        flux_future_continue_error (f, errno, NULL);
     flux_future_destroy (f);
 }
 
@@ -567,7 +567,7 @@ static void namespace_move (flux_future_t *fprev, void *arg)
     flux_future_destroy (fprev);
     return;
 error:
-    flux_future_continue_error (fprev, errno);
+    flux_future_continue_error (fprev, errno, NULL);
     flux_future_destroy (f);
     flux_future_destroy (fnext);
     flux_future_destroy (fprev);
@@ -605,7 +605,7 @@ static void jobinfo_cleanup (flux_future_t *fprev, void *arg)
     flux_future_destroy (fprev);
     return;
 error:
-    flux_future_continue_error (fprev, errno);
+    flux_future_continue_error (fprev, errno, NULL);
     flux_future_destroy (fprev);
 }
 
@@ -624,7 +624,7 @@ static void emit_cleanup_finish (flux_future_t *prev, void *arg)
                                        "rc=%d%s%s", rc,
                                         rc < 0 ? " " : "",
                                         rc < 0 ? strerror (errno) : "")))
-        flux_future_continue_error (prev, errno);
+        flux_future_continue_error (prev, errno, NULL);
     else
         flux_future_continue (prev, f);
     flux_future_destroy (prev);
@@ -930,7 +930,7 @@ static void namespace_link (flux_future_t *fprev, void *arg)
 error:
     saved_errno = errno;
     flux_future_destroy (cf);
-    flux_future_continue_error (fprev, saved_errno);
+    flux_future_continue_error (fprev, saved_errno, NULL);
     flux_future_destroy (fprev);
 }
 


### PR DESCRIPTION
Add error string parameter to flux_future_continue_error() so an
optional error string an be set on the future.

Update callers appropriately and add unit tests.

Fixes #2079