### PR TITLE
job-info: read job data in bulk

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -189,7 +189,7 @@ static struct optparse_subcommand subcommands[] = {
       wait_event_opts
     },
     { "info",
-      "id key",
+      "id key ...",
       "Display info for a job",
       cmd_info,
       0,
@@ -862,20 +862,18 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
 }
 
 struct info_ctx {
-    optparse_t *p;
     flux_jobid_t id;
-    const char *key;
+    json_t *keys;
 };
 
-void info_continuation (flux_future_t *f, void *arg)
+void info_output (flux_future_t *f, const char *suffix, flux_jobid_t id)
 {
-    struct info_ctx *ctx = arg;
     const char *s;
 
-    if (flux_rpc_get_unpack (f, "{s:s}", ctx->key, &s) < 0) {
+    if (flux_rpc_get_unpack (f, "{s:s}", suffix, &s) < 0) {
         if (errno == ENOENT) {
             flux_future_destroy (f);
-            log_msg_exit ("job %lu.%s not found", ctx->id, ctx->key);
+            log_msg_exit ("job %lu id or key not found", id);
         }
         else
             log_err_exit ("flux_rpc_get_unpack");
@@ -883,6 +881,19 @@ void info_continuation (flux_future_t *f, void *arg)
 
     /* XXX - prettier output later */
     printf ("%s\n", s);
+}
+
+void info_continuation (flux_future_t *f, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    size_t index;
+    json_t *key;
+
+    json_array_foreach (ctx->keys, index, key) {
+        const char *s = json_string_value (key);
+        info_output (f, s, ctx->id);
+    }
+
     flux_future_destroy (f);
 }
 
@@ -897,19 +908,29 @@ int cmd_info (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (argc - optindex != 2) {
+    if ((argc - optindex) < 2) {
         optparse_print_usage (p);
         exit (1);
     }
 
     ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
-    ctx.key = argv[optindex++];
-    ctx.p = p;
+
+    if (!(ctx.keys = json_array ()))
+        log_msg_exit ("json_array");
+
+    while (optindex < argc) {
+        json_t *s;
+        if (!(s = json_string (argv[optindex])))
+            log_msg_exit ("json_string");
+        if (json_array_append_new (ctx.keys, s) < 0)
+            log_msg_exit ("json_array_append");
+        optindex++;
+    }
 
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
-                             "{s:I s:[s] s:i}",
+                             "{s:I s:O s:i}",
                              "id", ctx.id,
-                             "keys", ctx.key,
+                             "keys", ctx.keys,
                              "flags", 0)))
         log_err_exit ("flux_rpc_pack");
     if (flux_future_then (f, -1., info_continuation, &ctx) < 0)
@@ -917,6 +938,7 @@ int cmd_info (optparse_t *p, int argc, char **argv)
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
         log_err_exit ("flux_reactor_run");
 
+    json_decref (ctx.keys);
     flux_close (h);
     return (0);
 }

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -753,9 +753,9 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
         log_msg_exit ("invalid context-format type");
 
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
-                             "{s:I s:s s:i}",
+                             "{s:I s:[s] s:i}",
                              "id", ctx.id,
-                             "key", "eventlog",
+                             "keys", "eventlog",
                              "flags", 0)))
         log_err_exit ("flux_rpc_pack");
     if (flux_future_then (f, -1., eventlog_continuation, &ctx) < 0)
@@ -893,7 +893,6 @@ int cmd_info (optparse_t *p, int argc, char **argv)
     flux_future_t *f;
     const char *topic = "job-info.lookup";
     struct info_ctx ctx = {0};
-    int flags = 0;
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
@@ -908,10 +907,10 @@ int cmd_info (optparse_t *p, int argc, char **argv)
     ctx.p = p;
 
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
-                             "{s:I s:s s:i}",
+                             "{s:I s:[s] s:i}",
                              "id", ctx.id,
