### PR TITLE
shell: Support stdout/stderr output to file modes

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -922,7 +922,7 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
     if (eventlog_entry_parse (o, &timestamp, &name, &context) < 0)
         log_err_exit ("eventlog_entry_parse");
 
-    if (!strcmp (name, "output-ready")) {
+    if (!strcmp (name, "output-kvs-ready")) {
         if (!(ctx->output_f = flux_job_event_watch (ctx->h,
                                                     ctx->id,
                                                     "guest.output",

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -466,6 +466,8 @@ static void closefd_child (void *arg, int fd)
  *   signal to proceed. This is done by writing 1 byte to child side of
  *   socketpair, and waiting for parent to write one byte back.
  *
+ *  Call fprintf instead of flux_log_error(), errors in child should
+ *   go to parent error streams.
  */
 static int local_child_ready (flux_subprocess_t *p)
 {
@@ -474,11 +476,12 @@ static int local_child_ready (flux_subprocess_t *p)
     char c = 0;
 
     if (write (fd, &c, sizeof (c)) != 1) {
-        flux_log_error (p->h, "local_child_ready: write");
+        fprintf (stderr, "local_child_ready: write: %s\n", strerror (errno));
         return -1;
     }
     if ((n = read (fd, &c, sizeof (c))) != 1) {
-        flux_log_error (p->h, "local_child_ready: read (fd=%d): rc=%d", fd, n);
+        fprintf (stderr, "local_child_ready: read (fd=%d): rc=%d: %s\n",
+                 fd, n, strerror (errno));
         return -1;
     }
     return 0;
@@ -487,8 +490,11 @@ static int local_child_ready (flux_subprocess_t *p)
 static void local_child_report_exec_failed_errno (flux_subprocess_t *p, int e)
 {
     int fd = p->sync_fds[1];
+    /* Call fprintf instead of flux_log_error(), errors in child
+     * should go to parent error streams. */
     if (write (fd, &e, sizeof (e)) != sizeof (e))
-        flux_log_error (p->h, "local_child_report_exec_failed_errno");
+        fprintf (stderr, "local_child_report_exec_failed_errno: %s\n",
+                 strerror (errno));
 }
 
 static int local_child (flux_subprocess_t *p)
@@ -500,10 +506,13 @@ static int local_child (flux_subprocess_t *p)
 
     /* Throughout this function use _exit() instead of exit(), to
      * avoid calling any atexit() routines of parent.
+     *
+     * Call fprintf instead of flux_log_error(), errors in child
+     * should go to parent error streams.
      */
 
     if (sigmask_unblock_all () < 0)
-        flux_log_error (p->h, "sigprocmask");
+        fprintf (stderr, "sigprocmask: %s\n", strerror (errno));
 
     close_parent_fds (p);
 
@@ -513,13 +522,13 @@ static int local_child (flux_subprocess_t *p)
                     || (c->flags & CHANNEL_INPUT_FD));
             if (c->flags & CHANNEL_WRITE) {
                 if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                    flux_log_error (p->h, "dup2");
+                    fprintf (stderr, "dup2: %s\n", strerror (errno));
                     _exit (1);
                 }
             }
             else if (c->flags & CHANNEL_INPUT_FD) {
                 if (dup2 (c->input_fd, STDIN_FILENO) < 0) {
-                    flux_log_error (p->h, "dup2");
+                    fprintf (stderr, "dup2: %s\n", strerror (errno));
                     _exit (1);
                 }
             }
@@ -530,13 +539,13 @@ static int local_child (flux_subprocess_t *p)
                     || (c->flags & CHANNEL_OUTPUT_FD));
             if (c->flags & CHANNEL_READ) {
                 if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                    flux_log_error (p->h, "dup2");
+                    fprintf (stderr, "dup2: %s\n", strerror (errno));
                     _exit (1);
                 }
             }
             else if (c->flags & CHANNEL_OUTPUT_FD) {
                 if (dup2 (c->output_fd, STDOUT_FILENO) < 0) {
-                    flux_log_error (p->h, "dup2");
+                    fprintf (stderr, "dup2: %s\n", strerror (errno));
                     _exit (1);
                 }
             }
@@ -549,13 +558,13 @@ static int local_child (flux_subprocess_t *p)
                     || (c->flags & CHANNEL_OUTPUT_FD));
             if (c->flags & CHANNEL_READ) {
                 if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                    flux_log_error (p->h, "dup2");
+                    fprintf (stderr, "dup2: %s\n", strerror (errno));
                     _exit (1);
                 }
             }
             else if (c->flags & CHANNEL_OUTPUT_FD) {
                 if (dup2 (c->output_fd, STDERR_FILENO) < 0) {
-                    flux_log_error (p->h, "dup2");
+                    fprintf (stderr, "dup2: %s\n", strerror (errno));
                     _exit (1);
                 }
             }
@@ -566,7 +575,9 @@ static int local_child (flux_subprocess_t *p)
 
     // Change working directory
     if ((cwd = flux_cmd_getcwd (p->cmd)) && chdir (cwd) < 0) {
-        flux_log_error (p->h, "Couldn't change dir to %s: going to /tmp instead", cwd);
+        fprintf (stderr,
+                 "Couldn't change dir to %s: going to /tmp instead: %s\n",
+                 cwd, strerror (errno));
         if (chdir ("/tmp") < 0)
             _exit (1);
     }
@@ -577,7 +588,7 @@ static int local_child (flux_subprocess_t *p)
 
     // Close fds
     if (fdwalk (closefd_child, (void *) p) < 0) {
-        flux_log_error (p->h, "Failed closing all fds");
+        fprintf (stderr, "Failed closing all fds: %s", strerror (errno));
         _exit (1);
     }
 
@@ -592,7 +603,7 @@ static int local_child (flux_subprocess_t *p)
 
     if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP) {
         if (setpgrp () < 0) {
-            flux_log_error (p->h, "setpgrp");
+            fprintf (stderr, "setpgrp: %s\n", strerror (errno));
             _exit (1);
         }
     }

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -13,6 +13,8 @@
 #endif
 
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <wait.h>
 #include <unistd.h>
 #include <errno.h>
