### PR TITLE
Add flux_job_kvs_namespace(3) and use it in job-exec for guest namespace

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -330,7 +330,7 @@ static unsigned long long parse_arg_unsigned (const char *s, const char *name)
     errno = 0;
     i = strtoull (s, &endptr, 10);
     if (errno != 0 || *endptr != '\0')
-        log_msg_exit ("error parsing %s", name);
+        log_msg_exit ("error parsing %s: \"%s\"", name, s);
     return i;
 }
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -43,6 +43,7 @@ int cmd_list (optparse_t *p, int argc, char **argv);
 int cmd_submit (optparse_t *p, int argc, char **argv);
 int cmd_attach (optparse_t *p, int argc, char **argv);
 int cmd_id (optparse_t *p, int argc, char **argv);
+int cmd_namespace (optparse_t *p, int argc, char **argv);
 int cmd_cancel (optparse_t *p, int argc, char **argv);
 int cmd_raise (optparse_t *p, int argc, char **argv);
 int cmd_kill (optparse_t *p, int argc, char **argv);
@@ -253,6 +254,13 @@ static struct optparse_subcommand subcommands[] = {
       NULL,
       "Re-enable job submissions after drain.",
       cmd_undrain,
+      0,
+      NULL
+    },
+    { "namespace",
+      "[id ...]",
+      "Convert job ids to job guest kvs namespace names",
+      cmd_namespace,
       0,
       NULL
     },
@@ -1026,6 +1034,31 @@ int cmd_id (optparse_t *p, int argc, char **argv)
             id_convert (p, argv[optindex++], dst, sizeof (dst));
             printf ("%s\n", dst);
         }
+    }
+    return 0;
+}
+
+static void print_job_namespace (const char *src)
+{
+    char ns[64];
+    flux_jobid_t id = parse_arg_unsigned (src, "jobid");
+    if (flux_job_kvs_namespace (ns, sizeof (ns), id) < 0)
+        log_msg_exit ("error getting kvs namespace for %ju", id);
+    printf ("%s\n", ns);
+}
+
+int cmd_namespace (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+
+    if (optindex == argc) {
+        char src[256];
+        while ((fgets (src, sizeof (src), stdin)))
+            print_job_namespace (trim_string (src));
+    }
+    else {
+        while (optindex < argc)
+            print_job_namespace (argv[optindex++]);
     }
     return 0;
 }

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -276,6 +276,18 @@ int flux_job_kvs_guest_key (char *buf,
     return len;
 }
 
+int flux_job_kvs_namespace (char *buf, int bufsz, flux_jobid_t id)
+{
+    int len;
+    if (buffer_arg_check (buf, bufsz) < 0)
+        return -1;
+    if ((len = snprintf (buf, bufsz, "job-%ju", id)) >= bufsz) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    return len;
+}
+
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id)
 {
     flux_future_t *f;

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -219,15 +219,22 @@ flux_future_t *flux_job_set_priority (flux_t *h, flux_jobid_t id, int priority)
     return f;
 }
 
