### PR TITLE
job-info: Support GUEST_EVENTLOG_WAITCREATE flag

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -179,19 +179,21 @@ Specify an alternate namespace to retrieve from via '-N'.  If '-o' is
 specified, display the namespace owner.  If '-s' is specified, display
 the root sequence number.
 
-*eventlog get* [-w] [-c count] [-u] 'key'::
+*eventlog get* [-N ns] [-w] [-c count] [-u] 'key'::
 Display the contents of an RFC 18 KVS eventlog referred to by 'key'.
 If '-u' is specified, display the log in raw form.  If '-w' is
 specified, after the existing contents have been displayed, the
 eventlog is monitored and updates are displayed as they are committed.
 This runs until the program is interrupted or an error occurs, unless
-the number of events is limited with the '-c' option.
+the number of events is limited with the '-c' option.  Specify an
+alternate namespace to display from via '-N'.
 
-*eventlog append* [-t SECONDS] 'key' 'name' ['context ...']::
+*eventlog append* [-N ns] [-t SECONDS] 'key' 'name' ['context ...']::
 Append an event to an RFC 18 KVS eventlog referred to by 'key'.
 The event 'name' and optional 'context' are specified on the command line.
 The timestamp may optionally be specified with '-t' as decimal seconds since
 the UNIX epoch (UTC), otherwise the current wall clock is used.
+Specify an alternate namespace to append to via '-N'.
 
 AUTHOR
 ------

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -943,7 +943,7 @@ void print_output (struct attach_ctx *ctx)
 {
     flux_future_t *f;
 
-    if (!(f = flux_job_event_watch (ctx->h, ctx->id, "guest.output")))
+    if (!(f = flux_job_event_watch (ctx->h, ctx->id, "guest.output", 0)))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (f, -1., print_output_continuation, ctx) < 0)
         log_err_exit ("flux_future_then");
@@ -973,7 +973,7 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     if (!(r = flux_get_reactor (ctx.h)))
         log_err_exit ("flux_get_reactor");
 
-    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id, "eventlog")))
+    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id, "eventlog", 0)))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (ctx.f, -1, attach_event_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");
@@ -1438,7 +1438,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
         *ctx.context_value++ = '\0';
     }
 
-    if (!(f = flux_job_event_watch (h, ctx.id, ctx.path)))
+    if (!(f = flux_job_event_watch (h, ctx.id, ctx.path, 0)))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (f, ctx.timeout, wait_event_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -289,7 +289,7 @@ int flux_job_kvs_namespace (char *buf, int bufsz, flux_jobid_t id)
 }
 
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
-                                     const char *path)
+                                     const char *path, int flags)
 {
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
@@ -306,9 +306,10 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
         guest = true;
     }
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
-                             "{s:I s:s}",
+                             "{s:I s:s s:i}",
                              "id", id,