@@ -155,7 +157,8 @@ static int channel_local_setup (flux_subprocess_t *p,
                                 flux_watcher_f in_cb,
                                 flux_watcher_f out_cb,
                                 const char *name,
-                                int channel_flags)
+                                int channel_flags,
+                                int input_fd)
 {
     struct subprocess_channel *c = NULL;
     int fds[2] = { -1, -1 };
@@ -234,6 +237,12 @@ static int channel_local_setup (flux_subprocess_t *p,
             p->channels_eof_expected++;
         }
     }
+    else {
+        if (channel_flags & CHANNEL_INPUT_FD) {
+            assert (input_fd >= 0);
+            c->input_fd = input_fd;
+        }
+    }
 
     if (channel_flags & CHANNEL_FD) {
         if (asprintf (&e, "%s", name) < 0) {
@@ -280,6 +289,9 @@ error:
 
 static int local_setup_stdio (flux_subprocess_t *p)
 {
+    int flags;
+    int fd;
+
     if (p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)
         return 0;
 
@@ -287,12 +299,21 @@ static int local_setup_stdio (flux_subprocess_t *p)
      * and/or write, and the buffer's automatically get a NUL char
      * appended on reads */
 
+    if (cmd_option_input_fd (p, "stdin", &fd) < 0)
+        return -1;
+
+    if (fd >= 0)
+        flags = CHANNEL_INPUT_FD;
+    else
+        flags = CHANNEL_WRITE;
+
     if (channel_local_setup (p,
                              NULL,
                              local_in_cb,
                              NULL,
                              "stdin",
-                             CHANNEL_WRITE) < 0)
+                             flags,
+                             fd) < 0)
         return -1;
 
     if (p->ops.on_stdout) {
@@ -301,7 +322,8 @@ static int local_setup_stdio (flux_subprocess_t *p)
                                  NULL,
                                  local_stdout_cb,
                                  "stdout",
-                                 CHANNEL_READ) < 0)
+                                 CHANNEL_READ,
+                                 -1) < 0)
             return -1;
     }
 
@@ -311,7 +333,8 @@ static int local_setup_stdio (flux_subprocess_t *p)
                                  NULL,
                                  local_stderr_cb,
                                  "stderr",
-                                 CHANNEL_READ) < 0)
+                                 CHANNEL_READ,
+                                 -1) < 0)
             return -1;
     }
 
@@ -343,7 +366,8 @@ static int local_setup_channels (flux_subprocess_t *p)
                                  local_in_cb,
                                  p->ops.on_channel_out ? local_out_cb : NULL,
                                  name,
-                                 channel_flags) < 0)
+                                 channel_flags,
+                                 -1) < 0)
             return -1;
         name = zlist_next (channels);
     }
@@ -456,8 +480,16 @@ static int local_child (flux_subprocess_t *p)
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
+            assert ((c->flags & CHANNEL_WRITE)
+                    || (c->flags & CHANNEL_INPUT_FD));
             if (c->flags & CHANNEL_WRITE) {
                 if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
+            }
+            else if (c->flags & CHANNEL_INPUT_FD) {
+                if (dup2 (c->input_fd, STDIN_FILENO) < 0) {
                     flux_log_error (p->h, "dup2");
                     _exit (1);
                 }

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -158,7 +158,8 @@ static int channel_local_setup (flux_subprocess_t *p,
                                 flux_watcher_f out_cb,
                                 const char *name,
                                 int channel_flags,
-                                int input_fd)
+                                int input_fd,
+                                int output_fd)
 {
     struct subprocess_channel *c = NULL;
     int fds[2] = { -1, -1 };
@@ -242,6 +243,10 @@ static int channel_local_setup (flux_subprocess_t *p,
             assert (input_fd >= 0);
             c->input_fd = input_fd;
         }
+        if (channel_flags & CHANNEL_OUTPUT_FD) {
+            assert (output_fd >= 0);
+            c->output_fd = output_fd;
+        }
     }
 
     if (channel_flags & CHANNEL_FD) {
@@ -313,28 +318,51 @@ static int local_setup_stdio (flux_subprocess_t *p)
                              NULL,
                              "stdin",
                              flags,
-                             fd) < 0)
+                             fd,
+                             -1) < 0)
         return -1;
 
-    if (p->ops.on_stdout) {
+    if (cmd_option_output_fd (p, "stdout", &fd) < 0)
+        return -1;
+
+    if (fd >= 0)
+        flags = CHANNEL_OUTPUT_FD;
+    else if (p->ops.on_stdout)
+        flags = CHANNEL_READ;
+    else
+        flags = 0;
+
+    if (flags) {
         if (channel_local_setup (p,
                                  p->ops.on_stdout,
                                  NULL,
                                  local_stdout_cb,
                                  "stdout",
-                                 CHANNEL_READ,
-                                 -1) < 0)
+                                 flags,
+                                 -1,
+                                 fd) < 0)
             return -1;
     }
 
-    if (p->ops.on_stderr) {
+    if (cmd_option_output_fd (p, "stderr", &fd) < 0)
+        return -1;
+
+    if (fd >= 0)
+        flags = CHANNEL_OUTPUT_FD;
+    else if (p->ops.on_stderr)
+        flags = CHANNEL_READ;
+    else
+        flags = 0;
+
+    if (flags) {
         if (channel_local_setup (p,
                                  p->ops.on_stderr,
                                  NULL,
                                  local_stderr_cb,
                                  "stderr",
-                                 CHANNEL_READ,
-                                 -1) < 0)
+                                 flags,
+                                 -1,
+                                 fd) < 0)
             return -1;
     }
 
@@ -367,6 +395,7 @@ static int local_setup_channels (flux_subprocess_t *p)
                                  p->ops.on_channel_out ? local_out_cb : NULL,
                                  name,
                                  channel_flags,
+                                 -1,
                                  -1) < 0)
             return -1;
         name = zlist_next (channels);
