### PR TITLE
flux-shell: use RFC 24 eventlog output

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -881,7 +881,7 @@ static void runlevel_io_cb (runlevel_t *r, const char *name,
                             const char *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
-    int loglevel = !strcmp (name, "STDERR") ? LOG_ERR : LOG_INFO;
+    int loglevel = !strcmp (name, "stderr") ? LOG_ERR : LOG_INFO;
     int runlevel = runlevel_get_level (r);
 
     flux_log (ctx->h, loglevel, "rc%d: %s", runlevel, msg);

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -177,7 +177,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
+    FILE *fstream = !strcmp (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 
@@ -207,7 +207,7 @@ static void stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
         while (p) {
             if (flux_subprocess_state (p) == FLUX_SUBPROCESS_INIT
                 || flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
-                if (flux_subprocess_write (p, "STDIN", ptr, lenp) < 0)
+                if (flux_subprocess_write (p, "stdin", ptr, lenp) < 0)
                     log_err_exit ("flux_subprocess_write");
             }
             p = zlist_next (subprocesses);
@@ -216,7 +216,7 @@ static void stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
     else {
         p = zlist_first (subprocesses);
         while (p) {
-            if (flux_subprocess_close (p, "STDIN") < 0)
+            if (flux_subprocess_close (p, "stdin") < 0)
                 log_err_exit ("flux_subprocess_close");
             p = zlist_next (subprocesses);
         }
@@ -398,13 +398,13 @@ int main (int argc, char *argv[])
     if (optparse_getopt (opts, "verbose", NULL) > 0)
         fprintf (stderr, "%03fms: Sent all requests\n", monotime_since (t0));
 
-    /* -n,--noinput: close subprocess STDIN
+    /* -n,--noinput: close subprocess stdin
      */
     if (optparse_getopt (opts, "noinput", NULL) > 0) {
         flux_subprocess_t *p;
         p = zlist_first (subprocesses);
         while (p) {
-            if (flux_subprocess_close (p, "STDIN") < 0)
+            if (flux_subprocess_close (p, "stdin") < 0)
                 log_err_exit ("flux_subprocess_close");
             p = zlist_next (subprocesses);
         }

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -883,7 +883,7 @@ void print_output (flux_t *h, flux_jobid_t id, optparse_t *p, bool missing_ok)
             if (iodecode (context, &stream, &rank, &data, &len, NULL) < 0)
                 log_msg_exit ("malformed event context");
             if (len > 0) {
-                FILE *fp = !strcmp (stream, "STDOUT") ? stdout : stderr;
+                FILE *fp = !strcmp (stream, "stdout") ? stdout : stderr;
                 if (optparse_hasopt (p, "label"))
                     fprintf (fp, "%d: ", rank);
                 fwrite (data, len, 1, fp);

--- a/src/common/libeventlog/eventlog.h
+++ b/src/common/libeventlog/eventlog.h
@@ -23,6 +23,9 @@ int eventlog_entry_parse (json_t *entry,
 /* decode an eventlog into an json array of event objects */
 json_t *eventlog_decode (const char *s);
 
+/* encode json array of event objects into an eventlog */
+char *eventlog_encode (json_t *o);
+
 /* decode a single eventlog entry into a json object */
 json_t *eventlog_entry_decode (const char *entry);
 

--- a/src/common/libeventlog/test/eventlog.c
+++ b/src/common/libeventlog/test/eventlog.c
@@ -162,23 +162,32 @@ void eventlog_decoding (void)
 {
     char buf[512];
     json_t *o;
+    char *s;
     int i;
 
     /* all good events are good logs */
     for (i = 0; goodevent[i] != NULL; i++) {
         o = eventlog_decode (goodevent[i]);
         ok (o != NULL,
-            "eventlog_decode event=\"%s\" success",
+            "eventlog_decode input=\"%s\" success",
             printable (buf, goodevent[i]));
+        s = eventlog_encode (o);
+        ok (s != NULL && !strcmp (s, goodevent[i]),
+            "eventlog_encode reversed it");
         json_decref (o);
+        free (s);
     }
 
     for (i = 0; goodlog[i] != NULL; i++) {
         o = eventlog_decode (goodlog[i]);
         ok (o != NULL,
-            "eventlog_decode event=\"%s\" success",
+            "eventlog_decode input=\"%s\" success",
             printable (buf, goodlog[i]));
+        s = eventlog_encode (o);
+        ok (s != NULL && !strcmp (s, goodlog[i]),
+            "eventlog_encode reversed it");
         json_decref (o);
+        free (s);
     }
 }
 

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -287,7 +287,7 @@ static int local_setup_stdio (flux_subprocess_t *p)
                              NULL,
                              local_in_cb,
                              NULL,
-                             "STDIN",
+                             "stdin",
                              CHANNEL_WRITE) < 0)
         return -1;
 
@@ -296,7 +296,7 @@ static int local_setup_stdio (flux_subprocess_t *p)
                                  p->ops.on_stdout,
                                  NULL,
                                  local_stdout_cb,
-                                 "STDOUT",
+                                 "stdout",
                                  CHANNEL_READ) < 0)
             return -1;
     }
@@ -306,7 +306,7 @@ static int local_setup_stdio (flux_subprocess_t *p)
                                  p->ops.on_stderr,
                                  NULL,
                                  local_stderr_cb,
-                                 "STDERR",
+                                 "stderr",
                                  CHANNEL_READ) < 0)
             return -1;
     }
@@ -451,14 +451,14 @@ static int local_child (flux_subprocess_t *p)
     close_parent_fds (p);
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
-        if ((c = zhash_lookup (p->channels, "STDIN"))) {
+        if ((c = zhash_lookup (p->channels, "stdin"))) {
             if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
                 flux_log_error (p->h, "dup2");
                 _exit (1);
             }
         }
 