-                             "key", ctx.key,
-                             "flags", flags)))
+                             "keys", ctx.key,
+                             "flags", 0)))
         log_err_exit ("flux_rpc_pack");
     if (flux_future_then (f, -1., info_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -140,17 +140,17 @@ void check_corner_case (void)
 
     /* flux_job_eventlog_watch */
 
-    errno = EINVAL;
+    errno = 0;
     ok (!flux_job_event_watch (NULL, 0)
         && errno == EINVAL,
         "flux_job_event_watch fails with EINVAL on bad input");
 
-    errno = EINVAL;
+    errno = 0;
     ok (flux_job_event_watch_get (NULL, NULL) < 0
         && errno == EINVAL,
         "flux_job_event_watch_get fails with EINVAL on bad input");
 
-    errno = EINVAL;
+    errno = 0;
     ok (flux_job_event_watch_cancel (NULL) < 0
         && errno == EINVAL,
         "flux_job_event_watch_cancel fails with EINVAL on bad input");

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -268,6 +268,43 @@ test_expect_success 'flux job info jobspec fails on bad id' '
 '
 
 #
+# job info tests (multiple info requests)
+#
+
+test_expect_success 'flux job info multiple keys works (active)' '
+        jobid=$(flux job submit test.json) &&
+	flux job info $jobid eventlog jobspec J > all_info_a.out &&
+        grep submit all_info_a.out &&
+        grep hostname all_info_a.out
+'
+
+test_expect_success 'flux job info multiple keys works (inactive)' '
+        jobid=$(flux job submit test.json) &&
+        move_inactive $jobid &&
+	flux job info $jobid eventlog jobspec J > all_info_b.out &&
+        grep submit all_info_b.out &&
+        grep hostname all_info_a.out
+'
+
+test_expect_success 'flux job info multiple keys fails on bad id' '
+	! flux job info 12345 eventlog jobspec J
+'
+
+test_expect_success 'flux job info multiple keys fails on 1 bad entry (include eventlog)' '
+        jobid=$(flux job submit test.json) &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        flux kvs unlink ${activekvsdir}.jobspec &&
+	! flux job info $jobid eventlog jobspec J > all_info_b.out
+'
+
+test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventlog)' '
+        jobid=$(flux job submit test.json) &&
+        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        flux kvs unlink ${activekvsdir}.jobspec &&
+	! flux job info $jobid jobspec J > all_info_b.out
+'
+
+#
 # stats
 #
 

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -244,6 +244,88 @@ test_expect_success 'flux job info jobspec fails (wrong user, inactive)' '
         unset_userid
 '
 
+test_expect_success 'flux job info multiple keys works (owner, include eventlog)' '
+        jobid=$(submit_job) &&
+        flux job info $jobid eventlog jobspec J
+'
+
+test_expect_success 'flux job info multiple keys works (user, include eventlog)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9000 &&
+        flux job info $jobid eventlog jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys fails (wrong user, include eventlog)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9999 &&
+        ! flux job info $jobid eventlog jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys works (owner, inactive, include eventlog)' '
+        jobid=$(submit_job) &&
+        move_inactive $jobid &&
+        flux job info $jobid eventlog jobspec J
+'
+
+test_expect_success 'flux job info multiple keys works (user, inactive, include eventlog)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9000 &&
+        flux job info $jobid eventlog jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys fails (wrong user, inactive, include eventlog)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9999 &&
+        ! flux job info $jobid jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys works (owner, no eventlog)' '
+        jobid=$(submit_job) &&
+        flux job info $jobid jobspec J
+'
+
+test_expect_success 'flux job info multiple keys works (user, no eventlog)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9000 &&
+        flux job info $jobid jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys fails (wrong user, no eventlog)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9999 &&
+        ! flux job info $jobid jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys works (owner, inactive, no eventlog)' '
+        jobid=$(submit_job) &&
+        move_inactive $jobid &&
+        flux job info $jobid jobspec J
+'
+
+test_expect_success 'flux job info multiple keys works (user, inactive, no eventlog)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9000 &&
+        flux job info $jobid jobspec J &&
+        unset_userid
+'
+
+test_expect_success 'flux job info multiple keys fails (wrong user, inactive, no eventlog)' '
+        jobid=$(submit_job 9000) &&
+        move_inactive $jobid &&
+        set_userid 9999 &&
+        ! flux job info $jobid jobspec J &&
+        unset_userid
+'
+
 test_expect_success 'flux job info foobar fails (owner)' '
         jobid=$(submit_job) &&
         ! flux job info $jobid foobar

--- a/t/valgrind/workload.d/job
+++ b/t/valgrind/workload.d/job
@@ -15,4 +15,7 @@ flux job wait-event ${id} start
 flux job cancel ${id}
 flux job wait-event ${id} clean
 
+# Test info fetch
+flux job info ${id} eventlog jobspec R
+
 flux job drain


### PR DESCRIPTION
This last PR from #2107 supports reading multiple information from a job in bulk via a single RPC.  It at first does two RPCs, a guest access check & then information retrieval.  Then later commits collapse both RPCs into a single composite RPC.

In addition, some cleanup in `libjob` tests.  Also added `job info` call to valgrind test.