### PR TITLE
libsubprocess: Remove invalid EOF calculation

### DIFF
--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -17,8 +17,8 @@ test_expect_success 'basic rexec functionality (process success)' '
 	${FLUX_BUILD_DIR}/t/rexec/rexec /bin/true
 '
 
-test_must_fail 'basic rexec functionality (process fail)' '
-	${FLUX_BUILD_DIR}/t/rexec/rexec /bin/false
+test_expect_success 'basic rexec functionality (process fail)' '
+	! ${FLUX_BUILD_DIR}/t/rexec/rexec /bin/false
 '
 
 test_expect_success 'basic rexec - cwd correct' '


### PR DESCRIPTION
As discussed in #2211 and #2228, there was an invalid EOF calculation / assumption in local processes in `libsubprocess`.

Unfortunately, I have been unable to create a reproducer that works solely against the `libsubprocess` library.  I can't seem to find that magic combination that makes this trigger regularly.

Perhaps the reproducer with `flux-shell` in #2211 could be added as an additional test in that PR or a later PR (which I can add after #2211 is merged or I can try and add one on that branch).

Also fixed something stupid I found in `t/t0005-rexec.t`.