### PR TITLE
job shell: add flux_shell_t and completion references

### DIFF
--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -22,6 +22,7 @@ fluxlibexec_PROGRAMS = flux-shell
 
 flux_shell_SOURCES = \
 	shell.c \
+	shell.h \
 	info.c \
 	info.h \
 	task.c \

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "shell.h"
 #include "jobspec.h"
 #include "rcalc.h"
 
@@ -23,23 +24,16 @@ struct shell_info {
     flux_jobid_t jobid;
     int shell_rank;
     int shell_size;
-    bool verbose;
     struct jobspec *jobspec;
     rcalc_t *rcalc;
     struct rcalc_rankinfo rankinfo;
 };
 
 /* Create shell_info.
- * If jobspec or R are NULL, or broker_rank == -1, then
- * missing info is fetched from the Flux instance.
- * Otherwise h may be NULL.
+ * Check for jobspec, R, and broker rank on cmdline or fetch from
+ *  job-info service
  */
-struct shell_info *shell_info_create (flux_t *h,
-                                      flux_jobid_t jobid,
-                                      int broker_rank,
-                                      const char *jobspec,
-                                      const char *R,
-                                      bool verbose);
+struct shell_info *shell_info_create (flux_shell_t *shell);
 
 void shell_info_destroy (struct shell_info *info);
 

--- a/src/shell/io.c
+++ b/src/shell/io.c
@@ -24,7 +24,6 @@
 #include <flux/core.h>
 
 #include "task.h"
