### PR TITLE
flux-job: Add context test in wait-event

### DIFF
--- a/src/common/libeventlog/test/eventlog.c
+++ b/src/common/libeventlog/test/eventlog.c
@@ -40,6 +40,20 @@ void eventlog_entry_parsing (void)
         "eventlog_entry_parse fails with EINVAL on bad event");
     json_decref (event);
 
+    event = json_pack ("{ s:f s:s s:[s] }",
+                       "timestamp", 52.0,
+                       "name", "bar",
+                       "context",
+                       "foo", "bar");
+    if (!event)
+        BAIL_OUT ("Error creating test json object");
+
+    errno = 0;
+    ok (eventlog_entry_parse (event, NULL, NULL, NULL) < 0
+        && errno == EINVAL,
+        "eventlog_entry_parse fails with EINVAL on bad context");
+    json_decref (event);
+
     event = json_pack ("{ s:f s:s }",
                        "timestamp", 42.0,
                        "name", "foo");

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -62,7 +62,7 @@ test_expect_success 'job-manager: queue list job with correct priority' '
 test_expect_success 'job-manager: raise non-fatal exception on job' '
 	jobid=$(cat list1_jobid.out) &&
 	flux job raise --severity=1 --type=testing ${jobid} Mumble grumble &&
-        flux job wait-event --timeout=5.0 ${jobid} exception &&
+        flux job wait-event --timeout=5.0 --match-context=type=testing ${jobid} exception &&
 	flux job eventlog $jobid \
 		| grep exception >list1_exception.out &&
 	grep -q "type=\"testing\"" list1_exception.out &&
@@ -82,7 +82,7 @@ test_expect_success 'job-manager: queue contains 1 jobs' '
 test_expect_success 'job-manager: cancel job' '
 	jobid=$(cat list1_jobid.out) &&
 	flux job cancel ${jobid} &&
-        flux job wait-event --timeout=5.0 ${jobid} exception &&
+        flux job wait-event --timeout=5.0 --match-context=type=cancel ${jobid} exception &&
 	flux job eventlog $jobid | grep exception \
 		| grep severity=0 | grep "type=\"cancel\""
 '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -252,6 +252,42 @@ test_expect_success 'flux job wait-event --format=invalid fails' '
 	! flux job wait-event --format=invalid $jobid submit
 '
 
+test_expect_success 'flux job wait-event w/ match-context works (string w/ quotes)' '
+        jobid=$(submit_job) &&
+	flux job wait-event --match-context="type=\"cancel\"" $jobid exception > wait_event_context1.out &&
+        grep -q "exception" wait_event_context1.out &&
+        grep -q "type=\"cancel\"" wait_event_context1.out
+'
+
+test_expect_success 'flux job wait-event w/ match-context works (string w/o quotes)' '
+        jobid=$(submit_job) &&
+	flux job wait-event --match-context=type=cancel $jobid exception > wait_event_context2.out &&
+        grep -q "exception" wait_event_context2.out &&
+        grep -q "type=\"cancel\"" wait_event_context2.out
+'
+
+test_expect_success 'flux job wait-event w/ match-context works (int)' '
+        jobid=$(submit_job) &&
+	flux job wait-event --match-context=flags=0 $jobid submit > wait_event_context3.out &&
+        grep -q "submit" wait_event_context3.out &&
+        grep -q "flags=0" wait_event_context3.out
+'
+
+test_expect_success 'flux job wait-event w/ bad match-context fails (invalid key)' '
+        jobid=$(submit_job) &&
+        ! run_timeout 0.2 flux job wait-event --match-context=foo=bar $jobid exception
+'
+
+test_expect_success 'flux job wait-event w/ bad match-context fails (invalid value)' '
+        jobid=$(submit_job) &&
+        ! run_timeout 0.2 flux job wait-event --match-context=type=foo $jobid exception
+'
+
+test_expect_success 'flux job wait-event w/ bad match-context fails (invalid input)' '
+        jobid=$(submit_job) &&
+        ! flux job wait-event --match-context=foo $jobid exception
+'
+
 #
 # job info tests
 #


### PR DESCRIPTION
As discussed in #2083, it would be useful for `flux job wait-event` to wait not just for an event but for some condition in the context.  As an initial step, add the ability for the user to specify an optional `key=val` to check in the context too.

Initial feature supports only one `key=val` input, it could be > 1, but didn't see a need for > 1 at the moment.

On the way, reverted a behavior change from #2085 where strings output from contexts were quoted (i.e. `data="foo"` instead of `data=foo`).  Users would have to be mindful of quoting strings in contexts, which I think is confusing.  So I decided to remove those quotations everywhere.