### PR TITLE
shell: add gpu affinity support

### DIFF
--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -56,7 +56,8 @@ flux_shell_SOURCES = \
 	svc.h \
 	kill.c \
 	signals.c \
-	affinity.c
+	affinity.c \
+	gpubind.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -34,6 +34,7 @@ extern struct shell_builtin builtin_output;
 extern struct shell_builtin builtin_kill;
 extern struct shell_builtin builtin_signals;
 extern struct shell_builtin builtin_affinity;
+extern struct shell_builtin builtin_gpubind;
 
 static struct shell_builtin * builtins [] = {
     &builtin_pmi,
@@ -41,6 +42,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_kill,
     &builtin_signals,
     &builtin_affinity,
+    &builtin_gpubind,
     &builtin_list_end,
 };
 

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -1,0 +1,166 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* GPU binding plugin
+ *
+ * Builtin GPU binding for flux-shell. Spread CUDA_VISIBLE_DEVICES
+ *  across tasks depending on number in slot.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <flux/idset.h>
+
+#include "src/common/libutil/log.h"
+#include "builtins.h"
+
+int ngpus_per_task = -1;
+
+int get_shell_gpus (flux_shell_t *shell,
+                    int *ntasks,
+                    struct idset **ids)
+{
+    int rc = -1;
+    char *s = NULL;
+    const char *gpu_list = NULL;
+    json_t *o = NULL;
+    json_error_t err;
+    struct idset *gpus = NULL;
+
+    if (flux_shell_get_rank_info (shell, -1, &s) < 0) {
+        log_err ("flux_shell_get_rank_info");
+        return -1;
+    }
+    if (!(o = json_loads (s, 0, NULL))) {
+        log_err ("json_loads");
+        goto out;
+    }
+    if (json_unpack_ex (o, &err, 0, "{s:i s:{s?:s}}",
+                                   "ntasks", ntasks,
+                                   "resources",
+                                     "gpus", &gpu_list) < 0) {
+        log_err ("json_unpack: %s", err.text);
+        goto out;
+    }
+    if (!(gpus = idset_decode (gpu_list ? gpu_list : ""))) {
+        log_err ("idset_encode (%s)", gpu_list);
+        goto out;
+    }
+    rc = 0;
+out:
+    free (s);
+    json_decref (o);
+    *ids = gpus;
+    return rc;
+}
+
+static int plugin_task_setenv (flux_plugin_t *p,
+                               const char *var,
+                               const char *val)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    flux_shell_task_t *task = flux_shell_current_task (shell);
+    flux_cmd_t *cmd = flux_shell_task_cmd (task);
+    if (cmd)
+        return flux_cmd_setenvf (cmd, 1, var, "%s", val);
+    return 0;
+}
+
+static int gpubind_task_init (flux_plugin_t *p,
+                              const char *topic,
+                              flux_plugin_arg_t *args,
+                              void *data)
+{
+    char *s;
+    struct idset *gpus = data;
+    struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
+
+    for (int i = 0; i < ngpus_per_task; i++) {
+        unsigned id = idset_first (gpus);
+        idset_set (ids, id);
+        idset_clear (gpus, id);
+    }
+    s = idset_encode (ids, IDSET_FLAG_RANGE);
+    plugin_task_setenv (p, "CUDA_VISIBLE_DEVICES", s);
+    free (s);
+    idset_destroy (ids);
+    return 0;
+}
+
+static int gpubind_init (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *args,
+                         void *data)
+{
+    int rc, ngpus, ntasks;
+    struct idset *gpus;
+    char *opt;
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+
+    if (!shell)
+        return -1;
+
+    if ((rc = flux_shell_getopt_unpack (shell,
+                                       "gpu-affinity",
+                                       "s",
+                                        &opt)) <= 0) {
+        if (rc < 0)
+            log_msg ("Failed to get gpu-affinity shell option, ignoring");
+        /* gpu-affinity defaults to "on" */
+        opt = "on";
+    }
+    if (strcmp (opt, "off") == 0)
+        return 0;
+    if (get_shell_gpus (shell, &ntasks, &gpus) < 0)
+        return -1;
+    if (flux_plugin_aux_set (p, NULL, gpus, (flux_free_f)idset_destroy) < 0) {
+        log_err ("flux_plugin_aux_set");
+        idset_destroy (gpus);
+        return -1;
+    }
+    if ((ngpus = idset_count (gpus)) <= 0)
+        return 0;
+
+    flux_shell_setenvf (shell, 0, "CUDA_DEVICE_ORDER", "PCI_BUS_ID");
+
+    if (strcmp (opt, "per-task") == 0) {
+        /*  Set global ngpus_per_task to use in task.init callback:
+         */
+        ngpus_per_task = ngpus / ntasks;
+        if (flux_plugin_add_handler (p,
+                                     "task.init",
+                                     gpubind_task_init,
+                                     gpus) < 0) {
+            log_err ("gpubind: flux_plugin_add_handler");
+            return -1;
+        }
+    }
+    else {
+        char *ids = idset_encode (gpus, IDSET_FLAG_RANGE);
+        flux_shell_setenvf (shell, 1, "CUDA_VISIBLE_DEVICES", "%s", ids);
+        free (ids);
+    }
+    return 0;
+}
+
+struct shell_builtin builtin_gpubind = {
+    .name = "gpu-affinity",
+    .init = gpubind_init
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/rcalc.h
+++ b/src/shell/rcalc.h
@@ -24,6 +24,7 @@ struct rcalc_rankinfo {
     int ncores;               /* Number of cores allocated on this rank  */
     cpu_set_t cpuset;         /* cpu_set_t representation of cores list  */
     char cores [128];         /* String core list (directly from R_lite) */
+    char gpus [128];          /* String gpu list (directly from R)       */
 };
 
 /* Create resource calc object from JSON string in "Rlite" format */
@@ -35,6 +36,8 @@ void rcalc_destroy (rcalc_t *r);
 
 /*  Return # of total cores asssigned to rcalc object */
 int rcalc_total_cores (rcalc_t *r);
+/*  Return # of total gpus asssigned to rcalc object */
+int rcalc_total_gpus (rcalc_t *r);
 /*  Return total # of nodes/ranks in rcalc object */
 int rcalc_total_nodes (rcalc_t *r);
 /*  Return the total # of nodes/ranks with at least 1 task assigned */

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -367,11 +367,12 @@ int flux_shell_get_rank_info (flux_shell_t *shell,
     if (rcalc_get_nth (shell->info->rcalc, shell_rank, &ri) < 0)
         return -1;
 
-    o = json_pack ("{ s:i s:i s:{s:s}}",
+    o = json_pack ("{ s:i s:i s:{s:s s:s?}}",
                    "broker_rank", ri.rank,
                    "ntasks", ri.ntasks,
                    "resources",
-                     "cores", shell->info->rankinfo.cores);
+                     "cores", shell->info->rankinfo.cores,
+                     "gpus",  shell->info->rankinfo.gpus);
     if (!o)
         return -1;
     *json_str = json_dumps (o, JSON_COMPACT);

--- a/t/shell/input/1r1c2gpu.json
+++ b/t/shell/input/1r1c2gpu.json
@@ -1,0 +1,8 @@
+{
+	"version": 1,
+	"execution":{
+		"R_lite":[
+			{ "children": { "core": "0", "gpu": "0-1" }, "rank": "0" }
+		]
+	}
+}

--- a/t/shell/output/1r1c2gpu.1.expected
+++ b/t/shell/output/1r1c2gpu.1.expected
@@ -1,0 +1,3 @@
+Distributing 1 tasks across 1 nodes with 1 cores 2 gpus
+Used 1 nodes
+0: rank=0 ntasks=1 basis=0 cores=0 gpus=0-1

--- a/t/shell/rcalc.c
+++ b/t/shell/rcalc.c
@@ -36,8 +36,11 @@ int main (int ac, char **av)
         fprintf (stderr, "Invalid value for ntasks: %s\n", av[1]);
         exit (1);
     }
-    printf ("Distributing %d tasks across %d nodes with %d cores\n",
+    printf ("Distributing %d tasks across %d nodes with %d cores",
             ntasks, rcalc_total_nodes (r), rcalc_total_cores (r));
+    if (rcalc_total_gpus (r))
+        printf (" %d gpus", rcalc_total_gpus (r));
+    printf ("\n");
 
     if (rcalc_distribute (r, ntasks) < 0) {
         fprintf (stderr, "rcalc_distribute: %s\n", strerror (errno));
@@ -52,8 +55,11 @@ int main (int ac, char **av)
                      i, strerror (errno));
             exit (1);
         }
-        printf ("%d: rank=%d ntasks=%d basis=%d cores=%s\n",
+        printf ("%d: rank=%d ntasks=%d basis=%d cores=%s",
                 ri.nodeid, ri.rank, ri.ntasks, ri.global_basis, ri.cores);
+        if (strlen(ri.gpus))
+            printf (" gpus=%s", ri.gpus);
+        printf ("\n");
     }
     rcalc_destroy (r);
     return (0);

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -6,9 +6,6 @@ test_description='Test flux-shell default affinity implementation'
 
 test_under_flux 2
 
-jq=$(which jq 2>/dev/null)
-test -z "$jq" || test_set_prereq HAVE_JQ
-
 if ! which hwloc-bind > /dev/null; then
     skip_all='skipping affinity tests since hwloc-bind not found'
     test_done
@@ -42,7 +39,7 @@ test_expect_success MULTICORE 'flux-shell: default affinity works (2 cores)' '
     test_debug "cat result.n1" &&
     test "$(cat result.n1)" = "2"
 '
-test_expect_success HAVE_JQ,MULTICORE 'flux-shell: per-task affinity works' '
+test_expect_success MULTICORE 'flux-shell: per-task affinity works' '
     flux mini run --label-io -ocpu-affinity=per-task -n2 -c1 \
 		hwloc-bind --get > per-task.out &&
     task0set=$(sed -n "s/^0: //p" per-task.out) &&
@@ -50,16 +47,16 @@ test_expect_success HAVE_JQ,MULTICORE 'flux-shell: per-task affinity works' '
     test_debug "echo checking ${task0set} not equal ${task1set}" &&
     test "$task0set" != "$task1set"
 '
-test_expect_success HAVE_JQ 'flux-shell: per-task affinity sanity check' '
+test_expect_success 'flux-shell: per-task affinity sanity check' '
     flux mini run --label-io -ocpu-affinity=per-task -n1 -c1 \
 		hwloc-bind --get
 '
-test_expect_success HAVE_JQ 'flux-shell: affinity can be disabled' '
+test_expect_success 'flux-shell: affinity can be disabled' '
     hwloc-bind --get > affinity-off.expected &&
     flux mini run -ocpu-affinity=off -n1 hwloc-bind --get >affinity-off.out &&
     test_cmp affinity-off.expected affinity-off.out
 '
-test_expect_success HAVE_JQ 'flux-shell: invalid option is ignored' '
+test_expect_success 'flux-shell: invalid option is ignored' '
     flux mini run -ocpu-affinity=1 -n1 hwloc-bind --get &&
     flux dmesg | grep "invalid option"
 '


### PR DESCRIPTION
This PR adds support for parsing `gpu` resources from *R* if assigned into the shell internal `rcalc` class. The gpu resources are then exposed to plugins via `flux_shell_get_rank_info()` and a `gpubind.c` builtin plugin is introduced to read the gpu list and set `CUDA_VISIBLE_DEVICES` appropriately.

The plugin can be controlled via the `gpu-affinity` shell option. `gpu-affinity="off"` disables plugin operation, `gpu-affinity="on"` is the default and sets `CUDA_VISIBLE_DEVICES` once per job, and `gpu-affinity="per-task"` divides available GPUs evenly among local tasks. (If GPUs do not evenly divide among tasks the current behavior is undefined :wink:. Probably should fix this, but I don't think it could actually happen in the current system)

I couldn't directly port the `cuda_visible_devices.lua` plugin from 0.11 because that depended on the lua `cpu_set_t` bindings which were removed in the wreck purge of '19.