### PR TITLE
[WIP] shell: Support stdin via a file

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -250,6 +250,12 @@ class SubmitCmd:
             metavar="KEY=VAL",
         )
         parser.add_argument(
+            "--input",
+            type=str,
+            help="Redirect job stdin from FILENAME, bypassing KVS",
+            metavar="FILENAME",
+        )
+        parser.add_argument(
             "--output",
             type=str,
             help="Redirect job stdout to FILENAME, bypassing KVS",
@@ -296,6 +302,10 @@ class SubmitCmd:
         jobspec.set_environment(dict(os.environ))
         if args.time_limit is not None:
             jobspec.set_duration(args.time_limit)
+
+        if args.input is not None:
+            jobspec.setattr_shopt("input.stdin.type", "file")
+            jobspec.setattr_shopt("input.stdin.path", args.input)
 
         if args.output is not None:
             jobspec.setattr_shopt("output.stdout.type", "file")

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -169,66 +169,70 @@ static int channel_local_setup (flux_subprocess_t *p,
         goto error;
     }
 
-    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log_error (p->h, "socketpair");
-        goto error;
-    }
+    if ((channel_flags & CHANNEL_READ)
+        || (channel_flags & CHANNEL_WRITE)) {
 
-    c->parent_fd = fds[0];
-    c->child_fd = fds[1];
-
-    /* set fds[] to -1, on error is now subprocess_free()'s
-     * responsibility
-     */
-    fds[0] = -1;
-    fds[1] = -1;
-
-    if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log_error (p->h, "fd_set_nonblocking");
-        goto error;
-    }
-
-    if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
-        goto error;
-    }
-
-    if ((channel_flags & CHANNEL_WRITE) && in_cb) {
-        c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
-                                                              c->parent_fd,
-                                                              buffer_size,
-                                                              in_cb,
-                                                              0,
-                                                              c);
-        if (!c->buffer_write_w) {
-            flux_log_error (p->h, "flux_buffer_write_watcher_create");
-            goto error;
-        }
-    }
-
-    if ((channel_flags & CHANNEL_READ) && out_cb) {
-        int wflag;
-
-        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+        if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
+            flux_log_error (p->h, "socketpair");
             goto error;
         }
 
-        if (wflag)
-            c->line_buffered = true;
+        c->parent_fd = fds[0];
+        c->child_fd = fds[1];
 
-        c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
-                                                            c->parent_fd,
-                                                            buffer_size,
-                                                            out_cb,
-                                                            wflag,
-                                                            c);
-        if (!c->buffer_read_w) {
-            flux_log_error (p->h, "flux_buffer_read_watcher_create");
+        /* set fds[] to -1, on error is now subprocess_free()'s
+         * responsibility
+         */
+        fds[0] = -1;
+        fds[1] = -1;
+
+        if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
+            flux_log_error (p->h, "fd_set_nonblocking");
             goto error;
         }
 
-        p->channels_eof_expected++;
+        if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_bufsize");
+            goto error;
+        }
+
+        if ((channel_flags & CHANNEL_WRITE) && in_cb) {
+            c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
+                                                                  c->parent_fd,
+                                                                  buffer_size,
+                                                                  in_cb,
+                                                                  0,
+                                                                  c);
+            if (!c->buffer_write_w) {
+                flux_log_error (p->h, "flux_buffer_write_watcher_create");
+                goto error;
+            }
+        }
+
+        if ((channel_flags & CHANNEL_READ) && out_cb) {
+            int wflag;
+
+            if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+                flux_log_error (p->h, "cmd_option_line_buffer");
+                goto error;
+            }
+
+            if (wflag)
+                c->line_buffered = true;
+
+            c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
+                                                                c->parent_fd,
+                                                                buffer_size,
+                                                                out_cb,
+                                                                wflag,
+                                                                c);
+            if (!c->buffer_read_w) {
+                flux_log_error (p->h, "flux_buffer_read_watcher_create");
+                goto error;
+            }
+
+            p->channels_eof_expected++;
+        }
     }
 
     if (channel_flags & CHANNEL_FD) {
@@ -455,26 +459,36 @@ static int local_child (flux_subprocess_t *p)
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
-            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_WRITE) {
+                if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
-            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDOUT_FILENO);
         }
         else
             close (STDOUT_FILENO);
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
-            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDERR_FILENO);
         }
         else
             close (STDERR_FILENO);
