### PR TITLE
libsubprocess: support buffering minimum before calling output callbacks

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -419,7 +419,7 @@ int main (int argc, char *argv[])
         if (fcntl (STDIN_FILENO, F_SETFL, stdin_flags | O_NONBLOCK) < 0)
             log_err_exit ("fcntl F_SETFL stdin");
         if (!(stdin_w = flux_buffer_read_watcher_create (r, STDIN_FILENO,
-                                                         1 << 20, stdin_cb,
+                                                         1 << 20, 0, stdin_cb,
                                                          0, NULL)))
             log_err_exit ("flux_buffer_read_watcher_create");
     }

--- a/src/common/libflux/ev_buffer_read.c
+++ b/src/common/libflux/ev_buffer_read.c
@@ -19,26 +19,24 @@
 
 static bool data_to_read (struct ev_buffer_read *ebr, bool *is_eof)
 {
-    if (ebr->line) {
-        if (flux_buffer_has_line (ebr->fb))
-            return true;
-        /* if eof read, no lines, but left over data non-line data,
-         * this data should be flushed to the user */
-        else if (ebr->eof_read
-                 && flux_buffer_bytes (ebr->fb))
-            return true;
-    }
-    else {
-        if (flux_buffer_bytes (ebr->fb) > 0)
-            return true;
-    }
+    int bytes = flux_buffer_bytes (ebr->fb);
 
-    if (ebr->eof_read
-        && !ebr->eof_sent
-        && !flux_buffer_bytes (ebr->fb)) {
-        if (is_eof)
-            (*is_eof) = true;
-        return true;
+    if (bytes > 0) {
+        if (ebr->eof_read)
+            return true;
+        else if (ebr->line) {
+            if (flux_buffer_has_line (ebr->fb))
+                return true;
+        }
+        else
+            return true;
+    }
+    else if (!bytes) {
+        if (ebr->eof_read && !ebr->eof_sent) {
+            if (is_eof)
+                (*is_eof) = true;
+            return true;
+        }
     }
 
     return false;

--- a/src/common/libflux/ev_buffer_read.h
+++ b/src/common/libflux/ev_buffer_read.h
@@ -26,6 +26,7 @@ struct ev_buffer_read {
     ev_idle          idle_w;
     ev_check         check_w;
     int              fd;
+    int              min_bytes;
     ev_buffer_read_f cb;
     flux_buffer_t    *fb;
     struct ev_loop   *loop;
@@ -39,6 +40,7 @@ struct ev_buffer_read {
 int ev_buffer_read_init (struct ev_buffer_read *ebr,
                          int fd,
                          int size,
+                         int min_bytes,
                          ev_buffer_read_f cb,
                          struct ev_loop *loop);
 void ev_buffer_read_cleanup (struct ev_buffer_read *ebr);

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -412,14 +412,15 @@ static struct flux_watcher_ops buffer_read_watcher = {
 };
 
 flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
-                                                 int size, flux_watcher_f cb,
+                                                 int size, int min_bytes,
+                                                 flux_watcher_f cb,
                                                  int flags, void *arg)
 {
     struct ev_buffer_read *ebr;
     flux_watcher_t *w = NULL;
     int fd_flags;
 
-    if (fd < 0) {
+    if (fd < 0 || min_bytes < 0) {
         errno = EINVAL;
         return NULL;
     }
@@ -442,6 +443,7 @@ flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
     if (ev_buffer_read_init (ebr,
                              fd,
                              size,
+                             min_bytes,
                              buffer_read_cb,
                              r->loop) < 0)
         goto cleanup;

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -101,10 +101,16 @@ int flux_fd_watcher_get_fd (flux_watcher_t *w);
 /* buffer
  */
 
-/* on eof, callback will be called with an empty buffer */
-/* if line buffered, second to last callback may not contain a full line */
+/* on eof, callback will be called with an empty buffer
+ *
+ * if min_bytes set, callback guaranteed to have atleast min_bytes,
+ * except for second to last callback before EOF
+ *
+ * if line buffered, second to last callback may not contain a full line
+ */
 flux_watcher_t *flux_buffer_read_watcher_create (flux_reactor_t *r, int fd,
-                                                 int size, flux_watcher_f cb,
+                                                 int size, int min_bytes,
+                                                 flux_watcher_f cb,
                                                  int flags, void *arg);
 
 flux_buffer_t *flux_buffer_read_watcher_get_buffer (flux_watcher_t *w);

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -383,6 +383,7 @@ static void test_buffer (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          1024,
+                                         0,
                                          buffer_read,
                                          0,
                                          &count);
@@ -414,6 +415,7 @@ static void test_buffer (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          1024,
+                                         0,
                                          buffer_read_line,
                                          FLUX_WATCHER_LINE_BUFFER,
                                          &count);
@@ -520,6 +522,7 @@ static void test_buffer (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          12, /* 12 bytes = 2 "foobars"s */
+                                         0,
                                          buffer_read_fill,
                                          0,
                                          &count);
@@ -554,6 +557,7 @@ static void test_buffer (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          12, /* 12 bytes = 2 "foobar"s */
+                                         0,
                                          buffer_read_overflow,
                                          0,
                                          &count);
@@ -832,6 +836,7 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          1024,
+                                         0,
                                          buffer_read_fd_close,
                                          0,
                                          &bfc);
@@ -869,6 +874,7 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          1024,
+                                         0,
                                          buffer_read_line_fd_close,
                                          FLUX_WATCHER_LINE_BUFFER,
                                          &bfc);
@@ -906,6 +912,7 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     w = flux_buffer_read_watcher_create (reactor,
                                          fd[0],
                                          1024,
+                                         0,
                                          buffer_read_line_fd_close_and_left_over_data,
                                          FLUX_WATCHER_LINE_BUFFER,
                                          &bfc);

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -227,6 +227,7 @@ static int channel_local_setup (flux_subprocess_t *p,
             c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
                                                                 c->parent_fd,
                                                                 buffer_size,
+                                                                0,
                                                                 out_cb,
                                                                 wflag,
                                                                 c);

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -169,66 +169,70 @@ static int channel_local_setup (flux_subprocess_t *p,
         goto error;
     }
 
-    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log_error (p->h, "socketpair");
-        goto error;
-    }
+    if ((channel_flags & CHANNEL_READ)
+        || (channel_flags & CHANNEL_WRITE)) {
 
-    c->parent_fd = fds[0];
-    c->child_fd = fds[1];
-
-    /* set fds[] to -1, on error is now subprocess_free()'s
-     * responsibility
-     */
-    fds[0] = -1;
-    fds[1] = -1;
-
-    if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log_error (p->h, "fd_set_nonblocking");
-        goto error;
-    }
-
-    if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
-        goto error;
-    }
-
-    if ((channel_flags & CHANNEL_WRITE) && in_cb) {
-        c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
-                                                              c->parent_fd,
-                                                              buffer_size,
-                                                              in_cb,
-                                                              0,
-                                                              c);
-        if (!c->buffer_write_w) {
-            flux_log_error (p->h, "flux_buffer_write_watcher_create");
-            goto error;
-        }
-    }
-
-    if ((channel_flags & CHANNEL_READ) && out_cb) {
-        int wflag;
-
-        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+        if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
+            flux_log_error (p->h, "socketpair");
             goto error;
         }
 
