### PR TITLE
shell: live output

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -739,128 +739,27 @@ struct attach_ctx {
     flux_t *h;
     int exit_code;
     flux_jobid_t id;
-    flux_future_t *f;
+    flux_future_t *eventlog_f;
+    flux_future_t *exec_eventlog_f;
+    flux_future_t *output_f;
     flux_watcher_t *sigint_w;
     flux_watcher_t *sigtstp_w;
     struct timespec t_sigint;
     bool show_events;
     optparse_t *p;
-    bool started;
-    bool missing_output_ok;
     bool output_header_parsed;
+    int eventlog_watch_count;
+    int eventlog_watch_completed;
 };
 
-void attach_cancel_continuation (flux_future_t *f, void *arg)
+void attach_eventlog_watch_completed_check (struct attach_ctx *ctx)
 {
-    if (flux_future_get (f, NULL) < 0)
-        log_msg ("cancel: %s", future_strerror (f, errno));
-    flux_future_destroy (f);
-}
-
-void attach_signal_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
-{
-    struct attach_ctx *ctx = arg;
-    flux_future_t *f;
-    int signum = flux_signal_watcher_get_signum (w);
-
-    if (signum == SIGINT) {
-        if (monotime_since (ctx->t_sigint) > 2000) {
-            monotime (&ctx->t_sigint);
-            flux_watcher_start (ctx->sigtstp_w);
-            log_msg ("one more ctrl-C within 2s to cancel or ctrl-Z to detach");
-        }
-        else {
-            if (!(f = flux_job_cancel (ctx->h, ctx->id,
-                                       "interrupted by ctrl-C")))
-                log_err_exit ("flux_job_cancel");
-            if (flux_future_then (f, -1, attach_cancel_continuation, NULL) < 0)
-                log_err_exit ("flux_future_then");
-        }
+    /* eventlog and output watch are the two eventlog watches we need
+     * to complete before shutting off reactor */
+    if (ctx->eventlog_watch_completed >= ctx->eventlog_watch_count) {
+        flux_watcher_stop (ctx->sigint_w);
+        flux_watcher_stop (ctx->sigtstp_w);
     }
-    else if (signum == SIGTSTP) {
-        if (monotime_since (ctx->t_sigint) <= 2000) {
-            if (flux_job_event_watch_cancel (ctx->f) < 0)
-                log_err_exit ("flux_job_event_watch_cancel");
-            log_msg ("detaching...");
-        }
-        else {
-            flux_watcher_stop (ctx->sigtstp_w);
-            log_msg ("one more ctrl-Z to suspend");
-        }
-    }
-}
-
-void attach_event_continuation (flux_future_t *f, void *arg)
-{
-    struct attach_ctx *ctx = arg;
-    const char *entry;
-    json_t *o;
-    const char *name;
-    json_t *context;
-    int status;
-
-    if (flux_job_event_watch_get (f, &entry) < 0) {
-        if (errno == ENODATA)
-            goto done;
-        log_msg_exit ("flux_job_event_watch_get: %s",
-                      future_strerror (f, errno));
-    }
-    if (!(o = eventlog_entry_decode (entry)))
-        log_err_exit ("eventlog_entry_decode");
-    if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
-        log_err_exit ("eventlog_entry_parse");
-    if (!strcmp (name, "exception")) {
-        const char *type;
-        int severity;
-        const char *note = NULL;
-
-        if (json_unpack (context, "{s:s s:i s?:s}",
-                         "type", &type,
-                         "severity", &severity,
-                         "note", &note) < 0)
-            log_err_exit ("error decoding exception context");
-        fprintf (stderr, "job-event: exception type=%s severity=%d %s\n",
-                 type,
-                 severity,
-                 note ? note : "");
-    }
-    else if (!strcmp (name, "start")) {
-        ctx->started = true;
-    }
-    else {
-        if (!strcmp (name, "finish")) {
-            if (json_unpack (context, "{s:i}", "status", &status) < 0)
-                log_err_exit ("error decoding finish context");
-            if (WIFSIGNALED (status)) {
-                ctx->exit_code = WTERMSIG (status) + 128;
-                log_msg ("task(s) %s", strsignal (WTERMSIG (status)));
-            }
-            else if (WIFEXITED (status)) {
-                ctx->exit_code = WEXITSTATUS (status);
-                if (ctx->exit_code != 0)
-                    log_msg ("task(s) exited with exit code %d",
-                             ctx->exit_code);
-            }
-        }
-    }
-    if (ctx->show_events && strcmp (name, "exception") != 0) {
-        char *s = NULL;
-        if (context && !(s = json_dumps (context, JSON_COMPACT)))
-            log_err_exit ("error re-encoding context");
-        fprintf (stderr, "job-event: %s%s%s\n",
-                 name,
-                 s ? " " : "",
-                 s ? s : "");
-        free (s);
-    }
-    json_decref (o);
-    flux_future_reset (f);
-    return;
-done:
-    flux_future_destroy (f);
-    flux_watcher_stop (ctx->sigint_w);
-    flux_watcher_stop (ctx->sigtstp_w);
 }
 
 void print_output_continuation (flux_future_t *f, void *arg)
@@ -872,8 +771,7 @@ void print_output_continuation (flux_future_t *f, void *arg)
     json_t *context;
 
     if (flux_job_event_watch_get (f, &entry) < 0) {
-        if (errno == ENODATA
-            || (errno == ENOENT && ctx->missing_output_ok))
+        if (errno == ENODATA)
             goto done;
         log_msg_exit ("flux_job_event_watch_get: %s",
                       future_strerror (f, errno));
@@ -914,18 +812,177 @@ void print_output_continuation (flux_future_t *f, void *arg)
     return;
 done:
     flux_future_destroy (f);
+    ctx->output_f = NULL;
+    ctx->eventlog_watch_completed++;
+    attach_eventlog_watch_completed_check (ctx);
 }
 
-void print_output (struct attach_ctx *ctx)
+void attach_cancel_continuation (flux_future_t *f, void *arg)
 {
-    flux_future_t *f;
+    if (flux_future_get (f, NULL) < 0)
+        log_msg ("cancel: %s", future_strerror (f, errno));
+    flux_future_destroy (f);
+}
 
-    if (!(f = flux_job_event_watch (ctx->h, ctx->id, "guest.output", 0)))
-        log_err_exit ("flux_job_event_watch");
-    if (flux_future_then (f, -1., print_output_continuation, ctx) < 0)
-        log_err_exit ("flux_future_then");
-    if (flux_reactor_run (flux_get_reactor (ctx->h), 0) < 0)
-        log_err_exit ("flux_reactor_run");
+void attach_signal_cb (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    struct attach_ctx *ctx = arg;
+    flux_future_t *f;
+    int signum = flux_signal_watcher_get_signum (w);
+
+    if (signum == SIGINT) {
+        if (monotime_since (ctx->t_sigint) > 2000) {
+            monotime (&ctx->t_sigint);
+            flux_watcher_start (ctx->sigtstp_w);
+            log_msg ("one more ctrl-C within 2s to cancel or ctrl-Z to detach");
+        }
+        else {
+            if (!(f = flux_job_cancel (ctx->h, ctx->id,
+                                       "interrupted by ctrl-C")))
+                log_err_exit ("flux_job_cancel");
+            if (flux_future_then (f, -1, attach_cancel_continuation, NULL) < 0)
+                log_err_exit ("flux_future_then");
+        }
+    }
+    else if (signum == SIGTSTP) {
+        if (monotime_since (ctx->t_sigint) <= 2000) {
+            if (ctx->eventlog_f) {
+                if (flux_job_event_watch_cancel (ctx->eventlog_f) < 0)
+                    log_err_exit ("flux_job_event_watch_cancel");
+            }
+            if (ctx->exec_eventlog_f) {
+                if (flux_job_event_watch_cancel (ctx->exec_eventlog_f) < 0)
+                    log_err_exit ("flux_job_event_watch_cancel");
+            }
+            if (ctx->output_f) {
+                if (flux_job_event_watch_cancel (ctx->output_f) < 0)
+                    log_err_exit ("flux_job_event_watch_cancel");
+            }
+            log_msg ("detaching...");
+        }
+        else {
+            flux_watcher_stop (ctx->sigtstp_w);
+            log_msg ("one more ctrl-Z to suspend");
+        }
+    }
+}
+
+void attach_exec_event_continuation (flux_future_t *f, void *arg)
+{
+    struct attach_ctx *ctx = arg;
+    const char *entry;
+    json_t *o;
+    const char *name;
+    json_t *context;
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
+        log_err_exit ("eventlog_entry_parse");
+    if (!strcmp (name, "output-ready")) {
+        if (!(ctx->output_f = flux_job_event_watch (ctx->h,
+                                                    ctx->id,
+                                                    "guest.output",
+                                                    0)))
+            log_err_exit ("flux_job_event_watch");
+
+        if (flux_future_then (ctx->output_f,
+                              -1.,
+                              print_output_continuation,
+                              ctx) < 0)
+            log_err_exit ("flux_future_then");
+
+        ctx->eventlog_watch_count++;
+
+        if (flux_job_event_watch_cancel (f) < 0)
+            log_err_exit ("flux_job_event_watch_cancel");
+    }
+
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+done:
+    flux_future_destroy (f);
+    ctx->exec_eventlog_f = NULL;
+    ctx->eventlog_watch_completed++;
+    attach_eventlog_watch_completed_check (ctx);
+}
+
+void attach_event_continuation (flux_future_t *f, void *arg)
+{
+    struct attach_ctx *ctx = arg;
+    const char *entry;
+    json_t *o;
+    const char *name;
+    json_t *context;
+    int status;
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
+        log_err_exit ("eventlog_entry_parse");
+    if (!strcmp (name, "exception")) {
+        const char *type;
+        int severity;
+        const char *note = NULL;
+
+        if (json_unpack (context, "{s:s s:i s?:s}",
+                         "type", &type,
+                         "severity", &severity,
+                         "note", &note) < 0)
+            log_err_exit ("error decoding exception context");
+        fprintf (stderr, "job-event: exception type=%s severity=%d %s\n",
+                 type,
+                 severity,
+                 note ? note : "");
+    }
+    else {
+        if (!strcmp (name, "finish")) {
+            if (json_unpack (context, "{s:i}", "status", &status) < 0)
+                log_err_exit ("error decoding finish context");
+            if (WIFSIGNALED (status)) {
+                ctx->exit_code = WTERMSIG (status) + 128;
+                log_msg ("task(s) %s", strsignal (WTERMSIG (status)));
+            }
+            else if (WIFEXITED (status)) {
+                ctx->exit_code = WEXITSTATUS (status);
+                if (ctx->exit_code != 0)
+                    log_msg ("task(s) exited with exit code %d",
+                             ctx->exit_code);
+            }
+        }
+    }
+    if (ctx->show_events && strcmp (name, "exception") != 0) {
+        char *s = NULL;
+        if (context && !(s = json_dumps (context, JSON_COMPACT)))
+            log_err_exit ("error re-encoding context");
+        fprintf (stderr, "job-event: %s%s%s\n",
+                 name,
+                 s ? " " : "",
+                 s ? s : "");
+        free (s);
+    }
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+done:
+    flux_future_destroy (f);
+    ctx->eventlog_f = NULL;
+    ctx->eventlog_watch_completed++;
+    attach_eventlog_watch_completed_check (ctx);
 }
 
 int cmd_attach (optparse_t *p, int argc, char **argv)
@@ -950,10 +1007,31 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     if (!(r = flux_get_reactor (ctx.h)))
         log_err_exit ("flux_get_reactor");
 
-    if (!(ctx.f = flux_job_event_watch (ctx.h, ctx.id, "eventlog", 0)))
+    if (!(ctx.eventlog_f = flux_job_event_watch (ctx.h,
+                                                 ctx.id,
+                                                 "eventlog",
+                                                 0)))
         log_err_exit ("flux_job_event_watch");
-    if (flux_future_then (ctx.f, -1, attach_event_continuation, &ctx) < 0)
+    if (flux_future_then (ctx.eventlog_f,
+                          -1,
+                          attach_event_continuation,
+                          &ctx) < 0)
         log_err_exit ("flux_future_then");
+
+    ctx.eventlog_watch_count++;
+
+    if (!(ctx.exec_eventlog_f = flux_job_event_watch (ctx.h,
+                                                      ctx.id,
+                                                      "guest.exec.eventlog",
+                                                      0)))
+        log_err_exit ("flux_job_event_watch");
+    if (flux_future_then (ctx.exec_eventlog_f,
+                          -1,
+                          attach_exec_event_continuation,
+                          &ctx) < 0)
+        log_err_exit ("flux_future_then");
+
+    ctx.eventlog_watch_count++;
 
     ctx.sigint_w = flux_signal_watcher_create (r,
                                                SIGINT,
@@ -969,12 +1047,6 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
 
     if (flux_reactor_run (r, 0) < 0)
         log_err_exit ("flux_reactor_run");
-
-    /* if job never ran, no output */
-    if (ctx.started) {
-        ctx.missing_output_ok = ctx.exit_code == 0 ? false : true;
-        print_output (&ctx);
-    }
 
     flux_watcher_destroy (ctx.sigint_w);
     flux_watcher_destroy (ctx.sigtstp_w);

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -64,8 +64,8 @@ static const int shell_output_hwm = 1000;
 /* Pause/resume output on 'stream' of 'task'.
  */
 static void shell_output_control_task (struct shell_task *task,
-                                   const char *stream,
-                                   bool stop)
+                                       const char *stream,
+                                       bool stop)
 {
     if (stop) {
         if (flux_subprocess_stream_stop (task->proc, stream) < 0)

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -13,14 +13,18 @@
  * Intercept task stdout, stderr and dispose of it according to
  * selected I/O mode.
  *
- * The leader shell implements an "shell-<id>.output" service that
- * all ranks send task output to.  Output objects accumulate in a json
- * array on the leader.  Upon task exit, the array is written to the
- * "output" key in the job's guest KVS namespace.
+ * The leader shell implements an "shell-<id>.output" service that all
+ * ranks send task output to.  Output objects accumulate in a json
+ * array on the leader.  If standalone is set, output is written
+ * directly to stdout/stderr.  If not standalone, output objects are
+ * written to the "output" key in the job's guest KVS namespace per
+ * RFC24.
  *
  * Notes:
  * - leader takes a completion reference which it gives up once each
  *   task sends an EOF for both stdout and stderr.
+ * - completion reference also taken for each KVS commit, to ensure
+ *   commits complete before shell exits
  * - all shells (even the leader) send I/O to the service with RPC
  * - Any errors getting I/O to the leader are logged by RPC completion
  *   callbacks.
@@ -55,6 +59,7 @@ struct shell_output {
     int eof_pending;
     zlist_t *pending_writes;
     json_t *output;
+    zlist_t *pending_commits;
     bool stopped;
 };
 
@@ -94,9 +99,95 @@ static void shell_output_control (struct shell_output *out, bool stop)
     }
 }
 
+static int shell_output_flush (struct shell_output *out)
+{
+    json_t *entry;
+    size_t index;
+    FILE *f;
+
+    json_array_foreach (out->output, index, entry) {
+        json_t *context;
+        const char *name;
+        const char *stream = NULL;
+        int rank;
+        char *data = NULL;
+        int len = 0;
+        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
+            log_err ("eventlog_entry_parse");
+            return -1;
+        }
+        if (!strcmp (name, "header")) {
+            // TODO: acquire per-stream encoding type
+        }
+        else if (!strcmp (name, "data")) {
+            if (iodecode (context, &stream, &rank, &data, &len, NULL) < 0) {
+                log_err ("iodecode");
+                return -1;
+            }
+            f = !strcmp (stream, "stdout") ? stdout : stderr;
+            if (len > 0) {
+                fprintf (f, "%d: ", rank);
+                fwrite (data, len, 1, f);
+            }
+            free (data);
+        }
+    }
+    if (json_array_clear (out->output) < 0)
+        log_msg ("json_array_clear failed");
+    return 0;
+}
+
+static void shell_output_commit_completion (flux_future_t *f, void *arg)
+{
+    struct shell_output *out = arg;
+
+    /* Error failing to commit is a fatal error.  Should be cleaner in
+     * future. Issue #2378 */
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("shell_output_commit");
+    zlist_remove (out->pending_commits, f);
+    flux_future_destroy (f);
+}
+
+static int shell_output_commit (struct shell_output *out)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    char *chunk = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(chunk = eventlog_encode (out->output)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "output", chunk) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_output_commit_completion, out) < 0)
+        goto error;
+    if (json_array_clear (out->output) < 0) {
+        log_msg ("json_array_clear failed");
+        goto error;
+    }
+    if (zlist_append (out->pending_commits, f) < 0)
+        log_msg ("zlist_append failed");
+    /* f memory responsibility of shell_output_commit_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    free (chunk);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
 /* Convert 'iodecode' object to an valid RFC 24 data event.
  * N.B. the iodecode object is a valid "context" for the event.
- * io->output is a JSON array of eventlog entries.
  */
 static void shell_output_write_cb (flux_t *h,
                                    flux_msg_handler_t *mh,
@@ -120,6 +211,16 @@ static void shell_output_write_cb (flux_t *h,
         json_decref (entry);
         errno = ENOMEM;
         goto error;
+    }
+    /* Error failing to commit is a fatal error.  Should be cleaner in
+     * future. Issue #2378 */
+    if (out->shell->standalone) {
+        if (shell_output_flush (out) < 0)
+            log_err_exit ("shell_output_flush");
+    }
+    else {
+        if (shell_output_commit (out) < 0)
+            log_err_exit ("shell_output_commit");
     }
     if (eof) {
         if (--out->eof_pending == 0) {
@@ -182,70 +283,6 @@ error:
     return -1;
 }
 
-static int shell_output_flush (struct shell_output *out)
-{
-    json_t *entry;
-    size_t index;
-    FILE *f;
-
-    json_array_foreach (out->output, index, entry) {
-        json_t *context;
-        const char *name;
-        const char *stream = NULL;
-        int rank;
-        char *data = NULL;
-        int len = 0;
-        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
-            log_err ("eventlog_entry_parse");
-            return -1;
-        }
-        if (!strcmp (name, "header")) {
-            // TODO: acquire per-stream encoding type
-        }
-        else if (!strcmp (name, "data")) {
-            if (iodecode (context, &stream, &rank, &data, &len, NULL) < 0) {
-                log_err ("iodecode");
-                return -1;
-            }
-            f = !strcmp (stream, "stdout") ? stdout : stderr;
-            if (len > 0) {
-                fprintf (f, "%d: ", rank);
-                fwrite (data, len, 1, f);
-            }
-            free (data);
-        }
-    }
-    return 0;
-}
-
-static int shell_output_commit (struct shell_output *out)
-{
-    flux_kvs_txn_t *txn;
-    flux_future_t *f = NULL;
-    char *chunk;
-    int saved_errno;
-    int rc = -1;
-
-    if (!(chunk = eventlog_encode (out->output)))
-        return -1;
-    if (!(txn = flux_kvs_txn_create ()))
-        goto out;
-    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "output", chunk) < 0)
-        goto out;
-    if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
-        goto out;
-    if (flux_future_get (f, NULL) < 0)
-        goto out;
-    rc = 0;
-out:
-    saved_errno = errno;
-    flux_future_destroy (f);
-    flux_kvs_txn_destroy (txn);
-    free (chunk);
-    errno = saved_errno;
-    return rc;
-}
-
 void shell_output_destroy (struct shell_output *out)
 {
     if (out) {
@@ -260,7 +297,7 @@ void shell_output_destroy (struct shell_output *out)
             }
             zlist_destroy (&out->pending_writes);
         }
