### PR TITLE
abstract in-tree detection into libutil, remove FLUX_CONF_INTREE environment variable

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -197,8 +197,6 @@ int main (int argc, char *argv[])
                           flux_conf_get ("rc3_path", flags), 0);
     environment_from_env (env, "FLUX_PMI_LIBRARY_PATH",
                           flux_conf_get ("pmi_library_path", flags), 0);
-    if ((flags & CONF_FLAG_INTREE))
-        environment_push (env, "FLUX_CONF_INTREE", "1");
 
     environment_apply (env);
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -119,7 +119,8 @@ TESTS = test_ev.t \
 	test_aux.t \
 	test_fdutils.t \
 	test_fsd.t \
-	test_zsecurity.t
+	test_zsecurity.t \
+	test_intree.t
 
 
 test_ldadd = \
@@ -240,3 +241,7 @@ test_fsd_t_LDADD = $(test_ldadd)
 test_zsecurity_t_SOURCES = test/zsecurity.c
 test_zsecurity_t_CPPFLAGS = $(test_cppflags)
 test_zsecurity_t_LDADD = $(test_ldadd)
+
+test_intree_t_SOURCES = test/intree.c
+test_intree_t_CPPFLAGS = $(test_cppflags)
+test_intree_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -90,7 +90,9 @@ libutil_la_SOURCES = \
 	fsd.h \
 	zsecurity.c \
 	zsecurity.h \
-	errno_safe.h
+	errno_safe.h \
+	intree.c \
+	intree.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -11,7 +11,8 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux
+	-I$(top_builddir)/src/common/libflux \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 
 noinst_LTLIBRARIES = libutil.la
 