-        if (wflag)
-            c->line_buffered = true;
+        c->parent_fd = fds[0];
+        c->child_fd = fds[1];
 
-        c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
-                                                            c->parent_fd,
-                                                            buffer_size,
-                                                            out_cb,
-                                                            wflag,
-                                                            c);
-        if (!c->buffer_read_w) {
-            flux_log_error (p->h, "flux_buffer_read_watcher_create");
+        /* set fds[] to -1, on error is now subprocess_free()'s
+         * responsibility
+         */
+        fds[0] = -1;
+        fds[1] = -1;
+
+        if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
+            flux_log_error (p->h, "fd_set_nonblocking");
             goto error;
         }
 
-        p->channels_eof_expected++;
+        if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_bufsize");
+            goto error;
+        }
+
+        if ((channel_flags & CHANNEL_WRITE) && in_cb) {
+            c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
+                                                                  c->parent_fd,
+                                                                  buffer_size,
+                                                                  in_cb,
+                                                                  0,
+                                                                  c);
+            if (!c->buffer_write_w) {
+                flux_log_error (p->h, "flux_buffer_write_watcher_create");
+                goto error;
+            }
+        }
+
+        if ((channel_flags & CHANNEL_READ) && out_cb) {
+            int wflag;
+
+            if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+                flux_log_error (p->h, "cmd_option_line_buffer");
+                goto error;
+            }
+
+            if (wflag)
+                c->line_buffered = true;
+
+            c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
+                                                                c->parent_fd,
+                                                                buffer_size,
+                                                                out_cb,
+                                                                wflag,
+                                                                c);
+            if (!c->buffer_read_w) {
+                flux_log_error (p->h, "flux_buffer_read_watcher_create");
+                goto error;
+            }
+
+            p->channels_eof_expected++;
+        }
     }
 
     if (channel_flags & CHANNEL_FD) {
@@ -455,26 +459,36 @@ static int local_child (flux_subprocess_t *p)
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
-            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_WRITE) {
+                if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
-            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDOUT_FILENO);
         }
         else
             close (STDOUT_FILENO);
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
-            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDERR_FILENO);
         }
         else
             close (STDERR_FILENO);
