### PR TITLE
flux-job: watch guest output instead of doing a lookup

### DIFF
--- a/src/shell/io.c
+++ b/src/shell/io.c
@@ -281,16 +281,19 @@ void shell_io_destroy (struct shell_io *io)
  * - no options
  * - no stdlog
  */
-static int shell_io_header_append (json_t *output)
+static int shell_io_header_append (flux_shell_t *shell, json_t *output)
 {
     json_t *o;
 
     o = eventlog_entry_pack (0, "header",
-                             "{s:i s:{s:s s:s} s:{}}",
+                             "{s:i s:{s:s s:s} s:{s:i s:i} s:{}}",
                              "version", 1,
                              "encoding",
                                "stdout", "base64",
                                "stderr", "base64",
+                             "count",
+                               "stdout", shell->info->jobspec->task_count,
+                               "stderr", shell->info->jobspec->task_count,
                              "options");
     if (!o || json_array_append_new (output, o) < 0) {
         json_decref (o);
@@ -319,7 +322,7 @@ struct shell_io *shell_io_create (flux_shell_t *shell)
             errno = ENOMEM;
             goto error;
         }
-        if (shell_io_header_append (io->output) < 0)
+        if (shell_io_header_append (shell, io->output) < 0)
             goto error;
     }
     return io;


### PR DESCRIPTION
As discussed yesterday, this PR changes `flux job attach` to use a job-info eventlog watch instead of a job-info lookup of of the `guest.output` log.    This is a step change for when `job attach` will attach to a running job and output stdout/err as it happens.

One corner case that came up in this change is when a job never runs, (e.g. resources are impossible), this would hang `flux job attach` b/c nothing ever gets output to `guest.output`.  So we have to check to make sure the job actually ran (event "start" occurs).

One other issue that had to be solved in this change is how to determine that all output has completed.  It's easy to count EOF occurrences, but `flux job attach` needs to know how man EOF occurrences to expect.  For the time being, I just stuffed a `task_count` into the IO eventlog header.  

If we think that this is a good idea, I can send a PR to update RFC24 to allow a `task_count` to be included in the header.