--- a/src/common/libutil/intree.c
+++ b/src/common/libutil/intree.c
@@ -1,0 +1,101 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/param.h> /* MAXPATHLEN */
+#include <libgen.h>    /* dirname(3) */
+#include <pthread.h>
+
+
+/*  Strip trailing ".libs", otherwise do nothing
+ */
+static char *strip_trailing_dot_libs (char *dir)
+{
+    char *p = dir + strlen (dir) - 1;
+    if (   (*(p--) == 's')
+        && (*(p--) == 'b')
+        && (*(p--) == 'i')
+        && (*(p--) == 'l')
+        && (*(p--) == '.')
+        && (*p == '/') )
+        *p = '\0';
+    return (dir);
+}
+
+/*  Return directory containing this executable.
+ */
+const char *executable_selfdir (void)
+{
+    static pthread_mutex_t selfdir_lock = PTHREAD_MUTEX_INITIALIZER;
+    static char current_exe_path [MAXPATHLEN];
+    static char *current_exe_dir = NULL;
+    pthread_mutex_lock (&selfdir_lock);
+    if (!current_exe_dir) {
+        memset (current_exe_path, 0, sizeof (current_exe_path));
+        if (readlink ("/proc/self/exe", current_exe_path, MAXPATHLEN - 1) < 0)
+            goto out;
+        current_exe_dir = strip_trailing_dot_libs (dirname (current_exe_path));
+    }
+out:
+    pthread_mutex_unlock (&selfdir_lock);
+    return current_exe_dir;
+}
+
+/*   Check if the path to the current executable is in a subdirectory
+ *   of the top build directory of flux-core. This should work to detect
+ *   if an executable is running in-tree no matter where in the build
+ *   tree that executable was built.
+ */
+static int is_intree (void)
+{
+    const char *selfdir = NULL;
+    char *builddir = NULL;
+    int ret = 0;
+
+    if (!(selfdir = executable_selfdir ()))
+        return -1;
+    /*
+     *  Calling realpath(3) with NULL second arg is safe since POSIX.1-2008.
+     *   (Equivalent to glibc's canonicalize_path_name(3))
+     *
+     *  If realpath(3) returns ENOENT, then BINDIR doesn't exist and flux
+     *   clearly can't be from the installed path:
+     */
+    if (!(builddir = realpath (ABS_TOP_BUILDDIR, NULL))
+       && (errno != ENOENT)
+       && (errno != EACCES))
+        ret = -1;
+    else if (strncmp (builddir, selfdir, strlen (builddir)) == 0)
+        ret = 1;
+    free (builddir);
+    return ret;
+}
+
+int executable_is_intree (void)
+{
+    static pthread_mutex_t intree_lock = PTHREAD_MUTEX_INITIALIZER;
+    static int current_exe_intree = -1;
+    /* If uninitialized, initialize current_exe_intree now */
+    pthread_mutex_lock (&intree_lock);
+    if (current_exe_intree < 0)
+        current_exe_intree = is_intree ();
+    pthread_mutex_unlock (&intree_lock);
+    return current_exe_intree;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/intree.h
+++ b/src/common/libutil/intree.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_INTREE_H
+#define _UTIL_INTREE_H
+
+/*  Check if the current executable was started from a build tree,
+ *  i.e. if top_builddir is a prefix of the pat the the current
+ *  executable.
+ *
+ *  Returns 1 if executable was started from the build tree, 0 if
+ *  not and -1 on any error.
+ */
+int executable_is_intree (void);
+
+/*  Return the directory containing the current executable.
+ */
+const char *executable_selfdir (void);
+
+#endif /* !_UTIL_INTREE_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/test/intree.c
+++ b/src/common/libutil/test/intree.c
@@ -1,0 +1,74 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <string.h>
+#include <errno.h>
+#include <pthread.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/intree.h"
+
+#define NTHREADS 16
+
+static pthread_barrier_t barrier;
+
+static void *thd_intree (void *arg)
+{
+    int *resultp = arg;
+    int e;
+    if ((e = pthread_barrier_wait (&barrier))
+        && e != PTHREAD_BARRIER_SERIAL_THREAD)
+        BAIL_OUT ("pthread_barrier_wait: %s %s", strerror (e), strerror (errno));
+    *resultp = executable_is_intree ();
+    return NULL;
+}
+
+int main (int argc, char *argv[])
+{
+    pthread_t threads [NTHREADS];
+    int results [NTHREADS];
+    int i;
+    plan (NO_PLAN);
+
+    ok (executable_is_intree (),
+        "executable_is_intree() works");
+    like (executable_selfdir (), ".*/src/common/libutil",
+        "executable_selfdir() works");
+
+    if (pthread_barrier_init (&barrier, NULL, NTHREADS))
+        BAIL_OUT ("pthread_barrier_init");
+
+    for (i = 0; i < NTHREADS; i++) {
+        int e = pthread_create (&threads[i], NULL, thd_intree, &results[i]);
+        if (e)
+            BAIL_OUT ("pthread_create");
+    }
+    int pass = 1;
+    for (i = 0; i < NTHREADS; i++) {
+        if (pthread_join (threads[i], NULL))
+            BAIL_OUT ("pthread_join");
+        if (results[i] != 1) {
+            pass = 0;
+            fail ("thread %d: executable_is_intree() returned %d",
+                  i, results[i]);
+        }
+    }
+
+    ok (pass == 1,
+        "%d threads ran executable_is_intree sucessfully", NTHREADS);
+
+    pthread_barrier_destroy (&barrier);
+    done_testing ();
+    return 0;
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-ingest/validate.c
+++ b/src/modules/job-ingest/validate.c
@@ -35,6 +35,8 @@
 #include <jansson.h>
 #include <flux/core.h>
 
+#include "src/common/libutil/intree.h"
+
 #include "validate.h"
 #include "worker.h"
 
@@ -83,7 +85,7 @@ struct validate *validate_create (flux_t *h)
         return NULL;
     v->h = h;
 
-    if (getenv ("FLUX_CONF_INTREE"))
+    if (executable_is_intree ())
         conf_flags |= CONF_FLAG_INTREE;
     argv[0] = (char *)flux_conf_get ("jobspec_validate_path", conf_flags);
     argv[1] = "--schema";


### PR DESCRIPTION
This is split off the shell plugin work, since it is fairly independent and may actually generate some discussion on its own.

In the shell we want to load a different default initrc depending on if we're running "in-tree" or not, but the code to detect if an executable was only available in `cmd/flux.c`. The `flux` command does export `FLUX_CONF_INTREE=1` if it detects it is running out of a build tree, but there are several potential problems with this approach -- including that `FLUX_CONF_INTREE` is set, but never unset. (Also I'm not sure if that env var would always be exported to flux-shell, e.g. if `--standalone` is used)

This PR abstracts the in-tree detection into `libutil/intree.c`, including two new functions:
```C
int executable_is_intree (void);
const char *executable_selfdir (void);
```

The algorithm for `executable_is_intree()` is slightly different here. To allow in-tree detection to work with any executable, instead of comparing expected directories directly (and thereby requiring the directory for every executable be stored in the "conf" table), this version just checks to see if the `executable_selfdir()` is a subdirectory of the `$abs_top_builddir`. In theory, this should work for any executable run from under the build directory, including flux-broker, flux-shell, and all other flux commands.

Additionally, the new code only computes results on the first call, since both the intree value and executable directory obviously will not change. Since the calls may now be made from broker modules, the critical sections and memoized results are protected by a mutex (since it seems flux commands are already linked with libpthread anyway)

Finally, users of `FLUX_CONF_INTREE` were converted to use `executable_is_intree()` and the `FLUX_CONF_INTREE` environment variable is now removed.