### PR TITLE
broker: go through main cleanup path, do not call log_err_exit()

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -535,11 +535,25 @@ int main (int argc, char *argv[])
         runlevel_set_io_callback (ctx.runlevel, runlevel_io_cb, &ctx);
         runlevel_set_flux (ctx.runlevel, ctx.h);
 
-        if (runlevel_set_rc (ctx.runlevel, 1, rc1, rc1 ? strlen (rc1) + 1 : 0, uri) < 0)
+        if (runlevel_set_rc (ctx.runlevel,
+                             1,
+                             rc1,
+                             rc1 ? strlen (rc1) + 1 : 0,
+                             uri) < 0)
             log_err_exit ("runlevel_set_rc 1");
-        if (runlevel_set_rc (ctx.runlevel, 2, rc2, rc2_len, uri) < 0)
+
+        if (runlevel_set_rc (ctx.runlevel,
+                             2,
+                             rc2,
+                             rc2_len,
+                             uri) < 0)
             log_err_exit ("runlevel_set_rc 2");
-        if (runlevel_set_rc (ctx.runlevel, 3, rc3, rc3 ? strlen (rc3) + 1 : 0, uri) < 0)
+
+        if (runlevel_set_rc (ctx.runlevel,
+                             3,
+                             rc3,
+                             rc3 ? strlen (rc3) + 1 : 0,
+                             uri) < 0)
             log_err_exit ("runlevel_set_rc 3");
     }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -665,7 +665,10 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
-    handlers = broker_add_services (&ctx);
+    if (!(handlers = broker_add_services (&ctx))) {
+        log_err ("broker_add_services");
+        goto cleanup;
+    }
 
     /* Initialize comms module infrastructure.
      */
@@ -1592,12 +1595,16 @@ static flux_msg_handler_t **broker_add_services (broker_ctx_t *ctx)
         if (!nodeset_member (svc->nodeset, overlay_get_rank (ctx->overlay)))
             continue;
         if (service_add (ctx->services, svc->name, NULL,
-                          route_to_handle, ctx) < 0)
-            log_err_exit ("error registering service for %s", svc->name);
+                         route_to_handle, ctx) < 0) {
+            log_err ("error registering service for %s", svc->name);
+            return NULL;
+        }
     }
 
-    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &handlers) < 0)
-        log_err_exit ("error registering message handlers");
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &handlers) < 0) {
+        log_err ("error registering message handlers");
+        return NULL;
+    }
     return handlers;
 }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -582,7 +582,7 @@ int main (int argc, char *argv[])
     if (attr_register_handlers (ctx.attrs, ctx.h) < 0)
         log_err_exit ("attr_register_handlers");
     if (heaptrace_initialize (ctx.h) < 0)
-        log_msg_exit ("heaptrace_initialize");
+        log_err_exit ("heaptrace_initialize");
     if (exec_initialize (ctx.h, rank, ctx.attrs) < 0)
         log_err_exit ("exec_initialize");
     if (ping_initialize (ctx.h, "cmb") < 0)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -480,7 +480,7 @@ int main (int argc, char *argv[])
     if (overlay_register_attrs (ctx.overlay, ctx.attrs) < 0)
         log_err_exit ("registering overlay attributes");
     if (hello_register_attrs (ctx.hello, ctx.attrs) < 0)
-        log_err_exit ("configuring attributes");
+        log_err_exit ("configuring hello attributes");
 
     if (rank == 0) {
         if (runlevel_register_attrs (ctx.runlevel, ctx.attrs) < 0)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -746,8 +746,10 @@ cleanup:
      */
     if (ctx.verbose)
         log_msg ("unloading connector-local");
-    if (unload_module_byname (&ctx, "connector-local", NULL, false) < 0)
-        log_err ("unload connector-local");
+    if (unload_module_byname (&ctx, "connector-local", NULL, false) < 0) {
+        if (errno != ENOENT)
+            log_err ("unload connector-local");
+    }
     if (ctx.verbose)
         log_msg ("finalizing modules");
     modhash_destroy (ctx.modhash);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -436,8 +436,8 @@ int main (int argc, char *argv[])
     }
     else
         log_err_exit ("unknown boot method: %s", boot_method);
