### PR TITLE
job-ingest/validator: configure python shebang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -286,6 +286,7 @@ AC_SUBST(fluxpymoddir)
 AC_SUBST(PYTHON_LIBRARY, lib${ac_python_library}.so)
 
 AC_DEFINE_UNQUOTED([PYTHON_INTERPRETER], ["$PYTHON"], [The python interpreter flux is configured with])
+AC_SUBST(PYTHON)
 
 AC_ARG_ENABLE([pylint],
   [AS_HELP_STRING([--enable-pylint],
@@ -491,6 +492,11 @@ AC_CONFIG_FILES( \
   t/Makefile \
   t/fluxometer/conf.lua \
   t/fluxometer/conf.lua.installed \
+)
+
+AC_CONFIG_FILES( \
+  [src/modules/job-ingest/validators/validate-schema.py],
+      [chmod +x src/modules/job-ingest/validators/validate-schema.py] \
 )
 
 AC_CONFIG_LINKS([ \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -53,7 +53,7 @@ intree_conf_cppflags = \
 	-DINTREE_KEYDIR=\"${abs_top_builddir}/etc/flux\" \
 	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\" \
 	-DINTREE_BINDIR=\"${abs_top_builddir}/src/cmd\" \
-	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/validators/validate-schema.py\" \
+	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_builddir}/src/modules/job-ingest/validators/validate-schema.py\" \
 	-DINTREE_JOBSPEC_SCHEMA_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/schemas/jobspec.jsonschema\"
 
 

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -30,7 +30,7 @@ job_ingest_la_LIBADD = $(fluxmod_libadd) \
 		    $(FLUX_SECURITY_LIBS) \
 		    $(ZMQ_LIBS)
 
-dist_fluxlibexec_SCRIPTS = \
+fluxlibexec_SCRIPTS = \
 	validators/validate-schema.py
 
 fluxschemadir = $(datadir)/flux/schema/jobspec/

--- a/src/modules/job-ingest/validators/validate-schema.py.in
+++ b/src/modules/job-ingest/validators/validate-schema.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 
 ##############################################################
 #  Copyright 2018 Lawrence Livermore National Security, LLC


### PR DESCRIPTION
Problem: validator.py uses #!/usr/bin/env python shebang,
which can pick up a user python without jsonschema installed.

Have configure substitute the configured python path instead.

Fixes #2434