### PR TITLE
increase efficiency of line buffered I/O

### DIFF
--- a/src/common/libflux/buffer.c
+++ b/src/common/libflux/buffer.c
@@ -138,13 +138,12 @@ int flux_buffer_readonly (flux_buffer_t *fb)
     return 0;
 }
 
-int flux_buffer_is_readonly (flux_buffer_t *fb)
+bool flux_buffer_is_readonly (flux_buffer_t *fb)
 {
     if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
         errno = EINVAL;
-        return -1;
+        return false;
     }
-
     return fb->readonly;
 }
 

--- a/src/common/libflux/buffer.c
+++ b/src/common/libflux/buffer.c
@@ -247,7 +247,7 @@ void check_read_cb (flux_buffer_t *fb)
         && flux_buffer_bytes (fb) > fb->cb_len)
             fb->cb (fb, fb->cb_arg);
     else if (fb->cb_type == FLUX_BUFFER_CB_TYPE_READ_LINE
-             && flux_buffer_lines (fb) > 0)
+             && flux_buffer_has_line (fb))
             fb->cb (fb, fb->cb_arg);
 }
 

--- a/src/common/libflux/buffer.c
+++ b/src/common/libflux/buffer.c
@@ -355,6 +355,16 @@ int flux_buffer_lines (flux_buffer_t *fb)
     return cbuf_lines_used (fb->cbuf);
 }
 
+bool flux_buffer_has_line (flux_buffer_t *fb)
+{
+    char buf[1];
+    if (!fb || fb->magic != FLUX_BUFFER_MAGIC) {
+        errno = EINVAL;
+        return false;
+    }
+    return (cbuf_peek_line (fb->cbuf, buf, 0, 1) > 0);
+}
+
 int flux_buffer_drop_line (flux_buffer_t *fb)
 {
     int ret;

--- a/src/common/libflux/buffer.c
+++ b/src/common/libflux/buffer.c
@@ -244,52 +244,11 @@ void check_write_cb (flux_buffer_t *fb)
 void check_read_cb (flux_buffer_t *fb)
 {
     if (fb->cb_type == FLUX_BUFFER_CB_TYPE_READ
-        && flux_buffer_bytes (fb) > fb->cb_len) {
-        int count = flux_buffer_bytes (fb);
-
-        /* we will iterate over all data, but only if the user is
-         * reading data.  If the user isn't reading data, we're not
-         * going to infinitely loop
-         */
-        while (fb->cb_type == FLUX_BUFFER_CB_TYPE_READ
-               && count > 0) {
-            int tmp;
-
+        && flux_buffer_bytes (fb) > fb->cb_len)
             fb->cb (fb, fb->cb_arg);
-
-            if ((tmp = flux_buffer_bytes (fb)) < 0)
-                break;
-
-            if (tmp < count && tmp > fb->cb_len)
-                count = tmp;
-            else
-                break;
-        }
-
-    }
     else if (fb->cb_type == FLUX_BUFFER_CB_TYPE_READ_LINE
-             && flux_buffer_lines (fb) > 0) {
-        int count = flux_buffer_lines (fb);
-
-        /* we will iterate over all lines, but only if the user is
-         * reading them.  If the user isn't reading lines, we're not
-         * going to infinitely loop
-         */
-        while (fb->cb_type == FLUX_BUFFER_CB_TYPE_READ_LINE
-               && count > 0) {
-            int tmp;
-
+             && flux_buffer_lines (fb) > 0)
             fb->cb (fb, fb->cb_arg);
-
-            if ((tmp = flux_buffer_lines (fb)) < 0)
-                break;
-
-            if (tmp < count)
-                count = tmp;
-            else
-                break;
-        }
-    }
 }
 
 int flux_buffer_drop (flux_buffer_t *fb, int len)

--- a/src/common/libflux/buffer.h
+++ b/src/common/libflux/buffer.h
@@ -11,6 +11,8 @@
 #ifndef FLUX_BUFFER_H
 #define FLUX_BUFFER_H
 
+#include <stdbool.h>
+
 typedef struct flux_buffer flux_buffer_t;
 
 /* Create buffer.
@@ -72,6 +74,9 @@ int flux_buffer_write (flux_buffer_t *fb, const void *data, int len);
 /* Determines lines available for peeking/reading.  Returns -1
  * on error, >= 0 for lines available */
 int flux_buffer_lines (flux_buffer_t *fb);
