### PR TITLE
misc cleanups & minor fixes

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -943,7 +943,7 @@ void print_output (struct attach_ctx *ctx)
 {
     flux_future_t *f;
 
-    if (!(f = flux_job_event_watch (ctx->h, ctx->id, "guest.output")))
+    if (!(f = flux_job_event_watch (ctx->h, ctx->id, "guest.output", 0)))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (f, -1., print_output_continuation, ctx) < 0)
         log_err_exit ("flux_future_then");
@@ -973,7 +973,7 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     if (!(r = flux_get_reactor (ctx.h)))
         log_err_exit ("flux_get_reactor");
 
-    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id, "eventlog")))
+    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id, "eventlog", 0)))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (ctx.f, -1, attach_event_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");
@@ -1438,7 +1438,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
         *ctx.context_value++ = '\0';
     }
 
-    if (!(f = flux_job_event_watch (h, ctx.id, ctx.path)))
+    if (!(f = flux_job_event_watch (h, ctx.id, ctx.path, 0)))
         log_err_exit ("flux_job_event_watch");
     if (flux_future_then (f, ctx.timeout, wait_event_continuation, &ctx) < 0)
         log_err_exit ("flux_future_then");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -930,8 +930,10 @@ void print_output_continuation (flux_future_t *f, void *arg)
     json_decref (o);
 
     if (ctx->stdout_eof_count >= ctx->stdout_count
-        && ctx->stderr_eof_count >= ctx->stderr_count)
-        goto done;
+        && ctx->stderr_eof_count >= ctx->stderr_count) {
+        if (flux_job_event_watch_cancel (f) < 0)
+            log_err_exit ("flux_job_event_watch_cancel");
+    }
 
     flux_future_reset (f);
     return;

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -747,6 +747,7 @@ struct attach_ctx {
     optparse_t *p;
     bool started;
     bool missing_output_ok;
+    bool output_header_parsed;
     int stdout_count;
     int stderr_count;
     int stdout_eof_count;
@@ -898,6 +899,7 @@ void print_output_continuation (flux_future_t *f, void *arg)
                          "stdout", &ctx->stdout_count,
                          "stderr", &ctx->stderr_count) < 0)
             log_msg_exit ("error parsing stream counts");
+        ctx->output_header_parsed = true;
     }
     else if (!strcmp (name, "data")) {
         FILE *fp;
@@ -907,6 +909,8 @@ void print_output_continuation (flux_future_t *f, void *arg)
         char *data;
         int len;
         bool eof;
+        if (!ctx->output_header_parsed)
+            log_msg_exit ("stream data read before header");
         if (iodecode (context, &stream, &rank, &data, &len, &eof) < 0)
             log_msg_exit ("malformed event context");
         if (!strcmp (stream, "stdout")) {

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -289,14 +289,15 @@ int flux_job_kvs_namespace (char *buf, int bufsz, flux_jobid_t id)
 }
 
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
-                                     const char *path)
+                                     const char *path, int flags)
 {
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
     bool guest = false;
 
-    if (!h || !path) {
+    /* No flags supported yet */
+    if (!h || !path || flags) {
         errno = EINVAL;
         return NULL;
     }
@@ -306,9 +307,10 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
         guest = true;
     }
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
-                             "{s:I s:s}",
+                             "{s:I s:s s:i}",
                              "id", id,
-                             "path", path)))
+                             "path", path,
+                             "flags", flags)))
         return NULL;
     if (guest) {
         /* value not relevant, set to anything */

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -123,7 +123,7 @@ int flux_job_kvs_namespace (char *buf,
  * - path specifies optional alternate eventlog path
  */
 flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
-                                     const char *path);
+                                     const char *path, int flags);
 int flux_job_event_watch_get (flux_future_t *f, const char **event);
 int flux_job_event_watch_cancel (flux_future_t *f);
 

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -159,7 +159,7 @@ void check_corner_case (void)
     /* flux_job_eventlog_watch */
 
     errno = 0;
