### PR TITLE
Initial shell stdin support

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -756,14 +756,13 @@ struct attach_ctx {
     bool output_header_parsed;
     double timestamp_zero;
     int eventlog_watch_count;
-    int eventlog_watch_completed;
 };
 
-void attach_eventlog_watch_completed_check (struct attach_ctx *ctx)
+void attach_completed_check (struct attach_ctx *ctx)
 {
     /* eventlog and output watch are the two eventlog watches we need
      * to complete before shutting off reactor */
-    if (ctx->eventlog_watch_completed >= ctx->eventlog_watch_count) {
+    if (!ctx->eventlog_watch_count) {
         flux_watcher_stop (ctx->sigint_w);
         flux_watcher_stop (ctx->sigtstp_w);
     }
@@ -872,8 +871,8 @@ void attach_output_continuation (flux_future_t *f, void *arg)
 done:
     flux_future_destroy (f);
     ctx->output_f = NULL;
-    ctx->eventlog_watch_completed++;
-    attach_eventlog_watch_completed_check (ctx);
+    ctx->eventlog_watch_count--;
+    attach_completed_check (ctx);
 }
 
 void attach_cancel_continuation (flux_future_t *f, void *arg)
@@ -988,8 +987,8 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
 done:
     flux_future_destroy (f);
     ctx->exec_eventlog_f = NULL;
-    ctx->eventlog_watch_completed++;
-    attach_eventlog_watch_completed_check (ctx);
+    ctx->eventlog_watch_count--;
+    attach_completed_check (ctx);
 }
 
 /* Handle an event in the main job eventlog.
@@ -1085,8 +1084,8 @@ void attach_event_continuation (flux_future_t *f, void *arg)
 done:
     flux_future_destroy (f);
     ctx->eventlog_f = NULL;
-    ctx->eventlog_watch_completed++;
-    attach_eventlog_watch_completed_check (ctx);
+    ctx->eventlog_watch_count--;
+    attach_completed_check (ctx);
 }
 
 int cmd_attach (optparse_t *p, int argc, char **argv)

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -250,6 +250,12 @@ class SubmitCmd:
             metavar="KEY=VAL",
         )
         parser.add_argument(
+            "--input",
+            type=str,
+            help="Redirect job stdin from FILENAME, bypassing KVS",
+            metavar="FILENAME",
+        )
+        parser.add_argument(
             "--output",
             type=str,
             help="Redirect job stdout to FILENAME, bypassing KVS",
@@ -296,6 +302,10 @@ class SubmitCmd:
         jobspec.set_environment(dict(os.environ))
         if args.time_limit is not None:
             jobspec.set_duration(args.time_limit)
+
+        if args.input is not None:
+            jobspec.setattr_shopt("input.stdin.type", "file")
+            jobspec.setattr_shopt("input.stdin.path", args.input)
 
         if args.output is not None:
             jobspec.setattr_shopt("output.stdout.type", "file")

--- a/src/common/libsubprocess/test/test_echo.c
+++ b/src/common/libsubprocess/test/test_echo.c
@@ -134,8 +134,9 @@ main (int argc, char *argv[])
 
         memset (buf, '\0', 1024);
         while ((len = read (fd, buf, 1024)) > 0) {
-            char outbuf[1025]; /* add extra char for -Werror=format-overflow */
+            char outbuf[1026]; /* add extra char for -Werror=format-overflow */
 
