### PR TITLE
libsubprocess: Support line buffering stdout/stderr

### DIFF
--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -38,6 +38,7 @@ TESTS = \
 check_PROGRAMS = \
 	$(TESTS) \
 	test_echo \
+	test_multi_echo \
 	test_fork_sleep
 
 TEST_EXTENSIONS = .t
@@ -65,5 +66,7 @@ test_subprocess_t_CPPFLAGS = \
 test_subprocess_t_LDADD = $(test_ldadd)
 
 test_echo_SOURCES = test/test_echo.c
+
+test_multi_echo_SOURCES = test/test_multi_echo.c
 
 test_fork_sleep_SOURCES = test/test_fork_sleep.c

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -206,11 +206,18 @@ static int channel_local_setup (flux_subprocess_t *p,
     }
 
     if ((channel_flags & CHANNEL_READ) && out_cb) {
+        int wflag;
+
+        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_line_buffer");
+            goto error;
+        }
+
         c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
                                                             c->parent_fd,
                                                             buffer_size,
                                                             out_cb,
-                                                            0,
+                                                            wflag,
                                                             c);
         if (!c->buffer_read_w) {
             flux_log_error (p->h, "flux_buffer_read_watcher_create");

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -245,6 +245,10 @@ static void remote_out_prep_cb (flux_reactor_t *r,
 {
     struct subprocess_channel *c = arg;
 
+    /* We won't handle line buffering as a special case.  Since line
+     * buffering is enabled on the server side, we can safely assume
+     * we only get data when a line is available */
+
     /* no need to handle failure states, on fatal error, these
      * reactors are closed */
     if (flux_buffer_bytes (c->read_buffer) > 0

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -293,15 +293,20 @@ static void remote_out_check_cb (flux_reactor_t *r,
 static int remote_channel_setup (flux_subprocess_t *p,
                                  flux_subprocess_output_f output_f,
                                  const char *name,
-                                 int channel_flags,
-                                 int buffer_size)
+                                 int channel_flags)
 {
     struct subprocess_channel *c = NULL;
     char *e = NULL;
     int save_errno;
+    int buffer_size;
 
     if (!(c = channel_create (p, output_f, name, channel_flags))) {
         flux_log_error (p->h, "calloc");
+        goto error;
+    }
+
+    if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
+        flux_log_error (p->h, "cmd_option_bufsize");
         goto error;
     }
 
@@ -395,43 +400,29 @@ static int remote_channel_setup (flux_subprocess_t *p,
 
 static int remote_setup_stdio (flux_subprocess_t *p)
 {
-    int buffer_size;
-
     /* stdio is identical to channels, except they are limited to read
      * and/or write, and the buffer's automatically get a NUL char
      * appended on reads */
 
-    if ((buffer_size = cmd_option_bufsize (p, "STDIN")) < 0)
-        return -1;
-
     if (remote_channel_setup (p,
                               NULL,
                               "STDIN",
-                              CHANNEL_WRITE,
-                              buffer_size) < 0)
+                              CHANNEL_WRITE) < 0)
         return -1;
 
     if (p->ops.on_stdout) {
-        if ((buffer_size = cmd_option_bufsize (p, "STDOUT")) < 0)
-            return -1;
-
         if (remote_channel_setup (p,
                                   p->ops.on_stdout,
                                   "STDOUT",
-                                  CHANNEL_READ,
-                                  buffer_size) < 0)
+                                  CHANNEL_READ) < 0)
             return -1;
     }
 
     if (p->ops.on_stderr) {
-        if ((buffer_size = cmd_option_bufsize (p, "STDERR")) < 0)
-            return -1;
-
         if (remote_channel_setup (p,
                                   p->ops.on_stderr,
                                   "STDERR",
-                                  CHANNEL_READ,
-                                  buffer_size) < 0)
+                                  CHANNEL_READ) < 0)
             return -1;
     }
 