-    uint32_t rank = overlay_get_rank(ctx.overlay);
-    uint32_t size = overlay_get_size(ctx.overlay);
+    uint32_t rank = overlay_get_rank (ctx.overlay);
+    uint32_t size = overlay_get_size (ctx.overlay);
 
     assert (size > 0);
     assert (attr_get (ctx.attrs, "session-id", NULL, NULL) == 0);
@@ -773,7 +773,7 @@ static void shutdown_cb (shutdown_t *s, bool expired, void *arg)
 {
     broker_ctx_t *ctx = arg;
     if (expired) {
-        if (overlay_get_rank(ctx->overlay) == 0)
+        if (overlay_get_rank (ctx->overlay) == 0)
             exit_rc = shutdown_get_rc (s);
         flux_reactor_stop (flux_get_reactor (ctx->h));
     }
@@ -1481,7 +1481,7 @@ static flux_msg_handler_t **broker_add_services (broker_ctx_t *ctx)
     flux_msg_handler_t **handlers;
     struct internal_service *svc;
     for (svc = &services[0]; svc->name != NULL; svc++) {
-        if (!nodeset_member (svc->nodeset, overlay_get_rank(ctx->overlay)))
+        if (!nodeset_member (svc->nodeset, overlay_get_rank (ctx->overlay)))
             continue;
         if (service_add (ctx->services, svc->name, NULL,
                           route_to_handle, ctx) < 0)
@@ -1756,7 +1756,7 @@ static int subvert_sendmsg_child (broker_ctx_t *ctx, const flux_msg_t *msg,
     char uuid[16];
     int rc = -1;
 
-    snprintf (uuid, sizeof (uuid), "%"PRIu32, overlay_get_rank(ctx->overlay));
+    snprintf (uuid, sizeof (uuid), "%"PRIu32, overlay_get_rank (ctx->overlay));
     if (flux_msg_push_route (cpy, uuid) < 0)
         goto done;
     snprintf (uuid, sizeof (uuid), "%"PRIu32, nodeid);
@@ -1787,8 +1787,8 @@ static int broker_request_sendmsg (broker_ctx_t *ctx, const flux_msg_t *msg,
     uint32_t nodeid, gw;
     uint8_t flags;
     int rc = -1;
-    uint32_t rank = overlay_get_rank(ctx->overlay);
-    uint32_t size = overlay_get_size(ctx->overlay);
+    uint32_t rank = overlay_get_rank (ctx->overlay);
+    uint32_t size = overlay_get_size (ctx->overlay);
     const char *topic;
     char errbuf[64];
     const char *errstr = NULL;
@@ -1866,7 +1866,7 @@ static int broker_response_sendmsg (broker_ctx_t *ctx, const flux_msg_t *msg)
         goto done;
     }
 
-    parent = kary_parentof (ctx->tbon_k, overlay_get_rank(ctx->overlay));
+    parent = kary_parentof (ctx->tbon_k, overlay_get_rank (ctx->overlay));
     snprintf (puuid, sizeof (puuid), "%"PRIu32, parent);
 
     /* See if it should go to the parent (backwards!)
@@ -1895,7 +1895,7 @@ done:
 static int broker_event_sendmsg (broker_ctx_t *ctx, const flux_msg_t *msg)
 {
 
-    if (overlay_get_rank(ctx->overlay) > 0) {
+    if (overlay_get_rank (ctx->overlay) > 0) {
         flux_msg_t *cpy;
         if (!(cpy = flux_msg_copy (msg, true)))
             return -1;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -403,7 +403,10 @@ int main (int argc, char *argv[])
      * zsecurity_comms_init().
      */
     overlay_set_sec (ctx.overlay, ctx.sec);
-    overlay_set_flux (ctx.overlay, ctx.h);
+    if (overlay_set_flux (ctx.overlay, ctx.h) < 0) {
+        log_err ("overlay_set_flux");
+        goto cleanup;
+    }
 
     overlay_set_parent_cb (ctx.overlay, parent_cb, &ctx);
     overlay_set_child_cb (ctx.overlay, child_cb, &ctx);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -642,7 +642,10 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
-    shutdown_set_flux (ctx.shutdown, ctx.h);
+    if (shutdown_set_flux (ctx.shutdown, ctx.h) < 0) {
+        log_err ("shutdown_set_flux");
+        goto cleanup;
+    }
     shutdown_set_callback (ctx.shutdown, shutdown_cb, &ctx);
 
     /* Register internal services

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -168,7 +168,7 @@ static void init_attrs (attr_t *attrs, pid_t pid);
 
 static const struct flux_handle_ops broker_handle_ops;
 
-static int exit_rc = 0;
+static int exit_rc = 1;
 
 #define OPTIONS "+vM:X:k:s:g:EIS:"
 static const struct option longopts[] = {
@@ -284,12 +284,12 @@ static int setup_profiling (const char *program, int rank)
 int main (int argc, char *argv[])
 {
     broker_ctx_t ctx;
-    zlist_t *sigwatchers;
+    zlist_t *sigwatchers = NULL;
     int sec_typemask = ZSECURITY_TYPE_CURVE;
     sigset_t old_sigmask;
     struct sigaction old_sigact_int;
     struct sigaction old_sigact_term;
-    flux_msg_handler_t **handlers;
+    flux_msg_handler_t **handlers = NULL;
     const char *boot_method;
 
     memset (&ctx, 0, sizeof (ctx));
@@ -348,8 +348,10 @@ int main (int argc, char *argv[])
 
     /* Initailize zeromq context
      */
-    if (!zsys_init ())
-        log_err_exit ("zsys_init");
+    if (!zsys_init ()) {
+        log_err ("zsys_init");
+        goto cleanup;
+    }
     zsys_set_logstream (stderr);
     zsys_set_logident ("flux-broker");
     zsys_handler_set (NULL);
@@ -359,16 +361,22 @@ int main (int argc, char *argv[])
 
     /* Set up the flux reactor.
      */
-    if (!(ctx.reactor = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
-        log_err_exit ("flux_reactor_create");
+    if (!(ctx.reactor = flux_reactor_create (FLUX_REACTOR_SIGCHLD))) {
+        log_err ("flux_reactor_create");
+        goto cleanup;
+    }
 
     /* Set up flux handle.
      * The handle is used for simple purposes such as logging.
      */
-    if (!(ctx.h = flux_handle_create (&ctx, &broker_handle_ops, 0)))
-        log_err_exit ("flux_handle_create");
-    if (flux_set_reactor (ctx.h, ctx.reactor) < 0)
-        log_err_exit ("flux_set_reactor");
+    if (!(ctx.h = flux_handle_create (&ctx, &broker_handle_ops, 0))) {
+        log_err ("flux_handle_create");
+        goto cleanup;
+    }
+    if (flux_set_reactor (ctx.h, ctx.reactor) < 0) {
+        log_err ("flux_set_reactor");
+        goto cleanup;
+    }
 
     /* Prepare signal handling
      */
@@ -379,10 +387,14 @@ int main (int argc, char *argv[])
      * the libzmq work thread until we are ready to communicate.
      */
     const char *keydir;
-    if (attr_get (ctx.attrs, "security.keydir", &keydir, NULL) < 0)
-        log_err_exit ("getattr security.keydir");
-    if (!(ctx.sec = zsecurity_create (sec_typemask, keydir)))
-        log_err_exit ("zsecurity_create");
+    if (attr_get (ctx.attrs, "security.keydir", &keydir, NULL) < 0) {
+        log_err ("getattr security.keydir");
+        goto cleanup;
+    }
+    if (!(ctx.sec = zsecurity_create (sec_typemask, keydir))) {
+        log_err ("zsecurity_create");
+        goto cleanup;
+    }
 
     /* The first call to overlay_bind() or overlay_connect() calls
      * zsecurity_comms_init().
@@ -396,14 +408,20 @@ int main (int argc, char *argv[])
     /* Arrange for the publisher to route event messages.
      * handle_event - local subscribers (ctx.h)
      */
-    if (publisher_set_flux (ctx.publisher, ctx.h) < 0)
-        log_err_exit ("publisher_set_flux");
+    if (publisher_set_flux (ctx.publisher, ctx.h) < 0) {
+        log_err ("publisher_set_flux");
+        goto cleanup;
+    }
     if (publisher_set_sender (ctx.publisher, "handle_event",
-                              (publisher_send_f)handle_event, &ctx) < 0)
-        log_err_exit ("publisher_set_sender");
+                              (publisher_send_f)handle_event, &ctx) < 0) {
+        log_err ("publisher_set_sender");
+        goto cleanup;
+    }
 
-    if (create_rundir (ctx.attrs) < 0)
-        log_err_exit ("create_rundir");
+    if (create_rundir (ctx.attrs) < 0) {
+        log_err ("create_rundir");
+        goto cleanup;
+    }
 
     /* Set & create broker.rundir *after* overlay initialization,
      * when broker rank is determined.
@@ -415,27 +433,39 @@ int main (int argc, char *argv[])
      */
     if (attr_get (ctx.attrs, "boot.method", &boot_method, NULL) < 0) {
         boot_method = "pmi";
-        if (attr_add (ctx.attrs, "boot.method", boot_method, 0))
-            log_err_exit ("setattr boot.method");
+        if (attr_add (ctx.attrs, "boot.method", boot_method, 0)) {
+            log_err ("setattr boot.method");
+            goto cleanup;
+        }
     }
-    if (attr_set_flags (ctx.attrs, "boot.method", FLUX_ATTRFLAG_IMMUTABLE) < 0)
-        log_err_exit ("attr_set_flags boot.method");
+    if (attr_set_flags (ctx.attrs,
+                        "boot.method",
+                        FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+        log_err ("attr_set_flags boot.method");
+        goto cleanup;
+    }
     if (!strcmp (boot_method, "config")) {
-        if (boot_config (ctx.overlay, ctx.attrs, ctx.tbon_k) < 0)
-            log_msg_exit ("bootstrap failed");
+        if (boot_config (ctx.overlay, ctx.attrs, ctx.tbon_k) < 0) {
+            log_msg ("bootstrap failed");
+            goto cleanup;
+        }
     }
     else if (!strcmp (boot_method, "pmi")) {
         double elapsed_sec;
         struct timespec start_time;
         monotime (&start_time);
-        if (boot_pmi (ctx.overlay, ctx.attrs, ctx.tbon_k) < 0)
-            log_msg_exit ("bootstrap failed");
+        if (boot_pmi (ctx.overlay, ctx.attrs, ctx.tbon_k) < 0) {
+            log_msg ("bootstrap failed");
+            goto cleanup;
+        }
         elapsed_sec = monotime_since (start_time) / 1000;
         flux_log (ctx.h, LOG_INFO, "pmi: bootstrap time %.1fs", elapsed_sec);
 
     }
-    else
-        log_err_exit ("unknown boot method: %s", boot_method);
+    else {
+        log_err ("unknown boot method: %s", boot_method);
+        goto cleanup;
+    }
     uint32_t rank = overlay_get_rank (ctx.overlay);
     uint32_t size = overlay_get_size (ctx.overlay);
 
@@ -448,8 +478,10 @@ int main (int argc, char *argv[])
         log_msg ("boot: rank=%d size=%d session-id=%s", rank, size, sid);
     }
 
-    if (attr_set_flags (ctx.attrs, "session-id", FLUX_ATTRFLAG_IMMUTABLE) < 0)
-        log_err_exit ("attr_set_flags session-id");
+    if (attr_set_flags (ctx.attrs, "session-id", FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+        log_err ("attr_set_flags session-id");
+        goto cleanup;
+    }
 
     // Setup profiling
     setup_profiling (argv[0], rank);
@@ -457,8 +489,10 @@ int main (int argc, char *argv[])
     /* If persist-filesystem or persist-directory are set, initialize those,
      * but only on rank 0.
      */
-    if (create_persistdir (ctx.attrs, rank) < 0)
-        log_err_exit ("create_persistdir");
+    if (create_persistdir (ctx.attrs, rank) < 0) {
+        log_err ("create_persistdir");
+        goto cleanup;
+    }
 
     /* Initialize logging.
      * OK to call flux_log*() after this.
@@ -467,24 +501,34 @@ int main (int argc, char *argv[])
 
     /* Allow flux_get_rank() and flux_get_size() to work in the broker.
      */
-    if (create_dummyattrs (ctx.h, rank, size) < 0)
-        log_err_exit ("creating dummy attributes");
+    if (create_dummyattrs (ctx.h, rank, size) < 0) {
+        log_err ("creating dummy attributes");
+        goto cleanup;
+    }
 
     /* Registers message handlers and obtains rank.
      */
-    if (content_cache_set_flux (ctx.cache, ctx.h) < 0)
-        log_err_exit ("content_cache_set_flux");
+    if (content_cache_set_flux (ctx.cache, ctx.h) < 0) {
+        log_err ("content_cache_set_flux");
+        goto cleanup;
+    }
 
     /* Configure attributes.
      */
-    if (overlay_register_attrs (ctx.overlay, ctx.attrs) < 0)
-        log_err_exit ("registering overlay attributes");
-    if (hello_register_attrs (ctx.hello, ctx.attrs) < 0)
-        log_err_exit ("configuring hello attributes");
+    if (overlay_register_attrs (ctx.overlay, ctx.attrs) < 0) {
+        log_err ("registering overlay attributes");
+        goto cleanup;
+    }
+    if (hello_register_attrs (ctx.hello, ctx.attrs) < 0) {
+        log_err ("configuring hello attributes");
+        goto cleanup;
+    }
 
     if (rank == 0) {
-        if (runlevel_register_attrs (ctx.runlevel, ctx.attrs) < 0)
-            log_err_exit ("configuring runlevel attributes");
+        if (runlevel_register_attrs (ctx.runlevel, ctx.attrs) < 0) {
+            log_err ("configuring runlevel attributes");
+            goto cleanup;
+        }
     }
 
     /* The previous value of FLUX_URI (refers to enclosing instance)
@@ -521,14 +565,22 @@ int main (int argc, char *argv[])
         const char *rc2 = ctx.init_shell_cmd;
         size_t rc2_len = ctx.init_shell_cmd_len;
 
-        if (attr_get (ctx.attrs, "local-uri", &uri, NULL) < 0)
-            log_err_exit ("local-uri is not set");
-        if (attr_get (ctx.attrs, "broker.rc1_path", &rc1, NULL) < 0)
-            log_err_exit ("conf.rc1_path is not set");
-        if (attr_get (ctx.attrs, "broker.rc3_path", &rc3, NULL) < 0)
-            log_err_exit ("conf.rc3_path is not set");
-        if (attr_get (ctx.attrs, "conf.pmi_library_path", &pmi, NULL) < 0)
-            log_err_exit ("conf.pmi_library_path is not set");
+        if (attr_get (ctx.attrs, "local-uri", &uri, NULL) < 0) {
+            log_err ("local-uri is not set");
+            goto cleanup;
+        }
+        if (attr_get (ctx.attrs, "broker.rc1_path", &rc1, NULL) < 0) {
+            log_err ("conf.rc1_path is not set");
+            goto cleanup;
+        }
+        if (attr_get (ctx.attrs, "broker.rc3_path", &rc3, NULL) < 0) {
+            log_err ("conf.rc3_path is not set");
+            goto cleanup;
+        }
+        if (attr_get (ctx.attrs, "conf.pmi_library_path", &pmi, NULL) < 0) {
+            log_err ("conf.pmi_library_path is not set");
+            goto cleanup;
+        }
 
         runlevel_set_size (ctx.runlevel, size);
         runlevel_set_callback (ctx.runlevel, runlevel_cb, &ctx);
@@ -539,22 +591,28 @@ int main (int argc, char *argv[])
                              1,
                              rc1,
                              rc1 ? strlen (rc1) + 1 : 0,
-                             uri) < 0)
-            log_err_exit ("runlevel_set_rc 1");
+                             uri) < 0) {
+            log_err ("runlevel_set_rc 1");
+            goto cleanup;
+        }
 
         if (runlevel_set_rc (ctx.runlevel,
                              2,
                              rc2,
                              rc2_len,
-                             uri) < 0)
-            log_err_exit ("runlevel_set_rc 2");
+                             uri) < 0) {
+            log_err ("runlevel_set_rc 2");
+            goto cleanup;
+        }
 
         if (runlevel_set_rc (ctx.runlevel,
                              3,
                              rc3,
                              rc3 ? strlen (rc3) + 1 : 0,
-                             uri) < 0)
-            log_err_exit ("runlevel_set_rc 3");
+                             uri) < 0) {
+            log_err ("runlevel_set_rc 3");
+            goto cleanup;
+        }
     }
 
     /* If Flux was launched by Flux, now that PMI bootstrap and runlevel
@@ -569,26 +627,40 @@ int main (int argc, char *argv[])
      */
     if (ctx.verbose)
         log_msg ("initializing overlay sockets");
-    if (overlay_bind (ctx.overlay) < 0) /* idempotent */
-        log_err_exit ("overlay_bind");
-    if (overlay_connect (ctx.overlay) < 0)
-        log_err_exit ("overlay_connect");
+    if (overlay_bind (ctx.overlay) < 0) { /* idempotent */
+        log_err ("overlay_bind");
+        goto cleanup;
+    }
+    if (overlay_connect (ctx.overlay) < 0) {
+        log_err ("overlay_connect");
+        goto cleanup;
+    }
 
     shutdown_set_flux (ctx.shutdown, ctx.h);
     shutdown_set_callback (ctx.shutdown, shutdown_cb, &ctx);
 
     /* Register internal services
      */
-    if (attr_register_handlers (ctx.attrs, ctx.h) < 0)
-        log_err_exit ("attr_register_handlers");
-    if (heaptrace_initialize (ctx.h) < 0)
-        log_err_exit ("heaptrace_initialize");
-    if (exec_initialize (ctx.h, rank, ctx.attrs) < 0)
-        log_err_exit ("exec_initialize");
-    if (ping_initialize (ctx.h, "cmb") < 0)
-        log_err_exit ("ping_initialize");
-    if (rusage_initialize (ctx.h, "cmb") < 0)
-        log_err_exit ("rusage_initialize");
+    if (attr_register_handlers (ctx.attrs, ctx.h) < 0) {
+        log_err ("attr_register_handlers");
+        goto cleanup;
+    }
+    if (heaptrace_initialize (ctx.h) < 0) {
+        log_err ("heaptrace_initialize");
+        goto cleanup;
+    }
+    if (exec_initialize (ctx.h, rank, ctx.attrs) < 0) {
+        log_err ("exec_initialize");
+        goto cleanup;
+    }
+    if (ping_initialize (ctx.h, "cmb") < 0) {
+        log_err ("ping_initialize");
+        goto cleanup;
+    }
+    if (rusage_initialize (ctx.h, "cmb") < 0) {
+        log_err ("rusage_initialize");
+        goto cleanup;
+    }
 
     handlers = broker_add_services (&ctx);
 
@@ -605,16 +677,22 @@ int main (int argc, char *argv[])
      */
     if (ctx.verbose)
         log_msg ("loading connector-local");
-    if (load_module_byname (&ctx, "connector-local", NULL, 0, NULL) < 0)
-        log_err_exit ("load_module connector-local");
+    if (load_module_byname (&ctx, "connector-local", NULL, 0, NULL) < 0) {
+        log_err ("load_module connector-local");
+        goto cleanup;
+    }
 
     /* install heartbeat (including timer on rank 0)
      */
     heartbeat_set_flux (ctx.heartbeat, ctx.h);
-    if (heartbeat_register_attrs (ctx.heartbeat, ctx.attrs) < 0)
-        log_err_exit ("initializing heartbeat attributes");
-    if (heartbeat_start (ctx.heartbeat) < 0)
-        log_err_exit ("heartbeat_start");
+    if (heartbeat_register_attrs (ctx.heartbeat, ctx.attrs) < 0) {
+        log_err ("initializing heartbeat attributes");
+        goto cleanup;
+    }
+    if (heartbeat_start (ctx.heartbeat) < 0) {
+        log_err ("heartbeat_start");
+        goto cleanup;
+    }
     if (rank == 0 && ctx.verbose)
         log_msg ("installing session heartbeat: T=%0.1fs",
                   heartbeat_get_rate (ctx.heartbeat));
@@ -625,13 +703,17 @@ int main (int argc, char *argv[])
      */
     hello_set_flux (ctx.hello, ctx.h);
     hello_set_callback (ctx.hello, hello_update_cb, &ctx);
-    if (hello_start (ctx.hello) < 0)
-        log_err_exit ("hello_start");
+    if (hello_start (ctx.hello) < 0) {
+        log_err ("hello_start");
+        goto cleanup;
+    }
 
     /* Event loop
      */
     if (ctx.verbose)
         log_msg ("entering event loop");
+    /* Once we enter the reactor, default exit_rc is now 0 */
+    exit_rc = 0;
     if (flux_reactor_run (ctx.reactor, 0) < 0)
         log_err ("flux_reactor_run");
     if (ctx.verbose)
@@ -642,6 +724,10 @@ int main (int argc, char *argv[])
      * the reactor.
      */
     exec_terminate_subprocesses (ctx.h);
+
+cleanup:
+    if (ctx.verbose)
+        log_msg ("cleaning up");
 
     /* Restore default sigmask and actions for SIGINT, SIGTERM
      */
@@ -674,8 +760,6 @@ int main (int argc, char *argv[])
     broker_unhandle_signals (sigwatchers);
     zlist_destroy (&sigwatchers);
 
-    if (ctx.verbose)
-        log_msg ("cleaning up");
     if (ctx.sec)
         zsecurity_destroy (ctx.sec);
     overlay_destroy (ctx.overlay);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -611,7 +611,7 @@ int main (int argc, char *argv[])
     /* install heartbeat (including timer on rank 0)
      */
     heartbeat_set_flux (ctx.heartbeat, ctx.h);
-    if (heartbeat_set_attrs (ctx.heartbeat, ctx.attrs) < 0)
+    if (heartbeat_register_attrs (ctx.heartbeat, ctx.attrs) < 0)
         log_err_exit ("initializing heartbeat attributes");
     if (heartbeat_start (ctx.heartbeat) < 0)
         log_err_exit ("heartbeat_start");

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -36,6 +36,10 @@ void exec_terminate_subprocesses (flux_t *h)
 {
     flux_subprocess_server_t *s = flux_aux_get (h, "flux::exec");
 
+    /* exec_initialize() never called */
+    if (!s)
+        return;
+
     if (flux_subprocess_server_subprocesses_kill (s,
                                                   SIGTERM,
                                                   EXEC_TERMINATE_TIMEOUT) < 0)

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -62,7 +62,7 @@ void heartbeat_set_flux (heartbeat_t *hb, flux_t *h)
     hb->h = h;
 }
 
-int heartbeat_set_attrs (heartbeat_t *hb, attr_t *attrs)
+int heartbeat_register_attrs (heartbeat_t *hb, attr_t *attrs)
 {
     if (attr_add_active_int (attrs, "heartbeat-epoch",
                              &hb->epoch, FLUX_ATTRFLAG_READONLY) < 0)

--- a/src/broker/heartbeat.h
+++ b/src/broker/heartbeat.h
@@ -40,7 +40,7 @@ int heartbeat_set_rate (heartbeat_t *hb, double rate);
 double heartbeat_get_rate (heartbeat_t *hb);
 
 void heartbeat_set_flux (heartbeat_t *hb, flux_t *h);
-int heartbeat_set_attrs (heartbeat_t *hb, attr_t *attrs);
+int heartbeat_register_attrs (heartbeat_t *hb, attr_t *attrs);
 
 void heartbeat_set_epoch (heartbeat_t *hb, int epoch);
 int heartbeat_get_epoch (heartbeat_t *hb);

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -221,7 +221,7 @@ void modservice_register (flux_t *h, module_t *p)
     if (rusage_initialize (h, module_get_name (ctx->p)) < 0)
         log_err_exit ("rusage_initialize");
 
-    register_event   (ctx, "stats.clear", stats_clear_event_cb);
+    register_event (ctx, "stats.clear", stats_clear_event_cb);
 
     if (!(ctx->w_prepare = flux_prepare_watcher_create (r, prepare_cb, ctx)))
         log_err_exit ("flux_prepare_watcher_create");

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -158,7 +158,9 @@ uint32_t overlay_get_size (overlay_t *ov)
     return ov->size;
 }
 
-void overlay_set_flux (overlay_t *ov, flux_t *h)
+/* Cleanup not done in this function, responsibiility of caller to
+ * call overlay_destroy() eventually */
+int overlay_set_flux (overlay_t *ov, flux_t *h)
 {
     struct flux_match match = FLUX_MATCH_EVENT;
 
@@ -166,11 +168,16 @@ void overlay_set_flux (overlay_t *ov, flux_t *h)
 
     match.topic_glob = "hb";
     if (!(ov->heartbeat = flux_msg_handler_create (ov->h, match,
-                                                   heartbeat_handler, ov)))
-        log_err_exit ("flux_msg_handler_create");
+                                                   heartbeat_handler, ov))) {
+        log_err ("flux_msg_handler_create");
+        return -1;
+    }
     flux_msg_handler_start (ov->heartbeat);
-    if (flux_event_subscribe (ov->h, "hb") < 0)
-        log_err_exit ("flux_event_subscribe");
+    if (flux_event_subscribe (ov->h, "hb") < 0) {
+        log_err ("flux_event_subscribe");
+        return -1;
+    }
+    return 0;
 }
 
 void overlay_set_idle_warning (overlay_t *ov, int heartbeats)
@@ -469,8 +476,10 @@ int overlay_connect (overlay_t *ov)
     if (overlay_sec_init (ov) < 0)
         goto done;
     if (ov->parent && !ov->parent->zs) {
-        if (connect_parent (ov, ov->parent) < 0)
-            log_err_exit ("%s", ov->parent->uri);
+        if (connect_parent (ov, ov->parent) < 0) {
+            log_err ("%s", ov->parent->uri);
+            goto done;
+        }
     }
     rc = 0;
 done:

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -372,21 +372,31 @@ static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
         ov->child_cb (ov, zsock, ov->child_arg);
 }
 