-#include "info.h"
 #include "io.h"
 
 struct shell_io {

--- a/src/shell/pmi.h
+++ b/src/shell/pmi.h
@@ -14,13 +14,14 @@
 #include <flux/core.h>
 #include <czmq.h>
 
+#include "shell.h"
 #include "info.h"
 #include "task.h"
 
 struct shell_pmi;
 
 void shell_pmi_destroy (struct shell_pmi *pmi);
-struct shell_pmi *shell_pmi_create (flux_t *h, struct shell_info *info);
+struct shell_pmi *shell_pmi_create (flux_shell_t *shell);
 
 // shell_task_pmi_ready_f callback footprint
 void shell_pmi_task_ready (struct shell_task *task, void *arg);

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -206,6 +206,8 @@ error:
 
 void rcalc_destroy (rcalc_t *r)
 {
+    if (r == NULL)
+        return;
     json_decref (r->json);
     free (r->ranks);
     free (r->alloc);

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -24,12 +24,12 @@
 #include "src/common/liboptparse/optparse.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libutil/log.h"
-#include "src/common/libutil/read_all.h"
 
+#include "shell.h"
 #include "info.h"
-#include "task.h"
-#include "pmi.h"
 #include "io.h"
+#include "pmi.h"
+#include "task.h"
 
 static char *shell_name = "flux-shell";
 static const char *shell_usage = "[OPTIONS] JOBID";
@@ -70,58 +70,21 @@ static int parse_jobid (const char *optarg, flux_jobid_t *jobid)
     return 0;
 }
 
-/* Read content of file 'optarg' and return it or NULL on failure (log error).
- * Caller must free returned result.
- */
-static char *parse_arg_file (const char *optarg)
-{
-    int fd;
-    ssize_t size;
-    void *buf = NULL;
-
-    if (!strcmp (optarg, "-"))
-        fd = STDIN_FILENO;
-    else {
-        if ((fd = open (optarg, O_RDONLY)) < 0) {
-            log_err ("error opening %s", optarg);
-            return NULL;
-        }
-    }
-    if ((size = read_all (fd, &buf)) < 0)
-        log_err ("error reading %s", optarg);
-    if (fd != STDIN_FILENO)
-        (void)close (fd);
-    return buf;
-}
-
 static void task_completion_cb (struct shell_task *task, void *arg)
 {
-    struct shell_info *info = arg;
+    struct flux_shell *shell = arg;
 
-    if (info->verbose)
+    if (shell->verbose)
         log_msg ("task %d complete status=%d", task->rank, task->rc);
 }
 
-int main (int argc, char *argv[])
+static void shell_parse_cmdline (flux_shell_t *shell, int argc, char *argv[])
 {
-    optparse_t *p;
     int optindex;
-    struct shell_info *info;
-    int rc;
-    flux_reactor_t *r;
-    flux_t *h = NULL;
-    flux_jobid_t jobid;
-    int broker_rank = -1;
-    char *jobspec = NULL;
-    char *R = NULL;
-    int i;
-    zlist_t *tasks;
-    struct shell_pmi *pmi;
-    struct shell_io *io;
+    optparse_t *p = optparse_create (shell_name);
 
-    log_init (shell_name);
-
-    p = optparse_create (shell_name);
+    if (p == NULL)
+        log_msg_exit ("optparse_create");
     if (optparse_add_option_table (p, shell_opts) != OPTPARSE_SUCCESS)
         log_msg_exit ("optparse_add_option_table failed");
     if (optparse_set (p, OPTPARSE_USAGE, shell_usage) != OPTPARSE_SUCCESS)
@@ -135,54 +98,94 @@ int main (int argc, char *argv[])
         optparse_print_usage (p);
         exit (1);
     }
-    if (parse_jobid (argv[optindex++], &jobid) < 0)
+    if (parse_jobid (argv[optindex++], &shell->jobid) < 0)
         exit (1);
 
-    /* Optional:  Parse jobspec and R from files.
-     * Otherwise shell_info_create() will fetch them from job-info service.
+    /* In standalone mode, jobspec, resources and broker-rank must be
+     *  set on command line:
      */
-    if (optparse_hasopt (p, "jobspec")) {
-        jobspec = parse_arg_file (optparse_get_str (p, "jobspec", NULL));
-        if (!jobspec)
-            exit (1);
+    if ((shell->standalone = optparse_hasopt (p, "standalone"))) {
+        if (  !optparse_hasopt (p, "jobspec")
+           || !optparse_hasopt (p, "resources")
+           || !optparse_hasopt (p, "broker-rank"))
+            log_err_exit ("standalone mode requires --jobspec, "
+                          "--resources and --broker-rank");
     }
-    if (optparse_hasopt (p, "resources")) {
-        R = parse_arg_file (optparse_get_str (p, "resources", NULL));
-        if (!R)
-            exit (1);
+
+    shell->verbose = optparse_getopt (p, "verbose", NULL);
+    shell->broker_rank = optparse_get_int (p, "broker-rank", -1);
+    shell->p = p;
+}
+
+static void shell_connect_flux (flux_shell_t *shell)
+{
+    if (!(shell->h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    /*  Set reactor for flux handle to our custom created reactor.
+     */
+    flux_set_reactor (shell->h, shell->r);
+
+    /*  Fetch local rank if not already set
+     */
+    if (shell->broker_rank < 0) {
+        uint32_t rank;
+        if (flux_get_rank (shell->h, &rank) < 0)
+            log_err ("error fetching broker rank");
+        shell->broker_rank = rank;
     }
-    broker_rank = optparse_get_int (p, "broker-rank", -1);
+}
+
+static void shell_finalize (flux_shell_t *shell)
+{
+    /* Process completed tasks:
+     * - reduce exit codes to shell 'rc'
+     * - destroy
+     */
+    shell->rc = 0;
+    if (shell->tasks) {
+        struct shell_task *task;
+
+        while ((task = zlist_pop (shell->tasks))) {
+            if (shell->rc < task->rc)
+                shell->rc = task->rc;
+            shell_task_destroy (task);
+        }
+        zlist_destroy (&shell->tasks);
+    }
+    shell_io_destroy (shell->io);
+    shell_pmi_destroy (shell->pmi);
+    shell_info_destroy (shell->info);
+
+    flux_reactor_destroy (shell->r);
+    flux_close (shell->h);
+
+    optparse_destroy (shell->p);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_shell_t shell;
+    int i;
+
+    log_init (shell_name);
+
+    memset (&shell, 0, sizeof (struct flux_shell));
+
+    shell_parse_cmdline (&shell, argc, argv);
 
     /* Get reactor capable of monitoring subprocesses.
      */
-    if (!(r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
+    if (!(shell.r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
         log_err_exit ("flux_reactor_create");
 
-    /* In standalone mode, broker connection is unavailable.
-     */
-    if (optparse_hasopt (p, "standalone")) {
-        if (!jobspec)
-            log_err_exit ("--jobspec is required in standalone mode");
-        if (!R)
-            log_err_exit ("--resources is required in standalone mode");
-        if (broker_rank == -1)
-            log_err_exit ("--broker-rank is required in standalone mode");
-    }
-    else {
-        if (!(h = flux_open (NULL, 0)))
-            log_err_exit ("flux_open");
-        flux_set_reactor (h, r);
-    }
+    if (!shell.standalone)
+        shell_connect_flux (&shell);
 
     /* Populate 'struct shell_info' for general use by shell components.
-     * Fetches missing info from 'h' if set.
+     * Fetches missing info from shell handle if set.
      */
-    if (!(info = shell_info_create (h,
-                                    jobid,
-                                    broker_rank,
-                                    jobspec,
-                                    R,
-                                    optparse_hasopt (p, "verbose"))))
+    if (!(shell.info = shell_info_create (&shell)))
         exit (1);
 
     /* Create PMI engine
@@ -190,31 +193,31 @@ int main (int argc, char *argv[])
      * Tasks send PMI wire proto to pmi.c via shell_pmi_task_ready() callback
      * registered below.
      */
-    if (!(pmi = shell_pmi_create (h, info)))
+    if (!(shell.pmi = shell_pmi_create (&shell)))
         log_err_exit ("shell_pmi_create");
 
     /* Create handler for stdio.
      */
-    if (!(io = shell_io_create (h, info)))
+    if (!(shell.io = shell_io_create (shell.h, shell.info)))
         log_err_exit ("shell_io_create");
 
     /* Create tasks
      */
-    if (!(tasks = zlist_new ()))
+    if (!(shell.tasks = zlist_new ()))
         log_msg_exit ("zlist_new failed");
-    for (i = 0; i < info->rankinfo.ntasks; i++) {
+    for (i = 0; i < shell.info->rankinfo.ntasks; i++) {
         struct shell_task *task;
 
-        if (!(task = shell_task_create (info, i)))
+        if (!(task = shell_task_create (shell.info, i)))
             log_err_exit ("shell_task_create index=%d", i);
-        if (shell_task_pmi_enable (task, shell_pmi_task_ready, pmi) < 0)
+        if (shell_task_pmi_enable (task, shell_pmi_task_ready, shell.pmi) < 0)
             log_err_exit ("shell_task_pmi_enable");
-        if (shell_task_io_enable (task, shell_io_task_ready, io) < 0)
+        if (shell_task_io_enable (task, shell_io_task_ready, shell.io) < 0)
             log_err_exit ("shell_task_io_enable");
-        if (shell_task_start (task, r, task_completion_cb, info) < 0)
+        if (shell_task_start (task, shell.r, task_completion_cb, &shell) < 0)
             log_err_exit ("shell_task_start index=%d", i);
 
-        if (zlist_append (tasks, task) < 0)
+        if (zlist_append (shell.tasks, task) < 0)
             log_msg_exit ("zlist_append failed");
 
     }
@@ -222,44 +225,16 @@ int main (int argc, char *argv[])
     /* Main reactor loop
      * Exits once final task exits.
      */
-    if (flux_reactor_run (r, 0) < 0)
+    if (flux_reactor_run (shell.r, 0) < 0)
         log_err ("flux_reactor_run");
 
-    /* Process completed tasks:
-     * - reduce exit codes to shell 'rc'
-     * - destroy
-     */
-    rc = 0;
-    if (tasks) {
-        struct shell_task *task;
+    shell_finalize (&shell);
 
-        while ((task = zlist_pop (tasks))) {
-            if (rc < task->rc)
-                rc = task->rc;
-            shell_task_destroy (task);
-        }
-        zlist_destroy (&tasks);
-    }
-    shell_io_destroy (io);
-    shell_pmi_destroy (pmi);
+    if (shell.verbose)
+        log_msg ("exit %d", shell.rc);
 
-    shell_info_destroy (info);
-
-    flux_reactor_destroy (r);
-
-    if (!optparse_hasopt (p, "standalone")) {
-        flux_close (h);
-    }
-
-    free (jobspec);
-    free (R);
-
-    optparse_destroy (p);
     log_fini ();
-
-    if (info->verbose)
-        log_msg ("exit %d", rc);
-    exit (rc);
+    exit (shell.rc);
 }
 
 /*

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -1,0 +1,70 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SHELL_H
+#define _SHELL_H
+
+#include <czmq.h>
+#include <flux/core.h>
+#include <flux/optparse.h>
+
+/* Later this typedef may be exported publicly. e.g. to shell plugins,
+ * but for now keep it internal to avoid the need for another header.
+ */
+typedef struct flux_shell flux_shell_t;
+
+struct flux_shell {
+    flux_jobid_t jobid;
+    int broker_rank;
+
+    optparse_t *p;
+    flux_t *h;
+    flux_reactor_t *r;
+
+    struct shell_info *info;
+    struct shell_io *io;
+    struct shell_pmi *pmi;
+    zlist_t *tasks;
+
+    zhashx_t *completion_refs;
+
+    int rc;
+
+    bool verbose;
+    bool standalone;
+};
+
+
+/*
+ *  Take a "completion reference" on the shell object `shell`.
+ *  This function takes a named reference on the shell so that it will
+ *  not consider a job "complete" until the reference is released with
+ *  flux_shell_remove_completion_ref().
+ *
+ *  Returns the reference count for the particular name, or -1 on error.
+ */
+int flux_shell_add_completion_ref (flux_shell_t *shell,
+                                   const char *fmt, ...);
+
+/*
+ *  Remove a named "completion reference" for the shell object `shell`.
+ *  Once all references have been removed, the shells reactor is stopped
+ *  with flux_reactor_stop (shell->r).
+ *
+ *  Returns 0 on success, -1 on failure.
+ */
+int flux_shell_remove_completion_ref (flux_shell_t *shell,
+                                      const char *fmt, ...);
+
+#endif /* !_SHELL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR addresses #2237.

I apologize in advance because this will be a difficult PR to review. I attempt to make a minor advance by adding a `struct flux_shell` structure to contain the independing `io` `info` and `pmi` structures used by the various components of the shell, but ended up making more changes than I wanted. Perhaps with the luxury of more time, this PR could be made cleaner, but hopefully after some rounds of feedback this approach could be acceptable.

As noted above, this branch adds a new `struct flux_shell` structure as container for the most of the other structures used by the shell. This structure can then be passed to callbacks that may require access to multiple shell components and data, without requiring those callers to use custom structures or push multiple pointers into the reactor or handle aux hashes.

The `struct flux_shell` may also serve as an opaque handle for plugins in the future (along with a set of accessors as yet unwritten), and thus a `flux_shell_t` typedef is used as the start of a public interface. Later when we need this we can install `flux/shell.h` and move the `struct flux_shell` definition internal.

Once the `flux_shell_t` structure was defined, many of the `init` functions were updated to take this function as an argument. This resulted in cascading changes that, unfortunately, come in one big commit. To help review, here's a summary of the changes:

 - move cmdline parsing and basic option checking into a function `shell_parse_cmdline()`
 - move shell "options" (verbose, standalone) set on cmdline to bools in `flux_shell_t`
 - set jobid in `shell->jobid`
 - move destruction of components of `flux_shell_t` into `shell_finalize()`
 - move fetch of `jobspec` and `R` fully into `shell_info_create()` (whether set on cmdline or fetched via kvs) (this is probably a majority of the code change, since some functions were moved from `shell.c` to `info.c`)

Finally, to address #2237, a concept from `wrexecd` was borrowed to add a "completion reference" interface for the shell's reactor.  Once all completion refs that are taken are dropped, the shell's reactor is manually stopped with `flux_reactor_stop()`. The references are also named as a future debugging aid. Initially, a reference is taken for each task, and released in the task completion handler.

Fixes #2237.