### PR TITLE
shell: Support stdout/stderr redirect to a file

### DIFF
--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -108,10 +108,6 @@ static int shell_output_flush (struct shell_output *out)
     json_array_foreach (out->output, index, entry) {
         json_t *context;
         const char *name;
-        const char *stream = NULL;
-        int rank;
-        char *data = NULL;
-        int len = 0;
         if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
             log_err ("eventlog_entry_parse");
             return -1;
@@ -120,6 +116,10 @@ static int shell_output_flush (struct shell_output *out)
             // TODO: acquire per-stream encoding type
         }
         else if (!strcmp (name, "data")) {
+            const char *stream = NULL;
+            int rank;
+            char *data = NULL;
+            int len = 0;
             if (iodecode (context, &stream, &rank, &data, &len, NULL) < 0) {
                 log_err ("iodecode");
                 return -1;

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -60,7 +60,6 @@ struct shell_output {
     zlist_t *pending_writes;
     json_t *output;
     bool stopped;
-    bool output_ready_sent;
 };
 
 static const int shell_output_lwm = 100;
@@ -99,6 +98,12 @@ static void shell_output_control (struct shell_output *out, bool stop)
     }
 }
 
+static int shell_output_flush_init (struct shell_output *out, json_t *header)
+{
+    // TODO: acquire per-stream encoding type
+    return 0;
+}
+
 static int shell_output_flush (struct shell_output *out)
 {
     json_t *entry;
@@ -112,10 +117,7 @@ static int shell_output_flush (struct shell_output *out)
             log_err ("eventlog_entry_parse");
             return -1;
         }
-        if (!strcmp (name, "header")) {
-            // TODO: acquire per-stream encoding type
-        }
-        else if (!strcmp (name, "data")) {
+        if (!strcmp (name, "data")) {
             const char *stream = NULL;
             int rank;
             char *data = NULL;
@@ -135,20 +137,6 @@ static int shell_output_flush (struct shell_output *out)
     if (json_array_clear (out->output) < 0)
         log_msg ("json_array_clear failed");
     return 0;
-}
-
-static void shell_output_commit_completion (flux_future_t *f, void *arg)
-{
-    struct shell_output *out = arg;
-
-    /* Error failing to commit is a fatal error.  Should be cleaner in
-     * future. Issue #2378 */
-    if (flux_future_get (f, NULL) < 0)
-        log_err_exit ("shell_output_commit");
-    flux_future_destroy (f);
-
-    if (flux_shell_remove_completion_ref (out->shell, "output.commit") < 0)
-        log_err ("flux_shell_remove_completion_ref");
 }
 
 /* log entry to exec.eventlog that we've created the output directory */
@@ -181,6 +169,71 @@ error:
     return rc;
 }
 
+static void shell_output_commit_init_completion (flux_future_t *f, void *arg)
+{
+    struct shell_output *out = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to commit output-ready or header is a fatal
+         * error.  Should be cleaner in future. Issue #2378 */
+        log_err_exit ("shell_output_commit_init");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (out->shell, "output.commit-init") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+}
+
+static int shell_output_commit_init (struct shell_output *out, json_t *header)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    char *headerstr = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(headerstr = eventlog_entry_encode (header)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "output", headerstr) < 0)
+        goto error;
+    if (shell_output_ready (out, txn) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_output_commit_init_completion, out) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (out->shell, "output.commit-init") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_output_commit_init_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    free (headerstr);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+static void shell_output_commit_completion (flux_future_t *f, void *arg)
+{
+    struct shell_output *out = arg;
+
+    /* Error failing to commit is a fatal error.  Should be cleaner in
+     * future. Issue #2378 */
+    if (flux_future_get (f, NULL) < 0)
+        log_err_exit ("shell_output_commit");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (out->shell, "output.commit") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+}
+
 static int shell_output_commit (struct shell_output *out)
 {
     flux_kvs_txn_t *txn = NULL;
@@ -195,16 +248,8 @@ static int shell_output_commit (struct shell_output *out)
         goto error;
     if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "output", chunk) < 0)
         goto error;
-    /* if the output-ready eventlog entry has not been sent, send now.
-     * This is usually sent when the output header is sent. */
-    if (!out->output_ready_sent) {
-        if (shell_output_ready (out, txn) < 0)
-            goto error;
-    }
     if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
         goto error;
