### PR TITLE
python: misc fixes, refactors, and additions

### DIFF
--- a/scripts/check-format
+++ b/scripts/check-format
@@ -14,8 +14,8 @@ if command -v black 2>&1 > /dev/null ; then
     if [[ $# -eq 0 ]]; then
         # awk cmd copied from:
         # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
-        find src t -type f \
-             \( -name "*.py" -print -o \
+        find src t -path "src/bindings/python/_flux" -prune -o \
+             -type f \( -name "*.py" -print -o \
              -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
             | xargs black --check
     else

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -1,13 +1,26 @@
 #!/bin/bash
 set -e
 
+function filter_pyfiles() {
+    # only echo files that end in .py or have a python shebang line
+    for infile in "$@"; do
+        if [[ -f $infile && ( $infile == *.py || $(head -n1 $infile) =~ ^#!.*python ) ]]; then
+           echo $infile
+        fi
+    done
+}
+
 if command -v black 2>&1 > /dev/null ; then
-    # awk cmd copied from:
-    # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
-    find src t -type f \
-         \( -name "*.py" -print -o \
-         -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
-        | xargs black --check
+    if [[ $# -eq 0 ]]; then
+        # awk cmd copied from:
+        # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
+        find src t -type f \
+             \( -name "*.py" -print -o \
+             -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
+            | xargs black --check
+    else
+        filter_pyfiles "$@" | xargs black --check
+    fi
 else
   echo "black not found, failing"
   exit 1

--- a/scripts/format
+++ b/scripts/format
@@ -3,8 +3,8 @@
 if command -v black 2>&1 > /dev/null ; then
     # awk cmd copied from:
     # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
-    find src t -type f \
-         \( -name "*.py" -print -o \
+    find src t -path "src/bindings/python/_flux" -prune -o \
+         -type f \( -name "*.py" -print -o \
          -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
         | xargs black
 else

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -15,7 +15,14 @@ from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 
 
-_THEN_HANDLES = set()
+# Reference count dictionary to keep futures with a pending `then` callback
+# alive, even if there are no remaining references to the future in the user's
+# program scope. When a callback is first set on the future, add an entry to the
+# dictionary with the future itself as the key and a value of 1. Whenever a
+# future's callback is run, decrement the count in the dictionary for that
+# future, and whenever reset is called on a future, increment the counter. If
+# the counter hits 0, delete the reference to the future from the dictionary.
+_THEN_HANDLES = {}
 
 
 @ffi.def_extern()
@@ -25,9 +32,12 @@ def continuation_callback(c_future, opaque_handle):
         assert c_future == py_future.pimpl.handle
         py_future.then_cb(py_future, py_future.then_arg)
     finally:
-        # allow future object to be garbage collected now that all
-        # registered callbacks have completed
-        py_future.cleanup_then()
+        _THEN_HANDLES[py_future] -= 1
+        if _THEN_HANDLES[py_future] <= 0:
+            # allow future object to be garbage collected now that all
+            # registered callbacks have completed
+            py_future.cb_handle = None
+            del _THEN_HANDLES[py_future]
 
 
 class Future(WrapperPimpl):
@@ -64,16 +74,6 @@ class Future(WrapperPimpl):
         self.then_arg = None
         self.cb_handle = None
 
-    def cleanup_then(self):
-        self.then_cb = None
-        self.then_arg = None
-        self.cb_handle = None
-        if self in _THEN_HANDLES:
-            _THEN_HANDLES.remove(self)
-
-    def __del__(self):
-        self.cleanup_then()
-
     def error_string(self):
         try:
             errmsg = self.pimpl.error_string()
@@ -98,6 +98,8 @@ class Future(WrapperPimpl):
             raise EnvironmentError(
                 errno.EEXIST, "then callback already exists for this future"
             )
+        if callback is None:
+            raise ValueError("Callback cannot be None")
 
         self.then_cb = callback
         self.then_arg = arg
@@ -105,9 +107,21 @@ class Future(WrapperPimpl):
         self.pimpl.then(timeout, lib.continuation_callback, self.cb_handle)
 
         # ensure that this future object is not garbage collected with a
-        # callback outstanding. Particularly important for anonymous calls.
-        # For example, `f.rpc.('topic').then(cb)`
-        _THEN_HANDLES.add(self)
+        # callback outstanding. Particularly important for anonymous calls and
+        # streaming RPCs.  For example, `f.rpc('topic').then(cb)`
+        _THEN_HANDLES[self] = 1
+
+        # return self to enable further chaining of the future.
+        # For example `f.rpc('topic').then(cb).wait_for(-1)
+        return self
+
+    def reset(self):
+        self.pimpl.reset()
+
+        if self.cb_handle is not None:
+            # ensure that this future object is not garbage collected with a
+            # callback outstanding. Particularly important for streaming RPCs.
+            _THEN_HANDLES[self] += 1
 
     def is_ready(self):
         return self.pimpl.is_ready()

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -15,6 +15,7 @@ number of assumptions about the error propagation and handling that flux uses.
 """
 import re
 import os
+import errno
 import inspect
 import six
 
@@ -212,7 +213,9 @@ class FunctionWrapper(object):
         if self.is_error(result):
             err = calling_object.ffi.errno
             if err != 0:
-                raise EnvironmentError(err, os.strerror(err))
+                raise EnvironmentError(
+                    err, "{}: {}".format(errno.errorcode[err], os.strerror(err))
+                )
 
         return result
 

--- a/src/cmd/flux-jobspec.py
+++ b/src/cmd/flux-jobspec.py
@@ -16,6 +16,7 @@ try:
 except AttributeError:
     collectionsAbc = collections
 
+from flux import util
 import yaml
 
 
@@ -163,6 +164,10 @@ def get_slurm_common_parser():
     return slurm_parser
 
 
+logger = logging.getLogger(__name__)
+
+
+@util.CLIMain(logger)
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--format", choices=["json", "yaml"], default="json")
@@ -190,18 +195,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO, format="%(module)s: %(levelname)s: %(message)s"
-    )
-    logger = logging.getLogger(__name__)
-    exit_code = 0
-    try:
-        main()
-    except SystemExit as e:  # don't intercept sys.exit calls
-        exit_code = e
-    except Exception as e:
-        exit_code = 1
-        logging.error(str(e))
-    finally:
-        logging.shutdown()
-        sys.exit(exit_code)
+    main()


### PR DESCRIPTION
Main changes are fixing streaming RPCs, fixing `job.get_id()`, and adding a `CLIMain` decorator for uniform exception handling by CLI tools written in Python.

Minor changes include adding some methods to the Flux handle class, improve error messages, and extending the check-format/format scripts to be usable as git commit hooks.

Fixes #2155