### PR TITLE
add flux-srun

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -55,7 +55,8 @@ nodist_flux_SOURCES = \
 
 dist_fluxcmd_SCRIPTS = \
 	flux-cron \
-	flux-jobspec.py
+	flux-jobspec.py \
+	flux-srun
 
 fluxcmd_PROGRAMS = \
 	flux-aggregate \

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -556,6 +556,8 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
     jobspecsz = read_jobspec (input, &jobspec);
     assert (((char *)jobspec)[jobspecsz] == '\0');
+    if (jobspecsz == 0)
+        log_msg_exit ("required jobspec is empty");
     priority = optparse_get_int (p, "priority", FLUX_JOB_PRIORITY_DEFAULT);
 
 #if HAVE_FLUX_SECURITY

--- a/src/cmd/flux-srun
+++ b/src/cmd/flux-srun
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+got_help() {
+    while [[ $1 == -* ]]; do
+        case "$1" in
+            --)          return 1 ;;
+            -h|--help)   return 0 ;;
+        esac
+        shift
+    done
+    return 1
+}
+
+submit_job() {
+    set -o pipefail
+    flux jobspec srun "$@" | flux job submit
+}
+
+if test $# -eq 0 || got_help "$@"; then
+    echo "Usage: flux srun OPTIONS command ..." >&2
+    echo "(see flux-jobspec srun for available OPTIONS)" >&2
+    exit 1
+fi
+
+JOBID=$(submit_job "$@") || exit 1
+
+exec flux job attach $JOBID
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -95,6 +95,7 @@ TESTSCRIPTS = \
 	t2300-sched-simple.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
+	t2500-job-attach.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \

--- a/t/t0002-request.t
+++ b/t/t0002-request.t
@@ -61,7 +61,7 @@ test_expect_success 'request: rpc returns expected error' '
 '
 
 test_expect_success 'request: rpc returns expected json' '
-	${FLUX_BUILD_DIR}/t/request/treq src 
+	${FLUX_BUILD_DIR}/t/request/treq src
 '
 
 test_expect_success 'request: rpc accepts expected json' '
@@ -73,7 +73,7 @@ test_expect_success 'request: 10K responses received in order' '
 '
 
 test_expect_success 'request: 10K responses received in order, with deferrals' '
-	${FLUX_BUILD_DIR}/t/request/treq putmsg 
+	${FLUX_BUILD_DIR}/t/request/treq putmsg
 '
 
 test_expect_success 'request: proxy ping 0 from 1 is 4 hops' '

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 
-test_description='Test basic module management 
+test_description='Test basic module management
 
 Verify module load/unload/list
 '

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -44,7 +44,7 @@ test_expect_success 'test_on_rank works' '
 '
 
 test_expect_success 'test_on_rank sends to correct rank' '
-	flux comms info | grep rank=0 && 
+	flux comms info | grep rank=0 &&
 	test_on_rank 1 sh -c "flux comms info | grep -q rank=1"
 '
 

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test broker log ring buffer' 
+test_description='Test broker log ring buffer'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test content-sqlite service' 
+test_description='Test content-sqlite service'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -68,7 +68,7 @@ test_expect_success 'flux broker with incompat attrs fails' '
 # size=1 boot from config file
 # N.B. "private" config sets rank and optionally size, while "shared"
 # config requires broker to infer rank from position of a local interface's
-# IP address in the tbon-endpoints array (which only works for size=1 in 
+# IP address in the tbon-endpoints array (which only works for size=1 in
 # a single-node test).
 #
 

--- a/t/t1103-apidisconnect.t
+++ b/t/t1103-apidisconnect.t
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 
-test_description='Test api disconnect generation 
+test_description='Test api disconnect generation
 '
 
 . `dirname $0`/sharness.sh

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 
-test_description='Test alternate hash config 
+test_description='Test alternate hash config
 
 Start a session with a non-default hash type for content/kvs.'
 

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 test_description='Test flux job command'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -44,6 +44,10 @@ test_expect_success 'flux-job: missing sub-command fails with usage message' '
 	grep -q Usage: usage2.out
 '
 
+test_expect_success 'flux-job: submit with empty jobpsec fails' '
+	test_must_fail flux job submit </dev/null
+'
+
 test_expect_success 'flux-job: submit with nonexistent jobpsec fails' '
 	test_must_fail flux job submit /noexist
 '
@@ -214,6 +218,18 @@ test_expect_success 'flux-job: id works with spaces in input' '
 	(echo "42"; echo "42") >despace.exp &&
 	(echo "42 "; echo " 42") | flux job id >despace.out &&
 	test_cmp despace.exp despace.out
+'
+
+test_expect_success 'flux-job: attach fails without jobid argument' '
+	test_must_fail flux job attach
+'
+
+test_expect_success 'flux-job: attach fails without jobid argument' '
+	test_must_fail flux job attach
+'
+
+test_expect_success 'flux-job: attach fails on invalid jobid' '
+	test_must_fail flux job attach $((${validjob}+1))
 '
 
 test_done

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -284,7 +284,7 @@ test_expect_success 'job-manager: there is still one job in the queue' '
 	test $(wc -l <list.out) -eq 1
 '
 
