### PR TITLE
libflux: change flux_respond(), flux_respond_error() plus misc fixes

### DIFF
--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -22,7 +22,7 @@ SYNOPSIS
                        int errnum, const void *data, int length);
 
  int flux_respond_error (flux_t *h, const flux_msg_t *request,
-                         int errnum, const char *fmt, ...);
+                         int errnum, const char *errmsg);
 
 DESCRIPTION
 -----------
@@ -44,10 +44,9 @@ building the payload using variable arguments with a format string in
 the style of jansson's `json_pack()` (used internally).
 
 `flux_respond_error()` returns an error response to the sender.
-_errnum_ must be non-zero.  If _fmt_ is non-NULL, an error string
-payload is included in the response, constructed using printf(3)-style
-arguments.  The error string may be used to provide a more
-detailed error message than can be conveyed via _errnum_.
+_errnum_ must be non-zero.  If _errmsg_ is non-NULL, an error string
+payload is included in the response.  The error string may be used to
+provide a more detailed error message than can be conveyed via _errnum_.
 
 include::JSON_PACK.adoc[]
 

--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -13,7 +13,7 @@ SYNOPSIS
  #include <flux/core.h>
 
  int flux_respond (flux_t *h, const flux_msg_t *request,
-                   int errnum, const char *s);
+                   const char *s);
 
  int flux_respond_pack (flux_t *h, const flux_msg_t *request,
                         const char *fmt, ...);
@@ -32,14 +32,12 @@ DESCRIPTION
 deriving topic string, matchtag, and route stack from the provided
 _request_.
 
-`flux_respond()` can operate in two modes.  If _errnum_ is non-zero,
-an error is returned to the sender such that `flux_rpc_get(3)` or
-variants will fail, with the system errno set to _errnum_.  Any payload
-arguments are ignored in this case.
+`flux_respond()` sends a response to _request_.  If _s_ is non-NULL,
+`flux_respond()` will send it as the response payload, otherwise there
+will be no payload.
 
-If _s_ is non-NULL, `flux_respond()` will send it as the response
-payload, otherwise there will be no payload.  Similarly, if _data_ is
-non-NULL, `flux_respond_raw()` will send it as the response payload.
+`flux_respond_raw()` is identical except if _data_ is non-NULL,
+`flux_respond_raw()` will send it as the response payload.
 
 `flux_respond_pack()` encodes a response message with a JSON payload,
 building the payload using variable arguments with a format string in

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -455,3 +455,4 @@ MATCHDEBUG
 Ctrl
 UNIQ
 startup
+errmsg

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -642,7 +642,7 @@ static int l_f_zi_resp_cb (lua_State *L,
     flux_t *f = arg;
     flux_msg_t **msgp = zmsg_info_zmsg (zi);
     int rc;
-    rc = flux_respond (f, *msgp, 0, json_str);
+    rc = flux_respond (f, *msgp, json_str);
     return l_pushresult (L, rc);
 }
 

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -325,7 +325,7 @@ void getattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
         FLUX_LOG_ERROR (h);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         FLUX_LOG_ERROR (h);
 }
 
@@ -345,7 +345,7 @@ void setattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
         if (attr_add (attrs, name, val, 0) < 0)
             goto error;
     }
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
@@ -363,7 +363,7 @@ void rmattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if (attr_delete (attrs, name, false) < 0)
         goto error;
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
@@ -402,7 +402,7 @@ void lsattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
     json_decref (names);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         FLUX_LOG_ERROR (h);
     json_decref (names);
 }

--- a/src/broker/heaptrace.c
+++ b/src/broker/heaptrace.c
@@ -43,11 +43,11 @@ static void start_cb (flux_t *h, flux_msg_handler_t *mh,
     errno = ENOSYS;
     goto error;
 #endif
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         FLUX_LOG_ERROR (h);
 }
 
@@ -68,11 +68,11 @@ static void dump_cb (flux_t *h, flux_msg_handler_t *mh,
     errno = ENOSYS;
     goto error;
 #endif
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         FLUX_LOG_ERROR (h);
 }
 
@@ -91,11 +91,11 @@ static void stop_cb (flux_t *h, flux_msg_handler_t *mh,
     errno = ENOSYS;
     goto error;
 #endif /* WITH_TCMALLOC */
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         FLUX_LOG_ERROR (h);
 }
 

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -570,10 +570,9 @@ static void dmesg_request_cb (flux_t *h, flux_msg_handler_t *mh,
         }
         goto error;
     }
-    if (flux_respond_pack (h, msg, "{ s:i s:s# }",
-                                   "seq", seq,
-                                   "buf", buf, len) < 0)
-        goto error;
+    flux_respond_pack (h, msg, "{ s:i s:s# }",
+                               "seq", seq,
+                               "buf", buf, len);
     return;
 
 error:

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -524,13 +524,13 @@ static void append_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (logbuf_append (logbuf, buf, len) < 0)
         goto error;
     if (matchtag != FLUX_MATCHTAG_NONE) {
-        if (flux_respond (h, msg, 0, NULL) < 0)
+        if (flux_respond (h, msg, NULL) < 0)
             log_err ("%s: error responding to log request", __FUNCTION__);
     }
     return;
 error:
     if (matchtag != FLUX_MATCHTAG_NONE) {
-        if (flux_respond (h, msg, errno, NULL) < 0)
+        if (flux_respond_error (h, msg, errno, NULL) < 0)
             log_err ("%s: error responding to log request", __FUNCTION__);
     }
 }
@@ -540,14 +540,14 @@ static void clear_request_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     logbuf_t *logbuf = arg;
     int seq;
-    int rc = -1;
 
     if (flux_request_unpack (msg, NULL, "{ s:i }", "seq", &seq) < 0)
-        goto done;
+        goto error;
     logbuf_clear (logbuf, seq);
-    rc = 0;
-done:
-    flux_respond (h, msg, rc < 0 ? errno : 0, NULL);
+    flux_respond (h, msg, NULL);
+    return;
+error:
+    flux_respond_error (h, msg, errno, NULL);
 }
 
 static void dmesg_request_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -577,7 +577,7 @@ static void dmesg_request_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 
 error:
-    flux_respond (h, msg, errno, NULL);
+    flux_respond_error (h, msg, errno, NULL);
 }
 
 static int cmp_sender (flux_msg_t *msg, const char *uuid)

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -101,7 +101,7 @@ static void stats_clear_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                     const flux_msg_t *msg, void *arg)
 {
     flux_clr_msgcounters (h);
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         FLUX_LOG_ERROR (h);
 }
 