-    ok (!flux_job_event_watch (NULL, 0, NULL)
+    ok (!flux_job_event_watch (NULL, 0, NULL, 0)
         && errno == EINVAL,
         "flux_job_event_watch fails with EINVAL on bad input");
 

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -603,10 +603,8 @@ static void guest_namespace_watch_continuation (flux_future_t *f, void *arg)
              *
              * Note that it is possible the guest eventlog is simply
              * empty / had no events in it.  There's no way to know
-             * for certain if it is this case or a race.  There is no
-             * behavior change for continuing to watch the eventlog in
-             * the main KVS namespace, so we do it and suffer the
-             * minor latency associated with it.
+             * for certain if it is this case or a race.  This is an
+             * unfortunate behavior difference.  Issue #2356.
              */
             gw->guest_namespace_removed = true;
             if (!gw->guest_namespace_events) {

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -405,6 +405,7 @@ done:
 static int wait_guest_namespace (struct guest_watch_ctx *gw)
 {
     const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
     flux_msg_t *msg = NULL;
     int save_errno, rv = -1;
 
@@ -418,7 +419,7 @@ static int wait_guest_namespace (struct guest_watch_ctx *gw)
     if (!(gw->wait_guest_namespace_f = flux_rpc_message (gw->ctx->h,
                                                          msg,
                                                          FLUX_NODEID_ANY,
-                                                         FLUX_RPC_STREAMING))) {
+                                                         rpc_flags))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }
@@ -547,13 +548,14 @@ error:
 
 static int guest_namespace_watch (struct guest_watch_ctx *gw)
 {
+    const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
     flux_msg_t *msg = NULL;
-    int flags = FLUX_RPC_STREAMING;
     int save_errno;
     int rv = -1;
 
     if (!(msg = guest_msg_pack (gw,
-                                "job-info.eventlog-watch",
+                                topic,
                                 "{s:I s:b s:s}",
                                 "id", gw->id,
                                 "guest", true,
@@ -563,7 +565,7 @@ static int guest_namespace_watch (struct guest_watch_ctx *gw)
     if (!(gw->guest_namespace_watch_f = flux_rpc_message (gw->ctx->h,
                                                           msg,
                                                           FLUX_NODEID_ANY,
-                                                          flags))) {
+                                                          rpc_flags))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }
@@ -666,8 +668,9 @@ error:
 
 static int main_namespace_watch (struct guest_watch_ctx *gw)
 {
+    const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
     flux_msg_t *msg = NULL;
-    int flags = FLUX_RPC_STREAMING;
     int save_errno;
     int rv = -1;
     char path[64];
@@ -681,7 +684,7 @@ static int main_namespace_watch (struct guest_watch_ctx *gw)
     }
 
     if (!(msg = guest_msg_pack (gw,
-                                "job-info.eventlog-watch",
+                                topic,
                                 "{s:I s:b s:s}",
                                 "id", gw->id,
                                 "guest", false,
@@ -691,7 +694,7 @@ static int main_namespace_watch (struct guest_watch_ctx *gw)
     if (!(gw->main_namespace_watch_f = flux_rpc_message (gw->ctx->h,
                                                          msg,
                                                          FLUX_NODEID_ANY,
-                                                         flags))) {
+                                                         rpc_flags))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -99,9 +99,9 @@ static void shell_output_control (struct shell_output *out, bool stop)
  * io->output is a JSON array of eventlog entries.
  */
 static void shell_output_write_cb (flux_t *h,
-                               flux_msg_handler_t *mh,
-                               const flux_msg_t *msg,
-                               void *arg)
+                                   flux_msg_handler_t *mh,
+                                   const flux_msg_t *msg,
+                                   void *arg)
 {
     struct shell_output *out = arg;
     bool eof = false;
@@ -150,11 +150,11 @@ static void shell_output_write_completion (flux_future_t *f, void *arg)
 }
 
 static int shell_output_write (struct shell_output *out,
-                           int rank,
-                           const char *stream,
-                           const char *data,
-                           int len,
-                           bool eof)
+                               int rank,
+                               const char *stream,
+                               const char *data,
+                               int len,
+                               bool eof)
 {
     flux_future_t *f = NULL;
     json_t *o = NULL;

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -26,11 +26,6 @@
  * Current working directory
  *    Ignore - shell should already be in it.
  *
- * Standard I/O
- *    Call shell_task_io_enable() to set up callbacks for stdio, stderr.
- *    The provided callback notifies shell when a line can be read from
- *    the channel.  Use flux_subprocess_read_line (task->proc, ...) to read it.
- *
  * Upon task completion, set task->rc and call shell_task_completion_f
  * supplied to shell task start.
  *

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -54,12 +54,6 @@ int shell_task_start (struct shell_task *task,
                       shell_task_completion_f cb,
                       void *arg);
 
-/* Call before task_start() to enable stdio capture.
- */
-int shell_task_io_enable (struct shell_task *task,
-                          shell_task_io_ready_f cb,
-                          void *arg);
-
 /* Send signal `signum` to shell task */
 int shell_task_kill (struct shell_task *task, int signum);
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -357,7 +357,7 @@ test_expect_success 'job-info: generate jobspec to consume all resources' '
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (wait job)' '
         jobidall=$(submit_job_live test-all.json)
         jobid=$(submit_job_wait)
-        flux job wait-event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path6.out &
+        flux job wait-event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path4.out &
         waitpid=$! &&
         wait_watchers_nonzero "watchers" &&
         wait_watchers_nonzero "guest_watchers" &&
@@ -367,7 +367,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
         wait_watcherscount_nonzero $guestns &&
         flux job cancel ${jobid} &&
         wait $waitpid &&
-        grep done wait_event_path6.out
+        grep done wait_event_path4.out
 '
 
 test_expect_success 'flux job wait-event -p hangs on no event (wait job)' '


### PR DESCRIPTION
Various misc cleanups & minor fixes peeled off of my now closed PRs (#2359, #2353, #2352).

Only one of note is the refactoring I did which added "flags" support to job-info event watches.  Even though the flags are not used, I figure we can keep it just in case for the future.