### PR TITLE
flux-kvs: Add eventlog namespace option

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -179,19 +179,21 @@ Specify an alternate namespace to retrieve from via '-N'.  If '-o' is
 specified, display the namespace owner.  If '-s' is specified, display
 the root sequence number.
 
-*eventlog get* [-w] [-c count] [-u] 'key'::
+*eventlog get* [-N ns] [-w] [-c count] [-u] 'key'::
 Display the contents of an RFC 18 KVS eventlog referred to by 'key'.
 If '-u' is specified, display the log in raw form.  If '-w' is
 specified, after the existing contents have been displayed, the
 eventlog is monitored and updates are displayed as they are committed.
 This runs until the program is interrupted or an error occurs, unless
-the number of events is limited with the '-c' option.
+the number of events is limited with the '-c' option.  Specify an
+alternate namespace to display from via '-N'.
 
-*eventlog append* [-t SECONDS] 'key' 'name' ['context ...']::
+*eventlog append* [-N ns] [-t SECONDS] 'key' 'name' ['context ...']::
 Append an event to an RFC 18 KVS eventlog referred to by 'key'.
 The event 'name' and optional 'context' are specified on the command line.
 The timestamp may optionally be specified with '-t' as decimal seconds since
 the UNIX epoch (UTC), otherwise the current wall clock is used.
+Specify an alternate namespace to append to via '-N'.
 
 AUTHOR
 ------

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -187,7 +187,7 @@ int flux_kvs_txn_vpack (flux_kvs_txn_t *txn, int flags,
         errno = EINVAL;
         goto error;
     }
-    if (validate_flags (flags, 0) < 0)
+    if (validate_flags (flags, FLUX_KVS_APPEND) < 0)
         goto error;
     val = json_vpack_ex (NULL, 0, fmt, ap);
     if (!val) {

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -129,9 +129,9 @@ void basic (void)
     txn = flux_kvs_txn_create ();
     ok (txn != NULL,
         "flux_kvs_txn_create works");
-    rc = flux_kvs_txn_pack (txn, 0, "foo.bar.baz",  "i", 42);
+    rc = flux_kvs_txn_pack (txn, FLUX_KVS_APPEND, "foo.bar.baz",  "i", 42);
     ok (rc == 0,
-        "1: flux_kvs_txn_pack(i) works");
+        "1: flux_kvs_txn_pack(i) flags=FLUX_KVS_APPEND works");
     rc = flux_kvs_txn_pack (txn, 0, "foo.bar.bleep",  "s", "foo");
     ok (rc == 0,
         "2: flux_kvs_txn_pack(s) works");
@@ -179,7 +179,7 @@ void basic (void)
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
     ok (!strcmp (key, "foo.bar.baz")
-        && flags == 0
+        && flags == FLUX_KVS_APPEND
         && check_int_value (dirent, 42) == 0,
         "1: put foo.bar.baz = 42");
 

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -57,4 +57,14 @@ test_expect_success 'flux kvs eventlog append fails with invalid context' '
 	! flux kvs eventlog append test.c foo not_a_object
 '
 
+test_expect_success 'flux kvs eventlog append and work on alternate namespaces' '
+        flux kvs namespace create EVENTLOGTESTNS &&
+        flux kvs eventlog append test.ns main &&
+        flux kvs eventlog append --namespace=EVENTLOGTESTNS test.ns guest &&
+        flux kvs eventlog get test.ns > get_f1.out &&
+        grep main get_f1.out &&
+        flux kvs eventlog get --namespace=EVENTLOGTESTNS test.ns > get_f2.out &&
+        grep guest get_f2.out
+'
+
 test_done


### PR DESCRIPTION
Pulled this off of an old abandoned PR #2352.  As we begin creating more eventlogs in guest namespaces (`guest.output`, `guest.input`, etc.) being able to get the logs via `flux kvs eventlog get` will be useful for debugging.