### PR TITLE
job-exec: fix exception handling of jobs in transition states

### DIFF
--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -47,12 +47,12 @@ bulk_exec_SOURCES = \
 	test/bulk-exec.c
 
 bulk_exec_LDADD = \
-	$(fluxmod_ldadd) \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-idset.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	libbulk-exec.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(ZMQ_LIBS)
 
 test_ldadd = \

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -37,7 +37,7 @@ job_exec_la_LDFLAGS = \
 	-module
 
 job_exec_la_LIBADD = \
-	$(fluxmod_ldadd) \
+	$(fluxmod_libadd) \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	libbulk-exec.la \

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -63,6 +63,16 @@ int bulk_exec_rc (struct bulk_exec *exec)
     return (exec->exit_status);
 }
 
+int bulk_exec_current (struct bulk_exec *exec)
+{
+    return zlist_size (exec->processes);
+}
+
+int bulk_exec_total (struct bulk_exec *exec)
+{
+    return exec->total;
+}
+
 static void exec_state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 {
     struct bulk_exec *exec = flux_subprocess_aux_get (p, "job-exec::exec");

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -443,7 +443,8 @@ flux_future_t *bulk_exec_kill (struct bulk_exec *exec, int signum)
         return (cf);
     }
     while (p) {
-        if (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
+        if (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING
+            || flux_subprocess_state (p) == FLUX_SUBPROCESS_INIT) {
             flux_future_t *f = NULL;
             char s[64];
             if (!(f = flux_subprocess_kill (p, signum))) {

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -19,6 +19,7 @@
 #include <flux/idset.h>
 #include <czmq.h>
 
+#include "src/common/libutil/aux.h"
 #include "bulk-exec.h"
 
 struct exec_cmd {
@@ -29,6 +30,8 @@ struct exec_cmd {
 
 struct bulk_exec {
     flux_t *h;
+
+    struct aux_item *aux;
 
     int max_start_per_loop;  /* Max subprocess started per event loop cb */
     int total;               /* Total processes expected to run */
@@ -314,6 +317,7 @@ void bulk_exec_destroy (struct bulk_exec *exec)
     flux_watcher_destroy (exec->prep);
     flux_watcher_destroy (exec->check);
     flux_watcher_destroy (exec->idle);
+    aux_destroy (&exec->aux);
     free (exec);
 }
 
@@ -452,5 +456,15 @@ flux_future_t *bulk_exec_kill (struct bulk_exec *exec, int signum)
     return cf;
 }
 
+int bulk_exec_aux_set (struct bulk_exec *exec, const char *key,
+                       void *val, flux_free_f free_fn)
+{
+    return (aux_set (&exec->aux, key, val, free_fn));
+}
+
+void * bulk_exec_aux_get (struct bulk_exec *exec, const char *key)
+{
+    return (aux_get (exec->aux, key));
+}
 /* vi: ts=4 sw=4 expandtab
  */

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -59,6 +59,8 @@ int bulk_exec_start (flux_t *h, struct bulk_exec *exec);
 
 flux_future_t * bulk_exec_kill (struct bulk_exec *exec, int signal);
 
+int bulk_exec_cancel (struct bulk_exec *exec);
+
 /* Returns max wait status returned from all exited processes */
 int bulk_exec_rc (struct bulk_exec *exec);
 

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -43,6 +43,13 @@ struct bulk_exec_ops {
 
 struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops, void *arg);
 
+void *bulk_exec_aux_get (struct bulk_exec *exec, const char *key);
+
+int bulk_exec_aux_set (struct bulk_exec *exec,
+                       const char *key,
+                       void *val,
+                       flux_free_f free_fn);
+
 /*  Set maximum number of flux_subprocess_rexex(3) calls per event
  *   loop iteration. (-1 for no max)
  */

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -71,4 +71,10 @@ int bulk_exec_cancel (struct bulk_exec *exec);
 /* Returns max wait status returned from all exited processes */
 int bulk_exec_rc (struct bulk_exec *exec);
 
+/* Returns current number of processes starting/running */
+int bulk_exec_current (struct bulk_exec *exec);
+
+/* Returns total number of processes expected to run */
+int bulk_exec_total (struct bulk_exec *exec);
+
 #endif /* !HAVE_JOB_EXEC_BULK_EXEC_H */

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -187,6 +187,12 @@ static int exec_kill (struct jobinfo *job, int signum)
     return 0;
 }
 
+static int exec_cancel (struct jobinfo *job)
+{
+    struct bulk_exec *exec = job->data;
+    return bulk_exec_cancel (exec);
+}
+
 static int exec_cleanup (struct jobinfo *job, const struct idset *idset)
 {
     /* No epilog supported */
@@ -207,6 +213,7 @@ struct exec_implementation bulkexec = {
     .exit =     exec_exit,
     .start =    exec_start,
     .kill =     exec_kill,
+    .cancel =   exec_cancel,
     .cleanup =  exec_cleanup
 };
 

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -273,7 +273,7 @@ static int exec_kill (struct jobinfo *job, int signum)
               signum);
 
     jobinfo_incref (job);
-    if (flux_future_then (f, -1., exec_kill_cb, job) < 0) {
+    if (flux_future_then (f, 3., exec_kill_cb, job) < 0) {
         flux_log_error (job->h, "%ju: exec_kill: flux_future_then", job->id);
         flux_future_destroy (f);
         return -1;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -952,6 +952,7 @@ static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     if (severity == 0
         && (job = zhashx_lookup (ctx->jobs, &id))
+        && (!job->finalizing)
         && (!job->exception_in_progress)) {
         job->exception_in_progress = 1;
         flux_log (h, LOG_DEBUG, "exec aborted: id=%ld", id);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -69,7 +69,8 @@
  * TEST CONFIGURATION
  *
  * The job-exec module supports an object in the jobspec under
- * attributes.system.exec.test, which supports the following keys
+ * attributes.system.exec.test, which enables mock execution and
+ * supports the following keys
  *
  * {
  *   "run_duration":s,      - alternate/override attributes.system.duration
@@ -77,6 +78,14 @@
  *   "wait_status":i        - report this value as status in the "finish" resp
  *   "mock_exception":s     - mock an exception during this phase of job
  *                             execution (currently "init" and "run")
+ * }
+ *
+ * The "bulk" execution implementation supports testing and other
+ * paramters under attributes.system.exec.bulkexec, including:
+ *
+ * {
+ *   "mock_exception":s     - cancel job after a certain number of shells
+ *                            have been launched.
  * }
  *
  */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -38,6 +38,8 @@ struct jobinfo;
  *   - kill:    signal executing job shells, e.g. due to exception or other
  *              fatal error.
  *
+ *   - cancel:  cancel any pending work (i.e. shells yet to be executed)
+ *
  *   - cleanup: Initiate any cleanup (epilog) on ranks.
  */
 struct exec_implementation {
@@ -46,6 +48,7 @@ struct exec_implementation {
     void (*exit)    (struct jobinfo *job);
     int  (*start)   (struct jobinfo *job);
     int  (*kill)    (struct jobinfo *job, int signum);
+    int  (*cancel)  (struct jobinfo *job);
     int  (*cleanup) (struct jobinfo *job, const struct idset *ranks);
 };
 

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -64,11 +64,12 @@ struct jobinfo {
     struct resource_set * R;         /* Fetched and parsed resource set R */
     json_t *              jobspec;   /* Fetched jobspec */
 
-    uint8_t               needs_cleanup:1;
     uint8_t               has_namespace:1;
     uint8_t               exception_in_progress:1;
-    uint8_t               running:1;
-    uint8_t               finalizing:1;
+
+    uint8_t               started:1;     /* some or all shells are starting */
+    uint8_t               running:1;     /* all shells are running */
+    uint8_t               finalizing:1;  /* in process of cleanup */
 
     int                   wait_status;
 

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -36,7 +36,7 @@ sched_simple_la_LDFLAGS = \
 	-module
 
 sched_simple_la_LIBADD = \
-	$(fluxmod_ldadd) \
+	$(fluxmod_libadd) \
 	libjj.la \
 	$(top_builddir)/src/common/libschedutil/libschedutil.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -92,7 +92,21 @@ test_expect_success 'job-exec: invalid job shell generates exception' '
 	     | flux job submit) &&
 	flux job wait-event -vt 1 $id clean
 '
+test_expect_success 'job-exec: exception during init terminates job' '
+	id=$(flux jobspec srun -N2 sleep 30 \
+	     | $jq ".attributes.system.exec.bulkexec.mock_exception = \"init\"" \
+	     | flux job submit) &&
+	flux job wait-event -vt 1 $id clean
+'
+test_expect_success 'job-exec: exception while starting terminates job' '
+	id=$(flux jobspec srun -N2 sleep 30 \
+	     | $jq ".attributes.system.exec.bulkexec.mock_exception = \"starting\"" \
+	     | flux job submit) &&
+	flux job wait-event -vt 1 $id clean
+'
 test_expect_success 'job-exec: unload job-exec & sched-simple modules' '
+	flux job list &&
+	flux job drain &&
 	flux module remove job-exec &&
 	flux module remove sched-simple
 '


### PR DESCRIPTION
This PR fixes some of the issues hit by @dongahn's stress test described in #2275. It doesn't fix the race described in #2279, which requires a rework of the exception protocol.

I'm still trying to figure out exactly how to test some of these conditions, especially the one that triggers cancellation of a partially running job (pending commands are descheduled in the bulk-exec implementation). However, on this branch, the current version of the cancel stress test:

```sh
#!/bin/bash

NREPEATS=100
NJOBS=12

flux jobspec srun -n 2 hostname >j
for j in $(seq 1 ${NREPEATS}); do
   t/ingest/submitbench -f 24 -r 100 j || exit 1
   flux job list
   flux job list | grep -v USERID | xargs -L 1 flux job cancel
   echo "Iteration"
   sleep 1
done


flux dmesg|grep "job-manager.err"
```

No longer reproduces the "start response" error (which was a particularly dangerous case, since it meant the job was still running after resources were released), nor the "emit_event" errors.

I still do see, however, the `connector-local` EPIPE errors (probably expected and nothing to worry about. Tasks were killed before a message or event could be delivered over the connector-local socket), and the following error from `sched-simple`, possibly due to #2279?
```
2019-08-14T15:28:28.971563Z sched-simple.err[0]: alloc received before previous one handled
2019-08-14T15:28:28.971575Z sched-simple.err[0]: alloc: flux_respond_error: Invalid argument

```