### PR TITLE
broker / libsubprocess : SIGTERM lingering subprocesses before shutting down broker

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -618,6 +618,12 @@ int main (int argc, char *argv[])
     if (ctx.verbose)
         log_msg ("exited event loop");
 
+    /* inform all lingering subprocesses we are tearing down.  Do this
+     * before any cleanup/teardown below, as this call will re-enter
+     * the reactor.
+     */
+    exec_terminate_subprocesses (ctx.h);
+
     /* Restore default sigmask and actions for SIGINT, SIGTERM
      */
     if (sigprocmask (SIG_SETMASK, &old_sigmask, NULL) < 0)

--- a/src/broker/exec.h
+++ b/src/broker/exec.h
@@ -15,6 +15,10 @@
 #include <flux/core.h>
 #include "attr.h"
 
+/* Send SIGTERM / SIGKILL to all subprocesses, to be called at
+ * beginning of teardown of broker */
+void exec_terminate_subprocesses (flux_t *h);
+
 /* Kill any processes started by disconnecting client.
  */
 int exec_terminate_subprocesses_by_uuid (flux_t *h, const char *id);

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -149,19 +149,6 @@ flux_msg_t *shutdown_vencode (double grace, int exitcode, int rank,
                             "exitcode", exitcode);
 }
 
-flux_msg_t *shutdown_encode (double grace, int exitcode, int rank,
-                             const char *fmt, ...)
-{
-    va_list ap;
-    flux_msg_t *msg;
-
-    va_start (ap, fmt);
-    msg = shutdown_vencode (grace, exitcode, rank, fmt, ap);
-    va_end (ap);
-
-    return msg;
-}
-
 int shutdown_decode (const flux_msg_t *msg, double *grace, int *exitcode,
                      int *rank, char *reason, int reason_len)
 {

--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -64,8 +64,6 @@ void shutdown_disarm (shutdown_t *s);
  */
 flux_msg_t *shutdown_vencode (double grace, int rc, int rank,
                               const char *fmt, va_list ap);
-flux_msg_t *shutdown_encode (double grace, int rc, int rank,
-                             const char *fmt, ...);
 int shutdown_decode (const flux_msg_t *msg, double *grace, int *rc, int *rank,
                      char *reason, int reason_len);
 

--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -37,6 +37,19 @@ void log_request_cb (flux_t *h, flux_msg_handler_t *w,
     flux_msg_handler_stop (w);
 }
 
+flux_msg_t *shutdown_encode (double grace, int exitcode, int rank,
+                             const char *fmt, ...)
+{
+    va_list ap;
+    flux_msg_t *msg;
+
+    va_start (ap, fmt);
+    msg = shutdown_vencode (grace, exitcode, rank, fmt, ap);
+    va_end (ap);
+
+    return msg;
+}
+
 void check_codec (void)
 {
     flux_msg_t *msg;

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -17,6 +17,8 @@ int server_start (flux_subprocess_server_t *s, const char *prefix);
 
 void server_stop (flux_subprocess_server_t *s);
 
+int server_signal_subprocesses (flux_subprocess_server_t *s, int signum);
+
 int server_terminate_subprocesses (flux_subprocess_server_t *s);
 
 int server_terminate_by_uuid (flux_subprocess_server_t *s,

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -24,4 +24,11 @@ int server_terminate_subprocesses (flux_subprocess_server_t *s);
 int server_terminate_by_uuid (flux_subprocess_server_t *s,
                               const char *id);
 
+int server_terminate_setup (flux_subprocess_server_t *s,
+                            double wait_time);
+
+void server_terminate_cleanup (flux_subprocess_server_t *s);
+
+int server_terminate_wait (flux_subprocess_server_t *s);
+
 #endif /* !_SUBPROCESS_SERVER_H */

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -297,7 +297,7 @@ void flux_subprocess_server_stop (flux_subprocess_server_t *s)
 int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,
                                               const char *id)
 {
-    if (!s || s->magic != SUBPROCESS_SERVER_MAGIC) {
+    if (!s || s->magic != SUBPROCESS_SERVER_MAGIC || !id) {
         errno = EINVAL;
         return -1;
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -209,6 +209,12 @@ static void subprocess_server_destroy (void *arg)
          */
         zhash_destroy (&s->subprocesses);
         free (s->local_uri);
+
+        flux_watcher_destroy (s->terminate_timer_w);
+        flux_watcher_destroy (s->terminate_prep_w);
+        flux_watcher_destroy (s->terminate_idle_w);
+        flux_watcher_destroy (s->terminate_check_w);
+
         s->magic = ~SUBPROCESS_SERVER_MAGIC;
         free (s);
     }
@@ -292,6 +298,35 @@ void flux_subprocess_server_stop (flux_subprocess_server_t *s)
         server_terminate_subprocesses (s);
         subprocess_server_destroy (s);
     }
+}
+
+int flux_subprocess_server_subprocesses_kill (flux_subprocess_server_t *s,
+                                              int signum,
+                                              double wait_time)
+{
+    int rv = -1;
+
+    if (!s || s->magic != SUBPROCESS_SERVER_MAGIC) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!zhash_size (s->subprocesses))
+        return 0;
+
+    if (server_terminate_setup (s, wait_time) < 0)
+        goto error;
+
+    if (server_signal_subprocesses (s, signum) < 0)
+        goto error;
+
+    if (server_terminate_wait (s) < 0)
+        goto error;
+
+    rv = 0;
+error:
+    server_terminate_cleanup (s);
+    return rv;
 }
 
 int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -125,6 +125,20 @@ flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
  */
 void flux_subprocess_server_stop (flux_subprocess_server_t *s);
 
+/* Send all subprocesses signal and wait up to wait_time seconds for
+ * all subprocesses to complete.  This is typically called to send
+ * SIGTERM before calling flux_subprocess_server_stop(), allowing
+ * users to send a signal to inform subprocesses to complete / cleanup
+ * before they are sent SIGKILL.
+ *
+ * This function will enter the reactor to wait for subprocesses to
+ * complete, should only be called on cleanup path when primary
+ * reactor has exited.
+ */
+int flux_subprocess_server_subprocesses_kill (flux_subprocess_server_t *s,
+                                              int signum,
+                                              double wait_time);
+
 /* Terminate all subprocesses started by a sender id */
 int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,
                                               const char *id);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -120,7 +120,9 @@ flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
                                                         const char *local_uri,
                                                         uint32_t rank);
 
