### PR TITLE
libschedutil: export library for use by flux-sched and others

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,12 @@ LIBFLUX_OPTPARSE_AGE=0
 LIBFLUX_OPTPARSE_VERSION_INFO=$LIBFLUX_OPTPARSE_CURRENT:$LIBFLUX_OPTPARSE_REVISION:$LIBFLUX_OPTPARSE_AGE
 AC_SUBST([LIBFLUX_OPTPARSE_VERSION_INFO])
 
+LIBFLUX_SCHEDUTIL_CURRENT=1
+LIBFLUX_SCHEDUTIL_REVISION=0
+LIBFLUX_SCHEDUTIL_AGE=0
+LIBFLUX_SCHEDUTIL_VERSION_INFO=$LIBFLUX_SCHEDUTIL_CURRENT:$LIBFLUX_SCHEDUTIL_REVISION:$LIBFLUX_SCHEDUTIL_AGE
+AC_SUBST([LIBFLUX_SCHEDUTIL_VERSION_INFO])
+
 ##
 # Checks for programs
 ##
@@ -380,6 +386,9 @@ AC_SUBST(fluxincludedir)
 AS_VAR_SET(fluxcoreincludedir, $includedir/flux/core)
 AC_SUBST(fluxcoreincludedir)
 
+AS_VAR_SET(fluxschedutilincludedir, $includedir/flux/schedutil)
+AC_SUBST(fluxschedutilincludedir)
+
 adl_RECURSIVE_EVAL([$bindir], fluxbindir)
 AS_VAR_SET(fluxbindir, $fluxbindir)
 AC_SUBST(fluxbindir)
@@ -457,6 +466,7 @@ AC_CONFIG_FILES( \
   etc/flux-pmi.pc \
   etc/flux-optparse.pc \
   etc/flux-idset.pc \
+  etc/flux-schedutil.pc \
   etc/flux.service \
   doc/Makefile \
   doc/man1/Makefile \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -35,7 +35,11 @@ clean-local:
 	-rm -rf flux
 
 if WITH_PKG_CONFIG
-pkgconfig_DATA = flux-core.pc flux-pmi.pc flux-optparse.pc flux-idset.pc
+pkgconfig_DATA = flux-core.pc \
+	flux-pmi.pc \
+	flux-optparse.pc \
+	flux-idset.pc \
+	flux-schedutil.pc
 endif
 
 EXTRA_DIST = \

--- a/etc/flux-schedutil.pc.in
+++ b/etc/flux-schedutil.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: flux-schedutil
+Description: Flux Resource Manager Scheduler Utility Library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lflux-schedutil
+Cflags: -I${includedir}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,4 +10,5 @@ noinst_HEADERS = \
 	include/flux/core.h \
 	include/flux/optparse.h \
 	include/flux/idset.h \
+	include/flux/schedutil.h \
 	include/flux/shell.h

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -21,7 +21,7 @@ AM_LDFLAGS = $(CODE_COVERAGE_LIBS)
 
 AM_CPPFLAGS =
 
-fluxinclude_HEADERS = core.h
+fluxinclude_HEADERS = core.h schedutil.h
 noinst_LTLIBRARIES = libflux-internal.la
 libflux_internal_la_SOURCES =
 libflux_internal_la_LIBADD = \
@@ -37,7 +37,11 @@ libflux_internal_la_LIBADD = \
 	$(LIBDL) $(LIBRT) $(FLUX_SECURITY_LIBS) $(LIBSODIUM_LIBS)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
-lib_LTLIBRARIES = libflux-core.la libflux-optparse.la libflux-idset.la
+lib_LTLIBRARIES = libflux-core.la \
+	libflux-optparse.la \
+	libflux-idset.la \
+	libflux-schedutil.la
+
 fluxlib_LTLIBRARIES = libpmi.la
 
 libflux_core_la_SOURCES =
@@ -75,6 +79,17 @@ libflux_idset_la_LDFLAGS = \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
 
+libflux_schedutil_la_SOURCES =
+libflux_schedutil_la_LIBADD = \
+	$(builddir)/libschedutil/libschedutil.la \
+	libflux-core.la \
+	$(JANSSON_LIBS)
+libflux_schedutil_la_LDFLAGS = \
+        -Wl,--version-script=$(srcdir)/libflux-schedutil.map \
+	-version-info @LIBFLUX_SCHEDUTIL_VERSION_INFO@ \
+	-shared -export-dynamic --disable-static \
+	$(san_ld_zdef_flag)
+
 libpmi_la_SOURCES =
 libpmi_la_LIBADD = \
 	$(builddir)/libpmi/libpmi_client.la
@@ -89,4 +104,5 @@ EXTRA_DIST = \
 	libflux-core.map \
 	libflux-optparse.map \
 	libflux-idset.map \
+	libflux-schedutil.map \
 	libpmi.map

--- a/src/common/libflux-schedutil.map
+++ b/src/common/libflux-schedutil.map
@@ -1,0 +1,5 @@
+{ global:
+    schedutil_*;
+    local: *;
+};
+

--- a/src/common/libschedutil/Makefile.am
+++ b/src/common/libschedutil/Makefile.am
@@ -14,8 +14,14 @@ AM_CPPFLAGS = \
 noinst_LTLIBRARIES = \
 	libschedutil.la
 
+fluxschedutilinclude_HEADERS = init.h \
+	hello.h \
+	ready.h \
+	ops.h \
+	alloc.h \
+	free.h
+
 libschedutil_la_SOURCES = \
-	schedutil.h \
 	schedutil_private.h \
 	init.h \
 	init.c \

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -23,7 +23,8 @@ static int schedutil_hello_job (flux_t *h,
                                 int priority,
                                 uint32_t userid,
                                 double t_submit,
-                                hello_f *cb, void *arg)
+                                schedutil_hello_cb_f *cb,
+                                void *arg)
 {
     char key[64];
     flux_future_t *f;
@@ -53,7 +54,7 @@ error:
     return -1;
 }
 
