### PR TITLE
libschedutil: extend hello protocol

### DIFF
--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -13,16 +13,23 @@
 
 #include <flux/core.h>
 
-/* Callback for ingesting allocated R's.
+/* Callback for ingesting R + metadata for jobs that have resources
  * Return 0 on success, -1 on failure with errno set.
  * Failure of the callback aborts iteration and causes schedutil_hello()
  * to return -1 with errno passed through.
  */
-typedef int (hello_f)(flux_t *h, const char *R, void *arg);
+typedef int (hello_f)(flux_t *h,
+                      flux_jobid_t id,
+                      int priority,
+                      uint32_t userid,
+                      double t_submit,
+                      const char *R,
+                      void *arg);
 
 /* Send hello announcement to job-manager.
  * The job-manager responds with a list of jobs that have resources assigned.
- * This function looks up R for each job and passes it 'cb' with 'arg'.
+ * This function looks up R for each job and passes R + metadata to 'cb'
+ * with 'arg'.
  */
 int schedutil_hello (flux_t *h, hello_f *cb, void *arg);
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -213,7 +213,13 @@ err:
         flux_log_error (h, "alloc: flux_respond_error");
 }
 
-static int hello_cb (flux_t *h, const char *R, void *arg)
+static int hello_cb (flux_t *h,
+                     flux_jobid_t id,
+                     int priority,
+                     uint32_t userid,
+                     double t_submit,
+                     const char *R,
+                     void *arg)
 {
     char *s;
     int rc = -1;

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -179,7 +179,13 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
-int hello_cb (flux_t *h, const char *R, void *arg)
+int hello_cb (flux_t *h,
+              flux_jobid_t id,
+              int priority,
+              uint32_t userid,
+              double t_submit,
+              const char *R,
+              void *arg)
 {
     struct sched_ctx *sc = arg;
 

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -189,7 +189,14 @@ int hello_cb (flux_t *h,
 {
     struct sched_ctx *sc = arg;
 
-    flux_log (h, LOG_DEBUG, "%s: R=%s", __FUNCTION__, R);
+    flux_log (h, LOG_DEBUG,
+              "%s: id=%ju priority=%d userid=%u t_submit=%0.1f R=%s",
+              __func__,
+              (uintmax_t)id,
+              priority,
+              (unsigned int)userid,
+              t_submit,
+              R);
     sc->cores_free--;
     return 0;
 }

--- a/t/t2203-job-manager-dummysched.t
+++ b/t/t2203-job-manager-dummysched.t
@@ -93,8 +93,23 @@ test_expect_success 'job-manager: canceled job has exception, free events' '
 '
 
 test_expect_success 'job-manager: reload sched-dummy --cores=4' '
+	flux dmesg -C &&
 	flux module remove -r 0 sched-dummy &&
-	flux module load -r 0 ${SCHED_DUMMY} --cores=4
+	flux module load -r 0 ${SCHED_DUMMY} --cores=4 &&
+	flux dmesg | grep "hello_cb:" >hello.dmesg
+'
+
+test_expect_success 'job-manager: hello handshake found jobs 1 3' '
+	grep id=$(cat job1.id) hello.dmesg &&
+	grep id=$(cat job3.id) hello.dmesg
+'
+
+test_expect_success 'job-manager: hello handshake priority is default' '
+	grep priority=16 hello.dmesg
+'
+
+test_expect_success 'job-manager: hello handshake userid is expected' '
+	grep userid=$(id -u) hello.dmesg
 '
 
 test_expect_success 'job-manager: job state RIRRR' '


### PR DESCRIPTION
Per discussion in flux-framework/flux-sched#493.

The  job-manger - scheduler "hello" handshake supports scheduler state recovery.  The initial interface in libschedutil issued a callback containing only  `R` for each job that has resources allocated.  Internally the job manager returned an array of job ID's, which libschedutil used to look up corresponding `R` values in the KVS.

In addition to simply marking resources allocated, flux-sched wants to reconstruct queue entries for running jobs, so it needs the same metadata that was passed in with the alloc request.  This is low overhead since the data is part of the active job record that job-manager keeps in memory.  This PR extends the hello handshake to send an array of "job objects" instead of an array of job ID's.  The job object contains job ID, priority, userid, and submit time. 

The hello_f callback prototype is expanded to include the new information in addition to `R`, and the two users in flux-core (sched-simple and the test dummy scheduler) are updated to use the new prototype, although they don't do anything with the new data.