@@ -676,15 +690,18 @@ static int start_local_watchers (flux_subprocess_t *p)
     c = zhash_first (p->channels);
     while (c) {
         int ret;
-        flux_watcher_start (c->buffer_write_w);
-        if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
-            return -1;
-        if (ret) {
-            flux_watcher_start (c->buffer_read_stopped_w);
-        }
-        else {
-            flux_watcher_start (c->buffer_read_w);
-            c->buffer_read_w_started = true;
+        if (c->flags & CHANNEL_WRITE)
+            flux_watcher_start (c->buffer_write_w);
+        if (c->flags & CHANNEL_READ) {
+            if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
+                return -1;
+            if (ret) {
+                flux_watcher_start (c->buffer_read_stopped_w);
+            }
+            else {
+                flux_watcher_start (c->buffer_read_w);
+                c->buffer_read_w_started = true;
+            }
         }
         c = zhash_next (p->channels);
     }

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -224,10 +224,13 @@ static int channel_local_setup (flux_subprocess_t *p,
             if (wflag)
                 c->line_buffered = true;
 
+            if ((c->min_bytes = cmd_option_min_bytes (p, name)) < 0)
+                goto error;
+
             c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
                                                                 c->parent_fd,
                                                                 buffer_size,
-                                                                0,
+                                                                c->min_bytes,
                                                                 out_cb,
                                                                 wflag,
                                                                 c);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -50,6 +50,8 @@ void channel_destroy (void *arg)
             close (c->child_fd);
         if (c->input_fd != -1)
             close (c->input_fd);
+        if (c->output_fd != -1)
+            close (c->output_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -94,6 +96,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
     c->parent_fd = -1;
     c->child_fd = -1;
     c->input_fd = -1;
+    c->output_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -671,6 +674,7 @@ static int check_local_only_cmd_options (const flux_cmd_t *cmd)
     /* check for options that do not apply to remote subprocesses */
     const char *substrings[] = { "STREAM_STOP",
                                  "INPUT_FD",
+                                 "OUTPUT_FD",
                                  NULL };
 
     return flux_cmd_find_opts (cmd, substrings);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -48,6 +48,8 @@ void channel_destroy (void *arg)
             close (c->parent_fd);
         if (c->child_fd != -1)
             close (c->child_fd);
+        if (c->input_fd != -1)
+            close (c->input_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -91,6 +93,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
 
     c->parent_fd = -1;
     c->child_fd = -1;
+    c->input_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -666,7 +669,9 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)
 {
     /* check for options that do not apply to remote subprocesses */
-    const char *substrings[] = { "STREAM_STOP", NULL };
+    const char *substrings[] = { "STREAM_STOP",
+                                 "INPUT_FD",
+                                 NULL };
 
     return flux_cmd_find_opts (cmd, substrings);
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -267,6 +267,25 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - stdout_LINE_BUFFER - configure line buffering for stdout
  *    - stderr_LINE_BUFFER - configure line buffering for stderr
  *
+ *  "MIN_BYTES" option
+ *
+ *    By default, output callbacks such as 'on_stdout' and 'on_stderr'
+ *    are called when a single amount of data is available.  If the
+ *    data is line buffered, this may be a single line.  If not line
+ *    buffered, it could be just 1 byte.  By setting this option to a
+ *    specific byte count, the callback will only be called if atleast
+ *    this number of bytes is available.  If EOF has been reached, the
+ *    last callback may have less than min data.
+ *
+ *    Note that if line buffering is enabled, MIN_BYTES only ensures
+ *    that atleast MIN_BYTES is buffered and atleast 1 line is
+ *    available for reading.  It does not ensure that MIN_BYTES worth
+ *    of lines are available.
+ *
+ *    - name + "_MIN_BYTES" - configure min data on channel name
+ *    - stdout_MIN_BYTES - configure min data on stdout
+ *    - stderr_MIN_BYTES - configure min data on stderr
+ *
  *  "STREAM_STOP" option
  *
  *    By default, the output callbacks such as 'on_stdout' and

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -294,6 +294,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    subprocesses.
  *
  *    - stdin_INPUT_FD - file descriptor for stdin
+ *
+ *  "OUTPUT_FD" option
+ *
+ *    By default, standard output is read from flux_subprocess_read()
+ *    (and family of functions) and the stream "stdout" or "stderr".
+ *    This option will inform the subprocess to redirect stdout /
+ *    stderr directly to a specified file descriptor.  Functions like
+ *    flux_subprocess_read() will return EINVAL when attempting to
+ *    read from stdout or stderr.  This option can only be used on
+ *    local subprocesses.
+ *
+ *    - stdout_OUTPUT_FD - file descriptor for stdout
+ *    - stderr_OUTPUT_FD - file descriptor for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -282,6 +282,18 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
  *    - stdout_STREAM_STOP - configure start/stop for stdout
  *    - stderr_STREAM_STOP - configure start/stop for stderr
+ *
+ *  "INPUT_FD" option
+ *
+ *    By default, standard input is sent to a subprocess via the
+ *    flux_subprocess_write() call and the stream "stdin".  This
+ *    option will inform the subprocess to read stdin directly from a
+ *    specified file descriptor.  As a result, functions liked
+ *    flux_subprocess_write() will return EINVAL when attempting to
+ *    write to "stdin".  This option can only be used on local
+ *    subprocesses.
+ *
+ *    - stdin_INPUT_FD - file descriptor for stdin
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -67,6 +67,7 @@ struct subprocess_channel {
 
     /* misc */
     bool line_buffered;         /* for buffer_read_w / read_buffer */
+    int min_bytes;
 };
 
 struct flux_subprocess {

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,9 +21,10 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ  0x01
-#define CHANNEL_WRITE 0x02
-#define CHANNEL_FD    0x04
+#define CHANNEL_READ     0x01
+#define CHANNEL_WRITE    0x02
+#define CHANNEL_FD       0x04
+#define CHANNEL_INPUT_FD 0x08
 
 struct subprocess_channel {
     int magic;
@@ -40,6 +41,7 @@ struct subprocess_channel {
     /* local */
     int parent_fd;
     int child_fd;
+    int input_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,10 +21,11 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ     0x01
-#define CHANNEL_WRITE    0x02
-#define CHANNEL_FD       0x04
-#define CHANNEL_INPUT_FD 0x08
+#define CHANNEL_READ      0x01
+#define CHANNEL_WRITE     0x02
+#define CHANNEL_FD        0x04
+#define CHANNEL_INPUT_FD  0x08
+#define CHANNEL_OUTPUT_FD 0x10
 
 struct subprocess_channel {
     int magic;
@@ -42,6 +43,7 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     int input_fd;
+    int output_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -796,6 +796,21 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     (*counter)++;
 }
 
+void write_multiple_lines_to_stdin (flux_subprocess_t *p)
+{
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_close (p, "stdin") == 0,
+        "flux_subprocess_close success");
+}
+
 void test_basic_multiple_lines (flux_reactor_t *r)
 {
     char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-O", "-E", "-n", NULL };
@@ -818,17 +833,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_close (p, "stdin") == 0,
-        "flux_subprocess_close success");
+    write_multiple_lines_to_stdin (p);
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");

--- a/src/common/libsubprocess/test/test_multi_echo.c
+++ b/src/common/libsubprocess/test/test_multi_echo.c
@@ -18,6 +18,7 @@
 
 int out = 0;
 int err = 0;
+int newline = 0;
 int count = 4;
 
 int
@@ -26,7 +27,7 @@ main (int argc, char *argv[])
     int maxcount;
 
     while (1) {
-        int c = getopt (argc, argv, "OEc:");
+        int c = getopt (argc, argv, "OEnc:");
         if (c < 0)
             break;
 
@@ -36,6 +37,9 @@ main (int argc, char *argv[])
             break;
         case 'E':
             err++;
+            break;
+        case 'n':
+            newline++;
             break;
         case 'c':
             count = atoi (optarg);
@@ -76,18 +80,22 @@ main (int argc, char *argv[])
                 exit (1);
             }
             if (out && pfds[0].revents & POLLOUT) {
-                if (outcount == count)
-                    fprintf (stdout, "\n");
+                if (outcount == count) {
+                    if (!newline)
+                        fprintf (stdout, "\n");
+                }
                 else
-                    fprintf (stdout, "%s", argv[optind]);
+                    fprintf (stdout, "%s%s", argv[optind], newline ? "\n" : "");
                 fflush (stdout);
                 outcount++;
             }
             if (err && pfds[1].revents & POLLOUT) {
-                if (errcount == count)
-                    fprintf (stderr, "\n");
+                if (errcount == count) {
+                    if (!newline)
+                        fprintf (stderr, "\n");
+                }
                 else
-                    fprintf (stderr, "%s", argv[optind]);
+                    fprintf (stderr, "%s%s", argv[optind], newline ? "\n" : "");
                 fflush (stderr);
                 errcount++;
             }

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,7 +122,10 @@ cleanup:
     return rv;
 }
 
-int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+static int cmd_option_fd (flux_subprocess_t *p,
+                          const char *name,
+                          const char *substring,
+                          int *fdp)
 {
     char *var;
     const char *val;
@@ -130,7 +133,7 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 
     (*fdp) = -1;
 
-    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+    if (asprintf (&var, "%s_%s", name, substring) < 0)
         goto cleanup;
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
@@ -151,6 +154,16 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 cleanup:
     free (var);
     return rv;
+}
+
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "INPUT_FD", fdp);
+}
+
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "OUTPUT_FD", fdp);
 }
 
 /*

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,6 +122,37 @@ cleanup:
     return rv;
 }
 
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    (*fdp) = -1;
+
+    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        int tmp;
+        errno = 0;
+        tmp = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || tmp < 0) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        (*fdp) = tmp;
+    }
+
+    rv = 0;
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -97,6 +97,35 @@ cleanup:
     return rv;
 }
 
+int cmd_option_min_bytes (flux_subprocess_t *p, const char *name)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    if (asprintf (&var, "%s_MIN_BYTES", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        errno = 0;
+        rv = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || rv <= 0) {
+            rv = -1;
+            errno = EINVAL;
+            goto cleanup;
+        }
+    }
+    else
+        rv = 0;
+
+cleanup:
+    free (var);
+    return rv;
+}
+
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name)
 {
     char *var;

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -21,6 +21,8 @@ int cmd_option_bufsize (flux_subprocess_t *p, const char *name);
 
 int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
+int cmd_option_min_bytes (flux_subprocess_t *p, const char *name);
+
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
 /* sets fdp to -1 if user did not set INPUT_FD */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -26,4 +26,7 @@ int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 /* sets fdp to -1 if user did not set INPUT_FD */
 int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
 