-        if ((c = zhash_lookup (p->channels, "STDOUT"))) {
+        if ((c = zhash_lookup (p->channels, "stdout"))) {
             if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
                 flux_log_error (p->h, "dup2");
                 _exit (1);
@@ -467,7 +467,7 @@ static int local_child (flux_subprocess_t *p)
         else
             close (STDOUT_FILENO);
 
-        if ((c = zhash_lookup (p->channels, "STDERR"))) {
+        if ((c = zhash_lookup (p->channels, "stderr"))) {
             if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
                 flux_log_error (p->h, "dup2");
                 _exit (1);

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -470,14 +470,14 @@ static int remote_setup_stdio (flux_subprocess_t *p)
 
     if (remote_channel_setup (p,
                               NULL,
-                              "STDIN",
+                              "stdin",
                               CHANNEL_WRITE) < 0)
         return -1;
 
     if (p->ops.on_stdout) {
         if (remote_channel_setup (p,
                                   p->ops.on_stdout,
-                                  "STDOUT",
+                                  "stdout",
                                   CHANNEL_READ) < 0)
             return -1;
     }
@@ -485,7 +485,7 @@ static int remote_setup_stdio (flux_subprocess_t *p)
     if (p->ops.on_stderr) {
         if (remote_channel_setup (p,
                                   p->ops.on_stderr,
-                                  "STDERR",
+                                  "stderr",
                                   CHANNEL_READ) < 0)
             return -1;
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -351,7 +351,7 @@ int flux_subprocess_server_terminate_by_uuid (flux_subprocess_server_t *s,
 void flux_standard_output (flux_subprocess_t *p, const char *stream)
 {
     /* everything except stderr goes to stdout */
-    FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
+    FILE *fstream = !strcasecmp (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -730,13 +730,12 @@ int flux_subprocess_stream_start (flux_subprocess_t *p, const char *stream)
     struct subprocess_channel *c;
     flux_buffer_t *fb;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return -1;
     }
-
-    if (!stream)
-        stream = "STDOUT";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_READ)) {
@@ -784,13 +783,12 @@ int flux_subprocess_stream_stop (flux_subprocess_t *p, const char *stream)
     struct subprocess_channel *c;
     flux_buffer_t *fb;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return -1;
     }
-
-    if (!stream)
-        stream = "STDOUT";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_READ)) {
@@ -822,13 +820,12 @@ int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream)
     struct subprocess_channel *c;
     int ret;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return -1;
     }
-
-    if (!stream)
-        stream = "STDOUT";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_READ)) {
@@ -853,7 +850,9 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
     flux_buffer_t *fb;
     int ret;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return -1;
     }
@@ -862,9 +861,6 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
         errno = EINVAL;
         return -1;
     }
-
-    if (!stream)
-        stream = "STDIN";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_WRITE)) {
@@ -911,13 +907,12 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream)
 {
     struct subprocess_channel *c;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return -1;
     }