@@ -676,15 +690,18 @@ static int start_local_watchers (flux_subprocess_t *p)
     c = zhash_first (p->channels);
     while (c) {
         int ret;
-        flux_watcher_start (c->buffer_write_w);
-        if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
-            return -1;
-        if (ret) {
-            flux_watcher_start (c->buffer_read_stopped_w);
-        }
-        else {
-            flux_watcher_start (c->buffer_read_w);
-            c->buffer_read_w_started = true;
+        if (c->flags & CHANNEL_WRITE)
+            flux_watcher_start (c->buffer_write_w);
+        if (c->flags & CHANNEL_READ) {
+            if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
+                return -1;
+            if (ret) {
+                flux_watcher_start (c->buffer_read_stopped_w);
+            }
+            else {
+                flux_watcher_start (c->buffer_read_w);
+                c->buffer_read_w_started = true;
+            }
         }
         c = zhash_next (p->channels);
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -50,6 +50,8 @@ void channel_destroy (void *arg)
             close (c->child_fd);
         if (c->input_fd != -1)
             close (c->input_fd);
+        if (c->output_fd != -1)
+            close (c->output_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -94,6 +96,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
     c->parent_fd = -1;
     c->child_fd = -1;
     c->input_fd = -1;
+    c->output_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -671,6 +674,7 @@ static int check_local_only_cmd_options (const flux_cmd_t *cmd)
     /* check for options that do not apply to remote subprocesses */
     const char *substrings[] = { "STREAM_STOP",
                                  "INPUT_FD",
+                                 "OUTPUT_FD",
                                  NULL };
 
     return flux_cmd_find_opts (cmd, substrings);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -48,6 +48,8 @@ void channel_destroy (void *arg)
             close (c->parent_fd);
         if (c->child_fd != -1)
             close (c->child_fd);
+        if (c->input_fd != -1)
+            close (c->input_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -91,6 +93,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
 
     c->parent_fd = -1;
     c->child_fd = -1;
+    c->input_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -666,7 +669,9 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)
 {
     /* check for options that do not apply to remote subprocesses */
-    const char *substrings[] = { "STREAM_STOP", NULL };
+    const char *substrings[] = { "STREAM_STOP",
+                                 "INPUT_FD",
+                                 NULL };
 
     return flux_cmd_find_opts (cmd, substrings);
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -294,6 +294,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    subprocesses.
  *
  *    - stdin_INPUT_FD - file descriptor for stdin
+ *
+ *  "OUTPUT_FD" option
+ *
+ *    By default, standard output is read from flux_subprocess_read()
+ *    (and family of functions) and the stream "stdout" or "stderr".
+ *    This option will inform the subprocess to redirect stdout /
+ *    stderr directly to a specified file descriptor.  Functions like
+ *    flux_subprocess_read() will return EINVAL when attempting to
+ *    read from stdout or stderr.  This option can only be used on
+ *    local subprocesses.
+ *
+ *    - stdout_OUTPUT_FD - file descriptor for stdout
+ *    - stderr_OUTPUT_FD - file descriptor for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -282,6 +282,18 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
  *    - stdout_STREAM_STOP - configure start/stop for stdout
  *    - stderr_STREAM_STOP - configure start/stop for stderr
+ *
+ *  "INPUT_FD" option
+ *
+ *    By default, standard input is sent to a subprocess via the
+ *    flux_subprocess_write() call and the stream "stdin".  This
+ *    option will inform the subprocess to read stdin directly from a
+ *    specified file descriptor.  As a result, functions liked
+ *    flux_subprocess_write() will return EINVAL when attempting to
+ *    write to "stdin".  This option can only be used on local
+ *    subprocesses.
+ *
+ *    - stdin_INPUT_FD - file descriptor for stdin
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,9 +21,10 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ  0x01
-#define CHANNEL_WRITE 0x02
-#define CHANNEL_FD    0x04
+#define CHANNEL_READ     0x01
+#define CHANNEL_WRITE    0x02
+#define CHANNEL_FD       0x04
+#define CHANNEL_INPUT_FD 0x08
 
 struct subprocess_channel {
     int magic;
@@ -40,6 +41,7 @@ struct subprocess_channel {
     /* local */
     int parent_fd;
     int child_fd;
+    int input_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,10 +21,11 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ     0x01
-#define CHANNEL_WRITE    0x02
-#define CHANNEL_FD       0x04
-#define CHANNEL_INPUT_FD 0x08
+#define CHANNEL_READ      0x01
+#define CHANNEL_WRITE     0x02
+#define CHANNEL_FD        0x04
+#define CHANNEL_INPUT_FD  0x08
+#define CHANNEL_OUTPUT_FD 0x10
 
 struct subprocess_channel {
     int magic;
@@ -42,6 +43,7 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     int input_fd;
+    int output_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -796,6 +796,21 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     (*counter)++;
 }
 
+void write_multiple_lines_to_stdin (flux_subprocess_t *p)
+{
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_close (p, "stdin") == 0,
+        "flux_subprocess_close success");
+}
+
 void test_basic_multiple_lines (flux_reactor_t *r)
 {
     char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-O", "-E", "-n", NULL };
@@ -818,17 +833,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_close (p, "stdin") == 0,
-        "flux_subprocess_close success");
+    write_multiple_lines_to_stdin (p);
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,7 +122,10 @@ cleanup:
     return rv;
 }
 
-int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+static int cmd_option_fd (flux_subprocess_t *p,
+                          const char *name,
+                          const char *substring,
+                          int *fdp)
 {
     char *var;
     const char *val;
@@ -130,7 +133,7 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 
     (*fdp) = -1;
 
-    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+    if (asprintf (&var, "%s_%s", name, substring) < 0)
         goto cleanup;
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
@@ -151,6 +154,16 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 cleanup:
     free (var);
     return rv;
+}
+
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "INPUT_FD", fdp);
+}
+
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "OUTPUT_FD", fdp);
 }
 
 /*

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,6 +122,37 @@ cleanup:
     return rv;
 }
 
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    (*fdp) = -1;
+
+    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        int tmp;
+        errno = 0;
+        tmp = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || tmp < 0) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        (*fdp) = tmp;
+    }
+
+    rv = 0;
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -26,4 +26,7 @@ int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 /* sets fdp to -1 if user did not set INPUT_FD */
 int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
 
