### PR TITLE
libsubprocess: Support stdin input via FD / stdout/stderr output to FD libsubprocess

### DIFF
--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -169,66 +169,70 @@ static int channel_local_setup (flux_subprocess_t *p,
         goto error;
     }
 
-    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log_error (p->h, "socketpair");
-        goto error;
-    }
+    if ((channel_flags & CHANNEL_READ)
+        || (channel_flags & CHANNEL_WRITE)) {
 
-    c->parent_fd = fds[0];
-    c->child_fd = fds[1];
-
-    /* set fds[] to -1, on error is now subprocess_free()'s
-     * responsibility
-     */
-    fds[0] = -1;
-    fds[1] = -1;
-
-    if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log_error (p->h, "fd_set_nonblocking");
-        goto error;
-    }
-
-    if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
-        goto error;
-    }
-
-    if ((channel_flags & CHANNEL_WRITE) && in_cb) {
-        c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
-                                                              c->parent_fd,
-                                                              buffer_size,
-                                                              in_cb,
-                                                              0,
-                                                              c);
-        if (!c->buffer_write_w) {
-            flux_log_error (p->h, "flux_buffer_write_watcher_create");
-            goto error;
-        }
-    }
-
-    if ((channel_flags & CHANNEL_READ) && out_cb) {
-        int wflag;
-
-        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+        if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
+            flux_log_error (p->h, "socketpair");
             goto error;
         }
 
-        if (wflag)
-            c->line_buffered = true;
+        c->parent_fd = fds[0];
+        c->child_fd = fds[1];
 
-        c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
-                                                            c->parent_fd,
-                                                            buffer_size,
-                                                            out_cb,
-                                                            wflag,
-                                                            c);
-        if (!c->buffer_read_w) {
-            flux_log_error (p->h, "flux_buffer_read_watcher_create");
+        /* set fds[] to -1, on error is now subprocess_free()'s
+         * responsibility
+         */
+        fds[0] = -1;
+        fds[1] = -1;
+
+        if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
+            flux_log_error (p->h, "fd_set_nonblocking");
             goto error;
         }
 
-        p->channels_eof_expected++;
+        if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_bufsize");
+            goto error;
+        }
+
+        if ((channel_flags & CHANNEL_WRITE) && in_cb) {
+            c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
+                                                                  c->parent_fd,
+                                                                  buffer_size,
+                                                                  in_cb,
+                                                                  0,
+                                                                  c);
+            if (!c->buffer_write_w) {
+                flux_log_error (p->h, "flux_buffer_write_watcher_create");
+                goto error;
+            }
+        }
+
+        if ((channel_flags & CHANNEL_READ) && out_cb) {
+            int wflag;
+
+            if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+                flux_log_error (p->h, "cmd_option_line_buffer");
+                goto error;
+            }
+
+            if (wflag)
+                c->line_buffered = true;
+
+            c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
+                                                                c->parent_fd,
+                                                                buffer_size,
+                                                                out_cb,
+                                                                wflag,
+                                                                c);
+            if (!c->buffer_read_w) {
+                flux_log_error (p->h, "flux_buffer_read_watcher_create");
+                goto error;
+            }
+
+            p->channels_eof_expected++;
+        }
     }
 
     if (channel_flags & CHANNEL_FD) {
@@ -455,26 +459,36 @@ static int local_child (flux_subprocess_t *p)
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
-            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_WRITE) {
+                if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
-            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDOUT_FILENO);
         }
         else
             close (STDOUT_FILENO);
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
-            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDERR_FILENO);
         }
         else
             close (STDERR_FILENO);