-
-    if (!stream)
-        stream = "STDIN";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_WRITE)) {
@@ -964,7 +959,9 @@ static const char *subprocess_read (flux_subprocess_t *p,
     flux_buffer_t *fb;
     const char *ptr;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return NULL;
     }
@@ -973,9 +970,6 @@ static const char *subprocess_read (flux_subprocess_t *p,
         errno = EINVAL;
         return NULL;
     }
-
-    if (!stream)
-        stream = "STDOUT";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_READ)) {
@@ -1043,13 +1037,12 @@ int flux_subprocess_read_stream_closed (flux_subprocess_t *p, const char *stream
     struct subprocess_channel *c;
     flux_buffer_t *fb;
 
-    if (!p || p->magic != SUBPROCESS_MAGIC || (p->local && p->in_hook)) {
+    if (!p || !stream
+           || p->magic != SUBPROCESS_MAGIC
+           || (p->local && p->in_hook)) {
         errno = EINVAL;
         return -1;
     }
-
-    if (!stream)
-        stream = "STDOUT";
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_READ)) {

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -333,8 +333,7 @@ int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream);
 
 /*
  *  Write data to "stream" stream of subprocess `p`.  'stream' can be
- *  "STDIN" or the name of a stream specified with
- *  flux_cmd_add_channel().  If 'stream' is NULL, defaults to "STDIN".
+ *  "STDIN" or the name of a stream specified with flux_cmd_add_channel().
  *
  *  Returns the total amount of data successfully buffered.
  */
@@ -344,16 +343,14 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
 /*
  *  Close "stream" stream of subprocess `p` and schedule EOF to be sent.
  *  'stream' can be "STDIN" or the name of a stream specified with
- *  flux_cmd_add_channel().  If 'stream' is NULL, defaults to "STDIN".
+ *  flux_cmd_add_channel().
  */
 int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
 
 /*
  *  Read up to `len` bytes of unread data from stream `stream`.  To
  *   read all data, specify 'len' of -1.  'stream' can be "STDOUT",
- *   "STDERR", or the name of a stream specified with
- *   flux_cmd_add_channel().  If 'stream' is NULL, defaults to
- *   "STDOUT".
+ *   "STDERR", or the name of a stream specified with flux_cmd_add_channel().
  *
  *   Returns pointer to buffer on success and NULL on error with errno
  *   set.  Buffer is guaranteed to be NUL terminated.  User shall not
@@ -368,8 +365,7 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
 /*
  *  Read line unread data from stream `stream`.  'stream' can be
  *   "STDOUT", "STDERR", or the name of a stream specified with
- *   flux_cmd_add_channel().  If 'stream' is NULL, defaults to
- *   "STDOUT".
+ *   flux_cmd_add_channel().
  *
  *   Returns pointer to buffer on success and NULL on error with errno
  *   set.  Buffer will include newline character and is guaranteed to

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -59,9 +59,9 @@ typedef enum {
  */
 enum {
     /* flux_exec(): let parent stdin, stdout, stderr, carry to child.
-     * Do not create "STDIN", "STDOUT", or "STDERR" channels.  Subsequently,
+     * Do not create "stdin", "stdout", or "stderr" channels.  Subsequently,
      * flux_subprocess_write()/close()/read()/read_line() will fail on
-     * streams of "STDIN", "STDOUT", or "STDERR".
+     * streams of "stdin", "stdout", or "stderr".
      */
     FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH = 1,
     /* flux_exec(): call setpgrp() before exec(2) */
@@ -250,9 +250,9 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *   The buffer size can be adjusted with this option.
  *
  *   - name + "_BUFSIZE" - set buffer size on channel name
- *   - STDIN_BUFSIZE - set buffer size on stdin
- *   - STDOUT_BUFSIZE - set buffer size on stdout
- *   - STDERR_BUFSIZE - set buffer size on stderr
+ *   - stdin_BUFSIZE - set buffer size on stdin
+ *   - stdout_BUFSIZE - set buffer size on stdout
+ *   - stderr_BUFSIZE - set buffer size on stderr
  *
  *  "LINE_BUFFER" option
  *
@@ -264,8 +264,8 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    "true" to keep default behavior of line buffering.
  *
  *    - name + "_LINE_BUFFER" - configuring line buffering on channel name
- *    - STDOUT_LINE_BUFFER - configure line buffering for stdout
- *    - STDERR_LINE_BUFFER - configure line buffering for stderr
+ *    - stdout_LINE_BUFFER - configure line buffering for stdout
+ *    - stderr_LINE_BUFFER - configure line buffering for stderr
  *
  *  "STREAM_STOP" option
  *
@@ -279,8 +279,8 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    keep default behavior.
  *
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
- *    - STDOUT_STREAM_STOP - configure start/stop for stdout
- *    - STDERR_STREAM_STOP - configure start/stop for stderr
+ *    - stdout_STREAM_STOP - configure start/stop for stdout
+ *    - stderr_STREAM_STOP - configure start/stop for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
@@ -333,7 +333,7 @@ int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream);
 
 /*
  *  Write data to "stream" stream of subprocess `p`.  'stream' can be
- *  "STDIN" or the name of a stream specified with flux_cmd_add_channel().
+ *  "stdin" or the name of a stream specified with flux_cmd_add_channel().
  *
  *  Returns the total amount of data successfully buffered.
  */
@@ -342,15 +342,15 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
 
 /*
  *  Close "stream" stream of subprocess `p` and schedule EOF to be sent.
- *  'stream' can be "STDIN" or the name of a stream specified with
+ *  'stream' can be "stdin" or the name of a stream specified with
  *  flux_cmd_add_channel().
  */
 int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
 
 /*
  *  Read up to `len` bytes of unread data from stream `stream`.  To
- *   read all data, specify 'len' of -1.  'stream' can be "STDOUT",
- *   "STDERR", or the name of a stream specified with flux_cmd_add_channel().
+ *   read all data, specify 'len' of -1.  'stream' can be "stdout",
+ *   "stderr", or the name of a stream specified with flux_cmd_add_channel().
  *
  *   Returns pointer to buffer on success and NULL on error with errno
  *   set.  Buffer is guaranteed to be NUL terminated.  User shall not
@@ -364,7 +364,7 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
 
 /*
  *  Read line unread data from stream `stream`.  'stream' can be
- *   "STDOUT", "STDERR", or the name of a stream specified with
+ *   "stdout", "stderr", or the name of a stream specified with
  *   flux_cmd_add_channel().
  *
  *   Returns pointer to buffer on success and NULL on error with errno

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -202,22 +202,22 @@ void test_basic_errors (flux_reactor_t *r)
         && errno == EINVAL,
         "flux_subprocess_stream_status fails with NULL pointer inputs");
 
-    ok (flux_subprocess_write (NULL, "STDIN", "foo", 3) < 0
+    ok (flux_subprocess_write (NULL, "stdin", "foo", 3) < 0
         && errno == EINVAL,
         "flux_subprocess_write fails with NULL pointer inputs");
-    ok (flux_subprocess_close (NULL, "STDIN") < 0
+    ok (flux_subprocess_close (NULL, "stdin") < 0
         && errno == EINVAL,
         "flux_subprocess_close fails with NULL pointer inputs");
-    ok (flux_subprocess_read (NULL, "STDOUT", -1, NULL) == NULL
+    ok (flux_subprocess_read (NULL, "stdout", -1, NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read fails with NULL pointer inputs");
-    ok (flux_subprocess_read_line (NULL, "STDOUT", NULL) == NULL
+    ok (flux_subprocess_read_line (NULL, "stdout", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read_line fails with NULL pointer inputs");
-    ok (flux_subprocess_read_trimmed_line (NULL, "STDOUT", NULL) == NULL
+    ok (flux_subprocess_read_trimmed_line (NULL, "stdout", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read_trimmed_line fails with NULL pointer inputs");
-    ok (flux_subprocess_read_stream_closed (NULL, "STDOUT") < 0
+    ok (flux_subprocess_read_stream_closed (NULL, "stdout") < 0
         && errno == EINVAL,
         "flux_subprocess_read_stream_closed fails with NULL pointer inputs");
     ok (flux_subprocess_kill (NULL, 0) == NULL
@@ -326,7 +326,7 @@ void test_errors (flux_reactor_t *r)
     ok (rc == 0, "flux_reactor_run returned zero status");
     ok (completion_cb_count == 1, "completion callback called 1 time");
 
-    ok (flux_subprocess_write (p, "STDIN", "foo", 3) < 0
+    ok (flux_subprocess_write (p, "stdin", "foo", 3) < 0
         && errno == EPIPE,
         "flux_subprocess_write returns EPIPE b/c process already completed");
 
@@ -341,9 +341,9 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &stderr_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -504,10 +504,10 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
 
     if (output_default_stream_cb_count == 0) {
-        ptr = flux_subprocess_read_line (p, "STDOUT", &lenp);
+        ptr = flux_subprocess_read_line (p, "stdout", &lenp);
         ok (ptr != NULL
             && lenp > 0,
-            "flux_subprocess_read_line on %s success", "STDOUT");
+            "flux_subprocess_read_line on %s success", "stdout");
 
         sprintf (cmpbuf, "%s:hi\n", stream);
 
@@ -519,12 +519,12 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream) > 0,
-            "flux_subprocess_read_stream_closed saw EOF on %s", "STDOUT");
+            "flux_subprocess_read_stream_closed saw EOF on %s", "stdout");
 
-        ptr = flux_subprocess_read (p, "STDOUT", -1, &lenp);
+        ptr = flux_subprocess_read (p, "stdout", -1, &lenp);
         ok (ptr != NULL
             && lenp == 0,
-            "flux_subprocess_read on %s read EOF", "STDOUT");
+            "flux_subprocess_read on %s read EOF", "stdout");
     }
 
     output_default_stream_cb_count++;
@@ -550,10 +550,10 @@ void test_basic_stdin (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "STDIN", "hi", 2) == 2,
+    ok (flux_subprocess_write (p, "stdin", "hi", 2) == 2,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_close (p, "STDIN") == 0,
+    ok (flux_subprocess_close (p, "stdin") == 0,
         "flux_subprocess_close success");
 
     int rc = flux_reactor_run (r, 0);
@@ -571,9 +571,9 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &stderr_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -650,9 +650,9 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &stderr_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -720,9 +720,9 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &multiple_lines_stdout_output_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &multiple_lines_stderr_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -797,16 +797,16 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "STDIN", "foo\n", 4) == 4,
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_write (p, "STDIN", "bar\n", 4) == 4,
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_write (p, "STDIN", "bo\n", 3) == 3,
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_close (p, "STDIN") == 0,
+    ok (flux_subprocess_close (p, "stdin") == 0,
         "flux_subprocess_close success");
 
     int rc = flux_reactor_run (r, 0);
@@ -824,9 +824,9 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &stderr_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -882,13 +882,13 @@ void test_basic_read_line_until_eof (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "STDIN", "foo\n", 4) == 4,
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_write (p, "STDIN", "bar", 3) == 3,
+    ok (flux_subprocess_write (p, "stdin", "bar", 3) == 3,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_close (p, "STDIN") == 0,
+    ok (flux_subprocess_close (p, "stdin") == 0,
         "flux_subprocess_close success");
 
     int rc = flux_reactor_run (r, 0);
@@ -906,7 +906,7 @@ void output_read_line_until_eof_error_cb (flux_subprocess_t *p, const char *stre
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -942,8 +942,8 @@ void test_basic_read_line_until_eof_error (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (3, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -988,13 +988,13 @@ void test_write_after_close (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "STDIN", "hi", 2) == 2,
+    ok (flux_subprocess_write (p, "stdin", "hi", 2) == 2,
         "flux_subprocess_write success");
 
-    ok (flux_subprocess_close (p, "STDIN") == 0,
+    ok (flux_subprocess_close (p, "stdin") == 0,
         "flux_subprocess_close success");
 
-    ok (flux_subprocess_write (p, "STDIN", "hi", 2) < 0
+    ok (flux_subprocess_write (p, "stdin", "hi", 2) < 0
         && errno == EPIPE,
         "flux_subprocess_write failed with EPIPE after a close");
 
@@ -1065,7 +1065,7 @@ void env_passed_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp = 0;
 
-    ok (!strcasecmp (stream, "STDOUT"),
+    ok (!strcasecmp (stream, "stdout"),
         "env_passed_cb called with correct stream");
 
     if (!env_passed_cb_count) {
@@ -1264,9 +1264,9 @@ void eof_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_eof_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &stderr_eof_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -1477,7 +1477,7 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp = 0;
 
-    ok (!strcasecmp (stream, "STDOUT"),
+    ok (!strcasecmp (stream, "stdout"),
         "channel_fd_env_cb called with correct stream");
 
     if (!channel_fd_env_cb_count) {
@@ -1539,7 +1539,7 @@ void channel_in_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp = 0;
 
-    ok (!strcasecmp (stream, "STDOUT"),
+    ok (!strcasecmp (stream, "stdout"),
         "channel_in_cb called with correct stream");
 
     if (!channel_in_cb_count) {
@@ -1814,14 +1814,14 @@ void test_bufsize (flux_reactor_t *r)
     ok (flux_cmd_add_channel (cmd, "TEST_CHANNEL") == 0,
         "flux_cmd_add_channel success adding channel TEST_CHANNEL");
 
-    ok (flux_cmd_setopt (cmd, "STDIN_BUFSIZE", "1024") == 0,
-        "flux_cmd_setopt set STDIN_BUFSIZE success");
+    ok (flux_cmd_setopt (cmd, "stdin_BUFSIZE", "1024") == 0,
+        "flux_cmd_setopt set stdin_BUFSIZE success");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_BUFSIZE", "1024") == 0,
-        "flux_cmd_setopt set STDOUT_BUFSIZE success");
+    ok (flux_cmd_setopt (cmd, "stdout_BUFSIZE", "1024") == 0,
+        "flux_cmd_setopt set stdout_BUFSIZE success");
 
-    ok (flux_cmd_setopt (cmd, "STDERR_BUFSIZE", "1024") == 0,
-        "flux_cmd_setopt set STDERR_BUFSIZE success");
+    ok (flux_cmd_setopt (cmd, "stderr_BUFSIZE", "1024") == 0,
+        "flux_cmd_setopt set stderr_BUFSIZE success");
 
     ok (flux_cmd_setopt (cmd, "TEST_CHANNEL_BUFSIZE", "1024") == 0,
         "flux_cmd_setopt set TEST_CHANNEL_BUFSIZE success");
@@ -1890,7 +1890,7 @@ void line_output_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -1953,8 +1953,8 @@ void test_line_buffer_enable (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (5, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "true") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "true") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -1983,9 +1983,9 @@ void count_output_cb (flux_subprocess_t *p, const char *stream)
 {
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
-    else if (!strcasecmp (stream, "STDERR"))
+    else if (!strcasecmp (stream, "stderr"))
         counter = &stderr_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -2004,8 +2004,8 @@ void test_line_buffer_disable (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (5, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -2038,8 +2038,8 @@ void test_line_buffer_error (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (1, av, NULL)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "ABCD") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "ABCD") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -2077,30 +2077,30 @@ void test_stream_start_stop_basic (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_stream_status (p, "STDOUT") > 0,
-        "flux_subprocess_stream_status says STDOUT is started");
-    ok (flux_subprocess_stream_status (p, "STDERR") > 0,
-        "flux_subprocess_stream_status says STDERR is started");
+    ok (flux_subprocess_stream_status (p, "stdout") > 0,
+        "flux_subprocess_stream_status says stdout is started");
+    ok (flux_subprocess_stream_status (p, "stderr") > 0,
+        "flux_subprocess_stream_status says stderr is started");
 
-    ok (!flux_subprocess_stream_stop (p, "STDOUT"),
-        "flux_subprocess_stream_stop on STDOUT success");
-    ok (!flux_subprocess_stream_stop (p, "STDERR"),
-        "flux_subprocess_stream_stop on STDERR success");
+    ok (!flux_subprocess_stream_stop (p, "stdout"),
+        "flux_subprocess_stream_stop on stdout success");
+    ok (!flux_subprocess_stream_stop (p, "stderr"),
+        "flux_subprocess_stream_stop on stderr success");
 
-    ok (flux_subprocess_stream_status (p, "STDOUT") == 0,
-        "flux_subprocess_stream_status says STDOUT is stopped");
-    ok (flux_subprocess_stream_status (p, "STDERR") == 0,
-        "flux_subprocess_stream_status says STDERR is stopped");
+    ok (flux_subprocess_stream_status (p, "stdout") == 0,
+        "flux_subprocess_stream_status says stdout is stopped");
+    ok (flux_subprocess_stream_status (p, "stderr") == 0,
+        "flux_subprocess_stream_status says stderr is stopped");
 
-    ok (!flux_subprocess_stream_start (p, "STDOUT"),
-        "flux_subprocess_stream_start on STDOUT success");
-    ok (!flux_subprocess_stream_start (p, "STDERR"),
-        "flux_subprocess_stream_start on STDERR success");
+    ok (!flux_subprocess_stream_start (p, "stdout"),
+        "flux_subprocess_stream_start on stdout success");
+    ok (!flux_subprocess_stream_start (p, "stderr"),
+        "flux_subprocess_stream_start on stderr success");
 
-    ok (flux_subprocess_stream_status (p, "STDOUT") > 0,
-        "flux_subprocess_stream_status says STDOUT is started");
-    ok (flux_subprocess_stream_status (p, "STDERR") > 0,
-        "flux_subprocess_stream_status says STDERR is started");
+    ok (flux_subprocess_stream_status (p, "stdout") > 0,
+        "flux_subprocess_stream_status says stdout is started");
+    ok (flux_subprocess_stream_status (p, "stderr") > 0,
+        "flux_subprocess_stream_status says stderr is started");
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
@@ -2118,11 +2118,11 @@ void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
     int *counter;
     int *len_counter;
 
-    if (!strcasecmp (stream, "STDOUT")) {
+    if (!strcasecmp (stream, "stdout")) {
         counter = &stdout_output_cb_count;
         len_counter = &stdout_output_cb_len_count;
     }
-    else if (!strcasecmp (stream, "STDERR")) {
+    else if (!strcasecmp (stream, "stderr")) {
         counter = &stderr_output_cb_count;
         len_counter = &stderr_output_cb_len_count;
     }
@@ -2136,12 +2136,12 @@ void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
     (*len_counter)+= lenp;
 
     if (ptr && lenp && (*len_counter) == 10001) {
-        if (!strcmp (stream, "STDERR")) {
+        if (!strcmp (stream, "stderr")) {
             ok (stdout_output_cb_count == 0
                 && stdout_output_cb_len_count == 0,
                 "received all stderr data and stdout output is still 0");
-            ok (!flux_subprocess_stream_start (p, "STDOUT"),
-                "flux_subprocess_stream_start on STDOUT success");
+            ok (!flux_subprocess_stream_start (p, "stdout"),
+                "flux_subprocess_stream_start on stdout success");
         }
     }
 }
@@ -2164,11 +2164,11 @@ void test_stream_start_stop_initial_stop (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (6, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
-    ok (flux_cmd_setopt (cmd, "STDERR_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDERR_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stderr_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stderr_LINE_BUFFER success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -2186,13 +2186,13 @@ void test_stream_start_stop_initial_stop (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (!flux_subprocess_stream_stop (p, "STDOUT"),
-        "flux_subprocess_stream_stop on STDOUT success");
+    ok (!flux_subprocess_stream_stop (p, "stdout"),
+        "flux_subprocess_stream_stop on stdout success");
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
     ok (completion_cb_count == 1, "completion callback called 1 time");
-    /* potential for == 2, b/c could all be buffered before STDOUT
+    /* potential for == 2, b/c could all be buffered before stdout
      * callback is re-started */
     ok (stdout_output_cb_count >= 2, "stdout output callback called >= 2 times: %d",
         stdout_output_cb_count);
@@ -2213,8 +2213,8 @@ void mid_stop_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     flux_subprocess_t *p = arg;
     ok (stdout_output_cb_count == 1,
         "stdout callback has not been called since timer activated");
-    ok (!flux_subprocess_stream_start (p, "STDOUT"),
-        "flux_subprocess_stream_start on STDOUT success");
+    ok (!flux_subprocess_stream_start (p, "stdout"),
+        "flux_subprocess_stream_start on stdout success");
     timer_cb_count++;
     flux_watcher_stop (w);
 }