-    if (!out->output_ready_sent)
-        out->output_ready_sent = true;
     if (flux_future_then (f, -1, shell_output_commit_completion, out) < 0)
         goto error;
     if (flux_shell_add_completion_ref (out->shell, "output.commit") < 0) {
@@ -355,15 +400,14 @@ void shell_output_destroy (struct shell_output *out)
     }
 }
 
-/* Append RFC 24 header event to 'output' JSON array and write out to
- * KVS.  Assume:
+/* Write RFC 24 header event to KVS.  Assume:
  * - fixed base64 encoding for stdout, stderr
  * - no options
  * - no stdlog
  */
 static int shell_output_header (struct shell_output *out)
 {
-    json_t *o;
+    json_t *o = NULL;
     int rc = -1;
 
     o = eventlog_entry_pack (0, "header",
@@ -380,22 +424,18 @@ static int shell_output_header (struct shell_output *out)
         errno = ENOMEM;
         goto error;
     }
-    if (json_array_append_new (out->output, o) < 0) {
-        json_decref (o);
-        errno = ENOMEM;
-        goto error;
-    }
     if (out->shell->standalone) {
-        if (shell_output_flush (out) < 0)
-            log_err ("shell_output_flush");
+        if (shell_output_flush_init (out, o) < 0)
+            log_err ("shell_output_flush_init");
     }
     else {
         /* will also emit output-ready event */
-        if (shell_output_commit (out) < 0)
-            log_err ("shell_output_commit");
+        if (shell_output_commit_init (out, o) < 0)
+            log_err ("shell_output_commit_init");
     }
     rc = 0;
 error:
+    json_decref (o);
     return rc;
 }
 

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -13,12 +13,14 @@
  * Intercept task stdout, stderr and dispose of it according to
  * selected I/O mode.
  *
- * If output goes to terminal or stdout/stderr is written to the KVS,
- * the leader shell implements an "shell-<id>.output" service that all
- * ranks send task output to.  Output objects accumulate in a json
- * array on the leader.  Depending on settings, output is written
- * directly to stdout/stderr or output objects are written to the
- * "output" key in the job's guest KVS namespace per RFC24.
+ * If output goes to terminal, stdout/stderr is written to the KVS, or
+ * stdout/stderr if written directly to a file, the leader shell
+ * implements an "shell-<id>.output" service that all ranks send task
+ * output to.  Output objects accumulate in a json array on the
+ * leader.  Depending on settings, output is written directly to
+ * stdout/stderr, output objects are written to the "output" key in
+ * the job's guest KVS namespace per RFC24, or output is written to a
+ * configured file.
  *
  * Notes:
  * - leader takes a completion reference which it gives up once each
@@ -30,6 +32,8 @@
  *   callbacks.
  * - Any outstanding RPCs at shell_output_destroy() are synchronously waited for
  *   there (checked for error, then destroyed).
+ * - Any outstanding file writes at shell_output_destroy() are
+ *   synchronously waited for to complete.
  * - In standalone mode, the loop:// connector enables RPCs to work
  * - In standalone mode, output is written to the shell's stdout/stderr not KVS
  * - The number of in-flight write requests on each shell is limited to
@@ -56,6 +60,16 @@
 enum {
     FLUX_OUTPUT_TYPE_TERM = 1,
     FLUX_OUTPUT_TYPE_KVS = 2,
+    FLUX_OUTPUT_TYPE_FILE = 3,
+};
+
+struct shell_output_fd {
+    int fd;
+};
+
+struct shell_output_type_file {
+    struct shell_output_fd *fdp;
+    const char *path;
 };
 
 struct shell_output {
@@ -67,6 +81,9 @@ struct shell_output {
     bool stopped;
     int stdout_type;
     int stderr_type;
+    struct shell_output_type_file stdout_file;
+    struct shell_output_type_file stderr_file;
+    zhash_t *fds;
 };
 
 static const int shell_output_lwm = 100;
@@ -313,6 +330,62 @@ error:
     return rc;
 }
 
