### PR TITLE
libsubprocess: Remove STARTED state

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -214,7 +214,6 @@ static void stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
         p = zlist_first (subprocesses);
         while (p) {
             if (flux_subprocess_state (p) == FLUX_SUBPROCESS_INIT
-                || flux_subprocess_state (p) == FLUX_SUBPROCESS_STARTED
                 || flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
                 if (flux_subprocess_write (p, "STDIN", ptr, lenp) < 0)
                     log_err_exit ("flux_subprocess_write");

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -622,8 +622,6 @@ static int local_fork (flux_subprocess_t *p)
     if (subprocess_parent_wait_on_child (p) < 0)
         return -1;
 
-    p->state = FLUX_SUBPROCESS_STARTED;
-
     if (p->hooks.post_fork) {
         /* always a chance caller may destroy subprocess in callback */
         flux_subprocess_ref (p);

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -91,11 +91,9 @@ static void process_new_state (flux_subprocess_t *p,
 
     p->state = state;
 
-    if (p->state == FLUX_SUBPROCESS_STARTED) {
+    if (p->state == FLUX_SUBPROCESS_RUNNING) {
         p->pid = pid;
         p->pid_set = true;
-    }
-    else if (p->state == FLUX_SUBPROCESS_RUNNING) {
         start_channel_watchers (p);
     }
     else if (state == FLUX_SUBPROCESS_EXEC_FAILED) {
@@ -499,7 +497,7 @@ static int remote_state (flux_subprocess_t *p, flux_future_t *f,
         return -1;
     }
 
-    if (state == FLUX_SUBPROCESS_STARTED) {
+    if (state == FLUX_SUBPROCESS_RUNNING) {
         if (flux_rpc_get_unpack (f, "{ s:i }", "pid", &pid) < 0) {
             flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
             return -1;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -158,21 +158,13 @@ static void rexec_state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t
 
     assert (s && msg);
 
-    if (state == FLUX_SUBPROCESS_STARTED) {
+    if (state == FLUX_SUBPROCESS_RUNNING) {
         if (store_pid (s, p) < 0)
             goto error;
         if (flux_respond_pack (s->h, msg, "{s:s s:i s:i s:i}",
                                "type", "state",
                                "rank", s->rank,
                                "pid", flux_subprocess_pid (p),
-                               "state", state) < 0) {
-            flux_log_error (s->h, "%s: flux_respond_pack", __FUNCTION__);
-            goto error;
-        }
-    } else if (state == FLUX_SUBPROCESS_RUNNING) {
-        if (flux_respond_pack (s->h, msg, "{s:s s:i s:i}",
-                               "type", "state",
-                               "rank", s->rank,
                                "state", state) < 0) {
             flux_log_error (s->h, "%s: flux_respond_pack", __FUNCTION__);
             goto error;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -382,9 +382,6 @@ static flux_subprocess_state_t state_change_next (flux_subprocess_t *p)
 
     switch (p->state_reported) {
     case FLUX_SUBPROCESS_INIT:
-        /* next state to report must be STARTED */
-        return FLUX_SUBPROCESS_STARTED;
-    case FLUX_SUBPROCESS_STARTED:
         /* next state must be RUNNING or EXEC_FAILED */
         if (p->state == FLUX_SUBPROCESS_EXEC_FAILED)
             return FLUX_SUBPROCESS_EXEC_FAILED;
@@ -720,8 +717,7 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
     }
 
     if (p->local) {
-        if (p->state != FLUX_SUBPROCESS_STARTED
-            && p->state != FLUX_SUBPROCESS_RUNNING) {
+        if (p->state != FLUX_SUBPROCESS_RUNNING) {
             errno = EPIPE;
             return -1;
         }
@@ -737,7 +733,6 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
     }
     else {
         if (p->state != FLUX_SUBPROCESS_INIT
-            && p->state != FLUX_SUBPROCESS_STARTED
             && p->state != FLUX_SUBPROCESS_RUNNING) {
             errno = EPIPE;
             return -1;
@@ -773,8 +768,7 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream)
         return 0;
 
     if (p->local) {
-        if (p->state == FLUX_SUBPROCESS_STARTED
-            || p->state == FLUX_SUBPROCESS_RUNNING) {
+        if (p->state == FLUX_SUBPROCESS_RUNNING) {
             if (flux_buffer_write_watcher_close (c->buffer_write_w) < 0) {
                 log_err ("flux_buffer_write_watcher_close");
                 return -1;
@@ -939,8 +933,6 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state)
     {
     case FLUX_SUBPROCESS_INIT:
         return "Init";
-    case FLUX_SUBPROCESS_STARTED:
-        return "Started";
     case FLUX_SUBPROCESS_EXEC_FAILED:
         return "Exec Failed";
     case FLUX_SUBPROCESS_RUNNING:

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -40,15 +40,13 @@ typedef struct flux_subprocess_server flux_subprocess_server_t;
  *
  * Possible state changes:
  *
- * init -> started
- * started -> exec failed
- * started -> running
+ * init -> running
+ * init -> exec failed
  * running -> exited
  * any state -> failed
  */
 typedef enum {
     FLUX_SUBPROCESS_INIT,         /* initial state */
-    FLUX_SUBPROCESS_STARTED,      /* fork() has been issued/requested */
     FLUX_SUBPROCESS_EXEC_FAILED,  /* exec(2) has failed, only for rexec() */
     FLUX_SUBPROCESS_RUNNING,      /* exec(2) has been called */
     FLUX_SUBPROCESS_EXITED,       /* process has exited */

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -1157,9 +1157,6 @@ void test_kill_eofs (flux_reactor_t *r)
 void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 {
     if (state_change_cb_count == 0)
-        ok (state == FLUX_SUBPROCESS_STARTED,
-            "subprocess state == STARTED in state change handler");
-    else if (state_change_cb_count == 1)
         ok (state == FLUX_SUBPROCESS_RUNNING,
             "subprocess state == RUNNING in state change handler");
     else
@@ -1191,7 +1188,7 @@ void test_state_change (flux_reactor_t *r)
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
     ok (completion_cb_count == 1, "completion callback called 1 time");
-    ok (state_change_cb_count == 3, "state change callback called 3 times");
+    ok (state_change_cb_count == 2, "state change callback called 3 times");
     flux_subprocess_destroy (p);
     flux_cmd_destroy (cmd);
 }
@@ -1199,8 +1196,6 @@ void test_state_change (flux_reactor_t *r)
 void test_state_strings (void)
 {
     ok (!strcasecmp (flux_subprocess_state_string (FLUX_SUBPROCESS_INIT), "Init"),
-        "flux_subprocess_state_string returns correct string");
-    ok (!strcasecmp (flux_subprocess_state_string (FLUX_SUBPROCESS_STARTED), "Started"),
         "flux_subprocess_state_string returns correct string");
     ok (!strcasecmp (flux_subprocess_state_string (FLUX_SUBPROCESS_RUNNING), "Running"),
         "flux_subprocess_state_string returns correct string");

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -196,13 +196,7 @@ static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state
 
     cron_task_state_update (t, flux_subprocess_state_string (state));
 
-    if (state == FLUX_SUBPROCESS_STARTED) {
-        t->started = 1;
-        clock_gettime (CLOCK_REALTIME, &t->starttime);
-        if (t->timeout >= 0.0)
-            cron_task_timeout_start (t);
-    }
-    else if (state == FLUX_SUBPROCESS_RUNNING) {
+    if (state == FLUX_SUBPROCESS_RUNNING) {
         clock_gettime (CLOCK_REALTIME, &t->runningtime);
         t->running = 1;
         t->pid = flux_subprocess_pid (p);
@@ -358,6 +352,12 @@ int cron_task_run (cron_task_t *t,
         flux_log_error (h, "flux_subprocess_aux_set");
         goto done;
     }
+
+    t->started = 1;
+    clock_gettime (CLOCK_REALTIME, &t->starttime);
+    cron_task_state_update (t, "Started");
+    if (t->timeout >= 0.0)
+        cron_task_timeout_start (t);
 
     t->p = p;
     rc = 0;

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -111,7 +111,6 @@ static void worker_state_cb (flux_subprocess_t *p,
             flux_log (w->h, LOG_ERR, "%s: %s", w->name,
                       flux_subprocess_state_string (state));
             break;
-        case FLUX_SUBPROCESS_STARTED:
         case FLUX_SUBPROCESS_EXITED:
         case FLUX_SUBPROCESS_INIT:
             break; // ignore

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -81,16 +81,14 @@ test_expect_success 'basic rexec propogates exit code()' '
 
 test_expect_success 'basic rexec functionality (check state changes)' '
 	${FLUX_BUILD_DIR}/t/rexec/rexec -s /bin/true > output &&
-        echo "Started" > expected &&
-        echo "Running" >> expected &&
+        echo "Running" > expected &&
         echo "Exited" >> expected &&
         test_cmp expected output
 '
 
 test_expect_success 'basic rexec fail exec() (check state changes)' '
 	! ${FLUX_BUILD_DIR}/t/rexec/rexec -s / > output &&
-        echo "Started" > expected &&
-        echo "Exec Failed" >> expected &&
+        echo "Exec Failed" > expected &&
         test_cmp expected output
 '
 


### PR DESCRIPTION
Remove the "Started" state, which serves little purpose, especially
after the addition of pre-exec and post-fork hooks.

Update all uses of the Started state outside of libsubprocess.

Fixes #2154