### PR TITLE
libschedutil: destroy pending futures on scheduler unload

### DIFF
--- a/src/common/libschedutil/Makefile.am
+++ b/src/common/libschedutil/Makefile.am
@@ -16,6 +16,9 @@ noinst_LTLIBRARIES = \
 
 libschedutil_la_SOURCES = \
 	schedutil.h \
+	schedutil_private.h \
+	init.h \
+	init.c \
 	hello.h \
 	hello.c \
 	ready.h \
@@ -26,3 +29,6 @@ libschedutil_la_SOURCES = \
 	alloc.c \
 	free.h \
 	free.c
+
+libschedutil_la_LIBADD = \
+	$(ZMQ_LIBS)

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -118,6 +118,7 @@ static void alloc_continuation (flux_future_t *f, void *arg)
         flux_log_error (h, "commit R");
         goto error;
     }
+    schedutil_remove_outstanding_future (util, f);
     if (schedutil_alloc_respond (h, ctx->msg, 0, ctx->note) < 0) {
         flux_log_error (h, "alloc response");
         goto error;
@@ -147,6 +148,7 @@ int schedutil_alloc_respond_R (schedutil_t *util, const flux_msg_t *msg,
     }
     if (flux_future_then (f, -1, alloc_continuation, ctx) < 0)
         goto error;
+    schedutil_add_outstanding_future (util, f);
     return 0;
 error:
     alloc_destroy (ctx);

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -148,6 +148,13 @@ int schedutil_alloc_respond_R (schedutil_t *util, const flux_msg_t *msg,
     }
     if (flux_future_then (f, -1, alloc_continuation, ctx) < 0)
         goto error;
+    if (!schedutil_hang_responses (util)) {
+        if (flux_future_then (f, -1, alloc_continuation, util) < 0)
+            goto error;
+    }
+    /* else: intentionally do not register a continuation to force
+     * a permanent outstanding request for testing
+     */
     schedutil_add_outstanding_future (util, f);
     return 0;
 error:

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <flux/core.h>
 
+#include "init.h"
+
 /* Decode an alloc request message.
  * Return 0 on success, -1 on error with errno set.
  */
@@ -28,21 +30,21 @@ int schedutil_alloc_request_decode (const flux_msg_t *msg,
  * is finally terminated with alloc_respond_denied() or alloc_respond_R().
  * Return 0 on success, -1 on error with errno set.
  */
-int schedutil_alloc_respond_note (flux_t *h, const flux_msg_t *msg,
+int schedutil_alloc_respond_note (schedutil_t *util, const flux_msg_t *msg,
                                   const char *note);
 
 /* Respond to alloc request message - the job cannot run.
  * Include human readable error message in 'note'.
  * Return 0 on success, -1 on error with errno set.
  */
-int schedutil_alloc_respond_denied (flux_t *h, const flux_msg_t *msg,
+int schedutil_alloc_respond_denied (schedutil_t *util, const flux_msg_t *msg,
                                     const char *note);
 
 /* Respond to alloc request message - allocate R.
  * R is committed to the KVS first, then the response is sent.
  * If something goes wrong after this function returns, the reactor is stopped.
  */
-int schedutil_alloc_respond_R (flux_t *h, const flux_msg_t *msg,
+int schedutil_alloc_respond_R (schedutil_t *util, const flux_msg_t *msg,
                                const char *R, const char *note);
 
 

--- a/src/common/libschedutil/free.c
+++ b/src/common/libschedutil/free.c
@@ -13,6 +13,8 @@
 #endif
 #include <flux/core.h>
 
+#include "schedutil_private.h"
+#include "init.h"
 #include "free.h"
 
 
@@ -21,13 +23,13 @@ int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id)
     return flux_request_unpack (msg, NULL, "{s:I}", "id", id);
 }
 
-int schedutil_free_respond (flux_t *h, const flux_msg_t *msg)
+int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg)
 {
     flux_jobid_t id;
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
         return -1;
-    return flux_respond_pack (h, msg, "{s:I}", "id", id);
+    return flux_respond_pack (util->h, msg, "{s:I}", "id", id);
 }
 
 /*

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -29,6 +29,11 @@ static int schedutil_hello_job (flux_t *h,
     flux_future_t *f;
     const char *R;
 
+    if (!h) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
         errno = EPROTO;
         return -1;

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -14,6 +14,8 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "schedutil_private.h"
+#include "init.h"
 #include "hello.h"
 
 static int schedutil_hello_job (flux_t *h,
@@ -46,18 +48,18 @@ error:
     return -1;
 }
 
-int schedutil_hello (flux_t *h, hello_f *cb, void *arg)
+int schedutil_hello (schedutil_t *util, hello_f *cb, void *arg)
 {
     flux_future_t *f;
     json_t *jobs;
     json_t *entry;
     size_t index;
 
-    if (!h || !cb) {
+    if (!util || !cb) {
         errno = EINVAL;
         return -1;
     }
-    if (!(f = flux_rpc (h, "job-manager.sched-hello",
+    if (!(f = flux_rpc (util->h, "job-manager.sched-hello",
                         NULL, FLUX_NODEID_ANY, 0)))
         return -1;
     if (flux_rpc_get_unpack (f, "{s:o}", "alloc", &jobs) < 0)
@@ -76,7 +78,7 @@ int schedutil_hello (flux_t *h, hello_f *cb, void *arg)
             errno = EPROTO;
             goto error;
         }
-        if (schedutil_hello_job (h,
+        if (schedutil_hello_job (util->h,
                                  id,
                                  priority,
                                  userid,

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -13,6 +13,8 @@
 
 #include <flux/core.h>
 
+#include "init.h"
+
 /* Callback for ingesting R + metadata for jobs that have resources
  * Return 0 on success, -1 on failure with errno set.
  * Failure of the callback aborts iteration and causes schedutil_hello()
@@ -31,7 +33,7 @@ typedef int (hello_f)(flux_t *h,
  * This function looks up R for each job and passes R + metadata to 'cb'
  * with 'arg'.
  */
-int schedutil_hello (flux_t *h, hello_f *cb, void *arg);
+int schedutil_hello (schedutil_t *util, hello_f *cb, void *arg);
 
 #endif /* !_FLUX_SCHEDUTIL_HELLO_H */
 

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -17,6 +17,17 @@
 #include "init.h"
 #include "schedutil_private.h"
 
+/* flux module debug --setbit 0x8000 sched
+ * flux module debug --clearbit 0x8000 sched
+ */
+enum module_debug_flags {
+    /* alloc and free responses received while this is set
+     * will never get a response
+     */
+    DEBUG_HANG_RESPONSES = 0x8000, // 16th bit
+};
+
+
 schedutil_t *schedutil_create (flux_t *h,
                                op_alloc_f *alloc_cb,
                                op_free_f *free_cb,
@@ -88,6 +99,11 @@ void schedutil_destroy (schedutil_t *util)
         errno = saved_errno;
     }
     return;
+}
+
+bool schedutil_hang_responses (const schedutil_t *util)
+{
+    return flux_module_debug_test (util->h, DEBUG_HANG_RESPONSES, false);
 }
 
 int schedutil_add_outstanding_future (schedutil_t *util, flux_future_t *fut)

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -1,0 +1,61 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <czmq.h>
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/aux.h"
+
+#include "init.h"
+#include "schedutil_private.h"
+
+schedutil_t *schedutil_create (flux_t *h,
+                               op_alloc_f *alloc_cb,
+                               op_free_f *free_cb,
+                               op_exception_f *exception_cb,
+                               void *cb_arg)
+{
+    schedutil_t *util;
+
+    if (!h || !alloc_cb || !free_cb || !exception_cb) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(util = calloc(1, sizeof(*util))))
+        return NULL;
+
+    util->h = h;
+    util->alloc_cb = alloc_cb;
+    util->free_cb = free_cb;
+    util->exception_cb = exception_cb;
+    util->cb_arg = cb_arg;
+    if (schedutil_ops_register (util) < 0)
+        goto error;
+    if (flux_event_subscribe (h, "job-exception") < 0)
+        goto error;
+
+    return util;
+
+error:
+    schedutil_destroy (util);
+    return NULL;
+}
+
+void schedutil_destroy (schedutil_t *util)
+{
+    if (util) {
+        int saved_errno = errno;
+        schedutil_ops_unregister (util);
+        free (util);
+        errno = saved_errno;
+    }
+    return;
+}

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -1,0 +1,39 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_INIT_H
+#define _FLUX_SCHEDUTIL_INIT_H
+
+#include <flux/core.h>
+
+#include "ops.h"
+
+typedef struct schedutil_ctx schedutil_t;
+
+/* Create a handle for the schedutil conveinence library.
+ *
+ * Used to track outstanding futures and register callbacks relevant for
+ * schedulers and simulators.
+ * Return NULL on error.
+ */
+schedutil_t *schedutil_create (flux_t *h,
+                               op_alloc_f *alloc_cb,
+                               op_free_f *free_cb,
+                               op_exception_f *exception_cb,
+                               void *cb_arg);
+
+/* Destory the handle for the schedutil conveinence library.
+ *
+ * Will automatically respond ENOSYS to any outstanding messages (e.g., free,
+ * alloc).
+ */
+void schedutil_destroy (schedutil_t* ctx);
+
+#endif /* !_FLUX_SCHEDUTIL_INIT_H */

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -76,8 +76,12 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_msg_decref (msg);
         goto error_future;
     }