+/* sets fdp to -1 if user did not set OUTPUT_FD */
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -23,4 +23,7 @@ int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
+/* sets fdp to -1 if user did not set INPUT_FD */
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/t/reactor/reactorcat.c
+++ b/t/reactor/reactorcat.c
@@ -99,7 +99,7 @@ int main (int argc, char *argv[])
 
     ww = flux_buffer_write_watcher_create (r, STDOUT_FILENO, 4096,
                                            write_cb, 0, NULL);
-    rw = flux_buffer_read_watcher_create (r, STDIN_FILENO, 4096,
+    rw = flux_buffer_read_watcher_create (r, STDIN_FILENO, 4096, 0,
                                           read_cb, 0, (void *) ww);
     if (!rw || !ww)
         die ("flux buffer watcher create failed\n");

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -31,6 +31,8 @@ static struct optparse_option cmdopts[] = {
       .usage = "Specify rank for test" },
     { .name = "linebuffer", .key = 'l', .has_arg = 1, .arginfo = "bool",
       .usage = "Specify true/false for line buffering" },
+    { .name = "minbytes", .key = 'm', .has_arg = 1, .arginfo = "num",
+      .usage = "Specify minimum bytes for buffering" },
     OPTPARSE_TABLE_END
 };
 
@@ -126,6 +128,19 @@ int main (int argc, char *argv[])
             && strcasecmp (optargp, "false"))
             log_err_exit ("invalid linebuffer value");
         if (flux_cmd_setopt (cmd, "stdout_LINE_BUFFER", optargp) < 0)
+            log_err_exit ("flux_cmd_setopt");
+    }
+
+    if (optparse_getopt (opts, "minbytes", &optargp) > 0) {
+        char *endptr;
+        int minbytes;
+        errno = 0;
+        minbytes = strtol (optargp, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || minbytes <= 0)
+            log_err_exit ("invalid minbytes value");
+        if (flux_cmd_setopt (cmd, "stdout_MIN_BYTES", optargp) < 0)
             log_err_exit ("flux_cmd_setopt");
     }
 


### PR DESCRIPTION
This is built on top of #2345 for the time being (could be added to that PR too).

- Support an option I call "MIN_BYTES" (name debateable), in which atleast MIN_BYTES of data must be buffered before an output callback is called.  This should support some of our discussed plans for limiting KVS writes or aggregating identical output from multiple libsubprocesses.

- Decided to implement this by updating the original buffer reactor to include a "min_bytes" parameter when it is created.  It was difficult to this feature with a flag and decided to do it this way instead of adding some new configuration function.

- If line buffering is enabled, the callback will be called if MIN_BYTES of data exist and atleast 1 line exists in the buffer.  It does not guarantee that "MIN_BYTES" worth of lines exists.  This is to avoid the costly overhead of counting lines in a buffer.
