### PR TITLE
Allow flux_future_continue(3) to work with flux_kvs_lookup(3)

### DIFF
--- a/doc/man3/flux_future_and_then.adoc
+++ b/doc/man3/flux_future_and_then.adoc
@@ -44,10 +44,12 @@ of a previous operation. That is, `flux_future_and_then()` returns a
 placeholder future for an eventual future that can't be created until
 the continuation `cb` is run. The returned future can then be
 used as a synchronization handle or even passed to another
-`flux_future_and_then()` in the chain. The callback `cb` *must* call
-either `flux_future_continue(3)` or `flux_future_continue_error(3)`
-to pass a result to the next future in the chain, otherwise the last
-future in the chain can never be fulfilled.
+`flux_future_and_then()` in the chain. By default, the next future
+in the chain will be fulfilled immediately using the result of the
+previous future after return from the callback `cb`. Most callbacks,
+however, should use either `flux_future_continue(3)` or
+`flux_future_continue_error(3)` to pass an intermediate future
+to use in fulfillment of the next future in the chain.
 
 `flux_future_or_then(3)` is like `flux_future_and_then()`, except
 the continuation callback `cb` is run when the future `f` is fulfilled
@@ -58,17 +60,23 @@ callback offers a chance to successfully fulfill the "next" future
 in the chain, even when the "previous" future was fulfilled with
 an error.
 
-As with `flux_future_and_then()` it is important that the continuation
-`cb` function for `flux_future_or_then()` calls `flux_future_continue()`
-or `flux_future_continue_error()` to avoid breaking the chain.
+As with `flux_future_and_then()` the continuation
+`cb` function for `flux_future_or_then()` should call
+`flux_future_continue()` or `flux_future_continue_error()`, or
+the result of the previous future will be propagated immediately
+to the next future in the chain.
 
 `flux_future_continue(3)` continues the next future embedded in `prev`
-(created by `flux_future_and_then()` or `flux_future_or_then()` with
+(created by `flux_future_and_then()` or `flux_future_or_then()`) with
 the eventual result of the provided future `f`. This allows a future
 that was not created until the context of the callback to continue
 a sequential chain of futures created earlier. After the call to
 `flux_future_continue(3)` completes, the future `prev` may safely be
-destroyed.
+destroyed. `flux_future_continue(3)` may be called with `f` equal
+to `NULL` if the caller desires the next future in the chain to
+*not* be fulfilled, in order to disable the automatic fulfillment
+that normally occurs for non-continued futures after the callback
+completes.
 
 `flux_future_continue_error(3)` is like `flux_future_continue()`
 but immediately fulfills the next future in the chain with an error and

--- a/doc/man3/flux_future_create.adoc
+++ b/doc/man3/flux_future_create.adoc
@@ -5,7 +5,7 @@ flux_future_create(3)
 
 NAME
 ----
-flux_future_create, flux_future_fulfill, flux_future_fulfill_error, flux_future_aux_get, flux_future_aux_set, flux_future_set_flux, flux_future_get_flux - support methods for classes that return futures
+flux_future_create, flux_future_fulfill, flux_future_fulfill_error, flux_future_fulfill_with, flux_future_aux_get, flux_future_aux_set, flux_future_set_flux, flux_future_get_flux - support methods for classes that return futures
 
 
 SYNOPSIS
@@ -22,6 +22,8 @@ SYNOPSIS
 
  void flux_future_fulfill_error (flux_future_t *f, int errnum,
                                  const char *errstr);
+
+ void flux_future_fulfill_with (flux_future_t *f, flux_future_t *p);
 
  void flux_future_fatal_error (flux_future_t *f, int errnum,
                                const char *errstr);
@@ -86,10 +88,21 @@ _errnum_ value and an optional error string.  After the future is
 fulfilled with an error, `flux_future_get()` will return -1 with errno
 set to _errnum_.
 
-Both `flux_future_fulfill()` and `flux_future_fulfill_error()` can be
-called multiple times to queue multiple results or errors.  When
-callers access future results via `flux_future_get()`, results or
-errors will be returned in FIFO order.
+`flux_future_fulfill_with()` fulfills the target future _f_ using a
+fulfilled future _p_. This function copies the pending result or error
+from _p_ into _f_, and adds read-only access to the _aux_ items for _p_
+from _f_. This ensures that any `get` method which requires _aux_ items
+for _p_ will work with _f_. This function takes a reference to the source
+future _p_, so it safe to call `flux_future_destroy (p)` after this call.
+`flux_future_fulfill_with()` returns -1 on error with _errno_
+set on failure.
+
+`flux_future_fulfill()`, `flux_future_fulfill_with()`, and
+`flux_future_fulfill_error()` can be called multiple times to queue
+multiple results or errors.  When callers access future results via
+`flux_future_get()`, results or errors will be returned in FIFO order.
+It is an error to call `flux_future_fulfill_with()` multiple times on
+the same target future _f_ with a different source future _p_.
 
 `flux_future_fatal_error()` fulfills the future, assigning an _errnum_
 value and an optional error string.  Unlike
@@ -181,6 +194,11 @@ NULL is returned and errno is set appropriately.
 `flux_future_get_reactor()` returns a flux_reactor_t on success.  On error,
 NULL is returned and errno is set appropriately.
 
+`flux_future_fulfill_with()` returns zero on success. On error, -1 is
+returned with errno set to EINVAL if either _f_ or _p_  is NULL, or
+_f_ and _p_ are the same, EAGAIN if the future _p_ is not ready, or
+EEXIST if the function is called multiple times with different _p_.
+
 
 ERRORS
 ------
@@ -193,6 +211,14 @@ Invalid argument.
 
 ENOENT::
 The requested object is not found.
+
+EAGAIN::
+The requested operation is not ready. For `flux_future_fulfill_with()`,
+the target future _p_ is not fulfilled.
+
+EEXIST::
+`flux_future_fulfill_with()` was called multiple times with a different
+target future _p_.
 
 AUTHOR
 ------

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -56,6 +56,8 @@ int flux_future_get (flux_future_t *f, const void **result);
 void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn);
 void flux_future_fulfill_error (flux_future_t *f, int errnum, const char *errstr);
 
