### PR TITLE
shell: add functions to get/set shell "options"

### DIFF
--- a/src/shell/initrc.lua
+++ b/src/shell/initrc.lua
@@ -4,12 +4,6 @@ if shell.info.options.standalone then return end
 -- Load all *.so plugins from plugin.searchpath
 plugin.load { file = "*.so", conf = {} }
 
--- Copy jobspec attributes.system.shell.options to shell.options
-jobspec = shell.info.jobspec
-if jobspec.attributes.system.shell then
-    shell.options = jobspec.attributes.system.shell.options or {}
-end
-
 -- Source all rc files under shell.rcpath/lua.d/*.lua of shell rcpath:
 source (shell.rcpath .. "/lua.d/*.lua")
 

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -85,14 +85,15 @@ struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error)
     if (!(job->jobspec = json_loads (jobspec, 0, error)))
         goto error;
     if (json_unpack_ex (job->jobspec, error, 0,
-                        "{s:i s:o s:o s:{s:{s?:s s?:o}}}",
+                        "{s:i s:o s:o s:{s:{s?:s s?:o s?:{s?:o}}}}",
                         "version", &version,
                         "resources", &resources,
                         "tasks", &tasks,
                         "attributes",
                             "system",
                                 "cwd", &job->cwd,
-                                "environment", &job->environment) < 0) {
+                                "environment", &job->environment,
+                                "shell", "options", &job->options) < 0) {
         goto error;
     }
     if (version != 1) {

--- a/src/shell/jobspec.h
+++ b/src/shell/jobspec.h
@@ -23,6 +23,7 @@ struct jobspec {
     json_t *command;
     const char *cwd;
     json_t *environment;
+    json_t *options;            // attributes.system.shell.options, if any
 };
 
 struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error);

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -38,6 +38,40 @@ int flux_shell_aux_set (flux_shell_t *shell,
 
 void * flux_shell_aux_get (flux_shell_t *shell, const char *name);
 
+/*  Get shell option as JSON string as set in jobspec
+ *   attributes.system.shell.options
+ *
+ *  Returns 1 on success, 0 if option "name" was not set, or -1 on failure.
+ */
+int flux_shell_getopt (flux_shell_t *shell, const char *name, char **json_str);
+
+/*  Unpack shell option from attributes.system.shell.options.<name> using
+ *   jansson style unpack arguments.
+ *
+ *  Returns 1 on success, 0 if option was not found, or -1 on error.
+ */
+int flux_shell_getopt_unpack (flux_shell_t *shell,
+                              const char *name,
+                              const char *fmt, ...);
+
+/*  Set shell option as a JSON string. Future calls to getopt will return
+ *   value encoded in the JSON string. If json_str is NULL, the option
+ *   will unset.
+ *
+ *  Returns 0 on success, -1 on error.
+ */
+int flux_shell_setopt (flux_shell_t *shell,
+                       const char *name,
+                       const char *json_str);
+
+/*  Set shell option using jansson style pack args
+ *
+ *  Returns 0 on success, -1 on error.
+ */
+int flux_shell_setopt_pack (flux_shell_t *shell,
+                            const char *name,
+                            const char *fmt, ...);
+
 /*  Get value of an environment variable from the global job environment
  */
 const char * flux_shell_getenv (flux_shell_t *shell, const char *name);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -229,7 +229,8 @@ check_LTLIBRARIES = \
 	job-manager/sched-dummy.la \
 	shell/plugins/dummy.la \
 	shell/plugins/conftest.la \
-	shell/plugins/invalid-args.la
+	shell/plugins/invalid-args.la \
+	shell/plugins/getopt.la
 
 dist_check_DATA = \
 	hwloc-data/sierra2/0.xml \
