### PR TITLE
libiobuf - output service for job shell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -420,6 +420,7 @@ AC_CONFIG_FILES( \
   src/common/libaggregate/Makefile \
   src/common/libschedutil/Makefile \
   src/common/libeventlog/Makefile \
+  src/common/libiobuf/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -12,7 +12,8 @@ SUBDIRS = libtap \
           libsubprocess \
           libaggregate \
           libschedutil \
-	  libeventlog
+	  libeventlog \
+	  libiobuf
 
 AM_CFLAGS = $(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)
@@ -29,6 +30,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libev/libev.la \
 	$(builddir)/libtomlc99/libtomlc99.la \
 	$(builddir)/libeventlog/libeventlog.la \
+	$(builddir)/libiobuf/libiobuf.la \
 	$(JANSSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) $(LIBRT) $(FLUX_SECURITY_LIBS) $(LIBSODIUM_LIBS)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)

--- a/src/common/libiobuf/Makefile.am
+++ b/src/common/libiobuf/Makefile.am
@@ -1,0 +1,53 @@
+AM_CFLAGS = \
+        $(WARNING_CFLAGS) \
+        $(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+        $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+noinst_LTLIBRARIES = \
+	libiobuf.la
+
+libiobuf_la_SOURCES = \
+	iobuf.h \
+	iobuf.c
+
+TESTS = \
+	test_iobuf.t \
+	test_iobuf_iter.t \
+	test_iobuf_eof_cb.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+        $(top_srcdir)/config/tap-driver.sh
+
+test_ldadd = \
+        $(top_builddir)/src/common/libiobuf/libiobuf.la \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libtap/libtap.la
+
+test_cppflags = \
+        $(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap
+
+test_iobuf_t_SOURCES = test/iobuf.c
+test_iobuf_t_CPPFLAGS = $(test_cppflags)
+test_iobuf_t_LDADD = $(test_ldadd)
+
+test_iobuf_iter_t_SOURCES = test/iobuf_iter.c
+test_iobuf_iter_t_CPPFLAGS = $(test_cppflags)
+test_iobuf_iter_t_LDADD = $(test_ldadd)
+
+test_iobuf_eof_cb_t_SOURCES = test/iobuf_eof_cb.c
+test_iobuf_eof_cb_t_CPPFLAGS = $(test_cppflags)
+test_iobuf_eof_cb_t_LDADD = $(test_ldadd)

--- a/src/common/libiobuf/iobuf.c
+++ b/src/common/libiobuf/iobuf.c
@@ -1,0 +1,923 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdarg.h>
+#include <sys/types.h>
+#include <wait.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <czmq.h>
+#include <sodium.h>
+
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+#include "iobuf.h"
+
+struct ioinfo {
+    char *stream;
+    int rank;
+    int data_len;
+    bool eof;
+    struct iodata *head;
+    struct iodata *tail;
+};
+
+struct iodata {
+    struct ioinfo *ioinfo;
+    char *data;
+    int data_len;
+    struct iodata *next;
+};
+
+struct iobuf {
+    flux_t *h;
+    flux_reactor_t *r;
+    char *name;
+    int max_count;
+    int flags;
+
+    flux_watcher_t *eof_count_cb_prep_w;
+    flux_watcher_t *eof_count_cb_idle_w;
+    flux_watcher_t *eof_count_cb_check_w;
+    int eof_count_cb_count;
+    iobuf_f eof_count_cb;
+    void *eof_count_cb_arg;
+    bool eof_count_cb_called;
+
+    struct iobuf_data iobuf_data; /* used in iterators */
+    zlist_t *data;
+    zhash_t *streamranks;
+    int eof_count;
+
+    flux_msg_handler_t *create_mh;
+    flux_msg_handler_t *write_mh;
+    flux_msg_handler_t *eof_mh;
+    flux_msg_handler_t *read_mh;
+};
+
+static void iobuf_log_error (iobuf_t *iob, const char *fmt, ...)
+{
+    if (iob->flags & IOBUF_FLAG_LOG_ERRORS) {
+        va_list va;
+        va_start (va, fmt);
+        flux_log_verror (iob->h, fmt, va);
+        va_end (va);
+    }
+}
+
+static char *topic_str (const char *name, const char *suffix)
+{
+    char *topic = NULL;
+    if (asprintf (&topic,
+                  "%s.%s",
+                  name,
+                  suffix) < 0)
+        return NULL;
+    return topic;
+}
+
+static char *streamrank_key (const char *stream, int rank)
+{
+    char *key;
+    if (asprintf (&key,
+                  "%s.%d",
+                  stream,
+                  rank) < 0)
+        return NULL;
+    return key;
+}
+
+static char *bin2base64 (const char *bin_data, int bin_len)
+{
+    char *base64_data;
+    int base64_len;
+
+    base64_len = sodium_base64_encoded_len (bin_len, sodium_base64_VARIANT_ORIGINAL);
+
+    if (!(base64_data = calloc (1, base64_len)))
+        return NULL;
+
+    sodium_bin2base64 (base64_data, base64_len,
+                       (unsigned char *)bin_data, bin_len,
+                       sodium_base64_VARIANT_ORIGINAL);
+
+    return base64_data;
+}
+
+static char *base642bin (const char *base64_data, size_t *bin_len)
+{
+    size_t base64_len;
+    char *bin_data = NULL;
+
+    base64_len = strlen (base64_data);
+    (*bin_len) = BASE64_DECODE_SIZE (base64_len);
+
+    if (!(bin_data = calloc (1, (*bin_len))))
+        return NULL;
+
+    if (sodium_base642bin ((unsigned char *)bin_data, (*bin_len),
+                           base64_data, base64_len,
+                           NULL, bin_len, NULL,
+                           sodium_base64_VARIANT_ORIGINAL) < 0) {
+        free (bin_data);
+        return NULL;
+    }
+
+    return bin_data;
+}
+
+static void create_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    iobuf_t *iob = arg;
+    const char *stream;
+    int rank;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:i}",
+                             "stream", &stream,
+                             "rank", &rank) < 0)
+        goto error;
+
+    if (iobuf_create (iob, stream, rank) < 0)
+        goto error;
+
+    if (flux_respond (h, msg, NULL) < 0) {
+        iobuf_log_error (iob, "flux_respond");
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (iob->h, msg, errno, NULL) < 0)
+        iobuf_log_error (iob, "flux_respond_error");
+}
+
+static void write_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    iobuf_t *iob = arg;
+    const char *stream;
+    const char *data;
+    int rank;
+    size_t bin_len;
+    char *bin_data = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:i s:s}",
+                             "stream", &stream,
+                             "rank", &rank,
+                             "data", &data) < 0)
+        goto error;
+
+    if (!(bin_data = base642bin (data, &bin_len)))
+        goto error;
+
+    if (iobuf_write (iob, stream, rank, bin_data, bin_len) < 0) {
+        iobuf_log_error (iob, "iobuf_write");
+        goto error;
+    }
+
+    if (flux_respond (h, msg, NULL) < 0) {
+        iobuf_log_error (iob, "flux_respond");
+        goto error;
+    }
+
+    free (bin_data);
+    return;
+
+error:
+    if (flux_respond_error (iob->h, msg, errno, NULL) < 0)
+        iobuf_log_error (iob, "flux_respond_error");
+    free (bin_data);
+}
+
+static void eof_cb (flux_t *h, flux_msg_handler_t *mh,
+                    const flux_msg_t *msg, void *arg)
+{
+    iobuf_t *iob = arg;
+    const char *stream;
+    int rank;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:i}",
+                             "stream", &stream,
+                             "rank", &rank) < 0)
+        goto error;
+
+    if (iobuf_eof (iob, stream, rank) < 0)
+        goto error;
+
+    if (flux_respond (h, msg, NULL) < 0) {
+        iobuf_log_error (iob, "flux_respond");
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (iob->h, msg, errno, NULL) < 0)
+        iobuf_log_error (iob, "flux_respond_error");
+}
+
+static void read_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    iobuf_t *iob = arg;
+    char *data = NULL;
+    const char *stream;
+    char *base64data = NULL;
+    int rank, data_len;
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:i}",
+                             "stream", &stream,
+                             "rank", &rank) < 0)
+        goto error;
+
+    if (iobuf_read (iob, stream, rank, &data, &data_len) < 0) {
+        iobuf_log_error (iob, "iobuf_read");
+        goto error;
+    }
+
+    if (!(base64data = bin2base64 (data, data_len)))
+        goto error;
+
+    if (flux_respond_pack (h, msg, "{s:s}", "data", base64data) < 0) {
+        iobuf_log_error (iob, "flux_respond_pack");
+        goto error;
+    }
+
+    free (data);
+    free (base64data);
+    return;
+
+error:
+    if (flux_respond_error (iob->h, msg, errno, NULL) < 0)
+        iobuf_log_error (iob, "flux_respond_error");
+    free (data);
+    free (base64data);
+}
+
+static flux_msg_handler_t *setup_handler (iobuf_t *iob, flux_msg_handler_f cb,
+                                          const char *suffix)
+{
+    struct flux_match match = FLUX_MATCH_REQUEST;
+    flux_msg_handler_t *mh = NULL;
+
+    if (!(match.topic_glob = topic_str (iob->name, suffix)))
+        goto cleanup;
+
+    if (!(mh = flux_msg_handler_create (iob->h,
+                                        match,
+                                        cb,
+                                        iob)))
+        goto cleanup;
+
+    flux_msg_handler_allow_rolemask (mh, FLUX_ROLE_OWNER);
+    flux_msg_handler_start (mh);
+
+    free (match.topic_glob);
+    return mh;
+
+cleanup:
+    flux_msg_handler_destroy (mh);
+    free (match.topic_glob);
+    return NULL;
+}
+
+static int setup_cbs (iobuf_t *iob)
+{
+    if (!(iob->create_mh = setup_handler (iob, create_cb, "create")))
+        return -1;
+
+    if (!(iob->write_mh = setup_handler (iob, write_cb, "write")))
+        return -1;
+
+    if (!(iob->eof_mh = setup_handler (iob, eof_cb, "eof")))
+        return -1;
+
+    if (!(iob->read_mh = setup_handler (iob, read_cb, "read")))
+        return -1;
+
+    return 0;
+}
+
+iobuf_t *iobuf_server_create (flux_t *h,
+                              const char *name,
+                              int max_count,
+                              int flags)
+{
+    iobuf_t *iob = NULL;
+    int save_errno;
+    int valid_flags = IOBUF_FLAG_LOG_ERRORS;
+
+    if (!h
+        || !name
+        || max_count < 0
+        || (flags & ~valid_flags)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    iob = calloc (1, sizeof (*iob));
+    if (!iob) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+    iob->h = h;
+    if (!(iob->r = flux_get_reactor (h)))
+        goto cleanup;
+    iob->max_count = max_count;
+    iob->flags = flags;
+
+    if (!(iob->name = strdup (name))) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+
+    if (!(iob->data = zlist_new ()))
+        goto cleanup;
+    if (!(iob->streamranks = zhash_new ()))
+        goto cleanup;
+
+    if (setup_cbs (iob) < 0)
+        goto cleanup;
+
+    return iob;
+
+cleanup:
+    save_errno = errno;
+    iobuf_server_destroy (iob);
+    errno = save_errno;
+    return NULL;
+}
+
+void iobuf_server_destroy (iobuf_t *iob)
+{
+    if (iob) {
+        flux_watcher_destroy (iob->eof_count_cb_prep_w);
+        flux_watcher_destroy (iob->eof_count_cb_idle_w);
+        flux_watcher_destroy (iob->eof_count_cb_check_w);
+        zlist_destroy (&iob->data);
+        zhash_destroy (&iob->streamranks);
+        flux_msg_handler_destroy (iob->create_mh);
+        flux_msg_handler_destroy (iob->write_mh);
+        flux_msg_handler_destroy (iob->eof_mh);
+        flux_msg_handler_destroy (iob->read_mh);
+        free (iob);
+    }
+}
+
+static void eof_count_cb_prep_cb (flux_reactor_t *r,
+                               flux_watcher_t *w,
+                               int revents,
+                               void *arg)
+{
+    iobuf_t *iob = arg;
+    flux_watcher_start (iob->eof_count_cb_idle_w);
+}
+
+static void eof_count_cb_check_cb (flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents,
+                                void *arg)
+{
+    iobuf_t *iob = arg;
+
+    flux_watcher_stop (iob->eof_count_cb_prep_w);
+    flux_watcher_stop (iob->eof_count_cb_idle_w);
+    flux_watcher_stop (iob->eof_count_cb_check_w);
+
+    if (iob->eof_count_cb
+        && !iob->eof_count_cb_called)
+        iob->eof_count_cb (iob, iob->eof_count_cb_arg);
+
+    iob->eof_count_cb_called = true;
+}
+
+int iobuf_set_eof_count_cb (iobuf_t *iob,
+                            int eof_count,
+                            iobuf_f eof_count_cb,
+                            void *arg)
+{
+    if (!iob || eof_count <= 0 || !eof_count_cb) {
+        errno = EINVAL;
+        return -1;
+    }
+    iob->eof_count_cb_prep_w = flux_prepare_watcher_create (iob->r,
+                                                            eof_count_cb_prep_cb,
+                                                            iob);
+    if (!iob->eof_count_cb_prep_w) {
+        iobuf_log_error (iob, "flux_prepare_watcher_create");
+        return -1;
+    }
+    iob->eof_count_cb_idle_w = flux_idle_watcher_create (iob->r,
+                                                         NULL,
+                                                         iob);
+    if (!iob->eof_count_cb_idle_w) {
+        iobuf_log_error (iob, "flux_idle_watcher_create");
+        return -1;
+    }
+    iob->eof_count_cb_check_w = flux_check_watcher_create (iob->r,
+                                                           eof_count_cb_check_cb,
+                                                           iob);
+    if (!iob->eof_count_cb_check_w) {
+        iobuf_log_error (iob, "flux_check_watcher_create");
+        return -1;
+    }
+    iob->eof_count_cb_count = eof_count;
+    iob->eof_count_cb = eof_count_cb;
+    iob->eof_count_cb_arg = arg;
+    return 0;
+}
+
+static void ioinfo_destroy (void *data)
+{
+    if (data) {
+        struct ioinfo *ioinfo = data;
+        free (ioinfo->stream);
+        free (ioinfo);
+    }
+}
+
+static struct ioinfo *ioinfo_create (const char *stream, int rank)
+{
+    struct ioinfo *ioinfo = NULL;
+    int save_errno;
+
+    if (!(ioinfo = calloc (1, sizeof (*ioinfo)))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (!(ioinfo->stream = strdup (stream))) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+    ioinfo->rank = rank;
+    ioinfo->eof = false;
+    ioinfo->head = NULL;
+    ioinfo->tail = NULL;
+    return ioinfo;
+
+cleanup:
+    save_errno = errno;
+    ioinfo_destroy (ioinfo);
+    errno = save_errno;
+    return NULL;
+}
+
+static void iodata_destroy (void *data)
+{
+    if (data) {
+        struct iodata *iodata = data;
+        free (iodata->data);
+        free (iodata);
+    }
+}
+
+static struct iodata *iodata_create (struct ioinfo *ioinfo,
+                                     const char *data,
+                                     int data_len)
+{
+    struct iodata *iodata = NULL;
+    int save_errno;
+
+    if (!(iodata = calloc (1, sizeof (*iodata)))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    iodata->ioinfo = ioinfo;
+    if (!(iodata->data = malloc (data_len))) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+    memcpy (iodata->data, data, data_len);
+    iodata->data_len = data_len;
+    return iodata;
+
+cleanup:
+    save_errno = errno;
+    iodata_destroy (iodata);
+    errno = save_errno;
+    return NULL;
+}
+
+static struct ioinfo *lookup_buffer (iobuf_t *iob,
+                                     const char *stream,
+                                     int rank)
+{
+    struct ioinfo *ioinfo;
+    char *key = NULL;
+
+    if (!(key = streamrank_key (stream, rank)))
+        return NULL;
+    if (!(ioinfo = zhash_lookup (iob->streamranks, key)))
+        errno = ENOENT;
+    free (key);
+    return ioinfo;
+}
+
+static struct ioinfo *create_buffer (iobuf_t *iob,
+                                     const char *stream,
+                                     int rank)
+{
+    struct ioinfo *ioinfo = NULL;
+    char *key = NULL;
+    int save_errno, ret;
+
+    if (iob->max_count
+        && zhash_size (iob->streamranks) >= iob->max_count) {
+        /* XXX: ok errno? */
+        errno = ENFILE;
+        goto cleanup;
+    }
+
+    if (!(key = streamrank_key (stream, rank)))
+        goto cleanup;
+
+    if (!(ioinfo = ioinfo_create (stream, rank)))
+        goto cleanup;
+
+    /* caller should check for existence first */
+    ret = zhash_insert (iob->streamranks, key, ioinfo);
+    assert (ret == 0);
+    zhash_freefn (iob->streamranks, key, ioinfo_destroy);
+
+    free (key);
+    return ioinfo;
+
+cleanup:
+    save_errno = errno;
+    free (key);
+    ioinfo_destroy (ioinfo);
+    errno = save_errno;
+    return NULL;
+}
+
+int iobuf_create (iobuf_t *iob,
+                  const char *stream,
+                  int data_rank)
+{
+    struct ioinfo *ioinfo;
+
+    if (!iob || !stream) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!(ioinfo = lookup_buffer (iob, stream, data_rank))) {
+        if (!(ioinfo = create_buffer (iob, stream, data_rank)))
+            return -1;
+    }
+    else {
+        errno = EEXIST;
+        return -1;
+    }
+
+    return 0;
+}
+
+int iobuf_write (iobuf_t *iob,
+                 const char *stream,
+                 int data_rank,
+                 const char *data,
+                 int data_len)
+{
+    struct ioinfo *ioinfo;
+    struct iodata *iodata = NULL;
+    int save_errno;
+
+    if (!iob || !stream || !data || data_len < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!(ioinfo = lookup_buffer (iob, stream, data_rank))) {
+        if (!(ioinfo = create_buffer (iob, stream, data_rank)))
+            return -1;
+    }
+
+    if (ioinfo->eof) {
+        errno = EROFS;
+        return -1;
+    }
+
+    if (!(iodata = iodata_create (ioinfo, data, data_len)))
+        return -1;
+
+    if (zlist_append (iob->data, iodata) < 0)
+        goto cleanup;
+    zlist_freefn (iob->data, iodata, iodata_destroy, true);
+
+    if (!ioinfo->head) {
+        ioinfo->head = iodata;
+        ioinfo->tail = iodata;
+    }
+    else {
+        ioinfo->tail->next = iodata;
+        ioinfo->tail = iodata;
+    }
+
+    ioinfo->data_len += data_len;
+    return 0;
+
+cleanup:
+    save_errno = errno;
+    iodata_destroy (iodata);
+    errno = save_errno;
+    return -1;
+}
+
+int iobuf_eof (iobuf_t *iob,
+               const char *stream,
+               int data_rank)
+{
+    struct ioinfo *ioinfo;
+
+    if (!iob || !stream) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!(ioinfo = lookup_buffer (iob, stream, data_rank))) {
+        if (!(ioinfo = create_buffer (iob, stream, data_rank)))
+            return -1;
+    }
+
+    if (!ioinfo->eof) {
+        ioinfo->eof = true;
+        iob->eof_count++;
+    }
+
+    if (iob->eof_count_cb_count
+        && iob->eof_count >= iob->eof_count_cb_count
+        && !iob->eof_count_cb_called) {
+        flux_watcher_start (iob->eof_count_cb_prep_w);
+        flux_watcher_start (iob->eof_count_cb_check_w);
+    }
+
+    return 0;
+}
+
+int iobuf_read (iobuf_t *iob,
+                const char *stream,
+                int data_rank,
+                char **data,
+                int *data_len)
+{
+    struct ioinfo *ioinfo;
+    char *bin_data = NULL;
+    int bin_len;
+
+    if (!iob || !stream) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!(ioinfo = lookup_buffer (iob, stream, data_rank))) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    bin_len = ioinfo->data_len;
+    if (data) {
+        if (bin_len) {
+            struct iodata *iodata;
+            int len = 0;
+            if (!(bin_data = malloc (ioinfo->data_len))) {
+                errno = ENOMEM;
+                return -1;
+            }
+            iodata = ioinfo->head;
+            while (iodata) {
+                memcpy (bin_data + len, iodata->data, iodata->data_len);
+                len += iodata->data_len;
+                iodata = iodata->next;
+            }
+        }
+        (*data) = bin_data;
+    }
+
+    if (data_len)
+        (*data_len) = bin_len;
+
+    return 0;
+}
+
+static void set_iobuf_data (iobuf_t *iob, struct iodata *iodata)
+{
+    iob->iobuf_data.stream = iodata->ioinfo->stream;
+    iob->iobuf_data.rank = iodata->ioinfo->rank;
+    iob->iobuf_data.data = iodata->data;
+    iob->iobuf_data.data_len = iodata->data_len;
+}
+
+const struct iobuf_data *iobuf_iter_first (iobuf_t *iob)
+{
+    struct iodata *iodata;
+
+    if (!iob) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if ((iodata = zlist_first (iob->data))) {
+        set_iobuf_data (iob, iodata);
+        return &(iob->iobuf_data);
+    }
+    return NULL;
+}
+
+const struct iobuf_data *iobuf_iter_next (iobuf_t *iob)
+{
+    struct iodata *iodata;
+
+    if (!iob) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if ((iodata = zlist_next (iob->data))) {
+        set_iobuf_data (iob, iodata);
+        return &(iob->iobuf_data);
+    }
+    return NULL;
+}
+
+int iobuf_count (iobuf_t *iob)
+{
+    if (!iob) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return zhash_size (iob->streamranks);
+}
+
+int iobuf_eof_count (iobuf_t *iob)
+{
+    if (!iob) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    return iob->eof_count;
+}
+
+flux_future_t *iobuf_rpc_create (flux_t *h,
+                                 const char *name,
+                                 int rpc_rank,
+                                 const char *stream,
+                                 int data_rank)
+{
+    flux_future_t *f = NULL;
+    char *topic = NULL;
+
+    if (!h || !name || !stream) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(topic = topic_str (name, "create")))
+        goto cleanup;
+
+    f = flux_rpc_pack (h, topic, rpc_rank, 0,
+                       "{s:s s:i}",
+                       "stream", stream,
+                       "rank", data_rank);
+cleanup:
+    free (topic);
+    return f;
+}
+
+flux_future_t *iobuf_rpc_write (flux_t *h,
+                                const char *name,
+                                int rpc_rank,
+                                const char *stream,
+                                int data_rank,
+                                const char *data,
+                                int data_len)
+{
+    flux_future_t *f = NULL;
+    char *topic = NULL;
+    char *base64_data = NULL;
+
+    if (!h || !name || !stream || !data || data_len < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(topic = topic_str (name, "write")))
+        goto cleanup;
+
+    if (!(base64_data = bin2base64 (data, data_len)))
+        goto cleanup;
+
+    f = flux_rpc_pack (h, topic, rpc_rank, 0,
+                       "{s:s s:i s:s}",
+                       "stream", stream,
+                       "rank", data_rank,
+                       "data", base64_data);
+cleanup:
+    free (topic);
+    free (base64_data);
+    return f;
+}
+
+flux_future_t *iobuf_rpc_eof (flux_t *h,
+                              const char *name,
+                              int rpc_rank,
+                              const char *stream,
+                              int data_rank)
+{
+    flux_future_t *f = NULL;
+    char *topic = NULL;
+
+    if (!h || !name || !stream) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(topic = topic_str (name, "eof")))
+        goto cleanup;
+
+    f = flux_rpc_pack (h, topic, rpc_rank, 0,
+                       "{s:s s:i}",
+                       "stream", stream,
+                       "rank", data_rank);
+cleanup:
+    free (topic);
+    return f;
+}
+
+flux_future_t *iobuf_rpc_read (flux_t *h,
+                               const char *name,
+                               int rpc_rank,
+                               const char *stream,
+                               int data_rank)
+{
+    flux_future_t *f = NULL;
+    char *topic = NULL;
+
+    if (!h || !name || !stream) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(topic = topic_str (name, "read")))
+        return NULL;
+
+    f = flux_rpc_pack (h, topic, rpc_rank, 0,
+                       "{s:s s:i}",
+                       "stream", stream,
+                       "rank", data_rank);
+    free (topic);
+    return f;
+}
+
+int iobuf_rpc_read_get (flux_future_t *f, char **data, int *data_len)
+{
+    const char *base64_data;
+    char *bin_data = NULL;
+    size_t bin_len;
+
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "data", &base64_data) < 0)
+        goto cleanup;
+
+    if (!(bin_data = base642bin (base64_data, &bin_len)))
+        goto cleanup;
+
+    if (data)
+        (*data) = bin_data;
+    else
+        free (bin_data);
+    if (data_len)
+        (*data_len) = bin_len;
+
+    return 0;
+
+cleanup:
+    free (bin_data);
+    return -1;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libiobuf/iobuf.h
+++ b/src/common/libiobuf/iobuf.h
@@ -1,0 +1,142 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _IOBUF_H
+#define _IOBUF_H
+
+#include <sys/types.h>
+
+#include <flux/core.h>
+
+enum iobuf_flags {
+    IOBUF_FLAG_LOG_ERRORS = 1,
+};
+
+struct iobuf_data {
+    const char *stream;
+    int rank;
+    const char *data;
+    int data_len;
+};
+
+typedef struct iobuf iobuf_t;
+
+typedef void (*iobuf_f) (iobuf_t *iob, void *arg);
+
+/* Create iobuf server with service name 'service_name'.  Set
+ * 'max_count' to maximum stream/rank combinations allowed.  Set
+ * 'max_count' to 0 for no max.
+ *
+ * User is responsible for calling `flux_service_register` and
+ * `flux_service_unregister` for `service_name`.
+ */
+iobuf_t *iobuf_server_create (flux_t *h,
+                              const char *service_name,
+                              int max_count,
+                              int flags);
+
+void iobuf_server_destroy (iobuf_t *iob);
+
+/* Set a callback to be called after 'eof_count' buffers have been
+ * EOFed.  Typically 'eof_count' is set to same 'max_count' in
+ * iobuf_server_create().  Callback is called at most once.
+ * - Returns 0 on success, -1 on error
+ */
+int iobuf_set_eof_count_cb (iobuf_t *iob,
+                            int eof_count,
+                            iobuf_f eof_count_cb,
+                            void *arg);
+
+/* Create a stream/rank buffer combination in the iobuf service.  It
+ * is not necessary to call this as the first call to iobuf_write() or
+ * iobuf_eof() will do this as well.  This is useful if user wishes
+ * "pre-setup" specific stream/rank combinations up to the
+ * `max_buffer_count` before using the service.
+ * - Returns 0 on success, -1 on error
+ */
+int iobuf_create (iobuf_t *iob,
+                  const char *stream,
+                  int data_rank);
+
+/* Write to the iobuf service for the stream/rank.
+ * - Returns 0 on success, -1 on error
+ */
+int iobuf_write (iobuf_t *iob,
+                 const char *stream,
+                 int data_rank,
+                 const char *data,
+                 int data_len);
+
+/* Mark the stream/rank combination as EOFed/complete.  No further
+ * writes can occur on the stream/rank.
+ * - Returns 0 on success, -1 on error
+ */
+int iobuf_eof (iobuf_t *iob,
+               const char *stream,
+               int data_rank);
+
+/* Read data stored in iobuf for the stream/rank.
+ * - Caller is required to free data result
+ * - If no data stored, 'data' will be set to NULL
+ * - Returns 0 on success, -1 on error
+ */
+int iobuf_read (iobuf_t *iob,
+                const char *stream,
+                int data_rank,
+                char **data,
+                int *data_len);
+
+/* Iterate through all writes to the iobuf service
+ * - Caller will not free results
+ */
+const struct iobuf_data *iobuf_iter_first (iobuf_t *iob);
+const struct iobuf_data *iobuf_iter_next (iobuf_t *iob);
+
+/* Get number of stream/ranks created */
+int iobuf_count (iobuf_t *iob);
+/* Get number of stream/ranks that have been EOFed in service */
+int iobuf_eof_count (iobuf_t *iob);
+
+/*
+ * RPC equivalent functions to above, returns future on success, NULL
+ * on error.
+ */
+
+flux_future_t *iobuf_rpc_create (flux_t *h,
+                                 const char *name,
+                                 int rpc_rank,
+                                 const char *stream,
+                                 int data_rank);
+
+flux_future_t *iobuf_rpc_write (flux_t *h,
+                                const char *name,
+                                int rpc_rank,
+                                const char *stream,
+                                int data_rank,
+                                const char *data,
+                                int data_len);
+
+flux_future_t *iobuf_rpc_eof (flux_t *h,
+                              const char *name,
+                              int rpc_rank,
+                              const char *stream,
+                              int data_rank);
+
+flux_future_t *iobuf_rpc_read (flux_t *h,
+                               const char *name,
+                               int rpc_rank,
+                               const char *stream,
+                               int data_rank);
+
+/* Returns 0 on success, -1 on error.  Caller is required to free data
+ * result */
+int iobuf_rpc_read_get (flux_future_t *f, char **data, int *data_len);
+
+#endif /* !_IOBUF_H */

