### PR TITLE
broker: don't read FLUX_RCX_PATH to set rc1,rc3 paths

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -198,10 +198,6 @@ int main (int argc, char *argv[])
     if (getenv ("FLUX_URI"))
         environment_from_env (env, "FLUX_URI", "", 0); /* pass-thru */
 
-    environment_from_env (env, "FLUX_RC1_PATH",
-                          flux_conf_get ("rc1_path", flags), 0);
-    environment_from_env (env, "FLUX_RC3_PATH",
-                          flux_conf_get ("rc3_path", flags), 0);
     environment_from_env (env, "FLUX_PMI_LIBRARY_PATH",
                           flux_conf_get ("pmi_library_path", flags), 0);
 

--- a/t/issues/t2284-initial-program-format-chars.sh
+++ b/t/issues/t2284-initial-program-format-chars.sh
@@ -1,11 +1,9 @@
 #!/bin/sh -e
 # broker cmdline preserves format characters
 
-export FLUX_RC1_PATH=""
-export FLUX_RC3_PATH=""
 for s in %h %g %%h %f; do
     echo "Running flux broker echo $s"
-    output=$(flux broker /bin/echo $s)
+    output=$(flux broker -Sbroker.rc1_path= -Sbroker.rc3_path= /bin/echo $s)
     test "$output" = "$s"
 done
 exit 0

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -91,16 +91,16 @@ test_under_flux() {
     fi
 
     if test "$personality" = "minimal"; then
-        export FLUX_RC1_PATH=""
-        export FLUX_RC3_PATH=""
+        RC1_PATH=""
+        RC3_PATH=""
     elif test "$personality" != "full"; then
-        export FLUX_RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
-        export FLUX_RC3_PATH=$FLUX_SOURCE_DIR/t/rc/rc3-$personality
-        test -x $FLUX_RC1_PATH || error "cannot execute $FLUX_RC1_PATH"
-        test -x $FLUX_RC3_PATH || error "cannot execute $FLUX_RC3_PATH"
+        RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
+        RC3_PATH=$FLUX_SOURCE_DIR/t/rc/rc3-$personality
+        test -x $RC1_PATH || error "cannot execute $RC1_PATH"
+        test -x $RC3_PATH || error "cannot execute $RC3_PATH"
     else
-        unset FLUX_RC1_PATH
-        unset FLUX_RC3_PATH
+        unset RC1_PATH
+        unset RC3_PATH
     fi
     if test -n "$FLUX_TEST_VALGRIND" ; then
         VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
@@ -115,6 +115,8 @@ test_under_flux() {
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
       exec flux start --bootstrap=selfpmi --size=${size} \
+                      ${RC1_PATH+-o -Sbroker.rc1_path=${RC1_PATH}} \
+                      ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
                       ${logopts} \
                       ${timeout} \
                       ${valgrind} \

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -55,8 +55,7 @@ ARGS="$ARGS $BUG1006"
 
 # Minimal is sufficient for these tests, but test_under_flux unavailable
 # clear the RC paths
-export FLUX_RC1_PATH=""
-export FLUX_RC3_PATH=""
+ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc_path="
 
 test_expect_success 'broker --shutdown-grace option works' '
 	flux start -o,--shutdown-grace=0.1 -o -Sbroker.rc1_path=/bin/true /bin/true
@@ -129,8 +128,6 @@ test_expect_success 'flux-start --wrap option works with --size' '
 test_expect_success 'flux-start dies gracefully when run from removed dir' '
 	mkdir foo && (
 	 cd foo &&
-	 unset FLUX_RC1_PATH &&
-	 unset FLUX_RC3_PATH &&
 	 rmdir ../foo &&
 	 test_must_fail flux start /bin/true )
 '

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -8,19 +8,18 @@ test_description='Test config file overlay bootstrap'
 TCONFDIR=${FLUX_SOURCE_DIR}/t/conf.d
 
 # Avoid loading unnecessary modules in back to back broker tests
-export FLUX_RC1_PATH=
-export FLUX_RC3_PATH=
+ARGS="-Sbroker.rc1_path= -Sbroker.rc3_path="
 
 #
 # check boot.method
 #
 
 test_expect_success 'flux broker with explicit PMI boot method works' '
-	flux broker -Sboot.method=pmi /bin/true
+	flux broker ${ARGS} -Sboot.method=pmi /bin/true
 '
 
 test_expect_success 'flux broker with unknown boot method fails' '
-	test_must_fail flux broker -Sboot.method=badmethod /bin/true
+	test_must_fail flux broker ${ARGS} -Sboot.method=badmethod /bin/true
 '
 
 #
@@ -28,26 +27,26 @@ test_expect_success 'flux broker with unknown boot method fails' '
 #
 
 test_expect_success 'flux broker without boot.config_file fails' '
-	test_must_fail flux broker -Sboot.method=config /bin/true
+	test_must_fail flux broker ${ARGS} -Sboot.method=config /bin/true
 '
 
 test_expect_success 'flux broker with boot.config_file=/badfile fails' '
-	test_must_fail flux broker -Sboot.method=config \
+	test_must_fail flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=/badfile /bin/true
 '
 
 test_expect_success 'flux broker with boot.config_file=bad-toml fails' '
-	test_must_fail flux broker -Sboot.method=config \
+	test_must_fail flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/bad-toml.conf /bin/true
 '
 
 test_expect_success 'flux broker with missing required items fails' '
-	test_must_fail flux broker -Sboot.method=config \
+	test_must_fail flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/bad-missing.conf /bin/true
 '
 
 test_expect_success 'flux broker with boot.config_file=bad-rank fails' '
-	test_must_fail flux broker -Sboot.method=config \
+	test_must_fail flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/bad-rank.conf /bin/true
 '
 
@@ -62,7 +61,7 @@ test_expect_success 'flux broker with boot.config_file=bad-rank fails' '
 #
 
 test_expect_success 'start size=1 with shared config file, expected attrs set' '
-	run_timeout 5 flux broker -Sboot.method=config \
+	run_timeout 5 flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/shared.conf \
 		--shutdown-grace=0.1 \
 		flux lsattr -v >1s.out &&
@@ -70,20 +69,20 @@ test_expect_success 'start size=1 with shared config file, expected attrs set' '
 '
 
 test_expect_success 'start size=1 with shared config file, ipc endpoint' '
-	run_timeout 5 flux broker -Sboot.method=config \
+	run_timeout 5 flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/shared_ipc.conf \
 		--shutdown-grace=0.1 \
 		/bin/true
 '
 
 test_expect_success 'start size=1 with shared config file, no endpoint' '
-	test_must_fail flux broker -Sboot.method=config \
+	test_must_fail flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/shared_none.conf \
 		/bin/true
 '
 
 test_expect_success 'start size=1 with private config file' '
-	run_timeout 5 flux broker -Sboot.method=config \
+	run_timeout 5 flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/private.conf /bin/true
 '
 
@@ -92,9 +91,9 @@ test_expect_success 'start size=1 with private config file' '
 #
 
 test_expect_success NO_CHAIN_LINT 'start size=2 with private config files' '
-	flux broker -Sboot.method=config \
+	flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/priv2.1.conf &
-	run_timeout 5 flux broker -Sboot.method=config \
+	run_timeout 5 flux broker ${ARGS} -Sboot.method=config \
 		-Sboot.config_file=${TCONFDIR}/priv2.0.conf \
 		--shutdown-grace=0.1 \
 		flux getattr size >2p.out &&

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -25,6 +25,7 @@ test_expect_success 'sharness minimal has transitioned normally thus far' '
 
 test_expect_success 'new init.mode=normal instance transitions appropriately' '
 	flux start -o,-Slog-stderr-level=6,-Sinit.mode=normal \
+		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
 		/bin/true 2>normal.log &&
 	grep -q "Run level 1 starting" normal.log &&
 	grep -q "Run level 1 Exited" normal.log &&
@@ -36,6 +37,7 @@ test_expect_success 'new init.mode=normal instance transitions appropriately' '
 
 test_expect_success 'new init.mode=none instance transitions appropriately' '
 	flux start -o,-Slog-stderr-level=6,-Sinit.mode=none \
+		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
 		/bin/true 2>none.log &&
 	grep -q "Run level 1 starting" none.log &&
 	grep -q "Run level 1 Skipped mode=none" none.log &&
@@ -46,7 +48,8 @@ test_expect_success 'new init.mode=none instance transitions appropriately' '
 '
 
 test_expect_success 'rc1 failure transitions to rc3, fails instance' '
-	! FLUX_RC1_PATH=/bin/false flux start \
+	test_expect_code 1 flux start \
+		-o,-Sbroker.rc1_path=/bin/false,-Sbroker.rc3_path= \
 		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
 		/bin/true 2>false.log &&
 	grep -q "Run level 1 starting" false.log &&
@@ -58,7 +61,8 @@ test_expect_success 'rc1 failure transitions to rc3, fails instance' '
 '
 
 test_expect_success 'rc1 bad path handled same as failure' '
-	! FLUX_RC1_PATH=rc1-nonexist flux start \
+	test_expect_code 127 flux start \
+		-o,-Sbroker.rc1_path=rc1-nonexist,-Sbroker.rc3_path= \
 		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
 		/bin/true 2>bad1.log &&
 	grep -q "Run level 1 starting" bad1.log &&
@@ -70,7 +74,8 @@ test_expect_success 'rc1 bad path handled same as failure' '
 '
 
 test_expect_success 'rc3 failure does not cause instance failure' '
-	FLUX_RC3_PATH=/bin/false flux start \
+	flux start \
+		-o,-Sbroker.rc3_path=/bin/false \
 		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
 		/bin/true 2>false3.log &&
 	grep -q "Run level 1 starting" false3.log &&
@@ -82,7 +87,8 @@ test_expect_success 'rc3 failure does not cause instance failure' '
 '
 
 test_expect_success 'rc1 environment is as expected' '
-	FLUX_RC1_PATH=${FLUX_SOURCE_DIR}/t/rc/rc1-testenv flux start \
+	flux start \
+		-o,-Sbroker.rc1_path=${FLUX_SOURCE_DIR}/t/rc/rc1-testenv \
 		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
 		/bin/true 2>&1 | tee rc1-test.log &&
 	grep "stderr-" rc1-test.log | egrep -q broker.*err &&


### PR DESCRIPTION
This is an attempted fix for #2304. The use of `FLUX_RC{1,3}_PATH` is deprecated in favor of setting the broker attribute directly. The broker now sets the default for these paths from the static "conf", and allows them to be overridden on the command line.

All tests were updated to use the new scheme. Still need to test with flux-under-flux, but this should solve that issue in theory.