### PR TITLE
sched-simple: fix alloc/free for resource sets with equal size but different cpusets

### DIFF
--- a/src/modules/sched-simple/rlist.c
+++ b/src/modules/sched-simple/rlist.c
@@ -83,11 +83,40 @@ static struct rnode *rlist_find_rank (struct rlist *rl, uint32_t rank)
     return NULL;
 }
 
+/*  Compare two values from idset_first()/idset_next():
+ *  Returns:
+ *    0   : if x == y
+ *    > 0 : if x > y
+ *    < 0 : if x < y
+ *
+ *  Where IDSET_INVALID_ID is considered to come before all numbers.
+ */
+static int idset_val_cmp (unsigned int x, unsigned int y)
+{
+    if (x == y)
+        return 0;
+    else if (x == IDSET_INVALID_ID)
+        return -1;
+    else if (y == IDSET_INVALID_ID)
+        return  1;
+    else
+        return (x - y);
+}
+
 static int idset_cmp (struct idset *set1, struct idset *set2)
 {
-    if (idset_equal (set1, set2))
-        return 0;
-    return idset_count (set1) - idset_count (set2);
+    int rv = 0;
+    if (!idset_equal (set1, set2)) {
+        /*  Sort on the first non-equal integer (see idset_val_cmp())
+         */
+        unsigned int a = idset_first (set1);
+        unsigned int b = idset_first (set2);
+        while ((rv = idset_val_cmp (a, b)) == 0) {
+            a = idset_next (set1, a);
+            b = idset_next (set2, b);
+        }
+    }
+    return rv;
 }
 
 static int idset_add_set (struct idset *set, struct idset *new)


### PR DESCRIPTION
This PR fixes #2202. The problem was a dumb implementation of an idset comparator internal to `sched-simple`'s `rlist` object. The `idset_cmp()` function compared non-equal idsets using `idset_count()`, but of course two idsets can have the same count but still not be equivalent.

The new implementation detects unequal idsets that have the same "count" and then falls back to comparing the first different stored integer.

This appears to fix the weirdness under Slurm with cpu-affinity:

```
$ srun --pty -N32 -n128 src/cmd/flux start
$ 
$ src/modules/sched-simple/rlist-query 
rank[2,6,10,14,18,22,26,30,34,38,42,46,50,54,58,62,66,70,74,78,82,86,90,94,98,102,106,110,114,118,122,126]/core2 rank[1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,93,97,101,105,109,113,117,121,125]/core1 rank[3,7,11,15,19,23,27,31,35,39,43,47,51,55,59,63,67,71,75,79,83,87,91,95,99,103,107,111,115,119,123,127]/core3 rank[0,4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120,124]/core0
$ flux srun -N128 hostname
$ echo $?
0
$ flux dmesg | tail
2019-06-21T16:47:13.705278Z sched-simple.debug[0]: req: 1069547520000: spec={128,128,1}
2019-06-21T16:47:13.705713Z sched-simple.debug[0]: alloc: 1069547520000: rank[0,4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120,124]/core0 rank[1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,93,97,101,105,109,113,117,121,125]/core1 rank[3,7,11,15,19,23,27,31,35,39,43,47,51,55,59,63,67,71,75,79,83,87,91,95,99,103,107,111,115,119,123,127]/core3 rank[2,6,10,14,18,22,26,30,34,38,42,46,50,54,58,62,66,70,74,78,82,86,90,94,98,102,106,110,114,118,122,126]/core2
2019-06-21T16:47:13.718219Z kvs.debug[0]: aggregated 2 transactions (2 ops)
2019-06-21T16:47:13.723366Z sched-simple.debug[0]: free: rank[0,4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120,124]/core0 rank[1,5,9,13,17,21,25,29,33,37,41,45,49,53,57,61,65,69,73,77,81,85,89,93,97,101,105,109,113,117,121,125]/core1 rank[3,7,11,15,19,23,27,31,35,39,43,47,51,55,59,63,67,71,75,79,83,87,91,95,99,103,107,111,115,119,123,127]/core3 rank[2,6,10,14,18,22,26,30,34,38,42,46,50,54,58,62,66,70,74,78,82,86,90,94,98,102,106,110,114,118,122,126]/core2