-/*  Stop a subprocess server / cleanup flux_subprocess_server_t */
+/*  Stop a subprocess server / cleanup flux_subprocess_server_t.  Will
+ *  send a SIGKILL to all remaining subprocesses.
+ */
 void flux_subprocess_server_stop (flux_subprocess_server_t *s);
 
 /* Terminate all subprocesses started by a sender id */

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -116,6 +116,12 @@ struct flux_subprocess_server {
     uint32_t rank;
     zhash_t *subprocesses;
     flux_msg_handler_t **handlers;
+
+    /* for teardown / termination */
+    flux_watcher_t *terminate_timer_w;
+    flux_watcher_t *terminate_prep_w;
+    flux_watcher_t *terminate_idle_w;
+    flux_watcher_t *terminate_check_w;
 };
 
 void subprocess_check_completed (flux_subprocess_t *p);

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -145,6 +145,10 @@ void test_basic_errors (flux_reactor_t *r)
     ok (!flux_subprocess_server_start (NULL, NULL, NULL, 0)
         && errno == EINVAL,
         "flux_subprocess_server_start fails with NULL pointer inputs");
+    ok (flux_subprocess_server_terminate_by_uuid (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_subprocess_server_terminate_by_uuid fails with NULL pointer inputs");
+
     ok (flux_exec (NULL, 0, NULL, NULL, NULL) == NULL
         && errno == EINVAL,
         "flux_exec fails with NULL pointer inputs");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -148,6 +148,9 @@ void test_basic_errors (flux_reactor_t *r)
     ok (flux_subprocess_server_terminate_by_uuid (NULL, NULL) < 0
         && errno == EINVAL,
         "flux_subprocess_server_terminate_by_uuid fails with NULL pointer inputs");
+    ok (flux_subprocess_server_subprocesses_kill (NULL, 0, 0.) < 0
+        && errno == EINVAL,
+        "flux_subprocess_server_subprocesses_kill fails with NULL pointer inputs");
 
     ok (flux_exec (NULL, 0, NULL, NULL, NULL) == NULL
         && errno == EINVAL,


### PR DESCRIPTION
This PR fixes up a long standing issue.  Any leftover subprocesses that are lingering when a broker is shutdown are killed via SIGKILL.  This fix will send a SIGTERM before hand, to give subprocesses some time to exit cleanly.  Accomplished by:

- adding `flux_subprocess_server_subprocesses_kill()` which allows a caller to send a signal to all subprocesses on a server, then waits some amount of time to see if all subprocesses have exited.

- calling this in the broker and sending SIGTERM.

- in addition, I elected to send SIGKILL to all lingering subprocesses BEFORE the shutdown of the broker begins.  I think this is safer than letting any lingering subprocesses possibly continue running as we begin to shutdown the broker (i.e. unload modules, etc.).

- For the time being, I hard coded a 5 second wait after sending signals.  This could be configurable, perhaps through a new broker attribute?  Or command line option input?  Could re-use grace shutdown?  Wasn't sure what would be best.

- The one semi-big negative is we have to re-enter the reactor as we're waiting for the subprocesses to exit.  Subprocesses are detected for completion via a child watcher, so we have to re-enter the reactor to detect when all subprocesses have completed.

- Since I was in the area, I fixed up dead code in issue #2171 too.
