### PR TITLE
Remove job.active/inactive directory

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -600,9 +600,7 @@ void id_convert (optparse_t *p, const char *src, char *dst, int dstsz)
         snprintf (dst, dstsz, "%llu", (unsigned long long)id);
     }
     else if (!strcmp (to, "kvs-active")) {
-        if (snprintf (dst, dstsz, "job.active.") >= dstsz
-                || fluid_encode (dst + strlen (dst), dstsz - strlen (dst),
-                                 id, FLUID_STRING_DOTHEX) < 0)
+        if (flux_job_kvs_key (dst, dstsz, id, NULL) < 0)
             log_msg_exit ("error encoding id");
     }
     else if (!strcmp (to, "words")) {

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -93,11 +93,11 @@ static struct optparse_option submit_opts[] =  {
 
 static struct optparse_option id_opts[] =  {
     { .name = "from", .key = 'f', .has_arg = 1,
-      .arginfo = "dec|kvs-active|words",
+      .arginfo = "dec|kvs|words",
       .usage = "Convert jobid from specified form",
     },
     { .name = "to", .key = 't', .has_arg = 1,
-      .arginfo = "dec|kvs-active|words",
+      .arginfo = "dec|kvs|words",
       .usage = "Convert jobid to specified form",
     },
     OPTPARSE_TABLE_END
@@ -581,10 +581,10 @@ void id_convert (optparse_t *p, const char *src, char *dst, int dstsz)
     if (!strcmp (from, "dec")) {
         id = parse_arg_unsigned (src, "input");
     }
-    else if (!strcmp (from, "kvs-active")) {
-        if (strncmp (src, "job.active.", 11) != 0)
-            log_msg_exit ("%s: missing 'job.active.' prefix", src);
-        if (fluid_decode (src + 11, &id, FLUID_STRING_DOTHEX) < 0)
+    else if (!strcmp (from, "kvs")) {
+        if (strncmp (src, "job.", 4) != 0)
+            log_msg_exit ("%s: missing 'job.' prefix", src);
+        if (fluid_decode (src + 4, &id, FLUID_STRING_DOTHEX) < 0)
             log_msg_exit ("%s: malformed input", src);
     }
     else if (!strcmp (from, "words")) {
@@ -599,7 +599,7 @@ void id_convert (optparse_t *p, const char *src, char *dst, int dstsz)
     if (!strcmp (to, "dec")) {
         snprintf (dst, dstsz, "%llu", (unsigned long long)id);
     }
-    else if (!strcmp (to, "kvs-active")) {
+    else if (!strcmp (to, "kvs")) {
         if (flux_job_kvs_key (dst, dstsz, id, NULL) < 0)
             log_msg_exit ("error encoding id");
     }

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -206,8 +206,7 @@ flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority)
     return f;
 }
 
-int flux_job_kvs_key (char *buf, int bufsz, bool active,
-                      flux_jobid_t id, const char *key)
+int flux_job_kvs_key (char *buf, int bufsz, flux_jobid_t id, const char *key)
 {
     char idstr[32];
     int len;
@@ -219,8 +218,7 @@ int flux_job_kvs_key (char *buf, int bufsz, bool active,
 
     if (fluid_encode (idstr, sizeof (idstr), id, FLUID_STRING_DOTHEX) < 0)
         return -1;
-    len = snprintf (buf, bufsz, "job.%s.%s%s%s",
-                    active ? "active" : "inactive",
+    len = snprintf (buf, bufsz, "job.%s%s%s",
                     idstr,
                     key ? "." : "",
                     key ? key : "");

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -224,8 +224,10 @@ int flux_job_kvs_key (char *buf, int bufsz, bool active,
                     idstr,
                     key ? "." : "",
                     key ? key : "");
-    if (len >= bufsz)
+    if (len >= bufsz) {
+        errno = EOVERFLOW;
         return -1;
+    }
     return len;
 }
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -93,12 +93,11 @@ flux_future_t *flux_job_cancel (flux_t *h, flux_jobid_t id, const char *reason);
  */
 flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority);
 
-/* Write KVS path to 'key' relative to active job directory for job 'id'.
+/* Write KVS path to 'key' relative to job directory for job 'id'.
  * If key=NULL, write the job directory.
  * Returns string length on success, or -1 on failure.
  */
-int flux_job_kvs_key (char *buf, int bufsz, bool active,
-                      flux_jobid_t id, const char *key);
+int flux_job_kvs_key (char *buf, int bufsz, flux_jobid_t id, const char *key);
 
 /* Job eventlog watch functions
  */

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -18,27 +18,24 @@
 
 struct jobkey_input {
     flux_jobid_t id;
-    bool active;
     const char *key;
     const char *expected;
 };
 
 struct jobkey_input jobkeytab[] = {
-    { 1, true, NULL,            "job.active.0000.0000.0000.0001" },
-    { 1, false, NULL,           "job.inactive.0000.0000.0000.0001" },
-    { 2, true, "foo",           "job.active.0000.0000.0000.0002.foo" },
-    { 2, false, "foo",          "job.inactive.0000.0000.0000.0002.foo" },
-    { 3, true, "a.b.c",         "job.active.0000.0000.0000.0003.a.b.c" },
-    { 0xdeadbeef, true, NULL,   "job.active.0000.0000.dead.beef" },
+    { 1, NULL,           "job.0000.0000.0000.0001" },
+    { 2, "foo",          "job.0000.0000.0000.0002.foo" },
+    { 3, "a.b.c",        "job.0000.0000.0000.0003.a.b.c" },
+    { 0xdeadbeef, NULL,  "job.0000.0000.dead.beef" },
 
     /* expected failure: overflow */
-    { 4, true, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", NULL },
+    { 4, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", NULL },
 
-    { 0, false, NULL, NULL },
+    { 0, NULL, NULL },
 };
 bool is_jobkeytab_end (struct jobkey_input *try)
 {
-    if (try->id == 0 && try->active == false && !try->key && !try->expected)
+    if (try->id == 0 && !try->key && !try->expected)
         return true;
     return false;
 }
@@ -50,7 +47,7 @@ void check_one_jobkey (struct jobkey_input *try)
     bool valid = false;
 
     memset (path, 0, sizeof (path));
-    len = flux_job_kvs_key (path, sizeof (path), try->active, try->id, try->key);
+    len = flux_job_kvs_key (path, sizeof (path), try->id, try->key);
 
     if (try->expected) {
         if (len >= 0 && len == strlen (try->expected)
@@ -62,9 +59,8 @@ void check_one_jobkey (struct jobkey_input *try)
             valid = true;
     }
     ok (valid == true,
-        "util_jobkey id=%llu active=%s key=%s %s",
+        "util_jobkey id=%llu key=%s %s",
         (unsigned long long)try->id,
-        try->active ? "true" : "false",
         try->key ? try->key : "NULL",
         try->expected ? "works" : "fails");
 
@@ -134,7 +130,7 @@ void check_corner_case (void)
     /* flux_job_kvs_key */
 
     errno = 0;
-    ok (flux_job_kvs_key (NULL, 0, false, 0, NULL) < 0
+    ok (flux_job_kvs_key (NULL, 0, 0, NULL) < 0
         && errno == EINVAL,
         "flux_job_kvs_key fails with errno == EINVAL");
 

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -87,7 +87,7 @@ static struct alloc *alloc_create (const flux_msg_t *msg, const char *R,
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
         return NULL;
-    if (flux_job_kvs_key (key, sizeof (key), true, id, "R") < 0) {
+    if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -23,7 +23,7 @@ static int schedutil_hello_job (flux_t *h, flux_jobid_t id,
     flux_future_t *f;
     const char *s;
 
-    if (flux_job_kvs_key (key, sizeof (key), true, id, "R") < 0) {
+    if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
         errno = EPROTO;
         return -1;
     }

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -57,7 +57,7 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
         goto error;
-    if (flux_job_kvs_key (key, sizeof (key), true, id, "jobspec") < 0) {
+    if (flux_job_kvs_key (key, sizeof (key), id, "jobspec") < 0) {
         errno = EPROTO;
         goto error;
     }
@@ -112,7 +112,7 @@ static void free_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
         goto error;
-    if (flux_job_kvs_key (key, sizeof (key), true, id, "R") < 0) {
+    if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
         errno = EPROTO;
         goto error;
     }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -475,7 +475,7 @@ static void namespace_copy (flux_future_t *f, void *arg)
     flux_future_t *fnext = NULL;
     char dst [265];
 
-    if (flux_job_kvs_key (dst, sizeof (dst), true, job->id, "guest") < 0) {
+    if (flux_job_kvs_key (dst, sizeof (dst), job->id, "guest") < 0) {
         flux_log_error (h, "namespace_move: flux_job_kvs_key");
         goto done;
     }
@@ -761,7 +761,7 @@ static flux_future_t *flux_jobid_kvs_lookup (flux_t *h, flux_jobid_t id,
                                              int flags, const char *key)
 {
     char path [256];
-    if (flux_job_kvs_key (path, sizeof (path), true, id, key) < 0)
+    if (flux_job_kvs_key (path, sizeof (path), id, key) < 0)
         return NULL;
     return flux_kvs_lookup (h, NULL, flags, path);
 }
@@ -843,7 +843,7 @@ static flux_future_t * jobinfo_link_guestns (struct jobinfo *job)
     flux_future_t *f = NULL;
     char key [64];
 
-    if (flux_job_kvs_key (key, sizeof (key), true, job->id, "guest") < 0) {
+    if (flux_job_kvs_key (key, sizeof (key), job->id, "guest") < 0) {
         flux_log_error (h, "link guestns: flux_job_kvs_key");
         return NULL;
     }

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -28,7 +28,6 @@ struct lookup_ctx {
     json_t *keys;
     bool check_eventlog;
     int flags;
-    bool active;
     flux_future_t *f;
     bool allow;
 };
@@ -61,7 +60,6 @@ static struct lookup_ctx *lookup_ctx_create (struct info_ctx *ctx,
     l->ctx = ctx;
     l->id = id;
     l->flags = flags;
-    l->active = true;
 
     if (!(l->keys = json_copy (keys))) {
         errno = ENOMEM;
@@ -159,20 +157,6 @@ error:
     return -1;
 }
 
-static int check_lookup_error (struct lookup_ctx *l)
-{
-    if (errno == ENOENT && l->active) {
-        /* transition / try the inactive key */
-        l->active = false;
-        if (lookup_keys (l) < 0)
-            return -1;
-        return 0;
-    }
-    else if (errno != ENOENT)
-        flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
-    return -1;
-}
-
 static void info_lookup_continuation (flux_future_t *fall, void *arg)
 {
     struct lookup_ctx *l = arg;
@@ -192,9 +176,9 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
         }
 
         if (flux_kvs_lookup_get (f, &s) < 0) {
-            if (check_lookup_error (l) < 0)
-                goto error;
-            return;
+            if (errno != ENOENT)
+                flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+            goto error;
         }
 
         if (eventlog_allow (ctx, l->msg, s) < 0)
@@ -221,9 +205,9 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
         }
 
         if (flux_kvs_lookup_get (f, &s) < 0) {
-            if (check_lookup_error (l) < 0)
-                goto error;
-            return;
+            if (errno != ENOENT)
+                flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+            goto error;
         }
 
         if (!(str = json_string (s)))

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -89,7 +89,7 @@ static int lookup_key (struct lookup_ctx *l,
     flux_future_t *f = NULL;
     char path[64];
 
-    if (flux_job_kvs_key (path, sizeof (path), l->active, l->id, key) < 0) {
+    if (flux_job_kvs_key (path, sizeof (path), l->id, key) < 0) {
         flux_log_error (l->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -82,7 +82,7 @@ static int watch_key (struct watch_ctx *w)
         w->f = NULL;
     }
 
-    if (flux_job_kvs_key (key, sizeof (key), w->active, w->id, "eventlog") < 0) {
+    if (flux_job_kvs_key (key, sizeof (key), w->id, "eventlog") < 0) {
         flux_log_error (w->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
         return -1;
     }

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -25,7 +25,6 @@ struct watch_ctx {
     struct info_ctx *ctx;
     flux_msg_t *msg;
     flux_jobid_t id;
-    bool active;
     flux_future_t *f;
     int offset;
     bool allow;
@@ -56,7 +55,6 @@ static struct watch_ctx *watch_ctx_create (struct info_ctx *ctx,
 
     w->ctx = ctx;
     w->id = id;
-    w->active = true;
 
     if (!(w->msg = flux_msg_copy (msg, true))) {
         flux_log_error (ctx->h, "%s: flux_msg_copy", __FUNCTION__);
@@ -123,14 +121,7 @@ static void watch_continuation (flux_future_t *f, void *arg)
     size_t toklen;
 
     if (flux_kvs_lookup_get (f, &s) < 0) {
-        if (errno == ENOENT && w->active) {
-            /* transition / try the inactive key */
-            w->active = false;
-            if (watch_key (w) < 0)
-                goto error;
-            return;
-        }
-        else if (errno == ENODATA) {
+        if (errno == ENODATA) {
             if (flux_respond_error (ctx->h, w->msg, ENODATA, NULL) < 0)
                 flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
             goto done;
@@ -154,32 +145,16 @@ static void watch_continuation (flux_future_t *f, void *arg)
 
     input = s;
     while (eventlog_parse_next (&input, &tok, &toklen)) {
-        if (w->active)
-            w->offset += toklen;
-
-        if (w->active || !w->offset) {
-            if (flux_respond_pack (ctx->h, w->msg,
-                                   "{s:s#}",
-                                   "event", tok, toklen) < 0) {
-                flux_log_error (ctx->h, "%s: flux_respond_pack",
-                                __FUNCTION__);
-                goto error;
-            }
+        if (flux_respond_pack (ctx->h, w->msg,
+                               "{s:s#}",
+                               "event", tok, toklen) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond_pack",
+                            __FUNCTION__);
+            goto error;
         }
-
-        if (!w->active && w->offset)
-            w->offset -= toklen;
     }
 
-    if (w->active)
-        flux_future_reset (f);
-    else {
-        /* we're in inactive state, there are no more events coming */
-        if (flux_respond_error (ctx->h, w->msg, ENODATA, NULL) < 0)
-            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
-        goto done;
-    }
-
+    flux_future_reset (f);
     return;
 
 error:

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -357,7 +357,7 @@ error:
  */
 static int make_key (char *buf, int bufsz, struct job *job, const char *name)
 {
-    if (flux_job_kvs_key (buf, bufsz, true, job->id, name) < 0) {
+    if (flux_job_kvs_key (buf, bufsz, job->id, name) < 0) {
         errno = EINVAL;
         return -1;
     }

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -357,8 +357,7 @@ error:
  */
 static int make_key (char *buf, int bufsz, struct job *job, const char *name)
 {
-    int n = flux_job_kvs_key (buf, bufsz, true, job->id, name ? name : NULL);
-    if (n < 0 || n >= bufsz) {
+    if (flux_job_kvs_key (buf, bufsz, true, job->id, name) < 0) {
         errno = EINVAL;
         return -1;
     }

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -41,10 +41,10 @@
  * The jobid is returned to the user in response to the job-ingest.submit RPC.
  * Responses are sent after the job has been successfully ingested.
  *
- * Currently all KVS data is committed under job.active.<fluid-dothex>,
+ * Currently all KVS data is committed under job.<fluid-dothex>,
  * where <fluid-dothex> is the jobid converted to 16-bit, 0-padded hex
  * strings delimited by periods, e.g.
- *   job.active.0000.0004.b200.0000
+ *   job.0000.0004.b200.0000
  *
  * The job-ingest module can be loaded on rank 0, or on many ranks across
  * the instance, rank < max FLUID id of 16384.  Each rank is relatively
@@ -230,7 +230,7 @@ static void batch_cleanup_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
-/* Remove KVS active job entries previously committed for all jobs in batch.
+/* Remove KVS job entries previously committed for all jobs in batch.
  */
 static int batch_cleanup (struct batch *batch)
 {

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -217,7 +217,7 @@ static int event_batch_commit_event (struct event_ctx *ctx, struct job *job,
 
     if (event_batch_start (ctx) < 0)
         return -1;
-    if (flux_job_kvs_key (key, sizeof (key), true, job->id, "eventlog") < 0)
+    if (flux_job_kvs_key (key, sizeof (key), job->id, "eventlog") < 0)
         return -1;
     if (!ctx->batch->txn && !(ctx->batch->txn = flux_kvs_txn_create ()))
         return -1;

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -151,7 +151,7 @@ static int restart_map_cb (struct job *job, void *arg)
 int restart_from_kvs (flux_t *h, struct queue *queue,
                       struct event_ctx *event_ctx)
 {
-    const char *dirname = "job.active";
+    const char *dirname = "job";
     int dirskip = strlen (dirname);
     int count;
     struct restart_ctx ctx;

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -61,7 +61,7 @@ static int depthfirst_map_one (flux_t *h, const char *key, int dirskip,
     }
     if (fluid_decode (key + dirskip + 1, &id, FLUID_STRING_DOTHEX) < 0)
         return -1;
-    if (flux_job_kvs_key (path, sizeof (path), true, id, "eventlog") < 0) {
+    if (flux_job_kvs_key (path, sizeof (path), id, "eventlog") < 0) {
         errno = EINVAL;
         return -1;
     }

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -73,7 +73,7 @@ test_expect_success 'job-ingest: YAML jobspec is rejected' '
 
 test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 	jobid=$(flux job submit basic.json) &&
-	kvsdir=$(flux job id --to=kvs-active $jobid) &&
+	kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs get --raw ${kvsdir}.jobspec >jobspec.out &&
 	test_cmp basic.json jobspec.out
 '

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -101,10 +101,10 @@ test_expect_success 'flux-job: id --from=words works' '
 	test "$jobid" = "$MINJOBID_DEC"
 '
 
-test_expect_success 'flux-job: id --from=kvs-active works' '
-	jobid=$(flux job id --from=kvs-active $MAXJOBID_KVS) &&
+test_expect_success 'flux-job: id --from=kvs works' '
+	jobid=$(flux job id --from=kvs $MAXJOBID_KVS) &&
 	test "$jobid" = "$MAXJOBID_DEC" &&
-	jobid=$(flux job id --from=kvs-active $MINJOBID_KVS) &&
+	jobid=$(flux job id --from=kvs $MINJOBID_KVS) &&
 	test "$jobid" = "$MINJOBID_DEC"
 '
 
@@ -122,18 +122,18 @@ test_expect_success 'flux-job: id --to=words works' '
 	test "$jobid" = "$MINJOBID_WORDS"
 '
 
-test_expect_success 'flux-job: id --to=kvs-active works' '
-	jobid=$(flux job id --to=kvs-active $MAXJOBID_DEC) &&
+test_expect_success 'flux-job: id --to=kvs works' '
+	jobid=$(flux job id --to=kvs $MAXJOBID_DEC) &&
 	test "$jobid" = "$MAXJOBID_KVS" &&
-	jobid=$(flux job id --to=kvs-active $MINJOBID_DEC) &&
+	jobid=$(flux job id --to=kvs $MINJOBID_DEC) &&
 	test "$jobid" = "$MINJOBID_KVS"
 '
 
-test_expect_success 'flux-job: id --from=kvs-active fails on bad input' '
-	test_must_fail flux job id --from=kvs-active badstring &&
-	test_must_fail flux job id --from=kvs-active \
+test_expect_success 'flux-job: id --from=kvs fails on bad input' '
+	test_must_fail flux job id --from=kvs badstring &&
+	test_must_fail flux job id --from=kvs \
 	    job.active.0000.0000 &&
-	test_must_fail flux job id --from=kvs-active \
+	test_must_fail flux job id --from=kvs \
 	    job.active.0000.0000.0000.000P
 '
 

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -9,11 +9,11 @@ fi
 
 # 2^64 - 1
 MAXJOBID_DEC=18446744073709551615
-MAXJOBID_KVS="job.active.ffff.ffff.ffff.ffff"
+MAXJOBID_KVS="job.ffff.ffff.ffff.ffff"
 MAXJOBID_WORDS="natural-analyze-verbal--natural-analyze-verbal"
 
 MINJOBID_DEC=0
-MINJOBID_KVS="job.active.0000.0000.0000.0000"
+MINJOBID_KVS="job.0000.0000.0000.0000"
 MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
 
 test_under_flux 1 job
@@ -132,9 +132,9 @@ test_expect_success 'flux-job: id --to=kvs works' '
 test_expect_success 'flux-job: id --from=kvs fails on bad input' '
 	test_must_fail flux job id --from=kvs badstring &&
 	test_must_fail flux job id --from=kvs \
-	    job.active.0000.0000 &&
+	    job.0000.0000 &&
 	test_must_fail flux job id --from=kvs \
-	    job.active.0000.0000.0000.000P
+	    job.0000.0000.0000.000P
 '
 
 test_expect_success 'flux-job: id --from=dec fails on bad input' '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -58,7 +58,7 @@ test_expect_success 'flux job eventlog works' '
 
 test_expect_success 'flux job eventlog works on multiple entries' '
         jobid=$(submit_job) &&
-        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foo &&
 	flux job eventlog $jobid >eventlog_b.out &&
 	grep -q submit eventlog_b.out &&
@@ -128,7 +128,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event works, event is later' '
         waitpid=$! &&
         wait_watchers_nonzero &&
         wait_watcherscount_nonzero primary &&
-        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
         wait $waitpid &&
         grep foobar wait_event3.out
@@ -146,7 +146,7 @@ test_expect_success 'flux job wait-event --quiet works' '
 
 test_expect_success 'flux job wait-event --verbose works' '
         jobid=$(submit_job) &&
-        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobaz &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
         flux job wait-event --verbose $jobid foobar > wait_event8.out &&
@@ -157,7 +157,7 @@ test_expect_success 'flux job wait-event --verbose works' '
 
 test_expect_success 'flux job wait-event --verbose doesnt show events after wait event' '
         jobid=$(submit_job) &&
-        kvsdir=$(flux job id --to=kvs-active $jobid) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
         flux job wait-event --verbose $jobid submit > wait_event9.out &&
         grep submit wait_event9.out &&
@@ -296,14 +296,14 @@ test_expect_success 'flux job info multiple keys fails on bad id' '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (include eventlog)' '
         jobid=$(flux job submit test.json) &&
-        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        activekvsdir=$(flux job id --to=kvs $jobid) &&
         flux kvs unlink ${activekvsdir}.jobspec &&
 	! flux job info $jobid eventlog jobspec J > all_info_b.out
 '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventlog)' '
         jobid=$(flux job submit test.json) &&
-        activekvsdir=$(flux job id --to=kvs-active $jobid) &&
+        activekvsdir=$(flux job id --to=kvs $jobid) &&
         flux kvs unlink ${activekvsdir}.jobspec &&
 	! flux job info $jobid jobspec J > all_info_b.out
 '

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -19,7 +19,7 @@ submit_job() {
         flux job cancel $jobid
         flux job wait-event $jobid clean >/dev/null
         if test -n "$userid"; then
-            kvsdir=$(flux job id --to=kvs-active $jobid)
+            kvsdir=$(flux job id --to=kvs $jobid)
             flux kvs get --raw ${kvsdir}.eventlog \
                 | sed -e 's/\("userid":\)[0-9]*/\1'${userid}/ \
                 | flux kvs put --raw ${kvsdir}.eventlog=-
@@ -32,7 +32,7 @@ submit_job() {
 bad_first_event() {
         jobid=$(flux job submit test.json)
         flux job wait-event $jobid depend >/dev/null
-        kvsdir=$(flux job id --to=kvs-active $jobid)
+        kvsdir=$(flux job id --to=kvs $jobid)
         flux kvs get --raw ${kvsdir}.eventlog \
             | sed -e s/submit/foobar/ \
             | flux kvs put --raw ${kvsdir}.eventlog=-

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -39,14 +39,6 @@ bad_first_event() {
         echo $jobid
 }
 
-# We cheat and manually move active to inactive in these tests.
-move_inactive() {
-        activekvsdir=$(flux job id --to=kvs-active $1)
-        inactivekvsdir=$(echo $activekvsdir | sed 's/active/inactive/')
-        flux kvs move ${activekvsdir} ${inactivekvsdir}
-        return 0
-}
-
 set_userid() {
         export FLUX_HANDLE_USERID=$1
         export FLUX_HANDLE_ROLEMASK=0x2
@@ -84,28 +76,6 @@ test_expect_success 'flux job eventlog fails (wrong user)' '
         unset_userid
 '
 
-test_expect_success 'flux job eventlog works (owner, inactive)' '
-        jobid=$(submit_job) &&
-        move_inactive $jobid &&
-        flux job eventlog $jobid
-'
-
-test_expect_success 'flux job eventlog works (user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9000 &&
-        flux job eventlog $jobid &&
-        unset_userid
-'
-
-test_expect_success 'flux job eventlog fails (wrong user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9999 &&
-        ! flux job eventlog $jobid &&
-        unset_userid
-'
-
 test_expect_success 'flux job eventlog fails on bad first event (user)' '
         jobid=$(bad_first_event 9000) &&
         set_userid 9999 &&
@@ -136,28 +106,6 @@ test_expect_success 'flux job wait-event fails (wrong user)' '
         unset_userid
 '
 
-test_expect_success 'flux job wait-event works (owner, inactive)' '
-        jobid=$(submit_job) &&
-        move_inactive $jobid &&
-        flux job wait-event $jobid submit
-'
-
-test_expect_success 'flux job wait-event works (user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9000 &&
-        flux job wait-event $jobid submit &&
-        unset_userid
-'
-
-test_expect_success 'flux job wait-event fails (wrong user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9999 &&
-        ! flux job wait-event $jobid submit &&
-        unset_userid
-'
-
 #
 # job info
 #
@@ -176,28 +124,6 @@ test_expect_success 'flux job info eventlog works (user)' '
 
 test_expect_success 'flux job info eventlog fails (wrong user)' '
         jobid=$(submit_job 9000) &&
-        set_userid 9999 &&
-        ! flux job info $jobid eventlog &&
-        unset_userid
-'
-
-test_expect_success 'flux job info eventlog works (owner, inactive)' '
-        jobid=$(submit_job) &&
-        move_inactive $jobid &&
-        flux job info $jobid eventlog
-'
-
-test_expect_success 'flux job info eventlog works (user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9000 &&
-        flux job info $jobid eventlog &&
-        unset_userid
-'
-
-test_expect_success 'flux job info eventlog fails (wrong user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
         set_userid 9999 &&
         ! flux job info $jobid eventlog &&
         unset_userid
@@ -222,28 +148,6 @@ test_expect_success 'flux job info jobspec fails (wrong user)' '
         unset_userid
 '
 
-test_expect_success 'flux job info jobspec works (owner, inactive)' '
-        jobid=$(submit_job) &&
-        move_inactive $jobid &&
-        flux job info $jobid jobspec
-'
-
-test_expect_success 'flux job info jobspec works (user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9000 &&
-        flux job info $jobid jobspec &&
-        unset_userid
-'
-
-test_expect_success 'flux job info jobspec fails (wrong user, inactive)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9999 &&
-        ! flux job info $jobid jobspec &&
-        unset_userid
-'
-
 test_expect_success 'flux job info multiple keys works (owner, include eventlog)' '
         jobid=$(submit_job) &&
         flux job info $jobid eventlog jobspec J
@@ -263,28 +167,6 @@ test_expect_success 'flux job info multiple keys fails (wrong user, include even
         unset_userid
 '
 
-test_expect_success 'flux job info multiple keys works (owner, inactive, include eventlog)' '
-        jobid=$(submit_job) &&
-        move_inactive $jobid &&
-        flux job info $jobid eventlog jobspec J
-'
-
-test_expect_success 'flux job info multiple keys works (user, inactive, include eventlog)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9000 &&
-        flux job info $jobid eventlog jobspec J &&
-        unset_userid
-'
-
-test_expect_success 'flux job info multiple keys fails (wrong user, inactive, include eventlog)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9999 &&
-        ! flux job info $jobid jobspec J &&
-        unset_userid
-'
-
 test_expect_success 'flux job info multiple keys works (owner, no eventlog)' '
         jobid=$(submit_job) &&
         flux job info $jobid jobspec J
@@ -299,28 +181,6 @@ test_expect_success 'flux job info multiple keys works (user, no eventlog)' '
 
 test_expect_success 'flux job info multiple keys fails (wrong user, no eventlog)' '
         jobid=$(submit_job 9000) &&
-        set_userid 9999 &&
-        ! flux job info $jobid jobspec J &&
-        unset_userid
-'
-
-test_expect_success 'flux job info multiple keys works (owner, inactive, no eventlog)' '
-        jobid=$(submit_job) &&
-        move_inactive $jobid &&
-        flux job info $jobid jobspec J
-'
-
-test_expect_success 'flux job info multiple keys works (user, inactive, no eventlog)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
-        set_userid 9000 &&
-        flux job info $jobid jobspec J &&
-        unset_userid
-'
-
-test_expect_success 'flux job info multiple keys fails (wrong user, inactive, no eventlog)' '
-        jobid=$(submit_job 9000) &&
-        move_inactive $jobid &&
         set_userid 9999 &&
         ! flux job info $jobid jobspec J &&
         unset_userid

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -13,8 +13,8 @@ query=${FLUX_BUILD_DIR}/src/modules/sched-simple/rlist-query
 hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
 hwloc_by_rank_first_fit='{"0": {"Core": 2}, "1": {"Core": 1}}'
 
-kvs_active() {
-	flux job id --to=kvs-active $1
+kvs_job_dir() {
+	flux job id --to=kvs $1
 }
 list_R() {
 	for id in "$@"; do
@@ -117,7 +117,7 @@ test_expect_success 'sched-simple: cancel pending job' '
 	flux job cancel $id &&
 	flux job wait-event --timeout=5.0 $id exception &&
 	flux job cancel $(cat job6.id) &&
-	test_expect_code 1 flux kvs get $(kvs_active $id).R
+	test_expect_code 1 flux kvs get $(kvs_job_dir $id).R
 '
 test_expect_success 'sched-simple: cancel remaining jobs' '
 	flux job cancel $(cat job7.id) &&

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -17,7 +17,7 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
 
-job_kvsdir()    { flux job id --to=kvs-active $1; }
+job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; } 
 exec_testattr() {
 	${jq} --arg key "$1" --arg value $2 \


### PR DESCRIPTION
As discussed in #2107 and #2093, remove the `job.active` and `job.inactive` directories, instead putting all job information simply in the `job` directory.

This is first step towards more work.  Future work to archive inactive jobs TBD.