-        if (out->output) { // leader only
+        if (out->output && json_array_size (out->output) > 0) { // leader only
             if (out->shell->standalone) {
                 if (shell_output_flush (out) < 0)
                     log_err ("shell_output_flush");
@@ -271,19 +308,31 @@ void shell_output_destroy (struct shell_output *out)
             }
         }
         json_decref (out->output);
+        if (out->pending_commits) { // leader only
+            flux_future_t *f;
+
+            while ((f = zlist_pop (out->pending_commits))) {
+                if (flux_future_get (f, NULL) < 0)
+                    log_err ("shell_output_commit");
+                flux_future_destroy (f);
+            }
+            zlist_destroy (&out->pending_commits);
+        }
         free (out);
         errno = saved_errno;
     }
 }
 
-/* Append RFC 24 header event to 'output' JSON array.  Assume:
+/* Append RFC 24 header event to 'output' JSON array and write out to
+ * KVS.  Assume:
  * - fixed base64 encoding for stdout, stderr
  * - no options
  * - no stdlog
  */
-static int shell_output_header_append (flux_shell_t *shell, json_t *output)
+static int shell_output_header (struct shell_output *out)
 {
     json_t *o;
+    int rc = -1;
 
     o = eventlog_entry_pack (0, "header",
                              "{s:i s:{s:s s:s} s:{s:i s:i} s:{}}",
@@ -292,15 +341,29 @@ static int shell_output_header_append (flux_shell_t *shell, json_t *output)
                                "stdout", "base64",
                                "stderr", "base64",
                              "count",
-                               "stdout", shell->info->jobspec->task_count,
-                               "stderr", shell->info->jobspec->task_count,
+                               "stdout", out->shell->info->jobspec->task_count,
+                               "stderr", out->shell->info->jobspec->task_count,
                              "options");
-    if (!o || json_array_append_new (output, o) < 0) {
+    if (!o) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (json_array_append_new (out->output, o) < 0) {
         json_decref (o);
         errno = ENOMEM;
-        return -1;
+        goto error;
     }
-    return 0;
+    if (out->shell->standalone) {
+        if (shell_output_flush (out) < 0)
+            log_err ("shell_output_flush");
+    }
+    else {
+        if (shell_output_commit (out) < 0)
+            log_err ("shell_output_commit");
+    }
+    rc = 0;
+error:
+    return rc;
 }
 
 struct shell_output *shell_output_create (flux_shell_t *shell)
@@ -325,7 +388,9 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
             errno = ENOMEM;
             goto error;
         }
