### PR TITLE
libsubprocess: rename/cleanup read_eof_reached() add flux_subprocess_read_until_eof()

### DIFF
--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -248,16 +248,9 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
     assert (r);
     assert (r->level == 1 || r->level == 3);
 
-    if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
-        flux_log_error (r->h, "%s: flux_subprocess_read_line", __FUNCTION__);
+    if (!(ptr = flux_subprocess_getline (p, stream, &lenp))) {
+        flux_log_error (r->h, "%s: flux_subprocess_getline", __FUNCTION__);
         return;
-    }
-
-    if (!lenp) {
-        if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
-            flux_log_error (r->h, "%s: flux_subprocess_read", __FUNCTION__);
-            return;
-        }
     }
 
     if (lenp && r->io_cb)

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -181,17 +181,8 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp;
 
-    if (!(ptr = flux_subprocess_read_line (p, stream, &lenp)))
-        log_err_exit ("flux_subprocess_read_line");
-
-    /* if process exited, read remaining stuff or EOF, otherwise
-     * wait for future newline */
-    if (!lenp
-        && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
-
-        if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp)))
-            log_err_exit ("flux_subprocess_read");
-    }
+    if (!(ptr = flux_subprocess_getline (p, stream, &lenp)))
+        log_err_exit ("flux_subprocess_getline");
 
     if (lenp) {
         if (optparse_getopt (opts, "labelio", NULL) > 0)

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -213,6 +213,9 @@ static int channel_local_setup (flux_subprocess_t *p,
             goto error;
         }
 
+        if (wflag)
+            c->line_buffered = true;
+
         c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
                                                             c->parent_fd,
                                                             buffer_size,

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -347,6 +347,16 @@ static int remote_channel_setup (flux_subprocess_t *p,
     }
 
     if (channel_flags & CHANNEL_READ) {
+        int wflag;
+
+        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_line_buffer");
+            goto error;
+        }
+
+        if (wflag)
+            c->line_buffered = true;
+
         if (!(c->read_buffer = flux_buffer_create (buffer_size))) {
             flux_log_error (p->h, "flux_buffer_create");
             goto error;

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -245,13 +245,10 @@ static void remote_out_prep_cb (flux_reactor_t *r,
 {
     struct subprocess_channel *c = arg;
 
-    /* We won't handle line buffering as a special case.  Since line
-     * buffering is enabled on the server side, we can safely assume
-     * we only get data when a line is available */
-
     /* no need to handle failure states, on fatal error, these
      * reactors are closed */
-    if (flux_buffer_bytes (c->read_buffer) > 0
+    if ((c->line_buffered && flux_buffer_lines (c->read_buffer) > 0)
+        || (!c->line_buffered && flux_buffer_bytes (c->read_buffer) > 0)
         || (c->read_eof_received && !c->eof_sent_to_caller))
         flux_watcher_start (c->out_idle_w);
 }
@@ -265,7 +262,11 @@ static void remote_out_check_cb (flux_reactor_t *r,
 
     flux_watcher_stop (c->out_idle_w);
 
-    if (flux_buffer_bytes (c->read_buffer) > 0) {
+    if ((c->line_buffered
+         && (flux_buffer_lines (c->read_buffer) > 0
+             || (c->read_eof_received
+                 && flux_buffer_bytes (c->read_buffer) > 0)))
+        || (!c->line_buffered && flux_buffer_bytes (c->read_buffer) > 0)) {
         c->output_f (c->p, c->name);
     }
 

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -901,7 +901,7 @@ const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
     return subprocess_read (p, stream, 0, lenp, true, true);
 }
 
-int flux_subprocess_read_eof_reached (flux_subprocess_t *p, const char *stream)
+int flux_subprocess_read_stream_closed (flux_subprocess_t *p, const char *stream)
 {
     struct subprocess_channel *c;
     flux_buffer_t *fb;
@@ -921,10 +921,8 @@ int flux_subprocess_read_eof_reached (flux_subprocess_t *p, const char *stream)
     }
 
     if (p->local) {
-        if (!(fb = flux_buffer_read_watcher_get_buffer (c->buffer_read_w))) {
-            errno = ENOSYS;     /* something */
+        if (!(fb = flux_buffer_read_watcher_get_buffer (c->buffer_read_w)))
             return -1;
-        }
     }
     else
         fb = c->read_buffer;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -356,10 +356,8 @@ void flux_standard_output (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    /* if process exited, read remaining stuff or EOF, otherwise
-     * wait for future newline */
-    if (!lenp
-        && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
+    /* we're at the end of the stream, read any lingering data */
+    if (!lenp && flux_subprocess_read_stream_closed (p, stream) > 0) {
         if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
             log_err ("flux_standard_output: read_line");
             return;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -351,6 +351,9 @@ void flux_standard_output (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp;
 
+    /* Do not use flux_subprocess_getline(), this should work
+     * regardless if stream is line buffered or not */
+
     if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
         log_err ("flux_standard_output: read_line");
         return;
@@ -828,7 +831,9 @@ static const char *subprocess_read (flux_subprocess_t *p,
                                     const char *stream,
                                     int len, int *lenp,
                                     bool read_line,
-                                    bool trimmed)
+                                    bool trimmed,
+                                    bool line_buffered_required,
+                                    int *readonly)
 {
     struct subprocess_channel *c;
     flux_buffer_t *fb;
@@ -853,12 +858,21 @@ static const char *subprocess_read (flux_subprocess_t *p,
         return NULL;
     }
 
+    if (line_buffered_required && !c->line_buffered) {
+        errno = EPERM;
+        return NULL;
+    }
+
     if (p->local) {
         if (!(fb = flux_buffer_read_watcher_get_buffer (c->buffer_read_w)))
             return NULL;
     }
     else
         fb = c->read_buffer;
+
+    /* if readonly marked, indicates EOF received */
+    if (readonly)
+        (*readonly) = flux_buffer_is_readonly (fb);
 
     if (read_line) {
         if (trimmed) {
@@ -882,21 +896,21 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
                                   const char *stream,
                                   int len, int *lenp)
 {
-    return subprocess_read (p, stream, len, lenp, false, false);
+    return subprocess_read (p, stream, len, lenp, false, false, false, NULL);
 }
 
 const char *flux_subprocess_read_line (flux_subprocess_t *p,
                                        const char *stream,
                                        int *lenp)
 {
-    return subprocess_read (p, stream, 0, lenp, true, false);
+    return subprocess_read (p, stream, 0, lenp, true, false, false, NULL);
 }
 
 const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
                                                const char *stream,
                                                int *lenp)
 {
-    return subprocess_read (p, stream, 0, lenp, true, true);
+    return subprocess_read (p, stream, 0, lenp, true, true, false, NULL);
 }
 
 int flux_subprocess_read_stream_closed (flux_subprocess_t *p, const char *stream)
@@ -926,6 +940,26 @@ int flux_subprocess_read_stream_closed (flux_subprocess_t *p, const char *stream
         fb = c->read_buffer;
 
     return flux_buffer_is_readonly (fb);
+}
+
+const char *flux_subprocess_getline (flux_subprocess_t *p,
+                                     const char *stream,
+                                     int *lenp)
+{
+    const char *ptr;
+    int len, readonly;
+
+    ptr = subprocess_read (p, stream, 0, &len, true, false, true, &readonly);
+
+    /* if no lines available and EOF received, read whatever is
+     * lingering in the buffer */
+    if (ptr && len == 0 && readonly > 0)
+        ptr = flux_subprocess_read (p, stream, -1, &len);
+
+    if (lenp)
+        (*lenp) = len;
+
+    return ptr;
 }
 
 flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signum)

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -368,6 +368,26 @@ const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
 int flux_subprocess_read_stream_closed (flux_subprocess_t *p,
                                         const char *stream);
 
+/* flux_subprocess_getline() is a special case function
+ * that behaves identically to flux_subprocess_read_line() but handles
+ * several common special cases.  It requires the stream of data to be
+ * line buffered (by default on, see LINE_BUFFER under
+ * flux_cmd_setopt()).
+ *
+ * - if the stream of data has internally completed (i.e. the
+ *   subprocess has closed the stream / EOF has been received) but the
+ *   last data on the stream does not terminate in a newline
+ *   character, this function will return that last data without the
+ *   trailing newline.
+ * - if the stream has been closed / reached EOF, lenp will be set to
+ *   0.
+ * - if the stream is not line buffered, NULL and errno = EPERM will
+ *   be returned.
+ */
+const char *flux_subprocess_getline (flux_subprocess_t *p,
+                                     const char *stream,
+                                     int *lenp);
+
 /*
  *  Create RPC to send signal `signo` to subprocess `p`.
  *  This call returns a flux_future_t. Use flux_future_then(3) to register

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -356,7 +356,17 @@ const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
                                                const char *stream,
                                                int *lenp);
 
-int flux_subprocess_read_eof_reached (flux_subprocess_t *p, const char *stream);
+/* Determine if the read stream has is closed / received an EOF.  This
+ * function can be useful if you are reading lines via
+ * flux_subprocess_read_line() or flux_subprocess_read_trimmed_line()
+ * in output callbacks.  Those functions will return length 0 when no
+ * lines are available, making it difficult to determine if the stream
+ * has been closed and there is any non-newline terminated data left
+ * available for reading with flux_subprocess_read().  Returns > 0 on
+ * closed / eof seen, 0 if not, -1 on error.
+ */
+int flux_subprocess_read_stream_closed (flux_subprocess_t *p,
+                                        const char *stream);
 
 /*
  *  Create RPC to send signal `signo` to subprocess `p`.

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -341,8 +341,9 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
  *
  *   Returns pointer to buffer on success and NULL on error with errno
  *   set.  Buffer will include newline character and is guaranteed to
- *   be NUL terminated.  User shall not free returned pointer.  Length
- *   of buffer returned can optionally returned in 'lenp'.
+ *   be NUL terminated.  If no line is available, returns pointer and
+ *   length of zero.  User shall not free returned pointer.  Length of
+ *   buffer returned can optionally returned in 'lenp'.
  */
 const char *flux_subprocess_read_line (flux_subprocess_t *p,
                                        const char *stream,

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -54,6 +54,9 @@ struct subprocess_channel {
     flux_watcher_t *out_prep_w;
     flux_watcher_t *out_idle_w;
     flux_watcher_t *out_check_w;
+
+    /* misc */
+    bool line_buffered;         /* for buffer_read_w / read_buffer */
 };
 
 struct flux_subprocess {

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -201,6 +201,9 @@ void test_basic_errors (flux_reactor_t *r)
     ok (flux_subprocess_read_line (NULL, "STDOUT", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read_line fails with NULL pointer inputs");
+    ok (flux_subprocess_read_trimmed_line (NULL, "STDOUT", NULL) == NULL
+        && errno == EINVAL,
+        "flux_subprocess_read_trimmed_line fails with NULL pointer inputs");
     ok (flux_subprocess_kill (NULL, 0) == NULL
         && errno == EINVAL,
         "flux_subprocess_kill fails with NULL pointer inputs");
@@ -274,6 +277,9 @@ void test_errors (flux_reactor_t *r)
     ok (flux_subprocess_read_line (p, "foo", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read_line returns EINVAL on bad stream");
+    ok (flux_subprocess_read_trimmed_line (p, "foo", NULL) == NULL
+        && errno == EINVAL,
+        "flux_subprocess_read_trimmed_line returns EINVAL on bad stream");
     ok (flux_subprocess_kill (p, 0) == NULL
         && errno == EINVAL,
         "flux_subprocess_kill returns EINVAL on illegal signum");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -273,7 +273,7 @@ void test_errors (flux_reactor_t *r)
         "flux_subprocess_read returns EINVAL on bad stream");
     ok (flux_subprocess_read_line (p, "foo", NULL) == NULL
         && errno == EINVAL,
-        "flux_subprocess_read returns EINVAL on bad stream");
+        "flux_subprocess_read_line returns EINVAL on bad stream");
     ok (flux_subprocess_kill (p, 0) == NULL
         && errno == EINVAL,
         "flux_subprocess_kill returns EINVAL on illegal signum");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -628,8 +628,8 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else {
-        ok (flux_subprocess_read_eof_reached (p, stream) > 0,
-            "flux_subprocess_read_eof_reached saw EOF on %s", stream);
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -204,6 +204,9 @@ void test_basic_errors (flux_reactor_t *r)
     ok (flux_subprocess_read_trimmed_line (NULL, "STDOUT", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read_trimmed_line fails with NULL pointer inputs");
+    ok (flux_subprocess_read_stream_closed (NULL, "STDOUT") < 0
+        && errno == EINVAL,
+        "flux_subprocess_read_stream_closed fails with NULL pointer inputs");
     ok (flux_subprocess_kill (NULL, 0) == NULL
         && errno == EINVAL,
         "flux_subprocess_kill fails with NULL pointer inputs");
@@ -280,6 +283,9 @@ void test_errors (flux_reactor_t *r)
     ok (flux_subprocess_read_trimmed_line (p, "foo", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read_trimmed_line returns EINVAL on bad stream");
+    ok (flux_subprocess_read_stream_closed (p, "foo") < 0
+        && errno == EINVAL,
+        "flux_subprocess_read_stream_closed returns EINVAL on bad stream");
     ok (flux_subprocess_kill (p, 0) == NULL
         && errno == EINVAL,
         "flux_subprocess_kill returns EINVAL on illegal signum");
@@ -337,6 +343,9 @@ void output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -487,6 +496,9 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", "STDOUT");
+
         ptr = flux_subprocess_read (p, NULL, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -699,6 +711,9 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_trimmed_line returned correct data");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -788,6 +803,9 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1063,6 +1081,9 @@ void output_processes_cb (flux_subprocess_t *p, const char *stream)
         }
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1141,6 +1162,9 @@ void eof_cb (flux_subprocess_t *p, const char *stream)
         ok (false, "unexpected stream %s", stream);
         return;
     }
+
+    ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+        "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
     ptr = flux_subprocess_read (p, stream, -1, &lenp);
     ok (ptr != NULL
@@ -1357,6 +1381,9 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
         /* no length check, can't predict channel FD value */
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1418,6 +1445,9 @@ void channel_in_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_close success");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1486,6 +1516,9 @@ void channel_in_and_out_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_close success");
     }
     else {
+        /* no check of flux_subprocess_read_stream_closed(), we aren't
+         * closing channel in test below */
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1573,6 +1606,9 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_close success");
     }
     else {
+        /* no check of flux_subprocess_read_stream_closed(), we aren't
+         * closing channel in test below */
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1645,6 +1681,9 @@ void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_close success");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
@@ -1754,6 +1793,9 @@ void line_output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line read line correctly");
     }
     else {
+        ok (flux_subprocess_read_stream_closed (p, stream) > 0,
+            "flux_subprocess_read_stream_closed saw EOF on %s", stream);
+
         ptr = flux_subprocess_read (p, stream, -1, &lenp);
         ok (ptr != NULL && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -162,15 +162,9 @@ static void exec_output_cb (flux_subprocess_t *p, const char *stream)
     const char *s;
     int len;
 
-    if (!(s = flux_subprocess_read_line (p, stream, &len))) {
-        flux_log_error (exec->h, "flux_subprocess_read_line");
+    if (!(s = flux_subprocess_getline (p, stream, &len))) {
+        flux_log_error (exec->h, "flux_subprocess_getline");
         return;
-    }
-    if (!len && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
-        if (!(s = flux_subprocess_read (p, stream, -1, &len))) {
-            flux_log_error (exec->h, "flux_subprocess_read");
-            return;
-        }
     }
     if (len) {
         int rank = flux_subprocess_rank (p);

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -148,14 +148,8 @@ int shell_task_io_readline (struct shell_task *task,
     const char *buf;
     int len;
 
-    if (!(buf = flux_subprocess_read_line (task->proc, name, &len)))
+    if (!(buf = flux_subprocess_getline (task->proc, name, &len)))
         return -1;
-    if (len == 0) {
-        if (flux_subprocess_read_stream_closed (task->proc, name)) {
-            if (!(buf = flux_subprocess_read (task->proc, name, -1, &len)))
-                return -1;
-        }
-    }
     *line = buf;
     return len;
 }

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -151,7 +151,7 @@ int shell_task_io_readline (struct shell_task *task,
     if (!(buf = flux_subprocess_read_line (task->proc, name, &len)))
         return -1;
     if (len == 0) {
-        if (flux_subprocess_read_eof_reached (task->proc, name)) {
+        if (flux_subprocess_read_stream_closed (task->proc, name)) {
             if (!(buf = flux_subprocess_read (task->proc, name, -1, &len)))
                 return -1;
         }
@@ -162,7 +162,7 @@ int shell_task_io_readline (struct shell_task *task,
 
 bool shell_task_io_at_eof (struct shell_task *task, const char *name)
 {
-    return flux_subprocess_read_eof_reached (task->proc, name);
+    return flux_subprocess_read_stream_closed (task->proc, name);
 }
 
 int shell_task_pmi_enable (struct shell_task *task,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -201,6 +201,7 @@ check_PROGRAMS = \
 	rexec/rexec_signal \
 	rexec/rexec_ps \
 	rexec/rexec_count_stdout \
+	rexec/rexec_getline \
 	ingest/submitbench \
 	sched-simple/jj-reader \
 	shell/rcalc \
@@ -407,6 +408,11 @@ rexec_rexec_ps_LDADD = \
 rexec_rexec_count_stdout_SOURCES = rexec/rexec_count_stdout.c
 rexec_rexec_count_stdout_CPPFLAGS = $(test_cppflags)
 rexec_rexec_count_stdout_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+rexec_rexec_getline_SOURCES = rexec/rexec_getline.c
+rexec_rexec_getline_CPPFLAGS = $(test_cppflags)
+rexec_rexec_getline_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 ingest_job_manager_dummy_la_SOURCES = ingest/job-manager-dummy.c

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -53,6 +53,9 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp;
 
+    /* Do not use flux_subprocess_getline(), testing is against
+     * streams that are line buffered and not line buffered */
+
     if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
         log_err ("flux_subprocess_read_line");
         return;

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -58,10 +58,8 @@ void output_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    /* if process exited, read remaining stuff or EOF, otherwise
-     * wait for future newline */
-    if (!lenp
-        && flux_subprocess_state (p) == FLUX_SUBPROCESS_EXITED) {
+    /* we're at the end of the stream, read any lingering data */
+    if (!lenp && flux_subprocess_read_stream_closed (p, stream) > 0) {
         if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
             log_err ("flux_subprocess_read");
             return;

--- a/t/rexec/rexec_getline.c
+++ b/t/rexec/rexec_getline.c
@@ -1,0 +1,165 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <inttypes.h>
+#include <flux/core.h>
+#include <flux/optparse.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/read_all.h"
+
+extern char **environ;
+
+static struct optparse_option cmdopts[] = {
+    { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "rank",
+      .usage = "Specify rank for test" },
+    { .name = "stdin2stream", .key = 'i', .has_arg = 1, .arginfo = "CHANNEL",
+      .usage = "Read in stdin and forward to subprocess channel" },
+    OPTPARSE_TABLE_END
+};
+
+optparse_t *opts;
+
+int exit_code = 0;
+
+void completion_cb (flux_subprocess_t *p)
+{
+    int ec = flux_subprocess_exit_code (p);
+
+    if (ec > exit_code)
+        exit_code = ec;
+}
+
+void stdin2stream (flux_subprocess_t *p, const char *stream)
+{
+    char *buf = NULL;
+    int tmp, len;
+
+    if ((len = read_all (STDIN_FILENO, (void **)&buf)) < 0)
+        log_err_exit ("read_all");
+
+    if (len) {
+        if ((tmp = flux_subprocess_write (p, stream, buf, len)) < 0)
+            log_err_exit ("flux_subprocess_write");
+
+        if (tmp != len)
+            log_err_exit ("overflow in write");
+    }
+
+    /* do not close for channel, b/c can race w/ data coming back */
+    if (!strcmp (stream, "STDIN")) {
+        if (flux_subprocess_close (p, stream) < 0)
+            log_err_exit ("flux_subprocess_close");
+    }
+
+    free (buf);
+}
+
+void output_cb (flux_subprocess_t *p, const char *stream)
+{
+    FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
+    const char *ptr;
+    int lenp;
+
+    if (!(ptr = flux_subprocess_getline (p, stream, &lenp)))
+        log_err_exit ("flux_subprocess_getline");
+    if (lenp)
+        fwrite (ptr, lenp, 1, fstream);
+    else
+        fprintf (fstream, "EOF\n");
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_reactor_t *reactor;
+    flux_cmd_t *cmd;
+    char *cwd;
+    flux_subprocess_t *p = NULL;
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_state_change = NULL,
+        .on_channel_out = NULL,
+        .on_stdout = output_cb,
+        .on_stderr = NULL,
+    };
+    const char *optargp;
+    int optindex;
+    int rank = 0;
+
+    log_init ("rexec-until-eof");
+
+    opts = optparse_create ("rexec-until-eof");
+    if (optparse_add_option_table (opts, cmdopts) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_option_table");
+    if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)
+        exit (1);
+
+    if (optparse_getopt (opts, "rank", &optargp) > 0)
+        rank = atoi (optargp);
+
+    if (optindex == argc) {
+        optparse_print_usage (opts);
+        exit (1);
+    }
+
+    /* all args to cmd */
+    if (!(cmd = flux_cmd_create (argc - optindex, &argv[optindex], environ)))
+        log_err_exit ("flux_cmd_create");
+
+    if (!(cwd = get_current_dir_name ()))
+        log_err_exit ("get_current_dir_name");
+
+    if (flux_cmd_setcwd (cmd, cwd) < 0)
+        log_err_exit ("flux_cmd_setcwd");
+
+    if (optparse_getopt (opts, "stdin2stream", &optargp) > 0) {
+        if (strcmp (optargp, "STDIN")
+            && strcmp (optargp, "STDOUT")
+            && strcmp (optargp, "STDERR")) {
+            if (flux_cmd_add_channel (cmd, optargp) < 0)
+                log_err_exit ("flux_cmd_add_channel");
+            ops.on_channel_out = flux_standard_output;
+        }
+    }
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(reactor = flux_get_reactor (h)))
+        log_err_exit ("flux_get_reactor");
+
+    if (!(p = flux_rexec (h, rank, 0, cmd, &ops)))
+        log_err_exit ("flux_rexec");
+
+    if (optparse_getopt (opts, "stdin2stream", &optargp) > 0)
+        stdin2stream (p, optargp);
+
+    if (flux_reactor_run (reactor, 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    /* Clean up.
+     */
+    flux_subprocess_destroy (p);
+    flux_close (h);
+    log_fini ();
+
+    return exit_code;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/rexec/rexec_signal.c
+++ b/t/rexec/rexec_signal.c
@@ -70,7 +70,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 void io_cb (flux_subprocess_t *p, const char *stream)
 {
     const char *ptr;
-    int lenp;
+    int ret, lenp;
 
     if (strcasecmp (stream, "STDOUT")
         && strcasecmp (stream, "STDERR")) {
@@ -83,6 +83,14 @@ void io_cb (flux_subprocess_t *p, const char *stream)
         exit (1);
     }
     if (ptr && lenp == 0)
+        fprintf (stderr, "stream %s got EOF\n", stream);
+
+    /* extra coverage for EOF */
+    if ((ret = flux_subprocess_read_stream_closed (p, stream)) < 0) {
+        perror ("flux_subprocess_read");
+        exit (1);
+    }
+    if (ret > 0)
         fprintf (stderr, "stream %s got EOF\n", stream);
 }
 

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -203,4 +203,14 @@ test_expect_success 'rexec line buffering can be disabled' '
         test "$count" -gt 2
 '
 
+# the last line of output is "bar" without a newline.  "EOF" is output
+# from "rexec_getline", so if everything is working correctly, we
+# should see the concatenation "barEOF" at the end of the output.
+test_expect_success 'rexec read_getline call works on remote streams' '
+	/bin/echo -en "foo\nbar" | ${FLUX_BUILD_DIR}/t/rexec/rexec_getline -i STDIN ${TEST_SUBPROCESS_DIR}/test_echo -O -n > output 2>&1 &&
+        echo "foo" > expected &&
+        echo "barEOF" >> expected &&
+        test_cmp expected output
+'
+
 test_done


### PR DESCRIPTION
This PR does two things (it could be split into two PRs, but keeping it as one given #2255 thought process).

After a lot of thought on how to 1) make it easier to deal with EOF scenarios with read streams and 2) how to make it easier / more convenient for callers, in this PR:

- The `flux_subprocess_read_eof_reached()` temporary function that was introduced in PR #2254 is now "promoted" into a real library function because there are a few circumstances it is useful and the convenience function (described below) couldn't' be used.  Renamed it to `flux_subprocess_read_stream_closed()`, added header usage information, added tests.

- Added a new convenience function `flux_subprocess_read_line_until_eof()`, that will always read a line from the stream, but once EOF has been reached, it can return a non-line for the last read.  Then finally, it'll return length = 0 when EOF has been reached.  The reason this could not be done with `flux_subprocess_read_line()` is because `flux_subprocess_read_line()` still needs to work on streams that are both line and non-line buffered.  This convenience function will fail with errno = EPERM (good errno?) if you try to read from a non-line buffered stream.  Updated usage in 4 locations (broker, flux-exec, shell, job-exec).

- Had to fix one line buffering corner case bug I found along the way.

- Some stupid fixes along the way as always.