@@ -458,16 +449,10 @@ static int remote_setup_channels (flux_subprocess_t *p)
 
     name = zlist_first (channels);
     while (name) {
-        int buffer_size;
-
-        if ((buffer_size = cmd_option_bufsize (p, name)) < 0)
-            return -1;
-
         if (remote_channel_setup (p,
                                   p->ops.on_channel_out,
                                   name,
-                                  channel_flags,
-                                  buffer_size) < 0)
+                                  channel_flags) < 0)
             return -1;
         name = zlist_next (channels);
     }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -247,6 +247,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *   - STDOUT_BUFSIZE - set buffer size on stdout
  *   - STDERR_BUFSIZE - set buffer size on stderr
  *
+ *  "LINE_BUFFER" option
+ *
+ *    By default, output callbacks such as 'on_stdout' and 'on_stderr'
+ *    are called when a line of data is available (with the exception
+ *    with data after a subprocess has exited).  By setting this
+ *    option to "false", output callbacks will be called whenever any
+ *    amount of data is available.  These options can also be set to
+ *    "true" to keep default behavior of line buffering.
+ *
+ *    - name + "_LINE_BUFFER" - configuring line buffering on channel name
+ *    - STDOUT_LINE_BUFFER - configure line buffering for stdout
+ *    - STDERR_LINE_BUFFER - configure line buffering for stderr
+ *
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -230,20 +230,23 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
 
 /*
  *  Set generic string options for command object `cmd`. As with environment
- *   variables, this function adds the option `var` to with value `val` to
+ *   variables, this function adds the option `var` with value `val` to
  *   the options array for this command. This can be used to enable optional
  *   behavior for executed processes (e.g. setpgrp(2))
  *
  *  String options, note that name indicates the 'name' argument used
  *  in flux_cmd_add_channel() above.
  *
- *  name + "_BUFSIZE" = buffer size
- *  STDIN_BUFSIZE = buffer size
- *  STDOUT_BUFSIZE = buffer size
- *  STDERR_BUFSIZE = buffer size
+ *  "BUFSIZE" option
  *
- *  By default, stdio and channels use an internal buffer of 1 meg.
- *  The buffer size can be adjusted with this option.
+ *   By default, stdio and channels use an internal buffer of 1 meg.
+ *   The buffer size can be adjusted with this option.
+ *
+ *   - name + "_BUFSIZE" - set buffer size on channel name
+ *   - STDIN_BUFSIZE - set buffer size on stdin
+ *   - STDOUT_BUFSIZE - set buffer size on stdout
+ *   - STDERR_BUFSIZE - set buffer size on stderr
+ *
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
@@ -308,10 +311,10 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
  *   "STDOUT".
  *
  *   Returns pointer to buffer on success and NULL on error with errno
- *   set.  If reading from "STDOUT" or "STDERR", buffer is guaranteed
- *   to be NUL terminated.  User shall not free returned pointer.
- *   Length of buffer returned can optionally returned in 'lenp'.  A
- *   length of 0 indicates that the subprocess has closed this stream.
+ *   set.  Buffer is guaranteed to be NUL terminated.  User shall not
+ *   free returned pointer.  Length of buffer returned can optionally
+ *   returned in 'lenp'.  A length of 0 indicates that the subprocess
+ *   has closed this stream.
  */
 const char *flux_subprocess_read (flux_subprocess_t *p,
                                   const char *stream,
@@ -324,9 +327,9 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
  *   "STDOUT".
  *
  *   Returns pointer to buffer on success and NULL on error with errno
- *   set.  If reading from "STDOUT" or "STDERR", buffer is guaranteed
- *   to be NUL terminated.  User shall not free returned pointer.
- *   Length of buffer returned can optionally returned in 'lenp'.
+ *   set.  Buffer will include newline character and is guaranteed to
+ *   be NUL terminated.  User shall not free returned pointer.  Length
+ *   of buffer returned can optionally returned in 'lenp'.
  */
 const char *flux_subprocess_read_line (flux_subprocess_t *p,
                                        const char *stream,

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -325,7 +325,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
         sprintf (cmpbuf, "%s:hi\n", stream);
 
         ok (!strcmp (ptr, cmpbuf),
-            "flux_subprocess_read_line returned correct data", stream);
+            "flux_subprocess_read_line returned correct data");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
@@ -472,7 +472,7 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
         sprintf (cmpbuf, "%s:hi\n", stream);
 
         ok (!strcmp (ptr, cmpbuf),
-            "flux_subprocess_read_line returned correct data", "STDOUT");
+            "flux_subprocess_read_line returned correct data");
     }
     else {
         ptr = flux_subprocess_read (p, NULL, -1, &lenp);
@@ -681,7 +681,7 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
         sprintf (cmpbuf, "%s:hi", stream);
 
         ok (!strcmp (ptr, cmpbuf),
-            "flux_subprocess_read_trimmed_line returned correct data", stream);
+            "flux_subprocess_read_trimmed_line returned correct data");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
@@ -746,7 +746,7 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!strcmp (ptr, "foo\n"),
-            "flux_subprocess_read_line returned correct data", stream);
+            "flux_subprocess_read_line returned correct data");
     }
     else if ((*counter) == 1) {
         ptr = flux_subprocess_read_line (p, stream, &lenp);
@@ -764,7 +764,7 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!strcmp (ptr, "bo\n"),
-            "flux_subprocess_read_line returned correct data", stream);
+            "flux_subprocess_read_line returned correct data");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
@@ -1525,7 +1525,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!strcmp (ptr, "bob\n"),
-            "flux_subprocess_read_line returned correct data", stream);
+            "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 1) {
         ptr = flux_subprocess_read_line (p, stream, &lenp);