@@ -463,5 +464,12 @@ shell_plugins_invalid_args_la_SOURCES = shell/plugins/invalid-args.c
 shell_plugins_invalid_args_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_invalid_args_la_LDFLAGS = -module -rpath /nowhere
 shell_plugins_invalid_args_la_LIBADD = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+        $(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_getopt_la_SOURCES = shell/plugins/getopt.c
+shell_plugins_getopt_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_getopt_la_LDFLAGS = -module -rpath /nowhere
+shell_plugins_getopt_la_LIBADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
         $(top_builddir)/src/common/libflux-core.la

--- a/t/shell/initrc/tests/0004-getopt.lua
+++ b/t/shell/initrc/tests/0004-getopt.lua
@@ -1,0 +1,23 @@
+require 'fluxometer' -- pull in Test.More
+
+plugin.register { name = "done",
+    handlers = {
+        { topic = "shell.exit", fn = function () done_testing() end }
+    }
+}
+
+is (shell.options.test, "test",
+    "shell option test has expected value")
+
+shell.options.mpi = "bar"
+is (shell.options.mpi, "bar",
+    "shell.options.mpi is assignable")
+
+ok (not shell.options.nosuchthing,
+    "access of unset shell option returns nil")
+
+shell.options.mpi = nil
+ok (not shell.options.mpi,
+    "shell.options.mpi can be unset")
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/shell/plugins/getopt.c
+++ b/t/shell/plugins/getopt.c
@@ -1,0 +1,90 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdarg.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "src/common/libtap/tap.h"
+
+static int die (const char *fmt, ...)
+{
+    va_list ap;
+    va_start (ap, fmt);
+    vfprintf (stderr, fmt, ap);
+    va_end (ap);
+    return -1;
+}
+
+static int check_getopt (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *args,
+                         void *data)
+{
+    int result;
+    char *json_str;
+
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    if (!p)
+        return die ("flux_plugin_get_shell\n");
+
+    ok (flux_shell_getopt (shell, "noexist", NULL) == 0,
+        "flux_shell_getopt of nonexistent option returns 0");
+    ok (flux_shell_getopt (shell, "test", &json_str) == 1,
+        "flux_shell_getopt returns 1 on success");
+    ok (json_str != NULL,
+        "flux_shell_getopt returned JSON string");
+    diag ("getopt: %s: test: %s", topic, json_str);
+    free (json_str);
+
+    ok (flux_shell_getopt_unpack (shell, "noexist", "i", &result) == 0,
+        "flux_shell_getopt_unpack of nonexistent option returns 0");
+    ok (flux_shell_getopt_unpack (shell, "test", "i", &result) == 1,
+        "flux_shell_getopt_unpack returns 1 on success");
+    ok (flux_shell_getopt_unpack (shell, "test", "s", &json_str) < 0,
+        "flux_shell_getopt_unpack returns -1 for bad unpack args");
+
+    ok (flux_shell_setopt (shell, "new", "42") == 0,
+        "flux_shell_setopt of new option works");
+    ok (flux_shell_getopt_unpack (shell, "new", "i", &result) == 1
+        && result == 42,
+        "setopt worked and set integer value");
+
+    ok (flux_shell_setopt (shell, "new", NULL) == 0,
+        "flux_shell_setopt with NULL value worked");
+    ok (flux_shell_getopt (shell, "new", NULL) == 0,
+        "flux_shell_getopt shows that unset option worked");
+
+    ok (flux_shell_setopt_pack (shell, "new", "i", 42) == 0,
+        "flux_shell_setopt_pack worked");
+    ok (flux_shell_getopt_unpack (shell, "new", "i", &result) == 1
+        && result == 42,
+        "setopt worked and set integer value");
+
+    if (strcmp (topic, "shell.exit") == 0 || strcmp (topic, "task.exec") == 0)
+        return exit_status () == 0 ? 0 : -1;
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    plan (NO_PLAN);
+    ok (flux_plugin_add_handler (p, "*", check_getopt, NULL) == 0,
+        "flux_plugin_add_handler works");
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -50,6 +50,20 @@ static int shell_cb (flux_plugin_t *p,
     ok (!flux_shell_aux_get (shell, NULL) && errno == EINVAL,
         "flux_shell_aux_get (shell, NULL) returns EINVAL");
 
+    ok (flux_shell_getopt (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_getopt with NULL args returns EINVAL");
+    ok (flux_shell_getopt (shell, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_getopt with NULL name returns EINVAL");
+    ok (flux_shell_getopt (shell, "foo", NULL) == 0,
+        "flux_shell_getopt no opt returns 0");
+
+    ok (flux_shell_getopt_unpack (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_getopt_unpack with NULL args returns EINVAL");
+    ok (flux_shell_getopt_unpack (shell, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_getopt_unpack with NULL name returns EINVAL");
+    ok (flux_shell_getopt_unpack (shell, "foo", NULL) == 0,
+        "flux_shell_getopt_unpack no opt returns 0");
+
     ok (flux_shell_getenv (NULL, "foo") == NULL && errno == EINVAL,
         "flux_shell_getenv (NULL, 'foo') returns EINVAL");
     ok (flux_shell_getenv (shell, NULL) == NULL && errno == EINVAL,

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -110,10 +110,14 @@ test_expect_success 'flux-shell: initrc: return false from plugin aborts shell' 
 	test_debug "cat ${name}.log" &&
 	grep "plugin.*: shell.init failed" ${name}.log
 '
+test_expect_success HAVE_JQ 'flux-shell: initrc: add test options to jobspec' "
+	cat j1 | jq '.attributes.system.shell.options.test = \"test\"' \
+		> j.initrc
+"
 
 for initrc in ${INITRC_TESTDIR}/tests/*.lua; do
     test_expect_success "flux-shell: initrc: runtest $(basename $initrc)" '
-	${FLUX_SHELL} -v -s -r 0 -j j1 -R R1 --initrc=${initrc} 0
+	${FLUX_SHELL} -v -s -r 0 -j j.initrc -R R1 --initrc=${initrc} 0
     '
 done
 

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -6,6 +6,9 @@ test_description='Test flux-shell initrc.lua implementation'
 
 test_under_flux 2
 
+jq=$(which jq 2>/dev/null)
+test -z "$jq" || test_set_prereq HAVE_JQ
+
 FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"
@@ -32,6 +35,24 @@ test_expect_success 'flux-shell: initrc: specifying initrc of /dev/null works' '
 		--initrc=/dev/null 0 > devnull.log 2>&1 &&
 	test_debug "cat devnull.log" &&
 	grep "Loading /dev/null" devnull.log
+'
+test_expect_success HAVE_JQ 'flux-shell: initrc: bad initrc in jobspec fails' '
+	flux jobspec srun -N1 -n1 echo Hi \
+	    | jq ".attributes.system.shell.options.initrc = \"nosuchfile\"" \
+	    > j2 &&
+	test_expect_code 1 ${FLUX_SHELL} -v -s -r 0 -j j2 -R R1 0
+'
+test_expect_success 'flux-shell: initrc: in jobspec works' '
+	name=ok &&
+	cat >${name}.lua <<-EOT &&
+	    print ("jobspec initrc OK")
+	EOT
+	flux jobspec srun -N1 -n1 echo Hi \
+	    | jq ".attributes.system.shell.options.initrc = \"${name}.lua\"" \
+	    > j3 &&
+	${FLUX_SHELL} -v -s -r 0 -j j3 -R R1 0 > ${name}.log 2>&1 &&
+	test_debug "cat ${name}.log" &&
+	grep "jobspec initrc OK" ${name}.log
 '
 test_expect_success 'flux-shell: initrc: failed initrc causes termination' '
 	name=failed &&

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -186,5 +186,15 @@ test_expect_success 'flux-shell: initrc: load invalid args plugins' '
 	${FLUX_SHELL} -v -s -r 0 -j j1 -R R1 \
 		--initrc=${name}.lua 0
 '
-
+test_expect_success HAVE_JQ 'flux-shell: initrc: load getopt plugin' '
+	name=getopt &&
+	cat >${name}.lua <<-EOF &&
+	plugin.searchpath = "${INITRC_PLUGINPATH}"
+	plugin.load { file = "getopt.so" }
+	EOF
+	cat j1 | jq ".attributes.system.shell.options.test = 1" >j.${name} &&
+	${FLUX_SHELL} -v -s -r 0 -j j.${name} -R R1 --initrc=${name}.lua 0 \
+		> ${name}.log 2>&1 &&
+	test_debug "cat ${name}.log"
+'
 test_done


### PR DESCRIPTION
This PR adds a new set of functions for managing the shell "options" set in jobspec via the public shell api:

```c
/*  Get shell option as JSON string as set in jobspec
 *   attributes.system.shell.options
 *
 *  Returns 1 on success, 0 if option "name" was not set, or -1 on failure.
 */
int flux_shell_getopt (flux_shell_t *shell, const char *name, char **json_str);

/*  Unpack shell option from attributes.system.shell.options.<name> using
 *   jansson style unpack arguments.
 *
 *  Returns 1 on success, 0 if option was not found, or -1 on error.
 */
int flux_shell_getopt_unpack (flux_shell_t *shell,
                              const char *name,
                              const char *fmt, ...);

/*  Set shell option as a JSON string. Future calls to getopt will return
 */
int flux_shell_setopt (flux_shell_t *shell,
                       const char *name,
                       const char *json_str);

/*  Set shell option using jansson style pack args
 */
int flux_shell_setopt_pack (flux_shell_t *shell,
                            const char *name,
                            const char *fmt, ...);
```

It may be surprising that there are functions for *setting* options, but it may be useful to allow plugins to set options for other plugins, or allow a system `initrc.lua` to set a default option (e.g. `if not shell.options.mpi then shell.options.mpi = "spectrum" end`)

As seen above, shell options are exposed in `initrc.lua` via a proxy `shell.options` table, which currently allows getting, setting, and un-setting options if necessary.

Finally, some errors were fixed in the current spectrum MPI plugin.