-test_expect_success 'job-manager: drain unblocks when last job is canceld' '
+test_expect_success 'job-manager: drain unblocks when last job is canceled' '
 	jobid=$(cut -f1 <list.out) &&
 	run_timeout 5 ${DRAIN_CANCEL} ${jobid}
 '

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -100,7 +100,7 @@ test_expect_success HAVE_JQ 'job-exec: simulate epilog/cleanup tasks' '
 #
 # XXX: Trying to generate an exception during cleanup is racy, however,
 #  there is not currently another way to do this until we have a *real*
-#  epilog script which could be triggered by events. If this test becoms
+#  epilog script which could be triggered by events. If this test becomes
 #  a problem, we can disable it until that time.
 #
 test_expect_success HAVE_JQ 'job-exec: exception during cleanup' '

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -18,7 +18,7 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
 
 job_kvsdir()    { flux job id --to=kvs $1; }
-exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; } 
+exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
 exec_testattr() {
 	${jq} --arg key "$1" --arg value $2 \
 	      '.attributes.system.exec.test[$key] = $value'

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+test_description='Test flux job attach and flux srun'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'attach: submit one job' '
+	flux jobspec srun -n1 hostname | flux job submit >jobid1
+'
+
+test_expect_success 'attach: job ran successfully' '
+	run_timeout 5 flux job attach $(cat jobid1)
+'
+
+test_expect_success 'attach: submit a job and cancel it' '
+	flux jobspec srun -t 00:30 -n1 hostname | flux job submit >jobid2 &&
+	flux job cancel $(cat jobid2)
+'
+
+test_expect_success 'attach: exit code reflects cancellation' '
+	test_must_fail flux job attach $(cat jobid2)
+'
+
+# Usage run_attach seq
+# Run a 30s job, then attach to it in the background
+# Write attach pid to pid${seq}.
+# Write jobid to jobid${seq}
+# Write attach stderr to attach${seq}.err (and poll until non-empty)
+run_attach() {
+	local seq=$1
+
+	flux jobspec srun -t 00:30 -n1 sleep 30 | flux job submit >jobid${seq}
+	flux job attach -E $(cat jobid${seq}) 2>attach${seq}.err &
+	echo $! >pid${seq}
+	while ! test -s attach${seq}.err; do sleep 0.1; done
+}
+
+test_expect_success 'attach: two SIGINTs cancel a job' '
+	run_attach 3 &&
+	pid=$(cat pid3) &&
+	kill -INT $pid &&
+	sleep 0.2 &&
+	kill -INT $pid &&
+	test_must_fail wait $pid
+'
+
+test_expect_success 'attach: SIGINT+SIGTSTP detaches from job' '
+	run_attach 4 &&
+	pid=$(cat pid4) &&
+	kill -INT $pid &&
+	sleep 0.2 &&
+	kill -TSTP $pid &&
+	test_must_fail wait $pid
+'
+
+test_expect_success 'attach: detached job was not canceled' '
+	flux job eventlog $(cat jobid4) >events4 &&
+	test_must_fail grep -q cancel events4
+'
+
+# Simple tests for flux srun
+
+test_expect_success 'flux srun with no args shows usage' '
+	flux srun 2>&1 | grep -i usage:
+'
+
+test_expect_success 'flux srun -h shows usage' '
+	flux srun -h 2>&1 | grep -i usage:
+'
+
+test_expect_success 'flux srun hostname works' '
+	flux srun hostname
+'
+
+test_expect_success 'flux srun -n4 hostname works' '
+	flux srun -n4 hostname
+'
+
+test_expect_success 'flux srun: -N4 hostname works' '
+	flux srun -N4 hostname
+'
+
+test_expect_success 'flux srun -c1 hostname works' '
+	flux srun -c1 hostname
+'
+
+test_expect_success 'flux srun -t0 hostname works' '
+	flux srun -t0 hostname
+'
+
+test_expect_success 'flux srun -N128 hostname fails' '
+	test_must_fail flux srun -N128 hostname
+'
+
+
+test_done


### PR DESCRIPTION
This is probably wrong.

Recall the idea for `flux srun` is to provide a simple run command that can be backported to the 0.11 series and provide a stable porting target across 0.11 -> 0.12, and take a little pressure off of having a complete porcelain run command right off in 0.12.

I added a `--wait` option to `flux job submit` so that the command will pause until the job reaches INACTIVE state, exiting with the highest exit code of the job shells, or 1 if the job was terminated by an exception.

Then I added the worlds simplest shell script that just called `flux jobspec srun $* | flux job submit --wait`.

I kind of think it would be better to do this as a python script that generates the jobspec (replicating some of what's in `flux jobspec` and then starts `flux job submit` as a subprocess.  The shell script just handing all its arguments to `flux jobspec srun` feels lame - it's not possible to print a reasonable usage message for example, nor to pass options to `flux job submit` without interpreting options.  And bash's `getopts` is not really longopt friendly.

Is the `--wait` option the proper default for this command?

I haven't written any tests b/c I wanted to get some early feedback on the direction.