+
+/* Return true if buffer has at least one unread line */
+bool flux_buffer_has_line (flux_buffer_t *fb);
 
 /* Drop a line in the buffer.  Returns number of bytes dropped on
  * success. */

--- a/src/common/libflux/buffer.h
+++ b/src/common/libflux/buffer.h
@@ -36,11 +36,11 @@ int flux_buffer_space (flux_buffer_t *fb);
  *   Changing a buffer to "readonly" can only be called once and
  *   cannot be disabled.  This is a convenience status can be used to
  *   indicate to users that the buffer is no longer usable.
- * - flux_buffer_is_readonly() returns > 0 if a buffer is readonly, 0
- *   if not, and -1 on error.
+ * - flux_buffer_is_readonly() returns true if a buffer is readonly,
+ *    and false if not.
  */
 int flux_buffer_readonly (flux_buffer_t *fb);
-int flux_buffer_is_readonly (flux_buffer_t *fb);
+bool  flux_buffer_is_readonly (flux_buffer_t *fb);
 
 /* Drop up to [len] bytes of data in the buffer. Set [len] to -1
  * to drop all data.  Returns number of bytes dropped on success.

--- a/src/common/libflux/ev_buffer_read.c
+++ b/src/common/libflux/ev_buffer_read.c
@@ -20,7 +20,7 @@
 static bool data_to_read (struct ev_buffer_read *ebr, bool *is_eof)
 {
     if (ebr->line) {
-        if (flux_buffer_lines (ebr->fb) > 0)
+        if (flux_buffer_has_line (ebr->fb))
             return true;
         /* if eof read, no lines, but left over data non-line data,
          * this data should be flushed to the user */

--- a/src/common/libflux/test/buffer.c
+++ b/src/common/libflux/test/buffer.c
@@ -871,6 +871,10 @@ void corner_case (void)
     ok (flux_buffer_lines (NULL) < 0
         && errno == EINVAL,
         "flux_buffer_lines fails on NULL pointer");
+    errno = 0;
+    ok (!flux_buffer_has_line (NULL)
+        && errno == EINVAL,
+        "flux_buffer_has_line returns false with errno set on NULL pointer");
     ok (flux_buffer_drop_line (NULL) < 0
         && errno == EINVAL,
         "flux_buffer_drop_line fails on NULL pointer");

--- a/src/common/libflux/test/buffer.c
+++ b/src/common/libflux/test/buffer.c
@@ -682,129 +682,6 @@ void basic_callback (void)
     close (pipefds[1]);
 }
 