+/* sets fdp to -1 if user did not set OUTPUT_FD */
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -23,4 +23,7 @@ int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
+/* sets fdp to -1 if user did not set INPUT_FD */
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -51,6 +51,7 @@ flux_shell_SOURCES = \
 	task.c \
 	task.h \
 	pmi.c \
+	input.c \
 	output.c \
 	svc.c \
 	svc.h \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -30,6 +30,7 @@ static struct shell_builtin builtin_list_end = { 0 };
  *  to get the builtin automatically loaded at shell startup.
  */
 extern struct shell_builtin builtin_pmi;
+extern struct shell_builtin builtin_input;
 extern struct shell_builtin builtin_output;
 extern struct shell_builtin builtin_kill;
 extern struct shell_builtin builtin_signals;
@@ -38,6 +39,7 @@ extern struct shell_builtin builtin_gpubind;
 
 static struct shell_builtin * builtins [] = {
     &builtin_pmi,
+    &builtin_input,
     &builtin_output,
     &builtin_kill,
     &builtin_signals,

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -1,0 +1,199 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* std input handling
+ *
+ * Currently, only standard input via file is supported.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+#include "task.h"
+#include "internal.h"
+#include "builtins.h"
+
+enum {
+    FLUX_INPUT_TYPE_NONE = 1,
+    FLUX_INPUT_TYPE_FILE = 2,
+};
+
+struct shell_input_type_file {
+    const char *path;
+    int *fds;
+    int count;
+};
+
+struct shell_input {
+    flux_shell_t *shell;
+    int stdin_type;
+    struct shell_input_type_file stdin_file;
+};
+
+static void shell_input_type_file_cleanup (struct shell_input_type_file *ifp)
+{
+    if (ifp->fds) {
+        int i;
+        for (i = 0; i < ifp->count; i++)
+            close (ifp->fds[i]);
+        free (ifp->fds);
+    }
+}
+
+void shell_input_destroy (struct shell_input *in)
+{
+    if (in) {
+        int saved_errno = errno;
+        shell_input_type_file_cleanup (&(in->stdin_file));
+        free (in);
+        errno = saved_errno;
+    }
+}
+
+static int shell_input_parse_type (struct shell_input *in)
+{
+    const char *typestr = NULL;
+    int ret;
+
+    if ((ret = flux_shell_getopt_unpack (in->shell, "input",
+                                         "{s?:{s?:s}}",
+                                         "stdin", "type", &typestr)) < 0)
+        return -1;
+
+    if (!ret || !typestr)
+        return 0;
+
+    if (!strcmp (typestr, "file")) {
+        struct shell_input_type_file *ifp = &(in->stdin_file);
+
+        in->stdin_type = FLUX_INPUT_TYPE_FILE;
+
+        if (flux_shell_getopt_unpack (in->shell, "input",
+                                      "{s:{s?:s}}",
+                                      "stdin", "path", &(ifp->path)) < 0)
+            return -1;
+
+        if (ifp->path == NULL) {
+            log_msg ("path for stdin file input not specified");
+            return -1;
+        }
+
+        ifp->fds = malloc (sizeof (int) * in->shell->info->rankinfo.ntasks);
+        if (!ifp->fds)
+            return -1;
+    }
+    else {
+        log_msg ("invalid input type specified '%s'", typestr);
+        return -1;
+    }
+
+    return 0;
+}
+
+struct shell_input *shell_input_create (flux_shell_t *shell)
+{
+    struct shell_input *in;
+
+    if (!(in = calloc (1, sizeof (*in))))
+        return NULL;
+    in->shell = shell;
+    in->stdin_type = FLUX_INPUT_TYPE_NONE;
+
+    /* Check if user specified shell input */
+    if (shell_input_parse_type (in) < 0)
+        goto error;
+
+    return in;
+error:
+    shell_input_destroy (in);
+    return NULL;
+}
+
+static int shell_input_type_file_setup (struct shell_input *in,
+                                        struct shell_task *task)
+{
+    struct shell_input_type_file *ifp = &(in->stdin_file);
+    char buf_fd[64];
+    int fd = -1;
+    int saved_errno;
+
+    if ((fd = open (ifp->path, O_RDONLY)) < 0) {
+        log_err ("error opening input file '%s'", ifp->path);
+        goto error;
+    }
+
+    snprintf (buf_fd, sizeof (buf_fd), "%d", fd);
+
+    if (flux_cmd_setopt (task->cmd, "stdin_INPUT_FD", buf_fd) < 0) {
+        log_err ("error setting 'stdin_INPUT_FD'");
+        goto error;
+    }
+
+    ifp->fds[ifp->count++] = fd;
+    return 0;
+error:
+    saved_errno = errno;
+    close (fd);
+    errno = saved_errno;
+    return -1;
+}
+
+static int shell_input_task_init (flux_plugin_t *p,
+                                   const char *topic,
+                                   flux_plugin_arg_t *args,
+                                   void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_input *in = flux_plugin_aux_get (p, "builtin.input");
+    flux_shell_task_t *task;
+
+    if (!shell || !in || !(task = flux_shell_current_task (shell)))
+        return -1;
+
+    if (in->stdin_type == FLUX_INPUT_TYPE_FILE) {
+        if (shell_input_type_file_setup (in, task) < 0)
+            return -1;
+    }
+
+    return 0;
+}
+
+static int shell_input_init (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_arg_t *args,
+                             void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_input *in = shell_input_create (shell);
+    if (!in)
+        return -1;
+    if (flux_plugin_aux_set (p, "builtin.input", in,
+                            (flux_free_f) shell_input_destroy) < 0) {
+        shell_input_destroy (in);
+        return -1;
+    }
+    return 0;
+}
+
+struct shell_builtin builtin_input = {
+    .name = "input",
+    .init = shell_input_init,
+    .task_init = shell_input_task_init
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -111,6 +111,8 @@ TESTSCRIPTS = \
 	t2604-job-shell-affinity.t \
 	t2605-job-shell-output-redirection-standalone.t \
 	t2606-job-shell-output-redirection.t \
+	t2607-job-shell-input-standalone.t \
+	t2608-job-shell-input.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2607-job-shell-input-standalone.t
+++ b/t/t2607-job-shell-input-standalone.t
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+test_description='Test flux-shell in --standalone mode'
+
+. `dirname $0`/sharness.sh
+
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+
+#  Run flux-shell under flux command to get correct paths
+FLUX_SHELL="flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
+
+unset FLUX_URI
+
+TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
+
+#
+# input file tests
+#
+
+test_expect_success 'flux-shell: generate input file for stdin input file tests' '
+       echo "foo" > input_stdin_file &&
+       echo "doh" >> input_stdin_file
+'
+
+test_expect_success 'flux-shell: generate echo stdin file jobspecs and matching Rs' '
+       flux jobspec srun -N1 -n1 ${TEST_SUBPROCESS_DIR}/test_echo -O -n > j1echostdinfile &&
+       flux jobspec srun -N2 -n2 ${TEST_SUBPROCESS_DIR}/test_echo -O -n > j2echostdinfile &&
+       cat >R1 <<-EOT &&
+{"version": 1, "execution":{ "R_lite":[
+        { "children": { "core": "0" }, "rank": "0" }
+]}}
+EOT
+       cat >R2 <<-EOT
+{"version": 1, "execution":{ "R_lite":[
+        { "children": { "core": "0-1" }, "rank": "0" }
+]}}
+EOT
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task input file as stdin job' '
+        cat j1echostdinfile \
+            |  $jq ".attributes.system.shell.options.input.stdin.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.input.stdin.path = \"input_stdin_file\"" \
+            > j1echostdinfile-0 &&
+        ${FLUX_SHELL} -v -s -r 0 -j j1echostdinfile-0 -R R1 0 > out0 &&
+        grep "0: foo" out0 &&
+        grep "0: doh" out0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task input file as stdin job' '
+        cat j2echostdinfile \
+            |  $jq ".attributes.system.shell.options.input.stdin.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.input.stdin.path = \"input_stdin_file\"" \
+            > j2echostdinfile-1 &&
+        ${FLUX_SHELL} -v -s -r 0 -j j2echostdinfile-1 -R R2 1 > out1 &&
+        grep "0: foo" out1 &&
+        grep "0: doh" out1 &&
+        grep "1: foo" out1 &&
+        grep "1: doh" out1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: input file as stdin bad type' '
+        cat j1echostdinfile \
+            |  $jq ".attributes.system.shell.options.input.stdin.type = \"foobar\"" \
+            |  $jq ".attributes.system.shell.options.input.stdin.path = \"input_stdin_file\"" \
+            > j1echostdinfile-2 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdinfile-2 -R R1 2 > out2
+'
+
+test_expect_success HAVE_JQ 'flux-shell: input file as stdin bad path' '
+        cat j1echostdinfile \
+            |  $jq ".attributes.system.shell.options.input.stdin.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.input.stdin.path = \"/foo/bar/baz\"" \
+            > j1echostdinfile-3 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdinfile-3 -R R1 3 > out3
+'
+
+test_done

--- a/t/t2608-job-shell-input.t
+++ b/t/t2608-job-shell-input.t
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+test_description='Test flux-shell'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
+
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
+
+test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+        #  Add fake by_rank configuration to kvs:
+        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux module load barrier &&
+        flux module load -r 0 sched-simple &&
+        flux module load -r 0 job-exec
+'
+
+test_expect_success 'flux-shell: generate input file for stdin input file tests' '
+       echo "foo" > input_stdin_file &&
+       echo "doh" >> input_stdin_file
+'
+
+#
+# input file tests
+#
+
+test_expect_success 'flux-shell: run 1-task input file as stdin job' '
+        flux mini run -n1 --input=input_stdin_file \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > out0 &&
+        test_cmp input_stdin_file out0
+'
+
+test_expect_success 'flux-shell: run 2-task input file as stdin job' '
+        flux mini run -n2 --input=input_stdin_file --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > out1 &&
+        grep "0: foo" out1 &&
+        grep "0: doh" out1 &&
+        grep "1: foo" out1 &&
+        grep "1: doh" out1
+'
+
+test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
+        flux module remove -r 0 job-exec &&
+        flux module remove -r 0 sched-simple &&
+        flux module remove barrier
+'
+
+test_done


### PR DESCRIPTION
Just wanted to throw this up for possible after milestone if it's a high user need or if we decide to be aggressive on some of these last PRs.  Built on top of #2345 (but doesn't require #2350 or #2396).  

Nothing too special to note.  Only note is that the same file is opened for all tasks for stdin.  Didn't add a per-task input file format (atleast yet).  Perhaps not best.  Should only leader open it and write to `guest.input`?

