### PR TITLE
flux -V: small fix to allow it to work outside of an instance

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -129,7 +129,7 @@ int main (int argc, char *argv[])
         exit (0);
     }
     if (optparse_hasopt (p, "version")) {
-        execlp ("flux", "flux", "version", (char *) NULL);
+        execlp (argv0, "flux", "version", (char *) NULL);
         log_err_exit ("Failed to run flux-version");
     }
     optindex = optparse_option_index (p);

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -50,7 +50,8 @@ test_expect_success 'version: flux -V works under an instance' '
 	grep -q FLUX_URI     version3.out
 '
 test_expect_success 'version: flux -V works not under and instance' '
-	(unset FLUX_URI; flux -V >version4.out) &&
+	(unset FLUX_URI; PATH=/bin:/usr/bin; \
+		${FLUX_BUILD_DIR}/src/cmd/flux -V >version4.out) &&
 	grep -q libflux-core version4.out &&
 	grep -q commands     version4.out &&
 	! grep -q broker     version4.out &&


### PR DESCRIPTION
When `flux -V` re-execs `flux version`, it doesn't find flux unless PATH includes it. For example, itt fails when run as `./flux -V` in a build tree, outside of a running instance.

Per suggestion from @grondo, exec the original argv[0] rather than "flux".

Update sharness test to reset the PATH in addition to FLUX_URI, and run `flux -V` using its builddir path.