@@ -144,8 +144,8 @@ static void debug_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
 /* Reactor loop is about to block.

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -154,7 +154,7 @@ static void *module_thread (void *arg)
         const char *topic = "unknown";
         (void)flux_msg_get_topic (msg, &topic);
         flux_log (p->h, LOG_DEBUG, "responding to post-shutdown %s", topic);
-        if (flux_respond (p->h, msg, ENOSYS, NULL) < 0)
+        if (flux_respond_error (p->h, msg, ENOSYS, NULL) < 0)
             flux_log_error (p->h, "responding to post-shutdown %s", topic);
         flux_msg_destroy (msg);
     }

--- a/src/broker/ping.c
+++ b/src/broker/ping.c
@@ -78,15 +78,15 @@ static void ping_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                                  userid, rolemask))) {
         goto error;
     }
-    if (flux_respond (h, msg, 0, resp_str) < 0)
+    if (flux_respond (h, msg, resp_str) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     free (route_str);
     free (full_route_str);
     free (resp_str);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     free (route_str);
     free (full_route_str);
     free (resp_str);

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -164,8 +164,8 @@ void pub_cb (flux_t *h, flux_msg_handler_t *mh,
 error_restore_seq:
     pub->seq--;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     flux_msg_destroy (event);
 }
 

--- a/src/broker/rusage.c
+++ b/src/broker/rusage.c
@@ -49,7 +49,7 @@ static void rusage_request_cb (flux_t *h, flux_msg_handler_t *mh,
             "nsignals", ru.ru_nsignals,
             "nvcsw", ru.ru_nvcsw,
             "nivcsw", ru.ru_nivcsw) < 0)
-        goto error;
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)

--- a/src/broker/rusage.c
+++ b/src/broker/rusage.c
@@ -52,8 +52,8 @@ static void rusage_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
 static void rusage_finalize (void *arg)

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -547,11 +547,7 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
     if (!(f = flux_job_submit (h, J ? J : jobspec, priority, flags)))
         log_err_exit ("flux_job_submit");
     if (flux_job_submit_get_id (f, &id) < 0) {
-        if (errno == ENOSYS)
-            log_msg_exit ("submit: job-ingest module is not loaded");
-        else
-            log_msg_exit ("%llu: %s", (unsigned long long)id,
-                          flux_future_error_string (f));
+        log_msg_exit ("%s", flux_future_error_string (f));
     }
     printf ("%llu\n", (unsigned long long)id);
     flux_future_destroy (f);

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -208,7 +208,7 @@ static void call_handler (flux_msg_handler_t *mh, const flux_msg_t *msg)
         if (flux_msg_cmp (msg, FLUX_MATCH_REQUEST)
                         && flux_msg_get_matchtag (msg, &matchtag) == 0
                         && matchtag != FLUX_MATCHTAG_NONE) {
-            (void)flux_respond (mh->d->h, msg, EPERM, NULL);
+            (void)flux_respond_error (mh->d->h, msg, EPERM, NULL);
         }
         return;
     }
@@ -335,7 +335,7 @@ static void handle_cb (flux_reactor_t *r,
         else {
             switch (type) {
                 case FLUX_MSGTYPE_REQUEST:
-                    if (flux_respond (d->h, msg, ENOSYS, NULL))
+                    if (flux_respond_error (d->h, msg, ENOSYS, NULL))
                         goto done;
                     break;
                 case FLUX_MSGTYPE_EVENT:

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -288,7 +288,7 @@ error:
 }
 
 int flux_respond_error (flux_t *h, const flux_msg_t *request,
-                        int errnum, const char *fmt, ...)
+                        int errnum, const char *errstr)
 {
     flux_msg_t *msg = derive_response (h, request, errnum);
     if (!msg)
@@ -297,12 +297,7 @@ int flux_respond_error (flux_t *h, const flux_msg_t *request,
         errno = EINVAL;
         goto error;
     }
-    if (fmt) {
-        va_list ap;
-        char errstr[1024];
-        va_start (ap, fmt);
-        (void)vsnprintf (errstr, sizeof (errstr), fmt, ap);
-        va_end (ap);
+    if (errstr) {
         if (flux_msg_set_string (msg, errstr) < 0)
             goto error;
     }

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -224,13 +224,12 @@ error:
     return NULL;
 }
 
-int flux_respond (flux_t *h, const flux_msg_t *request,
-                  int errnum, const char *s)
+int flux_respond (flux_t *h, const flux_msg_t *request, const char *s)
 {
-    flux_msg_t *msg = derive_response (h, request, errnum);
+    flux_msg_t *msg = derive_response (h, request, 0);
     if (!msg)
         goto error;
-    if (!errnum && s && flux_msg_set_string (msg, s) < 0)
+    if (s && flux_msg_set_string (msg, s) < 0)
         goto error;
     if (flux_send (h, msg, 0) < 0)
         goto error;

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -64,10 +64,8 @@ flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
 
 /* Create a response to the provided request message with optional
  * string payload.
- * If errnum is nonzero, payload argument is ignored.
  */
-int flux_respond (flux_t *h, const flux_msg_t *request,
-                  int errnum, const char *s);
+int flux_respond (flux_t *h, const flux_msg_t *request, const char *s);
 
 /* Create a response to the provided request message with json payload, using
  * jansson pack style variable arguments for encoding the JSON object

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -83,11 +83,10 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       const void *data, int len);
 
 /* Create an error response to the provided request message with optional
- * printf-style error string payload if 'fmt' is non-NULL.
+ * error string payload (if errstr is non-NULL).
  */
 int flux_respond_error (flux_t *h, const flux_msg_t *request,
-                        int errnum, const char *fmt, ...)
-                        __attribute__ ((format (printf, 4, 5)));
+                        int errnum, const char *errstr);
 
 
 #ifdef __cplusplus

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -92,7 +92,7 @@ void set_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     diag ("attr.set: %s=%s", name, value);
     zhashx_update (attrs, name, (char *)value);
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         BAIL_OUT ("flux_respond failed");
     return;
 error:
@@ -117,7 +117,7 @@ void rm_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     diag ("attr.rm: %s", name);
     zhashx_delete (attrs, name);
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         BAIL_OUT ("flux_respond failed");
     return;
 error:

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -83,7 +83,7 @@ void rpctest_echo_error_cb (flux_t *h, flux_msg_handler_t *mh,
                              "errnum", &errnum, "errstr", &errstr) < 0)
         goto error;
     if (errstr) {
-        if (flux_respond_error (h, msg, errnum, "Error: %s", errstr) < 0)
+        if (flux_respond_error (h, msg, errnum, errstr) < 0)
             BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
     }
     else {
@@ -350,7 +350,7 @@ void test_error (flux_t *h)
     ok (flux_rpc_get (f, NULL) < 0 && errno == 69,
         "flux_rpc_get failed with expected errno");
     errstr = flux_future_error_string (f);
-    ok (errstr != NULL && !strcmp (errstr, "Error: Hello world"),
+    ok (errstr != NULL && !strcmp (errstr, "Hello world"),
         "flux_rpc_get_error returned expected error string");
     flux_future_destroy (f);
 

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -64,7 +64,7 @@ void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EPROTO;
         goto error;
     }
-    if (flux_respond (h, msg, 0, s) < 0)
+    if (flux_respond (h, msg, s) < 0)
         BAIL_OUT ("flux_respond: %s", flux_strerror (errno));
     return;
 error:
@@ -126,7 +126,7 @@ void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EPROTO;
         goto error;
     }
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         BAIL_OUT ("flux_respond: %s", flux_strerror (errno));
     return;
 error:

--- a/src/common/libflux/test/rpc_security.c
+++ b/src/common/libflux/test/rpc_security.c
@@ -112,7 +112,7 @@ static void testrpc1 (flux_t *h, flux_msg_handler_t *mh,
 {
     diag ("testrpc1 handler invoked");
     testrpc1_called = true;
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         diag ("flux_respond: %s", flux_strerror (errno));
 }
 

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -388,8 +388,8 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 cleanup:
     flux_cmd_destroy (cmd);
     free (env);
@@ -539,10 +539,12 @@ static void server_signal_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (s->h, "kill");
         goto error;
     }
-
-error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
 char *subprocess_sender (flux_subprocess_t *p)
@@ -619,8 +621,8 @@ static void server_processes_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     json_decref (procs);
 }
 

--- a/src/modules/aggregator/aggregator.c
+++ b/src/modules/aggregator/aggregator.c
@@ -662,8 +662,14 @@ static void push_cb (flux_t *h, flux_msg_handler_t *mh,
         aggregate_sink (h, ag);
     rc = 0;
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, NULL) < 0)
-        flux_log_error (h, "aggregator.push: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
+            flux_log_error (h, "aggregator.push: flux_respond_error");
+    }
+    else {
+        if (flux_respond (h, msg, NULL) < 0)
+            flux_log_error (h, "aggregator.push: flux_respond");
+    }
 }
 
 

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -1018,7 +1018,7 @@ static void client_read_cb (flux_reactor_t *r, flux_watcher_t *w,
         if (!(c->rolemask & FLUX_ROLE_OWNER)) {
             flux_log (h, LOG_ERR, "message has inappropriate userid/rolemask");
             if (type == FLUX_MSGTYPE_REQUEST) {
-                if (flux_respond (h, msg, EPERM, NULL) < 0)
+                if (flux_respond_error (h, msg, EPERM, NULL) < 0)
                     flux_log_error (h, "error sending EPERM response");
             } /* else drop */
             goto done;

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -643,34 +643,26 @@ static void cron_create_handler (flux_t *h, flux_msg_handler_t *w,
     cron_ctx_t *ctx = arg;
     json_t *out = NULL;
     char *json_str = NULL;
-    int saved_errno = EPROTO;
-    int rc = -1;
 
-    if (!(e = cron_entry_create (ctx, msg))) {
-        saved_errno = errno;
-        goto done;
-    }
+    if (!(e = cron_entry_create (ctx, msg)))
+        goto error;
 
     if (zlist_append (ctx->entries, e) < 0) {
-        saved_errno = errno;
-        goto done;
+        errno = ENOMEM;
+        goto error;
     }
 
-    rc = 0;
     if ((out = cron_entry_to_json (e))) {
         json_str = json_dumps (out, JSON_COMPACT);
         json_decref (out);
     }
-done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
-            flux_log_error (h, "cron.request: flux_respond_error");
-    }
-    else {
-        if (flux_respond (h, msg, json_str) < 0)
-            flux_log_error (h, "cron.request: flux_respond");
-    }
+    if (flux_respond (h, msg, json_str) < 0)
+        flux_log_error (h, "cron.request: flux_respond");
     free (json_str);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "cron.request: flux_respond_error");
 }
 
 static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
@@ -680,7 +672,6 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
     const char *topic;
     int disable;
     double epsilon;
-    int rc = -1;
 
     if (flux_request_unpack (msg, NULL, "{}") < 0)
         goto error;
@@ -691,9 +682,10 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
 
     if (topic || disable)
         cron_ctx_sync_event_stop (ctx);
-    rc = topic ? cron_ctx_sync_event_init (ctx, topic) : 0;
-    if (rc < 0)
-        goto error;
+    if (topic) {
+        if (cron_ctx_sync_event_init (ctx, topic) < 0)
+            goto error;
+    }
 
     if (!flux_request_unpack (msg, NULL, "{ s:F }", "sync_epsilon", &epsilon))
         ctx->sync_epsilon = epsilon;
@@ -751,15 +743,10 @@ static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
     json_t *out = NULL;
     char *json_str = NULL;
     int kill = false;
-    int saved_errno;
-    int rc = -1;
 
-    if (!(e = entry_from_request (h, msg, ctx, "cron.delete"))) {
-        saved_errno = errno;
-        goto done;
-    }
+    if (!(e = entry_from_request (h, msg, ctx, "cron.delete")))
+        goto error;
 