+static int shell_output_write_fd (int fd, void *buf, size_t len)
+{
+    size_t count = 0;
+    int n = 0;
+    while (count < len) {
+        if ((n = write (fd, buf + count, len - count)) < 0) {
+            if (errno != EINTR)
+                return -1;
+            continue;
+        }
+        count += n;
+    }
+    return n;
+}
+
+static int shell_output_file (struct shell_output *out)
+{
+    json_t *entry;
+    size_t index;
+
+    json_array_foreach (out->output, index, entry) {
+        json_t *context;
+        const char *name;
+        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
+            log_err ("eventlog_entry_parse");
+            return -1;
+        }
+        if (!strcmp (name, "data")) {
+            struct shell_output_type_file *ofp;
+            int output_type;
+            const char *stream = NULL;
+            int rank;
+            char *data = NULL;
+            int len = 0;
+            if (iodecode (context, &stream, &rank, &data, &len, NULL) < 0) {
+                log_err ("iodecode");
+                return -1;
+            }
+            if (!strcmp (stream, "stdout")) {
+                output_type = out->stdout_type;
+                ofp = &out->stdout_file;
+            }
+            else {
+                output_type = out->stderr_type;
+                ofp = &out->stderr_file;
+            }
+            if ((output_type == FLUX_OUTPUT_TYPE_FILE) && len > 0) {
+                if (shell_output_write_fd (ofp->fdp->fd, data, len) < 0)
+                    return -1;
+            }
+            free (data);
+        }
+    }
+    return 0;
+}
+
 /* Convert 'iodecode' object to an valid RFC 24 data event.
  * N.B. the iodecode object is a valid "context" for the event.
  */
@@ -350,6 +423,11 @@ static void shell_output_write_cb (flux_t *h,
          || (out->stderr_type == FLUX_OUTPUT_TYPE_KVS))) {
         if (shell_output_kvs (out) < 0)
             log_err_exit ("shell_output_kvs");
+    }
+    if ((out->stdout_type == FLUX_OUTPUT_TYPE_FILE
+         || (out->stderr_type == FLUX_OUTPUT_TYPE_FILE))) {
+        if (shell_output_file (out) < 0)
+            log_err ("shell_output_file");
     }
     if (json_array_clear (out->output) < 0) {
         log_msg ("json_array_clear failed");
@@ -441,8 +519,21 @@ void shell_output_destroy (struct shell_output *out)
                 if (shell_output_kvs (out) < 0)
                     log_err ("shell_output_kvs");
             }
+            if ((out->stdout_type == FLUX_OUTPUT_TYPE_FILE
+                 || (out->stderr_type == FLUX_OUTPUT_TYPE_FILE))) {
+                if (shell_output_file (out) < 0)
+                    log_err ("shell_output_file");
+            }
         }
         json_decref (out->output);
+        if (out->fds) { // leader only
+            struct shell_output_fd *fdp = zhash_first (out->fds);
+            while (fdp) {
+                close (fdp->fd);
+                fdp = zhash_next (out->fds);
+            }
+            zhash_destroy (&out->fds);
+        }
         free (out);
         errno = saved_errno;
     }
@@ -452,9 +543,188 @@ void shell_output_destroy (struct shell_output *out)
 static bool output_type_requires_service (int type)
 {
     if ((type == FLUX_OUTPUT_TYPE_TERM)
-        || (type == FLUX_OUTPUT_TYPE_KVS))
+        || (type == FLUX_OUTPUT_TYPE_KVS)
+        || (type == FLUX_OUTPUT_TYPE_FILE))
         return true;
     return false;
