### PR TITLE
testsuite: fix LONGTEST and other small improvements

### DIFF
--- a/t/issues/t2284-initial-program-format-chars.sh
+++ b/t/issues/t2284-initial-program-format-chars.sh
@@ -3,7 +3,7 @@
 
 for s in %h %g %%h %f; do
     echo "Running flux broker echo $s"
-    output=$(flux broker -Sbroker.rc1_path= -Sbroker.rc3_path= /bin/echo $s)
+    output=$(flux broker --shutdown-grace=0.1 -Sbroker.rc1_path= -Sbroker.rc3_path= /bin/echo $s)
     test "$output" = "$s"
 done
 exit 0

--- a/t/kvs/watch_disconnect.c
+++ b/t/kvs/watch_disconnect.c
@@ -88,7 +88,7 @@ int main (int argc, char **argv)
         w1 = count_watchers (h) - w0;
         if (w1 == rankcount)
             break;
-        usleep (100000);
+        usleep (1000);
     }
 
     log_msg ("test watchers: %d", w1);

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -88,6 +88,8 @@ test_under_flux() {
     timeout="-o -Sinit.rc2_timeout=300"
     if test -n "$FLUX_TEST_DISABLE_TIMEOUT"; then
         timeout=""
+    elif test_have_prereq LONGTEST; then
+        timeout="-o,-Sinit.rc2_timeout=900"
     fi
 
     if test "$personality" = "minimal"; then

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -155,4 +155,11 @@ fi
 #  Some tests in flux don't work with --chain-lint, add a prereq for
 #   --no-chain-lint:
 test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
+
+#  Set LONGTEST prereq
+if test "$TEST_LONG" = "t" || test "$LONGTEST" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+
 # vi: ts=4 sw=4 expandtab

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -256,11 +256,13 @@ test_expect_success 'broker --verbose option works' '
 test_expect_success 'broker --heartrate option works' '
 	flux start ${ARGS} -o,--heartrate=0.1 /bin/true
 '
-test_expect_success 'broker --k-ary option works' '
-	flux start ${ARGS} -s4 -o,--k-ary=1 /bin/true &&
-	flux start ${ARGS} -s4 -o,--k-ary=2 /bin/true &&
-	flux start ${ARGS} -s4 -o,--k-ary=3 /bin/true &&
-	flux start ${ARGS} -s4 -o,--k-ary=4 /bin/true
+test_expect_success NO_CHAIN_LINT 'broker --k-ary option works' '
+	pids="" &&
+	flux start ${ARGS} -s4 -o,--k-ary=1 /bin/true & pids=$!
+	flux start ${ARGS} -s4 -o,--k-ary=2 /bin/true & pids="$pids $!"
+	flux start ${ARGS} -s4 -o,--k-ary=3 /bin/true & pids="$pids $!"
+	flux start ${ARGS} -s4 -o,--k-ary=4 /bin/true & pids="$pids $!" 
+	wait $pids
 '
 
 test_expect_success 'flux-help command list can be extended' '

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -55,7 +55,7 @@ ARGS="$ARGS $BUG1006"
 
 # Minimal is sufficient for these tests, but test_under_flux unavailable
 # clear the RC paths
-ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc_path="
+ARGS="$ARGS -o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
 
 test_expect_success 'broker --shutdown-grace option works' '
 	flux start -o,--shutdown-grace=0.1 -o -Sbroker.rc1_path=/bin/true /bin/true

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -4,10 +4,6 @@ test_description='Test broker content service'
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} minimal

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -4,10 +4,6 @@ test_description='Test content-sqlite service'
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} minimal

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -61,10 +61,13 @@ test_expect_success 'rc1 failure transitions to rc3, fails instance' '
 '
 
 test_expect_success 'rc1 bad path handled same as failure' '
-	test_expect_code 127 flux start \
+	(
+	  SHELL=/bin/sh &&
+	  test_expect_code 127 flux start \
 		-o,-Sbroker.rc1_path=rc1-nonexist,-Sbroker.rc3_path= \
 		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
-		/bin/true 2>bad1.log &&
+		/bin/true 2>bad1.log
+	) &&
 	grep -q "Run level 1 starting" bad1.log &&
 	grep -q "Run level 1 Exited with non-zero status" bad1.log &&
 	! grep -q "Run level 2 starting" bad1.log &&

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -6,10 +6,6 @@ test_description='Test flux cron service'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . $(dirname $0)/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 # Size the session to one more than the number of cores, minimum of 4

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -11,10 +11,6 @@ any other tests that require kvs functionality.
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 # Size the session to one more than the number of cores, minimum of 4

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -11,10 +11,6 @@ would be unaware of.
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} kvs

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -99,8 +99,8 @@ test_expect_success 'kvs: store 10,000 keys in one dir' '
 	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $DIR.bigdir --count 10000
 '
 