-    rc = 0;
     out = cron_entry_to_json (e);
     if (e->task
         && !flux_request_unpack (msg, NULL, "{ s:b }", "kill", &kill)
@@ -767,19 +754,16 @@ static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
         cron_task_kill (e->task, SIGTERM);
     cron_entry_destroy (e);
 
-done:
-    if (out && rc >= 0)
+    if (out)
         json_str = json_dumps (out, JSON_COMPACT);
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
-            flux_log_error (h, "cron.delete: flux_respond_error");
-    }
-    else {
-        if (flux_respond (h, msg, json_str) < 0)
-            flux_log_error (h, "cron.delete: flux_respond");
-    }
+    if (flux_respond (h, msg, json_str) < 0)
+        flux_log_error (h, "cron.delete: flux_respond");
     free (json_str);
     json_decref (out);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "cron.delete: flux_respond_error");
 }
 
 /*
@@ -792,28 +776,22 @@ static void cron_stop_handler (flux_t *h, flux_msg_handler_t *w,
     cron_ctx_t *ctx = arg;
     json_t *out = NULL;
     char *json_str = NULL;
-    int saved_errno = 0;
-    int rc = -1;
 
-    if (!(e = entry_from_request (h, msg, ctx, "cron.stop"))) {
-        saved_errno = errno;
-        goto done;
-    }
-    rc = cron_entry_stop (e);
+    if (!(e = entry_from_request (h, msg, ctx, "cron.stop")))
+        goto error;
+    if (cron_entry_stop (e) < 0)
+        goto error;
     if ((out = cron_entry_to_json (e))) {
         json_str = json_dumps (out, JSON_COMPACT);
         json_decref (out);
     }
-done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
-            flux_log_error (h, "cron.stop: flux_respond_error");
-    }
-    else {
-        if (flux_respond (h, msg, json_str) < 0)
-            flux_log_error (h, "cron.stop: flux_respond");
-    }
+    if (flux_respond (h, msg, json_str) < 0)
+        flux_log_error (h, "cron.stop: flux_respond");
     free (json_str);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "cron.stop: flux_respond_error");
 }
 
 /*
@@ -826,28 +804,22 @@ static void cron_start_handler (flux_t *h, flux_msg_handler_t *w,
     cron_ctx_t *ctx = arg;
     json_t *out = NULL;
     char *json_str = NULL;
-    int saved_errno = 0;
-    int rc = -1;
 
-    if (!(e = entry_from_request (h, msg, ctx, "cron.start"))) {
-        saved_errno = errno;
-        goto done;
-    }
-    rc = cron_entry_start (e);
+    if (!(e = entry_from_request (h, msg, ctx, "cron.start")))
+        goto error;
+    if (cron_entry_start (e) < 0)
+        goto error;
     if ((out = cron_entry_to_json (e))) {
         json_str = json_dumps (out, JSON_COMPACT);
         json_decref (out);
     }
-done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
-            flux_log_error (h, "cron.start: flux_respond_error");
-    }
-    else {
-        if (flux_respond (h, msg, json_str) < 0)
-            flux_log_error (h, "cron.start: flux_respond");
-    }
+    if (flux_respond (h, msg, json_str) < 0)
+        flux_log_error (h, "cron.start: flux_respond");
     free (json_str);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "cron.start: flux_respond_error");
 }
 
 

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -662,8 +662,14 @@ static void cron_create_handler (flux_t *h, flux_msg_handler_t *w,
         json_decref (out);
     }
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
-        flux_log_error (h, "cron.request: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
+            flux_log_error (h, "cron.request: flux_respond_error");
+    }
+    else {
+        if (flux_respond (h, msg, json_str) < 0)
+            flux_log_error (h, "cron.request: flux_respond");
+    }
     free (json_str);
 }
 
@@ -704,8 +710,8 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
     return;
 
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "cron.request: flux_respond");
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "cron.request: flux_respond_error");
 }
 
 static cron_entry_t *cron_ctx_find_entry (cron_ctx_t *ctx, int64_t id)
@@ -764,8 +770,14 @@ static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
 done:
     if (out && rc >= 0)
         json_str = json_dumps (out, JSON_COMPACT);
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
-        flux_log_error (h, "cron.delete: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
+            flux_log_error (h, "cron.delete: flux_respond_error");
+    }
+    else {
+        if (flux_respond (h, msg, json_str) < 0)
+            flux_log_error (h, "cron.delete: flux_respond");
+    }
     free (json_str);
     json_decref (out);
 }
@@ -793,8 +805,14 @@ static void cron_stop_handler (flux_t *h, flux_msg_handler_t *w,
         json_decref (out);
     }
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
-        flux_log_error (h, "cron.stop: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
+            flux_log_error (h, "cron.stop: flux_respond_error");
+    }
+    else {
+        if (flux_respond (h, msg, json_str) < 0)
+            flux_log_error (h, "cron.stop: flux_respond");
+    }
     free (json_str);
 }
 
@@ -821,8 +839,14 @@ static void cron_start_handler (flux_t *h, flux_msg_handler_t *w,
         json_decref (out);
     }
 done:
-    if (flux_respond (h, msg, rc < 0 ? saved_errno : 0, json_str) < 0)
-        flux_log_error (h, "cron.start: flux_respond");
+    if (rc < 0) {
+        if (flux_respond_error (h, msg, saved_errno, NULL) < 0)
+            flux_log_error (h, "cron.start: flux_respond_error");
+    }
+    else {
+        if (flux_respond (h, msg, json_str) < 0)
+            flux_log_error (h, "cron.start: flux_respond");
+    }
     free (json_str);
 }
 
@@ -840,7 +864,7 @@ static void cron_ls_handler (flux_t *h, flux_msg_handler_t *w,
     json_t *entries = json_array ();
 
     if (out == NULL || entries == NULL) {
-        flux_respond (h, msg, ENOMEM, NULL);
+        flux_respond_error (h, msg, ENOMEM, NULL);
         flux_log_error (h, "cron.list: Out of memory");
         return;
     }
@@ -858,7 +882,7 @@ static void cron_ls_handler (flux_t *h, flux_msg_handler_t *w,
 
     if (!(json_str = json_dumps (out, JSON_COMPACT)))
         flux_log_error (h, "cron.list: json_dumps");
-    else if (flux_respond (h, msg, 0, json_str) < 0)
+    else if (flux_respond (h, msg, json_str) < 0)
         flux_log_error (h, "cron.list: flux_respond");
     json_decref (out);
     free (json_str);

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -243,7 +243,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
     if (!(data = json_dumps (o, JSON_COMPACT)))
         goto enomem;
 
-    if (flux_respond (ctx->h, l->msg, 0, data) < 0) {
+    if (flux_respond (ctx->h, l->msg, data) < 0) {
         flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -270,9 +270,7 @@ static void batch_announce_continuation (flux_future_t *f, void *arg)
     flux_t *h = batch->ctx->h;
 
     if (flux_future_get (f, NULL) < 0) {
-        const char *errstr = flux_future_error_string (f);
-        batch_respond_error (batch, errno,
-                             errstr ? errstr : "job-manager request failed");
+        batch_respond_error (batch, errno, flux_future_error_string (f));
         if (batch_cleanup (batch) < 0)
             flux_log_error (h, "%s: KVS cleanup failure", __FUNCTION__);
     }

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -201,7 +201,7 @@ static void batch_respond_error (struct batch *batch,
     flux_t *h = batch->ctx->h;
     struct job *job = zlist_first (batch->jobs);
     while (job) {
-        if (flux_respond_error (h, job->msg, errnum, "%s", errstr) < 0)
+        if (flux_respond_error (h, job->msg, errnum, errstr) < 0)
             flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
         job = zlist_next (batch->jobs);
     }
@@ -452,7 +452,6 @@ void validate_continuation (flux_future_t *f, void *arg)
     struct job_ingest_ctx *ctx = job->ctx;
     flux_t *h = flux_future_get_flux (f);
     const char *errmsg = NULL;
-    int rc;
 
     /* If jobspec validation failed, respond immediately to the user.
      */
@@ -476,11 +475,7 @@ void validate_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
     return;
 error:
-    if (errmsg)
-        rc = flux_respond_error (h, job->msg, errno, "%s", errmsg);
-    else
-        rc = flux_respond_error (h, job->msg, errno, NULL);
-    if (rc < 0)
+    if (flux_respond_error (h, job->msg, errno, errmsg) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     job_destroy (job);
     flux_future_destroy (f);
@@ -498,7 +493,6 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     int64_t userid_signer;
     const char *mech_type;
     flux_future_t *f = NULL;
-    int rc;
 
     /* Parse request.
      */
@@ -583,11 +577,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     return;
 error:
-    if (errmsg)
-        rc = flux_respond_error (h, msg, errno, "%s", errmsg);
-    else
-        rc = flux_respond_error (h, msg, errno, NULL);
-    if (rc < 0)
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     job_destroy (job);
     flux_future_destroy (f);

--- a/src/modules/job-manager/drain.c
+++ b/src/modules/job-manager/drain.c
@@ -43,7 +43,7 @@ static void drain_complete_cb (struct queue *queue, void *arg)
     flux_msg_t *msg;
 
     while ((msg = zlist_pop (ctx->requests))) {
-        if (flux_respond (ctx->h, msg, 0, NULL) < 0)
+        if (flux_respond (ctx->h, msg, NULL) < 0)
             flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
         flux_msg_destroy (msg);
     }
@@ -91,7 +91,7 @@ static void undrain_cb (flux_t *h, flux_msg_handler_t *mh,
             flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
         flux_msg_destroy (req);
     }
-    if (flux_respond (ctx->h, msg, 0, NULL) < 0)
+    if (flux_respond (ctx->h, msg, NULL) < 0)
         flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
 }
 

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -47,7 +47,6 @@ void priority_handle_request (flux_t *h, struct queue *queue,
     flux_jobid_t id;
     struct job *job;
     int priority;
-    int rc;
     const char *errstr = NULL;
 
     if (flux_request_unpack (msg, NULL, "{s:I s:i}",
@@ -93,11 +92,7 @@ void priority_handle_request (flux_t *h, struct queue *queue,
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
-    if (errstr)
-        rc = flux_respond_error (h, msg, errno, "%s", errstr);
-    else
-        rc = flux_respond_error (h, msg, errno, NULL);
-    if (rc < 0)
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -88,7 +88,7 @@ void priority_handle_request (flux_t *h, struct queue *queue,
                              "priority", priority) < 0)
         goto error;
     queue_reorder (queue, job, job->queue_handle);
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -75,7 +75,6 @@ void raise_handle_request (flux_t *h, struct queue *queue,
     const char *note = NULL;
     flux_future_t *f;
     const char *errstr = NULL;
-    int rc;
 
     if (flux_request_unpack (msg, NULL, "{s:I s:i s:s s?:s}",
                                         "id", &id,
@@ -129,11 +128,7 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     return;
 error:
-    if (errstr)
-        rc = flux_respond_error (h, msg, errno, "%s", errstr);
-    else
-        rc = flux_respond_error (h, msg, errno, NULL);
-    if (rc < 0)
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -124,8 +124,8 @@ void raise_handle_request (flux_t *h, struct queue *queue,
                                        "severity", severity)))
         goto error;
     flux_future_destroy (f);
-    if (flux_respond (h, msg, 0, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -126,7 +126,7 @@ static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     if (asprintf (&ctx->start_topic, "%s.start", service_name) < 0)
         goto error;
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     /* Response has been sent, now take action on jobs in run state.
      */

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -195,7 +195,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: error enqueuing batch", __FUNCTION__);
         goto error;
     }
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__,
                             (int)zlist_size (newjobs));

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -181,7 +181,6 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     zlist_t *newjobs;
     struct job *job;
     const char *errmsg = NULL;
-    int rc;
 
     if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0) {
         flux_log_error (h, "%s", __FUNCTION__);
@@ -213,11 +212,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     zlist_destroy (&newjobs);
     return;
 error:
-    if (errmsg)
-        rc = flux_respond_error (h, msg, errno, "%s", errmsg);
-    else
-        rc = flux_respond_error (h, msg, errno, NULL);
-    if (rc < 0)
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1178,30 +1178,25 @@ static void dropcache_request_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     kvs_ctx_t *ctx = arg;
     int size, expcount = 0;
-    int rc = -1;
 
     /* irrelevant if root not initialized, drop cache entries */
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
-        goto done;
+        goto error;
     size = cache_count_entries (ctx->cache);
     if ((expcount = cache_expire_entries (ctx->cache, ctx->epoch, 0)) < 0) {
         flux_log_error (ctx->h, "%s: cache_expire_entries", __FUNCTION__);
-        goto done;
+        goto error;
     }
     else
         flux_log (h, LOG_ALERT, "dropped %d of %d cache entries",
                   expcount, size);
-    rc = 0;
-done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, errno, NULL) < 0)
-            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    }
-    else {
-        if (flux_respond (h, msg, NULL) < 0)
-            flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
 static void dropcache_event_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -1463,35 +1458,30 @@ stall:
 static void lookup_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                const flux_msg_t *msg, void *arg)
 {
-    lookup_t *lh = NULL;
-    json_t *val = NULL;
+    lookup_t *lh;
+    json_t *val;
     bool stall = false;
-    int rc = -1;
 
     if (!(lh = lookup_common (h, mh, msg, arg, lookup_request_cb,
                               &stall))) {
         if (stall)
-            goto stall;
-        goto done;
+            return;
+        goto error;
     }
 
     if (!(val = lookup_get_value (lh))) {
         errno = ENOENT;
-        goto done;
+        goto error;
     }
-
     if (flux_respond_pack (h, msg, "{ s:O }", "val", val) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-
-    rc = 0;
-done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, errno, NULL) < 0)
-            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    }
     lookup_destroy (lh);