-int schedutil_hello (schedutil_t *util, hello_f *cb, void *arg)
+int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
 {
     flux_future_t *f;
     json_t *jobs;

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -20,20 +20,20 @@
  * Failure of the callback aborts iteration and causes schedutil_hello()
  * to return -1 with errno passed through.
  */
-typedef int (hello_f)(flux_t *h,
-                      flux_jobid_t id,
-                      int priority,
-                      uint32_t userid,
-                      double t_submit,
-                      const char *R,
-                      void *arg);
+typedef int (schedutil_hello_cb_f)(flux_t *h,
+                                   flux_jobid_t id,
+                                   int priority,
+                                   uint32_t userid,
+                                   double t_submit,
+                                   const char *R,
+                                   void *arg);
 
 /* Send hello announcement to job-manager.
  * The job-manager responds with a list of jobs that have resources assigned.
  * This function looks up R for each job and passes R + metadata to 'cb'
  * with 'arg'.
  */
-int schedutil_hello (schedutil_t *util, hello_f *cb, void *arg);
+int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg);
 
 #endif /* !_FLUX_SCHEDUTIL_HELLO_H */
 

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -29,9 +29,9 @@ enum module_debug_flags {
 
 
 schedutil_t *schedutil_create (flux_t *h,
-                               op_alloc_f *alloc_cb,
-                               op_free_f *free_cb,
-                               op_exception_f *exception_cb,
+                               schedutil_alloc_cb_f *alloc_cb,
+                               schedutil_free_cb_f *free_cb,
+                               schedutil_exception_cb_f *exception_cb,
                                void *cb_arg)
 {
     schedutil_t *util;

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -24,9 +24,9 @@ typedef struct schedutil_ctx schedutil_t;
  * Return NULL on error.
  */
 schedutil_t *schedutil_create (flux_t *h,
-                               op_alloc_f *alloc_cb,
-                               op_free_f *free_cb,
-                               op_exception_f *exception_cb,
+                               schedutil_alloc_cb_f *alloc_cb,
+                               schedutil_free_cb_f *free_cb,
+                               schedutil_exception_cb_f *exception_cb,
                                void *cb_arg);
 
 /* Destory the handle for the schedutil conveinence library.

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -19,10 +19,10 @@
  * You should either respond to the request immediately (see alloc.h),
  * or cache this information for later response.
  */
-typedef void (op_alloc_f)(flux_t *h,
-                          const flux_msg_t *msg,
-                          const char *jobspec,
-                          void *arg);
+typedef void (schedutil_alloc_cb_f)(flux_t *h,
+                                    const flux_msg_t *msg,
+                                    const char *jobspec,
+                                    void *arg);
 
 /* Callback for a free request.  R is looked up as a convenience.
  * Decode msg with schedutil_free_request_decode().
@@ -30,10 +30,10 @@ typedef void (op_alloc_f)(flux_t *h,
  * You should either respond to the request immediately (see free.h),
  * or cache this information for later response.
  */
-typedef void (op_free_f)(flux_t *h,
-                         const flux_msg_t *msg,
-                         const char *R,
-                         void *arg);
+typedef void (schedutil_free_cb_f)(flux_t *h,
+                                   const flux_msg_t *msg,
+                                   const char *R,
+                                   void *arg);
 
 /* An exception occurred for job 'id'.
  * If the severity is zero, and there is an allocation pending for 'id',
@@ -41,11 +41,11 @@ typedef void (op_free_f)(flux_t *h,
  * setting the note field to something like "alloc aborted due to
  * exception type=%s"
  */
-typedef void (op_exception_f)(flux_t *h,
-                              flux_jobid_t id,
-                              const char *type,
-                              int severity,
-                              void *arg);
+typedef void (schedutil_exception_cb_f)(flux_t *h,
+                                        flux_jobid_t id,
+                                        const char *type,
+                                        int severity,
+                                        void *arg);
 
 #endif /* !_FLUX_SCHEDUTIL_OPS_H */
 

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -16,9 +16,9 @@
 struct schedutil_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
-    op_alloc_f *alloc_cb;
-    op_free_f *free_cb;
-    op_exception_f *exception_cb;
+    schedutil_alloc_cb_f *alloc_cb;
+    schedutil_free_cb_f *free_cb;
+    schedutil_exception_cb_f *exception_cb;
     void *cb_arg;
     zlistx_t *outstanding_futures;
 };

--- a/src/common/schedutil.h
+++ b/src/common/schedutil.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_H
+#define _FLUX_SCHEDUTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "schedutil/init.h"
+#include "schedutil/hello.h"
+#include "schedutil/ready.h"
+#include "schedutil/alloc.h"
+#include "schedutil/free.h"
+#include "schedutil/ops.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_SCHEDUTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/include/flux/schedutil.h
+++ b/src/include/flux/schedutil.h
@@ -8,23 +8,18 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* Allow in-tree programs to #include <flux/core.h> like out-of-tree would.
+ */
+
 #ifndef _FLUX_SCHEDUTIL_H
 #define _FLUX_SCHEDUTIL_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "init.h"
-#include "hello.h"
-#include "ready.h"
-#include "alloc.h"
-#include "free.h"
-#include "ops.h"
-
-#ifdef __cplusplus
-}
-#endif
+#include "src/common/libschedutil/init.h"
+#include "src/common/libschedutil/hello.h"
+#include "src/common/libschedutil/ready.h"
+#include "src/common/libschedutil/alloc.h"
+#include "src/common/libschedutil/free.h"
+#include "src/common/libschedutil/ops.h"
 
 #endif /* !_FLUX_SCHEDUTIL_H */
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -14,9 +14,9 @@
 #include <czmq.h>
 #include <flux/core.h>
 #include <flux/idset.h>
+#include <flux/schedutil.h>
 
 #include "src/common/libutil/errno_safe.h"
-#include "src/common/libschedutil/schedutil.h"
 #include "libjj.h"
 #include "rlist.h"
 

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -23,10 +23,10 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <flux/schedutil.h>
 #include <jansson.h>
 #include <czmq.h>
 #include "src/common/liboptparse/optparse.h"
-#include "src/common/libschedutil/schedutil.h"
 
 // flux module debug --setbit 0x1 sched-dummy
 // flux module debug --clearbit 0x1 sched-dummy


### PR DESCRIPTION
- installs the compiled schedutil shared library
- adds a libschedutil map file for `ld`
- installs the schedutil headers
- creates a schedutil .pc file
- prefixes all public function typedefs with `schedutil_`

Closes #2377 