### PR TITLE
job-info: Fix racy cancel

### DIFF
--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -626,7 +626,7 @@ static void guest_namespace_watch_continuation (flux_future_t *f, void *arg)
 
     if (gw->cancel) {
         errno = ENODATA;
-        goto error_cancel;
+        goto error;
     }
 
     if (flux_respond (ctx->h, gw->msg, s) < 0) {

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -611,6 +611,14 @@ static void guest_namespace_watch_continuation (flux_future_t *f, void *arg)
                 if (main_namespace_watch (gw) < 0)
                     goto error;
             }
+            else if (gw->cancel) {
+                /* Racy scenario - user attempted a cancel right as
+                 * ENOTSUP being sent.  Caller won't get a ENODATA
+                 * response b/c the original watcher is now dead.
+                 */
+                errno = ENODATA;
+                goto error;
+            }
             return;
         }
         else {


### PR DESCRIPTION
Per discussion in #2331, I think there may be a race where a user attempts to cancel the watch, but as the cancellation is in flight, the namespace is deleted.  Internally job-info gets a ENOTSUP, and therefore will never send ENODATA to the caller.

Labeling WIP for now - as we'll want to run this through travis many times to see if the issue hits.