-                             "path", path)))
+                             "path", path,
+                             "flags", flags)))
         return NULL;
     if (guest) {
         /* value not relevant, set to anything */

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -294,9 +294,10 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
+    int ok_flags = FLUX_JOB_INFO_GUEST_EVENTLOG_WAITCREATE;
     bool guest = false;
 
-    if (!h || !path) {
+    if (!h || !path || (flags & ~ok_flags)) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -123,7 +123,7 @@ int flux_job_kvs_namespace (char *buf,
  * - path specifies optional alternate eventlog path
  */
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
-                                     const char *path);
+                                     const char *path, int flags);
 int flux_job_event_watch_get (flux_future_t *f, const char **event);
 int flux_job_event_watch_cancel (flux_future_t *f);
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -24,6 +24,14 @@ enum job_submit_flags {
     FLUX_JOB_DEBUG = 2,
 };
 
+/* GUEST_EVENTLOG_WAITCREATE - Only in a guest KVS namespace, if an
+ * eventlog has not yet been created, wait for it to be created
+ * instead of returning ENOENT.
+ */
+enum job_info_flags {
+    FLUX_JOB_INFO_GUEST_EVENTLOG_WAITCREATE = 1,
+};
+
 enum job_priority {
     FLUX_JOB_PRIORITY_MIN = 0,
     FLUX_JOB_PRIORITY_DEFAULT = 16,

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -159,7 +159,7 @@ void check_corner_case (void)
     /* flux_job_eventlog_watch */
 
     errno = 0;
-    ok (!flux_job_event_watch (NULL, 0, NULL)
+    ok (!flux_job_event_watch (NULL, 0, NULL, 0)
         && errno == EINVAL,
         "flux_job_event_watch fails with EINVAL on bad input");
 

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -405,6 +405,7 @@ done:
 static int wait_guest_namespace (struct guest_watch_ctx *gw)
 {
     const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
     flux_msg_t *msg = NULL;
     int save_errno, rv = -1;
 
@@ -418,7 +419,7 @@ static int wait_guest_namespace (struct guest_watch_ctx *gw)
     if (!(gw->wait_guest_namespace_f = flux_rpc_message (gw->ctx->h,
                                                          msg,
                                                          FLUX_NODEID_ANY,
-                                                         FLUX_RPC_STREAMING))) {
+                                                         rpc_flags))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }
@@ -547,13 +548,14 @@ error:
 
 static int guest_namespace_watch (struct guest_watch_ctx *gw)
 {
+    const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
     flux_msg_t *msg = NULL;
-    int flags = FLUX_RPC_STREAMING;
     int save_errno;
     int rv = -1;
 
     if (!(msg = guest_msg_pack (gw,
-                                "job-info.eventlog-watch",
+                                topic,
                                 "{s:I s:b s:s}",
                                 "id", gw->id,
                                 "guest", true,
@@ -563,7 +565,7 @@ static int guest_namespace_watch (struct guest_watch_ctx *gw)
     if (!(gw->guest_namespace_watch_f = flux_rpc_message (gw->ctx->h,
                                                           msg,
                                                           FLUX_NODEID_ANY,
-                                                          flags))) {
+                                                          rpc_flags))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }
@@ -666,8 +668,9 @@ error:
 
 static int main_namespace_watch (struct guest_watch_ctx *gw)
 {
+    const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
     flux_msg_t *msg = NULL;
-    int flags = FLUX_RPC_STREAMING;
     int save_errno;
     int rv = -1;
     char path[64];
@@ -681,7 +684,7 @@ static int main_namespace_watch (struct guest_watch_ctx *gw)
     }
 
     if (!(msg = guest_msg_pack (gw,
-                                "job-info.eventlog-watch",
+                                topic,
                                 "{s:I s:b s:s}",
                                 "id", gw->id,
                                 "guest", false,
@@ -691,7 +694,7 @@ static int main_namespace_watch (struct guest_watch_ctx *gw)
     if (!(gw->main_namespace_watch_f = flux_rpc_message (gw->ctx->h,
                                                          msg,
                                                          FLUX_NODEID_ANY,
-                                                         flags))) {
+                                                         rpc_flags))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -554,9 +554,13 @@ static int guest_namespace_watch (struct guest_watch_ctx *gw)
 {
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
+    int watch_flags = 0;
     flux_msg_t *msg = NULL;
     int save_errno;
     int rv = -1;
+
+    if (gw->flags & FLUX_JOB_INFO_GUEST_EVENTLOG_WAITCREATE)
+        watch_flags = FLUX_JOB_INFO_GUEST_EVENTLOG_WAITCREATE;
 
     if (!(msg = guest_msg_pack (gw,
                                 topic,
@@ -564,7 +568,7 @@ static int guest_namespace_watch (struct guest_watch_ctx *gw)
                                 "id", gw->id,
                                 "guest", true,
                                 "path", gw->path,
-                                "flags", 0)))
+                                "flags", watch_flags)))
         goto error;
 
     if (!(gw->guest_namespace_watch_f = flux_rpc_message (gw->ctx->h,

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -66,6 +66,7 @@ struct guest_watch_ctx {
     uint32_t msg_userid;
     flux_jobid_t id;
     char *path;
+    int flags;
     bool cancel;
 
     /* transition possibilities
@@ -139,7 +140,8 @@ static void guest_watch_ctx_destroy (void *data)
 static struct guest_watch_ctx *guest_watch_ctx_create (struct info_ctx *ctx,
                                                        const flux_msg_t *msg,
                                                        flux_jobid_t id,
-                                                       const char *path)
+                                                       const char *path,
+                                                       int flags)
 {
     struct guest_watch_ctx *gw = calloc (1, sizeof (*gw));
     int saved_errno;
@@ -153,6 +155,7 @@ static struct guest_watch_ctx *guest_watch_ctx_create (struct info_ctx *ctx,
         errno = ENOMEM;
         goto error;
     }
+    gw->flags = flags;
     gw->state = GUEST_WATCH_STATE_INIT;
 
     gw->msg = flux_msg_incref (msg);
@@ -411,9 +414,10 @@ static int wait_guest_namespace (struct guest_watch_ctx *gw)
 
     if (!(msg = guest_msg_pack (gw,
                                 topic,
-                                "{s:I s:s}",
+                                "{s:I s:s s:i}",
                                 "id", gw->id,
-                                "path", "eventlog")))
+                                "path", "eventlog",
+                                "flags", 0)))
         goto error;
 
     if (!(gw->wait_guest_namespace_f = flux_rpc_message (gw->ctx->h,
@@ -556,10 +560,11 @@ static int guest_namespace_watch (struct guest_watch_ctx *gw)
 
     if (!(msg = guest_msg_pack (gw,
                                 topic,
-                                "{s:I s:b s:s}",
+                                "{s:I s:b s:s s:i}",
                                 "id", gw->id,
                                 "guest", true,
-                                "path", gw->path)))
+                                "path", gw->path,
+                                "flags", 0)))
         goto error;
 
     if (!(gw->guest_namespace_watch_f = flux_rpc_message (gw->ctx->h,
@@ -685,10 +690,11 @@ static int main_namespace_watch (struct guest_watch_ctx *gw)
 
     if (!(msg = guest_msg_pack (gw,
                                 topic,
-                                "{s:I s:b s:s}",
+                                "{s:I s:b s:s s:i}",
                                 "id", gw->id,
                                 "guest", false,
-                                "path", path)))
+                                "path", path,
+                                "flags", 0)))
         goto error;
 
     if (!(gw->main_namespace_watch_f = flux_rpc_message (gw->ctx->h,
@@ -762,11 +768,13 @@ void guest_watch_cb (flux_t *h, flux_msg_handler_t *mh,
     struct guest_watch_ctx *gw = NULL;
     flux_jobid_t id;
     const char *path = NULL;
+    int flags;
     const char *errmsg = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:I s:s}",
+    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
                              "id", &id,
-                             "path", &path) < 0) {
+                             "path", &path,
+                             "flags", &flags) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         goto error;
     }
@@ -777,7 +785,7 @@ void guest_watch_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(gw = guest_watch_ctx_create (ctx, msg, id, path)))
+    if (!(gw = guest_watch_ctx_create (ctx, msg, id, path, flags)))
         goto error;
 
     if (get_main_eventlog (gw) < 0)

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -123,6 +123,8 @@ static int watch_key (struct watch_ctx *w)
                             __FUNCTION__);
             return -1;
         }
+        if (w->flags & FLUX_JOB_INFO_GUEST_EVENTLOG_WAITCREATE)
+            flags |= FLUX_KVS_WAITCREATE;
         nsptr = ns;
         pathptr = w->path;
     }

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -57,4 +57,14 @@ test_expect_success 'flux kvs eventlog append fails with invalid context' '
 	! flux kvs eventlog append test.c foo not_a_object
 '
 
+test_expect_success 'flux kvs eventlog append and work on alternate namespaces' '
+        flux kvs namespace create EVENTLOGTESTNS &&
+        flux kvs eventlog append test.ns main &&
+        flux kvs eventlog append --namespace=EVENTLOGTESTNS test.ns guest &&
+        flux kvs eventlog get test.ns > get_f1.out &&
+        grep main get_f1.out &&
+        flux kvs eventlog get --namespace=EVENTLOGTESTNS test.ns > get_f2.out &&
+        grep guest get_f2.out
+'
+
 test_done

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -357,7 +357,7 @@ test_expect_success 'job-info: generate jobspec to consume all resources' '
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (wait job)' '
         jobidall=$(submit_job_live test-all.json)
         jobid=$(submit_job_wait)
-        flux job wait-event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path6.out &
+        flux job wait-event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path4.out &
         waitpid=$! &&
         wait_watchers_nonzero "watchers" &&
         wait_watchers_nonzero "guest_watchers" &&
@@ -367,7 +367,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
         wait_watcherscount_nonzero $guestns &&
         flux job cancel ${jobid} &&
         wait $waitpid &&
-        grep done wait_event_path6.out
+        grep done wait_event_path4.out
 '
 
 test_expect_success 'flux job wait-event -p hangs on no event (wait job)' '


### PR DESCRIPTION
Support a new flag to job-info which I call GUEST_EVENTLOG_WAITCREATE.  It waits for eventlog creation, but only in eventlogs in the guest namespace.  The reason is b/c waiting for eventlog creation doesn't make much sense in the main namespace.

- Perhaps doesn't need to be known by the user?  Could just call this "WAITCREATE" and hide details from user?  But the behavior would be a tad different than WAITCREATE in the KVS.  Maybe I should call this option a different name?

- In order to write tests, had to along the way add `--namespace` support to `flux kvs eventlog` commands.