### PR TITLE
libsubprocess: Support ability to start/stop output callbacks

### DIFF
--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -267,6 +267,20 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - STDOUT_LINE_BUFFER - configure line buffering for stdout
  *    - STDERR_LINE_BUFFER - configure line buffering for stderr
  *
+ *  "STREAM_STOP" option
+ *
+ *    By default, the output callbacks such as 'on_stdout' and
+ *    'on_stderr' can immediately begin receiving stdout/stderr data
+ *    once a subprocess has started.  There are circumstances where a
+ *    caller may wish to wait and can have these callbacks stopped by
+ *    default and restarted later by flux_subprocess_stream_start().
+ *    By setting this option to "true", output callbacks will be
+ *    stopped by default.  These options can also be set to "false" to
+ *    keep default behavior.
+ *
+ *    - name + "_STREAM_STOP" - configure start/stop on channel name
+ *    - STDOUT_STREAM_STOP - configure start/stop for stdout
+ *    - STDERR_STREAM_STOP - configure start/stop for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
@@ -305,6 +319,17 @@ flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
                                const flux_cmd_t *cmd,
                                const flux_subprocess_ops_t *ops);
 
+/* Start / stop a read stream temporarily on local processes.  This
+ * may be useful for flow control.  If you desire to have a stream not
+ * call 'on_stdout' or 'on_stderr' when the local subprocess has
+ * started, see STREAM_STOP configuration above.
+ *
+ * start and stop return 0 for success, -1 on error
+ * status returns > 0 for started, 0 for stopped, -1 on error
+ */
+int flux_subprocess_stream_start (flux_subprocess_t *p, const char *stream);
+int flux_subprocess_stream_stop (flux_subprocess_t *p, const char *stream);
+int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream);
 
 /*
  *  Write data to "stream" stream of subprocess `p`.  'stream' can be

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -42,6 +42,12 @@ struct subprocess_channel {
     int child_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
+    /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is
+     * stopped.  We need to put something into the reactor so we know
+     * that we still need to process it.
+     */
+    flux_watcher_t *buffer_read_stopped_w;
+    bool buffer_read_w_started;
 
     /* remote */
     flux_buffer_t *write_buffer;

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -1956,11 +1956,11 @@ void line_output_cb (flux_subprocess_t *p, const char *stream)
 
 void test_line_buffer_default (flux_reactor_t *r)
 {
-    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-c", "2200", "hi", NULL };
+    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-O", "-c", "2200", "hi", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
-    ok ((cmd = flux_cmd_create (4, av, environ)) != NULL, "flux_cmd_create");
+    ok ((cmd = flux_cmd_create (5, av, environ)) != NULL, "flux_cmd_create");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -1987,11 +1987,11 @@ void test_line_buffer_default (flux_reactor_t *r)
 
 void test_line_buffer_enable (flux_reactor_t *r)
 {
-    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-c", "2200", "hi", NULL };
+    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-O", "-c", "2200", "hi", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
-    ok ((cmd = flux_cmd_create (4, av, environ)) != NULL, "flux_cmd_create");
+    ok ((cmd = flux_cmd_create (5, av, environ)) != NULL, "flux_cmd_create");
 
     ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "true") == 0,
         "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
@@ -2036,11 +2036,11 @@ void count_output_cb (flux_subprocess_t *p, const char *stream)
 
 void test_line_buffer_disable (flux_reactor_t *r)
 {
-    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-c", "2200", "hi", NULL };
+    char *av[] = { TEST_SUBPROCESS_DIR "test_multi_echo", "-O", "-c", "2200", "hi", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
-    ok ((cmd = flux_cmd_create (4, av, environ)) != NULL, "flux_cmd_create");
+    ok ((cmd = flux_cmd_create (5, av, environ)) != NULL, "flux_cmd_create");
 
     ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
         "flux_cmd_setopt set STDOUT_LINE_BUFFER success");

--- a/src/common/libsubprocess/test/test_echo.c
+++ b/src/common/libsubprocess/test/test_echo.c
@@ -96,7 +96,7 @@ main (int argc, char *argv[])
 
     if ((out + err) == 0
         && (!channel && !channel_out)) {
-        fprintf (stderr, "must specify a way to output");
+        fprintf (stderr, "must specify -O, -E, and/or -C for output\n");
         exit (1);
     }
 

--- a/src/common/libsubprocess/test/test_echo.c
+++ b/src/common/libsubprocess/test/test_echo.c
@@ -152,7 +152,5 @@ main (int argc, char *argv[])
         }
     }
 
