### PR TITLE
shell: support per-task output redirect to file

### DIFF
--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -169,66 +169,70 @@ static int channel_local_setup (flux_subprocess_t *p,
         goto error;
     }
 
-    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log_error (p->h, "socketpair");
-        goto error;
-    }
+    if ((channel_flags & CHANNEL_READ)
+        || (channel_flags & CHANNEL_WRITE)) {
 
-    c->parent_fd = fds[0];
-    c->child_fd = fds[1];
-
-    /* set fds[] to -1, on error is now subprocess_free()'s
-     * responsibility
-     */
-    fds[0] = -1;
-    fds[1] = -1;
-
-    if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log_error (p->h, "fd_set_nonblocking");
-        goto error;
-    }
-
-    if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
-        goto error;
-    }
-
-    if ((channel_flags & CHANNEL_WRITE) && in_cb) {
-        c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
-                                                              c->parent_fd,
-                                                              buffer_size,
-                                                              in_cb,
-                                                              0,
-                                                              c);
-        if (!c->buffer_write_w) {
-            flux_log_error (p->h, "flux_buffer_write_watcher_create");
-            goto error;
-        }
-    }
-
-    if ((channel_flags & CHANNEL_READ) && out_cb) {
-        int wflag;
-
-        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+        if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
+            flux_log_error (p->h, "socketpair");
             goto error;
         }
 
-        if (wflag)
-            c->line_buffered = true;
+        c->parent_fd = fds[0];
+        c->child_fd = fds[1];
 
-        c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
-                                                            c->parent_fd,
-                                                            buffer_size,
-                                                            out_cb,
-                                                            wflag,
-                                                            c);
-        if (!c->buffer_read_w) {
-            flux_log_error (p->h, "flux_buffer_read_watcher_create");
+        /* set fds[] to -1, on error is now subprocess_free()'s
+         * responsibility
+         */
+        fds[0] = -1;
+        fds[1] = -1;
+
+        if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
+            flux_log_error (p->h, "fd_set_nonblocking");
             goto error;
         }
 
-        p->channels_eof_expected++;
+        if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_bufsize");
+            goto error;
+        }
+
+        if ((channel_flags & CHANNEL_WRITE) && in_cb) {
+            c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
+                                                                  c->parent_fd,
+                                                                  buffer_size,
+                                                                  in_cb,
+                                                                  0,
+                                                                  c);
+            if (!c->buffer_write_w) {
+                flux_log_error (p->h, "flux_buffer_write_watcher_create");
+                goto error;
+            }
+        }
+
+        if ((channel_flags & CHANNEL_READ) && out_cb) {
+            int wflag;
+
+            if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+                flux_log_error (p->h, "cmd_option_line_buffer");
+                goto error;
+            }
+
+            if (wflag)
+                c->line_buffered = true;
+
+            c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
+                                                                c->parent_fd,
+                                                                buffer_size,
+                                                                out_cb,
+                                                                wflag,
+                                                                c);
+            if (!c->buffer_read_w) {
+                flux_log_error (p->h, "flux_buffer_read_watcher_create");
+                goto error;
+            }
+
+            p->channels_eof_expected++;
+        }
     }
 
     if (channel_flags & CHANNEL_FD) {
@@ -455,26 +459,36 @@ static int local_child (flux_subprocess_t *p)
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
-            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_WRITE) {
+                if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
-            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDOUT_FILENO);
         }
         else
             close (STDOUT_FILENO);
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
-            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDERR_FILENO);
         }
         else
             close (STDERR_FILENO);
