### PR TITLE
flux-shell: limit the number of I/O requests in flight + cleanup

### DIFF
--- a/src/shell/io.c
+++ b/src/shell/io.c
@@ -280,7 +280,7 @@ void shell_io_task_ready (struct shell_task *task, const char *stream, void *arg
     const char *data;
     int len;
 
-    len = shell_task_io_readline (task, stream, &data);
+    data = flux_subprocess_getline (task->proc, stream, &len);
     if (len < 0) {
         log_err ("read %s task %d", stream, task->rank);
     }
@@ -288,7 +288,7 @@ void shell_io_task_ready (struct shell_task *task, const char *stream, void *arg
         if (shell_io_write (io, task->rank, stream, data, len, false) < 0)
             log_err ("write %s task %d", stream, task->rank);
     }
-    else if (len == 0 && shell_task_io_at_eof (task, stream)) {
+    else if (flux_subprocess_read_stream_closed (task->proc, stream)) {
         if (shell_io_write (io, task->rank, stream, NULL, 0, true) < 0)
             log_err ("write eof %s task %d", stream, task->rank);
     }

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -242,7 +242,7 @@ static int shell_pmi_response_send (void *client, const char *buf)
 {
     struct shell_task *task = client;
 
-    return shell_task_pmi_write (task, buf, strlen (buf));
+    return flux_subprocess_write (task->proc, "PMI_FD", buf, strlen (buf));
 }
 
 static void shell_pmi_debug_trace (void *client, const char *line)
@@ -260,7 +260,7 @@ void shell_pmi_task_ready (struct shell_task *task, void *arg)
     const char *line;
     int rc;
 
-    len = shell_task_pmi_readline (task, &line);
+    line = flux_subprocess_read_line (task->proc, "PMI_FD", &len);
     if (len < 0) {
         if (pmi->shell->verbose)
             fprintf (stderr, "%d: C: pmi read error: %s\n",

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -55,39 +55,11 @@ int shell_task_pmi_enable (struct shell_task *task,
                            shell_task_pmi_ready_f cb,
                            void *arg);
 
-/* Call readline once shell_task_pmi_ready_f has been called
- * indicating a line of PMI protocol from the task is ready.
- * Sets 'line' to the data read (do not free).
- * Returns number of bytes read, or -1 on error.
- */
-int shell_task_pmi_readline (struct shell_task *task, const char **line);
-
-/* Call to write a line of PMI protocol to the task.
- */
-int shell_task_pmi_write (struct shell_task *task,
-                          const char *data,
-                          int len);
-
 /* Call before task_start() to enable stdio capture.
  */
 int shell_task_io_enable (struct shell_task *task,
                           shell_task_io_ready_f cb,
                           void *arg);
-
-/* Call once shell_task_io_ready_f has been called, indicating
- * stdout or stderr from the task is ready.
- * Sets 'line' to the data read (do not free).
- * Returns number of bytes read, or -1 on error.
- */
-int shell_task_io_readline (struct shell_task *task,
-                            const char *stream,
-                            const char **line);
-
-/* Test whether stream has reached EOF.
- * Call after shell_task_io_readline() returns 0.
- */
-bool shell_task_io_at_eof (struct shell_task *task, const char *stream);
-
 
 /* Send signal `signum` to shell task */
 int shell_task_kill (struct shell_task *task, int signum);

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -144,6 +144,12 @@ test_expect_success 'job-shell: verify output of 4-task lptest job on stderr' '
 	sort -snk1 <lptest4_raw.err >lptest4.err &&
 	test_cmp lptest4.exp lptest4.err
 '
+test_expect_success 'job-shell: verify 10K line lptest output works' '
+	${LPTEST} 79 10000 | sed -e "s/^/0: /" >lptestXXL.exp &&
+        id=$(flux jobspec srun -n1 ${LPTEST} 79 10000 | flux job submit) &&
+	flux job attach -l $id >lptestXXL.out &&
+	test_cmp lptestXXL.exp lptestXXL.out
+'
 test_expect_success 'job-shell: test shell kill event handling' '
 	id=$(flux jobspec srun -N4 sleep 60 | flux job submit) &&
 	flux job wait-event $id start &&


### PR DESCRIPTION
When tasks produce a lot of output quickly, many write requests to the leader shell can be concurrently in flight.  This PR adds a hard coded high water mark of 1000 requests per shell, with a low water mark of 100, such that I/O is paused when the high water mark is reached, and resumed when the low water mark is reached.  This utilizes the subprocess stream start/stop mechanism added in #2271.

This limits the consumption of client resources such as matchtags, and also should meter the overall message rate somewhat, although this simple mechanism is completely local to a shell and has no idea what other shells are doing, so a many-task job can still overwhelm the leader shell.  Complexity is very low so it seemed like a good first step.

Without this patch, when running an lptest 79 X, where X is on the order of 100K, one can observe the matchtag pool incrementally growing as tags are consumed.  With the patch, the matchtag pool never grows beyond its initial size.  Yet wall clock performance is about the same.

In addition, some cleanup was performed to eliminate gratuitous wrapper functions for subprocess API in `shell/task.c`.

