### PR TITLE
libflux/reactor: add flux_reactor_active_incref(), _decref()

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -76,6 +76,8 @@ MAN3_FILES_SECONDARY = \
 	flux_reactor_run.3 \
 	flux_reactor_stop.3 \
 	flux_reactor_stop_error.3 \
+	flux_reactor_active_incref.3 \
+	flux_reactor_active_decref.3 \
 	flux_fd_watcher_get_fd.3 \
 	flux_watcher_stop.3 \
 	flux_watcher_destroy.3 \
@@ -218,6 +220,8 @@ flux_reactor_destroy.3: flux_reactor_create.3
 flux_reactor_run.3: flux_reactor_create.3
 flux_reactor_stop.3: flux_reactor_create.3
 flux_reactor_error.3: flux_reactor_create.3
+flux_reactor_active_incref.3: flux_reactor_create.3
+flux_reactor_active_decref.3: flux_reactor_create.3
 flux_fd_watcher_get_fd.3: flux_fd_watcher_create.3
 flux_watcher_stop.3: flux_watcher_start.3
 flux_watcher_destroy.3: flux_watcher_start.3

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -123,6 +123,7 @@ MAN3_FILES_SECONDARY = \
 	flux_future_get.3 \
 	flux_future_fulfill.3 \
 	flux_future_fulfill_error.3 \
+	flux_future_fulfill_with.3 \
 	flux_future_aux_set.3 \
 	flux_future_aux_get.3 \
 	flux_future_set_flux.3 \
@@ -266,6 +267,7 @@ flux_future_wait_for.3: flux_future_get.3
 flux_future_then.3: flux_future_get.3
 flux_future_fulfill.3: flux_future_create.3
 flux_future_fulfill_error.3: flux_future_create.3
+flux_future_fulfill_with.3: flux_future_create.3
 flux_future_aux_set.3: flux_future_create.3
 flux_future_aux_get.3: flux_future_create.3
 flux_future_set_flux.3: flux_future_create.3

--- a/doc/man3/flux_reactor_create.adoc
+++ b/doc/man3/flux_reactor_create.adoc
@@ -5,7 +5,7 @@ flux_reactor_create(3)
 
 NAME
 ----
-flux_reactor_create, flux_reactor_destroy, flux_reactor_run, flux_reactor_stop, flux_reactor_stop_error - create/destroy/control event reactor object
+flux_reactor_create, flux_reactor_destroy, flux_reactor_run, flux_reactor_stop, flux_reactor_stop_error, flux_reactor_active_incref, flux_reactor_active_decref - create/destroy/control event reactor object
 
 
 SYNOPSIS
@@ -22,6 +22,9 @@ void flux_reactor_stop (flux_reactor_t *r);
 
 void flux_reactor_stop_error (flux_reactor_t *r);
 
+void flux_reactor_active_incref (flux_reactor_t *r);
+
+void flux_reactor_active_decref (flux_reactor_t *r);
 
 DESCRIPTION
 -----------
@@ -73,6 +76,16 @@ errno(3) before calling this function.
 `flux_reactor_destroy()` releases an internal reference taken at
 `flux_reactor_create()` time.  Freeing of the underlying resources will
 be deferred if there are any remaining watchers associated with the reactor.
+
+`flux_reactor_active_decref()` and `flux_reactor_active_incref()` manipulate
+the reactor's internal count of active watchers.  Each active watcher takes
+a reference count on the reactor, and the reactor returns when this count
+reaches zero.  It is useful sometimes to have a watcher that can remain
+active without preventing the reactor from exiting.  To achieve this,
+call `flux_reactor_active_decref()` after the watcher is started, and
+`flux_reactor_active_incref()` before the watcher is stopped.
+Remember that destroying an active reactor internally stops it,
+so be sure to stop/incref such a watcher first.
 
 RETURN VALUE
 ------------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -457,3 +457,5 @@ UNIQ
 startup
 errmsg
 WAITCREATE
+incref
+decref

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -154,6 +154,18 @@ void flux_reactor_stop_error (flux_reactor_t *r)
     ev_break (r->loop, EVBREAK_ALL);
 }
 
+void flux_reactor_active_incref (flux_reactor_t *r)
+{
+    if (r)
+        ev_ref (r->loop);
+}
+
+void flux_reactor_active_decref (flux_reactor_t *r)
+{
+    if (r)
+        ev_unref (r->loop);
+}
+
 static int events_to_libev (int events)
 {
     int e = 0;

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -62,6 +62,14 @@ double flux_reactor_now (flux_reactor_t *r);
 void flux_reactor_now_update (flux_reactor_t *r);
 double flux_reactor_time (void);
 
+/* Change reactor reference count.
+ * Each active watcher holds a reference.
+ * When the reference count reaches zero, the reactor loop exits.
+ */
+void flux_reactor_active_incref (flux_reactor_t *r);
+void flux_reactor_active_decref (flux_reactor_t *r);
+
+
 /* Watchers
  */
 

--- a/src/common/libpmi/pmi2.c
+++ b/src/common/libpmi/pmi2.c
@@ -277,7 +277,7 @@ int PMI2_Info_GetJobAttr (const char name[],
 
         result = get_cached_kvsname (pmi_global_ctx, &kvsname);
         if (result != PMI2_SUCCESS)
-            return result;
+            goto error;
         result = pmi_simple_client_kvs_get (pmi_global_ctx,
                                             kvsname,
                                             name,


### PR DESCRIPTION
Per discussion in #2289, add two new reactor functions to manipulate active watcher counts.  When you want to start a watcher that should not increase the active watcher count, use:
```c
flux_watcher_start()
flux_reactor_active_decref()
```
to stop it use:
```c
flux_reactor_active_incref()
flux_watcher_stop()
```

This allowed for a bit of cleanup in the `flux job attach` command, which needed to externally track the "real" active watchers in order to stop some signal watchers that fall into the above category.

There's a loose PMI fix in here too (very minor, but was bugging me).