### PR TITLE
job-info: Return ENODATA when reaching the end of eventlogs

### DIFF
--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -39,9 +39,10 @@
  *    job is along (get_main_eventlog()).
  *
  * 2) If the guest namespace is already copied into the main namespace
- *    (event "release" and "final=true"), we watch the main eventlog
- *    (main_namespace_watch()).  This is "easy" case and is not so
- *    different from a typical call to 'job-info.eventlog-watch'.
+ *    (event "release" and "final=true"), we watch the eventlog in the
+ *    main namespace (main_namespace_watch()).  This is "easy" case
+ *    and is not so different from a typical call to
+ *    'job-info.eventlog-watch'.
  *
  * 3) If the guest namespace is still active (event "start" in the
  *    main eventlog, but not "release"), we need to watch the eventlog

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -258,10 +258,10 @@ static int send_cancel (struct guest_watch_ctx *gw, flux_future_t *f)
         matchtag = (int)flux_rpc_get_matchtag (f);
 
         if (!(f2 = flux_rpc_pack (gw->ctx->h,
-                                 "job-info.eventlog-watch-cancel",
-                                 FLUX_NODEID_ANY,
-                                 FLUX_RPC_NORESPONSE,
-                                 "{s:i}",
+                                  "job-info.eventlog-watch-cancel",
+                                  FLUX_NODEID_ANY,
+                                  FLUX_RPC_NORESPONSE,
+                                  "{s:i}",
                                   "matchtag", matchtag))) {
             flux_log_error (gw->ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
             return -1;

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -127,8 +127,7 @@ static int watch_key (struct watch_ctx *w)
         pathptr = w->path;
     }
     else {
-        if (flux_job_kvs_key (fullpath, sizeof (fullpath), w->id,
-                              w->path ? w->path : "eventlog") < 0) {
+        if (flux_job_kvs_key (fullpath, sizeof (fullpath), w->id, w->path) < 0) {
             flux_log_error (w->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
             return -1;
         }

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -348,7 +348,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
         grep done wait_event_path4.out
 '
 
-test_expect_success 'flux job wait-event -p hangs on no event (live job)' '
+test_expect_success 'flux job wait-event -p times out on no event (live job)' '
         jobid=$(submit_job_live sleeplong.json) &&
         ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
         flux job cancel $jobid
@@ -379,7 +379,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
         grep done wait_event_path5.out
 '
 
-test_expect_success 'flux job wait-event -p hangs on no event (wait job)' '
+test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
         jobidall=$(submit_job_live sleeplong-all-rsrc.json) &&
         jobid=$(submit_job_wait) &&
         ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -387,6 +387,23 @@ test_expect_success 'flux job wait-event -p hangs on no event (wait job)' '
         flux job cancel $jobid
 '
 
+# In order to test watching a guest event log that will never exist,
+# we will start a job that will take up all resources.  Then start
+# another job, which we will watch and know it hasn't started running
+# yet. Then we cancel the second job before we know it has started.
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (never start job)' '
+        jobidall=$(submit_job_live sleeplong-all-rsrc.json)
+        jobid=$(submit_job_wait)
+        flux job wait-event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path6.out &
+        waitpid=$! &&
+        wait_watchers_nonzero "watchers" &&
+        wait_watchers_nonzero "guest_watchers" &&
+        flux job cancel ${jobid} &&
+        ! wait $waitpid &&
+        flux job cancel ${jobidall}
+'
+
 #
 # job info tests
 #

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -168,14 +168,14 @@ test_expect_success 'flux job wait-event works' '
 
 test_expect_success NO_CHAIN_LINT 'flux job wait-event works, event is later' '
         jobid=$(submit_job)
-        flux job wait-event $jobid foobar > wait_event3.out &
+        flux job wait-event $jobid foobar > wait_event2.out &
         waitpid=$! &&
         wait_watchers_nonzero "watchers" &&
         wait_watcherscount_nonzero primary &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
         wait $waitpid &&
-        grep foobar wait_event3.out
+        grep foobar wait_event2.out
 '
 
 test_expect_success 'flux job wait-event fails on bad id' '
@@ -184,8 +184,8 @@ test_expect_success 'flux job wait-event fails on bad id' '
 
 test_expect_success 'flux job wait-event --quiet works' '
         jobid=$(submit_job) &&
-        flux job wait-event --quiet $jobid submit > wait_event7.out &&
-        ! test -s wait_event7.out
+        flux job wait-event --quiet $jobid submit > wait_event3.out &&
+        ! test -s wait_event3.out
 '
 
 test_expect_success 'flux job wait-event --verbose works' '
@@ -193,25 +193,25 @@ test_expect_success 'flux job wait-event --verbose works' '
         kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobaz &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
-        flux job wait-event --verbose $jobid foobar > wait_event8.out &&
-        grep submit wait_event8.out &&
-        grep foobaz wait_event8.out &&
-        grep foobar wait_event8.out
+        flux job wait-event --verbose $jobid foobar > wait_event4.out &&
+        grep submit wait_event4.out &&
+        grep foobaz wait_event4.out &&
+        grep foobar wait_event4.out
 '
 
 test_expect_success 'flux job wait-event --verbose doesnt show events after wait event' '
         jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
-        flux job wait-event --verbose $jobid submit > wait_event9.out &&
-        grep submit wait_event9.out &&
-        ! grep foobar wait_event9.out
+        flux job wait-event --verbose $jobid submit > wait_event5.out &&
+        grep submit wait_event5.out &&
+        ! grep foobar wait_event5.out
 '
 
 test_expect_success 'flux job wait-event --timeout works' '
         jobid=$(submit_job) &&
-        ! flux job wait-event --timeout=0.2 $jobid foobar 2> wait_event8.err &&
-        grep "wait-event timeout" wait_event8.err
+        ! flux job wait-event --timeout=0.2 $jobid foobar 2> wait_event6.err &&
+        grep "wait-event timeout" wait_event6.err
 '
 
 test_expect_success 'flux job wait-event hangs on no event' '
@@ -222,7 +222,7 @@ test_expect_success 'flux job wait-event hangs on no event' '
 test_expect_success 'flux job wait-event --format=json works' '
         jobid=$(submit_job) &&
 	flux job wait-event --format=json $jobid submit > wait_event_format1.out &&
-        grep -q "\"name\":\"submit\"" eventlog_format1.out &&
+        grep -q "\"name\":\"submit\"" wait_event_format1.out &&
         grep -q "\"userid\":$(id -u)" wait_event_format1.out
 '
 


### PR DESCRIPTION
Per discussion #2338.  This is built on top of #2366.

- It is easy to "reach the end" of
  - the main job eventlog (event "clean")
  - a guest eventlog in the guest namespace
  - a guest eventlog copied into the primary KVS namespace

- It is hard to know how to "reach the end" of a hypothetical namespace in the primary KVS that we don't know about.  So I did not support that case.  In that situation, the wait-event watches until it receives a cancellation notice.

- I don't return any events after "clean" in the main job eventlog.  So if the user were to do something stupid like, "flux kvs eventlog append" on it, that event won't show up via an eventlog watch.

- As a side effect of this work #2356 and #2361 are basically closed too.

- Once finishing this work, removed the now unncessary calls to "eventlog_watch_cancel" in `cmd/flux-job`.

- I realized there is a race condition (although never seen) where an entry placed into a guest eventlog will not be seen by job-info.  The race is:

  - user write to eventlog, kvs completes write, sends setroot event
  - user deletes namespace, kvs sends namespace-remove event kvs-watch
  - kvs-watch receives setroot event, does lookupat on key
  - kvs-watch receives namespace-remove event BEFORE lookupat returns, sends ENOTSUP to watchers
  - response from lookupat arrives after ENOTSUP sent

  - I elected to solve this by having watched eventlogs in the guest namespace ALWAYS fallthrough to the main KVS namespace afterwards.  Some offsets checks ensure that all data in the guest eventlog has been read, and if it hasn't, send it over.
