### PR TITLE
job-manager: add job state transition announcements

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -400,25 +400,6 @@ static int iso_timestr (double timestamp, char *buf, size_t size)
     return 0;
 }
 
-char statechar (flux_job_state_t state)
-{
-    switch (state) {
-        case FLUX_JOB_NEW:
-            return 'N';
-        case FLUX_JOB_DEPEND:
-            return 'D';
-        case FLUX_JOB_SCHED:
-            return 'S';
-        case FLUX_JOB_RUN:
-            return 'R';
-        case FLUX_JOB_CLEANUP:
-            return 'C';
-        case FLUX_JOB_INACTIVE:
-            return 'I';
-    }
-    return '?';
-}
-
 int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
@@ -461,8 +442,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
             log_msg_exit ("error parsing job data");
         if (iso_timestr (t_submit, timestr, sizeof (timestr)) < 0)
             log_err_exit ("time conversion error");
-        printf ("%llu\t%c\t%lu\t%d\t%s\n", (unsigned long long)id,
-                                       statechar (state),
+        printf ("%llu\t%s\t%lu\t%d\t%s\n", (unsigned long long)id,
+                                       flux_job_statetostr (state, true),
                                        (unsigned long)userid,
                                        priority,
                                        timestr);

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -305,6 +305,51 @@ int flux_job_event_watch_cancel (flux_future_t *f)
     return 0;
 }
 
