### PR TITLE
job-info: Support reading / waiting on guest event logs

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -929,7 +929,7 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     if (!(r = flux_get_reactor (ctx.h)))
         log_err_exit ("flux_get_reactor");
 
-    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id)))
+    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id, "eventlog")))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (ctx.f, -1, attach_event_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");
@@ -1385,7 +1385,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
         *ctx.context_value++ = '\0';
     }
 
-    if (!(f = flux_job_event_watch (h, ctx.id)))
+    if (!(f = flux_job_event_watch (h, ctx.id, "eventlog")))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (f, ctx.timeout, wait_event_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -238,7 +238,8 @@ static struct optparse_subcommand subcommands[] = {
       eventlog_opts
     },
     { "wait-event",
-      "[-f text|json] [-T raw|iso|offset] [-t seconds] [-m key=val] id event",
+      "[-f text|json] [-T raw|iso|offset] [-t seconds] [-m key=val] "
+      "[-p path] id event",
       "Wait for an event ",
       cmd_wait_event,
       0,

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -288,20 +288,21 @@ int flux_job_kvs_namespace (char *buf, int bufsz, flux_jobid_t id)
     return len;
 }
 
-flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id)
+flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
+                                     const char *path)
 {
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
 
-    if (!h) {
+    if (!h || !path) {
         errno = EINVAL;
         return NULL;
     }
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
                              "{s:I s:s}",
                              "id", id,
-                             "path", "eventlog")))
+                             "path", path)))
         return NULL;
     return f;
 }

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -299,8 +299,9 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id)
         return NULL;
     }
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
-                             "{s:I}",
-                             "id", id)))
+                             "{s:I s:s}",
+                             "id", id,
+                             "path", "eventlog")))
         return NULL;
     return f;
 }

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -294,16 +294,29 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
+    bool guest = false;
 
     if (!h || !path) {
         errno = EINVAL;
         return NULL;
+    }
+    if (path && !strncmp (path, "guest.", 6)) {
+        topic = "job-info.guest-eventlog-watch";
+        path += 6;
+        guest = true;
     }
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
                              "{s:I s:s}",
                              "id", id,
                              "path", path)))
         return NULL;
+    if (guest) {
+        /* value not relevant, set to anything */
+        if (flux_future_aux_set (f, "guest", "", NULL) < 0) {
+            flux_future_destroy (f);
+            return NULL;
+        }
+    }
     return f;
 }
 
