### PR TITLE
libflux/test: Fix race in stat watcher test

### DIFF
--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -1374,7 +1374,7 @@ static void test_stat (flux_reactor_t *reactor)
         "reactor ran successfully");
 
     tap_skip (stat_size == 1,
-        "stat watcher invoked once for size chnage");
+        "stat watcher invoked once for size change");
     ok (stat_nlink == 1,
         "stat watcher invoked once for nlink set to zero");
 

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -1373,7 +1373,7 @@ static void test_stat (flux_reactor_t *reactor)
     ok (flux_reactor_run (reactor, 0) == 0,
         "reactor ran successfully");
 
-    tap_skip (stat_size == 1,
+    ok (stat_size == 1,
         "stat watcher invoked once for size change");
     ok (stat_nlink == 1,
         "stat watcher invoked once for nlink set to zero");


### PR DESCRIPTION
This PR fixes issue #997, test failure was due to race in test.  The stat watcher test performs a append & unlink and wants the stat watcher to detect both changes.  However, the append + unlink can occur in between polling loops of the stat watcher, thus the append can be missed.  The solution was to add a state variable that would not unlink the file until the stat watcher noticed the file size change from the append.

This PR also reverts 7a319e36719991898a3373c74f3ef9e06b13b33d, which
temporarily disabled the test due to it failing so much.

Ran through travis several times before fix and hit the issue many times.  After the fix, ran through travis 3 times and never hit the problem again.