-    if (flux_future_then (f, -1, alloc_continuation, util) < 0)
-        goto error_future;
+    if (!schedutil_hang_responses (util)) {
+        if (flux_future_then (f, -1, alloc_continuation, util) < 0)
+            goto error_future;
+    }
+    // else: intentionally do not register a continuation to force a permanent
+    // outstanding request for testing
     if (schedutil_add_outstanding_future (util, f) < 0)
         flux_log_error (h, "sched.alloc unable to add outstanding future");
 
@@ -136,8 +140,13 @@ static void free_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_msg_decref (msg);
         goto error_future;
     }
-    if (flux_future_then (f, -1, free_continuation, util) < 0)
-        goto error_future;
+    if (!schedutil_hang_responses (util)) {
+        if (flux_future_then (f, -1, free_continuation, util) < 0)
+            goto error_future;
+    }
+    /* else: intentionally do not register a continuation to force
+     * a permanent outstanding request for testing
+     */
     if (schedutil_add_outstanding_future (util, f) < 0)
         flux_log_error (h, "sched.free unable to add outstanding future");
 

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -35,7 +35,7 @@ static void alloc_continuation (flux_future_t *f, void *arg)
     const char *jobspec;
 
     if (flux_kvs_lookup_get (f, &jobspec) < 0) {
-        flux_log_error (ctx->h, "sched.free lookup R");
+        flux_log_error (ctx->h, "sched.alloc lookup R");
         goto error;
     }
     ctx->alloc_cb (ctx->h, msg, jobspec, ctx->arg);
