### PR TITLE
flux-shell: populate PMI_process_mapping key

### DIFF
--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -19,7 +19,9 @@ libpmi_common_sources = \
 	pmi_strerror.c \
 	pmi_strerror.h \
 	keyval.c \
-	keyval.h
+	keyval.h \
+	clique.c \
+	clique.h
 
 libpmi_client_la_SOURCES = \
 	simple_client.c \
@@ -27,8 +29,6 @@ libpmi_client_la_SOURCES = \
 	pmi.c \
 	dgetline.c \
 	dgetline.h \
-	clique.c \
-	clique.h \
 	$(libpmi_common_sources)
 
 libpmi_server_la_SOURCES = \

--- a/src/common/libpmi/clique.h
+++ b/src/common/libpmi/clique.h
@@ -41,6 +41,14 @@ struct pmi_map_block {
 int pmi_process_mapping_parse (const char *s,
                                struct pmi_map_block **blocks, int *nblocks);
 
+/* Generate PMI_process_mapping value string from array of pmi_map_blocks,
+ * and place it in 'buf'.  Result will be null terminated.
+ */
+int pmi_process_mapping_encode (struct pmi_map_block *blocks,
+                                int nblocks,
+                                char *buf,
+                                int bufsz);
+
 
 /* Determine the nodeid that will start 'rank', and return it in 'nodeid'.
  */

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -205,6 +205,10 @@ static int shell_pmi_barrier_enter (void *arg)
     val = zhashx_first (pmi->kvs);
     while (val) {
         key = zhashx_cursor (pmi->kvs);
+        if (!strcmp (key, "PMI_process_mapping")) {
+            val = zhashx_next (pmi->kvs);
+            continue;
+        }
         if (shell_pmi_kvs_key (nkey,
                                sizeof (nkey),
                                pmi->shell->jobid,

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -27,10 +27,10 @@
  *
  * Other requests have callbacks from the engine to provide data,
  * which is fed back to the engine, which then calls shell_pmi_response_send().
- * These are kvs_get, kvs_put, and barrier.  Although the protocol engine
+ * These are kvs_get, kvs_put, and barrier.  Although the task
  * is effectively blocked while these callbacks are handled, they are
- * implemented with asynchronous continuation callbacks so that the shell's
- * reactor remains live while they are waiting for an answer.
+ * implemented with asynchronous continuation callbacks so that other tasks
+ * and the shell's reactor remain live while the task awaits an answer.
  *
  * The PMI KVS supports a put / barrier / get pattern.  The barrier
  * distributes KVS data that was "put" so that it is available to "get".

--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -135,6 +135,13 @@ test_expect_success 'flux-shell: shell PMI works' '
 	${FLUX_SHELL} -v -s -r 0 -j j8pmi -R R8 51 \
 		>pmi_info.out 2>pmi_info.err
 '
+test_expect_success 'flux-shell: shell PMI exports clique info' '
+	flux jobspec srun -N1 -n8 ${PMI_INFO} -c >j8pmi_clique &&
+	${FLUX_SHELL} -v -s -r 0 -j j8pmi_clique -R R8 51 \
+		>pmi_clique.out 2>pmi_clique.err &&
+	COUNT=$(grep "clique=0,1,2,3,4,5,6,7" pmi_clique.out | wc -l) &&
+	test ${COUNT} -eq 8
+'
 test_expect_success 'flux-shell: shell PMI KVS works' '
 	flux jobspec srun -N1 -n8 ${KVSTEST} >j8kvs &&
 	${FLUX_SHELL} -v -s -r 0 -j j8kvs -R R8 52 \


### PR DESCRIPTION
I forgot to populate this key, which, if present, is used by MPI to determine which procs can used shared memory to communicate because they are on the same node.

Add a helper function to libpmi, then use it in the shell's pmi implementation.

Add some tests that verify cliques work as intended for simple cases.