@@ -676,15 +690,18 @@ static int start_local_watchers (flux_subprocess_t *p)
     c = zhash_first (p->channels);
     while (c) {
         int ret;
-        flux_watcher_start (c->buffer_write_w);
-        if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
-            return -1;
-        if (ret) {
-            flux_watcher_start (c->buffer_read_stopped_w);
-        }
-        else {
-            flux_watcher_start (c->buffer_read_w);
-            c->buffer_read_w_started = true;
+        if (c->flags & CHANNEL_WRITE)
+            flux_watcher_start (c->buffer_write_w);
+        if (c->flags & CHANNEL_READ) {
+            if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
+                return -1;
+            if (ret) {
+                flux_watcher_start (c->buffer_read_stopped_w);
+            }
+            else {
+                flux_watcher_start (c->buffer_read_w);
+                c->buffer_read_w_started = true;
+            }
         }
         c = zhash_next (p->channels);
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -50,6 +50,8 @@ void channel_destroy (void *arg)
             close (c->child_fd);
         if (c->input_fd != -1)
             close (c->input_fd);
+        if (c->output_fd != -1)
+            close (c->output_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -94,6 +96,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
     c->parent_fd = -1;
     c->child_fd = -1;
     c->input_fd = -1;
+    c->output_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -671,6 +674,7 @@ static int check_local_only_cmd_options (const flux_cmd_t *cmd)
     /* check for options that do not apply to remote subprocesses */
     const char *substrings[] = { "STREAM_STOP",
                                  "INPUT_FD",
+                                 "OUTPUT_FD",
                                  NULL };
 
     return flux_cmd_find_opts (cmd, substrings);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -48,6 +48,8 @@ void channel_destroy (void *arg)
             close (c->parent_fd);
         if (c->child_fd != -1)
             close (c->child_fd);
+        if (c->input_fd != -1)
+            close (c->input_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -91,6 +93,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
 
     c->parent_fd = -1;
     c->child_fd = -1;
+    c->input_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -666,7 +669,9 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)
 {
     /* check for options that do not apply to remote subprocesses */
-    const char *substrings[] = { "STREAM_STOP", NULL };
+    const char *substrings[] = { "STREAM_STOP",
+                                 "INPUT_FD",
+                                 NULL };
 
     return flux_cmd_find_opts (cmd, substrings);
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -294,6 +294,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    subprocesses.
  *
  *    - stdin_INPUT_FD - file descriptor for stdin
+ *
+ *  "OUTPUT_FD" option
+ *
+ *    By default, standard output is read from flux_subprocess_read()
+ *    (and family of functions) and the stream "stdout" or "stderr".
+ *    This option will inform the subprocess to redirect stdout /
+ *    stderr directly to a specified file descriptor.  Functions like
+ *    flux_subprocess_read() will return EINVAL when attempting to
+ *    read from stdout or stderr.  This option can only be used on
+ *    local subprocesses.
+ *
+ *    - stdout_OUTPUT_FD - file descriptor for stdout
+ *    - stderr_OUTPUT_FD - file descriptor for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -282,6 +282,18 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
  *    - stdout_STREAM_STOP - configure start/stop for stdout
  *    - stderr_STREAM_STOP - configure start/stop for stderr
+ *
+ *  "INPUT_FD" option
+ *
+ *    By default, standard input is sent to a subprocess via the
+ *    flux_subprocess_write() call and the stream "stdin".  This
+ *    option will inform the subprocess to read stdin directly from a
+ *    specified file descriptor.  As a result, functions liked
+ *    flux_subprocess_write() will return EINVAL when attempting to
+ *    write to "stdin".  This option can only be used on local
+ *    subprocesses.
+ *
+ *    - stdin_INPUT_FD - file descriptor for stdin
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,9 +21,10 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ  0x01
-#define CHANNEL_WRITE 0x02
-#define CHANNEL_FD    0x04
+#define CHANNEL_READ     0x01
+#define CHANNEL_WRITE    0x02
+#define CHANNEL_FD       0x04
+#define CHANNEL_INPUT_FD 0x08
 
 struct subprocess_channel {
     int magic;
@@ -40,6 +41,7 @@ struct subprocess_channel {
     /* local */
     int parent_fd;
     int child_fd;
+    int input_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,10 +21,11 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ     0x01
-#define CHANNEL_WRITE    0x02
-#define CHANNEL_FD       0x04
-#define CHANNEL_INPUT_FD 0x08
+#define CHANNEL_READ      0x01
+#define CHANNEL_WRITE     0x02
+#define CHANNEL_FD        0x04
+#define CHANNEL_INPUT_FD  0x08
+#define CHANNEL_OUTPUT_FD 0x10
 
 struct subprocess_channel {
     int magic;
@@ -42,6 +43,7 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     int input_fd;
+    int output_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -796,6 +796,21 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     (*counter)++;
 }
 
+void write_multiple_lines_to_stdin (flux_subprocess_t *p)
+{
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_close (p, "stdin") == 0,
+        "flux_subprocess_close success");
+}
+
 void test_basic_multiple_lines (flux_reactor_t *r)
 {
     char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-O", "-E", "-n", NULL };
@@ -818,17 +833,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_close (p, "stdin") == 0,
-        "flux_subprocess_close success");
+    write_multiple_lines_to_stdin (p);
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,7 +122,10 @@ cleanup:
     return rv;
 }
 
-int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+static int cmd_option_fd (flux_subprocess_t *p,
+                          const char *name,
+                          const char *substring,
+                          int *fdp)
 {
     char *var;
     const char *val;
@@ -130,7 +133,7 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 
     (*fdp) = -1;
 
-    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+    if (asprintf (&var, "%s_%s", name, substring) < 0)
         goto cleanup;
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
@@ -151,6 +154,16 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 cleanup:
     free (var);
     return rv;
+}
+
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "INPUT_FD", fdp);
+}
+
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "OUTPUT_FD", fdp);
 }
 
 /*

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,6 +122,37 @@ cleanup:
     return rv;
 }
 
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    (*fdp) = -1;
+
+    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        int tmp;
+        errno = 0;
+        tmp = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || tmp < 0) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        (*fdp) = tmp;
+    }
+
+    rv = 0;
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -26,4 +26,7 @@ int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 /* sets fdp to -1 if user did not set INPUT_FD */
 int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
 
