### PR TITLE
libflux: add simple plugin interface

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -77,7 +77,8 @@ fluxcoreinclude_HEADERS = \
 	future.h \
 	barrier.h \
 	buffer.h \
-	service.h
+	service.h \
+	plugin.h
 
 nodist_fluxcoreinclude_HEADERS = \
 	version.h
@@ -117,7 +118,8 @@ libflux_la_SOURCES = \
 	buffer_private.h \
 	buffer.c \
 	service.c \
-	version.c
+	version.c \
+	plugin.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -149,7 +149,8 @@ TESTS = test_message.t \
 	test_rpc_security.t \
 	test_panic.t \
 	test_attr.t \
-	test_module.t
+	test_module.t \
+	test_plugin.t
 
 test_ldadd = \
 	$(builddir)/test/libtestutil.la \
@@ -168,7 +169,8 @@ test_cppflags = \
 check_LTLIBRARIES = \
 	test/libtestutil.la \
 	test/module_fake1.la \
-	test/module_fake2.la
+	test/module_fake2.la \
+	test/plugin_foo.la
 
 
 test_libtestutil_la_SOURCES = \
@@ -280,3 +282,12 @@ test_module_fake1_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
 test_module_fake2_la_SOURCES = test/module_fake2.c
 test_module_fake2_la_CPPFLAGS = $(test_cppflags)
 test_module_fake2_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
+
+test_plugin_t_SOURCES = test/plugin.c
+test_plugin_t_CPPFLAGS = $(test_cppflags)
+test_plugin_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_plugin_foo_la_SOURCES = test/plugin_foo.c
+test_plugin_foo_la_CPPFLAGS = $(test_cppflags)
+test_plugin_foo_la_LDFLAGS = -module -rpath /nowhere
+test_plugin_foo_la_LIBADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -35,6 +35,7 @@
 #include "buffer.h"
 #include "service.h"
 #include "version.h"
