### PR TITLE
libflux: Fix how flux_future_error_string() obscures errors

### DIFF
--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -25,6 +25,8 @@ SYNOPSIS
 
  void flux_future_destroy (flux_future_t *f);
 
+ bool flux_future_has_error (flux_future_t *f);
+
  const char *flux_future_error_string (flux_future_t *f);
 
 OVERVIEW
@@ -77,6 +79,11 @@ another `flux_future_then()`, if desired.
 
 `flux_future_destroy()` destroys a future, including any result contained
 within.
+
+`flux_future_has_error()` tests if an error exists in the future or not.
+It can be useful for determining if an error exists in a future or in
+other parts of code that may wrap around a future.  It is commonly
+called before calling `flux_future_error_string()`.
 
 `flux_future_error_string()` returns the error string stored in a
 future.  If the future was fulfilled with an optional error string,

--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -82,8 +82,8 @@ within.
 future.  If the future was fulfilled with an optional error string,
 `flux_future_error_string()` will return that string.  Otherwise, it
 will return the string associated with the error number set in a
-future.  If the future is a NULL pointer or is not fulfilled, NULL is
-returned.
+future.  If the future is a NULL pointer, not fulfilled, or fulfilled
+with a non-error, NULL is returned.
 
 RETURN VALUE
 ------------

--- a/doc/man3/flux_future_get.adoc
+++ b/doc/man3/flux_future_get.adoc
@@ -78,12 +78,12 @@ another `flux_future_then()`, if desired.
 `flux_future_destroy()` destroys a future, including any result contained
 within.
 
-`flux_future_error_string()` returns the error string associated with
-a future.  If the future was fulfilled with an optional error string,
+`flux_future_error_string()` returns the error string stored in a
+future.  If the future was fulfilled with an optional error string,
 `flux_future_error_string()` will return that string.  Otherwise, it
 will return the string associated with the error number set in a
-future.  If the future is not fulfilled or a NULL pointer is passed
-in, an appropriate error message is returned to indicate the issue.
+future.  If the future is a NULL pointer or is not fulfilled, NULL is
+returned.
 
 RETURN VALUE
 ------------

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -336,7 +336,7 @@ int cmd_priority (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_job_set_priority");
     if (flux_rpc_get (f, NULL) < 0)
         log_msg_exit ("%llu: %s", (unsigned long long)id,
-                      flux_future_error_string (f));
+                      future_strerror (f, errno));
     flux_future_destroy (f);
     flux_close (h);
     return 0;
@@ -367,7 +367,7 @@ int cmd_raise (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_job_raise");
     if (flux_rpc_get (f, NULL) < 0)
         log_msg_exit ("%llu: %s", (unsigned long long)id,
-                      flux_future_error_string (f));
+                      future_strerror (f, errno));
     flux_future_destroy (f);
     flux_close (h);
     free (note);
@@ -397,7 +397,7 @@ int cmd_cancel (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_job_cancel");
     if (flux_rpc_get (f, NULL) < 0)
         log_msg_exit ("%llu: %s", (unsigned long long)id,
-                      flux_future_error_string (f));
+                      future_strerror (f, errno));
     flux_future_destroy (f);
     flux_close (h);
     free (note);
@@ -558,7 +558,7 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
     if (!(f = flux_job_submit (h, J ? J : jobspec, priority, flags)))
         log_err_exit ("flux_job_submit");
     if (flux_job_submit_get_id (f, &id) < 0) {
-        log_msg_exit ("%s", flux_future_error_string (f));
+        log_msg_exit ("%s", future_strerror (f, errno));
     }
     printf ("%llu\n", (unsigned long long)id);
     flux_future_destroy (f);
@@ -1071,7 +1071,7 @@ int cmd_drain (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_rpc");
     if (flux_future_wait_for (f, timeout) < 0 || flux_rpc_get (f, NULL) < 0)
         log_msg_exit ("drain: %s", errno == ETIMEDOUT
-                                   ? "timeout" : flux_future_error_string (f));
+                                   ? "timeout" : future_strerror (f, errno));
     flux_future_destroy (f);
     flux_close (h);
     return (0);