+/* sets fdp to -1 if user did not set OUTPUT_FD */
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -23,4 +23,7 @@ int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
+/* sets fdp to -1 if user did not set INPUT_FD */
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -204,7 +204,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr
 '
 
 #
-# output file mustache tests
+# mustache {{id}} template tests
 #
 
 test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
@@ -230,29 +230,252 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout
 '
 
 #
+# 1 task output mustache {{taskid}} tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stdout)' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out16-{{taskid}}\"" \
+            > j1echostdout-16 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostdout-16 -R R1 16 &&
+	grep stdout:foo out16-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stderr)' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err17-{{taskid}}\"" \
+            > j1echostderr-17 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-17 -R R1 17 &&
+	grep stderr:bar err17-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr to stdout {{taskid}})' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out18-{{taskid}}\"" \
+            > j1echostderr-18 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-18 -R R1 18 &&
+	grep stderr:bar out18-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stdout & stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out19-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err19-{{taskid}}\"" \
+            > j1echoboth-19 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-19 -R R1 19 &&
+	grep stdout:baz out19-0 &&
+	grep stderr:baz err19-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout & stderr to stdout {{taskid}})' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out20-{{taskid}}\"" \
+            > j1echoboth-20 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-20 -R R1 20 &&
+	grep stdout:baz out20-0 &&
+	grep stderr:baz out20-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stdout/stderr term)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out21-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"term\"" \
+            > j1echoboth-21 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-21 -R R1 2> err21 21 &&
+	grep stdout:baz out21-0 &&
+	grep stderr:baz err21
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout term/{{taskid}} stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err22-{{taskid}}\"" \
+            > j1echoboth-22 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-22 -R R1 > out22 22 &&
+	grep stdout:baz out22 &&
+	grep stderr:baz err22-0
+'
+
+#
+# 2 task output mustache {{taskid}} tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout)' '
+        cat j2echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out23-{{taskid}}\"" \
+            > j2echostdout-23 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostdout-23 -R R2 23 &&
+	grep "stdout:foo" out23-0 &&
+	grep "stdout:foo" out23-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stderr)' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err24-{{taskid}}\"" \
+            > j2echostderr-24 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-24 -R R2 24 &&
+	grep "stderr:bar" err24-0 &&
+	grep "stderr:bar" err24-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr to stdout {{taskid}})' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out25-{{taskid}}\"" \
+            > j2echostderr-25 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-25 -R R2 25 &&
+	grep "stderr:bar" out25-0 &&
+	grep "stderr:bar" out25-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout & stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out26-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err26-{{taskid}}\"" \
+            > j2echoboth-26 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-26 -R R2 26 &&
+	grep "stdout:baz" out26-0 &&
+	grep "stdout:baz" out26-1 &&
+	grep "stderr:baz" err26-0 &&
+	grep "stderr:baz" err26-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout & stderr to stdout {{taskid}})' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out27-{{taskid}}\"" \
+            > j2echoboth-27 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-27 -R R2 27 &&
+	grep stdout:baz out27-0 &&
+	grep stdout:baz out27-1 &&
+	grep stderr:baz out27-0 &&
+	grep stderr:baz out27-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr term)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out28-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"term\"" \
+            > j2echoboth-28 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-28 -R R2 2> err28 28 &&
+	grep "stdout:baz" out28-0 &&
+	grep "stdout:baz" out28-1 &&
+	grep "0: stderr:baz" err28 &&
+	grep "1: stderr:baz" err28
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/{{taskid}} stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err29-{{taskid}}\"" \
+            > j2echoboth-29 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-29 -R R2 > out29 29 &&
+	grep "0: stdout:baz" out29 &&
+	grep "1: stdout:baz" out29 &&
+	grep "stderr:baz" err29-0 &&
+	grep "stderr:baz" err29-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out30-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err30\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echoboth-30 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-30 -R R2 30 &&
+	grep "stdout:baz" out30-0 &&
+	grep "stdout:baz" out30-1 &&
+	grep "0: stderr:baz" err30 &&
+	grep "1: stderr:baz" err30
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/{{taskid}} stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out31\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err31-{{taskid}}\"" \
+            > j2echoboth-31 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-31 -R R2 31 &&
+	grep "0: stdout:baz" out31 &&
+	grep "1: stdout:baz" out31 &&
+	grep "stderr:baz" err31-0 &&
+	grep "stderr:baz" err31-1
+'
+
+#
+# test both {{id}} and {{taskid}}
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id per-task stdout & stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err{{id}}-{{taskid}}\"" \
+            > j1echoboth-32 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-32 -R R1 32 &&
+	grep stdout:baz out32-0 &&
+	grep stderr:baz err32-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout per-task)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}-{{taskid}}\"" \
+            > j1echoboth-33 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-33 -R R1 33 &&
+	grep stdout:baz out33-0 &&
+	grep stderr:baz out33-0
+'
+
+#
 # output corner case tests
 #
 
 test_expect_success HAVE_JQ 'flux-shell: error on bad output type' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"foobar\"" \
