### PR TITLE
testsuite: extend some testing timeouts 

### DIFF
--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -19,10 +19,10 @@ test_expect_success 'run_timeout works' '
 	test_expect_code 142 run_timeout 0.001 sleep 2
 '
 test_expect_success 'test run_timeout with success' '
-	run_timeout 0.01 /bin/true
+	run_timeout 1 /bin/true
 '
 test_expect_success 'run_timeout fails if exec fails' '
-	test_must_fail run_timeout 0.01 /nonexistent/executable
+	test_must_fail run_timeout 1 /nonexistent/executable
 '
 test_expect_success 'we can find a flux binary' '
 	flux --help >/dev/null

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -39,7 +39,7 @@ test_expect_success \
   "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
 	run_timeout 120 \
 	flux start -s ${VALGRIND_NBROKERS} \
-		--killer-timeout=20 \
+		--killer-timeout=120 \
 		--wrap=libtool,e,${VALGRIND} \
 		--wrap=--tool=memcheck \
 		--wrap=--leak-check=full \


### PR DESCRIPTION
The last few builds under travis-ci have failed in the `t0001-basic.t` `run_timeout` tests, likely because Travis is getting even slower and the small 10ms timeout fires before `/bin/true` runs in one case and before `exec()` returns an error in the missing file case.

Similarly, even with the 20s killer-timeout we've still seen some valgrind test failures due to the `flux-start` killer-timeout firing. This PR extends the killer timeout to 120s (effectively disabling it)