### PR TITLE
flux-start: exit gracefully with error when getcwd() fails

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -143,6 +143,17 @@ static int parse_bootstrap_option (optparse_t *opts)
     log_msg_exit("Unknown bootstrap method \"%s\"", bootstrap);
 }
 
+/* Various things will go wrong with module loading, process execution, etc.
+ *  when current directory can't be found. Exit early with error to avoid
+ *  chaotic stream of error messages later in startup.
+ */
+static void sanity_check_working_directory (void)
+{
+    char buf [PATH_MAX+1024];
+    if (!getcwd (buf, sizeof (buf)))
+        log_err_exit ("Unable to get current working directory");
+}
+
 int main (int argc, char *argv[])
 {
     int e, status = 0;
@@ -154,6 +165,8 @@ int main (int argc, char *argv[])
     int bootstrap;
 
     log_init ("flux-start");
+
+    sanity_check_working_directory ();
 
     ctx.opts = optparse_create ("flux-start");
     if (optparse_add_option_table (ctx.opts, opts) != OPTPARSE_SUCCESS)

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -894,6 +894,8 @@ int mod_main (flux_t *h, int ac, char **av)
     int rc = -1;
     flux_msg_handler_t **handlers = NULL;
     cron_ctx_t *ctx = cron_ctx_create (h);
+    if (ctx == NULL)
+        return -1;
 
     process_args (ctx, ac, av);
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -126,6 +126,16 @@ test_expect_success 'flux-start --wrap option works with --size' '
 	test "$(grep -c test-wrap wrap2.output)" = "2"
 '
 
+test_expect_success 'flux-start dies gracefully when run from removed dir' '
+	mkdir foo && (
+	 cd foo &&
+	 unset FLUX_RC1_PATH &&
+	 unset FLUX_RC3_PATH &&
+	 rmdir ../foo &&
+	 test_must_fail flux start /bin/true )
+'
+
+
 test_expect_success 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&
         mkdir -p test-under-flux && (


### PR DESCRIPTION
This PR fixes the segv in the `cron` module found by @dongahn in issue #2274.

A test for `flux-start` run from a removed directory was also added.

Finally, while `flux-start` fails gracefully with the cron module fix, there is a huge number of errors. So a check was added early to `flux-start` `main()` to exit with an error if `getcwd()` fails to evoke an early exit.