### PR TITLE
job-exec: implement ability to execute job shells

### DIFF
--- a/src/cmd/flux-jobspec.py
+++ b/src/cmd/flux-jobspec.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import re
+import os
 import sys
 import math
 import logging
@@ -70,7 +71,7 @@ def create_slurm_style_jobspec(
                 "attributes": {},
             }
         ],
-        "attributes": {"system": {}},
+        "attributes": {"system": {"cwd": os.getcwd()}},
     }
     if walltime:
         jobspec["attributes"]["system"]["duration"] = walltime

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -14,6 +14,16 @@ AM_CPPFLAGS = \
 fluxmod_LTLIBRARIES = \
 	job-exec.la
 
+noinst_LTLIBRARIES = \
+	libbulk-exec.la
+
+noinst_PROGRAMS = \
+	bulk-exec
+
+libbulk_exec_la_SOURCES = \
+	bulk-exec.h \
+	bulk-exec.c
+
 job_exec_la_SOURCES = \
 	job-exec.h \
 	job-exec.c \
@@ -29,6 +39,18 @@ job_exec_la_LIBADD = \
 	$(fluxmod_ldadd) \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(ZMQ_LIBS)
+
+bulk_exec_SOURCES = \
+	test/bulk-exec.c
+
+bulk_exec_LDADD = \
+	$(fluxmod_ldadd) \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	libbulk-exec.la \
 	$(ZMQ_LIBS)
 
 test_ldadd = \

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -15,9 +15,11 @@ fluxmod_LTLIBRARIES = \
 	job-exec.la
 
 job_exec_la_SOURCES = \
+	job-exec.h \
 	job-exec.c \
 	rset.c \
-	rset.h
+	rset.h \
+	testexec.c
 
 job_exec_la_LDFLAGS = \
 	$(fluxmod_ldflags) \

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -29,7 +29,8 @@ job_exec_la_SOURCES = \
 	job-exec.c \
 	rset.c \
 	rset.h \
-	testexec.c
+	testexec.c \
+	exec.c
 
 job_exec_la_LDFLAGS = \
 	$(fluxmod_ldflags) \