-            > j1echostdout-16 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-16 -R R1 16
+            > j1echostdout-34 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-34 -R R1 34
 '
 
 test_expect_success HAVE_JQ 'flux-shell: error on no path with file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
-            > j1echostdout-17 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-17 -R R1 17
+            > j1echostdout-35 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-35 -R R1 35
 '
 
 test_expect_success HAVE_JQ 'flux-shell: error invalid path to file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz\"" \
-            > j1echostdout-18 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-18 -R R1 18
+            > j1echostdout-36 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-36 -R R1 36
+'
+
+test_expect_success HAVE_JQ 'flux-shell: error invalid path to file output ({{taskid}})' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz{{taskid}}\"" \
+            > j1echostdout-37 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-37 -R R1 37
 '
 
 test_done

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -154,7 +154,7 @@ test_expect_success 'job-shell: run 2-task echo job (stdout kvs/stderr file)' '
 '
 
 #
-# output file mustache tests
+# mustache {{id}} template tests
 #
 
 test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
@@ -176,96 +176,287 @@ test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stder
 '
 
 #
+# 1 task output mustache {{taskid}} tests
+#
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout)' '
+        flux mini run -n1 \
+             --output="out16-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo &&
+        grep stdout:foo out16-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stderr)' '
+        flux mini run -n1 \
+             --error="err17-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep stderr:bar err17-0
+'
+
+test_expect_success 'job-shell: run 1-task echo job (stderr to stdout {{taskid}})' '
+        flux mini run -n1 \
+             --output="out18-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "stderr:bar" out18-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout & stderr)' '
+        flux mini run -n1 \
+             --output="out19-{{taskid}}" --error="err19-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out19-0 &&
+        grep stderr:baz err19-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout & stderr to stdout {{taskid}})' '
+        flux mini run -n1 \
+             --output="out20-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out20-0 &&
+        grep stderr:baz out20-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout/stderr kvs)' '
+        id=$(flux mini submit -n1 \
+             --output="out21-{{taskid}}" --setopt "output.stderr.type=\"kvs\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> err21 &&
+        grep stdout:baz out21-0 &&
+        grep stderr:baz err21
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout kvs/{{taskid}} stderr)' '
+        id=$(flux mini submit -n1 \
+             --error="err22-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id > out22 &&
+        grep stdout:baz out22 &&
+        grep stderr:baz err22-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout/stderr file)' '
+        flux mini run -n1 \
+             --output="out23-{{taskid}}" --error="err23" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out23-0 &&
+        grep stderr:baz err23
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout file/{{taskid}} stderr)' '
+        flux mini run -n1 \
+             --output="out24" --error="err24-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out24 &&
+        grep stderr:baz err24-0
+'
+
+#
+# 2 task output mustache {{taskid}} tests
+#
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout)' '
+        flux mini run -n2 \
+             --output="out25-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo &&
+        grep "stdout:foo" out25-0 &&
+        grep "stdout:foo" out25-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stderr)' '
+        flux mini run -n2 \
+             --error="err26-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "stderr:bar" err26-0 &&
+        grep "stderr:bar" err26-1
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stderr to stdout {{taskid}})' '
+        flux mini run -n2 \
+             --output="out27-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "stderr:bar" out27-0 &&
+        grep "stderr:bar" out27-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout & stderr)' '
+        flux mini run -n2 \
+             --output="out28-{{taskid}}" --error="err28-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "stdout:baz" out28-0 &&
+        grep "stdout:baz" out28-1 &&
+        grep "stderr:baz" err28-0 &&
+        grep "stderr:baz" err28-1
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stdout & stderr to stdout {{taskid}})' '
+        flux mini run -n2 \
+             --output="out29-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "stdout:baz" out29-0 &&
+        grep "stdout:baz" out29-1 &&
+        grep "stderr:baz" out29-0 &&
+        grep "stderr:baz" out29-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr kvs)' '
+        id=$(flux mini submit -n2 \
+             --output="out30-{{taskid}}" --setopt "output.stderr.type=\"kvs\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id 2> err30 &&
+        grep "stdout:baz" out30-0 &&
+        grep "stdout:baz" out30-1 &&
+        grep "0: stderr:baz" err30 &&
+        grep "1: stderr:baz" err30
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout kvs/{{taskid}} stderr)' '
+        id=$(flux mini submit -n2 \
+             --error="err31-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id > out31 &&
+        grep "0: stdout:baz" out31 &&
+        grep "1: stdout:baz" out31 &&
+        grep "stderr:baz" err31-0 &&
+        grep "stderr:baz" err31-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr file)' '
+        flux mini run -n2 \
+             --output="out32-{{taskid}}" --error="err32" --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "stdout:baz" out32-0 &&
+        grep "stdout:baz" out32-1 &&
+        grep "0: stderr:baz" err32 &&
+        grep "1: stderr:baz" err32
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout file/{{taskid}} stderr)' '
+        flux mini run -n2 \
+             --output="out33" --label-io --error="err33-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "0: stdout:baz" out33 &&
+        grep "1: stdout:baz" out33 &&
+        grep "stderr:baz" err33-0 &&
+        grep "stderr:baz" err33-1
+'
+
+#
+# test both {{id}} and {{taskid}}
+#
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout & stderr)' '
+        id=$(flux mini submit -n1 \
+             --output="out{{id}}-{{taskid}}" --error="err{{id}}-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out${id}-0 &&
+        grep stderr:baz err${id}-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout & stderr to stdout {{taskid}})' '
+        id=$(flux mini submit -n1 \
+             --output="out{{id}}-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out${id}-0 &&
+        grep stderr:baz out${id}-0
+'
+
+#
 # output file outputs correct information to guest.output
 #
 
 test_expect_success 'job-shell: redirect events appear in guest.output (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out16 --error=err16 \
+             --output=out36 --error=err36 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog16.out &&
-        grep "stdout" eventlog16.out | grep redirect | grep "rank=\"0\"" | grep out16 &&
-        grep "stderr" eventlog16.out | grep redirect | grep "rank=\"0\"" | grep err16
+        flux job eventlog -p guest.output $id > eventlog36.out &&
+        grep "stdout" eventlog36.out | grep redirect | grep "rank=\"0\"" | grep out36 &&
+        grep "stderr" eventlog36.out | grep redirect | grep "rank=\"0\"" | grep err36
 '
 
 test_expect_success 'job-shell: redirect events appear in guest.output (1-task stderr to stdout)' '
         id=$(flux mini submit -n1 \
-             --output=out17 \
+             --output=out37 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog17.out &&
-        grep "stdout" eventlog17.out | grep redirect | grep "rank=\"0\"" | grep out17 &&
-        grep "stderr" eventlog17.out | grep redirect | grep "rank=\"0\"" | grep out17
+        flux job eventlog -p guest.output $id > eventlog37.out &&
+        grep "stdout" eventlog37.out | grep redirect | grep "rank=\"0\"" | grep out37 &&
+        grep "stderr" eventlog37.out | grep redirect | grep "rank=\"0\"" | grep out37
 '
 
 test_expect_success 'job-shell: redirect events appear in guest.output (2-task)' '
         id=$(flux mini submit -n2 \
-             --output=out18 --error=err18 \
+             --output=out38 --error=err38 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog18.out &&
-        grep "stdout" eventlog18.out | grep redirect | grep "0-1" | grep out18 &&
-        grep "stderr" eventlog18.out | grep redirect | grep "0-1" | grep err18
+        flux job eventlog -p guest.output $id > eventlog38.out &&
+        grep "stdout" eventlog38.out | grep redirect | grep "0-1" | grep out38 &&
+        grep "stderr" eventlog38.out | grep redirect | grep "0-1" | grep err38
 '
 
 test_expect_success 'job-shell: redirect events appear in guest.output (2-task stderr to stdout)' '
         id=$(flux mini submit -n2 \
-             --output=out19 \
+             --output=out39 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog19.out &&
-        grep "stdout" eventlog19.out | grep redirect | grep "0-1" | grep out19 &&
-        grep "stderr" eventlog19.out | grep redirect | grep "0-1" | grep out19
+        flux job eventlog -p guest.output $id > eventlog39.out &&
+        grep "stdout" eventlog39.out | grep redirect | grep "0-1" | grep out39 &&
+        grep "stderr" eventlog39.out | grep redirect | grep "0-1" | grep out39
 '
 
 test_expect_success 'job-shell: attach shows redirected file (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out20 --error=err20 \
+             --output=out40 --error=err40 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach20.err &&
-        grep "0: stdout redirected to out20" attach20.err &&
-        grep "0: stderr redirected to err20" attach20.err
+        flux job attach $id 2> attach40.err &&
+        grep "0: stdout redirected to out40" attach40.err &&
+        grep "0: stderr redirected to err40" attach40.err
 '
 
 test_expect_success 'job-shell: attach shows redirected file (1-task stderr to stdout)' '
         id=$(flux mini submit -n1 \
-             --output=out21 \
+             --output=out41 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach21.err &&
-        grep "0: stdout redirected to out21" attach21.err &&
-        grep "0: stderr redirected to out21" attach21.err
+        flux job attach $id 2> attach41.err &&
+        grep "0: stdout redirected to out41" attach41.err &&
+        grep "0: stderr redirected to out41" attach41.err
 '
 
 test_expect_success 'job-shell: attach shows redirected file (2-task)' '
         id=$(flux mini submit -n2 \
-             --output=out22 --error=err22 \
+             --output=out42 --error=err42 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach22.err &&
-        grep "[[0-1]]: stdout redirected to out22" attach22.err &&
-        grep "[[0-1]]: stderr redirected to err22" attach22.err
+        flux job attach $id 2> attach42.err &&
+        grep "[[0-1]]: stdout redirected to out42" attach42.err &&
+        grep "[[0-1]]: stderr redirected to err42" attach42.err
 '
 
 test_expect_success 'job-shell: attach shows redirected file (2-task stderr to stdout)' '
         id=$(flux mini submit -n2 \
-             --output=out23 \
+             --output=out43 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach23.err &&
-        grep "[[0-1]]: stdout redirected to out23" attach23.err &&
-        grep "[[0-1]]: stderr redirected to out23" attach23.err
+        flux job attach $id 2> attach43.err &&
+        grep "[[0-1]]: stdout redirected to out43" attach43.err &&
+        grep "[[0-1]]: stderr redirected to out43" attach43.err
 '
 
 test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out24 --error=err24 \
+             --output=out44 --error=err44 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach -q $id 2> attach24.err &&
-        ! grep "redirected" attach24.err
+        flux job attach -q $id 2> attach44.err &&
+        ! grep "redirected" attach44.err
 '
 
 #
@@ -274,34 +465,34 @@ test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-tas
 
 test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out25 --error=err25 \
+             --output=out45 --error=err45 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach -q ${id} > out25.attach 2> err25.attach &&
-        grep stdout:baz out25 &&
-        grep stderr:baz err25 &&
-        ! test -s out25.attach &&
-        ! test -s err25.attach
+        flux job attach -q ${id} > out45.attach 2> err45.attach &&
+        grep stdout:baz out45 &&
+        grep stderr:baz err45 &&
+        ! test -s out45.attach &&
+        ! test -s err45.attach
 '
 
 test_expect_success 'job-shell: job attach exits cleanly if no kvs output (2-task)' '
         id=$(flux mini submit -n2 \
-             --output=out26 --error=err26 \
+             --output=out46 --error=err46 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach -q ${id} > out26.attach 2> err26.attach &&
-        grep stdout:baz out26 &&
-        grep stderr:baz err26 &&
-        ! test -s out26.attach &&
-        ! test -s err26.attach
+        flux job attach -q ${id} > out46.attach 2> err46.attach &&
+        grep stdout:baz out46 &&
+        grep stderr:baz err46 &&
+        ! test -s out46.attach &&
+        ! test -s err46.attach
 '
 
 test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output (1-task, live job)' '
         id=$(flux mini submit -n1 \
-             --output=out27 --error=err27 \
+             --output=out47 --error=err47 \
              sleep 60)
         flux job wait-event $id start &&
-        flux job attach -E -X ${id} 2> attach27.err &
+        flux job attach -E -X ${id} 2> attach47.err &
         pid=$! &&
         flux job cancel $id &&
         ! wait $pid
@@ -309,10 +500,10 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
 
 test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output (2-task, live job)' '
         id=$(flux mini submit -n2 \
-             --output=out28 --error=err28 \
+             --output=out48 --error=err48 \
              sleep 60)
         flux job wait-event $id start &&
-        flux job attach -E -X ${id} 2> attach28.err &
+        flux job attach -E -X ${id} 2> attach48.err &
         pid=$! &&
         flux job cancel $id &&
         ! wait $pid


### PR DESCRIPTION
This PR adds support to the shell to have each task redirect stdout/stderr to their own file(s).

It is built on top of #2345 (but not #2350) and #2395 

Notes:

-  The user must set `attributes.system.shell.options.output.<stream>.type` to "per-task" and `attributes.system.shell.options.output.<stream>.path` to the path. The task number is appended to the path for each task.

- I wasn't sure what the mode should be on files created. I just did 644 for now.