@@ -1534,7 +1534,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!strcmp (ptr, "dan\n"),
-            "flux_subprocess_read_line returned correct data %s", stream);
+            "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 2) {
         ptr = flux_subprocess_read_line (p, stream, &lenp);
@@ -1543,7 +1543,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!strcmp (ptr, "jo\n"),
-            "flux_subprocess_read_line returned correct data", stream);
+            "flux_subprocess_read_line returned correct data");
 
         ok (flux_subprocess_close (p, "TEST_CHANNEL") == 0,
             "flux_subprocess_close success");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -326,6 +326,9 @@ void output_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strcmp (ptr, cmpbuf),
             "flux_subprocess_read_line returned correct data");
+        /* 1 + 2 + 1 for ':', "hi", '\n' */
+        ok (lenp == (strlen (stream) + 1 + 2 + 1),
+            "flux_subprocess_read_line returned correct data len");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
@@ -473,6 +476,9 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strcmp (ptr, cmpbuf),
             "flux_subprocess_read_line returned correct data");
+        /* 1 + 2 + 1 for ':', "hi", '\n' */
+        ok (lenp == (strlen (stream) + 1 + 2 + 1),
+            "flux_subprocess_read_line returned correct data len");
     }
     else {
         ptr = flux_subprocess_read (p, NULL, -1, &lenp);
@@ -611,6 +617,9 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strcmp (ptr, cmpbuf),
             "flux_subprocess_read returned correct data");
+        /* 1 + 2 + 1 for ':', "hi" */
+        ok (lenp == (strlen (stream) + 1 + 2),
+            "flux_subprocess_read_line returned correct data len");
     }
     else {
         ok (flux_subprocess_read_eof_reached (p, stream) > 0,
@@ -747,6 +756,8 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strcmp (ptr, "foo\n"),
             "flux_subprocess_read_line returned correct data");
+        ok (lenp == 4,
+            "flux_subprocess_read_line returned correct data len");
     }
     else if ((*counter) == 1) {
         ptr = flux_subprocess_read_line (p, stream, &lenp);
@@ -756,6 +767,8 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strcmp (ptr, "bar\n"),
             "flux_subprocess_read_line returned correct data");
+        ok (lenp == 4,
+            "flux_subprocess_read_line returned correct data len");
     }
     else if ((*counter) == 2) {
         ptr = flux_subprocess_read_line (p, stream, &lenp);
@@ -765,6 +778,8 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strcmp (ptr, "bo\n"),
             "flux_subprocess_read_line returned correct data");