@@ -497,27 +526,39 @@ static int local_child (flux_subprocess_t *p)
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
+            assert ((c->flags & CHANNEL_READ)
+                    || (c->flags & CHANNEL_OUTPUT_FD));
             if (c->flags & CHANNEL_READ) {
                 if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
                     flux_log_error (p->h, "dup2");
                     _exit (1);
                 }
             }
-            else
-                close (STDOUT_FILENO);
+            else if (c->flags & CHANNEL_OUTPUT_FD) {
+                if (dup2 (c->output_fd, STDOUT_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
+            }
         }
         else
             close (STDOUT_FILENO);
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
+            assert ((c->flags & CHANNEL_READ)
+                    || (c->flags & CHANNEL_OUTPUT_FD));
             if (c->flags & CHANNEL_READ) {
                 if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
                     flux_log_error (p->h, "dup2");
                     _exit (1);
                 }
             }
-            else
-                close (STDERR_FILENO);
+            else if (c->flags & CHANNEL_OUTPUT_FD) {
+                if (dup2 (c->output_fd, STDERR_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
+            }
         }
         else
             close (STDERR_FILENO);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -50,6 +50,8 @@ void channel_destroy (void *arg)
             close (c->child_fd);
         if (c->input_fd != -1)
             close (c->input_fd);
+        if (c->output_fd != -1)
+            close (c->output_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -94,6 +96,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
     c->parent_fd = -1;
     c->child_fd = -1;
     c->input_fd = -1;
+    c->output_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -671,6 +674,7 @@ static int check_local_only_cmd_options (const flux_cmd_t *cmd)
     /* check for options that do not apply to remote subprocesses */
     const char *substrings[] = { "STREAM_STOP",
                                  "INPUT_FD",
+                                 "OUTPUT_FD",
                                  NULL };
 
     return flux_cmd_find_opts (cmd, substrings);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -48,6 +48,8 @@ void channel_destroy (void *arg)
             close (c->parent_fd);
         if (c->child_fd != -1)
             close (c->child_fd);
+        if (c->input_fd != -1)
+            close (c->input_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -91,6 +93,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
 
     c->parent_fd = -1;
     c->child_fd = -1;
+    c->input_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -666,7 +669,9 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)
 {
     /* check for options that do not apply to remote subprocesses */
-    const char *substrings[] = { "STREAM_STOP", NULL };
+    const char *substrings[] = { "STREAM_STOP",
+                                 "INPUT_FD",
+                                 NULL };
 
     return flux_cmd_find_opts (cmd, substrings);
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -294,6 +294,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    subprocesses.
  *
  *    - stdin_INPUT_FD - file descriptor for stdin
+ *
+ *  "OUTPUT_FD" option
+ *
+ *    By default, standard output is read from flux_subprocess_read()
+ *    (and family of functions) and the stream "stdout" or "stderr".
+ *    This option will inform the subprocess to redirect stdout /
+ *    stderr directly to a specified file descriptor.  Functions like
+ *    flux_subprocess_read() will return EINVAL when attempting to
+ *    read from stdout or stderr.  This option can only be used on
+ *    local subprocesses.
+ *
+ *    - stdout_OUTPUT_FD - file descriptor for stdout
+ *    - stderr_OUTPUT_FD - file descriptor for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -282,6 +282,18 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
  *    - stdout_STREAM_STOP - configure start/stop for stdout
  *    - stderr_STREAM_STOP - configure start/stop for stderr
+ *
+ *  "INPUT_FD" option
+ *
+ *    By default, standard input is sent to a subprocess via the
+ *    flux_subprocess_write() call and the stream "stdin".  This
+ *    option will inform the subprocess to read stdin directly from a
+ *    specified file descriptor.  As a result, functions liked
+ *    flux_subprocess_write() will return EINVAL when attempting to
+ *    write to "stdin".  This option can only be used on local
+ *    subprocesses.
+ *
+ *    - stdin_INPUT_FD - file descriptor for stdin
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,9 +21,10 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ  0x01
-#define CHANNEL_WRITE 0x02
-#define CHANNEL_FD    0x04
+#define CHANNEL_READ     0x01
+#define CHANNEL_WRITE    0x02
+#define CHANNEL_FD       0x04
+#define CHANNEL_INPUT_FD 0x08
 
 struct subprocess_channel {
     int magic;
@@ -40,6 +41,7 @@ struct subprocess_channel {
     /* local */
     int parent_fd;
     int child_fd;
+    int input_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,10 +21,11 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ     0x01
-#define CHANNEL_WRITE    0x02
-#define CHANNEL_FD       0x04
-#define CHANNEL_INPUT_FD 0x08
+#define CHANNEL_READ      0x01
+#define CHANNEL_WRITE     0x02
+#define CHANNEL_FD        0x04
+#define CHANNEL_INPUT_FD  0x08
+#define CHANNEL_OUTPUT_FD 0x10
 
 struct subprocess_channel {
     int magic;
@@ -42,6 +43,7 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     int input_fd;
+    int output_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -796,6 +796,21 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     (*counter)++;
 }
 
+void write_multiple_lines_to_stdin (flux_subprocess_t *p)
+{
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_close (p, "stdin") == 0,
+        "flux_subprocess_close success");
+}
+
 void test_basic_multiple_lines (flux_reactor_t *r)
 {
     char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-O", "-E", "-n", NULL };
@@ -818,17 +833,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_close (p, "stdin") == 0,
-        "flux_subprocess_close success");
+    write_multiple_lines_to_stdin (p);
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,7 +122,10 @@ cleanup:
     return rv;
 }
 
-int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+static int cmd_option_fd (flux_subprocess_t *p,
+                          const char *name,
+                          const char *substring,
+                          int *fdp)
 {
     char *var;
     const char *val;
@@ -130,7 +133,7 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 
     (*fdp) = -1;
 
-    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+    if (asprintf (&var, "%s_%s", name, substring) < 0)
         goto cleanup;
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
@@ -151,6 +154,16 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 cleanup:
     free (var);
     return rv;
+}
+
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "INPUT_FD", fdp);
+}
+
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "OUTPUT_FD", fdp);
 }
 
 /*

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,6 +122,37 @@ cleanup:
     return rv;
 }
 
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    (*fdp) = -1;
+
+    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        int tmp;
+        errno = 0;
+        tmp = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || tmp < 0) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        (*fdp) = tmp;
+    }
+
+    rv = 0;
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -26,4 +26,7 @@ int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 /* sets fdp to -1 if user did not set INPUT_FD */
 int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
 
