### PR TITLE
rc: set URI's in enclosing instance for hierarchical flux

### DIFF
--- a/etc/rc1.d/01-enclosing-instance
+++ b/etc/rc1.d/01-enclosing-instance
@@ -2,19 +2,14 @@
 
 # Inform the enclosing instance (if any) of the URI's for this instance
 
-update_parent() {
-    local parent_uri=$(flux getattr parent-uri)
-    local key_prefix=${FLUX_JOB_KVSPATH}.flux
-    local local_uri=${FLUX_URI}
-    local remote_uri="ssh://$(hostname)/$(echo $local_uri|sed 's,^.*://,,')"
+if parent_uri=$(flux getattr parent-uri 2>/dev/null) \
+	&& parent_ns=$(flux getattr parent-kvs-namespace 2>/dev/null); then
+    key_prefix=flux
+    local_uri=${FLUX_URI}
+    remote_uri="ssh://$(hostname)/$(echo $local_uri|sed 's,^.*://,,')"
 
-    FLUX_URI=${parent_uri} \
-        flux kvs put --json ${key_prefix}.local_uri=${local_uri}
-    FLUX_URI=${parent_uri} \
-        flux kvs put --json ${key_prefix}.remote_uri=${remote_uri}
-}
-
-# Only run this on rank 0
-if test -n "${FLUX_JOB_KVSPATH}" -a $(flux getattr rank) -eq 0; then
-    update_parent
+    FLUX_URI=${parent_uri} FLUX_KVS_NAMESPACE=${parent_ns} \
+        flux kvs put ${key_prefix}.local_uri=${local_uri}
+    FLUX_URI=${parent_uri} FLUX_KVS_NAMESPACE=${parent_ns} \
+        flux kvs put ${key_prefix}.remote_uri=${remote_uri}
 fi

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -518,14 +518,6 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
-    /* The previous value of FLUX_URI (refers to enclosing instance)
-     * was stored above.  Clear it here so a connection to the enclosing
-     * instance is not made inadvertantly.
-     * Also ensure any KVS namespace used by job shell is not used here.
-     */
-    unsetenv ("FLUX_URI");
-    unsetenv ("FLUX_KVS_NAMESPACE");
-
     if (ctx.verbose) {
         const char *parent = overlay_get_parent (ctx.overlay);
         const char *child = overlay_get_child (ctx.overlay);
@@ -790,7 +782,8 @@ static struct attrmap attrmap[] = {
     { "FLUX_RC3_PATH",          "broker.rc3_path",          1, 0 },
     { "FLUX_SEC_DIRECTORY",     "security.keydir",          1, 0 },
 
-    { "FLUX_URI",               "parent-uri",               0, 0 },
+    { "FLUX_URI",               "parent-uri",               0, 1 },
+    { "FLUX_KVS_NAMESPACE",     "parent-kvs-namespace",     0, 1 },
     { NULL, NULL, 0, 0 },
 };
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -778,19 +778,20 @@ struct attrmap {
     const char *env;
     const char *attr;
     uint8_t required:1;
+    uint8_t sanitize:1;
 };
 
 static struct attrmap attrmap[] = {
-    { "FLUX_EXEC_PATH",         "conf.exec_path",           1 },
-    { "FLUX_CONNECTOR_PATH",    "conf.connector_path",      1 },
-    { "FLUX_MODULE_PATH",       "conf.module_path",         1 },
-    { "FLUX_PMI_LIBRARY_PATH",  "conf.pmi_library_path",    1 },
-    { "FLUX_RC1_PATH",          "broker.rc1_path",          1 },
-    { "FLUX_RC3_PATH",          "broker.rc3_path",          1 },
-    { "FLUX_SEC_DIRECTORY",     "security.keydir",          1 },
+    { "FLUX_EXEC_PATH",         "conf.exec_path",           1, 0 },
+    { "FLUX_CONNECTOR_PATH",    "conf.connector_path",      1, 0 },
+    { "FLUX_MODULE_PATH",       "conf.module_path",         1, 0 },
+    { "FLUX_PMI_LIBRARY_PATH",  "conf.pmi_library_path",    1, 0 },
+    { "FLUX_RC1_PATH",          "broker.rc1_path",          1, 0 },
+    { "FLUX_RC3_PATH",          "broker.rc3_path",          1, 0 },
+    { "FLUX_SEC_DIRECTORY",     "security.keydir",          1, 0 },
 
-    { "FLUX_URI",               "parent-uri",               0 },
-    { NULL, NULL, 0 },
+    { "FLUX_URI",               "parent-uri",               0, 0 },
+    { NULL, NULL, 0, 0 },
 };
 
 static void init_attrs_from_environment (attr_t *attrs)
@@ -805,6 +806,8 @@ static void init_attrs_from_environment (attr_t *attrs)
             log_msg_exit ("required environment variable %s is not set", m->env);
         if (attr_add (attrs, m->attr, val, flags) < 0)
             log_err_exit ("attr_add %s", m->attr);
+        if (m->sanitize)
+            unsetenv (m->env);
     }
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -101,6 +101,7 @@ TESTSCRIPTS = \
 	t2601-job-shell-standalone.t \
 	t2602-job-shell.t \
 	t3000-mpi-basic.t \
+	t3100-flux-in-flux.t \
 	t4000-issues-test-driver.t \
 	t5000-valgrind.t \
 	t9001-pymod.t \

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+
+test_description='Test that Flux can launch Flux'
+
+. `dirname $0`/sharness.sh
+
+# Size the session to one more than the number of cores, minimum of 4
+SIZE=$(test_size_large)
+test_under_flux ${SIZE}
+echo "# $0: flux session size will be ${SIZE}"
+
+test_expect_success "flux can run flux instance as a job" '
+	run_timeout 5 flux srun -n1 -N1 \
+		flux start flux getattr size >size.out &&
+	echo 1 >size.exp &&
+	test_cmp size.exp size.out
+'
+
+test_expect_success "flux subinstance leaves local_uri, remote_uri in KVS" '
+	flux jobspec srun -n1 -N1 flux start /bin/true >j &&
+	id=$(flux job submit j) &&
+	flux job wait-event $id finish &&
+	flux job info $id guest.flux.local_uri &&
+	flux job info $id guest.flux.remote_uri
+'
+
+test_done


### PR DESCRIPTION
To assist tools that need to look up the URI for child instances, repair  `rc1.d/01-enclosing-instance` to work with the new exec system and write e.g.
```
job.0000.0029.d400.0000.guest.flux.local_uri
job.0000.0029.d400.0000.guest.flux.remote_uri
```
    