@@ -96,7 +96,7 @@ static void free_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
     return;
 error:
-    flux_log_error (ctx->h, "sched.alloc");
+    flux_log_error (ctx->h, "sched.free");
     if (flux_respond_error (ctx->h, msg, errno, NULL) < 0)
         flux_log_error (ctx->h, "sched.free respond_error");
     flux_future_destroy (f);

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -47,18 +47,6 @@ typedef void (op_exception_f)(flux_t *h,
                               int severity,
                               void *arg);
 
-/* Register callbacks for alloc, free, exception.
- */
-struct ops_context *schedutil_ops_register (flux_t *h,
-                                            op_alloc_f *alloc_cb,
-                                            op_free_f *free_cb,
-                                            op_exception_f *exception_cb,
-                                            void *arg);
-
-/* Unregister callbacks.
- */
-void schedutil_ops_unregister (struct ops_context *ctx);
-
 #endif /* !_FLUX_SCHEDUTIL_OPS_H */
 
 /*

--- a/src/common/libschedutil/ready.c
+++ b/src/common/libschedutil/ready.c
@@ -14,18 +14,20 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "schedutil_private.h"
+#include "init.h"
 #include "ready.h"
 
-int schedutil_ready (flux_t *h, const char *mode, int *queue_depth)
+int schedutil_ready (schedutil_t *util, const char *mode, int *queue_depth)
 {
     flux_future_t *f;
     int count;
 
-    if (!h || !mode) {
+    if (!util || !mode) {
         errno = EINVAL;
         return -1;
     }
-    if (!(f = flux_rpc_pack (h, "job-manager.sched-ready",
+    if (!(f = flux_rpc_pack (util->h, "job-manager.sched-ready",
                              FLUX_NODEID_ANY, 0,
                              "{s:s}", "mode", mode)))
         return -1;

--- a/src/common/libschedutil/ready.h
+++ b/src/common/libschedutil/ready.h
@@ -13,12 +13,14 @@
 
 #include <flux/core.h>
 
+#include "init.h"
+
 /* Send ready request to job-manager, selecting interface 'mode'
  * ("single", "unlimited", ...).  'queue_depth', if non-NULL,
  * is set to the number of jobs in SCHED state that have not yet requested
  * resources.  Returns 0 on success, -1 on failure with errno set.
  */
