### PR TITLE
mergify: fix rule that prevents merging of "WIP" PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
       - "approved-reviews-by=@flux-framework/core"
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
-      - -title~="^\[*[Ww][Ii][Pp]"
+      - -title~=^\[*[Ww][Ii][Pp]
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Finally emailed mergify support to ask why our title match regex wasn't working, and it turned out the regex should not have been double-quoted.

Fixed and pushed in this small PR.