### PR TITLE
docker: update centos7 image to python3.6 and add valgrind-devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,13 @@ jobs:
        - IMG=centos7
        - DOCKER_TAG=t
        - PYTHON_VERSION=2.7
-    - name: "Centos 7: py3.4 --with-flux-security"
+    - name: "Centos 7: py3.6 --with-flux-security"
       stage: test
       compiler: gcc
       env:
        - ARGS="--with-flux-security --prefix=/usr"
        - IMG=centos7
-       - PYTHON_VERSION=3.4
+       - PYTHON_VERSION=3.6
 
 stages:
   - 'style checks'

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -53,6 +53,7 @@ RUN yum -y update \
       ruby \
       sqlite \
       valgrind \
+      valgrind-devel \
       man-db \
       aspell \
       aspell-en \

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -45,11 +45,11 @@ RUN yum -y update \
       python-six \
       python-yaml \
       python-jsonschema \
-      python34-devel \
-      python34-cffi \
-      python34-six \
-      python34-yaml \
-      python34-jsonschema \
+      python36-devel \
+      python36-cffi \
+      python36-six \
+      python36-yaml \
+      python36-jsonschema \
       ruby \
       sqlite \
       valgrind \


### PR DESCRIPTION
Problem: without the valgrind-devel package, valgrind.h is not found
during configure and the valgrind test is disabled by default. When
run with -d, the t5000-valgrind.t is forced to run, but may encounter
false positives and bad stack traces due to modules that are dlclosed.

Add valgrind-devel to the centos7 docker image. (valgrind.h is part of
the base valgrind package in Ubuntu)