### PR TITLE
flux-in-flux: set jobid attribute

### DIFF
--- a/doc/man1/flux-proxy.adoc
+++ b/doc/man1/flux-proxy.adoc
@@ -12,12 +12,12 @@ flux-proxy - create proxy environment for Flux instance
 
 SYNOPSIS
 --------
-*flux* *proxy* [OPTIONS] job [command [args...]]
+*flux* *proxy* [OPTIONS] URI [command [args...]]
 
 
 DESCRIPTION
 -----------
-*flux proxy* connects to the Flux instance identified by _job_,
+*flux proxy* connects to the Flux instance identified by _URI_,
 then spawns a shell with FLUX_URI pointing to a local:// socket
 managed by the proxy program.  As long as the shell is running,
 the proxy program routes messages between the instance and the
@@ -27,13 +27,6 @@ terminates and removes the socket.
 The purpose of *flux proxy* is to allow a connection to be reused,
 for example where connection establishment has high latency or
 requires authentication.
-
-JOB IDENTIFIER
---------------
-*flux proxy* requires a _job_ identifier argument.  If the
-argument is not a URI, then it is interpreted heuristically
-as a numeric Flux session-id, a session-id with a single 
-'/' character prefix, or the path component of a local:// URI.
 
 
 OPTIONS
@@ -59,22 +52,10 @@ shell:
 
   $ flux proxy local:///tmp/flux-123456-abcdef/0
 
-Connect to the same job by jobid:
-
-  $ flux proxy 123456
-
 Connect to the same job remotely on host foo.com:
 
   $ flux proxy ssh://foo.com/tmp/flux-123456-abcdef/0
 
-Connect to the same by jobid:
-
-  $ flux proxy ssh://foo.com/123456
-
-Same and also set TMPDIR in the remote `flux proxy --stdio`
-environment:
-
-  $ flux proxy ssh://foo.com/123456?setenv=TMPDIR=/var/tmp/fred
 
 USE BY SSH CONNECTOR
 --------------------

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -26,9 +26,6 @@ The rank of the local broker.
 size::
 The number of ranks in the comms session.
 
-session-id::
-The identity of the comms session.
-
 rundir::
 A global, shared temporary directory available for scratch storage
 within the session. By default, a temporary directory is created

--- a/etc/boot.conf
+++ b/etc/boot.conf
@@ -1,4 +1,3 @@
-session-id = "system"
 
 #mcast-endpoint = "epgm://eth0;229.0.0.1:8050"
 

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -203,6 +203,10 @@ int boot_config (overlay_t *overlay, attr_t *attrs, int tbon_k)
         log_err ("setattr tbon.endpoint");
         goto done;
     }