-stall:
     json_decref (val);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    lookup_destroy (lh);
 }
 
 /* similar to kvs.lookup, but root_ref / root_seq returned to caller.
@@ -1504,18 +1494,17 @@ stall:
 static void lookup_plus_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                     const flux_msg_t *msg, void *arg)
 {
-    lookup_t *lh = NULL;
+    lookup_t *lh;
     json_t *val = NULL;
-    const char *root_ref = NULL;
-    int root_seq = 0;
+    const char *root_ref;
+    int root_seq;
     bool stall = false;
-    int rc = -1;
 
     if (!(lh = lookup_common (h, mh, msg, arg, lookup_plus_request_cb,
                               &stall))) {
         if (stall)
-            goto stall;
-        goto done;
+            return;
+        goto error;
     }
 
     root_ref = lookup_get_root_ref (lh);
@@ -1524,36 +1513,25 @@ static void lookup_plus_request_cb (flux_t *h, flux_msg_handler_t *mh,
     assert (root_seq >= 0);
 
     if (!(val = lookup_get_value (lh))) {
-        errno = ENOENT;
-        goto done;
+        if (flux_respond_pack (h, msg, "{ s:i s:i s:s }",
+                               "errno", ENOENT,
+                               "rootseq", root_seq,
+                               "rootref", root_ref) < 0)
+            flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     }
-
-    if (flux_respond_pack (h, msg, "{ s:O s:i s:s }",
-                           "val", val,
-                           "rootseq", root_seq,
-                           "rootref", root_ref) < 0)
-        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-
-    rc = 0;
-done:
-    if (rc < 0) {
-        if (errno == ENOENT) {
-            if (flux_respond_pack (h, msg, "{ s:i s:i s:s }",
-                                   "errno", errno,
-                                   "rootseq", root_seq,
-                                   "rootref", root_ref) < 0) {
-                flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-                goto done;
-            }
-        }
-        else {
-            if (flux_respond_error (h, msg, errno, NULL) < 0)
-                flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-        }
+    else {
+        if (flux_respond_pack (h, msg, "{ s:O s:i s:s }",
+                               "val", val,
+                               "rootseq", root_seq,
+                               "rootref", root_ref) < 0)
+            flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     }
     lookup_destroy (lh);
-stall:
     json_decref (val);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
 
@@ -1681,7 +1659,7 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
                           commit_request_cb,
                           &stall))) {
         if (stall)
-            goto stall;
+            return;
         goto error;
     }
 
@@ -1740,8 +1718,6 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-stall:
-    return;
 }
 
 
@@ -1972,7 +1948,7 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!(root = getroot (ctx, ns, mh, msg, NULL, sync_request_cb,
                           &stall))) {
         if (stall)
-            goto stall;
+            return;
         goto error;
     }
 
@@ -1994,8 +1970,6 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-stall:
-    return;
 }
 
 static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -2030,7 +2004,7 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
         if (!(root = getroot (ctx, ns, mh, msg, NULL,
                               getroot_request_cb, &stall))) {
             if (stall)
-                goto done;
+                return;
             goto error;
         }
     }
@@ -2042,10 +2016,7 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
                            "rootref", root->ref,
                            "flags", root->flags) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-
-done:
     return;
-
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
@@ -2291,16 +2262,15 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
     tstat_t ts = { .min = 0.0, .max = 0.0, .M = 0.0, .S = 0.0, .newM = 0.0,
                    .newS = 0.0, .n = 0 };
     int size = 0, incomplete = 0, dirty = 0;
-    int rc = -1;
     double scale = 1E-3;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
-        goto done;
+        goto error;
 
     /* if no roots are initialized, respond with all zeroes as stats */
     if (kvsroot_mgr_root_count (ctx->krm) > 0) {
         if (cache_get_stats (ctx->cache, &ts, &size, &incomplete, &dirty) < 0)
-            goto done;
+            goto error;
     }
 
     if (!(tstats = json_pack ("{ s:i s:f s:f s:f s:f }",
@@ -2308,30 +2278,24 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
                               "min", tstat_min (&ts)*scale,
                               "mean", tstat_mean (&ts)*scale,
                               "stddev", tstat_stddev (&ts)*scale,
-                              "max", tstat_max (&ts)*scale))) {
-        errno = ENOMEM;
-        goto done;
-    }
+                              "max", tstat_max (&ts)*scale)))
+        goto nomem;
 
     if (!(cstats = json_pack ("{ s:f s:O s:i s:i s:i }",
                               "obj size total (MiB)", (double)size/1048576,
                               "obj size (KiB)", tstats,
                               "#obj dirty", dirty,
                               "#obj incomplete", incomplete,
-                              "#faults", ctx->faults))) {
-        errno = ENOMEM;
-        goto done;
-    }
+                              "#faults", ctx->faults)))
+        goto nomem;
 
-    if (!(nsstats = json_object ())) {
-        errno = ENOMEM;
-        goto done;
-    }
+    if (!(nsstats = json_object ()))
+        goto nomem;
 
     if (kvsroot_mgr_root_count (ctx->krm) > 0) {
         if (kvsroot_mgr_iter_roots (ctx->krm, stats_get_root_cb, nsstats) < 0) {
             flux_log_error (h, "%s: kvsroot_mgr_iter_roots", __FUNCTION__);
-            goto done;
+            goto error;
         }
     }
     else {
@@ -2342,12 +2306,13 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
                              "#no-op stores", 0,
                              "#transactions", 0,
                              "#readytransactions", 0,
-                             "store revision", 0))) {
-            errno = ENOMEM;
-            goto done;
-        }
+                             "store revision", 0)))
+            goto nomem;
 
-        json_object_set_new (nsstats, KVS_PRIMARY_NAMESPACE, s);
+        if (json_object_set_new (nsstats, KVS_PRIMARY_NAMESPACE, s) < 0) {
+            json_decref (s);
+            goto nomem;
+        }
     }
 
     if (flux_respond_pack (h, msg,
@@ -2355,13 +2320,15 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
                            "cache", cstats,
                            "namespace", nsstats) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-
-    rc = 0;
- done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, errno, NULL) < 0)
-            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    }
+    json_decref (tstats);
+    json_decref (cstats);
+    json_decref (nsstats);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     json_decref (tstats);
     json_decref (cstats);
     json_decref (nsstats);
@@ -2696,30 +2663,27 @@ static void namespace_list_request_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     kvs_ctx_t *ctx = arg;
     json_t *namespaces = NULL;
-    int rc = -1;
 
-    if (!(namespaces = json_array ())) {
-        errno = ENOMEM;
-        goto done;
-    }
+    if (!(namespaces = json_array ()))
+        goto nomem;
 
     if (kvsroot_mgr_iter_roots (ctx->krm, namespace_list_cb,
                                 namespaces) < 0) {
         flux_log_error (h, "%s: kvsroot_mgr_iter_roots", __FUNCTION__);
-        goto done;
+        goto error;
     }
 
     if (flux_respond_pack (h, msg, "{ s:O }",
                            "namespaces",
                            namespaces) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-
-    rc = 0;
-done:
-    if (rc < 0) {
-        if (flux_respond_error (h, msg, errno, NULL) < 0)
-            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    }
+    json_decref (namespaces);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     json_decref (namespaces);
 }
 