+/* Cleanup not done in this function, responsibiility of caller to
+ * call endpoint_destroy() eventually */
 static int bind_child (overlay_t *ov, struct endpoint *ep)
 {
-    if (!(ep->zs = zsock_new_router (NULL)))
-        log_err_exit ("zsock_new_router");
-    if (zsecurity_ssockinit (ov->sec, ep->zs) < 0)
-        log_msg_exit ("zsecurity_ssockinit: %s", zsecurity_errstr (ov->sec));
-    if (zsock_bind (ep->zs, "%s", ep->uri) < 0)
-        log_err_exit ("%s", ep->uri);
+    if (!(ep->zs = zsock_new_router (NULL))) {
+        log_err ("zsock_new_router");
+        return -1;
+    }
+    if (zsecurity_ssockinit (ov->sec, ep->zs) < 0) {
+        log_msg ("zsecurity_ssockinit: %s", zsecurity_errstr (ov->sec));
+        return -1;
+    }
+    if (zsock_bind (ep->zs, "%s", ep->uri) < 0) {
+        log_err ("%s", ep->uri);
+        return -1;
+    }
     if (strchr (ep->uri, '*')) { /* capture dynamically assigned port */
         free (ep->uri);
         ep->uri = zsock_last_endpoint (ep->zs);
     }
     if (!(ep->w = flux_zmq_watcher_create (flux_get_reactor (ov->h),
-                                           ep->zs, FLUX_POLLIN, child_cb, ov)))
-        log_err_exit ("flux_zmq_watcher_create");
+                                           ep->zs, FLUX_POLLIN, child_cb, ov))) {
+        log_err ("flux_zmq_watcher_create");
+        return -1;
+    }
     flux_watcher_start (ep->w);
     /* Ensure that ipc files are removed when the broker exits.
      */
