### PR TITLE
libioencode: convenience library for encoding io

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -420,6 +420,7 @@ AC_CONFIG_FILES( \
   src/common/libaggregate/Makefile \
   src/common/libschedutil/Makefile \
   src/common/libeventlog/Makefile \
+  src/common/libioencode/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -37,6 +37,7 @@
 #include "src/common/libutil/read_all.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libioencode/ioencode.h"
 
 int cmd_list (optparse_t *p, int argc, char **argv);
 int cmd_submit (optparse_t *p, int argc, char **argv);
@@ -849,10 +850,6 @@ void print_output (flux_t *h, flux_jobid_t id, optparse_t *p, bool missing_ok)
     json_t *output;
     size_t index;
     json_t *entry;
-    int rank;
-    const char *stream;
-    int len;
-    const char *data;
 
     if (!(f = flux_rpc_pack (h,
                              "job-info.lookup",
@@ -871,12 +868,11 @@ void print_output (flux_t *h, flux_jobid_t id, optparse_t *p, bool missing_ok)
     if (!(output = json_loads (s, 0, NULL)))
         log_msg_exit ("error decoding guest.output");
     json_array_foreach (output, index, entry) {
-        if (json_unpack (entry,
-                         "{s:i s:s s:i s:s}",
-                         "rank", &rank,
-                         "stream", &stream,
-                         "len", &len,
-                         "data", &data) < 0)
+        const char *stream = NULL;
+        int rank;
+        char *data = NULL;
+        int len = 0;
+        if (iodecode (entry, &stream, &rank, &data, &len, NULL) < 0)
             log_msg_exit ("malformed JSON entry");
         if (len > 0) {
             FILE *fp = !strcmp (stream, "STDOUT") ? stdout : stderr;
@@ -884,6 +880,7 @@ void print_output (flux_t *h, flux_jobid_t id, optparse_t *p, bool missing_ok)
                 fprintf (fp, "%d: ", rank);
             fwrite (data, len, 1, fp);
         }
+        free (data);
     }
     json_decref (output);
 out:

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -877,7 +877,7 @@ void print_output (flux_t *h, flux_jobid_t id, optparse_t *p, bool missing_ok)
                          "stream", &stream,
                          "len", &len,
                          "data", &data) < 0)
-            log_msg_exit ("malfomed JSON entry");
+            log_msg_exit ("malformed JSON entry");
         if (len > 0) {
             FILE *fp = !strcmp (stream, "STDOUT") ? stdout : stderr;
             if (optparse_hasopt (p, "label"))

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -12,7 +12,8 @@ SUBDIRS = libtap \
           libsubprocess \
           libaggregate \
           libschedutil \
-	  libeventlog
+	  libeventlog \
+	  libioencode
 
 AM_CFLAGS = $(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)
@@ -29,6 +30,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libev/libev.la \
 	$(builddir)/libtomlc99/libtomlc99.la \
 	$(builddir)/libeventlog/libeventlog.la \
+	$(builddir)/libioencode/libioencode.la \
 	$(JANSSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
 	$(LIBDL) $(LIBRT) $(FLUX_SECURITY_LIBS) $(LIBSODIUM_LIBS)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)

--- a/src/common/libioencode/Makefile.am
+++ b/src/common/libioencode/Makefile.am
@@ -1,0 +1,43 @@
+AM_CFLAGS = \
+        $(WARNING_CFLAGS) \
+        $(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+        $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+noinst_LTLIBRARIES = \
+	libioencode.la
+
+libioencode_la_SOURCES = \
+	ioencode.h \
+	ioencode.c
+
+TESTS = \
+	test_ioencode.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+        $(top_srcdir)/config/tap-driver.sh
+
+test_ldadd = \
+        $(top_builddir)/src/common/libioencode/libioencode.la \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libtap/libtap.la
+
+test_cppflags = \
+        $(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap
+
+test_ioencode_t_SOURCES = test/ioencode.c
+test_ioencode_t_CPPFLAGS = $(test_cppflags)
+test_ioencode_t_LDADD = $(test_ldadd)

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -1,0 +1,171 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdarg.h>
+#include <string.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include <sodium.h>
+#include <jansson.h>
+
+#include "src/common/libutil/macros.h"
+
+#include "ioencode.h"
+
+static char *bin2base64 (const char *bin_data, int bin_len)
+{
+    char *base64_data;
+    int base64_len;
+
+    base64_len = sodium_base64_encoded_len (bin_len, sodium_base64_VARIANT_ORIGINAL);
+
+    if (!(base64_data = calloc (1, base64_len)))
+        return NULL;
+
+    sodium_bin2base64 (base64_data, base64_len,
+                       (unsigned char *)bin_data, bin_len,
+                       sodium_base64_VARIANT_ORIGINAL);
+
+    return base64_data;
+}
+
+static char *base642bin (const char *base64_data, size_t *bin_len)
+{
+    size_t base64_len;
+    char *bin_data = NULL;
+
+    base64_len = strlen (base64_data);
+    (*bin_len) = BASE64_DECODE_SIZE (base64_len);
+
+    if (!(bin_data = calloc (1, (*bin_len))))
+        return NULL;
+
+    if (sodium_base642bin ((unsigned char *)bin_data, (*bin_len),
+                           base64_data, base64_len,
+                           NULL, bin_len, NULL,
+                           sodium_base64_VARIANT_ORIGINAL) < 0) {
+        free (bin_data);
+        return NULL;
+    }
+
+    return bin_data;
+}
+
+json_t *ioencode (const char *stream,
+                  int rank,
+                  const char *data,
+                  int len,
+                  bool eof)
+{
+    char *base64_data = NULL;
+    json_t *o = NULL;
+    json_t *rv = NULL;
+
+    /* data can be NULL and len == 0 if eof true */
+    if (!stream
+        || (data && len <= 0)
+        || (!data && len != 0)
+        || (!data && !len && !eof)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (data && len) {
+        if (!(base64_data = bin2base64 (data, len)))
+            goto error;
+        if (!(o = json_pack ("{s:s s:i s:s}",
+                             "stream", stream,
+                             "rank", rank,
+                             "data", base64_data)))
+            goto error;
+    }
+    else {
+        if (!(o = json_pack ("{s:s s:i}",
+                             "stream", stream,
+                             "rank", rank)))
+            goto error;
+    }
+    if (eof) {
+        if (json_object_set_new (o, "eof", json_true ()) < 0)
+            goto error;
+    }
+    rv = o;
+error:
+    free (base64_data);
+    return rv;
+}
+
+int iodecode (json_t *o,
+              const char **streamp,
+              int *rankp,
+              char **datap,
+              int *lenp,
+              bool *eofp)
+{
+    const char *stream;
+    int rank;
+    const char *base64_data;
+    char *bin_data = NULL;
+    size_t bin_len = 0;
+    int eof = 0;
+    bool has_data = false;
+    bool has_eof = false;
+    int rv = -1;
+
+    if (!o) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (json_unpack (o, "{s:s s:i}",
+                     "stream", &stream,
+                     "rank", &rank) < 0)
+        goto cleanup;
+
+    if (json_unpack (o, "{s:s}", "data", &base64_data) == 0) {
+        has_data = true;
+        if (!(bin_data = base642bin (base64_data, &bin_len)))
+            goto cleanup;
+    }
+    if (json_unpack (o, "{s:b}", "eof", &eof) == 0)
+        has_eof = true;
+
+    if (!has_data && !has_eof) {
+        errno = EPROTO;
+        goto cleanup;
+    }
+
+    if (streamp)
+        (*streamp) = stream;
+    if (rankp)
+        (*rankp) = rank;
+    if (datap) {
+        (*datap) = bin_data;
+        bin_data = NULL;
+    }
+    if (lenp)
+        (*lenp) = bin_len;
+    if (eofp)
+        (*eofp) = eof;
+
+    rv = 0;
+cleanup:
+    free (bin_data);
+    return rv;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libioencode/ioencode.h
+++ b/src/common/libioencode/ioencode.h
@@ -1,0 +1,40 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _IOENCODE_H
+#define _IOENCODE_H
+
+#include <stdbool.h>
+#include <jansson.h>
+
+/* encode io data and/or EOF into json_t object
+ * - to set only EOF, set data to NULL and data_len to 0
+ * - it is an error to provide no data and EOF = false
+ * - returned object should be json_decref()'d after use
+ */
+json_t *ioencode (const char *stream,
+                  int rank,
+                  const char *data,
+                  int len,
+                  bool eof);
+
+/* decode json_t io object
+ * - both data and EOF can be available
+ * - if no data available, data set to NULL and len to 0
+ * - data must be freed after return
+ */
+int iodecode (json_t *o,
+              const char **stream,
+              int *rank,
+              char **data,
+              int *len,
+              bool *eof);
+
+#endif /* !_IOENCODE_H */

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -1,0 +1,94 @@
+/************************************************************  \
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <jansson.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libioencode/ioencode.h"
+
+void basic_corner_case (void)
+{
+    errno = 0;
+    ok (ioencode (NULL, -1, NULL, -1, false) == NULL
+        && errno == EINVAL,
+        "ioencode returns EINVAL on bad input");
+
+    errno = 0;
+    ok (iodecode (NULL, NULL, NULL, NULL, NULL, NULL) < 0
+        && errno == EINVAL,
+        "iodecode returns EINVAL on bad input");
+}
+
+void basic (void)
+{
+    json_t *o;
+    const char *stream;
+    int rank;
+    char *data;
+    int len;
+    bool eof;
+
+    ok ((o = ioencode ("stdout", 1, "foo", 3, false)) != NULL,
+        "ioencode success (data, eof = false)");
+    ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
+        "iodecode success");
+    ok (!strcmp (stream, "stdout")
+        && rank == 1
+        && !strcmp (data, "foo")
+        && len == 3
+        && eof == false,
+        "iodecode returned correct info");
+    free (data);
+    json_decref (o);
+
+    ok ((o = ioencode ("stdout", 2, "bar", 3, true)) != NULL,
+        "ioencode success (data, eof = true)");
+    ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
+        "iodecode success");
+    ok (!strcmp (stream, "stdout")
+        && rank == 2
+        && !strcmp (data, "bar")
+        && len == 3
+        && eof == true,
+        "iodecode returned correct info");
+    free (data);
+    json_decref (o);
+
+    ok ((o = ioencode ("stderr", 3, NULL, 0, true)) != NULL,
+        "ioencode success (no data, eof = true)");
+    ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
+        "iodecode success");
+    ok (!strcmp (stream, "stderr")
+        && rank == 3
+        && data == NULL
+        && len == 0
+        && eof == true,
+        "iodecode returned correct info");
+    free (data);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic_corner_case ();
+    basic ();
+
+    done_testing ();
+
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This simple convenience library encodes/decodes io into json objects.  Being the non-creative person I am, I call the library `libioencode`.  The objects encode stream, rank, data in base64, or EOF.

Cleanup was nice, to remove alot of the random calls to `libsodium` all over the place and to common-ize code between `libsubprocess` and `shell`.

Design choice: When encoding I elected to have a different object for EOF.  When decoding, you can get data or EOF, but not both.  I felt this made things simpler in `libsubprocess`, but can understand there are circumstances this is not optimal.