@@ -2741,7 +2705,7 @@ static void setroot_pause_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_request_unpack (msg, NULL, "{ s:s }",
                              "namespace", &ns) < 0) {
         flux_log_error (ctx->h, "%s: flux_request_unpack", __FUNCTION__);
-        goto done;
+        goto error;
     }
 
     if (!(root = getroot (ctx,
@@ -2753,7 +2717,7 @@ static void setroot_pause_request_cb (flux_t *h, flux_msg_handler_t *mh,
                           &stall))) {
         if (stall)
             return;
-        goto done;
+        goto error;
     }
 
     root->setroot_pause = true;
@@ -2761,14 +2725,14 @@ static void setroot_pause_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!root->setroot_queue) {
         if (!(root->setroot_queue = zlist_new ())) {
             errno = ENOMEM;
-            goto done;
+            goto error;
         }
     }
 
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
-done:
+error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
@@ -2813,7 +2777,7 @@ static void setroot_unpause_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_request_unpack (msg, NULL, "{ s:s }",
                              "namespace", &ns) < 0) {
         flux_log_error (ctx->h, "%s: flux_request_unpack", __FUNCTION__);
-        goto done;
+        goto error;
     }
 
     if (!(root = getroot (ctx,
@@ -2825,25 +2789,22 @@ static void setroot_unpause_request_cb (flux_t *h, flux_msg_handler_t *mh,
                           &stall))) {
         if (stall)
             return;
-        goto done;
+        goto error;
     }
 
     root->setroot_pause = false;
 
-    /* user never called pause */
-    if (!root->setroot_queue)
-        goto out;
-
-    while ((m = zlist_pop (root->setroot_queue))) {
-        setroot_unpause_process_msg (ctx, root, m);
-        flux_msg_destroy (m);
+    /* user never called pause if !root->setroot_queue*/
+    if (root->setroot_queue) {
+        while ((m = zlist_pop (root->setroot_queue))) {
+            setroot_unpause_process_msg (ctx, root, m);
+            flux_msg_destroy (m);
+        }
     }
-
-out:
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
-done:
+error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1480,11 +1480,8 @@ static void lookup_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto done;
     }
 
-    if (flux_respond_pack (h, msg, "{ s:O }",
-                           "val", val) < 0) {
+    if (flux_respond_pack (h, msg, "{ s:O }", "val", val) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto done;
-    }
 
     rc = 0;
 done:
@@ -1534,10 +1531,8 @@ static void lookup_plus_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_respond_pack (h, msg, "{ s:O s:i s:s }",
                            "val", val,
                            "rootseq", root_seq,
-                           "rootref", root_ref) < 0) {
+                           "rootref", root_ref) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto done;
-    }
 
     rc = 0;
 done:
@@ -1991,10 +1986,8 @@ static void sync_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_respond_pack (h, msg, "{ s:i s:s }",
                            "rootseq", root->seq,
-                           "rootref", root->ref) < 0) {
+                           "rootref", root->ref) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto error;
-    }
 
     return;
 
@@ -2047,10 +2040,8 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
                            "owner", root->owner,
                            "rootseq", root->seq,
                            "rootref", root->ref,
-                           "flags", root->flags) < 0) {
+                           "flags", root->flags) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto error;
-    }
 
 done:
     return;
@@ -2362,10 +2353,8 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_respond_pack (h, msg,
                            "{ s:O s:O }",
                            "cache", cstats,
-                           "namespace", nsstats) < 0) {
+                           "namespace", nsstats) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto done;
-    }
 
     rc = 0;
  done:
@@ -2722,10 +2711,8 @@ static void namespace_list_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_respond_pack (h, msg, "{ s:O }",
                            "namespaces",
-                           namespaces) < 0) {
+                           namespaces) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto done;
-    }
 
     rc = 0;
 done:

--- a/src/modules/pymod/echo.py
+++ b/src/modules/pymod/echo.py
@@ -4,7 +4,7 @@ import flux
 
 def echo_cb(h, typemask, message, arg):
     h.log(syslog.LOG_INFO, "in cb, args:{}".format((typemask, message, arg)))
-    h.respond(message, 0, message.payload_str)
+    h.respond(message, message.payload_str)
     return 0
 
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -209,8 +209,8 @@ static void alloc_cb (flux_t *h, const flux_msg_t *msg,
     try_alloc (h, ss);
     return;
 err:
-    if (flux_respond (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "alloc: flux_respond");
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "alloc: flux_respond_error");
 }
 
 static int hello_cb (flux_t *h, const char *R, void *arg)

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -248,10 +248,8 @@ static void status_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "rlist_to_R_compressed");
         goto err;
     }
-    if (flux_respond_pack (h, msg, "o", o) < 0) {
+    if (flux_respond_pack (h, msg, "o", o) < 0)
         flux_log_error (h, "flux_respond_pack");
-        goto err;
-    }
     return;
 err:
     json_decref (o);

--- a/src/modules/userdb/userdb.c
+++ b/src/modules/userdb/userdb.c
@@ -216,7 +216,7 @@ static void lookup (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s", __FUNCTION__);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
 }
 
@@ -247,7 +247,7 @@ static void addrole (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s", __FUNCTION__);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
 }
 
@@ -272,7 +272,7 @@ static void delrole (flux_t *h, flux_msg_handler_t *mh,
         user_delete (ctx, userid);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
 }
 
@@ -321,7 +321,7 @@ static void getnext (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s", __FUNCTION__);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
     free (uuid);
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -185,6 +185,7 @@ check_PROGRAMS = \
 	kvs/waitcreate_cancel \
 	kvs/setrootevents \
 	request/treq \
+	request/rpc \
 	barrier/tbarrier \
 	reactor/reactorcat \
 	rexec/rexec \
@@ -330,6 +331,11 @@ kvs_setrootevents_LDADD = \
 request_treq_SOURCES = request/treq.c
 request_treq_CPPFLAGS = $(test_cppflags)
 request_treq_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+request_rpc_SOURCES = request/rpc.c
+request_rpc_CPPFLAGS = $(test_cppflags)
+request_rpc_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 module_parent_la_SOURCES = module/parent.c

--- a/t/ingest/job-manager-dummy.c
+++ b/t/ingest/job-manager-dummy.c
@@ -31,7 +31,7 @@ static void commit_continuation (flux_future_t *f, void *arg)
             flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     }
     else {
-        if (flux_respond (h, msg, 0, NULL) < 0)
+        if (flux_respond (h, msg, NULL) < 0)
             flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     }
     flux_msg_destroy (msg);

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -175,7 +175,7 @@ void alloc_cb (flux_t *h, const flux_msg_t *msg,
     try_alloc (sc);
     return;
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 

--- a/t/module/parent.c
+++ b/t/module/parent.c
@@ -167,7 +167,7 @@ static void insmod_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!(m = module_create (path, argz, argz_len)))
         goto error;
     flux_log (h, LOG_DEBUG, "insmod %s", m->name);
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     free (argz);
     return;
@@ -192,7 +192,7 @@ static void rmmod_request_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     zhash_delete (modules, name);
     flux_log (h, LOG_DEBUG, "rmmod %s", name);
