### PR TITLE
job-info: Allow reading more than eventlog

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -708,7 +708,7 @@ void eventlog_continuation (flux_future_t *f, void *arg)
     const char *s;
     const char *event;
 
-    if (flux_job_eventlog_lookup_get (f, &s) < 0) {
+    if (flux_rpc_get_unpack (f, "{s:s}", "eventlog", &s) < 0) {
         if (errno == ENOENT) {
             flux_future_destroy (f);
             log_msg_exit ("job %lu not found", ctx->id);
@@ -731,6 +731,7 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
     flux_t *h;
     int optindex = optparse_option_index (p);
     flux_future_t *f;
+    const char *topic = "job-info.lookup";
     struct eventlog_ctx ctx = {0};
 
     if (!(h = flux_open (NULL, 0)))
@@ -751,8 +752,12 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
         && strcasecmp (ctx.format, "json"))
         log_msg_exit ("invalid context-format type");
 
-    if (!(f = flux_job_eventlog_lookup (h, ctx.id)))
-        log_err_exit ("flux_job_eventlog_lookup");
+    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
+                             "{s:I s:s s:i}",
+                             "id", ctx.id,
+                             "key", "eventlog",
+                             "flags", 0)))
+        log_err_exit ("flux_rpc_pack");
     if (flux_future_then (f, -1., eventlog_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -229,35 +229,6 @@ int flux_job_kvs_key (char *buf, int bufsz, bool active,
     return len;
 }
 
-flux_future_t *flux_job_eventlog_lookup (flux_t *h, flux_jobid_t id)
-{
-    flux_future_t *f;
-    const char *topic = "job-info.lookup";
-
-    if (!h) {
-        errno = EINVAL;
-        return NULL;
-    }
-    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
-                             "{s:I s:s s:i}",
-                             "id", id,
-                             "key", "eventlog",
-                             "flags", 0)))
-        return NULL;
-    return f;
-}
-
-int flux_job_eventlog_lookup_get (flux_future_t *f, const char **event)
-{
-    const char *s;
-
-    if (flux_rpc_get_unpack (f, "{s:s}", "eventlog", &s) < 0)
-        return -1;
-    if (event)
-        *event = s;
-    return 0;
-}
-
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id)
 {
     flux_future_t *f;

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -100,11 +100,8 @@ flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority);
 int flux_job_kvs_key (char *buf, int bufsz, bool active,
                       flux_jobid_t id, const char *key);
 
-/* Job eventlog lookup functions
+/* Job eventlog watch functions
  */
-flux_future_t *flux_job_eventlog_lookup (flux_t *h, flux_jobid_t id);
-int flux_job_eventlog_lookup_get (flux_future_t *f, const char **event);
-
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id);
 int flux_job_event_watch_get (flux_future_t *f, const char **event);
 int flux_job_event_watch_cancel (flux_future_t *f);

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -138,17 +138,7 @@ void check_corner_case (void)
         && errno == EINVAL,
         "flux_job_kvs_key fails with errno == EINVAL");
 