+        ok (lenp == 3,
+            "flux_subprocess_read_line returned correct data len");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
@@ -927,6 +942,8 @@ void env_passed_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strncmp (ptr, "FOOBAR=foobaz", 13),
             "environment variable FOOBAR in subprocess");
+        ok (lenp == 14,
+            "flux_subprocess_read_line returned correct data len");
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
@@ -1331,6 +1348,7 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
 
         ok (!strncmp (ptr, "FOO=", 4),
             "environment variable FOO created in subprocess");
+        /* no length check, can't predict channel FD value */
     }
     else {
         ptr = flux_subprocess_read (p, stream, -1, &lenp);

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -1719,6 +1719,182 @@ void test_bufsize_error (flux_reactor_t *r)
     flux_cmd_destroy (cmd);
 }
 
+/* Line buffering tests are technically racy.  If the stdout in the
+ * test_multi_echo command occurs fast enough, a single on_stdout
+ * callback could occur.  But hopefully by repeating the word "hi" a
+ * lot of times, the probability of that occuring is zero if line
+ * buffering is not working.
+ *
+ * I pick 2200 to make sure we output enough to surpass 4096 bytes of
+ * output (i.e. 2200 * 2 bytes > 4096 bytes).
+*/
+
+void line_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    const char *ptr;
+    int lenp = 0;
+    int *counter;
+
+    if (!strcasecmp (stream, "STDOUT"))
+        counter = &stdout_output_cb_count;
+    else {
+        ok (false, "unexpected stream %s", stream);
+        return;
+    }
+
+    if ((*counter) == 0) {
+        ptr = flux_subprocess_read_line (p, stream, &lenp);
+        ok (ptr != NULL && lenp == 4401,
+            "flux_subprocess_read_line read line correctly");
+    }
+    else {
+        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ok (ptr != NULL && lenp == 0,
+            "flux_subprocess_read on %s read EOF", stream);
+    }
+
+    (*counter)++;
+}
+
+void test_line_buffer_default (flux_reactor_t *r)
+{
+    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-c", "2200", "hi", NULL };
+    flux_cmd_t *cmd;
+    flux_subprocess_t *p = NULL;
+
+    ok ((cmd = flux_cmd_create (4, av, environ)) != NULL, "flux_cmd_create");
+
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_stdout = line_output_cb
+    };
+    completion_cb_count = 0;
+    stdout_output_cb_count = 0;
+    stderr_output_cb_count = 0;
+    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    ok (p != NULL, "flux_local_exec");
+
+    ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
+        "subprocess state == RUNNING after flux_local_exec");
+
+    int rc = flux_reactor_run (r, 0);
+    ok (rc == 0, "flux_reactor_run returned zero status");
+    ok (completion_cb_count == 1, "completion callback called 1 time");
+    /* == 2 times means we got a single line and EOF */
+    ok (stdout_output_cb_count == 2, "stdout output callback called 2 times");
+    ok (stderr_output_cb_count == 0, "stderr output callback called 0 times");
+    flux_subprocess_destroy (p);
+    flux_cmd_destroy (cmd);
+}
+
+void test_line_buffer_enable (flux_reactor_t *r)
+{
+    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-c", "2200", "hi", NULL };
+    flux_cmd_t *cmd;
+    flux_subprocess_t *p = NULL;
+
+    ok ((cmd = flux_cmd_create (4, av, environ)) != NULL, "flux_cmd_create");
+
+    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "true") == 0,
+        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_stdout = line_output_cb
+    };
+    completion_cb_count = 0;
+    stdout_output_cb_count = 0;
+    stderr_output_cb_count = 0;
+    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    ok (p != NULL, "flux_local_exec");
+
+    ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
+        "subprocess state == RUNNING after flux_local_exec");
+
+    int rc = flux_reactor_run (r, 0);
+    ok (rc == 0, "flux_reactor_run returned zero status");
+    ok (completion_cb_count == 1, "completion callback called 1 time");
+    /* == 2 times means we got a single line and EOF */
+    ok (stdout_output_cb_count == 2, "stdout output callback called 2 times");
+    ok (stderr_output_cb_count == 0, "stderr output callback called 0 times");
+    flux_subprocess_destroy (p);
+    flux_cmd_destroy (cmd);
+}
+
+void count_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    int *counter;
+
+    if (!strcasecmp (stream, "STDOUT"))
+        counter = &stdout_output_cb_count;
+    else {
+        ok (false, "unexpected stream %s", stream);
+        return;
+    }
+
+    (void)flux_subprocess_read_line (p, stream, NULL);
+    (*counter)++;
+}
+
+void test_line_buffer_disable (flux_reactor_t *r)
+{
+    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-c", "2200", "hi", NULL };
+    flux_cmd_t *cmd;
+    flux_subprocess_t *p = NULL;
+
+    ok ((cmd = flux_cmd_create (4, av, environ)) != NULL, "flux_cmd_create");
+
+    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_stdout = count_output_cb
+    };
+    completion_cb_count = 0;
+    stdout_output_cb_count = 0;
+    stderr_output_cb_count = 0;
+    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    ok (p != NULL, "flux_local_exec");
+
+    ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
+        "subprocess state == RUNNING after flux_local_exec");
+
+    int rc = flux_reactor_run (r, 0);
+    ok (rc == 0, "flux_reactor_run returned zero status");
+    ok (completion_cb_count == 1, "completion callback called 1 time");
+    /* we care about greater than two, that it's not a single line and EOF */
+    ok (stdout_output_cb_count > 2, "stdout output callback got more than 2 calls: %d", stdout_output_cb_count);
+    ok (stderr_output_cb_count == 0, "stderr output callback called 0 times");
+    flux_subprocess_destroy (p);
+    flux_cmd_destroy (cmd);
+}
+
+void test_line_buffer_error (flux_reactor_t *r)
+{
+    char *av[] = { "/bin/true", NULL };
+    flux_cmd_t *cmd;
+    flux_subprocess_t *p = NULL;
+
+    ok ((cmd = flux_cmd_create (1, av, NULL)) != NULL, "flux_cmd_create");
+
+    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "ABCD") == 0,
+        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_channel_out = flux_standard_output,
+        .on_stdout = flux_standard_output,
+        .on_stderr = flux_standard_output
+    };
+    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    ok (p == NULL
+        && errno == EINVAL,
+        "flux_local_exec fails with EINVAL due to bad line_buffer input");
+
+    flux_cmd_destroy (cmd);
+}
+
 void shmem_hook_cb (flux_subprocess_t *p, void *arg)
 {
     int *shmem_count = arg;
@@ -1877,6 +2053,14 @@ int main (int argc, char *argv[])
     test_bufsize (r);
     diag ("bufsize_error");
     test_bufsize_error (r);
+    diag ("line_buffer_default");
+    test_line_buffer_default (r);
+    diag ("line_buffer_enable");
+    test_line_buffer_enable (r);
+    diag ("line_buffer_disable");
+    test_line_buffer_disable (r);
+    diag ("line_buffer_error");
+    test_line_buffer_error (r);
     diag ("pre_exec_hook");
     test_pre_exec_hook (r);
     diag ("post_fork_hook");

--- a/src/common/libsubprocess/test/test_multi_echo.c
+++ b/src/common/libsubprocess/test/test_multi_echo.c
@@ -1,0 +1,54 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* simple tool that outputs args to stdout multiple times */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+
+int count = 4;
+
+int
+main (int argc, char *argv[])
+{
+    while (1) {
+        int c = getopt (argc, argv, "nc:");
+        if (c < 0)
+            break;
+
+        switch (c) {
+        case 'c':
+            count = atoi (optarg);
+            if (count <= 0) {
+                fprintf (stderr, "count invalid\n");
+                exit (1);
+            }
+            break;
+        }
+    }
+
+    if (optind != argc) {
+        while (optind < argc) {
+            int i;
+            for (i = 0; i < count; i++) {
+                printf ("%s", argv[optind]);
+                fflush (stdout);
+            }
+            optind++;
+        }
+        printf ("\n");
+        fflush (stdout);
+    }
+
+    close (STDOUT_FILENO);
+    exit (0);
+}

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -21,7 +21,6 @@
 
 #include <flux/core.h>
 
-#include "src/common/libutil/log.h"
 #include "src/common/libutil/fdwalk.h"
 
 #include "subprocess.h"
@@ -50,10 +49,8 @@ int cmd_option_bufsize (flux_subprocess_t *p, const char *name)
     const char *val;
     int rv = -1;
 
-    if (asprintf (&var, "%s_BUFSIZE", name) < 0) {
-        log_err ("asprintf");
+    if (asprintf (&var, "%s_BUFSIZE", name) < 0)
         goto cleanup;
-    }
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
         char *endptr;

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -72,6 +72,31 @@ cleanup:
     return rv;
 }
 
