### PR TITLE
job-info: Watcher - cancel lookup on several error paths

### DIFF
--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -115,11 +115,6 @@ static int lookup_keys (struct lookup_ctx *l)
     size_t index;
     json_t *key;
 
-    if (l->f) {
-        flux_future_destroy (l->f);
-        l->f = NULL;
-    }
-
     if (!(fall = flux_future_wait_all_create ())) {
         flux_log_error (l->ctx->h, "%s: flux_wait_all_create", __FUNCTION__);
         goto error;

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* eventlog_watch.c - handle job-info.eventlog-watch &
+/* watch.c - handle job-info.eventlog-watch &
  * job-info.eventlog-watch-cancel for job-info */
 
 #if HAVE_CONFIG_H
@@ -91,6 +91,7 @@ static int watch_key (struct watch_ctx *w)
     }
 
     if (flux_future_then (w->f, -1, watch_continuation, w) < 0) {
+        /* w->f cleanup handled in context destruction */
         flux_log_error (w->ctx->h, "%s: flux_future_then", __FUNCTION__);
         return -1;
     }

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -26,7 +26,6 @@ struct watch_ctx {
     flux_msg_t *msg;
     flux_jobid_t id;
     flux_future_t *f;
-    int offset;
     bool allow;
     bool cancel;
 };
@@ -74,11 +73,6 @@ static int watch_key (struct watch_ctx *w)
 {
     char key[64];
     int flags = (FLUX_KVS_WATCH | FLUX_KVS_WATCH_APPEND);
-
-    if (w->f) {
-        flux_future_destroy (w->f);
-        w->f = NULL;
-    }
 
     if (flux_job_kvs_key (key, sizeof (key), w->id, "eventlog") < 0) {
         flux_log_error (w->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);


### PR DESCRIPTION
I realized in the job-info eventlog watch code, I don't cancel a lookup under several circumstances, such as when the user has a permission issue.  So this could lead to a matchtag leak.  So added a lookup cancellation call in the error path of some cleanup.

Also includes some random cleanup fixes.