### PR TITLE
broker: various cleanup + refactoring

### DIFF
--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -184,7 +184,8 @@ int boot_config (overlay_t *overlay, attr_t *attrs, int tbon_k)
 
     /* Initialize overlay network parameters.
      */
-    overlay_init (overlay, size, rank, tbon_k);
+    if (overlay_init (overlay, size, rank, tbon_k) < 0)
+        goto done;
     overlay_set_child (overlay, get_cf_endpoint (cf, rank));
     if (rank > 0) {
         int prank = kary_parentof (tbon_k, rank);

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -170,10 +170,11 @@ int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k)
         goto error;
     }
 
-    overlay_init (overlay,
-                  (uint32_t)pmi_params.size,
-                  (uint32_t)pmi_params.rank,
-                  tbon_k);
+    if (overlay_init (overlay,
+                      (uint32_t)pmi_params.size,
+                      (uint32_t)pmi_params.rank,
+                      tbon_k)< 0)
+        goto error;
 
     /* Set session-id attribute from PMI appnum if not already set.
      */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -767,12 +767,7 @@ cleanup:
     publisher_destroy (ctx.publisher);
     flux_close (ctx.h);
     flux_reactor_destroy (ctx.reactor);
-    if (ctx.subscriptions) {
-        char *s;
-        while ((s = zlist_pop (ctx.subscriptions)))
-            free (s);
-        zlist_destroy (&ctx.subscriptions);
-    }
+    zlist_destroy (&ctx.subscriptions);
     runlevel_destroy (ctx.runlevel);
     free (ctx.init_shell_cmd);
 
@@ -2073,6 +2068,7 @@ static int broker_subscribe (void *impl, const char *topic)
         goto nomem;
     if (zlist_append (ctx->subscriptions, cpy) < 0)
         goto nomem;
+    zlist_freefn (ctx->subscriptions, cpy, free, true);
     return 0;
 nomem:
     free (cpy);
@@ -2087,7 +2083,6 @@ static int broker_unsubscribe (void *impl, const char *topic)
     while (s) {
         if (!strcmp (s, topic)) {
             zlist_remove (ctx->subscriptions, s);
-            free (s);
             break;
         }
         s = zlist_next (ctx->subscriptions);

--- a/src/broker/heartbeat.c
+++ b/src/broker/heartbeat.c
@@ -81,17 +81,6 @@ error:
     return -1;
 }
 
-int heartbeat_set_ratestr (heartbeat_t *hb, const char *s)
-{
-    double rate;
-    if (fsd_parse_duration (s, &rate) < 0)
-        goto error;
-    return heartbeat_set_rate (hb, rate);
-error:
-    errno = EINVAL;
-    return -1;
-}
-
 double heartbeat_get_rate (heartbeat_t *hb)
 {
     return hb->rate;

--- a/src/broker/heartbeat.h
+++ b/src/broker/heartbeat.h
@@ -45,7 +45,7 @@ int heartbeat_register_attrs (heartbeat_t *hb, attr_t *attrs);
 void heartbeat_set_epoch (heartbeat_t *hb, int epoch);
 int heartbeat_get_epoch (heartbeat_t *hb);
 
-int heartbeat_start (heartbeat_t *hb); /* rank 0 only */
+int heartbeat_start (heartbeat_t *hb);
 void heartbeat_stop (heartbeat_t *hb);
 
 #endif /* !_BROKER_HEARTBEAT_H */

--- a/src/broker/heartbeat.h
+++ b/src/broker/heartbeat.h
@@ -30,12 +30,7 @@ typedef struct heartbeat_struct heartbeat_t;
 heartbeat_t *heartbeat_create (void);
 void heartbeat_destroy (heartbeat_t *hb);
 
-/* Default heart rate (seconds) can be set from a command line argument
- * that includes an optional "s" or "ms" unit suffix.
- * Returns -1, EINVAL if rate is out of range (0.1, 30).
- */
-int heartbeat_set_ratestr (heartbeat_t *hb, const char *s);
-
+/* Returns -1, EINVAL if rate is out of range (0.1, 30). */
 int heartbeat_set_rate (heartbeat_t *hb, double rate);
 double heartbeat_get_rate (heartbeat_t *hb);
 

--- a/src/broker/modservice.h
+++ b/src/broker/modservice.h
@@ -13,7 +13,7 @@
 
 #include "module.h"
 
-void modservice_register (flux_t *h, module_t *p);
+int modservice_register (flux_t *h, module_t *p);
 
 #endif /* !_BROKER_MODSERVICE_H */
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -129,7 +129,11 @@ static void *module_thread (void *arg)
         goto done;
     }
     flux_log_set_appname (p->h, p->name);