+static int buffer_arg_check (char *buf, int bufsz)
+{
+    if (!buf || bufsz <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
 int flux_job_kvs_key (char *buf, int bufsz, flux_jobid_t id, const char *key)
 {
     char idstr[32];
     int len;
 
-    if (!buf || !bufsz) {
-        errno = EINVAL;
+    if (buffer_arg_check (buf, bufsz) < 0)
         return -1;
-    }
 
     if (fluid_encode (idstr, sizeof (idstr), id, FLUID_STRING_DOTHEX) < 0)
         return -1;
@@ -250,10 +257,8 @@ int flux_job_kvs_guest_key (char *buf,
     char idstr[32];
     int len;
 
-    if (!buf || !bufsz) {
-        errno = EINVAL;
+    if (buffer_arg_check (buf, bufsz) < 0)
         return -1;
-    }
     if (getenv ("FLUX_KVS_NAMESPACE"))
         len = snprintf (buf, bufsz, "%s", key ? key : ".");
     else {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -111,6 +111,14 @@ int flux_job_kvs_guest_key (char *buf,
                             flux_jobid_t id,
                             const char *key);
 
+
+/* Write KVS job namespace name to to buffer 'buf'.
+ * Returns string length on success or < 0 on failure.
+ */
+int flux_job_kvs_namespace (char *buf,
+                            int bufsz,
+                            flux_jobid_t id);
+
 /* Job eventlog watch functions
  */
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id);

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -215,6 +215,21 @@ void check_statestr(void)
         "flux_job_statetostr (0, false) returned non-NULL");
 }
 
+void check_kvs_namespace (void)
+{
+    char buf[64];
+    ok (flux_job_kvs_namespace (buf, 64, 1234) == strlen ("job-1234"),
+        "flux_job_kvs_namespace works");
+    is (buf, "job-1234",
+        "flux_job_kvs_namespace returns expected namespace name");
+    ok (flux_job_kvs_namespace (buf, 7, 1234) < 0 && errno == EOVERFLOW,
+        "flux_job_kvs_namespace returns EOVERFLOW for too small buffer");
+    ok (flux_job_kvs_namespace (buf, -1, 1234) < 0 && errno == EINVAL,
+        "flux_job_kvs_namespace returns EINVAL on invalid buffer size");
+    ok (flux_job_kvs_namespace (NULL, 64, 1234) < 0 && errno == EINVAL,
+        "flux_job_kvs_namespace returns EINVAL on invalid buffer");
+}
+
 
 int main (int argc, char *argv[])
 {
@@ -225,6 +240,8 @@ int main (int argc, char *argv[])
     check_corner_case ();
 
     check_statestr ();
+
+    check_kvs_namespace ();
 
     done_testing ();
     return 0;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -843,13 +843,6 @@ err:
     return NULL;
 }
 
-/*  Create namespace name for jobid 'id'
- */
-static int job_get_ns_name (char *buf, int bufsz, flux_jobid_t id)
-{
-    return fluid_encode (buf, bufsz, id, FLUID_STRING_DOTHEX);
-}
-
 static double job_get_kill_timeout (flux_t *h)
 {
     double t = DEFAULT_KILL_TIMEOUT;
@@ -895,7 +888,7 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
         jobinfo_decref (job);
         return -1;
     }
-    if (job_get_ns_name (job->ns, sizeof (job->ns), job->id) < 0) {
+    if (flux_job_kvs_namespace (job->ns, sizeof (job->ns), job->id) < 0) {
         jobinfo_fatal_error (job, errno, "failed to create ns name for job");
         flux_log_error (ctx->h, "job_ns_create");
         return -1;

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -236,6 +236,12 @@ test_expect_success 'flux-job: id works with spaces in input' '
 	test_cmp despace.exp despace.out
 '
 
+test_expect_success 'flux-job: namespace works' '
+	test "$(flux job namespace 1)" = "job-1" &&
+	test "$(echo 1 | flux job namespace)" = "job-1" &&
+	test_expect_code 1 flux job namespace -1
+'
+
 test_expect_success 'flux-job: attach fails without jobid argument' '
 	test_must_fail flux job attach
 '

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -77,7 +77,7 @@ test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 	        | flux job submit) &&
 	flux job wait-event -vt 1 $id start &&
 	flux kvs get --waitcreate \
-		--namespace=$(flux job id --to=hex $id) \
+		--namespace=$(flux job namespace $id) \
 		trap-ready &&
 	flux job cancel $id &&
 	sleep 0.2 &&


### PR DESCRIPTION
As discussed #2313, this PR adds a new `flux_job_kvs_namespace(3)` function to libjob, a `flux-job namespace` command, and uses `flux_job_kvs_namespace` for naming the guest namespace for jobs. The guest namespace is now `job-<id>`.

Fixes #2306