-int schedutil_ready (flux_t *h, const char *mode, int *queue_depth);
+int schedutil_ready (schedutil_t *util, const char *mode, int *queue_depth);
 
 #endif /* !_FLUX_SCHEDUTIL_READY_H */
 

--- a/src/common/libschedutil/schedutil.h
+++ b/src/common/libschedutil/schedutil.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 
+#include "init.h"
 #include "hello.h"
 #include "ready.h"
 #include "alloc.h"

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -8,24 +8,21 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef _FLUX_SCHEDUTIL_FREE_H
-#define _FLUX_SCHEDUTIL_FREE_H
-
+#include <czmq.h>
 #include <flux/core.h>
 
 #include "init.h"
 
-/* Decode a free request.
- * Returns 0 on success, -1 on failure with errno set.
- */
-int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id);
+struct schedutil_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    op_alloc_f *alloc_cb;
+    op_free_f *free_cb;
+    op_exception_f *exception_cb;
+    void *cb_arg;
+};
 
-/* Respond to a free request.
+/* (Un-)register callbacks for alloc, free, exception.
  */
-int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg);
-
-#endif /* !_FLUX_SCHEDUTIL_FREE_H */
-
-/*
- * vi:tabstop=4 shiftwidth=4 expandtab
- */
+int schedutil_ops_register (schedutil_t *util);
+void schedutil_ops_unregister (schedutil_t *util);

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -20,7 +20,19 @@ struct schedutil_ctx {
     op_free_f *free_cb;
     op_exception_f *exception_cb;
     void *cb_arg;
+    zlistx_t *outstanding_futures;
 };
