### PR TITLE
broker: avoid accidentally consuming % format characters in initial program args

### DIFF
--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -382,10 +382,12 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *cmd_argz,
     flux_cmd_unsetenv (cmd, "PMI_FD");
     flux_cmd_unsetenv (cmd, "PMI_RANK");
     flux_cmd_unsetenv (cmd, "PMI_SIZE");
-    if (local_uri && flux_cmd_setenvf (cmd, 1, "FLUX_URI", local_uri) < 0)
+    if (local_uri && flux_cmd_setenvf (cmd, 1, "FLUX_URI",
+                                       "%s", local_uri) < 0)
         goto error;
     if (level == 1 || level == 3) {
-        if (flux_cmd_setenvf (cmd, 1, "FLUX_NODESET_MASK", r->nodeset) < 0)
+        if (flux_cmd_setenvf (cmd, 1, "FLUX_NODESET_MASK",
+                              "%s", r->nodeset) < 0)
             goto error;
     }
     r->rc[level].cmd = cmd;

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -830,7 +830,7 @@ static int child_create (proxy_ctx_t *ctx, int ac, char **av, const char *workpa
     if (!(cmd = flux_cmd_create (0, NULL, environ)))
         goto error;
 
-    if (flux_cmd_argv_append (cmd, "%s", shell) < 0)
+    if (flux_cmd_argv_append (cmd, shell) < 0)
         goto error;
 
     for (i = 0; i < ac; i++) {

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -482,7 +482,7 @@ const char *flux_cmd_arg (const flux_cmd_t *cmd, int n)
     return arg;
 }
 
-int flux_cmd_argv_append (flux_cmd_t *cmd, const char *fmt, ...)
+int flux_cmd_argv_appendf (flux_cmd_t *cmd, const char *fmt, ...)
 {
     int rc = 0;
     int errnum = 0;
@@ -493,6 +493,21 @@ int flux_cmd_argv_append (flux_cmd_t *cmd, const char *fmt, ...)
     va_end (ap);
     errno = errnum;
     return (rc);
+}
+
+int flux_cmd_argv_append (flux_cmd_t *cmd, const char *arg)
+{
+    int e;
+    if (arg == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    e = argz_add (&cmd->argz, &cmd->argz_len, arg);
+    if (e) {
+        errno = e;
+        return -1;
+    }
+    return 0;
 }
 
 static int flux_cmd_setenv (flux_cmd_t *cmd, const char *k, const char *v,

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -348,7 +348,7 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
         }
     }
 
-    if (flux_cmd_setenvf (cmd, 1, "FLUX_URI", s->local_uri) < 0)
+    if (flux_cmd_setenvf (cmd, 1, "FLUX_URI", "%s", s->local_uri) < 0)
         goto error;
 
     if (flux_respond_pack (s->h, msg, "{s:s s:i}",

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -177,7 +177,8 @@ void flux_cmd_destroy (flux_cmd_t *cmd);
 /*
  *  Append formatted string to argv of `cmd`.
  */
-int flux_cmd_argv_appendf (flux_cmd_t *cmd, const char *fmt, ...);
+int flux_cmd_argv_appendf (flux_cmd_t *cmd, const char *fmt, ...)
+                           __attribute__ ((format (printf, 2, 3)));
 
 /*
  *  Append string to argv of `cmd`.
@@ -199,7 +200,8 @@ const char *flux_cmd_arg (const flux_cmd_t *cmd, int n);
  *   If `overwrite` is non-zero then overwrite any existing setting for `name`.
  */
 int flux_cmd_setenvf (flux_cmd_t *cmd, int overwrite,
-		      const char *name, const char *fmt, ...);
+		      const char *name, const char *fmt, ...)
+                      __attribute__ ((format (printf, 4, 5)));
 
 /*
  *  Unset environment variable `name` in the command object `cmd`.

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -177,7 +177,12 @@ void flux_cmd_destroy (flux_cmd_t *cmd);
 /*
  *  Append formatted string to argv of `cmd`.
  */
-int flux_cmd_argv_append (flux_cmd_t *cmd, const char *fmt, ...);
+int flux_cmd_argv_appendf (flux_cmd_t *cmd, const char *fmt, ...);
+
+/*
+ *  Append string to argv of `cmd`.
+ */
+int flux_cmd_argv_append (flux_cmd_t *cmd, const char *arg);
 
 /*
  *  Return the current argument count for `cmd`.

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -83,8 +83,8 @@ void set_cmd_attributes (flux_cmd_t *cmd)
         "flux_cmd_argv_append");
     ok (flux_cmd_argv_append (cmd, "foo") >= 0,
         "flux_cmd_argv_append");
-    ok (flux_cmd_argv_append (cmd, "bar") >= 0,
-        "flux_cmd_argv_append");
+    ok (flux_cmd_argv_appendf (cmd, "%s", "bar") >= 0,
+        "flux_cmd_argv_appendf");
 
     // Test setenvf
     ok (flux_cmd_setenvf (cmd, 0, "PATH", "/bin:/usr/bin") >= 0,

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -287,9 +287,9 @@ static flux_cmd_t *exec_cmd_create (struct cron_task *t,
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_create");
         goto error;
     }
-    if (flux_cmd_argv_append (cmd, "%s", "sh") < 0
-        || flux_cmd_argv_append (cmd, "%s", "-c") < 0
-        || flux_cmd_argv_append (cmd, "%s", command) < 0) {
+    if (flux_cmd_argv_append (cmd, "sh") < 0
+        || flux_cmd_argv_append (cmd, "-c") < 0
+        || flux_cmd_argv_append (cmd, command) < 0) {
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_argv_append");
         goto error;
     }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -132,7 +132,7 @@ static int exec_init (struct jobinfo *job)
         goto err;
     }
     if (flux_cmd_argv_append (cmd, job_shell_path (job)) < 0
-        || flux_cmd_argv_append (cmd, "%ju", (uintmax_t) job->id) < 0) {
+        || flux_cmd_argv_appendf (cmd, "%ju", (uintmax_t) job->id) < 0) {
         flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
         goto err;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -158,6 +158,7 @@ dist_check_SCRIPTS = \
         issues/t0821-kvs-segfault.sh \
 	issues/t1760-kvs-use-after-free.sh \
 	issues/t2281-service-add-crash.sh \
+	issues/t2284-initial-program-format-chars.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t2284-initial-program-format-chars.sh
+++ b/t/issues/t2284-initial-program-format-chars.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+# broker cmdline preserves format characters
+
+export FLUX_RC1_PATH=""
+export FLUX_RC3_PATH=""
+for s in %h %g %%h %f; do
+    echo "Running flux broker echo $s"
+    output=$(flux broker /bin/echo $s)
+    test "$output" = "$s"
+done
+exit 0


### PR DESCRIPTION
Rename `flux_cmd_argv_append()` to `flux_cmd_argv_appendf()` to indicate this function takes printf style arguments. The new `flux_cmd_argv_append()` takes a string argument only, which satisfies most use cases and simultaneously fixes #2284, by avoiding passing user provided string as the `fmt` arg, as these strings may contain `%` characters.

This issue could have also been fixed by simply calling
```
 flux_cmd_argv_append (cmd, "%s", arg);
```
as one would do for `printf`, however it seemed important to try to avoid this confusion in the future, and perhaps the rename will help with that. (I'd be willing to redo the PR, though, if others feel different)
