### PR TITLE
sched-simple: reject requests with unknown resource types

### DIFF
--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -121,4 +121,26 @@ while read line; do
   '
 done < inputs.txt
 
+
+# Invalid inputs:
+# <mini command args> == <expected result>
+#
+cat <<EOF >mini-invalid.txt
+run -g1             ==jj-reader: Unsupported resource type 'gpu'
+run -N1 -n2 -c2 -g1 ==jj-reader: Unsupported resource type 'gpu'
+EOF
+
+while read line; do
+  args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
+  expected=$(echo $line | awk -F== '{print $2}')
+
+  test_expect_success "jj-reader: flux mini $args gets expected error" '
+	echo $expected >expected.$test_count &&
+	flux mini $args --dry-run hostname >$test_count.json &&
+	test_expect_code 1 $jj<$test_count.json > out.$test_count 2>&1 &&
+	test_cmp expected.$test_count out.$test_count
+  '
+done <mini-invalid.txt
+
+
 test_done

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -41,7 +41,7 @@ test_expect_success HAVE_JQ 'jj-reader: bad type throws error' '
 	  jq --arg f beans ".resources[0].type = \$f" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
 	cat >expected.$test_count <<-EOF &&
-	jj-reader: Invalid type '\''beans'\''
+	jj-reader: Unsupported resource type '\''beans'\''
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '
@@ -72,10 +72,10 @@ jobspec/valid/basic.yaml        ==jj-reader: Unable to determine slot size
 jobspec/valid/example2.yaml     ==jj-reader: Unable to determine slot size
 jobspec/valid/use_case_1.2.yaml ==jj-reader: level 0: Expected integer, got object
 jobspec/valid/use_case_1.3.yaml ==jj-reader: level 2: Expected integer, got object
-jobspec/valid/use_case_1.4.yaml ==jj-reader: Invalid type 'socket'
-jobspec/valid/use_case_1.5.yaml ==jj-reader: Invalid type 'cluster'
-jobspec/valid/use_case_1.6.yaml ==jj-reader: Invalid type 'cluster'
-jobspec/valid/use_case_1.7.yaml ==jj-reader: Invalid type 'switch'
+jobspec/valid/use_case_1.4.yaml ==jj-reader: Unsupported resource type 'socket'
+jobspec/valid/use_case_1.5.yaml ==jj-reader: Unsupported resource type 'cluster'
+jobspec/valid/use_case_1.6.yaml ==jj-reader: Unsupported resource type 'cluster'
+jobspec/valid/use_case_1.7.yaml ==jj-reader: Unsupported resource type 'switch'
 jobspec/valid/use_case_2.1.yaml ==jj-reader: Unable to determine slot size
 jobspec/valid/use_case_2.2.yaml ==jj-reader: Unable to determine slot size
 jobspec/valid/use_case_2.5.yaml ==jj-reader: level 1: Expected integer, got object

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -40,7 +40,11 @@ test_expect_success 'sched-simple: unsatisfiable request is canceled' '
         flux job wait-event --timeout=5.0 $job0id exception &&
 	flux job eventlog $job0id | grep "unsatisfiable request"
 '
-
+test_expect_success 'sched-simple: gpu request is canceled' '
+	jobid=$(flux mini run -n1 -g1 --dry-run hostname | flux job submit) &&
+	flux job wait-event --timeout=5.0 $jobid exception &&
+	flux job eventlog $jobid | grep  "Unsupported resource type .gpu."
+'
 Y2J=${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py
 SPEC=${SHARNESS_TEST_SRCDIR}/jobspec/valid/basic.yaml
 test_expect_success 'sched-simple: invalid minimal jobspec is canceled' '


### PR DESCRIPTION
The sched-simple implementation only supports resource types of `node` `slot` and `core`. If a request with more than one resource at  a level includes a non-supported type, then that type was being ignored and the job run just on the nodes/cores requested.

This PR fixes that oversight by requiring the scheduler to look at every resource at any given level in the jobspec request.

Note: Instead of canceling these jobs with the generic "unsatisfiable request" message as specified in #2417, the error message is more explicit:

```console
$ flux mini run -g1 hostname
job-event: exception type=alloc severity=0 Unsupported resource type 'gpu'
```

If that isn't ok then it is probably trivial to make the error message more generic.