### PR TITLE
job-exec: rename guest namespace

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -823,7 +823,10 @@ err:
  */
 static int job_get_ns_name (char *buf, int bufsz, flux_jobid_t id)
 {
-    return fluid_encode (buf, bufsz, id, FLUID_STRING_DOTHEX);
+    int n = snprintf (buf, bufsz - 1, "job-%ju", id);
+    if (n < 0 || n > bufsz - 1)
+        return -1;
+    return 0;
 }
 
 static double job_get_kill_timeout (flux_t *h)

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -77,7 +77,7 @@ test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 	        | flux job submit) &&
 	flux job wait-event -vt 1 $id start &&
 	flux kvs get --waitcreate \
-		--namespace=$(flux job id --to=hex $id) \
+		--namespace="job-$id" \
 		trap-ready &&
 	flux job cancel $id &&
 	sleep 0.2 &&


### PR DESCRIPTION
Problem: As it turns out, creating a namespace name with periods
in it is a bit inconvenient because the namespace names are used
as keys in kvs module stats output.

Since job guest namespace names are arbitrary, do not use the
"dothex" notation of a jobid to name then and instead just
use "job-<id>"

Fixes #2306