### PR TITLE
flux-shell: add output handling

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -682,10 +682,16 @@ void attach_event_continuation (flux_future_t *f, void *arg)
         if (!strcmp (name, "finish")) {
             if (json_unpack (context, "{s:i}", "status", &status) < 0)
                 log_err_exit ("error decoding finish context");
-            if (WIFSIGNALED (status))
+            if (WIFSIGNALED (status)) {
                 ctx->exit_code = WTERMSIG (status) + 128;
-            else if (WIFEXITED (status))
+                log_msg ("task(s) %s", strsignal (WTERMSIG (status)));
+            }
+            else if (WIFEXITED (status)) {
                 ctx->exit_code = WEXITSTATUS (status);
+                if (ctx->exit_code != 0)
+                    log_msg ("task(s) exited with exit code %d",
+                             ctx->exit_code);
+            }
         }
         else if (!strcmp (name, "clean")) {
             if (flux_job_event_watch_cancel (f) < 0)

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -369,11 +369,11 @@ done:
     return f;
 }
 
-static flux_future_t *flux_rpc_vpack (flux_t *h,
-                                      const char *topic,
-                                      uint32_t nodeid,
-                                      int flags,
-                                      const char *fmt, va_list ap)
+flux_future_t *flux_rpc_vpack (flux_t *h,
+                               const char *topic,
+                               uint32_t nodeid,
+                               int flags,
+                               const char *fmt, va_list ap)
 {
     flux_msg_t *msg;
     flux_future_t *f = NULL;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -29,6 +29,12 @@ flux_future_t *flux_rpc (flux_t *h, const char *topic, const char *s,
 flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
                               int flags, const char *fmt, ...);
 
+flux_future_t *flux_rpc_vpack (flux_t *h,
+                               const char *topic,
+                               uint32_t nodeid,
+                               int flags,
+                               const char *fmt, va_list ap);
+
 flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
                              const void *data, int len,
                              uint32_t nodeid, int flags);

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -164,7 +164,7 @@ static void exec_kill_cb (flux_future_t *f, void *arg)
     struct jobinfo *job = arg;
     if (flux_future_get (f, NULL) < 0)
         flux_log_error (job->h, "%ju: exec_kill", (uintmax_t) job->id);
-    jobinfo_incref (job);
+    jobinfo_decref (job);
     flux_future_destroy (f);
 }
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -30,7 +30,9 @@ flux_shell_SOURCES = \
 	pmi.c \
 	pmi.h \
 	io.c \
-	io.h
+	io.h \
+	svc.c \
+	svc.h
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -124,8 +124,8 @@ static char *optparse_check_and_loadfile (optparse_t *p, const char *name)
     return NULL;
 }
 
