### PR TITLE
libsubprocess: cleanup + return error on bad cmd options

### DIFF
--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -756,31 +756,26 @@ zlist_t *flux_cmd_channel_list (flux_cmd_t *cmd)
     return cmd->channels;
 }
 
-int flux_cmd_delete_opts (flux_cmd_t *cmd, const char **substrings)
+int flux_cmd_find_opts (const flux_cmd_t *cmd, const char **substrings)
 {
-    zlist_t *keys = NULL;
-    const char *key;
+    void *iter;
+    int rv = 0;
 
-    if (!(keys = zhash_keys (cmd->opts))) {
-        errno = ENOMEM;
-        return -1;
-    }
-
-    key = zlist_first (keys);
-    while (key) {
+    iter = zhash_first (cmd->opts);
+    while (iter && !rv) {
+        const char *key = zhash_cursor (cmd->opts);
         const char **str = substrings;
         while ((*str)) {
             if (strstr (key, (*str))) {
-                zhash_delete (cmd->opts, key);
+                rv++;
                 break;
             }
             str++;
         }
-        key = zlist_next (keys);
+        iter = zhash_next (cmd->opts);
     }
 
-    zlist_destroy (&keys);
-    return 0;
+    return rv;
 }
 
 

--- a/src/common/libsubprocess/command.h
+++ b/src/common/libsubprocess/command.h
@@ -53,8 +53,9 @@ int flux_cmd_set_env (flux_cmd_t *cmd, char **env);
 zlist_t *flux_cmd_channel_list (flux_cmd_t *cmd);
 
 /*
- * Delete opts that contain a specific substring
+ * Find opts that contain a specific substring.  Returns 1 if
+ * substrings found, 0 if not.
  */
-int flux_cmd_delete_opts (flux_cmd_t *cmd, const char **substrings);
+int flux_cmd_find_opts (const flux_cmd_t *cmd, const char **substrings);
 
 #endif /* !_SUBPROCESS_CMD_H */

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -154,10 +154,13 @@ void check_cmd_attributes (flux_cmd_t *cmd)
         "flux_cmd_getopt (cmd, 'OPTION') == VALUE");
 }
 
-void test_delete_opts (void)
+void test_find_opts (void)
 {
     flux_cmd_t *cmd;
-    const char *substrings[] = { "FOO", "BAZ", NULL };
+    const char *substrings1[] = { "FOO", NULL };
+    const char *substrings2[] = { "DUH", "BAZ", "UHH", NULL };
+    const char *substrings3[] = { "OOPS",  NULL };
+    const char *substrings4[] = { NULL };
 
     cmd = flux_cmd_create (0, NULL, NULL);
     ok (cmd != NULL,
@@ -174,30 +177,17 @@ void test_delete_opts (void)
     ok (flux_cmd_setopt (cmd, "b_BAZ", "val") == 0,
         "flux_cmd_setopt works");
 
-    ok (flux_cmd_getopt (cmd, "a_FOO") != NULL,
-        "flux_cmd_getopt finds key");
-    ok (flux_cmd_getopt (cmd, "a_BAR") != NULL,
-        "flux_cmd_getopt finds key");
-    ok (flux_cmd_getopt (cmd, "b_BAR") != NULL,
-        "flux_cmd_getopt finds key");
-    ok (flux_cmd_getopt (cmd, "a_BAZ") != NULL,
-        "flux_cmd_getopt finds key");
-    ok (flux_cmd_getopt (cmd, "b_BAZ") != NULL,
-        "flux_cmd_getopt finds key");
+    ok (flux_cmd_find_opts (cmd, substrings1) == 1,
+        "flux_cmd_find_opts finds substrings");
 
-    ok (flux_cmd_delete_opts (cmd, substrings) == 0,
-        "flux_cmd_delete_opts works");
+    ok (flux_cmd_find_opts (cmd, substrings2) == 1,
+        "flux_cmd_find_opts finds substrings");
 
-    ok (flux_cmd_getopt (cmd, "a_FOO") == NULL,
-        "flux_cmd_getopt does not find key");
-    ok (flux_cmd_getopt (cmd, "a_BAR") != NULL,
-        "flux_cmd_getopt finds key");
-    ok (flux_cmd_getopt (cmd, "b_BAR") != NULL,
-        "flux_cmd_getopt finds key");
-    ok (flux_cmd_getopt (cmd, "a_BAZ") == NULL,
-        "flux_cmd_getopt does not find key");
-    ok (flux_cmd_getopt (cmd, "b_BAZ") == NULL,
-        "flux_cmd_getopt does not find key");
+    ok (flux_cmd_find_opts (cmd, substrings3) == 0,
+        "flux_cmd_find_opts doesn't find substrings");
+
+    ok (flux_cmd_find_opts (cmd, substrings4) == 0,
+        "flux_cmd_find_opts doesn't find substrings");
 }
 
 int main (int argc, char *argv[])
@@ -283,7 +273,7 @@ int main (int argc, char *argv[])
     }
     flux_cmd_destroy (cmd);
 
-    test_delete_opts ();
+    test_find_opts ();
 
     done_testing ();
     return 0;

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -200,6 +200,17 @@ void test_basic_errors (flux_reactor_t *r)
         "flux_rexec fails with cmd with no cwd");
     flux_cmd_destroy (cmd);
 
+    ok ((cmd = flux_cmd_create (1, avgood, NULL)) != NULL,
+        "flux_cmd_create with 0 args works");
+    ok (flux_cmd_setcwd (cmd, "foobar") == 0,
+        "flux_cmd_setcwd works");
+    ok (flux_cmd_setopt (cmd, "stdout_STREAM_STOP", "true") == 0,
+        "flux_cmd_setopt works");
+    ok (flux_rexec (h, 0, 0, cmd, NULL) == NULL
+        && errno == EINVAL,
+        "flux_rexec fails with cmd with STREAM_STOP option");
+    flux_cmd_destroy (cmd);
+
     ok (flux_subprocess_stream_start (NULL, NULL) < 0
         && errno == EINVAL,
         "flux_subprocess_stream_start fails with NULL pointer inputs");


### PR DESCRIPTION
Peeled off from #2329, some minor cleanups.

Also, in #2333 I detected invalid options for remote subprocesses and silently removed them.  With the current set of options, it could go either way on silently removing vs return error to the user.  But once we add I/O options, it really should be errors returned to the user if an option doesn't apply to a remote subprocess.  So I now return an error to the user when an option doesn't apply to remote subprocesses.