-    modservice_register (p->h, p);
+
+    if (modservice_register (p->h, p) < 0) {
+        log_err ("%s: modservice_register", p->name);
+        goto done;
+    }
 
     /* Block all signals
      */

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -132,8 +132,8 @@ void overlay_set_init_callback (overlay_t *ov, overlay_init_cb_f cb, void *arg)
     ov->init_arg = arg;
 }
 
-void overlay_init (overlay_t *overlay,
-                   uint32_t size, uint32_t rank, int tbon_k)
+int overlay_init (overlay_t *overlay,
+                  uint32_t size, uint32_t rank, int tbon_k)
 {
     overlay->size = size;
     overlay->rank = rank;
@@ -142,7 +142,8 @@ void overlay_init (overlay_t *overlay,
     overlay->tbon_maxlevel = kary_levelof (tbon_k, size - 1);
     overlay->tbon_descendants = kary_sum_descendants (tbon_k, size, rank);
     if (overlay->init_cb)
-        (*overlay->init_cb) (overlay, overlay->init_arg);
+        return (*overlay->init_cb) (overlay, overlay->init_arg);
+    return 0;
 }
 
 uint32_t overlay_get_rank (overlay_t *ov)

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -516,7 +516,7 @@ static int overlay_attr_get_cb (const char *name, const char **val, void *arg)
     int rc = -1;
 
     if (!strcmp (name, "tbon.parent-endpoint"))
-        *val = overlay_get_parent(overlay);
+        *val = overlay_get_parent (overlay);
     else {
         errno = ENOENT;
         goto done;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -28,8 +28,8 @@ void overlay_set_init_callback (overlay_t *ov,
 
 /* These need to be called before connect/bind.
  */
-void overlay_set_sec (overlay_t *ov, zsecurity_t *sec);
 int overlay_set_flux (overlay_t *ov, flux_t *h);
+int overlay_setup_sec (overlay_t *ov, int sec_typemask, const char *keydir);
 void overlay_init (overlay_t *ov, uint32_t size, uint32_t rank, int tbon_k);
 void overlay_set_idle_warning (overlay_t *ov, int heartbeats);
 

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -16,7 +16,7 @@
 
 typedef struct overlay_struct overlay_t;
 typedef void (*overlay_cb_f)(overlay_t *ov, void *sock, void *arg);
-typedef void (*overlay_init_cb_f)(overlay_t *ov, void *arg);
+typedef int (*overlay_init_cb_f)(overlay_t *ov, void *arg);
 
 overlay_t *overlay_create (void);
 void overlay_destroy (overlay_t *ov);
@@ -30,7 +30,7 @@ void overlay_set_init_callback (overlay_t *ov,
  */
 int overlay_set_flux (overlay_t *ov, flux_t *h);
 int overlay_setup_sec (overlay_t *ov, int sec_typemask, const char *keydir);
-void overlay_init (overlay_t *ov, uint32_t size, uint32_t rank, int tbon_k);
+int overlay_init (overlay_t *ov, uint32_t size, uint32_t rank, int tbon_k);
 void overlay_set_idle_warning (overlay_t *ov, int heartbeats);
 
 /* Accessors

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -81,8 +81,6 @@ static int runlevel_set_mode (runlevel_t *r, const char *val)
 {
     if (!strcmp (val, "normal"))
         r->mode = "normal";
-    if (!strcmp (val, "normal"))
-        r->mode = "normal";
     else if (!strcmp (val, "none"))
         r->mode = "none";
     else {

--- a/src/broker/shutdown.h
+++ b/src/broker/shutdown.h
@@ -38,6 +38,10 @@ void shutdown_destroy (shutdown_t *s);
  */
 int shutdown_set_flux (shutdown_t *s, flux_t *h);
 
+/* Set shutdown grace.  If grace == 0., overlay size will be used to
+ * get estimate */
+int shutdown_set_grace (shutdown_t *s, double grace);
+
 /* Register a shutdown callback to be called
  * 1) when the grace timeout is armed, and
  * 2) when the grace timeout expires.
@@ -52,7 +56,7 @@ int shutdown_get_rc (shutdown_t *s);
 /* Call shutdown_arm() when shutdown should begin.
  * This sends the "cmb.shutdown" event to all ranks.
  */
-int shutdown_arm (shutdown_t *s, double grace, int rc, const char *fmt, ...);
+int shutdown_arm (shutdown_t *s, int rc, const char *fmt, ...);
 
 /* Call shutdown_disarm() once the clean shutdown path has succeeded.
  * This disarms the timer on the local rank only.

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -54,7 +54,7 @@ int main (int argc, char **argv)
     heartbeat_t *hb;
     flux_msg_handler_t *w;
 
-    plan (18);
+    plan (16);
 
     check_codec ();
 
@@ -79,10 +79,6 @@ int main (int argc, char **argv)
     errno = 0;
     ok (heartbeat_set_rate (hb, 1000000) < 0 && errno == EINVAL,
         "heartbeat_set_rate 1000000 fails with EINVAL");
-    ok (heartbeat_set_ratestr (hb, ".250s") == 0,
-        "heartbeat_set_ratestr .250s works");
-    ok (heartbeat_get_rate (hb) == 0.250,
-        "heartbeat_get_rate returns what was set");
     ok (heartbeat_set_rate (hb, 0.1) == 0,
         "heartbeat_set_rate 0.1 works");
     ok (heartbeat_get_rate (hb) == 0.1,

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -74,10 +74,10 @@ int main (int argc, char **argv)
     ok (heartbeat_get_rate (hb) == 2.,
         "heartbeat_get_rate returns default of 2s");
     errno = 0;
-    ok (heartbeat_set_rate (hb, -1) < 1 && errno == EINVAL,
+    ok (heartbeat_set_rate (hb, -1) < 0 && errno == EINVAL,
         "heartbeat_set_rate -1 fails with EINVAL");
     errno = 0;
-    ok (heartbeat_set_rate (hb, 1000000) < 1 && errno == EINVAL,
+    ok (heartbeat_set_rate (hb, 1000000) < 0 && errno == EINVAL,
         "heartbeat_set_rate 1000000 fails with EINVAL");
     ok (heartbeat_set_ratestr (hb, ".250s") == 0,
         "heartbeat_set_ratestr .250s works");

--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -89,6 +89,7 @@ int main (int argc, char **argv)
     ok ((sh = shutdown_create ()) != NULL,
         "shutdown_create works");
     shutdown_set_flux (sh, h);
+    shutdown_set_grace (sh, 0.1);
     shutdown_set_callback (sh, shutdown_cb, NULL);
 
     matchlog.topic_glob = "log.append";
@@ -97,7 +98,7 @@ int main (int argc, char **argv)
         "created log.append watcher");
     flux_msg_handler_start (log_w);
 
-    ok (shutdown_arm (sh, 0.1, 42, "testing %d %d %d", 1, 2, 3) == 0,
+    ok (shutdown_arm (sh, 42, "testing %d %d %d", 1, 2, 3) == 0,
         "shutdown event sent, starting reactor");
     ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,
         "flux reactor exited normally");
@@ -105,7 +106,7 @@ int main (int argc, char **argv)
     /* Make sure shutdown_disarm unwires timer.
      * (other watchers have already stopped themselves above)
      */
-    ok (shutdown_arm (sh, 0.1, 42, "testing %d %d %d", 1, 2, 3) == 0,
+    ok (shutdown_arm (sh, 42, "testing %d %d %d", 1, 2, 3) == 0,
         "shutdown event sent, then disarmed, starting reactor");
     shutdown_disarm (sh);
     ok (flux_reactor_run (flux_get_reactor (h), 0) == 0,


### PR DESCRIPTION
While PR #2181 is still half fresh in my mind, wanted to do these small cleanups & refactorings.

Obviously, way more refactoring can be done as I've listed things in #2182, but this is more of a refactoring "setup" for bigger things later.

Mostly small changes to slowly decouple objects from each other or clarify lack of dependency between objects.

Also, removed a few more `log_err_exit()` and similar paths, forcing callers to go through the main broker cleanup path.