+/* sets fdp to -1 if user did not set OUTPUT_FD */
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -23,4 +23,7 @@ int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
+/* sets fdp to -1 if user did not set INPUT_FD */
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -108,10 +108,6 @@ static int shell_output_flush (struct shell_output *out)
     json_array_foreach (out->output, index, entry) {
         json_t *context;
         const char *name;
-        const char *stream = NULL;
-        int rank;
-        char *data = NULL;
-        int len = 0;
         if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
             log_err ("eventlog_entry_parse");
             return -1;
@@ -120,6 +116,10 @@ static int shell_output_flush (struct shell_output *out)
             // TODO: acquire per-stream encoding type
         }
         else if (!strcmp (name, "data")) {
+            const char *stream = NULL;
+            int rank;
+            char *data = NULL;
+            int len = 0;
             if (iodecode (context, &stream, &rank, &data, &len, NULL) < 0) {
                 log_err ("iodecode");
                 return -1;

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -98,13 +98,13 @@ static void shell_output_control (struct shell_output *out, bool stop)
     }
 }
 
-static int shell_output_flush_init (struct shell_output *out, json_t *header)
+static int shell_output_term_init (struct shell_output *out, json_t *header)
 {
     // TODO: acquire per-stream encoding type
     return 0;
 }
 
-static int shell_output_flush (struct shell_output *out)
+static int shell_output_term (struct shell_output *out)
 {
     json_t *entry;
     size_t index;
@@ -169,21 +169,21 @@ error:
     return rc;
 }
 
-static void shell_output_commit_init_completion (flux_future_t *f, void *arg)
+static void shell_output_kvs_init_completion (flux_future_t *f, void *arg)
 {
     struct shell_output *out = arg;
 
     if (flux_future_get (f, NULL) < 0)
         /* failng to commit output-ready or header is a fatal
          * error.  Should be cleaner in future. Issue #2378 */
-        log_err_exit ("shell_output_commit_init");
+        log_err_exit ("shell_output_kvs_init");
     flux_future_destroy (f);
 
-    if (flux_shell_remove_completion_ref (out->shell, "output.commit-init") < 0)
+    if (flux_shell_remove_completion_ref (out->shell, "output.kvs-init") < 0)
         log_err ("flux_shell_remove_completion_ref");
 }
 