@@ -676,15 +690,18 @@ static int start_local_watchers (flux_subprocess_t *p)
     c = zhash_first (p->channels);
     while (c) {
         int ret;
-        flux_watcher_start (c->buffer_write_w);
-        if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
-            return -1;
-        if (ret) {
-            flux_watcher_start (c->buffer_read_stopped_w);
-        }
-        else {
-            flux_watcher_start (c->buffer_read_w);
-            c->buffer_read_w_started = true;
+        if (c->flags & CHANNEL_WRITE)
+            flux_watcher_start (c->buffer_write_w);
+        if (c->flags & CHANNEL_READ) {
+            if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
+                return -1;
+            if (ret) {
+                flux_watcher_start (c->buffer_read_stopped_w);
+            }
+            else {
+                flux_watcher_start (c->buffer_read_w);
+                c->buffer_read_w_started = true;
+            }
         }
         c = zhash_next (p->channels);
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -50,6 +50,8 @@ void channel_destroy (void *arg)
             close (c->child_fd);
         if (c->input_fd != -1)
             close (c->input_fd);
+        if (c->output_fd != -1)
+            close (c->output_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -94,6 +96,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
     c->parent_fd = -1;
     c->child_fd = -1;
     c->input_fd = -1;
+    c->output_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -671,6 +674,7 @@ static int check_local_only_cmd_options (const flux_cmd_t *cmd)
     /* check for options that do not apply to remote subprocesses */
     const char *substrings[] = { "STREAM_STOP",
                                  "INPUT_FD",
+                                 "OUTPUT_FD",
                                  NULL };
 
     return flux_cmd_find_opts (cmd, substrings);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -48,6 +48,8 @@ void channel_destroy (void *arg)
             close (c->parent_fd);
         if (c->child_fd != -1)
             close (c->child_fd);
+        if (c->input_fd != -1)
+            close (c->input_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -91,6 +93,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
 
     c->parent_fd = -1;
     c->child_fd = -1;
+    c->input_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -666,7 +669,9 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)
 {
     /* check for options that do not apply to remote subprocesses */
-    const char *substrings[] = { "STREAM_STOP", NULL };
+    const char *substrings[] = { "STREAM_STOP",
+                                 "INPUT_FD",
+                                 NULL };
 
     return flux_cmd_find_opts (cmd, substrings);
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -294,6 +294,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    subprocesses.
  *
  *    - stdin_INPUT_FD - file descriptor for stdin
+ *
+ *  "OUTPUT_FD" option
+ *
+ *    By default, standard output is read from flux_subprocess_read()
+ *    (and family of functions) and the stream "stdout" or "stderr".
+ *    This option will inform the subprocess to redirect stdout /
+ *    stderr directly to a specified file descriptor.  Functions like
+ *    flux_subprocess_read() will return EINVAL when attempting to
+ *    read from stdout or stderr.  This option can only be used on
+ *    local subprocesses.
+ *
+ *    - stdout_OUTPUT_FD - file descriptor for stdout
+ *    - stderr_OUTPUT_FD - file descriptor for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -282,6 +282,18 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
  *    - stdout_STREAM_STOP - configure start/stop for stdout
  *    - stderr_STREAM_STOP - configure start/stop for stderr
+ *
+ *  "INPUT_FD" option
+ *
+ *    By default, standard input is sent to a subprocess via the
+ *    flux_subprocess_write() call and the stream "stdin".  This
+ *    option will inform the subprocess to read stdin directly from a
+ *    specified file descriptor.  As a result, functions liked
+ *    flux_subprocess_write() will return EINVAL when attempting to
+ *    write to "stdin".  This option can only be used on local
+ *    subprocesses.
+ *
+ *    - stdin_INPUT_FD - file descriptor for stdin
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,9 +21,10 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ  0x01
-#define CHANNEL_WRITE 0x02
-#define CHANNEL_FD    0x04
+#define CHANNEL_READ     0x01
+#define CHANNEL_WRITE    0x02
+#define CHANNEL_FD       0x04
+#define CHANNEL_INPUT_FD 0x08
 
 struct subprocess_channel {
     int magic;
@@ -40,6 +41,7 @@ struct subprocess_channel {
     /* local */
     int parent_fd;
     int child_fd;
+    int input_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,10 +21,11 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ     0x01
-#define CHANNEL_WRITE    0x02
-#define CHANNEL_FD       0x04
-#define CHANNEL_INPUT_FD 0x08
+#define CHANNEL_READ      0x01
+#define CHANNEL_WRITE     0x02
+#define CHANNEL_FD        0x04
+#define CHANNEL_INPUT_FD  0x08
+#define CHANNEL_OUTPUT_FD 0x10
 
 struct subprocess_channel {
     int magic;
@@ -42,6 +43,7 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     int input_fd;
+    int output_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -796,6 +796,21 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     (*counter)++;
 }
 
+void write_multiple_lines_to_stdin (flux_subprocess_t *p)
+{
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_close (p, "stdin") == 0,
+        "flux_subprocess_close success");
+}
+
 void test_basic_multiple_lines (flux_reactor_t *r)
 {
     char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-O", "-E", "-n", NULL };
@@ -818,17 +833,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_close (p, "stdin") == 0,
-        "flux_subprocess_close success");
+    write_multiple_lines_to_stdin (p);
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");

--- a/src/common/libsubprocess/test/test_echo.c
+++ b/src/common/libsubprocess/test/test_echo.c
@@ -134,8 +134,9 @@ main (int argc, char *argv[])
 
         memset (buf, '\0', 1024);
         while ((len = read (fd, buf, 1024)) > 0) {
-            char outbuf[1025]; /* add extra char for -Werror=format-overflow */
+            char outbuf[1026]; /* add extra char for -Werror=format-overflow */
 
+            memset (outbuf, '\0', sizeof (outbuf));
             sprintf (outbuf,
                      "%s%s",
                      buf,

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,7 +122,10 @@ cleanup:
     return rv;
 }
 
-int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+static int cmd_option_fd (flux_subprocess_t *p,
+                          const char *name,
+                          const char *substring,
+                          int *fdp)
 {
     char *var;
     const char *val;
@@ -130,7 +133,7 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 
     (*fdp) = -1;
 
-    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+    if (asprintf (&var, "%s_%s", name, substring) < 0)
         goto cleanup;
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
@@ -151,6 +154,16 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 cleanup:
     free (var);
     return rv;
+}
+
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "INPUT_FD", fdp);
+}
+
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "OUTPUT_FD", fdp);
 }
 
 /*

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,6 +122,37 @@ cleanup:
     return rv;
 }
 
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    (*fdp) = -1;
+
+    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        int tmp;
+        errno = 0;
+        tmp = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || tmp < 0) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        (*fdp) = tmp;
+    }
+
+    rv = 0;
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -26,4 +26,7 @@ int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 /* sets fdp to -1 if user did not set INPUT_FD */
 int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
 
+/* sets fdp to -1 if user did not set OUTPUT_FD */
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -23,4 +23,7 @@ int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
+/* sets fdp to -1 if user did not set INPUT_FD */
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */


### PR DESCRIPTION
This PR adds stdin input via file and stdout/stderr output to file options in `libsubprocess`.  The options are set via `flux_cmd_setopt()` via a "INPUT_REDIRECT" or "OUTPUT_REDIRECT" option.

Notes on development:

- only works on local subprocesses right now.  Files are opened in parent process, then after local `fork()` occurs, file descriptors are `dup2()`-ed to their respective file descriptors.

- It only works on stdin/stdout/stderr as well (i.e. not on any channels).  Channel support should be quite easy to add, but didn't see a reason to add for the time being?

- I don't allow INPUT_REDIRECT / OUTPUT_REDIRECT to be passed to remote subprocesses b/c its not clear how this should be interpreted.  Are you redirecting a local file to the subprocess ona  remote node?  Or are you reading in a file that is local to the remote node?  Possibly could add new options like "REMOTE_INPUT_REDIRECT"?  TBD.

- It wasn't clear what mode output files should be if they have not yet been created.  I just did `0644` b/c that's what bash appears to do.

- Similary, I didn't know what to do if file exists for output redirection.  Return an EEXIST?  But what if the user wants to redirect to `/dev/null`?  For the time being, I return an error if the file exists, but make a special case exception for `/dev/null`.  This is probably not the right thing to do.
