### PR TITLE
experimental: add global rundir from which broker.rundir is derived

### DIFF
--- a/doc/man1/flux-start.adoc
+++ b/doc/man1/flux-start.adoc
@@ -59,11 +59,12 @@ built with --enable-caliper. Unless CALI_LOG_VERBOSITY is already
 set in the environment, it will default to 0 for all brokers.
 
 *--scratchdir*='DIR'::
-For selfpmi bootstrap mode, set a pre-existing directory that will
-contain the generated broker.rundir directories for the instance.
-If a DIR is not set with this option, a unique temporary directory will
-be created for the lifetime of the instance and removed when the
-instance is destroyed.
+For selfpmi bootstrap mode, set the directory that will be
+used as the rundir directory for the instance. If the directory
+does not exist then it will be created during instance startup.
+If a DIR is not set with this option, a unique temporary directory
+will be created. Unless DIR was pre-existing, it will be removed
+when the instance is destroyed.
 
 *--wrap*='ARGS,...'::
 Wrap broker execution in a comma-separated list of arguments. This is

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -29,11 +29,19 @@ The number of ranks in the comms session.
 session-id::
 The identity of the comms session.
 
+rundir::
+A global, shared temporary directory available for scratch storage
+within the session. By default, a temporary directory is created
+for each broker rank, but if rundir is set on the command line, this
+directory may be shared by all broker ranks (typically only within
+a node).  If rundir does not exist, it is created and subsequently
+removed during session exit. An existing rundir is not removed at exit.
+
 broker.rundir::
-A temporary directory available for scratch storage within
-the session.  This directory is unique to the local rank.
-Cleanup of directory contents is the responsibility of
-the creator.
+A temporary directory available for per-rank scratch storage within
+the session. By default broker.rundir is set to "${rundir}/${rank}",
+which guarantees a unique directory per rank.  It is not advisable
+to override this attribute on the command line. Use rundir instead.
 
 persist-directory::
 A persistent directory available for storage on rank 0 only.
@@ -80,7 +88,8 @@ based overlay network.  This attribute will not be set on rank zero.
 
 local-uri::
 The Flux URI that should be passed to flux_open(1) to establish
-a connection to the local broker rank.
+a connection to the local broker rank. By default, local-uri is
+created as "local://<broker.rank>/local".
 
 parent-uri::
 The Flux URI that should be passed to flux_open(1) to establish

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -454,3 +454,4 @@ SPDX
 MATCHDEBUG
 Ctrl
 UNIQ
+startup

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -3,7 +3,7 @@ Description=Flux message broker
 
 [Service]
 Environment=FLUX_USERDB_OPTIONS=--default-rolemask=user
-ExecStart=@X_BINDIR@/flux broker -Sbroker.rundir=@X_RUNSTATEDIR@/flux -Sboot.method=config -Sboot.config_file=@X_SYSCONFDIR@/flux/conf.d/boot.conf sleep inf
+ExecStart=@X_BINDIR@/flux broker -Srundir=@X_RUNSTATEDIR@/flux -Sboot.method=config -Sboot.config_file=@X_SYSCONFDIR@/flux/conf.d/boot.conf sleep inf
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -16,9 +16,15 @@
 
 typedef struct overlay_struct overlay_t;
 typedef void (*overlay_cb_f)(overlay_t *ov, void *sock, void *arg);
+typedef void (*overlay_init_cb_f)(overlay_t *ov, void *arg);
 
 overlay_t *overlay_create (void);
 void overlay_destroy (overlay_t *ov);
+
+/* Set a callback triggered during overlay_init()
+ */
+void overlay_set_init_callback (overlay_t *ov,
+                                overlay_init_cb_f cb, void *arg);
 
 /* These need to be called before connect/bind.
  */

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -368,7 +368,7 @@ char *create_scratch_dir (const char *session_id)
 
     if (!mkdtemp (scratchdir))
         log_err_exit ("mkdtemp %s", scratchdir);
-    cleanup_push_string (cleanup_directory, scratchdir);
+    cleanup_push_string (cleanup_directory_recursive, scratchdir);
     return scratchdir;
 }
 