-        if (shell_output_header_append (shell, out->output) < 0)
+        if (!(out->pending_commits = zlist_new ()))
+            goto error;
+        if (shell_output_header (out) < 0)
             goto error;
     }
     return out;

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -21,9 +21,9 @@ extern "C" {
 typedef struct flux_shell flux_shell_t;
 typedef struct shell_task flux_shell_task_t;
 
-typedef void (flux_shell_task_io_f) (flux_shell_task_t *task,
-                                     const char *stream,
-                                     void *arg);
+typedef void (*flux_shell_task_io_f) (flux_shell_task_t *task,
+                                      const char *stream,
+                                      void *arg);
 
 int flux_shell_aux_set (flux_shell_t *shell,
                         const char *name,

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -45,7 +45,7 @@
 #include "info.h"
 
 struct channel_watcher {
-    flux_shell_task_io_f *cb;
+    flux_shell_task_io_f cb;
     void *arg;
 };
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -176,6 +176,7 @@ dist_check_SCRIPTS = \
 	job-manager/drain-cancel.py \
 	job-manager/drain-undrain.py \
 	job-manager/bulk-state.py \
+	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
 	schedutil/req_and_unload.py
 

--- a/t/job-attach/outputsleep.sh
+++ b/t/job-attach/outputsleep.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo before
+
+# to prevent racyness, write something to eventlog to indicate we've
+# output foo
+flux kvs eventlog append exec.eventlog test-output-ready
+
+sleep inf
+
+echo after

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -97,4 +97,8 @@ test_expect_success 'flux srun -N128 hostname fails' '
 	test_must_fail flux srun -N128 hostname
 '
 
+test_expect_success 'flux srun bad executable fails' '
+	test_must_fail flux srun abadfile
+'
+
 test_done


### PR DESCRIPTION
builds on top of my misc cleanups PR in #2360.

- have shell send output to KVS live as it happens
- have shell emit a "output-ready" event to `exec.eventlog`
  - good name?  I considered "output {"ready":"true"}" as well.
- job attach checks for "output-ready" from `exec.eventlog`, and then reads / outputs from `guest.output` as it occurs.
- Fix racy completion in shell as discussued in #2363 