### PR TITLE
flux-version: make flux --version an alias, add manpage

### DIFF
--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -20,7 +20,8 @@ MAN1_FILES_PRIMARY = \
 	flux-cron.1 \
 	flux-user.1 \
 	flux-event.1 \
-	flux-mini.1
+	flux-mini.1 \
+	flux-version.1
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man1/flux-version.adoc
+++ b/doc/man1/flux-version.adoc
@@ -1,0 +1,39 @@
+// flux-help-description : Display flux version information
+FLUX-VERSION(1)
+===============
+:doctype: manpage
+
+
+NAME
+----
+flux-version - Display flux version information
+
+
+SYNOPSIS
+--------
+*flux* *version*
+
+
+DESCRIPTION
+-----------
+flux-version(1) prints version information for flux components.
+At a minimum, the version of flux commands and the currently linked
+libflux-core.so library is displayed. If running within an instance,
+the version of the flux-broker found and FLUX_URI are also included.
+Finally, if flux is compiled against flux-security, then the version
+of the currently linked libflux-security is included.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+

--- a/doc/man1/flux.adoc
+++ b/doc/man1/flux.adoc
@@ -38,6 +38,9 @@ in the parent. This option may be specified multiple times.
 *-v, --verbose*::
 Display command environment, and the path search for 'CMD'.
 
+*-V, --version*::
+Convenience option to run flux-version(1).
+
 
 SUB-COMMAND ENVIRONMENT
 -----------------------

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -42,6 +42,9 @@ static struct optparse_option opts[] = {
     { .name = "verbose",         .key = 'v', .has_arg = 0,
       .usage = "Be verbose about environment and command search",
     },
+    { .name = "version",         .key = 'V', .has_arg = 0,
+      .usage = "Display command and component versions",
+    },
     { .name = "parent",         .key = 'p', .has_arg = 0,
       .usage = "Set environment of parent instead of current instance",
     },
@@ -124,6 +127,10 @@ int main (int argc, char *argv[])
     if (optparse_hasopt (p, "help")) {
         usage (p); // N.B. accesses "conf_flags"
         exit (0);
+    }
+    if (optparse_hasopt (p, "version")) {
+        execlp ("flux", "flux", "version", (char *) NULL);
+        log_err_exit ("Failed to run flux-version");
     }
     optindex = optparse_option_index (p);
     if (argc - optindex == 0) {

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -42,6 +42,20 @@ test_expect_success 'version: reports expected values not under an instance' '
 	! grep -q broker     version2.out &&
 	! grep -q FLUX_URI   version2.out
 '
+test_expect_success 'version: flux -V works under an instance' '
+	flux --version >version3.out &&
+	grep -q libflux-core version3.out &&
+	grep -q commands     version3.out &&
+	grep -q broker       version3.out &&
+	grep -q FLUX_URI     version3.out
+'
+test_expect_success 'version: flux -V works not under and instance' '
+	(unset FLUX_URI; flux -V >version4.out) &&
+	grep -q libflux-core version4.out &&
+	grep -q commands     version4.out &&
+	! grep -q broker     version4.out &&
+	! grep -q FLUX_URI   version4.out
+'
 
 heaptrace_error_check()
 {


### PR DESCRIPTION
This PR adds a simple manpage for `flux-version(1)` (allowing `version` to appear in output of `flux-help(1)`.

Also, a quick hack is added to make `flux -V, --version` an alias for `flux version` (suggested by @SteVwonder)

It would be easy to just provide the flux-version manpage if the `flux -V` flag is a step too far.