### PR TITLE
libioencode: make rank parameters strings

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -817,7 +817,7 @@ void attach_output_continuation (flux_future_t *f, void *arg)
     else if (!strcmp (name, "data")) {
         FILE *fp;
         const char *stream;
-        int rank;
+        const char *rank;
         char *data;
         int len;
         if (!ctx->output_header_parsed)
@@ -830,7 +830,7 @@ void attach_output_continuation (flux_future_t *f, void *arg)
             fp = stderr;
         if (len > 0) {
             if (optparse_hasopt (ctx->p, "label-io"))
-                fprintf (fp, "%d: ", rank);
+                fprintf (fp, "%s: ", rank);
             fwrite (data, len, 1, fp);
         }
         free (data);

--- a/src/common/libioencode/ioencode.h
+++ b/src/common/libioencode/ioencode.h
@@ -14,25 +14,25 @@
 #include <stdbool.h>
 #include <jansson.h>
 
-/* encode io data and/or EOF into json_t object
+/* encode io data and/or EOF into RFC24 data event object
  * - to set only EOF, set data to NULL and data_len to 0
  * - it is an error to provide no data and EOF = false
  * - returned object should be json_decref()'d after use
  */
 json_t *ioencode (const char *stream,
-                  int rank,
+                  const char *rank,
                   const char *data,
                   int len,
                   bool eof);
 
-/* decode json_t io object
+/* decode RFC24 data event object
  * - both data and EOF can be available
  * - if no data available, data set to NULL and len to 0
  * - data must be freed after return
  */
 int iodecode (json_t *o,
               const char **stream,
-              int *rank,
+              const char **rank,
               char **data,
               int *len,
               bool *eof);

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -19,7 +19,7 @@
 void basic_corner_case (void)
 {
     errno = 0;
-    ok (ioencode (NULL, -1, NULL, -1, false) == NULL
+    ok (ioencode (NULL, NULL, NULL, -1, false) == NULL
         && errno == EINVAL,
         "ioencode returns EINVAL on bad input");
 
@@ -33,17 +33,17 @@ void basic (void)
 {
     json_t *o;
     const char *stream;
-    int rank;
+    const char *rank;
     char *data;
     int len;
     bool eof;
 
-    ok ((o = ioencode ("stdout", 1, "foo", 3, false)) != NULL,
+    ok ((o = ioencode ("stdout", "1", "foo", 3, false)) != NULL,
         "ioencode success (data, eof = false)");
     ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
         "iodecode success");
     ok (!strcmp (stream, "stdout")
-        && rank == 1
+        && !strcmp (rank, "1")
         && !strcmp (data, "foo")
         && len == 3
         && eof == false,
@@ -51,12 +51,12 @@ void basic (void)
     free (data);
     json_decref (o);
 
-    ok ((o = ioencode ("stdout", 2, "bar", 3, true)) != NULL,
+    ok ((o = ioencode ("stdout", "[0-8]", "bar", 3, true)) != NULL,
         "ioencode success (data, eof = true)");
     ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
         "iodecode success");
     ok (!strcmp (stream, "stdout")
-        && rank == 2
+        && !strcmp (rank, "[0-8]")
         && !strcmp (data, "bar")
         && len == 3
         && eof == true,
@@ -64,12 +64,12 @@ void basic (void)
     free (data);
     json_decref (o);
 
-    ok ((o = ioencode ("stderr", 3, NULL, 0, true)) != NULL,
+    ok ((o = ioencode ("stderr", "[4,5]", NULL, 0, true)) != NULL,
         "ioencode success (no data, eof = true)");
     ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
         "iodecode success");
     ok (!strcmp (stream, "stderr")
-        && rank == 3
+        && !strcmp (rank, "[4,5]")
         && data == NULL
         && len == 0
         && eof == true,

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -184,7 +184,7 @@ static int remote_write (struct subprocess_channel *c)
         eof = true;
 
     /* rank not needed, set to 0 */
-    if (!(io = ioencode (c->name, 0, ptr, lenp, eof))) {
+    if (!(io = ioencode (c->name, "0", ptr, lenp, eof))) {
         flux_log_error (c->p->h, "ioencode");
         goto error;
     }
@@ -215,7 +215,7 @@ static int remote_close (struct subprocess_channel *c)
     int rv = -1;
 
     /* rank not needed, set to 0 */
-    if (!(io = ioencode (c->name, 0, NULL, 0, true))) {
+    if (!(io = ioencode (c->name, "0", NULL, 0, true))) {
         flux_log_error (c->p->h, "ioencode");
         goto error;
     }

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -241,9 +241,11 @@ static int rexec_output (flux_subprocess_t *p,
                          bool eof)
 {
     json_t *io = NULL;
+    char rankstr[64];
     int rv = -1;
 
-    if (!(io = ioencode (stream, s->rank, data, len, eof))) {
+    snprintf (rankstr, sizeof (rankstr), "%d", s->rank);
+    if (!(io = ioencode (stream, rankstr, data, len, eof))) {
         flux_log_error (s->h, "%s: ioencode", __FUNCTION__);
         goto error;
     }


### PR DESCRIPTION
Per RFC24, ranks in I/O events are idset strings not integers.  Therefore
ioencode() and iodecode() should take/return string ranks as parameters,
not ints.

Update all callers appropriately for changes.

Fixes #2437