### PR TITLE
[WIP]: retain inactive jobs in the job manager queue

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -66,6 +66,9 @@ static struct optparse_option list_opts[] =  {
     { .name = "suppress-header", .key = 's', .has_arg = 0,
       .usage = "Suppress printing of header line",
     },
+    { .name = "all", .key = 'a', .has_arg = 0,
+      .usage = "Include inactive jobs",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -599,15 +602,18 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     json_t *jobs;
     size_t index;
     json_t *value;
+    int flags = 0;
 
     if (optindex != argc) {
         optparse_print_usage (p);
         exit (1);
     }
+    if (optparse_hasopt (p, "all"))
+        flags |= FLUX_JOB_LIST_ALL;
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list (h, max_entries, attrs)))
+    if (!(f = flux_job_list (h, max_entries, flags, attrs)))
         log_err_exit ("flux_job_list");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -127,7 +127,10 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *jobid)
     return 0;
 }
 
-flux_future_t *flux_job_list (flux_t *h, int max_entries, const char *json_str)
+flux_future_t *flux_job_list (flux_t *h,
+                              int max_entries,
+                              int flags,
+                              const char *json_str)
 {
     flux_future_t *f;
     json_t *o = NULL;
@@ -139,8 +142,9 @@ flux_future_t *flux_job_list (flux_t *h, int max_entries, const char *json_str)
         return NULL;
     }
     if (!(f = flux_rpc_pack (h, "job-manager.list", FLUX_NODEID_ANY, 0,
-                             "{s:i s:o}",
+                             "{s:i s:i s:o}",
                              "max_entries", max_entries,
+                             "flags", flags,
                              "attrs", o))) {
         saved_errno = errno;
         json_decref (o);

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -24,6 +24,10 @@ enum job_submit_flags {
     FLUX_JOB_DEBUG = 2,
 };
 
+enum job_list_flags {
+    FLUX_JOB_LIST_ALL = 1,
+};
+
 enum job_priority {
     FLUX_JOB_PRIORITY_MIN = 0,
     FLUX_JOB_PRIORITY_DEFAULT = 16,
@@ -62,6 +66,7 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
 
 /* Request a list of active jobs.
  * If 'max_entries' > 0, fetch at most that many jobs.
+ * If 'flags' is FLUX_JOB_LIST_ALL, include inactive jobs.
  * 'json_str' is an encoded JSON array of attribute strings, e.g.
  * ["id","userid",...] that will be returned in response.
 
@@ -73,7 +78,9 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
  *   ...
  * ])
  */
-flux_future_t *flux_job_list (flux_t *h, int max_entries,
+flux_future_t *flux_job_list (flux_t *h,
+                              int max_entries,
+                              int flags,
                               const char *json_str);
 
 /* Raise an exception for job.

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -115,23 +115,23 @@ void check_corner_case (void)
     /* flux_job_list */
 
     errno = 0;
-    ok (flux_job_list (NULL, 0, "{}") == NULL && errno == EINVAL,
+    ok (flux_job_list (NULL, 0, 0, "{}") == NULL && errno == EINVAL,
         "flux_job_list h=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, -1, "{}") == NULL && errno == EINVAL,
+    ok (flux_job_list (h, -1, 0, "{}") == NULL && errno == EINVAL,
         "flux_job_list max_entries=-1 fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, NULL) == NULL && errno == EINVAL,
+    ok (flux_job_list (h, 0, 0, NULL) == NULL && errno == EINVAL,
         "flux_job_list json_str=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, NULL) == NULL && errno == EINVAL,
+    ok (flux_job_list (h, 0, 0, NULL) == NULL && errno == EINVAL,
         "flux_job_list json_str=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, "wrong") == NULL && errno == EINVAL,
+    ok (flux_job_list (h, 0, 0, "wrong") == NULL && errno == EINVAL,
         "flux_job_list json_str=(inval JSON) fails with EINVAL");
 
     /* flux_job_raise */

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -168,7 +168,7 @@ static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
     job->free_pending = 0;
-    if (event_job_post_pack (ctx->event_ctx, job, "free", NULL) < 0)
+    if (event_job_post_pack (ctx->event_ctx, job, 0, "free", NULL) < 0)
         goto teardown;
     return;
 teardown:
@@ -245,7 +245,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
      * Raise alloc exception and transition to CLEANUP state.
      */
     if (type == 2) { // error: alloc was rejected
-        if (event_job_post_pack (ctx->event_ctx, job, "exception",
+        if (event_job_post_pack (ctx->event_ctx, job, 0, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", "alloc",
                                  "severity", 0,
@@ -265,7 +265,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
 
-    if (event_job_post_pack (ctx->event_ctx, job, "alloc",
+    if (event_job_post_pack (ctx->event_ctx, job, 0, "alloc",
                              "{ s:s }",
                              "note", note ? note : "") < 0)
         goto teardown;
@@ -427,7 +427,7 @@ static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
         job->alloc_queued = 0;
         ctx->active_alloc_count++;
         if ((job->flags & FLUX_JOB_DEBUG))
-            (void)event_job_post_pack (ctx->event_ctx, job,
+            (void)event_job_post_pack (ctx->event_ctx, job, 0,
                                        "debug.alloc-request", NULL);
 
     }
@@ -441,7 +441,7 @@ int alloc_send_free_request (struct alloc_ctx *ctx, struct job *job)
             return -1;
         job->free_pending = 1;
         if ((job->flags & FLUX_JOB_DEBUG))
-            (void)event_job_post_pack (ctx->event_ctx, job,
+            (void)event_job_post_pack (ctx->event_ctx, job, 0,
                                        "debug.free-request", NULL);
     }
     return 0;

--- a/src/modules/job-manager/drain.h
+++ b/src/modules/job-manager/drain.h
@@ -20,7 +20,9 @@
 struct drain_ctx;
 
 void drain_ctx_destroy (struct drain_ctx *ctx);
-struct drain_ctx *drain_ctx_create (flux_t *h, struct queue *queue,
+struct drain_ctx *drain_ctx_create (flux_t *h,
+                                    struct queue *queue,
+                                    struct event_ctx *event_ctx,
                                     struct submit_ctx *submit_ctx);
 
 #endif /* ! _FLUX_JOB_MANAGER_DRAIN_H */

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -295,7 +295,6 @@ int event_job_action (struct event_ctx *ctx, struct job *job)
             }
             break;
         case FLUX_JOB_INACTIVE:
-            queue_delete (ctx->queue, job, job->queue_handle);
             break;
     }
     return 0;

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -33,19 +33,21 @@ int event_job_action (struct event_ctx *ctx, struct job *job);
  */
 int event_job_update (struct job *job, json_t *event);
 
-/* Add notification of job's state transition to its current state
- * to batch for publication.
- */
-int event_batch_pub_state (struct event_ctx *ctx, struct job *job);
+enum event_job_post_flags {
+    EVENT_JOB_POST_NOLOG = 1, // skip posting event to eventlog (e.g. submit)
+};
 
 /* Post event 'name' and optionally 'context' to 'job'.
- * Internally, calls event_job_update(), then event_job_action(), then commits
- * the event to job KVS eventlog.  The KVS commit completes asynchronously.
- * The future passed in as an argument should not be destroyed.
+ * Internally, calls event_job_update(), then event_job_action(),
+ * then, if the EVENT_JOB_POST_NOLOG flag was not provided, commits the event
+ * to job KVS eventlog.  The KVS commit completes asynchronously.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int event_job_post_pack (struct event_ctx *ctx, struct job *job,
-                         const char *name, const char *context_fmt, ...);
+int event_job_post_pack (struct event_ctx *ctx,
+                         struct job *job,
+                         int flags,
+                         const char *name,
+                         const char *context_fmt, ...);
 
 void event_ctx_set_alloc_ctx (struct event_ctx *ctx,
                               struct alloc_ctx *alloc_ctx);

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -53,6 +53,8 @@ void event_ctx_set_alloc_ctx (struct event_ctx *ctx,
                               struct alloc_ctx *alloc_ctx);
 void event_ctx_set_start_ctx (struct event_ctx *ctx,
                               struct start_ctx *start_ctx);
+typedef void (*job_state_f)(struct job *job, flux_job_state_t old, void *arg);
+void event_ctx_set_state_cb (struct event_ctx *ctx, job_state_f cb, void *arg);
 
 void event_ctx_destroy (struct event_ctx *ctx);
 struct event_ctx *event_ctx_create (flux_t *h, struct queue *queue);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -102,7 +102,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating exec interface");
         goto done;
     }
-    if (!(ctx.drain_ctx = drain_ctx_create (h, ctx.queue, ctx.submit_ctx))) {
+    if (!(ctx.drain_ctx = drain_ctx_create (h,
+                                            ctx.queue,
+                                            ctx.event_ctx,
+                                            ctx.submit_ctx))) {
         flux_log_error (h, "error creating drain interface");
         goto done;
     }

--- a/src/modules/job-manager/list.h
+++ b/src/modules/job-manager/list.h
@@ -21,7 +21,11 @@ void list_handle_request (flux_t *h, struct queue *queue,
 
 /* exposed for unit testing only */
 json_t *list_one_job (struct job *job, json_t *attrs);
-json_t *list_job_array (struct queue *queue, int max_entries, json_t *attrs);
+json_t *list_job_array (struct queue *queue,
+                        int max_entries,
+                        int flags,
+                        json_t *attrs);
+
 
 #endif /* ! _FLUX_JOB_MANAGER_LIST_H */
 /*

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -81,7 +81,7 @@ void priority_handle_request (flux_t *h, struct queue *queue,
     }
     /* Post event, change job's queue position, and respond.
      */
-    if (event_job_post_pack (event_ctx, job,
+    if (event_job_post_pack (event_ctx, job, 0,
                              "priority",
                              "{ s:i s:i }",
                              "userid", userid,

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -71,6 +71,11 @@ void priority_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
+    if (job->state == FLUX_JOB_INACTIVE) {
+        errstr = "job is inactive";
+        errno = EINVAL;
+        goto error;
+    }
     /* Security: guests can only reduce priority, or increase up to default.
      */
     if (!(rolemask & FLUX_ROLE_OWNER)

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -25,8 +25,6 @@
 struct queue {
     zhashx_t *h;
     zlistx_t *l;
-    queue_notify_f empty_cb;
-    void *empty_arg;
 };
 
 #define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
@@ -153,22 +151,11 @@ void queue_delete (struct queue *queue, struct job *job, void *handle)
         zhashx_delete (queue->h, &job->id);
     rc = zlistx_delete (queue->l, handle); // calls job_decref ()
     assert (rc == 0);
-    if (queue->empty_cb && zlistx_size (queue->l) == 0)
-        queue->empty_cb (queue, queue->empty_arg);
 }
 
 int queue_size (struct queue *queue)
 {
     return zlistx_size (queue->l);
-}
-
-void queue_set_notify_empty (struct queue *queue,
-                             queue_notify_f cb, void *arg)
-{
-    queue->empty_cb = cb;
-    queue->empty_arg = arg;
-    if (queue->empty_cb && zlistx_size (queue->l) == 0)
-        queue->empty_cb (queue, queue->empty_arg);
 }
 
 struct job *queue_first (struct queue *queue)

--- a/src/modules/job-manager/queue.h
+++ b/src/modules/job-manager/queue.h
@@ -55,11 +55,6 @@ struct job *queue_next (struct queue *queue);
  */
 int queue_size (struct queue *queue);
 
-/* Arrange to be notified when queue size decreases to zero.
- */
-void queue_set_notify_empty (struct queue *queue,
-                             queue_notify_f cb, void *arg);
-
 #endif /* _FLUX_JOB_MANAGER_QUEUE_H */
 
 /*

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -103,7 +103,7 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
-    if ((job->state == FLUX_JOB_INACTIVE)) {
+    if (job->state == FLUX_JOB_INACTIVE) {
         errstr = "job is inactive";
         goto error;
     }

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -108,7 +108,9 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPROTO;
         goto error;
     }
-    if (event_job_post_pack (event_ctx, job,
+    if (event_job_post_pack (event_ctx,
+                             job,
+                             0,
                              "exception",
                              "{ s:s s:i s:i s:s }",
                              "type", type,

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -103,6 +103,10 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
+    if ((job->state == FLUX_JOB_INACTIVE)) {
+        errstr = "job is inactive";
+        goto error;
+    }
     if (note && strchr (note, '=')) {
         errstr = "exception note may not contain key=value attributes";
         errno = EPROTO;

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* restart - reload active jobs from the KVS */
+/* restart - reload jobs from the KVS */
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -146,7 +146,7 @@ static int restart_map_cb (struct job *job, void *arg)
     return 0;
 }
 
-/* Load any active jobs present in the KVS at startup.
+/* Load any jobs present in the KVS at startup.
  */
 int restart_from_kvs (flux_t *h, struct queue *queue,
                       struct event_ctx *event_ctx)

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -160,7 +160,7 @@ static void interface_teardown (struct start_ctx *ctx, char *s, int errnum)
         while (job) {
             if (job->start_pending) {
                 if ((job->flags & FLUX_JOB_DEBUG))
-                    (void)event_job_post_pack (ctx->event_ctx, job,
+                    (void)event_job_post_pack (ctx->event_ctx, job, 0,
                                                "debug.start-lost",
                                                "{ s:s }", "note", s);
                 job->start_pending = 0;
@@ -198,7 +198,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!strcmp (type, "start")) {
-        if (event_job_post_pack (ctx->event_ctx, job, "start", NULL) < 0)
+        if (event_job_post_pack (ctx->event_ctx, job, 0, "start", NULL) < 0)
             goto error_post;
     }
     else if (!strcmp (type, "release")) {
@@ -212,7 +212,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         }
         if (final) // final release is end-of-stream
             job->start_pending = 0;
-        if (event_job_post_pack (ctx->event_ctx, job, "release",
+        if (event_job_post_pack (ctx->event_ctx, job, 0, "release",
                                  "{ s:s s:b }",
                                  "ranks", idset,
                                  "final", final) < 0)
@@ -229,7 +229,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
             flux_log_error (h, "start: exception response: malformed data");
             goto error;
         }
-        if (event_job_post_pack (ctx->event_ctx, job, "exception",
+        if (event_job_post_pack (ctx->event_ctx, job, 0, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", xtype,
                                  "severity", xseverity,
@@ -244,7 +244,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
             flux_log_error (h, "start: finish response: malformed data");
             goto error;
         }
-        if (event_job_post_pack (ctx->event_ctx, job, "finish",
+        if (event_job_post_pack (ctx->event_ctx, job, 0, "finish",
                                  "{ s:i }", "status", status) < 0)
             goto error_post;
     }
@@ -281,7 +281,7 @@ int start_send_request (struct start_ctx *ctx, struct job *job)
         flux_msg_destroy (msg);
         job->start_pending = 1;
         if ((job->flags & FLUX_JOB_DEBUG))
-            (void)event_job_post_pack (ctx->event_ctx, job,
+            (void)event_job_post_pack (ctx->event_ctx, job, 0,
                                        "debug.start-request", NULL);
     }
     return 0;

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -59,14 +59,14 @@ int main (int argc, char *argv[])
 
     /* list_job_array */
 
-    o = list_job_array (q, 0, attrs);
+    o = list_job_array (q, 0, FLUX_JOB_LIST_ALL, attrs);
     ok (o != NULL && json_is_array (o),
         "list_job_array returns array");
     ok (json_array_size (o) == q_size,
         "array has expected size");
     json_decref (o);
 
-    o = list_job_array (q, 4, attrs);
+    o = list_job_array (q, 4, 0, attrs);
     ok (o != NULL && json_is_array (o),
         "list_job_array max_entries=4 returns array");
     ok (json_array_size (o) == 4,
@@ -86,11 +86,11 @@ int main (int argc, char *argv[])
     json_decref (o);
 
     errno = 0;
-    ok (list_job_array (q, -1, attrs) == NULL && errno == EPROTO,
+    ok (list_job_array (q, -1, 0, attrs) == NULL && errno == EPROTO,
         "list_job_array max_entries < 0 fails with EPROTO");
 
     errno = 0;
-    ok (list_job_array (q, -1, NULL) == NULL && errno == EPROTO,
+    ok (list_job_array (q, -1, 0, NULL) == NULL && errno == EPROTO,
         "list_job_array attrs=NULL fails with EPROTO");
 
     /* list_one_job */


### PR DESCRIPTION
Here's a quick hack (more proof of concept than actual proposal) to keep inactive jobs in the queue so they can be listed.  It adds a `--all` option to flux job list, e.g.
```console
$ flux job list --all
JOBID		STATE	USERID	PRI	T_SUBMIT
143428419584	I	5588	16	2019-09-29T20:06:32Z
305714429952	I	5588	16	2019-09-29T20:06:41Z
314723794944	I	5588	16	2019-09-29T20:06:42Z
320931364864	R	5588	16	2019-09-29T20:06:42Z
328430780416	R	5588	16	2019-09-29T20:06:43Z
334369914880	S	5588	16	2019-09-29T20:06:43Z
```
(the I jobs are inactive)

Some things that came up and were addressed:
* Needed to check for INACTIVE state in raise and priority handlers
* Drain needed a whole new strategy:  stop queue, count inactive jobs, then watch jobs transition to inactive until all jobs are

Loose ends
* Inactive jobs are listed before active ones
* flux job list is not a usable tool for users (need porcelain tool)
* the list rpc should be redesigned to support porcelain tool requirements (what's there is a hack)
* need to think carefully about how retaining the additional job records in memory affects scalability
* need tests including, including survival of queue over job manager restart