--- a/src/common/libiobuf/test/iobuf.c
+++ b/src/common/libiobuf/test/iobuf.c
@@ -1,0 +1,474 @@
+/************************************************************  \
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <assert.h>
+#include <jansson.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libiobuf/iobuf.h"
+
+int maxbuffers = 32;
+int streamrank_count = 0;
+int eof_count = 0;
+
+void basic_corner_case (void)
+{
+    errno = 0;
+    ok (iobuf_server_create (NULL, NULL, -1, -1) == NULL
+        && errno == EINVAL,
+        "iobuf_server_create returns EINVAL on bad input");
+
+    /* can pass NULL to destroy */
+    iobuf_server_destroy (NULL);
+
+    errno = 0;
+    ok (iobuf_set_eof_count_cb (NULL, -1, NULL, NULL) < 0
+        && errno == EINVAL,
+        "iobuf_set_eof_count_cb returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_create (NULL, NULL, -1) < 0
+        && errno == EINVAL,
+        "iobuf_create returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_write (NULL, NULL, -1, NULL, -1) < 0
+        && errno == EINVAL,
+        "iobuf_write returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_read (NULL, NULL, -1, NULL, NULL) < 0
+        && errno == EINVAL,
+        "iobuf_read returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_eof (NULL, NULL, -1) < 0
+        && errno == EINVAL,
+        "iobuf_eof returns EINVAL on bad input");
+
+    errno = 0;
+    ok (!iobuf_iter_first (NULL)
+        && errno == EINVAL,
+        "iobuf_iter_first returns EINVAL on bad input");
+
+    errno = 0;
+    ok (!iobuf_iter_next (NULL)
+        && errno == EINVAL,
+        "iobuf_iter_next returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_count (NULL) < 0
+        && errno == EINVAL,
+        "iobuf_count returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_eof_count (NULL) < 0
+        && errno == EINVAL,
+        "iobuf_eof_count returns EINVAL on bad input");
+
+    errno = 0;
+    ok (!iobuf_rpc_write (NULL, NULL, -1, NULL, -1, NULL, -1)
+        && errno == EINVAL,
+        "iobuf_rpc_write returns EINVAL on bad input");
+
+    errno = 0;
+    ok (!iobuf_rpc_read (NULL, NULL, -1, NULL, -1)
+        && errno == EINVAL,
+        "iobuf_rpc_read returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iobuf_rpc_read_get (NULL, NULL, NULL) < 0
+        && errno == EINVAL,
+        "iobuf_rpc_read_get returns EINVAL on bad input");
+
+    errno = 0;
+    ok (!iobuf_rpc_eof (NULL, NULL, -1, NULL, -1)
+        && errno == EINVAL,
+        "iobuf_rpc_eof returns EINVAL on bad input");
+}
+
+void check_counts (iobuf_t *iob)
+{
+    int tmp;
+
+    tmp = iobuf_count (iob);
+    ok (!(tmp < 0),
+        "iobuf_count works");
+
+    ok (tmp == streamrank_count,
+        "iobuf_count correct %d == %d",
+        tmp, streamrank_count);
+
+    tmp = iobuf_eof_count (iob);
+    ok (!(tmp < 0),
+        "iobuf_eof_count");
+
+    ok (tmp == eof_count,
+        "iobuf_eof_count correct %d == %d",
+        tmp, eof_count);
+}
+
+void basic_create_write_read (iobuf_t *iob)
+{
+    char *data;
+    int data_len;
+
+    ok (!iobuf_create (iob, "basic_create_write_read", 1),
+        "iobuf_create works");
+
+    ok (!iobuf_write (iob, "basic_create_write_read", 1, "foo", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_read (iob, "basic_create_write_read", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "foo", 3),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 3,
+        "iobuf_read returned correct data len");
+
+    free (data);
+    streamrank_count++;
+    check_counts (iob);
+}
+
+void basic_write_read (iobuf_t *iob)
+{
+    char *data;
+    int data_len;
+
+    ok (!iobuf_write (iob, "basic_write_read", 1, "foo", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_read (iob, "basic_write_read", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "foo", 3),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 3,
+        "iobuf_read returned correct data len");
+
+    free (data);
+    streamrank_count++;
+    check_counts (iob);
+}
+
+void basic_write_write_read (iobuf_t *iob)
+{
+    char *data;
+    int data_len;
+
+    ok (!iobuf_write (iob, "basic_write_write_read", 1, "foo", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "basic_write_write_read", 1, "foo", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_read (iob, "basic_write_write_read", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "foofoo", 6),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 6,
+        "iobuf_read returned correct data len");
+
+    free (data);
+    streamrank_count++;
+    check_counts (iob);
+}
+
+void basic_mixed_streams_and_ranks (iobuf_t *iob)
+{
+    char *data;
+    int data_len;
+
+    ok (!iobuf_write (iob, "mixed1", 1, "aaa", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed1", 2, "bbb", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 1, "ccc", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 2, "ddd", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 1, "eee", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 2, "fff", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed1", 2, "bbb", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 2, "fff", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 1, "eee", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 2, "fff", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 1, "ccc", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 2, "ddd", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 1, "eee", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed3", 2, "fff", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_read (iob, "mixed1", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "aaa", 3),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 3,
+        "iobuf_read returned correct data len");
+
+    free (data);
+
+    ok (!iobuf_read (iob, "mixed1", 2, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "bbbbbb", 6),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 6,
+        "iobuf_read returned correct data len");
+
+    free (data);
+
+    ok (!iobuf_read (iob, "mixed2", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "cccccc", 6),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 6,
+        "iobuf_read returned correct data len");
+
+    free (data);
+
+    ok (!iobuf_read (iob, "mixed2", 2, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "dddddd", 6),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 6,
+        "iobuf_read returned correct data len");
+
+    free (data);
+
+    ok (!iobuf_read (iob, "mixed3", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "eeeeeeeee", 9),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 9,
+        "iobuf_read returned correct data len");
+
+    free (data);
+
+    ok (!iobuf_read (iob, "mixed3", 2, &data, &data_len),
+        "iobuf_read works");
+
+    ok (!memcmp (data, "ffffffffffff", 12),
+        "iobuf_read returned correct data");
+
+    ok (data_len == 12,
+        "iobuf_read returned correct data len");
+
+    free (data);
+
+    streamrank_count+= 6;
+    check_counts (iob);
+}
+
+void basic_write_eof (iobuf_t *iob)
+{
+    ok (!iobuf_write (iob, "basic_write_eof", 1, "foo", 3),
+        "iobuf_write works");
+
+    streamrank_count++;
+    check_counts (iob);
+
+    ok (!iobuf_eof (iob, "basic_write_eof", 1),
+        "iobuf_eof works");
+
+    /* double eof shouldn't matter */
+    ok (!iobuf_eof (iob, "basic_write_eof", 1),
+        "iobuf_eof works");
+
+    eof_count++;
+    check_counts (iob);
+}
+
+void basic_write_after_eof (iobuf_t *iob)
+{
+    ok (!iobuf_write (iob, "basic_write_after_eof", 1, "foo", 3),
+        "iobuf_write works");
+
+    streamrank_count++;
+    check_counts (iob);
+
+    ok (!iobuf_eof (iob, "basic_write_after_eof", 1),
+        "iobuf_eof works");
+
+    ok (iobuf_write (iob, "basic_write_after_eof", 1, "foo", 3) < 0
+        && errno == EROFS,
+        "iobuf_write failed with EROFS");
+
+    eof_count++;
+    check_counts (iob);
+}
+
+void basic_eof_only (iobuf_t *iob)
+{
+    ok (!iobuf_eof (iob, "basic_eof_only", 1),
+        "iobuf_eof works");
+
+    streamrank_count++;
+    eof_count++;
+    check_counts (iob);
+}
+
+void corner_case_create_twice (iobuf_t *iob)
+{
+    ok (!iobuf_create (iob, "corner_case_create_twice", 1),
+        "iobuf_create works");
+
+    ok (iobuf_create (iob, "corner_case_create_twice", 1) < 0
+        && errno == EEXIST,
+        "iobuf_create failed with EEXIST");
+
+    streamrank_count++;
+    check_counts (iob);
+}
+
+void corner_case_invalid_read (iobuf_t *iob)
+{
+    char *data = NULL;
+    int data_len;
+
+    ok (iobuf_read (iob, "corner_case_invalid_read", 1, &data, &data_len) < 0
+        && errno == ENOENT,
+        "iobuf_read failed with ENOENT");
+}
+
+void corner_case_zero_length_write_read (iobuf_t *iob)
+{
+    char *data;
+    int data_len;
+
+    ok (!iobuf_create (iob, "corner_case_zero_length_write_read", 1),
+        "iobuf_create works");
+
+    ok (!iobuf_read (iob, "corner_case_zero_length_write_read", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (data == NULL,
+        "iobuf_read returned NULL for zero length read");
+
+    ok (data_len == 0,
+        "iobuf_read returned zero for zero length read");
+
+    ok (!iobuf_write (iob, "corner_case_zero_length_write_read", 1, "", 0),
+        "iobuf_write works");
+
+    ok (!iobuf_read (iob, "corner_case_zero_length_write_read", 1, &data, &data_len),
+        "iobuf_read works");
+
+    ok (data == NULL,
+        "iobuf_read returned NULL for zero length read");
+
+    ok (data_len == 0,
+        "iobuf_read returned zero for zero length read");
+
+    free (data);
+    streamrank_count++;
+    check_counts (iob);
+}
+
+void corner_case_too_many_buffers (iobuf_t *iob)
+{
+    int i;
+
+    for (i = streamrank_count; i < maxbuffers; i++) {
+        ok (!iobuf_write (iob, "corner_case_too_many_buffers", i + 1, "foo", 3),
+            "iobuf_write works");
+        streamrank_count++;
+    }
+
+    ok (iobuf_write (iob, "corner_case_too_many_buffers", ++i, "foo", 3) < 0
+        && errno == ENFILE,
+        "iobuf_write failed with ENFILE");
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    iobuf_t *iob;
+
+    plan (NO_PLAN);
+
+    basic_corner_case ();
+
+    /* N.B. flux handle necessary so iobuf can setup rpc message
+     * handlers, but it and reactor are unused in these tests */
+
+    (void)setenv ("FLUX_CONNECTOR_PATH",
+                  flux_conf_get ("connector_path", CONF_FLAG_INTREE), 0);
+
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "flux_open success");
+
+    ok ((iob = iobuf_server_create (h,
+                                    "iobuf-tests",
+                                    maxbuffers,
+                                    IOBUF_FLAG_LOG_ERRORS)) != NULL,
+        "iobuf_server_create success");
+
+    basic_create_write_read (iob);
+    basic_write_read (iob);
+    basic_write_write_read (iob);
+    basic_mixed_streams_and_ranks (iob);
+    basic_write_eof (iob);
+    basic_write_after_eof (iob);
+    basic_eof_only (iob);
+    corner_case_create_twice (iob);
+    corner_case_invalid_read (iob);
+    corner_case_zero_length_write_read (iob);
+    /* corner_case_too_many_buffers test should be last */
+    corner_case_too_many_buffers (iob);
+
+    done_testing ();
+
+    iobuf_server_destroy (iob);
+    flux_close (h);
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libiobuf/test/iobuf_eof_cb.c
+++ b/src/common/libiobuf/test/iobuf_eof_cb.c
@@ -1,0 +1,82 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* iobuf-eof-cb.c - iobuf test eof callback */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libiobuf/iobuf.h"
+#include "src/common/libutil/log.h"
+
+int eof_cb_called = 0;
+
+void eof_count_cb (iobuf_t *iob, void *arg)
+{
+    flux_reactor_t *r = arg;
+    flux_reactor_stop (r);
+    eof_cb_called++;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    iobuf_t *iob = NULL;
+    int maxbuffers = 4;
+    int eofcount = 4;
+    int i;
+
+    plan (NO_PLAN);
+
+    (void)setenv ("FLUX_CONNECTOR_PATH",
+                  flux_conf_get ("connector_path", CONF_FLAG_INTREE), 0);
+
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "flux_open success");
+
+    ok ((iob = iobuf_server_create (h,
+                                    "eof-cb-tests",
+                                    maxbuffers,
+                                    IOBUF_FLAG_LOG_ERRORS)) != NULL,
+        "iobuf_server_create success");
+
+    ok (!iobuf_set_eof_count_cb (iob,
+                                 eofcount,
+                                 eof_count_cb,
+                                 flux_get_reactor (h)),
+        "iobuf_set_eof_count_cb success");
+
+    for (i = 0; i < maxbuffers; i++) {
+        ok (!iobuf_eof (iob, "test-eof-cb", i + 1),
+            "iobuf_eof success");
+    }
+
+    ok (!(flux_reactor_run (flux_get_reactor (h), 0) < 0),
+        "flux_reactor_run exited");
+
+    ok (eof_cb_called == 1,
+        "eof count callback called correctly");
+
+    done_testing ();
+
+    iobuf_server_destroy (iob);
+    flux_close (h);
+    exit (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libiobuf/test/iobuf_iter.c
+++ b/src/common/libiobuf/test/iobuf_iter.c
@@ -1,0 +1,163 @@
+/************************************************************  \
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <assert.h>
+#include <jansson.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libiobuf/iobuf.h"
+
+void write_data (iobuf_t *iob)
+{
+    ok (!iobuf_write (iob, "mixed1", 1, "aaa", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed1", 2, "bbb", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 1, "cccccc", 6),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 2, "dddddd", 6),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed1", 2, "bbb", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed1", 1, "aaa", 3),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 2, "dddddd", 6),
+        "iobuf_write works");
+
+    ok (!iobuf_write (iob, "mixed2", 1, "cccccc", 6),
+        "iobuf_write works");
+
+}
+
+void check_data (const struct iobuf_data *iobuf_data,
+                 const char *stream,
+                 int rank,
+                 const char *data,
+                 int data_len)
+{
+    ok (!strcmp (iobuf_data->stream, stream),
+        "iobuf_data stream correct");
+    ok (iobuf_data->rank == rank,
+        "iobuf_data rank correct");
+    ok (!memcmp (iobuf_data->data, data, data_len),
+        "iobuf_data data correct");
+    ok (iobuf_data->data_len == data_len,
+        "iobuf_data data_len correct");
+}
+
+void iter_data (iobuf_t *iob)
+{
+    const struct iobuf_data *iobuf_data;
+
+    iobuf_data = iobuf_iter_first (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_first success");
+
+    check_data (iobuf_data, "mixed1", 1, "aaa", 3);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed1", 2, "bbb", 3);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed2", 1, "cccccc", 6);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed2", 2, "dddddd", 6);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed1", 2, "bbb", 3);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed1", 1, "aaa", 3);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed2", 2, "dddddd", 6);
+
+    iobuf_data = iobuf_iter_next (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_next success");
+
+    check_data (iobuf_data, "mixed2", 1, "cccccc", 6);
+
+    /* iter_first takes us back to the beginning */
+
+    iobuf_data = iobuf_iter_first (iob);
+    ok (iobuf_data != NULL,
+        "iobuf_iter_first success");
+
+    check_data (iobuf_data, "mixed1", 1, "aaa", 3);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    iobuf_t *iob;
+
+    plan (NO_PLAN);
+
+    /* N.B. flux handle necessary so iobuf can setup rpc message
+     * handlers, but it and reactor are unused in these tests */
+
+    (void)setenv ("FLUX_CONNECTOR_PATH",
+                  flux_conf_get ("connector_path", CONF_FLAG_INTREE), 0);
+
+    ok ((h = flux_open ("loop://", 0)) != NULL,
+        "flux_open success");
+
+    ok ((iob = iobuf_server_create (h,
+                                    "iobuf-iter-tests",
+                                    0,
+                                    IOBUF_FLAG_LOG_ERRORS)) != NULL,
+        "iobuf_server_create success");
+
+    ok (iobuf_iter_first (iob) == NULL,
+        "iobuf_iter_first returns NULL on empty data");
+    ok (iobuf_iter_next (iob) == NULL,
+        "iobuf_iter_next returns NULL on empty data");
+
+    write_data (iob);
+
+    iter_data (iob);
+
+    done_testing ();
+
+    iobuf_server_destroy (iob);
+    flux_close (h);
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -67,6 +67,7 @@ TESTSCRIPTS = \
 	t0020-emit-jobspec.t \
 	t0021-flux-jobspec.t \
 	t0022-jj-reader.t \
+	t0030-iobuf.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \
@@ -192,6 +193,8 @@ check_PROGRAMS = \
 	kvs/issue1876 \
 	kvs/waitcreate_cancel \
 	kvs/setrootevents \
+	iobuf/iobuf-service \
+	iobuf/iobuf-rpc \
 	request/treq \
 	request/rpc \
 	barrier/tbarrier \
@@ -419,3 +422,13 @@ sched_simple_jj_reader_CPPFLAGS = $(test_cppflags)
 sched_simple_jj_reader_LDADD = \
 	$(top_builddir)/src/modules/sched-simple/libjj.la \
 	$(test_ldadd)
+
+iobuf_iobuf_service_SOURCES = iobuf/iobuf-service.c
+iobuf_iobuf_service_CPPFLAGS = $(test_cppflags)
+iobuf_iobuf_service_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+iobuf_iobuf_rpc_SOURCES = iobuf/iobuf-rpc.c
+iobuf_iobuf_rpc_CPPFLAGS = $(test_cppflags)
+iobuf_iobuf_rpc_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)

--- a/t/iobuf/iobuf-rpc.c
+++ b/t/iobuf/iobuf-rpc.c
@@ -1,0 +1,166 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* iobuf.c - iobuf ops */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <flux/core.h>
+
+#include "src/common/libiobuf/iobuf.h"
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libutil/log.h"
+
+flux_t *h;
+char *name = NULL;
+char *stream = NULL;
+int rank = -1;
+
+void usage (void)
+{
+    fprintf (stderr,
+"Usage: iobuf create <name> <stream> <rank>\n"
+"Usage: iobuf write  <name> <stream> <rank> <stringinput>\n"
+"Usage: iobuf read   <name> <stream> <rank>\n"
+"Usage: iobuf eof    <name> <stream> <rank>\n"
+);
+    exit (1);
+}
+
+void parse_stream_rank (int argc, char *argv[])
+{
+    if (argc < 5)
+        usage ();
+
+    stream = argv[3];
+    rank = atoi (argv[4]);
+    if (rank < 0)
+        log_err_exit ("invalid rank");
+}
+
+void createcmd (int argc, char *argv[])
+{
+    flux_future_t *f;
+
+    parse_stream_rank (argc, argv);
+
+    if (!(f = iobuf_rpc_create (h, name, 0,
+                                stream, rank)))
+        log_err_exit ("iobuf_rpc_create");
+
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+
+    flux_future_destroy (f);
+}
+
+void writecmd (int argc, char *argv[])
+{
+    flux_future_t *f;
+
+    if (argc != 6)
+        usage ();
+
+    parse_stream_rank (argc, argv);
+
+    if (!(f = iobuf_rpc_write (h, name, 0,
+                               stream, rank,
+                               argv[5], strlen (argv[5]))))
+        log_err_exit ("iobuf_rpc_write");
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("iobuf_rpc_write: flux_future_get");
+}
+
+void readcmd (int argc, char *argv[])
+{
+    flux_future_t *f;
+    char *data = NULL;
+    int data_len = -1;
+
+    parse_stream_rank (argc, argv);
+
+    if (!(f = iobuf_rpc_read (h, name, 0,
+                              stream, rank)))
+        log_err_exit ("iobuf_rpc_read");
+
+    /* we call two times for coverage */
+
+    if (iobuf_rpc_read_get (f, &data, NULL) < 0)
+        log_err_exit ("iobuf_rpc_read_get: data");
+
+    if (iobuf_rpc_read_get (f, NULL, &data_len) < 0)
+        log_err_exit ("iobuf_rpc_read_get: data");
+
+    if (data)
+        printf ("data: %s\n", data);
+    printf ("data_len: %d\n", data_len);
+
+    free (data);
+    flux_future_destroy (f);
+}
+
+void eofcmd (int argc, char *argv[])
+{
+    flux_future_t *f;
+
+    parse_stream_rank (argc, argv);
+
+    if (!(f = iobuf_rpc_eof (h, name, 0, stream, rank)))
+        log_err_exit ("iobuf_rpc_eof");
+
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+
+    flux_future_destroy (f);
+}
+
+int main (int argc, char *argv[])
+{
+    char *cmd = NULL;
+
+    log_init ("iobuf");
+
+    if (argc < 3)
+        usage ();
+
+    cmd = argv[1];
+    name = argv[2];
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!strcmp (cmd, "create"))
+        createcmd (argc, argv);
+    else if (!strcmp (cmd, "write"))
+        writecmd (argc, argv);
+    else if (!strcmp (cmd, "read"))
+        readcmd (argc, argv);
+    else if (!strcmp (cmd, "eof"))
+        eofcmd (argc, argv);
+    else
+        log_err_exit ("invalid cmd: %s\n", cmd);
+
+    flux_close (h);
+    exit (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/iobuf/iobuf-service.c
+++ b/t/iobuf/iobuf-service.c
@@ -1,0 +1,137 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* iobuf-service.c - create/destroy iobuf service */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <flux/core.h>
+
+#include "src/common/libiobuf/iobuf.h"
+#include "src/common/libutil/log.h"
+
+void usage (void)
+{
+    fprintf (stderr,
+"Usage: iobuf-service <name> <maxbuffers> <eofcount>\n"
+);
+    exit (1);
+}
+
+void sig_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    int sig = flux_signal_watcher_get_signum (w);
+
+    if (sig == SIGTERM)
+        flux_reactor_stop (r);
+}
+
+void timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    printf ("reactor ready\n");
+    fflush (stdout);
+    flux_watcher_stop (w);
+}
+
+void eof_count_cb (iobuf_t *iob, void *arg)
+{
+    printf ("eof max reached\n");
+    fflush (stdout);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    char *name = NULL;
+    int maxbuffers;
+    int eofcount;
+    iobuf_t *iob = NULL;
+    flux_future_t *f = NULL;
+    flux_watcher_t *sigtermw = NULL;
+    flux_watcher_t *tw = NULL;
+
+    log_init ("iobuf-service");
+
+    if (argc != 4)
+        usage ();
+
+    name = argv[1];
+    maxbuffers = atoi (argv[2]);
+    if (maxbuffers < 0)
+        log_err_exit ("invalid maxbuffers");
+    eofcount = atoi (argv[3]);
+    if (eofcount < 0)
+        log_err_exit ("invalid eofcount");
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(iob = iobuf_server_create (h,
+                                     name,
+                                     maxbuffers,
+                                     IOBUF_FLAG_LOG_ERRORS)))
+        log_err_exit ("iobuf_server_create");
+
+    if (!(f = flux_service_register (h, name)))
+        log_err_exit ("flux_service_register");
+
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+
+    if (eofcount) {
+        if (iobuf_set_eof_count_cb (iob,
+                                    eofcount,
+                                    eof_count_cb,
+                                    NULL) < 0)
+            log_err_exit ("iobuf_set_eof_count_cb");
+    }
+
+    if (!(sigtermw = flux_signal_watcher_create (flux_get_reactor (h),
+                                          SIGTERM,
+                                          sig_cb,
+                                          iob)))
+        log_err_exit ("flux_signal_watcher_create");
+
+    flux_watcher_start (sigtermw);
+
+    /* the timer watcher is only for syncing with tests that
+     * background this service */
+    if (!(tw = flux_timer_watcher_create (flux_get_reactor (h),
+                                          0., 0.,
+                                          timer_cb,
+                                          iob)))
+        log_err_exit ("flux_timer_watcher_create");
+
+    flux_watcher_start (tw);
+
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    if (!(f = flux_service_unregister (h, name)))
+        log_err_exit ("flux_service_unregister");
+
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("flux_future_get");
+
+    flux_watcher_destroy (sigtermw);
+    flux_watcher_destroy (tw);
+    flux_future_destroy (f);
+    iobuf_server_destroy (iob);
+    flux_close (h);
+    exit (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0030-iobuf.t
+++ b/t/t0030-iobuf.t
@@ -1,0 +1,270 @@
+#!/bin/sh
+
+test_description='Test flux iobuf service'
+
+. $(dirname $0)/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+IOBUFSERVICE=${FLUX_BUILD_DIR}/t/iobuf/iobuf-service
+IOBUFRPC=${FLUX_BUILD_DIR}/t/iobuf/iobuf-rpc
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=4
+test_under_flux ${SIZE} full
+
+# after start iobuf service, check for "reactor ready" output to ensure it has
+# started up, so we will avoid raciness with the background process
+iobuf_start() {
+    name=$1
+    maxbuffers=$2
+    eofcount=$3
+    ${IOBUFSERVICE} ${name} ${maxbuffers} ${eofcount} > service-${name}.out &
+    pid=$! &&
+    $waitfile --quiet --count=1 --timeout=5 --pattern="reactor ready" service-${name}.out &&
+    echo ${pid}
+}
+
+# send SIGTERM to the iobuf-service tool, which will inform it to cleanup properly.
+# since it was executed in a sub-shell and is not our child process, use kill -0 to
+# monitor for completion
+iobuf_cleanup() {
+    pid=$1
+    kill -TERM ${pid}
+    while kill -0 "$pid" > /dev/null 2>&1; do
+        sleep 0.25
+    done
+}
+
+#
+# Basic tests
+#
+
+test_expect_success 'iobuf: basic setup and teardown' '
+    pid=$(iobuf_start "iobuf1" 0 0) &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: basic write & read' '
+    pid=$(iobuf_start "iobuf2" 0 0) &&
+    ${IOBUFRPC} write "iobuf2" "stdout" 1 "foo" &&
+    ${IOBUFRPC} read "iobuf2" "stdout" 1 > iobuf2-read.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foo" iobuf2-read.out &&
+    grep "data_len: 3" iobuf2-read.out
+'
+
+test_expect_success 'iobuf: basic create & write & read' '
+    pid=$(iobuf_start "iobuf3" 0 0) &&
+    ${IOBUFRPC} create "iobuf3" "stdout" 1 &&
+    ${IOBUFRPC} read "iobuf3" "stdout" 1 > iobuf3-read-1.out &&
+    ${IOBUFRPC} write "iobuf3" "stdout" 1 "foo" &&
+    ${IOBUFRPC} read "iobuf3" "stdout" 1 > iobuf3-read-2.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data_len: 0" iobuf3-read-1.out &&
+    grep "data: foo" iobuf3-read-2.out &&
+    grep "data_len: 3" iobuf3-read-2.out
+'
+
+test_expect_success 'iobuf: can read buffer multiple times' '
+    pid=$(iobuf_start "iobuf5" 0 0) &&
+    ${IOBUFRPC} write "iobuf5" "stdout" 1 "foo" &&
+    ${IOBUFRPC} read "iobuf5" "stdout" 1 > iobuf5-read-A.out &&
+    ${IOBUFRPC} read "iobuf5" "stdout" 1 > iobuf5-read-B.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foo" iobuf5-read-A.out &&
+    grep "data_len: 3" iobuf5-read-A.out &&
+    grep "data: foo" iobuf5-read-B.out &&
+    grep "data_len: 3" iobuf5-read-B.out
+'
+
+test_expect_success 'iobuf: multiple writes are appended' '
+    pid=$(iobuf_start "iobuf6" 0 0) &&
+    ${IOBUFRPC} write "iobuf6" "stdout" 1 "foo" &&
+    ${IOBUFRPC} write "iobuf6" "stdout" 1 "bar" &&
+    ${IOBUFRPC} write "iobuf6" "stdout" 1 "baz" &&
+    ${IOBUFRPC} read "iobuf6" "stdout" 1 > iobuf6-read.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foobarbaz" iobuf6-read.out &&
+    grep "data_len: 9" iobuf6-read.out
+'
+
+test_expect_success 'iobuf: different streams go to different buffers' '
+    pid=$(iobuf_start "iobuf7" 0 0) &&
+    ${IOBUFRPC} write "iobuf7" "stdout" 1 "foo" &&
+    ${IOBUFRPC} write "iobuf7" "stdout" 1 "bar" &&
+    ${IOBUFRPC} write "iobuf7" "stderr" 1 "foof" &&
+    ${IOBUFRPC} write "iobuf7" "stderr" 1 "barf" &&
+    ${IOBUFRPC} read "iobuf7" "stdout" 1 > iobuf7-read-stdout.out &&
+    ${IOBUFRPC} read "iobuf7" "stderr" 1 > iobuf7-read-stderr.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foobar" iobuf7-read-stdout.out &&
+    grep "data_len: 6" iobuf7-read-stdout.out &&
+    grep "data: foofbarf" iobuf7-read-stderr.out &&
+    grep "data_len: 8" iobuf7-read-stderr.out
+'
+
+test_expect_success 'iobuf: different ranks go to different buffers' '
+    pid=$(iobuf_start "iobuf8" 0 0) &&
+    ${IOBUFRPC} write "iobuf8" "stdout" 1 "foo" &&
+    ${IOBUFRPC} write "iobuf8" "stdout" 1 "bar" &&
+    ${IOBUFRPC} write "iobuf8" "stdout" 2 "foof" &&
+    ${IOBUFRPC} write "iobuf8" "stdout" 2 "barf" &&
+    ${IOBUFRPC} read "iobuf8" "stdout" 1 > iobuf8-read-1.out &&
+    ${IOBUFRPC} read "iobuf8" "stdout" 2 > iobuf8-read-2.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foobar" iobuf8-read-1.out &&
+    grep "data_len: 6" iobuf8-read-1.out &&
+    grep "data: foofbarf" iobuf8-read-2.out &&
+    grep "data_len: 8" iobuf8-read-2.out
+'
+
+test_expect_success 'iobuf: test eof' '
+    pid=$(iobuf_start "iobuf9" 0 0) &&
+    ${IOBUFRPC} write "iobuf9" "stdout" 1 "foo" &&
+    ${IOBUFRPC} eof "iobuf9" "stdout" 1 &&
+    ! ${IOBUFRPC} write "iobuf9" "stdout" 1 "foo" &&
+    ${IOBUFRPC} read "iobuf9" "stdout" 1 > iobuf9-read.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foo" iobuf9-read.out &&
+    grep "data_len: 3" iobuf9-read.out
+'
+
+test_expect_success 'iobuf: test eof on no-data buffer' '
+    pid=$(iobuf_start "iobuf10" 0 0) &&
+    ${IOBUFRPC} eof "iobuf10" "stdout" 1 &&
+    ! ${IOBUFRPC} write "iobuf10" "stdout" 1 "foo" &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: test eof_count cb' '
+    pid=$(iobuf_start "iobuf11" 2 2) &&
+    ! grep "eof max reached" service-iobuf11.out &&
+    ${IOBUFRPC} write "iobuf11" "stdout" 1 "foo" &&
+    ${IOBUFRPC} write "iobuf11" "stdout" 2 "foo" &&
+    ! grep "eof max reached" service-iobuf11.out &&
+    ${IOBUFRPC} eof "iobuf11" "stdout" 1 &&
+    ${IOBUFRPC} eof "iobuf11" "stdout" 2 &&
+    $waitfile --quiet --count=1 --timeout=5 --pattern="eof max reached" service-iobuf11.out &&
+    iobuf_cleanup ${pid}
+'
+
+#
+# Corner case tests
+#
+
+test_expect_success 'iobuf: invalid requests fail with EPROTO(71)' '
+    pid=$(iobuf_start "iobufcc1" 0 0) &&
+    ${RPC} iobufcc1.create 71 </dev/null &&
+    ${RPC} iobufcc1.write 71 </dev/null &&
+    ${RPC} iobufcc1.read 71 </dev/null &&
+    ${RPC} iobufcc1.eof 71 </dev/null &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: duplicate service name on setup results in error' '
+    pid=$(iobuf_start "iobufcc2" 0 0) &&
+    ! ${IOBUFSERVICE} "iobufcc2" &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: invalid name results in error' '
+    pid=$(iobuf_start "iobufcc3" 0 0) &&
+    ! ${IOBUFRPC} create "bad" "stdout" 1 - &&
+    ! ${IOBUFRPC} write "bad" "stdout" 1 "foo" &&
+    ! ${IOBUFRPC} read "bad" "stdout" 1 - &&
+    ! ${IOBUFRPC} eof "bad" "stdout" 1 - &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: duplicate stream/rank on create results in error' '
+    pid=$(iobuf_start "iobufcc4" 0 0) &&
+    ${IOBUFRPC} create "iobufcc4" "stdout" 1 &&
+    ! ${IOBUFRPC} create "iobufcc4" "stdout" 1 &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: invalid inputs on read results in error' '
+    pid=$(iobuf_start "iobufcc5" 0 0) &&
+    ${IOBUFRPC} write "iobufcc5" "stdout" 1 "foo" &&
+    ! ${IOBUFRPC} read "iobufcc5" "bad" 1 &&
+    ! ${IOBUFRPC} read "iobufcc5" "stdout" 5 &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: error creating too many buffers' '
+    pid=$(iobuf_start "iobufcc6" 2 0) &&
+    ${IOBUFRPC} write "iobufcc6" "stdout" 1 "foo" &&
+    ${IOBUFRPC} write "iobufcc6" "stdout" 2 "foo" &&
+    ! echo -n "foo" | ${IOBUFRPC} write "iobufcc6" "stdout" 3 - &&
+    iobuf_cleanup ${pid}
+'
+
+test_expect_success 'iobuf: 0 length writes work' '
+    pid=$(iobuf_start "iobufcc7" 0 0) &&
+    ${IOBUFRPC} write "iobufcc7" "stdout" 1 "" &&
+    ${IOBUFRPC} read "iobufcc7" "stdout" 1 > iobufcc7-read.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data_len: 0" iobufcc7-read.out
+'
+
+#
+# Test with flux-exec
+#
+
+test_expect_success 'iobuf: write on different ranks' '
+    pid=$(iobuf_start "iobufexec1" 0 0) &&
+    flux exec -r 0 ${IOBUFRPC} write "iobufexec1" "stdout" 0 "aaa" &&
+    flux exec -r 1 ${IOBUFRPC} write "iobufexec1" "stdout" 1 "bbb" &&
+    flux exec -r 2 ${IOBUFRPC} write "iobufexec1" "stdout" 2 "ccc" &&
+    flux exec -r 3 ${IOBUFRPC} write "iobufexec1" "stdout" 3 "ddd" &&
+    flux exec -r 1 ${IOBUFRPC} write "iobufexec1" "stdout" 1 "bbb" &&
+    flux exec -r 2 ${IOBUFRPC} write "iobufexec1" "stdout" 2 "ccc" &&
+    flux exec -r 1 ${IOBUFRPC} write "iobufexec1" "stdout" 1 "bbb" &&
+    flux exec -r 0 ${IOBUFRPC} eof "iobufexec1" "stdout" 0 &&
+    flux exec -r 1 ${IOBUFRPC} eof "iobufexec1" "stdout" 1 &&
+    flux exec -r 2 ${IOBUFRPC} eof "iobufexec1" "stdout" 2 &&
+    flux exec -r 3 ${IOBUFRPC} eof "iobufexec1" "stdout" 3 &&
+    ${IOBUFRPC} read "iobufexec1" "stdout" 0 > iobufexec1-read-0.out &&
+    ${IOBUFRPC} read "iobufexec1" "stdout" 1 > iobufexec1-read-1.out &&
+    ${IOBUFRPC} read "iobufexec1" "stdout" 2 > iobufexec1-read-2.out &&
+    ${IOBUFRPC} read "iobufexec1" "stdout" 3 > iobufexec1-read-3.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: aaa" iobufexec1-read-0.out &&
+    grep "data_len: 3" iobufexec1-read-0.out &&
+    grep "data: bbbbbbbbb" iobufexec1-read-1.out &&
+    grep "data_len: 9" iobufexec1-read-1.out &&
+    grep "data: cccccc" iobufexec1-read-2.out &&
+    grep "data_len: 6" iobufexec1-read-2.out &&
+    grep "data: ddd" iobufexec1-read-3.out &&
+    grep "data_len: 3" iobufexec1-read-3.out
+'
+
+test_expect_success 'iobuf: test eof on different ranks' '
+    pid=$(iobuf_start "iobufexec2" 0 0) &&
+    flux-exec -r 1 ${IOBUFRPC} write "iobufexec2" "stdout" 1 "foo" &&
+    flux-exec -r 1 ${IOBUFRPC} eof "iobufexec2" "stdout" 1 &&
+    ! flux-exec -r 1 ${IOBUFRPC} write "iobufexec2" "stdout" 1 "foo" &&
+    flux-exec ${IOBUFRPC} read "iobufexec2" "stdout" 1 > iobufexec2-read.out &&
+    iobuf_cleanup ${pid} &&
+    grep "data: foo" iobufexec2-read.out &&
+    grep "data_len: 3" iobufexec2-read.out
+'
+
+test_expect_success 'iobuf: test eof_count cb after eof on different ranks' '
+    pid=$(iobuf_start "iobufexec3" 2 2) &&
+    ! grep "eof max reached" service-iobufexec3.out &&
+    flux-exec -r 1 ${IOBUFRPC} write "iobufexec3" "stdout" 1 "foo" &&
+    flux-exec -r 2 ${IOBUFRPC} write "iobufexec3" "stdout" 2 "foo" &&
+    ! grep "eof max reached" service-iobufexec3.out &&
+    flux-exec -r 1 ${IOBUFRPC} eof "iobufexec3" "stdout" 1 &&
+    flux-exec -r 2 ${IOBUFRPC} eof "iobufexec3" "stdout" 2 &&
+    $waitfile --quiet --count=1 --timeout=5 --pattern="eof max reached" service-iobufexec3.out &&
+    iobuf_cleanup ${pid}
+'
+
+test_done


### PR DESCRIPTION
This is work in progress for #2201.  I'm thinking that something that isn't very feature-ful can go into the tree as a temporary step.  This first step is very minor as the only thing is supports is allowing callers to write repeatedly to the service, the service buffers all of the data, and a caller can read all of the data back at some point later.  That's all it provides right now.  Perhaps before a merge, I could minimally support:

- tests using `flux exec`
- read from an offset / get data length
- configure buffer size

before supporting some of the more advanced things mentioned in #2201.

Anyways, I wanted to atleast post this small WIP to get comments on a few subtleties.

- I chose the name for this library as `libiobuf`, which is the best name I could come up with but it doesn't sound great.  Any ideas on something better?  Technically, it could be "databuf" as it is data agnostic.

- the library is added to `libflux_internal`.  Is it something we might want to make public so stuff outside of the project would use it?  And thus prefix all functions with `flux_`.