@@ -478,8 +488,10 @@ int overlay_bind (overlay_t *ov)
     if (overlay_sec_init (ov) < 0)
         goto done;
 
-    if (ov->child && !ov->child->zs)
-        bind_child (ov, ov->child);
+    if (ov->child && !ov->child->zs) {
+        if (bind_child (ov, ov->child) < 0)
+            goto done;
+    }
 
     rc = 0;
 done:

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -29,7 +29,7 @@ void overlay_set_init_callback (overlay_t *ov,
 /* These need to be called before connect/bind.
  */
 void overlay_set_sec (overlay_t *ov, zsecurity_t *sec);
-void overlay_set_flux (overlay_t *ov, flux_t *h);
+int overlay_set_flux (overlay_t *ov, flux_t *h);
 void overlay_init (overlay_t *ov, uint32_t size, uint32_t rank, int tbon_k);
 void overlay_set_idle_warning (overlay_t *ov, int heartbeats);
 

--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -38,7 +38,7 @@ void shutdown_destroy (shutdown_t *s);
  */
 void shutdown_set_flux (shutdown_t *s, flux_t *h);
 
-/* Reigster a shutdown callback to be called
+/* Register a shutdown callback to be called
  * 1) when the grace timeout is armed, and
  * 2) when the grace timeout expires.
  */

--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -36,7 +36,7 @@ void shutdown_destroy (shutdown_t *s);
 /* Set the flux_t *handle to be used to configure the event message
  * handler, grace timer watcher, and log the shutdown message.
  */
-void shutdown_set_flux (shutdown_t *s, flux_t *h);
+int shutdown_set_flux (shutdown_t *s, flux_t *h);
 
 /* Register a shutdown callback to be called
  * 1) when the grace timeout is armed, and


### PR DESCRIPTION
In #1036, it was discovered that an assert can occur inside `zmq` b/c the broker calls `exit()` without doing some proper cleanup.

Generally speaking, I re-worked part of the overlay and broker to not call `log_err_exit()` and instead go through the cleanup path of the broker.

There are still a lot of `log_err_exit()` calls I got to remove, but wanted to throw up this PR for now to see if there are any comments.