@@ -2225,7 +2225,7 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
     int lenp = 0;
     int *counter;
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         counter = &stdout_output_cb_count;
     else {
         ok (false, "unexpected stream %s", stream);
@@ -2236,16 +2236,16 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
     if (stdout_output_cb_count == 0) {
         flux_watcher_t *tw = NULL;
         ok (ptr && lenp > 0,
-            "flux_subprocess_read read data on STDOUT: %d", lenp);
-        ok (!flux_subprocess_stream_stop (p, "STDOUT"),
-            "flux_subprocess_stream_stop on STDOUT success");
+            "flux_subprocess_read read data on stdout: %d", lenp);
+        ok (!flux_subprocess_stream_stop (p, "stdout"),
+            "flux_subprocess_stream_stop on stdout success");
         ok ((tw = flux_subprocess_aux_get (p, "tw")) != NULL,
             "flux_subprocess_aux_get timer success");
         flux_watcher_start (tw);
     }
     else if (stdout_output_cb_count == 1) {
         ok (ptr && lenp > 0,
-            "flux_subprocess_read read data on STDOUT: %d", lenp);
+            "flux_subprocess_read read data on stdout: %d", lenp);
         ok (timer_cb_count == 1,
             "next stdout callback called after time callback called");
     }
@@ -2271,8 +2271,8 @@ void test_stream_start_stop_mid_stop (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (5, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -2328,14 +2328,14 @@ void test_stream_stop_enable (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (6, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
-    ok (flux_cmd_setopt (cmd, "STDERR_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDERR_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stderr_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stderr_LINE_BUFFER success");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_STREAM_STOP", "true") == 0,
-        "flux_cmd_setopt set STDOUT_STREAM_STOP success");
+    ok (flux_cmd_setopt (cmd, "stdout_STREAM_STOP", "true") == 0,
+        "flux_cmd_setopt set stdout_STREAM_STOP success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -2356,7 +2356,7 @@ void test_stream_stop_enable (flux_reactor_t *r)
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
     ok (completion_cb_count == 1, "completion callback called 1 time");
-    /* potential for == 2, b/c could all be buffered before STDOUT
+    /* potential for == 2, b/c could all be buffered before stdout
      * callback is started */
     ok (stdout_output_cb_count >= 2, "stdout output callback called >= 2 times: %d",
         stdout_output_cb_count);
@@ -2380,17 +2380,17 @@ void test_stream_stop_disable (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (6, av, environ)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDOUT_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stdout_LINE_BUFFER success");
 
-    ok (flux_cmd_setopt (cmd, "STDERR_LINE_BUFFER", "false") == 0,
-        "flux_cmd_setopt set STDERR_LINE_BUFFER success");
+    ok (flux_cmd_setopt (cmd, "stderr_LINE_BUFFER", "false") == 0,
+        "flux_cmd_setopt set stderr_LINE_BUFFER success");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_STREAM_STOP", "false") == 0,
-        "flux_cmd_setopt set STDOUT_STREAM_STOP success");
+    ok (flux_cmd_setopt (cmd, "stdout_STREAM_STOP", "false") == 0,
+        "flux_cmd_setopt set stdout_STREAM_STOP success");
 
-    ok (flux_cmd_setopt (cmd, "STDERR_STREAM_STOP", "false") == 0,
-        "flux_cmd_setopt set STDERR_STREAM_STOP success");
+    ok (flux_cmd_setopt (cmd, "stderr_STREAM_STOP", "false") == 0,
+        "flux_cmd_setopt set stderr_STREAM_STOP success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,
@@ -2425,8 +2425,8 @@ void test_stream_stop_error (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (1, av, NULL)) != NULL, "flux_cmd_create");
 
-    ok (flux_cmd_setopt (cmd, "STDOUT_STREAM_STOP", "ABCD") == 0,
-        "flux_cmd_setopt set STDOUT_STREAM_STOP success");
+    ok (flux_cmd_setopt (cmd, "stdout_STREAM_STOP", "ABCD") == 0,
+        "flux_cmd_setopt set stdout_STREAM_STOP success");
 
     flux_subprocess_ops_t ops = {
         .on_completion = completion_cb,

--- a/src/common/libsubprocess/test/test_echo.c
+++ b/src/common/libsubprocess/test/test_echo.c
@@ -45,14 +45,14 @@ void output (const char *str)
     if (out) {
         fprintf (stdout,
                  "%s%s",
-                 prefix ? "STDOUT:" : "",
+                 prefix ? "stdout:" : "",
                  str);
         fflush (stdout);
     }
     if (err) {
         fprintf (stderr,
                  "%s%s",
-                 prefix ? "STDERR:" : "",
+                 prefix ? "stderr:" : "",
                  str);
         fflush (stderr);
     }

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -234,7 +234,7 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
 
     assert (t);
 
-    if (!strcmp (stream, "STDERR"))
+    if (!strcmp (stream, "stderr"))
         is_stderr = true;
 
     if (!(ptr = flux_subprocess_read_trimmed_line (p, stream, &lenp))) {

--- a/src/modules/job-exec/test/bulk-exec.c
+++ b/src/modules/job-exec/test/bulk-exec.c
@@ -60,7 +60,7 @@ void on_output (struct bulk_exec *exec, flux_subprocess_t *p,
                 int data_len, void *arg)
 {
     int rank = flux_subprocess_rank (p);
-    FILE *fp = strcmp (stream, "STDOUT") == 0 ? stdout : stderr;
+    FILE *fp = strcmp (stream, "stdout") == 0 ? stdout : stderr;
     fprintf (fp, "%d: %s", rank, data);
 }
 

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -37,7 +37,7 @@
  *   of the current queue depth, which may challenge subprocess buffer
  *   management.
  *
- * - Worker is stopped by closing STDIN, but worker_stop() may return
+ * - Worker is stopped by closing stdin, but worker_stop() may return
  *   before it is known to have stopped, leaving the broker to clean up
  *   with no possibility of reporting errors to the caller.
  *
@@ -183,8 +183,8 @@ error:
 }
 
 /* Subprocess output available
- * STDERR is logged
- * STDOUT fulfills future at the top of the worker's queue.
+ * stderr is logged
+ * stdout fulfills future at the top of the worker's queue.
  */
 static void worker_output_cb (flux_subprocess_t *p, const char *stream)
 {
@@ -198,7 +198,7 @@ static void worker_output_cb (flux_subprocess_t *p, const char *stream)
     }
     if (len == 0) // EOF
         return;
-    if (!strcmp (stream, "STDOUT")) {
+    if (!strcmp (stream, "stdout")) {
         flux_future_t *f;
 
         if (!(f = zlist_pop (w->queue))) {
@@ -211,7 +211,7 @@ static void worker_output_cb (flux_subprocess_t *p, const char *stream)
         if (zlist_size (w->queue) == 0)
             worker_inactive (w);
     }
-    else if (!strcmp (stream, "STDERR")) {
+    else if (!strcmp (stream, "stderr")) {
         flux_log (w->h, LOG_DEBUG, "%s: %s", w->name, s ? s : "");
     }
 }
@@ -243,7 +243,7 @@ flux_future_t *worker_request (struct worker *w, const char *s)
     memcpy (buf, s, bufsz - 1);
     buf[bufsz - 1] = '\n';
     worker_active (w);
-    if (flux_subprocess_write (w->p, "STDIN", buf, bufsz) != bufsz)
+    if (flux_subprocess_write (w->p, "stdin", buf, bufsz) != bufsz)
         goto error;
     if (zlist_append (w->queue, f) < 0)
         goto error;
@@ -258,7 +258,7 @@ error:
     return NULL;
 }
 
-/* Stop a worker by closing its STDIN.
+/* Stop a worker by closing its stdin.
  * This should cause it to exit, then worker_completion_cb() will destroy it.
  * Just in case we have to destroy the worker before then, add it to w->trash.
  */
@@ -266,7 +266,7 @@ static void worker_stop (struct worker *w)
 {
     if (w->p) {
         int saved_errno = errno;
-        if (flux_subprocess_close (w->p, "STDIN") < 0) {
+        if (flux_subprocess_close (w->p, "stdin") < 0) {
             flux_log_error (w->h, "%s: flux_subprocess_close", w->name);
             return;
         }

--- a/src/shell/io.c
+++ b/src/shell/io.c
@@ -86,8 +86,8 @@ static void shell_io_control (struct shell_io *io, bool stop)
     if (io->stopped != stop) {
         task = zlist_first (io->shell->tasks);
         while (task) {
-            shell_io_control_task (task, "STDOUT", stop);
-            shell_io_control_task (task, "STDERR", stop);
+            shell_io_control_task (task, "stdout", stop);
+            shell_io_control_task (task, "stderr", stop);
             task = zlist_next (io->shell->tasks);
         }
         io->stopped = stop;
@@ -207,7 +207,7 @@ static int shell_io_flush (struct shell_io *io)
                 log_err ("iodecode");
                 return -1;
             }
-            f = !strcmp (stream, "STDOUT") ? stdout : stderr;
+            f = !strcmp (stream, "stdout") ? stdout : stderr;
             if (len > 0) {
                 fprintf (f, "%d: ", rank);
                 fwrite (data, len, 1, f);

--- a/t/rexec/rexec.c
+++ b/t/rexec/rexec.c
@@ -110,7 +110,7 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
     }
 
     /* do not close for channel, b/c can race w/ data coming back */
-    if (!strcmp (stream, "STDIN")) {
+    if (!strcmp (stream, "stdin")) {
         if (flux_subprocess_close (p, stream) < 0)
             log_err_exit ("flux_subprocess_close");
     }
@@ -166,9 +166,9 @@ int main (int argc, char *argv[])
     free (cwd);
 
     if (optparse_getopt (opts, "stdin2stream", &optargp) > 0) {
-        if (strcmp (optargp, "STDIN")
-            && strcmp (optargp, "STDOUT")
-            && strcmp (optargp, "STDERR")) {
+        if (strcmp (optargp, "stdin")
+            && strcmp (optargp, "stdout")
+            && strcmp (optargp, "stderr")) {
             if (flux_cmd_add_channel (cmd, optargp) < 0)
                 log_err_exit ("flux_cmd_add_channel");
             ops.on_channel_out = flux_standard_output;

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -49,7 +49,7 @@ void completion_cb (flux_subprocess_t *p)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
+    FILE *fstream = !strcmp (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 
@@ -72,7 +72,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     if (lenp)
         fwrite (ptr, lenp, 1, fstream);
 
-    if (!strcasecmp (stream, "STDOUT"))
+    if (!strcasecmp (stream, "stdout"))
         stdout_count++;
 }
 
@@ -124,7 +124,7 @@ int main (int argc, char *argv[])
         if (strcasecmp (optargp, "true")
             && strcasecmp (optargp, "false"))
             log_err_exit ("invalid linebuffer value");
-        if (flux_cmd_setopt (cmd, "STDOUT_LINE_BUFFER", optargp) < 0)
+        if (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", optargp) < 0)
             log_err_exit ("flux_cmd_setopt");
     }
 

--- a/t/rexec/rexec_getline.c
+++ b/t/rexec/rexec_getline.c
@@ -60,7 +60,7 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
     }
 
     /* do not close for channel, b/c can race w/ data coming back */
-    if (!strcmp (stream, "STDIN")) {
+    if (!strcmp (stream, "stdin")) {
         if (flux_subprocess_close (p, stream) < 0)
             log_err_exit ("flux_subprocess_close");
     }
@@ -70,7 +70,7 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    FILE *fstream = !strcasecmp (stream, "STDERR") ? stderr : stdout;
+    FILE *fstream = !strcmp (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 
@@ -127,9 +127,9 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_cmd_setcwd");
 
     if (optparse_getopt (opts, "stdin2stream", &optargp) > 0) {
-        if (strcmp (optargp, "STDIN")
-            && strcmp (optargp, "STDOUT")
-            && strcmp (optargp, "STDERR")) {
+        if (strcmp (optargp, "stdin")
+            && strcmp (optargp, "stdout")
+            && strcmp (optargp, "stderr")) {
             if (flux_cmd_add_channel (cmd, optargp) < 0)
                 log_err_exit ("flux_cmd_add_channel");
             ops.on_channel_out = flux_standard_output;

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -35,13 +35,13 @@ test_expect_success 'basic rexec - env passed through' '
 
 test_expect_success 'basic rexec functionality (echo stdout)' '
 	${FLUX_BUILD_DIR}/t/rexec/rexec ${TEST_SUBPROCESS_DIR}/test_echo -P -O foobar.stdout > output &&
-        echo "STDOUT:foobar.stdout" > expected &&
+        echo "stdout:foobar.stdout" > expected &&
         test_cmp expected output
 '
 
 test_expect_success 'basic rexec functionality (echo stderr)' '
 	${FLUX_BUILD_DIR}/t/rexec/rexec ${TEST_SUBPROCESS_DIR}/test_echo -P -E foobar.stderr > output 2>&1 &&
-        echo "STDERR:foobar.stderr" > expected &&
+        echo "stderr:foobar.stderr" > expected &&
         test_cmp expected output
 '
 
@@ -93,14 +93,14 @@ test_expect_success 'basic rexec fail exec() (check state changes)' '
 '
 
 test_expect_success 'basic rexec stdin' '
-	echo -n "hello" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i STDIN ${TEST_SUBPROCESS_DIR}/test_echo -O -E > output 2>&1 &&
+	echo -n "hello" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i stdin ${TEST_SUBPROCESS_DIR}/test_echo -O -E > output 2>&1 &&
         echo "hello" > expected &&
         echo "hello" >> expected &&
         test_cmp expected output
 '
 
 test_expect_success 'basic rexec stdin / stdout multiple lines' '
-	/bin/echo -en "foo\nbar\nbaz\n" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i STDIN ${TEST_SUBPROCESS_DIR}/test_echo -O -n > output 2>&1 &&
+	/bin/echo -en "foo\nbar\nbaz\n" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i stdin ${TEST_SUBPROCESS_DIR}/test_echo -O -n > output 2>&1 &&
         echo "foo" > expected &&
         echo "bar" >> expected &&
         echo "baz" >> expected &&
@@ -123,7 +123,7 @@ test_expect_success 'rexec check channel FD created' '
 # bytes we're feeding in
 test_expect_success 'rexec channel input' '
 	echo -n "foobar" | ${FLUX_BUILD_DIR}/t/rexec/rexec -i TEST_CHANNEL ${TEST_SUBPROCESS_DIR}/test_echo -c TEST_CHANNEL -P -O -b 6 > output 2>&1 &&
-        echo "STDOUT:foobar" > expected &&
+        echo "stdout:foobar" > expected &&
         test_cmp expected output
 '
 
@@ -223,7 +223,7 @@ test_expect_success 'rexec line buffering can be disabled' '
 # from "rexec_getline", so if everything is working correctly, we
 # should see the concatenation "barEOF" at the end of the output.
 test_expect_success 'rexec read_getline call works on remote streams' '
-	/bin/echo -en "foo\nbar" | ${FLUX_BUILD_DIR}/t/rexec/rexec_getline -i STDIN ${TEST_SUBPROCESS_DIR}/test_echo -O -n > output 2>&1 &&
+	/bin/echo -en "foo\nbar" | ${FLUX_BUILD_DIR}/t/rexec/rexec_getline -i stdin ${TEST_SUBPROCESS_DIR}/test_echo -O -n > output 2>&1 &&
         echo "foo" > expected &&
         echo "barEOF" >> expected &&
         test_cmp expected output


### PR DESCRIPTION
This PR changes the format of the `guest.output` key in the KVS from a JSON array of "iodecode" objects to an RFC 24 eventlog.

This opens the door to more work such as
* "compressing" identical output that occurs within a time window down to one event
* UTF-8 encoding option
* committing output at regular intervals or upon reaching some buffer threshold

However in this PR, only the output format is changed.