### PR TITLE
libpmi: clean up simple server wire protocol code

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -65,7 +65,7 @@ flux_broker_LDADD = \
 	$(builddir)/libbroker.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libpmi/libpmi.la
+	$(top_builddir)/src/common/libpmi/libpmi_client.la
 
 flux_broker_LDFLAGS =
 
@@ -82,7 +82,7 @@ test_ldadd = \
 	$(builddir)/libbroker.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libpmi/libpmi.la \
+	$(top_builddir)/src/common/libpmi/libpmi_client.la \
 	$(top_builddir)/src/common/libtap/libtap.la
 
 test_cppflags = \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -73,7 +73,7 @@ fluxcmd_PROGRAMS = \
 
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \
-	$(top_builddir)/src/common/libpmi/libpmi.la \
+	$(top_builddir)/src/common/libpmi/libpmi_server.la \
 	$(LIBUTIL)
 
 #

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -343,7 +343,7 @@ void channel_cb (flux_subprocess_t *p, const char *stream)
         log_err_exit ("%s: flux_subprocess_read_line", __FUNCTION__);
 
     if (lenp) {
-        rc = pmi_simple_server_request (ctx.pmi.srv, ptr, cli);
+        rc = pmi_simple_server_request (ctx.pmi.srv, ptr, cli, cli->rank);
         if (rc < 0)
             log_err_exit ("%s: pmi_simple_server_request", __FUNCTION__);
         if (rc == 1)

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -73,8 +73,7 @@ libflux_idset_la_LDFLAGS = \
 
 libpmi_la_SOURCES =
 libpmi_la_LIBADD = \
-	$(builddir)/libpmi/libpmi.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL)
+	$(builddir)/libpmi/libpmi_client.la
 libpmi_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libpmi.map \
 	-version-info 0:0:0 \

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -11,22 +11,30 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 
-noinst_LTLIBRARIES = libpmi.la
+noinst_LTLIBRARIES = \
+	libpmi_client.la \
+	libpmi_server.la
 
-libpmi_la_SOURCES = \
-	simple_server.h \
-	simple_server.c \
-	simple_client.c \
-	simple_client.h \
-	pmi.c \
+libpmi_common_sources = \
 	pmi_strerror.c \
 	pmi_strerror.h \
 	keyval.c \
-	keyval.h \
+	keyval.h
+
+libpmi_client_la_SOURCES = \
+	simple_client.c \
+	simple_client.h \
+	pmi.c \
 	dgetline.c \
 	dgetline.h \
 	clique.c \
-	clique.h
+	clique.h \
+	$(libpmi_common_sources)
+
+libpmi_server_la_SOURCES = \
+	simple_server.h \
+	simple_server.c \
+	$(libpmi_common_sources)
 
 fluxinclude_HEADERS = \
 	pmi.h
@@ -38,7 +46,8 @@ TESTS = test_keyval.t \
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
-	$(top_builddir)/src/common/libpmi/libpmi.la \
+	$(top_builddir)/src/common/libpmi/libpmi_client.la \
+	$(top_builddir)/src/common/libpmi/libpmi_server.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/liblsd/liblsd.la \

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -46,7 +46,7 @@ enum {
 struct pmi_simple_server *pmi_simple_server_create (struct pmi_simple_ops ops,
                                                     int appnum,
                                                     int universe_size,
-                                                    int local_procs,
+                                                    int local_size,
                                                     const char *kvsname,
                                                     int flags,
                                                     void *arg);
@@ -57,7 +57,7 @@ void pmi_simple_server_destroy (struct pmi_simple_server *pmi);
  * Returns 1 indicating finalized / close fd, 0 on success, -1 on failure.
  */
 int pmi_simple_server_request (struct pmi_simple_server *pmi,
-                               const char *buf, void *client);
+                               const char *buf, void *client, int rank);
 
 /* Finalize a barrier.  Set rc to 0 for success, -1 for failure.
  */


### PR DESCRIPTION
The "server" end of the PMI-1 code in libpmi was pretty crufty, lacked documentation, and was sparse on tests.

This PR implements a little refactoring that hopefully makes it clearer, and adds tests for code that wasn't being exercised.

It also removes the server code from the installed `libpmi.so.0.0.0` because it was causing that library to have dependencies on zeromq and other libs.  (I don't know if this is really a problem, but since it was unnecessary and I did go to some trouble early on to make the library standalone, I went ahead and fixed it).