### PR TITLE
WIP: export libpmi2.so.0.0.0 for MPICH derivatives configured --with-pm=slurm --with-pmi=pmi2

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -64,8 +64,8 @@ libbroker_la_SOURCES = \
 flux_broker_LDADD = \
 	$(builddir)/libbroker.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libpmi/libpmi_client.la
+	$(top_builddir)/src/common/libpmi/libpmi_client.la \
+	$(top_builddir)/src/common/libflux-internal.la
 
 flux_broker_LDFLAGS =
 
@@ -81,8 +81,8 @@ TESTS = test_shutdown.t \
 test_ldadd = \
 	$(builddir)/libbroker.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libpmi/libpmi_client.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la
 
 test_cppflags = \

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -150,7 +150,7 @@ done:
  *  number of parents. If the PMI key is missing, this is not an error,
  *  instead the level of this instance is considered to be zero.
  *  Additonally, if level > 0, the shell will have put the instance's
- *  jobid in the PMI kvs for us as well.
+ *  jobid in the PMI kvsname for us as well, so populate the 'jobid' attr.
  */
 static int set_instance_level_attr (struct pmi_handle *pmi,
                                     const char *kvsname,
@@ -170,16 +170,8 @@ static int set_instance_level_attr (struct pmi_handle *pmi,
         level = val;
     if (attr_add (attrs, "instance-level", level, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
-    if (result == PMI_SUCCESS) {
-        result = broker_pmi_kvs_get (pmi,
-                                     kvsname,
-                                     "flux.jobid",
-                                     val,
-                                     sizeof (val));
-        if (result != PMI_SUCCESS)
-            return -1;
-        jobid = val;
-    }
+    if (result == PMI_SUCCESS)
+        jobid = kvsname;
     if (attr_add (attrs, "jobid", jobid, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
     return 0;

--- a/src/broker/pmiutil.c
+++ b/src/broker/pmiutil.c
@@ -249,14 +249,11 @@ struct pmi_handle *broker_pmi_create (void)
     if (!pmi)
         return NULL;
     pmi_debug = getenv ("FLUX_PMI_DEBUG");
-    if (!pmi_debug)
-        pmi_debug = getenv ("PMI_DEBUG");
     if (pmi_debug)
         pmi->debug = strtol (pmi_debug, NULL, 10);
     pmi->cli = pmi_simple_client_create_fd (getenv ("PMI_FD"),
                                             getenv ("PMI_RANK"),
                                             getenv ("PMI_SIZE"),
-                                            pmi_debug,
                                             NULL);
     /* N.B. SLURM boldly installs its libpmi.so into the system libdir,
      * so it will be found here, even if not running in a SLURM job.

--- a/src/broker/pmiutil.h
+++ b/src/broker/pmiutil.h
@@ -11,7 +11,6 @@
 struct pmi_params {
     int rank;
     int size;
-    int appnum;
     char kvsname[64];
 };
 

--- a/src/broker/test/pmiutil.c
+++ b/src/broker/test/pmiutil.c
@@ -57,7 +57,6 @@ int main (int argc, char **argv)
     ok (strlen (params.kvsname) > 0,
         "kvsname is not the empty string");
     diag ("kvsname=%s", params.kvsname);
-    diag ("appnum=%d", params.appnum);
 
     result = broker_pmi_kvs_put (pmi, params.kvsname, "foo", "bar");
     ok (result == PMI_SUCCESS,

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -92,7 +92,8 @@ libflux_schedutil_la_LDFLAGS = \
 
 libpmi_la_SOURCES =
 libpmi_la_LIBADD = \
-	$(builddir)/libpmi/libpmi_client.la
+	$(builddir)/libpmi/libpmi_client.la \
+	$(builddir)/libutil/aux.lo
 libpmi_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libpmi.map \
 	-version-info 0:0:0 \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -42,7 +42,7 @@ lib_LTLIBRARIES = libflux-core.la \
 	libflux-idset.la \
 	libflux-schedutil.la
 
-fluxlib_LTLIBRARIES = libpmi.la
+fluxlib_LTLIBRARIES = libpmi.la libpmi2.la
 
 libflux_core_la_SOURCES =
 libflux_core_la_LIBADD = \
@@ -101,9 +101,21 @@ libpmi_la_LDFLAGS = \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
 
+libpmi2_la_SOURCES =
+libpmi2_la_LIBADD = \
+	$(builddir)/libpmi/libpmi_client.la \
+	$(builddir)/libutil/aux.lo
+libpmi2_la_LDFLAGS = \
+        -Wl,--version-script=$(srcdir)/libpmi2.map \
+	-version-info 0:0:0 \
+	-Wl,--defsym=flux_pmi_library=1 \
+	-shared -export-dynamic --disable-static \
+	$(san_ld_zdef_flag)
+
 EXTRA_DIST = \
 	libflux-core.map \
 	libflux-optparse.map \
 	libflux-idset.map \
 	libflux-schedutil.map \
-	libpmi.map
+	libpmi.map \
+	libpmi2.map

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -44,6 +44,7 @@ fluxinclude_HEADERS = \
 TESTS = test_keyval.t \
 	test_simple.t \
 	test_canonical.t \
+	test_canonical2.t \
 	test_clique.t
 
 test_ldadd = \
@@ -87,6 +88,14 @@ test_canonical_t_SOURCES = \
 	test/server_thread.h
 test_canonical_t_CPPFLAGS = $(test_cppflags)
 test_canonical_t_LDADD = $(test_ldadd)
+
+test_canonical2_t_SOURCES = \
+	test/canonical2.c \
+	test/server_thread.c \
+	test/server_thread.h
+test_canonical2_t_CPPFLAGS = $(test_cppflags)
+test_canonical2_t_LDADD = $(test_ldadd)
+
 
 test_clique_t_SOURCES = test/clique.c
 test_clique_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -108,3 +108,6 @@ test_pmi_info_LDADD = $(test_ldadd)
 test_kvstest_SOURCES = test/kvstest.c
 test_kvstest_CPPFLAGS = $(test_cppflags)
 test_kvstest_LDADD = $(test_ldadd)
+
+EXTRA_DIST = \
+    ltrace.conf

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -27,6 +27,7 @@ libpmi_client_la_SOURCES = \
 	simple_client.c \
 	simple_client.h \
 	pmi.c \
+	pmi2.c \
 	dgetline.c \
 	dgetline.h \
 	$(libpmi_common_sources)
@@ -37,7 +38,8 @@ libpmi_server_la_SOURCES = \
 	$(libpmi_common_sources)
 
 fluxinclude_HEADERS = \
-	pmi.h
+	pmi.h \
+	pmi2.h
 
 TESTS = test_keyval.t \
 	test_simple.t \

--- a/src/common/libpmi/ltrace.conf
+++ b/src/common/libpmi/ltrace.conf
@@ -1,0 +1,74 @@
+;
+; ltrace.conf(5) file for tracing PMI library usage
+;
+; Usage: ltrace -tt -l 'libpmi*' -F ltrace.conf mpi-executable
+;
+
+;
+; Error enum represents combined PMI-1 and PMI-2 error codes (mostly identical)
+;
+typedef e_err = enum( SUCCESS=0, FAIL=-1, ERR_INIT=1, ERR_NOMEM=2, ERR_INVALID_ARG=3, ERR_INVALID_KEY=4, ERR_INVALID_KEY_LENGTH=5, ERR_INVALID_VAL=6, ERR_INVALID_VAL_LENGTH=7, ERR_INVALID_LENGTH=8, ERR_INVALID_NUM_ARGS=9, ERR_INVALID_ARGS=10, ERR_INVALID_NUM_PARSED=11, ERR_INVALID_KEYVALP=12, ERR_INVALID_SIZE=13, ERR_OTHER=14 );
+
+;
+; PMI-1
+;
+e_err PMI_Init (+int*);
+e_err PMI_Initialized (+int*);
+e_err PMI_Finalize ();
+e_err PMI_Abort (int, string);
+
+e_err PMI_Get_size (+int*);
+e_err PMI_Get_rank (+int*);
+e_err PMI_Get_universe_size (+int*);
+e_err PMI_Get_appnum (+int*);
+
+e_err PMI_Get_clique_size (+int*);
+e_err PMI_Get_clique_ranks (+array(int,arg2), int);
+
+e_err PMI_KVS_Get_name_length_max (+int*);
+e_err PMI_KVS_Get_key_length_max (+int*);
+e_err PMI_KVS_Get_value_length_max (+int*);
+
+e_err PMI_KVS_Put (string, string, string);
+e_err PMI_KVS_Get (string, string, +string, int);
+e_err PMI_KVS_Commit (string);
+e_err PMI_Barrier ();
+
+e_err PMI_Publish_name (string, string);
+e_err PMI_Unpublish_name (string);
+e_err PMI_Lookup_name (string, +string);
+
+e_err PMI_Get_id_length_max (+int*);
+e_err PMI_Get_id (+string, int);
+e_err PMI_Get_kvs_domain_id (+string, int);
+
+;PMI_Spawn_multiple
+
+;
+; PMI-2
+;
+e_err PMI2_Init (+int*, +int*, +int*, +int*);
+e_err PMI2_Finalize ();
+
+e_err PMI2_Job_GetId (+string, int);
+e_err PMI2_Job_GetRank (+int*);
+e_err PMI2_Job_Connect (string, void*);
+e_err PMI2_Job_Disconnect (string);
+
+e_err PMI2_KVS_Put (string, string);
+e_err PMI2_KVS_Get (string, int, string, +string, int, +int*);
+e_err PMI2_KVS_Fence ();
+
+e_err PMI2_Info_GetSize (+int*);
+e_err PMI2_Info_GetNodeAttr (string, +string, int, +int*, int);
+e_err PMI2_Info_GetNodeAttrIntArray (string, +array(int,arg3), int, +int*, +int*);
+e_err PMI2_Info_PutNodeAttr (string, string);
+
+e_err PMI2_Info_GetJobAttr (string, +string, int, +int*);
+e_err PMI2_Info_GetJobAttrIntArray (string, +array(int,arg3), int, +int*, +int*);
+
+e_err PMI2_Nameserv_publish (string, void*, string);
+e_err PMI2_Nameserv_unpublish (string, void*);
+e_err PMI2_Nameserv_lookup (string, void*, +string, int);
+
+;PMI2_Job_Spawn

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -32,8 +32,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/types.h>
-#include <dlfcn.h>
-#include <stdarg.h>
 
 #include "pmi.h"
 #include "pmi_strerror.h"

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -285,7 +285,7 @@ int PMI_KVS_Commit (const char kvsname[])
 
 int PMI_Barrier (void)
 {
-    int result = PMI_ERR_INIT;
+    int result;
 
     result = pmi_simple_client_barrier (pmi_global_ctx);
     DRETURN (result);

--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -40,29 +40,10 @@
 
 static struct pmi_simple_client *pmi_global_ctx;
 
-#define DPRINTF(fmt,...) do { \
-    if (pmi_global_ctx && pmi_global_ctx->debug) \
-        fprintf (stderr, fmt, ##__VA_ARGS__); \
-} while (0)
-
-#define DRETURN(rc) do { \
-    DPRINTF ("%d: %s rc=%d %s\n", \
-            pmi_global_ctx ? pmi_global_ctx->rank : -1, \
-            __func__, (rc), \
-            rc == PMI_SUCCESS ? "" : pmi_strerror (rc)); \
-    return (rc); \
-} while (0);
-
-
 int PMI_Init (int *spawned)
 {
-    int result = PMI_FAIL;
-    const char *pmi_debug;
+    int result;
     struct pmi_simple_client *ctx;
-
-    pmi_debug = getenv ("FLUX_PMI_DEBUG");
-    if (!pmi_debug)
-        pmi_debug = getenv ("PMI_DEBUG");
 
     if (pmi_global_ctx)
         return PMI_ERR_INIT;
@@ -70,7 +51,6 @@ int PMI_Init (int *spawned)
     ctx = pmi_simple_client_create_fd (getenv ("PMI_FD"),
                                        getenv ("PMI_RANK"),
                                        getenv ("PMI_SIZE"),
-                                       pmi_debug,
                                        getenv ("PMI_SPAWNED"));
     if (!ctx) {
         if (errno == ENOMEM)
@@ -86,30 +66,27 @@ int PMI_Init (int *spawned)
     pmi_global_ctx = ctx;
     if (spawned)
         *spawned = ctx->spawned;
-    DRETURN (result);
+    return PMI_SUCCESS;
 }
 
 int PMI_Initialized (int *initialized)
 {
-    int result = PMI_SUCCESS;
-
-    if (initialized)
-        *initialized = pmi_global_ctx ? pmi_global_ctx->initialized : 0;
-    else
-        result = PMI_ERR_INVALID_ARG;
-    DRETURN (result);
+    if (!initialized)
+        return PMI_ERR_INVALID_ARG;
+    *initialized = pmi_global_ctx ? pmi_global_ctx->initialized : 0;
+    return PMI_SUCCESS;
 }
 
 int PMI_Finalize (void)
 {
-    int result = PMI_ERR_INIT;
+    int result;
 
-    if (pmi_global_ctx) {
-        result = pmi_simple_client_finalize (pmi_global_ctx);
-        pmi_simple_client_destroy (pmi_global_ctx);
-        pmi_global_ctx = NULL;
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx)
+        return PMI_ERR_INIT;
+    result = pmi_simple_client_finalize (pmi_global_ctx);
+    pmi_simple_client_destroy (pmi_global_ctx);
+    pmi_global_ctx = NULL;
+    return result;
 }
 
 int PMI_Abort (int exit_code, const char error_msg[])
@@ -119,191 +96,118 @@ int PMI_Abort (int exit_code, const char error_msg[])
              error_msg);
     exit (exit_code);
     /*NOTREACHED*/
-    DRETURN (PMI_SUCCESS);
+    return PMI_SUCCESS;
 }
 
 int PMI_Get_size (int *size)
 {
-    int result = PMI_ERR_INIT;
-
-    if (pmi_global_ctx) {
-        if (!size)
-            result = PMI_ERR_INVALID_ARG;
-        else {
-            *size = pmi_global_ctx->size;
-            result = PMI_SUCCESS;
-        }
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx)
+        return PMI_ERR_INIT;
+    if (!size)
+        return PMI_ERR_INVALID_ARG;
+    *size = pmi_global_ctx->size;
+    return PMI_SUCCESS;
 }
 
 int PMI_Get_rank (int *rank)
 {
-    int result = PMI_ERR_INIT;
-
-    if (pmi_global_ctx) {
-        if (!rank)
-            result = PMI_ERR_INVALID_ARG;
-        else {
-            *rank = pmi_global_ctx->rank;
-            result = PMI_SUCCESS;
-        }
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx)
+        return PMI_ERR_INIT;
+    if (!rank)
+        return PMI_ERR_INVALID_ARG;
+    *rank = pmi_global_ctx->rank;
+    return PMI_SUCCESS;
 }
 
 int PMI_Get_universe_size (int *size)
 {
-    int result;
-
-    result = pmi_simple_client_get_universe_size (pmi_global_ctx, size);
-    DRETURN (result);
+    return pmi_simple_client_get_universe_size (pmi_global_ctx, size);
 }
 
 int PMI_Get_appnum (int *appnum)
 {
-    int result;
-
-    result = pmi_simple_client_get_appnum (pmi_global_ctx, appnum);
-    DRETURN (result);
+    return pmi_simple_client_get_appnum (pmi_global_ctx, appnum);
 }
 
 int PMI_KVS_Get_my_name (char kvsname[], int length)
 {
-    int result;
-
-    result = pmi_simple_client_kvs_get_my_name (pmi_global_ctx,
-                                                kvsname,
-                                                length);
-
-    DPRINTF ("%d: %s (\"%s\", %d) rc=%d %s\n",
-             pmi_global_ctx ? pmi_global_ctx->rank : -1,
-             __func__,
-             result == PMI_SUCCESS ? kvsname : "",
-             length,
-             result,
-             result == PMI_SUCCESS ? "" : pmi_strerror (result));
-
-    return result;
+    return pmi_simple_client_kvs_get_my_name (pmi_global_ctx,
+                                              kvsname,
+                                              length);
 }
 
 int PMI_KVS_Get_name_length_max (int *length)
 {
-    int result = PMI_ERR_INIT;
-
-    if (pmi_global_ctx && pmi_global_ctx->initialized) {
-        if (!length)
-            result = PMI_ERR_INVALID_ARG;
-        else {
-            *length = pmi_global_ctx->kvsname_max;
-            result = PMI_SUCCESS;
-        }
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx || !pmi_global_ctx->initialized)
+        return PMI_ERR_INIT;
+    if (!length)
+        return PMI_ERR_INVALID_ARG;
+    *length = pmi_global_ctx->kvsname_max;
+    return PMI_SUCCESS;
 }
 
 int PMI_KVS_Get_key_length_max (int *length)
 {
-    int result = PMI_ERR_INIT;
-
-    if (pmi_global_ctx && pmi_global_ctx->initialized) {
-        if (!length)
-            result = PMI_ERR_INVALID_ARG;
-        else {
-            *length = pmi_global_ctx->keylen_max;
-            result = PMI_SUCCESS;
-        }
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx || !pmi_global_ctx->initialized)
+        return PMI_ERR_INIT;
+    if (!length)
+        return PMI_ERR_INVALID_ARG;
+    *length = pmi_global_ctx->keylen_max;
+    return PMI_SUCCESS;
 }
 
 int PMI_KVS_Get_value_length_max (int *length)
 {
-    int result = PMI_ERR_INIT;
-
-    if (pmi_global_ctx && pmi_global_ctx->initialized) {
-        if (!length)
-            result = PMI_ERR_INVALID_ARG;
-        else {
-            *length = pmi_global_ctx->vallen_max;
-            result = PMI_SUCCESS;
-        }
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx || !pmi_global_ctx->initialized)
+        return PMI_ERR_INIT;
+    if (!length)
+        return PMI_ERR_INVALID_ARG;
+    *length = pmi_global_ctx->vallen_max;
+    return PMI_SUCCESS;
 }
 
 int PMI_KVS_Put (const char kvsname[], const char key[], const char value[])
 {
-    int result;
-
-    result = pmi_simple_client_kvs_put (pmi_global_ctx, kvsname, key, value);
-
-    DPRINTF ("%d: %s (\"%s\", \"%s\", \"%s\") rc=%d %s\n",
-             pmi_global_ctx ? pmi_global_ctx->rank : -1,
-             __func__,
-             kvsname ? kvsname : "NULL",
-             key ? key : "NULL",
-             value ? value : "NULL",
-             result,
-             result == PMI_SUCCESS ? "" : pmi_strerror (result));
-
-    return result;
+    return pmi_simple_client_kvs_put (pmi_global_ctx, kvsname, key, value);
 }
 
 int PMI_KVS_Get (const char kvsname[], const char key[],
                  char value[], int length)
 {
-    int result;
-
-    result = pmi_simple_client_kvs_get (pmi_global_ctx, kvsname, key,
-                                        value, length);
-
-    DPRINTF ("%d: %s (\"%s\", \"%s\", \"%s\") rc=%d %s\n",
-             pmi_global_ctx ? pmi_global_ctx->rank : -1,
-             __func__,
-             kvsname ? kvsname : "NULL",
-             key ? key : "NULL",
-             result == PMI_SUCCESS ? value : "",
-             result,
-             result == PMI_SUCCESS ? "" : pmi_strerror (result));
-
-    return result;
+    return pmi_simple_client_kvs_get (pmi_global_ctx,
+                                      kvsname,
+                                      key,
+                                      value,
+                                      length);
 }
 
 int PMI_KVS_Commit (const char kvsname[])
 {
-    int result = PMI_ERR_INIT;
-
-    if (pmi_global_ctx && pmi_global_ctx->initialized) {
-        if (!kvsname)
-            result = PMI_ERR_INVALID_ARG;
-        else
-            result = PMI_SUCCESS; // no-op in this implementation
-    }
-    DRETURN (result);
+    if (!pmi_global_ctx || !pmi_global_ctx->initialized)
+        return PMI_ERR_INIT;
+    if (!kvsname)
+        return PMI_ERR_INVALID_ARG;
+    return PMI_SUCCESS; // no-op in this implementation
 }
 
 int PMI_Barrier (void)
 {
-    int result;
-
-    result = pmi_simple_client_barrier (pmi_global_ctx);
-    DRETURN (result);
+    return pmi_simple_client_barrier (pmi_global_ctx);
 }
 
 int PMI_Publish_name (const char service_name[], const char port[])
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Unpublish_name (const char service_name[])
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Lookup_name (const char service_name[], char port[])
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Spawn_multiple(int count,
@@ -316,7 +220,7 @@ int PMI_Spawn_multiple(int count,
                        const PMI_keyval_t preput_keyval_vector[],
                        int errors[])
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 /* Old API funcs - signatures needed for ABI compliance.
@@ -324,86 +228,71 @@ int PMI_Spawn_multiple(int count,
 
 int PMI_Get_clique_ranks (int ranks[], int length)
 {
-    int result;
-
-    result = pmi_simple_client_get_clique_ranks (pmi_global_ctx, ranks, length);
-    DRETURN (result);
+    return pmi_simple_client_get_clique_ranks (pmi_global_ctx, ranks, length);
 }
 
 int PMI_Get_clique_size (int *size)
 {
-    int result;
-
-    result = pmi_simple_client_get_clique_size (pmi_global_ctx, size);
-    DRETURN (result);
+    return pmi_simple_client_get_clique_size (pmi_global_ctx, size);
 }
 
 int PMI_Get_id_length_max (int *length)
 {
-    int result;
-
-    result  = PMI_KVS_Get_name_length_max (length);
-    DRETURN (result);
+    return PMI_KVS_Get_name_length_max (length);
 }
 
 int PMI_Get_id (char kvsname[], int length)
 {
-    int result;
-
-    result = PMI_KVS_Get_my_name (kvsname, length);
-    DRETURN (result);
+    return PMI_KVS_Get_my_name (kvsname, length);
 }
 
 int PMI_Get_kvs_domain_id (char kvsname[], int length)
 {
-    int result;
-
-    result = PMI_KVS_Get_my_name (kvsname, length);
-    DRETURN (result);
+    return PMI_KVS_Get_my_name (kvsname, length);
 }
 
 int PMI_KVS_Create (char kvsname[], int length)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_KVS_Destroy (const char kvsname[])
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_KVS_Iter_first (const char kvsname[], char key[], int key_len,
                         char val[], int val_len)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_KVS_Iter_next (const char kvsname[], char key[], int key_len,
                        char val[], int val_len)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Parse_option (int num_args, char *args[], int *num_parsed,
                       PMI_keyval_t **keyvalp, int *size)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Args_to_keyval (int *argcp, char *((*argvp)[]),
                         PMI_keyval_t **keyvalp, int *size)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Free_keyvals (PMI_keyval_t keyvalp[], int size)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 int PMI_Get_options (char *str, int *length)
 {
-    DRETURN (PMI_FAIL);
+    return PMI_FAIL;
 }
 
 /*

--- a/src/common/libpmi/pmi2.c
+++ b/src/common/libpmi/pmi2.c
@@ -1,0 +1,344 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* pmi2.c - canonical PMI-2 API/ABI for libpmi2.so.0.0.0
+ *
+ * This is pretty much the minimum needed to bootstrap MPICH and
+ * derivatives under Flux, when they are configured with --with-pm=slurm
+ * --with-pmi=pmi2.  This configuration forces a dlopen of libpmi2.so.0.0.0,
+ * so use LD_LIBRARY_PATH to make it find ours before Slurm's.
+ *
+ * Caveats:
+ * - Only the API functions and attrs needed for bootstrap are implemented.
+ * - This is based on pmi_simple_client, which only supports the v1 wire proto.
+ * - Although the pmi_simple_client calls return PMI-1 error codes, PMI-2's
+ *   error codes are numerically identical so we don't bother converting.
+ * - The kvsname is cached in the pmi_simple_client aux cache on first use.
+ *   It is needed internally by PMI2_KVS_Put(), PMI2_Info_GetJobAttr(),
+ *   and caching it avoids the RTT of fetching it on each use.
+ * - This implementation is not thread safe.  Locks should be added so that
+ *   the global context can be shared across threads as is seemingly required
+ *   by the PMI-2 design documents (see references below).
+ * - Even if locks are added, pmi_simple_client does not support the v1 wire
+ *   proto split operations, so multiple PMI_KVS_Get() requests could not be
+ *   outstanding in multiple threads.
+ * - Is providing the 'PMI_process_mapping' attribute sufficient "clique"
+ *   support to allow MPI to use shmem to communicate on co-located ranks?
+ *
+ * See also:
+ * - https://wiki.mpich.org/mpich/index.php/PMI_v2_API
+ * - https://wiki.mpich.org/mpich/index.php/PMI_v2_Wire_Protocol
+ * - https://wiki.mpich.org/mpich/index.php/PMI_v2_Design_Thoughts
+ *   https://www.mcs.anl.gov/papers/P1760.pdf
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <string.h>
+
+#include "pmi.h"
+#include "pmi2.h"
+#include "pmi_strerror.h"
+#include "simple_client.h"
+
+static struct pmi_simple_client *pmi_global_ctx;
+
+int PMI2_Init (int *spawned, int *size, int *rank, int *appnum)
+{
+    int result = PMI2_FAIL;
+    struct pmi_simple_client *ctx;
+
+    if (pmi_global_ctx)
+        return PMI2_ERR_INIT;
+
+    ctx = pmi_simple_client_create_fd (getenv ("PMI_FD"),
+                                       getenv ("PMI_RANK"),
+                                       getenv ("PMI_SIZE"),
+                                       getenv ("PMI_SPAWNED"));
+    if (!ctx) {
+        if (errno == ENOMEM)
+            return PMI2_ERR_NOMEM;
+        return PMI2_FAIL;
+    }
+
+    result = pmi_simple_client_init (ctx);
+    if (result != PMI2_SUCCESS) {
+        pmi_simple_client_destroy (ctx);
+        return result;
+    }
+    if (appnum) {
+        result = pmi_simple_client_get_appnum (ctx, appnum);
+        if (result != PMI2_SUCCESS) {
+            pmi_simple_client_destroy (ctx);
+            return result;
+        }
+    }
+    if (spawned)
+        *spawned = ctx->spawned;
+    if (size)
+        *size = ctx->size;
+    if (rank)
+        *rank = ctx->rank;
+
+    pmi_global_ctx = ctx;
+    return PMI2_SUCCESS;
+}
+
+int PMI2_Finalize (void)
+{
+    int result;
+
+    result = pmi_simple_client_finalize (pmi_global_ctx);
+    pmi_simple_client_destroy (pmi_global_ctx);
+
+    pmi_global_ctx = NULL;
+    return result;
+}
+
+int PMI2_Initialized (void)
+{
+    if (pmi_global_ctx && pmi_global_ctx->initialized)
+        return 1;
+    return 0;
+}
+
+int PMI2_Abort (int flag, const char msg[])
+{
+    fprintf (stderr, "PMI2_Abort: (%d) %s\n",
+             pmi_global_ctx ? pmi_global_ctx->rank : -1,
+             msg ? msg : "NULL");
+    exit (1);
+    /*NOTREACHED*/
+    return PMI_SUCCESS;
+}
+
+int PMI2_Job_Spawn (int count, const char * cmds[],
+                    int argcs[], const char ** argvs[],
+                    const int maxprocs[],
+                    const int info_keyval_sizes[],
+                    const struct MPID_Info *info_keyval_vectors[],
+                    int preput_keyval_size,
+                    const struct MPID_Info *preput_keyval_vector[],
+                    char jobId[], int jobIdSize,
+                    int errors[])
+{
+    return PMI_FAIL;
+}
+
+/* Look up kvsname on first request, then cache for subsequent requests.
+ */
+static int get_cached_kvsname (struct pmi_simple_client *pmi, const char **name)
+{
+    const char *auxkey = "flux::kvsname";
+    char *kvsname;
+    int result;
+
+    if (!pmi)
+        return PMI2_ERR_INIT;
+    if ((kvsname = pmi_simple_client_aux_get (pmi, auxkey))) {
+        *name = kvsname;
+        return PMI2_SUCCESS;
+    }
+    if (!(kvsname = calloc (1, pmi->kvsname_max)))
+        return PMI2_ERR_NOMEM;
+    result = pmi_simple_client_kvs_get_my_name (pmi,
+                                                kvsname,
+                                                pmi->kvsname_max);
+    if (result != PMI2_SUCCESS) {
+        free (kvsname);
+        return result;
+    }
+    if (pmi_simple_client_aux_set (pmi, auxkey, kvsname, free) < 0) {
+        free (kvsname);
+        return PMI2_FAIL;
+    }
+    *name = kvsname;
+    return PMI2_SUCCESS;
+}
+
+/* MPICH: treats PMI2_Job_GetId() equivalent to PMI_KVS_Get_my_name().
+ */
+int PMI2_Job_GetId (char jobid[], int jobid_size)
+{
+    const char *kvsname;
+    int result;
+
+    result = get_cached_kvsname (pmi_global_ctx, &kvsname);
+    if (result != PMI2_SUCCESS)
+        return result;
+    if (!jobid || jobid_size < (int)strlen (kvsname) + 1)
+        return PMI2_ERR_INVALID_ARGS;
+    strcpy (jobid, kvsname);
+    return PMI2_SUCCESS;
+}
+
+int PMI2_Job_GetRank (int *rank)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Job_Connect (const char jobid[], PMI2_Connect_comm_t *conn)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Job_Disconnect (const char jobid[])
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_KVS_Put (const char key[], const char value[])
+{
+    const char *kvsname;
+    int result;
+
+    result = get_cached_kvsname (pmi_global_ctx, &kvsname);
+    if (result != PMI2_SUCCESS)
+        return result;
+
+    return pmi_simple_client_kvs_put (pmi_global_ctx, kvsname, key, value);
+}
+
+/* MPICH: treats jobid equivalent to kvsname.
+ * We ignore src_pmi_id.
+ */
+int PMI2_KVS_Get (const char *jobid,
+                  int src_pmi_id,
+                  const char key[],
+                  char value [],
+                  int maxvalue,
+                  int *vallen)
+{
+    int result;
+
+    result = pmi_simple_client_kvs_get (pmi_global_ctx,
+                                        jobid,
+                                        key,
+                                        value,
+                                        maxvalue);
+    if (vallen)
+        *vallen = (result == PMI2_SUCCESS) ? strlen (value) : 0;
+    return result;
+}
+
+int PMI2_KVS_Fence (void)
+{
+    return pmi_simple_client_barrier (pmi_global_ctx);
+}
+
+int PMI2_Info_GetSize (int *size)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Info_GetNodeAttr (const char name[],
+                           char value[], int valuelen, int *found, int waitfor)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Info_GetNodeAttrIntArray (const char name[], int array[],
+                                   int arraylen, int *outlen, int *found)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Info_PutNodeAttr (const char name[], const char value[])
+{
+    return PMI2_FAIL;
+}
+
+/* MPICH: only fetches PMI_process_mapping and universeSize
+ * with PMI2_Info_GetJobAttr().
+ */
+int PMI2_Info_GetJobAttr (const char name[],
+                          char value[], int valuelen, int *found)
+{
+    int result;
+
+    if (!name || !value) {
+        result = PMI2_ERR_INVALID_ARG;
+        goto error;
+    }
+    if (!strcmp (name, "PMI_process_mapping")) {
+        const char *kvsname;
+
+        result = get_cached_kvsname (pmi_global_ctx, &kvsname);
+        if (result != PMI2_SUCCESS)
+            return result;
+        result = pmi_simple_client_kvs_get (pmi_global_ctx,
+                                            kvsname,
+                                            name,
+                                            value,
+                                            valuelen);
+        if (result != PMI2_SUCCESS)
+            goto error;
+    }
+    else if (!strcmp (name, "universeSize")) {
+        int universe_size;
+
+        result = pmi_simple_client_get_universe_size (pmi_global_ctx,
+                                                      &universe_size);
+        if (result != PMI2_SUCCESS)
+            goto error;
+        if (snprintf (value,
+                      valuelen,
+                      "%d",
+                      universe_size) >= valuelen) {
+            result = PMI2_ERR_INVALID_VAL_LENGTH;
+            goto error;
+        }
+    }
+    else {
+        result = PMI2_ERR_INVALID_KEY;
+        goto error;
+    }
+    if (found)
+        *found = 1;
+    return PMI2_SUCCESS;
+error:
+    if (found)
+        *found = 0;
+    return result;
+}
+
+int PMI2_Info_GetJobAttrIntArray (const char name[], int array[],
+                                  int arraylen, int *outlen, int *found)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Nameserv_publish (const char service_name[],
+                           const struct MPID_Info *info_ptr, const char port[])
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Nameserv_lookup (const char service_name[],
+                          const struct MPID_Info *info_ptr,
+                          char port[], int portLen)
+{
+    return PMI2_FAIL;
+}
+
+int PMI2_Nameserv_unpublish (const char service_name[],
+                             const struct MPID_Info *info_ptr)
+{
+    return PMI2_FAIL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/pmi2.h
+++ b/src/common/libpmi/pmi2.h
@@ -1,0 +1,106 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_PMI2_H_INCLUDED
+#define FLUX_PMI2_H_INCLUDED
+
+#define PMI2_SUCCESS                0
+#define PMI2_FAIL                   -1
+#define PMI2_ERR_INIT               1
+#define PMI2_ERR_NOMEM              2
+#define PMI2_ERR_INVALID_ARG        3
+#define PMI2_ERR_INVALID_KEY        4
+#define PMI2_ERR_INVALID_KEY_LENGTH 5
+#define PMI2_ERR_INVALID_VAL        6
+#define PMI2_ERR_INVALID_VAL_LENGTH 7
+#define PMI2_ERR_INVALID_LENGTH     8
+#define PMI2_ERR_INVALID_NUM_ARGS   9
+#define PMI2_ERR_INVALID_ARGS       10
+#define PMI2_ERR_INVALID_NUM_PARSED 11
+#define PMI2_ERR_INVALID_KEYVALP    12
+#define PMI2_ERR_INVALID_SIZE       13
+#define PMI2_ERR_OTHER              14
+
+#define PMI2_MAX_KEYLEN             64
+#define PMI2_MAX_VALLEN             1024
+#define PMI2_MAX_ATTRVALUE          1024
+#define PMI2_ID_NULL                -1
+
+
+int PMI2_Init (int *spawned, int *size, int *rank, int *appnum);
+int PMI2_Finalize (void);
+int PMI2_Initialized (void);
+int PMI2_Abort (int flag, const char msg[]);
+
+
+typedef struct PMI2_Connect_comm {
+    int (*read)(void *buf, int maxlen, void *ctx);
+    int (*write)(const void *buf, int len, void *ctx);
+    void *ctx;
+    int  isMaster;
+} PMI2_Connect_comm_t;
+
+typedef struct MPID_Info {
+    int                 handle;
+    int                 pobj_mutex;
+    int                 ref_count;
+    struct MPID_Info    *next;
+    char                *key;
+    char                *value;
+} MPID_Info;
+
+int PMI2_Job_Spawn (int count, const char * cmds[],
+                    int argcs[], const char ** argvs[],
+                    const int maxprocs[],
+                    const int info_keyval_sizes[],
+                    const struct MPID_Info *info_keyval_vectors[],
+                    int preput_keyval_size,
+                    const struct MPID_Info *preput_keyval_vector[],
+                    char jobId[], int jobIdSize,
+                    int errors[]);
+int PMI2_Job_GetId (char jobid[], int jobid_size);
+int PMI2_Job_GetRank (int* rank);
+int PMI2_Job_Connect (const char jobid[], PMI2_Connect_comm_t *conn);
+int PMI2_Job_Disconnect (const char jobid[]);
+
+
+int PMI2_KVS_Put (const char key[], const char value[]);
+int PMI2_KVS_Get (const char *jobid, int src_pmi_id,
+                  const char key[], char value [], int maxvalue, int *vallen);
+int PMI2_KVS_Fence (void);
+
+
+int PMI2_Info_GetSize (int* size);
+int PMI2_Info_GetNodeAttr (const char name[],
+                           char value[], int valuelen, int *found, int waitfor);
+int PMI2_Info_GetNodeAttrIntArray (const char name[], int array[],
+                                   int arraylen, int *outlen, int *found);
+int PMI2_Info_PutNodeAttr (const char name[], const char value[]);
+int PMI2_Info_GetJobAttr (const char name[],
+                          char value[], int valuelen, int *found);
+int PMI2_Info_GetJobAttrIntArray (const char name[], int array[],
+                                  int arraylen, int *outlen, int *found);
+
+
+int PMI2_Nameserv_publish (const char service_name[],
+                           const struct MPID_Info *info_ptr, const char port[]);
+int PMI2_Nameserv_lookup (const char service_name[],
+                          const struct MPID_Info *info_ptr,
+                          char port[], int portLen);
+int PMI2_Nameserv_unpublish (const char service_name[],
+                             const struct MPID_Info *info_ptr);
+
+
+
+#endif /* !FLUX_PMI2_H_INCLUDED */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -394,7 +394,6 @@ void pmi_simple_client_destroy (struct pmi_simple_client *pmi)
 struct pmi_simple_client *pmi_simple_client_create_fd (const char *pmi_fd,
                                                        const char *pmi_rank,
                                                        const char *pmi_size,
-                                                       const char *pmi_debug,
                                                        const char *pmi_spawned)
 {
     struct pmi_simple_client *pmi;
@@ -414,12 +413,6 @@ struct pmi_simple_client *pmi_simple_client_create_fd (const char *pmi_fd,
     if (pmi_spawned) {
         errno = 0;
         pmi->spawned = strtol (pmi_spawned, NULL, 10);
-        if (errno != 0)
-            goto error;
-    }
-    if (pmi_debug) {
-        errno = 0;
-        pmi->debug = strtol (pmi_debug, NULL, 10);
         if (errno != 0)
             goto error;
     }

--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -20,6 +20,8 @@
 #include <sys/param.h>
 #include <assert.h>
 
+#include "src/common/libutil/aux.h"
+
 #include "simple_client.h"
 #include "simple_server.h"
 #include "clique.h"
@@ -354,11 +356,33 @@ int pmi_simple_client_get_clique_ranks (struct pmi_simple_client *pmi,
     return result;
 }
 
+void *pmi_simple_client_aux_get (struct pmi_simple_client *pmi,
+                                 const char *name)
+{
+    if (!pmi) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return aux_get (pmi->aux, name);
+}
+
+int pmi_simple_client_aux_set (struct pmi_simple_client *pmi,
+                               const char *name,
+                               void *aux,
+                               flux_free_f destroy)
+{
+    if (!pmi) {
+        errno = EINVAL;
+        return -1;
+    }
+    return aux_set (&pmi->aux, name, aux, destroy);
+}
 
 void pmi_simple_client_destroy (struct pmi_simple_client *pmi)
 {
     if (pmi) {
         int saved_errno = errno;
+        aux_destroy (&pmi->aux);
         if (pmi->fd != -1)
             (void)close (pmi->fd);
         free (pmi->buf);

--- a/src/common/libpmi/simple_client.h
+++ b/src/common/libpmi/simple_client.h
@@ -18,7 +18,6 @@ struct pmi_simple_client {
     // valid upon creation
     int rank;
     int size;
-    int debug;
     int spawned;
 
     // valid after client_init()
@@ -37,13 +36,12 @@ struct pmi_simple_client {
 /* Create/destroy
  * On error, create returns NULL and sets errno.
  * Required: pmi_fd, pmi_rank, and pmi_size from the environment.
- * Optional: pmi_debug and pmi_spawned from the environment (may be NULL).
+ * Optional: pmi_spawned from the environment (may be NULL).
  */
 void pmi_simple_client_destroy (struct pmi_simple_client *pmi);
 struct pmi_simple_client *pmi_simple_client_create_fd (const char *pmi_fd,
                                                        const char *pmi_rank,
                                                        const char *pmi_size,
-                                                       const char *pmi_debug,
                                                        const char *pmi_spawned);
 
 /* Core operations

--- a/src/common/libpmi/simple_client.h
+++ b/src/common/libpmi/simple_client.h
@@ -11,6 +11,9 @@
 #ifndef _FLUX_CORE_PMI_SIMPLE_CLIENT_H
 #define _FLUX_CORE_PMI_SIMPLE_CLIENT_H
 
+#include "src/common/libutil/aux.h"
+#include "src/common/libflux/types.h"
+
 struct pmi_simple_client {
     // valid upon creation
     int rank;
@@ -28,6 +31,7 @@ struct pmi_simple_client {
     char *buf;
     int buflen;
     int fd;
+    struct aux_item *aux;
 };
 
 /* Create/destroy
@@ -49,6 +53,13 @@ int pmi_simple_client_finalize (struct pmi_simple_client *pmi);
 int pmi_simple_client_get_appnum (struct pmi_simple_client *pmi, int *appnum);
 int pmi_simple_client_get_universe_size (struct pmi_simple_client *pmi,
                                          int *universe_size);
+
+void *pmi_simple_client_aux_get (struct pmi_simple_client *pmi,
+                                 const char *name);
+int pmi_simple_client_aux_set (struct pmi_simple_client *pmi,
+                               const char *name,
+                               void *aux,
+                               flux_free_f destroy);
 
 /* Synchronization
  */

--- a/src/common/libpmi/test/canonical2.c
+++ b/src/common/libpmi/test/canonical2.c
@@ -1,0 +1,241 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "src/common/libutil/oom.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libpmi/simple_client.h"
+#include "src/common/libpmi/dgetline.h"
+#include "src/common/libpmi/pmi2.h"
+#include "src/common/libflux/reactor.h"
+
+#include "src/common/libtap/tap.h"
+
+#include "server_thread.h"
+
+
+int main (int argc, char *argv[])
+{
+    struct pmi_server_context *srv;
+    int cfd[1];
+    char jobid[PMI2_MAX_ATTRVALUE + 1];
+    char val[PMI2_MAX_VALLEN + 1];
+    char pmi_fd[16];
+    char pmi_rank[16];
+    char pmi_size[16];
+    int result;
+    int spawned;
+    int size;
+    int appnum;
+    int rank;
+    char buf[64];
+    int vallen;
+    int found;
+
+    plan (NO_PLAN);
+
+    srv = pmi_server_create (cfd, 1);
+
+    snprintf (pmi_fd, sizeof (pmi_fd), "%d", cfd[0]);
+    snprintf (pmi_rank, sizeof (pmi_rank), "%d", 0);
+    snprintf (pmi_size, sizeof (pmi_size), "%d", 1);
+
+    setenv ("PMI_FD", pmi_fd, 1);
+    setenv ("PMI_RANK", pmi_rank, 1);
+    setenv ("PMI_SIZE", pmi_size, 1);
+
+    setenv ("PMI2_DEBUG", "1", 1);
+    setenv ("PMI_SPAWNED", "0", 1);
+
+    /* Elicit PMI2_ERR_INIT error by calling functions before PMI_Init()
+     */
+    ok (PMI2_Initialized () == 0,
+        "PMI2_Initialized() returns 0");
+
+    result = PMI2_Finalize ();
+    ok (result == PMI2_ERR_INIT,
+        "PMI2_Finalize before init fails with PMI2_ERR_INIT");
+
+    result = PMI2_Job_GetId (jobid, sizeof (jobid));
+    ok (result == PMI2_ERR_INIT,
+        "PMI2_Job_GetId before init fails with PMI2_ERR_INIT");
+
+    result = PMI2_KVS_Put ("foo", "bar");
+    ok (result == PMI2_ERR_INIT,
+        "PMI2_KVS_Put before init fails with PMI2_ERR_INIT");
+
+    result = PMI2_KVS_Fence ();
+    ok (result == PMI2_ERR_INIT,
+        "PMI2_KVS_Fence before init fails with PMI2_ERR_INIT");
+
+    result = PMI2_KVS_Get ("foo", 0, "bar", buf, sizeof (buf), &vallen);
+    ok (result == PMI2_ERR_INIT,
+        "PMI2_KVS_Get before init fails with PMI2_ERR_INIT");
+
+    /* Initialize
+     */
+    result = PMI2_Init (&spawned, &size, &rank, &appnum);
+    ok (result == PMI2_SUCCESS
+        && spawned == 0
+        && size == 1
+        && rank == 0
+        && appnum == 42,
+        "PMI2_Init works and set spawned=0 size=1 rank=0 appnum=42");
+
+    ok (PMI2_Initialized () != 0,
+        "PMI2_Initialized returns nonzero");
+
+    /* second init */
+    result = PMI2_Init (&spawned, &size, &rank, &appnum);
+    ok (result == PMI2_ERR_INIT,
+        "Second PMI2_Init fails with PMI_ERR2_INIT");
+
+    /* Get job attributes
+     */
+    found = 1;
+    result = PMI2_Info_GetJobAttr (NULL, val, sizeof (val), &found);
+    ok (result == PMI2_ERR_INVALID_ARG && found == 0,
+       "PMI2_Info_GetJobAttr name=NULL fails with PMI2_ERR_INVALID_ARG and found=0");
+
+    found = 1;
+    result = PMI2_Info_GetJobAttr ("universeSize", NULL, 0, &found);
+    ok (result == PMI2_ERR_INVALID_ARG && found == 0,
+       "PMI2_Info_GetJobAttr val=NULL fails with PMI2_ERR_INVALID_ARG and found=0");
+
+    found = 1;
+    result = PMI2_Info_GetJobAttr ("unknownKey", val, sizeof (val), &found);
+    ok (result == PMI2_ERR_INVALID_KEY && found == 0,
+       "PMI2_Info_GetJobAttr name=unknownKey fails with PMI2_ERR_INVALID_KEY and found=0");
+
+    found = 0;
+    val[0] = '\0';
+    result = PMI2_Info_GetJobAttr ("universeSize",
+                                   val,
+                                   sizeof (val),
+                                   &found);
+    ok (result == PMI2_SUCCESS && found != 0 && !strcmp (val, "1"),
+       "PMI2_Info_GetJobAttr PMI_process_mapping works and found != 0");
+
+    jobid[0] = '\0';
+    result = PMI2_Job_GetId (jobid, sizeof (jobid));
+    ok (result == PMI2_SUCCESS
+        && !strcmp (jobid, "bleepgorp"),
+        "PMI2_Job_GetId works");
+
+    /* put foo=bar / fence / get foo
+     */
+    result = PMI2_KVS_Put (NULL, "bar");
+    ok (result == PMI2_ERR_INVALID_ARG,
+        "PMI2_KVS_Put key=NULL fails with PMI2_ERR_INVALID_ARG");
+
+    result = PMI2_KVS_Put ("foo", NULL);
+    ok (result == PMI2_ERR_INVALID_ARG,
+        "PMI2_KVS_Put val=NULL fails with PMI2_ERR_INVALID_ARG");
+
+    result = PMI2_KVS_Put ("foo", "bar");
+    ok (result == PMI2_SUCCESS,
+        "PMI2_KVS_Put works");
+
+    result = PMI2_KVS_Fence();
+    ok (result == PMI2_SUCCESS,
+        "PMI2_KVS_Fence works");
+
+    result = PMI2_KVS_Get (NULL, 0, "foo", val, sizeof (val), &vallen);
+    ok (result == PMI2_ERR_INVALID_ARG,
+        "PMI2_KVS_Get jobid=NULL fails with PMI2_ERR_INVALID_ARG");
+
+    result = PMI2_KVS_Get (jobid, 0, "foo", val, sizeof (val), &vallen);
+    ok (result == PMI2_SUCCESS
+        && !strcmp (val, "bar")
+        && vallen == strlen (val),
+        "PMI2_KVS_Get works and got expected value");
+
+    /* not implemented
+     */
+    result = PMI2_Job_GetRank (NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Job_GetRank (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Job_Connect (NULL, NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Job_Connect (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Job_Disconnect (NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Job_Disconnect (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Info_GetSize (NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Info_GetSize (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Info_GetNodeAttr (NULL, NULL, 0, NULL, 0);
+    ok (result == PMI2_FAIL,
+        "PMI2_Info_GetNodeAttr (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Info_GetNodeAttrIntArray (NULL, NULL, 0, NULL, NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Info_GetNodeAttrIntArray (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Info_PutNodeAttr (NULL, NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Info_PutNodeAttr (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Info_GetJobAttrIntArray (NULL, NULL, 0, NULL, NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Info_GetJobAttrIntArray (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Nameserv_publish (NULL, NULL, NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Nameserv_publish (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Nameserv_lookup (NULL, NULL, NULL, 0);
+    ok (result == PMI2_FAIL,
+        "PMI2_Nameserv_lookup (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Nameserv_unpublish (NULL, NULL);
+    ok (result == PMI2_FAIL,
+        "PMI2_Nameserv_unpublish (unimplemented) returns PMI2_FAIL");
+
+    result = PMI2_Job_Spawn (0,     // count
+                             NULL,  // cmds
+                             NULL,  // argcs
+                             NULL,  // argvs
+                             NULL,  // maxprocs
+                             NULL,  // info_keyval_sizesp
+                             NULL,  // info_keyval_vectors
+                             0,     // preput_keyval_size
+                             NULL,  // preput_keyval_vector
+                             NULL,  // jobId
+                             0,     // jobIdSize
+                             NULL); // errors
+    ok (result == PMI2_FAIL,
+        "PMI2_Job_Spawn (unimplemented) returns PMI2_FAIL");
+
+    /* finalize
+     */
+    result = PMI2_Finalize ();
+    ok (result == PMI2_SUCCESS,
+        "PMI2_Finalize works");
+
+    result = PMI2_Finalize ();
+    ok (result == PMI2_ERR_INIT,
+        "second PMI2_Finalize fails with PMI2_ERR_INIT");
+
+    pmi_server_destroy (srv);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libpmi/test/pmi_info.c
+++ b/src/common/libpmi/test/pmi_info.c
@@ -23,9 +23,8 @@
 #include "src/common/libpmi/pmi_strerror.h"
 #include "src/common/libpmi/clique.h"
 
-#define OPTIONS "l:c"
+#define OPTIONS "c"
 static const struct option longopts[] = {
-    {"library",      required_argument,  0, 'l'},
     {"clique",       no_argument,        0, 'c'},
     {0, 0, 0, 0},
 };
@@ -37,22 +36,14 @@ int main(int argc, char *argv[])
     int universe_size;
     char *kvsname;
     int ch;
-    char *library = NULL;
     int copt = 0;
 
     while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (ch) {
-            case 'l':   /* --library */
-                library = optarg;
-                break;
             case 'c':   /* --clique */
                 copt++;
                 break;
         }
-    }
-    if (library) {
-        setenv ("PMI_LIBRARY", library, 1);
-        unsetenv ("PMI_FD");
     }
     e = PMI_Init (&spawned);
     if (e != PMI_SUCCESS)

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -128,8 +128,10 @@ int main (int argc, char *argv[])
     snprintf (pmi_rank, sizeof (pmi_rank), "%d", 0);
     snprintf (pmi_size, sizeof (pmi_size), "%d", 1);
 
-    ok ((cli = pmi_simple_client_create_fd (pmi_fd, pmi_rank, pmi_size,
-                                            NULL, NULL)) != NULL,
+    ok ((cli = pmi_simple_client_create_fd (pmi_fd,
+                                            pmi_rank,
+                                            pmi_size,
+                                            NULL)) != NULL,
         "pmi_simple_client_create OK");
     ok (cli->initialized == false,
         "cli->initialized == false");

--- a/src/common/libpmi2.map
+++ b/src/common/libpmi2.map
@@ -1,0 +1,6 @@
+{ global:
+    PMI2_*;
+    flux_pmi_library;
+    local: *;
+};
+

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -357,15 +357,6 @@ error:
     return -1;
 }
 
-static int set_flux_jobid (struct shell_pmi *pmi, flux_jobid_t id)
-{
-    char val [SIMPLE_KVS_VAL_MAX];
-
-    (void)snprintf (val, sizeof (val), "%ju", (uintmax_t)id);
-    pmi_kvs_put_local (pmi, "flux.jobid", val);
-    return 0;
-}
-
 static int set_flux_instance_level (struct shell_pmi *pmi)
 {
     char *p;
@@ -464,8 +455,6 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell)
         goto error;
     if (!shell->standalone) {
         if (set_flux_instance_level (pmi) < 0)
-            goto error;
-        if (set_flux_jobid (pmi, shell->jobid) < 0)
             goto error;
     }
     return pmi;


### PR DESCRIPTION
As discussed in #2347, this PR adds back the PMI-2 API implementation we used to have, in order for our existing mvapich2 configurations to continue to work with the new exec system.   It's effectively a rewrite, and now includes unit tests for the API.   This will need to be deployed along with an MPI "personality" that sets `LD_LIBRARY_PATH` such that our library gets picked up before slurm's by `dlopen()`.

Still todo: test that this actuall works with our mvapich2's  (the whole point!)