-/*  Read jobinfo (jobspec, R) from provided values or fetch from
- *   the job-info service
+/*  Fetch jobinfo (jobspec, R) from job-info service if not provided on
+ *   command line, and parse.
  */
 static int shell_init_jobinfo (flux_shell_t *shell,
                                struct shell_info *info,
@@ -136,10 +136,10 @@ static int shell_init_jobinfo (flux_shell_t *shell,
     flux_future_t *f = NULL;
     json_error_t error;
 
-    if (!shell->standalone) {
+    if (!R || !jobspec) {
         /* Fetch missing jobinfo from broker job-info service */
-        if (!shell->h) {
-            log_msg ("Invalid arguments: h==NULL and R or jobspec are unset");
+        if (shell->standalone) {
+            log_msg ("Invalid arguments: standalone and R/jobspec are unset");
             return -1;
         }
         if (!(f = lookup_job_info (shell->h, shell->jobid, jobspec, R))

--- a/src/shell/io.c
+++ b/src/shell/io.c
@@ -25,10 +25,10 @@
 
 #include "task.h"
 #include "io.h"
+#include "shell.h"
 
 struct shell_io {
-    flux_t *h;
-    struct shell_info *info;
+    flux_shell_t *shell;
 };
 
 void shell_io_destroy (struct shell_io *io)
@@ -40,14 +40,13 @@ void shell_io_destroy (struct shell_io *io)
     }
 }
 
-struct shell_io *shell_io_create (flux_t *h, struct shell_info *info)
+struct shell_io *shell_io_create (flux_shell_t *shell)
 {
     struct shell_io *io;
 
     if (!(io = calloc (1, sizeof (*io))))
         return NULL;
-    io->h = h;
-    io->info = info;
+    io->shell = shell;
 
     return io;
 }

--- a/src/shell/io.c
+++ b/src/shell/io.c
@@ -13,7 +13,23 @@
  * Intercept task stdout, stderr and dispose of it according to
  * selected I/O mode.
  *
- * N.B. for the moment, emit on shell's stdout, stderr with task labels.
+ * The leader shell implements an "shell-<id>.output" service that
+ * all ranks send task output to.  Output objects accumulate in a json
+ * array on the leader.  Upon task exit, the array is written to the
+ * "output" key in the job's guest KVS namespace.
+ *
+ * Notes:
+ * - EOF is indicated by an object with len = 0
+ * - leader takes a completion reference which it gives up once each
+ *   task sends an EOF for both stdout and stderr.
+ * - all shells (even the leader) send I/O to the service with RPC
+ * - Any errors getting I/O to the leader are logged by RPC completion
+ *   callbacks.
+ * - Any outstanding RPCs at shell_io_destroy() are synchronously waited for
+ *   there (checked for error, then destroyed).
+ * - In standalone mode, the loop:// connector enables RPCs to work
+ * - In standalone mode, output is written to the shell's stdout/stderr not KVS
+ * - Output data is encoded as JSON strings (not base64'ed).
  */
 
 #if HAVE_CONFIG_H
@@ -21,20 +37,166 @@
 #endif
 #include <stdio.h>
 #include <string.h>
+#include <jansson.h>
 #include <flux/core.h>
+
+#include "src/common/libutil/log.h"
 
 #include "task.h"
 #include "io.h"
+#include "svc.h"
 #include "shell.h"
 
 struct shell_io {
     flux_shell_t *shell;
+    int refcount;
+    int eof_pending;
+    zlist_t *pending_writes;
+    json_t *output;
 };
+
+static void shell_io_write_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
+{
+    struct shell_io *io = arg;
+    int len;        // just decode len for EOF (len==0) detection
+    json_t *o;      // decode output object for appending to io->output array
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "len", &len) < 0)
+        goto error;
+    if (flux_request_unpack (msg, NULL, "o", &o) < 0)
+        goto error;
+    if (shell_svc_allowed (io->shell->svc, msg) < 0)
+        goto error;
+    if (json_array_append (io->output, o) < 0)
+        goto error;
+    if (len == 0) {
+        if (--io->eof_pending == 0) {
+            flux_msg_handler_stop (mh);
+            if (flux_shell_remove_completion_ref (io->shell, "io-leader") < 0)
+                log_err ("flux_shell_remove_completion_ref");
+        }
+    }
+    if (flux_respond (io->shell->h, msg, NULL) < 0)
+        log_err ("flux_respond");
+    return;
+error:
+    if (flux_respond_error (io->shell->h, msg, errno, NULL) < 0)
+        log_err ("flux_respond");
+}
+
+static void shell_io_write_completion (flux_future_t *f, void *arg)
+{
+    struct shell_io *io = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        log_err ("shell_io_write");
+    zlist_remove (io->pending_writes, f);
+    flux_future_destroy (f);
+}
+
+static int shell_io_write (struct shell_io *io,
+                           int rank,
+                           const char *name,
+                           const char *data,
+                           int len)
+{
+    flux_future_t *f;
+
+    if (!(f = shell_svc_pack (io->shell->svc,
+                             "write",
+                             0,
+                             0,
+                             "{s:i s:s s:i s:s}",
+                             "rank", rank,
+                             "name", name,
+                             "len", len,
+                             "data", data)))
+        return -1;
+    if (flux_future_then (f, -1, shell_io_write_completion, io) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    if (zlist_append (io->pending_writes, f) < 0)
+        log_msg ("zlist_append failed");
+    return 0;
+}
+
+static int shell_io_flush (struct shell_io *io)
+{
+    json_t *entry;
+    size_t index;
+    int rank;
+    const char *name;
+    const char *data;
+    int len;
+    FILE *f;
+
+    json_array_foreach (io->output, index, entry) {
+        if (json_unpack (entry,
+                         "{s:i s:s s:i s:s}",
+                         "rank", &rank,
+                         "name", &name,
+                         "len", &len,
+                         "data", &data) < 0)
+            return -1;
+        f = !strcmp (name, "STDOUT") ? stdout : stderr;
+        if (len > 0) {
+            fprintf (f, "%d: ", rank);
+            fwrite (data, len, 1, f);
+        }
+    }
+    return 0;
+}
+
+static int shell_io_commit (struct shell_io *io)
+{
+    flux_kvs_txn_t *txn;
+    flux_future_t *f = NULL;
+    int rc = -1;
+
+    if (!(txn = flux_kvs_txn_create ()))
+        return -1;
+    if (flux_kvs_txn_pack (txn, 0, "output", "O", io->output) < 0)
+        goto out;
+    if (!(f = flux_kvs_commit (io->shell->h, NULL, 0, txn)))
+        goto out;
+    if (flux_future_get (f, NULL) < 0)
+        goto out;
+    rc = 0;
+out:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    return rc;
+}
 
 void shell_io_destroy (struct shell_io *io)
 {
     if (io) {
         int saved_errno = errno;
+        if (io->pending_writes) {
+            flux_future_t *f;
+
+            while ((f = zlist_pop (io->pending_writes))) { // leader+follower
+                if (flux_future_get (f, NULL) < 0)
+                    log_err ("shell_io_write");
+                flux_future_destroy (f);
+            }
+            zlist_destroy (&io->pending_writes);
+        }
+        if (io->output) { // leader only
+            if (io->shell->standalone) {
+                if (shell_io_flush (io) < 0)
+                    log_err ("shell_io_flush");
+            }
+            else {
+                if (shell_io_commit (io) < 0)
+                    log_err ("shell_io_commit");
+            }
+        }
+        json_decref (io->output);
         free (io);
         errno = saved_errno;
     }
@@ -47,23 +209,39 @@ struct shell_io *shell_io_create (flux_shell_t *shell)
     if (!(io = calloc (1, sizeof (*io))))
         return NULL;
     io->shell = shell;
-
+    if (!(io->pending_writes = zlist_new ()))
+        goto error;
+    if (shell->info->shell_rank == 0) {
+        if (shell_svc_register (shell->svc, "write", shell_io_write_cb, io) < 0)
+            goto error;
+        io->eof_pending = 2 * shell->info->jobspec->task_count;
+        if (flux_shell_add_completion_ref (shell, "io-leader") < 0)
+            goto error;
+        if (!(io->output = json_array ())) {
+            errno = ENOMEM;
+            goto error;
+        }
+    }
     return io;
+error:
+    shell_io_destroy (io);
+    return NULL;
 }
 
 // shell_task_io_ready_f callback footprint
 void shell_io_task_ready (struct shell_task *task, const char *name, void *arg)
 {
-    //struct shell_io *io = arg;
-
-    const char *line;
+    struct shell_io *io = arg;
+    const char *data;
     int len;
 
-    len = shell_task_io_readline (task, name, &line);
-    if (len > 0) {
-        FILE *f = !strcmp (name, "STDOUT") ? stdout : stderr;
-        fprintf (f, "%d: ", task->rank);
-        fwrite (line, len, 1, f);
+    len = shell_task_io_readline (task, name, &data);
+    if (len < 0) {
+        log_err ("read %s task %d", name, task->rank);
+    }
+    else if (len > 0 || (len == 0 && shell_task_io_at_eof (task, name))) {
+        if (shell_io_write (io, task->rank, name, data, len) < 0)
+            log_err ("write %s task %d", name, task->rank);
     }
 }
 

--- a/src/shell/io.h
+++ b/src/shell/io.h
@@ -15,11 +15,12 @@
 
 #include "info.h"
 #include "task.h"
+#include "shell.h"
 
 struct shell_io;
 
 void shell_io_destroy (struct shell_io *io);
-struct shell_io *shell_io_create (flux_t *h, struct shell_info *info);
+struct shell_io *shell_io_create (flux_shell_t *shell);
 
 // shell_task_io_ready_f callback footprint
 void shell_io_task_ready (struct shell_task *task, const char *name, void *arg);

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -28,6 +28,7 @@
 
 #include "shell.h"
 #include "info.h"
+#include "svc.h"
 #include "io.h"
 #include "pmi.h"
 #include "task.h"
@@ -159,6 +160,7 @@ static void shell_finalize (flux_shell_t *shell)
     }
     shell_io_destroy (shell->io);
     shell_pmi_destroy (shell->pmi);
+    shell_svc_destroy (shell->svc);
     shell_info_destroy (shell->info);
 
     flux_reactor_destroy (shell->r);
@@ -263,6 +265,11 @@ int main (int argc, char *argv[])
      */
     if (!(shell.info = shell_info_create (&shell)))
         exit (1);
+
+    /* Register service on the leader shell.
+     */
+    if (!(shell.svc = shell_svc_create (&shell)))
+        log_err_exit ("shell_svc_create");
 
     /* Create PMI engine
      * Uses 'h' for KVS access only if info->shell_size > 1.

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -124,7 +124,7 @@ static void shell_parse_cmdline (flux_shell_t *shell, int argc, char *argv[])
 
 static void shell_connect_flux (flux_shell_t *shell)
 {
-    if (!(shell->h = flux_open (NULL, 0)))
+    if (!(shell->h = flux_open (shell->standalone ? "loop://" : NULL, 0)))
         log_err_exit ("flux_open");
 
     /*  Set reactor for flux handle to our custom created reactor.
@@ -282,8 +282,9 @@ int main (int argc, char *argv[])
     if (!(shell.r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
         log_err_exit ("flux_reactor_create");
 
-    if (!shell.standalone)
-        shell_connect_flux (&shell);
+    /* Connect to broker, or if standalone, open loopback connector.
+     */
+    shell_connect_flux (&shell);
 
     /* Populate 'struct shell_info' for general use by shell components.
      * Fetches missing info from shell handle if set.

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -274,7 +274,7 @@ int main (int argc, char *argv[])
 
     /* Create handler for stdio.
      */
-    if (!(shell.io = shell_io_create (shell.h, shell.info)))
+    if (!(shell.io = shell_io_create (&shell)))
         log_err_exit ("shell_io_create");
 
     /* Create tasks

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -29,6 +29,7 @@ struct flux_shell {
     flux_reactor_t *r;
 
     struct shell_info *info;
+    struct shell_svc *svc;
     struct shell_io *io;
     struct shell_pmi *pmi;
     zlist_t *tasks;

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -1,0 +1,187 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Register a service named "shell-<jobid>" on each shell and provide
+ * helpers for registering request handlers for different "methods".
+ *
+ * Notes:
+ * - Message handlers are not exposed.  They are automatically set up to
+ *   allow FLUX_ROLE_USER access, started, and tied to flux_t for destruction.
+ *
+ * - Since request handlers can receive messages from any user, handlers
+ *   should call shell_svc_allowed() to verify that sender is instance owner,
+ *   or the shell user (job owner).
+ *
+ * - shell_svc_create () makes a synchronous RPC to register the service with
+ *   the broker.
+ *
+ * - Services should not be used until after the shells exit the init barrier,
+ *   to ensure service registration has completed.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <flux/core.h>
+
+#include "task.h"
+#include "io.h"
+#include "shell.h"
+#include "svc.h"
+
+#define TOPIC_STRING_SIZE  128
+
+struct shell_svc {
+    flux_shell_t *shell;
+    uid_t uid;      // effective uid of shell
+    int *rank_table;// map shell rank to broker rank
+};
+
+static int lookup_rank (struct shell_svc *svc, int shell_rank, int *rank)
+{
+    if (shell_rank < 0 || shell_rank >= svc->shell->info->shell_size) {
+        errno = EINVAL;
+        return -1;
+    }
+    *rank = svc->rank_table[shell_rank];
+    return 0;
+}
+
+static int build_topic (struct shell_svc *svc,
+                        const char *method,
+                        char *buf,
+                        int len)
+{
+    if (snprintf (buf,
+                  len,
+                  "shell-%ju%s%s",
+                  (uintmax_t)svc->shell->info->jobid,
+                  method ? "." : "",
+                  method ? method : "") >= len) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+flux_future_t *shell_svc_pack (struct shell_svc *svc,
+                               const char *method,
+                               int shell_rank,
+                               int flags,
+                               const char *fmt, ...)
+{
+    char topic[TOPIC_STRING_SIZE];
+    flux_future_t *f;
+    va_list ap;
+    int rank;
+
+    if (lookup_rank (svc, shell_rank, &rank) < 0)
+        return NULL;
+    if (build_topic (svc, method, topic, sizeof (topic)) < 0)
+        return NULL;
+
+    va_start (ap, fmt);
+    f = flux_rpc_vpack (svc->shell->h, topic, rank, flags, fmt, ap);
+    va_end (ap);
+
+    return f;
+}
+
+int shell_svc_allowed (struct shell_svc *svc, const flux_msg_t *msg)
+{
+    uint32_t rolemask;
+    uint32_t userid;
+
+    if (flux_msg_get_rolemask (msg, &rolemask) < 0
+            || flux_msg_get_userid (msg, &userid) < 0)
+        return -1;
+    if (!(rolemask & FLUX_ROLE_OWNER) && userid != svc->uid) {
+        errno = EPERM;
+        return -1;
+    }
+    return 0;
+}
+
+int shell_svc_register (struct shell_svc *svc,
+                        const char *method,
+                        flux_msg_handler_f cb,
+                        void *arg)
+{
+    struct flux_match match = FLUX_MATCH_REQUEST;
+    flux_msg_handler_t *mh;
+    flux_t *h = svc->shell->h;
+    char topic[TOPIC_STRING_SIZE];
+
+    if (build_topic (svc, method, topic, sizeof (topic)) < 0)
+        return -1;
+    match.topic_glob = topic;
+    if (!(mh = flux_msg_handler_create (h, match, cb, arg)))
+        return -1;
+    if (flux_aux_set (h, NULL, mh, (flux_free_f)flux_msg_handler_destroy) < 0) {
+        flux_msg_handler_destroy (mh);
+        return -1;
+    }
+    flux_msg_handler_allow_rolemask (mh, FLUX_ROLE_USER);
+    flux_msg_handler_start (mh);
+    return 0;
+}
+
+void shell_svc_destroy (struct shell_svc *svc)
+{
+    if (svc) {
+        int saved_errno = errno;
+        free (svc->rank_table);
+        free (svc);
+        errno = saved_errno;
+    }
+}
+
+struct shell_svc *shell_svc_create (flux_shell_t *shell)
+{
+    struct shell_svc *svc;
+    struct rcalc_rankinfo ri;
+    int shell_size = shell->info->shell_size;
+    int i;
+
+    if (!(svc = calloc (1, sizeof (*svc))))
+        return NULL;
+    svc->shell = shell;
+    svc->uid = geteuid ();
+    if (!(svc->rank_table = calloc (shell_size, sizeof (*svc->rank_table))))
+        goto error;
+    for (i = 0; i < shell_size; i++) {
+        if (rcalc_get_nth (shell->info->rcalc, i, &ri) < 0)
+            goto error;
+        svc->rank_table[i] = ri.rank;
+    }
+    if (!shell->standalone) {
+        flux_future_t *f;
+        char name[TOPIC_STRING_SIZE];
+        if (build_topic (svc, NULL, name, sizeof (name)) < 0)
+            goto error;
+        if (!(f = flux_service_register (shell->h, name)))
+            goto error;
+        if (flux_future_get (f, NULL) < 0) {
+            flux_future_destroy (f);
+            goto error;
+        }
+        flux_future_destroy (f);
+    }
+    return svc;
+error:
+    shell_svc_destroy (svc);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/svc.h
+++ b/src/shell/svc.h
@@ -1,0 +1,51 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef SHELL_SVC_H
+#define SHELL_SVC_H
+
+#include <flux/core.h>
+
+#include "info.h"
+#include "task.h"
+#include "shell.h"
+
+struct shell_svc;
+
+void shell_svc_destroy (struct shell_svc *svc);
+struct shell_svc *shell_svc_create (flux_shell_t *shell);
+
+/* Send an RPC to a shell 'method' by shell rank.
+ */
+flux_future_t *shell_svc_pack (struct shell_svc *svc,
+                               const char *method,
+                               int shell_rank,
+                               int flags,
+                               const char *fmt, ...);
+
+
+/* Register a message handler for 'method'.
+ * The message handler is destroyed when shell->h is destroyed.
+ */
+int shell_svc_register (struct shell_svc *svc,
+                        const char *method,
+                        flux_msg_handler_f cb,
+                        void *arg);
+
+/* Return 0 if request 'msg' was made by the shell user,
+ * else -1 with errno set.
+ */
+int shell_svc_allowed (struct shell_svc *svc, const flux_msg_t *msg);
+
+#endif /* !SHELL_SVC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -83,6 +83,11 @@ int shell_task_io_readline (struct shell_task *task,
                             const char *name,
                             const char **line);
 
+/* Test whether stream 'name' has reached EOF.
+ * Call after shell_task_io_readline() returns 0.
+ */
+bool shell_task_io_at_eof (struct shell_task *task, const char *name);
+
 
 #endif /* !SHELL_TASK_H */
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -100,6 +100,7 @@ TESTSCRIPTS = \
 	t2600-job-shell-rcalc.t \
 	t2601-job-shell-standalone.t \
 	t2602-job-shell.t \
+	t3000-mpi-basic.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -202,7 +202,8 @@ check_PROGRAMS = \
 	rexec/rexec_ps \
 	ingest/submitbench \
 	sched-simple/jj-reader \
-	shell/rcalc
+	shell/rcalc \
+	shell/lptest
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -375,6 +376,11 @@ shell_rcalc_SOURCES = shell/rcalc.c
 shell_rcalc_CPPFLAGS = $(test_cppflags)
 shell_rcalc_LDADD = \
         $(top_builddir)/src/shell/libshell.la \
+        $(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+shell_lptest_SOURCES = shell/lptest.c
+shell_lptest_CPPFLAGS = $(test_cppflags)
+shell_lptest_LDADD = \
         $(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 reactor_reactorcat_SOURCES = reactor/reactorcat.c

--- a/t/shell/lptest.c
+++ b/t/shell/lptest.c
@@ -1,0 +1,51 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* lptest.c - ripple test */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+
+void lptest (int length, int count)
+{
+    int i;
+    int j;
+
+    for (i = 0; i < count; i++) {
+        for (j = 0; j < length; j++)
+            putchar (0x21 + ((i + j) % 0x5e)); // charset: !(0x21) thru ~(0x7e)
+        putchar ('\n');
+    }
+}
+
+int main (int ac, char **av)
+{
+    int length = 79;
+    int count = 200;
+
+    if (ac > 3) {
+        fprintf (stderr, "Usage: %s [length] [count]\n", av[0]);
+        return 1;
+    }
+    if (ac > 2)
+        count = strtoul (av[2], NULL, 10);
+    if (ac > 1)
+        length = strtoul (av[1], NULL, 10);
+    lptest (length, count);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -4,35 +4,24 @@ test_description='Test flux job attach and flux srun'
 
 . $(dirname $0)/sharness.sh
 
-#  Set path to jq
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
-#
-#  Submit jobs using testexec exec implementation
-flux_jobspec() {
-	flux jobspec "$@" | $jq '.attributes.system.exec.test = {}'
-}
-
 test_under_flux 4
 
 flux setattr log-stderr-level 1
 
-test_expect_success HAVE_JQ 'attach: submit one job' '
-	flux_jobspec srun -n1 hostname | flux job submit >jobid1
+test_expect_success 'attach: submit one job' '
+	flux jobspec srun -n1 hostname | flux job submit >jobid1
 '
 
-test_expect_success HAVE_JQ 'attach: job ran successfully' '
+test_expect_success 'attach: job ran successfully' '
 	run_timeout 5 flux job attach $(cat jobid1)
 '
 
-test_expect_success HAVE_JQ 'attach: submit a job and cancel it' '
-	flux_jobspec srun -t 00:30 -n1 hostname | flux job submit >jobid2 &&
+test_expect_success 'attach: submit a job and cancel it' '
+	flux jobspec srun -n1 sleep 30 | flux job submit >jobid2 &&
 	flux job cancel $(cat jobid2)
 '
 
-test_expect_success HAVE_JQ 'attach: exit code reflects cancellation' '
+test_expect_success 'attach: exit code reflects cancellation' '
 	! flux job attach $(cat jobid2)
 '
 
@@ -44,13 +33,13 @@ test_expect_success HAVE_JQ 'attach: exit code reflects cancellation' '
 run_attach() {
 	local seq=$1
 
-	flux_jobspec srun -t 00:30 -n1 sleep 30 | flux job submit >jobid${seq}
+	flux jobspec srun -n1 sleep 30 | flux job submit >jobid${seq}
 	flux job attach -E $(cat jobid${seq}) 2>attach${seq}.err &
 	echo $! >pid${seq}
 	while ! test -s attach${seq}.err; do sleep 0.1; done
 }
 
-test_expect_success HAVE_JQ 'attach: two SIGINTs cancel a job' '
+test_expect_success 'attach: two SIGINTs cancel a job' '
 	run_attach 3 &&
 	pid=$(cat pid3) &&
 	kill -INT $pid &&
@@ -59,7 +48,7 @@ test_expect_success HAVE_JQ 'attach: two SIGINTs cancel a job' '
 	! wait $pid
 '
 
-test_expect_success HAVE_JQ 'attach: SIGINT+SIGTSTP detaches from job' '
+test_expect_success 'attach: SIGINT+SIGTSTP detaches from job' '
 	run_attach 4 &&
 	pid=$(cat pid4) &&
 	kill -INT $pid &&
@@ -68,7 +57,7 @@ test_expect_success HAVE_JQ 'attach: SIGINT+SIGTSTP detaches from job' '
 	test_must_fail wait $pid
 '
 
-test_expect_success HAVE_JQ 'attach: detached job was not canceled' '
+test_expect_success 'attach: detached job was not canceled' '
 	flux job eventlog $(cat jobid4) >events4 &&
 	test_must_fail grep -q cancel events4
 '

--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -4,7 +4,10 @@ test_description='Test flux-shell in --standalone mode'
 
 . `dirname $0`/sharness.sh
 
-FLUX_SHELL=${FLUX_BUILD_DIR}/src/shell/flux-shell
+# Needed for loop:// connector in standalone mode
+export FLUX_CONNECTOR_PATH=${FLUX_BUILD_DIR}/src/connectors
+
+FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 PMI_INFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -66,13 +66,13 @@ test_expect_success 'job-shell: /bin/false exit code propagated' '
 '
 test_expect_success 'job-shell: PMI works' '
         id=$(flux jobspec srun -N4 ${PMI_INFO} | flux job submit) &&
-	flux job wait-event $id finish >pmi_info.out 2>pmi_info.err &&
-	flux dmesg | grep kvsname= | grep size=4 >pmi_info.dmesg
+	flux job attach $id >pmi_info.out 2>pmi_info.err &&
+	grep size=4 pmi_info.out
 '
 test_expect_success 'job-shell: PMI KVS works' '
         id=$(flux jobspec srun -N4 ${KVSTEST} | flux job submit) &&
-	flux job wait-event $id finish >kvstest.out 2>kvstest.err &&
-	flux dmesg | grep "t phase" >kvstest.dmesg
+	flux job attach $id >kvstest.out 2>kvstest.err &&
+	grep "t phase" kvstest.out
 '
 test_expect_success 'job-exec: unload job-exec & sched-simple modules' '
         flux module remove -r 0 job-exec &&

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+
+test_description='Test that Flux can launch MPI'
+
+. `dirname $0`/sharness.sh
+
+if ! test -x ${FLUX_BUILD_DIR}/t/mpi/hello; then
+    skip_all='skipping MPI tests, MPI not available/configured'
+    test_done
+fi
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE}
+echo "# $0: flux session size will be ${SIZE}"
+
+# Usage: run_program timeout ntasks nnodes
+run_program() {
+	local timeout=$1
+	local ntasks=$2
+	local nnodes=$3
+        local opts=$4
+	shift 3
+	run_timeout $timeout flux srun \
+		    -n${ntasks} -N${nnodes} $*
+}
+
+test_expect_success "mpi hello singleton" '
+	run_program 5 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello >single.$OPTS
+'
+
+test_expect_success "mpi hello all ranks" '
+	run_program 5 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
+		| tee allranks.$OPTS \
+		&& grep -q "There are ${SIZE} tasks" allranks.$OPTS
+'
+
+test_done

--- a/t/valgrind/workload.d/job
+++ b/t/valgrind/workload.d/job
@@ -2,20 +2,12 @@
 
 NJOBS=${NJOBS:-10}
 
-flux jobspec srun -n 1 /bin/true > job.json
+flux jobspec srun /bin/true > job.json
 for i in `seq 1 $NJOBS`; do
-     id=$(flux job submit < job.json)
-     echo id=$id
+    id[$i]=$(flux job submit < job.json)
+    echo ${id[$i]} submitted
 done
-
-#  Test job cancelation
-set -x
-id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
-flux job wait-event ${id} start
-flux job cancel ${id}
-flux job wait-event ${id} clean
-
-# Test info fetch
-flux job info ${id} eventlog jobspec R
-
-flux job drain
+for i in `seq 1 $NJOBS`; do
+    flux job attach ${id[$i]}
+    echo ${id[$i]} complete
+done

--- a/t/valgrind/workload.d/job-cancel
+++ b/t/valgrind/workload.d/job-cancel
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -x
+
+#  Test job cancel
+id=$(flux jobspec srun sleep 60 | flux job submit)
+flux job wait-event ${id} start
+flux job cancel ${id}
+flux job wait-event ${id} clean

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+
+# Test info fetch
+
+id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
+flux job attach ${id}
+
+flux job info ${id} eventlog jobspec R >/dev/null


### PR DESCRIPTION
This PR adds the most basic output handling to the shell as proposed in #2190.

Task I/O is sent to a service on the leader shell (shell rank 0).  Each line of I/O is represented as a JSON object.  The lines are accumulated in a JSON array which is committed to the job's kvs guest namespace upon completion.
.
Flux attach then outputs the lines on its stdout and stderr.

Thus
```
$ flux srun -N4 -n8 printenv FLUX_TASK_RANK
0
1
2
4
5
3
6
7
```
or
```
flux job attach --label $(flux jobspec srun -n4 hostname | flux job submit)
2: morbo
1: morbo
0: morbo
3: morbo
```
A reusable I/O forwarding service library has been proposed in #2208.  This PRwas  worked on in parallel with that, so I will look at converting the quick and dirty "service" in here over to that (this one, for example, doesn't base64-encode output data, and doesn't provide a way to read the data back remotely).