-    if (flux_respond (h, msg, 0, NULL) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -55,7 +55,7 @@ class TestServiceAddRemove(unittest.TestCase):
 
     def test_003_add_service_message_watcher(self):
         def service_cb(f, t, msg, arg):
-            rc = f.respond(msg, 0, msg.payload_str)
+            rc = f.respond(msg, msg.payload_str)
             self.assertEqual(rc, 0)
 
         self.f.watcher = self.f.msg_watcher_create(

--- a/t/request/rpc.c
+++ b/t/request/rpc.c
@@ -1,0 +1,72 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_future_t *f;
+    const char *topic;
+    ssize_t inlen;
+    void *inbuf;
+    const void *outbuf;
+    int outlen;
+    int expected_errno = -1;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (argc != 2 && argc != 3) {
+        fprintf (stderr, "Usage: rpc topic [errnum] <payload >payload\n");
+        exit (1);
+    }
+    topic = argv[1];
+    if (argc == 3)
+        expected_errno = strtoul (argv[2], NULL, 10);
+
+    if ((inlen = read_all (STDIN_FILENO, &inbuf)) < 0)
+        log_err_exit ("read from stdin");
+
+    if (!(f = flux_rpc_raw (h, topic, inbuf, inlen, FLUX_NODEID_ANY, 0)))
+        log_err_exit ("flux_rpc_raw %s", topic);
+    if (flux_rpc_get_raw (f, &outbuf, &outlen) < 0) {
+        if (expected_errno > 0) {
+            if (errno != expected_errno)
+                log_msg_exit ("%s: failed with errno=%d != expected %d",
+                              topic, errno, expected_errno);
+        }
+        else
+            log_err_exit ("%s", topic);
+    }
+    else {
+        if (expected_errno > 0)
+            log_msg_exit ("%s: succeeded but expected failure errno=%d",
+                          topic, expected_errno);
+        if (write_all (STDOUT_FILENO, outbuf, outlen) < 0)
+            log_err_exit ("write to stdout");
+    }
+    flux_future_destroy (f);
+    free (inbuf);
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -4,6 +4,8 @@ test_description='Test broker log ring buffer'
 
 . `dirname $0`/sharness.sh
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_under_flux 4 minimal
 
 test_expect_success 'flux getattr log-count counts log messages' '
@@ -85,6 +87,12 @@ test_expect_success 'embedded blank log messages are ignored' '
 test_expect_success 'logged non-ascii characters handled ok' '
 	/bin/echo -n -e "\xFF\xFE\x82\x00" | flux logger &&
 	flux dmesg
+'
+test_expect_success 'dmesg request with empty payload fails with EPROTO(71)' '
+	${RPC} log.dmesg 71 </dev/null
+'
+test_expect_success 'clear request with empty payload fails with EPROTO(71)' '
+	${RPC} log.clear 71 </dev/null
 '
 
 test_done

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -14,6 +14,7 @@ test_under_flux ${SIZE} minimal
 echo "# $0: flux session size will be ${SIZE}"
 
 BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 MAXBLOB=`flux getattr content.blob-size-limit`
 HASHFUN=`flux getattr content.hash`
@@ -156,6 +157,13 @@ test_expect_success 'store 8K blobs from rank 0 using async RPC' '
 # Write 1024 blobs per rank
 test_expect_success 'store 1K blobs from all ranks using async RPC' '
 	flux exec -n flux content spam 1024 256
+'
+
+test_expect_success 'load request with empty payload fails with EPROTO(71)' '
+	${RPC} content.load 71 </dev/null
+'
+test_expect_success 'backing request with empty payload fails with EPROTO(71)' '
+	${RPC} content.backing 71 </dev/null
 '
 
 test_done

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test broker content service' 
+test_description='Test broker content service'
 
 . `dirname $0`/sharness.sh
 
@@ -22,7 +22,7 @@ test_expect_success 'store 100 blobs on rank 0' '
         for i in `seq 0 99`; do echo test$i | \
             flux content store >/dev/null; done &&
 	TOTAL=`flux module stats --type int --parse count content` &&
-        test $TOTAL -ge 100 
+        test $TOTAL -ge 100
 '
 
 # Write on rank 0, various size blobs

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -10,6 +10,8 @@ if test "$TEST_LONG" = "t"; then
     test_set_prereq LONGTEST
 fi
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=4
 test_under_flux ${SIZE} minimal
@@ -308,7 +310,25 @@ test_expect_success 'flux cron sync can set epsilon' '
     flux cron sync --epsilon=42s cron.sync2 &&
     flux cron sync | grep 42.000s
 '
+
+test_expect_success 'create request with empty payload fails with EPROTO(71)' '
+	${RPC} cron.create 71 </dev/null
+'
+test_expect_success 'delete request with empty payload fails with EPROTO(71)' '
+	${RPC} cron.delete 71 </dev/null
+'
+test_expect_success 'stop request with empty payload fails with EPROTO(71)' '
+	${RPC} cron.stop 71 </dev/null
+'
+test_expect_success 'start request with empty payload fails with EPROTO(71)' '
+	${RPC} cron.start 71 </dev/null
+'
+test_expect_success 'sync request with empty payload fails with EPROTO(71)' '
+	${RPC} cron.sync 71 </dev/null
+'
+
 test_expect_success 'flux module remove cron' '
     flux module remove cron
 '
+
 test_done

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -15,6 +15,8 @@ if test "$TEST_LONG" = "t"; then
     test_set_prereq LONGTEST
 fi
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} kvs
@@ -1144,4 +1146,37 @@ test_expect_success 'kvs: get --label works' '
 	flux kvs get --label test.ZZZ |grep test.ZZZ=42
 '
 
+#
+# Malformed requests
+#
+test_expect_success 'getroot request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.getroot 71 </dev/null
+'
+test_expect_success 'sync request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.sync 71 </dev/null
+'
+test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.lookup 71 </dev/null
+'
+test_expect_success 'lookup-plus request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.lookup-plus 71 </dev/null
+'
+test_expect_success 'commit request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.commit 71 </dev/null
+'
+test_expect_success 'fence request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.fence 71 </dev/null
+'
+test_expect_success 'namespace-create request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.namespace-create 71 </dev/null
+'
+test_expect_success 'namespace-remove request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.namespace-remove 71 </dev/null
+'
+test_expect_success 'setroot-pause request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.setroot-pause 71 </dev/null
+'
+test_expect_success 'setroot-unpause request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs.setroot-unpause 71 </dev/null
+'
 test_done

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -54,7 +54,7 @@ test_expect_success 'hwloc: each rank reloads a non-overlapping set of a node ' 
     flux hwloc reload $exclu2
 '
 
-test_expect_success 'hwloc: internal aggregate-load cmd works' '
+test_expect_success HAVE_JQ 'hwloc: internal aggregate-load cmd works' '
     flux exec -r all \
         flux hwloc aggregate-load --key=foo --unpack=bar --print-result | \
 	$jq -S . >aggregate.out &&

--- a/t/t2100-aggregate.t
+++ b/t/t2100-aggregate.t
@@ -4,6 +4,8 @@ test_description='Test basic flux aggreagation via aggregator module'
 
 . `dirname $0`/sharness.sh
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_under_flux 8
 
 #  Set path to jq
@@ -77,6 +79,10 @@ test_expect_success 'flux-aggregate: --fwd-count works' '
      "flux aggregate -t10 -c \$((1+\$(flux getattr tbon.descendants))) test 1" &&
     kvs_json_check test \
         ".count == 8 and .total == 8 and .min == 1 and .max == 1"
+'
+
+test_expect_success 'push request with empty payload fails with EPROTO(71)' '
+	${RPC} aggregator.push 71 </dev/null
 '
 
 test_done


### PR DESCRIPTION
This PR knocks off some easy bugs, and makes some changes to `flux_respond()` and `flux_respond_error()` proposed in #2088 and #2089.