### PR TITLE
testsuite: improve coverage of malformed RPC requests

### DIFF
--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -191,6 +191,7 @@ static void enter_request_cb (flux_t *h, flux_msg_handler_t *mh,
                              "internal", &internal) < 0
                 || flux_msg_get_route_first (msg, &sender) < 0) {
         flux_log_error (ctx->h, "%s: decoding request", __FUNCTION__);
+        flux_respond_error (ctx->h, msg, errno, NULL);
         goto done;
     }
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -970,7 +970,7 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
                                              "id", &job->id,
                                              "userid", &job->userid) < 0) {
         flux_log_error (ctx->h, "start: flux_request_unpack");
-        goto error;
+        return -1;
     }
     if (job_get_ns_name (job->ns, sizeof (job->ns), job->id) < 0) {
         jobinfo_fatal_error (job, errno, "failed to create ns name for job");
@@ -1003,6 +1003,9 @@ static void start_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (job_start (ctx, msg) < 0) {
         flux_log_error (h, "job_start");
+        /* The following "normal" RPC response will trigger the job-manager's
+         * teardown of the exec system interface.
+         */
         if (flux_respond_error (h, msg, errno, NULL) < 0)
             flux_log_error (h, "job-exec.start respond_error");
     }

--- a/t/request/rpc.c
+++ b/t/request/rpc.c
@@ -42,6 +42,8 @@ int main (int argc, char *argv[])
 
     if ((inlen = read_all (STDIN_FILENO, &inbuf)) < 0)
         log_err_exit ("read from stdin");
+    if (inlen > 0)  // flux stringified JSON payloads are sent with \0-term
+        inlen++;    //  and read_all() ensures inbuf has one, not acct in inlen
 
     if (!(f = flux_rpc_raw (h, topic, inbuf, inlen, FLUX_NODEID_ANY, 0)))
         log_err_exit ("flux_rpc_raw %s", topic);

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -8,6 +8,8 @@ SIZE=4
 LASTRANK=$(($SIZE-1))
 test_under_flux ${SIZE} minimal
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_expect_success 'heartbeat is received on all ranks' '
 	run_timeout 5 \
           flux exec -n flux event sub --count=1 hb >output_event_sub &&
@@ -75,6 +77,10 @@ test_expect_success 'publish private event with raw payload (synchronous)' '
 
 test_expect_success 'publish private event with no payload (synchronous,loopback)' '
 	run_timeout 5 flux event pub -p -s -l foo.bar
+'
+
+test_expect_success 'event.pub request with empty payload fails with EPROTO(71)' '
+	${RPC} event.pub 71 </dev/null
 '
 
 test_done

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -8,6 +8,8 @@ test_description='Test broker attributes'
 
 test_under_flux 1 minimal
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_expect_success 'flux getattr rank works' '
 	ATTR_VAL=`flux getattr rank` &&
 	test "${ATTR_VAL}" -eq 0
@@ -47,6 +49,15 @@ test_expect_success 'flux lsattr with extra argument fails' '
 '
 test_expect_success 'flux getattr with no attribute argument fails' '
 	test_must_fail flux getattr
+'
+test_expect_success 'get request with empty payload fails with EPROTO(71)' '
+	${RPC} attr.get 71 </dev/null
+'
+test_expect_success 'set request with empty payload fails with EPROTO(71)' '
+	${RPC} attr.set 71 </dev/null
+'
+test_expect_success 'rm request with empty payload fails with EPROTO(71)' '
+	${RPC} attr.rm 71 </dev/null
 '
 
 test_done

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -11,6 +11,8 @@ SIZE=4
 LASTRANK=$((SIZE-1))
 test_under_flux ${SIZE} kvs
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_expect_success 'event: can publish' '
 	run_timeout 5 \
 	  $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
@@ -55,5 +57,11 @@ test_expect_success 'heaptrace start' '
 	heaptrace_error_check stop
 '
 
+test_expect_success 'heaptrace.start request with empty payload fails with EPROTO(71)' '
+	${RPC} heaptrace.start 71 </dev/null
+'
+test_expect_success 'heaptrace.dump request with empty payload fails with EPROTO(71)' '
+	${RPC} heaptrace.dump 71 </dev/null
+'
 
 test_done

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -6,6 +6,8 @@ test_description='Test broker security'
 
 test_under_flux 4 minimal
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_expect_success 'simulated local connector auth failure returns EPERM' '
 	flux comms info &&
 	flux module debug --set 1 connector-local &&
@@ -97,9 +99,25 @@ test_expect_success 'flux user can add/lookup bin user by name' '
 	flux module remove userdb
 '
 
+test_expect_success 'load userdb module' '
+	flux module load userdb
+'
+
 test_expect_success 'flux user cannot add user with no roles' '
-	flux module load userdb &&
-	! flux user addrole 1234 0 &&
+	test_must_fail flux user addrole 1234 0
+'
+
+test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '
+	${RPC} userdb.lookup 71 </dev/null
+'
+test_expect_success 'addrole request with empty payload fails with EPROTO(71)' '
+	${RPC} userdb.addrole 71 </dev/null
+'
+test_expect_success 'delrole request with empty payload fails with EPROTO(71)' '
+	${RPC} userdb.delrole 71 </dev/null
+'
+
+test_expect_success 'unload userdb module' '
 	flux module remove userdb
 '
 

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -8,6 +8,8 @@ test_description='Test KVS get --watch && --waitcreate'
 
 test_under_flux 4 kvs
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 
 test_expect_success 'flux kvs get --watch --count=1 works' '
@@ -660,4 +662,7 @@ test_expect_success 'flux kvs get --watch allows owner access to guest ns' '
 	flux kvs namespace remove testns4
 '
 
+test_expect_success 'kvs-watch.lookup request with empty payload fails with EPROTO(71)' '
+	${RPC} kvs-watch.lookup 71 </dev/null
+'
 test_done

--- a/t/t1101-barrier-basic.t
+++ b/t/t1101-barrier-basic.t
@@ -14,6 +14,8 @@ test_under_flux ${SIZE} minimal
 tbarrier="${FLUX_BUILD_DIR}/t/barrier/tbarrier"
 test "$verbose" = "t" || tbarrier="${tbarrier} -q"
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 test_expect_success 'barrier: load barrier module' '
 	flux module load -r all barrier
 '
@@ -48,7 +50,9 @@ test_expect_success 'barrier: succeeds with name=NULL inside SLURM step' '
         SLURM_STEPID=1 && export SLURM_STEPID &&
 	flux exec -n ${tbarrier} --nprocs ${SIZE}
 '
-
+test_expect_success 'enter request with empty payload fails with EPROTO(71)' '
+	${RPC} barrier.enter 71 </dev/null
+'
 test_expect_success 'barrier: remove barrier module' '
 	flux module remove -r all barrier
 '

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -19,6 +19,7 @@ flux setattr log-stderr-level 1
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 Y2J=${JOBSPEC}/y2j.py
 SUBMITBENCH="${FLUX_BUILD_DIR}/t/ingest/submitbench"
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 DUMMY_EVENTLOG=test.ingest.eventlog
 
@@ -130,6 +131,10 @@ test_expect_success HAVE_FLUX_SECURITY 'job-ingest: non-owner mech=none fails' '
 	! FLUX_HANDLE_ROLEMASK=0x2 flux job submit \
 		--sign-type=none basic.json 2>badrole.out &&
 	grep -q "only instance owner" badrole.out
+'
+
+test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
+	${RPC} job-ingest.submit 71 </dev/null
 '
 
 test_expect_success 'job-ingest: remove modules' '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -10,6 +10,7 @@ flux setattr log-stderr-level 1
 
 DRAIN_UNDRAIN=${FLUX_SOURCE_DIR}/t/job-manager/drain-undrain.py
 DRAIN_CANCEL=${FLUX_SOURCE_DIR}/t/job-manager/drain-cancel.py
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 # List jobs without header
 list_jobs() {
@@ -286,6 +287,25 @@ test_expect_success 'job-manager: there is still one job in the queue' '
 test_expect_success 'job-manager: drain unblocks when last job is canceld' '
 	jobid=$(cut -f1 <list.out) &&
 	run_timeout 5 ${DRAIN_CANCEL} ${jobid}
+'
+
+test_expect_success 'list request with empty payload fails with EPROTO(71)' '
+	${RPC} job-manager.list 71 </dev/null
+'
+test_expect_success 'raise request with empty payload fails with EPROTO(71)' '
+	${RPC} job-manager.raise 71 </dev/null
+'
+test_expect_success 'priority request with empty payload fails with EPROTO(71)' '
+	${RPC} job-manager.priority 71 </dev/null
+'
+test_expect_success 'sched-ready request with empty payload fails with EPROTO(71)' '
+	${RPC} job-manager.sched-ready 71 </dev/null
+'
+test_expect_success 'exec-hello request with empty payload fails with EPROTO(71)' '
+	${RPC} job-manager.exec-hello 71 </dev/null
+'
+test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
+	${RPC} job-manager.submit 71 </dev/null
 '
 
 test_expect_success 'job-manager: remove job-manager, job-info, job-ingest' '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -8,6 +8,8 @@ test_description='Test flux job info service'
 
 test_under_flux 4 job
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 # Usage: submit_job
 # To ensure robustness of tests despite future job manager changes,
 # cancel the job, and wait for clean event.
@@ -328,6 +330,13 @@ test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventl
 test_expect_success 'job-info stats works' '
         flux module stats job-info | grep "lookups" &&
         flux module stats job-info | grep "watchers"
+'
+
+test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '
+	${RPC} job-info.lookup 71 </dev/null
+'
+test_expect_success 'eventlog-watch request with empty payload fails with EPROTO(71)' '
+	${RPC} job-info.eventlog-watch 71 </dev/null
 '
 
 test_done

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -13,6 +13,7 @@ flux setattr log-stderr-level 1
 jq=$(which jq 2>/dev/null)
 test -n "$jq" && test_set_prereq HAVE_JQ
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
 
@@ -111,6 +112,9 @@ test_expect_success HAVE_JQ 'job-exec: exception during cleanup' '
 	flux job wait-event -t 2.5 ${jobid} clean &&
 	exec_eventlog $jobid > exec.eventlog.$jobid &&
 	grep "cleanup\.finish " exec.eventlog.$jobid
+'
+test_expect_success 'start request with empty payload fails with EPROTO(71)' '
+	${RPC} job-exec.start 71 </dev/null
 '
 test_expect_success 'job-exec: remove sched-simple,job-exec modules' '
 	flux module remove -r 0 sched-simple &&


### PR DESCRIPTION
This PR adds some more tests that send a malformed request to services and make sure they get an EPROTO response.  In addition it addresses a problem with the encoding of request messages by the `t/request/rpc` test program and adds tests for that.

A couple of response handlers needed some minor tweaks to behave properly on error paths.