@@ -321,13 +334,16 @@ int flux_job_event_watch_get (flux_future_t *f, const char **event)
 int flux_job_event_watch_cancel (flux_future_t *f)
 {
     flux_future_t *f2;
+    const char *topic = "job-info.eventlog-watch-cancel";
 
     if (!f) {
         errno = EINVAL;
         return -1;
     }
+    if (flux_future_aux_get (f, "guest") != NULL)
+        topic = "job-info.guest-eventlog-watch-cancel";
     if (!(f2 = flux_rpc_pack (flux_future_get_flux (f),
-                              "job-info.eventlog-watch-cancel",
+                              topic,
                               FLUX_NODEID_ANY,
                               FLUX_RPC_NORESPONSE,
                               "{s:i}",

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -120,8 +120,10 @@ int flux_job_kvs_namespace (char *buf,
                             flux_jobid_t id);
 
 /* Job eventlog watch functions
+ * - path specifies optional alternate eventlog path
  */
-flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id);
+flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
+                                     const char *path);
 int flux_job_event_watch_get (flux_future_t *f, const char **event);
 int flux_job_event_watch_cancel (flux_future_t *f);
 

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -159,7 +159,7 @@ void check_corner_case (void)
     /* flux_job_eventlog_watch */
 
     errno = 0;
-    ok (!flux_job_event_watch (NULL, 0)
+    ok (!flux_job_event_watch (NULL, 0, NULL)
         && errno == EINVAL,
         "flux_job_event_watch fails with EINVAL on bad input");
 

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -21,7 +21,9 @@ job_info_la_SOURCES = \
 	lookup.h \
 	lookup.c \
 	watch.h \
-	watch.c
+	watch.c \
+	guest_watch.h \
+	guest_watch.c
 
 job_info_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_info_la_LIBADD = $(fluxmod_libadd) \

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -1,0 +1,859 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* guest_watch.c - handle job-info.guest-eventlog-watch &
+ * job-info.guest-eventlog-watch-cancel for job-info */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "info.h"
+#include "watch.h"
+#include "allow.h"
+
+/* The callback for job-info.guest-eventlog-watch handles all
+ * of the tricky / racy things related to reading an eventlog from the
+ * guest namespace.  Effectively it is a state machine, checking the
+ * main job eventlog (via job-info.lookup) to determine what state the
+ * guest eventlog is in.  Based on the results, calls are made to
+ * job-info.eventlog-watch to wait or determine how to read from the
+ * guest eventlog.
+ *
+ * Here is an overview of what the code below does:
+ *
+ * 1) Check the main eventlog, both for access & to see how far the
+ *    job is along (get_main_eventlog()).
+ *
+ * 2) If the guest namespace is already copied into the main namespace
+ *    (event "release" and "final=true"), we watch the main eventlog
+ *    (main_namespace_watch()).  This is "easy" case and is not so
+ *    different from a typical call to 'job-info.eventlog-watch'.
+ *
+ * 3) If the guest namespace is still active (event "start" in the
+ *    main eventlog, but not "release"), we need to watch the eventlog
+ *    directly from the guest namespce instead of the main KVS
+ *    namespace (guest_namespace_watch()).
+ *
+ * 3A) There is a race where the guest namespace has been removed
+ *     after part #1 above, but before we start reading it via a call
+ *     in #3.  Detect this case and convert to watching the main
+ *     namespace (#2).
+ *
+ * 4) If the namespace has not yet been created (event "start" has not
+ *    ocurred), must wait for the guest namespace to be created
+ *    (wait_guest_namespace()), then eventually follow the path of
+ *    watching events in the guest namespace (#3).
+ */
+
+struct guest_watch_ctx {
+    struct info_ctx *ctx;
+    flux_msg_t *msg;
+    uint32_t msg_rolemask;
+    uint32_t msg_userid;
+    flux_jobid_t id;
+    char *path;
+    bool cancel;
+
+    /* transition possibilities
+     *
+     * INIT -> GET_MAIN_EVENTLOG - this is when we check the main
+     * eventlog to see what state the job is in.
+     *
+     * GET_MAIN_EVENTLOG -> WAIT_GUEST_NAMESPACE - guest namespace
+     * not yet created, wait for its creation
+     *
+     * GET_MAIN_EVENTLOG -> GUEST_NAMESPACE_WATCH - guest namespace
+     * created, so we should watch it
+     *
+     * GET_MAIN_EVENTLOG -> MAIN_NAMESPACE_WATCH - guest namespace
+     * moved to main namespace, so watch in main namespace
+     *
+     * WAIT_GUEST_NAMESPACE -> GUEST_NAMESPACE_WATCH - guest namespace
+     * created, so we should watch it
+     *
+     * GUEST_NAMESPACE_WATCH -> MAIN_NAMESPACE_WATCH - under a racy
+     * situation, guest namespace could be removed before we began to
+     * read from it.  If so, transition to watch in main namespace
+     */
+    enum {
+        GUEST_WATCH_STATE_INIT = 1,
+        GUEST_WATCH_STATE_GET_MAIN_EVENTLOG = 2,
+        GUEST_WATCH_STATE_WAIT_GUEST_NAMESPACE = 3,
+        GUEST_WATCH_STATE_GUEST_NAMESPACE_WATCH = 4,
+        GUEST_WATCH_STATE_MAIN_NAMESPACE_WATCH = 5,
+    } state;
+
+    flux_future_t *get_main_eventlog_f;
+    flux_future_t *wait_guest_namespace_f;
+    flux_future_t *guest_namespace_watch_f;
+    flux_future_t *main_namespace_watch_f;
+
+    /* flags indicating what was found in main eventlog */
+    bool guest_started;
+    bool guest_released;
+
+    /* indicates if events have been read from the guest namespace
+     * eventlog */
+    bool guest_namespace_events;
+    /* indicates if the guest namespace has been removed */
+    bool guest_namespace_removed;
+};
+
+static int get_main_eventlog (struct guest_watch_ctx *gw);
+static void get_main_eventlog_continuation (flux_future_t *f, void *arg);
+static int wait_guest_namespace (struct guest_watch_ctx *gw);
+static void wait_guest_namespace_continuation (flux_future_t *f, void *arg);
+static int guest_namespace_watch (struct guest_watch_ctx *gw);
+static void guest_namespace_watch_continuation (flux_future_t *f, void *arg);
+static int main_namespace_watch (struct guest_watch_ctx *gw);
+static void main_namespace_watch_continuation (flux_future_t *f, void *arg);
+
+static void guest_watch_ctx_destroy (void *data)
+{
+    if (data) {
+        struct guest_watch_ctx *gw = data;
+        flux_msg_destroy (gw->msg);
+        free (gw->path);
+        flux_future_destroy (gw->get_main_eventlog_f);
+        flux_future_destroy (gw->wait_guest_namespace_f);
+        flux_future_destroy (gw->guest_namespace_watch_f);
+        flux_future_destroy (gw->main_namespace_watch_f);
+        free (gw);
+    }
+}
+
+static struct guest_watch_ctx *guest_watch_ctx_create (struct info_ctx *ctx,
+                                                       const flux_msg_t *msg,
+                                                       flux_jobid_t id,
+                                                       const char *path)
+{
+    struct guest_watch_ctx *gw = calloc (1, sizeof (*gw));
+    int saved_errno;
+
+    if (!gw)
+        return NULL;
+
+    gw->ctx = ctx;
+    gw->id = id;
+    if (!(gw->path = strdup (path))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    gw->state = GUEST_WATCH_STATE_INIT;
+
+    if (!(gw->msg = flux_msg_copy (msg, true))) {
+        flux_log_error (ctx->h, "%s: flux_msg_copy", __FUNCTION__);
+        goto error;
+    }
+    if (flux_msg_get_rolemask (msg, &gw->msg_rolemask) < 0) {
+        flux_log_error (ctx->h, "%s: flux_msg_get_rolemask", __FUNCTION__);
+        goto error;
+    }
+    if (flux_msg_get_userid (msg, &gw->msg_userid) < 0) {
+        flux_log_error (ctx->h, "%s: flux_msg_get_userid", __FUNCTION__);
+        goto error;
+    }
+
+    return gw;
+
+error:
+    saved_errno = errno;
+    guest_watch_ctx_destroy (gw);
+    errno = saved_errno;
+    return NULL;
+}
+
+/* we want to copy rolemask, userid, etc. from the original
+ * message when we redirect to other job-info targets.
+ */
+static flux_msg_t *guest_msg_pack (struct guest_watch_ctx *gw,
+                                   const char *topic,
+                                   const char *fmt,
+                                   ...)
+{
+    flux_msg_t *newmsg = NULL;
+    json_t *payload = NULL;
+    char *payloadstr = NULL;
+    flux_msg_t *rv = NULL;
+    int save_errno;
+    va_list ap;
+
+    va_start (ap, fmt);
+
+    if (!(newmsg = flux_request_encode (topic, NULL)))
+        goto error;
+    if (flux_msg_set_rolemask (newmsg, gw->msg_rolemask) < 0)
+        goto error;
+    if (flux_msg_set_userid (newmsg, gw->msg_userid) < 0)
+        goto error;
+    if (!(payload = json_vpack_ex (NULL, 0, fmt, ap)))
+        goto error;
+    if (!(payloadstr = json_dumps (payload, JSON_COMPACT))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_msg_set_string (newmsg, payloadstr) < 0)
+        goto error;
+
+    rv = newmsg;
+error:
+    save_errno = errno;
+    if (!rv)
+        flux_msg_destroy (newmsg);
+    json_decref (payload);
+    free (payloadstr);
+    va_end (ap);
+    errno = save_errno;
+    return rv;
+}
+
+static int send_cancel (struct guest_watch_ctx *gw, flux_future_t *f)
+{
+    if (!gw->cancel) {
+        flux_future_t *f2;
+        int matchtag;
+
+        if (!f) {
+            if (gw->state == GUEST_WATCH_STATE_WAIT_GUEST_NAMESPACE)
+                f = gw->wait_guest_namespace_f;
+            else if (gw->state == GUEST_WATCH_STATE_GUEST_NAMESPACE_WATCH) {
+                /* if guest namespace removed, nothing to cancel.  So
+                 * send back ENODATA to caller. */
+                if (gw->guest_namespace_removed) {
+                    gw->cancel = true;
+                    if (flux_respond_error (gw->ctx->h,
+                                            gw->msg,
+                                            ENODATA,
+                                            NULL) < 0)
+                        flux_log_error (gw->ctx->h, "%s: flux_respond_error",
+                                        __FUNCTION__);
+                    return 0;
+                }
+                f = gw->guest_namespace_watch_f;
+            }
+            else if (gw->state == GUEST_WATCH_STATE_MAIN_NAMESPACE_WATCH)
+                f = gw->main_namespace_watch_f;
+            else {
+                /* nothing to cancel */
+                gw->cancel = true;
+                return 0;
+            }
+        }
+
+        matchtag = (int)flux_rpc_get_matchtag (f);
+
+        if (!(f2 = flux_rpc_pack (gw->ctx->h,
+                                 "job-info.eventlog-watch-cancel",
+                                 FLUX_NODEID_ANY,
+                                 FLUX_RPC_NORESPONSE,
+                                 "{s:i}",
+                                  "matchtag", matchtag))) {
+            flux_log_error (gw->ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+            return -1;
+        }
+        flux_future_destroy (f2);
+        gw->cancel = true;
+    }
+    return 0;
+}
+
+static int get_main_eventlog (struct guest_watch_ctx *gw)
+{
+    const char *topic = "job-info.lookup";
+    flux_msg_t *msg = NULL;
+    int save_errno, rv = -1;
+
+    if (!(msg = guest_msg_pack (gw,
+                                topic,
+                                "{s:I s:[s] s:i}",
+                                "id", gw->id,
+                                "keys", "eventlog",
+                                "flags", 0)))
+        goto error;
+
+    if (!(gw->get_main_eventlog_f = flux_rpc_message (gw->ctx->h,
+                                                      msg,
+                                                      FLUX_NODEID_ANY,
+                                                      0))) {
+        flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (gw->get_main_eventlog_f,
+                          -1,
+                          get_main_eventlog_continuation,
+                          gw) < 0) {
+        /* future cleanup handled with context destruction */
+        flux_log_error (gw->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    gw->state = GUEST_WATCH_STATE_GET_MAIN_EVENTLOG;
+    rv = 0;
+error:
+    save_errno = errno;
+    flux_msg_destroy (msg);
+    errno = save_errno;
+    return rv;
+}
+
+/* if we see the event "start", we know the guest namespace has
+ * definitely been created, but we can't guarantee it before that.
+ *
+ * if we see the event "release" with "final=true", we know the guest
+ * namespace has definitely been removed / moved into the main KVS.
+ */
+static int check_guest_namespace_status (struct guest_watch_ctx *gw,
+                                         const char *s)
+{
+    json_t *a = NULL;
+    size_t index;
+    json_t *event;
+    int rv = -1;
+
+    if (!(a = eventlog_decode (s)))
+        goto error;
+
+    json_array_foreach (a, index, event) {
+        const char *name;
+        json_t *context = NULL;
+        if (eventlog_entry_parse (event, NULL, &name, &context) < 0)
+            goto error;
+        if (!strcmp (name, "start"))
+            gw->guest_started = true;
+        if (!strcmp (name, "release")) {
+            void *iter = json_object_iter (context);
+            while (iter && !gw->guest_released) {
+                const char *key = json_object_iter_key (iter);
+                if (!strcmp (key, "final")) {
+                    json_t *value = json_object_iter_value (iter);
+                    if (json_is_boolean (value) && json_is_true (value))
+                        gw->guest_released = true;
+                }
+                iter = json_object_iter_next (context, iter);
+            }
+        }
+    }
+
+    rv = 0;
+error:
+    json_decref (a);
+    return rv;
+}
+
+static void get_main_eventlog_continuation (flux_future_t *f, void *arg)
+{
+    struct guest_watch_ctx *gw = arg;
+    struct info_ctx *ctx = gw->ctx;
+    const char *s;
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "eventlog", &s) < 0) {
+        if (errno != ENOENT && errno != EPERM)
+            flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        goto error;
+    }
+
+    if (gw->cancel) {
+        if (flux_respond_error (ctx->h, gw->msg, ENODATA, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        goto done;
+    }
+
+    if (check_guest_namespace_status (gw, s) < 0)
+        goto error;
+
+    if (gw->guest_released) {
+        /* guest namespace copied to main KVS, just watch it like normal */
+        if (main_namespace_watch (gw) < 0)
+            goto error;
+    }
+    else if (gw->guest_started) {
+        /* guest namespace created, watch it and not the main KVS
+         * namespace */
+        if (guest_namespace_watch (gw) < 0)
+            goto error;
+    }
+    else {
+        /* wait eventlog for start */
+        if (wait_guest_namespace (gw) < 0)
+            goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (ctx->h, gw->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+done:
+    /* flux future destroyed in guest_watch_ctx_destroy, which is
+     * called via zlist_remove() */
+    zlist_remove (ctx->guest_watchers, gw);
+}
+
+static int wait_guest_namespace (struct guest_watch_ctx *gw)
+{
+    const char *topic = "job-info.eventlog-watch";
+    flux_msg_t *msg = NULL;
+    int save_errno, rv = -1;
+
+    if (!(msg = guest_msg_pack (gw,
+                                topic,
+                                "{s:I s:s}",
+                                "id", gw->id,
+                                "path", "eventlog")))
+        goto error;
+
+    if (!(gw->wait_guest_namespace_f = flux_rpc_message (gw->ctx->h,
+                                                         msg,
+                                                         FLUX_NODEID_ANY,
+                                                         FLUX_RPC_STREAMING))) {
+        flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (gw->wait_guest_namespace_f,
+                          -1,
+                          wait_guest_namespace_continuation,
+                          gw) < 0) {
+        /* future cleanup handled with context destruction */
+        flux_log_error (gw->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    gw->state = GUEST_WATCH_STATE_WAIT_GUEST_NAMESPACE;
+    rv = 0;
+error:
+    save_errno = errno;
+    flux_msg_destroy (msg);
+    errno = save_errno;
+    return rv;
+}
+
+static int check_guest_namespace_created (struct guest_watch_ctx *gw,
+                                          const char *event)
+{
+    json_t *o = NULL;
+    const char *name;
+    int save_errno, rv = -1;
+
+    if (!(o = eventlog_entry_decode (event))) {
+        flux_log_error (gw->ctx->h, "%s: eventlog_entry_decode", __FUNCTION__);
+        goto error;
+    }
+
+    if (eventlog_entry_parse (o, NULL, &name, NULL) < 0) {
+        flux_log_error (gw->ctx->h, "%s: eventlog_entry_decode", __FUNCTION__);
+        goto error;
+    }
+
+    if (!strcmp (name, "start"))
+        gw->guest_started = true;
+
+    rv = 0;
+error:
+    save_errno = errno;
+    json_decref (o);
+    errno = save_errno;
+    return rv;
+}
+
+static void wait_guest_namespace_continuation (flux_future_t *f, void *arg)
+{
+    struct guest_watch_ctx *gw = arg;
+    struct info_ctx *ctx = gw->ctx;
+    const char *event;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        if (errno == ENODATA) {
+            /* either user canceled this watch, or we did.  If we did,
+             * its because the guest namespace is now created and now
+             * we're going to watch it */
+            if (gw->guest_started) {
+                if (guest_namespace_watch (gw) < 0)
+                    goto error;
+                return;
+            }
+            goto error;
+        }
+        else if (errno != ENOENT)
+            flux_log_error (ctx->h, "%s: flux_rpc_get", __FUNCTION__);
+        goto error;
+    }
+
+    if (gw->cancel) {
+        errno = ENODATA;
+        goto error;
+    }
+
+    if (flux_job_event_watch_get (f, &event) < 0) {
+        flux_log_error (ctx->h, "%s: flux_job_event_watch_get", __FUNCTION__);
+        goto error_cancel;
+    }
+
+    if (check_guest_namespace_created (gw, event) < 0)
+        goto error_cancel;
+
+    if (gw->guest_started) {
+        int matchtag = (int)flux_rpc_get_matchtag (gw->wait_guest_namespace_f);
+        flux_future_t *f2;
+
+        /* cancel this watcher, and once its canceled, watch the guest
+         * namespace.  Don't call send_cancel(), this is not an error
+         * or "full" cancel */
+        if (!(f2 = flux_rpc_pack (gw->ctx->h,
+                                  "job-info.eventlog-watch-cancel",
+                                  FLUX_NODEID_ANY,
+                                  FLUX_RPC_NORESPONSE,
+                                  "{s:i}",
+                                  "matchtag", matchtag))) {
+            flux_log_error (gw->ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+            goto error;
+        }
+        flux_future_destroy (f2);
+    }
+
+    flux_future_reset (f);
+    return;
+
+error_cancel:
+    /* If we haven't sent a cancellation yet, must do so so that
+     * the future's matchtag will eventually be freed */
+    if (!gw->cancel) {
+        int save_errno = errno;
+        (void) send_cancel (gw, gw->wait_guest_namespace_f);
+        errno = save_errno;
+    }
+
+error:
+    if (flux_respond_error (ctx->h, gw->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+
+    /* flux future destroyed in guest_watch_ctx_destroy, which is
+     * called via zlist_remove() */
+    zlist_remove (ctx->guest_watchers, gw);
+}
+
+static int guest_namespace_watch (struct guest_watch_ctx *gw)
+{
+    flux_msg_t *msg = NULL;
+    int flags = FLUX_RPC_STREAMING;
+    int save_errno;
+    int rv = -1;
+
+    if (!(msg = guest_msg_pack (gw,
+                                "job-info.eventlog-watch",
+                                "{s:I s:b s:s}",
+                                "id", gw->id,
+                                "guest", true,
+                                "path", gw->path)))
+        goto error;
+
+    if (!(gw->guest_namespace_watch_f = flux_rpc_message (gw->ctx->h,
+                                                          msg,
+                                                          FLUX_NODEID_ANY,
+                                                          flags))) {
+        flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (gw->guest_namespace_watch_f,
+                          -1,
+                          guest_namespace_watch_continuation,
+                          gw) < 0) {
+        /* future cleanup handled with context destruction */
+        flux_log_error (gw->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    gw->state = GUEST_WATCH_STATE_GUEST_NAMESPACE_WATCH;
+    rv = 0;
+error:
+    save_errno = errno;
+    flux_msg_destroy (msg);
+    errno = save_errno;
+    return rv;
+}
+
+static void guest_namespace_watch_continuation (flux_future_t *f, void *arg)
+{
+    struct guest_watch_ctx *gw = arg;
+    struct info_ctx *ctx = gw->ctx;
+    const char *s;
+
+    if (flux_rpc_get (f, &s) < 0) {
+        if (errno == ENOTSUP) {
+            /* Guest namespace has been removed.  If we have read no
+             * events in the guest eventlog, assume job was moved into
+             * the main namespace before we began watching in the
+             * guest namespace.
+             *
+             * Note that it is possible the guest eventlog is simply
+             * empty / had no events in it.  There's no way to know
+             * for certain if it is this case or a race.  There is no
+             * behavior change for continuing to watch the eventlog in
+             * the main KVS namespace, so we do it and suffer the
+             * minor latency associated with it.
+             */
+            gw->guest_namespace_removed = true;
+            if (!gw->guest_namespace_events) {
+                if (main_namespace_watch (gw) < 0)
+                    goto error;
+            }
+            return;
+        }
+        else {
+            /* We assume ENODATA always comes from a user cancellation,
+             * or similar error.  There is no circumstance where would
+             * desire to ENODATA this stream.
+             */
+            if (errno != ENOENT && errno != ENODATA)
+                flux_log_error (ctx->h, "%s: flux_rpc_get", __FUNCTION__);
+            goto error;
+        }
+    }
+
+    if (gw->cancel) {
+        errno = ENODATA;
+        goto error_cancel;
+    }
+
+    if (flux_respond (ctx->h, gw->msg, s) < 0) {
+        flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+        goto error_cancel;
+    }
+
+    gw->guest_namespace_events = true;
+    flux_future_reset (f);
+    return;
+
+error_cancel:
+    /* If we haven't sent a cancellation yet, must do so so that
+     * the future's matchtag will eventually be freed */
+    if (!gw->cancel) {
+        int save_errno = errno;
+        (void) send_cancel (gw, gw->guest_namespace_watch_f);
+        errno = save_errno;
+    }
+
+error:
+    if (flux_respond_error (ctx->h, gw->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+
+    /* flux future destroyed in guest_watch_ctx_destroy, which is called
+     * via zlist_remove() */
+    zlist_remove (ctx->guest_watchers, gw);
+}
+
+static int main_namespace_watch (struct guest_watch_ctx *gw)
+{
+    flux_msg_t *msg = NULL;
+    int flags = FLUX_RPC_STREAMING;
+    int save_errno;
+    int rv = -1;
+    char path[64];
+    int tmp;
+
+    /* must prefix "guest." back to path */
+    tmp = snprintf (path, sizeof (path), "guest.%s", gw->path);
+    if (tmp >= sizeof (path)) {
+        errno = EOVERFLOW;
+        goto error;
+    }
+
+    if (!(msg = guest_msg_pack (gw,
+                                "job-info.eventlog-watch",
+                                "{s:I s:b s:s}",
+                                "id", gw->id,
+                                "guest", false,
+                                "path", path)))
+        goto error;
+
+    if (!(gw->main_namespace_watch_f = flux_rpc_message (gw->ctx->h,
+                                                         msg,
+                                                         FLUX_NODEID_ANY,
+                                                         flags))) {
+        flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (gw->main_namespace_watch_f,
+                          -1,
+                          main_namespace_watch_continuation,
+                          gw) < 0) {
+        /* future cleanup handled with context destruction */
+        flux_log_error (gw->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    gw->state = GUEST_WATCH_STATE_MAIN_NAMESPACE_WATCH;
+    rv = 0;
+error:
+    save_errno = errno;
+    flux_msg_destroy (msg);
+    errno = save_errno;
+    return rv;
+}
+
+static void main_namespace_watch_continuation (flux_future_t *f, void *arg)
+{
+    struct guest_watch_ctx *gw = arg;
+    struct info_ctx *ctx = gw->ctx;
+    const char *s;
+
+    if (flux_rpc_get (f, &s) < 0) {
+        if (errno != ENOENT && errno != ENODATA)
+            flux_log_error (ctx->h, "%s: flux_rpc_get", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_respond (ctx->h, gw->msg, s) < 0) {
+        flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+        goto error_cancel;
+    }
+
+    flux_future_reset (f);
+    return;
+
+error_cancel:
+    /* If we haven't sent a cancellation yet, must do so so that
+     * the future's matchtag will eventually be freed */
+    if (!gw->cancel) {
+        int save_errno = errno;
+        (void) send_cancel (gw, gw->main_namespace_watch_f);
+        errno = save_errno;
+    }
+
+error:
+    if (flux_respond_error (ctx->h, gw->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+
+    /* flux future destroyed in guest_watch_ctx_destroy, which is called
+     * via zlist_remove() */
+    zlist_remove (ctx->guest_watchers, gw);
+}
+
+void guest_watch_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    struct guest_watch_ctx *gw = NULL;
+    flux_jobid_t id;
+    const char *path = NULL;
+    const char *errmsg = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:s}",
+                             "id", &id,
+                             "path", &path) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        goto error;
+    }
+    if (!flux_msg_is_streaming (msg)) {
+        errno = EPROTO;
+        errmsg = "guest-eventlog-watch request rejected without streaming "
+                 "RPC flag";
+        goto error;
+    }
+
+    if (!(gw = guest_watch_ctx_create (ctx, msg, id, path)))
+        goto error;
+
+    if (get_main_eventlog (gw) < 0)
+        goto error;
+
+    if (zlist_append (ctx->guest_watchers, gw) < 0) {
+        flux_log_error (h, "%s: zlist_append", __FUNCTION__);
+        goto error;
+    }
+    zlist_freefn (ctx->guest_watchers, gw, guest_watch_ctx_destroy, true);
+    gw = NULL;
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    guest_watch_ctx_destroy (gw);
+}
+
+/* Cancel guest_watch 'gw' if it matches (sender, matchtag).
+ * matchtag=FLUX_MATCHTAG_NONE matches any matchtag.
+ */
+static void guest_watch_cancel (struct info_ctx *ctx,
+                                struct guest_watch_ctx *gw,
+                                const char *sender, uint32_t matchtag)
+{
+    uint32_t t;
+    char *s;
+
+    if (matchtag != FLUX_MATCHTAG_NONE
+        && (flux_msg_get_matchtag (gw->msg, &t) < 0 || matchtag != t))
+        return;
+    if (flux_msg_get_route_first (gw->msg, &s) < 0)
+        return;
+    if (!strcmp (sender, s))
+        send_cancel (gw, NULL);
+    free (s);
+}
+
+void guest_watchers_cancel (struct info_ctx *ctx,
+                            const char *sender, uint32_t matchtag)
+{
+    struct guest_watch_ctx *gw;
+
+    gw = zlist_first (ctx->guest_watchers);
+    while (gw) {
+        guest_watch_cancel (ctx, gw, sender, matchtag);
+        gw = zlist_next (ctx->guest_watchers);
+    }
+}
+
+void guest_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                            const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    uint32_t matchtag;
+    char *sender;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        return;
+    }
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
+        return;
+    }
+    guest_watchers_cancel (ctx, sender, matchtag);
+    free (sender);
+}
+
+void guest_watch_cleanup (struct info_ctx *ctx)
+{
+    struct guest_watch_ctx *gw;
+
+    while ((gw = zlist_pop (ctx->guest_watchers))) {
+        send_cancel (gw, NULL);
+
+        if (flux_respond_error (ctx->h, gw->msg, ENOSYS, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error",
+                            __FUNCTION__);
+        guest_watch_ctx_destroy (gw);
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_INFO_GUEST_WATCH_H
+#define _FLUX_JOB_INFO_GUEST_WATCH_H
+
+#include <flux/core.h>
+
+void guest_watch_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg);
+
+void guest_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                            const flux_msg_t *msg, void *arg);
+
+/* Cancel all lookups that match (sender, matchtag). */
+void guest_watchers_cancel (struct info_ctx *ctx,
+                            const char *sender, uint32_t matchtag);
+
+void guest_watch_cleanup (struct info_ctx *ctx);
+
+#endif /* ! _FLUX_JOB_INFO_EVENTLOG_GUEST_WATCH_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/info.h
+++ b/src/modules/job-info/info.h
@@ -19,6 +19,7 @@ struct info_ctx {
     flux_msg_handler_t **handlers;
     zlist_t *lookups;
     zlist_t *watchers;
+    zlist_t *guest_watchers;
 };
 
 #endif /* _FLUX_JOB_INFO_INFO_H */

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -15,7 +15,11 @@
 #include "config.h"
 #endif
 #include <czmq.h>
+#include <jansson.h>
 #include <flux/core.h>
+
+#include "src/common/libjob/job.h"
+#include "src/common/libeventlog/eventlog.h"
 
 #include "info.h"
 #include "watch.h"
@@ -25,26 +29,32 @@ struct watch_ctx {
     struct info_ctx *ctx;
     flux_msg_t *msg;
     flux_jobid_t id;
-    flux_future_t *f;
+    char *path;
+    flux_future_t *check_f;
+    flux_future_t *watch_f;
     bool allow;
     bool cancel;
 };
 
 static void watch_continuation (flux_future_t *f, void *arg);
+static void check_eventlog_continuation (flux_future_t *f, void *arg);
 
 static void watch_ctx_destroy (void *data)
 {
     if (data) {
         struct watch_ctx *ctx = data;
         flux_msg_destroy (ctx->msg);
-        flux_future_destroy (ctx->f);
+        free (ctx->path);
+        flux_future_destroy (ctx->check_f);
+        flux_future_destroy (ctx->watch_f);
         free (ctx);
     }
 }
 
 static struct watch_ctx *watch_ctx_create (struct info_ctx *ctx,
                                            const flux_msg_t *msg,
-                                           flux_jobid_t id)
+                                           flux_jobid_t id,
+                                           const char *path)
 {
     struct watch_ctx *w = calloc (1, sizeof (*w));
     int saved_errno;
@@ -54,6 +64,10 @@ static struct watch_ctx *watch_ctx_create (struct info_ctx *ctx,
 
     w->ctx = ctx;
     w->id = id;
+    if (!(w->path = strdup (path))) {
+        errno = ENOMEM;
+        goto error;
+    }
 
     if (!(w->msg = flux_msg_copy (msg, true))) {
         flux_log_error (ctx->h, "%s: flux_msg_copy", __FUNCTION__);
@@ -69,28 +83,91 @@ error:
     return NULL;
 }
 
-static int watch_key (struct watch_ctx *w)
+static int check_eventlog (struct watch_ctx *w)
 {
     char key[64];
-    int flags = (FLUX_KVS_WATCH | FLUX_KVS_WATCH_APPEND);
 
     if (flux_job_kvs_key (key, sizeof (key), w->id, "eventlog") < 0) {
         flux_log_error (w->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
         return -1;
     }
 
-    if (!(w->f = flux_kvs_lookup (w->ctx->h, NULL, flags, key))) {
+    if (!(w->check_f = flux_kvs_lookup (w->ctx->h, NULL, 0, key))) {
         flux_log_error (w->ctx->h, "%s: flux_kvs_lookup", __FUNCTION__);
         return -1;
     }
 
-    if (flux_future_then (w->f, -1, watch_continuation, w) < 0) {
-        /* w->f cleanup handled in context destruction */
+    if (flux_future_then (w->check_f, -1, check_eventlog_continuation, w) < 0) {
+        /* future cleanup handled in context destruction */
         flux_log_error (w->ctx->h, "%s: flux_future_then", __FUNCTION__);
         return -1;
     }
 
     return 0;
+}
+
+static int watch_key (struct watch_ctx *w)
+{
+    char fullpath[128];
+    int flags = (FLUX_KVS_WATCH | FLUX_KVS_WATCH_APPEND);
+
+    if (flux_job_kvs_key (fullpath, sizeof (fullpath), w->id, w->path) < 0) {
+        flux_log_error (w->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
+        return -1;
+    }
+
+    if (!(w->watch_f = flux_kvs_lookup (w->ctx->h, NULL, flags, fullpath))) {
+        flux_log_error (w->ctx->h, "%s: flux_kvs_lookup", __FUNCTION__);
+        return -1;
+    }
+
+    if (flux_future_then (w->watch_f, -1, watch_continuation, w) < 0) {
+        /* future cleanup handled in context destruction */
+        flux_log_error (w->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void check_eventlog_continuation (flux_future_t *f, void *arg)
+{
+    struct watch_ctx *w = arg;
+    struct info_ctx *ctx = w->ctx;
+    const char *s;
+
+    if (flux_kvs_lookup_get (f, &s) < 0) {
+        if (errno != ENOENT)
+            flux_log_error (ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+        goto error;
+    }
+
+    if (!w->allow) {
+        if (eventlog_allow (ctx, w->msg, s) < 0)
+            goto error;
+        w->allow = true;
+    }
+
+    /* There is a chance user canceled before we began legitimately
+     * "watching" the desired eventlog */
+    if (w->cancel) {
+        if (flux_respond_error (ctx->h, w->msg, ENODATA, NULL) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        goto done;
+    }
+
+    if (watch_key (w) < 0)
+        goto error;
+
+    return;
+
+error:
+    if (flux_respond_error (ctx->h, w->msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+done:
+    /* flux future destroyed in watch_ctx_destroy, which is called
+     * via zlist_remove() */
+    zlist_remove (ctx->watchers, w);
 }
 
 static bool eventlog_parse_next (const char **pp, const char **tok,
@@ -151,7 +228,7 @@ error_cancel:
      * the future's matchtag will eventually be freed */
     if (!w->cancel) {
         int save_errno = errno;
-        if (flux_kvs_lookup_cancel (w->f) < 0)
+        if (flux_kvs_lookup_cancel (w->watch_f) < 0)
             flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
                             __FUNCTION__);
         errno = save_errno;
@@ -172,9 +249,12 @@ void watch_cb (flux_t *h, flux_msg_handler_t *mh,
     struct info_ctx *ctx = arg;
     struct watch_ctx *w = NULL;
     flux_jobid_t id;
+    const char *path = NULL;
     const char *errmsg = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0) {
+    if (flux_request_unpack (msg, NULL, "{s:I s:s}",
+                             "id", &id,
+                             "path", &path) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         goto error;
     }
@@ -183,11 +263,22 @@ void watch_cb (flux_t *h, flux_msg_handler_t *mh,
         errmsg = "eventlog-watch request rejected without streaming RPC flag";
         goto error;
     }
-    if (!(w = watch_ctx_create (ctx, msg, id)))
+
+    if (!(w = watch_ctx_create (ctx, msg, id, path)))
         goto error;
 
-    if (watch_key (w) < 0)
-        goto error;
+    /* if user requested an alternate path and that alternate path is
+     * not the main eventlog, we have to check the main eventlog for
+     * access first.
+     */
+    if (path && strcasecmp (path, "eventlog")) {
+        if (check_eventlog (w) < 0)
+            goto error;
+    }
+    else {
+        if (watch_key (w) < 0)
+            goto error;
+    }
 
     if (zlist_append (ctx->watchers, w) < 0) {
         flux_log_error (h, "%s: zlist_append", __FUNCTION__);
@@ -220,10 +311,14 @@ static void watch_cancel (struct info_ctx *ctx,
     if (flux_msg_get_route_first (w->msg, &s) < 0)
         return;
     if (!strcmp (sender, s)) {
-        if (flux_kvs_lookup_cancel (w->f) < 0)
-            flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
-                            __FUNCTION__);
         w->cancel = true;
+
+        /* if the watching hasn't started yet, no need to cancel */
+        if (w->watch_f) {
+            if (flux_kvs_lookup_cancel (w->watch_f) < 0)
+                flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+                                __FUNCTION__);
+        }
     }
     free (s);
 }
@@ -264,10 +359,11 @@ void watch_cleanup (struct info_ctx *ctx)
     struct watch_ctx *w;
 
     while ((w = zlist_pop (ctx->watchers))) {
-        if (flux_kvs_lookup_cancel (w->f) < 0)
-            flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
-                                    __FUNCTION__);
-
+        if (w->watch_f) {
+            if (flux_kvs_lookup_cancel (w->watch_f) < 0)
+                flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+                                __FUNCTION__);
+        }
         if (flux_respond_error (ctx->h, w->msg, ENOSYS, NULL) < 0)
             flux_log_error (ctx->h, "%s: flux_respond_error",
                             __FUNCTION__);

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -296,15 +296,15 @@ test_expect_success 'flux job info multiple keys fails on bad id' '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (include eventlog)' '
         jobid=$(flux job submit test.json) &&
-        activekvsdir=$(flux job id --to=kvs $jobid) &&
-        flux kvs unlink ${activekvsdir}.jobspec &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
+        flux kvs unlink ${kvsdir}.jobspec &&
 	! flux job info $jobid eventlog jobspec J > all_info_b.out
 '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventlog)' '
         jobid=$(flux job submit test.json) &&
-        activekvsdir=$(flux job id --to=kvs $jobid) &&
-        flux kvs unlink ${activekvsdir}.jobspec &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
+        flux kvs unlink ${kvsdir}.jobspec &&
 	! flux job info $jobid jobspec J > all_info_b.out
 '
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -284,7 +284,7 @@ test_expect_success 'flux job info jobspec fails on bad id' '
 #
 
 test_expect_success 'flux job info multiple keys works' '
-        jobid=$(flux job submit test.json) &&
+        jobid=$(submit_job) &&
 	flux job info $jobid eventlog jobspec J > all_info_a.out &&
         grep submit all_info_a.out &&
         grep hostname all_info_a.out
@@ -295,14 +295,14 @@ test_expect_success 'flux job info multiple keys fails on bad id' '
 '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (include eventlog)' '
-        jobid=$(flux job submit test.json) &&
+        jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
         flux kvs unlink ${kvsdir}.jobspec &&
 	! flux job info $jobid eventlog jobspec J > all_info_b.out
 '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventlog)' '
-        jobid=$(flux job submit test.json) &&
+        jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
         flux kvs unlink ${kvsdir}.jobspec &&
 	! flux job info $jobid jobspec J > all_info_b.out

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -15,6 +15,7 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 # cancel the job, and wait for clean event.
 submit_job() {
         jobid=$(flux job submit test.json)
+        flux job wait-event $jobid start >/dev/null
         flux job cancel $jobid
         flux job wait-event $jobid clean >/dev/null
         echo $jobid

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -20,10 +20,26 @@ submit_job() {
         echo $jobid
 }
 
+# Unlike above, do not cancel the job, the test will cancel the job
+submit_job_live() {
+        jobspec=$1
+        jobid=$(flux job submit $jobspec)
+        flux job wait-event $jobid start >/dev/null
+        echo $jobid
+}
+
+# Test will cancel the job, is assumed won't run immediately
+submit_job_wait() {
+        jobid=$(flux job submit test.json)
+        flux job wait-event $jobid depend >/dev/null
+        echo $jobid
+}
+
 wait_watchers_nonzero() {
+        str=$1
         i=0
-        while (! flux module stats --parse watchers job-info > /dev/null 2>&1 \
-               || [ "$(flux module stats --parse watchers job-info 2> /dev/null)" = "0" ]) \
+        while (! flux module stats --parse $str job-info > /dev/null 2>&1 \
+               || [ "$(flux module stats --parse $str job-info 2> /dev/null)" = "0" ]) \
               && [ $i -lt 50 ]
         do
                 sleep 0.1
@@ -46,11 +62,12 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
         flux jobspec --format json srun -N1 sleep inf > test.json
 '
 
-hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
 test_expect_success 'load job-exec,sched-simple modules' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux module load -r all barrier &&
         flux module load -r 0 sched-simple &&
         flux module load -r 0 job-exec
 '
@@ -152,7 +169,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event works, event is later' '
         jobid=$(submit_job)
         flux job wait-event $jobid foobar > wait_event3.out &
         waitpid=$! &&
-        wait_watchers_nonzero &&
+        wait_watchers_nonzero "watchers" &&
         wait_watcherscount_nonzero primary &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
@@ -298,9 +315,66 @@ test_expect_success 'flux job wait-event -p fails on invalid path' '
         ! flux job wait-event -p "foobar" $jobid submit
 '
 
+test_expect_success 'flux job wait-event -p fails on path "guest."' '
+        jobid=$(submit_job) &&
+        ! flux job wait-event -p "guest." $jobid submit
+'
+
 test_expect_success 'flux job wait-event -p hangs on no event' '
         jobid=$(submit_job) &&
         ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (live job)' '
+        jobid=$(submit_job_live test.json)
+        flux job wait-event -p "guest.exec.eventlog" $jobid done > wait_event_path3.out &
+        waitpid=$! &&
+        wait_watchers_nonzero "watchers" &&
+        wait_watchers_nonzero "guest_watchers" &&
+        guestns=$(flux job namespace $jobid) &&
+        wait_watcherscount_nonzero $guestns &&
+        flux job cancel $jobid &&
+        wait $waitpid &&
+        grep done wait_event_path3.out
+'
+
+test_expect_success 'flux job wait-event -p hangs on no event (live job)' '
+        jobid=$(submit_job_live test.json) &&
+        ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
+        flux job cancel $jobid
+'
+
+# In order to test watching a guest event log that does not yet exist,
+# we will start a job that will take up all resources.  Then start
+# another job, which we will watch and know it hasn't started running
+# yet. Then we cancel the initial job to get the new one running.
+
+test_expect_success 'job-info: generate jobspec to consume all resources' '
+        flux jobspec --format json srun -n4 -c2 sleep inf > test-all.json
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (wait job)' '
+        jobidall=$(submit_job_live test-all.json)
+        jobid=$(submit_job_wait)
+        flux job wait-event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path6.out &
+        waitpid=$! &&
+        wait_watchers_nonzero "watchers" &&
+        wait_watchers_nonzero "guest_watchers" &&
+        flux job cancel ${jobidall} &&
+        flux job wait-event ${jobid} start &&
+        guestns=$(flux job namespace ${jobid}) &&
+        wait_watcherscount_nonzero $guestns &&
+        flux job cancel ${jobid} &&
+        wait $waitpid &&
+        grep done wait_event_path6.out
+'
+
+test_expect_success 'flux job wait-event -p hangs on no event (wait job)' '
+        jobidall=$(submit_job_live test-all.json) &&
+        jobid=$(submit_job_wait) &&
+        ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
+        flux job cancel $jobidall &&
+        flux job cancel $jobid
 '
 
 #
@@ -362,7 +436,8 @@ test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventl
 
 test_expect_success 'job-info stats works' '
         flux module stats job-info | grep "lookups" &&
-        flux module stats job-info | grep "watchers"
+        flux module stats job-info | grep "watchers" &&
+        flux module stats job-info | grep "guest_watchers"
 '
 
 test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '
@@ -371,11 +446,15 @@ test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '
 test_expect_success 'eventlog-watch request with empty payload fails with EPROTO(71)' '
 	${RPC} job-info.eventlog-watch 71 </dev/null
 '
+test_expect_success 'guest-eventlog-watch request with empty payload fails with EPROTO(71)' '
+	${RPC} job-info.guest-eventlog-watch 71 </dev/null
+'
 
 #
 # cleanup
 #
 test_expect_success 'remove sched-simple,job-exec modules' '
+        flux module remove -r all barrier &&
         flux module remove -r 0 sched-simple &&
         flux module remove -r 0 job-exec
 '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -281,6 +281,28 @@ test_expect_success 'flux job wait-event w/ bad match-context fails (invalid inp
         ! flux job wait-event --match-context=foo $jobid exception
 '
 
+test_expect_success 'flux job wait-event -p works' '
+        jobid=$(submit_job) &&
+        flux job wait-event -p "eventlog" $jobid submit > wait_event_path1.out &&
+        grep submit wait_event_path1.out
+'
+
+test_expect_success 'flux job wait-event -p works (guest.exec.eventlog)' '
+        jobid=$(submit_job) &&
+        flux job wait-event -p "guest.exec.eventlog" $jobid done > wait_event_path2.out &&
+        grep done wait_event_path2.out
+'
+
+test_expect_success 'flux job wait-event -p fails on invalid path' '
+        jobid=$(submit_job) &&
+        ! flux job wait-event -p "foobar" $jobid submit
+'
+
+test_expect_success 'flux job wait-event -p hangs on no event' '
+        jobid=$(submit_job) &&
+        ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar
+'
+
 #
 # job info tests
 #

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -25,6 +25,7 @@ update_job_userid() {
 # userid
 submit_job() {
         jobid=$(flux job submit test.json)
+        flux job wait-event $jobid start >/dev/null
         flux job cancel $jobid
         flux job wait-event $jobid clean >/dev/null
         update_job_userid $1

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -135,6 +135,25 @@ test_expect_success 'flux job wait-event fails (wrong user)' '
         unset_userid
 '
 
+test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (owner)' '
+        jobid=$(submit_job) &&
+        flux job wait-event -p guest.exec.eventlog $jobid done
+'
+
+test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9000 &&
+        flux job wait-event -p guest.exec.eventlog $jobid done &&
+        unset_userid
+'
+
+test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (wrong user)' '
+        jobid=$(submit_job 9000) &&
+        set_userid 9999 &&
+        ! flux job wait-event -p guest.exec.eventlog $jobid done &&
+        unset_userid
+'
+
 #
 # job info
 #


### PR DESCRIPTION
As discussed in meetings and #2105, this PR will allow users to read from and watch guest event logs.

There is a new `guest_watch.c` file in the job-info module that handles the new `job-info.guest-eventlog-watch` callback.  This callback handles a number of tricky scenarios as discussed in #2105.  Effectively, `job-info.guest-eventlog-watch` is a wrapper around `job-info.lookup` and `job-info.eventlog-watch` RPCs.

Interesting notes on development:

- Supporting an alternate eventlog path to `job-info.lookup` is easy.  It already takes a path argument, so just passing in something like `guest.exec.eventlog` is easy enough.

- The original `job-info.eventlog-watch` now takes an optional path to an eventlog and a flag that indicates if the eventlog should be read from the guest namespace.  i.e. this flag indicates if we're reading from the main KVS namespace in `job.0000.0000.0000.0000.<path>` or if we're reading from `<path>` in the guest namespace.

- `flux_job_event_watch()` - choose which callback to send to (i.e. main eventlog watch or guest eventlog watch) based on the path that is passed in to it.  If the path is prefixed with `guest.` it goes to the guest callback.  I considered several other options (flags, etc.) but this seemed the cleanest option.  It's probably the one part of this PR that is highly debatable what would be best.

- In `guest_watch.c`, you'll see a `guest_msg_pack()` function.  Since we're sending requests to `job-info.lookup` and `job-info.eventlog-watch` that will do access checks, we need to create messages that have the same rolemask & userid from the original message passed in.  So that's what this function does.

- Added a bunch of tests, but more can probably be added.  Just wanted to throw this up for now.
