### PR TITLE
testsuite: valgrind test improvements

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -42,9 +42,16 @@ uninstall-local:
 clean-local:
 	rm -fr trash-directory.* test-results .prove *.broker.log */*.broker.log *.output python/__pycache__
 
+#  Put long running tests here. They will be included first
+#   in TESTS so that `make check` runs them first, hopefully resulting
+#   in a reduced makespan overall.
+LONGTESTSCRIPTS = \
+	t5000-valgrind.t \
+	t3100-flux-in-flux.t
 
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \
+	$(LONGTESTSCRIPTS) \
 	t0000-sharness.t \
 	t0001-basic.t \
 	t0002-request.t \
@@ -104,9 +111,7 @@ TESTSCRIPTS = \
 	t2603-job-shell-initrc.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \
-	t3100-flux-in-flux.t \
 	t4000-issues-test-driver.t \
-	t5000-valgrind.t \
 	t9001-pymod.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -38,7 +38,9 @@ VALGRIND_SHUTDOWN_GRACE=${VALGRIND_SHUTDOWN_GRACE:-16}
 test_expect_success \
   "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
 	run_timeout 120 \
-	flux start -s ${VALGRIND_NBROKERS} --wrap=libtool,e,${VALGRIND} \
+	flux start -s ${VALGRIND_NBROKERS} \
+		--killer-timeout=20 \
+		--wrap=libtool,e,${VALGRIND} \
 		--wrap=--tool=memcheck \
 		--wrap=--leak-check=full \
 		--wrap=--gen-suppressions=all \

--- a/t/valgrind/workload.d/job
+++ b/t/valgrind/workload.d/job
@@ -2,7 +2,7 @@
 
 NJOBS=${NJOBS:-10}
 
-flux jobspec srun /bin/true > job.json
+flux jobspec srun ${SHARNESS_TEST_DIRECTORY}/shell/lptest 78 2 > job.json
 for i in `seq 1 $NJOBS`; do
     id[$i]=$(flux job submit < job.json)
     echo ${id[$i]} submitted


### PR DESCRIPTION
This PR adjusts the `--killer-timeout` for the valgrind test so that `flux-start` will be much less likely to kill brokers that are slow to exit.

Additionally, output is added to the current `job` workload to give better coverage during the valgrind run.

Finally, this may be controversial, but I noticed with `make -j2` the fact that the valgrind and `flux-in-flux` tests were run last really seems to delay the overall time to complete `make check`. So, these tests are moved first in `TESTS` in Makefile.am, allowing them to start first and get better overlap with faster tests.