@@ -1092,7 +1092,7 @@ int cmd_undrain (optparse_t *p, int argc, char **argv)
     if (!(f = flux_rpc (h, "job-manager.undrain", NULL, FLUX_NODEID_ANY, 0)))
         log_err_exit ("flux_rpc");
     if (flux_rpc_get (f, NULL) < 0)
-        log_msg_exit ("undrain: %s", flux_future_error_string (f));
+        log_msg_exit ("undrain: %s", future_strerror (f, errno));
     flux_future_destroy (f);
     flux_close (h);
     return (0);

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -740,9 +740,8 @@ const char *flux_future_error_string (flux_future_t *f)
                 return f->result.errnum_string;
             return flux_strerror (f->result.errnum);
         }
-        return "future not fulfilled";
     }
-    return "future NULL";
+    return NULL;
 }
 
 /* timer - for flux_future_then() timeout

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -721,6 +721,24 @@ void flux_future_fatal_error (flux_future_t *f, int errnum, const char *errstr)
     }
 }
 
+bool flux_future_has_error (flux_future_t *f)
+{
+    if (f) {
+        /* fatal errnum take precedence over any future
+         * fulfillments */
+        if (f->fatal_errnum_valid)
+            return true;
+        else if (f->result_valid) {
+            /* future contains a valid fulfillment, must check if it
+             * is a error fulfillment.
+             */
+            if (f->result.is_error)
+                return true;
+        }
+    }
+    return false;
+}
+
 const char *flux_future_error_string (flux_future_t *f)
 {
     if (f) {

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -731,10 +731,9 @@ const char *flux_future_error_string (flux_future_t *f)
                 return f->fatal_errnum_string;
             return flux_strerror (f->fatal_errnum);
         }
-        else if (f->result_valid) {
-            /* future contains a valid fulfillment.  The fulfillment
-             * may be a valid error (with or without optional string) or
-             * non-error (errnum == 0 passed to flux_strerror())
+        else if (f->result_valid && f->result.is_error) {
+            /* future contains a valid error fulfillment.  Return the
+             * optional error string or flux_strerror() of the errnum.
              */
             if (f->result.errnum_string)
                 return f->result.errnum_string;

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -60,6 +60,7 @@ int flux_future_fulfill_with (flux_future_t *f, flux_future_t *p);
 
 void flux_future_fatal_error (flux_future_t *f, int errnum, const char *errstr);
 
+bool flux_future_has_error (flux_future_t *f);
 const char *flux_future_error_string (flux_future_t *f);
 
 void flux_future_set_flux (flux_future_t *f, flux_t *h);

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -15,6 +15,7 @@
 #include "types.h"
 #include "handle.h"
 #include "msg_handler.h"
+#include "flog.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,12 @@ void flux_future_fulfill_error (flux_future_t *f, int errnum, const char *errstr
 int flux_future_fulfill_with (flux_future_t *f, flux_future_t *p);
 
 void flux_future_fatal_error (flux_future_t *f, int errnum, const char *errstr);
+
+/* Convenience macro */
+#define future_strerror(__f, __errno) \
+    (flux_future_has_error ((__f)) ? \
+     flux_future_error_string ((__f)) : \
+     flux_strerror ((__errno)))
 
 bool flux_future_has_error (flux_future_t *f);
 const char *flux_future_error_string (flux_future_t *f);

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -824,17 +824,14 @@ void test_error_string (void)
     flux_future_t *f;
     const char *str;
 
-    ok ((str = flux_future_error_string (NULL)) != NULL
-        && !strcmp (str, "future NULL"),
-        "flux_future_error_string returns \"future NULL\" on NULL input");
+    ok (flux_future_error_string (NULL) == NULL,
+        "flux_future_error_string returns NULL on NULL input");
 
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
 
-    ok ((str = flux_future_error_string (f)) != NULL
-        && !strcmp (str, "future not fulfilled"),
-        "flux_future_error_string returns \"future not fulfilled\" on "
-        "unfulfilled future");
+    ok (flux_future_error_string (f) == NULL,
+        "flux_future_error_string returns NULL on unfulfilled future");
 
     flux_future_fulfill (f, "Hello", NULL);
 

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -819,6 +819,50 @@ void test_fatal_error_async (void)
     flux_reactor_destroy (r);
 }
 
+void test_has_error (void)
+{
+    flux_future_t *f;
+
+    ok (flux_future_has_error (NULL) == false,
+        "flux_future_has_error returns false on NULL input");
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    ok (flux_future_has_error (f) == false,
+        "flux_future_has_error returns false on unfulfilled future");
+
+    flux_future_fulfill (f, "Hello", NULL);
+
+    ok (flux_future_has_error (f) == false,
+        "flux_future_has_error returns false on future fulfilled "
+        "with non-error result");
+
+    flux_future_destroy (f);
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fulfill_error (f, ENOENT, NULL);
+
+    ok (flux_future_has_error (f) == true,
+        "flux_future_has_error returns true on future fulfilled "
+        "with error result");
+
+    flux_future_destroy (f);
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        BAIL_OUT ("flux_future_create failed");
+
+    flux_future_fatal_error (f, ENOENT, NULL);
+
+    ok (flux_future_has_error (f) == true,
+        "flux_future_has_error returns true on future fulfilled "
+        "with fatal error");
+
+    flux_future_destroy (f);
+}
+
 void test_error_string (void)
 {
     flux_future_t *f;
@@ -1191,6 +1235,7 @@ int main (int argc, char *argv[])
     test_fatal_error ();
     test_fatal_error_async ();
 
+    test_has_error ();
     test_error_string ();
 
     test_multiple_fulfill ();

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -836,9 +836,8 @@ void test_error_string (void)
     flux_future_fulfill (f, "Hello", NULL);
 
     ok (flux_future_get (f, NULL) == 0
-        && (str = flux_future_error_string (f)) != NULL
-        && !strcmp (str, "Success"),
-        "flux_future_error_string returns \"Success\" when future fulfilled "
+        && flux_future_error_string (f) == NULL,
+        "flux_future_error_string returns NULL when future fulfilled "
         "with non-error result");
 
     flux_future_destroy (f);

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -115,14 +115,15 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *jobid)
 {
     flux_jobid_t id;
 
-    if (!f || !jobid) {
+    if (!f) {
         errno = EINVAL;
         return -1;
     }
     if (flux_rpc_get_unpack (f, "{s:I}",
                                 "id", &id) < 0)
         return -1;
-    *jobid = id;
+    if (jobid)
+        *jobid = id;
     return 0;
 }
 

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -271,7 +271,7 @@ static void batch_announce_continuation (flux_future_t *f, void *arg)
     flux_t *h = batch->ctx->h;
 
     if (flux_future_get (f, NULL) < 0) {
-        batch_respond_error (batch, errno, flux_future_error_string (f));
+        batch_respond_error (batch, errno, future_strerror (f, errno));
         if (batch_cleanup (batch) < 0)
             flux_log_error (h, "%s: KVS cleanup failure", __FUNCTION__);
     }
@@ -443,7 +443,7 @@ void validate_continuation (flux_future_t *f, void *arg)
     /* If jobspec validation failed, respond immediately to the user.
      */
     if (flux_future_get (f, NULL) < 0) {
-        errmsg = flux_future_error_string (f);
+        errmsg = future_strerror (f, errno);
         goto error;
     }
     if (fluid_generate (&ctx->gen, &job->id) < 0)

--- a/t/ingest/submitbench.c
+++ b/t/ingest/submitbench.c
@@ -140,7 +140,7 @@ void submitbench_continuation (flux_future_t *f, void *arg)
         if (errno == ENOSYS)
             log_msg_exit ("submit: job-ingest module is not loaded");
         else
-            log_msg_exit ("submit: %s", flux_future_error_string (f));
+            log_msg_exit ("submit: %s", future_strerror (f, errno));
     }
     printf ("%llu\n", (unsigned long long)id);
     flux_future_destroy (f);


### PR DESCRIPTION
Per discussion in #2160

- `flux_future_error_string()` now returns NULL if the future passed in is NULL, not fulfilled, or fulfilled with a non-error result.  The last one was not discussed in the issue, but after making changes, it no longer felt right that `flux_future_error_string()` return "Success" on a future fulfilled with a normal result.  We can debate on this.

- Added a `flux_future_has_error()`.

- Added `FLUX_FUTURE_STRERROR()`, which wraps a call to `flux_future_has_error()` and calls `flux_future_error_string()` or `flux_strerror (errno)` accordingly.

- Use `FLUX_FUTURE_STRERROR()` in code, most notably in `flux-job`.
