### PR TITLE
flux-job: Add --time-format option

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -181,12 +181,11 @@ the root sequence number.
 
 *eventlog get* [-w] [-c count] [-u] 'key'::
 Display the contents of an RFC 18 KVS eventlog referred to by 'key'.
-If '-u' is specified, display the log in raw form, otherwise format the
-dates as ISO 8601.  If '-w' is specified, after the existing contents
-have been displayed, the eventlog is monitored and updates are
-displayed as they are committed.  This runs until the program is
-interrupted or an error occurs, unless the number of events is limited
-with the '-c' option.
+If '-u' is specified, display the log in raw form.  If '-w' is
+specified, after the existing contents have been displayed, the
+eventlog is monitored and updates are displayed as they are committed.
+This runs until the program is interrupted or an error occurs, unless
+the number of events is limited with the '-c' option.
 
 *eventlog append* [-t SECONDS] 'key' 'name' ['context ...']::
 Append an event to an RFC 18 KVS eventlog referred to by 'key'.

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -180,14 +180,14 @@ static struct optparse_subcommand subcommands[] = {
       id_opts
     },
     { "eventlog",
-      "[-c text|json] id",
+      "[-f text|json] id",
       "Display eventlog for a job",
       cmd_eventlog,
       0,
       eventlog_opts
     },
     { "wait-event",
-      "[-c text|json] [-t seconds] [-m key=val] id event",
+      "[-f text|json] [-t seconds] [-m key=val] id event",
       "Wait for an event ",
       cmd_wait_event,
       0,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -108,7 +108,7 @@ static struct optparse_option eventlog_opts[] =  {
       .usage = "Specify output format: text, json",
     },
     { .name = "time-format", .key = 'T', .has_arg = 1, .arginfo = "FORMAT",
-      .usage = "Specify time format: raw, iso",
+      .usage = "Specify time format: raw, iso, offset",
     },
     OPTPARSE_TABLE_END
 };