@@ -39,6 +40,7 @@ job_exec_la_LIBADD = \
 	$(fluxmod_ldadd) \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	libbulk-exec.la \
 	$(ZMQ_LIBS)
 
 bulk_exec_SOURCES = \

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -1,0 +1,433 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <sys/wait.h>
+#define EXIT_CODE(x) __W_EXITCODE(x,0)
+
+#include <flux/core.h>
+#include <flux/idset.h>
+#include <czmq.h>
+
+#include "bulk-exec.h"
+
+struct exec_cmd {
+    struct idset *ranks;
+    flux_cmd_t *cmd;
+    int flags;
+};
+
+struct bulk_exec {
+    flux_t *h;
+
+    int max_start_per_loop;  /* Max subprocess started per event loop cb */
+    int total;               /* Total processes expected to run */
+    int started;             /* Number of processes that have reached start */
+    int complete;            /* Number of processes that have completed */
+
+    int exit_status;         /* Largest wait status of all complete procs */
+
+    unsigned int active:1;
+
+    flux_watcher_t *prep;
+    flux_watcher_t *check;
+    flux_watcher_t *idle;
+
+    struct idset *exit_batch;         /* Support for batched exit notify */
+    flux_watcher_t *exit_batch_timer; /* Timer for batched exit notify */
+
+    flux_subprocess_ops_t ops;
+
+    zlist_t *commands;
+    zlist_t *processes;
+
+    struct bulk_exec_ops *handlers;
+    void *arg;
+};
+
+int bulk_exec_rc (struct bulk_exec *exec)
+{
+    return (exec->exit_status);
+}
+
+static void exec_state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
+{
+    struct bulk_exec *exec = flux_subprocess_aux_get (p, "job-exec::exec");
+    if (state == FLUX_SUBPROCESS_RUNNING) {
+        if (++exec->started == exec->total) {
+            if (exec->handlers->on_start)
+                (*exec->handlers->on_start) (exec, exec->arg);
+        }
+    }
+    else if (state == FLUX_SUBPROCESS_FAILED
+            || state == FLUX_SUBPROCESS_EXEC_FAILED) {
+        int errnum = flux_subprocess_fail_errno (p);
+        int code = EXIT_CODE(1);
+
+        if (errnum == EPERM || errnum == EACCES)
+            code = EXIT_CODE(126);
+        else if (errnum == ENOENT)
+            code = EXIT_CODE(127);
+        else if (errnum == EHOSTUNREACH)
+            code = EXIT_CODE(68);
+
+        if (code > exec->exit_status)
+            exec->exit_status = code;
+
+        if (exec->handlers->on_error)
+            (*exec->handlers->on_error) (exec, p, exec->arg);
+    }
+}
+
+static int exec_exit_notify (struct bulk_exec *exec)
+{
+    if (exec->handlers->on_exit)
+        (*exec->handlers->on_exit) (exec, exec->arg, exec->exit_batch);
+    if (exec->exit_batch_timer) {
+        flux_watcher_destroy (exec->exit_batch_timer);
+        exec->exit_batch_timer = NULL;
+        idset_range_clear (exec->exit_batch, 0, INT_MAX);
+    }
+    return 0;
+}
+
+static void exit_batch_cb (flux_reactor_t *r, flux_watcher_t *w,
+                          int revents, void *arg)
+{
+    struct bulk_exec *exec = arg;
+    exec_exit_notify (exec);
+}
+
+/*  Append completed subprocess 'p' to the current batch for exit
+ *   notification. If this is the first exited process in the batch,
+ *   then start a timer which will fire and call the function to
+ *   notify bulk_exec user of the batch of subprocess exits.
+ *
+ *  This appraoch avoids unecessarily calling into user's callback
+ *   multiple times when all tasks exit within 0.01s.
+ */
+static void exit_batch_append (struct bulk_exec *exec, flux_subprocess_t *p)
+{
+    int rank = flux_subprocess_rank (p);
+    if (idset_set (exec->exit_batch, rank) < 0) {
+        flux_log_error (exec->h, "exit_batch_append:idset_set");
+        return;
+    }
+    if (!exec->exit_batch_timer) {
+        flux_reactor_t *r = flux_get_reactor (exec->h);
+        /*  XXX: batch timer should eventually be configurable by caller */
+        exec->exit_batch_timer =
+            flux_timer_watcher_create (r, 0.01, 0.,
+                                       exit_batch_cb,
+                                       exec);
+        if (!exec->exit_batch_timer) {
+            flux_log_error (exec->h, "exit_batch_append:timer create");
+            return;
+        }
+        flux_watcher_start (exec->exit_batch_timer);
+    }
+}
+
+static void exec_complete_cb (flux_subprocess_t *p)
+{
+    int status = flux_subprocess_status (p);
+    struct bulk_exec *exec = flux_subprocess_aux_get (p, "job-exec::exec");
+
+    if (status > exec->exit_status)
+        exec->exit_status = status;
+
+    /* Append this process to the current batch for notification */
+    exit_batch_append (exec, p);
+
+    if (++exec->complete == exec->total) {
+        exec_exit_notify (exec);
+        if (exec->handlers->on_complete)
+            (*exec->handlers->on_complete) (exec, exec->arg);
+    }
+}
+
+static void exec_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    struct bulk_exec *exec = flux_subprocess_aux_get (p, "job-exec::exec");
+    const char *s;
+    int len;
+
+    if (!(s = flux_subprocess_read_line (p, stream, &len))) {
+        flux_log_error (exec->h, "flux_subprocess_read_line");
+        return;
+    }
+    if (!len && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
+        if (!(s = flux_subprocess_read (p, stream, -1, &len))) {
+            flux_log_error (exec->h, "flux_subprocess_read");
+            return;
+        }
+    }
+    if (len) {
+        int rank = flux_subprocess_rank (p);
+        if (exec->handlers->on_output)
+            (*exec->handlers->on_output) (exec, p, stream, s, len, exec->arg);
+        else
+            flux_log (exec->h, LOG_INFO, "rank %d: %s: %s", rank, stream, s);
+    }
+}
+
+static void exec_cmd_destroy (void *arg)
+{
+    struct exec_cmd *cmd = arg;
+    idset_destroy (cmd->ranks);
+    flux_cmd_destroy (cmd->cmd);
+    free (cmd);
+}
+
+static struct exec_cmd *exec_cmd_create (const struct idset *ranks,
+                                         flux_cmd_t *cmd,
+                                         int flags)
+{
+    struct exec_cmd *c = calloc (1, sizeof (*c));
+    if (!c)
+        return NULL;
+    if (!(c->ranks = idset_copy (ranks)))
+        goto err;
+    c->cmd = flux_cmd_copy (cmd);
+    c->flags = flags;
+    return (c);
+err:
+    exec_cmd_destroy (c);
+    return NULL;
+}
+
+static void subprocess_destroy_finish (flux_future_t *f, void *arg)
+{
+    flux_subprocess_t *p = arg;
+    if (flux_future_get (f, NULL) < 0) {
+        flux_t *h = flux_subprocess_aux_get (p, "flux_t");
+        flux_log_error (h, "subprocess_kill: %ju: %s",
+                        (uintmax_t) flux_subprocess_pid,
+                        flux_strerror (errno));
+    }
+    flux_subprocess_destroy (p);
+    flux_future_destroy (f);
+}
+
+static int subprocess_destroy (flux_t *h, flux_subprocess_t *p)
+{
+    flux_future_t *f = flux_subprocess_kill (p, SIGKILL);
+    if (!f || flux_future_then (f, -1., subprocess_destroy_finish, p) < 0)
+        return -1;
+    return 0;
+}
+
+static int exec_start_cmd (struct bulk_exec *exec,
+                           struct exec_cmd *cmd,
+                           int max)
+{
+    int count = 0;
+    uint32_t rank;
+    rank = idset_first (cmd->ranks);
+    while (rank != IDSET_INVALID_ID && (max < 0 || count < max)) {
+        flux_subprocess_t *p = flux_rexec (exec->h,
+                                           rank,
+                                           cmd->flags,
+                                           cmd->cmd,
+                                           &exec->ops);
+        if (!p)
+            return -1;
+        if (flux_subprocess_aux_set (p, "job-exec::exec", exec, NULL) < 0
+           || zlist_append (exec->processes, p) < 0) {
+            if (subprocess_destroy (exec->h, p) < 0)
+                flux_log_error (exec->h, "Unable to destroy pid %ju",
+                        (uintmax_t) flux_subprocess_pid (p));
+            return -1;
+        }
+        zlist_freefn (exec->processes, p,
+                     (zlist_free_fn *) flux_subprocess_unref,
+                     true);
+
+        idset_clear (cmd->ranks, rank);
+        rank = idset_next (cmd->ranks, rank);
+        count++;
+    }
+    return count;
+}
+
+void bulk_exec_stop (struct bulk_exec *exec)
+{
+    flux_watcher_stop (exec->prep);
+    flux_watcher_stop (exec->check);
+}
+
+static int exec_start_cmds (struct bulk_exec *exec, int max)
+{
+    while (zlist_size (exec->commands) && (max != 0)) {
+        struct exec_cmd *cmd = zlist_first (exec->commands);
+        int rc = exec_start_cmd (exec, cmd, max);
+        if (rc < 0) {
+            flux_log_error (exec->h, "exec_start_cmd failed");
+            return -1;
+        }
+        if (idset_count (cmd->ranks) == 0)
+            zlist_remove (exec->commands, cmd);
+        if (max > 0)
+            max -= rc;
+
+    }
+    return 0;
+}
+
+static void prep_cb (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    struct bulk_exec *exec = arg;
+
+    /* Don't block in reactor if there are commands to run */
+    if (zlist_size (exec->commands) > 0) {
+        flux_watcher_start (exec->idle);
+        flux_watcher_start (exec->check);
+    }
+    else
+        bulk_exec_stop (exec);
+}
+
+static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
+                     int revents, void *arg)
+{
+    struct bulk_exec *exec = arg;
+    flux_watcher_stop (exec->idle);
+    flux_watcher_stop (exec->check);
+    if (exec_start_cmds (exec, exec->max_start_per_loop) < 0) {
+        bulk_exec_stop (exec);
+        if (exec->handlers->on_error)
+            (*exec->handlers->on_error) (exec, NULL, exec->arg);
+    }
+}
+
+void bulk_exec_destroy (struct bulk_exec *exec)
+{
+    zlist_destroy (&exec->processes);
+    zlist_destroy (&exec->commands);
+    idset_destroy (exec->exit_batch);
+    flux_watcher_destroy (exec->prep);
+    flux_watcher_destroy (exec->check);
+    flux_watcher_destroy (exec->idle);
+    free (exec);
+}
+
+struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops, void *arg)
+{
+    flux_subprocess_ops_t sp_ops = {
+        .on_completion =   exec_complete_cb,
+        .on_state_change = exec_state_cb,
+        .on_stdout =       exec_output_cb,
+        .on_stderr =       exec_output_cb,
+    };
+    struct bulk_exec *exec = calloc (1, sizeof (*exec));
+    if (!exec)
+        return NULL;
+    exec->ops = sp_ops;
+    exec->handlers = ops;
+    exec->arg = arg;
+    exec->processes = zlist_new ();
+    exec->commands = zlist_new ();
+    exec->exit_batch = idset_create (0, IDSET_FLAG_AUTOGROW);
+    exec->max_start_per_loop = 1;
+
+    return exec;
+}
+
+int bulk_exec_set_max_per_loop (struct bulk_exec *exec, int max)
+{
+    if (max == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    exec->max_start_per_loop = max;
+    return 0;
+}
+
+int bulk_exec_push_cmd (struct bulk_exec *exec,
+                       const struct idset *ranks,
+                       flux_cmd_t *cmd,
+                       int flags)
+{
+    struct exec_cmd *c = exec_cmd_create (ranks, cmd, flags);
+    if (!c)
+        return -1;
+
+    if (zlist_append (exec->commands, c) < 0) {
+        exec_cmd_destroy (c);
+        return -1;
+    }
+    zlist_freefn (exec->commands, c, exec_cmd_destroy, true);
+
+    exec->total += idset_count (ranks);
+    if (exec->active) {
+        flux_watcher_start (exec->prep);
+        flux_watcher_start (exec->check);
+    }
+
+    return 0;
+}
+
+int bulk_exec_start (flux_t *h, struct bulk_exec *exec)
+{
+    flux_reactor_t *r = flux_get_reactor (h);
+    exec->h = h;
+    exec->prep = flux_prepare_watcher_create (r, prep_cb, exec);
+    exec->check = flux_check_watcher_create (r, check_cb, exec);
+    exec->idle = flux_idle_watcher_create (r, NULL, NULL);
+    if (!exec->prep || !exec->check || !exec->idle)
+        return -1;
+    flux_watcher_start (exec->prep);
+    exec->active = 1;
+    return 0;
+}
+
+flux_future_t *bulk_exec_kill (struct bulk_exec *exec, int signum)
+{
+    flux_subprocess_t *p = zlist_first (exec->processes);
+    flux_future_t *cf = NULL;
+
+    if (!(cf = flux_future_wait_all_create ()))
+        return NULL;
+    flux_future_set_flux (cf, exec->h);
+
+    if (!p) {
+        flux_future_fulfill_error (cf, ENOENT, NULL);
+        return (cf);
+    }
+    while (p) {
+        if (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
+            flux_future_t *f = NULL;
+            char s[64];
+            if (!(f = flux_subprocess_kill (p, signum))) {
+                int err = errno;
+                const char *errstr = flux_strerror (errno);
+                if ((f = flux_future_create (NULL, NULL)))
+                    flux_future_fulfill_error (f, err, errstr);
+                else
+                    flux_future_fulfill_error (cf, err, "Internal error");
+            }
+            (void) snprintf (s, sizeof (s)-1, "%u",
+                            flux_subprocess_rank (p));
+            if (flux_future_push (cf, s, f) < 0) {
+                fprintf (stderr, "flux_future_push: %s\n", strerror (errno));
+                flux_future_destroy (f);
+            }
+        }
+        p = zlist_next (exec->processes);
+    }
+    return cf;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -1,0 +1,65 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* "bulk" subprocess execution wrapper around libsubprocess API */
+
+#ifndef HAVE_JOB_EXEC_BULK_EXEC_H
+#define HAVE_JOB_EXEC_BULK_EXEC_H 1
+
+#include <flux/core.h>
+
+struct bulk_exec;
+
+typedef void (*exec_cb_f)   (struct bulk_exec *, void *arg);
+
+typedef void (*exec_exit_f) (struct bulk_exec *, void *arg,
+                             const struct idset *ranks);
+
+typedef void (*exec_io_f)   (struct bulk_exec *,
+                             flux_subprocess_t *,
+                             const char *stream,
+			     const char *data,
+			     int data_len,
+                             void *arg);
+
+typedef void (*exec_error_f) (struct bulk_exec *,
+                              flux_subprocess_t *,
+                              void *arg);
+
+struct bulk_exec_ops {
+    exec_cb_f    on_start;    /* called when all processes are running  */
+    exec_exit_f  on_exit;     /* called when a set of tasks exits       */
+    exec_cb_f    on_complete; /* called when all processes are done     */
+    exec_io_f    on_output;   /* called on process output               */
+    exec_error_f on_error;    /* called on any fatal error              */
+};
+
+struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops, void *arg);
+
+/*  Set maximum number of flux_subprocess_rexex(3) calls per event
+ *   loop iteration. (-1 for no max)
+ */
+int bulk_exec_set_max_per_loop (struct bulk_exec *exec, int max);
+
+void bulk_exec_destroy (struct bulk_exec *exec);
+
+int bulk_exec_push_cmd (struct bulk_exec *exec,
+                       const struct idset *ranks,
+                       flux_cmd_t *cmd,
+                       int flags);
+
+int bulk_exec_start (flux_t *h, struct bulk_exec *exec);
+
+flux_future_t * bulk_exec_kill (struct bulk_exec *exec, int signal);
+
+/* Returns max wait status returned from all exited processes */
+int bulk_exec_rc (struct bulk_exec *exec);
+
+#endif /* !HAVE_JOB_EXEC_BULK_EXEC_H */

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -1,0 +1,213 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Flux subprocess-based exec implementation
+ *
+ * DESCRIPTION
+ *
+ * Launch configured job shell, one per rank.
+ *
+ */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <unistd.h>
+
+#include "job-exec.h"
+#include "bulk-exec.h"
+#include "rset.h"
+
+extern char **environ;
+static const char dummy_job_shell[] = "/bin/true";
+static const char *default_cwd = "/tmp";
+
+static const char *jobspec_get_job_shell (json_t *jobspec)
+{
+    const char *path = NULL;
+    (void) json_unpack (jobspec, "{s:{s:{s:{s:s}}}}",
+                                 "attributes", "system", "exec",
+                                 "job_shell", &path);
+    return path;
+}
+
+static const char *job_shell_path (struct jobinfo *job)
+{
+    const char *path = jobspec_get_job_shell (job->jobspec);
+    if (!path && !(path = flux_attr_get(job->h, "job-exec.job-shell"))) {
+        path = dummy_job_shell;
+        flux_log (job->h, LOG_INFO,
+                  "%ju: no configured job shell, using %s",
+                  (uintmax_t) job->id, path);
+    }
+    return path;
+}
+
+static const char *jobspec_get_cwd (json_t *jobspec)
+{
+    const char *cwd = NULL;
+    (void) json_unpack (jobspec, "{s:{s:{s:s}}}",
+                                 "attributes", "system",
+                                 "cwd", &cwd);
+    return cwd;
+}
+
+static const char *job_get_cwd (struct jobinfo *job)
+{
+    const char *cwd = jobspec_get_cwd (job->jobspec);
+    if (!cwd)
+        cwd = default_cwd;
+    return (cwd);
+}
+
+static void start_cb (struct bulk_exec *exec, void *arg)
+{
+    struct jobinfo *job = arg;
+    jobinfo_started (job, NULL);
+}
+
+static void complete_cb (struct bulk_exec *exec, void *arg)
+{
+    struct jobinfo *job = arg;
+    jobinfo_tasks_complete (job,
+                            resource_set_ranks (job->R),
+                            bulk_exec_rc (exec));
+}
+
+static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
+                       const char *stream,
+                       const char *data,
+                       int data_len,
+                       void *arg)
+{
+    struct jobinfo *job = arg;
+    flux_log (job->h, LOG_INFO, "%d: %d: %s: %s",
+                      flux_subprocess_rank (p),
+                      flux_subprocess_pid (p),
+                      stream, data);
+}
+
+static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
+{
+    struct jobinfo *job = arg;
+    const char *arg0 = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
+    jobinfo_fatal_error (job, flux_subprocess_fail_errno (p),
+                              "cmd=%s: rank=%d failed",
+                              arg0, flux_subprocess_rank (p));
+}
+
+static struct bulk_exec_ops exec_ops = {
+    .on_start =     start_cb,
+    .on_exit =      NULL,
+    .on_complete =  complete_cb,
+    .on_output =    output_cb,
+    .on_error =     error_cb
+};
+
+static int exec_init (struct jobinfo *job)
+{
+    flux_cmd_t *cmd = NULL;
+    struct bulk_exec *exec = NULL;
+    const struct idset *ranks = NULL;
+
+    if (!(ranks = resource_set_ranks (job->R))) {
+        flux_log_error (job->h, "exec_init: resource_set_ranks");
+        goto err;
+    }
+    if (!(exec = bulk_exec_create (&exec_ops, job))) {
+        flux_log_error (job->h, "exec_init: bulk_exec_create");
+        goto err;
+    }
+    if (!(cmd = flux_cmd_create (0, NULL, environ))) {
+        flux_log_error (job->h, "exec_init: flux_cmd_create");
+        goto err;
+    }
+    if (flux_cmd_argv_append (cmd, job_shell_path (job)) < 0
+        || flux_cmd_argv_append (cmd, "%ju", (uintmax_t) job->id) < 0) {
+        flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
+        goto err;
+    }
+    if (flux_cmd_setcwd (cmd, job_get_cwd (job)) < 0) {
+        flux_log_error (job->h, "exec_init: flux_cmd_setcwd");
+        goto err;
+    }
+    if (bulk_exec_push_cmd (exec, ranks, cmd, 0) < 0) {
+        flux_log_error (job->h, "exec_init: bulk_exec_push_cmd");
+        goto err;
+    }
+    flux_cmd_destroy (cmd);
+    job->data = exec;
+    return 1;
+err:
+    flux_cmd_destroy (cmd);
+    bulk_exec_destroy (exec);
+    return -1;
+}
+
+static int exec_start (struct jobinfo *job)
+{
+    struct bulk_exec *exec = job->data;
+    return bulk_exec_start (job->h, exec);
+}
+
+static void exec_kill_cb (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    if (flux_future_get (f, NULL) < 0)
+        flux_log_error (job->h, "%ju: exec_kill", (uintmax_t) job->id);
+    jobinfo_incref (job);
+    flux_future_destroy (f);
+}
+
+static int exec_kill (struct jobinfo *job, int signum)
+{
+    struct  bulk_exec *exec = job->data;
+    flux_future_t *f = bulk_exec_kill (exec, signum);
+
+    flux_log (job->h, LOG_DEBUG,
+              "exec_kill: %ju: signal %d",
+              (uintmax_t) job->id,
+              signum);
+
+    jobinfo_incref (job);
+    if (!f || flux_future_then (f, -1., exec_kill_cb, job) < 0) {
+        flux_log_error (job->h, "%ju: exec_kill: flux_future_then", job->id);
+        flux_future_destroy (f);
+        return -1;
+    }
+    return 0;
+}
+
+static int exec_cleanup (struct jobinfo *job, const struct idset *idset)
+{
+    /* No epilog supported */
+    jobinfo_cleanup_complete (job, idset, 0);
+    return 0;
+}
+
+static void exec_exit (struct jobinfo *job)
+{
+    struct bulk_exec *exec = job->data;
+    bulk_exec_destroy (exec);
+    job->data = NULL;
+}
+
+struct exec_implementation bulkexec = {
+    .name =     "bulk-exec",
+    .init =     exec_init,
+    .exit =     exec_exit,
+    .start =    exec_start,
+    .kill =     exec_kill,
+    .cleanup =  exec_cleanup
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -232,19 +232,12 @@ static void emit_event_continuation (flux_future_t *f, void *arg)
     jobinfo_decref (job);
 }
 