+const char *flux_job_statetostr (flux_job_state_t state, bool single_char)
+{
+    switch (state) {
+        case FLUX_JOB_NEW:
+            return single_char ? "N" : "NEW";
+        case FLUX_JOB_DEPEND:
+            return single_char ? "D" : "DEPEND";
+        case FLUX_JOB_SCHED:
+            return single_char ? "S" : "SCHED";
+        case FLUX_JOB_RUN:
+            return single_char ? "R" : "RUN";
+        case FLUX_JOB_CLEANUP:
+            return single_char ? "C" : "CLEANUP";
+        case FLUX_JOB_INACTIVE:
+            return single_char ? "I" : "INACTIVE";
+    }
+    return single_char ? "?" : "(unknown)";
+}
+
+int flux_job_strtostate (const char *s, flux_job_state_t *state)
+{
+    if (!s || !state)
+        goto inval;
+    if (!strcasecmp (s, "N") || !strcasecmp (s, "NEW"))
+        *state = FLUX_JOB_NEW;
+    else if (!strcasecmp (s, "D") || !strcasecmp (s, "DEPEND"))
+        *state = FLUX_JOB_DEPEND;
+    else if (!strcasecmp (s, "S") || !strcasecmp (s, "SCHED"))
+        *state = FLUX_JOB_SCHED;
+    else if (!strcasecmp (s, "R") || !strcasecmp (s, "RUN"))
+        *state = FLUX_JOB_RUN;
+    else if (!strcasecmp (s, "C") || !strcasecmp (s, "CLEANUP"))
+        *state = FLUX_JOB_CLEANUP;
+    else if (!strcasecmp (s, "I") || !strcasecmp (s, "INACTIVE"))
+        *state = FLUX_JOB_INACTIVE;
+    else
+        goto inval;
+
+    return 0;
+inval:
+    errno = EINVAL;
+    return -1;
+}
+
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -45,6 +45,10 @@ typedef enum {
 
 typedef uint64_t flux_jobid_t;
 
+const char *flux_job_statetostr (flux_job_state_t state, bool single_char);
+
+int flux_job_strtostate (const char *s, flux_job_state_t *state);
+
 /* Submit a job to the system.
  * 'jobspec' should be RFC 14 jobspec.
  * 'priority' should be a value from 0 to 31 (16 if not instance owner).

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -168,7 +168,7 @@ static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
     job->free_pending = 0;
-    if (event_job_post (ctx->event_ctx, job, NULL, NULL, "free", NULL) < 0)
+    if (event_job_post (ctx->event_ctx, job, "free", NULL) < 0)
         goto teardown;
     return;
 teardown:
@@ -245,7 +245,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
      * Raise alloc exception and transition to CLEANUP state.
      */
     if (type == 2) { // error: alloc was rejected
-        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "exception",
+        if (event_job_post_pack (ctx->event_ctx, job, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", "alloc",
                                  "severity", 0,
@@ -265,7 +265,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
 
-    if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "alloc",
+    if (event_job_post_pack (ctx->event_ctx, job, "alloc",
                              "{ s:s }",
                              "note", note ? note : "") < 0)
         goto teardown;
@@ -423,7 +423,7 @@ static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
         job->alloc_queued = 0;
         ctx->active_alloc_count++;
         if ((job->flags & FLUX_JOB_DEBUG))
-            (void)event_job_post (ctx->event_ctx, job, NULL, NULL,
+            (void)event_job_post (ctx->event_ctx, job,
                                  "debug.alloc-request", NULL);
 
     }
@@ -437,7 +437,7 @@ int alloc_send_free_request (struct alloc_ctx *ctx, struct job *job)
             return -1;
         job->free_pending = 1;
         if ((job->flags & FLUX_JOB_DEBUG))
-            (void)event_job_post (ctx->event_ctx, job, NULL, NULL,
+            (void)event_job_post (ctx->event_ctx, job,
                                   "debug.free-request", NULL);
     }
     return 0;

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -210,7 +210,10 @@ int event_job_action (struct event_ctx *ctx, struct job *job)
 {
     switch (job->state) {
         case FLUX_JOB_NEW:
+            break;
         case FLUX_JOB_DEPEND:
+            if (event_job_post (ctx, job, "depend", NULL) < 0)
+                return -1;
             break;
         case FLUX_JOB_SCHED:
             if (alloc_enqueue_alloc_request (ctx->alloc_ctx, job) < 0)
@@ -356,6 +359,11 @@ int event_job_update (struct job *job, const char *event)
                                          &job->userid,
                                          &job->flags) < 0)
             goto error;
+        job->state = FLUX_JOB_DEPEND;
+    }
+    if (!strcmp (name, "depend")) {
+        if (job->state != FLUX_JOB_DEPEND)
+            goto inval;
         job->state = FLUX_JOB_SCHED;
     }
     else if (!strcmp (name, "priority")) {

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -35,19 +35,16 @@ int event_job_update (struct job *job, const char *event);
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits
  * the event to job KVS eventlog.  The KVS commit completes asynchronously.
- * If 'cb' is non-NULL, it is called with 'arg' upon commit completion.
  * The future passed in as an argument should not be destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
 int event_job_post (struct event_ctx *ctx, struct job *job,
-                    flux_continuation_f cb, void *arg,
                     const char *name, const char *context);
 
 /* Same as above except event context is constructed from (fmt, ...)
  * using style of jansson's json_pack().
  */
 int event_job_post_pack (struct event_ctx *ctx, struct job *job,
-                         flux_continuation_f cb, void *arg,
                          const char *name, const char *fmt, ...);
 
 void event_ctx_set_alloc_ctx (struct event_ctx *ctx,

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -32,6 +32,11 @@ int event_job_action (struct event_ctx *ctx, struct job *job);
  */
 int event_job_update (struct job *job, const char *event);
 
+/* Add notification of job's state transition to its current state
+ * to batch for publication.
+ */
+int event_batch_pub_state (struct event_ctx *ctx, struct job *job);
+
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits
  * the event to job KVS eventlog.  The KVS commit completes asynchronously.

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -82,7 +82,7 @@ void priority_handle_request (flux_t *h, struct queue *queue,
     }
     /* Post event, change job's queue position, and respond.
      */
-    if (event_job_post_pack (event_ctx, job, NULL, NULL,
+    if (event_job_post_pack (event_ctx, job,
                              "priority",
                              "{ s:i s:i }",
                              "userid", userid,

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -109,7 +109,7 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPROTO;
         goto error;
     }
-    if (event_job_post_pack (event_ctx, job, NULL, NULL,
+    if (event_job_post_pack (event_ctx, job,
                              "exception",
                              "{ s:s s:i s:i s:s }",
                              "type", type,

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -160,7 +160,7 @@ static void interface_teardown (struct start_ctx *ctx, char *s, int errnum)
         while (job) {
             if (job->start_pending) {
                 if ((job->flags & FLUX_JOB_DEBUG))
-                    (void)event_job_post_pack (ctx->event_ctx, job, NULL, NULL,
+                    (void)event_job_post_pack (ctx->event_ctx, job,
                                                "debug.start-lost",
                                                "{ s:s }", "note", s);
                 job->start_pending = 0;
@@ -198,8 +198,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!strcmp (type, "start")) {
-        if (event_job_post (ctx->event_ctx, job, NULL, NULL,
-                            "start", NULL) < 0)
+        if (event_job_post (ctx->event_ctx, job, "start", NULL) < 0)
             goto error_post;
     }
     else if (!strcmp (type, "release")) {
@@ -213,7 +212,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         }
         if (final) // final release is end-of-stream
             job->start_pending = 0;
-        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "release",
+        if (event_job_post_pack (ctx->event_ctx, job, "release",
                                  "{ s:s s:b }",
                                  "ranks", idset,
                                  "final", final) < 0)
@@ -230,7 +229,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
             flux_log_error (h, "start: exception response: malformed data");
             goto error;
         }
-        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "exception",
+        if (event_job_post_pack (ctx->event_ctx, job, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", xtype,
                                  "severity", xseverity,
@@ -245,7 +244,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
             flux_log_error (h, "start: finish response: malformed data");
             goto error;
         }
-        if (event_job_post_pack (ctx->event_ctx, job, NULL, NULL, "finish",
+        if (event_job_post_pack (ctx->event_ctx, job, "finish",
                                  "{ s:i }", "status", status) < 0)
             goto error_post;
     }
@@ -282,7 +281,7 @@ int start_send_request (struct start_ctx *ctx, struct job *job)
         flux_msg_destroy (msg);
         job->start_pending = 1;
         if ((job->flags & FLUX_JOB_DEBUG))
-            (void)event_job_post (ctx->event_ctx, job, NULL, NULL,
+            (void)event_job_post (ctx->event_ctx, job,
                                   "debug.start-request", NULL);
     }
     return 0;

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -156,7 +156,9 @@ int submit_post_event (struct event_ctx *event_ctx, struct job *job)
 
     if (!(event = create_submit_event (job)))
         goto error;
-    if (event_job_update (job, event) < 0)
+    if (event_job_update (job, event) < 0) /* NEW -> DEPEND */
+        goto error;
+    if (event_batch_pub_state (event_ctx, job) < 0)
         goto error;
     if (event_job_action (event_ctx, job) < 0)
         goto error;

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -73,13 +73,15 @@ const char *test_input[] = {
 
     /* 4 */
     "42.2 submit {\"userid\":66,\"priority\":16,\"flags\":42}\n"
-    "42.3 alloc\n",
+    "42.3 depend\n"
+    "42.4 alloc\n",
 
     /* 5 */
     "42.3 alloc\n",
 
     /* 6 */
     "42.2 submit {\"userid\":66,\"priority\":16,\"flags\":42}\n"
+    "42.3 depend\n"
     "42.3 alloc\n"
     "42.4 exception {\"type\":\"gasp\",\"severity\":0,\"userid\":42}\n"
     "42.5 free\n",
@@ -109,8 +111,8 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit) set priority from submit");
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit) set t_submit from submit");
-    ok (job->state == FLUX_JOB_SCHED,
-        "job_create_from_eventlog log=(submit) set state=SCHED");
+    ok (job->state == FLUX_JOB_DEPEND,
+        "job_create_from_eventlog log=(submit) set state=DEPEND");
     job_decref (job);
 
     /* 1 - submit + priority */
@@ -129,8 +131,8 @@ void test_create_from_eventlog (void)
         && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+pri) set no internal flags");
-    ok (job->state == FLUX_JOB_SCHED,
-        "job_create_from_eventlog log=(submit+pri) set state=SCHED");
+    ok (job->state == FLUX_JOB_DEPEND,
+        "job_create_from_eventlog log=(submit+pri) set state=DEPEND");
     job_decref (job);
 
     /* 2 - submit + exception severity 0 */
@@ -155,24 +157,24 @@ void test_create_from_eventlog (void)
     job = job_create_from_eventlog (3, test_input[3]);
     if (job == NULL)
         BAIL_OUT ("job_create_from_eventlog log=(submit+ex1) failed");
-    ok (job->state == FLUX_JOB_SCHED,
-        "job_create_from_eventlog log=(submit+ex1) set state=SCHED");
+    ok (job->state == FLUX_JOB_DEPEND,
+        "job_create_from_eventlog log=(submit+ex1) set state=DEPEND");
     ok (!job->alloc_pending
         && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+ex1) set no internal flags");
     job_decref (job);
 
-    /* 4 - submit + alloc */
+    /* 4 - submit + depend + alloc */
     job = job_create_from_eventlog (3, test_input[4]);
     if (job == NULL)
-        BAIL_OUT ("job_create_from_eventlog log=(submit+alloc) failed");
+        BAIL_OUT ("job_create_from_eventlog log=(submit+depend+alloc) failed");
     ok (!job->alloc_pending
         && !job->free_pending
         && job->has_resources,
-        "job_create_from_eventlog log=(submit+alloc) set has_resources flag");
+        "job_create_from_eventlog log=(submit+depend+alloc) set has_resources flag");
     ok (job->state == FLUX_JOB_RUN,
-        "job_create_from_eventlog log=(submit+alloc) set state=RUN");
+        "job_create_from_eventlog log=(submit+depend+alloc) set state=RUN");
     job_decref (job);
 
     /* 5 - missing submit */
@@ -181,16 +183,16 @@ void test_create_from_eventlog (void)
     ok (job == NULL && errno == EINVAL,
         "job_create_from_eventlog log=(alloc) fails with EINVAL");
 
-    /* 6 - submit + alloc + ex0 + free */
+    /* 6 - submit + depend + alloc + ex0 + free */
     job = job_create_from_eventlog (3, test_input[6]);
     if (job == NULL)
-        BAIL_OUT ("job_create_from_eventlog log=(submit+alloc+ex0+free) failed");
+        BAIL_OUT ("job_create_from_eventlog log=(submit+depend+alloc+ex0+free) failed");
     ok (!job->alloc_pending
         && !job->free_pending
         && !job->has_resources,
-        "job_create_from_eventlog log=(submit+alloc+ex0+free) set no internal flags");
+        "job_create_from_eventlog log=(submit+depend+alloc+ex0+free) set no internal flags");
     ok (job->state == FLUX_JOB_CLEANUP,
-        "job_create_from_eventlog log=(submit+alloc+ex0+free) set state=CLEANUP");
+        "job_create_from_eventlog log=(submit+depend+alloc+ex0+free) set state=CLEANUP");
     job_decref (job);
 
 }

--- a/src/test/sched-bench.sh
+++ b/src/test/sched-bench.sh
@@ -64,7 +64,7 @@ log "broker.pid=$(flux getattr broker.pid)\n"
 flux module remove sched-simple
 flux kvs put --json \
     resource.hwloc.by_rank="{\"[1-$NNODES]\":{\"Core\":$CPN}}"
-flux jobspec srun hostname | jq '.attributes.system.duration = ".0001s"' > job.json
+flux jobspec srun hostname | jq '.attributes.system.duration = .0001' > job.json
 flux module load sched-simple
 
 #  If not testing exec system, remove the job-exec module

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -91,6 +91,7 @@ TESTSCRIPTS = \
 	t2203-job-manager-dummysched.t \
 	t2204-job-info.t \
 	t2205-job-info-security.t \
+	t2206-job-manager-bulk-state.t \
 	t2300-sched-simple.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
@@ -161,7 +162,8 @@ dist_check_SCRIPTS = \
 	kvs/kvs-helper.sh \
 	job-manager/exec-service.lua \
 	job-manager/drain-cancel.py \
-	job-manager/drain-undrain.py
+	job-manager/drain-undrain.py \
+	job-manager/bulk-state.py
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/job-manager/bulk-state.py
+++ b/t/job-manager/bulk-state.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: bulk-state.py njobs
+#
+# Submit njobs jobs while watching job state notification events.
+# Ensure that each job progresses through an expected set of states,
+# in order.
+#
+
+import flux
+from flux import job
+import sys
+import subprocess
+
+expected_states = ["NEW", "DEPEND", "SCHED", "RUN", "CLEANUP", "INACTIVE"]
+
+# Return jobspec for a simple job
+def make_jobspec():
+    out = subprocess.Popen(
+        ["flux", "jobspec", "srun", "hostname"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    stdout, stderr = out.communicate()
+    return stdout
+
+
+# Return True if all jobs in the jobs dictionary have reached 'INACTIVE' state
+def all_inactive(jobs):
+    for jobid in jobs:
+        states = jobs[jobid]
+        if states[-1] != "INACTIVE":
+            return False
+    return True
+
+
+# For each job mentioned in a job-state event message, append a
+# new state to its entry in the jobs dictionary.
+# Ignore state notifications for jobs that are not already in the dict
+def parse_notification(jobs, msg):
+    for entry in msg.payload["transitions"]:
+        jobid = entry[0]
+        state = entry[1]
+        if jobid in jobs:
+            jobs[jobid].append(state)
+
+
+if len(sys.argv) != 2:
+    njobs = 10
+else:
+    njobs = int(sys.argv[1])
+
+# Open connection to broker and subscribe to state notifications
+h = flux.Flux()
+h.event_subscribe("job-state")
+
+# Submit several test jobs, building dictionary by jobid,
+# where each entry contains a list of job states
+# N.B. no notification is provided for the NEW state
+jobspec = make_jobspec()
+jobs = {}
+for i in range(njobs):
+    jobid = job.submit(h, jobspec)
+    jobs[jobid] = ["NEW"]
+
+# Process events until all jobs have reached INACTIVE state.
+while not all_inactive(jobs):
+    event = h.event_recv()
+    parse_notification(jobs, event)
+
+# Verify that each job advanced through the expected set of states, in order
+for jobid in jobs:
+    if cmp(jobs[jobid], expected_states) != 0:
+        print("{}: {}: {}".format("bad state list", jobid, jobs[jobid]))
+        sys.exit(1)
+
+# Unsubscribe to state notifications and close connection to broker.
+h.event_unsubscribe("job-state")
+h.close()
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/t2206-job-manager-bulk-state.t
+++ b/t/t2206-job-manager-bulk-state.t
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+test_description='Test flux job manager state notification'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+flux setattr log-stderr-level 1
+
+BULK_STATE=${FLUX_SOURCE_DIR}/t/job-manager/bulk-state.py
+
+test_expect_success 'job-manager: all state events received (5 jobs from rank 0)' '
+	run_timeout 10 ${BULK_STATE} 5
+'
+
+test_expect_success 'job-manager: all state events received (2 jobs from 4 ranks)' '
+	run_timeout 10 flux exec -r all ${BULK_STATE} 2
+'
+
+test_done


### PR DESCRIPTION
As discussed in #2094, this PR adds a simple notification mechanism for bulk job state transitions based on published event messages.  This is just the job-manager end.  The events could be consumed by subscribing to `job-state` and interpreting each message (see below).  I would expect the simulator front end to be the first customer of this feature.

Eventually we may want to put a nicer interface in front of this, but I think that could be a separate PR and will require some more design (and maybe some experience using the raw event interface first?)

Each job state transition is represented as a [jobid,state] tuple, and is batched up in array form for publication after the event that triggered the state transition has landed in the KVS.  Each published message can included state transitions for multiple jobs, and multiple transitions per job.  Here's a little  snippet of `flux event sub job-state` while running `sched-bench.sh`:

```
job-state	{"transitions":[[612267720704,"D"],[612267720704,"S"],[612267720704,"R"],[612267720704,"C"],[612267720704,"I"]]}
job-state	{"transitions":[[677380096000,"D"],[677380096000,"S"],[677380096000,"R"],[677380096000,"C"],[677380096000,"I"]]}
job-state	{"transitions":[[1566656430080,"D"],[1566656430080,"S"],[1566572544000,"D"],[1566572544000,"S"],[1566572544000,"R"],[1566656430080,"R"],[1566572544000,"C"]]}
job-state	{"transitions":[[1566656430080,"C"],[1566840979456,"D"],[1566840979456,"S"],[1566757093376,"D"],[1566757093376,"S"],[1566757093376,"R"],[1567008751616,"D"],[1567008751616,"S"],[1566924865536,"D"],[1566924865536,"S"]]}
job-state	{"transitions":[[1566572544000,"I"],[1566840979456,"R"],[1566757093376,"C"],[1566656430080,"I"],[1566924865536,"R"]]}
```

I went with this form rather than a possibly more compact one (such as state => id array in an object) so that the order of _all_ the transitions is preserved, in case that ends up being important.

Along the way I added the DEPEND state (which immediately triggers a `depend` event, which causes a transition to SCHED state), and updated tests accordingly.  @chu11: I reworked that code in `t2205-job-info-security.t` for editing the eventlog in the KVS since what was there did not seem to be working after I added the `depend` event - let me know if those changes look OK to you (see  bfcfde2)

I still need to add a test that subscribes to these events and ensures all the state transitions are published for a group of jobs, but wanted to get this posted for early review.