+
+/*
+ * Add/remove futures that have associated outstandings messages whose response
+ * is blocked on the future's fulfillment.  Schedutil will automatically reply
+ * to the msg with ENOSYS and destroy the future when the scheduler gets
+ * unloaded.
+ * Return 0 on success and -1 on error.
+ */
+int schedutil_add_outstanding_future (schedutil_t *util, flux_future_t *fut);
+int schedutil_remove_outstanding_future (schedutil_t *util,
+                                         flux_future_t *fut);
 
 /* (Un-)register callbacks for alloc, free, exception.
  */

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -38,3 +38,10 @@ int schedutil_remove_outstanding_future (schedutil_t *util,
  */
 int schedutil_ops_register (schedutil_t *util);
 void schedutil_ops_unregister (schedutil_t *util);
+
+/* Testing interfaces
+ *
+ * Check to see if the scheduler has the debug flag set such
+ * that responses should hang, forcing outstanding requests to exist.
+ */
+bool schedutil_hang_responses (const schedutil_t *util);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -93,6 +93,7 @@ TESTSCRIPTS = \
 	t2205-job-info-security.t \
 	t2206-job-manager-bulk-state.t \
 	t2300-sched-simple.t \
+	t2301-schedutil-outstanding-requests.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \
@@ -175,7 +176,8 @@ dist_check_SCRIPTS = \
 	job-manager/drain-cancel.py \
 	job-manager/drain-undrain.py \
 	job-manager/bulk-state.py \
-	job-exec/dummy.sh
+	job-exec/dummy.sh \
+	schedutil/req_and_unload.py
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/job-manager/exec-service.lua
+++ b/t/job-manager/exec-service.lua
@@ -1,4 +1,4 @@
-#!/usr/bin/lua
+#!/usr/bin/env lua
 -------------------------------------------------------------
 -- Copyright 2019 Lawrence Livermore National Security, LLC
 -- (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/schedutil/req_and_unload.py
+++ b/t/schedutil/req_and_unload.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+import errno
+import flux
+import json
+
+
+def expect_enosys(rpc, timeout=1):
+    try:
+        rpc.wait_for(timeout=timeout)
+        rpc.get()
+    except EnvironmentError as e:
+        if e.errno == errno.ENOSYS:
+            print("Successfully received ENOSYS")
+            return
+        elif e.errno == errno.ETIMEDOUT:
+            sys.exit("Request timed out")
+        else:
+            sys.exit("Unexpected errno: {}".format(e))
+    raise RuntimeError("Did not receive ENOSYS")
+
+
+def main():
+    h = flux.Flux()
+
+    alloc = h.rpc("sched.alloc", json.dumps({"id": 0}))
+    free = h.rpc("sched.free", json.dumps({"id": 0}))
+    print("Sent alloc and free requests")
+
+    h.rpc("cmb.rmmod", json.dumps({"name": args.sched_module})).get()
+    print("Removed {}".format(args.sched_module))
+
+    expect_enosys(alloc)
+    expect_enosys(free)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sched_module")
+    args = parser.parse_args()
+
+    main()

--- a/t/t2301-schedutil-outstanding-requests.t
+++ b/t/t2301-schedutil-outstanding-requests.t
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+test_description='check for responses from sched to outstanding requests'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+REQ_AND_UNLOAD=${SHARNESS_TEST_SRCDIR}/schedutil/req_and_unload.py
+
+test_expect_success 'schedutil: load sched-dummy --cores=2' '
+	flux module load -r 0 ${SCHED_DUMMY} --cores=2
+'
+
+test_expect_success 'schedutil: set bit to hang alloc/free requests' '
+	flux module debug --setbit 0x8000 sched-dummy
+'
+
+test_expect_success 'schedutil: alloc/free fail with ENOSYS(38) after unload' '
+    ${REQ_AND_UNLOAD} sched-dummy
+'
+
+test_expect_success 'schedutil: load default by_rank' '
+	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank)" &&
+	flux kvs get resource.hwloc.by_rank
+'
+
+test_expect_success 'schedutil: successfully loaded sched-simple' '
+	flux module load -r 0 sched-simple
+'
+
+test_expect_success 'schedutil: set bit to hang alloc/free requests' '
+	flux module debug --setbit 0x8000 sched-simple
+'
+
+test_expect_success 'schedutil: alloc/free fail with ENOSYS(38) after unload' '
+    ${REQ_AND_UNLOAD} sched-simple
+'
+
+test_done

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -80,3 +80,13 @@
    fun:flux_reactor_run
    ...
 }
+{
+   <issue_2223>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:dl_open_worker
+   fun:_dl_catch_error
+   fun:_dl_open
+   ...
+}


### PR DESCRIPTION
Refactor schedutil to track outstanding messages and automatically respond with `ENOSYS` when the `schedutil_t` is destroyed.

Having a count of the outstanding messages will also be useful for the ongoing simulator work.

Closes #2193 

Still TODO:

- [x] Track the future associated with the respond and destroy that too
- [x] Comments
- [x] Squash the refactoring commit mess that I've made
- [x] Rebase onto master
  - Will fix python3.4 failure in Travis
- [x] Improve commit messages (will do on rebase)
- [x] switch to using `flux module debug`