-static int shell_output_commit_init (struct shell_output *out, json_t *header)
+static int shell_output_kvs_init (struct shell_output *out, json_t *header)
 {
     flux_kvs_txn_t *txn = NULL;
     flux_future_t *f = NULL;
@@ -201,13 +201,13 @@ static int shell_output_commit_init (struct shell_output *out, json_t *header)
         goto error;
     if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
         goto error;
-    if (flux_future_then (f, -1, shell_output_commit_init_completion, out) < 0)
+    if (flux_future_then (f, -1, shell_output_kvs_init_completion, out) < 0)
         goto error;
-    if (flux_shell_add_completion_ref (out->shell, "output.commit-init") < 0) {
+    if (flux_shell_add_completion_ref (out->shell, "output.kvs-init") < 0) {
         log_err ("flux_shell_remove_completion_ref");
         goto error;
     }
-    /* f memory responsibility of shell_output_commit_init_completion()
+    /* f memory responsibility of shell_output_kvs_init_completion()
      * callback */
     f = NULL;
     rc = 0;
@@ -220,21 +220,21 @@ error:
     return rc;
 }
 
-static void shell_output_commit_completion (flux_future_t *f, void *arg)
+static void shell_output_kvs_completion (flux_future_t *f, void *arg)
 {
     struct shell_output *out = arg;
 
     /* Error failing to commit is a fatal error.  Should be cleaner in
      * future. Issue #2378 */
     if (flux_future_get (f, NULL) < 0)
-        log_err_exit ("shell_output_commit");
+        log_err_exit ("shell_output_kvs");
     flux_future_destroy (f);
 
-    if (flux_shell_remove_completion_ref (out->shell, "output.commit") < 0)
+    if (flux_shell_remove_completion_ref (out->shell, "output.kvs") < 0)
         log_err ("flux_shell_remove_completion_ref");
 }
 
-static int shell_output_commit (struct shell_output *out)
+static int shell_output_kvs (struct shell_output *out)
 {
     flux_kvs_txn_t *txn = NULL;
     flux_future_t *f = NULL;
@@ -250,13 +250,13 @@ static int shell_output_commit (struct shell_output *out)
         goto error;
     if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
         goto error;
-    if (flux_future_then (f, -1, shell_output_commit_completion, out) < 0)
+    if (flux_future_then (f, -1, shell_output_kvs_completion, out) < 0)
         goto error;
-    if (flux_shell_add_completion_ref (out->shell, "output.commit") < 0) {
+    if (flux_shell_add_completion_ref (out->shell, "output.kvs") < 0) {
         log_err ("flux_shell_remove_completion_ref");
         goto error;
     }
-    /* f memory responsibility of shell_output_commit_completion()
+    /* f memory responsibility of shell_output_kvs_completion()
      * callback */
     f = NULL;
     if (json_array_clear (out->output) < 0) {
@@ -302,12 +302,12 @@ static void shell_output_write_cb (flux_t *h,
     /* Error failing to commit is a fatal error.  Should be cleaner in
      * future. Issue #2378 */
     if (out->shell->standalone) {
-        if (shell_output_flush (out) < 0)
-            log_err_exit ("shell_output_flush");
+        if (shell_output_term (out) < 0)
+            log_err_exit ("shell_output_term");
     }
     else {
-        if (shell_output_commit (out) < 0)
-            log_err_exit ("shell_output_commit");
+        if (shell_output_kvs (out) < 0)
+            log_err_exit ("shell_output_kvs");
     }
     if (eof) {
         if (--out->eof_pending == 0) {
@@ -386,12 +386,12 @@ void shell_output_destroy (struct shell_output *out)
         }
         if (out->output && json_array_size (out->output) > 0) { // leader only
             if (out->shell->standalone) {
-                if (shell_output_flush (out) < 0)
-                    log_err ("shell_output_flush");
+                if (shell_output_term (out) < 0)
+                    log_err ("shell_output_term");
             }
             else {
-                if (shell_output_commit (out) < 0)
-                    log_err ("shell_output_commit");
+                if (shell_output_kvs (out) < 0)
+                    log_err ("shell_output_kvs");
             }
         }
         json_decref (out->output);
@@ -426,13 +426,13 @@ static int shell_output_header (struct shell_output *out)
         goto error;
     }
     if (out->shell->standalone) {
-        if (shell_output_flush_init (out, o) < 0)
-            log_err ("shell_output_flush_init");
+        if (shell_output_term_init (out, o) < 0)
+            log_err ("shell_output_term_init");
     }
     else {
         /* will also emit output-ready event */
-        if (shell_output_commit_init (out, o) < 0)
-            log_err ("shell_output_commit_init");
+        if (shell_output_kvs_init (out, o) < 0)
+            log_err ("shell_output_kvs_init");
     }
     rc = 0;
 error:

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -13,12 +13,12 @@
  * Intercept task stdout, stderr and dispose of it according to
  * selected I/O mode.
  *
- * The leader shell implements an "shell-<id>.output" service that all
+ * If output goes to terminal or stdout/stderr is written to the KVS,
+ * the leader shell implements an "shell-<id>.output" service that all
  * ranks send task output to.  Output objects accumulate in a json
- * array on the leader.  If standalone is set, output is written
- * directly to stdout/stderr.  If not standalone, output objects are
- * written to the "output" key in the job's guest KVS namespace per
- * RFC24.
+ * array on the leader.  Depending on settings, output is written
+ * directly to stdout/stderr or output objects are written to the
+ * "output" key in the job's guest KVS namespace per RFC24.
  *
  * Notes:
  * - leader takes a completion reference which it gives up once each
@@ -53,6 +53,11 @@
 #include "internal.h"
 #include "builtins.h"
 
+enum {
+    FLUX_OUTPUT_TYPE_TERM = 1,
+    FLUX_OUTPUT_TYPE_KVS = 2,
+};
+
 struct shell_output {
     flux_shell_t *shell;
     int refcount;
@@ -60,6 +65,8 @@ struct shell_output {
     zlist_t *pending_writes;
     json_t *output;
     bool stopped;
+    int stdout_type;
+    int stderr_type;
 };
 
 static const int shell_output_lwm = 100;
@@ -108,7 +115,6 @@ static int shell_output_term (struct shell_output *out)
 {
     json_t *entry;
     size_t index;
-    FILE *f;
 
     json_array_foreach (out->output, index, entry) {
         json_t *context;
@@ -118,6 +124,8 @@ static int shell_output_term (struct shell_output *out)
             return -1;
         }
         if (!strcmp (name, "data")) {
+            int output_type;
+            FILE *f;
             const char *stream = NULL;
             int rank;
             char *data = NULL;
@@ -126,16 +134,21 @@ static int shell_output_term (struct shell_output *out)
                 log_err ("iodecode");
                 return -1;
             }
-            f = !strcmp (stream, "stdout") ? stdout : stderr;
-            if (len > 0) {
+            if (!strcmp (stream, "stdout")) {
+                output_type = out->stdout_type;
+                f = stdout;
+            }
+            else {
+                output_type = out->stderr_type;
+                f = stderr;
+            }
+            if ((output_type == FLUX_OUTPUT_TYPE_TERM) && len > 0) {
                 fprintf (f, "%d: ", rank);
                 fwrite (data, len, 1, f);
             }
             free (data);
         }
     }
-    if (json_array_clear (out->output) < 0)
-        log_msg ("json_array_clear failed");
     return 0;
 }
 
@@ -179,14 +192,40 @@ error:
     return rc;
 }
 
+/* check if this output type requires the service to be started */
+static bool output_type_requires_service (int type)
+{
+    if ((type == FLUX_OUTPUT_TYPE_TERM)
+        || (type == FLUX_OUTPUT_TYPE_KVS))
+        return true;
+    return false;
+}
+
+static const char *output_type_str (int type)
+{
+    switch (type) {
+    case FLUX_OUTPUT_TYPE_TERM:
+        return "term";
+    case FLUX_OUTPUT_TYPE_KVS:
+        return "kvs";
+    }
+    log_err_exit ("output type invalid: %d", type);
+}
+
 static int shell_output_eventlog (struct shell_output *out, flux_kvs_txn_t *txn)
 {
-    if (eventlog_append (txn, "output-stdout", "{s:s}", "type", "kvs") < 0)
+    const char *type;
+    type = output_type_str (out->stdout_type);
+    if (eventlog_append (txn, "output-stdout", "{s:s}", "type", type) < 0)
         return -1;
-    if (eventlog_append (txn, "output-stderr", "{s:s}", "type", "kvs") < 0)
+    type = output_type_str (out->stderr_type);
+    if (eventlog_append (txn, "output-stderr", "{s:s}", "type", type) < 0)
         return -1;
-    if (eventlog_append (txn, "output-kvs-ready", NULL) < 0)
-        return -1;
+    if ((out->stdout_type == FLUX_OUTPUT_TYPE_KVS)
+        || (out->stderr_type == FLUX_OUTPUT_TYPE_KVS)) {
+        if (eventlog_append (txn, "output-kvs-ready", NULL) < 0)
+            return -1;
+    }
     return 0;
 }
 
@@ -257,18 +296,50 @@ static void shell_output_kvs_completion (flux_future_t *f, void *arg)
 
 static int shell_output_kvs (struct shell_output *out)
 {
+    json_t *entry;
+    size_t index;
     flux_kvs_txn_t *txn = NULL;
     flux_future_t *f = NULL;
-    char *chunk = NULL;
     int saved_errno;
     int rc = -1;
 
-    if (!(chunk = eventlog_encode (out->output)))
-        goto error;
     if (!(txn = flux_kvs_txn_create ()))
         goto error;
-    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "output", chunk) < 0)
-        goto error;
+    json_array_foreach (out->output, index, entry) {
+        json_t *context;
+        const char *name;
+        const char *stream = NULL;
+        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
+            log_err ("eventlog_entry_parse");
+            return -1;
+        }
+        if (!strcmp (name, "data")) {
+            int output_type;
+            if (iodecode (context, &stream, NULL, NULL, NULL, NULL) < 0) {
+                log_err ("iodecode");
+                return -1;
+            }
+            if (!strcmp (stream, "stdout"))
+                output_type = out->stdout_type;
+            else
+                output_type = out->stderr_type;
+            if (output_type == FLUX_OUTPUT_TYPE_KVS) {
+                char *entrystr = eventlog_entry_encode (entry);
+                if (!entrystr) {
+                    log_err ("eventlog_entry_encode");
+                    goto error;
+                }
+                if (flux_kvs_txn_put (txn,
+                                      FLUX_KVS_APPEND,
+                                      "output",
+                                      entrystr) < 0) {
+                    free (entrystr);
+                    goto error;
+                }
+                free (entrystr);
+            }
+        }
+    }
     if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
         goto error;
     if (flux_future_then (f, -1, shell_output_kvs_completion, out) < 0)
@@ -280,15 +351,10 @@ static int shell_output_kvs (struct shell_output *out)
     /* f memory responsibility of shell_output_kvs_completion()
      * callback */
     f = NULL;
-    if (json_array_clear (out->output) < 0) {
-        log_msg ("json_array_clear failed");
-        goto error;
-    }
     rc = 0;
 error:
     saved_errno = errno;
     flux_kvs_txn_destroy (txn);
-    free (chunk);
     flux_future_destroy (f);
     errno = saved_errno;
     return rc;
@@ -322,13 +388,19 @@ static void shell_output_write_cb (flux_t *h,
     }
     /* Error failing to commit is a fatal error.  Should be cleaner in
      * future. Issue #2378 */
-    if (out->shell->standalone) {
+    if ((out->stdout_type == FLUX_OUTPUT_TYPE_TERM
+         || (out->stderr_type == FLUX_OUTPUT_TYPE_TERM))) {
         if (shell_output_term (out) < 0)
             log_err_exit ("shell_output_term");
     }
-    else {
+    if ((out->stdout_type == FLUX_OUTPUT_TYPE_KVS
+         || (out->stderr_type == FLUX_OUTPUT_TYPE_KVS))) {
         if (shell_output_kvs (out) < 0)
             log_err_exit ("shell_output_kvs");
+    }
+    if (json_array_clear (out->output) < 0) {
+        log_msg ("json_array_clear failed");
+        goto error;
     }
     if (eof) {
         if (--out->eof_pending == 0) {
@@ -406,11 +478,13 @@ void shell_output_destroy (struct shell_output *out)
             zlist_destroy (&out->pending_writes);
         }
         if (out->output && json_array_size (out->output) > 0) { // leader only
-            if (out->shell->standalone) {
+            if ((out->stdout_type == FLUX_OUTPUT_TYPE_TERM)
+                || (out->stderr_type == FLUX_OUTPUT_TYPE_TERM)) {
                 if (shell_output_term (out) < 0)
                     log_err ("shell_output_term");
             }
-            else {
+            if ((out->stdout_type == FLUX_OUTPUT_TYPE_KVS)
+                || (out->stderr_type == FLUX_OUTPUT_TYPE_KVS)) {
                 if (shell_output_kvs (out) < 0)
                     log_err ("shell_output_kvs");
             }
@@ -446,12 +520,16 @@ static int shell_output_header (struct shell_output *out)
         errno = ENOMEM;
         goto error;
     }
-    if (out->shell->standalone) {
+    if ((out->stdout_type == FLUX_OUTPUT_TYPE_TERM)
+        || (out->stderr_type == FLUX_OUTPUT_TYPE_TERM)) {
         if (shell_output_term_init (out, o) < 0)
             log_err ("shell_output_term_init");
     }
-    else {
-        /* will also emit necessary entries to exec.eventlog */
+    /* will also emit necessary entries to exec.eventlog.  Call this
+     * as long as we're not standalone.  Since we minimally want to
+     * log output type to the eventlog.
+     */
+    if (!out->shell->standalone) {
         if (shell_output_kvs_init (out, o) < 0)
             log_err ("shell_output_kvs_init");
     }
@@ -468,20 +546,34 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
     if (!(out = calloc (1, sizeof (*out))))
         return NULL;
     out->shell = shell;
+    if (out->shell->standalone) {
+        out->stdout_type = FLUX_OUTPUT_TYPE_TERM;
+        out->stderr_type = FLUX_OUTPUT_TYPE_TERM;
+    }
+    else {
+        out->stdout_type = FLUX_OUTPUT_TYPE_KVS;
+        out->stderr_type = FLUX_OUTPUT_TYPE_KVS;
+    }
     if (!(out->pending_writes = zlist_new ()))
         goto error;
     if (shell->info->shell_rank == 0) {
-        if (flux_shell_service_register (shell,
-                                         "write",
-                                         shell_output_write_cb,
-                                         out) < 0)
-            goto error;
-        out->eof_pending = 2 * shell->info->jobspec->task_count;
-        if (flux_shell_add_completion_ref (shell, "output.write") < 0)
-            goto error;
-        if (!(out->output = json_array ())) {
-            errno = ENOMEM;
-            goto error;
+        if (output_type_requires_service (out->stdout_type)
+            || output_type_requires_service (out->stderr_type)) {
+            if (flux_shell_service_register (shell,
+                                             "write",
+                                             shell_output_write_cb,
+                                             out) < 0)
+                goto error;
+            if (output_type_requires_service (out->stdout_type))
+                out->eof_pending += shell->info->jobspec->task_count;
+            if (output_type_requires_service (out->stderr_type))
+                out->eof_pending += shell->info->jobspec->task_count;
+            if (flux_shell_add_completion_ref (shell, "output.write") < 0)
+                goto error;
+            if (!(out->output = json_array ())) {
+                errno = ENOMEM;
+                goto error;
+            }
         }
         if (shell_output_header (out) < 0)
             goto error;
@@ -526,11 +618,17 @@ static int shell_output_task_init (flux_plugin_t *p,
     if (!shell || !out || !(task = flux_shell_current_task (shell)))
         return -1;
 
-    if (flux_shell_task_channel_subscribe (task, "stderr",
-                                           task_output_cb, out) < 0
-        || flux_shell_task_channel_subscribe (task, "stdout",
-                                              task_output_cb, out) < 0)
-        return -1;
+    if (output_type_requires_service (out->stdout_type)) {
+        if (flux_shell_task_channel_subscribe (task, "stdout",
+                                               task_output_cb, out) < 0)
+            return -1;
+    }
+    if (output_type_requires_service (out->stderr_type)) {
+        if (flux_shell_task_channel_subscribe (task, "stderr",
+                                               task_output_cb, out) < 0)
+            return -1;
+    }
+
     return 0;
 }
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -768,7 +768,7 @@ int main (int argc, char *argv[])
     for (i = 0; i < shell.info->rankinfo.ntasks; i++) {
         struct shell_task *task;
 
-        if (!(task = shell_task_create (shell.info, i)))
+        if (!(task = shell_task_create (&shell, i)))
             log_err_exit ("shell_task_create index=%d", i);
 
         task->pre_exec_cb = shell_task_exec;

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -42,6 +42,7 @@
 #include <flux/shell.h>
 
 #include "task.h"
+#include "internal.h"
 #include "info.h"
 
 struct channel_watcher {
@@ -85,9 +86,9 @@ error:
     return NULL;
 }
 
-struct shell_task *shell_task_create (struct shell_info *info,
-                                      int index)
+struct shell_task *shell_task_create (flux_shell_t *shell, int index)
 {
+    struct shell_info *info = shell->info;
     struct shell_task *task;
     const char *key;
     json_t *entry;

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -49,7 +49,7 @@ struct shell_task {
 
 void shell_task_destroy (struct shell_task *task);
 
-struct shell_task *shell_task_create (struct shell_info *info, int index);
+struct shell_task *shell_task_create (flux_shell_t *shell, int index);
 
 int shell_task_start (struct shell_task *task,
                       flux_reactor_t *r,

--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -309,26 +309,179 @@ test_expect_success 'flux-shell: run 2-task echo job (stdout term/stderr file)' 
 	grep "1: stderr:baz" err109
 '
 
+test_expect_success 'flux-shell: run 1-task echo job (per-task stdout)' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out110\"" \
+            > j1echostdout-110 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostdout-110 -R R1echo 110 &&
+	grep stdout:foo out110-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (per-task stderr)' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err111\"" \
+            > j1echostderr-111 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-111 -R R1echo 111 &&
+	grep stderr:bar err111-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (per-task stdout & stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out112\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err112\"" \
+            > j1echoboth-112 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-112 -R R1echo 112 &&
+	grep stdout:baz out112-0 &&
+	grep stderr:baz err112-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (per-task stdout/stderr term)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out113\"" \
+            > j1echoboth-113 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-113 -R R1echo 2> err113 113 &&
+	grep stdout:baz out113-0 &&
+	grep stderr:baz err113
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout term/per-task stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err114\"" \
+            > j1echoboth-114 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-114 -R R1echo > out114 114 &&
+	grep stdout:baz out114 &&
+	grep stderr:baz err114-0
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout)' '
+        cat j2echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out115\"" \
+            > j2echostdout-115 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostdout-115 -R R2echo 115 &&
+	grep "stdout:foo" out115-0 &&
+	grep "stdout:foo" out115-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stderr)' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err116\"" \
+            > j2echostderr-116 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-116 -R R2echo 116 &&
+	grep "stderr:bar" err116-0 &&
+	grep "stderr:bar" err116-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout & stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out117\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err117\"" \
+            > j2echoboth-117 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-117 -R R2echo 117 &&
+	grep "stdout:baz" out117-0 &&
+	grep "stdout:baz" out117-1 &&
+	grep "stderr:baz" err117-0 &&
+	grep "stderr:baz" err117-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout/stderr term)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out118\"" \
+            > j2echoboth-118 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-118 -R R2echo 2> err118 118 &&
+	grep "stdout:baz" out118-0 &&
+	grep "stdout:baz" out118-1 &&
+	grep "0: stderr:baz" err118 &&
+	grep "1: stderr:baz" err118
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout term/per-task stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err119\"" \
+            > j2echoboth-119 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-119 -R R2echo > out119 119 &&
+	grep "0: stdout:baz" out119 &&
+	grep "1: stdout:baz" out119 &&
+	grep "stderr:baz" err119-0 &&
+	grep "stderr:baz" err119-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout/stderr file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out120\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err120\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echoboth-120 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-120 -R R2echo 120 &&
+	grep "stdout:baz" out120-0 &&
+	grep "stdout:baz" out120-1 &&
+	grep "0: stderr:baz" err120 &&
+	grep "1: stderr:baz" err120
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout file/per-task stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out121\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err121\"" \
+            > j2echoboth-121 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-121 -R R2echo 121 &&
+	grep "0: stdout:baz" out121 &&
+	grep "1: stdout:baz" out121 &&
+	grep "stderr:baz" err121-0 &&
+	grep "stderr:baz" err121-1
+'
+
 test_expect_success 'flux-shell: error on bad output type' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"foobar\"" \
-            > j1echostdout-110 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-110 -R R1echo 110
+            > j1echostdout-122 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-122 -R R1echo 122
 '
 
 test_expect_success 'flux-shell: error on no path with file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
-            > j1echostdout-111 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-111 -R R1echo 111
+            > j1echostdout-123 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-123 -R R1echo 123
+'
+
+test_expect_success 'flux-shell: error on no path with per-task output' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            > j1echostdout-124 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-124 -R R1echo 124
 '
 
 test_expect_success 'flux-shell: error invalid path to file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz\"" \
-            > j1echostdout-112 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-112 -R R1echo 112
+            > j1echostdout-125 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-125 -R R1echo 125
+'
+
+test_expect_success 'flux-shell: error invalid path to per-task output' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz\"" \
+            > j1echostdout-126 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-126 -R R1echo 126
 '
 
 test_done

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -354,6 +354,160 @@ test_expect_success 'job-shell: run 2-task echo job (stdout kvs/stderr file)' '
         grep "1: stderr:baz" err9
 '
 
+test_expect_success 'flux-shell: run 1-task echo job (per-task stdout)' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out10\"" \
+            > j1echostdout-10 &&
+        id=$(cat j1echostdout-10 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep stdout:foo out10-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (per-task stderr)' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err11\"" \
+            > j1echostderr-11 &&
+        id=$(cat j1echostderr-11 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep stderr:bar err11-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (per-task stdout & stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out12\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err12\"" \
+            > j1echoboth-12 &&
+        id=$(cat j1echoboth-12 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep stdout:baz out12-0 &&
+	grep stderr:baz err12-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (per-task stdout/stderr term)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out13\"" \
+            > j1echoboth-13 &&
+        id=$(cat j1echoboth-13 | flux job submit) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id 2> err13 &&
+	grep stdout:baz out13-0 &&
+	grep stderr:baz err13
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout term/per-task stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err14\"" \
+            > j1echoboth-14 &&
+        id=$(cat j1echoboth-14 | flux job submit) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id > out14 &&
+	grep stdout:baz out14 &&
+	grep stderr:baz err14-0
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout)' '
+        cat j2echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out15\"" \
+            > j2echostdout-15 &&
+        id=$(cat j2echostdout-15 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep "stdout:foo" out15-0 &&
+	grep "stdout:foo" out15-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stderr)' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err16\"" \
+            > j2echostderr-16 &&
+        id=$(cat j2echostderr-16 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep "stderr:bar" err16-0 &&
+	grep "stderr:bar" err16-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout & stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out17\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err17\"" \
+            > j2echoboth-17 &&
+        id=$(cat j2echoboth-17 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep "stdout:baz" out17-0 &&
+	grep "stdout:baz" out17-1 &&
+	grep "stderr:baz" err17-0 &&
+	grep "stderr:baz" err17-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout/stderr term)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out18\"" \
+            > j2echoboth-18 &&
+        id=$(cat j2echoboth-18 | flux job submit) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id 2> err18 &&
+	grep "stdout:baz" out18-0 &&
+	grep "stdout:baz" out18-1 &&
+	grep "0: stderr:baz" err18 &&
+	grep "1: stderr:baz" err18
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout term/per-task stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err19\"" \
+            > j2echoboth-19 &&
+        id=$(cat j2echoboth-19 | flux job submit) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id > out19 &&
+	grep "0: stdout:baz" out19 &&
+	grep "1: stdout:baz" out19 &&
+	grep "stderr:baz" err19-0 &&
+	grep "stderr:baz" err19-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (per-task stdout/stderr file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out20\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err20\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echoboth-20 &&
+        id=$(cat j2echoboth-20 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep "stdout:baz" out20-0 &&
+	grep "stdout:baz" out20-1 &&
+	grep "0: stderr:baz" err20 &&
+	grep "1: stderr:baz" err20
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout file/per-task stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out21\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"per-task\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err21\"" \
+            > j2echoboth-21 &&
+        id=$(cat j2echoboth-21 | flux job submit) &&
+        flux job wait-event $id clean &&
+	grep "0: stdout:baz" out21 &&
+	grep "1: stdout:baz" out21 &&
+	grep "stderr:baz" err21-0 &&
+	grep "stderr:baz" err21-1
+'
+
 test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
         flux module remove -r 0 job-exec &&
         flux module remove -r 0 sched-simple &&


### PR DESCRIPTION
This PR adds support to the shell to output stdout/stderr to files instead of writing to the KVS.  All task stdout/stderr can be written to a single file or each task can write to their own file.

It is built on top of #2345 (but not #2350).

Notes:

- To set this, the user must set the `attributes.system.exec.shell.options.output.<stream>.type` field to "file" for a single file and "per-task" for a file per task.  The setting defaults to "kvs".

- The file to be written uses `attributes.system.exec.shell.options.output.<stream>.path`.  "per-task" output will simply append to the task number to whatever path is specified in this setting.

- `attributes.system.exec.shell.options.output.<stream>.label` will label each line of output with the task number it came from.  This is only used with the "file" type.

- stdout/stderr can be redirected differently than each other, but redirection can only be set to one of "kvs"/"file"/"per-task".  Code has been architected to allow for multiple if we want to come up for a way for the user to specify multiple. (`type = "kvs,file"`?  Or perhaps no "type" field, but instead user specifies `output.stdout.kvs` and `output.stdout.file`, and `outout.stdout.file.path`?)

- I wasn't sure what the mode should be on files created.  I just did `644` for now.

- Due to how code is structured in the shell, handling "per-task" support is done in the `task.c` file.  This sort of breaks the idea that only the `output` plugin for the shell should parse options in `attributes.system.exec.shell.options.output`.

- Single output to a file (type "file") currently is simple and just calls `write(2)` everytime there is data to write.  It'll block if the filesystem is busy.  Could attach to a FD watcher instead?

- It appears that if `shell_output_init()` has an error (such as an invalid output type), the shell only logs the error, it doesn't exit with error.  Therefore, on a few error scenarios (invalid "type", ENOENT opening a file), I `exit(1)` on error instead of returning an error to the caller.  Perhaps the plugin stack should be tweaked to exit when `shell_output_init()` has an error?