+int flux_future_fulfill_with (flux_future_t *f, flux_future_t *p);
+
 void flux_future_fatal_error (flux_future_t *f, int errnum, const char *errstr);
 
 const char *flux_future_error_string (flux_future_t *f);

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -221,6 +221,11 @@ static void step3 (flux_future_t *f2, void *arg)
         "chained: step3: flux_future_get returns success");
     strcat (str, "-step3");
     flux_future_t *next = flux_future_create (NULL, NULL);
+    /* Set an aux member in the 'next' future here, so we can ensure
+     *  we'll have access to it from the chained future later fulfilled
+     *  by this one.
+     */
+    flux_future_aux_set (next, "test_aux", (void *) 0x42, NULL);
     flux_future_continue (f2, next);
     flux_future_fulfill (next, NULL, NULL);
     flux_future_destroy (f2);
@@ -251,6 +256,8 @@ static void test_basic_chained (flux_reactor_t *r)
         "chained: flux_future_wait_for step3 returns");
     ok (flux_future_get (f3, NULL) == 0,
         "chained: flux_future_get == 0");
+    ok (flux_future_aux_get (f3, "test_aux") == (void *) 0x42,
+        "chained: aux item set in prev future available in chained future");
     is (str, "step1-step2-step3",
         "chained: futures ran in correct order");
 

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -575,6 +575,95 @@ void test_chained_async ()
     flux_reactor_destroy (r);
 }
 
