### PR TITLE
libflux/module: add flux_module_debug_test()

### DIFF
--- a/doc/man3/flux_msg_cmp.adoc
+++ b/doc/man3/flux_msg_cmp.adoc
@@ -33,8 +33,8 @@ matchtag group is nonzero, match on the group bits only (as defined by
 FLUX_MATCHTAG_GROUP_MASK).  If the matchtag group is zero, match on
 non-group bits only.
 
-If _match.topic_glob_ is not NULL, then the message topic string must
-match _match.topic_glob_ according to the rules of shell wildcards.
+If _match.topic_glob_ is not NULL or an empty string, then the message topic
+string must match _match.topic_glob_ according to the rules of shell wildcards.
 
 
 RETURN VALUE

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -114,6 +114,17 @@ char *flux_modfind (const char *searchpath, const char *modname,
     return result;
 }
 
+bool flux_module_debug_test (flux_t *h, int flag, bool clear)
+{
+    int *flagsp = flux_aux_get (h, "flux::debug_flags");
+
+    if (!flagsp || !(*flagsp & flag))
+        return false;
+    if (clear)
+        *flagsp &= ~flag;
+    return true;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -16,6 +16,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "handle.h"
 
@@ -53,6 +54,13 @@ char *flux_modname (const char *filename, flux_moderr_f *cb, void *arg);
  */
 char *flux_modfind (const char *searchpath, const char *modname,
                     flux_moderr_f *cb, void *arg);
+
+/* Test and optionally clear module debug bit from within a module, as
+ * described in RFC 5.  Return true if 'flag' bit is set.  If clear=true,
+ * clear the bit after testing.  The flux-module(1) debug subcommand
+ * manipulates these bits externally to set up test conditions.
+ */
+bool flux_module_debug_test (flux_t *h, int flag, bool clear);
 
 #ifdef __cplusplus
 }

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -85,19 +85,10 @@ error:
     return NULL;
 }
 
-static bool test_debug_flag (flux_t *h, int mask)
-{
-    int *debug_flags = flux_aux_get (h, "flux::debug_flags");
-
-    if (debug_flags && (*debug_flags & mask))
-        return true;
-    return false;
-}
-
 void try_alloc (struct sched_ctx *sc)
 {
     if (sc->job) {
-        if (test_debug_flag (sc->h, DEBUG_FAIL_ALLOC)) {
+        if (flux_module_debug_test (sc->h, DEBUG_FAIL_ALLOC, false)) {
             if (schedutil_alloc_respond_denied (sc->h, sc->job->msg,
                                                 "DEBUG_FAIL_ALLOC") < 0)
                 flux_log_error (sc->h, "schedutil_alloc_respond_denied");


### PR DESCRIPTION
Another tidbit peeled off of #2302 

Add a public API function for testing and optionally clearing module debug flags, as set with `flux module debug`.  This cleans up the couple of places where those debug flags are used, including in local connector authentication, where clarity of the code is somewhat critical.

This capability is mentioned in the `flux-module` man page as well as [RFC 5](https://github.com/flux-framework/rfc/blob/master/spec_5.adoc).