+            memset (outbuf, '\0', sizeof (outbuf));
             sprintf (outbuf,
                      "%s%s",
                      buf,

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -51,6 +51,7 @@ flux_shell_SOURCES = \
 	task.c \
 	task.h \
 	pmi.c \
+	input.c \
 	output.c \
 	svc.c \
 	svc.h \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -30,6 +30,7 @@ static struct shell_builtin builtin_list_end = { 0 };
  *  to get the builtin automatically loaded at shell startup.
  */
 extern struct shell_builtin builtin_pmi;
+extern struct shell_builtin builtin_input;
 extern struct shell_builtin builtin_output;
 extern struct shell_builtin builtin_kill;
 extern struct shell_builtin builtin_signals;
@@ -38,6 +39,7 @@ extern struct shell_builtin builtin_gpubind;
 
 static struct shell_builtin * builtins [] = {
     &builtin_pmi,
+    &builtin_input,
     &builtin_output,
     &builtin_kill,
     &builtin_signals,

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -1,0 +1,643 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* std input handling
+ *
+ * Currently, only standard input via file is supported.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libidset/idset.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libioencode/ioencode.h"
+
+#include "task.h"
+#include "internal.h"
+#include "builtins.h"
+
+struct shell_input;
+
+/* input type configured by user for input to the shell */
+enum {
+    FLUX_INPUT_TYPE_NONE = 1,
+    FLUX_INPUT_TYPE_FILE = 2,
+};
+
+/* how input will reach each task */
+enum {
+    FLUX_TASK_INPUT_KVS = 1,
+};
+
+struct shell_task_input_kvs {
+    flux_future_t *exec_f;
+    flux_future_t *input_f;
+    bool input_header_parsed;
+    bool eof_reached;
+};
+
+struct shell_task_input {
+    struct shell_input *in;
+    struct shell_task *task;
+    int type;
+    struct shell_task_input_kvs input_kvs;
+};
+
+struct shell_input_type_file {
+    const char *path;
+    int fd;
+    flux_watcher_t *w;
+    char *rankstr;
+};
+
+struct shell_input {
+    flux_shell_t *shell;
+    int stdin_type;
+    struct shell_task_input *task_inputs;
+    int task_inputs_count;
+    int ntasks;
+    struct shell_input_type_file stdin_file;
+};
+
+static void shell_task_input_kvs_cleanup (struct shell_task_input_kvs *kp)
+{
+    flux_future_destroy (kp->exec_f);
+    flux_future_destroy (kp->input_f);
+}
+
+static void shell_task_input_cleanup (struct shell_task_input *tp)
+{
+    shell_task_input_kvs_cleanup (&(tp->input_kvs));
+}
+
+static void shell_input_type_file_cleanup (struct shell_input_type_file *fp)
+{
+    close (fp->fd);
+    flux_watcher_destroy (fp->w);
+    free (fp->rankstr);
+}
+
+void shell_input_destroy (struct shell_input *in)
+{
+    if (in) {
+        int saved_errno = errno;
+        int i;
+        shell_input_type_file_cleanup (&(in->stdin_file));
+        for (i = 0; i < in->ntasks; i++)
+            shell_task_input_cleanup (&(in->task_inputs[i]));
+        free (in->task_inputs);
+        free (in);
+        errno = saved_errno;
+    }
+}
+
+static void shell_input_type_file_init (struct shell_input *in)
+{
+    struct shell_input_type_file *fp = &(in->stdin_file);
+    fp->fd = -1;
+}
+
+static int shell_input_parse_type (struct shell_input *in)
+{
+    const char *typestr = NULL;
+    int ret;
+
+    if ((ret = flux_shell_getopt_unpack (in->shell, "input",
+                                         "{s?:{s?:s}}",
+                                         "stdin", "type", &typestr)) < 0)
+        return -1;
+
+    if (!ret || !typestr)
+        return 0;
+
+    if (!strcmp (typestr, "file")) {
+        struct shell_input_type_file *fp = &(in->stdin_file);
+
+        in->stdin_type = FLUX_INPUT_TYPE_FILE;
+
+        if (flux_shell_getopt_unpack (in->shell, "input",
+                                      "{s:{s?:s}}",
+                                      "stdin", "path", &(fp->path)) < 0)
+            return -1;
+
+        if (fp->path == NULL) {
+            log_msg ("path for stdin file input not specified");
+            return -1;
+        }
+    }
+    else {
+        log_msg ("invalid input type specified '%s'", typestr);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* log entry to exec.eventlog that we've created the input eventlog */
+static int shell_input_ready (struct shell_input *in, flux_kvs_txn_t *txn)
+{
+    json_t *entry = NULL;
+    char *entrystr = NULL;
+    const char *key = "exec.eventlog";
+    int saved_errno, rc = -1;
+
+    if (!(entry = eventlog_entry_create (0., "input-ready", NULL))) {
+        log_err ("eventlog_entry_create");
+        goto error;
+    }
+    if (!(entrystr = eventlog_entry_encode (entry))) {
+        log_err ("eventlog_entry_encode");
+        goto error;
+    }
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, key, entrystr) < 0) {
+        log_err ("flux_kvs_txn_put");
+        goto error;
+    }
+    rc = 0;
+ error:
+    /* on error, future destroyed via shell_input destroy */
+    saved_errno = errno;
+    json_decref (entry);
+    free (entrystr);
+    errno = saved_errno;
+    return rc;
+}
+
+static void shell_input_kvs_init_completion (flux_future_t *f, void *arg)
+{
+    struct shell_input *in = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to commit header is a fatal error.  Should be
+         * cleaner in future. Issue #2378 */
+        log_err_exit ("shell_input_kvs_init");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (in->shell, "input.kvs-init") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+
+    if (in->stdin_type == FLUX_INPUT_TYPE_FILE)
+        flux_watcher_start (in->stdin_file.w);
+}
+
+static int shell_input_kvs_init (struct shell_input *in, json_t *header)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    char *headerstr = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(headerstr = eventlog_entry_encode (header)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", headerstr) < 0)
+        goto error;
+    if (shell_input_ready (in, txn) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_input_kvs_init_completion, in) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (in->shell, "input.kvs-init") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_input_kvs_init_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+ error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    free (headerstr);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+static int shell_input_header (struct shell_input *in)
+{
+    json_t *o = NULL;
+    int rc = -1;
+
+    o = eventlog_entry_pack (0, "header",
+                             "{s:i s:{s:s} s:{s:i} s:{}}",
+                             "version", 1,
+                             "encoding",
+                             "stdin", "base64",
+                             "count",
+                             "stdin", 1,
+                             "options");
+    if (!o) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (!in->shell->standalone) {
+        if (shell_input_kvs_init (in, o) < 0)
+            log_err ("shell_input_kvs_init");
+    }
+    rc = 0;
+ error:
+    json_decref (o);
+    return rc;
+}
+
+static void shell_input_put_kvs_completion (flux_future_t *f, void *arg)
+{
+    struct shell_input *in = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to write stdin to input is a fatal error.  Should be
+         * cleaner in future. Issue #2378 */
+        log_err_exit ("shell_input_put_kvs");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (in->shell, "input.kvs") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+}
+
+static int shell_input_put_kvs (struct shell_input *in,
+                                void *buf,
+                                int len,
+                                bool eof)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    json_t *entry = NULL;
+    char *entrystr = NULL;
+    json_t *context = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(context = ioencode ("stdin", in->stdin_file.rankstr, buf, len, eof)))
+        goto error;
+    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+        goto error;
+    if (!(entrystr = eventlog_entry_encode (entry)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_input_put_kvs_completion, in) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (in->shell, "input.kvs") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_input_put_kvs_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+ error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    json_decref (context);
+    free (entrystr);
+    json_decref (entry);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+static void shell_input_type_file_cb (flux_reactor_t *r, flux_watcher_t *w,
+                                      int revents, void *arg)
+{
+    struct shell_input *in = arg;
+    struct shell_input_type_file *fp = &(in->stdin_file);
+    long ps = sysconf (_SC_PAGESIZE);
+    char buf[ps];
+    ssize_t n;
+
+    assert (ps > 0);
+
+    /* Failure to read stdin in a fatal error.  Should be cleaner in
+     * future.  Issue #2378 */
+
+    while ((n = read (fp->fd, buf, ps)) > 0) {
+        if (shell_input_put_kvs (in, buf, n, false) < 0)
+            log_err_exit ("shell_input_put_kvs");
+    }
+
+    if (n < 0)
+        log_err_exit ("shell_input_put_kvs");
+
+    if (shell_input_put_kvs (in, NULL, 0, true) < 0)
+        log_err_exit ("shell_input_put_kvs");
+
+    flux_watcher_stop (w);
+}
+
+static int shell_input_type_file_setup (struct shell_input *in)
+{
+    struct shell_input_type_file *fp = &(in->stdin_file);
+
+    if ((fp->fd = open (fp->path, O_RDONLY)) < 0) {
+        log_err ("error opening input file '%s'", fp->path);
+        return -1;
+    }
+
+    if (!(fp->w = flux_fd_watcher_create (in->shell->r, fp->fd,
+                                          FLUX_POLLIN,
+                                          shell_input_type_file_cb,
+                                          in))) {
+        log_err ("flux_fd_watcher_create");
+        return -1;
+    }
+
+    if (in->shell->info->jobspec->task_count > 1) {
+        if (asprintf (&fp->rankstr, "[0-%d]",
+                      in->shell->info->jobspec->task_count) < 0) {
+            log_err ("asprintf");
+            return -1;
+        }
+    }
+    else {
+        if (!(fp->rankstr = strdup ("0"))) {
+            log_err ("asprintf");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+struct shell_input *shell_input_create (flux_shell_t *shell)
+{
+    struct shell_input *in;
+    size_t task_inputs_size;
+    int i;
+
+    if (!(in = calloc (1, sizeof (*in))))
+        return NULL;
+    in->shell = shell;
+    in->stdin_type = FLUX_INPUT_TYPE_NONE;
+    in->ntasks = shell->info->rankinfo.ntasks;
+
+    task_inputs_size = sizeof (struct shell_task_input) * in->ntasks;
+    if (!(in->task_inputs = calloc (1, task_inputs_size)))
+        goto error;
+
+    for (i = 0; i < in->ntasks; i++)
+        in->task_inputs[i].type = FLUX_TASK_INPUT_KVS;
+
+    shell_input_type_file_init (in);
+
+    /* Check if user specified shell input */
+    if (shell_input_parse_type (in) < 0)
+        goto error;
+
+    if (shell->info->shell_rank == 0) {
+        /* can't use stdin in standalone, no kvs to write to */
+        if (!in->shell->standalone) {
+            if (shell_input_header (in) < 0)
+                goto error;
+
+            if (in->stdin_type == FLUX_INPUT_TYPE_FILE) {
+                if (shell_input_type_file_setup (in) < 0)
+                    goto error;
+            }
+        }
+    }
+
+    return in;
+error:
+    shell_input_destroy (in);
+    return NULL;
+}
+
+static int shell_input_init (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_arg_t *args,
+                             void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_input *in = shell_input_create (shell);
+    if (!in)
+        return -1;
+    if (flux_plugin_aux_set (p, "builtin.input", in,
+                            (flux_free_f) shell_input_destroy) < 0) {
+        shell_input_destroy (in);
+        return -1;
+    }
+    return 0;
+}
+
+static void shell_task_input_kvs_input_cb (flux_future_t *f, void *arg)
+{
+    struct shell_task_input *task_input = arg;
+    struct shell_task_input_kvs *kp = &(task_input->input_kvs);
+    const char *entry;
+    json_t *o;
+    const char *name;
+    json_t *context;
+
+    /* Failure to read stdin in a fatal error.  Should be cleaner in
+     * future.  Issue #2378 */
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
+        log_err_exit ("eventlog_entry_parse");
+
+    if (!strcmp (name, "header")) {
+        /* Future: per-stream encoding */
+        kp->input_header_parsed = true;
+    }
+    else if (!strcmp (name, "data")) {
+        const char *rank = NULL;
+        bool data_ok = false;
+        if (!kp->input_header_parsed)
+            log_msg_exit ("stream data read before header");
+        if (iodecode (context, NULL, &rank, NULL, NULL, NULL) < 0)
+            log_msg_exit ("malformed event context");
+        if (!strcmp (rank, "all"))
+            data_ok = true;
+        else {
+            struct idset *idset;
+            if (!(idset = idset_decode (rank))) {
+                log_err ("idset_decode '%s'", rank);
+                goto out;
+            }
+            data_ok = idset_test (idset, task_input->task->rank);
+            idset_destroy (idset);
+        }
+        if (data_ok) {
+            const char *stream;
+            char *data = NULL;
+            int len;
+            bool eof;
+            if (kp->eof_reached) {
+                log_msg_exit ("stream data after EOF");
+                goto out;
+            }
+            if (iodecode (context, &stream, NULL, &data, &len, &eof) < 0)
+                log_msg_exit ("malformed event context");
+            if (len > 0) {
+                if (flux_subprocess_write (task_input->task->proc,
+                                           stream,
+                                           data,
+                                           len) < 0)
+                    log_err_exit ("flux_subprocess_write");
+            }
+            if (eof) {
+                if (flux_subprocess_close (task_input->task->proc, stream) < 0)
+                    log_err_exit ("flux_subprocess_close");
+                if (flux_job_event_watch_cancel (f) < 0)
+                    log_err_exit ("flux_job_event_watch_cancel");
+            }
+            free (data);
+        }
+    }
+
+out:
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+done:
+    flux_future_destroy (f);
+    kp->input_f = NULL;
+}
+
+static void shell_task_input_kvs_exec_cb (flux_future_t *f, void *arg)
+{
+    struct shell_task_input *task_input = arg;
+    struct shell_task_input_kvs *kp = &(task_input->input_kvs);
+    flux_future_t *input_f = NULL;
+    const char *entry;
+    json_t *o;
+    const char *name;
+
+    /* Failure to read stdin in a fatal error.  Should be cleaner in
+     * future.  Issue #2378 */
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, NULL, &name, NULL) < 0)
+        log_err_exit ("eventlog_entry_parse");
+
+    if (!strcmp (name, "input-ready")) {
+        if (!(input_f = flux_job_event_watch (task_input->in->shell->h,
+                                              task_input->in->shell->info->jobid,
+                                              "guest.input",
+                                              0)))
+            log_err_exit ("flux_job_event_watch");
+
+        if (flux_future_then (input_f,
+                              -1.,
+                              shell_task_input_kvs_input_cb,
+                              arg) < 0) {
+            flux_future_destroy (input_f);
+            log_err_exit ("flux_future_then");
+        }
+
+        kp->input_f = input_f;
+    }
+
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+ done:
+    flux_future_destroy (f);
+    kp->exec_f = NULL;
+}
+
+static int shell_task_input_kvs_setup (struct shell_task_input *task_input)
+{
+    /* Watch "guest.exec.eventlog" to determine when "guest.input" is ready */
+    struct shell_task_input_kvs *kp = &(task_input->input_kvs);
+    flux_future_t *f = NULL;
+    int saved_errno;
+
+    if (!(f = flux_job_event_watch (task_input->in->shell->h,
+                                    task_input->in->shell->info->jobid,
+                                    "guest.exec.eventlog",
+                                    0))) {
+        log_err ("flux_job_event_watch");
+        goto error;
+    }
+
+    if (flux_future_then (f,
+                          -1,
+                          shell_task_input_kvs_exec_cb,
+                          task_input) < 0) {
+        log_err ("flux_future_then");
+        goto error;
+    }
+
+    kp->exec_f = f;
+    return 0;
+ error:
+    saved_errno = errno;
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return -1;
+}
+
+static int shell_input_task_init (flux_plugin_t *p,
+                                  const char *topic,
+                                  flux_plugin_arg_t *args,
+                                  void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_input *in = flux_plugin_aux_get (p, "builtin.input");
+    struct shell_task_input *task_input;
+    flux_shell_task_t *task;
+
+    if (!shell || !in || !(task = flux_shell_current_task (shell)))
+        return -1;
+
+    task_input = &(in->task_inputs[in->task_inputs_count]);
+    task_input->in = in;
+    task_input->task = task;
+
+    if (task_input->type == FLUX_TASK_INPUT_KVS) {
+        /* can't read stdin in standalone mode, no KVS to read from */
+        if (!task_input->in->shell->standalone) {
+            if (shell_task_input_kvs_setup (task_input) < 0)
+                return -1;
+        }
+    }
+
+    in->task_inputs_count++;
+    return 0;
+}
+
+struct shell_builtin builtin_input = {
+    .name = "input",
+    .init = shell_input_init,
+    .task_init = shell_input_task_init
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -10,7 +10,9 @@
 
 /* std input handling
  *
- * Currently, only standard input via file is supported.
+ * Depending on inputs from user, a service is started to receive
+ * stdin from front-end command or file is read for redirected
+ * standard input.
  */
 
 #if HAVE_CONFIG_H
@@ -26,6 +28,7 @@
 #include "src/common/libioencode/ioencode.h"
 
 #include "task.h"
+#include "svc.h"
 #include "internal.h"
 #include "builtins.h"
 
@@ -33,7 +36,7 @@ struct shell_input;
 
 /* input type configured by user for input to the shell */
 enum {
-    FLUX_INPUT_TYPE_NONE = 1,
+    FLUX_INPUT_TYPE_SERVICE = 1, /* default */
     FLUX_INPUT_TYPE_FILE = 2,
 };
 
@@ -104,6 +107,89 @@ void shell_input_destroy (struct shell_input *in)
     }
 }
 
+static void shell_input_put_kvs_completion (flux_future_t *f, void *arg)
+{
+    struct shell_input *in = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to write stdin to input is a fatal error.  Should be
+         * cleaner in future. Issue #2378 */
+        log_err_exit ("shell_input_put_kvs");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (in->shell, "input.kvs") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+}
+
+static int shell_input_put_kvs (struct shell_input *in, json_t *context)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    json_t *entry = NULL;
+    char *entrystr = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+        goto error;
+    if (!(entrystr = eventlog_entry_encode (entry)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_input_put_kvs_completion, in) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (in->shell, "input.kvs") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_input_put_kvs_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+ error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    free (entrystr);
+    json_decref (entry);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+/* Convert 'iodecode' object to an valid RFC 24 data event.
+ * N.B. the iodecode object is a valid "context" for the event.
+ */
+static void shell_input_stdin_cb (flux_t *h,
+                                  flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg,
+                                  void *arg)
+{
+    struct shell_input *in = arg;
+    bool eof = false;
+    json_t *o;
+
+    if (shell_svc_allowed (in->shell->svc, msg) < 0)
+        goto error;
+    if (flux_request_unpack (msg, NULL, "o", &o) < 0)
+        goto error;
+    if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)
+        goto error;
+    if (shell_input_put_kvs (in, o) < 0)
+        goto error;
+    if (eof)
+        flux_msg_handler_stop (mh);
+    if (flux_respond (in->shell->h, msg, NULL) < 0)
+        log_err ("flux_respond");
+    return;
+error:
+    if (flux_respond_error (in->shell->h, msg, errno, NULL) < 0)
+        log_err ("flux_respond");
+}
+
 static void shell_input_type_file_init (struct shell_input *in)
 {
     struct shell_input_type_file *fp = &(in->stdin_file);
@@ -123,7 +209,9 @@ static int shell_input_parse_type (struct shell_input *in)
     if (!ret || !typestr)
         return 0;
 
-    if (!strcmp (typestr, "file")) {
+    if (!strcmp (typestr, "service"))
+        in->stdin_type = FLUX_INPUT_TYPE_SERVICE;
+    else if (!strcmp (typestr, "file")) {
         struct shell_input_type_file *fp = &(in->stdin_file);
 
         in->stdin_type = FLUX_INPUT_TYPE_FILE;
@@ -146,15 +234,19 @@ static int shell_input_parse_type (struct shell_input *in)
     return 0;
 }
 
-/* log entry to exec.eventlog that we've created the input eventlog */
+/* log entry to exec.eventlog that we've created the input eventlog /
+ * started stdin service */
 static int shell_input_ready (struct shell_input *in, flux_kvs_txn_t *txn)
 {
     json_t *entry = NULL;
     char *entrystr = NULL;
     const char *key = "exec.eventlog";
+    int rank = in->shell->info->rankinfo.rank;
     int saved_errno, rc = -1;
 
-    if (!(entry = eventlog_entry_create (0., "input-ready", NULL))) {
+    if (!(entry = eventlog_entry_pack (0., "input-ready",
+                                       "{s:i}",
+                                       "leader-rank", rank))) {
         log_err ("eventlog_entry_create");
         goto error;
     }
@@ -257,62 +349,23 @@ static int shell_input_header (struct shell_input *in)
     return rc;
 }
 
-static void shell_input_put_kvs_completion (flux_future_t *f, void *arg)
+static int shell_input_put_kvs_raw (struct shell_input *in,
+                                    void *buf,
+                                    int len,
+                                    bool eof)
 {
-    struct shell_input *in = arg;
-
-    if (flux_future_get (f, NULL) < 0)
-        /* failng to write stdin to input is a fatal error.  Should be
-         * cleaner in future. Issue #2378 */
-        log_err_exit ("shell_input_put_kvs");
-    flux_future_destroy (f);
-
-    if (flux_shell_remove_completion_ref (in->shell, "input.kvs") < 0)
-        log_err ("flux_shell_remove_completion_ref");
-}
-
-static int shell_input_put_kvs (struct shell_input *in,
-                                void *buf,
-                                int len,
-                                bool eof)
-{
-    flux_kvs_txn_t *txn = NULL;
-    flux_future_t *f = NULL;
-    json_t *entry = NULL;
-    char *entrystr = NULL;
     json_t *context = NULL;
     int saved_errno;
     int rc = -1;
 
     if (!(context = ioencode ("stdin", in->stdin_file.rankstr, buf, len, eof)))
         goto error;
-    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+    if (shell_input_put_kvs (in, context) < 0)
         goto error;
-    if (!(entrystr = eventlog_entry_encode (entry)))
-        goto error;
-    if (!(txn = flux_kvs_txn_create ()))
-        goto error;
-    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
-        goto error;
-    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
-        goto error;
-    if (flux_future_then (f, -1, shell_input_put_kvs_completion, in) < 0)
-        goto error;
-    if (flux_shell_add_completion_ref (in->shell, "input.kvs") < 0) {
-        log_err ("flux_shell_remove_completion_ref");
-        goto error;
-    }
-    /* f memory responsibility of shell_input_put_kvs_completion()
-     * callback */
-    f = NULL;
     rc = 0;
  error:
     saved_errno = errno;
-    flux_kvs_txn_destroy (txn);
     json_decref (context);
-    free (entrystr);
-    json_decref (entry);
-    flux_future_destroy (f);
     errno = saved_errno;
     return rc;
 }
@@ -332,15 +385,15 @@ static void shell_input_type_file_cb (flux_reactor_t *r, flux_watcher_t *w,
      * future.  Issue #2378 */
 
     while ((n = read (fp->fd, buf, ps)) > 0) {
-        if (shell_input_put_kvs (in, buf, n, false) < 0)
-            log_err_exit ("shell_input_put_kvs");
+        if (shell_input_put_kvs_raw (in, buf, n, false) < 0)
+            log_err_exit ("shell_input_put_kvs_raw");
     }
 
     if (n < 0)
-        log_err_exit ("shell_input_put_kvs");
+        log_err_exit ("shell_input_put_kvs_raw");
 
-    if (shell_input_put_kvs (in, NULL, 0, true) < 0)
-        log_err_exit ("shell_input_put_kvs");
+    if (shell_input_put_kvs_raw (in, NULL, 0, true) < 0)
+        log_err_exit ("shell_input_put_kvs_raw");
 
     flux_watcher_stop (w);
 }
@@ -388,7 +441,7 @@ struct shell_input *shell_input_create (flux_shell_t *shell)
     if (!(in = calloc (1, sizeof (*in))))
         return NULL;
     in->shell = shell;
-    in->stdin_type = FLUX_INPUT_TYPE_NONE;
+    in->stdin_type = FLUX_INPUT_TYPE_SERVICE;
     in->ntasks = shell->info->rankinfo.ntasks;
 
     task_inputs_size = sizeof (struct shell_task_input) * in->ntasks;
@@ -407,6 +460,17 @@ struct shell_input *shell_input_create (flux_shell_t *shell)
     if (shell->info->shell_rank == 0) {
         /* can't use stdin in standalone, no kvs to write to */
         if (!in->shell->standalone) {
+            if (in->stdin_type == FLUX_INPUT_TYPE_SERVICE) {
+                if (flux_shell_service_register (in->shell,
+                                                 "stdin",
+                                                 shell_input_stdin_cb,
+                                                 in) < 0)
+                    log_err_exit ("flux_shell_service_register");
+
+                /* Do not add a completion reference for the stdin service, we
+                 * don't care if the user ever sends stdin */
+            }
+
             if (shell_input_header (in) < 0)
                 goto error;
 

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -495,11 +495,11 @@ static void shell_output_write_cb (flux_t *h,
     json_t *o;
     json_t *entry;
 
+    if (shell_svc_allowed (out->shell->svc, msg) < 0)
+        goto error;
     if (flux_request_unpack (msg, NULL, "o", &o) < 0)
         goto error;
     if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)
-        goto error;
-    if (shell_svc_allowed (out->shell->svc, msg) < 0)
         goto error;
     if (!(entry = eventlog_entry_pack (0., "data", "O", o))) // increfs 'o'
         goto error;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -110,6 +110,7 @@ TESTSCRIPTS = \
 	t2604-job-shell-affinity.t \
 	t2605-job-shell-output-redirection-standalone.t \
 	t2606-job-shell-output-redirection.t \
+	t2607-job-shell-input.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -125,10 +125,18 @@ test_expect_success 'job-shell: verify output of 1-task lptest job' '
 	flux job attach -l $id >lptest.out &&
 	test_cmp lptest.exp lptest.out
 '
+#
+# sharness will redirect /dev/null to stdin by default, leading to the
+# possibility of seeing an EOF warning on stdin.  We'll check for that
+# manually in a few of the tests and filter it out from the stderr
+# output.
+#
+
 test_expect_success 'job-shell: verify output of 1-task lptest job on stderr' '
         id=$(flux jobspec srun -n1 bash -c "${LPTEST} >&2" \
 		| flux job submit) &&
 	flux job attach -l $id 2>lptest.err &&
+        sed -i -e "/stdin EOF could not be sent/d" lptest.err &&
 	test_cmp lptest.exp lptest.err
 '
 test_expect_success 'job-shell: verify output of 4-task lptest job' '
@@ -142,6 +150,7 @@ test_expect_success 'job-shell: verify output of 4-task lptest job on stderr' '
 		| flux job submit) &&
 	flux job attach -l $id 2>lptest4_raw.err &&
 	sort -snk1 <lptest4_raw.err >lptest4.err &&
+        sed -i -e "/stdin EOF could not be sent/d" lptest4.err &&
 	test_cmp lptest4.exp lptest4.err
 '
 test_expect_success LONGTEST 'job-shell: verify 10K line lptest output works' '

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -272,6 +272,13 @@ test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-tas
 # output corner case tests
 #
 
+#
+# sharness will redirect /dev/null to stdin by default, leading to the
+# possibility of seeing an EOF warning on stdin.  We'll check for that
+# manually in the next two tests and filter it out from the stderr
+# output.
+#
+
 test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-task)' '
         id=$(flux mini submit -n1 \
              --output=out25 --error=err25 \
@@ -281,6 +288,7 @@ test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-tas
         grep stdout:baz out25 &&
         grep stderr:baz err25 &&
         ! test -s out25.attach &&
+        sed -i -e "/stdin EOF could not be sent/d" err25.attach &&
         ! test -s err25.attach
 '
 
@@ -293,6 +301,7 @@ test_expect_success 'job-shell: job attach exits cleanly if no kvs output (2-tas
         grep stdout:baz out26 &&
         grep stderr:baz err26 &&
         ! test -s out26.attach &&
+        sed -i -e "/stdin EOF could not be sent/d" err26.attach &&
         ! test -s err26.attach
 '
 

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+test_description='Test flux-shell'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
+LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
+
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
+
+test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+        #  Add fake by_rank configuration to kvs:
+        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux module load barrier &&
+        flux module load -r 0 sched-simple &&
+        flux module load -r 0 job-exec
+'
+
+test_expect_success 'flux-shell: generate input for stdin input tests' '
+       echo "foo" > input_stdin_file &&
+       echo "doh" >> input_stdin_file &&
+       ${LPTEST} 79 10000 > lptestXXL_input
+'
+
+#
+# input file tests
+#
+
+test_expect_success 'flux-shell: run 1-task input file as stdin job' '
+        flux mini run -n1 --input=input_stdin_file \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file0.out &&
+        test_cmp input_stdin_file file0.out
+'
+
+test_expect_success 'flux-shell: run 2-task input file as stdin job' '
+        flux mini run -n2 --input=input_stdin_file --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file1.out &&
+        grep "0: foo" file1.out &&
+        grep "0: doh" file1.out &&
+        grep "1: foo" file1.out &&
+        grep "1: doh" file1.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: multiple jobs, each want stdin via file' '
+        id1=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id2=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id3=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id4=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        flux job attach $id1 > file2_1.out 2> file2_1.err &
+        pid1=$!
+        flux job attach $id2 > file2_2.out 2> file2_2.err &
+        pid2=$!
+        flux job attach $id3 > file2_3.out 2> file2_3.err &
+        pid3=$!
+        flux job attach $id4 > file2_4.out 2> file2_4.err &
+        pid4=$!
+        wait $pid1 &&
+        wait $pid2 &&
+        wait $pid3 &&
+        wait $pid4 &&
+        test_cmp input_stdin_file file2_1.out &&
+        test_cmp input_stdin_file file2_2.out &&
+        test_cmp input_stdin_file file2_3.out &&
+        test_cmp input_stdin_file file2_4.out
+'
+
+test_expect_success LONGTEST 'flux-shell: 10K line lptest input works' '
+        flux mini run -n1 --input=lptestXXL_input \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file3.out &&
+	test_cmp lptestXXL_input file3.out
+'
+
+test_expect_success 'flux-shell: input file invalid' '
+        test_must_fail flux mini run -n1 --input=/foo/bar/baz \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file4.out
+'
+
+test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
+        flux module remove -r 0 job-exec &&
+        flux module remove -r 0 sched-simple &&
+        flux module remove barrier
+'
+
+test_done

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -28,6 +28,127 @@ test_expect_success 'flux-shell: generate input for stdin input tests' '
 '
 
 #
+# pipe in stdin tests
+#
+
+test_expect_success 'flux-shell: run 1-task no pipe in stdin' '
+        id=$(flux mini submit -n1 echo foo) &&
+        flux job attach $id > pipe0.out &&
+        grep foo pipe0.out
+'
+
+test_expect_success 'flux-shell: run 1-task input file as stdin job' '
+        id=$(flux mini submit -n1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach $id < input_stdin_file > pipe1.out &&
+        test_cmp input_stdin_file pipe1.out
+'
+
+test_expect_success 'flux-shell: run 2-task input file as stdin job' '
+        id=$(flux mini submit -n2 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach -l $id < input_stdin_file > pipe2.out &&
+        grep "0: foo" pipe2.out &&
+        grep "0: doh" pipe2.out &&
+        grep "1: foo" pipe2.out &&
+        grep "1: doh" pipe2.out
+'
+
+test_expect_success LONGTEST 'flux-shell: 10K line lptest piped input works' '
+        id=$(flux mini submit -n1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach $id < lptestXXL_input > pipe3.out &&
+	test_cmp lptestXXL_input pipe3.out
+'
+
+#
+# sharness will redirect /dev/null to stdin by default, so we create a named pipe
+# and pipe that in for tests in which we need "no stdin".
+#
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: attach twice, one with data' '
+        mkfifo stdin4.pipe
+        id=$(flux mini submit -n1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        flux job attach $id < stdin4.pipe > pipe4A.out 2> pipe4A.err &
+        pid1=$!
+        flux job attach $id < input_stdin_file > pipe4B.out 2> pipe4B.err &
+        pid2=$!
+        exec 9> stdin4.pipe &&
+        wait $pid1 &&
+        wait $pid2 &&
+        exec 9>&- &&
+        test_cmp input_stdin_file pipe4A.out &&
+        test_cmp input_stdin_file pipe4B.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: multiple jobs, each want stdin' '
+        id1=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id2=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id3=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id4=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        flux job attach $id1 < input_stdin_file > pipe5_1.out 2> pipe5_1.err &
+        pid1=$!
+        flux job attach $id2 < input_stdin_file > pipe5_2.out 2> pipe5_2.err &
+        pid2=$!
+        flux job attach $id3 < input_stdin_file > pipe5_3.out 2> pipe5_3.err &
+        pid3=$!
+        flux job attach $id4 < input_stdin_file > pipe5_4.out 2> pipe5_4.err &
+        pid4=$!
+        wait $pid1 &&
+        wait $pid2 &&
+        wait $pid3 &&
+        wait $pid4 &&
+        test_cmp input_stdin_file pipe5_1.out &&
+        test_cmp input_stdin_file pipe5_2.out &&
+        test_cmp input_stdin_file pipe5_3.out &&
+        test_cmp input_stdin_file pipe5_4.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: no stdin desired in job' '
+        id=$(flux mini submit -n1 sleep 60)
+        flux job attach $id < input_stdin_file 2> pipe6A.err &
+        pid=$! &&
+        flux job wait-event -p guest.exec.eventlog $id input-ready 2> pipe6B.err &&
+        flux job wait-event -p guest.input -m eof=true $id data 2> pipe6C.err &&
+        flux job cancel $id 2> pipe6D.err &&
+        test_expect_code 143 wait $pid
+'
+
+# There is a small racy possibility that `flux job attach` could
+# notice the job is completed BEFORE it is informed the shell is not
+# receiving stdin, thus the `flux job attach` call does not fail.
+#
+# To greatly decrease the odds of that happening, make sure the test
+# job outputs a very nice chunk of data.
+test_expect_success 'flux-shell: task completed, try to pipe into stdin' '
+        ${LPTEST} 79 500 > big_dataset &&
+        id=$(flux mini submit -n1 cat big_dataset) &&
+        flux job wait-event $id clean 2> pipe7A.err &&
+        test_must_fail flux job attach $id < input_stdin_file 2> pipe7B.err
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: pipe to stdin twice, second fails' '
+        id=$(flux mini submit -n1 sleep 60)
+        flux job attach $id < input_stdin_file 2> pipe8A.err &
+        pid=$!
+        flux job wait-event -p guest.exec.eventlog $id input-ready 2> pipe8B.err &&
+        flux job wait-event -p guest.input -m eof=true $id data 2> pipe8C.err &&
+        test_must_fail flux job attach $id < input_stdin_file 2> pipe8D.err &&
+        flux job cancel $id 2> pipe8E.err &&
+        test_expect_code 143 wait $pid
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: pipe in zero data' '
+        flux mini run -n1 echo < /dev/null &&
+        cat /dev/null | flux mini run -n1 cat
+'
+
+#
 # input file tests
 #
 
@@ -81,7 +202,42 @@ test_expect_success LONGTEST 'flux-shell: 10K line lptest input works' '
 
 test_expect_success 'flux-shell: input file invalid' '
         test_must_fail flux mini run -n1 --input=/foo/bar/baz \
-             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file4.out
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n
+'
+
+test_expect_success 'flux-shell: task stdin via file, try to pipe into stdin fails' '
+        id=$(flux mini submit -n1 --input=input_stdin_file sleep 60) &&
+        flux job wait-event $id start &&
+        test_must_fail flux job attach $id < input_stdin_file &&
+        flux job cancel $id
+'
+
+#
+# corner case tests
+#
+
+test_expect_success 'flux-shell: run 1-task input file with service type' '
+        id=$(flux mini submit -n1 \
+             --setopt "input.stdin.type=\"service\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach $id < input_stdin_file > cc1.out &&
+        test_cmp input_stdin_file cc1.out
+'
+
+test_expect_success 'flux-shell: error on bad input type' '
+        id=$(flux mini submit -n1 \
+             --setopt "input.stdin.type=\"foobar\"" \
+             echo foo) &&
+        flux job wait-event $id clean &&
+        test_must_fail flux job attach $id
+'
+
+test_expect_success 'flux-shell: error on no path with file output' '
+        id=$(flux mini submit -n1 \
+             --label-io --setopt "input.stdin.type=\"file\"" \
+             echo foo) &&
+        flux job wait-event $id clean &&
+        test_must_fail flux job attach $id
 '
 
 test_expect_success 'job-shell: unload job-exec & sched-simple modules' '


### PR DESCRIPTION
After a lot of back and forth experimenting, initial stdin shell support via piping in via `flux job attach` and via file input (typically via `--input` in `flux mini`).

- if stdin is via file, leader shell reads file and writes to `guest.input`, otherwise service is started on leader shell to receive stdin and write to `guest.input`
- all tasks watch `guest.input` to get stdin, write to stdin via `flux_subprocess_write()`.  This was easier to implement for the time being and gives parity to wreck.
  - Should do single watcher per shell?
  - how to deal with potential buffer overflow in `flux_subprocess_write()` TBD.  `cbuf` can autogrow buffer size, but `cbuf` still requires a max-buffer size be specified.
- several corner cases handled via the service on leader not starting / shutting down.  e.g.
  - user requests stdin via file and tries to pipe stdin, since service not started, flux-job gets ENOSYS
  - user pipes in stdin, including EOF, then tries to pipe in stdin a second time.  Service has shut 
    down, flux-job gets ENOSYS.
  - job is done, user attaches and tries to pipe in stdin, gets ENOSYS
  - however cases are not really differentiable, so I just output a generic message of "stdin not accepted".
- allow a guest user to pipe in stdin to job?  Not yet supported and not sure of plan.
- Depends on some fixes I put in #2345 & #2441