### PR TITLE
kvs-watch: Fix namespace exist / delete detection issue

### DIFF
--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -225,7 +225,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, create 
                   --pattern="0" waitcreate4.out >/dev/null &&
         flux kvs namespace remove ns_create_and_remove &&
         ! wait $pid &&
-        grep "Operation not supported" waitcreate4.out
+        grep "Stale file handle" waitcreate4.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt work on removed namespace' '
@@ -237,7 +237,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt 
         wait_watcherscount_nonzero ns_remove &&
         flux kvs namespace remove ns_remove &&
         ! wait $pid &&
-        grep "Operation not supported" waitcreate5.out
+        grep "Stale file handle" waitcreate5.out
 '
 
 #


### PR DESCRIPTION
As I discussed in issue #2355 / #2356, there was an issue in the job-info module where the behavior was inconsistent while watching an eventlog in the guest KVS namespace.

- When we get the "start" state in the main eventlog, we know the guest KVS namespace has been created.

- scenario 1: We issue watch of eventlog in guest namespace, but the guest namespace has been deleted before we issue the watch.  We get an ENOTSUP errno.  This is no big deal, we'll transition to watch the guest eventlog in the primary KVS.

- scenario 2: Guest namespace is alive and well, but the eventlog in the guest namespace has no entries in it.  Eventually the guest namespace gets deleted, and we get an ENOTSUP errno.  We should wait for the user to cancel the watch, after which we'll return ENODATA.

The ENOTSUP in scenario 1 and 2 are not differentiable, and there's no way to know the next state transition.

Previously, I made an assumption that if we read atleast 1 eventlog entry, then we can assume ENOTSUP means the namespace was deleted and we can follow scenario 2 above.  But this is not a good assumption to make.

So I've updated the `kvs-watch` module to return ESTALE when a namespace is being watched, then is deleted while watching it.  I picked ESTALE half randomly (vs ECANCELED).  It seemed a pretty good choice, but of course we could pick a different errno.

I then updated the job-info module to be smart about its state transitions.

I then also fixed up a potential racy corner case with job-info guest watch cancellations.

Also of note, while this issue was not that critical / important, the more critical fix for #2346 will end up affecting code in this area (possibly largely).  So I thought it important to hammer this one out first.