-    close (STDOUT_FILENO);
-    close (STDERR_FILENO);
     exit (0);
 }

--- a/src/common/libsubprocess/test/test_multi_echo.c
+++ b/src/common/libsubprocess/test/test_multi_echo.c
@@ -8,24 +8,35 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* simple tool that outputs args to stdout multiple times */
+/* simple tool that outputs args to stdout/stderr multiple times */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <poll.h>
 
+int out = 0;
+int err = 0;
 int count = 4;
 
 int
 main (int argc, char *argv[])
 {
+    int maxcount;
+
     while (1) {
-        int c = getopt (argc, argv, "nc:");
+        int c = getopt (argc, argv, "OEc:");
         if (c < 0)
             break;
 
         switch (c) {
+        case 'O':
+            out++;
+            break;
+        case 'E':
+            err++;
+            break;
         case 'c':
             count = atoi (optarg);
             if (count <= 0) {
@@ -36,17 +47,52 @@ main (int argc, char *argv[])
         }
     }
 
-    if (optind != argc) {
-        while (optind < argc) {
-            int i;
-            for (i = 0; i < count; i++) {
-                printf ("%s", argv[optind]);
-                fflush (stdout);
+    if ((out + err) == 0) {
+        fprintf (stderr, "must specify -O and/or -E for output\n");
+        exit (1);
+    }
+
+    /* +1 for newline */
+    maxcount = count + 1;
+    while (optind < argc) {
+        int ret, outcount = 0, errcount = 0;
+
+        /* some tests can flood / hang fprintf calls, so check
+         * that we can output */
+        while ((out && outcount < maxcount)
+               || (err && errcount < maxcount)) {
+            struct pollfd pfds[2];
+
+            pfds[0].fd = STDOUT_FILENO;
+            pfds[0].events = (out && outcount < maxcount) ? POLLOUT: 0;
+            pfds[0].revents = 0;
+
+            pfds[1].fd = STDERR_FILENO;
+            pfds[1].events = (err && errcount < maxcount) ? POLLOUT: 0;
+            pfds[1].revents = 0;
+
+            if ((ret = poll (pfds, 2, -1)) < 0) {
+                perror ("poll");
+                exit (1);
             }
-            optind++;
+            if (out && pfds[0].revents & POLLOUT) {
+                if (outcount == count)
+                    fprintf (stdout, "\n");
+                else
+                    fprintf (stdout, "%s", argv[optind]);
+                fflush (stdout);
+                outcount++;
+            }
+            if (err && pfds[1].revents & POLLOUT) {
+                if (errcount == count)
+                    fprintf (stderr, "\n");
+                else
+                    fprintf (stderr, "%s", argv[optind]);
+                fflush (stderr);
+                errcount++;
+            }
         }
-        printf ("\n");
-        fflush (stdout);
+        optind++;
     }
 
     exit (0);

--- a/src/common/libsubprocess/test/test_multi_echo.c
+++ b/src/common/libsubprocess/test/test_multi_echo.c
@@ -49,6 +49,5 @@ main (int argc, char *argv[])
         fflush (stdout);
     }
 
-    close (STDOUT_FILENO);
     exit (0);
 }

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -97,6 +97,31 @@ cleanup:
     return rv;
 }
 
+int cmd_option_stream_stop (flux_subprocess_t *p, const char *name)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    if (asprintf (&var, "%s_STREAM_STOP", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        if (!strcasecmp (val, "true"))
+            rv = 1;
+        if (!strcasecmp (val, "false"))
+            rv = 0;
+        else
+            errno = EINVAL;
+    }
+    else
+        rv = 0;
+
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -21,4 +21,6 @@ int cmd_option_bufsize (flux_subprocess_t *p, const char *name);
 
 int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
+int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -186,19 +186,19 @@ test_expect_success NO_CHAIN_LINT 'disconnect terminates all running processes' 
 '
 
 test_expect_success 'rexec line buffering works (default)' '
-        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 ${TEST_SUBPROCESS_DIR}/test_multi_echo -c 2200 hi > linebuffer1.out &&
+        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 ${TEST_SUBPROCESS_DIR}/test_multi_echo -O -c 2200 hi > linebuffer1.out &&
         grep "final stdout callback count: 2" linebuffer1.out
 '
 
 test_expect_success 'rexec line buffering works (set to true)' '
-        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 -l true ${TEST_SUBPROCESS_DIR}/test_multi_echo -c 2200 hi > linebuffer2.out &&
+        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 -l true ${TEST_SUBPROCESS_DIR}/test_multi_echo -O -c 2200 hi > linebuffer2.out &&
         grep "final stdout callback count: 2" linebuffer2.out
 '
 
 # test is technically racy, but with 2200 hi outputs, probability is
 # extremely low all data is buffered in one shot.
 test_expect_success 'rexec line buffering can be disabled' '
-        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 -l false ${TEST_SUBPROCESS_DIR}/test_multi_echo -c 2200 hi > linebuffer3.out &&
+        ${FLUX_BUILD_DIR}/t/rexec/rexec_count_stdout -r 1 -l false ${TEST_SUBPROCESS_DIR}/test_multi_echo -O -c 2200 hi > linebuffer3.out &&
         count=$(grep "final stdout callback count:" linebuffer3.out | awk "{print \$5}") &&
         test "$count" -gt 2
 '


### PR DESCRIPTION
Per discussion in #2235, support ability to start/stop output callbacks (most notably `on_stdout` and `on_stderr`).

- Support three new functions, `flux_subprocess_stream_start()`, `flux_subprocess_stream_stop()`, and `flux_subprocess_stream_status()`, which do what you would think they do.

- To support a stream being stopped on start of the subprocess, support a cmd option `STREAM_STOP`.

- Interesting development notes:

- I only support this on local subprocesses.  Doing it over remote subprocesses "correctly", would be difficult, doing it over remote subprocesses "ok" would not be too hard.  But talking to @garlick, this isn't needed on remote subprocesses right now, so I'm punting.

- Had to manually track if a watcher was started/stopped through flags.  If we implement something in #2267, could be replaced.

- If I `flux_watcher_stop()` buffer watcher, that means the reactor is missing a watcher it normally would have and some assumed logic about when watchers are started/stopped breaks down.  To solve this, when the buffer watcher is stopped, I start a temporary "junk" check watcher that does nothing.

- The tests I write are a bit interesting.

  - some tests I basically have a test tool called `test_multi_echo` that will output a bunch of stuff to both stdout and stderr, the output being intermixed.  I tell the stdout callback to stop, but leave the stderr one on.  The hope of the tests is to get all stderr output, then turn on the stdout callback, and get all stdout data afterwards.  The tricky part about this test is if I output too much data to stdout (without reading from it), writing to stdout can eventually block.  So it had to be just the right amount of data.
  - the other interesting test is I basically write a lot of stuff to stdout.  I wait till the stdout callback gets some data, stop the stdout callback, start a timer, and make sure I don't get any stdout data/callbacks over the next 2 seconds, restart the callback, and make sure remaining stdout comes after the timeout callback was called.  I dislike having something that "waits a few seconds" , b/c it can be racy, but A) the odds of a failure are low B) there are limited options to test this scenario.  I had other testing ideas, but they seemed more complicated and not worth the effort.