-/*
- *  Send an event "open loop" -- takes a reference to the job and
- *   releases it in the continuation, logging an error if one was
- *   received.
- */
-static int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
-                                           const char *name,
-                                           const char *fmt, ...)
+static int jobinfo_emit_event_vpack_nowait (struct jobinfo *job,
+                                            const char *name,
+                                            const char *fmt,
+                                            va_list ap)
 {
-    va_list ap;
-    va_start (ap, fmt);
     flux_future_t *f = jobinfo_emit_event_vpack (job, name, fmt, ap);
-    va_end (ap);
     if (f == NULL)
         return -1;
     jobinfo_incref (job);
@@ -257,8 +250,25 @@ error:
     jobinfo_decref (job);
     flux_future_destroy (f);
     return -1;
+
 }
 
+/*
+ *  Send an event "open loop" -- takes a reference to the job and
+ *   releases it in the continuation, logging an error if one was
+ *   received.
+ */
+static int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
+                                           const char *name,
+                                           const char *fmt, ...)
+{
+    int rc = -1;
+    va_list ap;
+    va_start (ap, fmt);
+    rc = jobinfo_emit_event_vpack_nowait (job, name, fmt, ap);
+    va_end (ap);
+    return rc;
+}
 
 static void jobinfo_add_cleanup (struct jobinfo *job, const char *name,
                                  cleanup_task_f fn)

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -91,9 +91,11 @@
 #include "job-exec.h"
 
 extern struct exec_implementation testexec;
