### PR TITLE
bindings/python: change minimum python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       stage: test
       compiler: gcc
       env:
-       - PYTHON_VERSION=2.7
+       - PYTHON_VERSION=3.6
     - name: "Ubuntu: py3.6 distcheck"
       stage: test
       compiler: gcc
@@ -45,7 +45,7 @@ jobs:
        - CXX=g++-8
        - ARGS="--with-flux-security --enable-caliper"
        - DISTCHECK=t
-       - PYTHON_VERSION=2.7
+       - PYTHON_VERSION=3.6
     - name: "Ubuntu: clang-6.0 chain-lint --with-flux-security"
       stage: test
       compiler: clang-6.0
@@ -54,14 +54,14 @@ jobs:
        - CXX=clang++-6.0
        - chain_lint=t
        - ARGS="--with-flux-security"
-       - PYTHON_VERSION=2.7
+       - PYTHON_VERSION=3.6
     - name: "Ubuntu: COVERAGE=t, --with-flux-security --enable-caliper"
       stage: test
       compiler: gcc
       env:
        - COVERAGE=t
        - ARGS="--with-flux-security --enable-caliper"
-       - PYTHON_VERSION=2.7
+       - PYTHON_VERSION=3.6
     - name: "Ubuntu: TEST_INSTALL docker-deploy"
       stage: test
       compiler: gcc
@@ -69,7 +69,7 @@ jobs:
        - ARGS="--with-flux-security --enable-caliper"
        - TEST_INSTALL=t
        - DOCKER_TAG=t
-       - PYTHON_VERSION=2.7
+       - PYTHON_VERSION=3.6
     - name: "Centos 7: --with-flux-security --enable-caliper docker-deploy"
       stage: test
       compiler: gcc
@@ -77,7 +77,7 @@ jobs:
        - ARGS="--with-flux-security --enable-caliper --prefix=/usr"
        - IMG=centos7
        - DOCKER_TAG=t
-       - PYTHON_VERSION=2.7
+       - PYTHON_VERSION=3.6
     - name: "Centos 7: py3.6 --with-flux-security"
       stage: test
       compiler: gcc

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ sqlite-devel	| libsqlite3-dev	| >= 3.0.0		|
 lua		| lua5.1		| >= 5.1, < 5.3		|
 lua-devel	| liblua5.1-dev		| >= 5.1, < 5.3		|
 lua-posix 	| lua-posix             | 			| *1*
-python-devel	| python-dev		| >= 3.6		|
-python-cffi	| python-cffi		| >= 1.1		|
-python-six	| python-six		| >= 1.9		|
-python-yaml	| python-yaml		| >= 3.10.0		|
-python-jsonschema | python-jsonschema	| >= 2.3.0		|
+python36-devel	| python3-dev		| >= 3.6		|
+python36-cffi	| python3-cffi		| >= 1.1		|
+python36-six	| python3-six		| >= 1.9		|
+python36-yaml	| python3-yaml		| >= 3.10.0		|
+python36-jsonschema | python3-jsonschema | >= 2.3.0		|
 asciidoc	| asciidoc         	| 			| *2*
 asciidoctor	| asciidoctor         	| >= 1.5.7		| *2*
 aspell		| aspell		|			| *3*

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sqlite-devel	| libsqlite3-dev	| >= 3.0.0		|
 lua		| lua5.1		| >= 5.1, < 5.3		|
 lua-devel	| liblua5.1-dev		| >= 5.1, < 5.3		|
 lua-posix 	| lua-posix             | 			| *1*
-python-devel	| python-dev		| >= 2.7		|
+python-devel	| python-dev		| >= 3.6		|
 python-cffi	| python-cffi		| >= 1.1		|
 python-six	| python-six		| >= 1.9		|
 python-yaml	| python-yaml		| >= 3.10.0		|