-    /* flux_job_eventlog_lookup */
-
-    errno = EINVAL;
-    ok (!flux_job_eventlog_lookup (NULL, 0)
-        && errno == EINVAL,
-        "flux_job_eventlog_lookup fails with EINVAL on bad input");
-
-    errno = EINVAL;
-    ok (flux_job_eventlog_lookup_get (NULL, NULL) < 0
-        && errno == EINVAL,
-        "flux_job_eventlog_lookup_get fails with EINVAL on bad input");
+    /* flux_job_eventlog_watch */
 
     errno = EINVAL;
     ok (!flux_job_event_watch (NULL, 0)

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -157,6 +157,7 @@ void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
     struct lookup_ctx *l = NULL;
     const char *key;
     flux_jobid_t id;
+    uint32_t rolemask;
     int flags;
 
     if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
@@ -169,6 +170,13 @@ void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (!(l = lookup_ctx_create (ctx, msg, id, key, flags)))
         goto error;
+
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+        goto error;
+
+    /* if rpc from owner, no need to do guest access check */
+    if ((rolemask & FLUX_ROLE_OWNER))
+        l->allow = true;
 
     if (lookup_key (l, l->key, lookup_continuation) < 0)
         goto error;

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -106,7 +106,46 @@ static int lookup_key (struct lookup_ctx *l, const char *key,
     return 0;
 }
 
-static void lookup_continuation (flux_future_t *f, void *arg)
+static void info_lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct lookup_ctx *l = arg;
+    struct info_ctx *ctx = l->ctx;
+    const char *s;
+
+    /* must be done beforehand */
+    assert (l->allow);
+
+    if (flux_kvs_lookup_get (f, &s) < 0) {
+        if (errno == ENOENT && l->active) {
+            /* transition / try the inactive key */
+            l->active = false;
+            if (lookup_key (l, l->key, info_lookup_continuation) < 0)
+                goto error;
+            return;
+        }
+        else if (errno != ENOENT)
+            flux_log_error (ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_respond_pack (ctx->h, l->msg, "{s:s}", l->key, s) < 0) {
+        flux_log_error (ctx->h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
+
+    goto done;
+
+error:
+    if (flux_respond_error (ctx->h, l->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+
+done:
+    /* flux future destroyed in lookup_ctx_destroy, which is called
+     * via zlist_remove() */
+    zlist_remove (ctx->lookups, l);
+}
+
+static void eventlog_lookup_continuation (flux_future_t *f, void *arg)
 {
     struct lookup_ctx *l = arg;
     struct info_ctx *ctx = l->ctx;
@@ -116,7 +155,8 @@ static void lookup_continuation (flux_future_t *f, void *arg)
         if (errno == ENOENT && l->active) {
             /* transition / try the inactive key */
             l->active = false;
-            if (lookup_key (l, l->key, lookup_continuation) < 0)
+            if (lookup_key (l, "eventlog",
+                            eventlog_lookup_continuation) < 0)
                 goto error;
             return;
         }
@@ -131,20 +171,28 @@ static void lookup_continuation (flux_future_t *f, void *arg)
         l->allow = true;
     }
 
-    if (flux_respond_pack (ctx->h, l->msg, "{s:s}", l->key, s) < 0) {
-        flux_log_error (ctx->h, "%s: flux_respond_pack", __FUNCTION__);
-        goto error;
+    /* if user requested eventlog, we can return this data, no need to
+     * go through the "info" request path.
+     */
+    if (!strcmp (l->key, "eventlog")) {
+        if (flux_respond_pack (ctx->h, l->msg, "{s:s}", l->key, s) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond_pack", __FUNCTION__);
+            goto error;
+        }
+
+        goto done;
+    }
+    else {
+        if (lookup_key (l, l->key, info_lookup_continuation) < 0)
+            goto error;
     }
 
-    /* flux future destroyed in lookup_ctx_destroy, which is called
-     * via zlist_remove() */
-    zlist_remove (ctx->lookups, l);
     return;
 
 error:
     if (flux_respond_error (ctx->h, l->msg, errno, NULL) < 0)
         flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
-
+done:
     /* flux future destroyed in lookup_ctx_destroy, which is called
      * via zlist_remove() */
     zlist_remove (ctx->lookups, l);
@@ -178,8 +226,16 @@ void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
     if ((rolemask & FLUX_ROLE_OWNER))
         l->allow = true;
 
-    if (lookup_key (l, l->key, lookup_continuation) < 0)
-        goto error;
+    if (l->allow) {
+        if (lookup_key (l, l->key, info_lookup_continuation) < 0)
+            goto error;
+    }
+    else {
+        /* must lookup eventlog first to do access check */
+        if (lookup_key (l, "eventlog",
+                        eventlog_lookup_continuation) < 0)
+            goto error;
+    }
 
     if (zlist_append (ctx->lookups, l) < 0) {
         flux_log_error (h, "%s: zlist_append", __FUNCTION__);

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -229,6 +229,48 @@ test_expect_success 'flux job wait-event hangs on no event' '
         ! run_timeout 0.2 flux job wait-event $jobid foobar
 '
 
+#
+# job info tests
+#
+
+test_expect_success 'flux job info eventlog works (active)' '
+        jobid=$(submit_job) &&
+	flux job info $jobid eventlog > eventlog_info_a.out &&
+        grep submit eventlog_info_a.out
+'
+
+test_expect_success 'flux job info eventlog works (inactive)' '
+        jobid=$(submit_job) &&
+        move_inactive $jobid &&
+	flux job info $jobid eventlog > eventlog_info_b.out &&
+        grep submit eventlog_info_b.out
+'
+
+test_expect_success 'flux job info eventlog fails on bad id' '
+	! flux job info 12345 eventlog
+'
+
+test_expect_success 'flux job info jobspec works (active)' '
+        jobid=$(submit_job) &&
+	flux job info $jobid jobspec > jobspec_a.out &&
+        grep hostname jobspec_a.out
+'
+
+test_expect_success 'flux job info jobspec works (inactive)' '
+        jobid=$(submit_job) &&
+        move_inactive $jobid &&
+	flux job info $jobid jobspec > jobspec_b.out &&
+        grep hostname jobspec_b.out
+'
+
+test_expect_success 'flux job info jobspec fails on bad id' '
+	! flux job info 12345 jobspec
+'
+
+#
+# stats
+#
+
 test_expect_success 'job-info stats works' '
         flux module stats job-info | grep "lookups" &&
         flux module stats job-info | grep "watchers"

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -158,4 +158,109 @@ test_expect_success 'flux job wait-event fails (wrong user, inactive)' '
         unset_userid
 '
 
+#
+# job info
+#
+
+test_expect_success 'flux job info eventlog works (owner)' '
+        jobid=$(submit_job) &&
+        flux job info $jobid eventlog
+'
+
+test_expect_success 'flux job info eventlog works (user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9000 &&
+        flux job info $jobid eventlog &&
+        unset_userid
+'
+
+test_expect_success 'flux job info eventlog fails (wrong user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9999 &&
+        ! flux job info $jobid eventlog &&
+        unset_userid
+'
+
+test_expect_success 'flux job info eventlog works (owner, inactive)' '
+        jobid=$(submit_job) &&
+        move_inactive $jobid &&
+        flux job info $jobid eventlog
+'
+
+test_expect_success 'flux job info eventlog works (user, inactive)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9000 &&
+        flux job info $jobid eventlog &&
+        unset_userid
+'
+
+test_expect_success 'flux job info eventlog fails (wrong user, inactive)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9999 &&
+        ! flux job info $jobid eventlog &&
+        unset_userid
+'
+
+test_expect_success 'flux job info jobspec works (owner)' '
+        jobid=$(submit_job) &&
+        flux job info $jobid jobspec
+'
+
+test_expect_success 'flux job info jobspec works (user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9000 &&
+        flux job info $jobid jobspec &&
+        unset_userid
+'
+
+test_expect_success 'flux job info jobspec fails (wrong user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9999 &&
+        ! flux job info $jobid jobspec &&
+        unset_userid
+'
+
+test_expect_success 'flux job info jobspec works (owner, inactive)' '
+        jobid=$(submit_job) &&
+        move_inactive $jobid &&
+        flux job info $jobid jobspec
+'
+
+test_expect_success 'flux job info jobspec works (user, inactive)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9000 &&
+        flux job info $jobid jobspec &&
+        unset_userid
+'
+
+test_expect_success 'flux job info jobspec fails (wrong user, inactive)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9999 &&
+        ! flux job info $jobid jobspec &&
+        unset_userid
+'
+
+test_expect_success 'flux job info foobar fails (owner)' '
+        jobid=$(submit_job) &&
+        ! flux job info $jobid foobar
+'
+
+test_expect_success 'flux job info foobar fails (user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9000 &&
+        ! flux job info $jobid foobar &&
+        unset_userid
+'
+
+test_expect_success 'flux job info foobar fails (wrong user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9999 &&
+        ! flux job info $jobid foobar &&
+        unset_userid
+'
+
 test_done


### PR DESCRIPTION
part 2 peeled off from #2107.  This supports reading more than just the eventlog via the `job-info` module.  The bulk read isn't in this PR.  This adds the `flux job info` command.  There some extra cleanup in this PR at the end.