### PR TITLE
libsubprocess: pre-exec & post-fork hooks

### DIFF
--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -296,7 +296,8 @@ static int runlevel_start_subprocess (runlevel_t *r, int level)
         if (!(p = flux_exec (r->h,
                              flags,
                              r->rc[level].cmd,
-                             &ops)))
+                             &ops,
+                             NULL)))
             goto error;
 
         if (flux_subprocess_aux_set (p, "runlevel", r, NULL) < 0)

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -861,7 +861,8 @@ static int child_create (proxy_ctx_t *ctx, int ac, char **av, const char *workpa
     if (!(p = flux_local_exec (ctx->reactor,
                                FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
                                cmd,
-                               &ops)))
+                               &ops,
+                               NULL)))
         goto error;
 
     if (flux_subprocess_aux_set (p, "ctx", ctx, NULL) < 0)

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -563,7 +563,8 @@ int client_run (struct client *cli)
     if (!(cli->p = flux_local_exec (ctx.reactor,
                                     FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
                                     cli->cmd,
-                                    &ops)))
+                                    &ops,
+                                    NULL)))
         log_err_exit ("flux_exec");
     if (flux_subprocess_aux_set (cli->p, "cli", cli, NULL) < 0)
         log_err_exit ("flux_subprocess_aux_set");

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -361,7 +361,11 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(p = flux_exec (s->h, FLUX_SUBPROCESS_FLAGS_SETPGRP, cmd, &ops))) {
+    if (!(p = flux_exec (s->h,
+                         FLUX_SUBPROCESS_FLAGS_SETPGRP,
+                         cmd,
+                         &ops,
+                         NULL))) {
         /* error here, generate FLUX_SUBPROCESS_EXEC_FAILED state */
         if (flux_respond_pack (h, msg, "{s:s s:i s:i s:i}",
                                "type", "state",

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -79,6 +79,7 @@ typedef void (*flux_subprocess_output_f) (flux_subprocess_t *p,
                                           const char *stream);
 typedef void (*flux_subprocess_state_f) (flux_subprocess_t *p,
                                          flux_subprocess_state_t state);
+typedef void (*flux_subprocess_hook_f) (flux_subprocess_t *p, void *arg);
 
 /*
  *  Functions for event-driven subprocess handling:
@@ -95,6 +96,17 @@ typedef struct {
     flux_subprocess_output_f on_stdout; /* Read of stdout is ready           */
     flux_subprocess_output_f on_stderr; /* Read of stderr is ready           */
 } flux_subprocess_ops_t;
+
+/*
+ *  flux_subprocess_hooks_t: Hook functions to execute at pre-defined
+ *  points.  Hooks can only be executed on local processes.
+ */
+typedef struct {
+    flux_subprocess_hook_f pre_exec;
+    void *pre_exec_arg;
+    flux_subprocess_hook_f post_fork;
+    void *post_fork_arg;
+} flux_subprocess_hooks_t;
 
 /*
  *  General support:
@@ -222,8 +234,6 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
 
-
-
 /*
  *  Subprocesses:
  */
@@ -246,11 +256,13 @@ const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
  */
 flux_subprocess_t *flux_exec (flux_t *h, int flags,
                               const flux_cmd_t *cmd,
-                              const flux_subprocess_ops_t *ops);
+                              const flux_subprocess_ops_t *ops,
+                              const flux_subprocess_hooks_t *hooks);
 
 flux_subprocess_t *flux_local_exec (flux_reactor_t *r, int flags,
                                     const flux_cmd_t *cmd,
-                                    const flux_subprocess_ops_t *ops);
+                                    const flux_subprocess_ops_t *ops,
+                                    const flux_subprocess_hooks_t *hooks);
 
 flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
                                const flux_cmd_t *cmd,

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -97,7 +97,9 @@ struct flux_subprocess {
 
     /* fds[0] is parent/user, fds[1] is child */
     int sync_fds[2];                /* socketpair for fork/exec sync      */
+    bool in_hook;                   /* if presently in a hook */
     flux_watcher_t *child_w;
+    flux_subprocess_hooks_t hooks;
 
     /* remote */
 


### PR DESCRIPTION
WIP for #2008 .  Ignore most of this code & commits, which are garbage and I haven't even tested really.  Mostly posting this to get initial thoughts on the API in `subprocess.h`.  After going back and forth on a few ideas, I think this is not bad, but there's one hairy issue which I detail below.

```C
typedef enum {
    FLUX_SUBPROCESS_HOOK_TYPE_PRE_EXEC,
    FLUX_SUBPROCESS_HOOK_TYPE_POST_FORK,
} flux_subprocess_hook_type_t;

flux_subprocess_hooks_t * flux_subprocess_hooks_create (void);

flux_subprocess_hooks_t * flux_subprocess_hooks_copy (
    const flux_subprocess_hooks_t *hooks);

void flux_subprocess_hooks_destroy (flux_subprocess_hooks_t *hooks);

int flux_subprocess_hooks_add (flux_subprocess_hooks_t *hooks,
                               flux_subprocess_hook_type_t type,
                               flux_subprocess_f cb);
 ```

```
@@ -246,11 +288,13 @@ const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
  */
 flux_subprocess_t *flux_exec (flux_t *h, int flags,
                               const flux_cmd_t *cmd,
-                              flux_subprocess_ops_t *ops);
+                              flux_subprocess_ops_t *ops,
+                              flux_subprocess_hooks_t *hooks);
 
 flux_subprocess_t *flux_local_exec (flux_reactor_t *r, int flags,
                                     const flux_cmd_t *cmd,
-                                    flux_subprocess_ops_t *ops);
+                                    flux_subprocess_ops_t *ops,
+                                    flux_subprocess_hooks_t *hooks);


```

So basically, we have a new `flux_subprocess_hooks_t` data structure that users create/setup and pass into `flux_exec()` or `flux_local_exec()` as a new arg.  Pros / cons I found along the way:

- I considered adding "hooks" to `flux_cmd_t`, but I did not like the fact that hooks only work against local subprocess and not remote ones.  So I felt the the hook API/infrastructure had to be outside of the the `cmd` part.

- It's a tad inconsistent that we have `flux_cmd_t` which is a created/destroyed object, `flux_subprocess_ops_t`, which is just a struct, and now `flux_subprocess_hooks_t` which is a created/destroyed object.  I guess it's not a big deal, but that's there.

- I assume the hook callbacks need to be able to call accessors, such as `flux_subprocess_pid()`?  I think there are racy bits here and there that need to be handled for that case.  But that made me wonder, do hook callbacks need access to the `flux_subprocess_t` structure?  If no, that makes things easier.

- The callback set in `flux_subprocess_hooks_add()` uses the current `flux_subprocess_f` function prototype (which I picked half randomly), which is just `void (*flux_subprocess_f) (flux_subprocess_t *p);`.  So right now there is no way to pass an extra argument to the callback.  Is this important?
   - Right now you can't use `flux_subprocess_aux_set()`, b/c there's no way to know if a process has been forked yet or not by the time a user calls `flux_subprocess_aux_set()`.
     - in the old subprocess API, b/c there were functions like `subprocess_fork()` and `subprocess_exec()` that allowed callers to pause between hook points.
     -  This isn't a problem in the `libsubprocess` API in the general case b/c callbacks are handled via the reactor.  So as long as `flux_subprocess_aux_set()` is called before re-entering the reactor, you're guaranteed to get your aux pointer in any of the `ops` callbacks.
    - I assume the `POST_FORK` hook could be handled via a reactor callback, but I'm assuming the `PRE_EXEC` cannot, but didn't look into this too much.
   - So do we want/need to create a new callback function prototype that adds a `void *arg` argument to the hook callback?  And `flux_subprocess_hooks_add()` would be changed to something like `flux_subprocess_hooks_add (p, type, cb, arg, arg_free)`?