+void f_setbool (flux_future_t *prev, void *arg)
+{
+    bool *bp = arg;
+    *bp = true;
+    ok (true, "in setbool");
+    flux_future_destroy (prev);
+}
+
+void test_chained_no_continue ()
+{
+    flux_future_t *f1, *f2, *f3;
+    bool first = false;
+    bool second = false;
+
+    /*  Create empty first future to trigger auto-fulfill cascade:
+     */
+    if (!(f1 = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+    if (!(f2 = flux_future_and_then (f1, f_setbool, &first)))
+        BAIL_OUT ("flux_future_and_then");
+    if (!(f3 = flux_future_and_then (f2, f_setbool, &second)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fulfill (f1, NULL, NULL);
+
+    ok (flux_future_wait_for (f3, 5.) == 0,
+        "flux_future_wait_for()");
+
+    ok (first && second,
+        "All futures auto-fulfilled without flux_future_continue");
+    flux_future_destroy (f3);
+}
+
+/*  Multiple fulfill continuation. Only continue f when result is 3
+ */
+void check_cb (flux_future_t *f, void *arg)
+{
+    int *countp = arg;
+    int *rp = NULL;
+
+    ++*countp;
+
+    if (flux_future_get (f, (void *) &rp) < 0)
+        BAIL_OUT ("check_cb: flux_future_get failed");
+    pass ("multiple fulfill: flux_future_get() result = %d", *rp);
+    if (*rp == 3)
+        ok (flux_future_continue (f, f) == 0,
+            "multiple fulfill: flux_future_continue (f,f)");
+    else
+        ok (flux_future_continue (f, NULL) == 0,
+            "multiple fulfill: flux_future_continue (f, NULL)");
+    flux_future_reset (f);
+}
+
+
+void test_chained_multiple_fulfill ()
+{
+    flux_future_t *f1, *f;
+    int vals[4] = { 0, 1, 2, 3 };
+    int count = 0;
+    int *rp = NULL;
+
+    if (!(f1 = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+    if (!(f = flux_future_and_then (f1, check_cb, &count)))
+        BAIL_OUT ("flux_future_and_then");
+
+    for (int i = 0; i < 4; i++) {
+        flux_future_fulfill (f1, (void *) &vals[i], NULL);
+        pass ("multiple fulfill: flux_future_fulfill (f1, %d)", vals[i]);
+    }
+
+    if (flux_future_wait_for (f, 1.) < 0)
+        BAIL_OUT ("flux_future_wait_for()");
+
+    if (flux_future_get (f, (void *) &rp) < 0)
+        BAIL_OUT ("test_chained_multiple_fulfill: flux_future_get");
+    ok (*rp == 3,
+        "multiple fulfill: flux_future_get returned %d", *rp);
+    ok (count == 4,
+        "multiple fulfill: continuation called %d times", count);
+    flux_future_destroy (f);
+
+    /* NB: f1 not destroyed in its continuation since it is
+     *  multiply fulfilled. Destroy it here.
+     */
+    flux_future_destroy (f1);
+}
+
 int main (int argc, char *argv[])
 {
     flux_reactor_t *reactor;
@@ -596,6 +685,8 @@ int main (int argc, char *argv[])
     test_composite_any_async (false);
     test_composite_any_async (true);
     test_chained_async ();
+    test_chained_no_continue ();
+    test_chained_multiple_fulfill ();
 
     flux_reactor_destroy (reactor);
 


### PR DESCRIPTION
This PR fixes #2127 by adding a new function `flux_future_fulfill_with(3)`, which allows a fulfilled future to be used to fulfill another future. This is what `fulfill_next()` in `composite_future.c` tried to do, but its scope was limited because it didn't have access to `flux_future_t` internals.

`flux_future_fulfill_with(3)` copies any fatal error, error result, or normal result into the destination future. It also "embeds" the source future into the target future, so that calls to `flux_future_aux_get()` can access the source future aux list. This allows futures that are a result of calls which use aux data as part of custom `get()` methods to work after `flux_future_fulfill_with(3)`.  This function steals a reference to the source future, so `flux_future_destroy()` should not be called on the source future after `flux_future_fulfill_with()` is called. (If this is confusing, the function could just take a reference instead)

The destination future also "steals" the valid result by copying the result's destructor into its result structure, nullifying the destructor in the source future. This is so that multiple fulfillment can work properly, since once `flux_future_reset()` is called on the source future, a result pending in the destination future may point to invalid memory.

Finally, `composite_future.c:fulfill_next()` was updated to use `flux_future_fulfill_with()` to get these benefits, allowing `flux_future_and_then(3)` to be used with `flux_kvs_lookup(3)` and other functions that return futures and make use of the aux data in `flux_future_t`.