-test_expect_success LONGTEST 'kvs: store 1,000,000 keys in one dir' '
-	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $DIR.bigdir2 --count 1000000
+test_expect_success LONGTEST 'kvs: store 100,000 keys in one dir' '
+	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $DIR.bigdir2 --count 100000
 '
 
 # kvs merging tests

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -5,10 +5,6 @@ test_description='Stress test KVS in flux session'
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} kvs

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -9,10 +9,6 @@ These are tests for ensuring multiple namespaces work.
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
-fi
-
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} kvs

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -144,7 +144,7 @@ test_expect_success 'job-shell: verify output of 4-task lptest job on stderr' '
 	sort -snk1 <lptest4_raw.err >lptest4.err &&
 	test_cmp lptest4.exp lptest4.err
 '
-test_expect_success 'job-shell: verify 10K line lptest output works' '
+test_expect_success LONGTEST 'job-shell: verify 10K line lptest output works' '
 	${LPTEST} 79 10000 | sed -e "s/^/0: /" >lptestXXL.exp &&
         id=$(flux jobspec srun -n1 ${LPTEST} 79 10000 | flux job submit) &&
 	flux job attach -l $id >lptestXXL.out &&

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -10,9 +10,10 @@ SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 
+ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,--shutdown-grace=0.25"
 test_expect_success "flux can run flux instance as a job" '
 	run_timeout 10 flux mini run -n1 -N1 \
-		flux start flux getattr size >size.out &&
+		flux start ${ARGS} flux getattr size >size.out &&
 	echo 1 >size.exp &&
 	test_cmp size.exp size.out
 '
@@ -27,7 +28,7 @@ test_expect_success "flux subinstance leaves local_uri, remote_uri in KVS" '
 
 test_expect_success "flux --parent works in subinstance" '
 	id=$(flux jobspec srun -n1 \
-               flux start flux --parent kvs put test=ok \
+               flux start ${ARGS} flux --parent kvs put test=ok \
                | flux job submit) &&
 	flux job attach $id &&
 	flux job info $id guest.test > guest.test &&
@@ -39,7 +40,8 @@ test_expect_success "flux --parent works in subinstance" '
 
 test_expect_success "flux --parent --parent works in subinstance" '
 	id=$(flux jobspec srun -n1 \
-              flux start flux start flux --parent --parent kvs put test=ok \
+              flux start ${ARGS} \
+	      flux start ${ARGS} flux --parent --parent kvs put test=ok \
 	      | flux job submit) &&
 	flux job attach $id &&
 	flux job info $id guest.test > guest2.test &&
@@ -50,12 +52,12 @@ test_expect_success "flux --parent --parent works in subinstance" '
 '
 
 test_expect_success "flux sets instance-level attribute" '
-        level=$(flux mini run flux start \
+        level=$(flux mini run flux start ${ARGS} \
                 flux getattr instance-level) &&
         level2=$(flux mini run flux start \
-                 flux mini run flux start \
+                 flux mini run flux start ${ARGS} \
                  flux getattr instance-level) &&
-	level0=$(flux start flux getattr instance-level) &&
+	level0=$(flux start ${ARGS} flux getattr instance-level) &&
         test "$level" = "1" &&
         test "$level2" = "2" &&
         test "$level0" = "0"
@@ -63,7 +65,7 @@ test_expect_success "flux sets instance-level attribute" '
 
 test_expect_success "flux sets jobid attribute" '
 	id=$(flux jobspec srun -n1 \
-		flux start flux getattr jobid \
+		flux start ${ARGS} flux getattr jobid \
 		| flux job submit) &&
 	echo "$id" >jobid.exp &&
 	flux job attach $id >jobid.out &&


### PR DESCRIPTION
I instrumented `test_expect_success` in sharness in order to find the longest running tests in hopes of getting `make check` to run a little faster (in Travis, and on my machine with only 4 cores).

Some of the more obvious fixes were done here (run more in parallel, use a reduced `--shutdown-grace`, disable rc1/rc3 where possible), and some other minor errors were addressed.

Some other issues with `LONGTEST` tests were also addressed (all but #2443).

Finally, an error recently introduced by me in 91b493bf13940020526ca3af19fb6f071528bbbc was fixed.