### PR TITLE
flux-mini: add --gpus-per-task option, update flux-mini(1) man page

### DIFF
--- a/doc/man1/flux-mini.adoc
+++ b/doc/man1/flux-mini.adoc
@@ -118,7 +118,7 @@ is interpreted as a string.
 *--dry-run*::
 Don't actually submit the job.  Just emit jobspec on stdout and exit.
 
-*-d, --debug*::
+*--debug*::
 Enable job debug events, primarily for debugging Flux itself.
 The specific effects of this option may change in the future.
 

--- a/doc/man1/flux-mini.adoc
+++ b/doc/man1/flux-mini.adoc
@@ -131,6 +131,12 @@ Some useful options understood by shell plugins:
 Load the MPI personality plugin for IBM Spectrum MPI.  All other MPI
 plugins are loaded by default.
 
+*affinity=per-task*::
+Tasks are distributed across the assigned resources.
+
+*affinity=off*::
+Disable task affinity plugin.
+
 
 AUTHOR
 ------

--- a/doc/man1/flux-mini.adoc
+++ b/doc/man1/flux-mini.adoc
@@ -46,6 +46,9 @@ Set the number of tasks to launch (default 1).
 *-c, --cores-per-task=N*::
 Set the number of cores to assign to each task (default 1).
 
+*-g, --gpus-per-task=N*::
+Set the number of GPU devices to assign to each task (default none).
+
 *-N, --nodes=N*::
 Set the number of nodes to assign to the job.  Tasks will be distributed
 evenly across the allocated nodes.  It is an error to request more nodes
@@ -137,6 +140,14 @@ Tasks are distributed across the assigned resources.
 
 *affinity=off*::
 Disable task affinity plugin.
+
+*gpu-affinity=per-task*::
+GPU devices are distributed evenly among local tasks.  Otherwise,
+GPU device affinity is to the job.
+
+*gpu-affinity=off*::
+Disable GPU affinity for this job.
+
 
 
 AUTHOR

--- a/doc/man1/flux-mini.adoc
+++ b/doc/man1/flux-mini.adoc
@@ -125,7 +125,8 @@ The specific effects of this option may change in the future.
 
 SHELL OPTIONS
 -------------
-Some useful options understood by shell plugins:
+These options are provided by built-in shell plugins that may be
+overridden in some cases:
 
 *mpi=spectrum*::
 Load the MPI personality plugin for IBM Spectrum MPI.  All other MPI

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -465,3 +465,4 @@ jobspec
 FSD
 enqueues
 cpus
+gpu

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -149,6 +149,11 @@ test_expect_success HAVE_JQ 'flux mini submit command arguments work' '
 	test $(jq ".tasks[0].command[1]" args.out) = "\"b\"" &&
 	test $(jq ".tasks[0].command[2]" args.out) = "\"c\""
 '
+test_expect_success 'flux mini submit --gpus-per-task adds gpus to task slot' '
+	flux mini submit --dry-run -g2 hostname >gpu.out &&
+	test $(jq ".resources[0].with[1].type" gpu.out) = "\"gpu\"" &&
+	test $(jq ".resources[0].with[1].count" gpu.out) = "2"
+'
 
 
 test_done


### PR DESCRIPTION
This fixes an error pointed out by @grondo and makes mention of affinity plugin shell options.  That raises a question about where we should be documenting shell plugin options.  Since they'll be usable from multiple front end tools, this may be the wrong place.