-void read_multiple_cb (flux_buffer_t *fb, void *arg)
-{
-    int *count = arg;
-    const char *ptr;
-    int len;
-
-    (*count)++;
-
-    ok ((ptr = flux_buffer_read (fb, 3, &len)) != NULL
-        && len == 3,
-        "flux_buffer_read in callback works");
-
-    ok (len == 3,
-        "read in callback returns correct length");
-
-    ok (!memcmp (ptr, "foo", 3),
-        "read in callback returns expected data");
-}
-
-void read_line_multiple_cb (flux_buffer_t *fb, void *arg)
-{
-    int *count = arg;
-    const char *ptr;
-    int len;
-
-    (*count)++;
-
-    ok ((ptr = flux_buffer_read_line (fb, &len)) != NULL
-        && len == 4,
-        "flux_buffer_read_line in callback works");
-
-    ok (!memcmp (ptr, "foo\n", 4),
-        "read line in callback returns expected data");
-}
-
-void multiple_callback (void)
-{
-    flux_buffer_t *fb;
-    int count;
-
-    ok ((fb = flux_buffer_create (FLUX_BUFFER_TEST_MAXSIZE)) != NULL,
-        "flux_buffer_create works");
-
-    /* read callback w/ write */
-
-    count = 0;
-    ok (flux_buffer_set_low_read_cb (fb, read_multiple_cb, 3, &count) == 0,
-        "flux_buffer_set_low_read_cb success");
-
-    ok (flux_buffer_write (fb, "foofoofoo", 9) == 9,
-        "flux_buffer_write success");
-
-    ok (count == 2,
-        "read_cb called two times");
-
-    ok (flux_buffer_bytes (fb) == 3,
-        "flux_buffer_bytes returns 3 leftover bytes in buffer");
-
-    count = 0;
-    ok (flux_buffer_set_low_read_cb (fb, NULL, 3, &count) == 0,
-        "flux_buffer_set_low_read_cb clear callback success");
-
-    ok (flux_buffer_write (fb, "foo", 3) == 3,
-        "flux_buffer_write_line success");
-
-    ok (count == 0,
-        "read_cb cleared successfully");
-
-    ok (flux_buffer_drop (fb, -1) == 6,
-        "flux_buffer_drop cleared all data");
-
-    ok (flux_buffer_bytes (fb) == 0,
-        "flux_buffer_bytes returns 0 with all bytes dropped");
-
-    /* read line callback w/ write_line */
-
-    ok (flux_buffer_lines (fb) == 0,
-        "flux_buffer_lines returns 0 on no line");
-
-    ok (flux_buffer_write (fb, "foo\nfoo\n", 8) == 8,
-        "flux_buffer_write success");
-
-    ok (flux_buffer_lines (fb) == 2,
-        "flux_buffer_lines returns 2 on two lines written");
-
-    count = 0;
-    ok (flux_buffer_set_read_line_cb (fb, read_line_multiple_cb, &count) == 0,
-        "flux_buffer_set_read_line_cb success");
-
-    ok (flux_buffer_write (fb, "foo\n", 4) == 4,
-        "flux_buffer_write success");
-
-    ok (flux_buffer_bytes (fb) == 0,
-        "flux_buffer_bytes returns 0 because callback read all data");
-
-    ok (count == 3,
-        "read_line_cb called three times");
-
-    ok (flux_buffer_lines (fb) == 0,
-        "flux_buffer_lines returns 0 on no line, callback read all data");
-
-    count = 0;
-    ok (flux_buffer_set_read_line_cb (fb, NULL, &count) == 0,
-        "flux_buffer_set_read_line_cb clear callback success");
-
-    ok (flux_buffer_write_line (fb, "foo") == 4,
-        "flux_buffer_write_line success");
-
-    ok (count == 0,
-        "read_line_cb cleared successfully");
-
-    ok (flux_buffer_lines (fb) == 1,
-        "flux_buffer_lines returns 1, callback did not read line");
-
-    ok (flux_buffer_drop (fb, -1) == 4,
-        "flux_buffer_drop cleared all data");
-
-    ok (flux_buffer_lines (fb) == 0,
-        "flux_buffer_lines returns 0 after drop line");
-
-    flux_buffer_destroy (fb);
-}
-
 void disable_read_cb (flux_buffer_t *fb, void *arg)
 {
     int *count = arg;
@@ -1202,7 +1079,6 @@ int main (int argc, char *argv[])
 
     basic ();
     basic_callback ();
-    multiple_callback ();
     disable_callback ();
     corner_case ();
     full_buffer ();

--- a/src/common/libflux/test/buffer.c
+++ b/src/common/libflux/test/buffer.c
@@ -144,6 +144,8 @@ void basic (void)
 
     ok (flux_buffer_lines (fb) == 1,
         "flux_buffer_lines returns 1 on line written");
+    ok (flux_buffer_has_line (fb) == 1,
+        "flux_buffer_has_line returns true on line written");
 
     ok ((ptr = flux_buffer_peek_line (fb, &len)) != NULL
         && len == 4,
@@ -767,6 +769,8 @@ void disable_callback (void)
 
     ok (flux_buffer_lines (fb) == 0,
         "flux_buffer_lines returns 0 on no line");
+    ok (!flux_buffer_has_line (fb),
+        "flux_buffer_has_line returns false on no line");
 
     count = 0;
     ok (flux_buffer_set_read_line_cb (fb, disable_read_line_cb, &count) == 0,

--- a/src/common/libflux/test/buffer.c
+++ b/src/common/libflux/test/buffer.c
@@ -928,9 +928,9 @@ void corner_case (void)
     ok (flux_buffer_readonly (NULL) < 0
         && errno == EINVAL,
         "flux_buffer_readonly fails on NULL pointer");
-    ok (flux_buffer_is_readonly (NULL) < 0
-        && errno == EINVAL,
-        "flux_buffer_is_readonly fails on NULL pointer");
+    errno = 0;
+    ok (!flux_buffer_is_readonly (NULL) && errno == EINVAL,
+        "flux_buffer_is_readonly returns false on NULL pointer");
     ok (flux_buffer_set_low_read_cb (NULL, empty_cb, 0, NULL) < 0
         && errno == EINVAL,
         "flux_buffer_set_low_read_cb fails on NULL pointer");
@@ -1125,13 +1125,13 @@ void readonly_buffer (void)
     ok ((fb = flux_buffer_create (FLUX_BUFFER_TEST_MAXSIZE)) != NULL,
         "flux_buffer_create works");
 
-    ok (flux_buffer_is_readonly (fb) == 0,
+    ok (!flux_buffer_is_readonly (fb),
         "flux buffer is not readonly on creation");
 
     ok (flux_buffer_readonly (fb) == 0,
         "flux buffer readonly set");
 
-    ok (flux_buffer_is_readonly (fb) > 0,
+    ok (flux_buffer_is_readonly (fb),
         "flux buffer is readonly after setting");
 
     flux_buffer_destroy (fb);

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -247,7 +247,7 @@ static void remote_out_prep_cb (flux_reactor_t *r,
 
     /* no need to handle failure states, on fatal error, these
      * reactors are closed */
-    if ((c->line_buffered && flux_buffer_lines (c->read_buffer) > 0)
+    if ((c->line_buffered && flux_buffer_has_line (c->read_buffer))
         || (!c->line_buffered && flux_buffer_bytes (c->read_buffer) > 0)
         || (c->read_eof_received && !c->eof_sent_to_caller))
         flux_watcher_start (c->out_idle_w);
@@ -263,7 +263,7 @@ static void remote_out_check_cb (flux_reactor_t *r,
     flux_watcher_stop (c->out_idle_w);
 
     if ((c->line_buffered
-         && (flux_buffer_lines (c->read_buffer) > 0
+         && (flux_buffer_has_line (c->read_buffer)
              || (c->read_eof_received
                  && flux_buffer_bytes (c->read_buffer) > 0)))
         || (!c->line_buffered && flux_buffer_bytes (c->read_buffer) > 0)) {

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -958,7 +958,7 @@ static const char *subprocess_read (flux_subprocess_t *p,
                                     bool read_line,
                                     bool trimmed,
                                     bool line_buffered_required,
-                                    int *readonly)
+                                    bool *readonly)
 {
     struct subprocess_channel *c;
     flux_buffer_t *fb;
@@ -1072,13 +1072,14 @@ const char *flux_subprocess_getline (flux_subprocess_t *p,
                                      int *lenp)
 {
     const char *ptr;
-    int len, readonly;
+    int len;
+    bool readonly;
 
     ptr = subprocess_read (p, stream, 0, &len, true, false, true, &readonly);
 
     /* if no lines available and EOF received, read whatever is
      * lingering in the buffer */
-    if (ptr && len == 0 && readonly > 0)
+    if (ptr && len == 0 && readonly)
         ptr = flux_subprocess_read (p, stream, -1, &len);
 
     if (lenp)


### PR DESCRIPTION
Fixes #2287 

This PR includes the addition of `flux_buffer_has_lines()` and its use in place of `flux_buffer_lines()` as discussed in #2287.

Additionally, the "multiple callback" support for `flux_buffer_t` read callbacks was removed -- while it makes sense for standalone use, in the larger context of use by libsubprocess in a reactor, repeatedly calling the buffer callback until no more data was consumed could result in other parts of the system getting starved out by a heavily used buffer.

Since the multiple callback support was removed, I just removed the tests for that aspect of the code. Hope that was an ok approach.

Here's some timing results, before:
```console
Executing: git log --oneline -n1; make -j 12 >/dev/null 2>&1 && time src/cmd/flux start flux srun t/shell/lptest 79 10000 | wc -l
a972f14 libflux/test: remove multi-callback tests for flux_buffer_t
10000

real	0m56.864s
user	0m56.344s
sys	0m3.962s
```

After:
```console
Executing: git log --oneline -n1; make -j 12 >/dev/null 2>&1 && time src/cmd/flux start flux srun t/shell/lptest 79 10000 | wc -l
177cd4a libflux/test: test flux_buffer_has_line
10000

real	0m4.796s
user	0m2.259s
sys	0m3.057s
```



