### PR TITLE
cmd/flux-job attach: add timestamps, --show-exec option

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -745,7 +745,6 @@ struct attach_ctx {
     flux_watcher_t *sigint_w;
     flux_watcher_t *sigtstp_w;
     struct timespec t_sigint;
-    bool show_events;
     optparse_t *p;
     bool output_header_parsed;
 };
@@ -920,8 +919,8 @@ done:
 /* Handle an event in the main job eventlog.
  * This is a stream of responses, one response per event, terminated with
  * an ENODATA error response (or another error if something went wrong).
- * If a fatal exception occurs, print it on stderr.
- * If --show-events was specified, print all exceptions on stderr.
+ * If a fatal exception event occurs, print it on stderr.
+ * If --show-events was specified, print all events on stderr.
  * If finish event occurs, capture ctx->exit code.
  */
 void attach_event_continuation (flux_future_t *f, void *arg)
@@ -974,7 +973,8 @@ void attach_event_continuation (flux_future_t *f, void *arg)
             }
         }
     }
-    if (ctx->show_events && strcmp (name, "exception") != 0) {
+    if (optparse_hasopt (ctx->p, "show-events")
+                                    && strcmp (name, "exception") != 0) {
         char *s = NULL;
         if (context && !(s = json_dumps (context, JSON_COMPACT)))
             log_err_exit ("error re-encoding context");
@@ -1006,7 +1006,6 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
         exit (1);
     }
     ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
-    ctx.show_events = optparse_hasopt (p, "show-events");
     ctx.p = p;
 
     if (!(ctx.h = flux_open (NULL, 0)))

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -16,6 +16,17 @@ test_expect_success 'attach: job ran successfully' '
 	run_timeout 5 flux job attach $(cat jobid1)
 '
 
+test_expect_success 'attach: --show-events shows clean event' '
+	run_timeout 5 flux job attach \
+		--show-event $(cat jobid1) 2>jobid1.events &&
+	grep clean jobid1.events
+'
+test_expect_success 'attach: --show-events shows done event' '
+	run_timeout 5 flux job attach \
+		--show-exec $(cat jobid1) 2>jobid1.exec &&
+	grep done jobid1.exec
+'
+
 test_expect_success 'attach: shows output from job' '
 	run_timeout 5 flux job attach $(cat jobid1) | grep foo
 '


### PR DESCRIPTION
This PR adds timestamps (with t=0 normalized to the submit event) to events displayed with the `flux job attach --show-events` option.  It also adds a new `--show-exec` option that displays events from the guest.exec.eventlog in the same format.