+int cmd_option_line_buffer (flux_subprocess_t *p, const char *name)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    if (asprintf (&var, "%s_LINE_BUFFER", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        if (!strcasecmp (val, "false"))
+            rv = 0;
+        else if (!strcasecmp (val, "true"))
+            rv = FLUX_WATCHER_LINE_BUFFER;
+        else
+            errno = EINVAL;
+    }
+    else
+        rv = FLUX_WATCHER_LINE_BUFFER;
+
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -19,4 +19,6 @@ void close_pair_fds (int *fds);
 
 int cmd_option_bufsize (flux_subprocess_t *p, const char *name);
 
+int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -198,7 +198,8 @@ static struct exec_cmd *exec_cmd_create (const struct idset *ranks,
         return NULL;
     if (!(c->ranks = idset_copy (ranks)))
         goto err;
-    c->cmd = flux_cmd_copy (cmd);
+    if (!(c->cmd = flux_cmd_copy (cmd)))
+        goto err;
     c->flags = flags;
     return (c);
 err:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -200,6 +200,7 @@ check_PROGRAMS = \
 	rexec/rexec \
 	rexec/rexec_signal \
 	rexec/rexec_ps \
+	rexec/rexec_count_stdout \
 	ingest/submitbench \
 	sched-simple/jj-reader \
 	shell/rcalc \
@@ -401,6 +402,11 @@ rexec_rexec_signal_LDADD = \
 rexec_rexec_ps_SOURCES = rexec/rexec_ps.c
 rexec_rexec_ps_CPPFLAGS = $(test_cppflags)
 rexec_rexec_ps_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+rexec_rexec_count_stdout_SOURCES = rexec/rexec_count_stdout.c
+rexec_rexec_count_stdout_CPPFLAGS = $(test_cppflags)
+rexec_rexec_count_stdout_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 ingest_job_manager_dummy_la_SOURCES = ingest/job-manager-dummy.c

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -1,0 +1,156 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* rexec_count_stdout - predominant purpose is for line buffering
+ * tests, will count how many times the stdout callback is called */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <inttypes.h>
+#include <flux/core.h>
+#include <flux/optparse.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/read_all.h"
+
+extern char **environ;
+
+static struct optparse_option cmdopts[] = {
+    { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "rank",
+      .usage = "Specify rank for test" },
+    { .name = "linebuffer", .key = 'l', .has_arg = 1, .arginfo = "bool",
+      .usage = "Specify true/false for line buffering" },
+    OPTPARSE_TABLE_END
+};
+
+optparse_t *opts;
+
+int stdout_count = 0;
+int exit_code = 0;
+
+void completion_cb (flux_subprocess_t *p)
+{
+    int ec = flux_subprocess_exit_code (p);
+
+    if (ec > exit_code)
+        exit_code = ec;
+}
+
+void output_cb (flux_subprocess_t *p, const char *stream)
+{
+    FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
+    const char *ptr;
+    int lenp;
+
+    if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
+        log_err ("flux_subprocess_read_line");
+        return;
+    }
+
+    /* if process exited, read remaining stuff or EOF, otherwise
+     * wait for future newline */
+    if (!lenp
+        && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
+        if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
+            log_err ("flux_subprocess_read");
+            return;
+        }
+    }
+
+    if (lenp)
+        fwrite (ptr, lenp, 1, fstream);
+
+    if (!strcasecmp (stream, "STDOUT"))
+        stdout_count++;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_reactor_t *reactor;
+    flux_cmd_t *cmd;
+    char *cwd;
+    flux_subprocess_t *p = NULL;
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_state_change = NULL,
+        .on_channel_out = NULL,
+        .on_stdout = output_cb,
+        .on_stderr = output_cb,
+    };
+    const char *optargp;
+    int optindex;
+    int rank = 0;
+
+    log_init ("rexec-count-stdout");
+
+    opts = optparse_create ("rexec");
+    if (optparse_add_option_table (opts, cmdopts) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_option_table");
+    if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)
+        exit (1);
+
+    if (optparse_getopt (opts, "rank", &optargp) > 0)
+        rank = atoi (optargp);
+
+    if (optindex == argc) {
+        optparse_print_usage (opts);
+        exit (1);
+    }
+
+    /* all args to cmd */
+    if (!(cmd = flux_cmd_create (argc - optindex, &argv[optindex], environ)))
+        log_err_exit ("flux_cmd_create");
+
+    if (!(cwd = get_current_dir_name ()))
+        log_err_exit ("get_current_dir_name");
+
+    if (flux_cmd_setcwd (cmd, cwd) < 0)
+        log_err_exit ("flux_cmd_setcwd");
+
+    if (optparse_getopt (opts, "linebuffer", &optargp) > 0) {
+        if (strcasecmp (optargp, "true")
+            && strcasecmp (optargp, "false"))
+            log_err_exit ("invalid linebuffer value");
+        if (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", optargp) < 0)
+            log_err_exit ("flux_cmd_setopt");
+    }
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(reactor = flux_get_reactor (h)))
+        log_err_exit ("flux_get_reactor");
+
+    if (!(p = flux_rexec (h, rank, 0, cmd, &ops)))
+        log_err_exit ("flux_rexec");
+
+    if (flux_reactor_run (reactor, 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    printf ("final stdout callback count: %d\n", stdout_count);
+    fflush (stdout);
+
+    /* Clean up.
+     */
+    flux_subprocess_destroy (p);
+    flux_close (h);
+    log_fini ();
+
+    return exit_code;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -185,4 +185,22 @@ test_expect_success NO_CHAIN_LINT 'disconnect terminates all running processes' 
         test "$count" = "0"
 '
 
+test_expect_success 'rexec line buffering works (default)' '
+        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 ${TEST_SUBPROCESS_DIR}/test_multi_echo -c 2200 hi > linebuffer1.out &&
+        grep "final stdout callback count: 2" linebuffer1.out
+'
+
+test_expect_success 'rexec line buffering works (set to true)' '
+        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 -l true ${TEST_SUBPROCESS_DIR}/test_multi_echo -c 2200 hi > linebuffer2.out &&
+        grep "final stdout callback count: 2" linebuffer2.out
+'
+
+# test is technically racy, but with 2200 hi outputs, probability is
+# extremely low all data is buffered in one shot.
+test_expect_success 'rexec line buffering can be disabled' '
+        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 -l false ${TEST_SUBPROCESS_DIR}/test_multi_echo -c 2200 hi > linebuffer3.out &&
+        count=$(grep "final stdout callback count:" linebuffer3.out | awk "{print \$5}") &&
+        test "$count" -gt 2
+'
+
 test_done


### PR DESCRIPTION
To limit callbacks to the `on_stdout` and `on_stderr` callbacks, support the ability to specify if stdout/stderr/channel output should be line buffered.

Originally, I made this option to "enable" line buffering.  But upon further investigation, everything in flux reads lines.  So I enabled line buffering by default, but allow it to be disabled.

Lots of stupid cleanups/fixes along the way.