--- a/config/ax_python_devel.m4
+++ b/config/ax_python_devel.m4
@@ -74,15 +74,28 @@ AC_DEFUN([AX_PYTHON_DEVEL],[
 	#
 	# Allow the use of a (user set) custom python version
 	#
+	# N.B. modified for Flux:
+	# If PYTHON_VERSION is unset, look for "python3" first, then "python".
+	# Most os's now install the v2 interpreter as "python" and v3 as
+	# "python3" so users on those os's would otherwise be required to run
+	# "$PYTHON_VERSION=3 ./configure" to get a working python for Flux.
+	#
 	AC_ARG_VAR([PYTHON_VERSION],[The installed Python
 		version to use, for example '2.3'. This string
 		will be appended to the Python interpreter
 		canonical name.])
 
-	AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
-	if test -z "$PYTHON"; then
-	   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
-	   PYTHON_VERSION=""
+	if test -n "$PYTHON_VERSION"; then
+		AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
+		if test -z "$PYTHON"; then
+		   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
+		   PYTHON_VERSION=""
+		fi
+	else
+		AC_PATH_PROGS([PYTHON],[python3 python])
+		if test -z "$PYTHON"; then
+		   AC_MSG_ERROR([Cannot find python in your system path])
+		fi
 	fi
 
 	#

--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ AC_CHECK_LIB(m, floor)
 saved_PATH=$PATH
 export PATH=$(echo $PATH | sed "s|$(pwd)/src/cmd:*||")
 
-AX_PYTHON_DEVEL([>='2.7'])
+AX_PYTHON_DEVEL([>='3.6'])
 
 AM_PATH_PYTHON([$ac_python_version])
 if test "X$PYTHON" = "X"; then
@@ -247,6 +247,7 @@ AM_CHECK_PYMOD(cffi,
                ,
                [AC_MSG_ERROR([could not find python module cffi, version 1.1+ required])]
                )
+# TODO: remove this dependency when time permits, only needed for 2/3 compat
 AM_CHECK_PYMOD(six,
                [StrictVersion(six.__version__) >= StrictVersion('1.9.0')],
                ,
@@ -268,7 +269,7 @@ AM_CHECK_PYMOD(jsonschema,
 # search can lead to linking problems.
 #
 # Logic below assumes only newer Python versions, protected by
-# above check for atleast Python 2.7.
+# above check for atleast Python 3.6.
 if test "$ac_python_ldflags_set_by_user" != "true"; then
   AC_CHECK_LIB([$ac_python_library], [PyArg_ParseTuple],
                [ac_python_in_ld_path=true])

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -85,19 +85,6 @@ builtin-cmds.c : builtin builtin-cmds-list.sh
 	    $(srcdir)/builtin-cmds-list.sh $(srcdir)/builtin/*.c > $@
 
 #
-# Ensure we pick up configured python first in path during testing:
-#
-noinst_SCRIPTS = \
-	python
-python_sanity:
-	test $(PYTHON) != $(abs_builddir)/python
-python: Makefile python_sanity
-	$(AM_V_GEN)printf "#!/bin/sh\nexec $(PYTHON) \"\$$@\"\n" > python \
-	  && chmod 755 python
-clean-local:
-	rm -f python
-
-#
 # coverage:
 #  Ensure all programs are run at least once, so we can see which
 #  have zero coverage:

--- a/src/cmd/flux-jobspec.py
+++ b/src/cmd/flux-jobspec.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 import re

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env flux-python
-
 ##############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/job-manager/bulk-state.py
+++ b/t/job-manager/bulk-state.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 ###############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -10,7 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-# Usage: bulk-state.py njobs
+# Usage: flux python bulk-state.py njobs
 #
 # Submit njobs jobs while watching job state notification events.
 # Ensure that each job progresses through an expected set of states,

--- a/t/job-manager/drain-cancel.py
+++ b/t/job-manager/drain-cancel.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 ###############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -10,7 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-# Usage: drain-cancel.py jobid
+# Usage: flux python drain-cancel.py jobid
 #
 # Send a blocking drain request, then cancel jobid.
 # The drain response should be received, assuming the queue

--- a/t/job-manager/drain-undrain.py
+++ b/t/job-manager/drain-undrain.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 ###############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -10,7 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-# Usage: drain-undrain.py
+# Usage: flux python drain-undrain.py
 #
 # Send a drain request immediately followed by an undrain request.
 #

--- a/t/jobspec/summarize-minimal-jobspec.py
+++ b/t/jobspec/summarize-minimal-jobspec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# Usage: flux python summarize-minimal-jobspec.py -j jobspec >summary.txt
 
 from __future__ import print_function
 

--- a/t/jobspec/validate.py
+++ b/t/jobspec/validate.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-
-# Usage: validate.py --schema=jobspec.json data.json [data.json ...]
-# Usage: cat data.json | validate.py --schema=jobspec.json
+# Usage: flux python validate.py --schema=jobspec.json data.json [data.json ...]
+# Usage: cat data.json | flux python validate.py --schema=jobspec.json
 
 import sys
 import argparse

--- a/t/jobspec/y2j.py
+++ b/t/jobspec/y2j.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# Usage: flux python y2j <in.yaml >out.json
 
 import sys, yaml, json
 

--- a/t/schedutil/req_and_unload.py
+++ b/t/schedutil/req_and_unload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# Usage: flux python request-and-unload.py module-name
 
 import argparse
 import sys

--- a/t/t0019-jobspec-schema.t
+++ b/t/t0019-jobspec-schema.t
@@ -5,7 +5,7 @@ test_description='Test the jobspec schema validation'
 . `dirname $0`/sharness.sh
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
-VALIDATE=${JOBSPEC}/validate.py
+VALIDATE="flux python ${JOBSPEC}/validate.py"
 SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
 SCHEMA_V1=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
 

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -5,10 +5,10 @@ test_description='Test the flux-jobspec command'
 . `dirname $0`/sharness.sh
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
-VALIDATE=${JOBSPEC}/validate.py
+VALIDATE="flux python ${JOBSPEC}/validate.py"
 SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
 MINI_SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
-SUMMARIZE=${JOBSPEC}/summarize-minimal-jobspec.py
+SUMMARIZE="flux python ${JOBSPEC}/summarize-minimal-jobspec.py"
 
 #  Set path to jq
 #

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -9,7 +9,7 @@ test_description='Test json-jobspec *cough* parser *cough*'
 jq=$(which jq 2>/dev/null)
 test -n "$jq" && test_set_prereq HAVE_JQ
 jj=${FLUX_BUILD_DIR}/t/sched-simple/jj-reader
-y2j=${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py
+y2j="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 
 test_expect_success HAVE_JQ 'jj-reader: unexpected version throws error' '
 	flux jobspec srun hostname | jq ".version = 2" >input.$test_count &&

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -17,7 +17,7 @@ test_under_flux 4 kvs
 flux setattr log-stderr-level 1
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
-Y2J=${JOBSPEC}/y2j.py
+Y2J="flux python ${JOBSPEC}/y2j.py"
 SUBMITBENCH="${FLUX_BUILD_DIR}/t/ingest/submitbench"
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -8,8 +8,8 @@ test_under_flux 4 kvs
 
 flux setattr log-stderr-level 1
 
-DRAIN_UNDRAIN=${FLUX_SOURCE_DIR}/t/job-manager/drain-undrain.py
-DRAIN_CANCEL=${FLUX_SOURCE_DIR}/t/job-manager/drain-cancel.py
+DRAIN_UNDRAIN="flux python ${FLUX_SOURCE_DIR}/t/job-manager/drain-undrain.py"
+DRAIN_CANCEL="flux python ${FLUX_SOURCE_DIR}/t/job-manager/drain-cancel.py"
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 # List jobs without header

--- a/t/t2206-job-manager-bulk-state.t
+++ b/t/t2206-job-manager-bulk-state.t
@@ -8,7 +8,7 @@ test_under_flux 4
 
 flux setattr log-stderr-level 1
 
-BULK_STATE=${FLUX_SOURCE_DIR}/t/job-manager/bulk-state.py
+BULK_STATE="flux python ${FLUX_SOURCE_DIR}/t/job-manager/bulk-state.py"
 
 test_expect_success 'job-manager: all state events received (5 jobs from rank 0)' '
 	run_timeout 10 ${BULK_STATE} 5

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -51,7 +51,7 @@ test_expect_success 'sched-simple: gpu request is canceled' '
 	flux job wait-event --timeout=5.0 $jobid exception &&
 	flux job eventlog $jobid | grep  "Unsupported resource type .gpu."
 '
-Y2J=${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py
+Y2J="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 SPEC=${SHARNESS_TEST_SRCDIR}/jobspec/valid/basic.yaml
 test_expect_success 'sched-simple: invalid minimal jobspec is canceled' '
 	${Y2J}<${SPEC} | flux job submit >job00.id &&

--- a/t/t2301-schedutil-outstanding-requests.t
+++ b/t/t2301-schedutil-outstanding-requests.t
@@ -9,7 +9,7 @@ test_under_flux 1 job
 hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
-REQ_AND_UNLOAD=${SHARNESS_TEST_SRCDIR}/schedutil/req_and_unload.py
+REQ_AND_UNLOAD="flux python ${SHARNESS_TEST_SRCDIR}/schedutil/req_and_unload.py"
 
 test_expect_success 'schedutil: load sched-dummy --cores=2' '
 	flux module load -r 0 ${SCHED_DUMMY} --cores=2


### PR DESCRIPTION
This (should be) the absolute minimum to remove python 2 support.  Updates the config, README, and travis.  I'm not sure all of our docker images have a python 3 available, so we'll see on travis.