+#include "plugin.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -1,0 +1,471 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <fnmatch.h>
+#include <dlfcn.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/aux.h"
+
+#include "plugin.h"
+
+struct flux_plugin {
+    char *path;
+    char *name;
+    json_t *conf;
+    struct aux_item *aux;
+    void *dso;
+    zlistx_t *handlers;
+    char last_error [128];
+};
+
+struct flux_plugin_arg {
+    json_error_t error;
+    json_t * in;
+    json_t * out;
+};
+
+typedef const struct flux_plugin_handler *
+        (*find_handler_f) (flux_plugin_t *p, const char *topic);
+
+static void flux_plugin_handler_destroy (struct flux_plugin_handler *h)
+{
+    if (h) {
+        free (h->topic);
+        free (h);
+    }
+}
+
+static void handler_free (void **item)
+{
+    if (*item) {
+        struct flux_plugin_handler *h = *item;
+        flux_plugin_handler_destroy (h);
+        *item = NULL;
+    }
+}
+
+static const struct flux_plugin_handler * find_handler (flux_plugin_t *p,
+                                                        const char *string)
+{
+    struct flux_plugin_handler *h = zlistx_first (p->handlers);
+    while (h) {
+        if (strcmp (h->topic, string) == 0)
+            return h;
+        h = zlistx_next (p->handlers);
+    }
+    return NULL;
+}
+
+static const struct flux_plugin_handler * match_handler (flux_plugin_t *p,
+                                                         const char *string)
+{
+    struct flux_plugin_handler *h = zlistx_first (p->handlers);
+    while (h) {
+        if (fnmatch (h->topic, string, 0) == 0)
+            return h;
+        h = zlistx_next (p->handlers);
+    }
+    return NULL;
+}
+
+static struct flux_plugin_handler *
+flux_plugin_handler_create (const char *topic, flux_plugin_f cb, void *arg)
+{
+    struct flux_plugin_handler *h = calloc (1, sizeof (*h));
+    if (!h || !(h->topic = strdup (topic)))
+        goto error;
+    h->cb = cb;
+    h->data = arg;
+    return (h);
+error:
+    flux_plugin_handler_destroy (h);
+    return NULL;
+}
+
+void flux_plugin_destroy (flux_plugin_t *p)
+{
+    if (p) {
+        int saved_errno = errno;
+        json_decref (p->conf);
+        zlistx_destroy (&p->handlers);
+        free (p->path);
+        free (p->name);
+        aux_destroy (&p->aux);
+        if (p->dso)
+            dlclose (p->dso);
+        free (p);
+        errno = saved_errno;
+    }
+}
+
+static int plugin_seterror (flux_plugin_t *p, int errnum, const char *fmt, ...)
+{
+    if (p && fmt) {
+        va_list ap;
+        va_start (ap, fmt);
+        vsnprintf (p->last_error, sizeof (p->last_error), fmt, ap);
+        va_end (ap);
+    }
+    else if (p) {
+        snprintf (p->last_error,
+                  sizeof (p->last_error),
+                  "%s", strerror (errno));
+    }
+    errno = errnum;
+    return -1;
+}
+
+static inline void plugin_error_clear (flux_plugin_t *p)
+{
+    if (p)
+        p->last_error [0] = '\0';
+}
+
+flux_plugin_t *flux_plugin_create (void)
+{
+    flux_plugin_t *p = calloc (1, sizeof (*p));
+    if (!p || !(p->handlers = zlistx_new ())) {
+        flux_plugin_destroy (p);
+        return NULL;
+    }
+    zlistx_set_destructor (p->handlers, handler_free);
+    return p;
+}
+
+int flux_plugin_set_name (flux_plugin_t *p, const char *name)
+{
+    char *new = NULL;
+    plugin_error_clear (p);
+    if (!p || !name)
+        return plugin_seterror (p, EINVAL, NULL);
+    if (!(new = strdup (name)))
+        return -1;
+    free (p->name);
+    p->name = new;
+    return 0;
+}
+
+const char * flux_plugin_get_name (flux_plugin_t *p)
+{
+    plugin_error_clear (p);
+    if (!p) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return p->name;
+}
+
+int flux_plugin_aux_set (flux_plugin_t *p, const char *key,
+                         void *val, aux_free_f free_fn)
+{
+    return aux_set (&p->aux, key, val, free_fn);
+}
+
+void *flux_plugin_aux_get (flux_plugin_t *p, const char *key)
+{
+    return aux_get (p->aux, key);
+}
+
+const char *flux_plugin_strerror (flux_plugin_t *p)
+{
+    return p->last_error;
+}
+
+int flux_plugin_load_dso (flux_plugin_t *p, const char *path)
+{
+    flux_plugin_init_f init;
+    plugin_error_clear (p);
+    if (!p || !path)
+        return plugin_seterror (p, EINVAL, NULL);
+    if (access (path, R_OK) < 0)
+        return plugin_seterror (p, errno, "%s: %s", path, strerror (errno));
+    dlerror ();
+    if (!(p->dso = dlopen (path, RTLD_LAZY|RTLD_LOCAL|FLUX_DEEPBIND)))
+        return plugin_seterror (p, errno, "dlopen: %s", dlerror ());
+
+    free (p->path);
+    free (p->name);
+    if (!(p->path = strdup (path)) || !(p->name = strdup (path)))
+        return plugin_seterror (p, ENOMEM, NULL);
+
+    if ((init = dlsym (p->dso, "flux_plugin_init")))
+        return (*init) (p);
+    return 0;
+}
+
+int flux_plugin_set_conf (flux_plugin_t *p, const char *json_str)
+{
+    json_error_t err;
+    plugin_error_clear (p);
+    if (!p || !json_str)
+        return plugin_seterror (p, EINVAL, NULL);
+    if (!(p->conf = json_loads (json_str, 0, &err))) {
+        return plugin_seterror (p, errno,
+                                "parse error: col %d: %s",
+                                 err.column, err.text);
+    }
+    return 0;
+}
+
+int flux_plugin_conf_unpack (flux_plugin_t *p, const char *fmt, ...)
+{
+    json_error_t err;
+    va_list ap;
+    int rc;
+    plugin_error_clear (p);
+    if (!p || !fmt)
+        return plugin_seterror (p, EINVAL, NULL);
+    if (!p->conf)
+        return plugin_seterror (p, ENOENT, "No plugin conf set");
+    va_start (ap, fmt);
+    rc = json_vunpack_ex (p->conf, &err, 0, fmt, ap);
+    va_end (ap);
+    if (rc < 0)
+        return plugin_seterror (p, errno, "unpack error: %s", err.text);
+    return rc;
+}
+
+int flux_plugin_remove_handler (flux_plugin_t *p,
+                                const char *topic)
+{
+    plugin_error_clear (p);
+    if (!p || !topic)
+        return plugin_seterror (p, EINVAL, NULL);
+    if (find_handler (p, topic)) {
+        if (zlistx_delete (p->handlers, zlistx_cursor (p->handlers)) < 0)
+            return plugin_seterror (p, errno, NULL);
+    }
+    return 0;
+}
+
+static flux_plugin_f get_handler (flux_plugin_t *p,
+                                  const char *topic,
+                                  find_handler_f fn)
+{
+    const struct flux_plugin_handler *h;
+    plugin_error_clear (p);
+    if (!p || !topic) {
+        plugin_seterror (p, EINVAL, NULL);
+        return NULL;
+    }
+    if ((h = (*fn) (p, topic)))
+        return h->cb;
+    return NULL;
+}
+
+flux_plugin_f flux_plugin_get_handler (flux_plugin_t *p, const char *topic)
+{
+    return get_handler (p, topic, find_handler);
+}
+
+flux_plugin_f flux_plugin_match_handler (flux_plugin_t *p, const char *topic)
+{
+    return get_handler (p, topic, match_handler);
+}
+
+
+int flux_plugin_add_handler (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_f cb,
+                             void *arg)
+{
+    struct flux_plugin_handler *h = NULL;
+    plugin_error_clear (p);
+    if (!p || !topic)
+        return plugin_seterror (p, EINVAL, NULL);
+
+    if (!cb)
+        return flux_plugin_remove_handler (p, topic);
+
+    if (!(h = flux_plugin_handler_create (topic, cb, arg)))
+        return plugin_seterror (p, errno, NULL);
+
+    if (!(zlistx_add_end (p->handlers, h))) {
+        flux_plugin_handler_destroy (h);
+        return plugin_seterror (p, errno, NULL);
+    }
+
+    return 0;
+}
+
+int flux_plugin_register (flux_plugin_t *p,
+                          const char *name,
+                          const struct flux_plugin_handler t[])
+{
+    plugin_error_clear (p);
+    if (!p || !t)
+        return plugin_seterror (p, EINVAL, NULL);
+    if (name && flux_plugin_set_name (p, name))
+        return -1;
+    while (t->topic) {
+        if (flux_plugin_add_handler (p, t->topic, t->cb, t->data) < 0)
+            return -1;
+        t++;
+    }
+    return 0;
+}
+
+static int arg_seterror (flux_plugin_arg_t *arg, int errnum,
+                         const char *fmt, ...)
+{
+    if (fmt) {
+        va_list ap;
+        va_start (ap, fmt);
+        vsnprintf (arg->error.text, sizeof (arg->error.text), fmt, ap);
+        va_end (ap);
+    } else if (arg) {
+        snprintf (arg->error.text,
+                  sizeof (arg->error.text),
+                  "%s", strerror (errno));
+    }
+    errno = errnum;
+    return -1;
+}
+
+static inline void arg_clear_error (flux_plugin_arg_t *arg)
+{
+    if (arg)
+        arg->error.text[0] = '\0';
+}
+
+const char *flux_plugin_arg_strerror (flux_plugin_arg_t *args)
+{
+    if (!args)
+        return strerror (errno);
+    return args->error.text;
+}
+
+void flux_plugin_arg_destroy (flux_plugin_arg_t *args)
+{
+    if (args) {
+        json_decref (args->in);
+        json_decref (args->out);
+        free (args);
+    }
+}
+
+flux_plugin_arg_t *flux_plugin_arg_create (void)
+{
+    flux_plugin_arg_t *args = calloc (1, sizeof (*args));
+    return args;
+}
+
+static json_t **arg_get (flux_plugin_arg_t *args, int flags)
+{
+    return ((flags & FLUX_PLUGIN_ARG_OUT) ? &args->out : &args->in);
+}
+
+static int arg_set (flux_plugin_arg_t *args, int flags, json_t *o)
+{
+    json_t **dstp;
+    dstp = arg_get (args, flags);
+    json_decref (*dstp);
+    *dstp = o;
+    return 0;
+}
+
+int flux_plugin_arg_set (flux_plugin_arg_t *args, int flags,
+                         const char *json_str)
+{
+    json_t *o = NULL;
+    arg_clear_error (args);
+    if (!args)
+        return arg_seterror (args, EINVAL, NULL);
+    if (json_str && !(o = json_loads (json_str, 0, &args->error)))
+        return -1;
+    return arg_set (args, flags, o);
+}
+
+int flux_plugin_arg_get (flux_plugin_arg_t *args, int flags, char **json_str)
+{
+    json_t **op;
+    arg_clear_error (args);
+    if (!args || !json_str)
+        return arg_seterror (args, EINVAL, NULL);
+    op = arg_get (args, flags);
+    if (*op == NULL)
+        return arg_seterror (args, ENOENT, "No args currently set");
+    *json_str = json_dumps (*op, JSON_COMPACT);
+    return 0;
+}
+
+int flux_plugin_arg_vpack (flux_plugin_arg_t *args, int flags,
+                           const char *fmt, va_list ap)
+{
+    json_t *o;
+    arg_clear_error (args);
+    if (!args || !fmt)
+        return arg_seterror (args, EINVAL, NULL);
+    if (!(o = json_vpack_ex (&args->error, 0, fmt, ap)))
+        return -1;
+    return arg_set (args, flags, o);
+}
+
+int flux_plugin_arg_pack (flux_plugin_arg_t *args, int flags,
+                          const char *fmt, ...)
+{
+    int rc;
+    va_list ap;
+    va_start (ap, fmt);
+    rc = flux_plugin_arg_vpack (args, flags, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
+                             const char *fmt, va_list ap)
+{
+    json_t **op;
+    arg_clear_error (args);
+    if (!fmt || !args)
+        return arg_seterror (args, EINVAL, NULL);
+    op = arg_get (args, flags);
+    return json_vunpack_ex (*op, &args->error, 0, fmt, ap);
+}
+
+int flux_plugin_arg_unpack (flux_plugin_arg_t *args, int flags,
+                            const char *fmt, ...)
+{
+    int rc;
+    va_list ap;
+    va_start (ap, fmt);
+    rc = flux_plugin_arg_vunpack (args, flags, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+int flux_plugin_call (flux_plugin_t *p, const char *string,
+                      flux_plugin_arg_t *args)
+{
+    const struct flux_plugin_handler *h = NULL;
+    plugin_error_clear (p);
+    if (!p || !string)
+        return plugin_seterror (p, EINVAL, NULL);
+    h = match_handler (p, string);
+    if (!h)
+        return 0;
+    assert (h->cb);
+    return (*h->cb) (p, string, args, h->data);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -1,0 +1,167 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_CORE_PLUGIN_H
+#define FLUX_CORE_PLUGIN_H
+
+#include <flux/core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct flux_plugin flux_plugin_t;
+typedef struct flux_plugin_arg flux_plugin_arg_t;
+
+typedef int (*flux_plugin_f) (flux_plugin_t *p,
+                              const char *topic,
+                              flux_plugin_arg_t *args,
+                              void *data);
+
+typedef int (*flux_plugin_init_f) (flux_plugin_t *p);
+
+struct flux_plugin_handler {
+    char *topic;
+    flux_plugin_f cb;
+    void *data;
+};
+
+/*  Create and destroy a flux_plugin_t handle
+ */
+flux_plugin_t * flux_plugin_create (void);
+void flux_plugin_destroy (flux_plugin_t *p);
+
+/*  Returns the last error from a plugin. Only valid if
+ *   the last call returned an error.
+ */
+const char * flux_plugin_strerror (flux_plugin_t *p);
+
+/*  Set a name for plugin 'p'. Overrides any existing name.
+ */
+int flux_plugin_set_name (flux_plugin_t *p, const char *name);
+
+const char * flux_plugin_get_name (flux_plugin_t *p);
+
+/*  Add a handler for topic 'topic' for the plugin 'p'.
+ *  The topic string may be a glob to cause 'cb' to be invoked for
+ *  a set of topic strings called by the host.
+ */
+int flux_plugin_add_handler (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_f cb,
+                             void *arg);
+
+/*  Remove handler associated with exact topic glob `topic`
+ */
+int flux_plugin_remove_handler (flux_plugin_t *p, const char *topic);
+
+/*  Return handler that exactly matches topic glob `topic`.
+ */
+flux_plugin_f flux_plugin_get_handler (flux_plugin_t *p, const char *topic);
+
+/*  Return handler that would match topic string `topic`, i.e. return
+ *   the first handler in the list of handlers which would match topic
+ *   string.
+ */
+flux_plugin_f flux_plugin_match_handler (flux_plugin_t *p, const char *topic);
+
+/*  Convenience function to register a table of handlers along with
+ *   a plugin name for the plugin 'p'.
+ */
+int flux_plugin_register (flux_plugin_t *p,
+                          const char *name,
+                          const struct flux_plugin_handler t[]);
+
+/*  Associate auxillary data with the plugin handle 'p'. If free_fn is
+ *   set then this function will be called on the data at plugin
+ *   destruction.
+ *
+ *  If key == NULL, val != NULL, stores val for destruction, but it
+ *   cannot be retrieved with flux_plugin_aux_get ().
+ *  If key != NULL, val == NULL, destroys currently stored val.
+ *  For a duplicate key, current val is destroyed and new value stored.
+ */
+int flux_plugin_aux_set (flux_plugin_t *p,
+                         const char *key,
+                         void *val,
+                         flux_free_f free_fn);
+
+/*  Get current auxillary data under `key`.
+ */
+void * flux_plugin_aux_get (flux_plugin_t *p, const char *key);
+
+
+/*  Set optional JSON string as load-time config for plugin 'p'.
+ */
+int flux_plugin_set_conf (flux_plugin_t *p, const char *json_str);
+
+/*  Read configuration for plugin 'p' using jansson style unpack args */
+int flux_plugin_conf_unpack (flux_plugin_t *p, const char *fmt, ...);
+
+/*  Create/destroy containers for marshalling read-only arguments
+ *   and results between caller and plugin.
+ */
+flux_plugin_arg_t *flux_plugin_arg_create ();
+void flux_plugin_arg_destroy (flux_plugin_arg_t *args);
+
+const char *flux_plugin_arg_strerror (flux_plugin_arg_t *args);
+
+/*  Flags for flux_plugin_arg_get/set/pack/unpack
+ */
+enum {
+    FLUX_PLUGIN_ARG_IN =  0, /* Operate on input args  */
+    FLUX_PLUGIN_ARG_OUT = 1  /* Operate on output args */
+};
+
+/*  Get/set arguments in plugin arg object using JSON encoded strings
+ */
+int flux_plugin_arg_set (flux_plugin_arg_t *args,
+                         int flags,
+                         const char *json_str);
+int flux_plugin_arg_get (flux_plugin_arg_t *args,
+                         int flags,
+                         char **json_str);
+
+/*  Pack/unpack arguments into plugin arg object using jansson pack style args
+ */
+int flux_plugin_arg_pack (flux_plugin_arg_t *args, int flags,
+                          const char *fmt, ...);
+int flux_plugin_arg_vpack (flux_plugin_arg_t *args, int flags,
+                           const char *fmt, va_list ap);
+
+int flux_plugin_arg_unpack (flux_plugin_arg_t *args, int flags,
+                            const char *fmt, ...);
+int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
+                             const char *fmt, va_list ap);
+
+/*  Call first plugin callback matching 'name', passing optional plugin
+ *   arguments in 'args'.
+ */
+int flux_plugin_call (flux_plugin_t *p, const char *name,
+                      flux_plugin_arg_t *args);
+
+/*  Load a plugin from a shared object found in 'path'
+ *
+ *  Once the shared object is loaded, flux_plugin_init() is run from which
+ *   DSO should register itself.
+ *
+ *  Returns -1 on failure to load plugin, or failure of flux_plugin_init().
+ */
+int flux_plugin_load_dso (flux_plugin_t *p, const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !FLUX_CORE_PLUGIN_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -1,0 +1,415 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libflux/plugin.h"
+#include "src/common/libtap/tap.h"
+
+
+/* function prototype for invalid args testing below */
+static int foo (flux_plugin_t *p,
+                const char *topic,
+                flux_plugin_arg_t *args,
+                void *data)
+{
+    const char **sp = data;
+    return flux_plugin_arg_pack (args,
+                                 FLUX_PLUGIN_ARG_OUT,
+                                 "{s:s s:s}",
+                                 "fn", "foo",
+                                 "data", *sp);
+}
+
+static int bar (flux_plugin_t *p,
+                const char *topic,
+                flux_plugin_arg_t *args,
+                void *data)
+{
+    const char **sp = data;
+    return flux_plugin_arg_pack (args,
+                                 FLUX_PLUGIN_ARG_OUT,
+                                 "{s:s s:s}",
+                                 "fn", "bar",
+                                 "data", *sp);
+}
+
+static char *foodata = "this is foo";
+static char *bardata = "this is bar";
+
+static const struct flux_plugin_handler tab[] = {
+    { "foo.*", foo,  &foodata },
+    { "*",     bar,  &bardata },
+    { NULL,    NULL, NULL }
+};
+
+void test_invalid_args ()
+{
+    flux_plugin_t *p;
+    int i;
+
+    lives_ok ({flux_plugin_destroy (NULL);},
+              "flux_plugin_destroy (NULL) does not crash program");
+    if (!(p = flux_plugin_create ()))
+        BAIL_OUT ("flux_plugin_create failed");
+
+    ok (flux_plugin_set_name (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_set_name (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_set_name (p, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_set_name (p, NULL) returns EINVAL");
+
+    ok (flux_plugin_get_name (NULL) == NULL && errno == EINVAL,
+        "flux_plugin_get_name (NULL) returns EINVAL");
+
+    ok (flux_plugin_set_conf (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_set_conf (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_set_conf (p, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_set_conf (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_set_conf (p, "a") < 0 && errno == EINVAL,
+        "flux_plugin_set_conf (NULL, NULL) returns EINVAL");
+    like (flux_plugin_strerror (p), "^parse error: col 1:.*",
+        "flux_plugin_last_error returns error text");
+
+    ok (flux_plugin_conf_unpack (p, "{s:i}", "bar", &i) < 0 && errno == ENOENT,
+        "flux_plugin_conf_unpack () with no conf returns ENOENT");
+
+    ok (flux_plugin_set_conf (p, "{\"foo\":1, \"bar\":\"a\"}") == 0,
+        "flux_plugin_set_conf() works");
+
+    ok (flux_plugin_conf_unpack (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_conf_unpack (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_conf_unpack (p, NULL) < 0 && errno == EINVAL,
+        "flux_conf_unpack (p, NULL) returns EINVAL");
+
+    ok (flux_plugin_conf_unpack (p, "{s:i}", "bar", &i) < 0 && errno == EINVAL,
+        "flux_conf_unpack with wrong fmt (%s) got EINVAL",
+        flux_plugin_strerror (p), errno);
+
+    ok (flux_plugin_aux_set (p, NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_aux_set (p, NULL, NULL, NULL) returns EINVAL");
+    ok (flux_plugin_aux_get (p, NULL) == NULL && errno == EINVAL,
+        "flux_plugin_aux_get (p, NULL) returns EINVAL");
+    ok (flux_plugin_aux_get (p, "foo") == NULL && errno == ENOENT,
+        "flux_plugin_aux_get (p, 'foo') returns ENOENT");
+
+    ok (flux_plugin_add_handler (NULL, "foo.*", foo, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_add_handler (NULL, ...) returns EINVAL");
+    ok (flux_plugin_add_handler (p, NULL, foo, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_add_handler (p, NULL, foo) returns EINVAL");
+
+    ok (flux_plugin_remove_handler (NULL, "foo.*") < 0 && errno == EINVAL,
+        "flux_plugin_remove_handler (NULL, ...) returns EINVAL");
+    ok (flux_plugin_remove_handler (p, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_remove_handler (p, NULL) returns EINVAL");
+
+    ok (flux_plugin_register (NULL, NULL, tab) < 0 && errno == EINVAL,
+        "flux_plugin_add_handlers (NULL, NULL, t) fails with EINVAL");
+    ok (flux_plugin_register (p, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_add_handlers (p, NULL) fails with EINVAL");
+
+    ok (flux_plugin_get_handler (NULL, NULL) == NULL && errno == EINVAL,
+        "flux_plugin_get_handler (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_get_handler (p, NULL) == NULL && errno == EINVAL,
+        "flux_plugin_get_handler (p, NULL) returns EINVAL");
+    ok (flux_plugin_get_handler (NULL, "foo") == NULL && errno == EINVAL,
+        "flux_plugin_get_handler (NULL, 'foo') returns EINVAL");
+
+    ok (flux_plugin_match_handler (NULL, NULL) == NULL && errno == EINVAL,
+        "flux_plugin_match_handler (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_match_handler (p, NULL) == NULL && errno == EINVAL,
+        "flux_plugin_match_handler (p, NULL) returns EINVAL");
+    ok (flux_plugin_match_handler (NULL, "foo") == NULL && errno == EINVAL,
+        "flux_plugin_match_handler (NULL, 'foo') returns EINVAL");
+
+    ok (flux_plugin_load_dso (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_load_dso (NULL, NULL) returns EINVAL");
+    ok (flux_plugin_load_dso (p, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_load_dso (p, NULL) returns EINVAL");
+
+    flux_plugin_destroy (p);
+}
+
+void test_plugin_args ()
+{
+    flux_plugin_arg_t *args = flux_plugin_arg_create ();
+    char *s;
+    int arg;
+
+    if (!args)
+        BAIL_OUT ("flux_plugin_arg_create failed");
+
+    errno = EINVAL;
+    is (flux_plugin_arg_strerror (NULL), strerror (errno),
+        "flux_plugin_arg_strerror (NULL) defaults to strerror");
+
+    ok (flux_plugin_arg_get (NULL, 0, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_arg_get with NULL arg returns EINVAL");
+    ok (flux_plugin_arg_get (args, 0, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_arg_get with NULL string returns EINVAL");
+
+    ok (flux_plugin_arg_set (NULL, 0, NULL) < 0 && errno == EINVAL,
+        "flux_plugin_arg_set with NULL arg returns EINVAL");
+    ok (flux_plugin_arg_set (args, 0, NULL) == 0,
+        "flux_plugin_arg_set with NULL string returns success");
+
+    ok (flux_plugin_arg_get (args, 0, &s) < 0 && errno == ENOENT,
+        "flux_plugin_arg_get() returns ENOENT with no args set");
+    ok (flux_plugin_arg_get (args, FLUX_PLUGIN_ARG_OUT, &s) < 0
+        && errno == ENOENT,
+        "flux_plugin_arg_get() returns ENOENT with no args set");
+    is (flux_plugin_arg_strerror (args), "No args currently set",
+        "flux_plugin_arg_strerror returns 'No args currently set'");
+
+    /*  Test set
+     */
+    ok (flux_plugin_arg_set (args, FLUX_PLUGIN_ARG_IN, "{\"a\":5}") == 0,
+        "flux_plugin_arg_set works");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "a", &arg) == 0,
+        "flux_plugin_arg_unpack worked");
+    ok (arg == 5,
+        "flux_plugin_arg_unpack returned valid value for arg");
+
+    /*  Test pack
+     */
+    ok (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_IN,
+                              "{s:s s:i}",
+                              "string", "in",
+                              "int", 7) == 0,
+        "flux_plugin_arg_pack inargs works");
+    ok (flux_plugin_arg_get (args, FLUX_PLUGIN_ARG_IN, &s) == 0,
+        "flux_plugin_arg_get now returns success");
+    ok (s != NULL,
+        "flux_plugin_arg_get returned json str: %s", s);
+    free (s);
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "string", &arg) < 0,
+        "flux_plugin_arg_unpack detects bad format: errno = %d", errno);
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "int", &arg) == 0,
+        "flux_plugin_arg_unpack allows caller to get one arg");
+    ok (arg == 7,
+        "returned argument is valid");
+
+    ok (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
+                              "{s:s s:i}",
+                              "string", "out",
+                              "int", 8) == 0,
+        "flux_plugin_arg_pack outargs works");
+    ok (flux_plugin_arg_get (args, FLUX_PLUGIN_ARG_OUT, &s) == 0,
+        "flux_plugin_arg_get now returns success");
+    ok (s != NULL,
+        "flux_plugin_arg_get returned json str: %s", s);
+    free (s);
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:i}", "int", &arg) == 0,
+        "flux_plugin_arg_unpack allows caller to get one arg");
+    ok (arg == 8,
+        "returned argument is valid");
+
+    flux_plugin_arg_destroy (args);
+}
+
+/* Accumulate result of "add" or "multiply" in arg "a",
+ * result is "a" op "b".
+ */
+int op1 (flux_plugin_t *p, const char *topic,
+         flux_plugin_arg_t *args, void *data)
+{
+    int a, b;
+    if (flux_plugin_arg_unpack (args, 0, "{s:i s:i}", "a", &a, "b", &b) < 0)
+        return -1;
+    if (strcmp (topic, "op.add") == 0)
+        a += b;
+    else if (strcmp (topic, "op.multiply") == 0)
+        a *= b;
+    else {
+        errno = ENOTSUP;
+        return -1;
+    }
+    if (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT, "{s:i}", "a", a) < 0)
+        return -1;
+    return 0;
+}
+
+void test_basic ()
+{
+    int a, b;
+    flux_plugin_t *p = flux_plugin_create ();
+    flux_plugin_arg_t *args = flux_plugin_arg_create ();
+    if (!p || !args)
+        BAIL_OUT ("flux_plugin_{args_}create failed");
+
+    ok (flux_plugin_set_name (p, "op") == 0,
+        "flux_plugin_set_name works");
+    is (flux_plugin_get_name (p), "op",
+        "flux_plugin_get_name() works");
+
+    ok (flux_plugin_add_handler (p, "foo.*", NULL, NULL) == 0,
+        "flux_plugin_add_handler (p, 'foo.*', NULL) works");
+    ok (flux_plugin_get_handler (p, "foo.*") == NULL,
+        "flux_plugin_get_handler (p, 'foo.*') returns NULL");
+
+    ok (flux_plugin_add_handler (p, "op.*", op1, NULL) == 0,
+        "flux_plugin_add_handler() works");
+    ok (flux_plugin_get_handler (p, "op.*") == op1,
+        "flux_plugin_get_handler (p, 'op.*') returns op1");
+    ok (flux_plugin_match_handler (p, "op.add") == op1,
+        "flux_plugin_match_handler (p, 'op.add') returns op1");
+
+    a = 2;
+    b = 4;
+    ok (flux_plugin_arg_pack (args, 0, "{s:i s:i}", "a", a, "b", b) == 0,
+        "flux_plugin_arg_pack works");
+    ok (flux_plugin_call (p, "op.add", args) == 0,
+        "flux_plugin_call op.add works");
+
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:i}", "a", &a) == 0,
+        "flux_plugin_arg_unpack worked: %s", flux_plugin_arg_strerror (args));
+    ok (a == 6,
+        "callback with topic op.add worked");
+
+    a = 2;
+    ok (flux_plugin_arg_pack (args, 0, "{s:i s:i}", "a", a, "b", b) == 0,
+        "flux_plugin_arg_pack works");
+    ok (flux_plugin_call (p, "op.multiply", args) == 0,
+        "callback with topic op.multiply worked");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:i}", "a", &a) == 0,
+        "flux_plugin_arg_unpack worked");
+
+    ok (a == 8,
+        "callback with topic op.multiply worked");
+    ok (flux_plugin_call (p, "op.subtract", args) < 0 && errno == ENOTSUP,
+        "callback with topic op.subtract returned ENOTSUP");
+
+    ok (flux_plugin_call (p, "foo", args) == 0,
+        "callback with no match returns success and does nothing");
+
+    flux_plugin_arg_destroy (args);
+    flux_plugin_destroy (p);
+}
+
+void test_register ()
+{
+    const char *fn;
+    const char *data;
+
+    flux_plugin_t *p = flux_plugin_create ();
+    flux_plugin_arg_t *args = flux_plugin_arg_create ();
+    if (!args)
+        BAIL_OUT ("flux_plugin_arg_create()");
+    if (!p)
+        BAIL_OUT ("flux_plugin_create()");
+
+    /* Destroy args along with plugin object */
+    flux_plugin_aux_set (p, NULL, args, (flux_free_f) flux_plugin_arg_destroy);
+
+    ok (flux_plugin_register (p, "test_register", tab) == 0,
+        "flux_plugin_register 2 handlers works");
+    ok (flux_plugin_call (p, "foo.test", args) == 0,
+        "flux_plugin_call foo.test worked");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:s s:s}",
+                                 "fn", &fn,
+                                 "data", &data) == 0,
+        "flux_plugin_args_unpack result worked");
+    is (fn, "foo",
+        "flux_plugin_call foo.test called handler foo()");
+    is (data, foodata,
+        "flux_plugin_call passed correct void *data to foo()");
+
+    ok (flux_plugin_call (p, "fallthru", args) == 0,
+        "flux_plugin_call fallthru worked");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:s s:s}",
+                                 "fn", &fn,
+                                 "data", &data) == 0,
+        "flux_plugin_args_unpack result worked");
+    is (fn, "bar",
+        "flux_plugin_call 'fallthru' fell through to handler bar()");
+    is (data, bardata,
+        "handler bar() was passed correct void *data");
+
+    flux_plugin_destroy (p);
+}
+
+void test_load ()
+{
+    char *out;
+    const char *result;
+    flux_plugin_t *p = flux_plugin_create ();
+    if (!p)
+        BAIL_OUT ("flux_plugin_create");
+
+    ok (flux_plugin_load_dso (p, "/noexist") < 0 && errno == ENOENT,
+        "flux_plugin_load_dso on nonexistent path returns ENOENT");
+    is (flux_plugin_strerror (p), "/noexist: No such file or directory",
+        "flux_plugin_strerror returns expected result");
+    ok (flux_plugin_load_dso (p, "/tmp") < 0,
+        "flux_plugin_load_dso on directory fails");
+    like (flux_plugin_strerror (p), "^dlopen: .*Is a directory",
+        "flux_plugin_strerror returns expected result");
+
+    ok (flux_plugin_set_conf (p, "{\"foo\":\"bar\"}") == 0,
+        "flux_plugin_set_conf (): %s", flux_plugin_strerror (p));
+    ok (flux_plugin_load_dso (p, "test/.libs/plugin_foo.so") == 0,
+        "flux_plugin_load worked");
+    is (flux_plugin_get_name (p), "plugin-test",
+        "loaded dso registered its own name");
+
+    flux_plugin_arg_t *args = flux_plugin_arg_create ();
+    if (!args)
+        BAIL_OUT ("flux_plugin_arg_create failed");
+    ok (flux_plugin_call (p, "test.foo", args) == 0,
+        "flux_plugin_call (test.foo) success");
+    ok (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_OUT,
+                                "{s:s}",
+                                "result", &result) == 0,
+        "flux_plugin_args_unpack result");
+    is (result, "foo",
+        "call of test.foo set result foo");
+
+    result = NULL;
+    ok (flux_plugin_arg_get (args, FLUX_PLUGIN_ARG_OUT, &out) == 0,
+        "flux_plugin_arg_out works");
+    diag ("out = %s", out);
+    free (out);
+    ok (flux_plugin_call (p, "test.bar", args) == 0,
+        "flux_plugin_call (test.bar) success");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:s}", "result", &result) == 0,
+        "flux_plugin_args_unpack result");
+    is (result, "bar",
+        "call of test.bar set result bar");
+
+    flux_plugin_arg_destroy (args);
+    flux_plugin_destroy (p);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+    test_invalid_args ();
+    test_plugin_args ();
+    test_basic ();
+    test_register ();
+    test_load ();
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/test/plugin_foo.c
+++ b/src/common/libflux/test/plugin_foo.c
@@ -1,0 +1,45 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <flux/core.h>
+
+static int foo (flux_plugin_t *p,
+                const char *topic,
+                flux_plugin_arg_t *args,
+                void *data)
+{
+    return flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
+                                 "{s:s}", "result", "foo");
+}
+
+static int bar (flux_plugin_t *p,
+                const char *topic,
+                flux_plugin_arg_t *args,
+                void *data)
+{
+    return flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
+                                 "{s:s}", "result", "bar");
+}
+
+static const struct flux_plugin_handler tab []= {
+    { "test.foo", foo,  NULL },
+    { "test.bar", bar,  NULL },
+    { NULL,       NULL, NULL }
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, "plugin-test", tab) < 0)
+        return -1;
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR isn't meant for merging, but just to put up some code for discussion.

After trying several different approaches this simple `flux_plugin_t` class was factored out of the work on shell plugins. While working on that PR I ended up with a `flux_shell_plugin_t` class that seemed like it might be useful as a more generic interface, so I moved the code under libflux and propose it here before moving my other shell work on top of it.

I had started by resurrecting the "`flux_extensor_t`" work, but unfortunately didn't quite have the mental capacity at this point to get a universal solution like that going in the short time I needed to get the shell plugin work done.

There's a full description of this plugin interface design in 0e49922. At a high level, a `flux_plugin_t` object is a simple function dispatch service which, similar to flux message dispatcher, allows a plugin to "subscribe" to host program calls via a set of topic string globs dynamically registered by plugins or another entity on their behalf.

This approach simplifies a lot of things, including creation of statically built plugins, allowing plugins to load other plugins, and allowing plugins to call other plugins.

Identified tradeoffs include

 - extra overhead for every call
 - one size fits all callback signature means "arguments" have to be encapsulated

These two main caveats is why I'm sharing this code now. I don't want to convert shell plugins into this interface if it isn't acceptable for libflux. I also went back and forth on how to propagate callback "arguments", and ended up with the least clean, but most flexible method, a `flux_plugin_args_t` type (just a wrapper for an `struct aux_item`).

Another iteration I toyed with included no separate `flux_plugin_args_t` type, instead caller pushes args into a plugin before using `flux_plugin_call()` and removes them after the call. Plugins then use `void *flux_plugin_arg_get (flux_plugin_t *p, const char *name)` to get "arguments" directly.

Of course, there is also the original varargs-based implementation, which seemed kind of kludgy to me, but had a much cleaner interface for plugins themselves.