+}
+
+static int shell_output_parse_type (struct shell_output *out,
+                                    const char *typestr,
+                                    int *typep)
+{
+    if (out->shell->standalone && !strcmp (typestr, "term"))
+        (*typep) = FLUX_OUTPUT_TYPE_TERM;
+    else if (!strcmp (typestr, "kvs"))
+        (*typep) = FLUX_OUTPUT_TYPE_KVS;
+    else if (!strcmp (typestr, "file"))
+        (*typep) = FLUX_OUTPUT_TYPE_FILE;
+    else {
+        log_msg ("invalid output type specified '%s'", typestr);
+        return -1;
+    }
+    return 0;
+}
+
+static int
+shell_output_setup_type_file (struct shell_output *out,
+                              const char *stream,
+                              struct shell_output_type_file *ofp,
+                              struct shell_output_type_file *ofp_copy)
+{
+    if (flux_shell_getopt_unpack (out->shell, "output",
+                                  "{s:{s?:s}}",
+                                  stream, "path", &(ofp->path)) < 0)
+        return -1;
+
+    if (ofp->path == NULL) {
+        log_msg ("path for %s file output not specified", stream);
+        return -1;
+    }
+
+    if (ofp_copy)
+        ofp_copy->path = ofp->path;
+
+    return 0;
+}
+
+static int shell_output_setup_type (struct shell_output *out,
+                                    const char *stream,
+                                    int type,
+                                    bool copy_to_stderr)
+{
+    if (type == FLUX_OUTPUT_TYPE_FILE) {
+        struct shell_output_type_file *ofp = NULL;
+        struct shell_output_type_file *ofp_copy = NULL;
+
+        if (!strcmp (stream, "stdout"))
+            ofp = &(out->stdout_file);
+        else
+            ofp = &(out->stderr_file);
+
+        if (copy_to_stderr)
+            ofp_copy = &(out->stderr_file);
+
+        if (shell_output_setup_type_file (out, stream, ofp, ofp_copy) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int shell_output_check_alternate_output (struct shell_output *out)
+{
+    const char *stdout_typestr = NULL;
+    const char *stderr_typestr = NULL;
+
+    if (flux_shell_getopt_unpack (out->shell, "output",
+                                  "{s?:{s?:s}}",
+                                  "stdout", "type", &stdout_typestr) < 0)
+        return -1;
+
+    if (flux_shell_getopt_unpack (out->shell, "output",
+                                  "{s?:{s?:s}}",
+                                  "stderr", "type", &stderr_typestr) < 0)
+        return -1;
+
+    if (!stdout_typestr && !stderr_typestr)
+        return 0;
+
+    /* If stdout type is set but stderr type is not set, custom is for
+     * stderr type to follow stdout type, including all settings */
+    if (stdout_typestr && !stderr_typestr) {
+        if (shell_output_parse_type (out,
+                                     stdout_typestr,
+                                     &(out->stdout_type)) < 0)
+            return -1;
+
+        out->stderr_type = out->stdout_type;
+
+        if (shell_output_setup_type (out,
+                                     "stdout",
+                                     out->stdout_type,
+                                     true) < 0)
+            return -1;
+    }
+    else {
+        if (stdout_typestr) {
+            if (shell_output_parse_type (out,
+                                         stdout_typestr,
+                                         &(out->stdout_type)) < 0)
+                return -1;
+            if (shell_output_setup_type (out,
+                                         "stdout",
+                                         out->stdout_type,
+                                         false) < 0)
+                return -1;
+        }
+        if (stderr_typestr) {
+            if (shell_output_parse_type (out,
+                                         stderr_typestr,
+                                         &(out->stderr_type)) < 0)
+                return -1;
+            if (shell_output_setup_type (out,
+                                         "stderr",
+                                         out->stderr_type,
+                                         false) < 0)
+                return -1;
+        }
+    }
+    return 0;
+}
+
+static struct shell_output_fd *shell_output_fd_create (int fd)
+{
+    struct shell_output_fd *fdp = calloc (1, sizeof (*fdp));
+    if (!fdp)
+        return NULL;
+    fdp->fd = fd;
+    return fdp;
+}
+
+static void shell_output_fd_destroy (void *data)
+{
+    struct shell_output_fd *fdp = data;
+    if (fdp) {
+        close (fdp->fd);
+        free (fdp);
+    }
+}
+
+static int shell_output_type_file_setup (struct shell_output *out,
+                                         struct shell_output_type_file *ofp)
+{
+    mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+    int open_flags = O_CREAT | O_TRUNC | O_WRONLY;
+    struct shell_output_fd *fdp = NULL;
+    int saved_errno, fd = -1;
+
+    /* check if we're outputting to the same file as another stream */
+    if ((fdp = zhash_lookup (out->fds, ofp->path))) {
+        ofp->fdp = fdp;
+        return 0;
+    }
+
+    if ((fd = open (ofp->path, open_flags, mode)) < 0) {
+        log_err ("error opening output file '%s'", ofp->path);
+        goto error;
+    }
+
+    if (!(fdp = shell_output_fd_create (fd)))
+        goto error;
+
+    if (zhash_insert (out->fds, ofp->path, fdp) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zhash_freefn (out->fds, ofp->path, shell_output_fd_destroy);
+    ofp->fdp = fdp;
+    return 0;
+
+error:
+    saved_errno = errno;
+    shell_output_fd_destroy (fdp);
+    errno = saved_errno;
+    return -1;
 }
 
 /* Write RFC 24 header event to KVS.  Assume:
@@ -514,6 +784,10 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
         out->stdout_type = FLUX_OUTPUT_TYPE_KVS;
         out->stderr_type = FLUX_OUTPUT_TYPE_KVS;
     }
+
+    if (shell_output_check_alternate_output (out) < 0)
+        goto error;
+
     if (!(out->pending_writes = zlist_new ()))
         goto error;
     if (shell->info->shell_rank == 0) {
@@ -537,6 +811,22 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
         }
         if (shell_output_header (out) < 0)
             goto error;
+
+        if (out->stdout_type == FLUX_OUTPUT_TYPE_FILE
+            || out->stderr_type == FLUX_OUTPUT_TYPE_FILE) {
+            if (!(out->fds = zhash_new ())) {
+                errno = ENOMEM;
+                goto error;
+            }
+            if (out->stdout_type == FLUX_OUTPUT_TYPE_FILE) {
+                if (shell_output_type_file_setup (out, &(out->stdout_file)) < 0)
+                    goto error;
+            }
+            if (out->stderr_type == FLUX_OUTPUT_TYPE_FILE) {
+                if (shell_output_type_file_setup (out, &(out->stderr_file)) < 0)
+                    goto error;
+            }
+        }
     }
     return out;
 error:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -110,6 +110,7 @@ TESTSCRIPTS = \
 	t2603-job-shell-initrc.t \
 	t2604-job-shell-affinity.t \
 	t2605-job-shell-output-redirection-standalone.t \
+	t2606-job-shell-output-redirection.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -109,6 +109,7 @@ TESTSCRIPTS = \
 	t2602-job-shell.t \
 	t2603-job-shell-initrc.t \
 	t2604-job-shell-affinity.t \
+	t2605-job-shell-output-redirection-standalone.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -1,0 +1,258 @@
+#!/bin/sh
+#
+test_description='Test flux-shell in --standalone mode'
+
+. `dirname $0`/sharness.sh
+
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+
+#  Run flux-shell under flux command to get correct paths
+FLUX_SHELL="flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
+
+unset FLUX_URI
+
+TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
+
+test_expect_success 'flux-shell: generate 1-task echo jobspecs and matching R' '
+	flux jobspec srun -N1 -n1 ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo > j1echostdout &&
+	flux jobspec srun -N1 -n1 ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar > j1echostderr &&
+	flux jobspec srun -N1 -n1 ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz > j1echoboth &&
+	cat >R1 <<-EOT
+	{"version": 1, "execution":{ "R_lite":[
+		{ "children": { "core": "0" }, "rank": "0" }
+        ]}}
+	EOT
+'
+
+test_expect_success 'flux-shell: generate 2-task echo jobspecs and matching R' '
+	flux jobspec srun -N1 -n2 ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo > j2echostdout &&
+	flux jobspec srun -N1 -n2 ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar > j2echostderr &&
+	flux jobspec srun -N1 -n2 ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz > j2echoboth &&
+	cat >R2 <<-EOT
+	{"version": 1, "execution":{ "R_lite":[
+		{ "children": { "core": "0-1" }, "rank": "0" }
+        ]}}
+	EOT
+'
+
+#
+# 1 task output file tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file)' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out0\"" \
+            > j1echostdout-0 &&
+        ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-0 -R R1 0 &&
+	grep stdout:foo out0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr file)' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err1\"" \
+            > j1echostderr-1 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-1 -R R1 1 &&
+	grep stderr:bar err1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr to stdout file)' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out2\"" \
+            > j1echostderr-2 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-2 -R R1 2 &&
+	grep stderr:bar out2
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file/stderr file)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out3\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err3\"" \
+            > j1echoboth-3 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-3 -R R1 3 &&
+	grep stdout:baz out3 &&
+	grep stderr:baz err3
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout & stderr to stdout file)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out4\"" \
+            > j1echoboth-4 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-4 -R R1 4 &&
+	grep stdout:baz out4 &&
+	grep stderr:baz out4
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file/stderr term)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out5\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"term\"" \
+            > j1echoboth-5 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-5 -R R1 2> err5 5 &&
+	grep stdout:baz out5 &&
+	grep stderr:baz err5
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout term/stderr file)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err6\"" \
+            > j1echoboth-6 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-6 -R R1 > out6 6 &&
+	grep stdout:baz out6 &&
+	grep stderr:baz err6
+'
+
+#
+# 2 task output file tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file)' '
+        cat j2echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out7\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            > j2echostdout-7 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostdout-7 -R R2 7 &&
+	grep "0: stdout:foo" out7 &&
+	grep "1: stdout:foo" out7
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr file)' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err8\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echostderr-8 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-8 -R R2 8 &&
+	grep "0: stderr:bar" err8 &&
+	grep "1: stderr:bar" err8
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr to stdout file)' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out9\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            > j2echostderr-9 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-9 -R R2 9 &&
+	grep "0: stderr:bar" out9 &&
+	grep "1: stderr:bar" out9
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/stderr file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out10\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err10\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echoboth-10 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-10 -R R2 10 &&
+	grep "0: stdout:baz" out10 &&
+	grep "1: stdout:baz" out10 &&
+	grep "0: stderr:baz" err10 &&
+	grep "1: stderr:baz" err10
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout & stderr to stdout file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out11\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            > j2echoboth-11 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-11 -R R2 11 &&
+	grep "0: stdout:baz" out11 &&
+	grep "1: stdout:baz" out11 &&
+	grep "0: stderr:baz" out11 &&
+	grep "1: stderr:baz" out11
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/stderr term)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out12\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"term\"" \
+            > j2echoboth-12 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-12 -R R2 2> err12 12 &&
+	grep "0: stdout:baz" out12 &&
+	grep "1: stdout:baz" out12 &&
+	grep "0: stderr:baz" err12 &&
+	grep "1: stderr:baz" err12
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err13\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echoboth-13 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-13 -R R2 > out13 13 &&
+	grep "0: stdout:baz" out13 &&
+	grep "1: stdout:baz" out13 &&
+	grep "0: stderr:baz" err13 &&
+	grep "1: stderr:baz" err13
+'
+
+#
+# output file mustache tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err{{id}}\"" \
+            > j1echoboth-14 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-14 -R R1 14 &&
+	grep stdout:baz out14 &&
+	grep stderr:baz err14
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}\"" \
+            > j1echoboth-15 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-15 -R R1 15 &&
+	grep stdout:baz out15 &&
+	grep stderr:baz out15
+'
+
+#
+# output corner case tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: error on bad output type' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"foobar\"" \
+            > j1echostdout-16 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-16 -R R1 16
+'
+
+test_expect_success HAVE_JQ 'flux-shell: error on no path with file output' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            > j1echostdout-17 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-17 -R R1 17
+'
+
+test_expect_success HAVE_JQ 'flux-shell: error invalid path to file output' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz\"" \
+            > j1echostdout-18 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-18 -R R1 18
+'
+
+test_done

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -1,0 +1,327 @@
+#!/bin/sh
+#
+test_description='Test flux-shell'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
+
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
+
+test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+        #  Add fake by_rank configuration to kvs:
+        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux module load barrier &&
+        flux module load -r 0 sched-simple &&
+        flux module load -r 0 job-exec
+'
+
+#
+# 1 task output file tests
+#
+
+test_expect_success 'job-shell: run 1-task echo job (stdout file)' '
+        flux mini run -n1 \
+             --output=out0 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo &&
+        grep stdout:foo out0
+'
+
+test_expect_success 'job-shell: run 1-task echo job (stderr file)' '
+        flux mini run -n1 \
+             --error=err1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep stderr:bar err1
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stderr to stdout file)' '
+        flux mini run -n1 \
+             --output=out2 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep stderr:bar out2
+'
+
+test_expect_success 'job-shell: run 1-task echo job (stdout file/stderr file)' '
+        flux mini run -n1 \
+             --output=out3 --error=err3 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out3 &&
+        grep stderr:baz err3
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout & stderr to stdout file)' '
+        flux mini run -n1 \
+             --output=out4 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out4 &&
+        grep stderr:baz out4
+'
+
+test_expect_success 'job-shell: run 1-task echo job (stdout file/stderr kvs)' '
+        id=$(flux mini submit -n1 \
+             --output=out5 --setopt "output.stderr.type=\"kvs\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> err5 &&
+        grep stdout:baz out5 &&
+        grep stderr:baz err5
+'
+
+test_expect_success 'job-shell: run 1-task echo job (stdout kvs/stderr file)' '
+        id=$(flux mini submit -n1 \
+             --error=err6 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id > out6 &&
+        grep stdout:baz out6 &&
+        grep stderr:baz err6
+'
+
+#
+# 2 task output file tests
+#
+
+test_expect_success 'job-shell: run 2-task echo job (stdout file)' '
+        flux mini run -n2 \
+             --output=out7 --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo &&
+        grep "0: stdout:foo" out7 &&
+        grep "1: stdout:foo" out7
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stderr file)' '
+        flux mini run -n2 \
+             --error=err8 --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "0: stderr:bar" err8 &&
+        grep "1: stderr:bar" err8
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stderr to stdout file)' '
+        flux mini run -n2 \
+             --output=out9 --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "0: stderr:bar" out9 &&
+        grep "1: stderr:bar" out9
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stdout file/stderr file)' '
+        flux mini run -n2 \
+             --output=out10 --error=err10 --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "0: stdout:baz" out10 &&
+        grep "1: stdout:baz" out10 &&
+        grep "0: stderr:baz" err10 &&
+        grep "1: stderr:baz" err10
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stdout & stderr to stdout file)' '
+        flux mini run -n2 \
+             --output=out11 --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "0: stdout:baz" out11 &&
+        grep "1: stdout:baz" out11 &&
+        grep "0: stderr:baz" out11 &&
+        grep "1: stderr:baz" out11
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stdout file/stderr kvs)' '
+        id=$(flux mini submit -n2 \
+             --output=out12 --label-io --setopt "output.stderr.type=\"kvs\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id 2> err12 &&
+        grep "0: stdout:baz" out12 &&
+        grep "1: stdout:baz" out12 &&
+        grep "0: stderr:baz" err12 &&
+        grep "1: stderr:baz" err12
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stdout kvs/stderr file)' '
+        id=$(flux mini submit -n2 \
+             --error=err13 --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id > out13 &&
+        grep "0: stdout:baz" out13 &&
+        grep "1: stdout:baz" out13 &&
+        grep "0: stderr:baz" err13 &&
+        grep "1: stderr:baz" err13
+'
+
+#
+# output file mustache tests
+#
+
+test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
+        id=$(flux mini submit -n1 \
+             --output="out{{id}}" --error="err{{id}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out${id} &&
+        grep stderr:baz err${id}
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
+        id=$(flux mini submit -n1 \
+             --output="out{{id}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out${id} &&
+        grep stderr:baz out${id}
+'
+
+#
+# output file outputs correct information to guest.output
+#
+
+test_expect_success 'job-shell: redirect events appear in guest.output (1-task)' '
+        id=$(flux mini submit -n1 \
+             --output=out16 --error=err16 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job eventlog -p guest.output $id > eventlog16.out &&
+        grep "stdout" eventlog16.out | grep redirect | grep "rank=\"0\"" | grep out16 &&
+        grep "stderr" eventlog16.out | grep redirect | grep "rank=\"0\"" | grep err16
+'
+
+test_expect_success 'job-shell: redirect events appear in guest.output (1-task stderr to stdout)' '
+        id=$(flux mini submit -n1 \
+             --output=out17 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job eventlog -p guest.output $id > eventlog17.out &&
+        grep "stdout" eventlog17.out | grep redirect | grep "rank=\"0\"" | grep out17 &&
+        grep "stderr" eventlog17.out | grep redirect | grep "rank=\"0\"" | grep out17
+'
+
+test_expect_success 'job-shell: redirect events appear in guest.output (2-task)' '
+        id=$(flux mini submit -n2 \
+             --output=out18 --error=err18 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job eventlog -p guest.output $id > eventlog18.out &&
+        grep "stdout" eventlog18.out | grep redirect | grep "0-1" | grep out18 &&
+        grep "stderr" eventlog18.out | grep redirect | grep "0-1" | grep err18
+'
+
+test_expect_success 'job-shell: redirect events appear in guest.output (2-task stderr to stdout)' '
+        id=$(flux mini submit -n2 \
+             --output=out19 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job eventlog -p guest.output $id > eventlog19.out &&
+        grep "stdout" eventlog19.out | grep redirect | grep "0-1" | grep out19 &&
+        grep "stderr" eventlog19.out | grep redirect | grep "0-1" | grep out19
+'
+
+test_expect_success 'job-shell: attach shows redirected file (1-task)' '
+        id=$(flux mini submit -n1 \
+             --output=out20 --error=err20 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> attach20.err &&
+        grep "0: stdout redirected to out20" attach20.err &&
+        grep "0: stderr redirected to err20" attach20.err
+'
+
+test_expect_success 'job-shell: attach shows redirected file (1-task stderr to stdout)' '
+        id=$(flux mini submit -n1 \
+             --output=out21 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> attach21.err &&
+        grep "0: stdout redirected to out21" attach21.err &&
+        grep "0: stderr redirected to out21" attach21.err
+'
+
+test_expect_success 'job-shell: attach shows redirected file (2-task)' '
+        id=$(flux mini submit -n2 \
+             --output=out22 --error=err22 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> attach22.err &&
+        grep "[[0-1]]: stdout redirected to out22" attach22.err &&
+        grep "[[0-1]]: stderr redirected to err22" attach22.err
+'
+
+test_expect_success 'job-shell: attach shows redirected file (2-task stderr to stdout)' '
+        id=$(flux mini submit -n2 \
+             --output=out23 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> attach23.err &&
+        grep "[[0-1]]: stdout redirected to out23" attach23.err &&
+        grep "[[0-1]]: stderr redirected to out23" attach23.err
+'
+
+test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-task)' '
+        id=$(flux mini submit -n1 \
+             --output=out24 --error=err24 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -q $id 2> attach24.err &&
+        ! grep "redirected" attach24.err
+'
+
+#
+# output corner case tests
+#
+
+test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-task)' '
+        id=$(flux mini submit -n1 \
+             --output=out25 --error=err25 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -q ${id} > out25.attach 2> err25.attach &&
+        grep stdout:baz out25 &&
+        grep stderr:baz err25 &&
+        ! test -s out25.attach &&
+        ! test -s err25.attach
+'
+
+test_expect_success 'job-shell: job attach exits cleanly if no kvs output (2-task)' '
+        id=$(flux mini submit -n2 \
+             --output=out26 --error=err26 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -q ${id} > out26.attach 2> err26.attach &&
+        grep stdout:baz out26 &&
+        grep stderr:baz err26 &&
+        ! test -s out26.attach &&
+        ! test -s err26.attach
+'
+
+test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output (1-task, live job)' '
+        id=$(flux mini submit -n1 \
+             --output=out27 --error=err27 \
+             sleep 60)
+        flux job wait-event $id start &&
+        flux job attach -E -X ${id} 2> attach27.err &
+        pid=$! &&
+        flux job cancel $id &&
+        ! wait $pid
+'
+
+test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output (2-task, live job)' '
+        id=$(flux mini submit -n2 \
+             --output=out28 --error=err28 \
+             sleep 60)
+        flux job wait-event $id start &&
+        flux job attach -E -X ${id} 2> attach28.err &
+        pid=$! &&
+        flux job cancel $id &&
+        ! wait $pid
+'
+
+test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
+        flux module remove -r 0 job-exec &&
+        flux module remove -r 0 sched-simple &&
+        flux module remove barrier
+'
+
+test_done


### PR DESCRIPTION
This PR adds support to the shell to output stdout/stderr to a file instead of writing to the KVS. All task stdout/stderr is written to a single file.

Notes:

- To set this, the user must set the `attributes.system.shell.options.output.<stream>.type` field to "file". The setting defaults to "kvs".

- The file to be written uses `attributes.system.shell.options.output.<stream>.path`.

- `attributes.system.shell.options.output.<stream>.label` will label each line of output with the task number it came from.

- I wasn't sure what the mode should be on files created. I just did 644 for now.

- Writes to files just calls `write(2)` everytime there is data to write. It'll block if the filesystem is busy. Could attach to a FD watcher instead?