@@ -467,14 +467,9 @@ struct client *client_create (const char *broker_path, const char *scratch_dir,
     cli->rank = rank;
     add_args_list (&argz, &argz_len, ctx.opts, "wrap");
     argz_add (&argz, &argz_len, broker_path);
-    char *run_dir = xasprintf ("%s/%d", scratch_dir, rank);
-    if (mkdir (run_dir, 0755) < 0)
-        log_err_exit ("mkdir %s", run_dir);
-    cleanup_push_string (cleanup_directory, run_dir);
-    char *dir_arg = xasprintf ("--setattr=broker.rundir=%s", run_dir);
+    char *dir_arg = xasprintf ("--setattr=rundir=%s", scratch_dir);
     argz_add (&argz, &argz_len, dir_arg);
     argz_add (&argz, &argz_len, "--setattr=tbon.endpoint=ipc://%B/req");
-    free (run_dir);
     free (dir_arg);
     add_args_list (&argz, &argz_len, ctx.opts, "broker-opts");
     if (rank == 0 && cmd_argz)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -203,6 +203,11 @@ test_expect_success 'broker.rundir override works' '
 	test -d $RUNDIR &&
 	rmdir $RUNDIR
 '
+test_expect_success 'broker.rundir override creates nonexistent dirs' '
+	RUNDIR="$(pwd)/rundir" &&
+	flux start ${ARGS} -o,--setattr=broker.rundir=$RUNDIR sh -c "test -d $RUNDIR" &&
+	test_expect_code 1 test -d $RUNDIR
+'
 test_expect_success 'broker persist-directory works' '
 	PERSISTDIR=`mktemp -d` &&
 	flux start ${ARGS} -o,--setattr=persist-directory=$PERSISTDIR /bin/true &&


### PR DESCRIPTION
This should be considered an experimental PR for now, because some of the design choices made here need some thought and agreement.

This PR changes the current `broker.rundir` attribute into a "global" `rundir` attribute which, as before, is designed to be overridden on the command line. If not set, a temporary path is chosen with `mkdtemp(3)` as before, and in either case the directory is created (and subsequently cleaned up at exit) if it doesn't exist.

The `broker.rundir` attribute is now always derived from `rundir` as `${rundir}/<rank>` to seamlessly allow multiple brokers per node in either of the `rundir` situations (random directory vs preset directory).

After this change, `flux-start` no longer needs to set a different `broker.rundir` per broker it is launching (for the `--size` case). It now sets `rundir` to the created `scratchdir` and lets each broker handle creation of `broker.rundir`. Due to this change, the flux-start scratchdir needs to use cleanup_directory_recursive to clean scratchdir.

A questionable approach for initializing broker.rundir is used here, because the broker rank is required, but is not determined until early in the "boot" phase, during which the broker.rundir attribute is used to create ipc endpoints. Instead of duplicating code in both the boot methods (pmi and config), an "initialization" callback was added to the `overlay_t` structure, which is called at the end of `overlay_init()` where broker rank and session size are determined. This felt a bit icky since two new entries were added to the structure which are only used during initialization, but it resulted in the cleanest code. Also, presuming all future "boot" methods need to call `overlay_init()`, this method should seamlessly work for future extensions.

The other perhaps controversial decision here is the choice of `rundir` for the global rundir attribute itself, but I couldn't think of another reasonable name, and liked the simplicity of `rundir` for the "global" path and `broker.rundir` for the per-broker path. I'd be fine choosing something else, and this is why I've delayed updating docs, etc.

The end result of this PR is meant to give the ability to predetermine `FLUX_URI` by setting a known global `rundir` for the session. Of course, each broker rank can't ever have the same `FLUX_URI` when brokers may be run on the same node, so this PR does the next best thing, the `FLUX_URI ` can be derived from the known `rundir` as `local://${rundir}/${rank}`. e.g.

```console
$ srun -N4 --mpi=none src/cmd/flux start -o,-S,rundir=/tmp/grondo/foo flux exec -r all sh -c 'echo $FLUX_URI'
local:///tmp/grondo/foo/0
local:///tmp/grondo/foo/1
local:///tmp/grondo/foo/2
local:///tmp/grondo/foo/3
```

Resolves #2118