+    if (attr_add (attrs, "instance-level", "0", FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+        log_err ("setattr instance-level");
+        goto done;
+    }
 
     rc = 0;
 done:

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -29,7 +29,6 @@
  */
 static const char *badat[] = {
     "tbon.endpoint",
-    "session-id",
     NULL,
 };
 
@@ -37,7 +36,6 @@ static const char *badat[] = {
  */
 static const struct cf_option opts[] = {
     { "tbon-endpoints", CF_ARRAY, true },
-    { "session-id", CF_STRING, true },
     { "rank", CF_INT64, false },
     { "size", CF_INT64, false },
     CF_OPTIONS_TABLE_END,
@@ -200,11 +198,6 @@ int boot_config (overlay_t *overlay, attr_t *attrs, int tbon_k)
 
     /* Update attributes.
      */
-    if (attr_add (attrs, "session-id", cf_string (cf_get_in (cf, "session-id")),
-                  FLUX_ATTRFLAG_IMMUTABLE) < 0) {
-        log_err ("setattr session-id");
-        goto done;
-    }
     if (attr_add (attrs, "tbon.endpoint", get_cf_endpoint (cf, rank),
                   FLUX_ATTRFLAG_IMMUTABLE) < 0) {
         log_err ("setattr tbon.endpoint");

--- a/src/broker/boot_config.h
+++ b/src/broker/boot_config.h
@@ -17,8 +17,6 @@
  *
  * Example config file (TOML):
  *
- *   session-id = "hype"
- *
  *   # tbon-endpoints array is ordered by rank (zeromq URI format)
  *   tbon-endpoints = [
  *       "tcp://192.168.1.100:8020",  # rank 0
@@ -39,7 +37,6 @@
 
 /* Broker attributes read/written directly by this method:
  *   boot.config_file (r)
- *   session-id (w)
  *   tbon.endpoint (w)
  */
 

--- a/src/broker/boot_config.h
+++ b/src/broker/boot_config.h
@@ -38,6 +38,7 @@
 /* Broker attributes read/written directly by this method:
  *   boot.config_file (r)
  *   tbon.endpoint (w)
+ *   instance-level (w)
  */
 
 int boot_config (overlay_t *overlay, attr_t *attrs, int tbon_k);

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -204,14 +204,6 @@ int boot_pmi (overlay_t *overlay, attr_t *attrs, int tbon_k)
                       tbon_k)< 0)
         goto error;
 
-    /* Set session-id attribute from PMI appnum if not already set.
-     */
-    if (attr_get (attrs, "session-id", NULL, NULL) < 0) {
-        if (attr_add_int (attrs, "session-id", pmi_params.appnum,
-                          FLUX_ATTRFLAG_IMMUTABLE) < 0)
-            goto error;
-    }
-
     if (update_endpoint_attr (attrs, "tbon.endpoint", &tbonendpoint,
                                                         "tcp://%h:*") < 0)
         goto error;

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -435,7 +435,7 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell)
         return NULL;
     pmi->shell = shell;
     if (!(pmi->server = pmi_simple_server_create (shell_pmi_ops,
-                                                  shell->jobid,
+                                                  0, // appnum
                                                   info->jobspec->task_count,
                                                   info->rankinfo.ntasks,
                                                   "pmi",

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -357,6 +357,15 @@ error:
     return -1;
 }
 
+static int set_flux_jobid (struct shell_pmi *pmi, flux_jobid_t id)
+{
+    char val [SIMPLE_KVS_VAL_MAX];
+
+    (void)snprintf (val, sizeof (val), "%ju", (uintmax_t)id);
+    pmi_kvs_put_local (pmi, "flux.jobid", val);
+    return 0;
+}
+
 static int set_flux_instance_level (struct shell_pmi *pmi)
 {
     char *p;
@@ -451,8 +460,12 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell)
     zhashx_set_duplicator (pmi->kvs, kvs_value_duplicator);
     if (init_clique (pmi) < 0)
         goto error;
-    if (!shell->standalone && set_flux_instance_level (pmi) < 0)
-        goto error;
+    if (!shell->standalone) {
+        if (set_flux_instance_level (pmi) < 0)
+            goto error;
+        if (set_flux_jobid (pmi, shell->jobid) < 0)
+            goto error;
+    }
     return pmi;
 error:
     pmi_destroy (pmi);

--- a/t/conf.d/bad-missing.conf
+++ b/t/conf.d/bad-missing.conf
@@ -1,3 +1,1 @@
-session-id = "test"
-
 # missing tbon-endpoints array

--- a/t/conf.d/bad-rank.conf
+++ b/t/conf.d/bad-rank.conf
@@ -1,5 +1,3 @@
-session-id = "test"
-
 size = 1
 
 # rank is out of range

--- a/t/conf.d/priv2.0.conf
+++ b/t/conf.d/priv2.0.conf
@@ -1,5 +1,3 @@
-session-id = "test2"
-
 size = 2
 rank = 0
 

--- a/t/conf.d/priv2.1.conf
+++ b/t/conf.d/priv2.1.conf
@@ -1,5 +1,3 @@
-session-id = "test2"
-
 size = 2
 rank = 1
 

--- a/t/conf.d/private.conf
+++ b/t/conf.d/private.conf
@@ -1,5 +1,3 @@
-session-id = "test"
-
 size = 1
 rank = 0
 

--- a/t/conf.d/shared.conf
+++ b/t/conf.d/shared.conf
@@ -1,5 +1,3 @@
-session-id = "test"
-
 tbon-endpoints = [
     "tcp://127.0.0.1:8500",
 ]

--- a/t/conf.d/shared_ipc.conf
+++ b/t/conf.d/shared_ipc.conf
@@ -1,5 +1,3 @@
-session-id = "testipc"
-
 tbon-endpoints = [
     "ipc://@flux-testipc-1-0",
 ]

--- a/t/conf.d/shared_none.conf
+++ b/t/conf.d/shared_none.conf
@@ -1,5 +1,3 @@
-session-id = "testoops"
-
 tbon-endpoints = [
     "tcp://1.2.3.4:5",
 ]

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -51,17 +51,6 @@ test_expect_success 'flux broker with boot.config_file=bad-rank fails' '
 		-Sboot.config_file=${TCONFDIR}/bad-rank.conf /bin/true
 '
 
-#
-# trigger config_file boot failure due to incompat attr setting
-#
-
-test_expect_success 'flux broker with incompat attrs fails' '
-	test_must_fail flux broker -Sboot.method=config \
-		-Sboot.config_file=${TCONFDIR}/shared.conf \
-		-Ssession-id=xyz \
-		/bin/true
-'
-
 # N.B. set short shutdown grace to speed up test, as in t0001-basic
 
 #
@@ -77,7 +66,6 @@ test_expect_success 'start size=1 with shared config file, expected attrs set' '
 		-Sboot.config_file=${TCONFDIR}/shared.conf \
 		--shutdown-grace=0.1 \
 		flux lsattr -v >1s.out &&
-	grep -q "session-id[ ]*test$" 1s.out &&
 	grep -q "tbon.endpoint[ ]*tcp://127.0.0.1:8500$" 1s.out
 '
 

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -59,6 +59,15 @@ test_expect_success "flux sets instance-level attribute" '
         test "$level" = "1" &&
         test "$level2" = "2" &&
         test "$level0" = "0"
- '
+'
+
+test_expect_success "flux sets jobid attribute" '
+	id=$(flux jobspec srun -n1 \
+		flux start flux getattr jobid \
+		| flux job submit) &&
+	echo "$id" >jobid.exp &&
+	flux job attach $id >jobid.out &&
+	test_cmp jobid.exp jobid.out
+'
 
 test_done


### PR DESCRIPTION
As discussed in #2344, the `session-id` attribute no longer works properly with flux-in-flux.  This PR replaces it with a `jobid` attribute, passed in from the enclosing instance (the shell) using the PMI KVS rather than the PMI appnum, which was restricted to 32 bits.  The implementation tracks that of `instance-level`, added in #2326.

If flux is at instance level 0, the `jobid` attribute is unset.

This also drops the moribund `flux-proxy` feature that allowed a jobid to be specified instead of a URI, and derived the URI from the jobid by assuming a particular socket path.  That approach proved fragile, and thus I removed it rather than try to fix it now that the untruncated jobid is available.  We will need better ways of finding URI's for running flux instances anyway.