+extern struct exec_implementation bulkexec;
 
 static struct exec_implementation * implementations[] = {
     &testexec,
+    &bulkexec,
     NULL
 };
 
@@ -820,9 +822,9 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
 
     if (!(job->req = flux_msg_copy (msg, true))) {
         flux_log_error (ctx->h, "start: flux_msg_copy");
-        jobinfo_decref (job);
         if (flux_respond_error (ctx->h, msg, errno, "flux_msg_copy failed") < 0)
             flux_log_error (ctx->h, "flux_respond_error");
+        jobinfo_decref (job);
         return -1;
     }
     job->ctx = ctx;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -330,6 +330,7 @@ static int jobinfo_respond (flux_t *h, struct jobinfo *job,
 static void jobinfo_complete (struct jobinfo *job)
 {
     flux_t *h = job->ctx->h;
+    job->running = 0;
     if (h && job->req) {
         jobinfo_emit_event_pack_nowait (job, "complete",
                                         "{ s:i }",
@@ -360,7 +361,6 @@ static void jobinfo_started (struct jobinfo *job, const char *fmt, ...)
 static void jobinfo_kill (struct jobinfo *job)
 {
     flux_watcher_stop (job->timer);
-    job->running = 0;
     job->wait_status = 0x9; /* Killed */
 
     /* XXX: Manually send "finish" event here since our timer_cb won't

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -1,0 +1,115 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_JOB_EXEC_H
+#define HAVE_JOB_EXEC_H 1
+
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libutil/fluid.h"
+#include "rset.h"
+
+struct job_exec_ctx;
+struct jobinfo;
+
+/*  Exec implementation interface:
+ *
+ *  An exec implementation must include the methods below:
+ *
+ *   - init:    allow selection and initialization of an exec implementation
+ *              from jobspec and/or R. An implementation should return 0 to
+ *              "pass" on handling this job, > 0 to denote successful
+ *              initialization, or < 0 for a fatal error (generates immediate
+ *              exception).
+ *
+ *   - exit:    called at job destruction so implementation may free resources
+ *
+ *   - start:   start execution of job
+ *
+ *   - kill:    signal executing job shells, e.g. due to exception or other
+ *              fatal error.
+ *
+ *   - cleanup: Initiate any cleanup (epilog) on ranks.
+ */
+struct exec_implementation {
+    const char *name;
+    int  (*init)    (struct jobinfo *job);
+    void (*exit)    (struct jobinfo *job);
+    int  (*start)   (struct jobinfo *job);
+    int  (*kill)    (struct jobinfo *job, int signum);
+    int  (*cleanup) (struct jobinfo *job, const struct idset *ranks);
+};
+
+/*  Exec job information */
+struct jobinfo {
+    flux_t *              h;
+    flux_jobid_t          id;
+    char                  ns [64];   /* namespace string */
+    flux_msg_t *          req;       /* copy of initial request */
+    uint32_t              userid;    /* requesting userid */
+    int                   flags;     /* job flags */
+
+    struct resource_set * R;         /* Fetched and parsed resource set R */
+    json_t *              jobspec;   /* Fetched jobspec */
+
+    uint8_t               needs_cleanup:1;
+    uint8_t               has_namespace:1;
+    uint8_t               exception_in_progress:1;
+    uint8_t               running:1;
+    uint8_t               finalizing:1;
+
+    int                   wait_status;
+
+    /* Exec implementation for this job */
+    struct exec_implementation *impl;
+    void *                      data;
+
+    /* Private job-exec module data */
+    int                   refcount;
+    struct job_exec_ctx * ctx;
+};
+
+void jobinfo_incref (struct jobinfo *job);
+void jobinfo_decref (struct jobinfo *job);
+
+/* Emit an event to the exec.eventlog */
+int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
+                                     const char *name,
+                                     const char *fmt, ...);
+
+/* Emit  start event with optional note in jansson pack format */
+void jobinfo_started (struct jobinfo *job, const char *fmt, ...);
+
+/* Notify job-exec that ranks in idset `ranks` have completed
+ *  with the given wait status
+ */
+void jobinfo_tasks_complete (struct jobinfo *job,
+                             const struct idset *ranks,
+                             int wait_status);
+
+/* Notify job-exec that ranks in idset `ranks` have finished epilog,
+ *  and resources can be released
+ */
+void jobinfo_cleanup_complete (struct jobinfo *job,
+                               const struct idset *ranks,
+                               int rc);
+
+
+/* Notify job-exec of fatal error. Triggers kill/cleanup.
+ */
+void jobinfo_fatal_error (struct jobinfo *job, int errnum,
+                          const char *fmt, ...);
+
+#endif /* !HAVE_JOB_EXEC_EXEC_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/test/bulk-exec.c
+++ b/src/modules/job-exec/test/bulk-exec.c
@@ -1,0 +1,222 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  Test driver for job-exec/bulk-exec.[ch] bulk subprocess
+ *   execution API.
+ */
+
+#define _GNU_SOURCE 1
+#include <unistd.h>
+#include <assert.h>
+
+#include <flux/core.h>
+#include <flux/idset.h>
+#include <flux/optparse.h>
+
+#include "bulk-exec.h"
+#include "src/common/libutil/log.h"
+
+extern char **environ;
+
+void started (struct bulk_exec *exec, void *arg)
+{
+    log_msg ("started");
+}
+
+void complete (struct bulk_exec *exec, void *arg)
+{
+    log_msg ("complete");
+}
+
+void exited (struct bulk_exec *exec, void *arg, const struct idset *ids)
+{
+    char *s = idset_encode (ids, IDSET_FLAG_RANGE);
+    log_msg ("ranks %s: exited", s);
+    free (s);
+}
+
+void on_error (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
+{
+    if (p) {
+        flux_subprocess_state_t state = flux_subprocess_state (p);
+        log_msg ("%d: pid %ju: %s", flux_subprocess_rank (p),
+                (uintmax_t) flux_subprocess_pid (p),
+                flux_subprocess_state_string (state));
+    }
+    flux_future_t *f = bulk_exec_kill (exec, 9);
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("bulk_exec_kill");
+}
+
+void on_output (struct bulk_exec *exec, flux_subprocess_t *p,
+                const char *stream, const char *data,
+                int data_len, void *arg)
+{
+    int rank = flux_subprocess_rank (p);
+    FILE *fp = strcmp (stream, "STDOUT") == 0 ? stdout : stderr;
+    fprintf (fp, "%d: %s", rank, data);
+}
+
+static unsigned int idset_pop (struct idset *idset)
+{
+    unsigned int id = idset_first (idset);
+    if (id == IDSET_INVALID_ID)
+        return id;
+    (void) idset_clear (idset, id);
+    return id;
+}
+
+static struct idset * idset_pop_n (struct idset *idset, int n)
+{
+    unsigned int id;
+    struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
+    if (ids == NULL)
+        return NULL;
+    while ((n-- > 0) && ((id = idset_pop (idset)) != IDSET_INVALID_ID)) {
+        if (idset_set (ids, id) < 0)
+            goto err;
+    }
+    return ids;
+err:
+    idset_destroy (ids);
+    return NULL;
+}
+
+void push_commands (struct bulk_exec *exec,
+                    struct idset *idset,
+                    int ncmds,
+                    int ac, char **av)
+{
+    flux_cmd_t *cmd = flux_cmd_create (ac, av, environ);
+    char *cwd = get_current_dir_name ();
+    struct idset *ids = NULL;
+    int count;
+    int per_cmd;
+
+    if (cmd == NULL)
+        log_err_exit ("flux_cmd_create");
+
+    if ((count = idset_count (idset)) < ncmds)
+        log_err_exit ("Can't split %d ranks into %d cmds", count, ncmds);
+    flux_cmd_setcwd (cmd, cwd);
+    free (cwd);
+
+    per_cmd = count/ncmds;
+    fprintf (stderr, "per_cmd = %d\n", per_cmd);
+    while (idset_count (idset)) {
+        struct idset *ids = idset_pop_n (idset, per_cmd);
+        fprintf (stderr, "ids = %s\n", idset_encode (ids, IDSET_FLAG_RANGE));
+        if (bulk_exec_push_cmd (exec, ids, cmd, 0) < 0)
+            log_err_exit ("bulk_exec_push_cmd");
+        idset_destroy (ids);
+    }
+    idset_destroy (ids);
+    flux_cmd_destroy (cmd);
+}
+
+int main (int ac, char **av)
+{
+    struct bulk_exec *exec = NULL;
+    optparse_t *p = NULL;
+    const char *ranks = NULL;
+    struct idset *idset = NULL;
+    flux_t *h = NULL;
+    uint32_t size;
+    int ncmds = 1;
+    int optindex = -1;
+
+    struct optparse_option opts[] = {
+        { .name = "rank",
+          .key = 'r',
+          .has_arg = 1,
+          .arginfo = "IDS",
+          .usage = "Target ranks in IDS"
+        },
+        { .name = "mpl",
+          .key = 'm',
+          .has_arg = 1,
+          .arginfo = "COUNT",
+          .usage = "Max procs to start per loop iteration"
+        },
+        { .name = "ncmds",
+          .key = 'n',
+          .has_arg = 1,
+          .arginfo = "N",
+          .usage = "Internally, split into N 'cmds'"
+        },
+        OPTPARSE_TABLE_END
+    };
+
+    struct bulk_exec_ops ops = {
+        .on_start    = started,
+        .on_exit     = exited,
+        .on_complete = complete,
+        .on_error    = on_error,
+        .on_output   = on_output,
+    };
+
+    if (!(p = optparse_create ("execer")))
+        log_err_exit ("optparse_create");
+    if (optparse_add_option_table (p, opts) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_option_table");
+    if ((optindex = optparse_parse_args (p, ac, av)) < 0)
+        exit (1);
+    av += optindex;
+    ac -= optindex;
+
+    if (ac == 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+
+    if (!optparse_getopt (p, "rank", &ranks))
+        ranks = "all";
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (flux_get_size (h, &size) < 0)
+        log_err_exit ("flux_get_size");
+
+    if (strcmp (ranks, "all") == 0) {
+        if (!(idset = idset_create (size, 0)))
+            log_err_exit ("idset_create");
+        if (idset_range_set (idset, 0, size - 1) < 0)
+            log_err_exit ("idset_range_set");
+    }
+    else if (!(idset = idset_decode (ranks)))
+        log_err_exit ("idset_decode (%s)", ranks);
+
+    if (!(exec = bulk_exec_create (&ops, h)))
+        log_err_exit ("bulk_exec_create");
+
+    if (bulk_exec_set_max_per_loop (exec, optparse_get_int (p, "mpl", -1)) < 0)
+        log_err_exit ("bulk_exec_set_max_per_loop");
+
+    ncmds = optparse_get_int (p, "ncmds", 1);
+
+    push_commands (exec, idset, ncmds, ac, av);
+
+    if (bulk_exec_start (h, exec) < 0)
+        log_err_exit ("bulk_exec_start");
+
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    idset_destroy (idset);
+    bulk_exec_destroy (exec);
+    flux_close (h);
+    optparse_destroy (p);
+
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -1,0 +1,310 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Flux job test exec implementation
+ *
+ * DESCRIPTION
+ *
+ * This exec module implments timer driven test execution without any
+ * job-shells for testing and demonstration purposes. The module is
+ * activated either when it is the only active exec implementation
+ * loaded, or if the exec test configuration block is present in the
+ * submitted jobspec. See TEST CONFIGURATION for more information.
+ *
+ * TEST CONFIGURATION
+ *
+ *  The job-exec module supports an object in the jobspec under
+ * attributes.system.exec.test, which supports the following keys
+ *
+ * {
+ *   "run_duration":s,      - alternate/override attributes.system.duration
+ *   "cleanup_duration":s   - enable a fake job epilog and set its duration
+ *   "wait_status":i        - report this value as status in the "finish" resp
+ *   "mock_exception":s     - mock an exception during this phase of job
+ *                             execution (currently "init" and "run")
+ * }
+ *
+ */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "src/common/libutil/fsd.h"
+#include "job-exec.h"
+
+struct testconf {
+    bool                  enabled;          /* test execution enabled       */
+    double                run_duration;     /* duration of fake job in sec  */
+    double                cleanup_duration; /* if > 0., duration of epilog  */
+    int                   wait_status;      /* reported status for "finish" */
+    const char *          mock_exception;   /* fake excetion at this site   */
+};
+
+struct testexec {
+    struct testconf conf;
+    struct idset *ranks;
+    flux_watcher_t *timer;
+};
+
+static struct testexec * testexec_create (struct testconf conf)
+{
+    struct testexec *te = calloc (1, sizeof (*te));
+    if (te == NULL)
+        return NULL;
+    te->conf = conf;
+    return (te);
+}
+
+static void testexec_destroy (struct testexec *te)
+{
+    flux_watcher_destroy (te->timer);
+    idset_destroy (te->ranks);
+    free (te);
+}
+
+static double jobspec_duration (flux_t *h, json_t *jobspec)
+{
+    double duration = 0.;
+    if (json_unpack (jobspec, "{s:{s:{s:F}}}",
+                              "attributes", "system",
+                              "duration", &duration) < 0)
+        return -1.;
+    return duration;
+}
+
+static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
+{
+    const char *tclean = NULL;
+    const char *trun = NULL;
+    json_t *test = NULL;
+    json_error_t err;
+
+    /* get/set defaults */
+    conf->run_duration = jobspec_duration (h, jobspec);
+    conf->cleanup_duration = -1.;
+    conf->wait_status = 0;
+    conf->mock_exception = NULL;
+    conf->enabled = false;
+
+    if (json_unpack_ex (jobspec, &err, 0,
+                     "{s:{s:{s:{s:o}}}}",
+                     "attributes", "system", "exec",
+                     "test", &test) < 0)
+        return 0;
+    conf->enabled = true;
+    if (json_unpack_ex (test, &err, 0,
+                        "{s?s s?s s?i s?s}",
+                        "run_duration", &trun,
+                        "cleanup_duration", &tclean,
+                        "wait_status", &conf->wait_status,
+                        "mock_exception", &conf->mock_exception) < 0) {
+        flux_log (h, LOG_ERR, "init_testconf: %s", err.text);
+        return -1;
+    }
+    if (trun && fsd_parse_duration (trun, &conf->run_duration) < 0)
+        flux_log (h, LOG_ERR, "Unable to parse run duration: %s", trun);
+    if (tclean && fsd_parse_duration (tclean, &conf->cleanup_duration) < 0)
+        flux_log (h, LOG_ERR, "Unable to parse cleanup duration: %s", tclean);
+    return 0;
+}
+
+/*  Return true if mock exception was configured for call site "where"
+ */
+static bool testconf_mock_exception (struct testconf *conf, const char *where)
+{
+    const char *s = conf->mock_exception;
+    return (s && strcmp (s, where) == 0);
+}
+
+/* Timer callback, post the "finish" event and start "cleanup" tasks.
+ */
+static void timer_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    struct jobinfo *job = arg;
+    struct testexec *te = job->data;
+
+    /* Notify job-exec that tasks have completed:
+     */
+    jobinfo_tasks_complete (job,
+                            resource_set_ranks (job->R),
+                            te->conf.wait_status);
+}
+
+/*  Start a timer to simulate job shell execution. A start event
+ *   is sent before the timer is started, and the "finish" event
+ *   is sent when the timer fires (simulating the exit of the final
+ *   job shell.)
+ */
+static int start_timer (flux_t *h, struct testexec *te, struct jobinfo *job)
+{
+    flux_reactor_t *r = flux_get_reactor (h);
+    double t = te->conf.run_duration;
+
+    /*  For now, if a job duration wasn't found, complete job almost
+     *   immediately.
+     */
+    if (t < 0.)
+        t = 1.e-5;
+    if (t > 0.) {
+        char timebuf[256];
+        te->timer = flux_timer_watcher_create (r, t, 0., timer_cb, job);
+        if (!te->timer) {
+            flux_log_error (h, "jobinfo_start: timer_create");
+            return -1;
+        }
+        flux_watcher_start (te->timer);
+        snprintf (timebuf, sizeof (timebuf), "%.6fs", t);
+        jobinfo_started (job, "{ s:s }", "timer", timebuf);
+    }
+    else
+        return -1;
+    return 0;
+}
+
+
+static void cleanup_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
+                             int revents, void *arg)
+{
+    flux_future_fulfill ((flux_future_t *) arg, NULL, NULL);
+    flux_watcher_destroy (w);
+}
+
+static flux_future_t * fake_cleanup (struct jobinfo *job)
+{
+    struct testexec *te = job->data;
+    flux_t *h = job->h;
+    flux_reactor_t *r = flux_get_reactor (h);
+    flux_future_t *f = NULL;
+    flux_watcher_t *timer = NULL;
+    double t = te->conf.cleanup_duration;
+
+    if (!(f = flux_future_create (NULL, NULL)))
+        return NULL;
+    flux_future_set_flux (f, h);
+
+    /* If no cleanup, immediately fulfill future */
+    if (t <= 0.) {
+        flux_future_fulfill (f, NULL, NULL);
+        return f;
+    }
+
+    /*  O/w, start timer to simulate cleanup */
+    if (!(timer = flux_timer_watcher_create (r, t, 0.,
+                                             cleanup_timer_cb, f))) {
+        flux_log_error (h, "flux_timer_watcher_create");
+        flux_future_fulfill_error (f, errno, "flux_timer_watcher_create");
+    }
+    flux_watcher_start (timer);
+    return f;
+}
+
+static void fake_cleanup_cb (flux_future_t *f, void *arg)
+{
+    struct jobinfo *job = arg;
+    struct idset *idset = flux_future_aux_get (f, "idset");
+    /*  XXX: ranks idset not fully supported and may be NULL */
+    jobinfo_cleanup_complete (job, idset, 0);
+    flux_future_destroy (f);
+}
+
+static int fake_cleanup_start (struct jobinfo *job, const struct idset *ranks)
+{
+    struct idset *idset = ranks ? idset_copy (ranks) : NULL;
+    flux_future_t *f = fake_cleanup (job);
+    if (!f || flux_future_then (f, -1., fake_cleanup_cb, job) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_aux_set (f, "idset", idset, (flux_free_f) idset_destroy);
+    return (0);
+}
+
+static int testexec_init (struct jobinfo *job)
+{
+    flux_t *h = job->h;
+    struct testexec *te = NULL;
+    struct testconf conf;
+
+    if (init_testconf (h, &conf, job->jobspec) < 0) {
+        jobinfo_fatal_error (job, errno, "failed to initialize testconf");
+        return -1;
+    }
+    // XXX: testexec always enabled for now
+    //else if (!conf.enabled)
+    //    return 0;
+    if (!(te = testexec_create (conf))) {
+        jobinfo_fatal_error (job, errno, "failed to init test exec module");
+        return -1;
+    }
+    job->data = (void *) te;
+    if (testconf_mock_exception (&te->conf, "init")) {
+        jobinfo_fatal_error (job, 0, "mock initialization exception generated");
+        testexec_destroy (te);
+        return -1;
+    }
+    return 1;
+}
+
+static int testexec_start (struct jobinfo *job)
+{
+    struct testexec *te = job->data;
+
+    if (start_timer (job->h, te, job) < 0) {
+        jobinfo_fatal_error (job, errno, "unable to start test exec timer");
+        return -1;
+    }
+    if (testconf_mock_exception (&te->conf, "run")) {
+        jobinfo_fatal_error (job, 0, "mock run exception generated");
+        return -1;
+    }
+    return 0;
+}
+
+static int testexec_kill (struct jobinfo *job, int signum)
+{
+    struct testexec *te = job->data;
+
+    flux_watcher_stop (te->timer);
+
+    /* XXX: Manually send "finish" event here since our timer_cb won't
+     *  fire after we've canceled it. In a real workload a kill request
+     *  sent to all ranks would terminate processes that would exit and
+     *  report wait status through normal channels.
+     */
+    jobinfo_tasks_complete (job, te->ranks, signum);
+    return 0;
+}
+
+static int testexec_cleanup (struct jobinfo *job, const struct idset *idset)
+{
+    return fake_cleanup_start (job, idset);
+}
+
+static void testexec_exit (struct jobinfo *job)
+{
+    struct testexec *te = job->data;
+    testexec_destroy (te);
+    job->data = NULL;
+}
+
+struct exec_implementation testexec = {
+    .name =     "testexec",
+    .init =     testexec_init,
+    .exit =     testexec_exit,
+    .start =    testexec_start,
+    .kill =     testexec_kill,
+    .cleanup =  testexec_cleanup
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -239,9 +239,8 @@ static int testexec_init (struct jobinfo *job)
         jobinfo_fatal_error (job, errno, "failed to initialize testconf");
         return -1;
     }
-    // XXX: testexec always enabled for now
-    //else if (!conf.enabled)
-    //    return 0;
+    else if (!conf.enabled)
+        return 0;
     if (!(te = testexec_create (conf))) {
         jobinfo_fatal_error (job, errno, "failed to init test exec module");
         return -1;

--- a/src/test/sched-bench.sh
+++ b/src/test/sched-bench.sh
@@ -63,7 +63,7 @@ log "broker.pid=$(flux getattr broker.pid)\n"
 #  Reload scheduler so we can insert a fake resource set:
 flux module remove sched-simple
 flux kvs put --json \
-    resource.hwloc.by_rank="{\"[1-$NNODES]\":{\"Core\":$CPN}}"
+    resource.hwloc.by_rank="{\"[0-$(($NNODES-1))]\":{\"Core\":$CPN}}"
 flux jobspec srun hostname | jq '.attributes.system.duration = .0001' > job.json
 flux module load sched-simple
 
@@ -86,6 +86,10 @@ if test -z "$NOEXEC"; then
     runtime=$(flux job wait-event $last clean | awk '{print $1}')
     log_timing_msg ran $starttime $runtime
 fi
+
+flux job drain
+
+flux job eventlog $last
 
 t_done=$(date +%s.%N)
 log_timing_msg "total walltime for" $t_start $t_done

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -95,6 +95,7 @@ TESTSCRIPTS = \
 	t2300-sched-simple.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
+	t2402-job-exec-dummy.t \
 	t2500-job-attach.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
@@ -164,7 +165,8 @@ dist_check_SCRIPTS = \
 	job-manager/exec-service.lua \
 	job-manager/drain-cancel.py \
 	job-manager/drain-undrain.py \
-	job-manager/bulk-state.py
+	job-manager/bulk-state.py \
+	job-exec/dummy.sh
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+#  Dummy "job shell" for job-exec module testing
+#
+#  Usage: dummy.sh JOBID
+#
+#  OPERATION
+#
+#  After reading JOBID on command line, the dummy job shell script
+#  gathers the following variables for the job:
+#
+#  KVSDIR          Main KVS directory for this job
+#  NAMESPACE       Guest KVS directory for this job
+#  BROKER_RANK     Flux broker rank on which shell is executing
+#  JOBSPEC         Jobspec for this job
+#  R               Resource set for this job
+#  NNODES          Total number of broker ranks (nodes) in this job
+#  DURATION        Duration in seconds from jobspec or 0.01s by default
+#  RANKLIST        Indexed array of broker ranks assigned this job
+#  JOB_SHELL_RANK  Index of the current job shell within RANKLIST
+#  COMMAND         Indexed array of the first specified command in 'tasks'
+#                  section of jobspec
+#
+#  If any of the above information cannot be obtained, then the job
+#  shell will exit with failure. Otherwise, the job shell will execute
+#  a single copy of the commandline in COMMAND, which will have access
+#  to all of the above global variables. Thus, COMMAND can be used to
+#  drive tests of expected execution behavior.
+#
+
+die() { echo "dummy-shell: $@" >&2; exit 1; }
+
+#
+#  Declare globals:
+#
+declare -a RANKLIST
+declare -a COMMAND
+declare -i JOB_SHELL_RANK
+declare -i NNODES
+declare    DURATION
+
+declare -r JOBID=$1
+[[ -z "$JOBID" ]] && die "JOBID argument required"
+
+#
+#  Fetch read-only job information and verify all values found:
+#
+declare -r KVSDIR=$(flux job id --to=kvs $JOBID).guest
+declare -r NAMESPACE=${KVSDIR}.guest
+declare -r BROKER_RANK=$(flux getattr rank)
+declare -r JOBSPEC=$(flux job info $JOBID jobspec)
+declare -r R=$(flux job info $JOBID R)
+
+for var in KVSDIR BROKER_RANK JOBSPEC R; do
+    [[ -z "${!var}" ]] && die "Unable to determine ${var}!"
+done
+
+#
+#  Functions:
+#
+get_ranklist() {
+    while read line; do
+        IFS=',' read -ra split <<<$line
+        for entry in "${split[@]}"; do
+            if [[ $entry =~ - ]]; then
+                RANKLIST+=($(eval echo {${entry/-/..}}))
+            else
+                RANKLIST+=($entry)
+            fi
+        done
+    done < <(echo "$R" | jq -r '.execution.R_lite[] | .rank')
+}
+
+get_job_shell_rank() {
+    let i=0
+    get_ranklist
+    for r in "${RANKLIST[@]}"; do
+        if [[ $r == $BROKER_RANK ]]; then
+            JOB_SHELL_RANK=$r
+            return 0
+	fi
+        ((i++))
+    done
+    die "My rank: $BROKER_RANK, not found in ranklist!"
+}
+
+get_nnodes() {
+    NNODES=${#RANKLIST[@]}
+}
+
+json_get() { echo "$1" | jq -r $2; }
+
+get_duration() {
+    DURATION=$(json_get "$JOBSPEC" .attributes.system.duration)
+    if test "$DURATION" = "null"; then DURATION=0.01; fi
+}
+
+get_command() {
+    COMMAND=($(json_get "$JOBSPEC" '.tasks[0].command[]' | tr '\n' ' '))
+}
+
+
+#
+#  Gather remaining job information:
+#
+get_job_shell_rank
+get_nnodes
+get_duration
+get_command
+
+#
+#  Run specified COMMAND:
+#
+echo Running  "${COMMAND[@]}"
+eval "${COMMAND[@]}"
+

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -178,5 +178,8 @@ test_expect_success HAVE_JQ 'specifying -N8 -n25 -c2 should produce (in total) 8
     grep -q "Number of tasks is not an integer multiple of the number of nodes." all-three-5.warning.err
 '
 
+test_expect_success HAVE_JQ 'current working directory encoded in jobspec' '
+    flux jobspec srun hostname | jq -e ".attributes.system.cwd = \"$(pwd)\""
+'
 
 test_done

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+test_description='Test flux job execution service with dummy job shell'
+
+. $(dirname $0)/sharness.sh
+
+jq=$(which jq 2>/dev/null)
+if test -z "$jq" ; then
+	skip_all 'no jq found, skipping all tests'
+	test_done
+fi
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
+
+job_kvsdir()    { flux job id --to=kvs $1; }
+exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
+
+test_expect_success 'job-exec: load job-exec,sched-simple modules' '
+	#  Add fake by_rank configuration to kvs:
+	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+	flux module load -r 0 sched-simple &&
+	flux module load -r 0 job-exec
+'
+test_expect_success 'job-exec: no configured job shell uses /bin/true' '
+	id=$(flux jobspec srun hostname | flux job submit) &&
+	flux job attach ${id} &&
+	flux dmesg | grep "$id: no configured job shell, using /bin/true"
+'
+test_expect_success 'job-exec: set dummy test job shell' '
+	flux setattr job-exec.job-shell $SHARNESS_TEST_SRCDIR/job-exec/dummy.sh
+'
+test_expect_success 'job-exec: execute dummy job shell across all ranks' '
+	flux srun -N4 "flux kvs put test1.\$BROKER_RANK=\$JOB_SHELL_RANK" &&
+	test $(flux kvs get test1.0) = 0 &&
+	test $(flux kvs get test1.1) = 1 &&
+	test $(flux kvs get test1.2) = 2 &&
+	test $(flux kvs get test1.3) = 3
+'
+test_expect_success 'job-exec: job shell output sent to flux log' '
+	id=$(flux jobspec srun -n 1 "echo Hello from job \$JOBID" \
+	     | flux job submit) &&
+	flux job wait-event $id clean &&
+	flux dmesg | grep "Hello from job $id"
+'
+test_expect_success 'job-exec: job shell failure recorded' '
+	id=$(flux jobspec srun -N4  "test \$JOB_SHELL_RANK = 0 && exit 1" \
+	     | flux job submit) &&
+	flux job wait-event -vt 1 $id finish | grep status=256
+'
+test_expect_success 'job-exec: status is maximum job shell exit codes' '
+	id=$(flux jobspec srun -N4 "exit \$JOB_SHELL_RANK" | flux job submit) &&
+	flux job wait-event -vt 1 $id finish | grep status=768
+'
+test_expect_success 'job-exec: job exception kills job shells' '
+	id=$(flux jobspec srun -N4 sleep 300 | flux job submit) &&
+	flux job wait-event -vt 1 $id start &&
+	flux job cancel $id &&
+	flux job wait-event -vt 1 $id clean &&
+	flux job eventlog $id | grep status=9
+'
+test_expect_success 'job-exec: invalid job shell generates exception' '
+	id=$(flux jobspec srun -N1 /bin/true \
+	     | $jq ".attributes.system.exec.job_shell = \"/notthere\"" \
+	     | flux job submit) &&
+	flux job wait-event -vt 1 $id clean
+'
+test_expect_success 'job-exec: unload job-exec & sched-simple modules' '
+	flux module remove job-exec &&
+	flux module remove sched-simple
+'
+test_done

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -4,24 +4,35 @@ test_description='Test flux job attach and flux srun'
 
 . $(dirname $0)/sharness.sh
 
+#  Set path to jq
+#
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+
+#
+#  Submit jobs using testexec exec implementation
+flux_jobspec() {
+	flux jobspec "$@" | $jq '.attributes.system.exec.test = {}'
+}
+
 test_under_flux 4
 
 flux setattr log-stderr-level 1
 
-test_expect_success 'attach: submit one job' '
-	flux jobspec srun -n1 hostname | flux job submit >jobid1
+test_expect_success HAVE_JQ 'attach: submit one job' '
+	flux_jobspec srun -n1 hostname | flux job submit >jobid1
 '
 
-test_expect_success 'attach: job ran successfully' '
+test_expect_success HAVE_JQ 'attach: job ran successfully' '
 	run_timeout 5 flux job attach $(cat jobid1)
 '
 
-test_expect_success 'attach: submit a job and cancel it' '
-	flux jobspec srun -t 00:30 -n1 hostname | flux job submit >jobid2 &&
+test_expect_success HAVE_JQ 'attach: submit a job and cancel it' '
+	flux_jobspec srun -t 00:30 -n1 hostname | flux job submit >jobid2 &&
 	flux job cancel $(cat jobid2)
 '
 
-test_expect_success 'attach: exit code reflects cancellation' '
+test_expect_success HAVE_JQ 'attach: exit code reflects cancellation' '
 	test_must_fail flux job attach $(cat jobid2)
 '
 
@@ -33,13 +44,13 @@ test_expect_success 'attach: exit code reflects cancellation' '
 run_attach() {
 	local seq=$1
 
-	flux jobspec srun -t 00:30 -n1 sleep 30 | flux job submit >jobid${seq}
+	flux_jobspec srun -t 00:30 -n1 sleep 30 | flux job submit >jobid${seq}
 	flux job attach -E $(cat jobid${seq}) 2>attach${seq}.err &
 	echo $! >pid${seq}
 	while ! test -s attach${seq}.err; do sleep 0.1; done
 }
 
-test_expect_success 'attach: two SIGINTs cancel a job' '
+test_expect_success HAVE_JQ 'attach: two SIGINTs cancel a job' '
 	run_attach 3 &&
 	pid=$(cat pid3) &&
 	kill -INT $pid &&
@@ -48,7 +59,7 @@ test_expect_success 'attach: two SIGINTs cancel a job' '
 	test_must_fail wait $pid
 '
 
-test_expect_success 'attach: SIGINT+SIGTSTP detaches from job' '
+test_expect_success HAVE_JQ 'attach: SIGINT+SIGTSTP detaches from job' '
 	run_attach 4 &&
 	pid=$(cat pid4) &&
 	kill -INT $pid &&
@@ -57,7 +68,7 @@ test_expect_success 'attach: SIGINT+SIGTSTP detaches from job' '
 	test_must_fail wait $pid
 '
 
-test_expect_success 'attach: detached job was not canceled' '
+test_expect_success HAVE_JQ 'attach: detached job was not canceled' '
 	flux job eventlog $(cat jobid4) >events4 &&
 	test_must_fail grep -q cancel events4
 '
@@ -95,6 +106,5 @@ test_expect_success 'flux srun -t0 hostname works' '
 test_expect_success 'flux srun -N128 hostname fails' '
 	test_must_fail flux srun -N128 hostname
 '
-
 
 test_done


### PR DESCRIPTION
This PR is still a work in progress,  but I wanted to get a PR open in its current form to ensure I'm able to address likely feedback before I go away for a bit.

This PR adds the ability of the `job-exec` service to *actually* execute job shells for a job on receipt of a `start` request from the job manager. In the current implementation, the job shell used is set from configuration (the `job-exec.job-shell` broker attribute, falling back to `/bin/true`) overridden by the `attributes.system.exec.job-shell` key of submitted jobspec.

The refactoring of the `job-exec` module to support multiple execution "implementations" did not turn out as clean as I'd hoped, and it is still a bit rough around the edges. I tried to keep nice incremental commits as I worked on the refactor, but ended up throwing it away for one large garbage commit that changes a lot of code, so I apologize for that.

Existing tests for the job-exec module were adapted so that they drive the "test" exec mode, which allows testing of exception handling etc. Therefore, tests of actual execution still need to be added (along with fixes for the things found in testing).