### PR TITLE
flux-kvs: misc fixes

### DIFF
--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1514,7 +1514,7 @@ static int sort_cmp (void *item1, void *item2)
  * its contents are to be listed or not.  If -F is specified,
  * 'singles' key names are decorated based on their type.
  */
-static int categorize_key (optparse_t *p, const char *key,
+static int categorize_key (optparse_t *p, const char *ns, const char *key,
                             zlist_t *dirs, zlist_t *singles)
 {
     flux_t *h = (flux_t *)optparse_get_data (p, "flux_handle");
@@ -1533,7 +1533,7 @@ static int categorize_key (optparse_t *p, const char *key,
         nkey[strlen (nkey) - 1] = '\0';
         require_directory = true;
     }
-    if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_TREEOBJ, nkey)))
+    if (!(f = flux_kvs_lookup (h, ns, FLUX_KVS_TREEOBJ, nkey)))
         log_err_exit ("flux_kvs_lookup");
     if (flux_kvs_lookup_get_treeobj (f, &json_str) < 0) {
         fprintf (stderr, "%s: %s\n", nkey, flux_strerror (errno));
@@ -1609,11 +1609,11 @@ int cmd_ls (optparse_t *p, int argc, char **argv)
         log_err_exit ("zlist_new");
 
     if (optindex == argc) {
-        if (categorize_key (p, ".", dirs, singles) < 0)
+        if (categorize_key (p, ns, ".", dirs, singles) < 0)
             rc = -1;
     }
     while (optindex < argc) {
-        if (categorize_key (p, argv[optindex++], dirs, singles) < 0)
+        if (categorize_key (p, ns, argv[optindex++], dirs, singles) < 0)
             rc = -1;
     }
     if (zlist_size (singles) > 0) {

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1557,7 +1557,7 @@ static int categorize_key (optparse_t *p, const char *ns, const char *key,
             fprintf (stderr, "%s: Not a directory\n", nkey);
             goto error;
         }
-        if (zlist_append (singles, xstrdup (key)) < 0)
+        if (zlist_append (singles, nkey) < 0)
             log_err_exit ("zlist_append");
     }
     else if (treeobj_is_symlink (treeobj)) {

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -749,6 +749,27 @@ test_expect_success 'kvs: ls key. fails if key does not exist' '
 	flux kvs unlink -Rf $DIR &&
 	test_must_fail flux kvs ls $DIR.a
 '
+test_expect_success 'kvs: namespace create setup' '
+	flux kvs namespace create TESTLSNS
+'
+test_expect_success 'kvs: ls --namespace -1F DIR works' '
+	flux kvs unlink --namespace=TESTLSNS -Rf $DIR.ns &&
+	flux kvs put --namespace=TESTLSNS --json $DIR.ns.a=69 &&
+	flux kvs mkdir --namespace=TESTLSNS $DIR.ns.b &&
+	flux kvs link --namespace=TESTLSNS b $DIR.ns.c &&
+	flux kvs link --namespace=TESTLSNS --target-namespace=foo c $DIR.ns.d &&
+	flux kvs ls --namespace=TESTLSNS -1F $DIR.ns >output &&
+	cat >expected <<-EOF &&
+	a
+	b.
+	c@
+	d@
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: namespace remove cleanup' '
+	flux kvs namespace remove TESTLSNS
+'
 
 #
 # link/readlink tests

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -749,6 +749,66 @@ test_expect_success 'kvs: ls key. fails if key does not exist' '
 	flux kvs unlink -Rf $DIR &&
 	test_must_fail flux kvs ls $DIR.a
 '
+test_expect_success 'kvs: ls does not follow symlink with -d' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.foo=1 &&
+	flux kvs link $DIR.foo $DIR.link &&
+	flux kvs ls -d $DIR.link >output &&
+	cat >expected <<-EOF &&
+	$DIR.link
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls does not follow symlink with -F' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.foo=1 &&
+	flux kvs link $DIR.foo $DIR.link &&
+	flux kvs ls -F $DIR.link >output &&
+	cat >expected <<-EOF &&
+	$DIR.link@
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls outputs linkname when link points to value' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.foo=1 &&
+	flux kvs link $DIR.foo $DIR.link &&
+	flux kvs ls $DIR.link >output &&
+	cat >expected <<-EOF &&
+	$DIR.link
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls outputs linkname when link points to invalid target' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs link invalid $DIR.link &&
+	flux kvs ls $DIR.link >output &&
+	cat >expected <<-EOF &&
+	$DIR.link
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls outputs dir when link points to dir' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a.b=1 &&
+	flux kvs link $DIR.a $DIR.link &&
+	flux kvs ls $DIR.link >output &&
+	cat >expected <<-EOF &&
+	b
+	EOF
+	test_cmp expected output
+'
+test_expect_success 'kvs: ls outputs dir and header when link points to dir and -R' '
+	flux kvs unlink -Rf $DIR &&
+	flux kvs put $DIR.a.b=1 &&
+	flux kvs link $DIR.a $DIR.link &&
+	flux kvs ls -R $DIR.link >output &&
+	cat >expected <<-EOF &&
+	$DIR.link:
+	b
+	EOF
+	test_cmp expected output
+'
 test_expect_success 'kvs: namespace create setup' '
 	flux kvs namespace create TESTLSNS
 '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -653,7 +653,6 @@ test_expect_success 'kvs: ls -1Fd DIR.a DIR.b DIR.c DIR.d works' '
 	flux kvs mkdir $DIR.b &&
 	flux kvs link b $DIR.c &&
 	flux kvs link --target-namespace=foo c $DIR.d &&
-	flux kvs ls -1Fd $DIR.a $DIR.b $DIR.c $DIR.d >output-1 &&
 	flux kvs ls -1Fd $DIR.a $DIR.b $DIR.c $DIR.d >output &&
 	cat >expected <<-EOF &&
 	$DIR.a
@@ -668,7 +667,6 @@ test_expect_success 'kvs: ls -1RF shows directory titles' '
 	flux kvs put --json $DIR.a=69 &&
 	flux kvs put --json $DIR.b.d=42 &&
 	flux kvs link b $DIR.c &&
-	flux kvs ls -1RF $DIR | grep : >output-2 &&
 	flux kvs ls -1RF $DIR | grep : | wc -l >output &&
 	cat >expected <<-EOF &&
 	2

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -389,6 +389,25 @@ test_expect_success 'kvs: empty directory remains after key removed' '
         flux kvs unlink $DIR.a &&
 	test_empty_directory $DIR
 '
+test_expect_success 'kvs: unlink works on link that points to invalid target' '
+	flux kvs unlink -Rf $DIR &&
+        flux kvs link invalid $DIR.link &&
+        flux kvs unlink $DIR.link
+'
+test_expect_success 'kvs: unlink works on link that points to invalid namespace' '
+	flux kvs unlink -Rf $DIR &&
+        flux kvs put $DIR.foo=1 &&
+        flux kvs link --target-namespace=invalid $DIR.foo $DIR.link &&
+        flux kvs unlink $DIR.link
+'
+test_expect_success 'kvs: unlink works on link with infinite cycle' '
+	flux kvs unlink -Rf $DIR &&
+        flux kvs link $DIR.a $DIR.b &&
+        flux kvs link $DIR.b $DIR.a &&
+        flux kvs unlink $DIR.a &&
+        flux kvs unlink $DIR.b &&
+	test_empty_directory $DIR
+'
 
 #
 # empty string corner case tests


### PR DESCRIPTION
Started just wanting to fix issue #2086, and found two other issues along the way.

For issue #2129 (fix issues unlinking symlinks), the `unlink_safety_check()` function was a little tricky to begin with, so I re-worked the whole function do the check based on the lookup
of a `TREEOBJ`, hopefully minimizing the number of KVS lookups that have to be done to do an `unlink_safety_check()`.