@@ -118,7 +118,7 @@ static struct optparse_option wait_event_opts[] =  {
       .usage = "Specify output format: text, json",
     },
     { .name = "time-format", .key = 'T', .has_arg = 1, .arginfo = "FORMAT",
-      .usage = "Specify time format: raw, iso",
+      .usage = "Specify time format: raw, iso, offset",
     },
     { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "DURATION",
       .usage = "timeout after DURATION",
@@ -186,14 +186,14 @@ static struct optparse_subcommand subcommands[] = {
       id_opts
     },
     { "eventlog",
-      "[-f text|json] [-T raw|iso] id",
+      "[-f text|json] [-T raw|iso|offset] id",
       "Display eventlog for a job",
       cmd_eventlog,
       0,
       eventlog_opts
     },
     { "wait-event",
-      "[-f text|json] [-T raw|iso] [-t seconds] [-m key=val] id event",
+      "[-f text|json] [-T raw|iso|offset] [-t seconds] [-m key=val] id event",
       "Wait for an event ",
       cmd_wait_event,
       0,
@@ -649,20 +649,37 @@ int cmd_id (optparse_t *p, int argc, char **argv)
     return 0;
 }
 
+struct entry_format {
+    const char *format;
+    const char *time_format;
+};
+
+void entry_format_parse_options (optparse_t *p, struct entry_format *e)
+{
+    e->format = optparse_get_str (p, "format", "text");
+    if (strcasecmp (e->format, "text")
+        && strcasecmp (e->format, "json"))
+        log_msg_exit ("invalid format type");
+    e->time_format = optparse_get_str (p, "time-format", "raw");
+    if (strcasecmp (e->time_format, "raw")
+        && strcasecmp (e->time_format, "iso")
+        && strcasecmp (e->time_format, "offset"))
+        log_msg_exit ("invalid time-format type");
+}
+
 struct eventlog_ctx {
     optparse_t *p;
     flux_jobid_t id;
-    const char *format;
-    const char *time_format;
+    struct entry_format e;
 };
 
 /* convert floating point timestamp (UNIX epoch, UTC) to ISO 8601 string,
  * with microsecond precision
  */
-static int event_timestr (const char *time_format, double timestamp,
+static int event_timestr (struct entry_format *e, double timestamp,
                           char *buf, size_t size)
 {
-    if (!strcasecmp (time_format, "raw")) {
+    if (!strcasecmp (e->time_format, "raw")) {
         if (snprintf (buf, size, "%lf", timestamp) >= size)
             return -1;
     }
@@ -682,7 +699,7 @@ static int event_timestr (const char *time_format, double timestamp,
     return 0;
 }
 
-void output_event_text (json_t *event, const char *time_format)
+void output_event_text (struct entry_format *e, json_t *event)
 {
     double timestamp;
     const char *name;
@@ -692,7 +709,7 @@ void output_event_text (json_t *event, const char *time_format)
     if (eventlog_entry_parse (event, &timestamp, &name, &context) < 0)
         log_err_exit ("eventlog_entry_parse");
 
-    if (event_timestr (time_format, timestamp, buf, sizeof (buf)) < 0)
+    if (event_timestr (e, timestamp, buf, sizeof (buf)) < 0)
         log_msg_exit ("error converting timestamp to ISO 8601");
 
     printf ("%s %s", buf, name);
@@ -721,11 +738,11 @@ void output_event_json (json_t *event)
     free (e);
 }
 
-void output_event (json_t *event, const char *format, const char *time_format)
+void output_event (struct entry_format *e, json_t *event)
 {
-    if (!strcasecmp (format, "text"))
-        output_event_text (event, time_format);
-    else if (!strcasecmp (format, "json"))
+    if (!strcasecmp (e->format, "text"))
+        output_event_text (e, event);
+    else /* !strcasecmp (e->format, "json") */
         output_event_json (event);
 }
 
@@ -750,7 +767,7 @@ void eventlog_continuation (flux_future_t *f, void *arg)
         log_err_exit ("eventlog_decode");
 
     json_array_foreach (a, index, value) {
-        output_event (value, ctx->format, ctx->time_format);
+        output_event (&ctx->e, value);
     }
 
     fflush (stdout);
@@ -775,16 +792,8 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
     }
 
     ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
-
     ctx.p = p;
-    ctx.format = optparse_get_str (p, "format", "text");
-    if (strcasecmp (ctx.format, "text")
-        && strcasecmp (ctx.format, "json"))
-        log_msg_exit ("invalid format type");
-    ctx.time_format = optparse_get_str (p, "time-format", "raw");
-    if (strcasecmp (ctx.time_format, "raw")
-        && strcasecmp (ctx.time_format, "iso"))
-        log_msg_exit ("invalid time-format type");
+    entry_format_parse_options (p, &ctx.e);
 
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
                              "{s:I s:[s] s:i}",
@@ -807,8 +816,7 @@ struct wait_event_ctx {
     double timeout;
     flux_jobid_t id;
     bool got_event;
-    const char *format;
-    const char *time_format;
+    struct entry_format e;
     char *context_key;
     char *context_value;
 };
@@ -897,12 +905,12 @@ void wait_event_continuation (flux_future_t *f, void *arg)
     if (wait_event_test (ctx, o)) {
         ctx->got_event = true;
         if (!optparse_hasopt (ctx->p, "quiet"))
-            output_event (o, ctx->format, ctx->time_format);
+            output_event (&ctx->e, o);
         if (flux_job_event_watch_cancel (f) < 0)
             log_err_exit ("flux_job_event_watch_cancel");
     } else if (optparse_hasopt (ctx->p, "verbose")) {
         if (!ctx->got_event)
-            output_event (o, ctx->format, ctx->time_format);
+            output_event (&ctx->e, o);
     }
 
     json_decref (o);
@@ -933,14 +941,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
     ctx.p = p;
     ctx.wait_event = argv[optindex++];
     ctx.timeout = optparse_get_duration (p, "timeout", -1.0);
-    ctx.format = optparse_get_str (p, "format", "text");
-    if (strcasecmp (ctx.format, "text")
-        && strcasecmp (ctx.format, "json"))
-        log_msg_exit ("invalid format type");
-    ctx.time_format = optparse_get_str (p, "time-format", "raw");
-    if (strcasecmp (ctx.time_format, "raw")
-        && strcasecmp (ctx.time_format, "iso"))
-        log_msg_exit ("invalid time-format type");
+    entry_format_parse_options (p, &ctx.e);
     if ((str = optparse_get_str (p, "match-context", NULL))) {
         ctx.context_key = xstrdup (str);
         ctx.context_value = strchr (ctx.context_key, '=');

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -134,6 +134,13 @@ test_expect_success 'flux job eventlog --time-format=iso works' '
         get_timestamp_field submit eventlog_time_format2.out | grep T | grep Z
 '
 
+test_expect_success 'flux job eventlog --time-format=offset works' '
+        jobid=$(submit_job) &&
+	flux job eventlog --time-format=offset $jobid > eventlog_time_format3.out &&
+        get_timestamp_field submit eventlog_time_format3.out | grep "0.000000" &&
+        get_timestamp_field exception eventlog_time_format3.out | grep -v "0.000000"
+'
+
 test_expect_success 'flux job eventlog --time-format=invalid fails works' '
         jobid=$(submit_job) &&
 	! flux job eventlog --time-format=invalid $jobid
@@ -285,6 +292,14 @@ test_expect_success 'flux job wait-event --time-format=iso works' '
         jobid=$(submit_job) &&
 	flux job wait-event --time-format=iso $jobid submit > wait_event_time_format2.out &&
         get_timestamp_field submit wait_event_time_format2.out | grep T | grep Z
+'
+
+test_expect_success 'flux job wait-event --time-format=offset works' '
+        jobid=$(submit_job) &&
+	flux job wait-event --time-format=offset $jobid submit > wait_event_time_format3A.out &&
+        get_timestamp_field submit wait_event_time_format3A.out | grep "0.000000" &&
+	flux job wait-event --time-format=offset $jobid exception > wait_event_time_format3B.out &&
+        get_timestamp_field exception wait_event_time_format3B.out | grep -v "0.000000"
 '
 
 test_expect_success 'flux job wait-event --time-format=invalid fails works' '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -44,6 +44,12 @@ move_inactive() {
         return 0
 }
 
+get_timestamp_field() {
+        field=$1
+        file=$2
+        grep $field $file | awk '{print $1}'
+}
+
 test_expect_success 'job-info: generate jobspec for simple test job' '
         flux jobspec --format json srun -N1 hostname > test.json
 '
@@ -114,6 +120,23 @@ test_expect_success 'flux job eventlog --format=text works' '
 test_expect_success 'flux job eventlog --format=invalid fails' '
         jobid=$(submit_job) &&
 	! flux job eventlog --format=invalid $jobid
+'
+
+test_expect_success 'flux job eventlog --time-format=raw works' '
+        jobid=$(submit_job) &&
+	flux job eventlog --time-format=raw $jobid > eventlog_time_format1.out &&
+        get_timestamp_field submit eventlog_time_format1.out | grep "\."
+'
+
+test_expect_success 'flux job eventlog --time-format=iso works' '
+        jobid=$(submit_job) &&
+	flux job eventlog --time-format=iso $jobid > eventlog_time_format2.out &&
+        get_timestamp_field submit eventlog_time_format2.out | grep T | grep Z
+'
+
+test_expect_success 'flux job eventlog --time-format=invalid fails works' '
+        jobid=$(submit_job) &&
+	! flux job eventlog --time-format=invalid $jobid
 '
 
 #
@@ -250,6 +273,23 @@ test_expect_success 'flux job wait-event --format=text works' '
 test_expect_success 'flux job wait-event --format=invalid fails' '
         jobid=$(submit_job) &&
 	! flux job wait-event --format=invalid $jobid submit
+'
+
+test_expect_success 'flux job wait-event --time-format=raw works' '
+        jobid=$(submit_job) &&
+	flux job wait-event --time-format=raw $jobid submit > wait_event_time_format1.out &&
+        get_timestamp_field submit wait_event_time_format1.out | grep "\."
+'
+
+test_expect_success 'flux job wait-event --time-format=iso works' '
+        jobid=$(submit_job) &&
+	flux job wait-event --time-format=iso $jobid submit > wait_event_time_format2.out &&
+        get_timestamp_field submit wait_event_time_format2.out | grep T | grep Z
+'
+
+test_expect_success 'flux job wait-event --time-format=invalid fails works' '
+        jobid=$(submit_job) &&
+	! flux job wait-event --time-format=invalid $jobid submit
 '
 
 test_expect_success 'flux job wait-event w/ match-context works (string w/ quotes)' '


### PR DESCRIPTION
As discussed in #2074, it'd be nice to format job eventlog entry timestamps.

- Support a new `--time-format` option in `flux-job` that takes `raw`, `iso`, and `offset` as inputs.  Outputting floating point value, ISO8601, or offset from 0.0 (for the first entry).

- I considered making `flux-job eventlog` and `flux-kvs eventlog get` consistent with each other (both have `--format` and `--time-format` options), but my gut told me that `flux kvs eventlog get` doesn't have to support all of the "pretty" options that `flux-job` does. The `flux kvs` option is more for debugging/testing?

So I elected to have `flux kvs eventlog get` just output timestamps in floating point and that's it.

Obviously we can do differently, dunno what people's opinions are.
